### PR TITLE
feat: embed preview network configs in binary

### DIFF
--- a/config/cardano/embed.go
+++ b/config/cardano/embed.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import "embed"
+
+// EmbeddedConfigPreviewNetworkFS contains the embedded Cardano configuration files
+// for the preview network. This includes config.json and all genesis files required
+// for preview network operation when no external config files are available.
+//
+//go:embed preview
+var EmbeddedConfigPreviewNetworkFS embed.FS

--- a/config/cardano/embed_test.go
+++ b/config/cardano/embed_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"testing"
+)
+
+func TestNewCardanoNodeConfigFromEmbedFS(t *testing.T) {
+	// Test loading config from embedded filesystem
+	cfg, err := NewCardanoNodeConfigFromEmbedFS(
+		EmbeddedConfigPreviewNetworkFS,
+		"preview/config.json",
+	)
+	if err != nil {
+		t.Fatalf("failed to load cardano config from embedded FS: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+
+	// Verify that the config has expected values
+	if cfg.ShelleyGenesisFile == "" {
+		t.Error("expected ShelleyGenesisFile to be set")
+	}
+
+	if cfg.ByronGenesisFile == "" {
+		t.Error("expected ByronGenesisFile to be set")
+	}
+
+	// Verify genesis configs were actually loaded
+	if cfg.ShelleyGenesis() == nil {
+		t.Error("expected ShelleyGenesis to be loaded")
+	}
+
+	if cfg.ByronGenesis() == nil {
+		t.Error("expected ByronGenesis to be loaded")
+	}
+}
+
+func TestNewCardanoNodeConfigFromEmbedFS_InvalidPath(t *testing.T) {
+	// Test loading config from embedded filesystem with invalid path
+	_, err := NewCardanoNodeConfigFromEmbedFS(
+		EmbeddedConfigPreviewNetworkFS,
+		"nonexistent/config.json",
+	)
+	if err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+}
+
+func TestEmbedFS_ListFiles(t *testing.T) {
+	// Test that embedded FS contains expected files in preview directory
+	previewEntries, err := EmbeddedConfigPreviewNetworkFS.ReadDir("preview")
+	if err != nil {
+		t.Fatalf("failed to read preview directory: %v", err)
+	}
+
+	if len(previewEntries) == 0 {
+		t.Fatal("expected preview directory to contain files")
+	}
+
+	expectedFiles := []string{
+		"config.json",
+		"byron-genesis.json",
+		"shelley-genesis.json",
+		"alonzo-genesis.json",
+		"conway-genesis.json",
+	}
+	foundFiles := make(map[string]bool)
+
+	for _, entry := range previewEntries {
+		foundFiles[entry.Name()] = true
+	}
+
+	for _, expectedFile := range expectedFiles {
+		if !foundFiles[expectedFile] {
+			t.Errorf("expected to find %s in preview directory", expectedFile)
+		}
+	}
+}

--- a/config/cardano/loadhelper.go
+++ b/config/cardano/loadhelper.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"embed"
+	"fmt"
+	"os"
+)
+
+// LoadCardanoNodeConfigWithFallback tries to load config from file, then falls back to embed FS for preview network.
+func LoadCardanoNodeConfigWithFallback(
+	cfgPath, network string,
+	embedFS embed.FS,
+) (*CardanoNodeConfig, error) {
+	_, err := os.Stat(cfgPath)
+	if err == nil {
+		return NewCardanoNodeConfigFromFile(cfgPath)
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf(
+			"failed to check config file %q: %w",
+			cfgPath,
+			err,
+		)
+	}
+
+	// File doesn't exist, try embedded config for preview network
+	if network == "preview" {
+		return NewCardanoNodeConfigFromEmbedFS(embedFS, cfgPath)
+	}
+	return nil, fmt.Errorf(
+		"config file %q not found and no embedded config available for network %q",
+		cfgPath,
+		network,
+	)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ var globalConfig = &Config{
 	BadgerCacheSize:    1073741824,
 	MempoolCapacity:    1048576,
 	BindAddr:           "0.0.0.0",
-	CardanoConfig:      "./config/cardano/preview/config.json",
+	CardanoConfig:      "", // Will be set dynamically based on network
 	DatabasePath:       ".dingo",
 	SocketPath:         "dingo.socket",
 	IntersectTip:       false,
@@ -103,6 +103,7 @@ func LoadConfig(configFile string) (*Config, error) {
 			}
 		}
 	}
+
 	if configFile != "" {
 		buf, err := os.ReadFile(configFile)
 		if err != nil {
@@ -113,9 +114,19 @@ func LoadConfig(configFile string) (*Config, error) {
 			return nil, fmt.Errorf("error parsing config file: %w", err)
 		}
 	}
+	// Process environment variables
 	err := envconfig.Process("cardano", globalConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error processing environment: %+w", err)
+	}
+
+	// Set default CardanoConfig path based on network if not provided by user
+	if globalConfig.CardanoConfig == "" {
+		if globalConfig.Network == "preview" {
+			globalConfig.CardanoConfig = "preview/config.json"
+		} else {
+			globalConfig.CardanoConfig = "/opt/cardano/" + globalConfig.Network + "/config.json"
+		}
 	}
 
 	_, err = LoadTopologyConfig()

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -34,11 +34,15 @@ import (
 func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 	var nodeCfg *cardano.CardanoNodeConfig
 	if cfg.CardanoConfig != "" {
-		tmpCfg, err := cardano.NewCardanoNodeConfigFromFile(cfg.CardanoConfig)
+		var err error
+		nodeCfg, err = cardano.LoadCardanoNodeConfigWithFallback(
+			cfg.CardanoConfig,
+			cfg.Network,
+			cardano.EmbeddedConfigPreviewNetworkFS,
+		)
 		if err != nil {
 			return err
 		}
-		nodeCfg = tmpCfg
 		logger.Debug(
 			fmt.Sprintf(
 				"cardano network config: %+v",

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -44,11 +44,15 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	}
 	var nodeCfg *cardano.CardanoNodeConfig
 	if cfg.CardanoConfig != "" {
-		tmpCfg, err := cardano.NewCardanoNodeConfigFromFile(cfg.CardanoConfig)
+		var err error
+		nodeCfg, err = cardano.LoadCardanoNodeConfigWithFallback(
+			cfg.CardanoConfig,
+			cfg.Network,
+			cardano.EmbeddedConfigPreviewNetworkFS,
+		)
 		if err != nil {
 			return err
 		}
-		nodeCfg = tmpCfg
 		logger.Debug(
 			fmt.Sprintf(
 				"cardano network config: %+v",


### PR DESCRIPTION
Embeds preview network Cardano configs using Go `embed` package. Preview network uses embedded configs by default, other networks use `/opt/cardano` paths.

Closes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded preview network configuration and genesis assets so the app can run without external Cardano config files.
  * Added fallback loading to use embedded preview configs when filesystem configs are missing.

* **Behavior Change**
  * Default Cardano config path is now determined by network (preview uses embedded path; mainnet/devnet use system paths). Environment-based overrides are applied during config loading.

* **Tests**
  * Added tests validating embedded defaults, embedded genesis presence, fallback loading, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->