### PR TITLE
fix: guard against nil cert deposits

### DIFF
--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -80,7 +80,7 @@ func (d *LedgerDelta) apply(ls *LedgerState, txn *database.Txn) error {
 
 		// Calculate certificate deposits
 		certs := tr.Tx.Certificates()
-		certDeposits := make(map[int]uint64)
+		certDeposits := make(map[int]uint64, len(certs))
 		for i, cert := range certs {
 			deposit, err := ls.calculateCertificateDeposit(cert, d.BlockEraId)
 			if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Guarded transaction processing against nil certificate deposit maps to prevent errors when deposits are absent. Also pre-sized the deposit map to the number of certificates for safer and slightly faster handling.

- **Bug Fixes**
  - Skip certificate processing when certDeposits is nil.
  - Fail fast on unsupported certificate types for clearer errors.

- **Performance**
  - Pre-sized certDeposits map with len(certs) to avoid extra allocations.

<sup>Written for commit aecf39304cf6fbc04ba7584e4d579a6f49476a03. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unsupported certificate types with explicit failure notifications.
  * Enhanced null-check validation during transaction processing.

* **Performance**
  * Optimized memory allocation for certificate processing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->