### PR TITLE
fix(ledger): persist genesis UTxOs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0
 	golang.org/x/sys v0.39.0
 	google.golang.org/api v0.258.0
@@ -188,7 +189,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.38.0 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist all genesis UTxOs (Byron and Shelley) with CBOR-encoded outputs at slot 0 to fix missing genesis state in the DB.

- **Bug Fixes**
  - Save genesis UTxOs via AddUtxos with Slot=0.
  - Encode outputs to CBOR before storing.
  - Add debug logging and clearer errors for genesis UTxO processing.

- **Dependencies**
  - Promote golang.org/x/crypto to a direct dependency.

<sup>Written for commit 17a01abd05dcbf200fc02eba14886696b2346332. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and error propagation for genesis UTxO processing, including explicit errors for unsupported outputs and clearer reporting.
  * Added logging to surface genesis initialization details and counts.

* **Chores**
  * Promoted a cryptographic dependency to a direct requirement to align module configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->