### PR TITLE
feat(ledger): Create a slot timer

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -402,6 +402,10 @@ func (ls *LedgerState) processEpochRollover(
 	if err := ls.loadEpochs(txn); err != nil {
 		return fmt.Errorf("load epochs: %w", err)
 	}
+	// Update the slot timer interval based on the new epoch's slot length
+	if ls.SlotTimer != nil {
+		ls.SlotTimer.ChangeInterval(time.Duration(ls.currentEpoch.SlotLength) * time.Millisecond)
+	}
 	ls.config.Logger.Debug(
 		"added next epoch to DB",
 		"epoch", fmt.Sprintf("%+v", ls.currentEpoch),

--- a/ledger/timer.go
+++ b/ledger/timer.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"sync"
+	"time"
+)
+
+type ScheduledTask struct {
+	interval int
+	lastRun  int
+	task     func()
+}
+
+type SlotTimer struct {
+	mutex              sync.Mutex
+	interval           time.Duration
+	ticker             *time.Ticker
+	quit               chan struct{}
+	updateIntervalChan chan time.Duration
+	tasks              []*ScheduledTask
+	tickCount          int
+	startOnce          sync.Once
+}
+
+func NewSlotTimer(interval time.Duration) *SlotTimer {
+	return &SlotTimer{
+		interval:           interval,
+		quit:               make(chan struct{}),
+		updateIntervalChan: make(chan time.Duration),
+		tasks:              []*ScheduledTask{},
+	}
+}
+
+// Start the timer (run goroutine once)
+func (st *SlotTimer) Start() {
+	st.startOnce.Do(func() {
+		st.ticker = time.NewTicker(st.interval)
+		go st.run()
+	})
+}
+
+// Listens for tick events and interval updates and updating the ticker accordingly.
+func (st *SlotTimer) run() {
+	for {
+		select {
+		case <-st.ticker.C:
+			st.tick()
+		case newInterval := <-st.updateIntervalChan:
+			st.mutex.Lock()
+			st.ticker.Stop()
+			st.ticker = time.NewTicker(newInterval)
+			st.interval = newInterval
+			st.mutex.Unlock()
+		case <-st.quit:
+			st.ticker.Stop()
+			return
+		}
+	}
+}
+
+// Increments tick counter and executes pending tasks
+func (st *SlotTimer) tick() {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+
+	st.tickCount++
+	for _, task := range st.tasks {
+		if st.tickCount-task.lastRun >= task.interval {
+			go task.task()
+			task.lastRun = st.tickCount
+		}
+	}
+}
+
+// Adds a new task to be scheduled
+func (st *SlotTimer) Register(interval int, task func()) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+
+	st.tasks = append(st.tasks, &ScheduledTask{
+		interval: interval,
+		lastRun:  st.tickCount,
+		task:     task,
+	})
+}
+
+// ChangeInterval updates the tick interval of the SlotTimer at runtime.
+func (st *SlotTimer) ChangeInterval(newInterval time.Duration) {
+	st.updateIntervalChan <- newInterval
+}
+
+// Stop the timer (terminates)
+func (st *SlotTimer) Stop() {
+	close(st.quit)
+	if st.ticker != nil {
+		st.ticker.Stop()
+	}
+}

--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSlotTimer_RegistersAndRunsTask(t *testing.T) {
+	var counter int32
+
+	// Create a SlotTimer with 10ms tick interval
+	timer := NewSlotTimer(10 * time.Millisecond)
+	timer.Start()
+	defer timer.Stop()
+
+	// Registering task to execute every 3 ticks
+	timer.Register(3, func() {
+		atomic.AddInt32(&counter, 1)
+	})
+
+	// Sleeping for 100ms to allow multiple ticks to occur
+	time.Sleep(100 * time.Millisecond)
+
+	finalCount := atomic.LoadInt32(&counter)
+	t.Logf("Task executed %d times after 100ms (expected at least 2)", finalCount)
+
+	if finalCount < 2 {
+		t.Errorf("Expected task to run at least 2 times, but got %d", finalCount)
+	}
+}
+
+func TestSlotTimer_ChangeInterval(t *testing.T) {
+	var counter int32
+
+	// Create a SlotTimer with 50ms tick interval
+	timer := NewSlotTimer(50 * time.Millisecond)
+	timer.Start()
+	defer timer.Stop()
+
+	// Registering task with 50ms tick interval to execute for every 1 tick
+	timer.Register(1, func() {
+		atomic.AddInt32(&counter, 1)
+	})
+
+	// Waiting 120ms to observe task execution at 50ms interval
+	time.Sleep(120 * time.Millisecond)
+	beforeChange := atomic.LoadInt32(&counter)
+	t.Logf("Task executed %d times before interval change", beforeChange)
+	if beforeChange < 2 {
+		t.Errorf("Expected at least 2 executions before interval change, got %d", beforeChange)
+	}
+
+	// Change interval to 200ms
+	timer.ChangeInterval(200 * time.Millisecond)
+
+	// Sleep for 500ms after interval change to observe behavior
+	time.Sleep(500 * time.Millisecond)
+
+	secondCount := atomic.LoadInt32(&counter)
+	afterChange := secondCount - beforeChange
+	t.Logf("Task ran %d more times after interval change (total now = %d)", afterChange, secondCount)
+
+	if afterChange < 1 || afterChange > 3 {
+		t.Errorf("timer did not respect interval change, ran too frequently: %d more ticks", afterChange)
+	}
+}


### PR DESCRIPTION
1.  Implemented a SlotTimer that ticks at a specified interval (initially based on current epoch length from ledger state).
2. Added ChangeInterval method such that it cleanly updates the timer frequency during runtime. Added this inside processEpochRollover to adjust timer when slot length changes between epochs.
3. Timer runs its own goroutine (Start()) and independently tracks ticks, executes due tasks, and stops cleanly with Stop().
4. Added two test functions such as to ensures scheduled tasks run at expected ticks and verification of dynamic interval changes.
5. Added the functionality to register a function to run on custom interval (ticks/slots).

Closes #761 