### PR TITLE
fix(ledger): reduce batchSize to 50

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -45,6 +45,7 @@ import (
 const (
 	cleanupConsumedUtxosInterval   = 5 * time.Minute
 	cleanupConsumedUtxosSlotWindow = 50000 // TODO: calculate this from params (#395)
+	batchSize                      = 50    // Number of blocks to process in a single DB transaction
 )
 
 // DatabaseOperation represents an asynchronous database operation
@@ -905,12 +906,12 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				continue
 			}
 		}
-		// Process batch in groups of 200 to stay under DB txn limits
-		for i = 0; i < len(nextBatch); i += 200 {
+		// Process batch in groups of batchSize to stay under DB txn limits
+		for i = 0; i < len(nextBatch); i += batchSize {
 			ls.Lock()
 			end = min(
 				len(nextBatch),
-				i+200,
+				i+batchSize,
 			)
 			err = ls.SubmitAsyncDBTxn(func(txn *database.Txn) error {
 				deltaBatch = NewLedgerDeltaBatch()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduced ledger block processing batch size to 50 per DB transaction to stay within DB limits and improve stability.
Introduced a batchSize constant and replaced the previous hardcoded 200 in the batching loop.

<sup>Written for commit 191a3af20eabc68ba4f42231cbdbafa289334766. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted block processing batch size from 200 to 50 blocks per database transaction, improving transaction granularity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->