### PR TITLE
refactor: move listener and enable port re-use

### DIFF
--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -58,6 +58,21 @@ func (c *ConnectionManager) startListener(l ListenerConfig) error {
 			return fmt.Errorf("failed to open listening socket: %s", err)
 		}
 		l.Listener = listener
+		if l.UseNtC {
+			c.config.Logger.Info(
+				fmt.Sprintf(
+					"listening for ouroboros node-to-node connections on %s",
+					l.ListenAddress,
+				),
+			)
+		} else {
+			c.config.Logger.Info(
+				fmt.Sprintf(
+					"listening for ouroboros node-to-client connections on %s",
+					l.ListenAddress,
+				),
+			)
+		}
 	}
 	// Build connection options
 	defaultConnOpts := []ouroboros.ConnectionOptionFunc{


### PR DESCRIPTION
This migrates the listeners from the internal node entrypoint to the node framework, which enables re-use of the listening port as the outbound source port