### PR TITLE
feat(peergov): ledger peers

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,6 +55,10 @@ type Config struct {
 	devMode                  bool
 	shutdownTimeout          time.Duration
 	DatabaseWorkerPoolConfig ledger.DatabaseWorkerPoolConfig
+	// Peer limits (0 = use default, -1 = unlimited)
+	maxColdPeers int
+	maxWarmPeers int
+	maxHotPeers  int
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -285,5 +289,16 @@ func WithDatabaseWorkerPoolConfig(
 ) ConfigOptionFunc {
 	return func(c *Config) {
 		c.DatabaseWorkerPoolConfig = cfg
+	}
+}
+
+// WithPeerLimits specifies the maximum number of peers in each state.
+// Use 0 to use the default limit, or -1 for unlimited.
+// Default limits: cold=200, warm=50, hot=20
+func WithPeerLimits(maxCold, maxWarm, maxHot int) ConfigOptionFunc {
+	return func(c *Config) {
+		c.maxColdPeers = maxCold
+		c.maxWarmPeers = maxWarm
+		c.maxHotPeers = maxHot
 	}
 }

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -178,3 +178,95 @@ func (d *MetadataStoreSqlite) GetPoolRegistrations(
 	}
 	return ret, nil
 }
+
+// GetActivePoolRelays returns all relays from currently active pools.
+// A pool is considered active if it has a registration and either:
+// - No retirement, or
+// - The retirement epoch is in the future
+//
+// Implementation note: This function loads all registrations and retirements
+// per pool and filters in Go rather than using complex SQL JOINs. This approach
+// is necessary because:
+//  1. GORM's Preload with Limit(1) applies the limit globally, not per-parent
+//  2. Determining the "latest" registration/retirement requires comparing
+//     added_slot values which is cumbersome in a single query
+//  3. The filtering logic (retirement epoch vs current epoch) is clearer in Go
+//
+// For networks with thousands of pools, this may use significant memory.
+// Future optimization could use raw SQL with window functions (ROW_NUMBER)
+// or batch processing if memory becomes a concern.
+func (d *MetadataStoreSqlite) GetActivePoolRelays(
+	txn types.Txn,
+) ([]models.PoolRegistrationRelay, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the current epoch from the tip
+	var tmpTip models.Tip
+	if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+		// If we can't get the tip, return empty (no relays)
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return []models.PoolRegistrationRelay{}, nil
+		}
+		return nil, res.Error
+	}
+
+	var curEpoch models.Epoch
+	if res := db.Where(
+		"start_slot <= ?",
+		tmpTip.Slot,
+	).Order("start_slot DESC").First(&curEpoch); res.Error != nil {
+		// If we can't determine current epoch, return empty
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return []models.PoolRegistrationRelay{}, nil
+		}
+		return nil, res.Error
+	}
+
+	// Query all pools with their registrations, retirements, and relays.
+	// We load ALL registrations/retirements per pool and filter in Go because
+	// GORM's Preload with Limit(1) applies globally, not per-parent.
+	var pools []models.Pool
+	result := db.
+		Preload("Registration", func(db *gorm.DB) *gorm.DB {
+			return db.Order("added_slot DESC")
+		}).
+		Preload("Registration.Relays").
+		Preload("Retirement", func(db *gorm.DB) *gorm.DB {
+			return db.Order("added_slot DESC")
+		}).
+		Find(&pools)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	// Filter active pools and collect relays from the latest registration
+	var relays []models.PoolRegistrationRelay
+	for _, pool := range pools {
+		// Skip pools without registrations
+		if len(pool.Registration) == 0 {
+			continue
+		}
+
+		// Get the latest registration (already sorted by added_slot DESC)
+		latestReg := pool.Registration[0]
+
+		// Check if pool is retired
+		if len(pool.Retirement) > 0 {
+			// Get the latest retirement (already sorted by added_slot DESC)
+			latestRet := pool.Retirement[0]
+			// If retirement is more recent than registration and epoch has passed
+			if latestRet.AddedSlot > latestReg.AddedSlot &&
+				latestRet.Epoch <= curEpoch.EpochId {
+				continue // Pool is retired
+			}
+		}
+
+		// Pool is active, add relays from the latest registration
+		relays = append(relays, latestReg.Relays...)
+	}
+
+	return relays, nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -64,6 +64,10 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Pool, error)
 
+	// GetActivePoolRelays retrieves all relays from currently active pools.
+	// This is used for ledger peer discovery.
+	GetActivePoolRelays(types.Txn) ([]models.PoolRegistrationRelay, error)
+
 	// GetStakeRegistrations retrieves all stake registration certificates for an account.
 	GetStakeRegistrations(
 		[]byte, // stakeKey

--- a/database/pool.go
+++ b/database/pool.go
@@ -38,3 +38,13 @@ func (d *Database) GetPool(
 	}
 	return ret, nil
 }
+
+// GetActivePoolRelays returns all relays from currently active pools.
+// This is used for ledger peer discovery.
+func (d *Database) GetActivePoolRelays(txn *Txn) ([]models.PoolRegistrationRelay, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Commit() //nolint:errcheck
+	}
+	return d.metadata.GetActivePoolRelays(txn.Metadata())
+}

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -104,3 +104,14 @@ devMode: false
 
 # Validate historical blocks during ledger processing (default: false)
 validateHistorical: false
+
+# Peer limits - maximum number of peers in each state
+# Use 0 for default values, -1 for unlimited
+# Default: cold=200, warm=50, hot=20
+#
+# Maximum cold (known but not connected) peers
+maxColdPeers: 0
+# Maximum warm (connected but not active) peers
+maxWarmPeers: 0
+# Maximum hot (active) peers
+maxHotPeers: 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,11 @@ type Config struct {
 	// Database worker pool tuning (worker count and task queue size)
 	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
 	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
+
+	// Peer limits (0 = use default, -1 = unlimited)
+	MaxColdPeers int `yaml:"maxColdPeers" envconfig:"DINGO_MAX_COLD_PEERS"`
+	MaxWarmPeers int `yaml:"maxWarmPeers" envconfig:"DINGO_MAX_WARM_PEERS"`
+	MaxHotPeers  int `yaml:"maxHotPeers"  envconfig:"DINGO_MAX_HOT_PEERS"`
 }
 
 func (c *Config) ParseCmdlineArgs(programName string, args []string) error {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -152,6 +152,11 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				TaskQueueSize:  cfg.DatabaseQueueSize,
 				Disabled:       false,
 			}),
+			dingo.WithPeerLimits(
+				cfg.MaxColdPeers,
+				cfg.MaxWarmPeers,
+				cfg.MaxHotPeers,
+			),
 		),
 	)
 	if err != nil {

--- a/ledger/peer_provider.go
+++ b/ledger/peer_provider.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/peergov"
+)
+
+// LedgerPeerProviderAdapter implements peergov.LedgerPeerProvider using
+// the ledger state and database to discover stake pool relays.
+type LedgerPeerProviderAdapter struct {
+	ledgerState *LedgerState
+	db          *database.Database
+}
+
+// NewLedgerPeerProvider creates a new LedgerPeerProvider adapter.
+// Returns an error if ledgerState or db is nil.
+func NewLedgerPeerProvider(
+	ledgerState *LedgerState,
+	db *database.Database,
+) (*LedgerPeerProviderAdapter, error) {
+	if ledgerState == nil {
+		return nil, errors.New("ledgerState cannot be nil")
+	}
+	if db == nil {
+		return nil, errors.New("db cannot be nil")
+	}
+	return &LedgerPeerProviderAdapter{
+		ledgerState: ledgerState,
+		db:          db,
+	}, nil
+}
+
+// GetPoolRelays returns all active pool relays from the ledger.
+func (p *LedgerPeerProviderAdapter) GetPoolRelays() ([]peergov.PoolRelay, error) {
+	relays, err := p.db.GetActivePoolRelays(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]peergov.PoolRelay, 0, len(relays))
+	for _, relay := range relays {
+		pr := peergov.PoolRelay{
+			Hostname: relay.Hostname,
+			Port:     relay.Port,
+		}
+		if relay.Ipv4 != nil {
+			pr.IPv4 = relay.Ipv4
+		}
+		if relay.Ipv6 != nil {
+			pr.IPv6 = relay.Ipv6
+		}
+		result = append(result, pr)
+	}
+
+	return result, nil
+}
+
+// CurrentSlot returns the current chain tip slot number.
+func (p *LedgerPeerProviderAdapter) CurrentSlot() uint64 {
+	tip := p.ledgerState.Tip()
+	return tip.Point.Slot
+}
+
+// Ensure LedgerPeerProviderAdapter implements LedgerPeerProvider
+var _ peergov.LedgerPeerProvider = (*LedgerPeerProviderAdapter)(nil)

--- a/peergov/ledger.go
+++ b/peergov/ledger.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"net"
+	"strconv"
+)
+
+// LedgerPeerProvider defines an interface for querying ledger peer information.
+// This allows the peer governor to discover peers from on-chain stake pool
+// relay registrations without directly depending on the ledger package.
+//
+// Ledger peer discovery enables a node to find peers by reading stake pool
+// relay information from the blockchain itself. This is the primary mechanism
+// for peer discovery in Cardano's decentralized network, complementing
+// topology-based and gossip-based peer discovery.
+//
+// The provider is queried periodically (controlled by LedgerPeerRefreshInterval)
+// once the chain tip has passed UseLedgerAfterSlot. This allows nodes to
+// initially sync using bootstrap/topology peers before transitioning to
+// ledger-based discovery.
+type LedgerPeerProvider interface {
+	// GetPoolRelays returns all active pool relays from the ledger.
+	// A pool is considered active if it has a registration certificate and
+	// either no retirement certificate, or a retirement epoch in the future.
+	// Returns an empty slice if no relays are available.
+	// Returns an error if the underlying data cannot be read.
+	GetPoolRelays() ([]PoolRelay, error)
+
+	// CurrentSlot returns the current chain tip slot number.
+	// This is used to check if UseLedgerAfterSlot threshold has been reached.
+	CurrentSlot() uint64
+}
+
+// PoolRelay represents a stake pool relay for peer discovery.
+// This corresponds to the relay information in a pool registration certificate.
+//
+// Cardano supports three relay types:
+//   - SingleHostAddress: Direct IP address(es) with port
+//   - SingleHostName: DNS hostname with port
+//   - MultiHostName: DNS hostname without port (not commonly used)
+//
+// At least one of Hostname, IPv4, or IPv6 must be set.
+type PoolRelay struct {
+	// Hostname is the DNS hostname of the relay (for SingleHostName relays)
+	Hostname string
+
+	// IPv4 is the IPv4 address of the relay (for SingleHostAddress relays)
+	IPv4 *net.IP
+
+	// IPv6 is the IPv6 address of the relay (for SingleHostAddress relays)
+	IPv6 *net.IP
+
+	// Port is the port number of the relay. If 0, defaults to 3001.
+	Port uint
+}
+
+// Addresses returns the network addresses for this relay.
+// For hostname relays, returns "hostname:port".
+// For IP relays, returns "ip:port" for each configured IP address.
+func (r PoolRelay) Addresses() []string {
+	var addresses []string
+	portStr := formatPort(r.Port)
+
+	if r.Hostname != "" {
+		addresses = append(addresses, net.JoinHostPort(r.Hostname, portStr))
+	}
+	if r.IPv4 != nil && len(*r.IPv4) > 0 {
+		addresses = append(addresses, net.JoinHostPort(r.IPv4.String(), portStr))
+	}
+	if r.IPv6 != nil && len(*r.IPv6) > 0 {
+		addresses = append(addresses, net.JoinHostPort(r.IPv6.String(), portStr))
+	}
+
+	return addresses
+}
+
+// formatPort converts a port number to a string.
+// Returns the default Cardano port "3001" if port is 0.
+func formatPort(port uint) string {
+	if port == 0 {
+		return "3001" // Default Cardano port
+	}
+	return strconv.FormatUint(uint64(port), 10)
+}

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -33,6 +33,26 @@ const (
 	PeerSourceInboundConn           = 6
 )
 
+// String returns a human-readable name for the peer source.
+func (s PeerSource) String() string {
+	switch s {
+	case PeerSourceTopologyLocalRoot:
+		return "topology-local-root"
+	case PeerSourceTopologyPublicRoot:
+		return "topology-public-root"
+	case PeerSourceTopologyBootstrapPeer:
+		return "topology-bootstrap"
+	case PeerSourceP2PLedger:
+		return "ledger"
+	case PeerSourceP2PGossip:
+		return "gossip"
+	case PeerSourceInboundConn:
+		return "inbound"
+	default:
+		return "unknown"
+	}
+}
+
 type PeerState uint16
 
 const (
@@ -55,6 +75,7 @@ type Peer struct {
 	LastBlockFetchTime time.Time // Timestamp of last observed block fetch
 	Connection         *PeerConnection
 	Address            string
+	NormalizedAddress  string // Cached normalized form of Address for deduplication
 	// Performance metrics (used by the peer scoring system)
 	BlockFetchLatencyMs     float64 // Average block fetch latency in ms (EMA)
 	BlockFetchSuccessRate   float64 // Average block fetch success rate 0..1 (EMA)

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -24,7 +24,9 @@ import (
 	"net"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/blinklabs-io/dingo/connmanager"
@@ -36,12 +38,18 @@ import (
 )
 
 const (
-	defaultReconcileInterval    = 30 * time.Minute
-	defaultMaxReconnectFailures = 3
-	defaultMinHotPeers          = 3
-	defaultInactivityTimeout    = 10 * time.Minute
-	defaultTestCooldown         = 5 * time.Minute
-	defaultDenyDuration         = 30 * time.Minute
+	defaultReconcileInterval         = 30 * time.Minute
+	defaultMaxReconnectFailures      = 3
+	defaultMinHotPeers               = 3
+	defaultInactivityTimeout         = 10 * time.Minute
+	defaultTestCooldown              = 5 * time.Minute
+	defaultDenyDuration              = 30 * time.Minute
+	defaultLedgerPeerRefreshInterval = 1 * time.Hour
+
+	// Default peer limits (applied when config value is 0)
+	defaultMaxColdPeers = 200
+	defaultMaxWarmPeers = 50
+	defaultMaxHotPeers  = 20
 )
 
 const (
@@ -51,13 +59,14 @@ const (
 )
 
 type PeerGovernor struct {
-	metrics         *peerGovernorMetrics
-	reconcileTicker *time.Ticker
-	stopCh          chan struct{}
-	denyList        map[string]time.Time // address -> expiry time
-	peers           []*Peer
-	config          PeerGovernorConfig
-	mu              sync.Mutex
+	metrics               *peerGovernorMetrics
+	reconcileTicker       *time.Ticker
+	stopCh                chan struct{}
+	denyList              map[string]time.Time // address -> expiry time
+	peers                 []*Peer
+	config                PeerGovernorConfig
+	lastLedgerPeerRefresh atomic.Int64 // UnixNano timestamp of last ledger peer discovery
+	mu                    sync.Mutex
 }
 
 type PeerGovernorConfig struct {
@@ -74,6 +83,16 @@ type PeerGovernorConfig struct {
 	TestCooldown         time.Duration // Min time between suitability tests
 	DenyDuration         time.Duration // How long to deny failed peers
 	DisableOutbound      bool
+
+	// Ledger peer discovery configuration
+	LedgerPeerProvider        LedgerPeerProvider // Provider for ledger peer information
+	UseLedgerAfterSlot        int64              // Slot after which to enable ledger peers (-1 = disabled)
+	LedgerPeerRefreshInterval time.Duration      // How often to refresh ledger peers
+
+	// Peer limits (0 = use default, -1 = unlimited)
+	MaxColdPeers int // Maximum cold peers to keep
+	MaxWarmPeers int // Maximum warm peers to maintain
+	MaxHotPeers  int // Maximum hot peers to promote
 }
 
 type peerGovernorMetrics struct {
@@ -114,6 +133,25 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	}
 	if cfg.DenyDuration == 0 {
 		cfg.DenyDuration = defaultDenyDuration
+	}
+	if cfg.LedgerPeerRefreshInterval == 0 {
+		cfg.LedgerPeerRefreshInterval = defaultLedgerPeerRefreshInterval
+	}
+	// Peer limits: 0 means use default, -1 means unlimited
+	if cfg.MaxColdPeers == 0 {
+		cfg.MaxColdPeers = defaultMaxColdPeers
+	} else if cfg.MaxColdPeers < 0 {
+		cfg.MaxColdPeers = 0 // 0 internally means unlimited
+	}
+	if cfg.MaxWarmPeers == 0 {
+		cfg.MaxWarmPeers = defaultMaxWarmPeers
+	} else if cfg.MaxWarmPeers < 0 {
+		cfg.MaxWarmPeers = 0
+	}
+	if cfg.MaxHotPeers == 0 {
+		cfg.MaxHotPeers = defaultMaxHotPeers
+	} else if cfg.MaxHotPeers < 0 {
+		cfg.MaxHotPeers = 0
 	}
 	cfg.Logger = cfg.Logger.With("component", "peergov")
 	p := &PeerGovernor{
@@ -325,9 +363,10 @@ func (p *PeerGovernor) LoadTopologyConfig(
 		p.peers = append(
 			p.peers,
 			&Peer{
-				Address: tmpAddress,
-				Source:  PeerSourceTopologyBootstrapPeer,
-				State:   PeerStateCold,
+				Address:           tmpAddress,
+				NormalizedAddress: p.normalizeAddress(tmpAddress),
+				Source:            PeerSourceTopologyBootstrapPeer,
+				State:             PeerStateCold,
 			},
 		)
 	}
@@ -339,10 +378,11 @@ func (p *PeerGovernor) LoadTopologyConfig(
 				strconv.FormatUint(uint64(ap.Port), 10),
 			)
 			tmpPeer := &Peer{
-				Address:  tmpAddress,
-				Source:   PeerSourceTopologyLocalRoot,
-				State:    PeerStateCold,
-				Sharable: localRoot.Advertise,
+				Address:           tmpAddress,
+				NormalizedAddress: p.normalizeAddress(tmpAddress),
+				Source:            PeerSourceTopologyLocalRoot,
+				State:             PeerStateCold,
+				Sharable:          localRoot.Advertise,
 			}
 			// Check for existing peer with this address
 			existingPeerIdx := -1
@@ -379,10 +419,11 @@ func (p *PeerGovernor) LoadTopologyConfig(
 				strconv.FormatUint(uint64(ap.Port), 10),
 			)
 			tmpPeer := &Peer{
-				Address:  tmpAddress,
-				Source:   PeerSourceTopologyPublicRoot,
-				State:    PeerStateCold,
-				Sharable: publicRoot.Advertise,
+				Address:           tmpAddress,
+				NormalizedAddress: p.normalizeAddress(tmpAddress),
+				Source:            PeerSourceTopologyPublicRoot,
+				State:             PeerStateCold,
+				Sharable:          publicRoot.Advertise,
 			}
 			// Check for existing peer with this address
 			existingPeerIdx := -1
@@ -427,10 +468,11 @@ func (p *PeerGovernor) GetPeers() []Peer {
 }
 
 func (p *PeerGovernor) AddPeer(address string, source PeerSource) {
+	normalized := p.normalizeAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	// Check deny list before adding
-	if p.isDeniedLocked(address) {
+	if p.isDeniedLocked(normalized) {
 		p.config.Logger.Debug(
 			"not adding denied peer",
 			"address", address,
@@ -444,9 +486,10 @@ func (p *PeerGovernor) AddPeer(address string, source PeerSource) {
 		}
 	}
 	newPeer := &Peer{
-		Address: address,
-		Source:  source,
-		State:   PeerStateCold,
+		Address:           address,
+		NormalizedAddress: normalized,
+		Source:            source,
+		State:             PeerStateCold,
 	}
 	// Gossip-discovered peers are sharable since they were already shared
 	if source == PeerSourceP2PGossip {
@@ -477,6 +520,152 @@ func (p *PeerGovernor) AddPeer(address string, source PeerSource) {
 			),
 		)
 	}
+}
+
+// discoverLedgerPeers discovers peers from on-chain stake pool relay registrations.
+// This method is called during reconciliation if ledger peers are enabled.
+func (p *PeerGovernor) discoverLedgerPeers() {
+	// Check if ledger peer provider is configured
+	if p.config.LedgerPeerProvider == nil {
+		return
+	}
+
+	// Check UseLedgerAfterSlot threshold first (before claiming refresh)
+	if p.config.UseLedgerAfterSlot < 0 {
+		// Ledger peers are disabled
+		return
+	}
+	if p.config.UseLedgerAfterSlot > 0 {
+		currentSlot := p.config.LedgerPeerProvider.CurrentSlot()
+		// Safe conversion: UseLedgerAfterSlot is already checked to be > 0
+		useLedgerAfterSlot := uint64(p.config.UseLedgerAfterSlot) // #nosec G115
+		if currentSlot < useLedgerAfterSlot {
+			p.config.Logger.Debug(
+				"ledger peers not yet enabled",
+				"current_slot", currentSlot,
+				"use_ledger_after_slot", p.config.UseLedgerAfterSlot,
+			)
+			return
+		}
+	}
+
+	// Atomically check and claim the refresh to prevent concurrent discoveries.
+	// Use CompareAndSwap to ensure only one goroutine proceeds.
+	now := time.Now().UnixNano()
+	lastRefresh := p.lastLedgerPeerRefresh.Load()
+	if time.Duration(now-lastRefresh) < p.config.LedgerPeerRefreshInterval {
+		return
+	}
+	if !p.lastLedgerPeerRefresh.CompareAndSwap(lastRefresh, now) {
+		// Another goroutine claimed the refresh
+		return
+	}
+
+	// Get pool relays from ledger
+	relays, err := p.config.LedgerPeerProvider.GetPoolRelays()
+	if err != nil {
+		p.config.Logger.Error(
+			"failed to get ledger peers",
+			"error", err,
+		)
+		// Reset timestamp to allow retry on next reconciliation cycle
+		// rather than waiting for the full refresh interval
+		p.lastLedgerPeerRefresh.Store(lastRefresh)
+		return
+	}
+
+	// Track how many peers we added
+	addedCount := 0
+
+	// Add each relay as a peer (with deduplication)
+	for _, relay := range relays {
+		addresses := relay.Addresses()
+		for _, addr := range addresses {
+			if p.addLedgerPeer(addr) {
+				addedCount++
+			}
+		}
+	}
+
+	if addedCount > 0 {
+		p.config.Logger.Info(
+			"discovered ledger peers",
+			"added", addedCount,
+			"total_relays", len(relays),
+		)
+	} else {
+		p.config.Logger.Debug(
+			"ledger peer discovery complete",
+			"total_relays", len(relays),
+			"new_peers", 0,
+		)
+	}
+}
+
+// addLedgerPeer adds a peer from ledger discovery with deduplication.
+// Returns true if the peer was added, false if it already exists or is denied.
+func (p *PeerGovernor) addLedgerPeer(address string) bool {
+	normalized := p.normalizeAddress(address)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Check deny list
+	if p.isDeniedLocked(normalized) {
+		return false
+	}
+
+	// Check for existing peer using cached NormalizedAddress
+	for _, peer := range p.peers {
+		if peer == nil {
+			continue
+		}
+		if peer.NormalizedAddress == normalized || peer.Address == address {
+			return false // Already exists
+		}
+	}
+
+	// Add as new peer
+	newPeer := &Peer{
+		Address:           address,
+		NormalizedAddress: normalized,
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateCold,
+		Sharable:          true, // Ledger peers are public relays
+	}
+	p.peers = append(p.peers, newPeer)
+	p.updatePeerMetrics()
+
+	if p.metrics != nil {
+		p.metrics.increasedKnownPeers.Inc()
+	}
+
+	if p.config.EventBus != nil {
+		p.config.EventBus.Publish(
+			PeerAddedEventType,
+			event.NewEvent(
+				PeerAddedEventType,
+				PeerStateChangeEvent{Address: address, Reason: "ledger"},
+			),
+		)
+	}
+
+	return true
+}
+
+// normalizeAddress returns a canonical form of an address for deduplication.
+// This normalizes IP addresses to their canonical string form and lowercases hostnames.
+func (p *PeerGovernor) normalizeAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	// Parse IP to normalize format (e.g., ::1 vs 0:0:0:0:0:0:0:1)
+	if ip := net.ParseIP(host); ip != nil {
+		return net.JoinHostPort(ip.String(), port)
+	}
+	// For hostnames, lowercase them
+	return net.JoinHostPort(strings.ToLower(host), port)
 }
 
 func (p *PeerGovernor) peerIndexByAddress(address string) int {
@@ -547,9 +736,10 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 	if duration == 0 {
 		duration = p.config.DenyDuration
 	}
+	normalized := p.normalizeAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.denyList[address] = time.Now().Add(duration)
+	p.denyList[normalized] = time.Now().Add(duration)
 	p.config.Logger.Debug(
 		"peer added to deny list",
 		"address", address,
@@ -561,9 +751,10 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 // Returns true if the peer is denied and the denial has not expired.
 // This method is thread-safe.
 func (p *PeerGovernor) IsDenied(address string) bool {
+	normalized := p.normalizeAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.isDeniedLocked(address)
+	return p.isDeniedLocked(normalized)
 }
 
 // isDeniedLocked checks if a peer is on the deny list.
@@ -597,6 +788,7 @@ func (p *PeerGovernor) cleanupDenyList() {
 // suitable, false otherwise. Results are cached to avoid excessive testing.
 // This method is thread-safe.
 func (p *PeerGovernor) TestPeer(address string) (bool, error) {
+	normalized := p.normalizeAddress(address)
 	p.mu.Lock()
 
 	// Find or create peer entry
@@ -604,9 +796,10 @@ func (p *PeerGovernor) TestPeer(address string) (bool, error) {
 	if idx := p.peerIndexByAddress(address); idx == -1 {
 		// Peer not known yet, create temporary entry to track test result
 		peer = &Peer{
-			Address: address,
-			Source:  PeerSourceUnknown,
-			State:   PeerStateCold,
+			Address:           address,
+			NormalizedAddress: normalized,
+			Source:            PeerSourceUnknown,
+			State:             PeerStateCold,
 		}
 		p.peers = append(p.peers, peer)
 		p.updatePeerMetrics()
@@ -664,7 +857,8 @@ func (p *PeerGovernor) TestPeer(address string) (bool, error) {
 	if testErr != nil {
 		peer.LastTestResult = TestResultFail
 		// Add to deny list (we already hold the lock)
-		p.denyList[address] = time.Now().Add(p.config.DenyDuration)
+		// Use normalized address for consistent deny list lookups
+		p.denyList[p.normalizeAddress(address)] = time.Now().Add(p.config.DenyDuration)
 		p.config.Logger.Debug(
 			"peer suitability test failed, added to deny list",
 			"address", address,
@@ -760,16 +954,21 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 }
 
 func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
+	e := evt.Data.(connmanager.InboundConnectionEvent)
+	address := e.RemoteAddr.String()
+	normalized := p.normalizeAddress(address)
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	e := evt.Data.(connmanager.InboundConnectionEvent)
+
 	var tmpPeer *Peer
-	peerIdx := p.peerIndexByAddress(e.RemoteAddr.String())
+	peerIdx := p.peerIndexByAddress(address)
 	if peerIdx == -1 {
 		tmpPeer = &Peer{
-			Address: e.RemoteAddr.String(),
-			Source:  PeerSourceInboundConn,
-			State:   PeerStateCold,
+			Address:           address,
+			NormalizedAddress: normalized,
+			Source:            PeerSourceInboundConn,
+			State:             PeerStateCold,
 		}
 		// Add inbound peer
 		p.peers = append(
@@ -974,6 +1173,10 @@ func (p *PeerGovernor) reconcile() {
 		}
 	}
 
+	// Enforce peer limits by removing excess peers
+	// Priority order (highest to lowest): Topology > Gossip > Ledger > Inbound > Unknown
+	p.enforcePeerLimits(&knownRemoved)
+
 	// Collect eligible peers for peer sharing
 	var eligiblePeers []*Peer
 	if p.config.PeerRequestFunc != nil {
@@ -1009,5 +1212,157 @@ func (p *PeerGovernor) reconcile() {
 		for _, addr := range addrs {
 			p.AddPeer(addr, PeerSourceP2PGossip)
 		}
+	}
+
+	// Discover peers from ledger (stake pool relays)
+	p.discoverLedgerPeers()
+}
+
+// enforcePeerLimits removes excess peers when limits are exceeded.
+// It prioritizes keeping topology peers and removes lower-priority peers first.
+// Must be called with p.mu held.
+func (p *PeerGovernor) enforcePeerLimits(removedCount *int) {
+	// Enforce hot peer limit
+	if p.config.MaxHotPeers > 0 {
+		p.enforceStateLimit(PeerStateHot, p.config.MaxHotPeers, removedCount)
+	}
+
+	// Enforce warm peer limit
+	if p.config.MaxWarmPeers > 0 {
+		p.enforceStateLimit(PeerStateWarm, p.config.MaxWarmPeers, removedCount)
+	}
+
+	// Enforce cold peer limit
+	if p.config.MaxColdPeers > 0 {
+		p.enforceStateLimit(PeerStateCold, p.config.MaxColdPeers, removedCount)
+	}
+}
+
+// enforceStateLimit removes excess peers in a given state.
+// Must be called with p.mu held.
+func (p *PeerGovernor) enforceStateLimit(
+	state PeerState,
+	limit int,
+	removedCount *int,
+) {
+	// Collect peers in this state
+	var peersInState []*Peer
+	for _, peer := range p.peers {
+		if peer != nil && peer.State == state {
+			peersInState = append(peersInState, peer)
+		}
+	}
+
+	// Check if we're over the limit
+	excess := len(peersInState) - limit
+	if excess <= 0 {
+		return
+	}
+
+	// Sort peers by removal priority (lowest priority first)
+	// Priority order (highest to lowest):
+	// - Topology peers (LocalRoot, PublicRoot, Bootstrap) - never remove
+	// - Gossip peers
+	// - Ledger peers
+	// - Inbound peers
+	// - Unknown peers
+	slices.SortFunc(peersInState, func(a, b *Peer) int {
+		// First compare by source priority (lower priority = remove first)
+		aPriority := p.peerSourcePriority(a.Source)
+		bPriority := p.peerSourcePriority(b.Source)
+		if aPriority != bPriority {
+			return cmp.Compare(aPriority, bPriority)
+		}
+		// Same priority: lower score = remove first
+		return cmp.Compare(a.PerformanceScore, b.PerformanceScore)
+	})
+
+	// Remove excess peers (they're sorted lowest priority first)
+	removed := 0
+	for i := 0; i < len(peersInState) && removed < excess; i++ {
+		peer := peersInState[i]
+
+		// Never remove topology peers
+		if p.isTopologyPeer(peer.Source) {
+			continue
+		}
+
+		// Find and remove from main peer list
+		for j := len(p.peers) - 1; j >= 0; j-- {
+			if p.peers[j] == peer {
+				p.config.Logger.Info(
+					"removing peer due to limit exceeded",
+					"address", peer.Address,
+					"state", state,
+					"source", peer.Source,
+					"limit", limit,
+				)
+				// Close connection if peer has one (for warm/hot peers)
+				if peer.Connection != nil && p.config.ConnManager != nil {
+					conn := p.config.ConnManager.GetConnectionById(
+						peer.Connection.Id,
+					)
+					if conn != nil {
+						conn.Close()
+					}
+				}
+				if p.config.EventBus != nil {
+					p.config.EventBus.Publish(
+						PeerRemovedEventType,
+						event.NewEvent(
+							PeerRemovedEventType,
+							PeerStateChangeEvent{
+								Address: peer.Address,
+								Reason:  "limit exceeded",
+							},
+						),
+					)
+				}
+				p.peers = append(p.peers[:j], p.peers[j+1:]...)
+				removed++
+				*removedCount++
+				break
+			}
+		}
+	}
+
+	if removed > 0 {
+		p.config.Logger.Debug(
+			"enforced peer limit",
+			"state", state,
+			"limit", limit,
+			"removed", removed,
+		)
+	}
+}
+
+// peerSourcePriority returns a priority value for a peer source.
+// Higher values = higher priority (less likely to be removed).
+func (p *PeerGovernor) peerSourcePriority(source PeerSource) int {
+	switch source {
+	case PeerSourceTopologyLocalRoot,
+		PeerSourceTopologyPublicRoot,
+		PeerSourceTopologyBootstrapPeer:
+		return 100 // Topology peers - highest priority, never removed
+	case PeerSourceP2PGossip:
+		return 50 // Gossip peers - medium-high priority
+	case PeerSourceP2PLedger:
+		return 30 // Ledger peers - medium priority
+	case PeerSourceInboundConn:
+		return 20 // Inbound peers - lower priority
+	default:
+		return 10 // Unknown - lowest priority
+	}
+}
+
+// isTopologyPeer returns true if the peer source is a topology source.
+func (p *PeerGovernor) isTopologyPeer(source PeerSource) bool {
+	switch source {
+	case PeerSourceTopologyLocalRoot,
+		PeerSourceTopologyPublicRoot,
+		PeerSourceTopologyBootstrapPeer:
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
Closes #322 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ledger-based peer discovery and configurable peer limits to the peer governor, improving peer quality and control. Implements stake pool relay discovery per #322.

- **New Features**
  - Peer discovery from on-chain stake pool relays via a LedgerPeerProvider; enabled after UseLedgerAfterSlot, refreshed hourly, deduplicated, and deny-list aware.
  - Enforces peer caps per state (cold/warm/hot) with defaults 200/50/20; -1 = unlimited; never removes topology peers; removal priority: topology > gossip > ledger > inbound > unknown.
  - Database: new GetActivePoolRelays to fetch relays from active pools (registration present, retirement not yet effective), using current epoch from tip.
  - Config/wiring: new maxColdPeers/maxWarmPeers/maxHotPeers (env: DINGO_MAX_COLD_PEERS, DINGO_MAX_WARM_PEERS, DINGO_MAX_HOT_PEERS), WithPeerLimits option, and node wiring for UseLedgerAfterSlot and the ledger peer provider.

- **Migration**
  - No action required; defaults apply.
  - To customize limits, set maxColdPeers/maxWarmPeers/maxHotPeers in dingo.yaml or via env vars.
  - To enable ledger discovery earlier, set topology UseLedgerAfterSlot (e.g., 0 to enable immediately, -1 keeps it disabled).

<sup>Written for commit c451c5c225e23f36fdef6f78b7d53b92d41e008e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ledger-based peer discovery to improve network peer selection and management
  * Active pool relay discovery from the ledger to expand peer sources

* **Configuration**
  * New peer limit parameters: maxColdPeers, maxWarmPeers, maxHotPeers (0 = default, -1 = unlimited)

* **Tests**
  * Expanded test coverage around ledger peer discovery and peer-limit enforcement

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->