### PR TITLE
refactor(database): getters for pool and stake registration certificates

### DIFF
--- a/database/certs.go
+++ b/database/certs.go
@@ -18,6 +18,22 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// GetPoolRegistrations returns a list of pool registration certificates
+func (d *Database) GetPoolRegistrations(
+	poolKeyHash lcommon.PoolKeyHash,
+	txn *Txn,
+) ([]lcommon.PoolRegistrationCertificate, error) {
+	return d.metadata.GetPoolRegistrations(poolKeyHash, txn.Metadata())
+}
+
+// GetStakeRegistrations returns a list of stake registration certificates
+func (d *Database) GetStakeRegistrations(
+	stakingKey []byte,
+	txn *Txn,
+) ([]lcommon.StakeRegistrationCertificate, error) {
+	return d.metadata.GetStakeRegistrations(stakingKey, txn.Metadata())
+}
+
 // SetPoolRegistration saves a pool registration certificate
 func (d *Database) SetPoolRegistration(
 	cert *lcommon.PoolRegistrationCertificate,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -34,12 +34,10 @@ type MetadataStore interface {
 	Transaction() *gorm.DB
 
 	// Ledger state
-	// GetEpoch(uint64, *gorm.DB)
-	// GetEpochs(*gorm.DB) ([]models.Epoch, error)
 	GetPoolRegistrations(
-		[]byte, // pkh
+		lcommon.PoolKeyHash,
 		*gorm.DB,
-	) ([]models.PoolRegistration, error)
+	) ([]lcommon.PoolRegistrationCertificate, error)
 	GetPParams(
 		uint64, // epoch
 		*gorm.DB,
@@ -51,7 +49,7 @@ type MetadataStore interface {
 	GetStakeRegistrations(
 		[]byte, // stakeKey
 		*gorm.DB,
-	) ([]models.StakeRegistration, error)
+	) ([]lcommon.StakeRegistrationCertificate, error)
 	GetTip(*gorm.DB) (ochainsync.Tip, error)
 	GetUtxo(
 		[]byte, // txId

--- a/state/view.go
+++ b/state/view.go
@@ -58,48 +58,16 @@ func (lv *LedgerView) UtxoById(
 	}, nil
 }
 
+func (lv *LedgerView) PoolRegistration(
+	pkh []byte,
+) ([]lcommon.PoolRegistrationCertificate, error) {
+	poolKeyHash := lcommon.PoolKeyHash(lcommon.NewBlake2b224(pkh))
+	return lv.txn.DB().GetPoolRegistrations(poolKeyHash, lv.txn)
+}
+
 func (lv *LedgerView) StakeRegistration(
 	stakingKey []byte,
 ) ([]lcommon.StakeRegistrationCertificate, error) {
-	ret := []lcommon.StakeRegistrationCertificate{}
-	certs, err := lv.txn.DB().
-		Metadata().
-		GetStakeRegistrations(stakingKey, lv.txn.Metadata())
-	if err != nil {
-		return ret, err
-	}
-	for _, cert := range certs {
-		ret = append(
-			ret,
-			lcommon.StakeRegistrationCertificate{
-				StakeRegistration: lcommon.StakeCredential{
-					Credential: cert.StakingKey,
-				},
-			},
-		)
-	}
-	return ret, nil
-}
-
-func (lv *LedgerView) PoolRegistration(
-	poolKeyHash []byte,
-) ([]lcommon.PoolRegistrationCertificate, error) {
-	ret := []lcommon.PoolRegistrationCertificate{}
-	certs, err := lv.txn.DB().
-		Metadata().
-		GetPoolRegistrations(poolKeyHash, lv.txn.Metadata())
-	if err != nil {
-		return ret, err
-	}
-	for _, cert := range certs {
-		ret = append(
-			ret,
-			lcommon.PoolRegistrationCertificate{
-				Operator: lcommon.PoolKeyHash(
-					lcommon.NewBlake2b224(cert.PoolKeyHash),
-				),
-			},
-		)
-	}
-	return ret, nil
+	// stakingKey = lcommon.NewBlake2b224(stakingKey)
+	return lv.txn.DB().GetStakeRegistrations(stakingKey, lv.txn)
 }


### PR DESCRIPTION
Update `PoolRegistration` and `StakeRegistration` in ledger state view with new getters in the `database` package to return these certificates from the database.