### PR TITLE
refactor: allow split database transactions

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -55,6 +55,16 @@ func (d *Database) Transaction(readWrite bool) *Txn {
 	return NewTxn(d, readWrite)
 }
 
+// BlobTxn starts a new blob-only database transaction and returns a handle to it
+func (d *Database) BlobTxn(readWrite bool) *Txn {
+	return NewBlobOnlyTxn(d, readWrite)
+}
+
+// MetadataTxn starts a new metadata-only database transaction and returns a handle to it
+func (d *Database) MetadataTxn(readWrite bool) *Txn {
+	return NewMetadataOnlyTxn(d, readWrite)
+}
+
 // Close cleans up the database connections
 func (d *Database) Close() error {
 	var err error

--- a/database/txn.go
+++ b/database/txn.go
@@ -42,6 +42,22 @@ func NewTxn(db *Database, readWrite bool) *Txn {
 	}
 }
 
+func NewBlobOnlyTxn(db *Database, readWrite bool) *Txn {
+	return &Txn{
+		db:        db,
+		readWrite: readWrite,
+		blobTxn:   db.Blob().NewTransaction(readWrite),
+	}
+}
+
+func NewMetadataOnlyTxn(db *Database, readWrite bool) *Txn {
+	return &Txn{
+		db:          db,
+		readWrite:   readWrite,
+		metadataTxn: db.Metadata().Transaction(),
+	}
+}
+
 func (t *Txn) DB() *Database {
 	return t.db
 }
@@ -83,20 +99,26 @@ func (t *Txn) Commit() error {
 	if !t.readWrite {
 		return t.rollback()
 	}
-	// Update the commit timestamp for both DBs
-	commitTimestamp := time.Now().UnixMilli()
-	if err := t.db.updateCommitTimestamp(t, commitTimestamp); err != nil {
-		return err
+	// Update the commit timestamp in both DBs if using both
+	if t.blobTxn != nil && t.metadataTxn != nil {
+		commitTimestamp := time.Now().UnixMilli()
+		if err := t.db.updateCommitTimestamp(t, commitTimestamp); err != nil {
+			return err
+		}
 	}
 	// Commit sqlite transaction
-	if result := t.metadataTxn.Commit(); result.Error != nil {
-		// Failed to commit metadata DB, so discard blob txn
-		t.blobTxn.Discard()
-		return result.Error
+	if t.metadataTxn != nil {
+		if result := t.metadataTxn.Commit(); result.Error != nil {
+			// Failed to commit metadata DB, so discard blob txn
+			t.blobTxn.Discard()
+			return result.Error
+		}
 	}
 	// Commit badger transaction
-	if err := t.blobTxn.Commit(); err != nil {
-		return err
+	if t.blobTxn != nil {
+		if err := t.blobTxn.Commit(); err != nil {
+			return err
+		}
 	}
 	t.finished = true
 	return nil


### PR DESCRIPTION
This allows metadata-only and blob-only DB transactions. It also restricts updating the commit timestamp to transactions that use both.