### PR TITLE
feat: add Windows support with named pipes

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,13 +17,15 @@ jobs:
     strategy:
       matrix:
         go-version: [1.24.x, 1.25.x]
-        # We want to make sure that this builds on Linux and Darwin
-        platform: [ubuntu-latest, macos-latest]
+        # We want to make sure that this builds on Linux, Darwin, and Windows
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - platform: ubuntu-latest
             cache_path: ~/.cache/go-build
           - platform: macos-latest
             cache_path: ~/Library/Caches/go-build
+          - platform: windows-latest
+            cache_path: ~\AppData\Local\go-build
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
@@ -38,5 +40,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
+      - name: go-build
+        run: go build ./cmd/dingo
       - name: go-test
         run: go test ./...

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 ⚠️ This is a work in progress and is currently under heavy development
 
+**Note:** On Windows systems, named pipes are used instead of Unix sockets for node-to-client communication.
+
 <div align="center">
   <img src="./.github/dingo-20241210.png" alt="dingo screenshot" width="640">
 </div>

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -44,19 +45,32 @@ func (c *ConnectionManager) startListeners() error {
 func (c *ConnectionManager) startListener(l ListenerConfig) error {
 	// Create listener if none is provided
 	if l.Listener == nil {
-		listenConfig := net.ListenConfig{}
-		if l.ReuseAddress {
-			listenConfig.Control = socketControl
+		// On Windows, the "unix" network type is repurposed to create named pipes
+		// for compatibility with configurations that specify "unix" network on Unix systems.
+		if runtime.GOOS == "windows" && l.ListenNetwork == "unix" {
+			listener, err := createPipeListener(
+				l.ListenNetwork,
+				l.ListenAddress,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to open listening pipe: %w", err)
+			}
+			l.Listener = listener
+		} else {
+			listenConfig := net.ListenConfig{}
+			if l.ReuseAddress {
+				listenConfig.Control = socketControl
+			}
+			listener, err := listenConfig.Listen(
+				context.Background(),
+				l.ListenNetwork,
+				l.ListenAddress,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to open listening socket: %w", err)
+			}
+			l.Listener = listener
 		}
-		listener, err := listenConfig.Listen(
-			context.Background(),
-			l.ListenNetwork,
-			l.ListenAddress,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to open listening socket: %w", err)
-		}
-		l.Listener = listener
 		if l.UseNtC {
 			c.config.Logger.Info(
 				"listening for ouroboros node-to-client connections on " + l.ListenAddress,

--- a/connmanager/listener_unix.go
+++ b/connmanager/listener_unix.go
@@ -1,4 +1,6 @@
-// Copyright 2024 Blink Labs Software
+//go:build !windows
+
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +17,8 @@
 package connmanager
 
 import (
+	"errors"
+	"net"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -52,4 +56,9 @@ func socketControl(network, address string, c syscall.RawConn) error {
 		return err
 	}
 	return nil
+}
+
+// createPipeListener should never be called on non-Windows systems
+func createPipeListener(_, _ string) (net.Listener, error) {
+	return nil, errors.New("pipe listener not supported on non-Windows systems")
 }

--- a/connmanager/listener_windows.go
+++ b/connmanager/listener_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"syscall"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// socketControl is a no-op on Windows
+func socketControl(_network, _address string, _c syscall.RawConn) error {
+	return nil
+}
+
+type UnixConnAddr struct {
+	addr string
+}
+
+func (a UnixConnAddr) Network() string { return "pipe" }
+
+func (a UnixConnAddr) String() string { return a.addr }
+
+type UnixConn struct {
+	net.Conn
+	remoteAddr UnixConnAddr
+}
+
+func NewUnixConn(conn net.Conn) (*UnixConn, error) {
+	if conn == nil {
+		return nil, errors.New("connection is nil")
+	}
+	if conn.RemoteAddr() == nil {
+		return nil, errors.New("connection has no remote address")
+	}
+	return &UnixConn{
+		Conn:       conn,
+		remoteAddr: UnixConnAddr{addr: conn.RemoteAddr().String()},
+	}, nil
+}
+
+func (u *UnixConn) RemoteAddr() net.Addr {
+	return u.remoteAddr
+}
+
+// createPipeListener creates a named pipe listener on Windows
+func createPipeListener(_, address string) (net.Listener, error) {
+	// Adjust address to named pipe format if not already
+	if !strings.HasPrefix(address, `\\.\pipe\`) {
+		address = `\\.\pipe\` + address
+	}
+	return winio.ListenPipe(address, nil)
+}

--- a/connmanager/unix.go
+++ b/connmanager/unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/grpchealth v1.4.0
 	connectrpc.com/grpcreflect v1.3.0
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/aws/aws-sdk-go-v2/config v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.92.0
 	github.com/blinklabs-io/gouroboros v0.140.0

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -22,6 +22,7 @@ import (
 	_ "net/http/pprof" // #nosec G108
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -39,8 +40,10 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		"component", "node",
 	)
 	// TODO: make this safer, check PID, create parent, etc. (#276)
-	if _, err := os.Stat(cfg.SocketPath); err == nil {
-		os.Remove(cfg.SocketPath)
+	if runtime.GOOS != "windows" {
+		if _, err := os.Stat(cfg.SocketPath); err == nil {
+			os.Remove(cfg.SocketPath)
+		}
 	}
 	var nodeCfg *cardano.CardanoNodeConfig
 	if cfg.CardanoConfig != "" {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows support for node-to-client connections by using named pipes instead of Unix sockets. CI now builds and tests on Windows.

- **New Features**
  - On Windows, "unix" listeners use named pipes via go-winio (addresses auto-prefixed with \\.\pipe\ if needed).
  - Skip Unix socket file cleanup on Windows during node startup.
  - CI matrix includes windows-latest and adds a build step.
  - README notes the Windows named pipe behavior.

- **Dependencies**
  - Added github.com/Microsoft/go-winio.

<sup>Written for commit 42e4327d0017c98fa92094078f63bf7723520cd6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Full Windows support with named pipes for inter-process communication
  
* **Documentation**
  * Updated README to clarify Windows uses named pipes for node-to-client communication instead of Unix sockets

* **Tests**
  * Extended CI pipeline to include Windows testing alongside Linux and macOS

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->