### PR TITLE
fix: synchronize access to chainsyncBlockfetchBusyTime

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -179,6 +179,8 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 		e,
 	)
 	// Update busy time in order to detect fetch timeout
+	ls.chainsyncBlockfetchBusyTimeMutex.Lock()
+	defer ls.chainsyncBlockfetchBusyTimeMutex.Unlock()
 	ls.chainsyncBlockfetchBusyTime = time.Now()
 	return nil
 }
@@ -530,7 +532,10 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 		return fmt.Errorf("request block range: %w", err)
 	}
 	// Reset blockfetch busy time
+	ls.chainsyncBlockfetchBusyTimeMutex.Lock()
 	ls.chainsyncBlockfetchBusyTime = time.Now()
+	ls.chainsyncBlockfetchBusyTimeMutex.Unlock()
+
 	// Create our blockfetch done signal channels
 	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
 	ls.chainsyncBlockfetchBatchDoneChan = make(chan struct{})
@@ -543,8 +548,12 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 			case <-time.After(500 * time.Millisecond):
 			}
 			// Clear blockfetch busy flag on timeout
+			ls.chainsyncBlockfetchBusyTimeMutex.Lock()
+			busyTime := ls.chainsyncBlockfetchBusyTime
+			ls.chainsyncBlockfetchBusyTimeMutex.Unlock()
+
 			if time.Since(
-				ls.chainsyncBlockfetchBusyTime,
+				busyTime,
 			) > blockfetchBusyTimeout {
 				ls.blockfetchRequestRangeCleanup(true)
 				ls.config.Logger.Warn(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -285,6 +285,7 @@ type LedgerState struct {
 	metrics                          stateMetrics
 	currentEra                       eras.EraDesc
 	config                           LedgerStateConfig
+	chainsyncBlockfetchBusyTimeMutex sync.Mutex // protects chainsyncBlockfetchBusyTime
 	chainsyncBlockfetchBusyTime      time.Time
 	currentPParams                   lcommon.ProtocolParameters
 	mempool                          MempoolProvider


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes access to chainsyncBlockfetchBusyTime with a mutex to prevent data races and incorrect timeout detection during blockfetch.

- **Bug Fixes**
  - Guard writes in handleEventBlockfetchBlock and blockfetchRequestRangeStart; guard reads in the timeout loop.
  - Prevents spurious busy-time timeouts and race-related instability under load.

<sup>Written for commit 705c96d201afd6e7c8b821f1abb03e9a92621eae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue in block synchronization timeout handling by guarding busy-time updates and reads with mutex protection, reducing race conditions and improving stability during block fetch operations.
  * No changes to public APIs or function signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->