### PR TITLE
refactor: use only UNIX socket file descriptor for remote address

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.x, 1.24.x]
-        platform: [ubuntu-latest]
+        # We want to make sure that this builds on Linux and Darwin
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This works much better for cross-platform support, and it should still be unique within a single process