### PR TITLE
feat(database): metadata store interface

### DIFF
--- a/database/plugin/metadata/sqlite/commit_timestamp.go
+++ b/database/plugin/metadata/sqlite/commit_timestamp.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	commitTimestampRowId = 1
+)
+
+// CommitTimestamp represents the sqlite table used to track the current commit timestamp
+type CommitTimestamp struct {
+	ID        uint `gorm:"primarykey"`
+	Timestamp int64
+}
+
+func (CommitTimestamp) TableName() string {
+	return "commit_timestamp"
+}
+
+func (d *MetadataStoreSqlite) GetCommitTimestamp() (int64, error) {
+	// Create table if it doesn't exist
+	if err := d.AutoMigrate(&CommitTimestamp{}); err != nil {
+		return -1, err
+	}
+	// Get value from sqlite
+	var tmpCommitTimestamp CommitTimestamp
+	result := d.DB().First(&tmpCommitTimestamp)
+	if result.Error != nil {
+		// It's not an error if there's no records found
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, nil
+		}
+		return -1, result.Error
+	}
+	return tmpCommitTimestamp.Timestamp, nil
+}
+
+func (d *MetadataStoreSqlite) SetCommitTimestamp(
+	txn *gorm.DB,
+	timestamp int64,
+) error {
+	// Create table if it doesn't exist
+	if err := d.AutoMigrate(&CommitTimestamp{}); err != nil {
+		return err
+	}
+	tmpCommitTimestamp := CommitTimestamp{
+		ID:        commitTimestampRowId,
+		Timestamp: timestamp,
+	}
+	result := txn.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"timestamp"}),
+	}).Create(&tmpCommitTimestamp)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"database/sql"
+	"log/slog"
+
+	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+)
+
+type MetadataStore interface {
+	// matches gorm.DB
+	AutoMigrate(...interface{}) error
+	Begin(...*sql.TxOptions) *gorm.DB
+	Create(interface{}) *gorm.DB
+	DB() *gorm.DB
+	First(interface{}) *gorm.DB
+	Order(interface{}) *gorm.DB
+	Where(interface{}, ...interface{}) *gorm.DB
+
+	// Our specific functions
+	Close() error
+	GetCommitTimestamp() (int64, error)
+	SetCommitTimestamp(*gorm.DB, int64) error
+	Transaction() *gorm.DB
+}
+
+// For now, this always returns a sqlite plugin
+func New(
+	pluginName, dataDir string,
+	logger *slog.Logger,
+) (MetadataStore, error) {
+	return sqlite.New(dataDir, logger)
+}

--- a/database/types_test.go
+++ b/database/types_test.go
@@ -54,17 +54,27 @@ func TestTypesScanValue(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if !reflect.DeepEqual(valueOut, testDef.expectedValue) {
-			t.Fatalf("did not get expected value from Value(): got %#v, expected %#v", valueOut, testDef.expectedValue)
+			t.Fatalf(
+				"did not get expected value from Value(): got %#v, expected %#v",
+				valueOut,
+				testDef.expectedValue,
+			)
 		}
 		tmpScanner, ok := testDef.origValue.(sql.Scanner)
 		if !ok {
-			t.Fatalf("test original value does not implement sql.Scanner (it must be a pointer)")
+			t.Fatalf(
+				"test original value does not implement sql.Scanner (it must be a pointer)",
+			)
 		}
 		if err := tmpScanner.Scan(valueOut); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if !reflect.DeepEqual(tmpScanner, testDef.origValue) {
-			t.Fatalf("did not get expected value after Scan(): got %#v, expected %#v", tmpScanner, testDef.origValue)
+			t.Fatalf(
+				"did not get expected value after Scan(): got %#v, expected %#v",
+				tmpScanner,
+				testDef.origValue,
+			)
 		}
 	}
 }


### PR DESCRIPTION
Create a `MetadataStore` interface with the following methods to decouple the `database` package from `gorm.DB` directly.

The MetadataStore interface matches the `gorm.DB` type for the following functions.
- AutoMigrate
- Begin
- Close (really DB.DB().Close())
- Create
- DB
- First
- Order
- Where

We have also created custom functions.
- GetCommitTimestamp
- SetCommitTimestamp
- Transaction

This fully removes gorm from the `database` package.

Closes #325 