### PR TITLE
docs: remove credentials-file from GCS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Each plugin supports specific configuration options. See `dingo.yaml.example` fo
 - `bucket` - GCS bucket name
 - `project-id` - Google Cloud project ID
 - `prefix` - Path prefix within bucket
-- `credentials-file` - Path to service account credentials file (optional - uses Application Default Credentials if not provided)
 
 **AWS S3 Options:**
 - `bucket` - S3 bucket name

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -32,8 +32,6 @@ database:
       project-id: ""
       # Path prefix within the bucket
       prefix: ""
-      # Path to service account credentials file (optional - uses Application Default Credentials if not set)
-      credentials-file: ""
     s3:
       # AWS S3 bucket name
       bucket: ""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the credentials-file option from the GCS plugin docs and dingo.yaml.example to avoid implying manual credential paths are required. The plugin uses Google Application Default Credentials, so this field is unnecessary.

<sup>Written for commit 158d2696364992f3bd9aad65e6804274dc64887d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Google Cloud Storage credentials-file option documentation from README.

* **Chores**
  * Removed the credentials-file configuration field from example YAML.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->