### PR TITLE
fix(chain): off-by-one error in reconcile to primary chain

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -472,7 +472,8 @@ func (c *Chain) reconcile() error {
 	primaryChain := c.manager.PrimaryChain()
 	for i := len(c.blocks) - 1; i >= 0; i-- {
 		tmpBlock, err := primaryChain.blockByIndex(
-			c.lastCommonBlockIndex+uint64(i),
+			// Add 1 to prevent off-by-one error
+			c.lastCommonBlockIndex+uint64(i)+1,
 			nil,
 		)
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block synchronization during chain reconciliation to correctly calculate block position offsets, ensuring accurate block comparison and proper chain state alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->