### PR TITLE
fix(ledger): initialize logger before ledger state

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -108,16 +108,16 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 	if cfg.Database == nil {
 		return nil, errors.New("a Database is required")
 	}
+	if cfg.Logger == nil {
+		// Create logger to throw away logs
+		// We do this so we don't have to add guards around every log operation
+		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
 	ls := &LedgerState{
 		config:         cfg,
 		chainsyncState: InitChainsyncState,
 		db:             cfg.Database,
 		chain:          cfg.ChainManager.PrimaryChain(),
-	}
-	if cfg.Logger == nil {
-		// Create logger to throw away logs
-		// We do this so we don't have to add guards around every log operation
-		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
 	return ls, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Initialize the logger at the start of NewLedgerState so initialization code always has a valid logger. Falls back to a discard slog logger when none is provided.

- **Bug Fixes**
  - Move logger setup before LedgerState creation.
  - Prevent nil logger panics during state initialization.
  - No behavior change when a logger is provided.

<sup>Written for commit 23405e598652718d57df2a523c2a61b3e63a7771. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization sequence to ensure logger components are properly set up before use, enhancing overall system reliability and eliminating redundant setup logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->