### PR TITLE
refactor: run cleanup of consumed UTxOs at epoch rollover

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -397,6 +397,8 @@ func (ls *LedgerState) processEpochRollover(
 		"epoch", fmt.Sprintf("%+v", ls.currentEpoch),
 		"component", "ledger",
 	)
+	// Start background cleanup of consumed UTxOs
+	go ls.cleanupConsumedUtxos()
 	return nil
 }
 


### PR DESCRIPTION
This prevents long pauses and reduces overall sync time. It also adds missing locks around the epoch rollover processing

Fixes https://github.com/blinklabs-io/dingo/issues/690