### PR TITLE
fix(config): support absolute paths in cardano-node config

### DIFF
--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -69,9 +70,13 @@ func NewCardanoNodeConfigFromFile(file string) (*CardanoNodeConfig, error) {
 }
 
 func (c *CardanoNodeConfig) loadGenesisConfigs() error {
+	prefix := "/"
 	// Load Byron genesis
 	if c.ByronGenesisFile != "" {
-		byronGenesisPath := path.Join(c.path, c.ByronGenesisFile)
+		byronGenesisPath := c.ByronGenesisFile
+		if !strings.HasPrefix(byronGenesisPath, prefix) {
+			byronGenesisPath = path.Join(c.path, byronGenesisPath)
+		}
 		// TODO: check genesis file hash (#399)
 		byronGenesis, err := byron.NewByronGenesisFromFile(byronGenesisPath)
 		if err != nil {
@@ -81,7 +86,10 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	}
 	// Load Shelley genesis
 	if c.ShelleyGenesisFile != "" {
-		shelleyGenesisPath := path.Join(c.path, c.ShelleyGenesisFile)
+		shelleyGenesisPath := c.ShelleyGenesisFile
+		if !strings.HasPrefix(shelleyGenesisPath, prefix) {
+			shelleyGenesisPath = path.Join(c.path, shelleyGenesisPath)
+		}
 		// TODO: check genesis file hash (#399)
 		shelleyGenesis, err := shelley.NewShelleyGenesisFromFile(
 			shelleyGenesisPath,
@@ -93,7 +101,10 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	}
 	// Load Alonzo genesis
 	if c.AlonzoGenesisFile != "" {
-		alonzoGenesisPath := path.Join(c.path, c.AlonzoGenesisFile)
+		alonzoGenesisPath := c.AlonzoGenesisFile
+		if !strings.HasPrefix(alonzoGenesisPath, prefix) {
+			alonzoGenesisPath = path.Join(c.path, alonzoGenesisPath)
+		}
 		// TODO: check genesis file hash (#399)
 		alonzoGenesis, err := alonzo.NewAlonzoGenesisFromFile(alonzoGenesisPath)
 		if err != nil {
@@ -103,7 +114,10 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	}
 	// Load Conway genesis
 	if c.ConwayGenesisFile != "" {
-		conwayGenesisPath := path.Join(c.path, c.ConwayGenesisFile)
+		conwayGenesisPath := c.ConwayGenesisFile
+		if !strings.HasPrefix(conwayGenesisPath, prefix) {
+			conwayGenesisPath = path.Join(c.path, conwayGenesisPath)
+		}
 		// TODO: check genesis file hash (#399)
 		conwayGenesis, err := conway.NewConwayGenesisFromFile(conwayGenesisPath)
 		if err != nil {

--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
+	"path/filepath"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -70,11 +70,10 @@ func NewCardanoNodeConfigFromFile(file string) (*CardanoNodeConfig, error) {
 }
 
 func (c *CardanoNodeConfig) loadGenesisConfigs() error {
-	prefix := "/"
 	// Load Byron genesis
 	if c.ByronGenesisFile != "" {
 		byronGenesisPath := c.ByronGenesisFile
-		if !strings.HasPrefix(byronGenesisPath, prefix) {
+		if !filepath.IsAbs(byronGenesisPath) {
 			byronGenesisPath = path.Join(c.path, byronGenesisPath)
 		}
 		// TODO: check genesis file hash (#399)
@@ -87,7 +86,7 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	// Load Shelley genesis
 	if c.ShelleyGenesisFile != "" {
 		shelleyGenesisPath := c.ShelleyGenesisFile
-		if !strings.HasPrefix(shelleyGenesisPath, prefix) {
+		if !filepath.IsAbs(shelleyGenesisPath) {
 			shelleyGenesisPath = path.Join(c.path, shelleyGenesisPath)
 		}
 		// TODO: check genesis file hash (#399)
@@ -102,7 +101,7 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	// Load Alonzo genesis
 	if c.AlonzoGenesisFile != "" {
 		alonzoGenesisPath := c.AlonzoGenesisFile
-		if !strings.HasPrefix(alonzoGenesisPath, prefix) {
+		if !filepath.IsAbs(alonzoGenesisPath) {
 			alonzoGenesisPath = path.Join(c.path, alonzoGenesisPath)
 		}
 		// TODO: check genesis file hash (#399)
@@ -115,7 +114,7 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	// Load Conway genesis
 	if c.ConwayGenesisFile != "" {
 		conwayGenesisPath := c.ConwayGenesisFile
-		if !strings.HasPrefix(conwayGenesisPath, prefix) {
+		if !filepath.IsAbs(conwayGenesisPath) {
 			conwayGenesisPath = path.Join(c.path, conwayGenesisPath)
 		}
 		// TODO: check genesis file hash (#399)


### PR DESCRIPTION
If the given paths to the genesis files in the cardano-node config are absolute, use them. Otherwise, prepend the `config.json` directory to the file names.

Closes #519 