### PR TITLE
feat: wire up peer scoring with blockfetch latency

### DIFF
--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -245,6 +245,14 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 		return
 	}
 	connId := e.ConnectionId
+
+	// Record connection stability observation for peer scoring
+	// Connection closure indicates reduced stability
+	if o.PeerGov != nil {
+		// Treat connection closure as negative stability signal (0.0)
+		o.PeerGov.UpdatePeerConnectionStability(connId, 0.0)
+	}
+
 	// Remove any chainsync client state
 	if o.ChainsyncState != nil {
 		o.ChainsyncState.RemoveClient(connId)
@@ -271,6 +279,14 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 		return
 	}
 	connId := e.ConnectionId
+
+	// Record connection stability observation for peer scoring
+	// Successful outbound connection establishment indicates good stability
+	if o.PeerGov != nil {
+		// Treat successful connection as positive stability signal (1.0)
+		o.PeerGov.UpdatePeerConnectionStability(connId, 1.0)
+	}
+
 	// TODO: replace this with handling for multiple chainsync clients (#385)
 	// Start chainsync client if we don't have another
 	if o.ChainsyncState != nil {

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -480,6 +480,35 @@ func (p *PeerGovernor) SetPeerHotByConnId(connId ouroboros.ConnectionId) {
 	}
 }
 
+// UpdatePeerBlockFetchObservation updates block fetch metrics for the peer with
+// the given connection ID. This method is thread-safe.
+func (p *PeerGovernor) UpdatePeerBlockFetchObservation(
+	connId ouroboros.ConnectionId,
+	latencyMs float64,
+	success bool,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	idx := p.peerIndexByConnId(connId)
+	if idx != -1 && p.peers[idx] != nil {
+		p.peers[idx].UpdateBlockFetchObservation(latencyMs, success)
+	}
+}
+
+// UpdatePeerConnectionStability updates connection stability for the peer with
+// the given connection ID. This method is thread-safe.
+func (p *PeerGovernor) UpdatePeerConnectionStability(
+	connId ouroboros.ConnectionId,
+	observed float64,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	idx := p.peerIndexByConnId(connId)
+	if idx != -1 && p.peers[idx] != nil {
+		p.peers[idx].UpdateConnectionStability(observed)
+	}
+}
+
 func (p *PeerGovernor) startOutboundConnections() {
 	// Skip outbound connections if disabled
 	if p.config.DisableOutbound {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired peer scoring to BlockFetch latency and connection stability so we can evaluate peers based on real-time performance.

- **New Features**
  - BlockFetch: record request start; update peer score with latency (ms) on success/failure; clear start times after batches and errors.
  - Connection events: score stability (1.0 on successful outbound connect, 0.0 on connection closed).
  - PeerGovernor: add thread-safe UpdatePeerBlockFetchObservation and UpdatePeerConnectionStability by connection ID.

<sup>Written for commit 5f2be857192a8d5e75f89623d21af901c7f06f4e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable recording and reporting of fetch latency, including failures, and consistent cleanup of timing data.

* **Chores**
  * Added peer connection stability signals for open/close events.
  * Unified and strengthened per-peer metric updates and reporting for block fetches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->