### PR TITLE
fix: change default historical validation threshold

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ var globalConfig = &Config{
 	TlsCertFilePath:          "",
 	TlsKeyFilePath:           "",
 	DevMode:                  false,
-	LedgerValidateHistorical: "14d",
+	LedgerValidateHistorical: "12h",
 }
 
 func LoadConfig(configFile string) (*Config, error) {


### PR DESCRIPTION
The default couldn't be parsed by time.Duration