### PR TITLE
feat: stub utxorpc

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	network            string
 	networkMagic       uint32
 	outboundSourcePort uint
+	utxorpcPort        uint
 	peerSharing        bool
 	promRegistry       prometheus.Registerer
 	topologyConfig     *topology.TopologyConfig
@@ -179,6 +180,13 @@ func WithNetworkMagic(networkMagic uint32) ConfigOptionFunc {
 func WithOutboundSourcePort(port uint) ConfigOptionFunc {
 	return func(c *Config) {
 		c.outboundSourcePort = port
+	}
+}
+
+// WithUtxorpcPort specifies the port to use for the gRPC API listener. This defaults to port 9090
+func WithUtxorpcPort(port uint) ConfigOptionFunc {
+	return func(c *Config) {
+		c.utxorpcPort = port
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/blinklabs-io/dingo
 go 1.22.9
 
 require (
+	connectrpc.com/connect v1.17.0
+	connectrpc.com/grpchealth v1.3.0
+	connectrpc.com/grpcreflect v1.2.0
 	github.com/blinklabs-io/gouroboros v0.105.2
 	github.com/blinklabs-io/ouroboros-mock v0.3.5
 	github.com/dgraph-io/badger/v4 v4.5.0
@@ -10,12 +13,14 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/cobra v1.8.1
+	github.com/utxorpc/go-codegen v0.14.0
 	go.opentelemetry.io/otel v1.33.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.33.0
 	go.opentelemetry.io/otel/sdk v1.33.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/net v0.32.0
 	golang.org/x/sys v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.25.12
@@ -53,7 +58,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/utxorpc/go-codegen v0.14.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
@@ -62,7 +66,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+connectrpc.com/connect v1.17.0 h1:W0ZqMhtVzn9Zhn2yATuUokDLO5N+gIuBWMOnsQrfmZk=
+connectrpc.com/connect v1.17.0/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+connectrpc.com/grpchealth v1.3.0 h1:FA3OIwAvuMokQIXQrY5LbIy8IenftksTP/lG4PbYN+E=
+connectrpc.com/grpchealth v1.3.0/go.mod h1:3vpqmX25/ir0gVgW6RdnCPPZRcR6HvqtXX5RNPmDXHM=
+connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U=
+connectrpc.com/grpcreflect v1.2.0/go.mod h1:nwSOKmE8nU5u/CidgHtPYk1PFI3U9ignz7iDMxOYkSY=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Network       string
 	MetricsPort   uint `split_words:"true"`
 	Port          uint
+	UtxorpcPort   uint `split_words:"true"`
 	Topology      string
 }
 
@@ -44,6 +45,7 @@ var globalConfig = &Config{
 	Network:       "preview",
 	MetricsPort:   12798,
 	Port:          3001,
+	UtxorpcPort:   9090,
 	Topology:      "",
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -78,6 +78,7 @@ func Run(logger *slog.Logger) error {
 				},
 			),
 			dingo.WithOutboundSourcePort(cfg.Port),
+			dingo.WithUtxorpcPort(cfg.UtxorpcPort),
 			// Enable metrics with default prometheus registry
 			dingo.WithPrometheusRegistry(prometheus.DefaultRegisterer),
 			// TODO: make this configurable

--- a/internal/utxorpc/query.go
+++ b/internal/utxorpc/query.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	query "github.com/utxorpc/go-codegen/utxorpc/v1alpha/query"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
+)
+
+// queryServiceServer implements the QueryService API
+type queryServiceServer struct {
+	queryconnect.UnimplementedQueryServiceHandler
+}
+
+// ReadParams
+func (s *queryServiceServer) ReadParams(
+	ctx context.Context,
+	req *connect.Request[query.ReadParamsRequest],
+) (*connect.Response[query.ReadParamsResponse], error) {
+	fieldMask := req.Msg.GetFieldMask()
+
+	log.Printf("Got a ReadParams request with fieldMask %v", fieldMask)
+	resp := &query.ReadParamsResponse{}
+
+	return connect.NewResponse(resp), nil
+}
+
+// ReadUtxos
+func (s *queryServiceServer) ReadUtxos(
+	ctx context.Context,
+	req *connect.Request[query.ReadUtxosRequest],
+) (*connect.Response[query.ReadUtxosResponse], error) {
+	keys := req.Msg.GetKeys() // []*TxoRef
+
+	log.Printf("Got a ReadUtxos request with keys %v", keys)
+	resp := &query.ReadUtxosResponse{}
+
+	return connect.NewResponse(resp), nil
+}
+
+// SearchUtxos
+func (s *queryServiceServer) SearchUtxos(
+	ctx context.Context,
+	req *connect.Request[query.SearchUtxosRequest],
+) (*connect.Response[query.SearchUtxosResponse], error) {
+	predicate := req.Msg.GetPredicate() // UtxoPredicate
+
+	log.Printf("Got a SearchUtxos request with predicate %v", predicate)
+	resp := &query.SearchUtxosResponse{}
+
+	return connect.NewResponse(resp), nil
+}
+
+// StreamUtxos

--- a/internal/utxorpc/submit.go
+++ b/internal/utxorpc/submit.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	submit "github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit/submitconnect"
+)
+
+// submitServiceServer implements the SubmitService API
+type submitServiceServer struct {
+	submitconnect.UnimplementedSubmitServiceHandler
+}
+
+// SubmitTx
+func (s *submitServiceServer) SubmitTx(
+	ctx context.Context,
+	req *connect.Request[submit.SubmitTxRequest],
+) (*connect.Response[submit.SubmitTxResponse], error) {
+	txRawList := req.Msg.GetTx() // []*AnyChainTx
+
+	log.Printf("Got a SubmitTx request with %d transactions", len(txRawList))
+	resp := &submit.SubmitTxResponse{}
+
+	return connect.NewResponse(resp), nil
+}
+
+func (s *submitServiceServer) WaitForTx(
+	ctx context.Context,
+	req *connect.Request[submit.WaitForTxRequest],
+	stream *connect.ServerStream[submit.WaitForTxResponse],
+) error {
+	ref := req.Msg.GetRef() // [][]byte
+
+	log.Printf("Received WaitForTx request with %d transactions", len(ref))
+	return nil
+}
+
+// ReadMempool
+func (s *submitServiceServer) ReadMempool(
+	ctx context.Context,
+	req *connect.Request[submit.ReadMempoolRequest],
+) (*connect.Response[submit.ReadMempoolResponse], error) {
+
+	log.Printf("Got a ReadMempool request")
+	resp := &submit.ReadMempoolResponse{}
+
+	return connect.NewResponse(resp), nil
+}
+
+// WatchMempool
+func (s *submitServiceServer) WatchMempool(
+	ctx context.Context,
+	req *connect.Request[submit.WatchMempoolRequest],
+	stream *connect.ServerStream[submit.WatchMempoolResponse],
+) error {
+
+	predicate := req.Msg.GetPredicate() // Predicate
+	fieldMask := req.Msg.GetFieldMask()
+
+	log.Printf(
+		"Got a WatchMempool request with predicate %v and fieldMask %v",
+		predicate,
+		fieldMask,
+	)
+	return nil
+}

--- a/internal/utxorpc/sync.go
+++ b/internal/utxorpc/sync.go
@@ -1,0 +1,99 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	sync "github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync/syncconnect"
+)
+
+// syncServiceServer implements the SyncService API
+type syncServiceServer struct {
+	syncconnect.UnimplementedSyncServiceHandler
+}
+
+// FetchBlock
+func (s *syncServiceServer) FetchBlock(
+	ctx context.Context,
+	req *connect.Request[sync.FetchBlockRequest],
+) (*connect.Response[sync.FetchBlockResponse], error) {
+	ref := req.Msg.GetRef() // BlockRef
+	fieldMask := req.Msg.GetFieldMask()
+
+	log.Printf(
+		"Got a FetchBlock request with ref %v and fieldMask %v",
+		ref,
+		fieldMask,
+	)
+
+	resp := &sync.FetchBlockResponse{}
+	// TODO: replace with something that works NtC
+	// for _, point := range points {
+	// 	log.Printf("Point Slot: %d, Hash: %x\n", point.Slot, point.Hash)
+	// 	block, err := oConn.BlockFetch().Client.GetBlock(
+	// 		ocommon.NewPoint(point.Slot, point.Hash),
+	// 	)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	var acb sync.AnyChainBlock
+	// 	var acbc sync.AnyChainBlock_Cardano
+	// 	ret := NewBlockFromBlock(block)
+	// 	acbc.Cardano = &ret
+	// 	acb.Chain = &acbc
+	// 	resp.Block = append(resp.Block, &acb)
+	// }
+
+	return connect.NewResponse(resp), nil
+}
+
+// DumpHistory
+func (s *syncServiceServer) DumpHistory(
+	ctx context.Context,
+	req *connect.Request[sync.DumpHistoryRequest],
+) (*connect.Response[sync.DumpHistoryResponse], error) {
+	startToken := req.Msg.GetStartToken() // BlockRef
+	maxItems := req.Msg.GetMaxItems()
+	fieldMask := req.Msg.GetFieldMask()
+
+	log.Printf(
+		"Got a DumpHistory request with token %v and maxItems %d and fieldMask %v",
+		startToken,
+		maxItems,
+		fieldMask,
+	)
+
+	resp := &sync.DumpHistoryResponse{}
+	// TODO: the thing
+	return connect.NewResponse(resp), nil
+}
+
+// FollowTip
+func (s *syncServiceServer) FollowTip(
+	ctx context.Context,
+	req *connect.Request[sync.FollowTipRequest],
+	stream *connect.ServerStream[sync.FollowTipResponse],
+) error {
+	intersect := req.Msg.GetIntersect() // []*BlockRef
+
+	log.Printf("Got a FollowTip request with intersect %v", intersect)
+
+	// TODO: the thing
+	return nil
+}

--- a/internal/utxorpc/utxorpc.go
+++ b/internal/utxorpc/utxorpc.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+	"connectrpc.com/grpchealth"
+	"connectrpc.com/grpcreflect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit/submitconnect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync/syncconnect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch/watchconnect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+func Start(address string, logger *slog.Logger) error {
+	logger.Info(
+		fmt.Sprintf(
+			"starting gRPC listener on %s",
+			address,
+		),
+	)
+	mux := http.NewServeMux()
+	compress1KB := connect.WithCompressMinBytes(1024)
+	queryPath, queryHandler := queryconnect.NewQueryServiceHandler(
+		&queryServiceServer{},
+		compress1KB,
+	)
+	submitPath, submitHandler := submitconnect.NewSubmitServiceHandler(
+		&submitServiceServer{},
+		compress1KB,
+	)
+	syncPath, syncHandler := syncconnect.NewSyncServiceHandler(
+		&syncServiceServer{},
+		compress1KB,
+	)
+	watchPath, watchHandler := watchconnect.NewWatchServiceHandler(
+		&watchServiceServer{},
+		compress1KB,
+	)
+	mux.Handle(queryPath, queryHandler)
+	mux.Handle(submitPath, submitHandler)
+	mux.Handle(syncPath, syncHandler)
+	mux.Handle(watchPath, watchHandler)
+	mux.Handle(
+		grpchealth.NewHandler(
+			grpchealth.NewStaticChecker(
+				queryconnect.QueryServiceName,
+				submitconnect.SubmitServiceName,
+				syncconnect.SyncServiceName,
+				watchconnect.WatchServiceName,
+			),
+			compress1KB,
+		),
+	)
+	mux.Handle(
+		grpcreflect.NewHandlerV1(
+			grpcreflect.NewStaticReflector(
+				queryconnect.QueryServiceName,
+				submitconnect.SubmitServiceName,
+				syncconnect.SyncServiceName,
+				watchconnect.WatchServiceName,
+			),
+			compress1KB,
+		),
+	)
+	mux.Handle(
+		grpcreflect.NewHandlerV1Alpha(
+			grpcreflect.NewStaticReflector(
+				queryconnect.QueryServiceName,
+				submitconnect.SubmitServiceName,
+				syncconnect.SyncServiceName,
+				watchconnect.WatchServiceName,
+			),
+			compress1KB,
+		),
+	)
+	// TODO: tls
+	err := http.ListenAndServe(
+		address,
+		// Use h2c so we can serve HTTP/2 without TLS
+		h2c.NewHandler(mux, &http2.Server{}),
+	)
+	return err
+}

--- a/internal/utxorpc/watch.go
+++ b/internal/utxorpc/watch.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	watch "github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch/watchconnect"
+)
+
+// watchServiceServer implements the WatchService API
+type watchServiceServer struct {
+	watchconnect.UnimplementedWatchServiceHandler
+}
+
+// WatchTx
+func (s *watchServiceServer) WatchTx(
+	ctx context.Context,
+	req *connect.Request[watch.WatchTxRequest],
+	stream *connect.ServerStream[watch.WatchTxResponse],
+) error {
+	predicate := req.Msg.GetPredicate() // Predicate
+	fieldMask := req.Msg.GetFieldMask()
+
+	log.Printf(
+		"Got a WatchTx request with predicate %v and fieldMask %v",
+		predicate,
+		fieldMask,
+	)
+	return nil
+}

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/utxorpc"
+	"github.com/blinklabs-io/dingo/mempool"
+	"github.com/blinklabs-io/dingo/state"
+)
+
+type Utxorpc struct {
+	config UtxorpcConfig
+}
+
+type UtxorpcConfig struct {
+	Logger      *slog.Logger
+	EventBus    *event.EventBus
+	LedgerState *state.LedgerState
+	Mempool     *mempool.Mempool
+	Host        string
+	Port        uint
+}
+
+func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	cfg.Logger = cfg.Logger.With("component", "utxorpc")
+	if cfg.Host == "" {
+		cfg.Host = "0.0.0.0"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 9090
+	}
+	return &Utxorpc{
+		config: cfg,
+	}
+}
+
+func (u *Utxorpc) Start() error {
+	return utxorpc.Start(
+		fmt.Sprintf(
+			"%s:%d",
+			u.config.Host,
+			u.config.Port,
+		),
+		u.config.Logger,
+	)
+}


### PR DESCRIPTION
This copies over a hollowed out version of the cardano-node-api UTxO RPC implementation.

This sets the framework for the items in #43 