### PR TITLE
fix(database): use any instead of interface{}

### DIFF
--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1198,7 +1198,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				// Build CASE statement for batch update
 				var ids []uint
 				var whenClauses []string
-				var values []interface{}
+				var values []any
 
 				for unifiedID, specializedID := range certIDUpdates {
 					ids = append(ids, unifiedID)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace interface{} with any in the SQLite metadata transaction code to align with modern Go usage. No functional changes; this is a small refactor for clarity and consistency.

<sup>Written for commit c5f5a258c48dd4d6d73e4ff230153b857fcfacb2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

