### PR TITLE
fix(lint): prealloc all the things

### DIFF
--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -91,11 +91,12 @@ func (c *ConnectionManager) startListener(
 	c.listenersMutex.Unlock()
 
 	// Build connection options
-	defaultConnOpts := []ouroboros.ConnectionOptionFunc{
+	defaultConnOpts := make([]ouroboros.ConnectionOptionFunc, 0, 3+len(l.ConnectionOpts))
+	defaultConnOpts = append(defaultConnOpts,
 		ouroboros.WithLogger(c.config.Logger),
 		ouroboros.WithNodeToNode(!l.UseNtC),
 		ouroboros.WithServer(true),
-	}
+	)
 	defaultConnOpts = append(
 		defaultConnOpts,
 		l.ConnectionOpts...,

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -60,10 +60,11 @@ func (c *ConnectionManager) CreateOutboundConn(
 		return nil, err
 	}
 	// Build connection options
-	connOpts := []ouroboros.ConnectionOptionFunc{
+	connOpts := make([]ouroboros.ConnectionOptionFunc, 0, 2+len(c.config.OutboundConnOpts))
+	connOpts = append(connOpts,
 		ouroboros.WithConnection(tmpConn),
 		ouroboros.WithLogger(c.config.Logger),
-	}
+	)
 	connOpts = append(
 		connOpts,
 		c.config.OutboundConnOpts...,

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -769,7 +769,7 @@ func (d *BlobStoreGCS) Start() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
-	var clientOpts []option.ClientOption
+	clientOpts := make([]option.ClientOption, 0, 1)
 	clientOpts = append(clientOpts, storage.WithDisabledClientMetrics())
 
 	client, err := storage.NewGRPCClient(

--- a/database/sops/sops.go
+++ b/database/sops/sops.go
@@ -92,8 +92,9 @@ func getMasterKeyGroupsFromEnv() ([]sopsapi.KeyGroup, error) {
 
 	// Configure Google KMS from env to encrypt
 	if rid := os.Getenv("DINGO_GCP_KMS_RESOURCE_ID"); rid != "" {
-		keys := []skeys.MasterKey{}
-		for _, k := range gcpkms.MasterKeysFromResourceIDString(rid) {
+		gcpKeys := gcpkms.MasterKeysFromResourceIDString(rid)
+		keys := make([]skeys.MasterKey, 0, len(gcpKeys))
+		for _, k := range gcpKeys {
 			keys = append(keys, k)
 		}
 		if len(keys) > 0 {
@@ -103,9 +104,10 @@ func getMasterKeyGroupsFromEnv() ([]sopsapi.KeyGroup, error) {
 
 	// Configure AWS KMS from env to encrypt
 	if arns := os.Getenv("DINGO_AWS_KMS_KEY_ARNS"); arns != "" {
-		keys := []skeys.MasterKey{}
 		profile := os.Getenv("DINGO_AWS_KMS_PROFILE")
-		for _, k := range awskms.MasterKeysFromArnString(arns, nil, profile) {
+		awsKeys := awskms.MasterKeysFromArnString(arns, nil, profile)
+		keys := make([]skeys.MasterKey, 0, len(awsKeys))
+		for _, k := range awsKeys {
 			keys = append(keys, k)
 		}
 		if len(keys) > 0 {

--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -143,7 +143,7 @@ func ValidateTxAllegra(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	errs := []error{}
+	errs := make([]error, 0, len(allegra.UtxoValidationRules))
 	for _, validationFunc := range allegra.UtxoValidationRules {
 		errs = append(
 			errs,

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -147,7 +147,7 @@ func ValidateTxAlonzo(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	errs := []error{}
+	errs := make([]error, 0, len(alonzo.UtxoValidationRules))
 	for _, validationFunc := range alonzo.UtxoValidationRules {
 		errs = append(
 			errs,

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -143,7 +143,7 @@ func ValidateTxBabbage(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	errs := []error{}
+	errs := make([]error, 0, len(babbage.UtxoValidationRules))
 	for _, validationFunc := range babbage.UtxoValidationRules {
 		errs = append(
 			errs,

--- a/ledger/eras/mary.go
+++ b/ledger/eras/mary.go
@@ -143,7 +143,7 @@ func ValidateTxMary(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	errs := []error{}
+	errs := make([]error, 0, len(mary.UtxoValidationRules))
 	for _, validationFunc := range mary.UtxoValidationRules {
 		errs = append(
 			errs,

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -166,7 +166,7 @@ func ValidateTxShelley(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	errs := []error{}
+	errs := make([]error, 0, len(shelley.UtxoValidationRules))
 	for _, validationFunc := range shelley.UtxoValidationRules {
 		errs = append(
 			errs,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1463,11 +1463,11 @@ func (ls *LedgerState) UtxoByRef(
 func (ls *LedgerState) UtxosByAddress(
 	addr ledger.Address,
 ) ([]models.Utxo, error) {
-	ret := []models.Utxo{}
 	utxos, err := ls.db.UtxosByAddress(addr, nil)
 	if err != nil {
-		return ret, err
+		return nil, err
 	}
+	ret := make([]models.Utxo, 0, len(utxos))
 	ret = append(ret, utxos...)
 	return ret, nil
 }

--- a/utxorpc/submit.go
+++ b/utxorpc/submit.go
@@ -224,8 +224,9 @@ func (s *submitServiceServer) ReadMempool(
 	s.utxorpc.config.Logger.Info("Got a ReadMempool request")
 	resp := &submit.ReadMempoolResponse{}
 
-	mempool := []*submit.TxInMempool{}
-	for _, tx := range s.utxorpc.config.Mempool.Transactions() {
+	txs := s.utxorpc.config.Mempool.Transactions()
+	mempool := make([]*submit.TxInMempool, 0, len(txs))
+	for _, tx := range txs {
 		record := &submit.TxInMempool{
 			NativeBytes: tx.Cbor,
 			Stage:       submit.Stage_STAGE_MEMPOOL,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preallocated slices across networking, storage, ledger, and RPC code to fix linter warnings and reduce allocations. No behavior changes; small performance gains under load.

- **Refactors**
  - Preallocate and append slices in connection options (listener/outbound), GCS client options, SOPS KMS key lists (GCP/AWS), ledger validation error lists (all eras), LedgerState UTXO results, and mempool responses.
  - Reduces allocations and silences prealloc lints.

<sup>Written for commit ad18beb05a5954e3ec5b57cd0d782cece8d1d641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal slice allocation patterns across multiple components to improve memory efficiency and reduce unnecessary allocations during runtime operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->