### PR TITLE
feat(database): track mir certificates

### DIFF
--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import "github.com/blinklabs-io/dingo/database/types"
+
+type MoveInstantaneousRewards struct {
+	Pot           uint `gorm:"index"`
+	CertificateID uint `gorm:"index"`
+	ID            uint `gorm:"primarykey"`
+	AddedSlot     uint64
+}
+
+func (MoveInstantaneousRewards) TableName() string {
+	return "move_instantaneous_rewards"
+}
+
+type MoveInstantaneousRewardsReward struct {
+	Credential []byte
+	Amount     types.Uint64
+	ID         uint `gorm:"primarykey"`
+	MIRID      uint `gorm:"index;constraint:OnDelete:CASCADE"`
+}
+
+func (MoveInstantaneousRewardsReward) TableName() string {
+	return "move_instantaneous_rewards_reward"
+}

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -26,6 +26,8 @@ var MigrateModels = []any{
 	&DeregistrationDrep{},
 	&Drep{},
 	&Epoch{},
+	&MoveInstantaneousRewards{},
+	&MoveInstantaneousRewardsReward{},
 	&Pool{},
 	&PoolRegistration{},
 	&PoolRegistrationOwner{},

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -820,6 +820,31 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if err := saveCertRecord(&tmpResign, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					tmpMIR := models.MoveInstantaneousRewards{
+						Pot:           c.Reward.Source,
+						AddedSlot:     point.Slot,
+						CertificateID: uint(i), //nolint:gosec
+					}
+
+					// Save the MIR record
+					result := txn.Create(&tmpMIR)
+					if result.Error != nil {
+						return fmt.Errorf("process certificate: %w", result.Error)
+					}
+
+					// Save individual rewards
+					for credential, amount := range c.Reward.Rewards {
+						tmpReward := models.MoveInstantaneousRewardsReward{
+							Credential: credential.Credential[:],
+							Amount:     types.Uint64(amount),
+							MIRID:      tmpMIR.ID,
+						}
+						result := txn.Create(&tmpReward)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
 				default:
 					return fmt.Errorf("unsupported certificate type %T", cert)
 				}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added database support to record Move Instantaneous Rewards (MIR) certificates and their per-credential payouts, making MIR activity queryable.

- **New Features**
  - Added models and tables: move_instantaneous_rewards and move_instantaneous_rewards_reward; included in migrations.
  - Transaction processing now persists MIR certificates with pot, slot, certificate index, and individual rewards (credential, amount).

<sup>Written for commit 7eb1a0720bd38094c2a18a19fddcca7cd5a9b6c8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added backend support to store Move Instantaneous Rewards (MIR) and associated reward entries.
  * Extended certificate processing to persist MIR records and their rewards during transaction handling.
  * Registered new models for database migrations so MIR data is included in schema updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->