### PR TITLE
refactor(database): configure DB pools and badger log size

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -213,6 +213,10 @@ func main() {
 		StringP("blob", "b", config.DefaultBlobPlugin, "blob store plugin to use, 'list' to show available")
 	rootCmd.PersistentFlags().
 		StringP("metadata", "m", config.DefaultMetadataPlugin, "metadata store plugin to use, 'list' to show available")
+	rootCmd.PersistentFlags().
+		Int("db-workers", 5, "database worker pool worker count")
+	rootCmd.PersistentFlags().
+		Int("db-queue-size", 50, "database worker pool task queue size")
 
 	// Add plugin-specific flags
 	if err := plugin.PopulateCmdlineOptions(rootCmd.PersistentFlags()); err != nil {
@@ -242,6 +246,18 @@ func main() {
 		}
 		if metadataPlugin != config.DefaultMetadataPlugin {
 			cfg.MetadataPlugin = metadataPlugin
+		}
+
+		// Override database worker pool config if flags are provided
+		if cmd.Root().PersistentFlags().Changed("db-workers") {
+			if workers, err := cmd.Root().PersistentFlags().GetInt("db-workers"); err == nil {
+				cfg.DatabaseWorkers = workers
+			}
+		}
+		if cmd.Root().PersistentFlags().Changed("db-queue-size") {
+			if queueSize, err := cmd.Root().PersistentFlags().GetInt("db-queue-size"); err == nil {
+				cfg.DatabaseQueueSize = queueSize
+			}
 		}
 
 		cmd.SetContext(config.WithContext(cmd.Context(), cfg))

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -32,27 +33,28 @@ import (
 type ListenerConfig = connmanager.ListenerConfig
 
 type Config struct {
-	promRegistry       prometheus.Registerer
-	topologyConfig     *topology.TopologyConfig
-	logger             *slog.Logger
-	cardanoNodeConfig  *cardano.CardanoNodeConfig
-	dataDir            string
-	network            string
-	tlsCertFilePath    string
-	tlsKeyFilePath     string
-	intersectPoints    []ocommon.Point
-	listeners          []ListenerConfig
-	mempoolCapacity    int64
-	outboundSourcePort uint
-	utxorpcPort        uint
-	networkMagic       uint32
-	intersectTip       bool
-	peerSharing        bool
-	validateHistorical bool
-	tracing            bool
-	tracingStdout      bool
-	devMode            bool
-	shutdownTimeout    time.Duration
+	promRegistry             prometheus.Registerer
+	topologyConfig           *topology.TopologyConfig
+	logger                   *slog.Logger
+	cardanoNodeConfig        *cardano.CardanoNodeConfig
+	dataDir                  string
+	network                  string
+	tlsCertFilePath          string
+	tlsKeyFilePath           string
+	intersectPoints          []ocommon.Point
+	listeners                []ListenerConfig
+	mempoolCapacity          int64
+	outboundSourcePort       uint
+	utxorpcPort              uint
+	networkMagic             uint32
+	intersectTip             bool
+	peerSharing              bool
+	validateHistorical       bool
+	tracing                  bool
+	tracingStdout            bool
+	devMode                  bool
+	shutdownTimeout          time.Duration
+	DatabaseWorkerPoolConfig ledger.DatabaseWorkerPoolConfig
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -274,5 +276,14 @@ func WithDevMode(devMode bool) ConfigOptionFunc {
 func WithValidateHistorical(validate bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.validateHistorical = validate
+	}
+}
+
+// WithDatabaseWorkerPoolConfig specifies the database worker pool configuration
+func WithDatabaseWorkerPoolConfig(
+	cfg ledger.DatabaseWorkerPoolConfig,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.DatabaseWorkerPoolConfig = cfg
 	}
 }

--- a/database/plugin/blob/badger/options.go
+++ b/database/plugin/blob/badger/options.go
@@ -65,3 +65,17 @@ func WithGc(enabled bool) BlobStoreBadgerOptionFunc {
 		b.gcEnabled = enabled
 	}
 }
+
+// WithValueLogFileSize specifies the value log file size in bytes
+func WithValueLogFileSize(size int64) BlobStoreBadgerOptionFunc {
+	return func(b *BlobStoreBadger) {
+		b.valueLogFileSize = size
+	}
+}
+
+// WithMemTableSize specifies the memtable size in bytes
+func WithMemTableSize(size int64) BlobStoreBadgerOptionFunc {
+	return func(b *BlobStoreBadger) {
+		b.memTableSize = size
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,9 @@ type Config struct {
 	IntersectTip       bool   `yaml:"intersectTip"                                                  split_words:"true"`
 	ValidateHistorical bool   `yaml:"validateHistorical"                                            split_words:"true"`
 	DevMode            bool   `yaml:"devMode"                                                       split_words:"true"`
+	// Database worker pool tuning (worker count and task queue size)
+	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
+	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
 }
 
 func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
@@ -105,6 +108,19 @@ func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
 		"metadata",
 		DefaultMetadataPlugin,
 		"metadata store plugin to use, 'list' to show available",
+	)
+	// Database worker pool flags
+	fs.IntVar(
+		&c.DatabaseWorkers,
+		"db-workers",
+		5,
+		"database worker pool worker count",
+	)
+	fs.IntVar(
+		&c.DatabaseQueueSize,
+		"db-queue-size",
+		50,
+		"database worker pool task queue size",
 	)
 	// NOTE: Plugin flags are handled by Cobra in main.go
 	// if err := plugin.PopulateCmdlineOptions(fs); err != nil {
@@ -156,6 +172,9 @@ var globalConfig = &Config{
 	MetadataPlugin:     DefaultMetadataPlugin,
 	DevMode:            false,
 	ShutdownTimeout:    DefaultShutdownTimeout,
+	// Defaults for database worker pool tuning
+	DatabaseWorkers:   5,
+	DatabaseQueueSize: 50,
 }
 
 func LoadConfig(configFile string) (*Config, error) {

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -85,6 +85,11 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 			CardanoNodeConfig:  nodeCfg,
 			EventBus:           eventBus,
 			ValidateHistorical: cfg.ValidateHistorical,
+			DatabaseWorkerPoolConfig: ledger.DatabaseWorkerPoolConfig{
+				WorkerPoolSize: cfg.DatabaseWorkers,
+				TaskQueueSize:  cfg.DatabaseQueueSize,
+				Disabled:       false,
+			},
 		},
 	)
 	if err != nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/dingo"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -138,6 +139,11 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			// TODO: make this configurable (#387)
 			// dingo.WithTracing(true),
 			dingo.WithTopologyConfig(config.GetTopologyConfig()),
+			dingo.WithDatabaseWorkerPoolConfig(ledger.DatabaseWorkerPoolConfig{
+				WorkerPoolSize: cfg.DatabaseWorkers,
+				TaskQueueSize:  cfg.DatabaseQueueSize,
+				Disabled:       false,
+			}),
 		),
 	)
 	if err != nil {

--- a/node.go
+++ b/node.go
@@ -134,6 +134,7 @@ func (n *Node) Run() error {
 			ForgeBlocks:                n.config.devMode,
 			ValidateHistorical:         n.config.validateHistorical,
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
+			DatabaseWorkerPoolConfig:   n.config.DatabaseWorkerPoolConfig,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds configurable database worker pool size and queue, and exposes BadgerDB value log and memtable size tuning to improve throughput and stability. Settings are wired through config and node with safe defaults.

- **New Features**
  - CLI flags: --db-workers and --db-queue-size (defaults 5 and 50); env support via DINGO_DATABASE_WORKERS and DINGO_DATABASE_QUEUE_SIZE.
  - Badger plugin flags: --value-log-file-size (default 1GB) and --memtable-size (default 64MB), with safe int64 capping.
  - Config plumbing: new DatabaseWorkerPoolConfig (WithDatabaseWorkerPoolConfig) passed from internal config through node to ledger; Badger DB now sets ValueLogFileSize and MemTableSize on open.

<sup>Written for commit a2c199691bc2e7c317f4cdb330770c243dd8a8ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--db-workers` and `--db-queue-size` CLI flags to configure database worker pool parameters (defaults: 5 workers, queue size 50). Configuration available via CLI flags, environment variables, or YAML.
  * Added new storage tuning options for value log file size and memtable size to optimize database performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->