### PR TITLE
fix(ledger): increase block batch size to 200

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -674,12 +674,12 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				continue
 			}
 		}
-		// Process batch in groups of 50 to stay under DB txn limits
-		for i = 0; i < len(nextBatch); i += 50 {
+		// Process batch in groups of 200 to stay under DB txn limits
+		for i = 0; i < len(nextBatch); i += 200 {
 			ls.Lock()
 			end = min(
 				len(nextBatch),
-				i+50,
+				i+200,
 			)
 			txn = ls.db.Transaction(true)
 			err = txn.Do(func(txn *database.Txn) error {


### PR DESCRIPTION
Tested with "make test-load"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase ledger block processing batch size from 50 to 200 to improve throughput while staying under database transaction limits. This speeds up block processing without changing behavior.

<sup>Written for commit 4c5c40b603d64367448e10fe5dd5fbad6f73f6a2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized ledger batch processing to handle larger data sets more efficiently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->