### PR TITLE
build(make): remove golines from default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' 
 .PHONY: all build mod-tidy clean format golines test bench test-load-profile
 
 # Default target
-all: format golines build test
+all: format build test
 
 # Build target
 build: $(BINARIES)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed golines from the default make all target to speed up builds and avoid auto-wrapping lines by default. Run make golines manually when needed.

<sup>Written for commit 5257c1e86564dbe781148dbd42fba9bab9e52c73. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

