### PR TITLE
fix(peergov): use slices instead of append

### DIFF
--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -233,9 +234,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 					tmpPeer.Sharable = existingPeer.Sharable
 				}
 				// Remove the existing peer
-				p.peers = append(
-					p.peers[:existingPeerIdx],
-					p.peers[existingPeerIdx+1:]...)
+				p.peers = slices.Delete(
+					p.peers, existingPeerIdx,
+					existingPeerIdx+1)
 			}
 			p.peers = append(p.peers, tmpPeer)
 		}
@@ -273,9 +274,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 					tmpPeer.Sharable = existingPeer.Sharable
 				}
 				// Remove the existing peer
-				p.peers = append(
-					p.peers[:existingPeerIdx],
-					p.peers[existingPeerIdx+1:]...)
+				p.peers = slices.Delete(
+					p.peers, existingPeerIdx,
+					existingPeerIdx+1)
 			}
 			p.peers = append(p.peers, tmpPeer)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace manual slice reassembly with slices.Delete when removing existing peers during topology config updates. This makes the code clearer and reduces the risk of index errors.

<sup>Written for commit 1bc9abddde3beb0838a7209d809f83b94b64be95. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of peer management through safer boundary handling during topology configuration processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->