### PR TITLE
feat: unix socket for ouroboros node-to-client

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	BindAddr      string `split_words:"true"`
 	CardanoConfig string `                   envconfig:"config"`
 	DatabasePath  string `split_words:"true"`
+	SocketPath    string `split_words:"true"`
 	IntersectTip  bool   `split_words:"true"`
 	Network       string
 	MetricsPort   uint `split_words:"true"`
@@ -38,6 +39,7 @@ var globalConfig = &Config{
 	BindAddr:      "0.0.0.0",
 	CardanoConfig: "./configs/cardano/preview/config.json",
 	DatabasePath:  ".dingo",
+	SocketPath:    "dingo.socket",
 	IntersectTip:  false,
 	Network:       "preview",
 	MetricsPort:   12798,


### PR DESCRIPTION
Create the initial UNIX socket. This will need some improvements around the socket file handling, but is suitable to begin work on wiring up node-to-client protocols.