### PR TITLE
feat(node): per-node life-cycle management

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -147,6 +147,9 @@ func TestChainBasic(t *testing.T) {
 				err,
 			)
 		}
+		if next == nil {
+			t.Fatal("unexpected nil result from chain iterator")
+		}
 		if testBlockIdx >= len(testBlocks) {
 			t.Fatal("ran out of test blocks before reaching chain tip")
 		}
@@ -244,6 +247,9 @@ func TestChainRollback(t *testing.T) {
 				err,
 			)
 		}
+		if next == nil {
+			t.Fatal("unexpected nil result from chain iterator")
+		}
 		if testBlockIdx >= len(testBlocks) {
 			t.Fatal("ran out of test blocks before reaching chain tip")
 		}
@@ -288,6 +294,9 @@ func TestChainRollback(t *testing.T) {
 	next, err := iter.Next(false)
 	if err != nil {
 		t.Fatalf("unexpected error calling chain iterator next: %s", err)
+	}
+	if next == nil {
+		t.Fatal("unexpected nil result from chain iterator")
 	}
 	if !next.Rollback {
 		t.Fatalf(
@@ -576,6 +585,9 @@ func TestChainFork(t *testing.T) {
 				"unexpected error getting next block from chain iterator: %s",
 				err,
 			)
+		}
+		if next == nil {
+			t.Fatal("unexpected nil result from chain iterator")
 		}
 		if testBlockIdx >= len(testBlocks) {
 			t.Fatal("ran out of test blocks before reaching chain tip")

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -76,6 +76,11 @@ func (s *State) AddClient(
 func (s *State) RemoveClient(connId connection.ConnectionId) {
 	s.Lock()
 	defer s.Unlock()
+	// Cancel any pending iterator operations
+	if clientState, exists := s.clients[connId]; exists &&
+		clientState.ChainIter != nil {
+		clientState.ChainIter.Cancel()
+	}
 	// Remove client state entry
 	delete(s.clients, connId)
 }

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -210,8 +210,8 @@ func (c *ConnectionManager) updateConnectionMetrics() {
 	}
 }
 
-func (c *ConnectionManager) Start() error {
-	if err := c.startListeners(); err != nil {
+func (c *ConnectionManager) Start(ctx context.Context) error {
+	if err := c.startListeners(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/connmanager/connection_manager_test.go
+++ b/connmanager/connection_manager_test.go
@@ -227,7 +227,7 @@ func TestConnectionManager_Stop_WithListener(t *testing.T) {
 	}
 	// Use package-level constructor
 	cm := connmanager.NewConnectionManager(cfg)
-	if err := cm.Start(); err != nil {
+	if err := cm.Start(context.Background()); err != nil {
 		t.Fatalf("start failed: %v", err)
 	}
 

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -34,16 +34,19 @@ type ListenerConfig struct {
 	ReuseAddress   bool
 }
 
-func (c *ConnectionManager) startListeners() error {
+func (c *ConnectionManager) startListeners(ctx context.Context) error {
 	for _, l := range c.config.Listeners {
-		if err := c.startListener(l); err != nil {
+		if err := c.startListener(ctx, l); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *ConnectionManager) startListener(l ListenerConfig) error {
+func (c *ConnectionManager) startListener(
+	ctx context.Context,
+	l ListenerConfig,
+) error {
 	// Create listener if none is provided
 	if l.Listener == nil {
 		// On Windows, the "unix" network type is repurposed to create named pipes
@@ -63,7 +66,7 @@ func (c *ConnectionManager) startListener(l ListenerConfig) error {
 				listenConfig.Control = socketControl
 			}
 			listener, err := listenConfig.Listen(
-				context.Background(),
+				ctx,
 				l.ListenNetwork,
 				l.ListenAddress,
 			)

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -684,9 +684,17 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					}
 				}
 				if certDeposits == nil && certRequiresDeposit(cert) {
-					d.logger.Error("certDeposits is nil for deposit-bearing certificate",
-						"index", i, "type", fmt.Sprintf("%T", cert))
-					return fmt.Errorf("missing certDeposits for deposit-bearing certificate at index %d", i)
+					d.logger.Error(
+						"certDeposits is nil for deposit-bearing certificate",
+						"index",
+						i,
+						"type",
+						fmt.Sprintf("%T", cert),
+					)
+					return fmt.Errorf(
+						"missing certDeposits for deposit-bearing certificate at index %d",
+						i,
+					)
 				}
 				switch c := cert.(type) {
 				case *lcommon.PoolRegistrationCertificate:

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -95,7 +96,7 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
-	if err := ls.Start(); err != nil {
+	if err := ls.Start(context.Background()); err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
 	// Open immutable DB

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -192,7 +192,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	errChan := make(chan error, 1)
 	go func() {
 		//nolint:contextcheck
-		err := d.Run()
+		err := d.Run(signalCtx)
 		select {
 		case errChan <- err:
 		case <-signalCtx.Done():

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -300,6 +301,7 @@ type LedgerState struct {
 	currentTip                       ochainsync.Tip
 	currentEpoch                     models.Epoch
 	dbWorkerPool                     *DatabaseWorkerPool
+	ctx                              context.Context
 	sync.RWMutex
 	chainsyncMutex             sync.Mutex
 	chainsyncBlockfetchMutex   sync.Mutex
@@ -334,7 +336,8 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 	return ls, nil
 }
 
-func (ls *LedgerState) Start() error {
+func (ls *LedgerState) Start(ctx context.Context) error {
+	ls.ctx = ctx
 	// Init metrics
 	ls.metrics.init(ls.config.PromRegistry)
 
@@ -754,7 +757,10 @@ type readChainResult struct {
 	rollback      bool
 }
 
-func (ls *LedgerState) ledgerReadChain(resultCh chan readChainResult) {
+func (ls *LedgerState) ledgerReadChain(
+	ctx context.Context,
+	resultCh chan readChainResult,
+) {
 	// Create chain iterator
 	iter, err := ls.chain.FromPoint(ls.currentTip.Point, false)
 	if err != nil {
@@ -770,6 +776,11 @@ func (ls *LedgerState) ledgerReadChain(resultCh chan readChainResult) {
 	var rollbackPoint ocommon.Point
 	var result readChainResult
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		// We chose 500 as an arbitrary max batch size. A "chain extended" message will be logged after each batch
 		nextBatch := make([]ledger.Block, 0, 500)
 		// Gather up next batch of blocks
@@ -836,14 +847,18 @@ func (ls *LedgerState) ledgerReadChain(resultCh chan readChainResult) {
 				blocks: nextBatch,
 			}
 		}
-		resultCh <- result
+		select {
+		case resultCh <- result:
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 
 func (ls *LedgerState) ledgerProcessBlocks() {
 	// Start chain reader goroutine
 	readChainResultCh := make(chan readChainResult)
-	go ls.ledgerReadChain(readChainResultCh)
+	go ls.ledgerReadChain(ls.ctx, readChainResultCh)
 	// Process blocks
 	var nextEpochEraId uint
 	var needsEpochRollover bool
@@ -887,23 +902,27 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			cachedNextBatch = nil
 		} else {
 			// Read next result from readChain channel
-			result, ok := <-readChainResultCh
-			if !ok {
-				return
-			}
-			nextBatch = result.blocks
-			// Process rollback
-			if result.rollback {
-				ls.Lock()
-				if err = ls.rollback(result.rollbackPoint); err != nil {
-					ls.Unlock()
-					ls.config.Logger.Error(
-						"failed to process rollback: " + err.Error(),
-					)
+			select {
+			case result, ok := <-readChainResultCh:
+				if !ok {
 					return
 				}
-				ls.Unlock()
-				continue
+				nextBatch = result.blocks
+				// Process rollback
+				if result.rollback {
+					ls.Lock()
+					if err = ls.rollback(result.rollbackPoint); err != nil {
+						ls.Unlock()
+						ls.config.Logger.Error(
+							"failed to process rollback: " + err.Error(),
+						)
+						return
+					}
+					ls.Unlock()
+					continue
+				}
+			case <-ls.ctx.Done():
+				return
 			}
 		}
 		// Process batch in groups of batchSize to stay under DB txn limits

--- a/node.go
+++ b/node.go
@@ -46,7 +46,8 @@ type Node struct {
 	ouroboros      *ouroborosPkg.Ouroboros
 	shutdownFuncs  []func(context.Context) error
 	config         Config
-	done           chan struct{}
+	ctx            context.Context
+	cancel         context.CancelFunc
 	shutdownOnce   sync.Once
 }
 
@@ -55,7 +56,6 @@ func New(cfg Config) (*Node, error) {
 	n := &Node{
 		config:   cfg,
 		eventBus: eventBus,
-		done:     make(chan struct{}),
 	}
 	if err := n.configPopulateNetworkMagic(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
@@ -66,13 +66,14 @@ func New(cfg Config) (*Node, error) {
 	return n, nil
 }
 
-func (n *Node) Run() error {
+func (n *Node) Run(ctx context.Context) error {
 	// Configure tracing
 	if n.config.tracing {
-		if err := n.setupTracing(); err != nil {
+		if err := n.setupTracing(); err != nil { //nolint:contextcheck
 			return err
 		}
 	}
+	n.ctx, n.cancel = context.WithCancel(ctx)
 	// Load database
 	dbNeedsRecovery := false
 	dbConfig := &database.Config{
@@ -149,7 +150,7 @@ func (n *Node) Run() error {
 		}
 	}
 	// Start ledger
-	if err := n.ledgerState.Start(); err != nil {
+	if err := n.ledgerState.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("failed to start ledger: %w", err)
 	}
 	// Initialize mempool
@@ -189,7 +190,7 @@ func (n *Node) Run() error {
 		n.ouroboros.HandleConnClosedEvent,
 	)
 	// Start listeners
-	if err := n.connManager.Start(); err != nil {
+	if err := n.connManager.Start(n.ctx); err != nil { //nolint:contextcheck
 		return err
 	}
 	// Configure peer governor
@@ -211,7 +212,7 @@ func (n *Node) Run() error {
 	if n.config.topologyConfig != nil {
 		n.peerGov.LoadTopologyConfig(n.config.topologyConfig)
 	}
-	if err := n.peerGov.Start(); err != nil {
+	if err := n.peerGov.Start(n.ctx); err != nil { //nolint:contextcheck
 		return err
 	}
 	// Configure UTxO RPC
@@ -224,12 +225,12 @@ func (n *Node) Run() error {
 			Port:        n.config.utxorpcPort,
 		},
 	)
-	if err := n.utxorpc.Start(); err != nil {
+	if err := n.utxorpc.Start(n.ctx); err != nil { //nolint:contextcheck
 		return err
 	}
 
 	// Wait for shutdown signal
-	<-n.done
+	<-n.ctx.Done()
 	return nil
 }
 
@@ -249,6 +250,9 @@ func (n *Node) shutdown() error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
+	if n.cancel != nil {
+		n.cancel()
+	}
 
 	var err error
 
@@ -313,6 +317,5 @@ func (n *Node) shutdown() error {
 	}
 
 	n.config.logger.Debug("graceful shutdown complete")
-	close(n.done)
 	return err
 }

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -33,7 +33,7 @@ func TestUtxorpc_StartStop(t *testing.T) {
 		Host:     "127.0.0.1",
 		Port:     0,
 	})
-	if err := u.Start(); err != nil {
+	if err := u.Start(context.Background()); err != nil {
 		t.Fatalf("failed to start utxorpc: %v", err)
 	}
 	// Brief delay to ensure server is listening


### PR DESCRIPTION


















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce node-scoped context and shutdown hooks to manage service lifecycles. Core services now start with the node context and stop cleanly on cancel.

- **New Features**
  - Node creates a context.WithCancel and cancels it during shutdown.
  - LedgerState.Start now accepts a context; Load passes context.Background.
  - Added per-component shutdown functions for ledger, connection manager, peer governor, and UTxO RPC.
  - Ouroboros BlockFetch, ChainSync, and TxSubmission stop work on connection errors.
  - Chain iterator is cancelable and is cancelled when a ChainSync client is removed.

- **Bug Fixes**
  - Validate ChainSync availability on a connection before starting the client.
  - Validate TxSubmission availability on a connection before starting the client.

<sup>Written for commit a2932a2a54f9699f128a704e0fb0ff82b85d2870. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Core services now use context-driven lifecycle for coordinated startup/shutdown and graceful cancellation.
  * HTTP server startup unified with clearer TLS/non‑TLS handling and graceful shutdown on cancel.

* **Bug Fixes**
  * Improved responsiveness to connection errors and cancellations across networking, block fetch, chain sync, and tx submission.
  * Reduced risk of hanging loops and ensured earlier termination of in‑flight work.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->