### PR TITLE
refactor: move transaction validity checks to database

### DIFF
--- a/database/models/transaction.go
+++ b/database/models/transaction.go
@@ -31,6 +31,7 @@ type Transaction struct {
 	Metadata         []byte
 	Fee              types.Uint64
 	TTL              types.Uint64
+	Valid            bool
 }
 
 func (Transaction) TableName() string {

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -59,7 +59,7 @@ func (d *Database) SetTransaction(
 	}
 
 	// Protocol parameter updates
-	if updateEpoch > 0 {
+	if updateEpoch > 0 && tx.IsValid() {
 		for genesisHash, update := range pparamUpdates {
 			err := d.SetPParamUpdate(
 				genesisHash.Bytes(),

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -99,18 +99,6 @@ func (d *Database) UtxoByRef(
 	return utxo, nil
 }
 
-func (d *Database) UtxoConsume(
-	utxoId ledger.TransactionInput,
-	slot uint64,
-	txn *Txn,
-) error {
-	if txn == nil {
-		txn = NewMetadataOnlyTxn(d, true)
-		defer txn.Commit() //nolint:errcheck
-	}
-	return d.metadata.SetUtxoDeletedAtSlot(utxoId, slot, txn.Metadata())
-}
-
 func (d *Database) UtxosByAddress(
 	addr ledger.Address,
 	txn *Txn,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -409,20 +409,6 @@ func (ls *LedgerState) transitionToEra(
 	return nil
 }
 
-// consumeUtxo marks a UTxO as "deleted" without actually deleting it. This allows for a UTxO
-// to be easily on rollback
-func (ls *LedgerState) consumeUtxo(
-	txn *database.Txn,
-	utxoId ledger.TransactionInput,
-	slot uint64,
-) error {
-	return ls.db.UtxoConsume(
-		utxoId,
-		slot,
-		txn,
-	)
-}
-
 // calculateStabilityWindow returns the stability window based on the current era.
 // For Byron era, returns 2k. For Shelley+ eras, returns 3k/f.
 // Returns the default threshold if genesis data is unavailable or invalid.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shifted transaction validity handling to the database layer to ensure consistent state updates and simplify ledger logic. Invalid transactions now consume collateral UTxOs and skip certificates, datums, and protocol updates.

- **Refactors**
  - Persist tx validity via a new Transaction.Valid field.
  - UTxO consumption moved to DB: valid uses Consumed; invalid uses Collateral.
  - Certificates and datum storage run only for valid transactions.
  - Protocol parameter updates gated by tx.IsValid().
  - Removed UtxoConsume and related ledger helpers; invalid-tx path stripped from ledger/delta.go.
  - Improved UTxO-not-found logging with hash/index context.

<sup>Written for commit a37f6a60108afc3aa050b8ca653ba6c769ecfd6b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of invalid transactions throughout the system, ensuring proper validity checks are applied during processing.
  * Enhanced protocol parameter update logic to account for transaction validity status.

* **Chores**
  * Refined transaction data model for better validity state tracking.
  * Removed deprecated UTXO handling logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->