### PR TITLE
feat(config): Configuration file loading should use a search path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,14 +78,12 @@ var globalConfig = &Config{
 
 func LoadConfig(configFile string) (*Config, error) {
 	// Load config file as YAML if provided
-	fmt.Println(configFile)
 	if configFile == "" {
 		// Check for config file in this path: ~/.dingo/dingo.yaml
 		if homeDir, err := os.UserHomeDir(); err == nil {
 			userPath := filepath.Join(homeDir, ".dingo", "dingo.yaml")
 			if _, err := os.Stat(userPath); err == nil {
 				configFile = userPath
-				fmt.Printf("Using fallback config file: %s\n", configFile)
 			}
 		}
 
@@ -94,12 +92,10 @@ func LoadConfig(configFile string) (*Config, error) {
 			systemPath := "/etc/dingo/dingo.yaml"
 			if _, err := os.Stat(systemPath); err == nil {
 				configFile = systemPath
-				fmt.Printf("Using system config file: %s\n", configFile)
 			}
 		}
 	}
 	if configFile != "" {
-		fmt.Printf("Reading from config file %s\n", configFile)
 		buf, err := os.ReadFile(configFile)
 		if err != nil {
 			return nil, fmt.Errorf("error reading config file: %w", err)
@@ -108,9 +104,6 @@ func LoadConfig(configFile string) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error parsing config file: %w", err)
 		}
-		fmt.Printf("Successfully loaded the config file %s\n", configFile)
-	} else {
-		fmt.Println("No config file found, using built-in defaults")
 	}
 	err := envconfig.Process("cardano", globalConfig)
 	if err != nil {


### PR DESCRIPTION
1. Added support in LoadConfig() to load configuration from ~/.dingo/dingo.yaml and /etc/dingo/dingo.yaml when no file is passed.
2. This function loads the built-in default if no configuration file is present.


Closes #622 