### PR TITLE
refactor: move block to blob store

### DIFF
--- a/state/chainsync.go
+++ b/state/chainsync.go
@@ -26,7 +26,6 @@ import (
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
-	"gorm.io/gorm"
 )
 
 const (
@@ -353,7 +352,7 @@ func (ls *LedgerState) calculateEpochNonce(
 	// the previous block by number
 	blockBeforePrevEpoch, err := models.BlockBeforeSlotTxn(txn, ls.currentEpoch.StartSlot)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if err == models.ErrBlockNotFound {
 			return blockBeforeStabilityWindow.Nonce, nil
 		}
 		return nil, err

--- a/state/models/models.go
+++ b/state/models/models.go
@@ -16,7 +16,7 @@ package models
 
 // MigrateModels contains a list of model objects that should have DB migrations applied
 var MigrateModels = []any{
-	&Block{},
+	//&Block{},
 	&Epoch{},
 	&PoolRegistration{},
 	&PoolRegistrationOwner{},


### PR DESCRIPTION
This removes blocks from sqlite entirely and stores all metadata in Badger. This allows for cleaner separation between the block store and the ledger.