### PR TITLE
fix: use cut vs has/trim on string prefix check

### DIFF
--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -63,8 +63,8 @@ func New(
 
 	const prefix = "gcs://"
 	var bucketName string
-	if strings.HasPrefix(dataDir, prefix) {
-		bucketName = strings.TrimPrefix(dataDir, prefix)
+	if after, ok := strings.CutPrefix(dataDir, prefix); ok {
+		bucketName = after
 	}
 	if bucketName == "" {
 		cancel()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code efficiency for extracting bucket configuration from data directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->