### PR TITLE
build(docker): fix binary versions in image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,6 +170,9 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+            COMMIT_HASH=${{ github.sha }}
       - name: Attest Docker Hub image
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0 https://github.com/actions/attest-build-provenance/releases/tag/v3.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM ghcr.io/blinklabs-io/go:1.25.4-1 AS build
 
+ARG VERSION
+ARG COMMIT_HASH
+ENV VERSION=${VERSION}
+ENV COMMIT_HASH=${COMMIT_HASH}
+
 WORKDIR /code
 RUN go env -w GOCACHE=/go-cache
 RUN go env -w GOMODCACHE=/gomod-cache

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,15 @@ BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)
 # Extract Go module name from go.mod
 GOMODULE=$(shell grep ^module $(ROOT_DIR)/go.mod | awk '{ print $$2 }')
 
-# Set version strings based on git tag and current ref
-GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(shell git describe --tags --exact-match 2>/dev/null)' -X '$(GOMODULE)/internal/version.CommitHash=$(shell git rev-parse --short HEAD)'"
+# Set version strings: use env vars if set, else git
+VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null)
+COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
+GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' -X '$(GOMODULE)/internal/version.CommitHash=$(COMMIT_HASH)'"
 
 .PHONY: all build mod-tidy clean format golines test bench test-load-profile
 
 # Default target
-all: build test bench
+all: format golines build test
 
 # Build target
 build: $(BINARIES)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure binaries in Docker images embed the correct version and commit hash. CI now injects VERSION and COMMIT_HASH during build so internal/version fields are accurate.

- **Bug Fixes**
  - publish.yml: pass VERSION (tag when present) and COMMIT_HASH (sha) as docker build-args.
  - Dockerfile: read these args and export them as ENV for the build.
  - Makefile: use VERSION/COMMIT_HASH env vars for ldflags, with git fallback, so container builds set metadata correctly.

<sup>Written for commit 4f3188f2922a3bbf26b85c7dd2b37ee36e364442. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded CI/CD pipeline to include dynamic version and commit tracking in builds.
  * Enhanced build configuration to support flexible, environment-based deployment settings.
  * Streamlined default build workflow with automated code quality checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->