### PR TITLE
fix(database): guard nil pointer in pool margin

### DIFF
--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -108,9 +109,15 @@ func (d *MetadataStoreSqlite) GetPoolRegistrations(
 	}
 	var addrKeyHash lcommon.AddrKeyHash
 	var tmpCert lcommon.PoolRegistrationCertificate
-	var tmpMargin lcommon.GenesisRat
 	var tmpRelay lcommon.PoolRelay
 	for _, cert := range certs {
+		var tmpMargin lcommon.GenesisRat
+		if cert.Margin == nil || cert.Margin.Rat == nil {
+			return nil, fmt.Errorf(
+				"pool registration margin is nil (id=%d)",
+				cert.ID,
+			)
+		}
 		tmpMargin = lcommon.GenesisRat{Rat: cert.Margin.Rat}
 		tmpCert = lcommon.PoolRegistrationCertificate{
 			CertType: uint(lcommon.CertificateTypePoolRegistration),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a nil guard for pool registration margin in the SQLite metadata store to prevent crashes when margin or Rat is nil. When encountered, the method returns a clear error that includes the certificate ID.

<sup>Written for commit fc3963fa7712a4ce39ba72441d4dfaae00c157dd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for pool registration margin data to ensure data integrity and provide clearer error messages when validation fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->