### PR TITLE
fix: use Shelley genesis slot length at chain genesis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	connectrpc.com/grpchealth v1.4.0
 	connectrpc.com/grpcreflect v1.3.0
-	github.com/blinklabs-io/gouroboros v0.129.0
+	github.com/blinklabs-io/gouroboros v0.130.1
 	github.com/blinklabs-io/ouroboros-mock v0.3.8
 	github.com/dgraph-io/badger/v4 v4.8.0
 	github.com/glebarez/sqlite v1.11.0
@@ -38,7 +38,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blinklabs-io/plutigo v0.0.2-0.20250717183329-b331a97fb319 // indirect
+	github.com/blinklabs-io/plutigo v0.0.3 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,12 @@ github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7X
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blinklabs-io/gouroboros v0.129.0 h1:TqjRqtTlen7+2NEGjtNK2pHIRBid0ds9o1iOyeX64+w=
-github.com/blinklabs-io/gouroboros v0.129.0/go.mod h1:H8alqj9rvoaBb3NpAOoN771SGZPSlkToQ7JSlapJdVM=
+github.com/blinklabs-io/gouroboros v0.130.1 h1:OrNxV1z/YIqAYBkAJZcVi2lDg16rZ3RJCk9YxsJvp6M=
+github.com/blinklabs-io/gouroboros v0.130.1/go.mod h1:+tBHYgbI9TsFs31WQrLXItWLVQhcahXS5YzthS0bwfQ=
 github.com/blinklabs-io/ouroboros-mock v0.3.8 h1:+DAt2rx0ouZUxee5DBMgZq3I1+ZdxFSHG9g3tYl/FKU=
 github.com/blinklabs-io/ouroboros-mock v0.3.8/go.mod h1:UwQIf4KqZwO13P9d90fbi3UL/X7JaJfeEbqk+bEeFQA=
-github.com/blinklabs-io/plutigo v0.0.2-0.20250717183329-b331a97fb319 h1:1LDEbQwobPtbaZYJ+imWoDQ0n5aAKKbFQocek2HxXXU=
-github.com/blinklabs-io/plutigo v0.0.2-0.20250717183329-b331a97fb319/go.mod h1:Bh2zD801zEN90MIFv78HF1d3c/RpG/GD18wQrbdeN+0=
+github.com/blinklabs-io/plutigo v0.0.3 h1:t5ujYD+1uCFy/JPu04dZEyN5Wfzhp4KsOTQabkRSPng=
+github.com/blinklabs-io/plutigo v0.0.3/go.mod h1:49P8jixVWblHzdYdiFmnPPCTDd8SxZ6IvlfRBQRIldQ=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
+	"math/big"
 	"sync"
 	"time"
 
@@ -141,43 +141,12 @@ func (ls *LedgerState) Start() error {
 	if err := ls.createGenesisBlock(); err != nil {
 		return fmt.Errorf("failed to create genesis block: %w", err)
 	}
-	// Initialize timer with current slot length
-	if ls.currentEpoch.SlotLength > 0 {
-		slotLength := float64(ls.currentEpoch.SlotLength)
-		if slotLength <= 0 {
-			return fmt.Errorf("SlotLength must be greater than 0, got %.3f", slotLength)
-		}
-		durationNs := slotLength * float64(time.Second)
-		if durationNs > float64(math.MaxInt64) {
-			return fmt.Errorf("SlotLength %.3f too large; overflows time.Duration", slotLength)
-		}
-
-		interval := time.Duration(durationNs)
-		ls.Scheduler = NewScheduler(interval)
-		ls.Scheduler.Start()
-
-		// Schedule block forging if dev mode is enabled
-		if ls.config.ForgeBlocks {
-			// Calculate block interval from ActiveSlotsCoeff
-			shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
-			if shelleyGenesis != nil {
-				// Calculate block interval (1 / ActiveSlotsCoeff)
-				activeSlotsCoeff := shelleyGenesis.ActiveSlotsCoeff
-				if activeSlotsCoeff.Rat != nil && activeSlotsCoeff.Rat.Num().Int64() > 0 {
-					blockInterval := int((1 * activeSlotsCoeff.Rat.Denom().Int64()) / activeSlotsCoeff.Rat.Num().Int64())
-					// Scheduled forgeBlock to run at the calculated block interval
-					ls.Scheduler.Register(blockInterval, ls.forgeBlock)
-
-					ls.config.Logger.Info(
-						"dev mode block forging enabled",
-						"component", "ledger",
-						"block_interval", blockInterval,
-						"active_slots_coeff", activeSlotsCoeff.String(),
-					)
-				}
-			}
-		}
+	// Initialize scheduler
+	if err := ls.initScheduler(); err != nil {
+		return fmt.Errorf("initialize scheduler: %w", err)
 	}
+	// Schedule block forging
+	ls.initForge()
 	// Start goroutine to process new blocks
 	go ls.ledgerProcessBlocks()
 	return nil
@@ -210,6 +179,56 @@ func (ls *LedgerState) Chain() *chain.Chain {
 
 func (ls *LedgerState) Close() error {
 	return ls.db.Close()
+}
+
+func (ls *LedgerState) initScheduler() error {
+	// Initialize timer with current slot length
+	slotLength := ls.currentEpoch.SlotLength
+	if slotLength == 0 {
+		shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+		if shelleyGenesis == nil {
+			return errors.New("could not get genesis config")
+		}
+		slotLength = uint(
+			new(big.Int).Div(
+				new(big.Int).Mul(
+					big.NewInt(1000),
+					shelleyGenesis.SlotLength.Num(),
+				),
+				shelleyGenesis.SlotLength.Denom(),
+			).Uint64(),
+		)
+	}
+	// nolint:gosec
+	// Slot length is small enough to not overflow int64
+	interval := time.Duration(slotLength) * time.Millisecond
+	ls.Scheduler = NewScheduler(interval)
+	ls.Scheduler.Start()
+	return nil
+}
+
+func (ls *LedgerState) initForge() {
+	// Schedule block forging if dev mode is enabled
+	if ls.config.ForgeBlocks {
+		// Calculate block interval from ActiveSlotsCoeff
+		shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+		if shelleyGenesis != nil {
+			// Calculate block interval (1 / ActiveSlotsCoeff)
+			activeSlotsCoeff := shelleyGenesis.ActiveSlotsCoeff
+			if activeSlotsCoeff.Rat != nil && activeSlotsCoeff.Rat.Num().Int64() > 0 {
+				blockInterval := int((1 * activeSlotsCoeff.Rat.Denom().Int64()) / activeSlotsCoeff.Rat.Num().Int64())
+				// Scheduled forgeBlock to run at the calculated block interval
+				ls.Scheduler.Register(blockInterval, ls.forgeBlock)
+
+				ls.config.Logger.Info(
+					"dev mode block forging enabled",
+					"component", "ledger",
+					"block_interval", blockInterval,
+					"active_slots_coeff", activeSlotsCoeff.String(),
+				)
+			}
+		}
+	}
 }
 
 func (ls *LedgerState) scheduleCleanupConsumedUtxos() {


### PR DESCRIPTION
When we don't have information about the current epoch, use the Shelley genesis slot length for calculating things like time-to-slot and the scheduler interval