### PR TITLE
fix: additional locking in chainsync/blockfetch

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -70,6 +70,7 @@ type LedgerState struct {
 	currentTipBlockNonce        []byte
 	metrics                     stateMetrics
 	chainsyncHeaderPoints       []ocommon.Point
+	chainsyncHeaderPointsMutex  sync.Mutex
 	chainsyncBlockEvents        []BlockfetchEvent
 	chainsyncBlockfetchBusy     bool
 	chainsyncBlockfetchBusyTime time.Time


### PR DESCRIPTION
This prevents cases where cached chainsync headers can get overwritten when there are multiple pending blockfetch batches