### PR TITLE
feat(query): Implement query.ReadData

### DIFF
--- a/database/datum.go
+++ b/database/datum.go
@@ -21,6 +21,8 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+var ErrDatumNotFound = errors.New("datum not found")
+
 // SetDatum saves the raw datum into the database by computing the hash before inserting.
 func (d *Database) SetDatum(
 	rawDatum []byte,
@@ -43,7 +45,7 @@ func (d *Database) GetDatum(
 	txn *Txn,
 ) (*models.Datum, error) {
 	if len(hash) == 0 {
-		return nil, errors.New("datum not found")
+		return nil, ErrDatumNotFound
 	}
 	if txn == nil {
 		txn = d.Transaction(false)
@@ -55,7 +57,7 @@ func (d *Database) GetDatum(
 		return nil, err
 	}
 	if ret == nil {
-		return nil, errors.New("datum not found")
+		return nil, ErrDatumNotFound
 	}
 	return ret, nil
 }

--- a/utxorpc/query.go
+++ b/utxorpc/query.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	query "github.com/utxorpc/go-codegen/utxorpc/v1alpha/query"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
@@ -321,7 +322,7 @@ func (s *queryServiceServer) ReadData(
 	for _, key := range keys {
 		datum, err := s.utxorpc.config.LedgerState.Datum(key)
 		if err != nil {
-			if errors.Is(err, errors.New("datum not found")) {
+			if errors.Is(err, database.ErrDatumNotFound) {
 				return nil, connect.NewError(
 					connect.CodeNotFound,
 					fmt.Errorf("datum not found: %x", key),


### PR DESCRIPTION
1. Implemented ReadData and related to #1015 

Closes #741 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented query.ReadData to fetch datums for given keys and return the current ledger tip. Adds clear NotFound handling for missing datums.

- **New Features**
  - Look up datums via LedgerState.Datum and return as AnyChainDatum (hash, raw bytes).
  - Include ChainPoint (slot, hash) from LedgerState.Tip in the response.
  - Return CodeNotFound when a datum is missing; wrap other errors.

<sup>Written for commit 22be4538bdfe6b186f58bf52330f71c58133379a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented full data retrieval for ledger queries, including per-item not-found handling, propagation of retrieval errors, and assembling returned datum values.
  * Ensure responses include current ledger tip (slot and hash) so clients receive up-to-date chain position.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->