### PR TITLE
fix(peergov): share gossip peers

### DIFF
--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -443,11 +443,16 @@ func (p *PeerGovernor) AddPeer(address string, source PeerSource) {
 			return
 		}
 	}
-	p.peers = append(p.peers, &Peer{
+	newPeer := &Peer{
 		Address: address,
 		Source:  source,
 		State:   PeerStateCold,
-	})
+	}
+	// Gossip-discovered peers are sharable since they were already shared
+	if source == PeerSourceP2PGossip {
+		newPeer.Sharable = true
+	}
+	p.peers = append(p.peers, newPeer)
 	p.updatePeerMetrics()
 	if source == PeerSourceP2PGossip && p.metrics != nil {
 		p.metrics.increasedKnownPeers.Inc()


### PR DESCRIPTION
Closes #323 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks gossip-discovered peers as sharable so they can be shared with other nodes. Adds tests to confirm gossip peers are sharable and non-gossip peers are not by default.

- **Bug Fixes**
  - Set Sharable=true for peers added from PeerSourceP2PGossip in AddPeer.
  - Extended tests to validate sharable behavior for gossip and non-gossip peers.

<sup>Written for commit 492d3a9dc4b49c033065e3342bb06552402937d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Peers discovered through gossip are now marked as shareable, while peers from other sources are not shareable by default.

* **Tests**
  * Updated test coverage to validate peer shareability behavior based on discovery source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->