### PR TITLE
fix(cmd): preserve non-profiling args correctly.

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -141,6 +141,7 @@ func main() {
 	// Parse profiling flags before cobra setup (handle both --flag=value and --flag value syntax)
 	cpuprofile := ""
 	memprofile := ""
+	var newArgs []string
 	args := os.Args
 	if len(args) > 0 {
 		args = args[1:] // Skip program name
@@ -160,8 +161,17 @@ func main() {
 		case arg == "--memprofile" && i+1 < len(args):
 			memprofile = args[i+1]
 			i++ // Skip next arg
+		default:
+			// Not a profiling flag, keep it
+			newArgs = append(newArgs, arg)
 		}
 	}
+	// Reconstruct os.Args with program name (os.Args[0] is never nil in practice, but nilaway doesn't know this)
+	programName := "dingo"
+	if len(os.Args) > 0 {
+		programName = os.Args[0]
+	}
+	os.Args = append([]string{programName}, newArgs...)
 
 	// Initialize CPU profiling (starts immediately, stops on exit)
 	if cpuprofile != "" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed CLI parsing so non-profiling args are preserved when handling --cpuprofile and --memprofile before Cobra init. Rebuilds os.Args with the program name and filtered args to prevent commands and options from being dropped.

<sup>Written for commit 24d2bbf4514d2321a18f7c7e6366b3969bfba0c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced argument processing to properly handle profiling options during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->