### PR TITLE
refactor(database): setters for pool and stake certificates

### DIFF
--- a/database/certs.go
+++ b/database/certs.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// SetPoolRegistration saves a pool registration certificate
+func (d *Database) SetPoolRegistration(
+	cert *lcommon.PoolRegistrationCertificate,
+	slot, deposit uint64, // slot
+	txn *Txn,
+) error {
+	return d.metadata.SetPoolRegistration(cert, slot, deposit, txn.Metadata())
+}
+
+// SetPoolRetirement saves a pool retirement certificate
+func (d *Database) SetPoolRetirement(
+	cert *lcommon.PoolRetirementCertificate,
+	slot uint64,
+	txn *Txn,
+) error {
+	return d.metadata.SetPoolRetirement(cert, slot, txn.Metadata())
+}
+
+// SetStakeDelegation saves a stake delegation certificate
+func (d *Database) SetStakeDelegation(
+	cert *lcommon.StakeDelegationCertificate,
+	slot uint64,
+	txn *Txn,
+) error {
+	return d.metadata.SetStakeDelegation(cert, slot, txn.Metadata())
+}
+
+// SetStakeDeregistration saves a stake deregistration certificate
+func (d *Database) SetStakeDeregistration(
+	cert *lcommon.StakeDeregistrationCertificate,
+	slot uint64,
+	txn *Txn,
+) error {
+	return d.metadata.SetStakeDeregistration(cert, slot, txn.Metadata())
+}
+
+// SetStakeRegistration saves a stake registration certificate
+func (d *Database) SetStakeRegistration(
+	cert *lcommon.StakeRegistrationCertificate,
+	slot, deposit uint64,
+	txn *Txn,
+) error {
+	return d.metadata.SetStakeRegistration(cert, slot, deposit, txn.Metadata())
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -16,7 +16,6 @@ package metadata
 
 import (
 	"log/slog"
-	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite/models"
@@ -70,22 +69,14 @@ type MetadataStore interface {
 		*gorm.DB,
 	) error
 	SetPoolRegistration(
-		[]byte, // pkh
-		[]byte, // vrf
-		uint64, // pledge
-		uint64, // cost
+		*lcommon.PoolRegistrationCertificate,
 		uint64, // slot
 		uint64, // deposit
-		*big.Rat, // margin
-		[]lcommon.AddrKeyHash, // owners
-		[]lcommon.PoolRelay, // relays
-		*lcommon.PoolMetadata, // metadata
 		*gorm.DB,
 	) error
 	SetPoolRetirement(
-		[]byte, // pkh
+		*lcommon.PoolRetirementCertificate,
 		uint64, // slot
-		uint64, // epoch
 		*gorm.DB,
 	) error
 	SetPParams(
@@ -103,18 +94,17 @@ type MetadataStore interface {
 		*gorm.DB,
 	) error
 	SetStakeDelegation(
-		[]byte, // stakeKey
-		[]byte, // pkh
+		*lcommon.StakeDelegationCertificate,
 		uint64, // slot
 		*gorm.DB,
 	) error
 	SetStakeDeregistration(
-		[]byte, // stakeKey
+		*lcommon.StakeDeregistrationCertificate,
 		uint64, // slot
 		*gorm.DB,
 	) error
 	SetStakeRegistration(
-		[]byte, // stakeKey
+		*lcommon.StakeRegistrationCertificate,
 		uint64, // slot
 		uint64, // deposit
 		*gorm.DB,

--- a/state/certs.go
+++ b/state/certs.go
@@ -37,57 +37,48 @@ func (ls *LedgerState) processTransactionCertificates(
 		}
 		switch cert := tmpCert.(type) {
 		case *lcommon.PoolRegistrationCertificate:
-			err := txn.DB().Metadata().SetPoolRegistration(
-				cert.Operator[:],
-				cert.VrfKeyHash[:],
-				cert.Pledge,
-				cert.Cost,
+			err := txn.DB().SetPoolRegistration(
+				cert,
 				blockPoint.Slot,
 				certDeposit,
-				cert.Margin.Rat,
-				cert.PoolOwners,
-				cert.Relays,
-				cert.PoolMetadata,
-				txn.Metadata(),
+				txn,
 			)
 			if err != nil {
 				return err
 			}
 		case *lcommon.PoolRetirementCertificate:
-			err := txn.DB().Metadata().SetPoolRetirement(
-				cert.PoolKeyHash[:],
+			err := txn.DB().SetPoolRetirement(
+				cert,
 				blockPoint.Slot,
-				cert.Epoch,
-				txn.Metadata(),
-			)
-			if err != nil {
-				return err
-			}
-		case *lcommon.StakeRegistrationCertificate:
-			err := txn.DB().Metadata().SetStakeRegistration(
-				cert.StakeRegistration.Credential,
-				blockPoint.Slot,
-				certDeposit,
-				txn.Metadata(),
-			)
-			if err != nil {
-				return err
-			}
-		case *lcommon.StakeDeregistrationCertificate:
-			err := txn.DB().Metadata().SetStakeDeregistration(
-				cert.StakeDeregistration.Credential,
-				blockPoint.Slot,
-				txn.Metadata(),
+				txn,
 			)
 			if err != nil {
 				return err
 			}
 		case *lcommon.StakeDelegationCertificate:
-			err := txn.DB().Metadata().SetStakeDelegation(
-				cert.StakeCredential.Credential,
-				cert.PoolKeyHash[:],
+			err := txn.DB().SetStakeDelegation(
+				cert,
 				blockPoint.Slot,
-				txn.Metadata(),
+				txn,
+			)
+			if err != nil {
+				return err
+			}
+		case *lcommon.StakeDeregistrationCertificate:
+			err := txn.DB().SetStakeDeregistration(
+				cert,
+				blockPoint.Slot,
+				txn,
+			)
+			if err != nil {
+				return err
+			}
+		case *lcommon.StakeRegistrationCertificate:
+			err := txn.DB().SetStakeRegistration(
+				cert,
+				blockPoint.Slot,
+				certDeposit,
+				txn,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
Update `processTransactionCertificates` so it does not need to be aware of which database stores certificates. This requires creation of setters in `database` which calls the correct underlying store interface.