### PR TITLE
feat(peergov): track denied peers

### DIFF
--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -50,34 +50,25 @@ const (
 )
 
 type Peer struct {
-	LastActivity   time.Time
-	Connection     *PeerConnection
-	Address        string
-	ReconnectCount int
-	ReconnectDelay time.Duration
-	Source         PeerSource
-	State          PeerState
-	Sharable       bool
+	LastActivity       time.Time
+	LastTestTime       time.Time // When peer was last tested for suitability
+	LastBlockFetchTime time.Time // Timestamp of last observed block fetch
+	Connection         *PeerConnection
+	Address            string
 	// Performance metrics (used by the peer scoring system)
-	// Average block fetch latency in milliseconds (exponential moving average)
-	BlockFetchLatencyMs float64
-	// Whether we have seen an initial block fetch latency observation
-	BlockFetchLatencyInit bool
-	// Average block fetch success rate [0..1] (exponential moving average)
-	BlockFetchSuccessRate float64
-	// Whether we have seen an initial block fetch success observation
-	BlockFetchSuccessInit bool
-	// Connection stability score [0..1] (uptime / expected uptime)
-	ConnectionStability float64
-	// Whether we have seen an initial connection stability observation
-	ConnectionStabilityInit bool
-	// Timestamp of last observed block fetch
-	LastBlockFetchTime time.Time
-	// Composite performance score computed from the above metrics
-	PerformanceScore float64
-	// Suitability test results
-	LastTestTime   time.Time  // When peer was last tested for suitability
-	LastTestResult TestResult // Result of last suitability test
+	BlockFetchLatencyMs     float64 // Average block fetch latency in ms (EMA)
+	BlockFetchSuccessRate   float64 // Average block fetch success rate 0..1 (EMA)
+	ConnectionStability     float64 // Connection stability score 0..1
+	ReconnectDelay          time.Duration
+	PerformanceScore        float64 // Composite score from the above metrics
+	ReconnectCount          int
+	State                   PeerState
+	Source                  PeerSource
+	Sharable                bool
+	BlockFetchLatencyInit   bool       // Whether latency has been initialized
+	BlockFetchSuccessInit   bool       // Whether success rate has been initialized
+	ConnectionStabilityInit bool       // Whether stability has been initialized
+	LastTestResult          TestResult // Result of last suitability test
 }
 
 func (p *Peer) setConnection(conn *ouroboros.Connection, outbound bool) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deny list to PeerGovernor to temporarily block peers that fail suitability tests or are manually denied. This prevents re-adding bad peers and automatically cleans up expired entries.

- **New Features**
  - Added DenyPeer and IsDenied methods with a default DenyDuration of 30m (configurable).
  - AddPeer checks the deny list and skips denied peers.
  - TestPeer adds failing peers to the deny list.
  - Reconcile cleans up expired deny list entries.
  - Added tests for denial, expiry, add behavior, test failures, and cleanup.

- **Refactors**
  - Reorganized Peer struct fields and comments for clarity without changing behavior.

<sup>Written for commit e9b528d4db789ac6174d147268f1dc41527ab06f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added peer denial mechanism to temporarily block peers from the network.
  * Introduced enhanced peer performance metrics including latency, success rate, connection stability, and overall performance scoring.

* **Tests**
  * Added comprehensive tests for peer denial functionality and performance tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->