### PR TITLE
feat(config): Create dingo.yaml.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@
 
 ## Running
 
-Dingo does not support a configuration file of its own and uses environment
+Dingo supports configuration via both a YAML config file (`dingo.yaml`) and uses environment
 variables to modify its own behavior.
 
+A sample configuration file is provided at `dingo.yaml.example`.You can copy and edit this file to configure Dingo for your local or production environment:
 This behavior can be changed via the following environment variables:
 
 - `CARDANO_BIND_ADDR`

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -1,0 +1,53 @@
+# Example config file for dingo
+# The values shown below correspond to the in-code defaults
+
+# Public bind address for the Dingo server
+bindAddr: "0.0.0.0"
+
+# Path to the Cardano node configuration file
+#
+# Can be overridden with the config environment variable
+cardanoConfig: "./config/cardano/preview/config.json"
+
+# A directory which contains the ledger database files
+databasePath: ".dingo"
+
+# Path to the UNIX domain socket file used by the server
+socketPath: "dingo.socket"
+
+# Name of the Cardano network
+network: "preview"
+
+# TLS certificate file path (for HTTPS)
+#
+# Can be overridden with the TLS_CERT_FILE_PATH environment variable
+tlsCertFilePath: ""
+
+# TLS key file path (for HTTPS)
+#
+# Can be overridden with the TLS_KEY_FILE_PATH environment variable
+tlsKeyFilePath: ""
+
+# Path to the topology configuration file for Cardano node
+topology: ""
+
+# TCP port to bind for Prometheus metrics endpoint
+metricsPort: 12798
+
+# Internal/private address to bind for listening for Ouroboros NtC
+privateBindAddr: "127.0.0.1"
+
+# TCP port to bind for listening for Ouroboros NtC
+privatePort: 3002
+
+# TCP port to bind for listening for Ouroboros NtN
+#
+# Can be overridden with the port environment variable
+relayPort: 3001
+
+# TCP port to bind for listening for UTxO RPC
+utxorpcPort: 9090
+
+# Ignore prior chain history and start from current tip (default: false)
+# This is experimental and may break — use with caution
+intersectTip: false


### PR DESCRIPTION
1. Added dingo.yaml.example`with all config fields from the Config struct
2. Used default values from globalConfig.
3. Updated comments for each one in the config and updated the readme file as well to use this config file.

Closes #651 