### PR TITLE
refactor: prevent concurrent runs of same task in scheduler

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -224,7 +224,8 @@ func (ls *LedgerState) initForge() {
 			if activeSlotsCoeff.Rat != nil && activeSlotsCoeff.Rat.Num().Int64() > 0 {
 				blockInterval := int((1 * activeSlotsCoeff.Rat.Denom().Int64()) / activeSlotsCoeff.Rat.Num().Int64())
 				// Scheduled forgeBlock to run at the calculated block interval
-				ls.Scheduler.Register(blockInterval, ls.forgeBlock)
+				// TODO: add callback to capture task run failure and increment "missed slot leader check" metric
+				ls.Scheduler.Register(blockInterval, ls.forgeBlock, nil)
 
 				ls.config.Logger.Info(
 					"dev mode block forging enabled",


### PR DESCRIPTION
This adds a lock to each scheduler task to prevent concurrent runs. It also adds a mechanism for providing a notification when a task fails to run because the previous instance is still running

Fixes #824