### PR TITLE
fix(mempool): lock/unlock before iterating consumers

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -338,12 +338,14 @@ func (m *Mempool) removeTransactionByIndex(txIdx int) bool {
 	m.metrics.txsInMempool.Dec()
 	m.metrics.mempoolBytes.Sub(float64(len(tx.Cbor)))
 	// Update consumer indexes to reflect removed TX
+	m.consumersMutex.Lock()
 	for _, consumer := range m.consumers {
 		// Decrement consumer index if the consumer has reached the removed TX
 		if consumer.nextTxIdx > txIdx {
 			consumer.nextTxIdx--
 		}
 	}
+	m.consumersMutex.Unlock()
 	// Generate event
 	m.eventBus.Publish(
 		RemoveTransactionEventType,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lock the consumers mutex before iterating in removeTransactionByIndex to ensure thread-safe updates to consumer indexes. This prevents race conditions when adjusting nextTxIdx after a transaction is removed.

<sup>Written for commit 8074ca36c68fdee41250f82397ff518816a13c5b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safety during transaction removal operations to ensure consistent behavior under concurrent access, improving system stability and preventing potential data inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->