### PR TITLE
fix(database): restore use of consumed helper

### DIFF
--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -321,13 +321,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	}
 
 	// Consume UTxOs
-	var consumed []lcommon.TransactionInput
-	if tx.IsValid() {
-		consumed = tx.Consumed()
-	} else {
-		consumed = tx.Collateral()
-	}
-	for _, input := range consumed {
+	for _, input := range tx.Consumed() {
 		inTxId := input.Id().Bytes()
 		inIdx := input.Index()
 		utxo, err := d.GetUtxo(inTxId, inIdx, txn)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored use of tx.Consumed() to mark inputs as spent in the SQLite metadata store. This removes custom validity/collateral checks and ensures consistent UTxO consumption.

- **Bug Fixes**
  - Replace manual valid/collateral branching with tx.Consumed() in SetTransaction.

<sup>Written for commit 4949c76a28471f4ff4a6f467237f290dc4ace906. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

