### PR TITLE
feat(database): use grpc for gcs and disable telemetry

### DIFF
--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -71,7 +71,7 @@ func New(
 		return nil, errors.New("gcs blob: bucket not set (expected dataDir='gcs://<bucket>')")
 	}
 
-	client, err := storage.NewClient(ctx)
+	client, err := storage.NewGRPCClient(ctx, storage.WithDisabledClientMetrics())
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("gcs blob: failed in creating storage client: %w", err)


### PR DESCRIPTION
Using gRPC provides a more compact data transfer and allows the client to use direct connectivity when running on Google Cloud. Disabling the client side metrics reduces the permissions required and prevents pushing telemetry to Google Cloud Monitoring.