### PR TITLE
chore: increase chainsync pipeline limit

### DIFF
--- a/chainsync.go
+++ b/chainsync.go
@@ -43,7 +43,7 @@ func (n *Node) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 		ochainsync.WithRollForwardFunc(n.chainsyncClientRollForward),
 		ochainsync.WithRollBackwardFunc(n.chainsyncClientRollBackward),
 		// Enable pipelining of RequestNext messages to speed up chainsync
-		ochainsync.WithPipelineLimit(10),
+		ochainsync.WithPipelineLimit(50),
 	}
 }
 


### PR DESCRIPTION
The limit of 50 increases the chainsync speed with public nodes. Going higher than this risks violating the protocol buffer limits and breaking the connection