### PR TITLE
build(publish): use go 1.25 when building binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,15 +81,15 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0 https://github.com/actions/setup-go/releases/tag/v6.1.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0
         with:
           path: |
             ~/go/pkg/mod
             ${{ runner.os == 'macOS' && '~/Library/Caches/go-build' || '~/.cache/go-build' }}
-          key: ${{ runner.os }}-go-1.24.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.25.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.24.x-
+            ${{ runner.os }}-go-1.25.x-
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Build release binaries with Go 1.25 in the publish workflow, and update the cache key to 1.25 to prevent cache collisions. This standardizes builds on Go 1.25 for consistent, reproducible artifacts.

<sup>Written for commit 3b821662c198d6721630522181017346f8dd4c5c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.25.x in CI/CD workflows for improved build infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->