### PR TITLE
feat(peergov): test peers for suitability

### DIFF
--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -41,6 +41,14 @@ const (
 	PeerStateHot
 )
 
+type TestResult uint8
+
+const (
+	TestResultUnknown TestResult = iota
+	TestResultPass
+	TestResultFail
+)
+
 type Peer struct {
 	LastActivity   time.Time
 	Connection     *PeerConnection
@@ -67,6 +75,9 @@ type Peer struct {
 	LastBlockFetchTime time.Time
 	// Composite performance score computed from the above metrics
 	PerformanceScore float64
+	// Suitability test results
+	LastTestTime   time.Time  // When peer was last tested for suitability
+	LastTestResult TestResult // Result of last suitability test
 }
 
 func (p *Peer) setConnection(conn *ouroboros.Connection, outbound bool) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds peer suitability testing with cached results to filter bad peers and reduce wasted outbound connection attempts. Introduces a configurable test function and a cooldown to avoid retesting too often.

- **New Features**
  - Added PeerGovernor.TestPeer(address) with thread-safe, cached results.
  - New config options: PeerTestFunc (custom check) and TestCooldown (default 5m).
  - Default test uses ConnManager to attempt an outbound connection and logs pass/fail.
  - Peer now tracks LastTestTime and LastTestResult (Unknown/Pass/Fail).
  - Comprehensive tests for custom func, cached pass/fail, existing peers, and no-config error.

- **Migration**
  - No breaking changes. To use testing, set PeerTestFunc or ensure ConnManager is configured.
  - Adjust TestCooldown if needed.

<sup>Written for commit a552fbe3fe5b9462e77576e56c491f520f343e04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Peer test results are now tracked with timing information
- Configurable cooldown intervals to manage testing frequency
- Support for custom peer test functions through governance configuration
- Failed, passed, and unknown test states are now recorded

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->