### PR TITLE
feat(database): badger plugin value threshold

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -156,6 +156,7 @@ type BlobStoreBadger struct {
 	indexCacheSize   uint64
 	valueLogFileSize int64
 	memTableSize     int64
+	valueThreshold   int64
 	gcEnabled        bool
 }
 
@@ -168,6 +169,7 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 		indexCacheSize:   DefaultIndexCacheSize,
 		valueLogFileSize: int64(DefaultValueLogFileSize),
 		memTableSize:     int64(DefaultMemTableSize),
+		valueThreshold:   int64(DefaultValueThreshold),
 	}
 	for _, opt := range opts {
 		opt(db)
@@ -182,7 +184,8 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 			WithLogger(NewBadgerLogger(db.logger)).
 			// The default INFO logging is a bit verbose
 			WithLoggingLevel(badger.WARNING).
-			WithInMemory(true)
+			WithInMemory(true).
+			WithValueThreshold(db.valueThreshold)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
 			return nil, err
@@ -209,6 +212,7 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 			WithIndexCacheSize(int64(db.indexCacheSize)). //nolint:gosec // indexCacheSize is controlled and reasonable
 			WithValueLogFileSize(db.valueLogFileSize).
 			WithMemTableSize(db.memTableSize).
+			WithValueThreshold(db.valueThreshold).
 			WithCompression(options.Snappy)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {

--- a/database/plugin/blob/badger/options.go
+++ b/database/plugin/blob/badger/options.go
@@ -79,3 +79,10 @@ func WithMemTableSize(size int64) BlobStoreBadgerOptionFunc {
 		b.memTableSize = size
 	}
 }
+
+// WithValueThreshold specifies the value threshold for keeping values in LSM tree
+func WithValueThreshold(threshold int64) BlobStoreBadgerOptionFunc {
+	return func(b *BlobStoreBadger) {
+		b.valueThreshold = threshold
+	}
+}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a configurable Badger value threshold to control when values stay in LSM vs the value log, defaulting to 1MB. Also increases the default memtable size to 128MB for better write buffering.

- **New Features**
  - New value-threshold option (default 1MB); exposed via plugin CLI and wired to Badger.
  - Added WithValueThreshold option for programmatic config.
  - Increased DefaultMemTableSize to 128MB.

<sup>Written for commit b02bf2fc5bb089033b82c09c0b94c40350cdbd68. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable value-threshold for the database storage backend to control where values are stored (default: 1 MB).
  * Increased the default memory table size from 64 MB to 128 MB to improve storage performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->