### PR TITLE
fix(database): preload associations for pool registrations

### DIFF
--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -100,7 +100,10 @@ func (d *MetadataStoreSqlite) GetPoolRegistrations(
 	if err != nil {
 		return ret, err
 	}
-	result := db.Where("pool_key_hash = ?", pkh.Bytes()).
+	result := db.
+		Preload("Owners").
+		Preload("Relays").
+		Where("pool_key_hash = ?", pkh.Bytes()).
 		Order("id DESC").
 		Find(&certs)
 	if result.Error != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preload Owners and Relays when fetching pool registrations to return complete data and avoid N+1 queries. Fixes cases where owners or relays were missing in GetPoolRegistrations results.

<sup>Written for commit 9d36e50c1519783da787aba1ac5f2ced1c078f5f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool registration data retrieval to ensure complete and accurate information is returned.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->