### PR TITLE
refactor: cleanup consumed UTxOs in batches

### DIFF
--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -183,13 +183,12 @@ type MetadataStore interface {
 	DeleteUtxo(any, *gorm.DB) error
 	DeleteUtxos([]any, *gorm.DB) error
 	DeleteUtxosAfterSlot(uint64, *gorm.DB) error
-	DeleteUtxosBeforeSlot(uint64, *gorm.DB) error
 	GetEpochLatest(*gorm.DB) (models.Epoch, error)
 	GetEpochsByEra(uint, *gorm.DB) ([]models.Epoch, error)
 	GetEpochs(*gorm.DB) ([]models.Epoch, error)
 	GetUtxosAddedAfterSlot(uint64, *gorm.DB) ([]models.Utxo, error)
 	GetUtxosByAddress(ledger.Address, *gorm.DB) ([]models.Utxo, error)
-	GetUtxosDeletedBeforeSlot(uint64, *gorm.DB) ([]models.Utxo, error)
+	GetUtxosDeletedBeforeSlot(uint64, int, *gorm.DB) ([]models.Utxo, error)
 	SetUtxoDeletedAtSlot(ledger.TransactionInput, uint64, *gorm.DB) error
 	SetUtxosNotDeletedAfterSlot(uint64, *gorm.DB) error
 }


### PR DESCRIPTION
This prevents long stop-the-world pauses in the ledger during cleanup of consumed UTxOs

Fixes #695