### PR TITLE
feat(blockfetch): tracking cardano-node compatible metrics

### DIFF
--- a/node.go
+++ b/node.go
@@ -32,7 +32,6 @@ import (
 )
 
 type Node struct {
-	config         Config
 	connManager    *connmanager.ConnectionManager
 	peerGov        *peergov.PeerGovernor
 	chainsyncState *chainsync.State
@@ -44,6 +43,7 @@ type Node struct {
 	utxorpc        *utxorpc.Utxorpc
 	ouroboros      *ouroborosPkg.Ouroboros
 	shutdownFuncs  []func(context.Context) error
+	config         Config
 }
 
 func New(cfg Config) (*Node, error) {
@@ -115,6 +115,7 @@ func (n *Node) Run() error {
 		PeerSharing:     n.config.peerSharing,
 		IntersectTip:    n.config.intersectTip,
 		IntersectPoints: n.config.intersectPoints,
+		PromRegistry:    n.config.promRegistry,
 	})
 	// Load state
 	state, err := ledger.NewLedgerState(


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cardano-node-compatible BlockFetch Prometheus metrics and per-connection timing to measure fetch delays and counts. Metrics are enabled only when a Prometheus registry is provided.

- **New Features**
  - Exposes Prom metrics: cardano_node_metrics_served_block_count_int, cardano_node_metrics_blockfetchclient_blockdelay_s, cardano_node_metrics_blockfetchclient_lateblocks, cardano_node_metrics_blockfetchclient_blockdelay_cdfOne, cdfThree, cdfFive.
  - Tracks start time per connection to compute block delay, update CDFs (<1s, <3s, <5s), and count late blocks (>5s).
  - Adds ConnectionId to BlockfetchEvent for better tracing.

- **Migration**
  - To enable metrics, pass a Prometheus registerer via Node config (promRegistry). If not set, behavior is unchanged and no metrics are registered.

<sup>Written for commit cbcf55353312a8144467ba579ccecd3f4a979596. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Prometheus metrics for block fetching: served block counts, per-connection fetch latencies, and latency-distribution tracking.

* **Improvements**
  * More accurate and granular block-fetch metrics with per-connection timing, latency buckets, and smoother CDF metrics.
  * Metrics initialization is now optional via a registry and cleaned up on connection close.
  * Node startup now propagates the metrics registry to components that expose metrics.

* **Bug Fixes**
  * Improved cleanup and error handling to prevent stale per-connection timing data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->