### PR TITLE
feat(docker): add nview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache m
 FROM ghcr.io/blinklabs-io/cardano-cli:10.12.0.0-1 AS cardano-cli
 FROM ghcr.io/blinklabs-io/cardano-configs:20251014-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/mithril-client:0.12.33-1 AS mithril-client
+FROM ghcr.io/blinklabs-io/nview:0.12.0 AS nview
 FROM ghcr.io/blinklabs-io/txtop:0.13.1 AS txtop
 
 FROM debian:bookworm-slim AS dingo
@@ -40,6 +41,7 @@ COPY --from=cardano-cli /usr/local/include/ /usr/local/include/
 COPY --from=cardano-cli /usr/local/lib/ /usr/local/lib/
 COPY --from=cardano-configs /config/ /opt/cardano/config/
 COPY --from=mithril-client /bin/mithril-client /usr/local/bin/
+COPY --from=nview /bin/nview /usr/local/bin/
 COPY --from=txtop /bin/txtop /usr/local/bin/
 ENV CARDANO_NODE_BINARY=dingo
 ENV CARDANO_CONFIG=/opt/cardano/config/preview/config.json


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add nview v0.12.0 to the Docker image to provide the nview CLI alongside existing Cardano tools. The Dockerfile now pulls the nview image and copies /bin/nview to /usr/local/bin for use at runtime.

<sup>Written for commit fe8088093b6630736e80f29c893dab6c55b2e977. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to incorporate the nview binary into the distribution image through a new multi-stage build configuration.
  * The nview utility is now bundled with the final image alongside other included tools.
  * Enhanced the build pipeline consistency with existing multi-stage build stages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->