### PR TITLE
fix(ledger): read lock getting tip

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -285,7 +285,9 @@ func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
 
 func (ls *LedgerState) cleanupConsumedUtxos() {
 	// Get the current tip, since we're querying by slot
-	tip := ls.Tip()
+	ls.RLock()
+	tip := ls.currentTip
+	ls.RUnlock()
 	// Delete UTxOs that are marked as deleted and older than our slot window
 	ls.config.Logger.Debug(
 		"cleaning up consumed UTxOs",
@@ -1037,7 +1039,9 @@ func (ls *LedgerState) RecentChainPoints(count int) ([]ocommon.Point, error) {
 func (ls *LedgerState) GetIntersectPoint(
 	points []ocommon.Point,
 ) (*ocommon.Point, error) {
-	tip := ls.Tip()
+	ls.RLock()
+	tip := ls.currentTip
+	ls.RUnlock()
 	var ret ocommon.Point
 	var tmpBlock models.Block
 	var err error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a read lock when accessing the ledger tip to prevent race conditions during UTxO cleanup and chain intersection. This stabilizes concurrent operations that query by slot.

- **Bug Fixes**
  - Use RLock/RUnlock to read currentTip in cleanupConsumedUtxos and GetIntersectPoint instead of calling Tip(), avoiding concurrent read/write issues.

<sup>Written for commit cb5db3072ba5eb4ab1c0f3626bc4064484e256cd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal thread-safety mechanisms to ensure more reliable concurrent access to system state. No changes to user-facing functionality or APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->