### PR TITLE
ci(benchmark): fix script output

### DIFF
--- a/generate_benchmarks.sh
+++ b/generate_benchmarks.sh
@@ -281,10 +281,10 @@ $benchmark"
     done < <(list_previous_benchmarks)
 
     # Count items (remove empty lines and count)
-    faster_count=$(echo "$faster_benchmarks" | grep -c "^." || echo "0")
-    slower_count=$(echo "$slower_benchmarks" | grep -c "^." || echo "0")
-    new_count=$(echo "$new_benchmarks" | grep -c "^." || echo "0")
-    removed_count=$(echo "$removed_benchmarks" | grep -c "^." || echo "0")
+    faster_count=$(echo "$faster_benchmarks" | sed '/^$/d' | wc -l)
+    slower_count=$(echo "$slower_benchmarks" | sed '/^$/d' | wc -l)
+    new_count=$(echo "$new_benchmarks" | sed '/^$/d' | wc -l)
+    removed_count=$(echo "$removed_benchmarks" | sed '/^$/d' | wc -l)
 
     echo ""
     echo "Performance Changes Summary:"
@@ -362,10 +362,10 @@ $benchmark"
             done < <(list_previous_benchmarks)
 
             # Count items
-            faster_count=$(echo "$faster_benchmarks" | grep -c "^." || echo "0")
-            slower_count=$(echo "$slower_benchmarks" | grep -c "^." || echo "0")
-            new_count=$(echo "$new_benchmarks" | grep -c "^." || echo "0")
-            removed_count=$(echo "$removed_benchmarks" | grep -c "^." || echo "0")
+            faster_count=$(echo "$faster_benchmarks" | sed '/^$/d' | wc -l)
+            slower_count=$(echo "$slower_benchmarks" | sed '/^$/d' | wc -l)
+            new_count=$(echo "$new_benchmarks" | sed '/^$/d' | wc -l)
+            removed_count=$(echo "$removed_benchmarks" | sed '/^$/d' | wc -l)
 
             echo "### Summary"
             echo "- **Faster benchmarks**: $faster_count"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix benchmark summary counts by excluding empty lines, ensuring accurate totals for faster/slower/new/removed benchmarks. Replaces grep-based counting with sed + wc -l for reliable CI output and PR comments.

<sup>Written for commit 327c56ea59f73cef6dbe749626f27e5b18f43607. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

