### PR TITLE
feat(database): support getting inactive items

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -21,13 +21,18 @@ import (
 // GetAccount returns an account by staking key
 func (d *Database) GetAccount(
 	stakeKey []byte,
+	includeInactive bool,
 	txn *Txn,
 ) (*models.Account, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Commit() //nolint:errcheck
 	}
-	account, err := d.metadata.GetAccount(stakeKey, txn.Metadata())
+	account, err := d.metadata.GetAccount(
+		stakeKey,
+		includeInactive,
+		txn.Metadata(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/database/drep.go
+++ b/database/drep.go
@@ -13,3 +13,27 @@
 // limitations under the License.
 
 package database
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// GetDrep returns a drep by credential
+func (d *Database) GetDrep(
+	cred []byte,
+	includeInactive bool,
+	txn *Txn,
+) (*models.Drep, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Commit() //nolint:errcheck
+	}
+	ret, err := d.metadata.GetDrep(cred, includeInactive, txn.Metadata())
+	if err != nil {
+		return nil, err
+	}
+	if ret == nil {
+		return nil, models.ErrDrepNotFound
+	}
+	return ret, nil
+}

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -14,7 +14,13 @@
 
 package models
 
-import "github.com/blinklabs-io/dingo/database/types"
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+var ErrDrepNotFound = errors.New("drep not found")
 
 type Drep struct {
 	AnchorUrl     string

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -25,13 +25,18 @@ import (
 // GetAccount gets an account
 func (d *MetadataStoreSqlite) GetAccount(
 	stakeKey []byte,
+	includeInactive bool,
 	txn *gorm.DB,
 ) (*models.Account, error) {
 	ret := &models.Account{}
 	if txn == nil {
 		txn = d.DB()
 	}
-	result := txn.Where("staking_key = ? AND active = ?", stakeKey, true).First(ret)
+	query := txn
+	if !includeInactive {
+		query = query.Where("active = ?", true)
+	}
+	result := query.First(ret, "staking_key = ?", stakeKey)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -45,6 +45,7 @@ type MetadataStore interface {
 	) ([]lcommon.PoolRegistrationCertificate, error)
 	GetPool(
 		lcommon.PoolKeyHash,
+		bool, // includeInactive
 		*gorm.DB,
 	) (*models.Pool, error)
 	GetStakeRegistrations(
@@ -55,6 +56,7 @@ type MetadataStore interface {
 
 	GetAccount(
 		[]byte, // stakeKey
+		bool, // includeInactive
 		*gorm.DB,
 	) (*models.Account, error)
 	GetBlockNonce(
@@ -67,8 +69,9 @@ type MetadataStore interface {
 	) (*models.Datum, error)
 	GetDrep(
 		[]byte, // credential
+		bool, // includeInactive
 		*gorm.DB,
-	) (models.Drep, error)
+	) (*models.Drep, error)
 	GetPParams(
 		uint64, // epoch
 		*gorm.DB,

--- a/database/pool.go
+++ b/database/pool.go
@@ -22,13 +22,14 @@ import (
 // GetPool returns a pool by its key hash
 func (d *Database) GetPool(
 	pkh lcommon.PoolKeyHash,
+	includeInactive bool,
 	txn *Txn,
 ) (*models.Pool, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Commit() //nolint:errcheck
 	}
-	ret, err := d.metadata.GetPool(pkh, txn.Metadata())
+	ret, err := d.metadata.GetPool(pkh, includeInactive, txn.Metadata())
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -517,7 +517,7 @@ func BenchmarkAccountLookupByStakeKeyNoData(b *testing.B) {
 
 	// Benchmark lookup (on empty database for now)
 	for b.Loop() {
-		_, err := db.Metadata().GetAccount(testStakeKey, nil)
+		_, err := db.Metadata().GetAccount(testStakeKey, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -591,7 +591,7 @@ func BenchmarkAccountLookupByStakeKeyRealData(b *testing.B) {
 	// Benchmark lookup against real seeded data
 	for i := 0; b.Loop(); i++ {
 		key := testStakeKeys[i%len(testStakeKeys)]
-		_, err := db.Metadata().GetAccount(key, nil)
+		_, err := db.Metadata().GetAccount(key, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -621,7 +621,7 @@ func BenchmarkPoolLookupByKeyHashNoData(b *testing.B) {
 
 	// Benchmark lookup (on empty database for now)
 	for b.Loop() {
-		_, err := db.Metadata().GetPool(testPoolKeyHash, nil)
+		_, err := db.Metadata().GetPool(testPoolKeyHash, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -695,7 +695,7 @@ func BenchmarkPoolLookupByKeyHashRealData(b *testing.B) {
 	// Benchmark lookup against real seeded data
 	for i := 0; b.Loop(); i++ {
 		hash := testPoolKeyHashes[i%len(testPoolKeyHashes)]
-		_, err := db.Metadata().GetPool(hash, nil)
+		_, err := db.Metadata().GetPool(hash, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -725,9 +725,8 @@ func BenchmarkDRepLookupByKeyHashNoData(b *testing.B) {
 
 	// Benchmark lookup (on empty database for now)
 	for b.Loop() {
-		_, err := db.Metadata().GetDrep(testDRepCredential, nil)
-		// Don't fail on "record not found" - this is expected for non-existent DReps
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		_, err := db.Metadata().GetDrep(testDRepCredential, false, nil)
+		if err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -800,9 +799,8 @@ func BenchmarkDRepLookupByKeyHashRealData(b *testing.B) {
 	// Benchmark lookup against real seeded data
 	for i := 0; b.Loop(); i++ {
 		cred := testDRepCredentials[i%len(testDRepCredentials)]
-		_, err := db.Metadata().GetDrep(cred, nil)
-		// Don't fail on "record not found" - this is expected for non-existent DReps
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		_, err := db.Metadata().GetDrep(cred, false, nil)
+		if err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -81,7 +81,7 @@ func (lv *LedgerView) StakeRegistration(
 func (lv *LedgerView) PoolCurrentState(
 	pkh lcommon.PoolKeyHash,
 ) (*lcommon.PoolRegistrationCertificate, *uint64, error) {
-	pool, err := lv.ls.db.GetPool(pkh, lv.txn)
+	pool, err := lv.ls.db.GetPool(pkh, false, lv.txn)
 	if err != nil {
 		if errors.Is(err, models.ErrPoolNotFound) {
 			pool = &models.Pool{}


### PR DESCRIPTION
























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add includeInactive support to account, pool, and drep lookups so callers can fetch inactive records when needed. Default behavior remains active-only; callers now pass the flag where needed.

- **New Features**
  - Added includeInactive to GetAccount, GetPool, and GetDrep in Database and MetadataStore.
  - SQLite queries filter active=true when includeInactive is false; pools also check latest registration vs retirement.
  - Preloaded Pool Retirement for accurate active/retired checks.
  - Added models.ErrDrepNotFound.

- **Migration**
  - Update call sites to pass the new includeInactive flag.
  - Transactions pass true when handling registrations/retirements to allow reactivation; ledger view and benchmarks use false.
  - No schema changes.

<sup>Written for commit 0f6aa18bc1b0bd8030ed253e6d07a082ae6c6fe2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

























<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added include/exclude flag to fetch inactive/archived accounts, pools, and DREPs across metadata APIs.

* **Bug Fixes**
  * More consistent handling of missing pools/DREPs (nil vs explicit not-found errors).
  * Certificate processing now explicitly reactivates or deactivates entities and preserves active/inactive semantics.
  * Pool active-state checks refined to respect retirement/epoch logic.

* **Tests**
  * Benchmarks/tests updated to use the new flag and adjusted call signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->