### PR TITLE
build(make): all: format test build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' 
 .PHONY: all build mod-tidy clean format golines test bench test-load test-load-profile
 
 # Default target
-all: format build test
+all: format test build
 
 # Build target
 build: $(BINARIES)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reordered the Makefile default all target to run format, then test, then build. This runs tests before building so failures are caught early and avoids wasted builds.

<sup>Written for commit ce5b83e5f2002109c587563bda15ee5d707b6cf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build process execution order to optimize development workflow efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->