### PR TITLE
feat(ledger): use fixed-size worker pool

### DIFF
--- a/ledger/timer.go
+++ b/ledger/timer.go
@@ -19,6 +19,18 @@ import (
 	"time"
 )
 
+type SchedulerConfig struct {
+	WorkerPoolSize int
+	TaskQueueSize  int
+}
+
+func DefaultSchedulerConfig() SchedulerConfig {
+	return SchedulerConfig{
+		WorkerPoolSize: 10,
+		TaskQueueSize:  100,
+	}
+}
+
 type ScheduledTask struct {
 	taskFunc          func()
 	runFailFunc       func()
@@ -35,14 +47,37 @@ type Scheduler struct {
 	interval           time.Duration
 	startOnce          sync.Once
 	mutex              sync.Mutex
+	// Worker pool fields
+	workerPoolSize int
+	taskQueue      chan func()
+	workers        []chan struct{}
+	workerWg       sync.WaitGroup
 }
 
 func NewScheduler(interval time.Duration) *Scheduler {
+	return NewSchedulerWithConfig(interval, DefaultSchedulerConfig())
+}
+
+func NewSchedulerWithConfig(
+	interval time.Duration,
+	config SchedulerConfig,
+) *Scheduler {
+	// Validate and coerce configuration values
+	if config.WorkerPoolSize <= 0 {
+		config.WorkerPoolSize = 10 // Default to 10 workers
+	}
+	if config.TaskQueueSize <= 0 {
+		config.TaskQueueSize = 100 // Default to 100 task queue size
+	}
+
 	return &Scheduler{
 		interval:           interval,
 		quit:               make(chan struct{}),
 		updateIntervalChan: make(chan time.Duration),
 		tasks:              []*ScheduledTask{},
+		workerPoolSize:     config.WorkerPoolSize,
+		taskQueue:          make(chan func(), config.TaskQueueSize),
+		workers:            make([]chan struct{}, 0),
 	}
 }
 
@@ -50,8 +85,40 @@ func NewScheduler(interval time.Duration) *Scheduler {
 func (st *Scheduler) Start() {
 	st.startOnce.Do(func() {
 		st.ticker = time.NewTicker(st.interval)
+		st.startWorkerPool()
 		go st.run()
 	})
+}
+
+// startWorkerPool initializes the worker pool
+func (st *Scheduler) startWorkerPool() {
+	for i := 0; i < st.workerPoolSize; i++ {
+		quit := make(chan struct{})
+		st.workers = append(st.workers, quit)
+		st.workerWg.Add(1)
+		go st.worker(quit)
+	}
+}
+
+// worker runs tasks from the queue
+func (st *Scheduler) worker(quit <-chan struct{}) {
+	defer st.workerWg.Done()
+	for {
+		select {
+		case task := <-st.taskQueue:
+			task()
+		case <-quit:
+			return
+		}
+	}
+}
+
+// stopWorkerPool shuts down the worker pool
+func (st *Scheduler) stopWorkerPool() {
+	for _, quit := range st.workers {
+		close(quit)
+	}
+	st.workerWg.Wait()
 }
 
 // Listens for tick events and interval updates and updating the ticker accordingly.
@@ -82,10 +149,19 @@ func (st *Scheduler) tick() {
 		task.ticksSinceLastRun++
 		if task.ticksSinceLastRun >= task.interval {
 			if task.mutex.TryLock() {
-				go func() {
+				// Submit task to worker pool instead of spawning goroutine
+				select {
+				case st.taskQueue <- func() {
+					defer task.mutex.Unlock()
 					task.taskFunc()
+				}:
+				default:
+					// Queue is full, unlock and call failure function
 					task.mutex.Unlock()
-				}()
+					if task.runFailFunc != nil {
+						task.runFailFunc()
+					}
+				}
 			} else {
 				// Run callback on failure to acquire task lock
 				// This means a previous instance of the task is still running
@@ -129,4 +205,5 @@ func (st *Scheduler) Stop() {
 	if st.ticker != nil {
 		st.ticker.Stop()
 	}
+	st.stopWorkerPool()
 }

--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -117,3 +117,112 @@ func TestSchedulerRunFailFunc(t *testing.T) {
 		)
 	}
 }
+
+func TestScheduler_Config(t *testing.T) {
+	// Test default configuration
+	defaultScheduler := NewScheduler(100 * time.Millisecond)
+	if defaultScheduler.workerPoolSize != 10 {
+		t.Errorf(
+			"Expected default worker pool size 10, got %d",
+			defaultScheduler.workerPoolSize,
+		)
+	}
+	if cap(defaultScheduler.taskQueue) != 100 {
+		t.Errorf(
+			"Expected default task queue size 100, got %d",
+			cap(defaultScheduler.taskQueue),
+		)
+	}
+
+	// Test custom configuration
+	config := SchedulerConfig{
+		WorkerPoolSize: 5,
+		TaskQueueSize:  50,
+	}
+	customScheduler := NewSchedulerWithConfig(100*time.Millisecond, config)
+	if customScheduler.workerPoolSize != 5 {
+		t.Errorf(
+			"Expected custom worker pool size 5, got %d",
+			customScheduler.workerPoolSize,
+		)
+	}
+	if cap(customScheduler.taskQueue) != 50 {
+		t.Errorf(
+			"Expected custom task queue size 50, got %d",
+			cap(customScheduler.taskQueue),
+		)
+	}
+
+	// Test default config function
+	defaultConfig := DefaultSchedulerConfig()
+	if defaultConfig.WorkerPoolSize != 10 {
+		t.Errorf(
+			"Expected default config worker pool size 10, got %d",
+			defaultConfig.WorkerPoolSize,
+		)
+	}
+	if defaultConfig.TaskQueueSize != 100 {
+		t.Errorf(
+			"Expected default config task queue size 100, got %d",
+			defaultConfig.TaskQueueSize,
+		)
+	}
+
+	// Test validation/coercion of invalid values
+	// Test zero values
+	zeroConfig := SchedulerConfig{
+		WorkerPoolSize: 0,
+		TaskQueueSize:  0,
+	}
+	zeroScheduler := NewSchedulerWithConfig(100*time.Millisecond, zeroConfig)
+	if zeroScheduler.workerPoolSize != 10 {
+		t.Errorf(
+			"Expected zero worker pool size to be coerced to 10, got %d",
+			zeroScheduler.workerPoolSize,
+		)
+	}
+	if cap(zeroScheduler.taskQueue) != 100 {
+		t.Errorf(
+			"Expected zero task queue size to be coerced to 100, got %d",
+			cap(zeroScheduler.taskQueue),
+		)
+	}
+
+	// Test negative values
+	negativeConfig := SchedulerConfig{
+		WorkerPoolSize: -5,
+		TaskQueueSize:  -10,
+	}
+	negativeScheduler := NewSchedulerWithConfig(100*time.Millisecond, negativeConfig)
+	if negativeScheduler.workerPoolSize != 10 {
+		t.Errorf(
+			"Expected negative worker pool size to be coerced to 10, got %d",
+			negativeScheduler.workerPoolSize,
+		)
+	}
+	if cap(negativeScheduler.taskQueue) != 100 {
+		t.Errorf(
+			"Expected negative task queue size to be coerced to 100, got %d",
+			cap(negativeScheduler.taskQueue),
+		)
+	}
+
+	// Test mixed valid/invalid values
+	mixedConfig := SchedulerConfig{
+		WorkerPoolSize: 15,  // Valid
+		TaskQueueSize:  -5,  // Invalid
+	}
+	mixedScheduler := NewSchedulerWithConfig(100*time.Millisecond, mixedConfig)
+	if mixedScheduler.workerPoolSize != 15 {
+		t.Errorf(
+			"Expected valid worker pool size 15 to be preserved, got %d",
+			mixedScheduler.workerPoolSize,
+		)
+	}
+	if cap(mixedScheduler.taskQueue) != 100 {
+		t.Errorf(
+			"Expected invalid task queue size to be coerced to 100, got %d",
+			cap(mixedScheduler.taskQueue),
+		)
+	}
+}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Scheduler to a fixed-size, configurable worker pool for task execution. This caps concurrency, reduces goroutine churn, and ensures clean shutdowns.

- **Refactors**
  - Added a configurable worker pool (defaults: 10 workers, queue 100).
  - Introduced SchedulerConfig and a new constructor to tune concurrency.
  - Tasks are queued; if full, unlocks and calls runFailFunc. Start initializes the pool; Stop shuts down workers and waits.

<sup>Written for commit 3f1e24a1f27136b94723a336886cbcccf82dbdcb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a configurable background worker pool for scheduled tasks to improve reliability, queue handling, and controlled startup/shutdown.
* **Tests**
  * Added coverage validating default and custom scheduler configurations and queue capacities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->