### PR TITLE
fix(database): save account active state

### DIFF
--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -31,7 +31,7 @@ func (d *MetadataStoreSqlite) GetAccount(
 	if txn == nil {
 		txn = d.DB()
 	}
-	result := txn.First(ret, "staking_key = ?", stakeKey)
+	result := txn.Where("staking_key = ? AND active = ?", stakeKey, true).First(ret)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -53,6 +53,7 @@ func (d *MetadataStoreSqlite) SetAccount(
 		AddedSlot:  slot,
 		Pool:       pkh,
 		Drep:       drep,
+		Active:     active,
 	}
 	onConflict := clause.OnConflict{
 		Columns:   []clause.Column{{Name: "staking_key"}},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Save the account active flag and return only active accounts when fetching by staking key. Prevents inactive accounts from being returned.

- **Bug Fixes**
  - Persist Active state in SetAccount.
  - Filter GetAccount queries by active = true.

<sup>Written for commit 35c4c76c89a002237945216256116f97985d8d81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account retrieval to ensure only active accounts are displayed
  * Enhanced account creation with proper status initialization and tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->