### PR TITLE
feat(config): support dingo.yaml config file loading with env overrides in dingo

### DIFF
--- a/cmd/dingo/load.go
+++ b/cmd/dingo/load.go
@@ -18,17 +18,18 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/spf13/cobra"
 )
 
-func loadRun(_ *cobra.Command, args []string) {
+func loadRun(_ *cobra.Command, args []string, cfg *config.Config) {
 	if len(args) != 1 {
 		slog.Error("you must provide the path to an ImmutableDB")
 		os.Exit(1)
 	}
 	logger := commonRun()
-	if err := node.Load(logger, args[0]); err != nil {
+	if err := node.Load(cfg, logger, args[0]); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
 	}
@@ -39,7 +40,12 @@ func loadCommand() *cobra.Command {
 		Use:   "load db-path",
 		Short: "Load blocks from ImmutableDB",
 		Run: func(cmd *cobra.Command, args []string) {
-			loadRun(cmd, args)
+			cfg := config.FromContext(cmd.Context())
+			if cfg == nil {
+				slog.Error("no config found in context")
+				os.Exit(1)
+			}
+			loadRun(cmd, args, cfg)
 		},
 	}
 	return cmd

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/version"
 	"github.com/spf13/cobra"
 	"go.uber.org/automaxprocs/maxprocs"
@@ -34,10 +35,13 @@ func slogPrintf(format string, v ...any) {
 	)
 }
 
-var globalFlags struct {
-	version bool
-	debug   bool
-}
+var (
+	globalFlags = struct {
+		version bool
+		debug   bool
+	}{}
+	configFile string
+)
 
 func commonRun() *slog.Logger {
 	if globalFlags.version {
@@ -76,7 +80,8 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use: programName,
 		Run: func(cmd *cobra.Command, args []string) {
-			serveRun(cmd, args)
+			cfg := config.FromContext(cmd.Context())
+			serveRun(cmd, args, cfg)
 		},
 	}
 
@@ -85,6 +90,17 @@ func main() {
 		BoolVarP(&globalFlags.debug, "debug", "D", false, "enable debug logging")
 	rootCmd.PersistentFlags().
 		BoolVarP(&globalFlags.version, "version", "", false, "show version and exit")
+	rootCmd.PersistentFlags().
+		StringVar(&configFile, "config", "", "path to config file")
+
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.LoadConfig(configFile)
+		if err != nil {
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+		cmd.SetContext(config.WithContext(cmd.Context(), cfg))
+		return nil
+	}
 
 	// Subcommands
 	rootCmd.AddCommand(serveCommand())
@@ -93,6 +109,8 @@ func main() {
 	// Execute cobra command
 	if err := rootCmd.Execute(); err != nil {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
+		fmt.Println(config.GetConfig())
 		os.Exit(1)
 	}
+
 }

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -111,5 +111,4 @@ func main() {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
 		os.Exit(1)
 	}
-
 }

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -81,6 +81,10 @@ func main() {
 		Use: programName,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.FromContext(cmd.Context())
+			if cfg == nil {
+				slog.Error("no config found in context")
+				os.Exit(1)
+			}
 			serveRun(cmd, args, cfg)
 		},
 	}

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -109,7 +109,6 @@ func main() {
 	// Execute cobra command
 	if err := rootCmd.Execute(); err != nil {
 		// NOTE: we purposely don't display the error, since cobra will have already displayed it
-		fmt.Println(config.GetConfig())
 		os.Exit(1)
 	}
 

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -18,14 +18,15 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/spf13/cobra"
 )
 
-func serveRun(_ *cobra.Command, _ []string) {
+func serveRun(_ *cobra.Command, _ []string, cfg *config.Config) {
 	logger := commonRun()
 	// Run node
-	if err := node.Run(logger); err != nil {
+	if err := node.Run(cfg, logger); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
 	}
@@ -36,7 +37,12 @@ func serveCommand() *cobra.Command {
 		Use:   "serve",
 		Short: "Run as a node",
 		Run: func(cmd *cobra.Command, args []string) {
-			serveRun(cmd, args)
+			cfg := config.FromContext(cmd.Context())
+			if cfg == nil {
+				slog.Error("no config found in context")
+				os.Exit(1)
+			}
+			serveRun(cmd, args, cfg)
 		},
 	}
 	return cmd

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func resetGlobalConfig() {
+	globalConfig = &Config{
+		BindAddr:        "0.0.0.0",
+		CardanoConfig:   "./config/cardano/preview/config.json",
+		DatabasePath:    ".dingo",
+		SocketPath:      "dingo.socket",
+		IntersectTip:    false,
+		Network:         "preview",
+		MetricsPort:     12798,
+		PrivateBindAddr: "127.0.0.1",
+		PrivatePort:     3002,
+		RelayPort:       3001,
+		UtxorpcPort:     9090,
+		Topology:        "",
+		TlsCertFilePath: "",
+		TlsKeyFilePath:  "",
+	}
+}
+
+func TestLoad_CompareFullStruct(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+bindAddr: "127.0.0.1"
+cardanoConfig: "./cardano/preview/config.json"
+databasePath: ".dingo"
+socketPath: "env.socket"
+intersectTip: true
+network: "preview"
+metricsPort: 8088
+privateBindAddr: "127.0.0.1"
+privatePort: 8000
+relayPort: 4000
+utxorpcPort: 9940
+topology: ""
+tlsCertFilePath: "cert1.pem"
+tlsKeyFilePath: "key1.pem"
+`
+
+	tmpFile := "test-dingo.yaml"
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	defer os.Remove(tmpFile)
+
+	expected := &Config{
+		BindAddr:        "127.0.0.1",
+		CardanoConfig:   "./cardano/preview/config.json",
+		DatabasePath:    ".dingo",
+		SocketPath:      "env.socket",
+		IntersectTip:    true,
+		Network:         "preview",
+		MetricsPort:     8088,
+		PrivateBindAddr: "127.0.0.1",
+		PrivatePort:     8000,
+		RelayPort:       4000,
+		UtxorpcPort:     9940,
+		Topology:        "",
+		TlsCertFilePath: "cert1.pem",
+		TlsKeyFilePath:  "key1.pem",
+	}
+
+	actual, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Loaded config does not match expected.\nActual: %+v\nExpected: %+v", actual, expected)
+	}
+}
+func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
+	resetGlobalConfig()
+
+	// Without Config file
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Expected is the original default values from globalConfig
+	expected := &Config{
+		BindAddr:        "0.0.0.0",
+		CardanoConfig:   "./config/cardano/preview/config.json",
+		DatabasePath:    ".dingo",
+		SocketPath:      "dingo.socket",
+		IntersectTip:    false,
+		Network:         "preview",
+		MetricsPort:     12798,
+		PrivateBindAddr: "127.0.0.1",
+		PrivatePort:     3002,
+		RelayPort:       3001,
+		UtxorpcPort:     9090,
+		Topology:        "",
+		TlsCertFilePath: "",
+		TlsKeyFilePath:  "",
+	}
+
+	if !reflect.DeepEqual(cfg, expected) {
+		t.Errorf("config mismatch without file:\nExpected: %+v\nGot:      %+v", expected, cfg)
+	}
+}

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -28,11 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 )
 
-func Load(logger *slog.Logger, immutableDir string) error {
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return err
-	}
+func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 	var nodeCfg *cardano.CardanoNodeConfig
 	if cfg.CardanoConfig != "" {
 		tmpCfg, err := cardano.NewCardanoNodeConfigFromFile(cfg.CardanoConfig)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -32,11 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func Run(logger *slog.Logger) error {
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return err
-	}
+func Run(cfg *config.Config, logger *slog.Logger) error {
 	logger.Debug(fmt.Sprintf("config: %+v", cfg), "component", "node")
 	logger.Debug(
 		fmt.Sprintf("topology: %+v", config.GetTopologyConfig()),


### PR DESCRIPTION
1. Added `--config` flag in cmd/dingo to make sure of custom configuration file as input.
2. Added proper yaml tags on all fields in the dingo `Config` struct to enable unmarshaling from YAML.
3. Implemented logic to load configuration from YAML first, and then override with environment variables
4. Updated node.Run() to accept loaded config from main instead of reloading internally.
5. Wrote unit tests to validate config loading with and without a YAML file.
6. Executed the cmd/dingo/main.go with and without config file as input and it is working fine.

Closes #529 