### PR TITLE
fix(deps): upgrade github.com/blinklabs-io/gouroboros to v0.140.0

### DIFF
--- a/blockfetch.go
+++ b/blockfetch.go
@@ -38,8 +38,6 @@ func (n *Node) blockfetchClientConnOpts() []blockfetch.BlockFetchOptionFunc {
 		blockfetch.WithBatchDoneFunc(n.blockfetchClientBatchDone),
 		blockfetch.WithBatchStartTimeout(2 * time.Second),
 		blockfetch.WithBlockTimeout(2 * time.Second),
-		// Set the recv queue size to 2x our block batch size
-		blockfetch.WithRecvQueueSize(1000),
 	}
 }
 

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -66,7 +66,9 @@ func New(
 	const prefix = "s3://"
 	if !strings.HasPrefix(strings.ToLower(dataDir), prefix) {
 		cancel()
-		return nil, errors.New("s3 blob: expected dataDir='s3://<bucket>[/prefix]'")
+		return nil, errors.New(
+			"s3 blob: expected dataDir='s3://<bucket>[/prefix]'",
+		)
 	}
 
 	path := strings.TrimPrefix(strings.ToLower(dataDir), prefix)

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -268,11 +268,11 @@ func (d *MetadataStoreSqlite) SetStakeRegistrationDelegation(
 	pkh := cert.PoolKeyHash
 	tmpItem := models.StakeRegistrationDelegation{
 		StakingKey:    stakeKey,
-		PoolKeyHash:   pkh,
+		PoolKeyHash:   pkh[:],
 		AddedSlot:     slot,
 		DepositAmount: deposit,
 	}
-	if err := d.SetAccount(stakeKey, pkh, nil, slot, true, txn); err != nil {
+	if err := d.SetAccount(stakeKey, pkh[:], nil, slot, true, txn); err != nil {
 		return err
 	}
 	if txn != nil {

--- a/database/plugin/metadata/sqlite/certs.go
+++ b/database/plugin/metadata/sqlite/certs.go
@@ -45,7 +45,7 @@ func (d *MetadataStoreSqlite) GetStakeRegistrations(
 	var tmpCert lcommon.StakeRegistrationCertificate
 	for _, cert := range certs {
 		tmpCert = lcommon.StakeRegistrationCertificate{
-			CertType: lcommon.CertificateTypeStakeRegistration,
+			CertType: uint(lcommon.CertificateTypeStakeRegistration),
 			StakeCredential: lcommon.Credential{
 				// TODO: determine correct type
 				// CredType: lcommon.CredentialTypeAddrKeyHash,

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -81,7 +81,7 @@ func (d *MetadataStoreSqlite) GetPoolRegistrations(
 	for _, cert := range certs {
 		tmpMargin = lcommon.GenesisRat{Rat: cert.Margin.Rat}
 		tmpCert = lcommon.PoolRegistrationCertificate{
-			CertType: lcommon.CertificateTypePoolRegistration,
+			CertType: uint(lcommon.CertificateTypePoolRegistration),
 			Operator: lcommon.PoolKeyHash(
 				lcommon.NewBlake2b224(cert.PoolKeyHash),
 			),

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	connectrpc.com/grpcreflect v1.3.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.11
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.88.3
-	github.com/blinklabs-io/gouroboros v0.139.0
+	github.com/blinklabs-io/gouroboros v0.140.0
 	github.com/blinklabs-io/ouroboros-mock v0.3.9
 	github.com/blinklabs-io/plutigo v0.0.13
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blinklabs-io/gouroboros v0.139.0 h1:ctoHFEuXhJlMcUC1fe5x6IX1tqZnS/BAaBDeHiXskeU=
-github.com/blinklabs-io/gouroboros v0.139.0/go.mod h1:FxKQNNNRQN5F/Cl4pnW7SHhpPo7fD57mTPGo4N9ulnY=
+github.com/blinklabs-io/gouroboros v0.140.0 h1:dFK2iunkTflCI2hlDSGZJJ7JerYhpdE41HnBUVvjj9E=
+github.com/blinklabs-io/gouroboros v0.140.0/go.mod h1:FxKQNNNRQN5F/Cl4pnW7SHhpPo7fD57mTPGo4N9ulnY=
 github.com/blinklabs-io/ouroboros-mock v0.3.9 h1:UnciDccJ5tZCR1xI0BcxGZcYjJ/PS5MpnjiiGtrZ680=
 github.com/blinklabs-io/ouroboros-mock v0.3.9/go.mod h1:uTkE8/LAYL7yQSntH48Pudf5Xn+jaBWMj+9udbzYXhI=
 github.com/blinklabs-io/plutigo v0.0.13 h1:JztPigFmknQmQ3Ti1+mdTY96ihOUDh6wJ3pPnN2YYBU=

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -101,7 +101,7 @@ func (lv *LedgerView) PoolCurrentState(
 		}
 		reg := pool.Registration[latestIdx]
 		tmp := lcommon.PoolRegistrationCertificate{
-			CertType: lcommon.CertificateTypePoolRegistration,
+			CertType: uint(lcommon.CertificateTypePoolRegistration),
 			Operator: lcommon.PoolKeyHash(
 				lcommon.NewBlake2b224(pool.PoolKeyHash),
 			),


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade gouroboros to v0.140.0 and update ledger/metadata and blockfetch code to match its API/type changes. No functional behavior changes expected.

- **Dependencies**
  - Bump github.com/blinklabs-io/gouroboros to v0.140.0.

- **Refactors**
  - Cast certificate types to uint where required (stake registration, pool registration, ledger view).
  - Store PoolKeyHash as []byte when writing account metadata and update SetAccount calls accordingly.
  - Remove deprecated BlockFetch recv queue option; use library defaults.

<sup>Written for commit 9208f5f0bada4d7992fafe2bc7524738505d4790. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer release.
  * Refined type handling in database operations for more consistent data representation.
  * Removed an internal connection option to streamline client behavior.

* **Style**
  * Minor formatting cleanup in error construction for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->