### PR TITLE
fix(chain): reconcile up to security parameter

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -484,6 +484,7 @@ func (c *Chain) iterNext(
 }
 
 func (c *Chain) reconcile() error {
+	securityParam := c.manager.securityParam
 	// We reconcile against the primary/persistent chain, so no need to check if we are that chain
 	if c.persistent {
 		return nil
@@ -535,7 +536,12 @@ func (c *Chain) reconcile() error {
 	}
 	lastPrevHash := decodedKnownBlock.PrevHash().Bytes()
 	// Iterate backward through chain based on prev-hash until we find a matching block on the primary chain
+	iterationCount := 0
 	for {
+		if iterationCount >= securityParam {
+			return models.ErrBlockNotFound
+		}
+		iterationCount++
 		tmpBlock, err := c.manager.blockByHash(lastPrevHash)
 		if err != nil {
 			return err

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -37,6 +37,7 @@ const (
 type ChainManager struct {
 	db                  *database.Database
 	eventBus            *event.EventBus
+	securityParam       int
 	chains              map[ChainId]*Chain
 	chainRollbackEvents map[ChainId][]uint64
 	blocks              map[string]models.Block
@@ -58,6 +59,12 @@ func NewManager(
 		return nil, err
 	}
 	return cm, nil
+}
+
+func (cm *ChainManager) SetLedger(
+	ledgerState interface{ SecurityParam() int },
+) {
+	cm.securityParam = ledgerState.SecurityParam()
 }
 
 func (cm *ChainManager) PrimaryChain() *Chain {

--- a/node.go
+++ b/node.go
@@ -142,6 +142,7 @@ func (n *Node) Run() error {
 	}
 	n.ledgerState = state
 	n.ouroboros.LedgerState = n.ledgerState
+	n.chainManager.SetLedger(n.ledgerState)
 	// Run DB recovery if needed
 	if dbNeedsRecovery {
 		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit chain reconciliation to the ledger’s security parameter to prevent unbounded backtracking and align with consensus rules. The parameter is derived from the current era’s genesis and wired into the chain manager.

- **Bug Fixes**
  - Stop reconcile traversal after securityParam iterations; return ErrBlockNotFound when the limit is reached.
  - ChainManager stores securityParam; Node.Run sets it via SetLedger(LedgerState).
  - Added LedgerState.SecurityParam(): uses Shelley genesis SecurityParam and Byron genesis k, validates values, and falls back to a safe default when config/genesis are missing or invalid.

<sup>Written for commit 4f90664167862c77d9dfe6b43c2ec1fc377d81ef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced security parameter mechanism to chain manager, integrated with ledger state configuration for Byron and Shelley eras.

* **Improvements**
  * Added iteration bounds to chain traversal operations to enhance stability and prevent unbounded loops during reconciliation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->