### PR TITLE
feat(database): blob store interface

### DIFF
--- a/database/plugin/blob/badger/commit_timestamp.go
+++ b/database/plugin/blob/badger/commit_timestamp.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package badger
+
+import (
+	"math/big"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+const (
+	commitTimestampBlobKey = "metadata_commit_timestamp"
+)
+
+func (b *BlobStoreBadger) GetCommitTimestamp() (int64, error) {
+	txn := b.NewTransaction(false)
+	item, err := txn.Get([]byte(commitTimestampBlobKey))
+	if err != nil {
+		return 0, err
+	}
+	val, err := item.ValueCopy(nil)
+	if err != nil {
+		return 0, err
+	}
+	return new(big.Int).SetBytes(val).Int64(), nil
+}
+
+func (b *BlobStoreBadger) SetCommitTimestamp(
+	txn *badger.Txn,
+	timestamp int64,
+) error {
+	// Update badger
+	tmpTimestamp := new(big.Int).SetInt64(timestamp)
+	if err := txn.Set([]byte(commitTimestampBlobKey), tmpTimestamp.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/database/plugin/blob/badger/metrics.go
+++ b/database/plugin/blob/badger/metrics.go
@@ -23,7 +23,7 @@ const (
 	badgerMetricNamePrefix = "database_blob_"
 )
 
-func (d *Database) registerBlobMetrics() {
+func (d *BlobStoreBadger) registerBlobMetrics() {
 	// Badger exposes metrics via expvar, so we need to set up some translation
 	collector := collectors.NewExpvarCollector(
 		map[string]*prometheus.Desc{

--- a/database/plugin/blob/blob.go
+++ b/database/plugin/blob/blob.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+)

--- a/database/plugin/blob/store.go
+++ b/database/plugin/blob/store.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	"log/slog"
+
+	badgerPlugin "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+type BlobStore interface {
+	// matches badger.DB
+	Close() error
+	NewTransaction(bool) *badger.Txn
+
+	// Our specific functions
+	GetCommitTimestamp() (int64, error)
+	SetCommitTimestamp(*badger.Txn, int64) error
+}
+
+// For now, this always returns a badger plugin
+func New(
+	pluginName, dataDir string,
+	logger *slog.Logger,
+) (BlobStore, error) {
+	return badgerPlugin.New(dataDir, logger)
+}


### PR DESCRIPTION
Create a `BlobStore` interface with the following methods to decouple the `database` package from `badger.DB` directly.

The BlobStore interface matches `badger.DB` type for the following functions.

- Close
- NewTransaction

We have also created custom functions.

- GetCommitTimestamp
- SetCommitTimestamp

Closes #326 