### PR TITLE
refactor(database): data manipulation methods for blob storage

### DIFF
--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -26,6 +26,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -254,6 +255,336 @@ func (d *BlobStoreGCS) NewIterator(
 		}
 	}
 	return &gcsIterator{store: d, txn: txn, keys: keys, reverse: opts.Reverse}
+}
+
+// SetBlock stores a block with its metadata and index
+func (d *BlobStoreGCS) SetBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+	cborData []byte,
+	id uint64,
+	blockType uint,
+	height uint64,
+	prevHash []byte,
+) error {
+	if err := d.validateTxn(txn); err != nil {
+		return err
+	}
+	t := txn.(*gcsTxn) // safe after validateTxn
+	if err := t.assertWritable(); err != nil {
+		return err
+	}
+	ctx, cancel := d.opContext()
+	defer cancel()
+
+	// Track written objects for cleanup on failure
+	var writtenObjects []string
+
+	// Block content by point
+	key := types.BlockBlobKey(slot, hash)
+	w := d.bucket.Object(string(key)).NewWriter(ctx)
+	if _, err := w.Write(cborData); err != nil {
+		_ = w.Close()
+		d.logger.Errorf("failed to write object %q: %v", string(key), err)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		d.logger.Errorf("failed to close writer for %q: %v", string(key), err)
+		return err
+	}
+	writtenObjects = append(writtenObjects, string(key))
+
+	// Block index to point key
+	indexKey := types.BlockBlobIndexKey(id)
+	w = d.bucket.Object(string(indexKey)).NewWriter(ctx)
+	if _, err := w.Write(key); err != nil {
+		_ = w.Close()
+		d.logger.Errorf("failed to write object %q: %v", string(indexKey), err)
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		d.logger.Errorf(
+			"failed to close writer for %q: %v",
+			string(indexKey),
+			err,
+		)
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+	writtenObjects = append(writtenObjects, string(indexKey))
+
+	// Block metadata by point
+	metadataKey := types.BlockBlobMetadataKey(key)
+	tmpMetadata := types.BlockMetadata{
+		ID:       id,
+		Type:     blockType,
+		Height:   height,
+		PrevHash: prevHash,
+	}
+	tmpMetadataBytes, err := cbor.Encode(tmpMetadata)
+	if err != nil {
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+	w = d.bucket.Object(string(metadataKey)).NewWriter(ctx)
+	if _, err := w.Write(tmpMetadataBytes); err != nil {
+		_ = w.Close()
+		d.logger.Errorf(
+			"failed to write object %q: %v",
+			string(metadataKey),
+			err,
+		)
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		d.logger.Errorf(
+			"failed to close writer for %q: %v",
+			string(metadataKey),
+			err,
+		)
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+
+	return nil
+}
+
+// cleanupObjects deletes the specified objects from GCS, logging any failures
+// but not treating them as fatal since cleanup is best-effort
+func (d *BlobStoreGCS) cleanupObjects(
+	ctx context.Context,
+	objectNames []string,
+) {
+	for _, objName := range objectNames {
+		if err := d.bucket.Object(objName).Delete(ctx); err != nil {
+			if !errors.Is(err, storage.ErrObjectNotExist) {
+				d.logger.Warningf(
+					"failed to cleanup orphaned object during SetBlock failure: object=%s error=%v",
+					objName,
+					err,
+				)
+			}
+			// Ignore ErrObjectNotExist as the object may have been deleted already
+		} else {
+			d.logger.Debugf(
+				"cleaned up orphaned object during SetBlock failure: object=%s",
+				objName,
+			)
+		}
+	}
+}
+
+// GetBlock retrieves a block's CBOR data and metadata
+func (d *BlobStoreGCS) GetBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
+	if err := d.validateTxn(txn); err != nil {
+		return nil, types.BlockMetadata{}, err
+	}
+	ctx, cancel := d.opContext()
+	defer cancel()
+	key := types.BlockBlobKey(slot, hash)
+	r, err := d.bucket.Object(string(key)).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, types.BlockMetadata{}, types.ErrBlobKeyNotFound
+		}
+		wrappedErr := fmt.Errorf(
+			"read object %q from bucket %q: %w",
+			string(key),
+			d.bucketName,
+			err,
+		)
+		d.logger.Errorf("%v", wrappedErr)
+		return nil, types.BlockMetadata{}, wrappedErr
+	}
+	defer r.Close()
+	cborData, err := io.ReadAll(r)
+	if err != nil {
+		wrappedErr := fmt.Errorf(
+			"read object %q from bucket %q: %w",
+			string(key),
+			d.bucketName,
+			err,
+		)
+		d.logger.Errorf("%v", wrappedErr)
+		return nil, types.BlockMetadata{}, wrappedErr
+	}
+	metadataKey := types.BlockBlobMetadataKey(key)
+	r, err = d.bucket.Object(string(metadataKey)).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			// Block content exists but metadata is missing - this indicates a partial write
+			d.logger.Warningf(
+				"block content exists but metadata is missing, possible partial write: key=%s metadataKey=%s",
+				string(key),
+				string(metadataKey),
+			)
+			return nil, types.BlockMetadata{}, types.ErrBlobKeyNotFound
+		}
+		wrappedErr := fmt.Errorf(
+			"read object %q from bucket %q: %w",
+			string(metadataKey),
+			d.bucketName,
+			err,
+		)
+		d.logger.Errorf("%v", wrappedErr)
+		return nil, types.BlockMetadata{}, wrappedErr
+	}
+	defer r.Close()
+	metadataBytes, err := io.ReadAll(r)
+	if err != nil {
+		wrappedErr := fmt.Errorf(
+			"read object %q from bucket %q: %w",
+			string(metadataKey),
+			d.bucketName,
+			err,
+		)
+		d.logger.Errorf("%v", wrappedErr)
+		return nil, types.BlockMetadata{}, wrappedErr
+	}
+	var tmpMetadata types.BlockMetadata
+	if _, err := cbor.Decode(metadataBytes, &tmpMetadata); err != nil {
+		return nil, types.BlockMetadata{}, err
+	}
+	return cborData, tmpMetadata, nil
+}
+
+// DeleteBlock removes a block and its associated data
+func (d *BlobStoreGCS) DeleteBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+	id uint64,
+) error {
+	if err := d.validateTxn(txn); err != nil {
+		return err
+	}
+	t := txn.(*gcsTxn) // safe after validateTxn
+	if err := t.assertWritable(); err != nil {
+		return err
+	}
+	ctx, cancel := d.opContext()
+	defer cancel()
+	key := types.BlockBlobKey(slot, hash)
+	if err := d.bucket.Object(string(key)).Delete(ctx); err != nil &&
+		!errors.Is(err, storage.ErrObjectNotExist) {
+		d.logger.Errorf("gcs delete %q failed: %v", string(key), err)
+		return err
+	}
+	indexKey := types.BlockBlobIndexKey(id)
+	if err := d.bucket.Object(string(indexKey)).Delete(ctx); err != nil &&
+		!errors.Is(err, storage.ErrObjectNotExist) {
+		d.logger.Errorf("gcs delete %q failed: %v", string(indexKey), err)
+		return err
+	}
+	metadataKey := types.BlockBlobMetadataKey(key)
+	if err := d.bucket.Object(string(metadataKey)).Delete(ctx); err != nil &&
+		!errors.Is(err, storage.ErrObjectNotExist) {
+		d.logger.Errorf("gcs delete %q failed: %v", string(metadataKey), err)
+		return err
+	}
+	return nil
+}
+
+// SetUtxo stores a UTxO's CBOR data
+func (d *BlobStoreGCS) SetUtxo(
+	txn types.Txn,
+	txId []byte,
+	outputIdx uint32,
+	cborData []byte,
+) error {
+	if err := d.validateTxn(txn); err != nil {
+		return err
+	}
+	t := txn.(*gcsTxn) // safe after validateTxn
+	if err := t.assertWritable(); err != nil {
+		return err
+	}
+	ctx, cancel := d.opContext()
+	defer cancel()
+	key := types.UtxoBlobKey(txId, outputIdx)
+	w := d.bucket.Object(string(key)).NewWriter(ctx)
+	if _, err := w.Write(cborData); err != nil {
+		_ = w.Close()
+		d.logger.Errorf("failed to write object %q: %v", string(key), err)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		d.logger.Errorf("failed to close writer for %q: %v", string(key), err)
+		return err
+	}
+	return nil
+}
+
+// GetUtxo retrieves a UTxO's CBOR data
+func (d *BlobStoreGCS) GetUtxo(
+	txn types.Txn,
+	txId []byte,
+	outputIdx uint32,
+) ([]byte, error) {
+	if err := d.validateTxn(txn); err != nil {
+		return nil, err
+	}
+	ctx, cancel := d.opContext()
+	defer cancel()
+	key := types.UtxoBlobKey(txId, outputIdx)
+	r, err := d.bucket.Object(string(key)).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, types.ErrBlobKeyNotFound
+		}
+		wrappedErr := fmt.Errorf(
+			"read object %q from bucket %q: %w",
+			string(key),
+			d.bucketName,
+			err,
+		)
+		d.logger.Errorf("%v", wrappedErr)
+		return nil, wrappedErr
+	}
+	defer r.Close()
+	ciphertext, err := io.ReadAll(r)
+	if err != nil {
+		wrappedErr := fmt.Errorf(
+			"read object %q from bucket %q: %w",
+			string(key),
+			d.bucketName,
+			err,
+		)
+		d.logger.Errorf("%v", wrappedErr)
+		return nil, wrappedErr
+	}
+	return ciphertext, nil
+}
+
+// DeleteUtxo removes a UTxO's data
+func (d *BlobStoreGCS) DeleteUtxo(
+	txn types.Txn,
+	txId []byte,
+	outputIdx uint32,
+) error {
+	if err := d.validateTxn(txn); err != nil {
+		return err
+	}
+	t := txn.(*gcsTxn) // safe after validateTxn
+	if err := t.assertWritable(); err != nil {
+		return err
+	}
+	ctx, cancel := d.opContext()
+	defer cancel()
+	key := types.UtxoBlobKey(txId, outputIdx)
+	if err := d.bucket.Object(string(key)).Delete(ctx); err != nil &&
+		!errors.Is(err, storage.ErrObjectNotExist) {
+		d.logger.Errorf("gcs delete %q failed: %v", string(key), err)
+		return err
+	}
+	return nil
 }
 
 func (t *gcsTxn) Commit() error {

--- a/database/plugin/blob/store.go
+++ b/database/plugin/blob/store.go
@@ -51,6 +51,29 @@ type BlobStore interface {
 	// SetCommitTimestamp stores the last commit timestamp; parameter order is
 	// (timestamp, txn) to keep the transaction as the final parameter.
 	SetCommitTimestamp(int64, types.Txn) error
+
+	// Block operations
+	SetBlock(
+		txn types.Txn,
+		slot uint64,
+		hash []byte,
+		cbor []byte,
+		id uint64,
+		blockType uint,
+		height uint64,
+		prevHash []byte,
+	) error
+	GetBlock(
+		txn types.Txn,
+		slot uint64,
+		hash []byte,
+	) ([]byte, types.BlockMetadata, error)
+	DeleteBlock(txn types.Txn, slot uint64, hash []byte, id uint64) error
+
+	// UTxO operations
+	SetUtxo(txn types.Txn, txId []byte, outputIdx uint32, cbor []byte) error
+	GetUtxo(txn types.Txn, txId []byte, outputIdx uint32) ([]byte, error)
+	DeleteUtxo(txn types.Txn, txId []byte, outputIdx uint32) error
 }
 
 // New returns the started blob plugin selected by name

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -684,9 +684,17 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					}
 				}
 				if certDeposits == nil && certRequiresDeposit(cert) {
-					d.logger.Error("certDeposits is nil for deposit-bearing certificate",
-						"index", i, "type", fmt.Sprintf("%T", cert))
-					return fmt.Errorf("missing certDeposits for deposit-bearing certificate at index %d", i)
+					d.logger.Error(
+						"certDeposits is nil for deposit-bearing certificate",
+						"index",
+						i,
+						"type",
+						fmt.Sprintf("%T", cert),
+					)
+					return fmt.Errorf(
+						"missing certDeposits for deposit-bearing certificate at index %d",
+						i,
+					)
 				}
 				switch c := cert.(type) {
 				case *lcommon.PoolRegistrationCertificate:

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -67,8 +67,7 @@ func (d *Database) SetTransaction(
 				outputIdx = realIdx
 			}
 		}
-		key := UtxoBlobKey(utxo.Id.Id().Bytes(), outputIdx)
-		if err := blob.Set(blobTxn, key, utxo.Output.Cbor()); err != nil {
+		if err := blob.SetUtxo(blobTxn, utxo.Id.Id().Bytes(), outputIdx, utxo.Output.Cbor()); err != nil {
 			return err
 		}
 	}

--- a/database/types/keys.go
+++ b/database/types/keys.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/binary"
+	"slices"
+)
+
+const (
+	BlockBlobKeyPrefix         = "bp"
+	BlockBlobIndexKeyPrefix    = "bi"
+	BlockBlobMetadataKeySuffix = "_metadata"
+	UtxoBlobKeyPrefix          = "u"
+)
+
+func BlockBlobKeyUint64ToBytes(input uint64) []byte {
+	ret := make([]byte, 8)
+	binary.BigEndian.PutUint64(ret, input)
+	return ret
+}
+
+func BlockBlobKey(slot uint64, hash []byte) []byte {
+	key := []byte(BlockBlobKeyPrefix)
+	// Convert slot to bytes
+	slotBytes := BlockBlobKeyUint64ToBytes(slot)
+	key = append(key, slotBytes...)
+	key = append(key, hash...)
+	return key
+}
+
+func BlockBlobIndexKey(blockNumber uint64) []byte {
+	key := []byte(BlockBlobIndexKeyPrefix)
+	// Convert block number to bytes
+	blockNumberBytes := BlockBlobKeyUint64ToBytes(blockNumber)
+	key = append(key, blockNumberBytes...)
+	return key
+}
+
+func BlockBlobMetadataKey(baseKey []byte) []byte {
+	return slices.Concat(baseKey, []byte(BlockBlobMetadataKeySuffix))
+}
+
+func UtxoBlobKey(txId []byte, outputIdx uint32) []byte {
+	key := []byte(UtxoBlobKeyPrefix)
+	key = append(key, txId...)
+	// Convert index to bytes
+	idxBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(idxBytes, outputIdx)
+	key = append(key, idxBytes...)
+	return key
+}

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
 )
 
 //nolint:recvcheck
@@ -125,4 +127,13 @@ type BlobIteratorOptions struct {
 type Txn interface {
 	Commit() error
 	Rollback() error
+}
+
+// BlockMetadata contains metadata for a block stored in blob
+type BlockMetadata struct {
+	cbor.StructAsArray
+	ID       uint64
+	Type     uint
+	Height   uint64
+	PrevHash []byte
 }

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -57,7 +57,10 @@ func (o *Ouroboros) txsubmissionClientStart(
 	}
 	tx := conn.TxSubmission()
 	if tx == nil {
-		return fmt.Errorf("TxSubmission protocol not available on connection: %s", connId.String())
+		return fmt.Errorf(
+			"TxSubmission protocol not available on connection: %s",
+			connId.String(),
+		)
 	}
 	tx.Client.Init()
 	return nil


### PR DESCRIPTION
Closes #330 
Closes #333 













<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored blob storage to centralize block and UTxO read/write/delete operations in the BlobStore interface, and updated S3, GCS, and Badger plugins to implement them. This simplifies block/UTxO handling, consolidates key generation, and standardizes metadata storage.

- **Refactors**
  - Added SetBlock/GetBlock/DeleteBlock and SetUtxo/GetUtxo/DeleteUtxo to BlobStore.
  - Moved key helpers and prefixes to database/types/keys.go; added types.BlockMetadata (CBOR).
  - Updated block.go and utxo.go to use new BlobStore methods and types; removed legacy key/metadata helpers.
  - Implemented new methods for S3, GCS, and Badger, including index and metadata handling.
  - Adjusted iteration and key prefixes to use types constants.

- **Migration**
  - Third-party BlobStore plugins must implement the new block and UTxO methods.
  - Replace direct blob Set/Get/Delete calls with the new helpers and use types.BlockBlobKey/UtxoBlobKey and types.BlockMetadata.

<sup>Written for commit 9b9295b912c46b393bcfdf0293e474caccf029c1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Block storage, metadata and content unified behind a single blob API across backends; iteration and lookup flows updated to use typed prefixes.
  * UTxO handling consolidated to unified set/get/delete UTxO blob operations.

* **New Features**
  * Added unified block blob operations that store/retrieve block payload and structured metadata together.

* **Bug Fixes**
  * Improved not-found handling, cleanup for partial writes, and simplified delete logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->