### PR TITLE
fix: use correct column in on-conflict clauses

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -20,7 +20,7 @@ import (
 
 type Account struct {
 	ID         uint   `gorm:"primarykey"`
-	StakingKey []byte `gorm:"index,unique"`
+	StakingKey []byte `gorm:"uniqueIndex"`
 	Pool       []byte `gorm:"index"`
 	Drep       []byte `gorm:"index"`
 	AddedSlot  uint64

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -54,12 +54,16 @@ func (d *MetadataStoreSqlite) SetAccount(
 		Pool:       pkh,
 		Drep:       drep,
 	}
+	onConflict := clause.OnConflict{
+		Columns:   []clause.Column{{Name: "staking_key"}},
+		UpdateAll: true,
+	}
 	if txn != nil {
-		if result := txn.Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		if result := txn.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 			return result.Error
 		}
 	} else {
-		if result := d.DB().Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		if result := d.DB().Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 			return result.Error
 		}
 	}

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -57,12 +57,16 @@ func (d *MetadataStoreSqlite) SetDrep(
 		AnchorHash: hash,
 		Active:     active,
 	}
+	onConflict := clause.OnConflict{
+		Columns:   []clause.Column{{Name: "credential"}},
+		UpdateAll: true,
+	}
 	if txn != nil {
-		if result := txn.Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		if result := txn.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 			return result.Error
 		}
 	} else {
-		if result := d.DB().Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		if result := d.DB().Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 			return result.Error
 		}
 	}

--- a/database/plugin/metadata/sqlite/models/drep.go
+++ b/database/plugin/metadata/sqlite/models/drep.go
@@ -16,7 +16,7 @@ package models
 
 type Drep struct {
 	ID         uint   `gorm:"primarykey"`
-	Credential []byte `gorm:"index"`
+	Credential []byte `gorm:"uniqueIndex"`
 	AnchorUrl  string
 	AnchorHash []byte
 	AddedSlot  uint64

--- a/database/plugin/metadata/sqlite/models/pool.go
+++ b/database/plugin/metadata/sqlite/models/pool.go
@@ -22,7 +22,7 @@ import (
 
 type Pool struct {
 	ID            uint   `gorm:"primarykey"`
-	PoolKeyHash   []byte `gorm:"index"`
+	PoolKeyHash   []byte `gorm:"uniqueIndex"`
 	VrfKeyHash    []byte
 	Pledge        types.Uint64
 	Cost          types.Uint64

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -199,12 +199,16 @@ func (d *MetadataStoreSqlite) SetPoolRegistration(
 	}
 	tmpItem.Registration = append(tmpItem.Registration, tmpReg)
 	tmpItem.Relays = tmpReg.Relays
+	onConflict := clause.OnConflict{
+		Columns:   []clause.Column{{Name: "pool_key_hash"}},
+		UpdateAll: true,
+	}
 	if txn != nil {
-		if result := txn.Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		if result := txn.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 			return result.Error
 		}
 	} else {
-		if result := d.DB().Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		if result := d.DB().Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 			return result.Error
 		}
 	}


### PR DESCRIPTION
This also adds unique indexes on the pool/drep tables to allow the on-conflict clause to work