### PR TITLE
refactor(database): collapse database interface into struct

### DIFF
--- a/database/block.go
+++ b/database/block.go
@@ -95,7 +95,7 @@ func BlockDeleteTxn(txn *Txn, block Block) error {
 	return nil
 }
 
-func BlockByPoint(db Database, point ocommon.Point) (Block, error) {
+func BlockByPoint(db *Database, point ocommon.Point) (Block, error) {
 	var ret Block
 	txn := db.Transaction(false)
 	err := txn.Do(func(txn *Txn) error {
@@ -148,7 +148,7 @@ func BlockByPointTxn(txn *Txn, point ocommon.Point) (Block, error) {
 	return blockByKey(txn, key)
 }
 
-func BlockByNumber(db Database, blockNumber uint64) (Block, error) {
+func BlockByNumber(db *Database, blockNumber uint64) (Block, error) {
 	var ret Block
 	txn := db.Transaction(false)
 	err := txn.Do(func(txn *Txn) error {
@@ -175,7 +175,7 @@ func BlockByNumberTxn(txn *Txn, blockNumber uint64) (Block, error) {
 	return blockByKey(txn, blockKey)
 }
 
-func BlocksRecent(db Database, count int) ([]Block, error) {
+func BlocksRecent(db *Database, count int) ([]Block, error) {
 	var ret []Block
 	txn := db.Transaction(false)
 	err := txn.Do(func(txn *Txn) error {
@@ -219,7 +219,7 @@ func BlocksRecentTxn(txn *Txn, count int) ([]Block, error) {
 	return ret, nil
 }
 
-func BlockBeforeSlot(db Database, slotNumber uint64) (Block, error) {
+func BlockBeforeSlot(db *Database, slotNumber uint64) (Block, error) {
 	var ret Block
 	txn := db.Transaction(false)
 	err := txn.Do(func(txn *Txn) error {

--- a/database/commit_timestamp.go
+++ b/database/commit_timestamp.go
@@ -31,7 +31,7 @@ func (e CommitTimestampError) Error() string {
 	)
 }
 
-func (b *BaseDatabase) checkCommitTimestamp() error {
+func (b *Database) checkCommitTimestamp() error {
 	// Get value from metadata
 	metadataTimestamp, metadataErr := b.Metadata().GetCommitTimestamp()
 	if metadataErr != nil {
@@ -62,7 +62,7 @@ func (b *BaseDatabase) checkCommitTimestamp() error {
 	return nil
 }
 
-func (b *BaseDatabase) updateCommitTimestamp(txn *Txn, timestamp int64) error {
+func (b *Database) updateCommitTimestamp(txn *Txn, timestamp int64) error {
 	// Update metadata
 	if err := b.Metadata().SetCommitTimestamp(txn.Metadata(), timestamp); err != nil {
 		return err

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ type TestTable struct {
 // concurrent transactions when using in-memory mode. This requires special URI flags, and
 // this is mostly making sure that we don't lose them
 func TestInMemorySqliteMultipleTransaction(t *testing.T) {
-	var db database.Database
+	var db *database.Database
 	doQuery := func(sleep time.Duration) error {
 		txn := db.Metadata().Transaction()
 		if result := txn.First(&TestTable{}); result.Error != nil {
@@ -42,7 +42,7 @@ func TestInMemorySqliteMultipleTransaction(t *testing.T) {
 		}
 		return nil
 	}
-	db, err := database.NewInMemory(nil)
+	db, err := database.New(nil, "") // in-memory
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/database/txn.go
+++ b/database/txn.go
@@ -27,13 +27,13 @@ import (
 type Txn struct {
 	lock        sync.Mutex
 	finished    bool
-	db          Database
+	db          *Database
 	readWrite   bool
 	blobTxn     *badger.Txn
 	metadataTxn *gorm.DB
 }
 
-func NewTxn(db Database, readWrite bool) *Txn {
+func NewTxn(db *Database, readWrite bool) *Txn {
 	return &Txn{
 		db:          db,
 		readWrite:   readWrite,
@@ -42,7 +42,7 @@ func NewTxn(db Database, readWrite bool) *Txn {
 	}
 }
 
-func (t *Txn) DB() Database {
+func (t *Txn) DB() *Database {
 	return t.db
 }
 

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -58,14 +58,14 @@ func (u *Utxo) loadCbor(txn *Txn) error {
 }
 
 func UtxoByRef(
-	db Database,
+	db *Database,
 	txId []byte,
 	outputIdx uint32,
 ) (Utxo, error) {
-	return db.(*BaseDatabase).UtxoByRef(txId, outputIdx, nil)
+	return db.UtxoByRef(txId, outputIdx, nil)
 }
 
-func (d *BaseDatabase) UtxoByRef(
+func (d *Database) UtxoByRef(
 	txId []byte,
 	outputIdx uint32,
 	txn *Txn,
@@ -92,13 +92,13 @@ func (d *BaseDatabase) UtxoByRef(
 }
 
 func UtxosByAddress(
-	db Database,
+	db *Database,
 	addr ledger.Address,
 ) ([]Utxo, error) {
-	return db.(*BaseDatabase).UtxosByAddress(addr, nil)
+	return db.UtxosByAddress(addr, nil)
 }
 
-func (d *BaseDatabase) UtxosByAddress(
+func (d *Database) UtxosByAddress(
 	addr ledger.Address,
 	txn *Txn,
 ) ([]Utxo, error) {
@@ -129,13 +129,13 @@ func (d *BaseDatabase) UtxosByAddress(
 }
 
 func UtxoDelete(
-	db Database,
+	db *Database,
 	utxo Utxo,
 ) error {
-	return db.(*BaseDatabase).UtxoDelete(utxo, nil)
+	return db.UtxoDelete(utxo, nil)
 }
 
-func (d *BaseDatabase) UtxoDelete(
+func (d *Database) UtxoDelete(
 	utxo Utxo,
 	txn *Txn,
 ) error {
@@ -157,13 +157,13 @@ func (d *BaseDatabase) UtxoDelete(
 }
 
 func UtxosDelete(
-	db Database,
+	db *Database,
 	utxos []Utxo,
 ) error {
-	return db.(*BaseDatabase).UtxosDelete(utxos, nil)
+	return db.UtxosDelete(utxos, nil)
 }
 
-func (d *BaseDatabase) UtxosDelete(
+func (d *Database) UtxosDelete(
 	utxos []Utxo,
 	txn *Txn,
 ) error {

--- a/state/view.go
+++ b/state/view.go
@@ -40,28 +40,11 @@ func (lv *LedgerView) NetworkId() uint {
 func (lv *LedgerView) UtxoById(
 	utxoId lcommon.TransactionInput,
 ) (lcommon.Utxo, error) {
-	var utxo database.Utxo
-	var err error
-	switch lv.ls.db.(type) {
-	case *database.BaseDatabase:
-		utxo, err = lv.ls.db.(*database.BaseDatabase).UtxoByRef(
-			utxoId.Id().Bytes(),
-			utxoId.Index(),
-			lv.txn,
-		)
-	case *database.InMemoryDatabase:
-		utxo, err = lv.ls.db.(*database.InMemoryDatabase).UtxoByRef(
-			utxoId.Id().Bytes(),
-			utxoId.Index(),
-			lv.txn,
-		)
-	case *database.PersistentDatabase:
-		utxo, err = lv.ls.db.(*database.PersistentDatabase).UtxoByRef(
-			utxoId.Id().Bytes(),
-			utxoId.Index(),
-			lv.txn,
-		)
-	}
+	utxo, err := lv.ls.db.UtxoByRef(
+		utxoId.Id().Bytes(),
+		utxoId.Index(),
+		lv.txn,
+	)
 	if err != nil {
 		return lcommon.Utxo{}, err
 	}


### PR DESCRIPTION
Replace the Database interface with a Database struct and get rid of the entire InMemoryDatabase and PersistentDatabase separation.