### PR TITLE
fix: adjust genesis block condition

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -212,7 +212,7 @@ func (ls *LedgerState) processBlockEvents() error {
 }
 
 func (ls *LedgerState) createGenesisBlock() error {
-	if ls.currentEpoch.SlotLength > 0 {
+	if ls.currentTip.Point.Slot > 0 {
 		return nil
 	}
 	txn := ls.db.Transaction(true)


### PR DESCRIPTION
We accidentially broke this when adding pre-population of the initial epoch