### PR TITLE
test(ledger): increase sleep timer for fail check

### DIFF
--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -98,7 +98,7 @@ func TestSchedulerRunFailFunc(t *testing.T) {
 		3,
 		// Task func
 		func() {
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		},
 		// Run fail func
 		func() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase sleep in TestSchedulerRunFailFunc from 50ms to 100ms to stabilize the fail-check timing. This reduces flakiness by giving the task enough time to trigger the run-fail callback, especially on slower CI.

<sup>Written for commit 22e9526bfdb7083295d4f1aa57ff81ad1e3d9805. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test timing parameters to better validate execution dynamics.

---

**Note:** This release contains internal test improvements with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->