### PR TITLE
perf: use sync pools for buffer reuse in ledger deltas

### DIFF
--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -17,10 +17,40 @@ package ledger
 import (
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/blinklabs-io/dingo/database"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Buffer pools for memory reuse
+// Pre-allocation capacities (currently 10) may need tuning for high-throughput scenarios
+var (
+	ledgerDeltaPool = sync.Pool{
+		New: func() any {
+			return &LedgerDelta{}
+		},
+	}
+	transactionRecordSlicePool = sync.Pool{
+		New: func() any {
+			// Pre-allocate with reasonable capacity and return pointer to slice
+			s := make([]TransactionRecord, 0, 10)
+			return &s
+		},
+	}
+	certDepositsMapPool = sync.Pool{
+		New: func() any {
+			return make(map[int]uint64)
+		},
+	}
+	ledgerDeltaBatchPool = sync.Pool{
+		New: func() any {
+			return &LedgerDeltaBatch{
+				deltas: make([]*LedgerDelta, 0, 10),
+			}
+		},
+	}
 )
 
 type TransactionRecord struct {
@@ -32,6 +62,30 @@ type LedgerDelta struct {
 	Point        ocommon.Point
 	BlockEraId   uint
 	Transactions []TransactionRecord
+	txSlicePtr   *[]TransactionRecord // store original pointer from pool
+}
+
+func NewLedgerDelta(point ocommon.Point, blockEraId uint) *LedgerDelta {
+	delta := ledgerDeltaPool.Get().(*LedgerDelta)
+	delta.Point = point
+	delta.BlockEraId = blockEraId
+	slicePtr := transactionRecordSlicePool.Get().(*[]TransactionRecord)
+	delta.Transactions = (*slicePtr)[:0] // Reset slice
+	delta.txSlicePtr = slicePtr          // Store original pointer
+	return delta
+}
+
+func (d *LedgerDelta) Release() {
+	// Return the transaction slice to the pool
+	if d.txSlicePtr != nil {
+		// Reset slice and put original pointer back to pool
+		*d.txSlicePtr = (*d.txSlicePtr)[:0]
+		transactionRecordSlicePool.Put(d.txSlicePtr)
+		d.txSlicePtr = nil
+		d.Transactions = nil
+	}
+	// Return the delta to the pool
+	ledgerDeltaPool.Put(d)
 }
 
 func (d *LedgerDelta) addTransaction(
@@ -55,10 +109,16 @@ func (d *LedgerDelta) apply(ls *LedgerState, txn *database.Txn) error {
 
 		// Calculate certificate deposits
 		certs := tr.Tx.Certificates()
-		certDeposits := make(map[int]uint64)
+		certDeposits := certDepositsMapPool.Get().(map[int]uint64)
+		// Clear the map
+		for k := range certDeposits {
+			delete(certDeposits, k)
+		}
 		for i, cert := range certs {
 			deposit, err := ls.calculateCertificateDeposit(cert, d.BlockEraId)
 			if err != nil {
+				// Return the map to pool before returning error
+				certDepositsMapPool.Put(certDeposits)
 				return fmt.Errorf("calculate certificate deposit: %w", err)
 			}
 			certDeposits[i] = deposit
@@ -73,6 +133,8 @@ func (d *LedgerDelta) apply(ls *LedgerState, txn *database.Txn) error {
 			certDeposits,
 			txn,
 		)
+		// Return the map to pool
+		certDepositsMapPool.Put(certDeposits)
 		if err != nil {
 			return fmt.Errorf("record transaction: %w", err)
 		}
@@ -84,12 +146,35 @@ type LedgerDeltaBatch struct {
 	deltas []*LedgerDelta
 }
 
+func NewLedgerDeltaBatch() *LedgerDeltaBatch {
+	batch := ledgerDeltaBatchPool.Get().(*LedgerDeltaBatch)
+	batch.deltas = batch.deltas[:0] // Reset slice
+	return batch
+}
+
+func (b *LedgerDeltaBatch) Release() {
+	// Release all individual deltas back to their pools
+	for i, delta := range b.deltas {
+		if delta != nil {
+			delta.Release()
+			b.deltas[i] = nil // Avoid double-release
+		}
+	}
+	// Clear the batch slice
+	b.deltas = b.deltas[:0]
+	// Return the batch to the pool
+	ledgerDeltaBatchPool.Put(b)
+}
+
 func (b *LedgerDeltaBatch) addDelta(delta *LedgerDelta) {
 	b.deltas = append(b.deltas, delta)
 }
 
 func (b *LedgerDeltaBatch) apply(ls *LedgerState, txn *database.Txn) error {
 	for _, delta := range b.deltas {
+		if delta == nil {
+			continue // Skip nil deltas (shouldn't happen in normal operation)
+		}
 		err := delta.apply(ls, txn)
 		if err != nil {
 			return err


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use sync.Pool to reuse LedgerDelta buffers and related data structures, cutting allocations and GC pressure during block processing. This improves throughput when applying transaction batches.

- **Refactors**
  - Added pools for LedgerDelta, LedgerDeltaBatch, transaction slice, and certificate deposit map.
  - Introduced NewLedgerDelta/NewLedgerDeltaBatch and Release methods; integrated into block and batch apply flow.
  - Ensured pooled maps/slices are cleared and returned on success and error paths.

<sup>Written for commit b071f0095faea6da5870beb07bad2e36f994f837. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented memory pooling for ledger delta and transaction buffers to reduce allocations and improve throughput.
  * Added pool-backed preallocation for transaction records.

* **New Features**
  * Exposed lifecycle APIs to acquire and release ledger deltas and batches for safe reuse.

* **Bug Fixes**
  * Ensured pooled resources are always returned on error paths to prevent leaks and improve stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->