### PR TITLE
feat(database): Implement relational interface over PostgreSQL

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,16 +12,59 @@ permissions:
   contents: read
 
 jobs:
-  go-test:
-    name: go-test
+  # Linux job with Postgres service for integration tests
+  go-test-linux:
+    name: go-test (Linux)
     strategy:
       matrix:
         go-version: [1.24.x, 1.25.x]
-        # We want to make sure that this builds on Linux, Darwin, and Windows
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: dingo_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DATABASE: dingo_test
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0 https://github.com/actions/setup-go/releases/tag/v6.1.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1 https://github.com/actions/cache/releases/tag/v5.0.1
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
+      - name: go-build
+        run: go build ./cmd/dingo
+      - name: go-test
+        run: go test ./...
+
+  # macOS and Windows jobs without Postgres service
+  go-test-other:
+    name: go-test (${{ matrix.platform }})
+    strategy:
+      matrix:
+        go-version: [1.24.x, 1.25.x]
+        platform: [macos-latest, windows-latest]
         include:
-          - platform: ubuntu-latest
-            cache_path: ~/.cache/go-build
           - platform: macos-latest
             cache_path: ~/Library/Caches/go-build
           - platform: windows-latest

--- a/config.go
+++ b/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	logger                   *slog.Logger
 	cardanoNodeConfig        *cardano.CardanoNodeConfig
 	dataDir                  string
+	blobPlugin               string
+	metadataPlugin           string
 	network                  string
 	tlsCertFilePath          string
 	tlsKeyFilePath           string
@@ -155,6 +157,20 @@ func WithCardanoNodeConfig(
 func WithDatabasePath(dataDir string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.dataDir = dataDir
+	}
+}
+
+// WithBlobPlugin specifies the blob storage plugin to use.
+func WithBlobPlugin(plugin string) ConfigOptionFunc {
+	return func(c *Config) {
+		c.blobPlugin = plugin
+	}
+}
+
+// WithMetadataPlugin specifies the metadata storage plugin to use.
+func WithMetadataPlugin(plugin string) ConfigOptionFunc {
+	return func(c *Config) {
+		c.metadataPlugin = plugin
 	}
 }
 

--- a/database/plugin/metadata/metadata.go
+++ b/database/plugin/metadata/metadata.go
@@ -15,5 +15,6 @@
 package metadata
 
 import (
+	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/postgres"
 	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 )

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// GetAccount gets an account
+func (d *MetadataStorePostgres) GetAccount(
+	stakeKey []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Account, error) {
+	ret := &models.Account{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db
+	if !includeInactive {
+		query = query.Where("active = ?", true)
+	}
+	result := query.First(ret, "staking_key = ?", stakeKey)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// SetAccount saves an account
+func (d *MetadataStorePostgres) SetAccount(
+	stakeKey, pkh, drep []byte,
+	slot uint64,
+	active bool,
+	txn types.Txn,
+) error {
+	tmpItem := models.Account{
+		StakingKey: stakeKey,
+		AddedSlot:  slot,
+		Pool:       pkh,
+		Drep:       drep,
+		Active:     active,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "staking_key"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"added_slot", "pool", "drep", "active"},
+		),
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/asset.go
+++ b/database/plugin/metadata/postgres/asset.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+)
+
+// GetAssetByPolicyAndName returns an asset by policy ID and asset name
+func (d *MetadataStorePostgres) GetAssetByPolicyAndName(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) (models.Asset, error) {
+	var asset models.Asset
+	var result *gorm.DB
+
+	query, err := d.resolveDB(txn)
+	if err != nil {
+		return models.Asset{}, err
+	}
+
+	result = query.Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		First(&asset)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return models.Asset{}, nil
+		}
+		return models.Asset{}, result.Error
+	}
+	return asset, nil
+}
+
+// GetAssetsByPolicy returns all assets for a given policy ID
+func (d *MetadataStorePostgres) GetAssetsByPolicy(
+	policyId lcommon.Blake2b224,
+	txn types.Txn,
+) ([]models.Asset, error) {
+	var assets []models.Asset
+	var result *gorm.DB
+
+	query, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	result = query.Where("policy_id = ?", policyId[:]).Find(&assets)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return assets, nil
+}
+
+// GetAssetsByUTxO returns all assets for a given UTxO using transaction ID and output index
+func (d *MetadataStorePostgres) GetAssetsByUTxO(
+	txId []byte,
+	idx uint32,
+	txn types.Txn,
+) ([]models.Asset, error) {
+	var assets []models.Asset
+	var result *gorm.DB
+
+	query, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Join with UTxO table to find assets by transaction ID and output index
+	result = query.Joins("INNER JOIN utxos ON assets.utxo_id = utxos.id").
+		Where("utxos.tx_id = ? AND utxos.idx = ?", txId, idx).
+		Find(&assets)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return assets, nil
+}

--- a/database/plugin/metadata/postgres/block_nonce.go
+++ b/database/plugin/metadata/postgres/block_nonce.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"gorm.io/gorm"
+)
+
+// SetBlockNonce inserts a block nonce into the block_nonce table
+func (d *MetadataStorePostgres) SetBlockNonce(
+	blockHash []byte,
+	slotNumber uint64,
+	nonce []byte,
+	isCheckpoint bool,
+	txn types.Txn,
+) error {
+	item := models.BlockNonce{
+		Hash:         blockHash,
+		Slot:         slotNumber,
+		Nonce:        nonce,
+		IsCheckpoint: isCheckpoint,
+	}
+
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Create(&item)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+// GetBlockNonce retrieves the block nonce for a specific block
+func (d *MetadataStorePostgres) GetBlockNonce(
+	point ocommon.Point,
+	txn types.Txn,
+) ([]byte, error) {
+	ret := models.BlockNonce{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Where("hash = ? AND slot = ?", point.Hash, point.Slot).
+		First(&ret)
+	if result.Error != nil {
+		if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, result.Error
+		}
+		return nil, nil // Record not found
+	}
+	return ret.Nonce, nil
+}
+
+// DeleteBlockNoncesBeforeSlot deletes block_nonce records with slot less than the specified value
+func (d *MetadataStorePostgres) DeleteBlockNoncesBeforeSlot(
+	slotNumber uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.
+		Where("slot < ?", slotNumber).
+		Delete(&models.BlockNonce{})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}
+
+// DeleteBlockNoncesBeforeSlotWithoutCheckpoints deletes block_nonce records with slot < given value AND is_checkpoint = false
+func (d *MetadataStorePostgres) DeleteBlockNoncesBeforeSlotWithoutCheckpoints(
+	slotNumber uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.
+		Where("slot < ? AND is_checkpoint = ?", slotNumber, false).
+		Delete(&models.BlockNonce{})
+
+	return result.Error
+}

--- a/database/plugin/metadata/postgres/certs.go
+++ b/database/plugin/metadata/postgres/certs.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// GetStakeRegistrations returns stake registration certificates
+func (d *MetadataStorePostgres) GetStakeRegistrations(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]lcommon.StakeRegistrationCertificate, error) {
+	ret := []lcommon.StakeRegistrationCertificate{}
+	certs := []models.StakeRegistration{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, err
+	}
+	result := db.Where("staking_key = ?", stakingKey).
+		Order("id DESC").
+		Find(&certs)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	var tmpCert lcommon.StakeRegistrationCertificate
+	for _, cert := range certs {
+		tmpCert = lcommon.StakeRegistrationCertificate{
+			CertType: uint(lcommon.CertificateTypeStakeRegistration),
+			StakeCredential: lcommon.Credential{
+				CredType:   lcommon.CredentialTypeAddrKeyHash,
+				Credential: lcommon.CredentialHash(cert.StakingKey),
+			},
+		}
+		ret = append(ret, tmpCert)
+	}
+	return ret, nil
+}

--- a/database/plugin/metadata/postgres/commit_timestamp.go
+++ b/database/plugin/metadata/postgres/commit_timestamp.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	commitTimestampRowId = 1
+)
+
+// CommitTimestamp represents the postgres used to track the current commit timestamp
+type CommitTimestamp struct {
+	ID        uint `gorm:"primarykey"`
+	Timestamp int64
+}
+
+func (CommitTimestamp) TableName() string {
+	return "commit_timestamp"
+}
+
+func (d *MetadataStorePostgres) GetCommitTimestamp() (int64, error) {
+	// Get value from postgres database
+	var tmpCommitTimestamp CommitTimestamp
+	result := d.DB().First(&tmpCommitTimestamp)
+	if result.Error != nil {
+		// It's not an error if there's no records found
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, nil
+		}
+		return 0, result.Error
+	}
+	return tmpCommitTimestamp.Timestamp, nil
+}
+
+func (d *MetadataStorePostgres) SetCommitTimestamp(
+	timestamp int64,
+	txn types.Txn,
+) error {
+	tmpCommitTimestamp := CommitTimestamp{
+		ID:        commitTimestampRowId,
+		Timestamp: timestamp,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"timestamp"}),
+	}).Create(&tmpCommitTimestamp)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -1,0 +1,315 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+	"gorm.io/plugin/opentelemetry/tracing"
+)
+
+// postgresTxn wraps a gorm transaction and implements types.Txn
+type postgresTxn struct {
+	db       *gorm.DB
+	finished bool
+	beginErr error
+}
+
+func newPostgresTxn(db *gorm.DB) *postgresTxn {
+	return &postgresTxn{db: db}
+}
+
+func newFailedPostgresTxn(err error) *postgresTxn {
+	return &postgresTxn{beginErr: err}
+}
+
+func (t *postgresTxn) Commit() error {
+	if t.beginErr != nil {
+		return t.beginErr
+	}
+	if t.finished {
+		return nil
+	}
+	if t.db == nil {
+		t.finished = true
+		return nil
+	}
+	if result := t.db.Commit(); result.Error != nil {
+		return result.Error
+	}
+	t.finished = true
+	return nil
+}
+
+func (t *postgresTxn) Rollback() error {
+	if t.beginErr != nil {
+		return t.beginErr
+	}
+	if t.finished {
+		return nil
+	}
+	if t.db != nil {
+		if result := t.db.Rollback(); result.Error != nil {
+			return result.Error
+		}
+	}
+	t.finished = true
+	return nil
+}
+
+// MetadataStorePostgres stores metadata in Postgres.
+type MetadataStorePostgres struct {
+	promRegistry prometheus.Registerer
+	db           *gorm.DB
+	logger       *slog.Logger
+
+	host     string
+	port     uint
+	user     string
+	password string
+	database string
+	sslMode  string
+	timeZone string
+	dsn      string // Data source name (postgres connection string)
+}
+
+// New creates a new database
+func New(
+	host string,
+	port uint,
+	user string,
+	password string,
+	database string,
+	sslMode string,
+	timeZone string,
+	logger *slog.Logger,
+	promRegistry prometheus.Registerer,
+) (*MetadataStorePostgres, error) {
+	return NewWithOptions(
+		WithHost(host),
+		WithPort(port),
+		WithUser(user),
+		WithPassword(password),
+		WithDatabase(database),
+		WithSSLMode(sslMode),
+		WithTimeZone(timeZone),
+		WithLogger(logger),
+		WithPromRegistry(promRegistry),
+	)
+}
+
+// NewWithOptions creates a new database with options
+func NewWithOptions(opts ...PostgresOptionFunc) (*MetadataStorePostgres, error) {
+	db := &MetadataStorePostgres{}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(db)
+	}
+
+	// Set defaults after options are applied (no side effects)
+	if db.host == "" {
+		db.host = "localhost"
+	}
+	if db.port == 0 {
+		db.port = 5432
+	}
+	if db.user == "" {
+		db.user = "postgres"
+	}
+	if db.database == "" {
+		db.database = "postgres"
+	}
+	if db.sslMode == "" {
+		db.sslMode = "disable"
+	}
+	if db.timeZone == "" {
+		db.timeZone = "UTC"
+	}
+	if db.logger == nil {
+		db.logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+
+	// Note: Database initialization moved to Start()
+	return db, nil
+}
+
+func (d *MetadataStorePostgres) init() error {
+	if d.logger == nil {
+		// Create logger to throw away logs
+		// We do this so we don't have to add guards around every log operation
+		d.logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	// Configure tracing for GORM
+	if err := d.db.Use(tracing.NewPlugin(tracing.WithoutMetrics())); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AutoMigrate wraps the gorm AutoMigrate
+func (d *MetadataStorePostgres) AutoMigrate(dst ...any) error {
+	return d.DB().AutoMigrate(dst...)
+}
+
+// Start implements the plugin.Plugin interface
+func (d *MetadataStorePostgres) Start() error {
+	dsn := strings.TrimSpace(d.dsn)
+
+	if dsn == "" {
+		parts := []string{
+			"host=" + d.host,
+			"user=" + d.user,
+			"password=" + d.password,
+			"dbname=" + d.database,
+			"port=" + strconv.FormatUint(uint64(d.port), 10),
+			"sslmode=" + d.sslMode,
+		}
+		if d.timeZone != "" {
+			parts = append(parts, "TimeZone="+d.timeZone)
+		}
+		dsn = strings.Join(parts, " ")
+	}
+
+	metadataDb, err := gorm.Open(
+		postgres.Open(dsn),
+		&gorm.Config{
+			Logger:                 gormlogger.Discard,
+			SkipDefaultTransaction: true,
+			PrepareStmt:            true,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	d.logger.Info(
+		"connected to postgres metadata store",
+		"host", d.host,
+		"port", d.port,
+		"database", d.database,
+	)
+	d.db = metadataDb
+	// Configure connection pool
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		return err
+	}
+	sqlDB.SetMaxIdleConns(10)
+	sqlDB.SetMaxOpenConns(100)
+	sqlDB.SetConnMaxLifetime(time.Hour)
+
+	if err := d.init(); err != nil {
+		// MetadataStorePostgres is available for recovery, so return error but keep instance
+		return err
+	}
+	// Create table schemas
+	d.logger.Debug(fmt.Sprintf("creating table: %#v", &CommitTimestamp{}))
+	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
+		return err
+	}
+	for _, model := range models.MigrateModels {
+		d.logger.Debug(fmt.Sprintf("creating table: %#v", model))
+		if err := d.db.AutoMigrate(model); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Stop implements the plugin.Plugin interface
+func (d *MetadataStorePostgres) Stop() error {
+	return d.Close()
+}
+
+// Close gets the database handle from our MetadataStore and closes it
+func (d *MetadataStorePostgres) Close() error {
+	// Guard against nil DB handle (e.g., if Start() failed or was never called)
+	if d.db == nil {
+		return nil
+	}
+	// get DB handle from gorm.DB
+	db, err := d.DB().DB()
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}
+
+// Create creates a record
+func (d *MetadataStorePostgres) Create(value any) *gorm.DB {
+	return d.DB().Create(value)
+}
+
+// DB returns the database handle
+func (d *MetadataStorePostgres) DB() *gorm.DB {
+	return d.db
+}
+
+// First returns the first DB entry
+func (d *MetadataStorePostgres) First(args any) *gorm.DB {
+	return d.DB().First(args)
+}
+
+// Order orders a DB query
+func (d *MetadataStorePostgres) Order(args any) *gorm.DB {
+	return d.DB().Order(args)
+}
+
+// Transaction creates a gorm transaction
+func (d *MetadataStorePostgres) Transaction() types.Txn {
+	db := d.DB().Begin()
+	if db.Error != nil {
+		d.logger.Error(
+			"failed to begin transaction",
+			"error", db.Error,
+		)
+		return newFailedPostgresTxn(db.Error)
+	}
+	return newPostgresTxn(db)
+}
+
+// BeginTxn starts a transaction and returns the handle with an error.
+// Callers that prefer explicit error handling can use this instead of Transaction().
+func (d *MetadataStorePostgres) BeginTxn() (types.Txn, error) {
+	db := d.DB().Begin()
+	if db.Error != nil {
+		d.logger.Error(
+			"failed to begin transaction",
+			"error", db.Error,
+		)
+		return newFailedPostgresTxn(db.Error), db.Error
+	}
+	return newPostgresTxn(db), nil
+}
+
+// Where constrains a DB query
+func (d *MetadataStorePostgres) Where(
+	query any,
+	args ...any,
+) *gorm.DB {
+	return d.DB().Where(query, args...)
+}

--- a/database/plugin/metadata/postgres/datum.go
+++ b/database/plugin/metadata/postgres/datum.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// GetDatum returns a datum by its hash
+func (d *MetadataStorePostgres) GetDatum(
+	hash lcommon.Blake2b256,
+	txn types.Txn,
+) (*models.Datum, error) {
+	ret := &models.Datum{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.First(ret, "hash = ?", hash[:])
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// SetDatum saves a datum
+func (d *MetadataStorePostgres) SetDatum(
+	hash lcommon.Blake2b256,
+	rawDatum []byte,
+	addedSlot uint64,
+	txn types.Txn,
+) error {
+	tmpItem := models.Datum{
+		Hash:      hash[:],
+		RawDatum:  rawDatum,
+		AddedSlot: addedSlot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.Assignments(map[string]any{
+			"raw_datum": rawDatum,
+		}),
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Clauses(onConflict).Create(&tmpItem)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// GetDrep gets a drep
+func (d *MetadataStorePostgres) GetDrep(
+	cred []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Drep, error) {
+	var drep models.Drep
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if !includeInactive {
+		db = db.Where("active = ?", true)
+	}
+	if result := db.First(&drep, "credential = ?", cred); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &drep, nil
+}
+
+// SetDrep saves a drep
+func (d *MetadataStorePostgres) SetDrep(
+	cred []byte,
+	slot uint64,
+	url string,
+	hash []byte,
+	active bool,
+	txn types.Txn,
+) error {
+	tmpItem := models.Drep{
+		Credential: cred,
+		AddedSlot:  slot,
+		AnchorUrl:  url,
+		AnchorHash: hash,
+		Active:     active,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "credential"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"added_slot",
+			"anchor_url",
+			"anchor_hash",
+			"active",
+		}),
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/epoch.go
+++ b/database/plugin/metadata/postgres/epoch.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm/clause"
+)
+
+// GetEpochsByEra returns the list of epochs by era
+func (d *MetadataStorePostgres) GetEpochsByEra(
+	eraId uint,
+	txn types.Txn,
+) ([]models.Epoch, error) {
+	ret := []models.Epoch{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Where("era_id = ?", eraId).Order("epoch_id").Find(&ret)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	return ret, nil
+}
+
+// GetEpochs returns the list of epochs
+func (d *MetadataStorePostgres) GetEpochs(
+	txn types.Txn,
+) ([]models.Epoch, error) {
+	ret := []models.Epoch{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Order("epoch_id").Find(&ret)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	return ret, nil
+}
+
+// SetEpoch saves an epoch
+func (d *MetadataStorePostgres) SetEpoch(
+	slot, epoch uint64,
+	nonce []byte,
+	era, slotLength, lengthInSlots uint,
+	txn types.Txn,
+) error {
+	tmpItem := models.Epoch{
+		EpochId:       epoch,
+		StartSlot:     slot,
+		Nonce:         nonce,
+		EraId:         era,
+		SlotLength:    slotLength,
+		LengthInSlots: lengthInSlots,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "epoch_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"start_slot",
+			"nonce",
+			"era_id",
+			"slot_length",
+			"length_in_slots",
+		}),
+	}).Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/options.go
+++ b/database/plugin/metadata/postgres/options.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PostgresOptionFunc func(*MetadataStorePostgres)
+
+// WithLogger specifies the logger object to use for logging messages
+func WithLogger(logger *slog.Logger) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.logger = logger
+	}
+}
+
+// WithPromRegistry specifies the prometheus registry to use for metrics
+func WithPromRegistry(
+	registry prometheus.Registerer,
+) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.promRegistry = registry
+	}
+}
+
+// WithHost specifies the Postgres host
+func WithHost(host string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.host = host
+	}
+}
+
+// WithPort specifies the Postgres port
+func WithPort(port uint) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.port = port
+	}
+}
+
+// WithUser specifies the Postgres user
+func WithUser(user string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.user = user
+	}
+}
+
+// WithPassword specifies the Postgres password
+func WithPassword(password string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.password = password
+	}
+}
+
+// WithDatabase specifies the Postgres database name
+func WithDatabase(database string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.database = database
+	}
+}
+
+// WithSSLMode specifies the Postgres sslmode
+func WithSSLMode(sslMode string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.sslMode = sslMode
+	}
+}
+
+// WithTimeZone specifies the Postgres TimeZone
+func WithTimeZone(timeZone string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.timeZone = timeZone
+	}
+}
+
+// WithDSN specifies a full Postgres DSN string and takes precedence over
+// individual connection options.
+func WithDSN(dsn string) PostgresOptionFunc {
+	return func(m *MetadataStorePostgres) {
+		m.dsn = dsn
+	}
+}

--- a/database/plugin/metadata/postgres/options_test.go
+++ b/database/plugin/metadata/postgres/options_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestWithHost(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithHost("db.local")
+
+	option(m)
+
+	if m.host != "db.local" {
+		t.Errorf("Expected host to be 'db.local', got '%s'", m.host)
+	}
+}
+
+func TestWithPort(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithPort(uint(5432))
+
+	option(m)
+
+	if m.port != 5432 {
+		t.Errorf("Expected port to be 5432, got '%d'", m.port)
+	}
+}
+
+func TestWithUser(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithUser("postgres")
+
+	option(m)
+
+	if m.user != "postgres" {
+		t.Errorf("Expected user to be 'postgres', got '%s'", m.user)
+	}
+}
+
+func TestWithPassword(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithPassword("secret")
+
+	option(m)
+
+	if m.password != "secret" {
+		t.Errorf("Expected password to be set")
+	}
+}
+
+func TestWithDatabase(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithDatabase("dingo")
+
+	option(m)
+
+	if m.database != "dingo" {
+		t.Errorf("Expected database to be 'dingo', got '%s'", m.database)
+	}
+}
+
+func TestWithSSLMode(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithSSLMode("require")
+
+	option(m)
+
+	if m.sslMode != "require" {
+		t.Errorf("Expected sslMode to be 'require', got '%s'", m.sslMode)
+	}
+}
+
+func TestWithTimeZone(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithTimeZone("UTC")
+
+	option(m)
+
+	if m.timeZone != "UTC" {
+		t.Errorf("Expected timeZone to be 'UTC', got '%s'", m.timeZone)
+	}
+}
+
+func TestWithDSN(t *testing.T) {
+	m := &MetadataStorePostgres{}
+	option := WithDSN("host=localhost dbname=dingo")
+
+	option(m)
+
+	if m.dsn != "host=localhost dbname=dingo" {
+		t.Errorf("Expected dsn to be set")
+	}
+}
+
+func TestWithLogger(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := &MetadataStorePostgres{}
+	option := WithLogger(logger)
+
+	option(m)
+
+	if m.logger != logger {
+		t.Errorf("Expected logger to be set")
+	}
+}
+
+func TestWithPromRegistry(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &MetadataStorePostgres{}
+	option := WithPromRegistry(reg)
+
+	option(m)
+
+	if m.promRegistry != reg {
+		t.Errorf("Expected promRegistry to be set")
+	}
+}

--- a/database/plugin/metadata/postgres/plugin.go
+++ b/database/plugin/metadata/postgres/plugin.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"sync"
+
+	"github.com/blinklabs-io/dingo/database/plugin"
+)
+
+var (
+	cmdlineOptions struct {
+		host     string
+		port     uint64
+		user     string
+		password string
+		database string
+		sslMode  string
+		timeZone string
+		dsn      string
+	}
+	cmdlineOptionsMutex sync.RWMutex
+)
+
+// initCmdlineOptions sets default values for cmdlineOptions.
+// Note: password is intentionally empty - users must provide their own credentials.
+func initCmdlineOptions() {
+	cmdlineOptionsMutex.Lock()
+	defer cmdlineOptionsMutex.Unlock()
+	cmdlineOptions.host = "localhost"
+	cmdlineOptions.port = 5432
+	cmdlineOptions.user = "postgres"
+	cmdlineOptions.password = ""
+	cmdlineOptions.database = "postgres"
+	cmdlineOptions.sslMode = "disable"
+	cmdlineOptions.timeZone = "UTC"
+	cmdlineOptions.dsn = ""
+}
+
+// Register plugin
+func init() {
+	initCmdlineOptions()
+	plugin.Register(
+		plugin.PluginEntry{
+			Type:               plugin.PluginTypeMetadata,
+			Name:               "postgres",
+			Description:        "Postgres relational database",
+			NewFromOptionsFunc: NewFromCmdlineOptions,
+			Options: []plugin.PluginOption{
+				{
+					Name:         "host",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Postgres host",
+					DefaultValue: "localhost",
+					Dest:         &(cmdlineOptions.host),
+				},
+				{
+					Name:         "port",
+					Type:         plugin.PluginOptionTypeUint,
+					Description:  "Postgres port",
+					DefaultValue: uint64(5432),
+					Dest:         &(cmdlineOptions.port),
+				},
+				{
+					Name:         "user",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Postgres user",
+					DefaultValue: "postgres",
+					Dest:         &(cmdlineOptions.user),
+				},
+				{
+					Name:         "password",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Postgres password (required)",
+					DefaultValue: "",
+					Dest:         &(cmdlineOptions.password),
+				},
+				{
+					Name:         "database",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Postgres database name",
+					DefaultValue: "postgres",
+					Dest:         &(cmdlineOptions.database),
+				},
+				{
+					Name:         "ssl-mode",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Postgres sslmode",
+					DefaultValue: "disable",
+					Dest:         &(cmdlineOptions.sslMode),
+				},
+				{
+					Name:         "timezone",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Postgres TimeZone",
+					DefaultValue: "UTC",
+					Dest:         &(cmdlineOptions.timeZone),
+				},
+				{
+					Name:         "dsn",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Full Postgres DSN (overrides other options when set)",
+					DefaultValue: "",
+					Dest:         &(cmdlineOptions.dsn),
+				},
+			},
+		},
+	)
+}
+
+func NewFromCmdlineOptions() plugin.Plugin {
+	cmdlineOptionsMutex.RLock()
+	host := cmdlineOptions.host
+	port := uint(cmdlineOptions.port)
+	user := cmdlineOptions.user
+	password := cmdlineOptions.password
+	database := cmdlineOptions.database
+	sslMode := cmdlineOptions.sslMode
+	timeZone := cmdlineOptions.timeZone
+	dsn := cmdlineOptions.dsn
+	cmdlineOptionsMutex.RUnlock()
+
+	opts := []PostgresOptionFunc{
+		WithHost(host),
+		WithPort(port),
+		WithUser(user),
+		WithPassword(password),
+		WithDatabase(database),
+		WithSSLMode(sslMode),
+		WithTimeZone(timeZone),
+		WithDSN(dsn),
+		// Logger and promRegistry will use defaults if nil
+	}
+	p, err := NewWithOptions(opts...)
+	if err != nil {
+		// Return a plugin that defers the error to Start()
+		return plugin.NewErrorPlugin(err)
+	}
+	return p
+}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -1,0 +1,196 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+)
+
+// GetPool gets a pool
+func (d *MetadataStorePostgres) GetPool(
+	pkh lcommon.PoolKeyHash,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Pool, error) {
+	ret := &models.Pool{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Preload(
+			"Registration",
+			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC").Limit(1) },
+		).
+		Preload(
+			"Retirement",
+			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC").Limit(1) },
+		).
+		First(
+			ret,
+			"pool_key_hash = ?",
+			pkh.Bytes(),
+		)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	if !includeInactive {
+		hasReg := len(ret.Registration) > 0
+		hasRet := len(ret.Retirement) > 0
+		if !hasReg {
+			return nil, nil
+		}
+		// If the latest retirement is more recent than the latest registration,
+		// check whether the retirement epoch has passed. A retirement in the
+		// future means the pool is still active until that epoch is reached.
+		if hasRet &&
+			ret.Retirement[0].AddedSlot > ret.Registration[0].AddedSlot {
+			retEpoch := ret.Retirement[0].Epoch
+			// Determine current epoch from tip -> epoch table. If we cannot
+			// determine the current epoch, conservatively treat the pool as active.
+			var tmpTip models.Tip
+			if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+				if d.logger != nil {
+					d.logger.Warn("failed to load tip; treating pool as active", "err", res.Error)
+				}
+				return ret, nil //nolint:nilerr
+			}
+			var curEpoch models.Epoch
+			if res := db.Where("start_slot <= ?", tmpTip.Slot).Order("start_slot DESC").First(&curEpoch); res.Error != nil {
+				if d.logger != nil {
+					d.logger.Warn("failed to determine current epoch; treating pool as active", "err", res.Error)
+				}
+				return ret, nil //nolint:nilerr
+			}
+			if retEpoch > curEpoch.EpochId {
+				// Retirement is in the future -> pool still active
+				return ret, nil
+			}
+			// Retirement epoch has passed -> treat as inactive
+			return nil, nil
+		}
+	}
+	return ret, nil
+}
+
+// GetPoolRegistrations returns pool registration certificates
+func (d *MetadataStorePostgres) GetPoolRegistrations(
+	pkh lcommon.PoolKeyHash,
+	txn types.Txn,
+) ([]lcommon.PoolRegistrationCertificate, error) {
+	ret := []lcommon.PoolRegistrationCertificate{}
+	certs := []models.PoolRegistration{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, err
+	}
+	result := db.
+		Preload("Owners").
+		Preload("Relays").
+		Where("pool_key_hash = ?", pkh.Bytes()).
+		Order("id DESC").
+		Find(&certs)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	var addrKeyHash lcommon.AddrKeyHash
+	var tmpCert lcommon.PoolRegistrationCertificate
+	var tmpRelay lcommon.PoolRelay
+	for _, cert := range certs {
+		var tmpMargin lcommon.GenesisRat
+		if cert.Margin == nil || cert.Margin.Rat == nil {
+			return nil, fmt.Errorf(
+				"pool registration margin is nil (id=%d)",
+				cert.ID,
+			)
+		}
+		tmpMargin = lcommon.GenesisRat{Rat: cert.Margin.Rat}
+		tmpCert = lcommon.PoolRegistrationCertificate{
+			CertType: uint(lcommon.CertificateTypePoolRegistration),
+			Operator: lcommon.PoolKeyHash(
+				lcommon.NewBlake2b224(cert.PoolKeyHash),
+			),
+			VrfKeyHash: lcommon.VrfKeyHash(
+				lcommon.NewBlake2b256(cert.VrfKeyHash),
+			),
+			Pledge: uint64(cert.Pledge),
+			Cost:   uint64(cert.Cost),
+			Margin: tmpMargin,
+			RewardAccount: lcommon.AddrKeyHash(
+				lcommon.NewBlake2b224(cert.RewardAccount),
+			),
+		}
+		for _, owner := range cert.Owners {
+			addrKeyHash = lcommon.AddrKeyHash(
+				lcommon.NewBlake2b224(owner.KeyHash),
+			)
+			tmpCert.PoolOwners = append(tmpCert.PoolOwners, addrKeyHash)
+		}
+		for _, relay := range cert.Relays {
+			tmpRelay = lcommon.PoolRelay{}
+			// Determine type
+			if relay.Port != 0 {
+				if relay.Port > math.MaxUint32 {
+					return nil, fmt.Errorf("pool relay port out of range: %d", relay.Port)
+				}
+				port := uint32(relay.Port)
+				tmpRelay.Port = &port
+				if relay.Hostname != "" {
+					hostname := relay.Hostname
+					tmpRelay.Type = lcommon.PoolRelayTypeSingleHostName
+					tmpRelay.Hostname = &hostname
+				} else {
+					tmpRelay.Type = lcommon.PoolRelayTypeSingleHostAddress
+					tmpRelay.Ipv4 = relay.Ipv4
+					tmpRelay.Ipv6 = relay.Ipv6
+				}
+			} else {
+				// Port is 0, check if we have IP addresses first
+				if relay.Ipv4 != nil || relay.Ipv6 != nil {
+					tmpRelay.Type = lcommon.PoolRelayTypeSingleHostAddress
+					tmpRelay.Ipv4 = relay.Ipv4
+					tmpRelay.Ipv6 = relay.Ipv6
+					// Port remains nil
+				} else if relay.Hostname != "" {
+					hostname := relay.Hostname
+					tmpRelay.Type = lcommon.PoolRelayTypeMultiHostName
+					tmpRelay.Hostname = &hostname
+				}
+			}
+			tmpCert.Relays = append(tmpCert.Relays, tmpRelay)
+		}
+		if cert.MetadataUrl != "" {
+			poolMetadata := &lcommon.PoolMetadata{
+				Url: cert.MetadataUrl,
+				Hash: lcommon.PoolMetadataHash(
+					lcommon.NewBlake2b256(cert.MetadataHash),
+				),
+			}
+			tmpCert.PoolMetadata = poolMetadata
+		}
+		ret = append(ret, tmpCert)
+	}
+	return ret, nil
+}

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -1,0 +1,811 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"math/big"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	"gorm.io/gorm"
+)
+
+// TestTable is a simple table for testing concurrent transactions
+type TestTable struct {
+	gorm.Model
+}
+
+type mockTransaction struct {
+	hash         lcommon.Blake2b256
+	certificates []lcommon.Certificate
+	isValid      bool
+}
+
+func (m *mockTransaction) Hash() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m *mockTransaction) Id() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m *mockTransaction) Type() int {
+	return 0 // Shelley transaction
+}
+
+func (m *mockTransaction) Fee() *big.Int {
+	return big.NewInt(1000)
+}
+
+func (m *mockTransaction) TTL() uint64 {
+	return 1000000
+}
+
+func (m *mockTransaction) IsValid() bool {
+	return m.isValid
+}
+
+func (m *mockTransaction) Metadata() lcommon.TransactionMetadatum {
+	return nil
+}
+
+func (m *mockTransaction) AuxiliaryData() lcommon.AuxiliaryData {
+	return nil
+}
+
+func (m *mockTransaction) RawAuxiliaryData() []byte {
+	return nil
+}
+
+func (m *mockTransaction) CollateralReturn() lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockTransaction) Produced() []lcommon.Utxo {
+	return nil
+}
+
+func (m *mockTransaction) Outputs() []lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockTransaction) Inputs() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransaction) Collateral() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransaction) Certificates() []lcommon.Certificate {
+	return m.certificates
+}
+
+func (m *mockTransaction) ProtocolParameterUpdates() (uint64, map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate) {
+	return 0, nil
+}
+
+func (m *mockTransaction) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	return nil
+}
+
+func (m *mockTransaction) AuxDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockTransaction) Cbor() []byte {
+	return []byte("mock_cbor")
+}
+
+func (m *mockTransaction) Consumed() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransaction) Witnesses() lcommon.TransactionWitnessSet {
+	return nil
+}
+
+func (m *mockTransaction) ValidityIntervalStart() uint64 {
+	return 0
+}
+
+func (m *mockTransaction) ReferenceInputs() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransaction) TotalCollateral() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockTransaction) Withdrawals() map[*lcommon.Address]*big.Int {
+	return nil
+}
+
+func (m *mockTransaction) RequiredSigners() []lcommon.Blake2b224 {
+	return nil
+}
+
+func (m *mockTransaction) ScriptDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockTransaction) VotingProcedures() lcommon.VotingProcedures {
+	return lcommon.VotingProcedures{}
+}
+
+func (m *mockTransaction) ProposalProcedures() []lcommon.ProposalProcedure {
+	return nil
+}
+
+func (m *mockTransaction) CurrentTreasuryValue() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockTransaction) Donation() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
+	return nil, nil
+}
+
+func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// isPostgresConfigured checks if postgres is configured via cmdlineOptions or environment variables.
+// It first checks cmdlineOptions (the plugin's configured state), then falls back to environment variables.
+// Returns true if a password or DSN is configured, false otherwise.
+func isPostgresConfigured() bool {
+	// Check if cmdlineOptions has a password or DSN set
+	cmdlineOptionsMutex.RLock()
+	password := cmdlineOptions.password
+	dsn := cmdlineOptions.dsn
+	cmdlineOptionsMutex.RUnlock()
+
+	if password != "" || dsn != "" {
+		return true
+	}
+
+	// Fall back to environment variables
+	return os.Getenv("POSTGRES_PASSWORD") != "" || os.Getenv("POSTGRES_DSN") != ""
+}
+
+// getTestPostgresOptions returns options for creating a test postgres store.
+// It uses cmdlineOptions if configured, otherwise falls back to environment variables.
+func getTestPostgresOptions() []PostgresOptionFunc {
+	cmdlineOptionsMutex.RLock()
+	host := cmdlineOptions.host
+	port := uint(cmdlineOptions.port)
+	user := cmdlineOptions.user
+	password := cmdlineOptions.password
+	database := cmdlineOptions.database
+	sslMode := cmdlineOptions.sslMode
+	timeZone := cmdlineOptions.timeZone
+	dsn := cmdlineOptions.dsn
+	cmdlineOptionsMutex.RUnlock()
+
+	// Override with environment variables if cmdlineOptions password is not set
+	if password == "" {
+		password = os.Getenv("POSTGRES_PASSWORD")
+
+		// Also check for other env vars when using env-based config
+		if envHost := os.Getenv("POSTGRES_HOST"); envHost != "" {
+			host = envHost
+		}
+		if envPort := os.Getenv("POSTGRES_PORT"); envPort != "" {
+			if p, err := strconv.ParseUint(envPort, 10, 32); err == nil {
+				port = uint(p)
+			}
+		}
+		if envUser := os.Getenv("POSTGRES_USER"); envUser != "" {
+			user = envUser
+		}
+		if envDB := os.Getenv("POSTGRES_DATABASE"); envDB != "" {
+			database = envDB
+		} else if database == "postgres" {
+			// Use a separate test database by default
+			database = "dingo_test"
+		}
+		if envSSL := os.Getenv("POSTGRES_SSLMODE"); envSSL != "" {
+			sslMode = envSSL
+		}
+		if envDSN := os.Getenv("POSTGRES_DSN"); envDSN != "" {
+			dsn = envDSN
+		}
+	}
+
+	return []PostgresOptionFunc{
+		WithHost(host),
+		WithPort(port),
+		WithUser(user),
+		WithPassword(password),
+		WithDatabase(database),
+		WithSSLMode(sslMode),
+		WithTimeZone(timeZone),
+		WithDSN(dsn),
+	}
+}
+
+// newTestPostgresStore creates a new postgres store for testing.
+// It skips the test if postgres is not configured (no password in cmdlineOptions or POSTGRES_PASSWORD env var).
+func newTestPostgresStore(t *testing.T) *MetadataStorePostgres {
+	t.Helper()
+
+	if !isPostgresConfigured() {
+		t.Skip("Skipping postgres integration test: postgres not configured (set POSTGRES_PASSWORD or configure via cmdline options)")
+	}
+
+	opts := getTestPostgresOptions()
+	store, err := NewWithOptions(opts...)
+	if err != nil {
+		t.Fatalf("failed to create postgres store: %v", err)
+	}
+
+	if err := store.Start(); err != nil {
+		t.Fatalf("failed to start postgres store: %v", err)
+	}
+
+	return store
+}
+
+// newTestPostgresStoreFromPlugin creates a postgres store using NewFromCmdlineOptions.
+// This tests the plugin registration path. Skips if not configured.
+func newTestPostgresStoreFromPlugin(t *testing.T) *MetadataStorePostgres {
+	t.Helper()
+
+	if !isPostgresConfigured() {
+		t.Skip("Skipping postgres integration test: postgres not configured (set POSTGRES_PASSWORD or configure via cmdline options)")
+	}
+
+	// Capture original cmdlineOptions before any modifications
+	cmdlineOptionsMutex.RLock()
+	originalHost := cmdlineOptions.host
+	originalPort := cmdlineOptions.port
+	originalUser := cmdlineOptions.user
+	originalPassword := cmdlineOptions.password
+	originalDatabase := cmdlineOptions.database
+	originalSslMode := cmdlineOptions.sslMode
+	originalTimeZone := cmdlineOptions.timeZone
+	originalDsn := cmdlineOptions.dsn
+	cmdlineOptionsMutex.RUnlock()
+
+	// Restore original cmdlineOptions after test setup
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions.host = originalHost
+		cmdlineOptions.port = originalPort
+		cmdlineOptions.user = originalUser
+		cmdlineOptions.password = originalPassword
+		cmdlineOptions.database = originalDatabase
+		cmdlineOptions.sslMode = originalSslMode
+		cmdlineOptions.timeZone = originalTimeZone
+		cmdlineOptions.dsn = originalDsn
+		cmdlineOptionsMutex.Unlock()
+	})
+
+	if originalPassword == "" && originalDsn == "" {
+		// Set cmdlineOptions from environment for this test
+		cmdlineOptionsMutex.Lock()
+		if envHost := os.Getenv("POSTGRES_HOST"); envHost != "" {
+			cmdlineOptions.host = envHost
+		}
+		if envPort := os.Getenv("POSTGRES_PORT"); envPort != "" {
+			if p, err := strconv.ParseUint(envPort, 10, 32); err == nil {
+				cmdlineOptions.port = p
+			}
+		}
+		if envUser := os.Getenv("POSTGRES_USER"); envUser != "" {
+			cmdlineOptions.user = envUser
+		}
+		cmdlineOptions.password = os.Getenv("POSTGRES_PASSWORD")
+		if envDB := os.Getenv("POSTGRES_DATABASE"); envDB != "" {
+			cmdlineOptions.database = envDB
+		} else {
+			cmdlineOptions.database = "dingo_test"
+		}
+		if envSSL := os.Getenv("POSTGRES_SSLMODE"); envSSL != "" {
+			cmdlineOptions.sslMode = envSSL
+		}
+		if envDSN := os.Getenv("POSTGRES_DSN"); envDSN != "" {
+			cmdlineOptions.dsn = envDSN
+		}
+		cmdlineOptionsMutex.Unlock()
+	}
+
+	p := NewFromCmdlineOptions()
+	if p == nil {
+		t.Fatal("NewFromCmdlineOptions returned nil")
+	}
+
+	// Check if it's an error plugin
+	if _, ok := p.(*plugin.ErrorPlugin); ok {
+		t.Fatal("NewFromCmdlineOptions returned an error plugin")
+	}
+
+	store, ok := p.(*MetadataStorePostgres)
+	if !ok {
+		t.Fatalf("expected *MetadataStorePostgres, got %T", p)
+	}
+
+	if err := store.Start(); err != nil {
+		t.Fatalf("failed to start postgres store: %v", err)
+	}
+
+	return store
+}
+
+// TestPostgresMultipleTransaction tests that postgres allows multiple
+// concurrent transactions
+func TestPostgresMultipleTransaction(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+
+	if err := pgStore.DB().AutoMigrate(&TestTable{}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if result := pgStore.DB().Create(&TestTable{}); result.Error != nil {
+		t.Fatalf("unexpected error: %s", result.Error)
+	}
+
+	doQuery := func(sleep time.Duration) error {
+		txn := pgStore.DB().Begin()
+		defer txn.Rollback() //nolint:errcheck
+		if result := txn.First(&TestTable{}); result.Error != nil {
+			return result.Error
+		}
+		time.Sleep(sleep)
+		if result := txn.Commit(); result.Error != nil {
+			return result.Error
+		}
+		return nil
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- doQuery(5 * time.Second)
+	}()
+	time.Sleep(1 * time.Second)
+	if err := doQuery(0); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("goroutine error: %s", err)
+	}
+}
+
+// TestPostgresUnifiedCertificateCreation tests that unified certificate records are created
+// correctly and linked to specialized certificate records
+func TestPostgresUnifiedCertificateCreation(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+
+	// Clean up any existing records from previous test runs to ensure deterministic results
+	pgStore.DB().Where("1 = 1").Delete(&models.StakeRegistration{})
+	pgStore.DB().Where("1 = 1").Delete(&models.PoolRegistration{})
+	pgStore.DB().Where("1 = 1").Delete(&models.AuthCommitteeHot{})
+	pgStore.DB().Where("1 = 1").Delete(&models.Certificate{})
+
+	// Create a mock transaction with certificates
+	mockTx := &mockTransaction{
+		hash: lcommon.NewBlake2b256(
+			[]byte("test_hash_1234567890123456789012345678901234567890"),
+		),
+		isValid: true,
+		certificates: []lcommon.Certificate{
+			&lcommon.StakeRegistrationCertificate{
+				CertType: uint(lcommon.CertificateTypeStakeRegistration),
+				StakeCredential: lcommon.Credential{
+					CredType: lcommon.CredentialTypeAddrKeyHash,
+					Credential: lcommon.CredentialHash(
+						[]byte("stake_key_hash_1234567890123456789012345678"),
+					),
+				},
+			},
+			&lcommon.PoolRegistrationCertificate{
+				CertType: uint(lcommon.CertificateTypePoolRegistration),
+				Operator: lcommon.PoolKeyHash(
+					[]byte("pool_key_hash_1234567890123456789012345678"),
+				),
+				VrfKeyHash: lcommon.VrfKeyHash(
+					[]byte("vrf_key_hash_12345678901234567890123456789012"),
+				),
+				Pledge: 1000000,
+				Cost:   340000000,
+				Margin: cbor.Rat{Rat: big.NewRat(1, 100)},
+				RewardAccount: lcommon.AddrKeyHash(
+					[]byte("reward_account_1234567890123456789012345678"),
+				),
+				PoolOwners: []lcommon.AddrKeyHash{
+					lcommon.AddrKeyHash(
+						[]byte("owner1_1234567890123456789012345678"),
+					),
+				},
+			},
+			&lcommon.AuthCommitteeHotCertificate{
+				CertType: uint(lcommon.CertificateTypeAuthCommitteeHot),
+				ColdCredential: lcommon.Credential{
+					CredType: lcommon.CredentialTypeAddrKeyHash,
+					Credential: lcommon.CredentialHash(
+						[]byte("cold_cred_hash_1234567890123456789012345678"),
+					),
+				},
+				HotCredential: lcommon.Credential{
+					CredType: lcommon.CredentialTypeAddrKeyHash,
+					Credential: lcommon.CredentialHash(
+						[]byte("hot_cred_hash_1234567890123456789012345678"),
+					),
+				},
+			},
+		},
+	}
+
+	point := ocommon.Point{
+		Hash: []byte("block_hash_12345678901234567890123456789012"),
+		Slot: 1000000,
+	}
+
+	// Process the transaction
+	err := pgStore.SetTransaction(
+		mockTx,
+		point,
+		0,
+		map[int]uint64{0: 2000000, 1: 500000000},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to set transaction: %v", err)
+	}
+
+	// Verify unified certificate records were created
+	var unifiedCerts []models.Certificate
+	if result := pgStore.DB().Order("cert_index ASC").Find(&unifiedCerts); result.Error != nil {
+		t.Fatalf("failed to query unified certificates: %v", result.Error)
+	}
+
+	if len(unifiedCerts) != 3 {
+		t.Errorf("expected 3 unified certificates, got %d", len(unifiedCerts))
+	}
+
+	// Verify the unified certificates have correct data
+	for i, cert := range unifiedCerts {
+		if cert.TransactionID == 0 {
+			t.Errorf("certificate %d has zero transaction ID", i)
+		}
+		if cert.CertIndex != uint(i) {
+			t.Errorf(
+				"certificate %d has cert_index %d, expected %d",
+				i,
+				cert.CertIndex,
+				i,
+			)
+		}
+		if cert.Slot != point.Slot {
+			t.Errorf(
+				"certificate %d has slot %d, expected %d",
+				i,
+				cert.Slot,
+				point.Slot,
+			)
+		}
+		if string(cert.BlockHash) != string(point.Hash) {
+			t.Errorf("certificate %d has wrong block hash", i)
+		}
+	}
+
+	// Verify specialized certificate records were created with correct CertificateID
+	var stakeReg models.StakeRegistration
+	if result := pgStore.DB().First(&stakeReg); result.Error != nil {
+		t.Fatalf("failed to query stake registration: %v", result.Error)
+	}
+
+	// Find the unified cert for stake registration (should be index 0)
+	var stakeUnified models.Certificate
+	if result := pgStore.DB().Where("cert_index = ? AND cert_type = ?", 0, uint(lcommon.CertificateTypeStakeRegistration)).First(&stakeUnified); result.Error != nil {
+		t.Fatalf(
+			"failed to find unified stake registration cert: %v",
+			result.Error,
+		)
+	}
+
+	if stakeReg.CertificateID != stakeUnified.ID {
+		t.Errorf(
+			"stake registration CertificateID %d does not match unified cert ID %d",
+			stakeReg.CertificateID,
+			stakeUnified.ID,
+		)
+	}
+
+	var poolReg models.PoolRegistration
+	if result := pgStore.DB().First(&poolReg); result.Error != nil {
+		t.Fatalf("failed to query pool registration: %v", result.Error)
+	}
+
+	// Find the unified cert for pool registration (should be index 1)
+	var poolUnified models.Certificate
+	if result := pgStore.DB().Where("cert_index = ? AND cert_type = ?", 1, uint(lcommon.CertificateTypePoolRegistration)).First(&poolUnified); result.Error != nil {
+		t.Fatalf(
+			"failed to find unified pool registration cert: %v",
+			result.Error,
+		)
+	}
+
+	if poolReg.CertificateID != poolUnified.ID {
+		t.Errorf(
+			"pool registration CertificateID %d does not match unified cert ID %d",
+			poolReg.CertificateID,
+			poolUnified.ID,
+		)
+	}
+
+	var authHot models.AuthCommitteeHot
+	if result := pgStore.DB().First(&authHot); result.Error != nil {
+		t.Fatalf("failed to query auth committee hot: %v", result.Error)
+	}
+
+	// Find the unified cert for auth committee hot (should be index 2)
+	var authUnified models.Certificate
+	if result := pgStore.DB().Where("cert_index = ? AND cert_type = ?", 2, uint(lcommon.CertificateTypeAuthCommitteeHot)).First(&authUnified); result.Error != nil {
+		t.Fatalf(
+			"failed to find unified auth committee hot cert: %v",
+			result.Error,
+		)
+	}
+
+	if authHot.CertificateID != authUnified.ID {
+		t.Errorf(
+			"auth committee hot CertificateID %d does not match unified cert ID %d",
+			authHot.CertificateID,
+			authUnified.ID,
+		)
+	}
+}
+
+// TestPostgresSetAccountPreservesCertificateID tests that SetAccount does not
+// overwrite the CertificateID field when updating an existing account
+func TestPostgresSetAccountPreservesCertificateID(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+
+	stakeKey := []byte("test_stake_key_123456789012345678901234567890")
+
+	// First, create an account with a CertificateID via direct DB access
+	account := &models.Account{
+		StakingKey:    stakeKey,
+		AddedSlot:     1000,
+		Pool:          []byte("pool1"),
+		Drep:          []byte("drep1"),
+		Active:        true,
+		CertificateID: 42, // Set a non-zero CertificateID
+	}
+	if result := pgStore.DB().Create(account); result.Error != nil {
+		t.Fatalf("failed to create account: %v", result.Error)
+	}
+
+	// Now use SetAccount to update the account (this should NOT overwrite CertificateID)
+	err := pgStore.SetAccount(
+		stakeKey,
+		[]byte("pool2"), // new pool
+		[]byte("drep2"), // new drep
+		2000,            // new slot
+		true,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to set account: %v", err)
+	}
+
+	// Fetch the account and verify CertificateID was preserved
+	var updatedAccount models.Account
+	if result := pgStore.DB().Where("staking_key = ?", stakeKey).First(&updatedAccount); result.Error != nil {
+		t.Fatalf("failed to fetch updated account: %v", result.Error)
+	}
+
+	if updatedAccount.CertificateID != 42 {
+		t.Errorf(
+			"CertificateID was overwritten: expected 42, got %d",
+			updatedAccount.CertificateID,
+		)
+	}
+
+	// Verify other fields were updated
+	if string(updatedAccount.Pool) != "pool2" {
+		t.Errorf("Pool was not updated: expected 'pool2', got '%s'", string(updatedAccount.Pool))
+	}
+	if string(updatedAccount.Drep) != "drep2" {
+		t.Errorf("Drep was not updated: expected 'drep2', got '%s'", string(updatedAccount.Drep))
+	}
+	if updatedAccount.AddedSlot != 2000 {
+		t.Errorf("AddedSlot was not updated: expected 2000, got %d", updatedAccount.AddedSlot)
+	}
+}
+
+// TestPostgresFeeConversion tests that the Fee field handles nil and large values correctly
+func TestPostgresFeeConversion(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+
+	// Test with nil Fee
+	mockTxNilFee := &mockTransactionNilFee{
+		hash:    lcommon.NewBlake2b256([]byte("nil_fee_tx_hash_12345678901234567890")),
+		isValid: true,
+	}
+
+	point := ocommon.Point{
+		Hash: []byte("block_hash_nil_fee_test_1234567890123456"),
+		Slot: 2000000,
+	}
+
+	err := pgStore.SetTransaction(mockTxNilFee, point, 0, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to set transaction with nil fee: %v", err)
+	}
+
+	// Verify the transaction was created with fee = 0
+	var tx models.Transaction
+	if result := pgStore.DB().Where("hash = ?", mockTxNilFee.hash.Bytes()).First(&tx); result.Error != nil {
+		t.Fatalf("failed to fetch transaction: %v", result.Error)
+	}
+
+	if uint64(tx.Fee) != 0 {
+		t.Errorf("expected fee to be 0 for nil fee, got %d", tx.Fee)
+	}
+}
+
+// mockTransactionNilFee is a mock transaction that returns nil for Fee()
+type mockTransactionNilFee struct {
+	hash    lcommon.Blake2b256
+	isValid bool
+}
+
+func (m *mockTransactionNilFee) Hash() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m *mockTransactionNilFee) Id() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m *mockTransactionNilFee) Type() int {
+	return 0
+}
+
+func (m *mockTransactionNilFee) Fee() *big.Int {
+	return nil // Return nil to test nil handling
+}
+
+func (m *mockTransactionNilFee) TTL() uint64 {
+	return 1000000
+}
+
+func (m *mockTransactionNilFee) IsValid() bool {
+	return m.isValid
+}
+
+func (m *mockTransactionNilFee) Metadata() lcommon.TransactionMetadatum {
+	return nil
+}
+
+func (m *mockTransactionNilFee) AuxiliaryData() lcommon.AuxiliaryData {
+	return nil
+}
+
+func (m *mockTransactionNilFee) RawAuxiliaryData() []byte {
+	return nil
+}
+
+func (m *mockTransactionNilFee) CollateralReturn() lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Produced() []lcommon.Utxo {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Outputs() []lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Inputs() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Collateral() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Certificates() []lcommon.Certificate {
+	return nil
+}
+
+func (m *mockTransactionNilFee) ProtocolParameterUpdates() (uint64, map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate) {
+	return 0, nil
+}
+
+func (m *mockTransactionNilFee) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	return nil
+}
+
+func (m *mockTransactionNilFee) AuxDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Cbor() []byte {
+	return []byte("mock_cbor")
+}
+
+func (m *mockTransactionNilFee) Consumed() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransactionNilFee) Witnesses() lcommon.TransactionWitnessSet {
+	return nil
+}
+
+func (m *mockTransactionNilFee) ValidityIntervalStart() uint64 {
+	return 0
+}
+
+func (m *mockTransactionNilFee) ReferenceInputs() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockTransactionNilFee) TotalCollateral() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockTransactionNilFee) Withdrawals() map[*lcommon.Address]*big.Int {
+	return nil
+}
+
+func (m *mockTransactionNilFee) RequiredSigners() []lcommon.Blake2b224 {
+	return nil
+}
+
+func (m *mockTransactionNilFee) ScriptDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockTransactionNilFee) VotingProcedures() lcommon.VotingProcedures {
+	return lcommon.VotingProcedures{}
+}
+
+func (m *mockTransactionNilFee) ProposalProcedures() []lcommon.ProposalProcedure {
+	return nil
+}
+
+func (m *mockTransactionNilFee) CurrentTreasuryValue() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockTransactionNilFee) Donation() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockTransactionNilFee) Utxorpc() (*cardano.Tx, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionNilFee) LeiosHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}

--- a/database/plugin/metadata/postgres/pparams.go
+++ b/database/plugin/metadata/postgres/pparams.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetPParams returns a list of protocol parameters for a given epoch. If there are no pparams
+// for the specified epoch, it will return the most recent pparams before the specified epoch
+func (d *MetadataStorePostgres) GetPParams(
+	epoch uint64,
+	txn types.Txn,
+) ([]models.PParams, error) {
+	ret := []models.PParams{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, err
+	}
+	result := db.Where("epoch <= ?", epoch).
+		Order("epoch DESC, id DESC").
+		Limit(1).
+		Find(&ret)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	return ret, nil
+}
+
+// GetPParamUpdates returns a list of protocol parameter updates for a given epoch
+func (d *MetadataStorePostgres) GetPParamUpdates(
+	epoch uint64,
+	txn types.Txn,
+) ([]models.PParamUpdate, error) {
+	ret := []models.PParamUpdate{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, err
+	}
+	result := db.Where("epoch = ?", epoch).Order("id DESC").Find(&ret)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	return ret, nil
+}
+
+// SetPParams saves protocol parameters
+func (d *MetadataStorePostgres) SetPParams(
+	params []byte,
+	slot, epoch uint64,
+	eraId uint,
+	txn types.Txn,
+) error {
+	tmpItem := models.PParams{
+		Cbor:      params,
+		AddedSlot: slot,
+		Epoch:     epoch,
+		EraId:     eraId,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// SetPParamUpdate saves a protocol parameter update
+func (d *MetadataStorePostgres) SetPParamUpdate(
+	genesis, update []byte,
+	slot, epoch uint64,
+	txn types.Txn,
+) error {
+	tmpItem := models.PParamUpdate{
+		GenesisHash: genesis,
+		Cbor:        update,
+		AddedSlot:   slot,
+		Epoch:       epoch,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/script.go
+++ b/database/plugin/metadata/postgres/script.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+)
+
+// GetScript returns the script content by its hash
+func (d *MetadataStorePostgres) GetScript(
+	hash lcommon.ScriptHash,
+	txn types.Txn,
+) (*models.Script, error) {
+	ret := &models.Script{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.First(ret, "hash = ?", hash[:])
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return ret, nil
+}

--- a/database/plugin/metadata/postgres/tip.go
+++ b/database/plugin/metadata/postgres/tip.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	tipEntryId = 1
+)
+
+// GetTip returns the current metadata Tip as ocommon.Tip
+func (d *MetadataStorePostgres) GetTip(
+	txn types.Txn,
+) (ocommon.Tip, error) {
+	ret := ocommon.Tip{}
+	tmpTip := models.Tip{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, err
+	}
+	result := db.Where("id = ?", tipEntryId).First(&tmpTip)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ret, nil
+		}
+		return ret, result.Error
+	}
+	ret.Point = ocommon.Point{
+		Slot: tmpTip.Slot,
+		Hash: tmpTip.Hash,
+	}
+	ret.BlockNumber = tmpTip.BlockNumber
+	return ret, nil
+}
+
+// SetTip saves a tip
+func (d *MetadataStorePostgres) SetTip(
+	tip ochainsync.Tip,
+	txn types.Txn,
+) error {
+	tmpItem := models.Tip{
+		ID:          tipEntryId,
+		Slot:        tip.Point.Slot,
+		Hash:        tip.Point.Hash,
+		BlockNumber: tip.BlockNumber,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1,0 +1,1408 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// dbFromTxn returns d.DB() only when txn is nil, unwraps known *postgresTxn or provider.MetadataTxn() when available, and returns nil for unrecognized txn types so callers can detect errors
+func (d *MetadataStorePostgres) dbFromTxn(txn types.Txn) *gorm.DB {
+	if txn == nil {
+		return d.DB()
+	}
+	if stx, ok := txn.(*postgresTxn); ok && stx != nil {
+		return stx.db
+	}
+	if provider, ok := txn.(interface{ MetadataTxn() *gorm.DB }); ok {
+		if db := provider.MetadataTxn(); db != nil {
+			return db
+		}
+	}
+	return nil // Return nil for unrecognized txn types to allow callers to detect errors
+}
+
+// resolveDB returns the *gorm.DB for the given transaction, or d.DB() if txn is nil.
+// Returns nil, ErrTxnWrongType if txn is non-nil but not the expected type.
+func (d *MetadataStorePostgres) resolveDB(txn types.Txn) (*gorm.DB, error) {
+	if stx, ok := txn.(*postgresTxn); ok {
+		if stx != nil && stx.beginErr != nil {
+			return nil, stx.beginErr
+		}
+	}
+	if txn == nil {
+		return d.DB(), nil
+	}
+	db := d.dbFromTxn(txn)
+	if db == nil {
+		return nil, types.ErrTxnWrongType
+	}
+	return db, nil
+}
+
+// GetTransactionByHash returns a transaction by its hash
+func (d *MetadataStorePostgres) GetTransactionByHash(
+	hash []byte,
+	txn types.Txn,
+) (*models.Transaction, error) {
+	ret := &models.Transaction{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Preload(clause.Associations).
+		First(ret, "hash = ?", hash)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// processScripts is a generic helper to process any script type
+func processScripts[T lcommon.Script](
+	db *gorm.DB,
+	transactionID uint,
+	scriptType uint8,
+	scripts []T,
+	point ocommon.Point,
+) error {
+	for _, script := range scripts {
+		witnessScript := models.WitnessScripts{
+			TransactionID: transactionID,
+			Type:          scriptType,
+			ScriptHash:    script.Hash().Bytes(),
+		}
+		if result := db.Create(&witnessScript); result.Error != nil {
+			return fmt.Errorf("create witness script: %w", result.Error)
+		}
+		scriptContent := models.Script{
+			Hash:        script.Hash().Bytes(),
+			Type:        scriptType,
+			Content:     script.RawScriptBytes(),
+			CreatedSlot: point.Slot,
+		}
+		if result := db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "hash"}},
+			DoNothing: true,
+		}).Create(&scriptContent); result.Error != nil {
+			return fmt.Errorf("create script content: %w", result.Error)
+		}
+	}
+	return nil
+}
+
+// certRequiresDeposit returns true if the certificate type requires a deposit
+func certRequiresDeposit(cert lcommon.Certificate) bool {
+	switch cert.(type) {
+	case *lcommon.PoolRegistrationCertificate,
+		*lcommon.RegistrationCertificate,
+		*lcommon.RegistrationDrepCertificate,
+		*lcommon.StakeRegistrationCertificate,
+		*lcommon.StakeRegistrationDelegationCertificate,
+		*lcommon.StakeVoteRegistrationDelegationCertificate,
+		*lcommon.VoteRegistrationDelegationCertificate:
+		return true
+	default:
+		return false
+	}
+}
+
+// getOrCreateAccount retrieves an existing account or creates a new one
+func (d *MetadataStorePostgres) getOrCreateAccount(
+	stakeKey []byte,
+	txn types.Txn,
+) (*models.Account, error) {
+	// Include inactive accounts to allow reactivation on registration.
+	tmpAccount, err := d.GetAccount(stakeKey, true, txn)
+	if err != nil {
+		if !errors.Is(err, models.ErrAccountNotFound) {
+			return nil, err
+		}
+	}
+	if tmpAccount == nil {
+		tmpAccount = &models.Account{
+			StakingKey: stakeKey,
+		}
+	} else if !tmpAccount.Active {
+		tmpAccount.Active = true
+	}
+	return tmpAccount, nil
+}
+
+// saveAccount persists the account to the database. It creates a new
+// record when `account.ID == 0` (with an upsert on `staking_key`) or saves
+// the existing record otherwise.
+func saveAccount(account *models.Account, db *gorm.DB) error {
+	if account.ID == 0 {
+		result := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"pool", "drep", "active", "certificate_id"},
+			),
+		},
+			clause.Returning{Columns: []clause.Column{{Name: "id"}}},
+		).Create(account)
+		if result.Error != nil {
+			return result.Error
+		}
+	} else {
+		result := db.Save(account)
+		if result.Error != nil {
+			return result.Error
+		}
+	}
+	return nil
+}
+
+// saveCertRecord saves a certificate record and returns any error
+func saveCertRecord(record any, db *gorm.DB) error {
+	result := db.Create(record)
+	return result.Error
+}
+
+// SetTransaction adds a new transaction to the database and processes all certificates
+func (d *MetadataStorePostgres) SetTransaction(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	// Safely convert tx.Fee() (*big.Int) to uint64
+	var feeUint uint64
+	if txFee := tx.Fee(); txFee != nil {
+		if txFee.BitLen() > 64 {
+			feeUint = math.MaxUint64
+		} else {
+			feeUint = txFee.Uint64()
+		}
+	}
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Fee:        types.Uint64(feeUint),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	if tx.Metadata() != nil {
+		tmpMetadata, err := cbor.Encode(tx.Metadata())
+		if err != nil {
+			return fmt.Errorf("failed to encode metadata: %w", err)
+		}
+		tmpTx.Metadata = tmpMetadata
+	}
+	collateralReturn := tx.CollateralReturn()
+	// For invalid transactions with collateral returns, fix indices via CBOR matching
+	// since Produced() uses enumerated indices rather than real transaction indices
+	var realIndexMap map[lcommon.Blake2b256]uint32
+	if !tx.IsValid() && collateralReturn != nil {
+		realIndexMap = make(map[lcommon.Blake2b256]uint32)
+		for idx, out := range tx.Outputs() {
+			if out != nil && idx <= int(^uint32(0)) {
+				// Hash CBOR for efficient map key
+				outputHash := lcommon.NewBlake2b256(out.Cbor())
+				//nolint:gosec // G115: idx bounds already checked above
+				realIndexMap[outputHash] = uint32(idx)
+			}
+		}
+	}
+	for _, utxo := range tx.Produced() {
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			m := models.UtxoLedgerToModel(utxo, point.Slot)
+			// Fix collateral return index for invalid transactions
+			if realIndexMap != nil && m.Cbor != nil {
+				outputHash := lcommon.NewBlake2b256(m.Cbor)
+				if realIdx, ok := realIndexMap[outputHash]; ok {
+					m.OutputIdx = realIdx
+				}
+			}
+			tmpTx.CollateralReturn = &m
+			continue
+		}
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		tmpTx.Outputs = append(tmpTx.Outputs, m)
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}}, // unique txn hash
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index"},
+		),
+	}).Create(tmpTx)
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create transaction at slot %d, block %x, txHash %x, txIndex %d: %#v, %w",
+			point.Slot,
+			point.Hash,
+			txHash,
+			idx,
+			tx,
+			result.Error,
+		)
+	}
+	// Defensive: when an upsert hits a conflict path, we may not have an ID for
+	// the existing row. Fetch it explicitly so we can link witness records to
+	// the correct transaction (behavior varies by driver/DB).
+	if tmpTx.ID == 0 {
+		existingTx, err := d.GetTransactionByHash(txHash, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to fetch transaction ID after upsert: %w",
+				err,
+			)
+		}
+		if existingTx == nil {
+			return fmt.Errorf("transaction not found after upsert: %x", txHash)
+		}
+		tmpTx.ID = existingTx.ID
+	}
+	// Add Inputs to Transaction
+	for _, input := range tx.Inputs() {
+		inTxId := input.Id().Bytes()
+		inIdx := input.Index()
+		utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to fetch input %x#%d: %w",
+				inTxId,
+				inIdx,
+				err,
+			)
+		}
+		if utxo == nil {
+			d.logger.Warn(
+				"Skipping missing input UTxO",
+				"hash",
+				input.Id().String(),
+				"index",
+				inIdx,
+			)
+			continue
+		}
+		tmpTx.Inputs = append(
+			tmpTx.Inputs,
+			*utxo,
+		)
+	}
+	// Add Collateral to Transaction
+	if len(tx.Collateral()) > 0 {
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+
+		for _, input := range tx.Collateral() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch input %x#%d: %w",
+					inTxId,
+					inIdx,
+					err,
+				)
+			}
+			if utxo == nil {
+				d.logger.Warn(
+					"Skipping missing collateral UTxO",
+					"hash",
+					input.Id().String(),
+					"index",
+					inIdx,
+				)
+				continue
+			}
+			// Found the Utxo, add it to the SQL UPDATE list
+			// First, add it to the CASE statement so it's selected
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			// Also add it to the WHERE clause in the SQL UPDATE
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			// Add it to the Transaction
+			tmpTx.Collateral = append(
+				tmpTx.Collateral,
+				*utxo,
+			)
+		}
+		// Update reference where this Utxo was used as collateral in a Transaction
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			result = db.Exec(sql, args...)
+			if result.Error != nil {
+				return fmt.Errorf("batch update collateral: %w", result.Error)
+			}
+		}
+	}
+	// Add ReferenceInputs to Transaction
+	if len(tx.ReferenceInputs()) > 0 {
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+
+		for _, input := range tx.ReferenceInputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch input %x#%d: %w",
+					inTxId,
+					inIdx,
+					err,
+				)
+			}
+			if utxo == nil {
+				d.logger.Warn(
+					"Skipping missing reference input UTxO",
+					"hash",
+					input.Id().String(),
+					"index",
+					inIdx,
+				)
+				continue
+			}
+			// Found the Utxo, add it to the SQL UPDATE list
+			// First, add it to the CASE statement so it's selected
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			// Also add it to the WHERE clause in the SQL UPDATE
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			// Add it to the Transaction
+			tmpTx.ReferenceInputs = append(
+				tmpTx.ReferenceInputs,
+				*utxo,
+			)
+		}
+		// Update reference where this Utxo was used as a reference input in a Transaction
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			result = db.Exec(sql, args...)
+			if result.Error != nil {
+				return fmt.Errorf(
+					"batch update reference inputs: %w",
+					result.Error,
+				)
+			}
+		}
+	}
+
+	// Consume UTxOs
+	for _, input := range tx.Consumed() {
+		inTxId := input.Id().Bytes()
+		inIdx := input.Index()
+		utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to fetch input %x#%d: %w",
+				inTxId,
+				inIdx,
+				err,
+			)
+		}
+		if utxo == nil {
+			d.logger.Warn(
+				"input UTxO not found",
+				"hash",
+				input.Id().String(),
+				"index",
+				inIdx,
+			)
+			continue
+		}
+		// Update existing UTxOs
+		result = db.Model(&models.Utxo{}).
+			Where("tx_id = ? AND output_idx = ?", inTxId, inIdx).
+			Where("spent_at_tx_id IS NULL OR spent_at_tx_id = ?", txHash).
+			Updates(map[string]any{
+				"deleted_slot":   point.Slot,
+				"spent_at_tx_id": txHash,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+	}
+	// Extract and save witness set data
+	// Delete existing witness records to ensure idempotency on retry
+	if result := db.Where("transaction_id = ?", tmpTx.ID).Delete(&models.KeyWitness{}); result.Error != nil {
+		return fmt.Errorf("delete existing key witnesses: %w", result.Error)
+	}
+	if result := db.Where("transaction_id = ?", tmpTx.ID).Delete(&models.WitnessScripts{}); result.Error != nil {
+		return fmt.Errorf("delete existing witness scripts: %w", result.Error)
+	}
+	if result := db.Where("transaction_id = ?", tmpTx.ID).Delete(&models.Redeemer{}); result.Error != nil {
+		return fmt.Errorf("delete existing redeemers: %w", result.Error)
+	}
+	if result := db.Where("transaction_id = ?", tmpTx.ID).Delete(&models.PlutusData{}); result.Error != nil {
+		return fmt.Errorf("delete existing plutus data: %w", result.Error)
+	}
+	ws := tx.Witnesses()
+	if ws != nil {
+		// Add Vkey Witnesses
+		for _, vkey := range ws.Vkey() {
+			keyWitness := models.KeyWitness{
+				TransactionID: tmpTx.ID,
+				Type:          models.KeyWitnessTypeVkey,
+				Vkey:          vkey.Vkey,
+				Signature:     vkey.Signature,
+			}
+			if result := db.Create(&keyWitness); result.Error != nil {
+				return fmt.Errorf("create vkey witness: %w", result.Error)
+			}
+		}
+
+		// Add Bootstrap Witnesses
+		for _, bootstrap := range ws.Bootstrap() {
+			keyWitness := models.KeyWitness{
+				TransactionID: tmpTx.ID,
+				Type:          models.KeyWitnessTypeBootstrap,
+				PublicKey:     bootstrap.PublicKey,
+				Signature:     bootstrap.Signature,
+				ChainCode:     bootstrap.ChainCode,
+				Attributes:    bootstrap.Attributes,
+			}
+			if result := db.Create(&keyWitness); result.Error != nil {
+				return fmt.Errorf("create bootstrap witness: %w", result.Error)
+			}
+		}
+
+		// Process all script types using the generic helper
+		if err := processScripts(db, tmpTx.ID, uint8(lcommon.ScriptRefTypeNativeScript), ws.NativeScripts(), point); err != nil {
+			return err
+		}
+		if err := processScripts(db, tmpTx.ID, uint8(lcommon.ScriptRefTypePlutusV1), ws.PlutusV1Scripts(), point); err != nil {
+			return err
+		}
+		if err := processScripts(db, tmpTx.ID, uint8(lcommon.ScriptRefTypePlutusV2), ws.PlutusV2Scripts(), point); err != nil {
+			return err
+		}
+		if err := processScripts(db, tmpTx.ID, uint8(lcommon.ScriptRefTypePlutusV3), ws.PlutusV3Scripts(), point); err != nil {
+			return err
+		}
+
+		// Add PlutusData (Datums)
+		for _, datum := range ws.PlutusData() {
+			plutusData := models.PlutusData{
+				TransactionID: tmpTx.ID,
+				Data:          datum.Cbor(),
+			}
+			if result := db.Create(&plutusData); result.Error != nil {
+				return fmt.Errorf("create plutus data: %w", result.Error)
+			}
+		}
+
+		// Add Redeemers
+		if ws.Redeemers() != nil {
+			for key, value := range ws.Redeemers().Iter() {
+				//nolint:gosec
+				redeemer := models.Redeemer{
+					TransactionID: tmpTx.ID,
+					Tag:           uint8(key.Tag),
+					Index:         key.Index,
+					Data:          value.Data.Cbor(),
+					ExUnitsMemory: uint64(
+						max(0, value.ExUnits.Memory),
+					),
+					ExUnitsCPU: uint64(
+						max(0, value.ExUnits.Steps),
+					),
+				}
+				if result := db.Create(&redeemer); result.Error != nil {
+					return fmt.Errorf("create redeemer: %w", result.Error)
+				}
+			}
+		}
+	}
+
+	// Avoid updating associations
+	result = db.Omit(clause.Associations).Save(tmpTx)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	// Process certificates - all certificate types are handled here in a consolidated manner
+	// This centralizes certificate processing logic within the metadata layer following DRY principles
+	if tx.IsValid() {
+		certs := tx.Certificates()
+		if len(certs) > 0 {
+			// Delete existing specialized certificate records to ensure idempotency on retry
+			// This ensures 1:1 correspondence between unified and specialized certificates
+			unifiedIDs := []uint{}
+			if result := db.Model(&models.Certificate{}).Where("transaction_id = ?", tmpTx.ID).Pluck("id", &unifiedIDs); result.Error != nil {
+				return fmt.Errorf(
+					"query existing unified certificates: %w",
+					result.Error,
+				)
+			}
+			if len(unifiedIDs) > 0 {
+				// Delete specialized records linked to existing unified certificates.
+				// Child tables must be deleted before parent tables due to FK constraints.
+				// Note: move_instantaneous_rewards_reward is deleted via CASCADE when its
+				// parent move_instantaneous_rewards is deleted (MIRID FK constraint).
+				tables := []string{
+					"pool_registration_owner",
+					"pool_registration_relay",
+					"stake_registration",
+					"pool_registration",
+					"pool_retirement",
+					"auth_committee_hot",
+					"resign_committee_cold",
+					"deregistration",
+					"stake_delegation",
+					"stake_registration_delegation",
+					"stake_vote_delegation",
+					"stake_vote_registration_delegation",
+					"registration",
+					"registration_drep",
+					"deregistration_drep",
+					"update_drep",
+					"vote_delegation",
+					"vote_registration_delegation",
+					"move_instantaneous_rewards",
+				}
+				for _, table := range tables {
+					if result := db.Table(table).Where("certificate_id IN ?", unifiedIDs).Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing %s records: %w",
+							table,
+							result.Error,
+						)
+					}
+				}
+			}
+			// Create unified certificate records first (idempotent with ON CONFLICT DO NOTHING)
+			certIDMap := make(map[int]uint)
+			certIDUpdates := make(map[uint]uint) // unifiedID -> specializedID
+			for i, cert := range certs {
+				var certType uint
+				switch cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypePoolRegistration)
+				case *lcommon.StakeRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistration)
+				case *lcommon.PoolRetirementCertificate:
+					certType = uint(lcommon.CertificateTypePoolRetirement)
+				case *lcommon.StakeDeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDeregistration)
+				case *lcommon.DeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistration)
+				case *lcommon.StakeDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDelegation)
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistrationDelegation)
+				case *lcommon.StakeVoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteDelegation)
+				case *lcommon.RegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeRegistration)
+				case *lcommon.RegistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeRegistrationDrep)
+				case *lcommon.DeregistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistrationDrep)
+				case *lcommon.UpdateDrepCertificate:
+					certType = uint(lcommon.CertificateTypeUpdateDrep)
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation)
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteRegistrationDelegation)
+				case *lcommon.VoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteDelegation)
+				case *lcommon.AuthCommitteeHotCertificate:
+					certType = uint(lcommon.CertificateTypeAuthCommitteeHot)
+				case *lcommon.ResignCommitteeColdCertificate:
+					certType = uint(lcommon.CertificateTypeResignCommitteeCold)
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					certType = uint(lcommon.CertificateTypeMoveInstantaneousRewards)
+				default:
+					d.logger.Warn("unknown certificate type", "type", fmt.Sprintf("%T", cert))
+					continue
+				}
+				unifiedCert := models.Certificate{
+					TransactionID: tmpTx.ID,
+					CertIndex:     uint(i), //nolint:gosec
+					CertType:      certType,
+					Slot:          point.Slot,
+					BlockHash:     point.Hash,
+					CertificateID: 0, // Will be set to specialized record ID later if needed
+				}
+				// Use ON CONFLICT DO NOTHING to handle retries idempotently
+				if result := db.Clauses(clause.OnConflict{
+					Columns:   []clause.Column{{Name: "transaction_id"}, {Name: "cert_index"}},
+					DoNothing: true,
+				}).Create(&unifiedCert); result.Error != nil {
+					return fmt.Errorf(
+						"create unified certificate: %w",
+						result.Error,
+					)
+				}
+				// If the record already existed, we need to fetch its ID
+				if unifiedCert.ID == 0 {
+					result := db.Where("transaction_id = ? AND cert_index = ?", tmpTx.ID, uint(i)). // #nosec G115
+															First(&unifiedCert)
+					if result.Error != nil {
+						return fmt.Errorf(
+							"fetch existing unified certificate: %w",
+							result.Error,
+						)
+					}
+				}
+				certIDMap[i] = unifiedCert.ID
+			}
+			for i, cert := range certs {
+				deposit := uint64(0)
+				if certDeposits != nil {
+					if depositVal, ok := certDeposits[i]; ok {
+						deposit = depositVal
+					} else if certRequiresDeposit(cert) {
+						d.logger.Warn("missing deposit for deposit-bearing certificate",
+							"index", i, "type", fmt.Sprintf("%T", cert))
+					}
+				}
+				if certDeposits == nil && certRequiresDeposit(cert) {
+					d.logger.Error(
+						"certDeposits is nil for deposit-bearing certificate",
+						"index",
+						i,
+						"type",
+						fmt.Sprintf("%T", cert),
+					)
+					return fmt.Errorf(
+						"missing certDeposits for deposit-bearing certificate at index %d",
+						i,
+					)
+				}
+				switch c := cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					// Include inactive pools to allow re-registration.
+					tmpPool, err := d.GetPool(lcommon.PoolKeyHash(c.Operator[:]), true, txn)
+					if err != nil {
+						if !errors.Is(err, models.ErrPoolNotFound) {
+							return fmt.Errorf("process certificate: %w", err)
+						}
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{
+							PoolKeyHash: c.Operator[:],
+							VrfKeyHash:  c.VrfKeyHash[:],
+						}
+					}
+
+					// Reactivation handled by writing a registration record.
+
+					// Update pool's current state
+					tmpPool.Pledge = types.Uint64(c.Pledge)
+					tmpPool.Cost = types.Uint64(c.Cost)
+					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
+					tmpPool.RewardAccount = c.RewardAccount[:]
+
+					// Create registration record
+					tmpReg := models.PoolRegistration{
+						PoolKeyHash:   c.Operator[:],
+						VrfKeyHash:    c.VrfKeyHash[:],
+						Pledge:        types.Uint64(c.Pledge),
+						Cost:          types.Uint64(c.Cost),
+						Margin:        &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount: c.RewardAccount[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if c.PoolMetadata != nil {
+						tmpReg.MetadataUrl = c.PoolMetadata.Url
+						tmpReg.MetadataHash = c.PoolMetadata.Hash[:]
+					}
+					for _, owner := range c.PoolOwners {
+						tmpReg.Owners = append(
+							tmpReg.Owners,
+							models.PoolRegistrationOwner{KeyHash: owner[:]},
+						)
+					}
+
+					var tmpRelay models.PoolRegistrationRelay
+					for _, relay := range c.Relays {
+						tmpRelay = models.PoolRegistrationRelay{
+							Ipv4: relay.Ipv4,
+							Ipv6: relay.Ipv6,
+						}
+						if relay.Port != nil {
+							tmpRelay.Port = uint(*relay.Port)
+						}
+						if relay.Hostname != nil {
+							tmpRelay.Hostname = *relay.Hostname
+						}
+						tmpReg.Relays = append(tmpReg.Relays, tmpRelay)
+					}
+
+					// Set the PoolID for the registration record
+					if tmpPool.ID == 0 {
+						result := db.Create(tmpPool)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					} else {
+						result := db.Save(tmpPool)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+					tmpReg.PoolID = tmpPool.ID
+
+					// Save the registration record
+					result := db.Omit("Owners", "Relays").Create(&tmpReg)
+					if result.Error != nil {
+						return fmt.Errorf("process certificate: %w", result.Error)
+					}
+
+					if len(tmpReg.Owners) > 0 {
+						for i := range tmpReg.Owners {
+							tmpReg.Owners[i].PoolRegistrationID = tmpReg.ID
+							tmpReg.Owners[i].PoolID = tmpPool.ID
+						}
+						if result := db.Create(&tmpReg.Owners); result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+
+					if len(tmpReg.Relays) > 0 {
+						for i := range tmpReg.Relays {
+							tmpReg.Relays[i].PoolRegistrationID = tmpReg.ID
+							tmpReg.Relays[i].PoolID = tmpPool.ID
+						}
+						if result := db.Create(&tmpReg.Relays); result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeRegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpReg := models.StakeRegistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+						tmpAccount.CertificateID = certIDMap[i]
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.PoolRetirementCertificate:
+					// Include inactive pools when retiring.
+					tmpPool, err := d.GetPool(lcommon.PoolKeyHash(c.PoolKeyHash[:]), true, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					if tmpPool == nil {
+						d.logger.Warn("retiring non-existent pool", "hash", c.PoolKeyHash)
+						tmpPool = &models.Pool{PoolKeyHash: c.PoolKeyHash[:]}
+						result := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "pool_key_hash"}},
+							UpdateAll: true,
+						}).Create(&tmpPool)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+
+					tmpItem := models.PoolRetirement{
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Epoch:         c.Epoch,
+						AddedSlot:     point.Slot,
+						PoolID:        tmpPool.ID,
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					if tmpAccount == nil {
+						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
+						tmpAccount = &models.Account{
+							StakingKey: stakeKey,
+						}
+						result := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+
+					tmpAccount.Active = false
+
+					tmpItem := models.StakeDeregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.DeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					if tmpAccount == nil {
+						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
+						tmpAccount = &models.Account{
+							StakingKey: stakeKey,
+						}
+						result := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+
+					tmpAccount.Active = false
+
+					tmpItem := models.Deregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+						Amount:        types.Uint64(deposit),
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpAccount.Pool = c.PoolKeyHash[:]
+
+					tmpItem := models.StakeDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpAccount.Pool = c.PoolKeyHash[:]
+
+					tmpReg := models.StakeRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeVoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = c.Drep.Credential[:]
+
+					tmpItem := models.StakeVoteDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          c.Drep.Credential[:],
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.RegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpReg := models.Registration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+						tmpAccount.CertificateID = certIDMap[i]
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.RegistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+
+					// Registration (re)creates/activates the DRep regardless of prior state.
+
+					tmpReg := models.RegistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpReg.AnchorUrl = c.Anchor.Url
+						tmpReg.AnchorHash = c.Anchor.DataHash[:]
+					}
+
+					// Persist DRep anchor and active state
+					if err := d.SetDrep(drepCredential, point.Slot, tmpReg.AnchorUrl, tmpReg.AnchorHash, true, txn); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.DeregistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+
+					tmpDereg := models.DeregistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+
+					// Mark DRep inactive
+					// Ensure we don't create a new DRep during deregistration. Check existence first.
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil {
+						if !errors.Is(err, models.ErrDrepNotFound) {
+							return fmt.Errorf("process certificate: %w", err)
+						}
+					}
+					if existingDrep == nil {
+						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
+					}
+					if err := d.SetDrep(drepCredential, point.Slot, "", nil, false, txn); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpDereg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpDereg.ID
+				case *lcommon.UpdateDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+
+					tmpUpdate := models.UpdateDrep{
+						Credential:    drepCredential,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpUpdate.AnchorUrl = c.Anchor.Url
+						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
+					}
+
+					// Update DRep anchor and mark active
+					// Require that the DRep already exists for updates.
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil {
+						if !errors.Is(err, models.ErrDrepNotFound) {
+							return fmt.Errorf("process certificate: %w", err)
+						}
+					}
+					if existingDrep == nil {
+						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
+					}
+					if err := d.SetDrep(drepCredential, point.Slot, tmpUpdate.AnchorUrl, tmpUpdate.AnchorHash, true, txn); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpUpdate, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = c.Drep.Credential[:]
+
+					tmpReg := models.StakeVoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          c.Drep.Credential[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpAccount.Drep = c.Drep.Credential[:]
+
+					tmpReg := models.VoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						Drep:          c.Drep.Credential[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					tmpAccount.Drep = c.Drep.Credential[:]
+
+					tmpItem := models.VoteDelegation{
+						StakingKey:    stakeKey,
+						Drep:          c.Drep.Credential[:],
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.AuthCommitteeHotCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					hotCredential := c.HotCredential.Credential[:]
+
+					tmpAuth := models.AuthCommitteeHot{
+						ColdCredential: coldCredential,
+						HostCredential: hotCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+
+					if err := saveCertRecord(&tmpAuth, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpAuth.ID
+				case *lcommon.ResignCommitteeColdCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+
+					tmpResign := models.ResignCommitteeCold{
+						ColdCredential: coldCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if c.Anchor != nil {
+						tmpResign.AnchorUrl = c.Anchor.Url
+						tmpResign.AnchorHash = c.Anchor.DataHash[:]
+					}
+
+					if err := saveCertRecord(&tmpResign, db); err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpResign.ID
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					tmpMIR := models.MoveInstantaneousRewards{
+						Pot:           c.Reward.Source,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+
+					// Save the MIR record
+					result := db.Create(&tmpMIR)
+					if result.Error != nil {
+						return fmt.Errorf("process certificate: %w", result.Error)
+					}
+
+					// Collect update for batch processing
+					certIDUpdates[certIDMap[i]] = tmpMIR.ID
+
+					// Save individual rewards
+					for credential, amount := range c.Reward.Rewards {
+						tmpReward := models.MoveInstantaneousRewardsReward{
+							Credential: credential.Credential[:],
+							Amount:     types.Uint64(amount),
+							MIRID:      tmpMIR.ID,
+						}
+						result := db.Create(&tmpReward)
+						if result.Error != nil {
+							return fmt.Errorf("process certificate: %w", result.Error)
+						}
+					}
+				default:
+					return fmt.Errorf("unsupported certificate type %T", cert)
+				}
+			}
+
+			// Batch update unified certificates with specialized record IDs
+			if len(certIDUpdates) > 0 {
+				// Build CASE statement for batch update
+				var ids []uint
+				var whenClauses []string
+				var values []any
+
+				for unifiedID, specializedID := range certIDUpdates {
+					ids = append(ids, unifiedID)
+					whenClauses = append(whenClauses, "WHEN id = ? THEN CAST(? AS bigint)")
+					values = append(values, unifiedID, specializedID)
+				}
+
+				caseStmt := strings.Join(whenClauses, " ")
+				query := fmt.Sprintf(
+					"UPDATE certs SET certificate_id = CASE %s END WHERE id IN ?",
+					caseStmt,
+				)
+				values = append(values, ids)
+
+				if result := db.Exec(query, values...); result.Error != nil {
+					return fmt.Errorf(
+						"batch update unified certificates: %w",
+						result.Error,
+					)
+				}
+			}
+		}
+
+		if err := d.storeTransactionDatums(tx, point.Slot, txn); err != nil {
+			return fmt.Errorf("store datums failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Traverse each utxo and check for inline datum & calls storeDatum
+func (d *MetadataStorePostgres) storeTransactionDatums(
+	tx lcommon.Transaction,
+	slot uint64,
+	txn types.Txn,
+) error {
+	for _, utxo := range tx.Produced() {
+		if err := d.storeDatum(utxo.Output.Datum(), slot, txn); err != nil {
+			return err
+		}
+	}
+	witnesses := tx.Witnesses()
+	if witnesses == nil {
+		return nil
+	}
+	// Looks over the transaction witness set & store each datum.
+	for _, datum := range witnesses.PlutusData() {
+		datumCopy := datum
+		if err := d.storeDatum(&datumCopy, slot, txn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Marshal the raw CBOR and hashes with Blake2b256Hash & calls SetDatum of metadata store.
+func (d *MetadataStorePostgres) storeDatum(
+	datum *lcommon.Datum,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if datum == nil {
+		return nil
+	}
+	rawDatum := datum.Cbor()
+	if len(rawDatum) == 0 {
+		var err error
+		rawDatum, err = datum.MarshalCBOR()
+		if err != nil {
+			return fmt.Errorf("marshal datum: %w", err)
+		}
+	}
+	if len(rawDatum) == 0 {
+		return nil
+	}
+	datumHash := lcommon.Blake2b256Hash(rawDatum)
+	return d.SetDatum(datumHash, rawDatum, slot, txn)
+}

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -1,0 +1,245 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"gorm.io/gorm"
+)
+
+// GetUtxo returns a Utxo by reference
+func (d *MetadataStorePostgres) GetUtxo(
+	txId []byte,
+	idx uint32,
+	txn types.Txn,
+) (*models.Utxo, error) {
+	ret := &models.Utxo{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Where("deleted_slot = 0").
+		First(ret, "tx_id = ? AND output_idx = ?", txId, idx)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// GetUtxosAddedAfterSlot returns a list of Utxos added after a given slot
+func (d *MetadataStorePostgres) GetUtxosAddedAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.Utxo, error) {
+	var ret []models.Utxo
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Where("added_slot > ?", slot).
+		Order("id DESC").
+		Find(&ret)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	return ret, nil
+}
+
+// GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
+func (d *MetadataStorePostgres) GetUtxosDeletedBeforeSlot(
+	slot uint64,
+	limit int,
+	txn types.Txn,
+) ([]models.Utxo, error) {
+	var ret []models.Utxo
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot).
+		Order("id DESC")
+	if limit > 0 {
+		db = db.Limit(limit)
+	}
+	result := db.Find(&ret)
+	if result.Error != nil {
+		return ret, result.Error
+	}
+	return ret, nil
+}
+
+// GetUtxosByAddress returns a list of Utxos
+func (d *MetadataStorePostgres) GetUtxosByAddress(
+	addr ledger.Address,
+	txn types.Txn,
+) ([]models.Utxo, error) {
+	var ret []models.Utxo
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPaymentKey := addr.PaymentKeyHash() != ledger.NewBlake2b224(nil)
+	hasStakeKey := addr.StakeKeyHash() != ledger.NewBlake2b224(nil)
+
+	// Build sub-query for address
+	var addrQuery *gorm.DB
+	if hasPaymentKey && hasStakeKey {
+		// Base address: both credentials must match (AND)
+		addrQuery = db.Where(
+			"payment_key = ? AND staking_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		)
+	} else if hasPaymentKey {
+		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
+	} else if hasStakeKey {
+		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
+	}
+
+	if addrQuery == nil {
+		return ret, nil
+	}
+	result := db.
+		Where("deleted_slot = 0").
+		Where(addrQuery).
+		Find(&ret)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+func (d *MetadataStorePostgres) DeleteUtxo(
+	utxoId models.UtxoId,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Where("tx_id = ? AND output_idx = ?", utxoId.Hash, utxoId.Idx).
+		Delete(&models.Utxo{})
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+func (d *MetadataStorePostgres) DeleteUtxos(
+	utxos []models.UtxoId,
+	txn types.Txn,
+) error {
+	if len(utxos) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	// Delete each UTxO by tx_id and output_idx. Use a transaction-aware delete.
+	for _, u := range utxos {
+		result := db.Where("tx_id = ? AND output_idx = ?", u.Hash, u.Idx).
+			Delete(&models.Utxo{})
+		if result.Error != nil {
+			return result.Error
+		}
+	}
+	return nil
+}
+
+func (d *MetadataStorePostgres) DeleteUtxosAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Where("added_slot > ?", slot).
+		Delete(&models.Utxo{})
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// AddUtxos saves a batch of UTxOs
+func (d *MetadataStorePostgres) AddUtxos(
+	utxos []models.UtxoSlot,
+	txn types.Txn,
+) error {
+	items := make([]models.Utxo, 0, len(utxos))
+	for _, utxo := range utxos {
+		items = append(
+			items,
+			models.UtxoLedgerToModel(utxo.Utxo, utxo.Slot),
+		)
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Session(&gorm.Session{FullSaveAssociations: true}).
+		CreateInBatches(items, 1000)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// SetUtxoDeletedAtSlot marks a UTxO as deleted at a given slot
+func (d *MetadataStorePostgres) SetUtxoDeletedAtSlot(
+	utxoId ledger.TransactionInput,
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Model(models.Utxo{}).
+		Where("tx_id = ? AND output_idx = ?", utxoId.Id().Bytes(), utxoId.Index()).
+		Update("deleted_slot", slot)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot
+func (d *MetadataStorePostgres) SetUtxosNotDeletedAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Model(models.Utxo{}).
+		Where("deleted_slot > ?", slot).
+		Update("deleted_slot", 0)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -46,12 +46,31 @@ database:
 
   # Metadata storage plugin configuration
   metadata:
-    # Plugin to use for metadata storage (sqlite)
+    # Plugin to use for metadata storage (sqlite, postgres)
     plugin: "sqlite"
     # Configuration options for each plugin
     sqlite:
-      # Data directory for SQLite database file
+      # Path to SQLite database file
       data-dir: ".dingo/metadata.db"
+    postgres:
+      # NOTE: These are example values for local development only.
+      # Do not use these credentials in production environments.
+      # Postgres host
+      host: "localhost"
+      # Postgres port
+      port: 5432
+      # Postgres user
+      user: "postgres"
+      # Postgres password (required - no default)
+      password: ""
+      # Postgres database name
+      database: "postgres"
+      # Postgres sslmode
+      ssl-mode: "disable"
+      # Postgres TimeZone
+      timezone: "UTC"
+      # Full Postgres DSN (overrides other options when set)
+      dsn: ""
 
 # Path to the UNIX domain socket file used by the server
 socketPath: "dingo.socket"

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/sys v0.40.0
 	google.golang.org/api v0.259.0
 	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/postgres v1.5.11
 	gorm.io/gorm v1.31.1
 	gorm.io/plugin/opentelemetry v0.1.16
 )
@@ -205,7 +206,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gorm.io/driver/clickhouse v0.7.0 // indirect
 	gorm.io/driver/mysql v1.5.7 // indirect
-	gorm.io/driver/postgres v1.5.11 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -131,6 +131,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithIntersectTip(cfg.IntersectTip),
 			dingo.WithLogger(logger),
 			dingo.WithDatabasePath(cfg.DatabasePath),
+			dingo.WithBlobPlugin(cfg.BlobPlugin),
+			dingo.WithMetadataPlugin(cfg.MetadataPlugin),
 			dingo.WithMempoolCapacity(cfg.MempoolCapacity),
 			dingo.WithNetwork(cfg.Network),
 			dingo.WithCardanoNodeConfig(nodeCfg),

--- a/node.go
+++ b/node.go
@@ -77,9 +77,11 @@ func (n *Node) Run(ctx context.Context) error {
 	// Load database
 	dbNeedsRecovery := false
 	dbConfig := &database.Config{
-		DataDir:      n.config.dataDir,
-		Logger:       n.config.logger,
-		PromRegistry: n.config.promRegistry,
+		DataDir:        n.config.dataDir,
+		Logger:         n.config.logger,
+		PromRegistry:   n.config.promRegistry,
+		BlobPlugin:     n.config.blobPlugin,
+		MetadataPlugin: n.config.metadataPlugin,
 	}
 	db, err := database.New(dbConfig)
 	if db == nil {


### PR DESCRIPTION
1. Added changes in config.go with `blobPlugin` and `metadataPlugin` where runtime uses the plugin which we pass from command line instead of always defaulting to badger & sqlite. (we can pass `s3`, `gcs` & `postgres`)
2. Made changes to add our new plugin metadata store i.e, `PostgresDB`. The defaullt metadata store will be sqlite and we have to pass if we want to store in postgres.
3. Modified all the tables `account`, `asset`, `block_nonce`, `certs`, `commit_timestamp`, `datum`, `drep`, `epoch`, `pool`, `pparams`, `script`, `tip`,  `transaction`, `utxo` & the change will be from `MetadataStoreSqlite` to `MetadataStorePostgres` & the remaining contents will be almost same (nothing changed).
4. Modified the database.go to use postgres gorm driver & added a new `MetadataStorePostgres` similar to `MetadataStoreSqlite`. Also, added configuaration things for postrges such as `host`, `port`, `user`, `password`, `database`, `sslMode`, `timeZone`, `dsn` (postgres connection string). Modified the `Start()` function & the remaining changes are mostly like `MetadataStoreSqlite` to `MetadataStorePostgres`
5. Added all the necessary command line options or helpers in `plugin.go` for this new metadata store postgres.
6. Updated dingo.yaml.example with the default postgres credentials.

Closes #329 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL added as a metadata backend alongside SQLite, supporting transactions, UTxOs, tips, pools, epochs, scripts, datums, protocol parameters, commit timestamps and full metadata APIs.
  * New runtime options to select blob and metadata plugins at node startup.

* **Chores**
  * Example configuration updated to document Postgres options.
  * CI/workflows updated to run Postgres-based tests.

* **Tests**
  * Integration and unit tests added for Postgres metadata functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->