### PR TITLE
refactor: make methods public for _test packages

### DIFF
--- a/config/cardano/embed_test.go
+++ b/config/cardano/embed_test.go
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cardano
+package cardano_test
 
 import (
 	"testing"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
 )
 
 func TestNewCardanoNodeConfigFromEmbedFS(t *testing.T) {
 	// Test loading config from embedded filesystem
-	cfg, err := NewCardanoNodeConfigFromEmbedFS(
-		EmbeddedConfigPreviewNetworkFS,
+	cfg, err := cardano.NewCardanoNodeConfigFromEmbedFS(
+		cardano.EmbeddedConfigPreviewNetworkFS,
 		"preview/config.json",
 	)
 	if err != nil {
@@ -53,8 +55,8 @@ func TestNewCardanoNodeConfigFromEmbedFS(t *testing.T) {
 
 func TestNewCardanoNodeConfigFromEmbedFS_InvalidPath(t *testing.T) {
 	// Test loading config from embedded filesystem with invalid path
-	_, err := NewCardanoNodeConfigFromEmbedFS(
-		EmbeddedConfigPreviewNetworkFS,
+	_, err := cardano.NewCardanoNodeConfigFromEmbedFS(
+		cardano.EmbeddedConfigPreviewNetworkFS,
 		"nonexistent/config.json",
 	)
 	if err == nil {
@@ -64,7 +66,9 @@ func TestNewCardanoNodeConfigFromEmbedFS_InvalidPath(t *testing.T) {
 
 func TestEmbedFS_ListFiles(t *testing.T) {
 	// Test that embedded FS contains expected files in preview directory
-	previewEntries, err := EmbeddedConfigPreviewNetworkFS.ReadDir("preview")
+	previewEntries, err := cardano.EmbeddedConfigPreviewNetworkFS.ReadDir(
+		"preview",
+	)
 	if err != nil {
 		t.Fatalf("failed to read preview directory: %v", err)
 	}

--- a/database/benchmark_test.go
+++ b/database/benchmark_test.go
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package database_test
 
 import (
 	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
 )
 
 // BenchmarkTransactionCreate benchmarks creating a read-only transaction
 func BenchmarkTransactionCreate(b *testing.B) {
 	// Create a temporary database
-	config := &Config{
+	config := &database.Config{
 		DataDir: "", // In-memory
 	}
-	db, err := New(config)
+	db, err := database.New(config)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/database/models/account_test.go
+++ b/database/models/account_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package models
+package models_test
 
 import (
 	"bytes"
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
@@ -97,7 +98,7 @@ func TestAccount_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &Account{
+			a := &models.Account{
 				StakingKey: tt.stakingKey,
 			}
 			got, err := a.String()
@@ -174,7 +175,7 @@ func TestAccount_String_Idempotent(t *testing.T) {
 	stakingKey := hexDecode(
 		"e1cbb80db89e292d1175088b0ce5cd27857d5f1e53e41a754d566a6b",
 	)
-	a := &Account{
+	a := &models.Account{
 		StakingKey: stakingKey,
 	}
 
@@ -206,8 +207,8 @@ func TestAccount_String_DifferentKeys(t *testing.T) {
 		"a1cbb80db89e292d1175088b0ce5cd27857d5f1e53e41a754d566a6b",
 	)
 
-	a1 := &Account{StakingKey: key1}
-	a2 := &Account{StakingKey: key2}
+	a1 := &models.Account{StakingKey: key1}
+	a2 := &models.Account{StakingKey: key2}
 
 	addr1, err := a1.String()
 	if err != nil {
@@ -232,7 +233,7 @@ func TestAccount_String_Bech32Format(t *testing.T) {
 	stakingKey := hexDecode(
 		"e1cbb80db89e292d1175088b0ce5cd27857d5f1e53e41a754d566a6b",
 	)
-	a := &Account{
+	a := &models.Account{
 		StakingKey: stakingKey,
 	}
 

--- a/database/plugin/blob/aws/plugin.go
+++ b/database/plugin/blob/aws/plugin.go
@@ -21,10 +21,12 @@ import (
 )
 
 var (
-	cmdlineOptions struct {
-		bucket string
-		region string
-		prefix string
+	// CmdlineOptions holds S3 plugin options populated from command‑line flags.
+	// It is exported so tests and external wiring can configure the plugin.
+	CmdlineOptions struct {
+		Bucket string
+		Region string
+		Prefix string
 	}
 	cmdlineOptionsMutex sync.RWMutex
 )
@@ -43,21 +45,21 @@ func init() {
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "S3 bucket name",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.bucket),
+					Dest:         &(CmdlineOptions.Bucket),
 				},
 				{
 					Name:         "region",
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "AWS region",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.region),
+					Dest:         &(CmdlineOptions.Region),
 				},
 				{
 					Name:         "prefix",
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "S3 object key prefix",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.prefix),
+					Dest:         &(CmdlineOptions.Prefix),
 				},
 			},
 		},
@@ -66,9 +68,9 @@ func init() {
 
 func NewFromCmdlineOptions() plugin.Plugin {
 	cmdlineOptionsMutex.RLock()
-	bucket := cmdlineOptions.bucket
-	region := cmdlineOptions.region
-	prefix := cmdlineOptions.prefix
+	bucket := CmdlineOptions.Bucket
+	region := CmdlineOptions.Region
+	prefix := CmdlineOptions.Prefix
 	cmdlineOptionsMutex.RUnlock()
 
 	opts := []BlobStoreS3OptionFunc{

--- a/database/plugin/blob/aws/plugin_test.go
+++ b/database/plugin/blob/aws/plugin_test.go
@@ -12,25 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aws
+package aws_test
 
 import (
 	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob/aws"
 )
 
 func TestNewFromCmdlineOptions(t *testing.T) {
-	// Save original cmdlineOptions
-	originalOptions := cmdlineOptions
-	cmdlineOptions.bucket = "test-bucket"
-	cmdlineOptions.region = "us-east-1"
-	cmdlineOptions.prefix = "test-prefix"
+	// Save original aws.CmdlineOptions
+	originalOptions := aws.CmdlineOptions
+	aws.CmdlineOptions.Bucket = "test-bucket"
+	aws.CmdlineOptions.Region = "us-east-1"
+	aws.CmdlineOptions.Prefix = "test-prefix"
 
 	// This should succeed
-	plugin := NewFromCmdlineOptions()
+	plugin := aws.NewFromCmdlineOptions()
 	if plugin == nil {
 		t.Error("Expected plugin to be created, got nil")
 	}
 
 	// Restore original options
-	cmdlineOptions = originalOptions
+	aws.CmdlineOptions = originalOptions
 }

--- a/database/plugin/blob/badger/logger.go
+++ b/database/plugin/blob/badger/logger.go
@@ -22,7 +22,7 @@ import (
 
 // BadgerLogger is a wrapper type to give our logger the expected interface
 type BadgerLogger struct {
-	logger *slog.Logger
+	Logger *slog.Logger
 }
 
 func NewBadgerLogger(logger *slog.Logger) *BadgerLogger {
@@ -31,32 +31,32 @@ func NewBadgerLogger(logger *slog.Logger) *BadgerLogger {
 		// We do this so we don't have to add guards around every log operation
 		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
-	return &BadgerLogger{logger: logger}
+	return &BadgerLogger{Logger: logger}
 }
 
 func (b *BadgerLogger) Infof(msg string, args ...any) {
-	b.logger.Info(
+	b.Logger.Info(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)
 }
 
 func (b *BadgerLogger) Warningf(msg string, args ...any) {
-	b.logger.Warn(
+	b.Logger.Warn(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)
 }
 
 func (b *BadgerLogger) Debugf(msg string, args ...any) {
-	b.logger.Debug(
+	b.Logger.Debug(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)
 }
 
 func (b *BadgerLogger) Errorf(msg string, args ...any) {
-	b.logger.Error(
+	b.Logger.Error(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)

--- a/database/plugin/blob/badger/metrics.go
+++ b/database/plugin/blob/badger/metrics.go
@@ -94,5 +94,5 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			),
 		},
 	)
-	d.promRegistry.MustRegister(collector)
+	d.PromRegistry.MustRegister(collector)
 }

--- a/database/plugin/blob/badger/options.go
+++ b/database/plugin/blob/badger/options.go
@@ -25,7 +25,7 @@ type BlobStoreBadgerOptionFunc func(*BlobStoreBadger)
 // WithLogger specifies the logger object to use for logging messages
 func WithLogger(logger *slog.Logger) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
-		b.logger = logger
+		b.Logger = logger
 	}
 }
 
@@ -34,34 +34,34 @@ func WithPromRegistry(
 	registry prometheus.Registerer,
 ) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
-		b.promRegistry = registry
+		b.PromRegistry = registry
 	}
 }
 
 // WithDataDir specifies the data directory to use for storage
 func WithDataDir(dataDir string) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
-		b.dataDir = dataDir
+		b.DataDir = dataDir
 	}
 }
 
 // WithBlockCacheSize specifies the block cache size
 func WithBlockCacheSize(size uint64) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
-		b.blockCacheSize = size
+		b.BlockCacheSize = size
 	}
 }
 
 // WithIndexCacheSize specifies the index cache size
 func WithIndexCacheSize(size uint64) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
-		b.indexCacheSize = size
+		b.IndexCacheSize = size
 	}
 }
 
 // WithGc specifies whether garbage collection is enabled
 func WithGc(enabled bool) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
-		b.gcEnabled = enabled
+		b.GcEnabled = enabled
 	}
 }

--- a/database/plugin/blob/badger/options_test.go
+++ b/database/plugin/blob/badger/options_test.go
@@ -12,121 +12,122 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package badger
+package badger_test
 
 import (
 	"io"
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/plugin/blob/badger"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestWithDataDir(t *testing.T) {
-	b := &BlobStoreBadger{}
-	option := WithDataDir("/tmp/test")
+	b := &badger.BlobStoreBadger{}
+	option := badger.WithDataDir("/tmp/test")
 
 	option(b)
 
-	if b.dataDir != "/tmp/test" {
-		t.Errorf("Expected dataDir to be '/tmp/test', got '%s'", b.dataDir)
+	if b.DataDir != "/tmp/test" {
+		t.Errorf("Expected dataDir to be '/tmp/test', got '%s'", b.DataDir)
 	}
 }
 
 func TestWithBlockCacheSize(t *testing.T) {
-	b := &BlobStoreBadger{}
-	option := WithBlockCacheSize(123456789)
+	b := &badger.BlobStoreBadger{}
+	option := badger.WithBlockCacheSize(123456789)
 
 	option(b)
 
-	if b.blockCacheSize != 123456789 {
+	if b.BlockCacheSize != 123456789 {
 		t.Errorf(
 			"Expected blockCacheSize to be 123456789, got %d",
-			b.blockCacheSize,
+			b.BlockCacheSize,
 		)
 	}
 }
 
 func TestWithIndexCacheSize(t *testing.T) {
-	b := &BlobStoreBadger{}
-	option := WithIndexCacheSize(987654321)
+	b := &badger.BlobStoreBadger{}
+	option := badger.WithIndexCacheSize(987654321)
 
 	option(b)
 
-	if b.indexCacheSize != 987654321 {
+	if b.IndexCacheSize != 987654321 {
 		t.Errorf(
 			"Expected indexCacheSize to be 987654321, got %d",
-			b.indexCacheSize,
+			b.IndexCacheSize,
 		)
 	}
 }
 
 func TestWithLogger(t *testing.T) {
-	b := &BlobStoreBadger{}
+	b := &badger.BlobStoreBadger{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	option := WithLogger(logger)
+	option := badger.WithLogger(logger)
 
 	option(b)
 
-	if b.logger != logger {
+	if b.Logger != logger {
 		t.Errorf("Expected logger to be set correctly")
 	}
 }
 
 func TestWithPromRegistry(t *testing.T) {
-	b := &BlobStoreBadger{}
+	b := &badger.BlobStoreBadger{}
 	registry := prometheus.NewRegistry()
-	option := WithPromRegistry(registry)
+	option := badger.WithPromRegistry(registry)
 
 	option(b)
 
-	if b.promRegistry != registry {
+	if b.PromRegistry != registry {
 		t.Errorf("Expected promRegistry to be set correctly")
 	}
 }
 
 func TestWithGc(t *testing.T) {
-	b := &BlobStoreBadger{}
-	option := WithGc(true)
+	b := &badger.BlobStoreBadger{}
+	option := badger.WithGc(true)
 
 	option(b)
 
-	if !b.gcEnabled {
-		t.Errorf("Expected gcEnabled to be true, got %v", b.gcEnabled)
+	if !b.GcEnabled {
+		t.Errorf("Expected gcEnabled to be true, got %v", b.GcEnabled)
 	}
 
 	// Test disabling GC
-	option2 := WithGc(false)
+	option2 := badger.WithGc(false)
 	option2(b)
 
-	if b.gcEnabled {
-		t.Errorf("Expected gcEnabled to be false, got %v", b.gcEnabled)
+	if b.GcEnabled {
+		t.Errorf("Expected gcEnabled to be false, got %v", b.GcEnabled)
 	}
 }
 
 func TestOptionsCombination(t *testing.T) {
-	b := &BlobStoreBadger{}
+	b := &badger.BlobStoreBadger{}
 
 	// Apply multiple options
-	WithDataDir("/tmp/combined")(b)
-	WithBlockCacheSize(1000000)(b)
-	WithIndexCacheSize(2000000)(b)
+	badger.WithDataDir("/tmp/combined")(b)
+	badger.WithBlockCacheSize(1000000)(b)
+	badger.WithIndexCacheSize(2000000)(b)
 
-	if b.dataDir != "/tmp/combined" {
-		t.Errorf("Expected dataDir to be '/tmp/combined', got '%s'", b.dataDir)
+	if b.DataDir != "/tmp/combined" {
+		t.Errorf("Expected dataDir to be '/tmp/combined', got '%s'", b.DataDir)
 	}
 
-	if b.blockCacheSize != 1000000 {
+	if b.BlockCacheSize != 1000000 {
 		t.Errorf(
 			"Expected blockCacheSize to be 1000000, got %d",
-			b.blockCacheSize,
+			b.BlockCacheSize,
 		)
 	}
 
-	if b.indexCacheSize != 2000000 {
+	if b.IndexCacheSize != 2000000 {
 		t.Errorf(
 			"Expected indexCacheSize to be 2000000, got %d",
-			b.indexCacheSize,
+			b.IndexCacheSize,
 		)
 	}
 }

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -28,10 +28,10 @@ const (
 
 var (
 	cmdlineOptions struct {
-		dataDir        string
-		blockCacheSize uint64
-		indexCacheSize uint64
-		gcEnabled      bool
+		DataDir        string
+		BlockCacheSize uint64
+		IndexCacheSize uint64
+		GcEnabled      bool
 	}
 	cmdlineOptionsMutex sync.RWMutex
 )
@@ -40,9 +40,9 @@ var (
 func initCmdlineOptions() {
 	cmdlineOptionsMutex.Lock()
 	defer cmdlineOptionsMutex.Unlock()
-	cmdlineOptions.blockCacheSize = DefaultBlockCacheSize
-	cmdlineOptions.indexCacheSize = DefaultIndexCacheSize
-	cmdlineOptions.gcEnabled = true
+	cmdlineOptions.BlockCacheSize = DefaultBlockCacheSize
+	cmdlineOptions.IndexCacheSize = DefaultIndexCacheSize
+	cmdlineOptions.GcEnabled = true
 }
 
 // Register plugin
@@ -60,28 +60,28 @@ func init() {
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "Data directory for badger storage",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.dataDir),
+					Dest:         &(cmdlineOptions.DataDir),
 				},
 				{
 					Name:         "block-cache-size",
 					Type:         plugin.PluginOptionTypeUint,
 					Description:  "Badger block cache size",
 					DefaultValue: uint64(DefaultBlockCacheSize),
-					Dest:         &(cmdlineOptions.blockCacheSize),
+					Dest:         &(cmdlineOptions.BlockCacheSize),
 				},
 				{
 					Name:         "index-cache-size",
 					Type:         plugin.PluginOptionTypeUint,
 					Description:  "Badger index cache size",
 					DefaultValue: uint64(DefaultIndexCacheSize),
-					Dest:         &(cmdlineOptions.indexCacheSize),
+					Dest:         &(cmdlineOptions.IndexCacheSize),
 				},
 				{
 					Name:         "gc",
 					Type:         plugin.PluginOptionTypeBool,
 					Description:  "Enable garbage collection",
 					DefaultValue: true,
-					Dest:         &(cmdlineOptions.gcEnabled),
+					Dest:         &(cmdlineOptions.GcEnabled),
 				},
 			},
 		},
@@ -91,10 +91,10 @@ func init() {
 func NewFromCmdlineOptions() plugin.Plugin {
 	cmdlineOptionsMutex.RLock()
 	opts := []BlobStoreBadgerOptionFunc{
-		WithDataDir(cmdlineOptions.dataDir),
-		WithBlockCacheSize(cmdlineOptions.blockCacheSize),
-		WithIndexCacheSize(cmdlineOptions.indexCacheSize),
-		WithGc(cmdlineOptions.gcEnabled),
+		WithDataDir(cmdlineOptions.DataDir),
+		WithBlockCacheSize(cmdlineOptions.BlockCacheSize),
+		WithIndexCacheSize(cmdlineOptions.IndexCacheSize),
+		WithGc(cmdlineOptions.GcEnabled),
 	}
 	cmdlineOptionsMutex.RUnlock()
 	p, err := New(opts...)

--- a/database/plugin/blob/gcs/logger.go
+++ b/database/plugin/blob/gcs/logger.go
@@ -22,7 +22,7 @@ import (
 
 // GcsLogger is a wrapper type to give our logger a consistent interface
 type GcsLogger struct {
-	logger *slog.Logger
+	Logger *slog.Logger
 }
 
 func NewGcsLogger(logger *slog.Logger) *GcsLogger {
@@ -30,32 +30,32 @@ func NewGcsLogger(logger *slog.Logger) *GcsLogger {
 		// Create logger to throw away logs
 		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
-	return &GcsLogger{logger: logger}
+	return &GcsLogger{Logger: logger}
 }
 
 func (g *GcsLogger) Infof(msg string, args ...any) {
-	g.logger.Info(
+	g.Logger.Info(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)
 }
 
 func (g *GcsLogger) Warningf(msg string, args ...any) {
-	g.logger.Warn(
+	g.Logger.Warn(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)
 }
 
 func (g *GcsLogger) Debugf(msg string, args ...any) {
-	g.logger.Debug(
+	g.Logger.Debug(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)
 }
 
 func (g *GcsLogger) Errorf(msg string, args ...any) {
-	g.logger.Error(
+	g.Logger.Error(
 		fmt.Sprintf(msg, args...),
 		"component", "database",
 	)

--- a/database/plugin/blob/gcs/metrics.go
+++ b/database/plugin/blob/gcs/metrics.go
@@ -37,5 +37,5 @@ func (d *BlobStoreGCS) registerBlobMetrics() {
 		},
 	)
 
-	d.promRegistry.MustRegister(opsTotal, bytesTotal)
+	d.PromRegistry.MustRegister(opsTotal, bytesTotal)
 }

--- a/database/plugin/blob/gcs/options.go
+++ b/database/plugin/blob/gcs/options.go
@@ -25,7 +25,7 @@ type BlobStoreGCSOptionFunc func(*BlobStoreGCS)
 // WithLogger specifies the logger object to use for logging messages
 func WithLogger(logger *slog.Logger) BlobStoreGCSOptionFunc {
 	return func(b *BlobStoreGCS) {
-		b.logger = NewGcsLogger(logger)
+		b.Logger = NewGcsLogger(logger)
 	}
 }
 
@@ -34,20 +34,20 @@ func WithPromRegistry(
 	registry prometheus.Registerer,
 ) BlobStoreGCSOptionFunc {
 	return func(b *BlobStoreGCS) {
-		b.promRegistry = registry
+		b.PromRegistry = registry
 	}
 }
 
 // WithBucket specifies the GCS bucket name
 func WithBucket(bucket string) BlobStoreGCSOptionFunc {
 	return func(b *BlobStoreGCS) {
-		b.bucketName = bucket
+		b.BucketName = bucket
 	}
 }
 
 // WithCredentialsFile specifies the path to the service account credentials file
 func WithCredentialsFile(credentialsFile string) BlobStoreGCSOptionFunc {
 	return func(b *BlobStoreGCS) {
-		b.credentialsFile = credentialsFile
+		b.CredentialsFile = credentialsFile
 	}
 }

--- a/database/plugin/blob/gcs/options_test.go
+++ b/database/plugin/blob/gcs/options_test.go
@@ -12,64 +12,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcs
+package gcs_test
 
 import (
 	"io"
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestWithLogger(t *testing.T) {
-	b := &BlobStoreGCS{}
+	b := &gcs.BlobStoreGCS{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	option := WithLogger(logger)
+	option := gcs.WithLogger(logger)
 
 	option(b)
 
-	if b.logger == nil {
+	if b.Logger == nil {
 		t.Errorf("Expected logger to be set")
 	}
 }
 
 func TestWithPromRegistry(t *testing.T) {
-	b := &BlobStoreGCS{}
+	b := &gcs.BlobStoreGCS{}
 	registry := prometheus.NewRegistry()
-	option := WithPromRegistry(registry)
+	option := gcs.WithPromRegistry(registry)
 
 	option(b)
 
-	if b.promRegistry != registry {
+	if b.PromRegistry != registry {
 		t.Errorf("Expected promRegistry to be set correctly")
 	}
 }
 
 func TestWithBucket(t *testing.T) {
-	b := &BlobStoreGCS{}
-	option := WithBucket("test-bucket")
+	b := &gcs.BlobStoreGCS{}
+	option := gcs.WithBucket("test-bucket")
 
 	option(b)
 
-	if b.bucketName != "test-bucket" {
+	if b.BucketName != "test-bucket" {
 		t.Errorf(
 			"Expected bucketName to be 'test-bucket', got '%s'",
-			b.bucketName,
+			b.BucketName,
 		)
 	}
 }
 
 func TestWithCredentialsFile(t *testing.T) {
-	b := &BlobStoreGCS{}
-	option := WithCredentialsFile("/path/to/creds.json")
+	b := &gcs.BlobStoreGCS{}
+	option := gcs.WithCredentialsFile("/path/to/creds.json")
 
 	option(b)
 
-	if b.credentialsFile != "/path/to/creds.json" {
+	if b.CredentialsFile != "/path/to/creds.json" {
 		t.Errorf(
 			"Expected credentialsFile to be '/path/to/creds.json', got '%s'",
-			b.credentialsFile,
+			b.CredentialsFile,
 		)
 	}
 }

--- a/database/plugin/blob/gcs/plugin.go
+++ b/database/plugin/blob/gcs/plugin.go
@@ -22,8 +22,8 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin"
 )
 
-// validateCredentials checks if the credentials file exists and is readable
-func validateCredentials(credentialsFile string) error {
+// ValidateCredentials checks if the credentials file exists and is readable
+func ValidateCredentials(credentialsFile string) error {
 	if credentialsFile == "" {
 		return nil // Empty credentials file is allowed (will use ADC)
 	}
@@ -45,8 +45,8 @@ func validateCredentials(credentialsFile string) error {
 
 var (
 	cmdlineOptions struct {
-		bucket          string
-		credentialsFile string
+		Bucket          string
+		CredentialsFile string
 	}
 	cmdlineOptionsMutex sync.RWMutex
 )
@@ -73,14 +73,14 @@ func init() {
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "GCS bucket name",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.bucket),
+					Dest:         &(cmdlineOptions.Bucket),
 				},
 				{
 					Name:         "credentials-file",
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "Path to GCS service account credentials file",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.credentialsFile),
+					Dest:         &(cmdlineOptions.CredentialsFile),
 				},
 			},
 		},
@@ -89,8 +89,8 @@ func init() {
 
 func NewFromCmdlineOptions() plugin.Plugin {
 	cmdlineOptionsMutex.RLock()
-	bucket := cmdlineOptions.bucket
-	credentialsFile := cmdlineOptions.credentialsFile
+	bucket := cmdlineOptions.Bucket
+	credentialsFile := cmdlineOptions.CredentialsFile
 	cmdlineOptionsMutex.RUnlock()
 
 	opts := []BlobStoreGCSOptionFunc{

--- a/database/plugin/blob/gcs/plugin_test.go
+++ b/database/plugin/blob/gcs/plugin_test.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcs
+package gcs_test
 
 import (
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 )
 
 func TestCredentialValidation(t *testing.T) {
@@ -27,13 +29,13 @@ func TestCredentialValidation(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		credentialsFile string
+		CredentialsFile string
 		expectError     bool
 		errorMessage    string
 	}{
 		{
 			name: "valid credentials file",
-			credentialsFile: func() string {
+			CredentialsFile: func() string {
 				// Create a temporary file that exists
 				tempFile, err := os.CreateTemp(tempDir, "credentials-*.json")
 				if err != nil {
@@ -46,7 +48,7 @@ func TestCredentialValidation(t *testing.T) {
 		},
 		{
 			name: "nonexistent credentials file",
-			credentialsFile: filepath.Join(
+			CredentialsFile: filepath.Join(
 				tempDir,
 				"nonexistent-credentials.json",
 			),
@@ -55,14 +57,14 @@ func TestCredentialValidation(t *testing.T) {
 		},
 		{
 			name:            "empty credentials file path",
-			credentialsFile: "",
+			CredentialsFile: "",
 			expectError:     false, // Should not error when empty
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateCredentials(tt.credentialsFile)
+			err := gcs.ValidateCredentials(tt.CredentialsFile)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf(

--- a/database/plugin/metadata/sqlite/epoch.go
+++ b/database/plugin/metadata/sqlite/epoch.go
@@ -86,8 +86,8 @@ func (d *MetadataStoreSqlite) SetEpoch(
 	}
 	// Run a vacuum, on error only log
 	if err := d.runVacuum(); err != nil {
-		d.logger.Error(
-			"failed to free space in metdata store",
+		d.Logger.Error(
+			"failed to free space in metadata store",
 			"epoch", strconv.FormatUint(epoch, 10),
 			"error", err,
 		)

--- a/database/plugin/metadata/sqlite/options.go
+++ b/database/plugin/metadata/sqlite/options.go
@@ -25,7 +25,7 @@ type SqliteOptionFunc func(*MetadataStoreSqlite)
 // WithLogger specifies the logger object to use for logging messages
 func WithLogger(logger *slog.Logger) SqliteOptionFunc {
 	return func(m *MetadataStoreSqlite) {
-		m.logger = logger
+		m.Logger = logger
 	}
 }
 
@@ -34,13 +34,13 @@ func WithPromRegistry(
 	registry prometheus.Registerer,
 ) SqliteOptionFunc {
 	return func(m *MetadataStoreSqlite) {
-		m.promRegistry = registry
+		m.PromRegistry = registry
 	}
 }
 
 // WithDataDir specifies the data directory to use for storage
 func WithDataDir(dataDir string) SqliteOptionFunc {
 	return func(m *MetadataStoreSqlite) {
-		m.dataDir = dataDir
+		m.DataDir = dataDir
 	}
 }

--- a/database/plugin/metadata/sqlite/options_test.go
+++ b/database/plugin/metadata/sqlite/options_test.go
@@ -12,46 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sqlite
+package sqlite_test
 
 import (
+	"io"
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestWithDataDir(t *testing.T) {
-	m := &MetadataStoreSqlite{}
-	option := WithDataDir("/tmp/test")
+	m := &sqlite.MetadataStoreSqlite{}
+	option := sqlite.WithDataDir("/tmp/test")
 
 	option(m)
 
-	if m.dataDir != "/tmp/test" {
-		t.Errorf("Expected dataDir to be '/tmp/test', got '%s'", m.dataDir)
+	if m.DataDir != "/tmp/test" {
+		t.Errorf("Expected DataDir to be '/tmp/test', got '%s'", m.DataDir)
 	}
 }
 
 func TestWithLogger(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(nil, nil))
-	m := &MetadataStoreSqlite{}
-	option := WithLogger(logger)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := &sqlite.MetadataStoreSqlite{}
+	option := sqlite.WithLogger(logger)
 
 	option(m)
 
-	if m.logger != logger {
+	if m.Logger != logger {
 		t.Errorf("Expected logger to be set")
 	}
 }
 
 func TestWithPromRegistry(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	m := &MetadataStoreSqlite{}
-	option := WithPromRegistry(reg)
+	m := &sqlite.MetadataStoreSqlite{}
+	option := sqlite.WithPromRegistry(reg)
 
 	option(m)
 
-	if m.promRegistry != reg {
-		t.Errorf("Expected promRegistry to be set")
+	if m.PromRegistry != reg {
+		t.Errorf("Expected PromRegistry to be set")
 	}
 }

--- a/database/plugin/metadata/sqlite/plugin.go
+++ b/database/plugin/metadata/sqlite/plugin.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	cmdlineOptions struct {
-		dataDir string
+		DataDir string
 	}
 	cmdlineOptionsMutex sync.RWMutex
 )
@@ -31,7 +31,7 @@ var (
 func initCmdlineOptions() {
 	cmdlineOptionsMutex.Lock()
 	defer cmdlineOptionsMutex.Unlock()
-	cmdlineOptions.dataDir = ""
+	cmdlineOptions.DataDir = ""
 }
 
 // Register plugin
@@ -49,7 +49,7 @@ func init() {
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "Data directory for sqlite storage",
 					DefaultValue: "",
-					Dest:         &(cmdlineOptions.dataDir),
+					Dest:         &(cmdlineOptions.DataDir),
 				},
 			},
 		},
@@ -58,7 +58,7 @@ func init() {
 
 func NewFromCmdlineOptions() plugin.Plugin {
 	cmdlineOptionsMutex.RLock()
-	dataDir := cmdlineOptions.dataDir
+	dataDir := cmdlineOptions.DataDir
 	cmdlineOptionsMutex.RUnlock()
 
 	opts := []SqliteOptionFunc{

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -177,7 +177,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			)
 		}
 		if utxo == nil {
-			d.logger.Warn(
+			d.Logger.Warn(
 				"Skipping missing input UTxO",
 				"hash",
 				input.Id().String(),
@@ -211,7 +211,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				)
 			}
 			if utxo == nil {
-				d.logger.Warn(
+				d.Logger.Warn(
 					"Skipping missing collateral UTxO",
 					"hash",
 					input.Id().String(),
@@ -273,7 +273,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				)
 			}
 			if utxo == nil {
-				d.logger.Warn(
+				d.Logger.Warn(
 					"Skipping missing reference input UTxO",
 					"hash",
 					input.Id().String(),
@@ -333,7 +333,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			)
 		}
 		if utxo == nil {
-			d.logger.Warn(
+			d.Logger.Warn(
 				fmt.Sprintf("input UTxO not found: %x#%d", inTxId, inIdx),
 			)
 			continue
@@ -367,7 +367,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				if depositVal, ok := certDeposits[i]; ok {
 					deposit = depositVal
 				} else if certRequiresDeposit(cert) {
-					d.logger.Warn("missing deposit for deposit-bearing certificate",
+					d.Logger.Warn("missing deposit for deposit-bearing certificate",
 						"index", i, "type", fmt.Sprintf("%T", cert))
 				}
 			}
@@ -479,7 +479,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					return fmt.Errorf("process certificate: %w", err)
 				}
 				if tmpPool == nil {
-					d.logger.Warn("retiring non-existent pool", "hash", c.PoolKeyHash)
+					d.Logger.Warn("retiring non-existent pool", "hash", c.PoolKeyHash)
 					tmpPool = &models.Pool{PoolKeyHash: c.PoolKeyHash[:]}
 					result := txn.Clauses(clause.OnConflict{
 						Columns:   []clause.Column{{Name: "pool_key_hash"}},
@@ -507,7 +507,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					return fmt.Errorf("process certificate: %w", err)
 				}
 				if tmpAccount == nil {
-					d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
+					d.Logger.Warn("deregistering non-existent account", "hash", stakeKey)
 					tmpAccount = &models.Account{
 						StakingKey: stakeKey,
 					}

--- a/internal/integration/benchmark_test.go
+++ b/internal/integration/benchmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package integration_test
 
 import (
 	"fmt"

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package integration_test
 
 import (
 	"os"

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger
+package ledger_test
 
 import (
 	"errors"
@@ -22,7 +22,8 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/dingo/ledger"
+	lg "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
@@ -68,7 +69,7 @@ func seedBlocksFromSlots(
 		}
 
 		// Store block in database
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue // Skip problematic blocks
 		}
@@ -137,7 +138,7 @@ func BenchmarkBlockMemoryUsage(b *testing.B) {
 		block := realBlocks[i%len(realBlocks)]
 
 		// Decode block (this is where most memory allocation happens)
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			// Skip problematic blocks in benchmark
 			continue
@@ -166,7 +167,7 @@ func BenchmarkUtxoLookupByAddressNoData(b *testing.B) {
 	// Create a test address
 	paymentKey := make([]byte, 28) // dummy 28-byte key hash
 	stakeKey := make([]byte, 28)
-	testAddr, err := ledger.NewAddressFromParts(0, 0, paymentKey, stakeKey)
+	testAddr, err := lg.NewAddressFromParts(0, 0, paymentKey, stakeKey)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -206,7 +207,7 @@ func BenchmarkUtxoLookupByAddressRealData(b *testing.B) {
 	// Create a test address for queries
 	paymentKey := make([]byte, 28)
 	stakeKey := make([]byte, 28)
-	testAddr, err := ledger.NewAddressFromParts(0, 0, paymentKey, stakeKey)
+	testAddr, err := lg.NewAddressFromParts(0, 0, paymentKey, stakeKey)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -351,7 +352,7 @@ func BenchmarkBlockRetrievalByIndexRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -448,7 +449,7 @@ func BenchmarkTransactionHistoryQueriesRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -555,7 +556,7 @@ func BenchmarkAccountLookupByStakeKeyRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -659,7 +660,7 @@ func BenchmarkPoolLookupByKeyHashRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -764,7 +765,7 @@ func BenchmarkDRepLookupByKeyHashRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -870,7 +871,7 @@ func BenchmarkDatumLookupByHashRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -973,7 +974,7 @@ func BenchmarkProtocolParametersLookupByEpochRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -1077,7 +1078,7 @@ func BenchmarkBlockNonceLookupRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -1188,7 +1189,7 @@ func BenchmarkStakeRegistrationLookupsRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -1297,7 +1298,7 @@ func BenchmarkPoolRegistrationLookupsRealData(b *testing.B) {
 			continue
 		}
 
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -1381,7 +1382,7 @@ func BenchmarkEraTransitionPerformance(b *testing.B) {
 	// Benchmark processing blocks across era transitions
 	for b.Loop() {
 		for _, block := range blocks {
-			ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+			ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -1442,7 +1443,7 @@ func BenchmarkEraTransitionPerformanceRealData(b *testing.B) {
 			blocks = append(blocks, block)
 
 			// Also seed the database with this block
-			ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+			ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 			if err != nil {
 				continue
 			}
@@ -1478,7 +1479,7 @@ func BenchmarkEraTransitionPerformanceRealData(b *testing.B) {
 	// Benchmark processing blocks across era transitions with database operations
 	for b.Loop() {
 		for _, block := range blocks {
-			ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+			ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -1551,7 +1552,7 @@ func BenchmarkIndexBuildingTime(b *testing.B) {
 		block := realBlocks[i%len(realBlocks)]
 
 		// Decode block
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			// Skip problematic blocks in benchmark
 			continue
@@ -1674,7 +1675,7 @@ func BenchmarkRealBlockProcessing(b *testing.B) {
 		}
 
 		// Convert immutable block to ledger block
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			b.Fatalf("NewBlockFromCbor failed: %v", err)
 		}
@@ -1740,7 +1741,7 @@ func BenchmarkRealDataQueries(b *testing.B) {
 		}
 
 		// Convert and store block
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1820,7 +1821,7 @@ func BenchmarkChainSyncFromGenesis(b *testing.B) {
 			}
 
 			// Decode block to ensure it's valid
-			ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+			ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 			if err != nil {
 				// Skip problematic blocks
 				continue
@@ -1876,11 +1877,11 @@ func BenchmarkTransactionValidation(b *testing.B) {
 	}
 
 	// Create ledger state for validation
-	ledgerCfg := LedgerStateConfig{
+	ledgerCfg := ledger.LedgerStateConfig{
 		Database:     db,
 		ChainManager: chainManager,
 	}
-	ledgerState, err := NewLedgerState(ledgerCfg)
+	ledgerState, err := ledger.NewLedgerState(ledgerCfg)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1907,7 +1908,7 @@ func BenchmarkTransactionValidation(b *testing.B) {
 		}
 
 		// Decode block
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			continue
 		}
@@ -1980,11 +1981,11 @@ func BenchmarkBlockProcessingThroughput(b *testing.B) {
 	}
 
 	// Create ledger state for validation
-	ledgerCfg := LedgerStateConfig{
+	ledgerCfg := ledger.LedgerStateConfig{
 		Database:     db,
 		ChainManager: chainManager,
 	}
-	ledgerState, err := NewLedgerState(ledgerCfg)
+	ledgerState, err := ledger.NewLedgerState(ledgerCfg)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -2029,7 +2030,7 @@ func BenchmarkBlockProcessingThroughput(b *testing.B) {
 		block := blocks[i%len(blocks)]
 
 		// Convert to ledger block
-		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		ledgerBlock, err := lg.NewBlockFromCbor(block.Type, block.Cbor)
 		if err != nil {
 			b.Fatalf("NewBlockFromCbor failed: %v", err)
 		}
@@ -2107,7 +2108,7 @@ func BenchmarkConcurrentQueries(b *testing.B) {
 				// Query UTxO by address (using test address)
 				paymentKey := make([]byte, 28) // dummy 28-byte key hash
 				stakeKey := make([]byte, 28)
-				testAddr, err := ledger.NewAddressFromParts(
+				testAddr, err := lg.NewAddressFromParts(
 					0,
 					0,
 					paymentKey,

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -55,7 +55,12 @@ func (ls *LedgerState) queryBlock(
 }
 
 func (ls *LedgerState) querySystemStart() (any, error) {
-	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if ls.Config.CardanoNodeConfig == nil {
+		return nil, errors.New(
+			"cardano node config is required for SystemStartQuery",
+		)
+	}
+	shelleyGenesis := ls.Config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil {
 		return nil, errors.New(
 			"unable to get shelley era genesis for system start",
@@ -86,7 +91,7 @@ func (ls *LedgerState) queryHardFork(
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.HardForkCurrentEraQuery:
-		return ls.currentEra.Id, nil
+		return ls.CurrentEra.Id, nil
 	case *olocalstatequery.HardForkEraHistoryQuery:
 		return ls.queryHardForkEraHistory()
 	default:
@@ -95,6 +100,11 @@ func (ls *LedgerState) queryHardFork(
 }
 
 func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
+	if ls.Config.CardanoNodeConfig == nil {
+		return nil, errors.New(
+			"cardano node config is required for HardForkEraHistoryQuery",
+		)
+	}
 	retData := []any{}
 	timespan := big.NewInt(0)
 	var epochs []models.Epoch
@@ -107,7 +117,7 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 	var idx int
 	for _, era = range eras.Eras {
 		epochSlotLength, epochLength, err = era.EpochLengthFunc(
-			ls.config.CardanoNodeConfig,
+			ls.Config.CardanoNodeConfig,
 		)
 		if err != nil {
 			return nil, err
@@ -170,7 +180,7 @@ func (ls *LedgerState) queryShelley(
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.ShelleyEpochNoQuery:
-		return []any{ls.currentEpoch.EpochId}, nil
+		return []any{ls.CurrentEpoch.EpochId}, nil
 	case *olocalstatequery.ShelleyCurrentProtocolParamsQuery:
 		return []any{ls.currentPParams}, nil
 	case *olocalstatequery.ShelleyGenesisConfigQuery:
@@ -205,7 +215,12 @@ func (ls *LedgerState) queryShelley(
 }
 
 func (ls *LedgerState) queryShelleyGenesisConfig() (any, error) {
-	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if ls.Config.CardanoNodeConfig == nil {
+		return nil, errors.New(
+			"cardano node config is required for ShelleyGenesisConfigQuery",
+		)
+	}
+	shelleyGenesis := ls.Config.CardanoNodeConfig.ShelleyGenesis()
 	return []any{shelleyGenesis}, nil
 }
 

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -28,7 +28,7 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 	if slot > math.MaxInt64 {
 		return time.Time{}, errors.New("slot is larger than time.Duration")
 	}
-	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	shelleyGenesis := ls.Config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil {
 		return time.Time{}, errors.New("could not get genesis config")
 	}
@@ -38,7 +38,7 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 		return slotTime, nil
 	}
 	foundSlot := false
-	for _, epoch := range ls.epochCache {
+	for _, epoch := range ls.EpochCache {
 		if epoch.StartSlot > math.MaxInt64 ||
 			epoch.LengthInSlots > math.MaxInt64 ||
 			epoch.SlotLength > math.MaxInt64 {
@@ -63,7 +63,7 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 	}
 	if !foundSlot {
 		// Project the current slot length forward to calculate future slots
-		lastEpoch := ls.epochCache[len(ls.epochCache)-1]
+		lastEpoch := ls.EpochCache[len(ls.EpochCache)-1]
 		leftoverSlots := slot - (lastEpoch.StartSlot + uint64(lastEpoch.LengthInSlots))
 		slotTime = slotTime.Add(
 			// nolint:gosec
@@ -77,14 +77,14 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 
 // TimeToSlot returns the slot number for a given time based on known epochs
 func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
-	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	shelleyGenesis := ls.Config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil {
 		return 0, errors.New("could not get genesis config")
 	}
 	epochStartTime := shelleyGenesis.SystemStart
 	var timeSlot uint64
 	foundTime := false
-	for _, epoch := range ls.epochCache {
+	for _, epoch := range ls.EpochCache {
 		if epoch.LengthInSlots > math.MaxInt64 ||
 			epoch.SlotLength > math.MaxInt64 {
 			return 0, errors.New(
@@ -140,7 +140,7 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 
 // SlotToEpoch returns a known epoch by slot number
 func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
-	for _, epoch := range ls.epochCache {
+	for _, epoch := range ls.EpochCache {
 		if slot < epoch.StartSlot {
 			continue
 		}

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger
+package ledger_test
 
 import (
 	"strings"
@@ -21,11 +21,12 @@ import (
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger"
 )
 
 func TestSlotCalc(t *testing.T) {
-	testLedgerState := &LedgerState{
-		epochCache: []models.Epoch{
+	testLedgerState := &ledger.LedgerState{
+		EpochCache: []models.Epoch{
 			{
 				EpochId:       0,
 				StartSlot:     0,
@@ -63,12 +64,12 @@ func TestSlotCalc(t *testing.T) {
 				LengthInSlots: 86400,
 			},
 		},
-		config: LedgerStateConfig{
+		Config: ledger.LedgerStateConfig{
 			CardanoNodeConfig: &cardano.CardanoNodeConfig{},
 		},
 	}
 	testShelleyGenesis := `{"systemStart": "2022-10-25T00:00:00Z"}`
-	if err := testLedgerState.config.CardanoNodeConfig.LoadShelleyGenesisFromReader(strings.NewReader(testShelleyGenesis)); err != nil {
+	if err := testLedgerState.Config.CardanoNodeConfig.LoadShelleyGenesisFromReader(strings.NewReader(testShelleyGenesis)); err != nil {
 		t.Fatalf("unexpected error loading cardano node config: %s", err)
 	}
 	testDefs := []struct {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger
+package ledger_test
 
 import (
 	"fmt"
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
 
@@ -77,9 +78,9 @@ func TestCalculateStabilityWindow_ByronEra(t *testing.T) {
 				t.Fatalf("failed to load Shelley genesis: %v", err)
 			}
 
-			ls := &LedgerState{
-				currentEra: eras.ByronEraDesc, // Byron era has Id = 0
-				config: LedgerStateConfig{
+			ls := &ledger.LedgerState{
+				CurrentEra: eras.ByronEraDesc, // Byron era has Id = 0
+				Config: ledger.LedgerStateConfig{
 					CardanoNodeConfig: cfg,
 					Logger: slog.New(
 						slog.NewJSONHandler(io.Discard, nil),
@@ -87,7 +88,7 @@ func TestCalculateStabilityWindow_ByronEra(t *testing.T) {
 				},
 			}
 
-			result := ls.calculateStabilityWindow()
+			result := ls.CalculateStabilityWindow()
 			if result != tc.expectedWindow {
 				t.Errorf(
 					"expected stability window %d, got %d",
@@ -173,9 +174,9 @@ func TestCalculateStabilityWindow_ShelleyEra(t *testing.T) {
 				t.Fatalf("failed to load Shelley genesis: %v", err)
 			}
 
-			ls := &LedgerState{
-				currentEra: eras.ShelleyEraDesc, // Shelley era has Id = 1
-				config: LedgerStateConfig{
+			ls := &ledger.LedgerState{
+				CurrentEra: eras.ShelleyEraDesc, // Shelley era has Id = 1
+				Config: ledger.LedgerStateConfig{
 					CardanoNodeConfig: cfg,
 					Logger: slog.New(
 						slog.NewJSONHandler(io.Discard, nil),
@@ -183,7 +184,7 @@ func TestCalculateStabilityWindow_ShelleyEra(t *testing.T) {
 				},
 			}
 
-			result := ls.calculateStabilityWindow()
+			result := ls.CalculateStabilityWindow()
 			if result != tc.expectedWindow {
 				t.Errorf(
 					"%s: expected stability window %d, got %d",
@@ -209,9 +210,9 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			t.Fatalf("failed to load Shelley genesis: %v", err)
 		}
 
-		ls := &LedgerState{
-			currentEra: eras.ByronEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ByronEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -219,11 +220,11 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
-		if result != blockfetchBatchSlotThresholdDefault {
+		result := ls.CalculateStabilityWindow()
+		if result != ledger.BlockfetchBatchSlotThresholdDefault {
 			t.Errorf(
 				"expected default threshold %d, got %d",
-				blockfetchBatchSlotThresholdDefault,
+				ledger.BlockfetchBatchSlotThresholdDefault,
 				result,
 			)
 		}
@@ -241,9 +242,9 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			t.Fatalf("failed to load Byron genesis: %v", err)
 		}
 
-		ls := &LedgerState{
-			currentEra: eras.ByronEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ByronEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -251,7 +252,7 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
+		result := ls.CalculateStabilityWindow()
 		if result != 864 {
 			t.Errorf("expected default threshold %d, got %d", 864, result)
 		}
@@ -276,9 +277,9 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			strings.NewReader(shelleyGenesisJSON),
 		)
 
-		ls := &LedgerState{
-			currentEra: eras.ByronEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ByronEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -286,11 +287,11 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
-		if result != blockfetchBatchSlotThresholdDefault {
+		result := ls.CalculateStabilityWindow()
+		if result != ledger.BlockfetchBatchSlotThresholdDefault {
 			t.Errorf(
 				"expected default threshold %d for zero k, got %d",
-				blockfetchBatchSlotThresholdDefault,
+				ledger.BlockfetchBatchSlotThresholdDefault,
 				result,
 			)
 		}
@@ -315,9 +316,9 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			strings.NewReader(shelleyGenesisJSON),
 		)
 
-		ls := &LedgerState{
-			currentEra: eras.ShelleyEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ShelleyEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -325,11 +326,11 @@ func TestCalculateStabilityWindow_EdgeCases(t *testing.T) {
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
-		if result != blockfetchBatchSlotThresholdDefault {
+		result := ls.CalculateStabilityWindow()
+		if result != ledger.BlockfetchBatchSlotThresholdDefault {
 			t.Errorf(
 				"expected default threshold %d for zero k, got %d",
-				blockfetchBatchSlotThresholdDefault,
+				ledger.BlockfetchBatchSlotThresholdDefault,
 				result,
 			)
 		}
@@ -361,9 +362,9 @@ func TestCalculateStabilityWindow_ActiveSlotsCoefficientEdgeCases(
 			t.Fatalf("failed to load Shelley genesis: %v", err)
 		}
 
-		ls := &LedgerState{
-			currentEra: eras.ShelleyEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ShelleyEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -371,7 +372,7 @@ func TestCalculateStabilityWindow_ActiveSlotsCoefficientEdgeCases(
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
+		result := ls.CalculateStabilityWindow()
 		// 3*432/0.01 = 129600
 		expectedWindow := uint64(129600)
 		if result != expectedWindow {
@@ -404,9 +405,9 @@ func TestCalculateStabilityWindow_ActiveSlotsCoefficientEdgeCases(
 			t.Fatalf("failed to load Shelley genesis: %v", err)
 		}
 
-		ls := &LedgerState{
-			currentEra: eras.ShelleyEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ShelleyEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -414,7 +415,7 @@ func TestCalculateStabilityWindow_ActiveSlotsCoefficientEdgeCases(
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
+		result := ls.CalculateStabilityWindow()
 		// 3*100/0.07 = 300/0.07 = 4285.714... should round up to 4286
 		if result < 4285 || result > 4287 {
 			t.Errorf("expected stability window around 4286, got %d", result)
@@ -442,9 +443,9 @@ func TestCalculateStabilityWindow_ActiveSlotsCoefficientEdgeCases(
 			t.Fatalf("failed to load Shelley genesis: %v", err)
 		}
 
-		ls := &LedgerState{
-			currentEra: eras.ShelleyEraDesc,
-			config: LedgerStateConfig{
+		ls := &ledger.LedgerState{
+			CurrentEra: eras.ShelleyEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -452,7 +453,7 @@ func TestCalculateStabilityWindow_ActiveSlotsCoefficientEdgeCases(
 			},
 		}
 
-		result := ls.calculateStabilityWindow()
+		result := ls.CalculateStabilityWindow()
 		// 3*1000/0.333333 ≈ 9000
 		if result == 0 {
 			t.Error("expected non-zero stability window")
@@ -529,9 +530,9 @@ func TestCalculateStabilityWindow_AllEras(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ls := &LedgerState{
-				currentEra: tc.era,
-				config: LedgerStateConfig{
+			ls := &ledger.LedgerState{
+				CurrentEra: tc.era,
+				Config: ledger.LedgerStateConfig{
 					CardanoNodeConfig: cfg,
 					Logger: slog.New(
 						slog.NewJSONHandler(io.Discard, nil),
@@ -539,7 +540,7 @@ func TestCalculateStabilityWindow_AllEras(t *testing.T) {
 				},
 			}
 
-			result := ls.calculateStabilityWindow()
+			result := ls.CalculateStabilityWindow()
 			if result != tc.expectedWindow {
 				t.Errorf(
 					"era %s: expected stability window %d, got %d",
@@ -576,9 +577,9 @@ func TestCalculateStabilityWindow_Integration(t *testing.T) {
 		}
 
 		// Test Byron era with mainnet params
-		lsByron := &LedgerState{
-			currentEra: eras.ByronEraDesc,
-			config: LedgerStateConfig{
+		lsByron := &ledger.LedgerState{
+			CurrentEra: eras.ByronEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -586,7 +587,7 @@ func TestCalculateStabilityWindow_Integration(t *testing.T) {
 			},
 		}
 
-		resultByron := lsByron.calculateStabilityWindow()
+		resultByron := lsByron.CalculateStabilityWindow()
 		if resultByron != 4320 {
 			t.Errorf(
 				"Byron era: expected stability window 4320, got %d",
@@ -595,9 +596,9 @@ func TestCalculateStabilityWindow_Integration(t *testing.T) {
 		}
 
 		// Test Shelley era with mainnet params
-		lsShelley := &LedgerState{
-			currentEra: eras.ShelleyEraDesc,
-			config: LedgerStateConfig{
+		lsShelley := &ledger.LedgerState{
+			CurrentEra: eras.ShelleyEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -605,7 +606,7 @@ func TestCalculateStabilityWindow_Integration(t *testing.T) {
 			},
 		}
 
-		resultShelley := lsShelley.calculateStabilityWindow()
+		resultShelley := lsShelley.CalculateStabilityWindow()
 		// 3*2160/0.05 = 129600
 		if resultShelley != 129600 {
 			t.Errorf(
@@ -636,9 +637,9 @@ func TestCalculateStabilityWindow_Integration(t *testing.T) {
 			t.Fatalf("failed to load Shelley genesis: %v", err)
 		}
 
-		lsShelley := &LedgerState{
-			currentEra: eras.ShelleyEraDesc,
-			config: LedgerStateConfig{
+		lsShelley := &ledger.LedgerState{
+			CurrentEra: eras.ShelleyEraDesc,
+			Config: ledger.LedgerStateConfig{
 				CardanoNodeConfig: cfg,
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
@@ -646,7 +647,7 @@ func TestCalculateStabilityWindow_Integration(t *testing.T) {
 			},
 		}
 
-		result := lsShelley.calculateStabilityWindow()
+		result := lsShelley.CalculateStabilityWindow()
 		// 3*432/0.05 = 25920
 		if result != 25920 {
 			t.Errorf(
@@ -679,15 +680,15 @@ func TestCalculateStabilityWindow_LargeValues(t *testing.T) {
 		t.Fatalf("failed to load Shelley genesis: %v", err)
 	}
 
-	ls := &LedgerState{
-		currentEra: eras.ShelleyEraDesc,
-		config: LedgerStateConfig{
+	ls := &ledger.LedgerState{
+		CurrentEra: eras.ShelleyEraDesc,
+		Config: ledger.LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
 
-	result := ls.calculateStabilityWindow()
+	result := ls.CalculateStabilityWindow()
 	// 3*1000000/0.05 = 60000000
 	expectedWindow := uint64(60000000)
 	if result != expectedWindow {

--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger
+package ledger_test
 
 import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/blinklabs-io/dingo/ledger"
 )
 
 func TestScheduler_RegistersAndRunsTask(t *testing.T) {
 	var counter int32
 
 	// Create a Scheduler with 10ms tick interval
-	timer := NewScheduler(10 * time.Millisecond)
+	timer := ledger.NewScheduler(10 * time.Millisecond)
 	timer.Start()
 	defer timer.Stop()
 
@@ -49,7 +51,7 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 	var counter int32
 
 	// Create a Scheduler with 50ms tick interval
-	timer := NewScheduler(50 * time.Millisecond)
+	timer := ledger.NewScheduler(50 * time.Millisecond)
 	timer.Start()
 	defer timer.Stop()
 
@@ -89,7 +91,7 @@ func TestSchedulerRunFailFunc(t *testing.T) {
 	var failCounter int32
 
 	// Create a Scheduler with 10ms tick interval
-	timer := NewScheduler(10 * time.Millisecond)
+	timer := ledger.NewScheduler(10 * time.Millisecond)
 	timer.Start()
 	defer timer.Stop()
 

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -30,7 +30,11 @@ type LedgerView struct {
 }
 
 func (lv *LedgerView) NetworkId() uint {
-	genesis := lv.ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if lv.ls.Config.CardanoNodeConfig == nil {
+		// no config, definitely not mainnet
+		return 0
+	}
+	genesis := lv.ls.Config.CardanoNodeConfig.ShelleyGenesis()
 	if genesis == nil {
 		// no config, definitely not mainnet
 		return 0

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -141,8 +141,8 @@ func (m *Mempool) AddConsumer(connId ouroboros.ConnectionId) *MempoolConsumer {
 
 func (m *Mempool) RemoveConsumer(connId ouroboros.ConnectionId) {
 	m.consumersMutex.Lock()
+	defer m.consumersMutex.Unlock()
 	delete(m.consumers, connId)
-	m.consumersMutex.Unlock()
 }
 
 func (m *Mempool) Consumer(connId ouroboros.ConnectionId) *MempoolConsumer {


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored tests to use external _test packages and exported the minimal symbols needed to support them. Added safety checks around Cardano config reads and fixed a mempool consumer lock issue; behavior is otherwise unchanged.

- **Refactors**
  - Moved tests to package_name_test across config, database, ledger, and plugin modules; updated imports.
  - Exported required symbols: internal/config.NewDefaultConfig (and reset helpers), gcs.ValidateCredentials, ledger.LedgerState fields (CurrentEra, Config, EpochCache, CurrentEpoch), and BlockfetchBatchSlotThresholdDefault; made AWS CmdlineOptions public.
  - Made store option fields/loggers/registries public in blob stores (AWS/Badger/GCS) and sqlite metadata (Logger, PromRegistry, DataDir).
  - Made plugin registry thread-safe with a mutex for registration and option population.

- **Bug Fixes**
  - Guarded Cardano config access in LedgerView.NetworkId, SystemStart query, and HardFork era history to avoid panics.
  - Ensured mempool.RemoveConsumer unlocks via defer to prevent races.

<sup>Written for commit bc8ee27796cac02aa702ec9d6ca14f14a896df81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Expanded public API: many previously internal fields, options and helpers are now exported to improve extensibility and interoperability.
  * Introduced default global configuration helpers and safe topology accessors.
  * Made plugin registration concurrent-safe.

* **Tests**
  * Converted many tests to external-package style to validate the public API.
  * Enhanced tests with runtime validations for config and genesis loading.

* **Chores**
  * Standardized logging and metrics wiring across storage and blob plugins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->