### PR TITLE
fix(ouroboros): guard against empty txsubmission

### DIFF
--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -55,7 +55,11 @@ func (o *Ouroboros) txsubmissionClientStart(
 	if conn == nil {
 		return fmt.Errorf("failed to lookup connection ID: %s", connId.String())
 	}
-	conn.TxSubmission().Client.Init()
+	tx := conn.TxSubmission()
+	if tx == nil {
+		return fmt.Errorf("TxSubmission protocol not available on connection: %s", connId.String())
+	}
+	tx.Client.Init()
 	return nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Guard txsubmissionClientStart against missing TxSubmission by checking for nil before initializing. Prevents a nil-pointer crash and surfaces a clear error when the protocol isn't available on a connection.

<sup>Written for commit 756d44574a0ec0584c3eacf6bfda7ac4a4549dca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

