### PR TITLE
fix(connmanager): register missing metrics

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -109,6 +109,14 @@ func (c *ConnectionManager) initMetrics() {
 		Name: metricNamePrefix + "duplexConns",
 		Help: "number of peers with duplex connections",
 	})
+	c.metrics.fullDuplexConns = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: metricNamePrefix + "fullDuplexConns",
+		Help: "number of full-duplex connections",
+	})
+	c.metrics.prunableConns = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: metricNamePrefix + "prunableConns",
+		Help: "number of prunable connections",
+	})
 }
 
 func (c *ConnectionManager) updateConnectionMetrics() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Registers missing Prometheus gauges for full-duplex and prunable connections, so these metrics are exposed and updated correctly. Fixes an issue where these metrics were never created during init, causing no data and potential update errors.

- **Bug Fixes**
  - Register gauges: fullDuplexConns and prunableConns in initMetrics.
  - Prevent nil metric updates during metric refresh.

<sup>Written for commit a6192eb33f2b4b3dca791d4a97d86ae1b5495002. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced connection manager observability with two new metrics: full-duplex connection tracking and prunable connection monitoring. These metrics enable better visibility into connection pool health and performance characteristics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->