### PR TITLE
build(make): use binary for test-load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' -X '$(GOMODULE)/internal/version.CommitHash=$(COMMIT_HASH)'"
 
-.PHONY: all build mod-tidy clean format golines test bench test-load-profile
+.PHONY: all build mod-tidy clean format golines test bench test-load test-load-profile
 
 # Default target
 all: format build test
@@ -51,13 +51,12 @@ test: mod-tidy
 bench: mod-tidy
 	go test -run=^$$ -bench=. -benchmem ./...
 
-test-load: mod-tidy
+test-load: build
 	rm -rf .dingo
-	go run ./cmd/dingo load database/immutable/testdata
+	./dingo load database/immutable/testdata
 
-test-load-profile: mod-tidy
-	rm -rf .dingo dingo
-	go build -o dingo ./cmd/dingo
+test-load-profile: build
+	rm -rf .dingo
 	./dingo --cpuprofile=cpu.prof --memprofile=mem.prof load database/immutable/testdata
 	@echo "Profiling complete. Run 'go tool pprof cpu.prof' or 'go tool pprof mem.prof' to analyze"
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch test-load and test-load-profile to use the compiled dingo binary and depend on build. This speeds up reruns and makes profiling reflect the actual binary.

- **Refactors**
  - test-load: depends on build, runs ./dingo load, cleans only .dingo.
  - test-load-profile: depends on build, removes inline build, runs profiling with existing binary, cleans only .dingo.

<sup>Written for commit d1c3bb39e94d03621a76ab89553519810a044324. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified test-load target to execute prebuilt binary with build dependency
  * Updated test-load-profile target build dependencies and cleanup procedure
  * Simplified build artifact cleanup process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->