### PR TITLE
perf(database): double badger cache sizes

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -88,7 +89,8 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 			WithLogger(NewBadgerLogger(db.logger)).
 			WithLoggingLevel(badger.WARNING).
 			WithBlockCacheSize(int64(db.blockCacheSize)). //nolint:gosec // blockCacheSize is controlled and reasonable
-			WithIndexCacheSize(int64(db.indexCacheSize))  //nolint:gosec // indexCacheSize is controlled and reasonable
+			WithIndexCacheSize(int64(db.indexCacheSize)). //nolint:gosec // indexCacheSize is controlled and reasonable
+			WithCompression(options.Snappy)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
 			return nil, err

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -22,8 +22,8 @@ import (
 
 // Default cache sizes for BadgerDB (in bytes)
 const (
-	DefaultBlockCacheSize = 805306368 // 768MB
-	DefaultIndexCacheSize = 268435456 // 256MB
+	DefaultBlockCacheSize = 1610612736 // 1.5GB (increased from 768MB)
+	DefaultIndexCacheSize = 536870912  // 512MB (increased from 256MB)
 )
 
 var (

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -19,10 +19,10 @@ database:
     badger:
       # Data directory for BadgerDB storage
       data-dir: ".dingo/badger"
-      # Block cache size in bytes (default: 805306368 ~768MB)
-      block-cache-size: 805306368
-      # Index cache size in bytes (default: 268435456 ~256MB)
-      index-cache-size: 268435456
+      # Block cache size in bytes (default: 1610612736 ~1.5GB)
+      block-cache-size: 1610612736
+      # Index cache size in bytes (default: 536870912 ~512MB)
+      index-cache-size: 536870912
       # Enable garbage collection (default: true)
       gc: true
     gcs:


### PR DESCRIPTION
The snappy compression isn't a change but merely codifying the state since we compile without CGO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doubled BadgerDB block and index cache defaults to improve read performance and reduce disk I/O. Explicitly set Snappy compression to match current non-CGO builds.

- **Migration**
  - New defaults use ~2GB total cache (was ~1GB). Adjust block/index cache sizes in dingo.yaml if memory is tight.
  - No data changes or reindex needed; safe to roll out.

<sup>Written for commit 573f443c136e3df49d9c16f599a4c53c0ed9a201. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Snappy compression for Badger database storage
  * Increased default cache sizes for Badger database: block cache from 768MB to 1.5GB, index cache from 256MB to 512MB

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->