### PR TITLE
refactor: simplify chainsync header waiting on blockfetch

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -70,11 +70,10 @@ type LedgerState struct {
 	currentTipBlockNonce        []byte
 	metrics                     stateMetrics
 	chainsyncBlockEvents        []BlockfetchEvent
-	chainsyncBlockfetchBusy     bool
 	chainsyncBlockfetchBusyTime time.Time
+	chainsyncBlockfetchDoneChan chan struct{}
 	chainsyncBlockfetchMutex    sync.Mutex
 	chainsyncBlockfetchWaiting  bool
-	chainsyncHeaderMutex        sync.Mutex
 	chain                       *chain.Chain
 }
 


### PR DESCRIPTION
This removes a mutex around chainsync headers and the "blockfetch busy" flag. It also generalizes the code around starting and finishing a blockfetch batch request.

Fixes #589