### PR TITLE
fix(database): update account on conflict updates

### DIFF
--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -87,8 +87,10 @@ func (d *MetadataStoreSqlite) getOrCreateAccount(
 func saveAccountIfNew(account *models.Account, txn *gorm.DB) error {
 	if account.ID == 0 {
 		result := txn.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
-			UpdateAll: true,
+			Columns: []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"pool", "drep"},
+			),
 		}).Create(account)
 		if result.Error != nil {
 			return result.Error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix account upsert behavior to correctly update delegation fields on conflict. When inserting an account with an existing staking_key, only pool and drep are updated, avoiding unintended overwrites of other columns.

<sup>Written for commit dd111491e68083a8066c32314be844b0113c60b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database conflict handling to prevent unintended data overwrites during staking key operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->