### PR TITLE
refactor(database): sqlite metadata plugin

### DIFF
--- a/database/plugin/log.go
+++ b/database/plugin/log.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+// Logger provides a logging interface for plugins.
+type Logger interface {
+	Info(string, ...any)
+	Warn(string, ...any)
+	Debug(string, ...any)
+	Error(string, ...any)
+
+	// Deprecated
+	// Fatal(string, ...any) in favor of Error
+	// With slog Fatal is replaced with Error and os.Exit(1)
+}

--- a/database/plugin/metadata/metadata.go
+++ b/database/plugin/metadata/metadata.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+)

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+	"gorm.io/plugin/opentelemetry/tracing"
+
+	"github.com/blinklabs-io/dingo/database/plugin"
+)
+
+// Register plugin
+func init() {
+	plugin.Register(
+		plugin.PluginEntry{
+			Type: plugin.PluginTypeMetadata,
+			Name: "sqlite",
+		},
+	)
+}
+
+// Database stores all data in sqlite. Data may not be persisted
+type Database struct {
+	dataDir string
+	db      *gorm.DB
+	logger  *slog.Logger
+}
+
+// New creates a new in-memory database
+func New(
+	dataDir string,
+	logger *slog.Logger,
+) (*Database, error) {
+	var metadataDb *gorm.DB
+	var err error
+	if dataDir == "" {
+		// No dataDir, use in-memory config
+		metadataDb, err = gorm.Open(
+			sqlite.Open("file::memory:?cache=shared"),
+			&gorm.Config{
+				Logger: gormlogger.Discard,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Make sure that we can read data dir, and create if it doesn't exist
+		if _, err := os.Stat(dataDir); err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return nil, fmt.Errorf("failed to read data dir: %w", err)
+			}
+			// Create data directory
+			if err := os.MkdirAll(dataDir, fs.ModePerm); err != nil {
+				return nil, fmt.Errorf("failed to create data dir: %w", err)
+			}
+		}
+		// Open sqlite DB
+		metadataDbPath := filepath.Join(
+			dataDir,
+			"metadata.sqlite",
+		)
+		// WAL journal mode, disable sync on write, increase cache size to 50MB (from 2MB)
+		metadataConnOpts := "_pragma=journal_mode(WAL)&_pragma=sync(OFF)&_pragma=cache_size(-50000)"
+		metadataDb, err = gorm.Open(
+			sqlite.Open(
+				fmt.Sprintf("file:%s?%s", metadataDbPath, metadataConnOpts),
+			),
+			&gorm.Config{
+				Logger: gormlogger.Discard,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	db := &Database{
+		db:      metadataDb,
+		dataDir: dataDir,
+		logger:  logger,
+	}
+	if err := db.init(); err != nil {
+		// Database is available for recovery, so return it with error
+		return db, err
+	}
+	return db, nil
+}
+
+func (d *Database) init() error {
+	if d.logger == nil {
+		// Create logger to throw away logs
+		// We do this so we don't have to add guards around every log operation
+		d.logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	// Configure tracing for GORM
+	if err := d.db.Use(tracing.NewPlugin(tracing.WithoutMetrics())); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Database) DB() *gorm.DB {
+	return d.db
+}

--- a/database/plugin/option.go
+++ b/database/plugin/option.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type PluginOptionType int
+
+const (
+	PluginOptionTypeNone   PluginOptionType = 0
+	PluginOptionTypeString PluginOptionType = 1
+	PluginOptionTypeBool   PluginOptionType = 2
+	PluginOptionTypeInt    PluginOptionType = 3
+	PluginOptionTypeUint   PluginOptionType = 4
+)
+
+type PluginOption struct {
+	Name         string
+	Type         PluginOptionType
+	CustomEnvVar string
+	CustomFlag   string
+	Description  string
+	DefaultValue interface{}
+	Dest         interface{}
+}
+
+func (p *PluginOption) AddToFlagSet(
+	fs *flag.FlagSet,
+	pluginType string,
+	pluginName string,
+) error {
+	var flagName string
+	if p.CustomFlag != "" {
+		flagName = fmt.Sprintf("%s-%s", pluginType, p.CustomFlag)
+	} else {
+		flagName = fmt.Sprintf("%s-%s-%s", pluginType, pluginName, p.Name)
+	}
+	switch p.Type {
+	case PluginOptionTypeString:
+		fs.StringVar(
+			p.Dest.(*string),
+			flagName,
+			p.DefaultValue.(string),
+			p.Description,
+		)
+	case PluginOptionTypeBool:
+		fs.BoolVar(
+			p.Dest.(*bool),
+			flagName,
+			p.DefaultValue.(bool),
+			p.Description,
+		)
+	case PluginOptionTypeInt:
+		fs.IntVar(p.Dest.(*int), flagName, p.DefaultValue.(int), p.Description)
+	case PluginOptionTypeUint:
+		fs.UintVar(
+			p.Dest.(*uint),
+			flagName,
+			p.DefaultValue.(uint),
+			p.Description,
+		)
+	default:
+		return fmt.Errorf(
+			"unknown plugin option type %d for option %s",
+			p.Type,
+			p.Name,
+		)
+	}
+	return nil
+}
+
+func (p *PluginOption) ProcessEnvVars(envPrefix string) error {
+	envVars := []string{
+		// Automatically generate env var from specified prefix and option name
+		strings.ToUpper(
+			strings.ReplaceAll(
+				fmt.Sprintf(
+					"%s%s",
+					envPrefix,
+					p.Name,
+				),
+				"-",
+				"_",
+			),
+		),
+	}
+	// Also check any custom env var specified
+	if p.CustomEnvVar != "" {
+		envVars = append(envVars, p.CustomEnvVar)
+	}
+	for _, envVar := range envVars {
+		if value, ok := os.LookupEnv(envVar); ok {
+			switch p.Type {
+			case PluginOptionTypeString:
+				*(p.Dest.(*string)) = value
+			case PluginOptionTypeBool:
+				value, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("error processing env vars: %s", err)
+				}
+				*(p.Dest.(*bool)) = value
+			case PluginOptionTypeInt:
+				// We limit to 32-bit to not get inconsistent behavior on 32-bit platforms
+				value, err := strconv.ParseInt(value, 10, 32)
+				if err != nil {
+					return fmt.Errorf("error processing env vars: %s", err)
+				}
+				*(p.Dest.(*int)) = int(value)
+			case PluginOptionTypeUint:
+				// We limit to 32-bit to not get inconsistent behavior on 32-bit platforms
+				value, err := strconv.ParseUint(value, 10, 32)
+				if err != nil {
+					return fmt.Errorf("error processing env vars: %s", err)
+				}
+				*(p.Dest.(*uint)) = uint(value)
+			default:
+				return fmt.Errorf(
+					"unknown plugin option type %d for option %s",
+					p.Type,
+					p.Name,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func (p *PluginOption) ProcessConfig(
+	pluginData map[interface{}]interface{},
+) error {
+	if optionData, ok := pluginData[p.Name]; ok {
+		switch p.Type {
+		case PluginOptionTypeString:
+			switch value := optionData.(type) {
+			case string:
+				*(p.Dest.(*string)) = value
+			default:
+				return fmt.Errorf("invalid value for option '%s': expected string and got %T", p.Name, optionData)
+			}
+		case PluginOptionTypeBool:
+			switch value := optionData.(type) {
+			case bool:
+				*(p.Dest.(*bool)) = value
+			default:
+				return fmt.Errorf("invalid value for option '%s': expected bool and got %T", p.Name, optionData)
+			}
+		case PluginOptionTypeInt:
+			switch value := optionData.(type) {
+			case int:
+				*(p.Dest.(*int)) = value
+			default:
+				return fmt.Errorf("invalid value for option '%s': expected int and got %T", p.Name, optionData)
+			}
+		case PluginOptionTypeUint:
+			switch value := optionData.(type) {
+			case int:
+				if value < 0 {
+					return fmt.Errorf("invalid value for option '%s': negative value: %T", p.Name, optionData)
+				}
+				*(p.Dest.(*uint)) = uint(value)
+			default:
+				return fmt.Errorf("invalid value for option '%s': expected uint and got %T", p.Name, optionData)
+			}
+		default:
+			return fmt.Errorf(
+				"unknown plugin option type %d for option %s",
+				p.Type,
+				p.Name,
+			)
+
+		}
+	}
+	return nil
+}

--- a/database/plugin/plugin.go
+++ b/database/plugin/plugin.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+type Plugin interface {
+	Start() error
+	Stop() error
+}

--- a/database/plugin/register.go
+++ b/database/plugin/register.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"flag"
+	"fmt"
+)
+
+type PluginType int
+
+const (
+	PluginTypeMetadata PluginType = 1
+	PluginTypeBlob     PluginType = 2
+)
+
+func PluginTypeName(pluginType PluginType) string {
+	switch pluginType {
+	case PluginTypeMetadata:
+		return "metadata"
+	case PluginTypeBlob:
+		return "blob"
+	default:
+		return ""
+	}
+}
+
+type PluginEntry struct {
+	Type               PluginType
+	Name               string
+	Description        string
+	Options            []PluginOption
+	NewFromOptionsFunc func() Plugin
+}
+
+var pluginEntries []PluginEntry
+
+func Register(pluginEntry PluginEntry) {
+	pluginEntries = append(pluginEntries, pluginEntry)
+}
+
+func PopulateCmdlineOptions(fs *flag.FlagSet) error {
+	for _, plugin := range pluginEntries {
+		for _, option := range plugin.Options {
+			if err := option.AddToFlagSet(fs, PluginTypeName(plugin.Type), plugin.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ProcessEnvVars() error {
+	for _, plugin := range pluginEntries {
+		// Generate env var prefix based on plugin type and name
+		envVarPrefix := fmt.Sprintf(
+			"%s-%s-",
+			PluginTypeName(plugin.Type),
+			plugin.Name,
+		)
+		for _, option := range plugin.Options {
+			if err := option.ProcessEnvVars(envVarPrefix); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ProcessConfig(
+	pluginConfig map[string]map[string]map[interface{}]interface{},
+) error {
+	for _, plugin := range pluginEntries {
+		if pluginTypeData, ok := pluginConfig[PluginTypeName(plugin.Type)]; ok {
+			if pluginData, ok := pluginTypeData[plugin.Name]; ok {
+				for _, option := range plugin.Options {
+					if err := option.ProcessConfig(pluginData); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func GetPlugins(pluginType PluginType) []PluginEntry {
+	ret := []PluginEntry{}
+	for _, plugin := range pluginEntries {
+		if plugin.Type == pluginType {
+			ret = append(ret, plugin)
+		}
+	}
+	return ret
+}
+
+func GetPlugin(pluginType PluginType, name string) Plugin {
+	for _, plugin := range pluginEntries {
+		if plugin.Type == pluginType {
+			if plugin.Name == name {
+				return plugin.NewFromOptionsFunc()
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This introduces the idea of database plugins and creates a `sqlite` metadata plugin. The plugin package is heavily inspired by Adder. This doesn't change the base database metadata interface from *gorm.DB so it's a drop-in replacement.