### PR TITLE
fix(database): stricter deposit validation

### DIFF
--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -681,6 +681,11 @@ func (d *MetadataStoreSqlite) SetTransaction(
 							"index", i, "type", fmt.Sprintf("%T", cert))
 					}
 				}
+				if certDeposits == nil && certRequiresDeposit(cert) {
+					d.logger.Error("certDeposits is nil for deposit-bearing certificate",
+						"index", i, "type", fmt.Sprintf("%T", cert))
+					return fmt.Errorf("missing certDeposits for deposit-bearing certificate at index %d", i)
+				}
 				switch c := cert.(type) {
 				case *lcommon.PoolRegistrationCertificate:
 					// Include inactive pools to allow re-registration.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces deposit validation for certificates in transaction processing: if a certificate requires a deposit but certDeposits is nil, we now log an error and return a clear failure. This prevents invalid transactions from being persisted and improves diagnostics.

<sup>Written for commit c54d86000c14eaedafe892e7919731d4d9c09e47. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

