### PR TITLE
refactor: rework mempool consumer

### DIFF
--- a/txsubmission.go
+++ b/txsubmission.go
@@ -191,7 +191,6 @@ func (n *Node) txsubmissionClientRequestTxIds(
 		}
 	}
 	for _, tmpTx := range tmpTxs {
-
 		// Add to return value
 		txHashBytes, err := hex.DecodeString(tmpTx.Hash)
 		if err != nil {


### PR DESCRIPTION
This switches from a lossy push-based model to a much simpler pull-based model. It removes a level of locking and prevents potential goroutine leaks.