### PR TITLE
feat: clean shutdown

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
@@ -51,6 +52,7 @@ type Config struct {
 	tracing            bool
 	tracingStdout      bool
 	devMode            bool
+	shutdownTimeout    time.Duration
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -244,6 +246,13 @@ func WithTracing(tracing bool) ConfigOptionFunc {
 func WithTracingStdout(stdout bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.tracingStdout = stdout
+	}
+}
+
+// WithShutdownTimeout specifies the timeout for graceful shutdown. The default is 30 seconds
+func WithShutdownTimeout(timeout time.Duration) ConfigOptionFunc {
+	return func(c *Config) {
+		c.shutdownTimeout = timeout
 	}
 }
 

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -207,7 +207,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	if tmpTx.ID == 0 {
 		existingTx, err := d.GetTransactionByHash(txHash, txn)
 		if err != nil {
-			return fmt.Errorf("failed to fetch transaction ID after upsert: %w", err)
+			return fmt.Errorf(
+				"failed to fetch transaction ID after upsert: %w",
+				err,
+			)
 		}
 		if existingTx == nil {
 			return fmt.Errorf("transaction not found after upsert: %x", txHash)
@@ -477,13 +480,18 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		// Add Redeemers
 		if ws.Redeemers() != nil {
 			for key, value := range ws.Redeemers().Iter() {
+				//nolint:gosec
 				redeemer := models.Redeemer{
 					TransactionID: tmpTx.ID,
 					Tag:           uint8(key.Tag),
 					Index:         key.Index,
 					Data:          value.Data.Cbor(),
-					ExUnitsMemory: uint64(max(0, value.ExUnits.Memory)), //nolint:gosec
-					ExUnitsCPU:    uint64(max(0, value.ExUnits.Steps)),  //nolint:gosec
+					ExUnitsMemory: uint64(
+						max(0, value.ExUnits.Memory),
+					),
+					ExUnitsCPU: uint64(
+						max(0, value.ExUnits.Steps),
+					),
 				}
 				if result := txn.Create(&redeemer); result.Error != nil {
 					return fmt.Errorf("create redeemer: %w", result.Error)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,8 @@ type ctxKey string
 
 const configContextKey ctxKey = "dingo.config"
 
+const DefaultShutdownTimeout = "30s"
+
 func WithContext(ctx context.Context, cfg *Config) context.Context {
 	return context.WithValue(ctx, configContextKey, cfg)
 }
@@ -68,7 +70,7 @@ type databaseConfig struct {
 }
 
 type Config struct {
-	Network            string `yaml:"network"`
+	MetadataPlugin     string `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
 	TlsKeyFilePath     string `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
 	Topology           string `yaml:"topology"`
 	CardanoConfig      string `yaml:"cardanoConfig"      envconfig:"config"`
@@ -76,14 +78,15 @@ type Config struct {
 	SocketPath         string `yaml:"socketPath"                                                    split_words:"true"`
 	TlsCertFilePath    string `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
 	BindAddr           string `yaml:"bindAddr"                                                      split_words:"true"`
-	PrivateBindAddr    string `yaml:"privateBindAddr"                                               split_words:"true"`
 	BlobPlugin         string `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
-	MetadataPlugin     string `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
+	PrivateBindAddr    string `yaml:"privateBindAddr"                                               split_words:"true"`
+	ShutdownTimeout    string `yaml:"shutdownTimeout"                                               split_words:"true"`
+	Network            string `yaml:"network"`
 	MempoolCapacity    int64  `yaml:"mempoolCapacity"                                               split_words:"true"`
-	MetricsPort        uint   `yaml:"metricsPort"                                                   split_words:"true"`
 	PrivatePort        uint   `yaml:"privatePort"                                                   split_words:"true"`
 	RelayPort          uint   `yaml:"relayPort"          envconfig:"port"`
 	UtxorpcPort        uint   `yaml:"utxorpcPort"                                                   split_words:"true"`
+	MetricsPort        uint   `yaml:"metricsPort"                                                   split_words:"true"`
 	IntersectTip       bool   `yaml:"intersectTip"                                                  split_words:"true"`
 	ValidateHistorical bool   `yaml:"validateHistorical"                                            split_words:"true"`
 	DevMode            bool   `yaml:"devMode"                                                       split_words:"true"`
@@ -152,6 +155,7 @@ var globalConfig = &Config{
 	BlobPlugin:         DefaultBlobPlugin,
 	MetadataPlugin:     DefaultMetadataPlugin,
 	DevMode:            false,
+	ShutdownTimeout:    DefaultShutdownTimeout,
 }
 
 func LoadConfig(configFile string) (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,7 @@ func resetGlobalConfig() {
 		TlsCertFilePath: "",
 		TlsKeyFilePath:  "",
 		DevMode:         false,
+		ShutdownTimeout: DefaultShutdownTimeout,
 	}
 }
 
@@ -89,6 +90,7 @@ tlsKeyFilePath: "key1.pem"
 		TlsCertFilePath: "cert1.pem",
 		TlsKeyFilePath:  "key1.pem",
 		DevMode:         false,
+		ShutdownTimeout: DefaultShutdownTimeout,
 	}
 
 	actual, err := LoadConfig(tmpFile)
@@ -131,6 +133,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 		TlsCertFilePath: "",
 		TlsKeyFilePath:  "",
 		DevMode:         false,
+		ShutdownTimeout: DefaultShutdownTimeout,
 	}
 
 	if !reflect.DeepEqual(cfg, expected) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -99,6 +99,7 @@ type LedgerState struct {
 	chainsyncBlockfetchMutex   sync.Mutex
 	chainsyncBlockfetchWaiting bool
 	checkpointWrittenForEpoch  bool
+	closed                     bool
 }
 
 func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
@@ -201,6 +202,13 @@ func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 }
 
 func (ls *LedgerState) Close() error {
+	ls.Lock()
+	if ls.closed {
+		ls.Unlock()
+		return nil
+	}
+	ls.closed = true
+	ls.Unlock()
 	return ls.db.Close()
 }
 

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -59,6 +59,9 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 			m.nextTxIdx = len(m.mempool.transactions) - 1
 		}
 	}
+	if m.nextTxIdx < 0 || m.nextTxIdx >= len(m.mempool.transactions) {
+		return nil
+	}
 	nextTx := m.mempool.transactions[m.nextTxIdx]
 	if nextTx != nil {
 		// Increment next TX index

--- a/node.go
+++ b/node.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainsync"
@@ -44,6 +46,8 @@ type Node struct {
 	ouroboros      *ouroborosPkg.Ouroboros
 	shutdownFuncs  []func(context.Context) error
 	config         Config
+	done           chan struct{}
+	shutdownOnce   sync.Once
 }
 
 func New(cfg Config) (*Node, error) {
@@ -51,6 +55,7 @@ func New(cfg Config) (*Node, error) {
 	n := &Node{
 		config:   cfg,
 		eventBus: eventBus,
+		done:     make(chan struct{}),
 	}
 	if err := n.configPopulateNetworkMagic(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
@@ -134,13 +139,6 @@ func (n *Node) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to load state database: %w", err)
 	}
-	// Add shutdown cleanup for ledger/database
-	n.shutdownFuncs = append(
-		n.shutdownFuncs,
-		func(_ context.Context) error {
-			return state.Close()
-		},
-	)
 	n.ledgerState = state
 	n.ouroboros.LedgerState = n.ledgerState
 	// Run DB recovery if needed
@@ -229,23 +227,87 @@ func (n *Node) Run() error {
 		return err
 	}
 
-	// Wait forever
-	select {}
+	// Wait for shutdown signal
+	<-n.done
+	return nil
 }
 
 func (n *Node) Stop() error {
-	return n.shutdown()
+	var err error
+	n.shutdownOnce.Do(func() {
+		err = n.shutdown()
+	})
+	return err
 }
 
 func (n *Node) shutdown() error {
-	ctx := context.TODO()
+	// Create shutdown context with timeout (default 30s if not configured)
+	shutdownTimeout := 30 * time.Second
+	if n.config.shutdownTimeout > 0 {
+		shutdownTimeout = n.config.shutdownTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
 	var err error
-	// Shutdown ledger
-	err = errors.Join(err, n.ledgerState.Close())
-	// Call shutdown functions
+
+	n.config.logger.Debug("starting graceful shutdown")
+
+	// Phase 1: Stop accepting new work
+	n.config.logger.Debug("shutdown phase 1: stopping new work")
+
+	if n.peerGov != nil {
+		n.peerGov.Stop()
+	}
+
+	if n.utxorpc != nil {
+		if stopErr := n.utxorpc.Stop(ctx); stopErr != nil {
+			err = errors.Join(err, fmt.Errorf("utxorpc shutdown: %w", stopErr))
+		}
+	}
+
+	// Phase 2: Drain and close connections
+	n.config.logger.Debug("shutdown phase 2: draining connections")
+
+	if n.mempool != nil {
+		if stopErr := n.mempool.Stop(ctx); stopErr != nil {
+			err = errors.Join(err, fmt.Errorf("mempool shutdown: %w", stopErr))
+		}
+	}
+
+	if n.connManager != nil {
+		if stopErr := n.connManager.Stop(ctx); stopErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("connection manager shutdown: %w", stopErr),
+			)
+		}
+	}
+
+	// Phase 3: Flush state and close database
+	n.config.logger.Debug("shutdown phase 3: flushing state")
+
+	if n.ledgerState != nil {
+		if closeErr := n.ledgerState.Close(); closeErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("ledger state close: %w", closeErr),
+			)
+		}
+	}
+
+	// Phase 4: Cleanup resources
+	n.config.logger.Debug("shutdown phase 4: cleanup resources")
+
+	// Call registered shutdown functions
 	for _, fn := range n.shutdownFuncs {
-		err = errors.Join(err, fn(ctx))
+		if fnErr := fn(ctx); fnErr != nil {
+			err = errors.Join(err, fmt.Errorf("shutdown function: %w", fnErr))
+		}
 	}
 	n.shutdownFuncs = nil
+
+	n.config.logger.Debug("graceful shutdown complete")
+	close(n.done)
 	return err
 }

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"io"
+	"log/slog"
+
+	"github.com/blinklabs-io/dingo/event"
+)
+
+func TestUtxorpc_StartStop(t *testing.T) {
+	// Start server on ephemeral port by setting Port to 0
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil),
+		Host:     "127.0.0.1",
+		Port:     0,
+	})
+	if err := u.Start(); err != nil {
+		t.Fatalf("failed to start utxorpc: %v", err)
+	}
+	// Brief delay to ensure server is listening
+	time.Sleep(100 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := u.Stop(ctx); err != nil {
+		t.Fatalf("failed to stop utxorpc: %v", err)
+	}
+}


### PR DESCRIPTION
















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds graceful shutdown across the node, connection manager, mempool, and UTXORPC server to close listeners and connections cleanly and avoid noisy errors. Improves signal handling and shuts down the metrics server and services with configurable timeouts.

- **New Features**
  - Node: phased shutdown with a configurable timeout (default 30s); handles SIGINT/SIGTERM, stops services, shuts down the metrics server, and returns errors cleanly.
  - ConnectionManager: Stop(ctx) to close listeners and existing connections; tracks listeners and treats net.ErrClosed/closed-conn errors as normal during shutdown.
  - UTXORPC: Start is non-blocking and stores the http.Server; Stop(ctx) gracefully shuts down TLS/h2c servers.
  - Mempool: Stop(ctx) clears consumers and transactions to release resources.
  - Tests: added start/stop tests for ConnectionManager and UTXORPC.

<sup>Written for commit 3f3871756e95672f9ec0ad934fd038129760693f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated, configurable graceful shutdown across services (default 30s) with Stop APIs for servers, connection manager, mempool, and node components.

* **Bug Fixes**
  * Suppresses noisy accept errors during shutdown and improves shutdown logging.
  * Ensures idempotent closes and aggregates shutdown errors.
  * Safer event handling and bounds-checks to prevent nil/panic scenarios.

* **Tests**
  * Added start/stop tests validating shutdown behavior for networked services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->