### PR TITLE
refactor(database): remove funcs and use database

### DIFF
--- a/database/epoch.go
+++ b/database/epoch.go
@@ -30,10 +30,6 @@ func (Epoch) TableName() string {
 	return "epoch"
 }
 
-func GetEpochLatest(db *Database) (Epoch, error) {
-	return db.GetEpochLatest(nil)
-}
-
 func (d *Database) GetEpochLatest(txn *Txn) (Epoch, error) {
 	tmpEpoch := Epoch{}
 	if txn == nil {
@@ -52,10 +48,6 @@ func (d *Database) GetEpochLatest(txn *Txn) (Epoch, error) {
 	return tmpEpoch, nil
 }
 
-func GetEpochsByEra(db *Database, eraId uint) ([]Epoch, error) {
-	return db.GetEpochsByEra(eraId, nil)
-}
-
 func (d *Database) GetEpochsByEra(eraId uint, txn *Txn) ([]Epoch, error) {
 	tmpEpochs := []Epoch{}
 	if txn == nil {
@@ -67,7 +59,7 @@ func (d *Database) GetEpochsByEra(eraId uint, txn *Txn) ([]Epoch, error) {
 			tmpEpochs = append(tmpEpochs, Epoch(epoch))
 		}
 	} else {
-		epochs, err := txn.DB().metadata.GetEpochsByEra(eraId, txn.Metadata())
+		epochs, err := txn.db.metadata.GetEpochsByEra(eraId, txn.Metadata())
 		if err != nil {
 			return tmpEpochs, err
 		}

--- a/database/tip.go
+++ b/database/tip.go
@@ -16,10 +16,7 @@ package database
 
 import ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 
-func GetTip(db *Database) (ochainsync.Tip, error) {
-	return db.GetTip(nil)
-}
-
+// GetTip returns the current tip as represented by the protocol
 func (d *Database) GetTip(txn *Txn) (ochainsync.Tip, error) {
 	tmpTip := ochainsync.Tip{}
 	if txn == nil {
@@ -39,10 +36,6 @@ func (d *Database) GetTip(txn *Txn) (ochainsync.Tip, error) {
 }
 
 // SetTip saves the current tip
-func SetTip(db *Database, tip ochainsync.Tip) error {
-	return db.SetTip(tip, nil)
-}
-
 func (d *Database) SetTip(tip ochainsync.Tip, txn *Txn) error {
 	if txn == nil {
 		return d.metadata.SetTip(tip, nil)

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -58,14 +58,6 @@ func (u *Utxo) loadCbor(txn *Txn) error {
 	return nil
 }
 
-func UtxoByRef(
-	db *Database,
-	txId []byte,
-	outputIdx uint32,
-) (Utxo, error) {
-	return db.UtxoByRef(txId, outputIdx, nil)
-}
-
 func (d *Database) UtxoByRef(
 	txId []byte,
 	outputIdx uint32,
@@ -85,13 +77,6 @@ func (d *Database) UtxoByRef(
 		return tmpUtxo, err
 	}
 	return tmpUtxo, nil
-}
-
-func UtxosByAddress(
-	db *Database,
-	addr ledger.Address,
-) ([]Utxo, error) {
-	return db.UtxosByAddress(addr, nil)
 }
 
 func (d *Database) UtxosByAddress(
@@ -115,13 +100,6 @@ func (d *Database) UtxosByAddress(
 		ret = append(ret, tmpUtxo)
 	}
 	return ret, nil
-}
-
-func UtxosCleanup(
-	db *Database,
-	slot uint64,
-) error {
-	return db.UtxosCleanup(slot, nil)
 }
 
 func (d *Database) UtxosCleanup(
@@ -235,19 +213,12 @@ func (d *Database) UtxosDeleteRolledback(
 	return ret
 }
 
-func UtxosUnspend(
-	db *Database,
-	slot uint64,
-) error {
-	return db.UtxosUnspend(slot, nil)
-}
-
 func (d *Database) UtxosUnspend(
 	slot uint64,
 	txn *Txn,
 ) error {
 	if txn == nil {
-		txn = d.Transaction(true)
+		txn = NewMetadataOnlyTxn(d, false)
 		defer txn.Commit() //nolint:errcheck
 	}
 	return d.metadata.SetUtxosNotDeletedAfterSlot(slot, txn.Metadata())

--- a/state/queries.go
+++ b/state/queries.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/state/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -208,7 +207,7 @@ func (ls *LedgerState) queryShelleyUtxoByAddress(
 ) (any, error) {
 	ret := make(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
 	// TODO: support multiple addresses (#391)
-	utxos, err := database.UtxosByAddress(ls.db, addrs[0])
+	utxos, err := ls.db.UtxosByAddress(addrs[0], nil)
 	if err != nil {
 		return nil, err
 	}
@@ -231,10 +230,10 @@ func (ls *LedgerState) queryShelleyUtxoByTxIn(
 ) (any, error) {
 	ret := make(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
 	// TODO: support multiple TxIns (#392)
-	utxo, err := database.UtxoByRef(
-		ls.db,
+	utxo, err := ls.db.UtxoByRef(
 		txIns[0].Id().Bytes(),
 		txIns[0].Index(),
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/state/state.go
+++ b/state/state.go
@@ -626,7 +626,7 @@ func (ls *LedgerState) UtxoByRef(
 	txId []byte,
 	outputIdx uint32,
 ) (database.Utxo, error) {
-	return database.UtxoByRef(ls.db, txId, outputIdx)
+	return ls.db.UtxoByRef(txId, outputIdx, nil)
 }
 
 // UtxosByAddress returns all UTxOs that belong to the specified address
@@ -634,21 +634,12 @@ func (ls *LedgerState) UtxosByAddress(
 	addr ledger.Address,
 ) ([]database.Utxo, error) {
 	ret := []database.Utxo{}
-	utxos, err := database.UtxosByAddress(ls.db, addr)
+	utxos, err := ls.db.UtxosByAddress(addr, nil)
 	if err != nil {
 		return ret, err
 	}
 	for _, utxo := range utxos {
-		tmpUtxo := database.Utxo{
-			ID:          utxo.ID,
-			TxId:        utxo.TxId,
-			OutputIdx:   utxo.OutputIdx,
-			AddedSlot:   utxo.AddedSlot,
-			DeletedSlot: utxo.DeletedSlot,
-			PaymentKey:  utxo.PaymentKey,
-			StakingKey:  utxo.StakingKey,
-			Cbor:        utxo.Cbor,
-		}
+		tmpUtxo := database.Utxo(utxo)
 		ret = append(ret, tmpUtxo)
 	}
 	return ret, nil


### PR DESCRIPTION
Remove the funcs on database which executed the database type methods and switch to simply using those methods directly.