### PR TITLE
fix(database):Panic on load from immutable DB

### DIFF
--- a/database/immutable/immutable.go
+++ b/database/immutable/immutable.go
@@ -82,6 +82,13 @@ func (i *ImmutableDb) getChunkNamesFromPoint(
 	for lowerBound <= upperBound {
 		// Get chunk in the middle of the current bounds
 		middlePoint := (lowerBound + upperBound) / 2
+		if middlePoint < 0 || middlePoint >= len(chunkNames) {
+			return nil, fmt.Errorf(
+				"immutable DB: middlePoint %d out of bounds (chunkNames len=%d)",
+				middlePoint,
+				len(chunkNames),
+			)
+		}
 		middleChunkName := chunkNames[middlePoint]
 		middleSecondary, err := i.getChunkSecondaryIndex(middleChunkName)
 		if err != nil {


### PR DESCRIPTION
1. Prevents immutable DB panics by validating the binary-search index and returning a proper error instead of crashing.

Closes #914 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability by fixing a potential crash that could occur during data retrieval operations. Added validation checks to prevent out-of-bounds errors and ensure safe access to stored data under all conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->