### PR TITLE
fix: use correct receivers for custom database types

### DIFF
--- a/database/types.go
+++ b/database/types.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,11 +21,12 @@ import (
 	"strconv"
 )
 
+//nolint:recvcheck
 type Rat struct {
 	*big.Rat
 }
 
-func (r *Rat) Value() (driver.Value, error) {
+func (r Rat) Value() (driver.Value, error) {
 	if r.Rat == nil {
 		return "", nil
 	}
@@ -49,10 +50,11 @@ func (r *Rat) Scan(val any) error {
 	return nil
 }
 
+//nolint:recvcheck
 type Uint64 uint64
 
-func (u *Uint64) Value() (driver.Value, error) {
-	return strconv.FormatUint(uint64(*u), 10), nil
+func (u Uint64) Value() (driver.Value, error) {
+	return strconv.FormatUint(uint64(u), 10), nil
 }
 
 func (u *Uint64) Scan(val any) error {

--- a/database/types_test.go
+++ b/database/types_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+)
+
+func TestTypesScanValue(t *testing.T) {
+	testDefs := []struct {
+		origValue     any
+		expectedValue any
+	}{
+		{
+			origValue: func(v database.Uint64) *database.Uint64 { return &v }(
+				database.Uint64(123),
+			),
+			expectedValue: "123",
+		},
+		{
+			origValue: func(v database.Rat) *database.Rat { return &v }(
+				database.Rat{
+					Rat: big.NewRat(3, 5),
+				},
+			),
+			expectedValue: "3/5",
+		},
+	}
+	for _, testDef := range testDefs {
+		tmpValuer, ok := testDef.origValue.(driver.Valuer)
+		if !ok {
+			t.Fatalf("test original value does not implement driver.Valuer")
+		}
+		valueOut, err := tmpValuer.Value()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(valueOut, testDef.expectedValue) {
+			t.Fatalf("did not get expected value from Value(): got %#v, expected %#v", valueOut, testDef.expectedValue)
+		}
+		tmpScanner, ok := testDef.origValue.(sql.Scanner)
+		if !ok {
+			t.Fatalf("test original value does not implement sql.Scanner (it must be a pointer)")
+		}
+		if err := tmpScanner.Scan(valueOut); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(tmpScanner, testDef.origValue) {
+			t.Fatalf("did not get expected value after Scan(): got %#v, expected %#v", tmpScanner, testDef.origValue)
+		}
+	}
+}


### PR DESCRIPTION
We must use mixed pointer and non-pointer receivers for our custom database types to satisfy both the sql.Scanner and driver.Valuer interfaces. Tests have been added to ensure that our custom types are working as they are supposed to.