### PR TITLE
feat: Add TXs to forged blocks and add to chain

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1066,7 +1066,7 @@ func (ls *LedgerState) forgeBlock() {
 						// Check MaxBlockSize limit and added afe conversion to prevent integer overflow
 						var totalBlockSize uint
 						if blockSize >= 0 && txSize >= 0 {
-							// Check if addition would overflow by comparing with max int
+							// Check for overflow by comparing with max int
 							maxInt := 1<<31 - 1
 							if blockSize <= maxInt && txSize <= maxInt && blockSize+txSize <= maxInt {
 								totalBlockSize = uint(blockSize + txSize)

--- a/node.go
+++ b/node.go
@@ -157,6 +157,8 @@ func (n *Node) Run() error {
 		LedgerState:     n.ledgerState,
 	},
 	)
+	// Set mempool in ledger state for block forging
+	n.ledgerState.SetMempool(n.mempool)
 	// Initialize chainsync state
 	n.chainsyncState = chainsync.NewState(
 		n.eventBus,


### PR DESCRIPTION
Implemented accessing of mempool transactionsin forgeBlock such a way that we decoded them into full ConwayTransaction structures, and populate blocks until hitting any of the configured protocol parameter limits (MaxTxSize, MaxBlockBodySize, MaxBlockExUnits).
Created Conway transaction structures from mempool transaction and added them to form a block.
Added comprehensive protocol parameter validation with proper limit checking for transaction size, block size, and execution units.
After adding transactions to conway block, I have created the ledger block from the conway block and added the created block to the primary chain.
Included the mempool transactions in ledger state by using SetMempool function.

Closes #810 