### PR TITLE
feat(database): release function for deferred commits

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -26,7 +26,7 @@ func (d *Database) GetAccount(
 ) (*models.Account, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	account, err := d.metadata.GetAccount(
 		stakeKey,

--- a/database/datum.go
+++ b/database/datum.go
@@ -33,8 +33,7 @@ func (d *Database) SetDatum(
 	datumHash := lcommon.Blake2b256Hash(rawDatum)
 
 	if txn == nil {
-		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		return d.metadata.SetDatum(datumHash, rawDatum, addedSlot, nil)
 	}
 	return d.metadata.SetDatum(datumHash, rawDatum, addedSlot, txn.Metadata())
 }
@@ -49,7 +48,7 @@ func (d *Database) GetDatum(
 	}
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	tmpHash := lcommon.NewBlake2b256(hash)
 	ret, err := d.metadata.GetDatum(tmpHash, txn.Metadata())

--- a/database/drep.go
+++ b/database/drep.go
@@ -26,7 +26,7 @@ func (d *Database) GetDrep(
 ) (*models.Drep, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	ret, err := d.metadata.GetDrep(cred, includeInactive, txn.Metadata())
 	if err != nil {

--- a/database/pool.go
+++ b/database/pool.go
@@ -27,7 +27,7 @@ func (d *Database) GetPool(
 ) (*models.Pool, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	ret, err := d.metadata.GetPool(pkh, includeInactive, txn.Metadata())
 	if err != nil {
@@ -44,7 +44,7 @@ func (d *Database) GetPool(
 func (d *Database) GetActivePoolRelays(txn *Txn) ([]models.PoolRegistrationRelay, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	return d.metadata.GetActivePoolRelays(txn.Metadata())
 }

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -103,7 +103,7 @@ func (d *Database) GetTransactionByHash(
 	}
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	return d.metadata.GetTransactionByHash(hash, txn.Metadata())
 }

--- a/database/txn.go
+++ b/database/txn.go
@@ -185,3 +185,17 @@ func (t *Txn) rollback() error {
 	t.finished = true
 	return errors.Join(errs...)
 }
+
+// Release releases transaction resources. For read-only transactions, this
+// releases locks and resources. For read-write transactions, this is equivalent
+// to Rollback. Use this in defer statements for clean resource cleanup.
+// Errors are logged but not returned, making this safe for deferred calls.
+func (t *Txn) Release() {
+	if err := t.Rollback(); err != nil {
+		t.db.logger.Debug(
+			"transaction release failed",
+			"error", err,
+			"read_write", t.readWrite,
+		)
+	}
+}

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -159,7 +159,7 @@ func (d *Database) UtxoByRef(
 ) (*models.Utxo, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	utxo, err := d.metadata.GetUtxo(txId, outputIdx, txn.Metadata())
 	if err != nil {
@@ -182,7 +182,7 @@ func (d *Database) UtxosByAddress(
 	tmpUtxo := models.Utxo{}
 	if txn == nil {
 		txn = d.Transaction(false)
-		defer txn.Commit() //nolint:errcheck
+		defer txn.Release()
 	}
 	utxos, err := d.metadata.GetUtxosByAddress(addr, txn.Metadata())
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Txn.Release() for safe deferred cleanup and replaces deferred Commit() in read-only paths. Also delegates SetDatum writes to metadata when no txn is provided to avoid unnecessary transactions.

- **New Features**
  - Added Txn.Release(): releases read-only txns and logs errors; for read-write, behaves like rollback; safe to use in defer.

- **Refactors**
  - Swapped defer txn.Commit() with defer txn.Release() in read-only getters (accounts, datums, dreps, pools, transactions, UTXOs).
  - SetDatum: when txn is nil, call metadata directly instead of opening a txn.
  - No functional change for reads; improves safety and clarity.

<sup>Written for commit e09885d7c115bd14be00630b3397744bbd3f732d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed automatic transaction cleanup to release resources instead of committing for autogenerated transactions, reducing risk of unintended commits.
  * Added a safer cleanup path that ensures resources are freed and logs cleanup errors.
  * General database resource-management tweaks for improved stability and more predictable behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->