### PR TITLE
build(make): add mod-tidy to format dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ mod-tidy:
 clean:
 	rm -f $(BINARIES)
 
-format:
+format: mod-tidy
 	go fmt ./...
 	gofmt -s -w $(GO_FILES)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `make format` run `mod-tidy` first so dependencies are tidied whenever code is formatted. This keeps go.mod and go.sum up to date and consistent.

<sup>Written for commit 036cff4ecf437a01e495dc378b3f72c21894c8f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

