### PR TITLE
feat(config): support dingo.yaml config file loading with env overrides in dingo

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,27 +16,29 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/kelseyhightower/envconfig"
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
-	BindAddr        string `split_words:"true"`
-	CardanoConfig   string `                   envconfig:"config"`
-	DatabasePath    string `split_words:"true"`
-	SocketPath      string `split_words:"true"`
-	Network         string
-	TlsCertFilePath string `envconfig:"TLS_CERT_FILE_PATH"`
-	TlsKeyFilePath  string `envconfig:"TLS_KEY_FILE_PATH"`
-	Topology        string
-	MetricsPort     uint   `split_words:"true"`
-	PrivateBindAddr string `split_words:"true"`
-	PrivatePort     uint   `split_words:"true"`
-	RelayPort       uint   `envconfig:"port"`
-	UtxorpcPort     uint   `split_words:"true"`
-	IntersectTip    bool   `split_words:"true"`
+	BindAddr        string `yaml:"bindAddr" split_words:"true"`
+	CardanoConfig   string `yaml:"cardanoConfig" envconfig:"config"`
+	DatabasePath    string `yaml:"databasePath" split_words:"true"`
+	SocketPath      string `yaml:"socketPath" split_words:"true"`
+	Network         string `yaml:"network"`
+	TlsCertFilePath string `yaml:"tlsCertFilePath" envconfig:"TLS_CERT_FILE_PATH"`
+	TlsKeyFilePath  string `yaml:"tlsKeyFilePath" envconfig:"TLS_KEY_FILE_PATH"`
+	Topology        string `yaml:"topology"`
+	MetricsPort     uint   `yaml:"metricsPort" split_words:"true"`
+	PrivateBindAddr string `yaml:"privateBindAddr" split_words:"true"`
+	PrivatePort     uint   `yaml:"privatePort" split_words:"true"`
+	RelayPort       uint   `yaml:"relayPort" envconfig:"port"`
+	UtxorpcPort     uint   `yaml:"utxorpcPort" split_words:"true"`
+	IntersectTip    bool   `yaml:"intersectTip" split_words:"true"`
 }
 
 var globalConfig = &Config{
@@ -56,7 +58,21 @@ var globalConfig = &Config{
 	TlsKeyFilePath:  "",
 }
 
-func LoadConfig() (*Config, error) {
+func LoadConfig(configFile string) (*Config, error) {
+	// Load config file as YAML if provided
+	if configFile != "" {
+		fmt.Printf("Reading from config file %s\n", configFile)
+		buf, err := os.ReadFile(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading config file: %w", err)
+		}
+		err = yaml.Unmarshal(buf, globalConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing config file: %w", err)
+		}
+		fmt.Printf("Successfully loaded the config file %s\n", configFile)
+	}
+
 	err := envconfig.Process("cardano", globalConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error processing environment: %+w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func resetGlobalConfig() {
+	globalConfig = &Config{
+		BindAddr:        "0.0.0.0",
+		CardanoConfig:   "./config/cardano/preview/config.json",
+		DatabasePath:    ".dingo",
+		SocketPath:      "dingo.socket",
+		IntersectTip:    false,
+		Network:         "preview",
+		MetricsPort:     12798,
+		PrivateBindAddr: "127.0.0.1",
+		PrivatePort:     3002,
+		RelayPort:       3001,
+		UtxorpcPort:     9090,
+		Topology:        "",
+		TlsCertFilePath: "",
+		TlsKeyFilePath:  "",
+	}
+}
+
+func TestLoad_CompareFullStruct(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+bindAddr: "127.0.0.1"
+cardanoConfig: "./cardano/preview/config.json"
+databasePath: ".dingo"
+socketPath: "env.socket"
+intersectTip: true
+network: "preview"
+metricsPort: 8088
+privateBindAddr: "127.0.0.1"
+privatePort: 8000
+relayPort: 4000
+utxorpcPort: 9940
+topology: ""
+tlsCertFilePath: "cert1.pem"
+tlsKeyFilePath: "key1.pem"
+`
+
+	tmpFile := "test-dingo.yaml"
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	defer os.Remove(tmpFile)
+
+	expected := &Config{
+		BindAddr:        "127.0.0.1",
+		CardanoConfig:   "./cardano/preview/config.json",
+		DatabasePath:    ".dingo",
+		SocketPath:      "env.socket",
+		IntersectTip:    true,
+		Network:         "preview",
+		MetricsPort:     8088,
+		PrivateBindAddr: "127.0.0.1",
+		PrivatePort:     8000,
+		RelayPort:       4000,
+		UtxorpcPort:     9940,
+		Topology:        "",
+		TlsCertFilePath: "cert1.pem",
+		TlsKeyFilePath:  "key1.pem",
+	}
+
+	actual, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Loaded config does not match expected.\nActual: %+v\nExpected: %+v", actual, expected)
+	}
+}
+func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
+	resetGlobalConfig()
+
+	// Without Config file
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Expected is the original default values from globalConfig
+	expected := &Config{
+		BindAddr:        "0.0.0.0",
+		CardanoConfig:   "./config/cardano/preview/config.json",
+		DatabasePath:    ".dingo",
+		SocketPath:      "dingo.socket",
+		IntersectTip:    false,
+		Network:         "preview",
+		MetricsPort:     12798,
+		PrivateBindAddr: "127.0.0.1",
+		PrivatePort:     3002,
+		RelayPort:       3001,
+		UtxorpcPort:     9090,
+		Topology:        "",
+		TlsCertFilePath: "",
+		TlsKeyFilePath:  "",
+	}
+
+	if !reflect.DeepEqual(cfg, expected) {
+		t.Errorf("config mismatch without file:\nExpected: %+v\nGot:      %+v", expected, cfg)
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -32,11 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func Run(logger *slog.Logger) error {
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return err
-	}
+func Run(cfg *config.Config, logger *slog.Logger) error {
 	logger.Debug(fmt.Sprintf("config: %+v", cfg), "component", "node")
 	logger.Debug(
 		fmt.Sprintf("topology: %+v", config.GetTopologyConfig()),


### PR DESCRIPTION
1. Added `--config` flag in cmd/dingo to make sure of custom configuration file as input. 
2. Added proper yaml tags on all fields in the dingo `Config` struct to enable unmarshaling from YAML.
3. Implemented logic to load configuration from YAML first, and then override with environment variables
4. Updated `node.Run()` to accept loaded config from main instead of reloading internally.
5. Wrote unit tests to validate config loading with and without a YAML file.
6. Executed the cmd/dingo/main.go with and without config file as input and it is working fine.

Closes #529 