### PR TITLE
refactor: complete certificate deposit handling

### DIFF
--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -128,7 +128,7 @@ type MetadataStore interface {
 		lcommon.Transaction,
 		ocommon.Point,
 		uint32, // idx
-		map[int]uint64, // certDeposits
+		map[int]uint64, // certDeposits: indexed by certificate position in tx.Certificates(); absent keys are treated as zero/no deposit
 		*gorm.DB,
 	) error
 

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -220,7 +220,8 @@ func (p *PeerGovernor) LoadTopologyConfig(
 			if existingPeerIdx >= 0 {
 				existingPeer := p.peers[existingPeerIdx]
 				// Preserve active inbound connection state
-				if existingPeer.Source == PeerSourceInboundConn && existingPeer.Connection != nil {
+				if existingPeer.Source == PeerSourceInboundConn &&
+					existingPeer.Connection != nil {
 					tmpPeer.Connection = existingPeer.Connection
 					tmpPeer.State = existingPeer.State
 					tmpPeer.ReconnectCount = existingPeer.ReconnectCount
@@ -228,7 +229,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 					tmpPeer.Sharable = existingPeer.Sharable
 				}
 				// Remove the existing peer
-				p.peers = append(p.peers[:existingPeerIdx], p.peers[existingPeerIdx+1:]...)
+				p.peers = append(
+					p.peers[:existingPeerIdx],
+					p.peers[existingPeerIdx+1:]...)
 			}
 			p.peers = append(p.peers, tmpPeer)
 		}
@@ -257,7 +260,8 @@ func (p *PeerGovernor) LoadTopologyConfig(
 			if existingPeerIdx >= 0 {
 				existingPeer := p.peers[existingPeerIdx]
 				// Preserve active inbound connection state
-				if existingPeer.Source == PeerSourceInboundConn && existingPeer.Connection != nil {
+				if existingPeer.Source == PeerSourceInboundConn &&
+					existingPeer.Connection != nil {
 					tmpPeer.Connection = existingPeer.Connection
 					tmpPeer.State = existingPeer.State
 					tmpPeer.ReconnectCount = existingPeer.ReconnectCount
@@ -265,7 +269,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 					tmpPeer.Sharable = existingPeer.Sharable
 				}
 				// Remove the existing peer
-				p.peers = append(p.peers[:existingPeerIdx], p.peers[existingPeerIdx+1:]...)
+				p.peers = append(
+					p.peers[:existingPeerIdx],
+					p.peers[existingPeerIdx+1:]...)
 			}
 			p.peers = append(p.peers, tmpPeer)
 		}


### PR DESCRIPTION
- Strengthen deposit handling contract with required certDeposits map
- Add missing certificates for Conway era deposit requirements
- Standardize CertificateID assignment to uint(i) across all certificate types
- Add helper functions:
  - certRequiresDeposit
  - getOrCreateAccount
  - saveAccountIfNew
  - saveCertRecord
- Clarify certDeposits parameter documentation in store interface



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes deposit handling across all stake and governance certificates and consolidates certificate processing in the metadata store. Standardizes CertificateID to the certificate index and adds small helpers to reduce duplication.

- **Refactors**
  - Use certDeposits map keyed by certificate index; warn when missing for deposit-bearing types.
  - Add deposit support for Conway certificates: Registration, RegistrationDrep, StakeVoteRegistrationDelegation, VoteRegistrationDelegation.
  - Introduce helpers: certRequiresDeposit, getOrCreateAccount, saveAccountIfNew, saveCertRecord.
  - Unify CertificateID = uint(i) across records and simplify account save paths.
  - Minor cleanup in peer topology loading to preserve inbound connection state when replacing peers.

- **Migration**
  - Pass certDeposits with entries for each deposit-bearing certificate (by index in tx.Certificates()); absent keys are treated as zero.
  - If you relied on CertificateID being an account ID, update usage to the certificate index.

<sup>Written for commit 5a2ef412cb6a491a96efdb0f2c4092574f7871f9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized certificate processing and account handling, improving reliability and consistency of deposit handling and record persistence.
  * Replaced duplicated persistence logic with helper-driven flows and preserved error context for clearer failure reporting.

* **Documentation**
  * Clarified parameter documentation to explain certificate-indexed deposit mapping and default-zero behavior.

* **Style**
  * Minor formatting improvements for readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->