### PR TITLE
fix(database): use min in badger number bounds checks

### DIFF
--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -15,6 +15,7 @@
 package badger
 
 import (
+	"math"
 	"sync"
 
 	"github.com/blinklabs-io/dingo/database/plugin"
@@ -122,18 +123,15 @@ func init() {
 func NewFromCmdlineOptions() plugin.Plugin {
 	cmdlineOptionsMutex.RLock()
 	// Safe conversion from uint64 to int64 with bounds checking
-	valueLogFileSize := cmdlineOptions.valueLogFileSize
-	if valueLogFileSize > 1<<63-1 {
-		valueLogFileSize = 1<<63 - 1 // Cap at max int64
-	}
-	memTableSize := cmdlineOptions.memTableSize
-	if memTableSize > 1<<63-1 {
-		memTableSize = 1<<63 - 1 // Cap at max int64
-	}
-	valueThreshold := cmdlineOptions.valueThreshold
-	if valueThreshold > 1<<63-1 {
-		valueThreshold = 1<<63 - 1 // Cap at max int64
-	}
+	valueLogFileSize := min(cmdlineOptions.valueLogFileSize,
+		// Cap at max int64
+		uint64(math.MaxInt64))
+	memTableSize := min(cmdlineOptions.memTableSize,
+		// Cap at max int64
+		uint64(math.MaxInt64))
+	valueThreshold := min(cmdlineOptions.valueThreshold,
+		// Cap at max int64
+		uint64(math.MaxInt64))
 	// #nosec G115
 	opts := []BlobStoreBadgerOptionFunc{
 		WithDataDir(cmdlineOptions.dataDir),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use min() to cap Badger blob-store options at int64 max. Prevents overflow on uint64-to-int64 conversion and simplifies bounds checks.

<sup>Written for commit 1ca8a23c91648f4834f38665e3a54911f918830f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of numeric configuration limits by consolidating redundant checks into a single cap operation. Behavior and defaults remain unchanged; this reduces code complexity and maintenance effort.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->