### PR TITLE
feat: transaction rollback support

### DIFF
--- a/chain/event.go
+++ b/chain/event.go
@@ -30,7 +30,8 @@ type ChainBlockEvent struct {
 }
 
 type ChainRollbackEvent struct {
-	Point ocommon.Point
+	Point            ocommon.Point
+	RolledBackBlocks []models.Block // Blocks that were rolled back, in reverse order (newest first)
 }
 
 // ChainForkEvent is emitted when a chain fork is detected.

--- a/database/immutable/immutable.go
+++ b/database/immutable/immutable.go
@@ -47,6 +47,12 @@ func New(dataDir string) (*ImmutableDb, error) {
 	return i, nil
 }
 
+// Close releases any resources held by the ImmutableDb.
+// Currently a no-op, but provided for interface consistency.
+func (i *ImmutableDb) Close() error {
+	return nil
+}
+
 func (i *ImmutableDb) getChunkNames() ([]string, error) {
 	ret := []string{}
 	files, err := os.ReadDir(i.dataDir)

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -25,13 +25,12 @@ import (
 var ErrAccountNotFound = errors.New("account not found")
 
 type Account struct {
-	StakingKey    []byte `gorm:"uniqueIndex"`
-	Pool          []byte `gorm:"index"`
-	Drep          []byte `gorm:"index"`
-	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
-	CertificateID uint `gorm:"index"`
-	Active        bool `gorm:"default:true"`
+	StakingKey []byte `gorm:"uniqueIndex"`
+	Pool       []byte `gorm:"index"`
+	Drep       []byte `gorm:"index"`
+	ID         uint   `gorm:"primarykey"`
+	AddedSlot  uint64 `gorm:"index"`
+	Active     bool   `gorm:"default:true"`
 }
 
 func (a *Account) TableName() string {
@@ -61,7 +60,7 @@ type Deregistration struct {
 	StakingKey    []byte `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	Amount        types.Uint64
 }
 
@@ -73,7 +72,7 @@ type Registration struct {
 	StakingKey    []byte `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -86,7 +85,7 @@ type StakeDelegation struct {
 	PoolKeyHash   []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (StakeDelegation) TableName() string {
@@ -97,7 +96,7 @@ type StakeDeregistration struct {
 	StakingKey    []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (StakeDeregistration) TableName() string {
@@ -108,7 +107,7 @@ type StakeRegistration struct {
 	StakingKey    []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -121,7 +120,7 @@ type StakeRegistrationDelegation struct {
 	PoolKeyHash   []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -135,7 +134,7 @@ type StakeVoteDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (StakeVoteDelegation) TableName() string {
@@ -148,7 +147,7 @@ type StakeVoteRegistrationDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -161,7 +160,7 @@ type VoteDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (VoteDelegation) TableName() string {
@@ -173,7 +172,7 @@ type VoteRegistrationDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 

--- a/database/models/account_test.go
+++ b/database/models/account_test.go
@@ -26,11 +26,11 @@ import (
 func TestAccount_String(t *testing.T) {
 	tests := []struct {
 		name         string
+		wantErrMsg   string
+		expectedHRP  string
 		stakingKey   []byte
 		wantErr      bool
-		wantErrMsg   string
 		validateAddr bool
-		expectedHRP  string
 	}{
 		{
 			name: "valid staking key - 28 bytes",

--- a/database/models/auth_committee_hot.go
+++ b/database/models/auth_committee_hot.go
@@ -19,7 +19,7 @@ type AuthCommitteeHot struct {
 	HostCredential []byte `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
 	CertificateID  uint   `gorm:"index"`
-	AddedSlot      uint64
+	AddedSlot      uint64 `gorm:"index"`
 }
 
 func (AuthCommitteeHot) TableName() string {

--- a/database/models/certs.go
+++ b/database/models/certs.go
@@ -22,7 +22,7 @@ package models
 type Certificate struct {
 	BlockHash     []byte `gorm:"index"`
 	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"index;uniqueIndex:uniq_tx_cert;constraint:OnDelete:CASCADE"`
+	TransactionID uint   `gorm:"index;uniqueIndex:uniq_tx_cert"`
 	CertificateID uint   `gorm:"index"` // Polymorphic FK to certificate table based on CertType. Not DB-enforced.
 	Slot          uint64 `gorm:"index"`
 	CertIndex     uint   `gorm:"column:cert_index;uniqueIndex:uniq_tx_cert"`

--- a/database/models/datum.go
+++ b/database/models/datum.go
@@ -18,7 +18,7 @@ type Datum struct {
 	Hash      []byte `gorm:"index;not null;unique"`
 	RawDatum  []byte `gorm:"not null"`
 	ID        uint   `gorm:"primarykey"`
-	AddedSlot uint64 `gorm:"not null"`
+	AddedSlot uint64 `gorm:"index;not null"`
 }
 
 func (Datum) TableName() string {
@@ -27,10 +27,10 @@ func (Datum) TableName() string {
 
 // PlutusData represents a Plutus data value in the witness set
 type PlutusData struct {
+	Transaction   *Transaction `gorm:"foreignKey:TransactionID"`
+	Data          []byte
 	ID            uint `gorm:"primaryKey"`
 	TransactionID uint `gorm:"index"`
-	Data          []byte
-	Transaction   *Transaction
 }
 
 func (PlutusData) TableName() string {

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -23,13 +23,12 @@ import (
 var ErrDrepNotFound = errors.New("drep not found")
 
 type Drep struct {
-	AnchorUrl     string
-	Credential    []byte `gorm:"uniqueIndex"`
-	AnchorHash    []byte
-	CertificateID uint `gorm:"index"`
-	ID            uint `gorm:"primarykey"`
-	AddedSlot     uint64
-	Active        bool `gorm:"default:true"`
+	AnchorUrl  string
+	Credential []byte `gorm:"uniqueIndex"`
+	AnchorHash []byte
+	ID         uint   `gorm:"primarykey"`
+	AddedSlot  uint64 `gorm:"index"`
+	Active     bool   `gorm:"default:true"`
 }
 
 func (d *Drep) TableName() string {
@@ -40,7 +39,7 @@ type DeregistrationDrep struct {
 	DrepCredential []byte `gorm:"index"`
 	CertificateID  uint   `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
-	AddedSlot      uint64
+	AddedSlot      uint64 `gorm:"index"`
 	DepositAmount  types.Uint64
 }
 
@@ -52,9 +51,9 @@ type RegistrationDrep struct {
 	AnchorUrl      string
 	DrepCredential []byte `gorm:"index"`
 	AnchorHash     []byte
-	CertificateID  uint `gorm:"index"`
-	ID             uint `gorm:"primarykey"`
-	AddedSlot      uint64
+	CertificateID  uint   `gorm:"index"`
+	ID             uint   `gorm:"primarykey"`
+	AddedSlot      uint64 `gorm:"index"`
 	DepositAmount  types.Uint64
 }
 
@@ -66,9 +65,9 @@ type UpdateDrep struct {
 	AnchorUrl     string
 	Credential    []byte `gorm:"index"`
 	AnchorHash    []byte
-	CertificateID uint `gorm:"index"`
-	ID            uint `gorm:"primarykey"`
-	AddedSlot     uint64
+	CertificateID uint   `gorm:"index"`
+	ID            uint   `gorm:"primarykey"`
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (UpdateDrep) TableName() string {

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -17,10 +17,11 @@ package models
 import "github.com/blinklabs-io/dingo/database/types"
 
 type MoveInstantaneousRewards struct {
-	Pot           uint `gorm:"index"`
-	CertificateID uint `gorm:"index"`
-	ID            uint `gorm:"primarykey"`
-	AddedSlot     uint64
+	Rewards       []MoveInstantaneousRewardsReward `gorm:"foreignKey:MIRID;constraint:OnDelete:CASCADE"`
+	Pot           uint                             `gorm:"index"`
+	CertificateID uint                             `gorm:"index"`
+	ID            uint                             `gorm:"primarykey"`
+	AddedSlot     uint64                           `gorm:"index"`
 }
 
 func (MoveInstantaneousRewards) TableName() string {
@@ -31,7 +32,7 @@ type MoveInstantaneousRewardsReward struct {
 	Credential []byte
 	Amount     types.Uint64
 	ID         uint `gorm:"primarykey"`
-	MIRID      uint `gorm:"index;constraint:OnDelete:CASCADE"`
+	MIRID      uint `gorm:"index"`
 }
 
 func (MoveInstantaneousRewardsReward) TableName() string {

--- a/database/models/pparams.go
+++ b/database/models/pparams.go
@@ -16,8 +16,8 @@ package models
 
 type PParams struct {
 	Cbor      []byte
-	ID        uint `gorm:"primarykey"`
-	AddedSlot uint64
+	ID        uint   `gorm:"primarykey"`
+	AddedSlot uint64 `gorm:"index"`
 	Epoch     uint64
 	EraId     uint
 }
@@ -29,8 +29,8 @@ func (PParams) TableName() string {
 type PParamUpdate struct {
 	GenesisHash []byte
 	Cbor        []byte
-	ID          uint `gorm:"primarykey"`
-	AddedSlot   uint64
+	ID          uint   `gorm:"primarykey"`
+	AddedSlot   uint64 `gorm:"index"`
 	Epoch       uint64
 }
 

--- a/database/models/redeemer.go
+++ b/database/models/redeemer.go
@@ -16,13 +16,13 @@ package models
 
 // Redeemer represents a redeemer in the witness set
 type Redeemer struct {
-	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"index"`
-	Tag           uint8  `gorm:"index"` // Redeemer tag
-	Index         uint32 `gorm:"index"`
-	Data          []byte // Plutus data
+	Data          []byte
+	ID            uint `gorm:"primaryKey"`
+	TransactionID uint `gorm:"index"`
 	ExUnitsMemory uint64
 	ExUnitsCPU    uint64
+	Index         uint32 `gorm:"index"`
+	Tag           uint8  `gorm:"index"`
 }
 
 func (Redeemer) TableName() string {

--- a/database/models/resign_committee_cold.go
+++ b/database/models/resign_committee_cold.go
@@ -18,9 +18,9 @@ type ResignCommitteeCold struct {
 	AnchorUrl      string
 	ColdCredential []byte `gorm:"index"`
 	AnchorHash     []byte
-	ID             uint `gorm:"primarykey"`
-	CertificateID  uint `gorm:"index"`
-	AddedSlot      uint64
+	ID             uint   `gorm:"primarykey"`
+	CertificateID  uint   `gorm:"index"`
+	AddedSlot      uint64 `gorm:"index"`
 }
 
 func (ResignCommitteeCold) TableName() string {

--- a/database/models/script.go
+++ b/database/models/script.go
@@ -18,11 +18,11 @@ package models
 // This avoids storing duplicate script data when the same script appears
 // in multiple transactions
 type Script struct {
-	ID          uint   `gorm:"primaryKey"`
-	Hash        []byte `gorm:"index;unique"` // Script hash
-	Type        uint8  `gorm:"index"`        // Script type
-	Content     []byte // Script content
-	CreatedSlot uint64 // Slot when this script was first seen
+	Hash        []byte `gorm:"index;unique"`
+	Content     []byte
+	ID          uint `gorm:"primaryKey"`
+	CreatedSlot uint64
+	Type        uint8 `gorm:"index"`
 }
 
 func (Script) TableName() string {

--- a/database/models/transaction.go
+++ b/database/models/transaction.go
@@ -18,23 +18,28 @@ import "github.com/blinklabs-io/dingo/database/types"
 
 // Transaction represents a transaction record
 type Transaction struct {
+	// CollateralReturn uses a separate FK (CollateralReturnForTxID) to distinguish
+	// from regular Outputs which use TransactionID. This allows GORM to load each
+	// association correctly without ambiguity.
+	CollateralReturn *Utxo            `gorm:"foreignKey:CollateralReturnForTxID;references:ID;constraint:OnDelete:CASCADE"`
+	PlutusData       []PlutusData     `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	Certificates     []Certificate    `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	Outputs          []Utxo           `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
 	Hash             []byte           `gorm:"uniqueIndex"`
-	BlockHash        []byte           `gorm:"index"`
-	Inputs           []Utxo           `gorm:"foreignKey:SpentAtTxId;references:Hash"`
-	Outputs          []Utxo           `gorm:"foreignKey:TransactionID;references:ID"`
-	ReferenceInputs  []Utxo           `gorm:"foreignKey:ReferencedByTxId;references:Hash"`
 	Collateral       []Utxo           `gorm:"foreignKey:CollateralByTxId;references:Hash"`
-	CollateralReturn *Utxo            `gorm:"foreignKey:TransactionID;references:ID"`
-	KeyWitnesses     []KeyWitness     `gorm:"foreignKey:TransactionID;references:ID"`
-	WitnessScripts   []WitnessScripts `gorm:"foreignKey:TransactionID;references:ID"`
-	Redeemers        []Redeemer       `gorm:"foreignKey:TransactionID;references:ID"`
-	PlutusData       []PlutusData     `gorm:"foreignKey:TransactionID;references:ID"`
-	ID               uint             `gorm:"primaryKey"`
-	Type             int
-	BlockIndex       uint32
+	BlockHash        []byte           `gorm:"index"`
+	KeyWitnesses     []KeyWitness     `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	WitnessScripts   []WitnessScripts `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	Inputs           []Utxo           `gorm:"foreignKey:SpentAtTxId;references:Hash"`
+	Redeemers        []Redeemer       `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	ReferenceInputs  []Utxo           `gorm:"foreignKey:ReferencedByTxId;references:Hash"`
 	Metadata         []byte
+	Slot             uint64 `gorm:"index"`
+	Type             int
+	ID               uint `gorm:"primaryKey"`
 	Fee              types.Uint64
 	TTL              types.Uint64
+	BlockIndex       uint32
 	Valid            bool
 }
 

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -22,20 +22,21 @@ import (
 
 // Utxo represents an unspent transaction output
 type Utxo struct {
-	TransactionID    *uint  `gorm:"index"`
-	TxId             []byte `gorm:"uniqueIndex:tx_id_output_idx"`
-	PaymentKey       []byte `gorm:"index"`
-	StakingKey       []byte `gorm:"index"`
-	Assets           []Asset
-	Cbor             []byte       `gorm:"-"` // This is here for convenience but not represented in the metadata DB
-	SpentAtTxId      []byte       `gorm:"index"`
-	ReferencedByTxId []byte       `gorm:"index"`
-	CollateralByTxId []byte       `gorm:"index"`
-	ID               uint         `gorm:"primarykey"`
-	AddedSlot        uint64       `gorm:"index"`
-	DeletedSlot      uint64       `gorm:"index"`
-	Amount           types.Uint64 `gorm:"index"`
-	OutputIdx        uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
+	TransactionID           *uint        `gorm:"index"`
+	CollateralReturnForTxID *uint        `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
+	TxId                    []byte       `gorm:"uniqueIndex:tx_id_output_idx"`
+	PaymentKey              []byte       `gorm:"index"`
+	StakingKey              []byte       `gorm:"index"`
+	Assets                  []Asset      `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
+	Cbor                    []byte       `gorm:"-"` // This is here for convenience but not represented in the metadata DB
+	SpentAtTxId             []byte       `gorm:"index"`
+	ReferencedByTxId        []byte       `gorm:"index"`
+	CollateralByTxId        []byte       `gorm:"index"`
+	ID                      uint         `gorm:"primarykey"`
+	AddedSlot               uint64       `gorm:"index"`
+	DeletedSlot             uint64       `gorm:"index"`
+	Amount                  types.Uint64 `gorm:"index"`
+	OutputIdx               uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
 }
 
 func (u *Utxo) TableName() string {

--- a/database/models/witness.go
+++ b/database/models/witness.go
@@ -24,14 +24,14 @@ const (
 // KeyWitness represents a key witness entry (Vkey or Bootstrap)
 // Type: KeyWitnessTypeVkey = VkeyWitness, KeyWitnessTypeBootstrap = BootstrapWitness
 type KeyWitness struct {
-	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"index"`
-	Type          uint8  `gorm:"index"` // See KeyWitnessType* constants
-	Vkey          []byte // Vkey witness key
-	Signature     []byte // Witness signature
-	PublicKey     []byte // For Bootstrap witness
-	ChainCode     []byte // For Bootstrap witness
-	Attributes    []byte // For Bootstrap witness
+	Vkey          []byte
+	Signature     []byte
+	PublicKey     []byte
+	ChainCode     []byte
+	Attributes    []byte
+	ID            uint  `gorm:"primaryKey"`
+	TransactionID uint  `gorm:"index"`
+	Type          uint8 `gorm:"index"`
 }
 
 func (KeyWitness) TableName() string {

--- a/database/models/witness_script.go
+++ b/database/models/witness_script.go
@@ -25,10 +25,10 @@ package models
 // transactions, we store only the script hash here. The actual script content
 // is stored separately in Script table, indexed by hash.
 type WitnessScripts struct {
+	ScriptHash    []byte `gorm:"index"`
 	ID            uint   `gorm:"primaryKey"`
 	TransactionID uint   `gorm:"index"`
-	Type          uint8  `gorm:"index"` // Script type
-	ScriptHash    []byte `gorm:"index"` // Hash of the script
+	Type          uint8  `gorm:"index"`
 }
 
 func (WitnessScripts) TableName() string {

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -848,7 +848,6 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					if tmpAccount.ID == 0 {
 						tmpAccount.AddedSlot = point.Slot
-						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1066,7 +1065,6 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					if tmpAccount.ID == 0 {
 						tmpAccount.AddedSlot = point.Slot
-						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate: %w", err)

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -23,6 +23,579 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// certRecord holds common fields extracted from certificate records for
+// batch processing during account state restoration.
+// Includes certIndex for same-slot disambiguation.
+type certRecord struct {
+	pool      []byte
+	drep      []byte
+	addedSlot uint64
+	certIndex uint32
+}
+
+// isMoreRecent checks if this certificate is more recent than the other.
+// When slots are equal, certIndex determines order (higher = later in transaction).
+func (r certRecord) isMoreRecent(other certRecord) bool {
+	if r.addedSlot > other.addedSlot {
+		return true
+	}
+	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
+		return true
+	}
+	return false
+}
+
+// accountCertCache holds batch-fetched certificate data for all accounts
+// being restored. This eliminates N+1 queries by fetching all certificates
+// for all affected accounts in a small number of queries upfront.
+type accountCertCache struct {
+	// Maps staking key (as string) to the most recent registration
+	latestReg map[string]certRecord
+	hasReg    map[string]bool
+
+	// Maps staking key to the most recent deregistration
+	latestDereg map[string]certRecord
+	hasDereg    map[string]bool
+
+	// Maps staking key to the most recent pool delegation
+	poolDelegation map[string]certRecord
+
+	// Maps staking key to the most recent DRep delegation
+	drepDelegation map[string]certRecord
+}
+
+// newAccountCertCache creates an empty certificate cache.
+func newAccountCertCache(capacity int) *accountCertCache {
+	return &accountCertCache{
+		latestReg:      make(map[string]certRecord, capacity),
+		hasReg:         make(map[string]bool, capacity),
+		latestDereg:    make(map[string]certRecord, capacity),
+		hasDereg:       make(map[string]bool, capacity),
+		poolDelegation: make(map[string]certRecord, capacity),
+		drepDelegation: make(map[string]certRecord, capacity),
+	}
+}
+
+// updateReg updates the registration if this one is more recent.
+func (c *accountCertCache) updateReg(key string, rec certRecord) {
+	if !c.hasReg[key] || rec.isMoreRecent(c.latestReg[key]) {
+		c.latestReg[key] = rec
+		c.hasReg[key] = true
+	}
+}
+
+// updateDereg updates the deregistration if this one is more recent.
+func (c *accountCertCache) updateDereg(key string, rec certRecord) {
+	if !c.hasDereg[key] || rec.isMoreRecent(c.latestDereg[key]) {
+		c.latestDereg[key] = rec
+		c.hasDereg[key] = true
+	}
+}
+
+// updatePoolDelegation updates the pool delegation if this one is more recent.
+func (c *accountCertCache) updatePoolDelegation(key string, rec certRecord) {
+	existing, ok := c.poolDelegation[key]
+	if !ok || rec.isMoreRecent(existing) {
+		c.poolDelegation[key] = rec
+	}
+}
+
+// updateDrepDelegation updates the DRep delegation if this one is more recent.
+func (c *accountCertCache) updateDrepDelegation(key string, rec certRecord) {
+	existing, ok := c.drepDelegation[key]
+	if !ok || rec.isMoreRecent(existing) {
+		c.drepDelegation[key] = rec
+	}
+}
+
+// batchFetchCerts fetches all relevant certificates for the given staking keys
+// at or before the given slot. Uses one query per certificate table. Chunks
+// queries to avoid exceeding SQLite bind variable limits.
+func batchFetchCerts(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+) (*accountCertCache, error) {
+	cache := newAccountCertCache(len(stakingKeys))
+
+	// Process staking keys in chunks to avoid SQLite bind variable limits
+	for start := 0; start < len(stakingKeys); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(stakingKeys))
+		keyChunk := stakingKeys[start:end]
+
+		// Registration certificates (5 types)
+		if err := batchFetchStakeRegistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeRegistrationDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeVoteRegistrationDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchVoteRegistrationDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchRegistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+
+		// Deregistration certificates (2 types)
+		if err := batchFetchStakeDeregistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchDeregistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+
+		// Pool delegation certificates - StakeDelegation is pool-only
+		if err := batchFetchStakeDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		// StakeVoteDelegation has both pool and DRep
+		if err := batchFetchStakeVoteDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+
+		// DRep delegation certificates - VoteDelegation is DRep-only
+		if err := batchFetchVoteDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+	}
+
+	return cache, nil
+}
+
+func batchFetchStakeRegistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_registration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateReg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{
+			pool:      r.PoolKeyHash,
+			addedSlot: r.AddedSlot,
+			certIndex: r.CertIndex,
+		}
+		cache.updateReg(key, rec)
+		cache.updatePoolDelegation(key, rec)
+	}
+	return nil
+}
+
+func batchFetchStakeVoteRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		Drep        []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_vote_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{
+			pool:      r.PoolKeyHash,
+			drep:      r.Drep,
+			addedSlot: r.AddedSlot,
+			certIndex: r.CertIndex,
+		}
+		cache.updateReg(key, rec)
+		cache.updatePoolDelegation(key, rec)
+		cache.updateDrepDelegation(
+			key,
+			certRecord{
+				drep:      r.Drep,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
+func batchFetchVoteRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		Drep       []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM vote_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{
+			drep:      r.Drep,
+			addedSlot: r.AddedSlot,
+			certIndex: r.CertIndex,
+		}
+		cache.updateReg(key, rec)
+		cache.updateDrepDelegation(key, rec)
+	}
+	return nil
+}
+
+func batchFetchRegistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM registration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateReg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeDeregistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_deregistration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDereg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchDeregistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM deregistration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDereg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updatePoolDelegation(
+			string(r.StakingKey),
+			certRecord{
+				pool:      r.PoolKeyHash,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
+func batchFetchVoteDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		Drep       []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM vote_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDrepDelegation(
+			string(r.StakingKey),
+			certRecord{
+				drep:      r.Drep,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeVoteDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		Drep        []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_vote_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		cache.updatePoolDelegation(
+			key,
+			certRecord{
+				pool:      r.PoolKeyHash,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+		cache.updateDrepDelegation(
+			key,
+			certRecord{
+				drep:      r.Drep,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
 // GetAccount gets an account
 func (d *MetadataStoreSqlite) GetAccount(
 	stakeKey []byte,
@@ -75,5 +648,111 @@ func (d *MetadataStoreSqlite) SetAccount(
 	if result := db.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 		return result.Error
 	}
+	return nil
+}
+
+// RestoreAccountStateAtSlot reverts account delegation state to the given slot.
+// For accounts modified after the slot, this restores their Pool and Drep
+// delegations to the state they had at the given slot, or deletes them
+// if they were registered after that slot.
+//
+// This implementation uses batch fetching to avoid N+1 query patterns:
+// instead of querying certificates per-account, it fetches all relevant
+// certificates for all affected accounts upfront (one query per table),
+// then processes them in memory.
+func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Find all accounts that were modified after the rollback slot
+	var accountsToRestore []models.Account
+	if result := db.Where("added_slot > ?", slot).Find(&accountsToRestore); result.Error != nil {
+		return result.Error
+	}
+
+	if len(accountsToRestore) == 0 {
+		return nil
+	}
+
+	// Extract staking keys for batch fetching
+	stakingKeys := make([][]byte, len(accountsToRestore))
+	for i, account := range accountsToRestore {
+		stakingKeys[i] = account.StakingKey
+	}
+
+	// Batch-fetch all certificates for all affected accounts
+	cache, err := batchFetchCerts(db, stakingKeys, slot)
+	if err != nil {
+		return err
+	}
+
+	// Process each account using the cached certificate data
+	for _, account := range accountsToRestore {
+		key := string(account.StakingKey)
+
+		// Check if this account had any registration before the rollback slot
+		latestReg, hasReg := cache.latestReg[key], cache.hasReg[key]
+
+		if !hasReg {
+			// Account was registered after rollback slot, delete it
+			if result := db.Delete(&account); result.Error != nil {
+				return result.Error
+			}
+			continue
+		}
+
+		// Get pool delegation from cache
+		var pool []byte
+		var poolRec certRecord
+		if rec, ok := cache.poolDelegation[key]; ok {
+			pool = rec.pool
+			poolRec = rec
+		}
+
+		// Get DRep delegation from cache
+		var drep []byte
+		var drepRec certRecord
+		if rec, ok := cache.drepDelegation[key]; ok {
+			drep = rec.drep
+			drepRec = rec
+		}
+
+		// Get deregistration info from cache
+		latestDereg, hasDereg := cache.latestDereg[key], cache.hasDereg[key]
+
+		// Account is active if either:
+		// - There is no deregistration, or
+		// - The most recent registration is after the most recent deregistration
+		active := !hasDereg || latestReg.isMoreRecent(latestDereg)
+
+		// Compute the actual last modification slot as the max of all relevant events
+		lastModSlot := latestReg.addedSlot
+		if hasDereg && latestDereg.addedSlot > lastModSlot {
+			lastModSlot = latestDereg.addedSlot
+		}
+		// Only consider pool/drep slots if they were found in the cache
+		if _, hasPool := cache.poolDelegation[key]; hasPool && poolRec.addedSlot > lastModSlot {
+			lastModSlot = poolRec.addedSlot
+		}
+		if _, hasDrep := cache.drepDelegation[key]; hasDrep && drepRec.addedSlot > lastModSlot {
+			lastModSlot = drepRec.addedSlot
+		}
+
+		// Update the account with restored state
+		if result := db.Model(&account).Updates(map[string]any{
+			"pool":       pool,
+			"drep":       drep,
+			"active":     active,
+			"added_slot": lastModSlot,
+		}); result.Error != nil {
+			return result.Error
+		}
+	}
+
 	return nil
 }

--- a/database/plugin/metadata/sqlite/datum.go
+++ b/database/plugin/metadata/sqlite/datum.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -68,7 +69,7 @@ func (d *MetadataStoreSqlite) SetDatum(
 	}
 	result := db.Clauses(onConflict).Create(&tmpItem)
 	if result.Error != nil {
-		return result.Error
+		return fmt.Errorf("create datum: %w", result.Error)
 	}
 	return nil
 }

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -16,12 +16,167 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+// drepCertRecord holds certificate data for batch processing during DRep restoration.
+// Includes cert_index for same-slot disambiguation.
+type drepCertRecord struct {
+	addedSlot  uint64
+	certIndex  uint32
+	anchorUrl  string
+	anchorHash []byte
+}
+
+// isMoreRecent checks if this certificate is more recent than the other.
+// When slots are equal, cert_index determines order (higher = later in transaction).
+func (r drepCertRecord) isMoreRecent(other drepCertRecord) bool {
+	if r.addedSlot > other.addedSlot {
+		return true
+	}
+	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
+		return true
+	}
+	return false
+}
+
+// drepCertCache holds batch-fetched certificate data for all DReps being restored.
+type drepCertCache struct {
+	// Maps credential (as string) to the most recent registration
+	registration map[string]drepCertRecord
+	hasReg       map[string]bool
+
+	// Maps credential to the most recent deregistration
+	deregistration map[string]drepCertRecord
+	hasDereg       map[string]bool
+
+	// Maps credential to the most recent update
+	update    map[string]drepCertRecord
+	hasUpdate map[string]bool
+}
+
+// newDrepCertCache creates an empty DRep certificate cache.
+func newDrepCertCache(capacity int) *drepCertCache {
+	return &drepCertCache{
+		registration:   make(map[string]drepCertRecord, capacity),
+		hasReg:         make(map[string]bool, capacity),
+		deregistration: make(map[string]drepCertRecord, capacity),
+		hasDereg:       make(map[string]bool, capacity),
+		update:         make(map[string]drepCertRecord, capacity),
+		hasUpdate:      make(map[string]bool, capacity),
+	}
+}
+
+// batchFetchDrepCerts fetches all relevant certificates for the given credentials
+// at or before the given slot. Uses one query per certificate table with JOIN
+// to get cert_index for same-slot disambiguation. Chunks queries to avoid
+// exceeding SQLite bind variable limits.
+func batchFetchDrepCerts(
+	db *gorm.DB,
+	credentials [][]byte,
+	slot uint64,
+) (*drepCertCache, error) {
+	cache := newDrepCertCache(len(credentials))
+
+	// Process credentials in chunks to avoid SQLite bind variable limits
+	for start := 0; start < len(credentials); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(credentials))
+		credChunk := credentials[start:end]
+
+		// Fetch registration certificates with cert_index
+		type regResult struct {
+			DrepCredential []byte
+			AddedSlot      uint64
+			CertIndex      uint32
+			AnchorUrl      string
+			AnchorHash     []byte
+		}
+		var regRecords []regResult
+		if err := db.Table("registration_drep").
+			Select("registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, certs.cert_index").
+			Joins("INNER JOIN certs ON certs.id = registration_drep.certificate_id").
+			Where("drep_credential IN ? AND registration_drep.added_slot <= ?", credChunk, slot).
+			Find(&regRecords).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range regRecords {
+			key := string(r.DrepCredential)
+			rec := drepCertRecord{
+				addedSlot:  r.AddedSlot,
+				certIndex:  r.CertIndex,
+				anchorUrl:  r.AnchorUrl,
+				anchorHash: r.AnchorHash,
+			}
+			if !cache.hasReg[key] || rec.isMoreRecent(cache.registration[key]) {
+				cache.registration[key] = rec
+				cache.hasReg[key] = true
+			}
+		}
+
+		// Fetch deregistration certificates with cert_index
+		type deregResult struct {
+			DrepCredential []byte
+			AddedSlot      uint64
+			CertIndex      uint32
+		}
+		var deregRecords []deregResult
+		if err := db.Table("deregistration_drep").
+			Select("deregistration_drep.drep_credential, deregistration_drep.added_slot, certs.cert_index").
+			Joins("INNER JOIN certs ON certs.id = deregistration_drep.certificate_id").
+			Where("drep_credential IN ? AND deregistration_drep.added_slot <= ?", credChunk, slot).
+			Find(&deregRecords).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range deregRecords {
+			key := string(r.DrepCredential)
+			rec := drepCertRecord{
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			}
+			if !cache.hasDereg[key] || rec.isMoreRecent(cache.deregistration[key]) {
+				cache.deregistration[key] = rec
+				cache.hasDereg[key] = true
+			}
+		}
+
+		// Fetch update certificates with cert_index
+		type updateResult struct {
+			Credential []byte
+			AddedSlot  uint64
+			CertIndex  uint32
+			AnchorUrl  string
+			AnchorHash []byte
+		}
+		var updateRecords []updateResult
+		if err := db.Table("update_drep").
+			Select("update_drep.credential, update_drep.added_slot, update_drep.anchor_url, update_drep.anchor_hash, certs.cert_index").
+			Joins("INNER JOIN certs ON certs.id = update_drep.certificate_id").
+			Where("credential IN ? AND update_drep.added_slot <= ?", credChunk, slot).
+			Find(&updateRecords).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range updateRecords {
+			key := string(r.Credential)
+			rec := drepCertRecord{
+				addedSlot:  r.AddedSlot,
+				certIndex:  r.CertIndex,
+				anchorUrl:  r.AnchorUrl,
+				anchorHash: r.AnchorHash,
+			}
+			if !cache.hasUpdate[key] || rec.isMoreRecent(cache.update[key]) {
+				cache.update[key] = rec
+				cache.hasUpdate[key] = true
+			}
+		}
+	}
+
+	return cache, nil
+}
 
 // GetDrep gets a drep
 func (d *MetadataStoreSqlite) GetDrep(
@@ -44,6 +199,148 @@ func (d *MetadataStoreSqlite) GetDrep(
 		return nil, result.Error
 	}
 	return &drep, nil
+}
+
+// RestoreDrepStateAtSlot reverts DRep state to the given slot.
+//
+// This function handles two cases for DReps modified after the rollback slot:
+//  1. DReps with no registration certificates at or before the slot are deleted
+//     (they didn't exist at that point in the chain).
+//  2. DReps with prior registrations have their state restored by examining
+//     all relevant certificates (registration, deregistration, update) and
+//     determining the correct Active status and anchor data.
+//
+// The Active status follows these rules:
+//   - A registration certificate activates a DRep
+//   - A deregistration certificate deactivates a DRep
+//   - An update certificate can modify anchor data but cannot reactivate a
+//     deregistered DRep (per Cardano protocol rules)
+//
+// The added_slot field is set to the slot of the most recent effective
+// certificate that modified the DRep's state at or before the rollback slot.
+//
+// This implementation uses batch fetching to avoid N+1 query patterns:
+// instead of querying certificates per-DRep, it fetches all relevant
+// certificates for all affected DReps upfront (one query per table),
+// then processes them in memory.
+func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Phase 1: Delete DReps that have no registration certificates at or before
+	// the rollback slot. These DReps were first registered after the rollback
+	// point and should not exist in the restored state.
+	drepsWithNoValidRegsSubquery := db.Model(&models.Drep{}).
+		Select("drep.id").
+		Where("added_slot > ?", slot).
+		Where(
+			"NOT EXISTS (?)",
+			db.Model(&models.RegistrationDrep{}).
+				Select("1").
+				Where("registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
+		)
+
+	if result := db.Where(
+		"id IN (?)",
+		drepsWithNoValidRegsSubquery,
+	).Delete(&models.Drep{}); result.Error != nil {
+		return result.Error
+	}
+
+	// Phase 2: Restore state for DReps that have at least one registration
+	// certificate at or before the rollback slot.
+	var drepsToRestore []models.Drep
+	if result := db.Where("added_slot > ?", slot).Find(&drepsToRestore); result.Error != nil {
+		return result.Error
+	}
+
+	if len(drepsToRestore) == 0 {
+		return nil
+	}
+
+	// Extract credentials for batch fetching
+	credentials := make([][]byte, len(drepsToRestore))
+	for i, drep := range drepsToRestore {
+		credentials[i] = drep.Credential
+	}
+
+	// Batch-fetch all certificates for all affected DReps
+	cache, err := batchFetchDrepCerts(db, credentials, slot)
+	if err != nil {
+		return err
+	}
+
+	// Process each DRep using the cached certificate data
+	for _, drep := range drepsToRestore {
+		key := string(drep.Credential)
+
+		// Get registration from cache (must exist due to Phase 1 deletion)
+		lastReg, hasRegAtSlot := cache.registration[key], cache.hasReg[key]
+		if !hasRegAtSlot {
+			// This indicates database inconsistency: Phase 1 should have deleted
+			// any DRep without a registration cert at or before the rollback slot.
+			return fmt.Errorf(
+				"DRep %x has no registration cert at or before slot %d but wasn't deleted in Phase 1",
+				drep.Credential,
+				slot,
+			)
+		}
+
+		// Determine the correct state by processing certificates in order.
+		// Start with registration state (DRep is active with registration's anchor data)
+		active := true
+		anchorUrl := lastReg.anchorUrl
+		anchorHash := lastReg.anchorHash
+		latestSlot := lastReg.addedSlot
+		latestCertIndex := lastReg.certIndex
+		latestWasDereg := false
+
+		// Apply deregistration if it's more recent than registration
+		if cache.hasDereg[key] {
+			lastDereg := cache.deregistration[key]
+			if lastDereg.addedSlot > latestSlot ||
+				(lastDereg.addedSlot == latestSlot && lastDereg.certIndex > latestCertIndex) {
+				active = false
+				latestSlot = lastDereg.addedSlot
+				latestCertIndex = lastDereg.certIndex
+				anchorUrl = ""
+				anchorHash = nil
+				latestWasDereg = true
+			}
+		}
+
+		// Apply update certificate only if it's the most recent event AND the
+		// DRep is still active. Per CIP-1694 and Cardano protocol rules, an update
+		// certificate is only valid for registered DReps. If a DRep deregisters,
+		// any subsequent update certificates are ignored - the DRep must re-register
+		// to become active again. Therefore, we skip updates when latestWasDereg is true.
+		if cache.hasUpdate[key] && !latestWasDereg {
+			lastUpdate := cache.update[key]
+			if lastUpdate.addedSlot > latestSlot ||
+				(lastUpdate.addedSlot == latestSlot && lastUpdate.certIndex > latestCertIndex) {
+				anchorUrl = lastUpdate.anchorUrl
+				anchorHash = lastUpdate.anchorHash
+				latestSlot = lastUpdate.addedSlot
+			}
+		}
+
+		// Update the DRep record with the restored state.
+		if result := db.Model(&drep).Updates(map[string]any{
+			"active":      active,
+			"anchor_url":  anchorUrl,
+			"anchor_hash": anchorHash,
+			"added_slot":  latestSlot,
+		}); result.Error != nil {
+			return result.Error
+		}
+	}
+
+	return nil
 }
 
 // SetDrep saves a drep

--- a/database/plugin/metadata/sqlite/pparams.go
+++ b/database/plugin/metadata/sqlite/pparams.go
@@ -101,3 +101,33 @@ func (d *MetadataStoreSqlite) SetPParamUpdate(
 	}
 	return nil
 }
+
+// DeletePParamsAfterSlot removes protocol parameter records added after the given slot.
+func (d *MetadataStoreSqlite) DeletePParamsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Where("added_slot > ?", slot).Delete(&models.PParams{}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// DeletePParamUpdatesAfterSlot removes protocol parameter update records added after the given slot.
+func (d *MetadataStoreSqlite) DeletePParamUpdatesAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Where("added_slot > ?", slot).Delete(&models.PParamUpdate{}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -32,8 +32,8 @@ type TestTable struct {
 }
 
 type mockTransaction struct {
-	hash         lcommon.Blake2b256
 	certificates []lcommon.Certificate
+	hash         lcommon.Blake2b256
 	isValid      bool
 }
 
@@ -167,6 +167,27 @@ func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
 
 func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
 	return lcommon.Blake2b256{}
+}
+
+// createTestTransaction creates a Transaction record for testing with foreign key constraints.
+func createTestTransaction(db *gorm.DB, id uint, slot uint64) error {
+	tx := models.Transaction{
+		Hash:       []byte{byte(id), byte(id >> 8), byte(id >> 16), byte(id >> 24)},
+		Slot:       slot,
+		Valid:      true,
+		Type:       0,
+		BlockIndex: 0,
+	}
+	// Use raw SQL to insert with specific ID
+	return db.Exec(
+		"INSERT INTO \"transaction\" (id, hash, slot, valid, type, block_index) VALUES (?, ?, ?, ?, ?, ?)",
+		id,
+		tx.Hash,
+		tx.Slot,
+		tx.Valid,
+		tx.Type,
+		tx.BlockIndex,
+	).Error
 }
 
 // TestInMemorySqliteMultipleTransaction tests that our sqlite connection allows multiple
@@ -405,4 +426,2386 @@ func TestUnifiedCertificateCreation(t *testing.T) {
 			authUnified.ID,
 		)
 	}
+}
+
+// TestDeleteCertificatesAfterSlot tests that certificates added after a given slot are deleted
+func TestDeleteCertificatesAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create Transaction records for foreign key constraints
+	if err := createTestTransaction(sqliteStore.DB(), 1, 1000); err != nil {
+		t.Fatalf("failed to create transaction 1: %v", err)
+	}
+	if err := createTestTransaction(sqliteStore.DB(), 2, 2000); err != nil {
+		t.Fatalf("failed to create transaction 2: %v", err)
+	}
+
+	// Create certificate at slot 1000 directly
+	cert1 := models.Certificate{
+		Slot: 1000,
+		BlockHash: []byte(
+			"block_hash_1000_12345678901234567890123456789012",
+		),
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		TransactionID: 1,
+		CertIndex:     0,
+	}
+	if result := sqliteStore.DB().Create(&cert1); result.Error != nil {
+		t.Fatalf("failed to create cert1: %v", result.Error)
+	}
+
+	stakeReg1 := models.StakeDelegation{
+		CertificateID: cert1.ID,
+		StakingKey:    []byte("stake_key_1_1234567890123456789012345678"),
+		PoolKeyHash:   []byte("pool_hash_1_12345678901234567890123456789012"),
+		AddedSlot:     1000,
+	}
+	if result := sqliteStore.DB().Create(&stakeReg1); result.Error != nil {
+		t.Fatalf("failed to create stakeReg1: %v", result.Error)
+	}
+
+	// Create certificate at slot 2000
+	cert2 := models.Certificate{
+		Slot: 2000,
+		BlockHash: []byte(
+			"block_hash_2000_12345678901234567890123456789012",
+		),
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		TransactionID: 2,
+		CertIndex:     0,
+	}
+	if result := sqliteStore.DB().Create(&cert2); result.Error != nil {
+		t.Fatalf("failed to create cert2: %v", result.Error)
+	}
+
+	stakeReg2 := models.StakeDelegation{
+		CertificateID: cert2.ID,
+		StakingKey:    []byte("stake_key_2_1234567890123456789012345678"),
+		PoolKeyHash:   []byte("pool_hash_2_12345678901234567890123456789012"),
+		AddedSlot:     2000,
+	}
+	if result := sqliteStore.DB().Create(&stakeReg2); result.Error != nil {
+		t.Fatalf("failed to create stakeReg2: %v", result.Error)
+	}
+
+	// Verify we have 2 certificates
+	var countBefore int64
+	sqliteStore.DB().Model(&models.Certificate{}).Count(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf("expected 2 certificates before rollback, got %d", countBefore)
+	}
+
+	// Delete certificates after slot 1500 (should delete the one at slot 2000)
+	if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete certificates: %v", err)
+	}
+
+	// Verify only 1 certificate remains
+	var countAfter int64
+	sqliteStore.DB().Model(&models.Certificate{}).Count(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 certificate after rollback, got %d", countAfter)
+	}
+
+	// Verify the remaining certificate is at slot 1000
+	var remainingCert models.Certificate
+	if result := sqliteStore.DB().First(&remainingCert); result.Error != nil {
+		t.Fatalf("failed to query remaining certificate: %v", result.Error)
+	}
+	if remainingCert.Slot != 1000 {
+		t.Errorf(
+			"expected remaining certificate at slot 1000, got %d",
+			remainingCert.Slot,
+		)
+	}
+
+	// Verify specialized delegation record was also deleted
+	var delegationCount int64
+	sqliteStore.DB().Model(&models.StakeDelegation{}).Count(&delegationCount)
+	if delegationCount != 1 {
+		t.Errorf(
+			"expected 1 delegation after rollback, got %d",
+			delegationCount,
+		)
+	}
+}
+
+// TestRestoreAccountStateAtSlot tests that account delegation state is correctly restored
+func TestRestoreAccountStateAtSlot(t *testing.T) {
+	t.Run("account delegation is restored to prior pool", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		// Run auto-migration
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		// Create Transaction records for foreign key constraints
+		for i := uint(1); i <= 3; i++ {
+			if err := createTestTransaction(sqliteStore.DB(), i, uint64(i*500)); err != nil {
+				t.Fatalf("failed to create transaction %d: %v", i, err)
+			}
+		}
+
+		stakingKey := []byte("staking_key_test_1234567890123456789012345678")
+		poolHash1 := []byte("pool_hash_1_12345678901234567890123456789012")
+		poolHash2 := []byte("pool_hash_2_12345678901234567890123456789012")
+
+		// Create an account with delegation to pool2 at slot 2000
+		// (simulating current state after delegation change)
+		account := models.Account{
+			StakingKey: stakingKey,
+			Pool:       poolHash2,
+			AddedSlot:  2000,
+			Active:     true,
+		}
+		if result := sqliteStore.DB().Create(&account); result.Error != nil {
+			t.Fatalf("failed to create account: %v", result.Error)
+		}
+
+		// Create stake registration certificate at slot 500 (registration must exist before delegation)
+		regCert := models.Certificate{
+			Slot: 500,
+			BlockHash: []byte(
+				"block_500_1234567890123456789012345678901234",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+			TransactionID: 1,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&regCert); result.Error != nil {
+			t.Fatalf("failed to create regCert: %v", result.Error)
+		}
+
+		stakeReg := models.StakeRegistration{
+			CertificateID: regCert.ID,
+			StakingKey:    stakingKey,
+			AddedSlot:     500,
+		}
+		if result := sqliteStore.DB().Create(&stakeReg); result.Error != nil {
+			t.Fatalf("failed to create stakeReg: %v", result.Error)
+		}
+
+		// Create initial stake delegation certificate at slot 1000 (to pool1)
+		cert1 := models.Certificate{
+			Slot: 1000,
+			BlockHash: []byte(
+				"block_1000_12345678901234567890123456789012",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+			TransactionID: 2,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&cert1); result.Error != nil {
+			t.Fatalf("failed to create cert1: %v", result.Error)
+		}
+
+		delegation1 := models.StakeDelegation{
+			CertificateID: cert1.ID,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolHash1,
+			AddedSlot:     1000,
+		}
+		if result := sqliteStore.DB().Create(&delegation1); result.Error != nil {
+			t.Fatalf("failed to create delegation1: %v", result.Error)
+		}
+
+		// Create stake delegation certificate at slot 2000 (to pool2)
+		cert2 := models.Certificate{
+			Slot: 2000,
+			BlockHash: []byte(
+				"block_2000_12345678901234567890123456789012",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+			TransactionID: 3,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&cert2); result.Error != nil {
+			t.Fatalf("failed to create cert2: %v", result.Error)
+		}
+
+		delegation2 := models.StakeDelegation{
+			CertificateID: cert2.ID,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolHash2,
+			AddedSlot:     2000,
+		}
+		if result := sqliteStore.DB().Create(&delegation2); result.Error != nil {
+			t.Fatalf("failed to create delegation2: %v", result.Error)
+		}
+
+		// Delete certificates after slot 1500 (removes cert2 and delegation2)
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+
+		// Restore account state to slot 1500
+		if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore account state: %v", err)
+		}
+
+		// Verify account is delegated back to pool1
+		var restoredAccount models.Account
+		if result := sqliteStore.DB().First(&restoredAccount); result.Error != nil {
+			t.Fatalf("failed to query restored account: %v", result.Error)
+		}
+		if string(restoredAccount.Pool) != string(poolHash1) {
+			t.Errorf(
+				"expected account delegated to pool1, got %x",
+				restoredAccount.Pool,
+			)
+		}
+	})
+
+	t.Run(
+		"account deregistered after rollback slot is restored to active",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create Transaction records for foreign key constraints
+			for i := uint(1); i <= 2; i++ {
+				if err := createTestTransaction(sqliteStore.DB(), i, uint64(i*1000)); err != nil {
+					t.Fatalf("failed to create transaction %d: %v", i, err)
+				}
+			}
+
+			stakingKey := []byte("staking_key_active_test_12345678901234567890")
+
+			// Create an account that is currently inactive (deregistered at slot 2000)
+			account := models.Account{
+				StakingKey: stakingKey,
+				AddedSlot:  2000,
+				Active:     false, // Currently inactive due to deregistration
+			}
+			if result := sqliteStore.DB().Create(&account); result.Error != nil {
+				t.Fatalf("failed to create account: %v", result.Error)
+			}
+
+			// Create stake registration certificate at slot 1000
+			regCert := models.Certificate{
+				Slot: 1000,
+				BlockHash: []byte(
+					"block_1000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+				TransactionID: 1,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&regCert); result.Error != nil {
+				t.Fatalf("failed to create regCert: %v", result.Error)
+			}
+
+			stakeReg := models.StakeRegistration{
+				CertificateID: regCert.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     1000,
+			}
+			if result := sqliteStore.DB().Create(&stakeReg); result.Error != nil {
+				t.Fatalf("failed to create stakeReg: %v", result.Error)
+			}
+
+			// Create stake deregistration certificate at slot 2000 (after rollback point)
+			deregCert := models.Certificate{
+				Slot: 2000,
+				BlockHash: []byte(
+					"block_2000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeDeregistration),
+				TransactionID: 2,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&deregCert); result.Error != nil {
+				t.Fatalf("failed to create deregCert: %v", result.Error)
+			}
+
+			stakeDereg := models.StakeDeregistration{
+				CertificateID: deregCert.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     2000,
+			}
+			if result := sqliteStore.DB().Create(&stakeDereg); result.Error != nil {
+				t.Fatalf("failed to create stakeDereg: %v", result.Error)
+			}
+
+			// Delete certificates after slot 1500 (removes deregistration)
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+
+			// Restore account state to slot 1500
+			if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore account state: %v", err)
+			}
+
+			// Verify account is now active (deregistration was rolled back)
+			var restoredAccount models.Account
+			if result := sqliteStore.DB().First(&restoredAccount); result.Error != nil {
+				t.Fatalf("failed to query restored account: %v", result.Error)
+			}
+			if !restoredAccount.Active {
+				t.Error(
+					"expected account to be active after rolling back deregistration",
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"account deregistered before rollback slot remains inactive",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create Transaction records for foreign key constraints
+			for i := uint(1); i <= 3; i++ {
+				if err := createTestTransaction(sqliteStore.DB(), i, uint64(i*500)); err != nil {
+					t.Fatalf("failed to create transaction %d: %v", i, err)
+				}
+			}
+
+			stakingKey := []byte("staking_key_inactive_test_123456789012345678")
+
+			// Create an account that was re-registered at slot 2000 (currently active)
+			account := models.Account{
+				StakingKey: stakingKey,
+				AddedSlot:  2000,
+				Active:     true,
+			}
+			if result := sqliteStore.DB().Create(&account); result.Error != nil {
+				t.Fatalf("failed to create account: %v", result.Error)
+			}
+
+			// Create stake registration certificate at slot 500
+			regCert1 := models.Certificate{
+				Slot: 500,
+				BlockHash: []byte(
+					"block_500_1234567890123456789012345678901234",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+				TransactionID: 1,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&regCert1); result.Error != nil {
+				t.Fatalf("failed to create regCert1: %v", result.Error)
+			}
+
+			stakeReg1 := models.StakeRegistration{
+				CertificateID: regCert1.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     500,
+			}
+			if result := sqliteStore.DB().Create(&stakeReg1); result.Error != nil {
+				t.Fatalf("failed to create stakeReg1: %v", result.Error)
+			}
+
+			// Create stake deregistration certificate at slot 1000 (before rollback point)
+			deregCert := models.Certificate{
+				Slot: 1000,
+				BlockHash: []byte(
+					"block_1000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeDeregistration),
+				TransactionID: 2,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&deregCert); result.Error != nil {
+				t.Fatalf("failed to create deregCert: %v", result.Error)
+			}
+
+			stakeDereg := models.StakeDeregistration{
+				CertificateID: deregCert.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     1000,
+			}
+			if result := sqliteStore.DB().Create(&stakeDereg); result.Error != nil {
+				t.Fatalf("failed to create stakeDereg: %v", result.Error)
+			}
+
+			// Create re-registration certificate at slot 2000 (after rollback point)
+			regCert2 := models.Certificate{
+				Slot: 2000,
+				BlockHash: []byte(
+					"block_2000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+				TransactionID: 3,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&regCert2); result.Error != nil {
+				t.Fatalf("failed to create regCert2: %v", result.Error)
+			}
+
+			stakeReg2 := models.StakeRegistration{
+				CertificateID: regCert2.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     2000,
+			}
+			if result := sqliteStore.DB().Create(&stakeReg2); result.Error != nil {
+				t.Fatalf("failed to create stakeReg2: %v", result.Error)
+			}
+
+			// Delete certificates after slot 1500 (removes re-registration at slot 2000)
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+
+			// Restore account state to slot 1500
+			if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore account state: %v", err)
+			}
+
+			// Verify account is inactive (deregistration at slot 1000 is more recent than registration at slot 500)
+			var restoredAccount models.Account
+			if result := sqliteStore.DB().First(&restoredAccount); result.Error != nil {
+				t.Fatalf("failed to query restored account: %v", result.Error)
+			}
+			if restoredAccount.Active {
+				t.Error(
+					"expected account to be inactive (deregistered before rollback slot)",
+				)
+			}
+		},
+	)
+
+	t.Run("account with no prior registration is deleted", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		// Create Transaction for foreign key constraints
+		if err := createTestTransaction(sqliteStore.DB(), 1, 2000); err != nil {
+			t.Fatalf("failed to create transaction: %v", err)
+		}
+
+		stakingKey := []byte("staking_key_test_1234567890123456789012345678")
+
+		// Create an account registered at slot 2000 (after rollback point)
+		account := models.Account{
+			StakingKey: stakingKey,
+			AddedSlot:  2000,
+			Active:     true,
+		}
+		if result := sqliteStore.DB().Create(&account); result.Error != nil {
+			t.Fatalf("failed to create account: %v", result.Error)
+		}
+
+		// Create stake registration certificate at slot 2000 (after rollback point)
+		regCert := models.Certificate{
+			Slot: 2000,
+			BlockHash: []byte(
+				"block_2000_12345678901234567890123456789012",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+			TransactionID: 1,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&regCert); result.Error != nil {
+			t.Fatalf("failed to create regCert: %v", result.Error)
+		}
+
+		stakeReg := models.StakeRegistration{
+			CertificateID: regCert.ID,
+			StakingKey:    stakingKey,
+			AddedSlot:     2000,
+		}
+		if result := sqliteStore.DB().Create(&stakeReg); result.Error != nil {
+			t.Fatalf("failed to create stakeReg: %v", result.Error)
+		}
+
+		// Delete certificates after slot 1500 (removes registration)
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+
+		// Restore account state to slot 1500
+		if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore account state: %v", err)
+		}
+
+		// Verify account is deleted (no registration before rollback slot)
+		var count int64
+		sqliteStore.DB().Model(&models.Account{}).Count(&count)
+		if count != 0 {
+			t.Errorf("expected 0 accounts after rollback, got %d", count)
+		}
+	})
+}
+
+// TestDeletePParamsAfterSlot tests that protocol parameters after a slot are deleted
+func TestDeletePParamsAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create pparams at slot 1000
+	pparams1 := models.PParams{
+		AddedSlot: 1000,
+		Epoch:     100,
+		Cbor:      []byte("pparams_cbor_1"),
+	}
+	if result := sqliteStore.DB().Create(&pparams1); result.Error != nil {
+		t.Fatalf("failed to create pparams1: %v", result.Error)
+	}
+
+	// Create pparams at slot 2000
+	pparams2 := models.PParams{
+		AddedSlot: 2000,
+		Epoch:     101,
+		Cbor:      []byte("pparams_cbor_2"),
+	}
+	if result := sqliteStore.DB().Create(&pparams2); result.Error != nil {
+		t.Fatalf("failed to create pparams2: %v", result.Error)
+	}
+
+	// Verify we have 2 pparams
+	var countBefore int64
+	sqliteStore.DB().Model(&models.PParams{}).Count(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf("expected 2 pparams before rollback, got %d", countBefore)
+	}
+
+	// Delete pparams after slot 1500
+	if err := sqliteStore.DeletePParamsAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete pparams: %v", err)
+	}
+
+	// Verify only 1 remains
+	var countAfter int64
+	sqliteStore.DB().Model(&models.PParams{}).Count(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 pparams after rollback, got %d", countAfter)
+	}
+}
+
+// TestDeletePParamUpdatesAfterSlot tests that protocol parameter updates after a slot are deleted
+func TestDeletePParamUpdatesAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create pparam update at slot 1000
+	update1 := models.PParamUpdate{
+		AddedSlot:   1000,
+		Epoch:       100,
+		GenesisHash: []byte("genesis_hash_1"),
+		Cbor:        []byte("update_cbor_1"),
+	}
+	if result := sqliteStore.DB().Create(&update1); result.Error != nil {
+		t.Fatalf("failed to create update1: %v", result.Error)
+	}
+
+	// Create pparam update at slot 2000
+	update2 := models.PParamUpdate{
+		AddedSlot:   2000,
+		Epoch:       101,
+		GenesisHash: []byte("genesis_hash_2"),
+		Cbor:        []byte("update_cbor_2"),
+	}
+	if result := sqliteStore.DB().Create(&update2); result.Error != nil {
+		t.Fatalf("failed to create update2: %v", result.Error)
+	}
+
+	// Verify we have 2 updates
+	var countBefore int64
+	sqliteStore.DB().Model(&models.PParamUpdate{}).Count(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf(
+			"expected 2 pparam updates before rollback, got %d",
+			countBefore,
+		)
+	}
+
+	// Delete updates after slot 1500
+	if err := sqliteStore.DeletePParamUpdatesAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete pparam updates: %v", err)
+	}
+
+	// Verify only 1 remains
+	var countAfter int64
+	sqliteStore.DB().Model(&models.PParamUpdate{}).Count(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 pparam update after rollback, got %d", countAfter)
+	}
+}
+
+// TestDeleteTransactionsAfterSlot tests that transactions and their child records are deleted
+func TestDeleteTransactionsAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create transaction at slot 1000 (should be kept)
+	tx1 := models.Transaction{
+		Hash:       []byte("tx_hash_1_123456789012345678901234567890123456"),
+		BlockHash:  []byte("block_1000_12345678901234567890123456789012"),
+		Slot:       1000,
+		BlockIndex: 0,
+	}
+	if result := sqliteStore.DB().Create(&tx1); result.Error != nil {
+		t.Fatalf("failed to create tx1: %v", result.Error)
+	}
+
+	// Create child records for tx1
+	kw1 := models.KeyWitness{TransactionID: tx1.ID, Type: 1}
+	if result := sqliteStore.DB().Create(&kw1); result.Error != nil {
+		t.Fatalf("failed to create key witness for tx1: %v", result.Error)
+	}
+
+	// Create transaction at slot 2000 (should be deleted)
+	tx2 := models.Transaction{
+		Hash:       []byte("tx_hash_2_123456789012345678901234567890123456"),
+		BlockHash:  []byte("block_2000_12345678901234567890123456789012"),
+		Slot:       2000,
+		BlockIndex: 0,
+	}
+	if result := sqliteStore.DB().Create(&tx2); result.Error != nil {
+		t.Fatalf("failed to create tx2: %v", result.Error)
+	}
+
+	// Create child records for tx2
+	kw2 := models.KeyWitness{TransactionID: tx2.ID, Type: 1}
+	if result := sqliteStore.DB().Create(&kw2); result.Error != nil {
+		t.Fatalf("failed to create key witness for tx2: %v", result.Error)
+	}
+	ws2 := models.WitnessScripts{TransactionID: tx2.ID, Type: 1}
+	if result := sqliteStore.DB().Create(&ws2); result.Error != nil {
+		t.Fatalf("failed to create witness script for tx2: %v", result.Error)
+	}
+	rd2 := models.Redeemer{TransactionID: tx2.ID}
+	if result := sqliteStore.DB().Create(&rd2); result.Error != nil {
+		t.Fatalf("failed to create redeemer for tx2: %v", result.Error)
+	}
+	pd2 := models.PlutusData{TransactionID: tx2.ID}
+	if result := sqliteStore.DB().Create(&pd2); result.Error != nil {
+		t.Fatalf("failed to create plutus data for tx2: %v", result.Error)
+	}
+
+	// Verify we have 2 transactions and their child records
+	var txCountBefore int64
+	sqliteStore.DB().Model(&models.Transaction{}).Count(&txCountBefore)
+	if txCountBefore != 2 {
+		t.Fatalf(
+			"expected 2 transactions before rollback, got %d",
+			txCountBefore,
+		)
+	}
+
+	var kwCountBefore int64
+	sqliteStore.DB().Model(&models.KeyWitness{}).Count(&kwCountBefore)
+	if kwCountBefore != 2 {
+		t.Fatalf(
+			"expected 2 key witnesses before rollback, got %d",
+			kwCountBefore,
+		)
+	}
+
+	// Delete transactions after slot 1500
+	if err := sqliteStore.DeleteTransactionsAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete transactions: %v", err)
+	}
+
+	// Verify only tx1 remains
+	var txCountAfter int64
+	sqliteStore.DB().Model(&models.Transaction{}).Count(&txCountAfter)
+	if txCountAfter != 1 {
+		t.Errorf("expected 1 transaction after rollback, got %d", txCountAfter)
+	}
+
+	// Verify only kw1 remains (child record of tx1)
+	var kwCountAfter int64
+	sqliteStore.DB().Model(&models.KeyWitness{}).Count(&kwCountAfter)
+	if kwCountAfter != 1 {
+		t.Errorf("expected 1 key witness after rollback, got %d", kwCountAfter)
+	}
+
+	// Verify all other child records of tx2 are deleted
+	var wsCountAfter int64
+	sqliteStore.DB().Model(&models.WitnessScripts{}).Count(&wsCountAfter)
+	if wsCountAfter != 0 {
+		t.Errorf(
+			"expected 0 witness scripts after rollback, got %d",
+			wsCountAfter,
+		)
+	}
+
+	var rdCountAfter int64
+	sqliteStore.DB().Model(&models.Redeemer{}).Count(&rdCountAfter)
+	if rdCountAfter != 0 {
+		t.Errorf("expected 0 redeemers after rollback, got %d", rdCountAfter)
+	}
+
+	var pdCountAfter int64
+	sqliteStore.DB().Model(&models.PlutusData{}).Count(&pdCountAfter)
+	if pdCountAfter != 0 {
+		t.Errorf("expected 0 plutus data after rollback, got %d", pdCountAfter)
+	}
+}
+
+// TestRestorePoolStateAtSlot tests that pool state is correctly restored during rollback
+func TestRestorePoolStateAtSlot(t *testing.T) {
+	t.Run("pool with no prior registrations is deleted", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+		// Create a pool with registration after rollback point
+		pool := models.Pool{PoolKeyHash: poolHash}
+		if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+			t.Fatalf("failed to create pool: %v", result.Error)
+		}
+
+		poolReg := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   2000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
+			t.Fatalf("failed to create pool registration: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestorePoolStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore pool state: %v", err)
+		}
+
+		// Pool should be deleted
+		var count int64
+		sqliteStore.DB().Model(&models.Pool{}).Count(&count)
+		if count != 0 {
+			t.Errorf("expected 0 pools after rollback, got %d", count)
+		}
+	})
+
+	t.Run("pool with prior registration is kept", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+		// Create a pool with registration BEFORE rollback point
+		pool := models.Pool{PoolKeyHash: poolHash}
+		if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+			t.Fatalf("failed to create pool: %v", result.Error)
+		}
+
+		// Registration at slot 1000 (before rollback)
+		poolReg1 := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   1000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg1); result.Error != nil {
+			t.Fatalf("failed to create pool registration 1: %v", result.Error)
+		}
+
+		// Registration at slot 2000 (after rollback)
+		poolReg2 := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   2000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg2); result.Error != nil {
+			t.Fatalf("failed to create pool registration 2: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestorePoolStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore pool state: %v", err)
+		}
+
+		// Pool should still exist (has registration before rollback)
+		var count int64
+		sqliteStore.DB().Model(&models.Pool{}).Count(&count)
+		if count != 1 {
+			t.Errorf("expected 1 pool after rollback, got %d", count)
+		}
+
+		// Only one registration should remain
+		var regCount int64
+		sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+		if regCount != 1 {
+			t.Errorf(
+				"expected 1 pool registration after rollback, got %d",
+				regCount,
+			)
+		}
+	})
+
+	t.Run("pool with retirement after rollback has retirement undone", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+		// Create a pool with registration BEFORE rollback point
+		pool := models.Pool{PoolKeyHash: poolHash}
+		if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+			t.Fatalf("failed to create pool: %v", result.Error)
+		}
+
+		// Registration at slot 1000 (before rollback)
+		poolReg := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   1000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
+			t.Fatalf("failed to create pool registration: %v", result.Error)
+		}
+
+		// Retirement at slot 2000 (after rollback)
+		poolRetirement := models.PoolRetirement{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   2000,
+			Epoch:       100,
+		}
+		if result := sqliteStore.DB().Create(&poolRetirement); result.Error != nil {
+			t.Fatalf("failed to create pool retirement: %v", result.Error)
+		}
+
+		// Verify pool has retirement before rollback
+		var retirementCountBefore int64
+		sqliteStore.DB().Model(&models.PoolRetirement{}).Count(&retirementCountBefore)
+		if retirementCountBefore != 1 {
+			t.Fatalf(
+				"expected 1 retirement before rollback, got %d",
+				retirementCountBefore,
+			)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestorePoolStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore pool state: %v", err)
+		}
+
+		// Pool should still exist
+		var count int64
+		sqliteStore.DB().Model(&models.Pool{}).Count(&count)
+		if count != 1 {
+			t.Errorf("expected 1 pool after rollback, got %d", count)
+		}
+
+		// Retirement should be removed (CASCADE from DeleteCertificatesAfterSlot)
+		var retirementCountAfter int64
+		sqliteStore.DB().Model(&models.PoolRetirement{}).Count(&retirementCountAfter)
+		if retirementCountAfter != 0 {
+			t.Errorf(
+				"expected 0 retirements after rollback, got %d",
+				retirementCountAfter,
+			)
+		}
+
+		// Registration should still exist
+		var regCount int64
+		sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+		if regCount != 1 {
+			t.Errorf(
+				"expected 1 pool registration after rollback, got %d",
+				regCount,
+			)
+		}
+	})
+}
+
+// TestRestoreDrepStateAtSlot tests that DRep state is correctly restored during rollback
+func TestRestoreDrepStateAtSlot(t *testing.T) {
+	t.Run("DRep with no prior registrations is deleted", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		drepCredential := []byte("drep_credential_12345678901234567890123456")
+
+		// Create a DRep registered at slot 2000 (after rollback point)
+		drep := models.Drep{
+			Credential: drepCredential,
+			Active:     true,
+			AddedSlot:  2000,
+		}
+		if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+			t.Fatalf("failed to create drep: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore DRep state: %v", err)
+		}
+
+		// DRep should be deleted
+		var count int64
+		sqliteStore.DB().Model(&models.Drep{}).Count(&count)
+		if count != 0 {
+			t.Errorf("expected 0 DReps after rollback, got %d", count)
+		}
+	})
+
+	t.Run(
+		"DRep with prior registration has state restored",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep1"
+			anchorHash1 := []byte("anchor_hash_1_1234567890123456789012345678")
+			anchorUrl2 := "https://example.com/drep2"
+			anchorHash2 := []byte("anchor_hash_2_1234567890123456789012345678")
+
+			// Create a DRep with current state at slot 2000
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl2,
+				AnchorHash: anchorHash2,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records for proper JOIN support
+			tx1 := models.Transaction{Hash: []byte("tx_hash_1000"), Slot: 1000}
+			if result := sqliteStore.DB().Create(&tx1); result.Error != nil {
+				t.Fatalf("failed to create tx1: %v", result.Error)
+			}
+			cert1 := models.Certificate{
+				Slot:          1000,
+				CertIndex:     0,
+				TransactionID: tx1.ID,
+			}
+			if result := sqliteStore.DB().Create(&cert1); result.Error != nil {
+				t.Fatalf("failed to create cert1: %v", result.Error)
+			}
+			tx2 := models.Transaction{Hash: []byte("tx_hash_2000"), Slot: 2000}
+			if result := sqliteStore.DB().Create(&tx2); result.Error != nil {
+				t.Fatalf("failed to create tx2: %v", result.Error)
+			}
+			cert2 := models.Certificate{
+				Slot:          2000,
+				CertIndex:     0,
+				TransactionID: tx2.ID,
+			}
+			if result := sqliteStore.DB().Create(&cert2); result.Error != nil {
+				t.Fatalf("failed to create cert2: %v", result.Error)
+			}
+
+			// Registration at slot 1000 (before rollback) with original anchor data
+			reg1 := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      1000,
+				CertificateID:  cert1.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg1); result.Error != nil {
+				t.Fatalf("failed to create registration 1: %v", result.Error)
+			}
+
+			// Registration at slot 2000 (after rollback) with new anchor data
+			reg2 := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl2,
+				AnchorHash:     anchorHash2,
+				AddedSlot:      2000,
+				CertificateID:  cert2.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg2); result.Error != nil {
+				t.Fatalf("failed to create registration 2: %v", result.Error)
+			}
+
+			// Delete certificates and restore state
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should still exist with original anchor data
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.AnchorUrl != anchorUrl1 {
+				t.Errorf(
+					"expected anchor URL %s, got %s",
+					anchorUrl1,
+					restoredDrep.AnchorUrl,
+				)
+			}
+			if string(restoredDrep.AnchorHash) != string(anchorHash1) {
+				t.Errorf("expected anchor hash to be restored")
+			}
+			if !restoredDrep.Active {
+				t.Errorf("expected DRep to be active")
+			}
+		},
+	)
+
+	t.Run("DRep deregistered before rollback is inactive", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		drepCredential := []byte("drep_credential_12345678901234567890123456")
+
+		// DRep is currently active (re-registered at slot 2000)
+		drep := models.Drep{
+			Credential: drepCredential,
+			Active:     true,
+			AddedSlot:  2000,
+		}
+		if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+			t.Fatalf("failed to create drep: %v", result.Error)
+		}
+
+		// Create Transaction and Certificate records for proper JOIN support
+		txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+		if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+			t.Fatalf("failed to create txReg: %v", result.Error)
+		}
+		certReg := models.Certificate{
+			Slot:          500,
+			CertIndex:     0,
+			TransactionID: txReg.ID,
+		}
+		if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+			t.Fatalf("failed to create certReg: %v", result.Error)
+		}
+		txDereg := models.Transaction{Hash: []byte("tx_hash_1000"), Slot: 1000}
+		if result := sqliteStore.DB().Create(&txDereg); result.Error != nil {
+			t.Fatalf("failed to create txDereg: %v", result.Error)
+		}
+		certDereg := models.Certificate{
+			Slot:          1000,
+			CertIndex:     0,
+			TransactionID: txDereg.ID,
+		}
+		if result := sqliteStore.DB().Create(&certDereg); result.Error != nil {
+			t.Fatalf("failed to create certDereg: %v", result.Error)
+		}
+		txReg2 := models.Transaction{Hash: []byte("tx_hash_2000"), Slot: 2000}
+		if result := sqliteStore.DB().Create(&txReg2); result.Error != nil {
+			t.Fatalf("failed to create txReg2: %v", result.Error)
+		}
+		certReg2 := models.Certificate{
+			Slot:          2000,
+			CertIndex:     0,
+			TransactionID: txReg2.ID,
+		}
+		if result := sqliteStore.DB().Create(&certReg2); result.Error != nil {
+			t.Fatalf("failed to create certReg2: %v", result.Error)
+		}
+
+		// Registration at slot 500
+		reg := models.RegistrationDrep{
+			DrepCredential: drepCredential,
+			AddedSlot:      500,
+			CertificateID:  certReg.ID,
+		}
+		if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+			t.Fatalf("failed to create registration: %v", result.Error)
+		}
+
+		// Deregistration at slot 1000 (before rollback)
+		dereg := models.DeregistrationDrep{
+			DrepCredential: drepCredential,
+			AddedSlot:      1000,
+			CertificateID:  certDereg.ID,
+		}
+		if result := sqliteStore.DB().Create(&dereg); result.Error != nil {
+			t.Fatalf("failed to create deregistration: %v", result.Error)
+		}
+
+		// Re-registration at slot 2000 (after rollback)
+		reg2 := models.RegistrationDrep{
+			DrepCredential: drepCredential,
+			AddedSlot:      2000,
+			CertificateID:  certReg2.ID,
+		}
+		if result := sqliteStore.DB().Create(&reg2); result.Error != nil {
+			t.Fatalf("failed to create re-registration: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore DRep state: %v", err)
+		}
+
+		// DRep should exist but be inactive (deregistered at slot 1000)
+		var restoredDrep models.Drep
+		if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+			t.Fatalf("failed to query restored DRep: %v", result.Error)
+		}
+		if restoredDrep.Active {
+			t.Errorf(
+				"expected DRep to be inactive after rollback (was deregistered at slot 1000)",
+			)
+		}
+	})
+
+	t.Run(
+		"DRep with update certificate has anchor restored",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep_initial"
+			anchorHash1 := []byte("anchor_hash_initial_123456789012345678901")
+			anchorUrl2 := "https://example.com/drep_updated"
+			anchorHash2 := []byte("anchor_hash_updated_123456789012345678901")
+			anchorUrl3 := "https://example.com/drep_final"
+			anchorHash3 := []byte("anchor_hash_final_12345678901234567890123")
+
+			// DRep currently has final anchor data
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl3,
+				AnchorHash: anchorHash3,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records for proper JOIN support
+			txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+			if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+				t.Fatalf("failed to create txReg: %v", result.Error)
+			}
+			certReg := models.Certificate{
+				Slot:          500,
+				CertIndex:     0,
+				TransactionID: txReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+				t.Fatalf("failed to create certReg: %v", result.Error)
+			}
+			txUpdate1 := models.Transaction{
+				Hash: []byte("tx_hash_1000"),
+				Slot: 1000,
+			}
+			if result := sqliteStore.DB().Create(&txUpdate1); result.Error != nil {
+				t.Fatalf("failed to create txUpdate1: %v", result.Error)
+			}
+			certUpdate1 := models.Certificate{
+				Slot:          1000,
+				CertIndex:     0,
+				TransactionID: txUpdate1.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate1); result.Error != nil {
+				t.Fatalf("failed to create certUpdate1: %v", result.Error)
+			}
+			txUpdate2 := models.Transaction{
+				Hash: []byte("tx_hash_2000"),
+				Slot: 2000,
+			}
+			if result := sqliteStore.DB().Create(&txUpdate2); result.Error != nil {
+				t.Fatalf("failed to create txUpdate2: %v", result.Error)
+			}
+			certUpdate2 := models.Certificate{
+				Slot:          2000,
+				CertIndex:     0,
+				TransactionID: txUpdate2.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate2); result.Error != nil {
+				t.Fatalf("failed to create certUpdate2: %v", result.Error)
+			}
+
+			// Registration at slot 500
+			reg := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      500,
+				CertificateID:  certReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+				t.Fatalf("failed to create registration: %v", result.Error)
+			}
+
+			// Update at slot 1000 (before rollback)
+			update := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl2,
+				AnchorHash:    anchorHash2,
+				AddedSlot:     1000,
+				CertificateID: certUpdate1.ID,
+			}
+			if result := sqliteStore.DB().Create(&update); result.Error != nil {
+				t.Fatalf("failed to create update: %v", result.Error)
+			}
+
+			// Update at slot 2000 (after rollback)
+			update2 := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl3,
+				AnchorHash:    anchorHash3,
+				AddedSlot:     2000,
+				CertificateID: certUpdate2.ID,
+			}
+			if result := sqliteStore.DB().Create(&update2); result.Error != nil {
+				t.Fatalf("failed to create update 2: %v", result.Error)
+			}
+
+			// Delete certificates and restore state
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should have anchor data from slot 1000 update
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.AnchorUrl != anchorUrl2 {
+				t.Errorf(
+					"expected anchor URL %s, got %s",
+					anchorUrl2,
+					restoredDrep.AnchorUrl,
+				)
+			}
+			if string(restoredDrep.AnchorHash) != string(anchorHash2) {
+				t.Errorf("expected anchor hash from update at slot 1000")
+			}
+			if !restoredDrep.Active {
+				t.Errorf("expected DRep to be active")
+			}
+		},
+	)
+
+	t.Run(
+		"DRep with update after deregistration stays inactive",
+		func(t *testing.T) {
+			// This test verifies that an update certificate does NOT reactivate
+			// a deregistered DRep. Per CIP-1694, update certificates only modify
+			// anchor data and cannot change the active status.
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep_reg"
+			anchorHash1 := []byte("anchor_hash_reg_123456789012345678901234")
+			anchorUrl2 := "https://example.com/drep_update"
+			anchorHash2 := []byte("anchor_hash_update_1234567890123456789012")
+
+			// DRep currently shows as active at slot 2000 (after rollback point)
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl2,
+				AnchorHash: anchorHash2,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records
+			txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+			if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+				t.Fatalf("failed to create txReg: %v", result.Error)
+			}
+			certReg := models.Certificate{
+				Slot:          500,
+				CertIndex:     0,
+				TransactionID: txReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+				t.Fatalf("failed to create certReg: %v", result.Error)
+			}
+
+			txDereg := models.Transaction{Hash: []byte("tx_hash_1000"), Slot: 1000}
+			if result := sqliteStore.DB().Create(&txDereg); result.Error != nil {
+				t.Fatalf("failed to create txDereg: %v", result.Error)
+			}
+			certDereg := models.Certificate{
+				Slot:          1000,
+				CertIndex:     0,
+				TransactionID: txDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certDereg); result.Error != nil {
+				t.Fatalf("failed to create certDereg: %v", result.Error)
+			}
+
+			txUpdate := models.Transaction{Hash: []byte("tx_hash_1200"), Slot: 1200}
+			if result := sqliteStore.DB().Create(&txUpdate); result.Error != nil {
+				t.Fatalf("failed to create txUpdate: %v", result.Error)
+			}
+			certUpdate := models.Certificate{
+				Slot:          1200,
+				CertIndex:     0,
+				TransactionID: txUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate); result.Error != nil {
+				t.Fatalf("failed to create certUpdate: %v", result.Error)
+			}
+
+			// Registration at slot 500
+			reg := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      500,
+				CertificateID:  certReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+				t.Fatalf("failed to create registration: %v", result.Error)
+			}
+
+			// Deregistration at slot 1000
+			dereg := models.DeregistrationDrep{
+				DrepCredential: drepCredential,
+				AddedSlot:      1000,
+				CertificateID:  certDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&dereg); result.Error != nil {
+				t.Fatalf("failed to create deregistration: %v", result.Error)
+			}
+
+			// Update at slot 1200 (AFTER deregistration - should be ignored per protocol)
+			update := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl2,
+				AnchorHash:    anchorHash2,
+				AddedSlot:     1200,
+				CertificateID: certUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&update); result.Error != nil {
+				t.Fatalf("failed to create update: %v", result.Error)
+			}
+
+			// Rollback to slot 1500 (all certs are within the rollback window)
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should be INACTIVE because:
+			// - Registered at 500 (active)
+			// - Deregistered at 1000 (inactive)
+			// - Update at 1200 should NOT reactivate (update only changes anchor, not status)
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.Active {
+				t.Errorf(
+					"expected DRep to be inactive (update after deregistration should not reactivate)",
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"DRep update as latest event does not reactivate deregistered DRep",
+		func(t *testing.T) {
+			// This test verifies the specific bug scenario where the update
+			// certificate is the chronologically latest event. The DRep should
+			// remain inactive because updates cannot change active status.
+			//
+			// Scenario: Reg(500) -> Dereg(600) -> Update(700) (update is latest)
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep_reg"
+			anchorHash1 := []byte("anchor_hash_reg_123456789012345678901234")
+			anchorUrl2 := "https://example.com/drep_update"
+			anchorHash2 := []byte("anchor_hash_update_1234567890123456789012")
+
+			// DRep currently shows as active at slot 2000 (after rollback point)
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl2,
+				AnchorHash: anchorHash2,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records
+			txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+			if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+				t.Fatalf("failed to create txReg: %v", result.Error)
+			}
+			certReg := models.Certificate{
+				Slot:          500,
+				CertIndex:     0,
+				TransactionID: txReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+				t.Fatalf("failed to create certReg: %v", result.Error)
+			}
+
+			txDereg := models.Transaction{Hash: []byte("tx_hash_600"), Slot: 600}
+			if result := sqliteStore.DB().Create(&txDereg); result.Error != nil {
+				t.Fatalf("failed to create txDereg: %v", result.Error)
+			}
+			certDereg := models.Certificate{
+				Slot:          600,
+				CertIndex:     0,
+				TransactionID: txDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certDereg); result.Error != nil {
+				t.Fatalf("failed to create certDereg: %v", result.Error)
+			}
+
+			// Update is at slot 700 - the latest event chronologically
+			txUpdate := models.Transaction{Hash: []byte("tx_hash_700"), Slot: 700}
+			if result := sqliteStore.DB().Create(&txUpdate); result.Error != nil {
+				t.Fatalf("failed to create txUpdate: %v", result.Error)
+			}
+			certUpdate := models.Certificate{
+				Slot:          700,
+				CertIndex:     0,
+				TransactionID: txUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate); result.Error != nil {
+				t.Fatalf("failed to create certUpdate: %v", result.Error)
+			}
+
+			// Registration at slot 500
+			reg := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      500,
+				CertificateID:  certReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+				t.Fatalf("failed to create registration: %v", result.Error)
+			}
+
+			// Deregistration at slot 600
+			dereg := models.DeregistrationDrep{
+				DrepCredential: drepCredential,
+				AddedSlot:      600,
+				CertificateID:  certDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&dereg); result.Error != nil {
+				t.Fatalf("failed to create deregistration: %v", result.Error)
+			}
+
+			// Update at slot 700 - the latest event (AFTER deregistration)
+			update := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl2,
+				AnchorHash:    anchorHash2,
+				AddedSlot:     700,
+				CertificateID: certUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&update); result.Error != nil {
+				t.Fatalf("failed to create update: %v", result.Error)
+			}
+
+			// Rollback to slot 1500 (all certs are within the rollback window)
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should be INACTIVE because:
+			// - Registered at 500 (active)
+			// - Deregistered at 600 (inactive)
+			// - Update at 700 should NOT reactivate (update only changes anchor, not status)
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.Active {
+				t.Errorf(
+					"expected DRep to be inactive (update as latest event should not reactivate)",
+				)
+			}
+		},
+	)
+}
+
+// TestPoolCascadeDelete tests that Pool deletion cascades correctly to child records
+func TestPoolCascadeDelete(t *testing.T) {
+	t.Run(
+		"pool deletion cascades to registrations, owners, relays",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+			// Create a pool
+			pool := models.Pool{PoolKeyHash: poolHash}
+			if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+				t.Fatalf("failed to create pool: %v", result.Error)
+			}
+
+			// Create a registration with owners and relays
+			poolReg := models.PoolRegistration{
+				PoolID:      pool.ID,
+				PoolKeyHash: poolHash,
+				AddedSlot:   1000,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: []byte("owner1"), PoolID: pool.ID},
+					{KeyHash: []byte("owner2"), PoolID: pool.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: "relay1.example.com", PoolID: pool.ID},
+				},
+			}
+			if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
+				t.Fatalf("failed to create pool registration: %v", result.Error)
+			}
+
+			// Verify records exist
+			var regCount, ownerCount, relayCount int64
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 1 || ownerCount != 2 || relayCount != 1 {
+				t.Fatalf(
+					"expected 1 reg, 2 owners, 1 relay; got %d, %d, %d",
+					regCount,
+					ownerCount,
+					relayCount,
+				)
+			}
+
+			// Delete the pool
+			if result := sqliteStore.DB().Delete(&pool); result.Error != nil {
+				t.Fatalf("failed to delete pool: %v", result.Error)
+			}
+
+			// All related records should be deleted via cascade
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 0 {
+				t.Errorf(
+					"expected 0 registrations after pool delete, got %d",
+					regCount,
+				)
+			}
+			if ownerCount != 0 {
+				t.Errorf(
+					"expected 0 owners after pool delete, got %d",
+					ownerCount,
+				)
+			}
+			if relayCount != 0 {
+				t.Errorf(
+					"expected 0 relays after pool delete, got %d",
+					relayCount,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"registration deletion cascades to its owners/relays only",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+			// Create a pool
+			pool := models.Pool{PoolKeyHash: poolHash}
+			if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+				t.Fatalf("failed to create pool: %v", result.Error)
+			}
+
+			// Create first registration with owners and relays
+			poolReg1 := models.PoolRegistration{
+				PoolID:      pool.ID,
+				PoolKeyHash: poolHash,
+				AddedSlot:   1000,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: []byte("owner1_reg1"), PoolID: pool.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: "relay1_reg1.example.com", PoolID: pool.ID},
+				},
+			}
+			if result := sqliteStore.DB().Create(&poolReg1); result.Error != nil {
+				t.Fatalf(
+					"failed to create pool registration 1: %v",
+					result.Error,
+				)
+			}
+
+			// Create second registration with different owners and relays
+			poolReg2 := models.PoolRegistration{
+				PoolID:      pool.ID,
+				PoolKeyHash: poolHash,
+				AddedSlot:   2000,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: []byte("owner1_reg2"), PoolID: pool.ID},
+					{KeyHash: []byte("owner2_reg2"), PoolID: pool.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: "relay1_reg2.example.com", PoolID: pool.ID},
+				},
+			}
+			if result := sqliteStore.DB().Create(&poolReg2); result.Error != nil {
+				t.Fatalf(
+					"failed to create pool registration 2: %v",
+					result.Error,
+				)
+			}
+
+			// Verify initial counts
+			var regCount, ownerCount, relayCount int64
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 2 || ownerCount != 3 || relayCount != 2 {
+				t.Fatalf(
+					"expected 2 regs, 3 owners, 2 relays; got %d, %d, %d",
+					regCount,
+					ownerCount,
+					relayCount,
+				)
+			}
+
+			// Delete the second registration only
+			if result := sqliteStore.DB().Delete(&poolReg2); result.Error != nil {
+				t.Fatalf(
+					"failed to delete pool registration 2: %v",
+					result.Error,
+				)
+			}
+
+			// Pool should still exist
+			var poolCount int64
+			sqliteStore.DB().Model(&models.Pool{}).Count(&poolCount)
+			if poolCount != 1 {
+				t.Errorf(
+					"expected pool to still exist, got %d pools",
+					poolCount,
+				)
+			}
+
+			// First registration and its owners/relays should still exist
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 1 {
+				t.Errorf(
+					"expected 1 registration after deleting one, got %d",
+					regCount,
+				)
+			}
+			if ownerCount != 1 {
+				t.Errorf(
+					"expected 1 owner from first registration, got %d",
+					ownerCount,
+				)
+			}
+			if relayCount != 1 {
+				t.Errorf(
+					"expected 1 relay from first registration, got %d",
+					relayCount,
+				)
+			}
+		},
+	)
+}
+
+// TestPoolCrossPoolOwnerRelay tests that owners/relays with the same key hash
+// across different pools are stored as separate records and don't affect each other
+func TestPoolCrossPoolOwnerRelay(t *testing.T) {
+	t.Run(
+		"same owner key hash in different pools are independent records",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create two different pools
+			poolA := models.Pool{
+				PoolKeyHash: []byte("pool_A_hash_123456789012345678901234"),
+			}
+			if result := sqliteStore.DB().Create(&poolA); result.Error != nil {
+				t.Fatalf("failed to create pool A: %v", result.Error)
+			}
+			poolB := models.Pool{
+				PoolKeyHash: []byte("pool_B_hash_123456789012345678901234"),
+			}
+			if result := sqliteStore.DB().Create(&poolB); result.Error != nil {
+				t.Fatalf("failed to create pool B: %v", result.Error)
+			}
+
+			// Both pools use the SAME owner key hash and relay hostname
+			sharedOwnerHash := []byte("shared_owner_key_hash_1234567890123")
+			sharedRelayHost := "shared-relay.example.com"
+
+			// Create registration for Pool A
+			regA := models.PoolRegistration{
+				PoolID:      poolA.ID,
+				PoolKeyHash: poolA.PoolKeyHash,
+				AddedSlot:   500,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: sharedOwnerHash, PoolID: poolA.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: sharedRelayHost, PoolID: poolA.ID, Port: 3001},
+				},
+			}
+			if result := sqliteStore.DB().Create(&regA); result.Error != nil {
+				t.Fatalf("failed to create registration A: %v", result.Error)
+			}
+
+			// Create registration for Pool B with SAME owner hash and relay
+			regB := models.PoolRegistration{
+				PoolID:      poolB.ID,
+				PoolKeyHash: poolB.PoolKeyHash,
+				AddedSlot:   1000,
+				Owners: []models.PoolRegistrationOwner{
+					{
+						KeyHash: sharedOwnerHash,
+						PoolID:  poolB.ID,
+					}, // Same key hash!
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{
+						Hostname: sharedRelayHost,
+						PoolID:   poolB.ID,
+						Port:     3001,
+					}, // Same relay!
+				},
+			}
+			if result := sqliteStore.DB().Create(&regB); result.Error != nil {
+				t.Fatalf("failed to create registration B: %v", result.Error)
+			}
+
+			// Verify we have 2 owner records and 2 relay records (separate records, same data)
+			var ownerCount, relayCount int64
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if ownerCount != 2 {
+				t.Fatalf("expected 2 owner records, got %d", ownerCount)
+			}
+			if relayCount != 2 {
+				t.Fatalf("expected 2 relay records, got %d", relayCount)
+			}
+
+			// Delete Pool B - this should only delete Pool B's records
+			if result := sqliteStore.DB().Delete(&poolB); result.Error != nil {
+				t.Fatalf("failed to delete pool B: %v", result.Error)
+			}
+
+			// Pool A should still exist with its registration, owner, and relay
+			var poolCount int64
+			sqliteStore.DB().Model(&models.Pool{}).Count(&poolCount)
+			if poolCount != 1 {
+				t.Errorf("expected 1 pool remaining, got %d", poolCount)
+			}
+
+			var regCount int64
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			if regCount != 1 {
+				t.Errorf("expected 1 registration remaining, got %d", regCount)
+			}
+
+			// Verify Pool A's owner and relay still exist
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if ownerCount != 1 {
+				t.Errorf(
+					"expected 1 owner remaining (Pool A's), got %d",
+					ownerCount,
+				)
+			}
+			if relayCount != 1 {
+				t.Errorf(
+					"expected 1 relay remaining (Pool A's), got %d",
+					relayCount,
+				)
+			}
+
+			// Verify the remaining records belong to Pool A
+			var remainingOwner models.PoolRegistrationOwner
+			sqliteStore.DB().First(&remainingOwner)
+			if remainingOwner.PoolID != poolA.ID {
+				t.Errorf("remaining owner should belong to Pool A")
+			}
+		},
+	)
+}
+
+// TestUtxoCascadeDelete tests that Utxo deletion cascades correctly to Asset records
+func TestUtxoCascadeDelete(t *testing.T) {
+	t.Run("utxo deletion cascades to assets", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		txId := []byte("tx_hash_1234567890123456789012345678901234567890")
+
+		// Create a Utxo with multiple assets
+		utxo := models.Utxo{
+			TxId:       txId,
+			OutputIdx:  0,
+			AddedSlot:  1000,
+			PaymentKey: []byte("payment_key_123456789012345678901234567890"),
+			Amount:     1000000,
+			Assets: []models.Asset{
+				{
+					PolicyId: []byte(
+						"policy_id_1234567890123456789012345678901234",
+					),
+					Name:   []byte("asset_name_1"),
+					Amount: 100,
+				},
+				{
+					PolicyId: []byte(
+						"policy_id_1234567890123456789012345678901234",
+					),
+					Name:   []byte("asset_name_2"),
+					Amount: 200,
+				},
+			},
+		}
+		if result := sqliteStore.DB().Create(&utxo); result.Error != nil {
+			t.Fatalf("failed to create utxo: %v", result.Error)
+		}
+
+		// Verify records exist
+		var utxoCount, assetCount int64
+		sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+		sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+		if utxoCount != 1 || assetCount != 2 {
+			t.Fatalf(
+				"expected 1 utxo, 2 assets; got %d, %d",
+				utxoCount,
+				assetCount,
+			)
+		}
+
+		// Delete the utxo
+		if result := sqliteStore.DB().Delete(&utxo); result.Error != nil {
+			t.Fatalf("failed to delete utxo: %v", result.Error)
+		}
+
+		// All related assets should be deleted via cascade
+		sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+		sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+		if utxoCount != 0 {
+			t.Errorf("expected 0 utxos after delete, got %d", utxoCount)
+		}
+		if assetCount != 0 {
+			t.Errorf(
+				"expected 0 assets after utxo delete (cascade), got %d",
+				assetCount,
+			)
+		}
+	})
+
+	t.Run(
+		"deleting one utxo does not affect assets of other utxos",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create first utxo with asset
+			utxo1 := models.Utxo{
+				TxId: []byte(
+					"tx_hash_1111111111111111111111111111111111111111",
+				),
+				OutputIdx: 0,
+				AddedSlot: 1000,
+				PaymentKey: []byte(
+					"payment_key_123456789012345678901234567890",
+				),
+				Amount: 1000000,
+				Assets: []models.Asset{
+					{
+						PolicyId: []byte(
+							"policy_id_1234567890123456789012345678901234",
+						),
+						Name:   []byte("asset_utxo1"),
+						Amount: 100,
+					},
+				},
+			}
+			if result := sqliteStore.DB().Create(&utxo1); result.Error != nil {
+				t.Fatalf("failed to create utxo1: %v", result.Error)
+			}
+
+			// Create second utxo with asset
+			utxo2 := models.Utxo{
+				TxId: []byte(
+					"tx_hash_2222222222222222222222222222222222222222",
+				),
+				OutputIdx: 0,
+				AddedSlot: 1000,
+				PaymentKey: []byte(
+					"payment_key_123456789012345678901234567890",
+				),
+				Amount: 2000000,
+				Assets: []models.Asset{
+					{
+						PolicyId: []byte(
+							"policy_id_1234567890123456789012345678901234",
+						),
+						Name:   []byte("asset_utxo2"),
+						Amount: 200,
+					},
+				},
+			}
+			if result := sqliteStore.DB().Create(&utxo2); result.Error != nil {
+				t.Fatalf("failed to create utxo2: %v", result.Error)
+			}
+
+			// Verify initial counts
+			var utxoCount, assetCount int64
+			sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+			sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+			if utxoCount != 2 || assetCount != 2 {
+				t.Fatalf(
+					"expected 2 utxos, 2 assets; got %d, %d",
+					utxoCount,
+					assetCount,
+				)
+			}
+
+			// Delete only the first utxo
+			if result := sqliteStore.DB().Delete(&utxo1); result.Error != nil {
+				t.Fatalf("failed to delete utxo1: %v", result.Error)
+			}
+
+			// Second utxo and its asset should still exist
+			sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+			sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+			if utxoCount != 1 {
+				t.Errorf(
+					"expected 1 utxo after deleting one, got %d",
+					utxoCount,
+				)
+			}
+			if assetCount != 1 {
+				t.Errorf(
+					"expected 1 asset from remaining utxo, got %d",
+					assetCount,
+				)
+			}
+
+			// Verify the remaining asset belongs to utxo2
+			var remainingAsset models.Asset
+			if result := sqliteStore.DB().First(&remainingAsset); result.Error != nil {
+				t.Fatalf("failed to query remaining asset: %v", result.Error)
+			}
+			if string(remainingAsset.Name) != "asset_utxo2" {
+				t.Errorf(
+					"expected remaining asset to be 'asset_utxo2', got '%s'",
+					string(remainingAsset.Name),
+				)
+			}
+		},
+	)
+}
+
+// TestCollateralReturnUniqueConstraint verifies that CollateralReturnForTxID has a unique constraint:
+//   - Multiple UTXOs with NULL CollateralReturnForTxID are allowed (regular outputs)
+//   - Two UTXOs with the same non-NULL CollateralReturnForTxID are rejected (per Cardano protocol,
+//     a transaction has at most one collateral return output)
+func TestCollateralReturnUniqueConstraint(t *testing.T) {
+	t.Run("multiple NULL CollateralReturnForTxID allowed", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		// Create multiple UTXOs with NULL CollateralReturnForTxID (normal outputs)
+		utxo1 := models.Utxo{
+			TxId: []byte(
+				"tx_hash_1111111111111111111111111111111111111111",
+			),
+			OutputIdx: 0,
+			AddedSlot: 1000,
+			Amount:    1000000,
+			// CollateralReturnForTxID is nil (NULL)
+		}
+		if result := sqliteStore.DB().Create(&utxo1); result.Error != nil {
+			t.Fatalf("failed to create utxo1: %v", result.Error)
+		}
+
+		utxo2 := models.Utxo{
+			TxId: []byte(
+				"tx_hash_2222222222222222222222222222222222222222",
+			),
+			OutputIdx: 0,
+			AddedSlot: 1000,
+			Amount:    2000000,
+			// CollateralReturnForTxID is nil (NULL)
+		}
+		if result := sqliteStore.DB().Create(&utxo2); result.Error != nil {
+			t.Fatalf("failed to create utxo2: %v", result.Error)
+		}
+
+		// Both should exist
+		var count int64
+		sqliteStore.DB().Model(&models.Utxo{}).Count(&count)
+		if count != 2 {
+			t.Errorf(
+				"expected 2 UTXOs with NULL CollateralReturnForTxID, got %d",
+				count,
+			)
+		}
+	})
+
+	t.Run(
+		"duplicate non-NULL CollateralReturnForTxID rejected",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create a transaction first (needed for FK)
+			tx := models.Transaction{
+				Hash: []byte(
+					"tx_hash_for_collateral_test_1234567890123456",
+				),
+				Slot:       1000,
+				BlockIndex: 0,
+				Valid:      false, // Invalid tx that used collateral
+			}
+			if result := sqliteStore.DB().Create(&tx); result.Error != nil {
+				t.Fatalf("failed to create transaction: %v", result.Error)
+			}
+
+			// Create first UTXO with CollateralReturnForTxID pointing to tx
+			txID := tx.ID
+			utxo1 := models.Utxo{
+				TxId: []byte(
+					"collateral_return_1111111111111111111111111111111",
+				),
+				OutputIdx:               0,
+				AddedSlot:               1000,
+				Amount:                  1000000,
+				CollateralReturnForTxID: &txID,
+			}
+			if result := sqliteStore.DB().Create(&utxo1); result.Error != nil {
+				t.Fatalf(
+					"failed to create first collateral return: %v",
+					result.Error,
+				)
+			}
+
+			// Try to create second UTXO with same CollateralReturnForTxID - should fail
+			utxo2 := models.Utxo{
+				TxId: []byte(
+					"collateral_return_2222222222222222222222222222222",
+				),
+				OutputIdx:               1,
+				AddedSlot:               1000,
+				Amount:                  2000000,
+				CollateralReturnForTxID: &txID, // Same transaction ID - violates unique constraint
+			}
+			result := sqliteStore.DB().Create(&utxo2)
+			if result.Error == nil {
+				t.Fatal(
+					"expected unique constraint violation for duplicate CollateralReturnForTxID, but insert succeeded",
+				)
+			}
+			// Verify only one UTXO with this CollateralReturnForTxID exists
+			var count int64
+			sqliteStore.DB().
+				Model(&models.Utxo{}).
+				Where("collateral_return_for_tx_id = ?", txID).
+				Count(&count)
+			if count != 1 {
+				t.Errorf(
+					"expected exactly 1 UTXO with CollateralReturnForTxID=%d, got %d",
+					txID,
+					count,
+				)
+			}
+		},
+	)
 }

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -244,6 +244,42 @@ type MetadataStore interface {
 
 	// SetUtxosNotDeletedAfterSlot marks all UTxOs created after the given slot as not deleted.
 	SetUtxosNotDeletedAfterSlot(uint64, types.Txn) error
+
+	// Rollback methods
+
+	// DeleteCertificatesAfterSlot removes all certificate records added after the given slot.
+	// This includes all certificate-related tables: stake registrations, delegations,
+	// pool registrations, DRep registrations, and their associated records.
+	DeleteCertificatesAfterSlot(uint64, types.Txn) error
+
+	// RestoreAccountStateAtSlot reverts account delegation state to the given slot.
+	// For accounts modified after the slot, this restores their Pool and Drep
+	// delegations to the state they had at the given slot, or marks them inactive
+	// if they were registered after that slot.
+	RestoreAccountStateAtSlot(uint64, types.Txn) error
+
+	// RestorePoolStateAtSlot reverts pool state to the given slot.
+	// Pools that have no registrations at or before the given slot are deleted.
+	// Pool retirement records added after the slot are removed via
+	// DeleteCertificatesAfterSlot, effectively undoing any retirements.
+	RestorePoolStateAtSlot(uint64, types.Txn) error
+
+	// RestoreDrepStateAtSlot reverts DRep state to the given slot.
+	// DReps that have no registrations at or before the given slot are deleted.
+	// DReps that have prior registrations have their Active status and anchor
+	// data restored based on the most recent certificate at or before the slot.
+	// DRep retirement records added after the slot are removed via
+	// DeleteCertificatesAfterSlot, effectively undoing any retirements.
+	RestoreDrepStateAtSlot(uint64, types.Txn) error
+
+	// DeletePParamsAfterSlot removes protocol parameter records added after the given slot.
+	DeletePParamsAfterSlot(uint64, types.Txn) error
+
+	// DeletePParamUpdatesAfterSlot removes protocol parameter update records added after the given slot.
+	DeletePParamUpdatesAfterSlot(uint64, types.Txn) error
+
+	// DeleteTransactionsAfterSlot removes transaction records added after the given slot.
+	DeleteTransactionsAfterSlot(uint64, types.Txn) error
 }
 
 // New creates a new metadata store instance using the specified plugin

--- a/database/pool.go
+++ b/database/pool.go
@@ -50,3 +50,22 @@ func (d *Database) GetActivePoolRelays(
 	}
 	return d.metadata.GetActivePoolRelays(txn.Metadata())
 }
+
+// RestorePoolStateAtSlot reverts pool state to the given slot.
+func (d *Database) RestorePoolStateAtSlot(slot uint64, txn *Txn) error {
+	owned := false
+	if txn == nil {
+		txn = d.Transaction(true)
+		owned = true
+		defer txn.Rollback() //nolint:errcheck
+	}
+	if err := d.metadata.RestorePoolStateAtSlot(slot, txn.Metadata()); err != nil {
+		return err
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/database/pparams.go
+++ b/database/pparams.go
@@ -149,3 +149,43 @@ func (d *Database) SetPParamUpdate(
 	}
 	return nil
 }
+
+// DeletePParamsAfterSlot removes protocol parameter records added after the given slot.
+// This is used during chain rollbacks to undo protocol parameter changes.
+func (d *Database) DeletePParamsAfterSlot(slot uint64, txn *Txn) error {
+	owned := false
+	if txn == nil {
+		txn = d.Transaction(true)
+		owned = true
+		defer txn.Rollback() //nolint:errcheck
+	}
+	if err := d.metadata.DeletePParamsAfterSlot(slot, txn.Metadata()); err != nil {
+		return err
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeletePParamUpdatesAfterSlot removes protocol parameter update records added after the given slot.
+// This is used during chain rollbacks to undo pending protocol parameter updates.
+func (d *Database) DeletePParamUpdatesAfterSlot(slot uint64, txn *Txn) error {
+	owned := false
+	if txn == nil {
+		txn = d.Transaction(true)
+		owned = true
+		defer txn.Rollback() //nolint:errcheck
+	}
+	if err := d.metadata.DeletePParamUpdatesAfterSlot(slot, txn.Metadata()); err != nil {
+		return err
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -107,3 +107,22 @@ func (d *Database) GetTransactionByHash(
 	}
 	return d.metadata.GetTransactionByHash(hash, txn.Metadata())
 }
+
+// DeleteTransactionsAfterSlot removes transaction records added after the given slot.
+func (d *Database) DeleteTransactionsAfterSlot(slot uint64, txn *Txn) error {
+	owned := false
+	if txn == nil {
+		txn = d.Transaction(true)
+		owned = true
+		defer txn.Rollback() //nolint:errcheck
+	}
+	if err := d.metadata.DeleteTransactionsAfterSlot(slot, txn.Metadata()); err != nil {
+		return err
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -133,7 +133,10 @@ type Txn interface {
 	Rollback() error
 }
 
-// BlockMetadata contains metadata for a block stored in blob
+// BlockMetadata contains metadata for a block stored in blob.
+// IMPORTANT: Field order must remain [ID, Type, Height, PrevHash] because
+// cbor.StructAsArray encodes/decodes by position. Changing the order would
+// break deserialization of existing stored data.
 type BlockMetadata struct {
 	cbor.StructAsArray
 	ID       uint64

--- a/event/event.go
+++ b/event/event.go
@@ -24,7 +24,9 @@ import (
 )
 
 const (
-	EventQueueSize = 20
+	EventQueueSize      = 20
+	AsyncQueueSize      = 1000
+	AsyncWorkerPoolSize = 4
 )
 
 type EventType string
@@ -47,15 +49,29 @@ func NewEvent(eventType EventType, eventData any) Event {
 	}
 }
 
+// asyncEvent wraps an event with its type for the async queue
+type asyncEvent struct {
+	eventType EventType
+	event     Event
+}
+
 type EventBus struct {
 	subscribers map[EventType]map[EventSubscriberId]Subscriber
 	metrics     *eventMetrics
 	lastSubId   EventSubscriberId
 	mu          sync.RWMutex
 	Logger      *slog.Logger
+
+	// Async publishing infrastructure
+	asyncQueue chan asyncEvent
+	asyncWg    sync.WaitGroup
+	stopCh     chan struct{}
+	stopped    bool
+	stopMu     sync.RWMutex
+	stopOpMu   sync.Mutex // Serializes Stop() calls to prevent duplicate worker pools
 }
 
-// NewEventBus creates a new EventBus
+// NewEventBus creates a new EventBus with async worker pool
 func NewEventBus(
 	promRegistry prometheus.Registerer,
 	logger *slog.Logger,
@@ -63,11 +79,34 @@ func NewEventBus(
 	e := &EventBus{
 		subscribers: make(map[EventType]map[EventSubscriberId]Subscriber),
 		Logger:      logger,
+		asyncQueue:  make(chan asyncEvent, AsyncQueueSize),
+		stopCh:      make(chan struct{}),
 	}
 	if promRegistry != nil {
 		e.initMetrics(promRegistry)
 	}
+	// Start async worker pool
+	for range AsyncWorkerPoolSize {
+		e.asyncWg.Add(1)
+		go e.asyncWorker()
+	}
 	return e
+}
+
+// asyncWorker processes events from the async queue
+func (e *EventBus) asyncWorker() {
+	defer e.asyncWg.Done()
+	for {
+		select {
+		case <-e.stopCh:
+			return
+		case ae, ok := <-e.asyncQueue:
+			if !ok {
+				return
+			}
+			e.Publish(ae.eventType, ae.event)
+		}
+	}
 }
 
 // Subscriber is a delivery abstraction that allows the EventBus to deliver
@@ -260,6 +299,38 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 	}
 }
 
+// PublishAsync enqueues an event for asynchronous delivery to all subscribers.
+// This method returns immediately without blocking on subscriber delivery.
+// Use this for non-critical events where immediate delivery is not required.
+// Returns false if the EventBus is stopped or the async queue is full.
+func (e *EventBus) PublishAsync(eventType EventType, evt Event) bool {
+	e.stopMu.RLock()
+	if e.stopped {
+		e.stopMu.RUnlock()
+		return false
+	}
+	e.stopMu.RUnlock()
+
+	select {
+	case e.asyncQueue <- asyncEvent{eventType: eventType, event: evt}:
+		return true
+	default:
+		// Queue is full, log and drop the event
+		if e.Logger != nil {
+			e.Logger.Warn(
+				"async event queue full, dropping event",
+				"type",
+				eventType,
+			)
+		}
+		if e.metrics != nil {
+			e.metrics.deliveryErrors.WithLabelValues(string(eventType), "async-dropped").
+				Inc()
+		}
+		return false
+	}
+}
+
 // RegisterSubscriber allows external adapters (e.g., network-backed subscribers)
 // to register with the EventBus. It returns the assigned subscriber id.
 func (e *EventBus) RegisterSubscriber(
@@ -282,7 +353,25 @@ func (e *EventBus) RegisterSubscriber(
 
 // Stop closes all subscriber channels and clears the subscribers map.
 // This ensures that SubscribeFunc goroutines exit cleanly during shutdown.
+// The EventBus can still be reused after Stop() is called.
 func (e *EventBus) Stop() {
+	// Serialize Stop() calls to prevent race conditions that could spawn
+	// duplicate worker pools when called concurrently
+	e.stopOpMu.Lock()
+	defer e.stopOpMu.Unlock()
+
+	// Mark as stopped to prevent new async publishes during shutdown
+	e.stopMu.Lock()
+	wasAlreadyStopped := e.stopped
+	e.stopped = true
+	e.stopMu.Unlock()
+
+	if !wasAlreadyStopped {
+		// Signal async workers to stop and wait for them to finish
+		close(e.stopCh)
+		e.asyncWg.Wait()
+	}
+
 	e.mu.Lock()
 	// Copy and clear subscribers
 	subsCopy := e.subscribers
@@ -299,5 +388,18 @@ func (e *EventBus) Stop() {
 	// Reset subscriber metrics if they exist
 	if e.metrics != nil {
 		e.metrics.subscribers.Reset()
+	}
+
+	// Reinitialize async infrastructure to allow continued use
+	e.stopMu.Lock()
+	e.asyncQueue = make(chan asyncEvent, AsyncQueueSize)
+	e.stopCh = make(chan struct{})
+	e.stopped = false
+	e.stopMu.Unlock()
+
+	// Restart async worker pool
+	for range AsyncWorkerPoolSize {
+		e.asyncWg.Add(1)
+		go e.asyncWorker()
 	}
 }

--- a/internal/integration/rollback_test.go
+++ b/internal/integration/rollback_test.go
@@ -1,0 +1,781 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"encoding/hex"
+	"errors"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin"
+	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// testDataDir returns the path to the immutable testdata directory
+func testDataDir() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(
+		filepath.Dir(thisFile),
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+}
+
+// mockLedgerState implements the interface for ChainManager.SetLedger
+type mockLedgerState struct {
+	securityParam int
+}
+
+func (m *mockLedgerState) SecurityParam() int {
+	return m.securityParam
+}
+
+// loadBlocksFromImmutable loads blocks from the immutable testdata into the chain
+// Returns the loaded blocks and points for use in rollback tests
+func loadBlocksFromImmutable(
+	t *testing.T,
+	c *chain.Chain,
+	maxBlocks int,
+) ([]ledger.Block, []ocommon.Point) {
+	t.Helper()
+
+	imm, err := immutable.New(testDataDir())
+	if err != nil {
+		t.Fatalf("failed to open immutable db: %v", err)
+	}
+	defer imm.Close() //nolint:errcheck
+
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: []byte{}})
+	if err != nil {
+		t.Fatalf("failed to create block iterator: %v", err)
+	}
+	defer iter.Close()
+
+	var blocks []ledger.Block
+	var points []ocommon.Point
+
+	for range maxBlocks {
+		immBlock, err := iter.Next()
+		if err != nil {
+			t.Fatalf("unexpected error reading block: %v", err)
+		}
+		if immBlock == nil {
+			// No more blocks
+			break
+		}
+
+		// Decode the block
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		if err != nil {
+			t.Fatalf(
+				"failed to decode block at slot %d: %v",
+				immBlock.Slot,
+				err,
+			)
+		}
+
+		// Add block to chain
+		if err := c.AddBlock(block, nil); err != nil {
+			t.Fatalf(
+				"failed to add block to chain at slot %d: %v",
+				immBlock.Slot,
+				err,
+			)
+		}
+
+		blocks = append(blocks, block)
+		points = append(points, ocommon.Point{
+			Slot: block.SlotNumber(),
+			Hash: block.Hash().Bytes(),
+		})
+	}
+
+	return blocks, points
+}
+
+func TestRollbackToSecurityParamDepth(t *testing.T) {
+	// Set up temporary directory for test database
+	tmpDir := t.TempDir()
+
+	// Configure plugins with temp directory
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		config.DefaultBlobPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set blob plugin data-dir: %v", err)
+	}
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeMetadata,
+		config.DefaultMetadataPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set metadata plugin data-dir: %v", err)
+	}
+
+	// Create database
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		BlobPlugin:     config.DefaultBlobPlugin,
+		MetadataPlugin: config.DefaultMetadataPlugin,
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create chain manager with database
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("failed to create chain manager: %v", err)
+	}
+
+	// Set security parameter (K=432 for preview network)
+	// For this test, we use a smaller value to avoid loading too many blocks
+	const testSecurityParam = 50
+	mockLedger := &mockLedgerState{securityParam: testSecurityParam}
+	cm.SetLedger(mockLedger)
+
+	// Get primary chain
+	c := cm.PrimaryChain()
+	if c == nil {
+		t.Fatal("primary chain is nil")
+	}
+
+	// Load enough blocks to test rollback (K + 10 blocks)
+	numBlocks := testSecurityParam + 10
+	blocks, points := loadBlocksFromImmutable(t, c, numBlocks)
+
+	if len(blocks) < numBlocks || len(points) < numBlocks {
+		t.Skipf(
+			"not enough blocks in testdata: got %d, need %d",
+			len(blocks),
+			numBlocks,
+		)
+	}
+
+	// Get current tip before rollback
+	tipBefore := c.Tip()
+	t.Logf(
+		"chain tip before rollback: slot=%d hash=%s",
+		tipBefore.Point.Slot,
+		hex.EncodeToString(tipBefore.Point.Hash),
+	)
+
+	// Test 1: Rollback to exactly K blocks back (should succeed)
+	// The rollback point is at index (len(blocks) - 1 - K) = last block - K
+	rollbackIndex := len(blocks) - 1 - testSecurityParam
+	if rollbackIndex < 0 || rollbackIndex >= len(points) {
+		t.Fatalf(
+			"rollback index out of range: %d (blocks=%d, points=%d, K=%d)",
+			rollbackIndex,
+			len(blocks),
+			len(points),
+			testSecurityParam,
+		)
+	}
+	rollbackPoint := points[rollbackIndex]
+
+	t.Logf(
+		"rolling back to K blocks back: slot=%d hash=%s (index=%d)",
+		rollbackPoint.Slot,
+		hex.EncodeToString(rollbackPoint.Hash),
+		rollbackIndex,
+	)
+
+	err = c.Rollback(rollbackPoint)
+	if err != nil {
+		t.Fatalf("rollback to K blocks should succeed, but got error: %v", err)
+	}
+
+	// Verify chain tip after rollback
+	tipAfterRollback := c.Tip()
+	t.Logf(
+		"chain tip after rollback: slot=%d hash=%s",
+		tipAfterRollback.Point.Slot,
+		hex.EncodeToString(tipAfterRollback.Point.Hash),
+	)
+
+	if tipAfterRollback.Point.Slot != rollbackPoint.Slot {
+		t.Errorf(
+			"tip slot mismatch after rollback: got %d, want %d",
+			tipAfterRollback.Point.Slot,
+			rollbackPoint.Slot,
+		)
+	}
+	if string(tipAfterRollback.Point.Hash) != string(rollbackPoint.Hash) {
+		t.Errorf(
+			"tip hash mismatch after rollback: got %s, want %s",
+			hex.EncodeToString(tipAfterRollback.Point.Hash),
+			hex.EncodeToString(rollbackPoint.Hash),
+		)
+	}
+
+	t.Log("rollback to K blocks back succeeded as expected")
+}
+
+func TestRollbackBeyondSecurityParam(t *testing.T) {
+	// Set up temporary directory for test database
+	tmpDir := t.TempDir()
+
+	// Configure plugins with temp directory
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		config.DefaultBlobPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set blob plugin data-dir: %v", err)
+	}
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeMetadata,
+		config.DefaultMetadataPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set metadata plugin data-dir: %v", err)
+	}
+
+	// Create database
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		BlobPlugin:     config.DefaultBlobPlugin,
+		MetadataPlugin: config.DefaultMetadataPlugin,
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create chain manager with database
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("failed to create chain manager: %v", err)
+	}
+
+	// Set security parameter (K=432 for preview network)
+	// For this test, we use a smaller value to avoid loading too many blocks
+	const testSecurityParam = 50
+	mockLedger := &mockLedgerState{securityParam: testSecurityParam}
+	cm.SetLedger(mockLedger)
+
+	// Get primary chain
+	c := cm.PrimaryChain()
+	if c == nil {
+		t.Fatal("primary chain is nil")
+	}
+
+	// Load enough blocks to test rollback beyond K (K + 20 blocks)
+	numBlocks := testSecurityParam + 20
+	blocks, points := loadBlocksFromImmutable(t, c, numBlocks)
+
+	if len(blocks) < numBlocks || len(points) < numBlocks {
+		t.Skipf(
+			"not enough blocks in testdata: got %d, need %d",
+			len(blocks),
+			numBlocks,
+		)
+	}
+
+	// Get current tip before rollback attempt
+	tipBefore := c.Tip()
+	t.Logf(
+		"chain tip before rollback attempt: slot=%d hash=%s",
+		tipBefore.Point.Slot,
+		hex.EncodeToString(tipBefore.Point.Hash),
+	)
+
+	// Test: Attempt rollback to a point that doesn't exist in the chain
+	// We use a valid slot from the chain but with a fake hash
+	// This simulates a rollback to a point that was never added
+	fakeHash := make([]byte, 32)
+	for i := range fakeHash {
+		fakeHash[i] = byte(i)
+	}
+	// Use a slot from the middle of the chain but with wrong hash
+	midIndex := len(points) / 2
+	midSlot := points[midIndex].Slot
+	fakePoint := ocommon.Point{
+		Slot: midSlot,
+		Hash: fakeHash,
+	}
+
+	t.Logf(
+		"attempting rollback to non-existent point: slot=%d hash=%s",
+		fakePoint.Slot,
+		hex.EncodeToString(fakePoint.Hash),
+	)
+
+	err = c.Rollback(fakePoint)
+	if err == nil {
+		t.Fatal("rollback to non-existent point should fail, but succeeded")
+	}
+
+	// Assert expected error type - rollback to non-existent point should return ErrBlockNotFound
+	if !errors.Is(err, models.ErrBlockNotFound) {
+		t.Errorf(
+			"expected ErrBlockNotFound, got error type: %T, value: %v",
+			err,
+			err,
+		)
+	} else {
+		t.Log("rollback failed with ErrBlockNotFound as expected")
+	}
+
+	// Verify chain tip is unchanged after failed rollback
+	tipAfterFailed := c.Tip()
+	if tipAfterFailed.Point.Slot != tipBefore.Point.Slot {
+		t.Errorf(
+			"tip slot changed after failed rollback: got %d, want %d",
+			tipAfterFailed.Point.Slot,
+			tipBefore.Point.Slot,
+		)
+	}
+	if string(tipAfterFailed.Point.Hash) != string(tipBefore.Point.Hash) {
+		t.Errorf(
+			"tip hash changed after failed rollback: got %s, want %s",
+			hex.EncodeToString(tipAfterFailed.Point.Hash),
+			hex.EncodeToString(tipBefore.Point.Hash),
+		)
+	}
+
+	t.Log("chain state preserved after failed rollback attempt")
+}
+
+func TestRollbackStateRestoration(t *testing.T) {
+	// Set up temporary directory for test database
+	tmpDir := t.TempDir()
+
+	// Configure plugins with temp directory
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		config.DefaultBlobPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set blob plugin data-dir: %v", err)
+	}
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeMetadata,
+		config.DefaultMetadataPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set metadata plugin data-dir: %v", err)
+	}
+
+	// Create database
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		BlobPlugin:     config.DefaultBlobPlugin,
+		MetadataPlugin: config.DefaultMetadataPlugin,
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create chain manager with database
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("failed to create chain manager: %v", err)
+	}
+
+	// Set security parameter
+	const testSecurityParam = 30
+	mockLedger := &mockLedgerState{securityParam: testSecurityParam}
+	cm.SetLedger(mockLedger)
+
+	// Get primary chain
+	c := cm.PrimaryChain()
+	if c == nil {
+		t.Fatal("primary chain is nil")
+	}
+
+	// Load blocks
+	numBlocks := 100
+	blocks, points := loadBlocksFromImmutable(t, c, numBlocks)
+
+	if len(blocks) < numBlocks || len(points) < numBlocks {
+		t.Skipf(
+			"not enough blocks in testdata: got %d, need %d",
+			len(blocks),
+			numBlocks,
+		)
+	}
+
+	// Get initial tip
+	initialTip := c.Tip()
+	t.Logf(
+		"initial chain tip: slot=%d hash=%s blockNumber=%d",
+		initialTip.Point.Slot,
+		hex.EncodeToString(initialTip.Point.Hash),
+		initialTip.BlockNumber,
+	)
+
+	// Rollback to a midpoint
+	midpointIndex := len(points) / 2
+	midpointPoint := points[midpointIndex]
+
+	t.Logf(
+		"rolling back to midpoint: slot=%d hash=%s (index=%d)",
+		midpointPoint.Slot,
+		hex.EncodeToString(midpointPoint.Hash),
+		midpointIndex,
+	)
+
+	err = c.Rollback(midpointPoint)
+	if err != nil {
+		t.Fatalf("rollback to midpoint failed: %v", err)
+	}
+
+	// Verify tip after rollback
+	tipAfterRollback := c.Tip()
+	if tipAfterRollback.Point.Slot != midpointPoint.Slot {
+		t.Errorf(
+			"tip slot mismatch after rollback: got %d, want %d",
+			tipAfterRollback.Point.Slot,
+			midpointPoint.Slot,
+		)
+	}
+	if string(tipAfterRollback.Point.Hash) != string(midpointPoint.Hash) {
+		t.Errorf(
+			"tip hash mismatch after rollback: got %s, want %s",
+			hex.EncodeToString(tipAfterRollback.Point.Hash),
+			hex.EncodeToString(midpointPoint.Hash),
+		)
+	}
+
+	// Verify the chain tip reflects the rollback point
+	// Note: BlockByPoint may still find blocks in blob storage after rollback
+	// since blob storage retains block data even after chain rollback.
+	// The important thing is that the chain tip is correct.
+	if tipAfterRollback.BlockNumber != blocks[midpointIndex].BlockNumber() {
+		t.Errorf(
+			"tip block number mismatch after rollback: got %d, want %d",
+			tipAfterRollback.BlockNumber,
+			blocks[midpointIndex].BlockNumber(),
+		)
+	}
+
+	// Verify the rollback point block is still accessible
+	block, err := c.BlockByPoint(midpointPoint, nil)
+	if err != nil {
+		t.Errorf(
+			"rollback point block should still be accessible, got error: %v",
+			err,
+		)
+	} else if block.Slot != midpointPoint.Slot {
+		t.Errorf(
+			"rollback point block slot mismatch: got %d, want %d",
+			block.Slot,
+			midpointPoint.Slot,
+		)
+	}
+
+	t.Log("state correctly restored after rollback")
+
+	// Test that we can add new blocks after rollback
+	// We need to reload blocks from the rollback point forward
+	imm, err := immutable.New(testDataDir())
+	if err != nil {
+		t.Fatalf("failed to reopen immutable db: %v", err)
+	}
+	defer imm.Close() //nolint:errcheck
+
+	iter, err := imm.BlocksFromPoint(midpointPoint)
+	if err != nil {
+		t.Fatalf("failed to create block iterator from midpoint: %v", err)
+	}
+	defer iter.Close()
+
+	// Skip the midpoint block itself (it's already in the chain)
+	_, err = iter.Next()
+	if err != nil {
+		t.Fatalf("failed to skip midpoint block: %v", err)
+	}
+
+	// Add a few more blocks after the rollback point
+	blocksAdded := 0
+	for range 10 {
+		immBlock, err := iter.Next()
+		if err != nil {
+			t.Fatalf("unexpected error reading block after rollback: %v", err)
+		}
+		if immBlock == nil {
+			break
+		}
+
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		if err != nil {
+			t.Fatalf("failed to decode block: %v", err)
+		}
+
+		if err := c.AddBlock(block, nil); err != nil {
+			t.Fatalf("failed to add block after rollback: %v", err)
+		}
+		blocksAdded++
+	}
+
+	t.Logf("successfully added %d blocks after rollback", blocksAdded)
+
+	// Verify new tip is correct
+	newTip := c.Tip()
+	if newTip.Point.Slot <= midpointPoint.Slot {
+		t.Errorf(
+			"new tip slot should be greater than midpoint: got %d, midpoint was %d",
+			newTip.Point.Slot,
+			midpointPoint.Slot,
+		)
+	}
+
+	t.Logf(
+		"final chain tip: slot=%d hash=%s blockNumber=%d",
+		newTip.Point.Slot,
+		hex.EncodeToString(newTip.Point.Hash),
+		newTip.BlockNumber,
+	)
+}
+
+func TestRollbackToOrigin(t *testing.T) {
+	// Set up temporary directory for test database
+	tmpDir := t.TempDir()
+
+	// Configure plugins with temp directory
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		config.DefaultBlobPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set blob plugin data-dir: %v", err)
+	}
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeMetadata,
+		config.DefaultMetadataPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set metadata plugin data-dir: %v", err)
+	}
+
+	// Create database
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		BlobPlugin:     config.DefaultBlobPlugin,
+		MetadataPlugin: config.DefaultMetadataPlugin,
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create chain manager with database
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("failed to create chain manager: %v", err)
+	}
+
+	// Set security parameter
+	mockLedger := &mockLedgerState{securityParam: 100}
+	cm.SetLedger(mockLedger)
+
+	// Get primary chain
+	c := cm.PrimaryChain()
+	if c == nil {
+		t.Fatal("primary chain is nil")
+	}
+
+	// Load some blocks
+	numBlocks := 50
+	blocks, _ := loadBlocksFromImmutable(t, c, numBlocks)
+
+	if len(blocks) < numBlocks {
+		t.Skipf(
+			"not enough blocks in testdata: got %d, need %d",
+			len(blocks),
+			numBlocks,
+		)
+	}
+
+	// Get tip before rollback
+	tipBefore := c.Tip()
+	t.Logf(
+		"chain tip before rollback to origin: slot=%d hash=%s",
+		tipBefore.Point.Slot,
+		hex.EncodeToString(tipBefore.Point.Hash),
+	)
+
+	// Rollback to origin (slot 0, empty hash)
+	originPoint := ocommon.Point{
+		Slot: 0,
+		Hash: []byte{},
+	}
+
+	err = c.Rollback(originPoint)
+	if err != nil {
+		t.Fatalf("rollback to origin failed: %v", err)
+	}
+
+	// Verify tip is at origin
+	tipAfter := c.Tip()
+	if tipAfter.Point.Slot != 0 {
+		t.Errorf(
+			"tip slot after origin rollback should be 0, got %d",
+			tipAfter.Point.Slot,
+		)
+	}
+	if len(tipAfter.Point.Hash) != 0 {
+		t.Errorf(
+			"tip hash after origin rollback should be empty, got %s",
+			hex.EncodeToString(tipAfter.Point.Hash),
+		)
+	}
+
+	t.Log("successfully rolled back to origin")
+}
+
+func TestChainIteratorAfterRollback(t *testing.T) {
+	// Set up temporary directory for test database
+	tmpDir := t.TempDir()
+
+	// Configure plugins with temp directory
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		config.DefaultBlobPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set blob plugin data-dir: %v", err)
+	}
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeMetadata,
+		config.DefaultMetadataPlugin,
+		"data-dir",
+		tmpDir,
+	); err != nil {
+		t.Fatalf("failed to set metadata plugin data-dir: %v", err)
+	}
+
+	// Create database
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		BlobPlugin:     config.DefaultBlobPlugin,
+		MetadataPlugin: config.DefaultMetadataPlugin,
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create chain manager with database
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("failed to create chain manager: %v", err)
+	}
+
+	// Set security parameter
+	mockLedger := &mockLedgerState{securityParam: 50}
+	cm.SetLedger(mockLedger)
+
+	// Get primary chain
+	c := cm.PrimaryChain()
+	if c == nil {
+		t.Fatal("primary chain is nil")
+	}
+
+	// Load blocks
+	numBlocks := 100
+	blocks, points := loadBlocksFromImmutable(t, c, numBlocks)
+
+	if len(blocks) < numBlocks || len(points) < numBlocks {
+		t.Skipf(
+			"not enough blocks in testdata: got %d, need %d",
+			len(blocks),
+			numBlocks,
+		)
+	}
+
+	// Create iterator from origin
+	iter, err := c.FromPoint(ocommon.NewPointOrigin(), false)
+	if err != nil {
+		t.Fatalf("failed to create chain iterator: %v", err)
+	}
+	defer iter.Cancel()
+
+	// Advance iterator to near the tip
+	for i := 0; i < len(blocks)-10; i++ {
+		next, err := iter.Next(false)
+		if err != nil {
+			if errors.Is(err, chain.ErrIteratorChainTip) {
+				break
+			}
+			t.Fatalf("unexpected error from iterator: %v", err)
+		}
+		if next == nil {
+			t.Fatal("unexpected nil from iterator")
+		}
+	}
+
+	// Rollback to midpoint
+	midpointIndex := len(points) / 2
+	midpointPoint := points[midpointIndex]
+
+	t.Logf(
+		"rolling back while iterator is active: slot=%d",
+		midpointPoint.Slot,
+	)
+
+	err = c.Rollback(midpointPoint)
+	if err != nil {
+		t.Fatalf("rollback failed: %v", err)
+	}
+
+	// Iterator should report rollback on next call
+	next, err := iter.Next(false)
+	if err != nil {
+		t.Fatalf("iterator.Next after rollback failed: %v", err)
+	}
+	if next == nil {
+		t.Fatal("iterator returned nil after rollback")
+	}
+	if !next.Rollback {
+		t.Error("iterator should report rollback, but Rollback flag is false")
+	}
+
+	// Verify rollback point matches
+	if next.Point.Slot != midpointPoint.Slot {
+		t.Errorf(
+			"rollback point slot mismatch: got %d, want %d",
+			next.Point.Slot,
+			midpointPoint.Slot,
+		)
+	}
+
+	t.Log("iterator correctly reported rollback event")
+}

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	BlockfetchEventType  event.EventType = "blockfetch.event"
-	ChainsyncEventType   event.EventType = "chainsync.event"
-	LedgerErrorEventType event.EventType = "ledger.error"
+	BlockfetchEventType        event.EventType = "blockfetch.event"
+	ChainsyncEventType         event.EventType = "chainsync.event"
+	LedgerErrorEventType       event.EventType = "ledger.error"
+	TransactionEventType       event.EventType = "ledger.tx"
+	PoolStateRestoredEventType event.EventType = "ledger.pool.restored"
 )
 
 // BlockfetchEvent represents either a Block or BatchDone blockfetch event. We use
@@ -55,4 +57,20 @@ type LedgerErrorEvent struct {
 	Error     error         // The actual error that occurred
 	Operation string        // The operation that failed (e.g., "block_header", "rollback")
 	Point     ocommon.Point // Chain point where the error occurred, if applicable
+}
+
+// TransactionEvent is emitted when a transaction is applied or rolled back.
+// Check the Rollback field to determine direction.
+type TransactionEvent struct {
+	Transaction ledger.Transaction
+	Point       ocommon.Point
+	BlockNumber uint64
+	TxIndex     uint32
+	Rollback    bool
+}
+
+// PoolStateRestoredEvent is emitted after pool state is restored during a rollback.
+// Subscribers (like peer providers) can use this to invalidate cached pool data.
+type PoolStateRestoredEvent struct {
+	Slot uint64 // The slot to which pool state was restored
 }

--- a/ledger/peer_provider.go
+++ b/ledger/peer_provider.go
@@ -16,23 +16,43 @@ package ledger
 
 import (
 	"errors"
+	"net"
+	"sync"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/peergov"
 )
 
+// defaultRelayCacheTTL is the default time-to-live for cached pool relays.
+// Pool relay data changes infrequently (only on pool registration/update/retirement),
+// so a 1-minute cache significantly reduces database load while keeping data fresh.
+const defaultRelayCacheTTL = 1 * time.Minute
+
 // LedgerPeerProviderAdapter implements peergov.LedgerPeerProvider using
 // the ledger state and database to discover stake pool relays.
+// It includes a time-based cache to avoid repeatedly querying the database
+// for pool relay data that rarely changes.
 type LedgerPeerProviderAdapter struct {
 	ledgerState *LedgerState
 	db          *database.Database
+
+	// Cache for pool relays
+	cacheMu      sync.RWMutex
+	cachedRelays []peergov.PoolRelay
+	cacheTime    time.Time
+	cacheTTL     time.Duration
 }
 
 // NewLedgerPeerProvider creates a new LedgerPeerProvider adapter.
 // Returns an error if ledgerState or db is nil.
+// If eventBus is provided, the adapter will automatically invalidate its cache
+// when pool state is restored during rollbacks.
 func NewLedgerPeerProvider(
 	ledgerState *LedgerState,
 	db *database.Database,
+	eventBus *event.EventBus,
 ) (*LedgerPeerProviderAdapter, error) {
 	if ledgerState == nil {
 		return nil, errors.New("ledgerState cannot be nil")
@@ -40,14 +60,37 @@ func NewLedgerPeerProvider(
 	if db == nil {
 		return nil, errors.New("db cannot be nil")
 	}
-	return &LedgerPeerProviderAdapter{
+	adapter := &LedgerPeerProviderAdapter{
 		ledgerState: ledgerState,
 		db:          db,
-	}, nil
+		cacheTTL:    defaultRelayCacheTTL,
+	}
+	// Subscribe to pool state restored events to invalidate cache on rollbacks
+	if eventBus != nil {
+		eventBus.SubscribeFunc(
+			PoolStateRestoredEventType,
+			func(_ event.Event) {
+				adapter.InvalidateCache()
+			},
+		)
+	}
+	return adapter, nil
 }
 
 // GetPoolRelays returns all active pool relays from the ledger.
+// Results are cached for cacheTTL duration to reduce database load.
 func (p *LedgerPeerProviderAdapter) GetPoolRelays() ([]peergov.PoolRelay, error) {
+	// Check cache first (read lock)
+	p.cacheMu.RLock()
+	if p.cachedRelays != nil && time.Since(p.cacheTime) < p.cacheTTL {
+		// Return a deep copy to prevent external modification of cached IP pointers
+		result := copyPoolRelays(p.cachedRelays)
+		p.cacheMu.RUnlock()
+		return result, nil
+	}
+	p.cacheMu.RUnlock()
+
+	// Cache miss or expired - fetch from database
 	relays, err := p.db.GetActivePoolRelays(nil)
 	if err != nil {
 		return nil, err
@@ -68,7 +111,28 @@ func (p *LedgerPeerProviderAdapter) GetPoolRelays() ([]peergov.PoolRelay, error)
 		result = append(result, pr)
 	}
 
-	return result, nil
+	// Update cache (write lock)
+	// Re-check cache validity after acquiring write lock to avoid redundant updates
+	// from concurrent goroutines that may have populated the cache while we were fetching.
+	p.cacheMu.Lock()
+	if p.cachedRelays == nil || time.Since(p.cacheTime) >= p.cacheTTL {
+		p.cachedRelays = result
+		p.cacheTime = time.Now()
+	}
+	p.cacheMu.Unlock()
+
+	// Return a deep copy to prevent external modification of cached IP pointers
+	return copyPoolRelays(result), nil
+}
+
+// InvalidateCache clears the cached pool relays, forcing the next
+// GetPoolRelays call to fetch fresh data from the database.
+// This can be called after pool registration/retirement events.
+func (p *LedgerPeerProviderAdapter) InvalidateCache() {
+	p.cacheMu.Lock()
+	p.cachedRelays = nil
+	p.cacheTime = time.Time{}
+	p.cacheMu.Unlock()
 }
 
 // CurrentSlot returns the current chain tip slot number.
@@ -79,3 +143,25 @@ func (p *LedgerPeerProviderAdapter) CurrentSlot() uint64 {
 
 // Ensure LedgerPeerProviderAdapter implements LedgerPeerProvider
 var _ peergov.LedgerPeerProvider = (*LedgerPeerProviderAdapter)(nil)
+
+// copyPoolRelays returns a deep copy of the relay slice, including IP pointers.
+func copyPoolRelays(relays []peergov.PoolRelay) []peergov.PoolRelay {
+	result := make([]peergov.PoolRelay, len(relays))
+	for i, r := range relays {
+		result[i] = peergov.PoolRelay{
+			Hostname: r.Hostname,
+			Port:     r.Port,
+		}
+		if r.IPv4 != nil {
+			ipCopy := make(net.IP, len(*r.IPv4))
+			copy(ipCopy, *r.IPv4)
+			result[i].IPv4 = &ipCopy
+		}
+		if r.IPv6 != nil {
+			ipCopy := make(net.IP, len(*r.IPv6))
+			copy(ipCopy, *r.IPv6)
+			result[i].IPv6 = &ipCopy
+		}
+	}
+	return result
+}

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -112,9 +112,13 @@ func (lv *LedgerView) PoolCurrentState(
 	if len(pool.Registration) > 0 {
 		var latestIdx int
 		var latestSlot uint64
+		var latestCertID uint
 		for i, reg := range pool.Registration {
-			if reg.AddedSlot >= latestSlot {
+			// Use CertificateID for deterministic disambiguation when slots are equal
+			if reg.AddedSlot > latestSlot ||
+				(reg.AddedSlot == latestSlot && reg.CertificateID > latestCertID) {
 				latestSlot = reg.AddedSlot
+				latestCertID = reg.CertificateID
 				latestIdx = i
 			}
 		}
@@ -136,13 +140,13 @@ func (lv *LedgerView) PoolCurrentState(
 		tmp.RewardAccount = lcommon.AddrKeyHash(
 			lcommon.NewBlake2b224(pool.RewardAccount),
 		)
-		for _, owner := range pool.Owners {
+		for _, owner := range reg.Owners {
 			tmp.PoolOwners = append(
 				tmp.PoolOwners,
 				lcommon.AddrKeyHash(lcommon.NewBlake2b224(owner.KeyHash)),
 			)
 		}
-		for _, relay := range pool.Relays {
+		for _, relay := range reg.Relays {
 			r := lcommon.PoolRelay{}
 			if relay.Port != 0 {
 				port := uint32(relay.Port) // #nosec G115

--- a/node.go
+++ b/node.go
@@ -305,7 +305,11 @@ func (n *Node) Run(ctx context.Context) error {
 	})
 	// Configure peer governor
 	// Create ledger peer provider for discovering peers from stake pool relays
-	ledgerPeerProvider, err := ledger.NewLedgerPeerProvider(n.ledgerState, n.db)
+	ledgerPeerProvider, err := ledger.NewLedgerPeerProvider(
+		n.ledgerState,
+		n.db,
+		n.eventBus,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create ledger peer provider: %w", err)
 	}


### PR DESCRIPTION
Closes #978 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end chain rollback support that reverts database state to a target slot and emits per-transaction rollback events so clients can undo their changes. Restores accounts, pools, DReps, and protocol parameters to the rollback point and publishes richer rollback metadata.

- **New Features**
  - Chain.Rollback collects rolled-back blocks and includes them in ChainRollbackEvent.
  - Emits ledger.tx TransactionEvent for each transaction in rolled-back blocks (Rollback=true).
  - Ledger rollback deletes certificates and transactions after the slot, restores account/pool/DRep state, removes protocol params and updates, then reloads tip and params.
  - MetadataStore adds rollback APIs (DeleteCertificatesAfterSlot, RestoreAccountStateAtSlot, RestorePoolStateAtSlot, RestoreDrepStateAtSlot, DeletePParamsAfterSlot, DeletePParamUpdatesAfterSlot, DeleteTransactionsAfterSlot) with SQLite implementations and tests.
  - LedgerState subscribes to ChainUpdateEvent to trigger rollback events.
  - Strengthened foreign-key cascade rules (enabled SQLite foreign_keys), added batch UTXO lookups, and added a short-lived pool relay cache to reduce DB load.
  - Event bus adds async, non-blocking publishing with a worker pool; shutdown waits for pending rollback emitters.

- **Migration**
  - Subscribe to ledger.tx and handle events with Rollback=true to revert application state on rollbacks.
  - Metadata plugin implementations must add the new rollback methods to match MetadataStore.

<sup>Written for commit 16402b4166f4cd2382adee9943fcbeaea9a191fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain rollback events now include rolled-back blocks information for better tracking of chain reorganizations.
  * Transaction rollback events emitted to subscribers when blocks are rolled back.
  * Pool, account, and DRep state can now be restored at specific slots during chain rollback recovery.

* **Tests**
  * Added comprehensive rollback scenario tests covering various reorganization depths and state restoration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->