### PR TITLE
fix(ledger): rollback failures are fatal

### DIFF
--- a/ledger/event.go
+++ b/ledger/event.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	BlockfetchEventType event.EventType = "blockfetch.event"
-	ChainsyncEventType  event.EventType = "chainsync.event"
+	BlockfetchEventType  event.EventType = "blockfetch.event"
+	ChainsyncEventType   event.EventType = "chainsync.event"
+	LedgerErrorEventType event.EventType = "ledger.error"
 )
 
 // BlockfetchEvent represents either a Block or BatchDone blockfetch event. We use
@@ -47,4 +48,11 @@ type ChainsyncEvent struct {
 	BlockNumber  uint64
 	Type         uint // Block or header type ID
 	Rollback     bool // Set to true for a Rollback event
+}
+
+// LedgerErrorEvent represents an error that occurred during ledger processing.
+type LedgerErrorEvent struct {
+	Error     error         // The actual error that occurred
+	Operation string        // The operation that failed (e.g., "block_header", "rollback")
+	Point     ocommon.Point // Chain point where the error occurred, if applicable
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -260,6 +260,10 @@ const (
 	SyncingChainsyncState  ChainsyncState = "syncing"
 )
 
+// FatalErrorFunc is a callback invoked when a fatal error occurs that requires
+// the node to shut down. The callback should trigger graceful shutdown.
+type FatalErrorFunc func(err error)
+
 type LedgerStateConfig struct {
 	PromRegistry               prometheus.Registerer
 	Logger                     *slog.Logger
@@ -268,6 +272,7 @@ type LedgerStateConfig struct {
 	EventBus                   *event.EventBus
 	CardanoNodeConfig          *cardano.CardanoNodeConfig
 	BlockfetchRequestRangeFunc BlockfetchRequestRangeFunc
+	FatalErrorFunc             FatalErrorFunc
 	ValidateHistorical         bool
 	ForgeBlocks                bool
 	DatabaseWorkerPoolConfig   DatabaseWorkerPoolConfig

--- a/node.go
+++ b/node.go
@@ -136,6 +136,13 @@ func (n *Node) Run(ctx context.Context) error {
 			ValidateHistorical:         n.config.validateHistorical,
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
 			DatabaseWorkerPoolConfig:   n.config.DatabaseWorkerPoolConfig,
+			FatalErrorFunc: func(err error) {
+				n.config.logger.Error(
+					"fatal ledger error, initiating shutdown",
+					"error", err,
+				)
+				n.cancel()
+			},
 		},
 	)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make ledger rollback failures fatal to avoid running on an inconsistent chain state. Adds a fatal error callback to shut down the node and improves error reporting via events and structured logs.

- **Bug Fixes**
  - Treat rollback handling errors as fatal to ensure immediate shutdown and prevent corrupt state.

- **New Features**
  - Add FatalErrorFunc to LedgerStateConfig; Node wires it to cancel context on fatal ledger errors.
  - Introduce ledger.error event and publish it on block header and blockfetch failures; logs now include slot and hash for easier diagnosis.

<sup>Written for commit edd320e33546392e962ce4a3373166ceacf3dc38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error logging and reporting for chain synchronization and block fetch operations with enhanced failure diagnostics.
  * Added event-based error tracking for ledger operations to enable better monitoring and visibility of failure events.
  * Implemented fatal error callback mechanism to trigger graceful shutdown when critical ledger errors occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->