### PR TITLE
feat(mempool): Make mempool capacity configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -260,7 +260,3 @@ func WithMempoolCapacity(capacity int64) ConfigOptionFunc {
 		c.mempoolCapacity = capacity
 	}
 }
-
-func (c *Config) MempoolCapacity() int64 {
-	return c.mempoolCapacity
-}

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type ListenerConfig = connmanager.ListenerConfig
 
 type Config struct {
 	badgerCacheSize    int64
+	mempoolCapacity    int64
 	cardanoNodeConfig  *cardano.CardanoNodeConfig
 	dataDir            string
 	intersectPoints    []ocommon.Point
@@ -251,4 +252,15 @@ func WithBadgerCacheSize(cacheSize int64) ConfigOptionFunc {
 	return func(c *Config) {
 		c.badgerCacheSize = cacheSize
 	}
+}
+
+// WithMempoolCapacity sets the mempool capacity (in bytes)
+func WithMempoolCapacity(capacity int64) ConfigOptionFunc {
+	return func(c *Config) {
+		c.mempoolCapacity = capacity
+	}
+}
+
+func (c *Config) MempoolCapacity() int64 {
+	return c.mempoolCapacity
 }

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -55,3 +55,8 @@ intersectTip: false
 # Maximum cache size in bytes used by BadgerDB for block/index cache
 # Default: 1073741824 (1 GB)
 badgerCacheSize: 1073741824
+
+# Maximum total size (in bytes) of all transactions allowed in the mempool.
+# Transactions exceeding this limit will be rejected.
+# Default: 1048576 (1 MB)
+mempoolCapacity: 1048576

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ func FromContext(ctx context.Context) *Config {
 
 type Config struct {
 	BadgerCacheSize int64  `split_words:"true" yaml:"badgerCacheSize"`
+	MempoolCapacity int64  `split_words:"true" yaml:"mempoolCapacity"`
 	BindAddr        string `split_words:"true" yaml:"bindAddr"`
 	CardanoConfig   string `                   yaml:"cardanoConfig"   envconfig:"config"`
 	DatabasePath    string `split_words:"true" yaml:"databasePath"`
@@ -62,6 +63,7 @@ type Config struct {
 
 var globalConfig = &Config{
 	BadgerCacheSize: 1073741824,
+	MempoolCapacity: 1048576,
 	BindAddr:        "0.0.0.0",
 	CardanoConfig:   "./config/cardano/preview/config.json",
 	DatabasePath:    ".dingo",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 func resetGlobalConfig() {
 	globalConfig = &Config{
 		BadgerCacheSize: 1073741824,
+		MempoolCapacity: 1048576,
 		BindAddr:        "0.0.0.0",
 		CardanoConfig:   "./config/cardano/preview/config.json",
 		DatabasePath:    ".dingo",
@@ -30,6 +31,7 @@ func TestLoad_CompareFullStruct(t *testing.T) {
 	resetGlobalConfig()
 	yamlContent := `
 badgerCacheSize: 8388608
+mempoolCapacity: 2097152
 bindAddr: "127.0.0.1"
 cardanoConfig: "./cardano/preview/config.json"
 databasePath: ".dingo"
@@ -55,6 +57,7 @@ tlsKeyFilePath: "key1.pem"
 
 	expected := &Config{
 		BadgerCacheSize: 8388608,
+		MempoolCapacity: 2097152,
 		BindAddr:        "127.0.0.1",
 		CardanoConfig:   "./cardano/preview/config.json",
 		DatabasePath:    ".dingo",
@@ -96,6 +99,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 	// Expected is the original default values from globalConfig
 	expected := &Config{
 		BadgerCacheSize: 1073741824,
+		MempoolCapacity: 1048576,
 		BindAddr:        "0.0.0.0",
 		CardanoConfig:   "./config/cardano/preview/config.json",
 		DatabasePath:    ".dingo",

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -105,6 +105,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithLogger(logger),
 			dingo.WithDatabasePath(cfg.DatabasePath),
 			dingo.WithBadgerCacheSize(cfg.BadgerCacheSize),
+			dingo.WithMempoolCapacity(cfg.MempoolCapacity),
 			dingo.WithNetwork(cfg.Network),
 			dingo.WithCardanoNodeConfig(nodeCfg),
 			dingo.WithListeners(listeners...),

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -78,11 +78,14 @@ type Mempool struct {
 }
 
 type MempoolFullError struct {
-	Message string
+	CurrentSize int
+	TxSize      int
+	Capacity    int64
 }
 
 func (e *MempoolFullError) Error() string {
-	return e.Message
+	return fmt.Sprintf("mempool full: current size=%d bytes, tx size=%d bytes, capacity=%d bytes",
+		e.CurrentSize, e.TxSize, e.Capacity)
 }
 
 func NewMempool(config MempoolConfig) *Mempool {
@@ -235,12 +238,9 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 	}
 	if currentSize+len(tx.Cbor) > int(m.config.MempoolCapacity) {
 		return &MempoolFullError{
-			Message: fmt.Sprintf(
-				"mempool full: current size %d + new tx %d > capacity %d bytes",
-				currentSize,
-				len(tx.Cbor),
-				m.config.MempoolCapacity,
-			),
+			CurrentSize: currentSize,
+			TxSize:      len(tx.Cbor),
+			Capacity:    m.config.MempoolCapacity,
 		}
 	}
 	// Add transaction record

--- a/node.go
+++ b/node.go
@@ -143,7 +143,7 @@ func (n *Node) Run() error {
 	}
 	// Initialize mempool
 	n.mempool = mempool.NewMempool(mempool.MempoolConfig{
-		MempoolCapacity: n.config.MempoolCapacity(),
+		MempoolCapacity: n.config.mempoolCapacity,
 		Logger:          n.config.logger,
 		EventBus:        n.eventBus,
 		PromRegistry:    n.config.promRegistry,

--- a/node.go
+++ b/node.go
@@ -142,14 +142,13 @@ func (n *Node) Run() error {
 		return fmt.Errorf("failed to start ledger: %w", err)
 	}
 	// Initialize mempool
-	n.mempool = mempool.NewMempool(
-		n.config.logger,
-		n.eventBus,
-		n.config.promRegistry,
-		n.ledgerState,
-		mempool.MempoolConfig{
-			MempoolCapacity: n.config.MempoolCapacity(),
-		},
+	n.mempool = mempool.NewMempool(mempool.MempoolConfig{
+		MempoolCapacity: n.config.MempoolCapacity(),
+		Logger:          n.config.logger,
+		EventBus:        n.eventBus,
+		PromRegistry:    n.config.promRegistry,
+		LedgerState:     n.ledgerState,
+	},
 	)
 	// Initialize chainsync state
 	n.chainsyncState = chainsync.NewState(

--- a/node.go
+++ b/node.go
@@ -147,6 +147,9 @@ func (n *Node) Run() error {
 		n.eventBus,
 		n.config.promRegistry,
 		n.ledgerState,
+		mempool.MempoolConfig{
+			MempoolCapacity: n.config.MempoolCapacity(),
+		},
 	)
 	// Initialize chainsync state
 	n.chainsyncState = chainsync.NewState(


### PR DESCRIPTION
1. Added support for a configurable mempoolCapacity limit via dingo.yaml for enabling memory-based size restrictions on mempool transactions.
2. Updated AddTransaction() logic to enforce this limit and return an error if exceeded.

Closes #400 