### PR TITLE
refactor(database): badger blob plugin

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package badger
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/plugin"
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+// Register plugin
+func init() {
+	plugin.Register(
+		plugin.PluginEntry{
+			Type: plugin.PluginTypeMetadata,
+			Name: "sqlite",
+		},
+	)
+}
+
+// Database stores all data in badger. Data may not be persisted
+type Database struct {
+	dataDir   string
+	db        *badger.DB
+	logger    *slog.Logger
+	gcEnabled bool
+}
+
+// New creates a new database
+func New(
+	dataDir string,
+	logger *slog.Logger,
+) (*Database, error) {
+	var blobDb *badger.DB
+	var err error
+	db := &Database{
+		dataDir: dataDir,
+		logger:  logger,
+	}
+	if dataDir == "" {
+		// No dataDir, use in-memory config
+		badgerOpts := badger.DefaultOptions("").
+			WithLogger(NewBadgerLogger(logger)).
+			// The default INFO logging is a bit verbose
+			WithLoggingLevel(badger.WARNING).
+			WithInMemory(true)
+		blobDb, err = badger.Open(badgerOpts)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Make sure that we can read data dir, and create if it doesn't exist
+		if _, err := os.Stat(dataDir); err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return nil, fmt.Errorf("failed to read data dir: %w", err)
+			}
+			// Create data directory
+			if err := os.MkdirAll(dataDir, fs.ModePerm); err != nil {
+				return nil, fmt.Errorf("failed to create data dir: %w", err)
+			}
+		}
+		blobDir := filepath.Join(
+			dataDir,
+			"blob",
+		)
+		// Run GC periodically
+		db.gcEnabled = true
+		badgerOpts := badger.DefaultOptions(blobDir).
+			WithLogger(NewBadgerLogger(logger)).
+			// The default INFO logging is a bit verbose
+			WithLoggingLevel(badger.WARNING)
+		blobDb, err = badger.Open(badgerOpts)
+		if err != nil {
+			return nil, err
+		}
+	}
+	db.db = blobDb
+	if err := db.init(); err != nil {
+		return db, err
+	}
+	return db, nil
+}
+
+func (d *Database) init() error {
+	if d.logger == nil {
+		// Create logger to throw away logs
+		// We do this so we don't have to add guards around every log operation
+		d.logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	// Configure metrics
+	d.registerBlobMetrics()
+	// Configure GC
+	if d.gcEnabled {
+		go d.blobGc(time.NewTicker(5 * time.Minute))
+	}
+	return nil
+}
+
+func (d *Database) blobGc(t *time.Ticker) {
+	for range t.C {
+	again:
+		err := d.DB().RunValueLogGC(0.5)
+		if err != nil {
+			// Log any actual errors
+			if !errors.Is(err, badger.ErrNoRewrite) {
+				d.logger.Warn(
+					fmt.Sprintf("blob DB: GC failure: %s", err),
+					"component", "database",
+				)
+			}
+		} else {
+			// Run it again if it just ran successfully
+			goto again
+		}
+	}
+}
+
+func (d *Database) DB() *badger.DB {
+	return d.db
+}

--- a/database/plugin/blob/badger/logger.go
+++ b/database/plugin/blob/badger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package badger
 
 import (
 	"fmt"

--- a/database/plugin/blob/badger/metrics.go
+++ b/database/plugin/blob/badger/metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package badger
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +23,7 @@ const (
 	badgerMetricNamePrefix = "database_blob_"
 )
 
-func (d *BaseDatabase) registerBadgerMetrics() {
+func (d *Database) registerBlobMetrics() {
 	// Badger exposes metrics via expvar, so we need to set up some translation
 	collector := collectors.NewExpvarCollector(
 		map[string]*prometheus.Desc{


### PR DESCRIPTION
Create a `badger` blob plugin. This doesn't change the base database blob interface from *badger.DB so it's a drop-in replacement.