### PR TITLE
fix(database): set default .dingo data dir

### DIFF
--- a/PLUGIN_DEVELOPMENT.md
+++ b/PLUGIN_DEVELOPMENT.md
@@ -277,3 +277,23 @@ Test environment variables and YAML configuration:
 ```bash
 DINGO_DATABASE_BLOB_MYPLUGIN_OPTION1=value ./dingo --blob myplugin
 ```
+
+## Programmatic Option Overrides (for tests)
+
+When writing tests or programmatically constructing database instances you can override plugin options
+without importing plugin implementation packages directly by using the plugin registry helper:
+
+```go
+// Set data-dir for the blob plugin to a per-test temp directory
+plugin.SetPluginOption(plugin.PluginTypeBlob, "badger", "data-dir", t.TempDir())
+
+// Set data-dir for the metadata plugin
+plugin.SetPluginOption(plugin.PluginTypeMetadata, "sqlite", "data-dir", t.TempDir())
+```
+
+The helper sets the plugin option's destination variable in the registry before plugin instantiation.
+If the requested option is not defined by the targeted plugin the call is non-fatal and returns nil,
+allowing tests to run regardless of which plugin implementation is selected.
+
+Using `t.TempDir()` guarantees each test uses its own on-disk path and prevents concurrent tests from
+colliding on shared directories (for example the default `.dingo` Badger directory).

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -36,8 +36,8 @@ const (
 
 type connectionInfo struct {
 	conn      *ouroboros.Connection
-	isInbound bool
 	peerAddr  string
+	isInbound bool
 }
 
 type peerConnectionState struct {
@@ -47,19 +47,19 @@ type peerConnectionState struct {
 
 type ConnectionManager struct {
 	connections      map[ouroboros.ConnectionId]*connectionInfo
+	metrics          *connectionManagerMetrics
 	config           ConnectionManagerConfig
 	connectionsMutex sync.Mutex
-	metrics          *connectionManagerMetrics
 }
 
 type ConnectionManagerConfig struct {
+	PromRegistry       prometheus.Registerer
 	Logger             *slog.Logger
 	EventBus           *event.EventBus
 	ConnClosedFunc     ConnectionManagerConnClosedFunc
 	Listeners          []ListenerConfig
 	OutboundConnOpts   []ouroboros.ConnectionOptionFunc
 	OutboundSourcePort uint
-	PromRegistry       prometheus.Registerer
 }
 
 type connectionManagerMetrics struct {

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -35,10 +35,10 @@ type BlobStoreS3 struct {
 	startupCtx    context.Context
 	logger        *S3Logger
 	client        *s3.Client
+	startupCancel context.CancelFunc
 	bucket        string
 	prefix        string
 	region        string
-	startupCancel context.CancelFunc
 	timeout       time.Duration
 }
 

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -34,13 +34,13 @@ type BlobStoreBadger struct {
 	promRegistry   prometheus.Registerer
 	db             *badger.DB
 	logger         *slog.Logger
-	dataDir        string
-	gcEnabled      bool
-	blockCacheSize uint64
-	indexCacheSize uint64
 	gcTicker       *time.Ticker
 	gcStopCh       chan struct{}
+	dataDir        string
 	gcWg           sync.WaitGroup
+	blockCacheSize uint64
+	indexCacheSize uint64
+	gcEnabled      bool
 }
 
 // New creates a new database
@@ -76,7 +76,7 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 				return nil, fmt.Errorf("failed to read data dir: %w", err)
 			}
 			// Create data directory
-			if err := os.MkdirAll(db.dataDir, fs.ModePerm); err != nil {
+			if err := os.MkdirAll(db.dataDir, 0o755); err != nil {
 				return nil, fmt.Errorf("failed to create data dir: %w", err)
 			}
 		}

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -43,6 +43,7 @@ func initCmdlineOptions() {
 	cmdlineOptions.blockCacheSize = DefaultBlockCacheSize
 	cmdlineOptions.indexCacheSize = DefaultIndexCacheSize
 	cmdlineOptions.gcEnabled = true
+	cmdlineOptions.dataDir = ".dingo"
 }
 
 // Register plugin
@@ -59,7 +60,7 @@ func init() {
 					Name:         "data-dir",
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "Data directory for badger storage",
-					DefaultValue: "",
+					DefaultValue: ".dingo",
 					Dest:         &(cmdlineOptions.dataDir),
 				},
 				{

--- a/database/plugin/blob/gcs/plugin_test.go
+++ b/database/plugin/blob/gcs/plugin_test.go
@@ -28,8 +28,8 @@ func TestCredentialValidation(t *testing.T) {
 	tests := []struct {
 		name            string
 		credentialsFile string
-		expectError     bool
 		errorMessage    string
+		expectError     bool
 	}{
 		{
 			name: "valid credentials file",

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -39,8 +39,8 @@ type MetadataStoreSqlite struct {
 	db           *gorm.DB
 	logger       *slog.Logger
 	timerVacuum  *time.Timer
-	timerMutex   sync.Mutex
 	dataDir      string
+	timerMutex   sync.Mutex
 	closed       bool
 }
 
@@ -159,7 +159,7 @@ func (d *MetadataStoreSqlite) Start() error {
 				return fmt.Errorf("failed to read data dir: %w", err)
 			}
 			// Create data directory
-			if err := os.MkdirAll(d.dataDir, fs.ModePerm); err != nil {
+			if err := os.MkdirAll(d.dataDir, 0o755); err != nil {
 				return fmt.Errorf("failed to create data dir: %w", err)
 			}
 		}

--- a/database/plugin/metadata/sqlite/plugin.go
+++ b/database/plugin/metadata/sqlite/plugin.go
@@ -31,7 +31,7 @@ var (
 func initCmdlineOptions() {
 	cmdlineOptionsMutex.Lock()
 	defer cmdlineOptionsMutex.Unlock()
-	cmdlineOptions.dataDir = ""
+	cmdlineOptions.dataDir = ".dingo"
 }
 
 // Register plugin
@@ -48,7 +48,7 @@ func init() {
 					Name:         "data-dir",
 					Type:         plugin.PluginOptionTypeString,
 					Description:  "Data directory for sqlite storage",
-					DefaultValue: "",
+					DefaultValue: ".dingo",
 					Dest:         &(cmdlineOptions.dataDir),
 				},
 			},

--- a/database/plugin/plugin.go
+++ b/database/plugin/plugin.go
@@ -63,3 +63,173 @@ func StartPlugin(pluginType PluginType, pluginName string) (Plugin, error) {
 
 	return p, nil
 }
+
+// SetPluginOption sets the value of a named option for a plugin entry. This
+// is used by callers that need to programmatically override plugin defaults
+// (for example to set data-dir before starting a plugin). It returns an error
+// if the plugin or option is not found or if the value type is incompatible.
+// NOTE: This function accesses the global pluginEntries slice without
+// synchronization. It should only be called during initialization or in
+// single-threaded contexts to avoid race conditions.
+// NOTE: This function writes directly to plugin option destinations (e.g.,
+// cmdlineOptions fields) without acquiring the plugin's cmdlineOptionsMutex.
+// It must be called before any plugin instantiation to avoid data races with
+// concurrent reads in NewFromCmdlineOptions.
+func SetPluginOption(
+	pluginType PluginType,
+	pluginName string,
+	optionName string,
+	value any,
+) error {
+	for i := range pluginEntries {
+		p := &pluginEntries[i]
+		if p.Type != pluginType || p.Name != pluginName {
+			continue
+		}
+		for _, opt := range p.Options {
+			if opt.Name != optionName {
+				continue
+			}
+			// Perform a type-checked assignment into the Dest pointer
+			switch opt.Type {
+			case PluginOptionTypeString:
+				v, ok := value.(string)
+				if !ok {
+					return fmt.Errorf(
+						"invalid type for option %s: expected string",
+						optionName,
+					)
+				}
+				if opt.Dest == nil {
+					return fmt.Errorf(
+						"nil destination for option %s",
+						optionName,
+					)
+				}
+				dest, ok := opt.Dest.(*string)
+				if !ok {
+					return fmt.Errorf(
+						"invalid destination type for option %s: expected *string",
+						optionName,
+					)
+				}
+				if dest == nil {
+					return fmt.Errorf(
+						"nil destination pointer for option %s",
+						optionName,
+					)
+				}
+				*dest = v
+				return nil
+			case PluginOptionTypeBool:
+				v, ok := value.(bool)
+				if !ok {
+					return fmt.Errorf(
+						"invalid type for option %s: expected bool",
+						optionName,
+					)
+				}
+				if opt.Dest == nil {
+					return fmt.Errorf(
+						"nil destination for option %s",
+						optionName,
+					)
+				}
+				dest, ok := opt.Dest.(*bool)
+				if !ok {
+					return fmt.Errorf(
+						"invalid destination type for option %s: expected *bool",
+						optionName,
+					)
+				}
+				if dest == nil {
+					return fmt.Errorf(
+						"nil destination pointer for option %s",
+						optionName,
+					)
+				}
+				*dest = v
+				return nil
+			case PluginOptionTypeInt:
+				v, ok := value.(int)
+				if !ok {
+					return fmt.Errorf(
+						"invalid type for option %s: expected int",
+						optionName,
+					)
+				}
+				if opt.Dest == nil {
+					return fmt.Errorf(
+						"nil destination for option %s",
+						optionName,
+					)
+				}
+				dest, ok := opt.Dest.(*int)
+				if !ok {
+					return fmt.Errorf(
+						"invalid destination type for option %s: expected *int",
+						optionName,
+					)
+				}
+				if dest == nil {
+					return fmt.Errorf(
+						"nil destination pointer for option %s",
+						optionName,
+					)
+				}
+				*dest = v
+				return nil
+			case PluginOptionTypeUint:
+				// accept uint64 or int
+				switch tv := value.(type) {
+				case uint64:
+					if opt.Dest == nil {
+						return fmt.Errorf("nil destination for option %s", optionName)
+					}
+					dest, ok := opt.Dest.(*uint64)
+					if !ok {
+						return fmt.Errorf("invalid destination type for option %s: expected *uint64", optionName)
+					}
+					if dest == nil {
+						return fmt.Errorf("nil destination pointer for option %s", optionName)
+					}
+					*dest = tv
+					return nil
+				case int:
+					if tv < 0 {
+						return fmt.Errorf("invalid value for option %s: negative int", optionName)
+					}
+					if opt.Dest == nil {
+						return fmt.Errorf("nil destination for option %s", optionName)
+					}
+					dest, ok := opt.Dest.(*uint64)
+					if !ok {
+						return fmt.Errorf("invalid destination type for option %s: expected *uint64", optionName)
+					}
+					if dest == nil {
+						return fmt.Errorf("nil destination pointer for option %s", optionName)
+					}
+					*dest = uint64(tv)
+					return nil
+				default:
+					return fmt.Errorf("invalid type for option %s: expected uint64 or int", optionName)
+				}
+			default:
+				return fmt.Errorf(
+					"unknown plugin option type %d for option %s",
+					opt.Type,
+					optionName,
+				)
+			}
+		}
+		// Option not found for this plugin: treat as non-fatal. This allows
+		// callers to attempt to set options that may not exist for all
+		// implementations (for example `data-dir` may not be relevant).
+		return nil
+	}
+	return fmt.Errorf(
+		"plugin %s of type %s not found",
+		pluginName,
+		PluginTypeName(pluginType),
+	)
+}

--- a/database/plugin/plugin_test.go
+++ b/database/plugin/plugin_test.go
@@ -1,0 +1,56 @@
+package plugin_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin"
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/internal/config"
+)
+
+// Basic tests for SetPluginOption to ensure programmatic option setting works
+func TestSetPluginOption_SuccessAndTypeCheck(t *testing.T) {
+	// Note: This test mutates global plugin state (cmdlineOptions in subpackages).
+	// If tests run in parallel, this could cause interference. Currently, tests
+	// are run sequentially, but consider adding cleanup if parallelism is enabled.
+
+	// Set data-dir for sqlite plugin to an empty string (in-memory) and ensure no error
+	if err := plugin.SetPluginOption(plugin.PluginTypeMetadata, config.DefaultMetadataPlugin, "data-dir", ""); err != nil {
+		t.Fatalf("unexpected error setting sqlite data-dir: %v", err)
+	}
+
+	// Setting with wrong type should return an error
+	if err := plugin.SetPluginOption(plugin.PluginTypeMetadata, config.DefaultMetadataPlugin, "data-dir", 123); err == nil {
+		t.Fatalf(
+			"expected type error when setting sqlite data-dir with int, got nil",
+		)
+	}
+
+	// Setting an unknown option is a no-op (non-fatal) so should not return an error
+	if err := plugin.SetPluginOption(plugin.PluginTypeMetadata, config.DefaultMetadataPlugin, "does-not-exist", "x"); err != nil {
+		t.Fatalf("unexpected error when setting unknown option: %v", err)
+	}
+
+	// Test setting data-dir for badger plugin (blob type)
+	if err := plugin.SetPluginOption(plugin.PluginTypeBlob, config.DefaultBlobPlugin, "data-dir", t.TempDir()); err != nil {
+		t.Fatalf("unexpected error setting badger data-dir: %v", err)
+	}
+
+	// Test uint option handling for badger block-cache-size
+	if err := plugin.SetPluginOption(plugin.PluginTypeBlob, config.DefaultBlobPlugin, "block-cache-size", uint64(100000000)); err != nil {
+		t.Fatalf("unexpected error setting badger block-cache-size: %v", err)
+	}
+
+	// Test bool option handling for badger gc
+	if err := plugin.SetPluginOption(plugin.PluginTypeBlob, config.DefaultBlobPlugin, "gc", true); err != nil {
+		t.Fatalf("unexpected error setting badger gc: %v", err)
+	}
+
+	// Test plugin not found error
+	if err := plugin.SetPluginOption(plugin.PluginTypeMetadata, "nonexistent", "data-dir", t.TempDir()); err == nil {
+		t.Fatalf(
+			"expected error when setting option for nonexistent plugin, got nil",
+		)
+	}
+}

--- a/database/plugin/register.go
+++ b/database/plugin/register.go
@@ -49,6 +49,10 @@ type PluginEntry struct {
 
 var pluginEntries []PluginEntry
 
+// Register adds a plugin entry to the global registry.
+// NOTE: This function is not thread-safe and should only be called during
+// package initialization (e.g., in init() functions) before any concurrent
+// goroutines begin. Concurrent access to pluginEntries is not protected.
 func Register(pluginEntry PluginEntry) {
 	pluginEntries = append(pluginEntries, pluginEntry)
 }

--- a/internal/integration/benchmark_test.go
+++ b/internal/integration/benchmark_test.go
@@ -99,12 +99,12 @@ func loadBlockData(numBlocks int) ([][]byte, error) {
 
 // getTestBackends returns a slice of test backends for benchmarking
 func getTestBackends(b *testing.B, diskDataDir string) []struct {
-	name   string
 	config *database.Config
+	name   string
 } {
 	backends := []struct {
-		name   string
 		config *database.Config
+		name   string
 	}{
 		{
 			name: "memory",
@@ -133,8 +133,8 @@ func getTestBackends(b *testing.B, diskDataDir string) []struct {
 		// Use path prefix for isolation instead of unique bucket names
 		testPrefix := strings.ReplaceAll(b.Name(), "/", "-")
 		backends = append(backends, struct {
-			name   string
 			config *database.Config
+			name   string
 		}{
 			name: "GCS",
 			config: &database.Config{
@@ -153,8 +153,8 @@ func getTestBackends(b *testing.B, diskDataDir string) []struct {
 		// Use path prefix for isolation instead of unique bucket names
 		testPrefix := strings.ReplaceAll(b.Name(), "/", "-")
 		backends = append(backends, struct {
-			name   string
 			config *database.Config
+			name   string
 		}{
 			name: "S3",
 			config: &database.Config{


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default data directory to ".dingo" for the Badger blob and SQLite metadata plugins, with programmatic overrides via SetPluginOption (used in database.New). This ensures predictable local storage and lets tests or configs choose per-run dirs or in-memory mode.

<sup>Written for commit 930411a07bc988071beb3f7f199f29eafdbcb82d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Programmatic plugin option overrides for tests
  * Plugin registration API to register available plugins

* **Documentation**
  * Added guidance and examples for overriding plugin options in tests, with per-test temporary directories

* **Configuration**
  * Default storage directory set to ".dingo" for blob and metadata plugins
  * Directory creation now uses stricter permissions for on-disk storage

* **Tests**
  * New tests validating option overrides, type checks, and isolated test data dirs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->