### PR TITLE
fix(mempool): panic on consumer out of bounds

### DIFF
--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -60,7 +60,7 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 		}
 	}
 	if m.nextTxIdx < 0 || m.nextTxIdx >= len(m.mempool.transactions) {
-		return nil
+		panic("mempool consumer nextTxIdx out of bounds")
 	}
 	nextTx := m.mempool.transactions[m.nextTxIdx]
 	if nextTx != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Change NextTx to panic when nextTxIdx is out of bounds, replacing the silent nil return. This fails fast on invalid mempool state and prevents hidden bugs.

<sup>Written for commit 527cf2afccfe9db50236e430dc6d71fd31db3fc9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

