### PR TITLE
fix(connmanager): guard against setting nil metrics

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -120,6 +120,9 @@ func (c *ConnectionManager) initMetrics() {
 }
 
 func (c *ConnectionManager) updateConnectionMetrics() {
+	if c == nil {
+		return
+	}
 	if c.metrics == nil {
 		return
 	}
@@ -181,12 +184,24 @@ func (c *ConnectionManager) updateConnectionMetrics() {
 		}
 	}
 
-	c.metrics.incomingConns.Set(float64(incomingCount))
-	c.metrics.outgoingConns.Set(float64(outgoingCount))
-	c.metrics.unidirectionalConns.Set(float64(unidirectionalCount))
-	c.metrics.duplexConns.Set(float64(duplexCount))
-	c.metrics.fullDuplexConns.Set(float64(fullDuplexCount))
-	c.metrics.prunableConns.Set(float64(prunableCount))
+	if c.metrics.incomingConns != nil {
+		c.metrics.incomingConns.Set(float64(incomingCount))
+	}
+	if c.metrics.outgoingConns != nil {
+		c.metrics.outgoingConns.Set(float64(outgoingCount))
+	}
+	if c.metrics.unidirectionalConns != nil {
+		c.metrics.unidirectionalConns.Set(float64(unidirectionalCount))
+	}
+	if c.metrics.duplexConns != nil {
+		c.metrics.duplexConns.Set(float64(duplexCount))
+	}
+	if c.metrics.fullDuplexConns != nil {
+		c.metrics.fullDuplexConns.Set(float64(fullDuplexCount))
+	}
+	if c.metrics.prunableConns != nil {
+		c.metrics.prunableConns.Set(float64(prunableCount))
+	}
 }
 
 func (c *ConnectionManager) Start() error {


### PR DESCRIPTION
This fixes the current crash on main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes in ConnectionManager by guarding against nil metrics when updating counters. We now early-return if the manager or metrics are nil, and check each gauge before calling Set, fixing the current crash on main.

<sup>Written for commit c7f61e7200c5ca17ed5680512ff3efca80b72140. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness by adding defensive nil checks to prevent potential crashes in metric update operations.
  * Improved stability when handling edge cases where metrics may not be initialized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->