### PR TITLE
fix(peergov): initial peers and guard against nil

### DIFF
--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -55,6 +55,7 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	cfg.Logger = cfg.Logger.With("component", "peergov")
 	return &PeerGovernor{
 		config: cfg,
+		peers:  []*Peer{},
 	}
 }
 
@@ -84,6 +85,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 	// Remove peers originally sourced from the topology
 	tmpPeers := []*Peer{}
 	for _, tmpPeer := range p.peers {
+		if tmpPeer == nil {
+			continue
+		}
 		if tmpPeer.Source == PeerSourceTopologyBootstrapPeer ||
 			tmpPeer.Source == PeerSourceTopologyLocalRoot ||
 			tmpPeer.Source == PeerSourceTopologyPublicRoot {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Initialize the peers slice in NewPeerGovernor and skip nil entries in LoadTopologyConfig. This prevents nil-pointer panics during topology cleanup and ensures a predictable empty state.

<sup>Written for commit b9770b097a6aae29328eb9a1011aa9233d5c6787. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code stability with defensive nil-safety checks to prevent potential runtime errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->