### PR TITLE
refactor: use batch writes for UTxOs

### DIFF
--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -34,6 +35,10 @@ type MetadataStore interface {
 	Transaction() *gorm.DB
 
 	// Ledger state
+	AddUtxos(
+		[]types.UtxoSlot,
+		*gorm.DB,
+	) error
 	GetPoolRegistrations(
 		lcommon.PoolKeyHash,
 		*gorm.DB,

--- a/database/types/wrappers.go
+++ b/database/types/wrappers.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// UtxoSlot allows providing a slot number with a ledger.Utxo object in a batch
+type UtxoSlot struct {
+	Utxo ledger.Utxo
+	Slot uint64
+}

--- a/ledger/certs.go
+++ b/ledger/certs.go
@@ -35,7 +35,7 @@ func (ls *LedgerState) processTransactionCertificates(
 			ls.currentPParams,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("get certificate deposit: %w", err)
 		}
 		switch cert := tmpCert.(type) {
 		case *lcommon.DeregistrationCertificate:


### PR DESCRIPTION
Batch writes to the DB for produced UTxOs when not validating. This improves initial sync time by ~17%