### PR TITLE
feat(network): connection manager and peer governor metrics

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,35 @@ import (
 
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	oprotocol "github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // ConnectionManagerConnClosedFunc is a function that takes a connection ID and an optional error
 type ConnectionManagerConnClosedFunc func(ouroboros.ConnectionId, error)
 
+const (
+	// metricNamePrefix is the common prefix for all connection manager metrics
+	metricNamePrefix = "cardano_node_metrics_connectionManager_"
+)
+
+type connectionInfo struct {
+	conn      *ouroboros.Connection
+	isInbound bool
+	peerAddr  string
+}
+
+type peerConnectionState struct {
+	hasIncoming bool
+	hasOutgoing bool
+}
+
 type ConnectionManager struct {
-	connections      map[ouroboros.ConnectionId]*ouroboros.Connection
+	connections      map[ouroboros.ConnectionId]*connectionInfo
 	config           ConnectionManagerConfig
 	connectionsMutex sync.Mutex
+	metrics          *connectionManagerMetrics
 }
 
 type ConnectionManagerConfig struct {
@@ -39,6 +59,16 @@ type ConnectionManagerConfig struct {
 	Listeners          []ListenerConfig
 	OutboundConnOpts   []ouroboros.ConnectionOptionFunc
 	OutboundSourcePort uint
+	PromRegistry       prometheus.Registerer
+}
+
+type connectionManagerMetrics struct {
+	incomingConns       prometheus.Gauge
+	outgoingConns       prometheus.Gauge
+	unidirectionalConns prometheus.Gauge
+	duplexConns         prometheus.Gauge
+	fullDuplexConns     prometheus.Gauge
+	prunableConns       prometheus.Gauge
 }
 
 func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
@@ -46,12 +76,109 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
 	cfg.Logger = cfg.Logger.With("component", "connmanager")
-	return &ConnectionManager{
+	c := &ConnectionManager{
 		config: cfg,
 		connections: make(
-			map[ouroboros.ConnectionId]*ouroboros.Connection,
+			map[ouroboros.ConnectionId]*connectionInfo,
 		),
 	}
+	if cfg.PromRegistry != nil {
+		c.initMetrics()
+	}
+	return c
+}
+
+func (c *ConnectionManager) initMetrics() {
+	promautoFactory := promauto.With(c.config.PromRegistry)
+	c.metrics = &connectionManagerMetrics{}
+	c.metrics.incomingConns = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: metricNamePrefix + "incomingConns",
+		Help: "number of incoming connections",
+	})
+	c.metrics.outgoingConns = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: metricNamePrefix + "outgoingConns",
+		Help: "number of outgoing connections",
+	})
+	c.metrics.unidirectionalConns = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: metricNamePrefix + "unidirectionalConns",
+			Help: "number of peers with unidirectional connections",
+		},
+	)
+	c.metrics.duplexConns = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: metricNamePrefix + "duplexConns",
+		Help: "number of peers with duplex connections",
+	})
+}
+
+func (c *ConnectionManager) updateConnectionMetrics() {
+	if c.metrics == nil {
+		return
+	}
+	c.connectionsMutex.Lock()
+	defer c.connectionsMutex.Unlock()
+
+	incomingCount := 0
+	outgoingCount := 0
+	fullDuplexCount := 0
+	prunableCount := 0
+	peerConnectivity := make(
+		map[string]*peerConnectionState,
+	) // peerAddr -> connection state
+
+	// Count connections and track peer connectivity in a single pass
+	for _, info := range c.connections {
+		if info.isInbound {
+			incomingCount++
+		} else {
+			outgoingCount++
+		}
+
+		if peerConnectivity[info.peerAddr] == nil {
+			peerConnectivity[info.peerAddr] = &peerConnectionState{}
+		}
+		if info.isInbound {
+			peerConnectivity[info.peerAddr].hasIncoming = true
+		} else {
+			peerConnectivity[info.peerAddr].hasOutgoing = true
+		}
+	}
+
+	// Count full-duplex and prunable connections
+	for _, info := range c.connections {
+		// Full-duplex: inbound connections that support bidirectional protocols
+		if info.isInbound && info.conn != nil {
+			_, versionData := info.conn.ProtocolVersion()
+			if versionData.DiffusionMode() == oprotocol.DiffusionModeInitiatorAndResponder {
+				fullDuplexCount++
+			}
+		}
+
+		// Prunable: inbound connections from peers we don't have outgoing connections to
+		// These are lower priority and candidates for pruning under resource pressure
+		if info.isInbound && peerConnectivity[info.peerAddr] != nil &&
+			!peerConnectivity[info.peerAddr].hasOutgoing {
+			prunableCount++
+		}
+	}
+
+	// Count duplex and unidirectional connections
+	duplexCount := 0
+	unidirectionalCount := 0
+	for _, state := range peerConnectivity {
+		if state.hasIncoming && state.hasOutgoing {
+			duplexCount++
+		} else if state.hasIncoming || state.hasOutgoing {
+			unidirectionalCount++
+		}
+	}
+
+	c.metrics.incomingConns.Set(float64(incomingCount))
+	c.metrics.outgoingConns.Set(float64(outgoingCount))
+	c.metrics.unidirectionalConns.Set(float64(unidirectionalCount))
+	c.metrics.duplexConns.Set(float64(duplexCount))
+	c.metrics.fullDuplexConns.Set(float64(fullDuplexCount))
+	c.metrics.prunableConns.Set(float64(prunableCount))
 }
 
 func (c *ConnectionManager) Start() error {
@@ -61,11 +188,20 @@ func (c *ConnectionManager) Start() error {
 	return nil
 }
 
-func (c *ConnectionManager) AddConnection(conn *ouroboros.Connection) {
+func (c *ConnectionManager) AddConnection(
+	conn *ouroboros.Connection,
+	isInbound bool,
+	peerAddr string,
+) {
 	connId := conn.Id()
 	c.connectionsMutex.Lock()
-	c.connections[connId] = conn
+	c.connections[connId] = &connectionInfo{
+		conn:      conn,
+		isInbound: isInbound,
+		peerAddr:  peerAddr,
+	}
 	c.connectionsMutex.Unlock()
+	c.updateConnectionMetrics()
 	go func() {
 		err := <-conn.ErrorChan()
 		// Remove connection
@@ -94,6 +230,7 @@ func (c *ConnectionManager) RemoveConnection(connId ouroboros.ConnectionId) {
 	c.connectionsMutex.Lock()
 	delete(c.connections, connId)
 	c.connectionsMutex.Unlock()
+	c.updateConnectionMetrics()
 }
 
 func (c *ConnectionManager) GetConnectionById(
@@ -101,5 +238,8 @@ func (c *ConnectionManager) GetConnectionById(
 ) *ouroboros.Connection {
 	c.connectionsMutex.Lock()
 	defer c.connectionsMutex.Unlock()
-	return c.connections[connId]
+	if info, exists := c.connections[connId]; exists {
+		return info.conn
+	}
+	return nil // nil indicates connection not found
 }

--- a/connmanager/connection_manager_test.go
+++ b/connmanager/connection_manager_test.go
@@ -109,7 +109,7 @@ func TestConnectionManagerConnError(t *testing.T) {
 		if i == testIdx {
 			expectedConnId = oConn.Id()
 		}
-		connManager.AddConnection(oConn)
+		connManager.AddConnection(oConn, false, "127.0.0.1:1234")
 		connIds = append(connIds, oConn.Id())
 	}
 	select {
@@ -167,7 +167,7 @@ func TestConnectionManagerConnClosed(t *testing.T) {
 		t.Fatalf("unexpected error when creating Ouroboros object: %s", err)
 	}
 	expectedConnId = oConn.Id()
-	connManager.AddConnection(oConn)
+	connManager.AddConnection(oConn, false, "127.0.0.1:1234")
 	time.AfterFunc(
 		1*time.Second,
 		func() {

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -121,7 +121,11 @@ func (c *ConnectionManager) startListener(l ListenerConfig) error {
 				continue
 			}
 			// Add to connection manager
-			c.AddConnection(oConn)
+			peerAddr := "unknown"
+			if conn.RemoteAddr() != nil {
+				peerAddr = conn.RemoteAddr().String()
+			}
+			c.AddConnection(oConn, true, peerAddr)
 			// Generate event
 			if c.config.EventBus != nil {
 				c.config.EventBus.Publish(

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -88,6 +88,16 @@ func (c *ConnectionManager) CreateOutboundConn(
 		"role", "client",
 		"connection_id", oConn.Id().String(),
 	)
-	c.AddConnection(oConn)
+	peerAddr := address
+	if tmpConn.RemoteAddr() != nil {
+		peerAddr = tmpConn.RemoteAddr().String()
+	}
+	c.config.Logger.Debug(
+		"outbound connection established",
+		"target_address", address,
+		"resolved_address", peerAddr,
+		"connection_id", oConn.Id().String(),
+	)
+	c.AddConnection(oConn, false, peerAddr)
 	return oConn, nil
 }

--- a/node.go
+++ b/node.go
@@ -180,6 +180,7 @@ func (n *Node) Run() error {
 			Listeners:          tmpListeners,
 			OutboundSourcePort: n.config.outboundSourcePort,
 			OutboundConnOpts:   n.ouroboros.OutboundConnOpts(),
+			PromRegistry:       n.config.promRegistry,
 		},
 	)
 	n.ouroboros.ConnManager = n.connManager
@@ -199,6 +200,7 @@ func (n *Node) Run() error {
 			EventBus:        n.eventBus,
 			ConnManager:     n.connManager,
 			DisableOutbound: n.config.devMode,
+			PromRegistry:    n.config.promRegistry,
 		},
 	)
 	n.ouroboros.PeerGov = n.peerGov

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -72,6 +72,9 @@ func (o *Ouroboros) chainsyncClientStart(connId ouroboros.ConnectionId) error {
 				intersectPoints,
 				tip.Point,
 			)
+			if o.PeerGov != nil {
+				o.PeerGov.SetPeerHotByConnId(connId)
+			}
 			return conn.ChainSync().Client.Sync(intersectPoints)
 		} else if len(o.config.IntersectPoints) > 0 {
 			// Start initial chainsync at specific point(s)
@@ -80,6 +83,9 @@ func (o *Ouroboros) chainsyncClientStart(connId ouroboros.ConnectionId) error {
 				o.config.IntersectPoints...,
 			)
 		}
+	}
+	if o.PeerGov != nil {
+		o.PeerGov.SetPeerHotByConnId(connId)
 	}
 	return conn.ChainSync().Client.Sync(intersectPoints)
 }

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -33,12 +33,21 @@ const (
 	PeerSourceInboundConn           = 6
 )
 
+type PeerState uint16
+
+const (
+	PeerStateCold PeerState = iota
+	PeerStateWarm
+	PeerStateHot
+)
+
 type Peer struct {
 	Connection     *PeerConnection
 	Address        string
 	ReconnectCount int
 	ReconnectDelay time.Duration
 	Source         PeerSource
+	State          PeerState
 	Sharable       bool
 }
 


### PR DESCRIPTION
















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus metrics for the connection manager and peer governor to track connection directions and peer states. Wires the registry through Node into ConnectionManager and PeerGovernor, and marks peers hot when ChainSync starts.

- **New Features**
  - ConnectionManager metrics: incoming, outgoing, unidirectional, duplex, full-duplex, prunable.
  - PeerGovernor metrics: cold, warm, hot, active, established, known.
  - Peer states added (cold/warm/hot) with transitions: warm on connection, hot on ChainSync start, cold on close.
  - ConnectionManager now records isInbound and peerAddr to compute directional metrics.
  - PromRegistry plumbed through Node into ConnectionManager and PeerGovernor.

- **Migration**
  - To enable metrics, pass a PromRegistry in Node config.
  - If calling ConnectionManager.AddConnection directly, update calls to include isInbound and peerAddr.

<sup>Written for commit 2902b4313052858f4a756fb9d26b9bf35e56ccb0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for connections and peers
  * Introduced peer state tiers (Cold, Warm, Hot)

* **Improvements**
  * Enhanced connection tracking with peer address and direction
  * More robust connection lifecycle handling with events and callbacks
  * Peers are now marked hotter during chain synchronization, improving governance visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->