### PR TITLE
feat(peergov): initial peer scoring

### DIFF
--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,23 @@ type Peer struct {
 	Source         PeerSource
 	State          PeerState
 	Sharable       bool
+	// Performance metrics (used by the peer scoring system)
+	// Average block fetch latency in milliseconds (exponential moving average)
+	BlockFetchLatencyMs float64
+	// Whether we have seen an initial block fetch latency observation
+	BlockFetchLatencyInit bool
+	// Average block fetch success rate [0..1] (exponential moving average)
+	BlockFetchSuccessRate float64
+	// Whether we have seen an initial block fetch success observation
+	BlockFetchSuccessInit bool
+	// Connection stability score [0..1] (uptime / expected uptime)
+	ConnectionStability float64
+	// Whether we have seen an initial connection stability observation
+	ConnectionStabilityInit bool
+	// Timestamp of last observed block fetch
+	LastBlockFetchTime time.Time
+	// Composite performance score computed from the above metrics
+	PerformanceScore float64
 }
 
 func (p *Peer) setConnection(conn *ouroboros.Connection, outbound bool) {

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -285,9 +285,9 @@ func TestPeerGovernor_Reconcile_MinimumHotPeers(t *testing.T) {
 	}
 	assert.Equal(
 		t,
-		3,
+		2,
 		hotCount,
-	) // All warm peers with connections should be promoted to hot
+	) // Only MinHotPeers warm peers should be promoted to hot (score-based selection)
 
 	// Event publishing is tested indirectly
 }

--- a/peergov/score.go
+++ b/peergov/score.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"math"
+	"time"
+)
+
+// Scoring weights and parameters. These are conservative defaults and
+// intended to be tuned via configuration in follow-up work.
+const (
+	defaultLatencyWeight   = 0.5
+	defaultSuccessWeight   = 0.35
+	defaultStabilityWeight = 0.15
+	// Minimal latency (ms) used to normalize inverse latency. Avoid div-by-zero.
+	minLatencyMs = 1.0
+	// EMA smoothing factor (alpha) used when updating observed metrics.
+	defaultEMAAlpha = 0.2
+)
+
+// UpdateBlockFetchObservation updates the peer's block fetch metrics using an
+// observed latency (in milliseconds) and success (0 or 1). Uses an exponential
+// moving average for smoothing.
+func (p *Peer) UpdateBlockFetchObservation(latencyMs float64, success bool) {
+	if latencyMs <= 0 {
+		latencyMs = minLatencyMs
+	}
+	// Initialize latency EMA on first observation
+	if !p.BlockFetchLatencyInit {
+		p.BlockFetchLatencyMs = latencyMs
+		p.BlockFetchLatencyInit = true
+	} else {
+		p.BlockFetchLatencyMs = ema(p.BlockFetchLatencyMs, latencyMs, defaultEMAAlpha)
+	}
+	var successF float64
+	if success {
+		successF = 1.0
+	}
+	// Initialize success rate EMA on first observation. We must treat a 0
+	// observed success (all failures) as a valid value, so track initialization
+	// separately.
+	if !p.BlockFetchSuccessInit {
+		p.BlockFetchSuccessRate = successF
+		p.BlockFetchSuccessInit = true
+	} else {
+		p.BlockFetchSuccessRate = ema(p.BlockFetchSuccessRate, successF, defaultEMAAlpha)
+	}
+	p.LastBlockFetchTime = time.Now()
+	// Recompute composite score
+	p.UpdatePeerScore()
+}
+
+// UpdateConnectionStability updates the connection stability observation. The
+// value should be in [0..1]. Uses EMA smoothing as well.
+func (p *Peer) UpdateConnectionStability(observed float64) {
+	observed = clamp01(observed)
+	if !p.ConnectionStabilityInit {
+		p.ConnectionStability = observed
+		p.ConnectionStabilityInit = true
+	} else {
+		p.ConnectionStability = ema(p.ConnectionStability, observed, defaultEMAAlpha)
+	}
+	p.UpdatePeerScore()
+}
+
+// UpdatePeerScore computes the composite PerformanceScore from the available
+// metrics. Missing metrics will be treated conservatively.
+func (p *Peer) UpdatePeerScore() {
+	// Normalize metrics
+	latencyMs := p.BlockFetchLatencyMs
+	if !p.BlockFetchLatencyInit || latencyMs <= 0 {
+		latencyMs = 1000.0 // unknown => penalize with high latency
+	}
+
+	// Map latency in ms to a bounded 0..1 latency score where lower latency
+	// yields a higher score. The chosen mapping gives reasonable spacing for
+	// latencies in the 10ms..2000ms range without requiring external scaling.
+	latencyScore := 1.0 / (1.0 + latencyMs/200.0)
+
+	success := p.BlockFetchSuccessRate
+	stability := p.ConnectionStability
+
+	// If a metric has not been initialized, apply conservative defaults.
+	if !p.BlockFetchSuccessInit {
+		success = 0.5
+	}
+	if !p.ConnectionStabilityInit {
+		stability = 0.5
+	}
+
+	// Weighted aggregate (already in 0..1 range)
+	score := (latencyScore*defaultLatencyWeight + success*defaultSuccessWeight + stability*defaultStabilityWeight) / (defaultLatencyWeight + defaultSuccessWeight + defaultStabilityWeight)
+
+	// Ensure within bounds
+	score = clamp01(score)
+
+	// Keep the score stable (if NaN etc)
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		score = 0.0
+	}
+	p.PerformanceScore = score
+}
+
+func ema(prev, observed, alpha float64) float64 {
+	return prev*(1.0-alpha) + observed*alpha
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/peergov/score_test.go
+++ b/peergov/score_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpdateBlockFetchObservationAndScore(t *testing.T) {
+	p := &Peer{}
+
+	// First observation: 200ms, success=true
+	p.UpdateBlockFetchObservation(200, true)
+	if p.BlockFetchLatencyMs == 0 {
+		t.Fatalf("expected latency to be initialized")
+	}
+	if p.BlockFetchSuccessRate <= 0 {
+		t.Fatalf("expected success rate to be initialized")
+	}
+	if p.PerformanceScore <= 0 {
+		t.Fatalf(
+			"expected performance score to be >0, got %v",
+			p.PerformanceScore,
+		)
+	}
+
+	prevScore := p.PerformanceScore
+
+	// A worse latency should reduce the score
+	p.UpdateBlockFetchObservation(1000, true)
+	if p.BlockFetchLatencyMs <= 200 {
+		t.Fatalf(
+			"expected latency EMA to increase, got %v",
+			p.BlockFetchLatencyMs,
+		)
+	}
+	if p.PerformanceScore <= 0 || p.PerformanceScore >= prevScore {
+		t.Fatalf(
+			"expected performance score to decrease after worse latency; prev=%v now=%v",
+			prevScore,
+			p.PerformanceScore,
+		)
+	}
+}
+
+func TestConnectionStabilityAndScore(t *testing.T) {
+	p := &Peer{}
+	p.UpdateConnectionStability(0.9)
+	if p.ConnectionStability < 0.8 {
+		t.Fatalf(
+			"expected stability to be set high, got %v",
+			p.ConnectionStability,
+		)
+	}
+	if p.PerformanceScore == 0 {
+		t.Fatalf("expected score to be non-zero after stability update")
+	}
+
+	// Low stability should reduce the score
+	prev := p.PerformanceScore
+	p.UpdateConnectionStability(0.1)
+	if p.PerformanceScore >= prev {
+		t.Fatalf(
+			"expected score to decrease when stability drops from 0.9 to 0.1; prev=%v now=%v",
+			prev,
+			p.PerformanceScore,
+		)
+	}
+}
+
+func TestLastBlockFetchTimeUpdated(t *testing.T) {
+	p := &Peer{}
+	before := time.Now()
+	p.UpdateBlockFetchObservation(150, true)
+	if p.LastBlockFetchTime.Before(before) {
+		t.Fatalf("expected LastBlockFetchTime to be updated")
+	}
+}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces initial peer performance scoring to prioritize reliable peers during warm-to-hot promotions. Scores use latency, success rate, and connection stability with EMA smoothing.

- **New Features**
  - Added peer metrics and a computed PerformanceScore (0..1).
  - Implemented scoring in score.go with UpdateBlockFetchObservation and UpdateConnectionStability.
  - Reconcile now sorts warm peers by score and promotes top candidates until MinHotPeers; logs score and emits PeerPromoted events.
  - Added unit tests for scoring behavior and LastBlockFetchTime.

<sup>Written for commit db35a7baf75c912d063f5c3138c2c09428539532. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced performance-based peer promotion using a composite performance score.
  * Continuous tracking of peer performance metrics: fetch latency, success rate, connection stability, and last-fetch timestamp.
  * Promotion logic now ranks candidates by score to meet minimum hot-peer targets.

* **Tests**
  * Added and adjusted tests covering metric updates, score computation, timestamp updates, and minimum-hot-peers promotion behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->