### PR TITLE
fix: prevent exceeding blockfetch batch size

### DIFF
--- a/blockfetch.go
+++ b/blockfetch.go
@@ -40,6 +40,8 @@ func (n *Node) blockfetchClientConnOpts() []oblockfetch.BlockFetchOptionFunc {
 		oblockfetch.WithBatchDoneFunc(n.blockfetchClientBatchDone),
 		oblockfetch.WithBatchStartTimeout(2 * time.Second),
 		oblockfetch.WithBlockTimeout(2 * time.Second),
+		// Set the recv queue size to 2x our block batch size
+		oblockfetch.WithRecvQueueSize(1000),
 	}
 }
 

--- a/chainsync.go
+++ b/chainsync.go
@@ -43,6 +43,8 @@ func (n *Node) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 		ochainsync.WithRollBackwardFunc(n.chainsyncClientRollBackward),
 		// Enable pipelining of RequestNext messages to speed up chainsync
 		ochainsync.WithPipelineLimit(50),
+		// Set the recv queue size to 2x our pipeline limit
+		ochainsync.WithRecvQueueSize(100),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	connectrpc.com/grpchealth v1.3.0
 	connectrpc.com/grpcreflect v1.3.0
-	github.com/blinklabs-io/gouroboros v0.113.1
+	github.com/blinklabs-io/gouroboros v0.114.0
 	github.com/blinklabs-io/ouroboros-mock v0.3.7
 	github.com/dgraph-io/badger/v4 v4.6.0
 	github.com/glebarez/sqlite v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blinklabs-io/gouroboros v0.113.1 h1:klOq2CcqyTXu8o8INwpf0EmrIIW6p4xwpFF3O1Y28LY=
-github.com/blinklabs-io/gouroboros v0.113.1/go.mod h1:lG6kfR3SfHXhDjkQO15CVXZT3DzuhxUN7ElhqGDI1Ss=
+github.com/blinklabs-io/gouroboros v0.114.0 h1:xP6MLCzyp48O3KeW1J5aOEdJC+Dxqmhm7LF6FXOKZp8=
+github.com/blinklabs-io/gouroboros v0.114.0/go.mod h1:E43ihaCCqNYMsTtdGbTv6Un0QVYcSXb3E/SbADJNBIM=
 github.com/blinklabs-io/ouroboros-mock v0.3.7 h1:86FvD591XhdGk2BqQweRKfwc6Y6ll5Lunmo/RUehJ6o=
 github.com/blinklabs-io/ouroboros-mock v0.3.7/go.mod h1:611xZgdWCxZsSaS5tjgxqjmWIkSpsM9eKuQAKozw+sk=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/state/state.go
+++ b/state/state.go
@@ -73,7 +73,9 @@ type LedgerState struct {
 	chainsyncBlockEvents        []BlockfetchEvent
 	chainsyncBlockfetchBusy     bool
 	chainsyncBlockfetchBusyTime time.Time
+	chainsyncBlockfetchMutex    sync.Mutex
 	chainsyncBlockfetchWaiting  bool
+	chainsyncHeaderMutex        sync.Mutex
 }
 
 func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {


### PR DESCRIPTION
This prevents random disconnects during bulk chainsync due to exceeding protocol buffer sizes