### PR TITLE
fix(event): range over int and update formatting

### DIFF
--- a/event/delivery_test.go
+++ b/event/delivery_test.go
@@ -38,6 +38,8 @@ func TestDeliverFailureUnregisters(t *testing.T) {
 		}
 	}
 	if !sub.closed {
-		t.Fatalf("expected subscriber Close() to be called after deliver failure")
+		t.Fatalf(
+			"expected subscriber Close() to be called after deliver failure",
+		)
 	}
 }

--- a/event/event.go
+++ b/event/event.go
@@ -243,7 +243,13 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 			}
 			// Log the delivery error/panic for observability using provided logger if present
 			if e.Logger != nil {
-				e.Logger.Debug("event delivery error", "type", eventType, "err", deliverErr)
+				e.Logger.Debug(
+					"event delivery error",
+					"type",
+					eventType,
+					"err",
+					deliverErr,
+				)
 			} else {
 				slog.Default().Debug("event delivery error", "type", eventType, "err", deliverErr)
 			}

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -11,7 +11,7 @@ import (
 // surface races; the implementation should be deterministic and not panic.
 func TestPublishUnsubscribeRace(t *testing.T) {
 	const iters = 1000
-	for i := 0; i < iters; i++ {
+	for range iters {
 		eb := NewEventBus(nil, nil)
 		typ := EventType("race.test")
 
@@ -25,7 +25,7 @@ func TestPublishUnsubscribeRace(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			// Publish many events to increase chance of overlapping with close
-			for j := 0; j < 10; j++ {
+			for j := range 10 {
 				eb.Publish(typ, NewEvent(typ, j))
 			}
 		}()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Modernized tests to use Go 1.22 range-over-int loops and improved formatting for readability. No behavior changes to event publishing or delivery.

- **Refactors**
  - Simplified race test loops using range-over-int to remove manual index handling.
  - Reformatted logger.Debug and t.Fatalf calls onto multiple lines for clearer logs and messages.

- **Migration**
  - Requires Go 1.22+ to compile the new range-over-int syntax in tests.

<sup>Written for commit 80f457ca11bace9bea426a6dd9527684cdb0189e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

