### PR TITLE
fix: interface{} and any are the same

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,15 +55,6 @@ const (
 // This is not an error condition but a successful operation that displays plugin information
 var ErrPluginListRequested = errors.New("plugin list requested")
 
-// convertToStringAnyMap converts map[string]interface{} to map[string]any for YAML compatibility
-func convertToStringAnyMap(m map[string]interface{}) map[string]any {
-	result := make(map[string]any)
-	for k, v := range m {
-		result[k] = v
-	}
-	return result
-}
-
 type tempConfig struct {
 	Config   *Config                   `yaml:"config,omitempty"`
 	Database *databaseConfig           `yaml:"database,omitempty"`
@@ -240,14 +231,14 @@ func LoadConfig(configFile string) (*Config, error) {
 					if val, ok := v.(map[string]any); ok {
 						blobConfig[k] = val
 					} else if val, ok := v.(map[any]any); ok {
-						// Convert map[any]any to map[string]interface{} then to map[string]any
-						stringInterfaceMap := make(map[string]interface{})
+						// Convert map[any]any to map[string]any
+						stringAnyMap := make(map[string]any)
 						for vk, vv := range val {
 							if keyStr, ok := vk.(string); ok {
-								stringInterfaceMap[keyStr] = vv
+								stringAnyMap[keyStr] = vv
 							}
 						}
-						blobConfig[k] = convertToStringAnyMap(stringInterfaceMap)
+						blobConfig[k] = stringAnyMap
 					} else {
 						// Log skipped non-map config entries
 						fmt.Fprintf(os.Stderr, "warning: skipping blob config entry %q: expected map, got %T\n", k, v)
@@ -275,14 +266,14 @@ func LoadConfig(configFile string) (*Config, error) {
 					if val, ok := v.(map[string]any); ok {
 						metadataConfig[k] = val
 					} else if val, ok := v.(map[any]any); ok {
-						// Convert map[any]any to map[string]interface{} then to map[string]any
-						stringInterfaceMap := make(map[string]interface{})
+						// Convert map[any]any to map[string]any
+						stringAnyMap := make(map[string]any)
 						for vk, vv := range val {
 							if keyStr, ok := vk.(string); ok {
-								stringInterfaceMap[keyStr] = vv
+								stringAnyMap[keyStr] = vv
 							}
 						}
-						metadataConfig[k] = convertToStringAnyMap(stringInterfaceMap)
+						metadataConfig[k] = stringAnyMap
 					} else {
 						// Log skipped non-map config entries
 						fmt.Fprintf(os.Stderr, "warning: skipping metadata config entry %q: expected map, got %T\n", k, v)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified YAML config map conversions by removing the unnecessary interface{} to any step. LoadConfig now converts map[any]any directly to map[string]any for blob and metadata configs, and the convertToStringAnyMap helper was removed.

<sup>Written for commit 494e94a0740f4d1b753171a68f2142d24298eefb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of configuration handling code with no impact on user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->