### PR TITLE
refactor(event): create subscriber interface

### DIFF
--- a/event/delivery_test.go
+++ b/event/delivery_test.go
@@ -1,0 +1,43 @@
+package event
+
+import (
+	"fmt"
+	"testing"
+)
+
+// mockSubscriber returns an error on Deliver to simulate a failing remote client.
+type mockSubscriber struct {
+	closed bool
+}
+
+func (m *mockSubscriber) Deliver(evt Event) error {
+	return fmt.Errorf("deliver failed")
+}
+
+func (m *mockSubscriber) Close() {
+	m.closed = true
+}
+
+func TestDeliverFailureUnregisters(t *testing.T) {
+	// Create a bus without metrics
+	eb := NewEventBus(nil, nil)
+	// Register mock subscriber
+	sub := &mockSubscriber{}
+	subId := eb.RegisterSubscriber("test.fail", sub)
+	if subId == 0 {
+		t.Fatalf("expected non-zero sub id")
+	}
+	// Publish event should cause deliver failure and unregister
+	eb.Publish("test.fail", NewEvent("test.fail", "x"))
+	// After publish, subscriber map for event type should not contain subId
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	if subs, ok := eb.subscribers["test.fail"]; ok {
+		if _, exists := subs[subId]; exists {
+			t.Fatalf("expected subscriber to be removed after deliver failure")
+		}
+	}
+	if !sub.closed {
+		t.Fatalf("expected subscriber Close() to be called after deliver failure")
+	}
+}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -24,7 +24,7 @@ import (
 func TestEventBusSingleSubscriber(t *testing.T) {
 	var testEvtData int = 999
 	var testEvtType event.EventType = "test.event"
-	eb := event.NewEventBus(nil)
+	eb := event.NewEventBus(nil, nil)
 	_, subCh := eb.Subscribe(testEvtType)
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, testEvtData))
 	select {
@@ -48,7 +48,7 @@ func TestEventBusSingleSubscriber(t *testing.T) {
 func TestEventBusMultipleSubscribers(t *testing.T) {
 	var testEvtData int = 999
 	var testEvtType event.EventType = "test.event"
-	eb := event.NewEventBus(nil)
+	eb := event.NewEventBus(nil, nil)
 	_, sub1Ch := eb.Subscribe(testEvtType)
 	_, sub2Ch := eb.Subscribe(testEvtType)
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, testEvtData))
@@ -99,24 +99,25 @@ func TestEventBusMultipleSubscribers(t *testing.T) {
 func TestEventBusUnsubscribe(t *testing.T) {
 	var testEvtData int = 999
 	var testEvtType event.EventType = "test.event"
-	eb := event.NewEventBus(nil)
+	eb := event.NewEventBus(nil, nil)
 	subId, subCh := eb.Subscribe(testEvtType)
 	eb.Unsubscribe(testEvtType, subId)
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, testEvtData))
 	select {
 	case _, ok := <-subCh:
 		if !ok {
-			t.Fatalf("event channel closed unexpectedly")
+			// Expected: Unsubscribe closes the subscriber channel
+			return
 		}
 		t.Fatalf("received unexpected event")
 	case <-time.After(1 * time.Second):
-		// NOTE: this is the expected way for the test to end
+		t.Fatalf("subscriber channel was not closed after Unsubscribe")
 	}
 }
 
 func TestEventBusStop(t *testing.T) {
 	var testEvtType event.EventType = "test.event"
-	eb := event.NewEventBus(nil)
+	eb := event.NewEventBus(nil, nil)
 
 	// Subscribe regular subscriber
 	_, subCh1 := eb.Subscribe(testEvtType)

--- a/event/metrics.go
+++ b/event/metrics.go
@@ -20,8 +20,9 @@ import (
 )
 
 type eventMetrics struct {
-	eventsTotal *prometheus.CounterVec
-	subscribers *prometheus.GaugeVec
+	eventsTotal    *prometheus.CounterVec
+	subscribers    *prometheus.GaugeVec
+	deliveryErrors *prometheus.CounterVec
 }
 
 func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
@@ -37,8 +38,15 @@ func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
 	e.metrics.subscribers = promautoFactory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "event_subscribers",
-			Help: "subscribers by event type",
+			Help: "subscribers by event type and kind",
 		},
-		[]string{"type"},
+		[]string{"type", "kind"},
+	)
+	e.metrics.deliveryErrors = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_delivery_errors_total",
+			Help: "total delivery errors by event type and kind",
+		},
+		[]string{"type", "kind"},
 	)
 }

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -1,0 +1,50 @@
+package event
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestPublishUnsubscribeRace attempts to reproduce the race between Publish
+// and Unsubscribe/Stop where a send on a channel could hit a concurrently
+// closing channel. The test runs many iterations to probabilistically
+// surface races; the implementation should be deterministic and not panic.
+func TestPublishUnsubscribeRace(t *testing.T) {
+	const iters = 1000
+	for i := 0; i < iters; i++ {
+		eb := NewEventBus(nil, nil)
+		typ := EventType("race.test")
+
+		// Subscribe a channel-backed subscriber
+		subId, ch := eb.Subscribe(typ)
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+
+		// Publisher goroutine
+		go func() {
+			defer wg.Done()
+			// Publish many events to increase chance of overlapping with close
+			for j := 0; j < 10; j++ {
+				eb.Publish(typ, NewEvent(typ, j))
+			}
+		}()
+
+		// Concurrently unsubscribe/stop the bus
+		go func() {
+			defer wg.Done()
+			// Unsubscribe the subscriber and Stop the bus concurrently
+			eb.Unsubscribe(typ, subId)
+			eb.Stop()
+		}()
+
+		// Drain channel until closed or timeout (no timeout here; Publish/Close should finish)
+		go func() {
+			defer wg.Done()
+			for range ch {
+			}
+		}()
+
+		wg.Wait()
+	}
+}

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -64,7 +64,7 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 		return err
 	}
 	// Load chain
-	eventBus := event.NewEventBus(nil)
+	eventBus := event.NewEventBus(nil, logger)
 	cm, err := chain.NewManager(
 		db,
 		eventBus,

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -32,7 +32,7 @@ func TestMempool_Stop(t *testing.T) {
 	// Create a mempool with minimal config
 	m := NewMempool(MempoolConfig{
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:     event.NewEventBus(nil),
+		EventBus:     event.NewEventBus(nil, nil),
 		PromRegistry: prometheus.NewRegistry(),
 	})
 

--- a/node.go
+++ b/node.go
@@ -51,7 +51,7 @@ type Node struct {
 }
 
 func New(cfg Config) (*Node, error) {
-	eventBus := event.NewEventBus(cfg.promRegistry)
+	eventBus := event.NewEventBus(cfg.promRegistry, cfg.logger)
 	n := &Node{
 		config:   cfg,
 		eventBus: eventBus,

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -32,7 +32,7 @@ import (
 
 func newMockEventBus() *event.EventBus {
 	// Use the real EventBus for simplicity
-	return event.NewEventBus(nil)
+	return event.NewEventBus(nil, nil)
 }
 
 func TestNewPeerGovernor(t *testing.T) {

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -29,7 +29,7 @@ func TestUtxorpc_StartStop(t *testing.T) {
 	// Start server on ephemeral port by setting Port to 0
 	u := NewUtxorpc(UtxorpcConfig{
 		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus: event.NewEventBus(nil),
+		EventBus: event.NewEventBus(nil, nil),
 		Host:     "127.0.0.1",
 		Port:     0,
 	})


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduced a subscriber interface in EventBus while preserving the channel-based API. This enables network-backed subscribers, adds delivery error logging/metrics, and makes shutdown and unsubscribe safer.

- **Refactors**
  - Replaced channel maps with a Subscriber interface; channelSubscriber keeps blocking delivery semantics.
  - Stop and Unsubscribe now close subscribers safely (clear under lock, close outside).

- **New Features**
  - Added RegisterSubscriber(eventType, subscriber) for non-channel subscribers.
  - Added logger support, deliveryErrors metric, kind labels for the subscribers gauge, and automatic unregister on delivery errors/panics.

<sup>Written for commit 0a30f011651d560c0d28469e20f254151facd84d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive logging support for event delivery operations
  * Automatic removal of failed subscribers to enhance system reliability
  * New metrics tracking delivery errors for improved monitoring and observability

* **Bug Fixes**
  * Improved panic handling during event delivery to prevent cascading failures
  * Enhanced thread-safety in concurrent event operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->