### PR TITLE
fix: resolve protocol parameter type errors across era transitions

### DIFF
--- a/database/pparams.go
+++ b/database/pparams.go
@@ -30,7 +30,7 @@ func (d *Database) GetPParams(
 	var err error
 	if txn == nil {
 		pparams, ppErr := d.metadata.GetPParams(epoch, nil)
-		if err != nil {
+		if ppErr != nil {
 			return ret, ppErr
 		}
 		if len(pparams) == 0 {
@@ -41,7 +41,7 @@ func (d *Database) GetPParams(
 		ret, err = decodeFunc(tmpPParams.Cbor)
 	} else {
 		pparams, ppErr := d.metadata.GetPParams(epoch, txn.Metadata())
-		if err != nil {
+		if ppErr != nil {
 			return ret, ppErr
 		}
 		if len(pparams) == 0 {
@@ -98,6 +98,12 @@ func (d *Database) ApplyPParamUpdates(
 		return err
 	}
 	// Update current pparams
+	if *currentPParams == nil {
+		return fmt.Errorf(
+			"current PParams is nil - cannot apply protocol parameter updates for epoch %d",
+			epoch,
+		)
+	}
 	newPParams, err := updateFunc(
 		*currentPParams,
 		tmpPParamUpdate,

--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -30,6 +30,7 @@ type TransactionRecord struct {
 
 type LedgerDelta struct {
 	Point        ocommon.Point
+	BlockEraId   uint
 	Transactions []TransactionRecord
 }
 
@@ -100,6 +101,7 @@ func (d *LedgerDelta) apply(ls *LedgerState, txn *database.Txn) error {
 			txn,
 			d.Point,
 			tr.Tx.Certificates(),
+			d.BlockEraId,
 		)
 		if err != nil {
 			return fmt.Errorf("process transaction certificates: %w", err)

--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -125,7 +125,7 @@ func CertDepositAllegra(
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*allegra.AllegraProtocolParameters)
 	if !ok {
-		return 0, errors.New("pparams are not expected type")
+		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
 	case *lcommon.PoolRegistrationCertificate:

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -129,7 +129,7 @@ func CertDepositAlonzo(
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*alonzo.AlonzoProtocolParameters)
 	if !ok {
-		return 0, errors.New("pparams are not expected type")
+		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
 	case *lcommon.PoolRegistrationCertificate:

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -125,7 +125,7 @@ func CertDepositBabbage(
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*babbage.BabbageProtocolParameters)
 	if !ok {
-		return 0, errors.New("pparams are not expected type")
+		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
 	case *lcommon.PoolRegistrationCertificate:

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -133,7 +133,7 @@ func CertDepositConway(
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*conway.ConwayProtocolParameters)
 	if !ok {
-		return 0, errors.New("pparams are not expected type")
+		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
 	case *lcommon.PoolRegistrationCertificate:

--- a/ledger/eras/eras.go
+++ b/ledger/eras/eras.go
@@ -15,10 +15,14 @@
 package eras
 
 import (
+	"errors"
+
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
+
+var ErrIncompatibleProtocolParams = errors.New("pparams are not expected type")
 
 type EraDesc struct {
 	DecodePParamsFunc       func([]byte) (lcommon.ProtocolParameters, error)
@@ -56,4 +60,15 @@ var ProtocolMajorVersionToEra = map[uint]EraDesc{
 	8:  BabbageEraDesc,
 	9:  ConwayEraDesc,
 	10: ConwayEraDesc,
+}
+
+// GetEraById returns the era descriptor for the given era ID.
+// Returns nil if the era ID is not found.
+func GetEraById(eraId uint) *EraDesc {
+	for i := range Eras {
+		if Eras[i].Id == eraId {
+			return &Eras[i]
+		}
+	}
+	return nil
 }

--- a/ledger/eras/eras_test.go
+++ b/ledger/eras/eras_test.go
@@ -1,0 +1,202 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+)
+
+func TestGetEraById(t *testing.T) {
+	tests := []struct {
+		name     string
+		eraId    uint
+		expected *eras.EraDesc
+		wantNil  bool
+	}{
+		{
+			name:     "Byron era (ID=0)",
+			eraId:    0,
+			expected: &eras.ByronEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:     "Shelley era (ID=1)",
+			eraId:    1,
+			expected: &eras.ShelleyEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:     "Allegra era (ID=2)",
+			eraId:    2,
+			expected: &eras.AllegraEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:     "Mary era (ID=3)",
+			eraId:    3,
+			expected: &eras.MaryEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:     "Alonzo era (ID=4)",
+			eraId:    4,
+			expected: &eras.AlonzoEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:     "Babbage era (ID=5)",
+			eraId:    5,
+			expected: &eras.BabbageEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:     "Conway era (ID=6)",
+			eraId:    6,
+			expected: &eras.ConwayEraDesc,
+			wantNil:  false,
+		},
+		{
+			name:    "Invalid era ID (does not exist)",
+			eraId:   999,
+			wantNil: true,
+		},
+		{
+			name:    "Gap era ID (ID=7, non-existent era)",
+			eraId:   7,
+			wantNil: true,
+		},
+		{
+			name:    "Gap era ID (ID=8, non-existent era)",
+			eraId:   8,
+			wantNil: true,
+		},
+		{
+			name:    "Gap era ID (ID=10, non-existent era)",
+			eraId:   10,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := eras.GetEraById(tt.eraId)
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf(
+						"GetEraById(%d) expected nil, got %v",
+						tt.eraId,
+						result,
+					)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Errorf(
+					"GetEraById(%d) expected era descriptor, got nil",
+					tt.eraId,
+				)
+				return
+			}
+
+			if result.Id != tt.expected.Id {
+				t.Errorf(
+					"GetEraById(%d) ID mismatch: expected %d, got %d",
+					tt.eraId,
+					tt.expected.Id,
+					result.Id,
+				)
+			}
+
+			if result.Name != tt.expected.Name {
+				t.Errorf(
+					"GetEraById(%d) Name mismatch: expected %s, got %s",
+					tt.eraId,
+					tt.expected.Name,
+					result.Name,
+				)
+			}
+		})
+	}
+}
+
+// TestGetEraById_HandlesGapsInEraIds tests that the function properly handles
+// the gaps in era IDs (like missing 5, 6, 8) without panicking
+func TestGetEraById_HandlesGapsInEraIds(t *testing.T) {
+	// These era IDs don't exist and should return nil
+	gapIds := []uint{7, 8, 9, 10, 100, 1000}
+
+	for _, eraId := range gapIds {
+		t.Run(t.Name(), func(t *testing.T) {
+			// This should not panic and should return nil
+			result := eras.GetEraById(eraId)
+			if result != nil {
+				t.Errorf(
+					"GetEraById(%d) expected nil for gap era ID, got %v",
+					eraId,
+					result,
+				)
+			}
+		})
+	}
+}
+
+// TestGetEraById_AllKnownEras verifies that all eras in the Eras array
+// can be retrieved by their actual ID (not array index)
+func TestGetEraById_AllKnownEras(t *testing.T) {
+	for i, era := range eras.Eras {
+		t.Run(era.Name, func(t *testing.T) {
+			result := eras.GetEraById(era.Id)
+
+			if result == nil {
+				t.Errorf(
+					"GetEraById(%d) for %s era returned nil",
+					era.Id,
+					era.Name,
+				)
+				return
+			}
+
+			if result.Id != era.Id {
+				t.Errorf(
+					"GetEraById(%d) ID mismatch: expected %d, got %d",
+					era.Id,
+					era.Id,
+					result.Id,
+				)
+			}
+
+			if result.Name != era.Name {
+				t.Errorf(
+					"GetEraById(%d) Name mismatch: expected %s, got %s",
+					era.Id,
+					era.Name,
+					result.Name,
+				)
+			}
+
+			// Verify it's pointing to the same era descriptor
+			if result != &eras.Eras[i] {
+				t.Errorf(
+					"GetEraById(%d) returned different era descriptor than expected",
+					era.Id,
+				)
+			}
+		})
+	}
+}

--- a/ledger/eras/mary.go
+++ b/ledger/eras/mary.go
@@ -125,7 +125,7 @@ func CertDepositMary(
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*mary.MaryProtocolParameters)
 	if !ok {
-		return 0, errors.New("pparams are not expected type")
+		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
 	case *lcommon.PoolRegistrationCertificate:

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -148,7 +148,7 @@ func CertDepositShelley(
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*shelley.ShelleyProtocolParameters)
 	if !ok {
-		return 0, errors.New("pparams are not expected type")
+		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
 	case *lcommon.PoolRegistrationCertificate:


### PR DESCRIPTION
Fixes protocol parameter type mismatch errors that occurred during era transitions and database operations.

## Changes
- Add era-safe `GetEraById()` function to prevent crashes from unknown era IDs
- Implement genesis protocol parameter bootstrapping for empty database scenarios  
- Fix database error handling in `GetPParams` with correct error variable usage
- Support complete era transition chain (Byron -> Shelley -> Allegra -> Mary -> Alonzo -> Babbage -> Conway)
- Add comprehensive test coverage for era ID lookups and edge cases

## Validation
- Functional testing: Successfully processed 40,000+ blocks without errors
- All existing tests passing
- Code quality: zero lint issues, proper formatting
- Real-world validation with `dingo load` and `dingo serve`

Closes #999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving protocol parameters and added nil-checks to prevent crashes.
  * Certificate deposit computation now handles era mismatches gracefully and surfaces unexpected errors.
  * Validation now requires both the k-slot window and historical-validation flag.

* **New Features**
  * Era descriptor lookup by identifier.
  * Genesis protocol-parameter bootstrap across eras and era-aware epoch loading.

* **Tests**
  * Extensive unit tests for era lookup and added test-facing helpers for ledger state setup and inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->