### PR TITLE
feat: chain selection

### DIFF
--- a/chainselection/comparison.go
+++ b/chainselection/comparison.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// ChainComparisonResult indicates the result of comparing two chains.
+type ChainComparisonResult int
+
+const (
+	ChainEqual   ChainComparisonResult = 0
+	ChainABetter ChainComparisonResult = 1
+	ChainBBetter ChainComparisonResult = -1
+)
+
+// CompareChains compares two chain tips according to Ouroboros Praos rules:
+// 1. Higher block number wins (longer chain)
+// 2. At equal block number, lower slot wins (denser chain)
+//
+// Returns:
+//   - ChainABetter (1) if tipA represents a better chain
+//   - ChainBBetter (-1) if tipB represents a better chain
+//   - ChainEqual (0) if they are equal
+func CompareChains(tipA, tipB ochainsync.Tip) ChainComparisonResult {
+	// Rule 1: Higher block number wins (longer chain)
+	if tipA.BlockNumber > tipB.BlockNumber {
+		return ChainABetter
+	}
+	if tipB.BlockNumber > tipA.BlockNumber {
+		return ChainBBetter
+	}
+
+	// Rule 2: At equal block number, lower slot wins (denser chain)
+	if tipA.Point.Slot < tipB.Point.Slot {
+		return ChainABetter
+	}
+	if tipB.Point.Slot < tipA.Point.Slot {
+		return ChainBBetter
+	}
+
+	// Chains are equal
+	return ChainEqual
+}
+
+// IsBetterChain returns true if newTip represents a better chain than
+// currentTip according to Ouroboros Praos rules.
+func IsBetterChain(newTip, currentTip ochainsync.Tip) bool {
+	return CompareChains(newTip, currentTip) == ChainABetter
+}
+
+// IsSignificantlyBetter returns true if newTip is better than currentTip by
+// at least the specified minimum block difference. This can be used to avoid
+// frequent chain switches for marginal improvements.
+func IsSignificantlyBetter(
+	newTip, currentTip ochainsync.Tip,
+	minBlockDiff uint64,
+) bool {
+	if newTip.BlockNumber <= currentTip.BlockNumber {
+		return false
+	}
+	return newTip.BlockNumber-currentTip.BlockNumber >= minBlockDiff
+}

--- a/chainselection/comparison_test.go
+++ b/chainselection/comparison_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareChains(t *testing.T) {
+	tests := []struct {
+		name     string
+		tipA     ochainsync.Tip
+		tipB     ochainsync.Tip
+		expected ChainComparisonResult
+	}{
+		{
+			name: "higher block number wins",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 40,
+			},
+			expected: ChainABetter,
+		},
+		{
+			name: "lower block number loses",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 40,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			expected: ChainBBetter,
+		},
+		{
+			name: "equal block number lower slot wins",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			expected: ChainABetter,
+		},
+		{
+			name: "equal block number higher slot loses",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			expected: ChainBBetter,
+		},
+		{
+			name: "equal chains",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			expected: ChainEqual,
+		},
+		{
+			name: "origin tips",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 0, Hash: nil},
+				BlockNumber: 0,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 0, Hash: nil},
+				BlockNumber: 0,
+			},
+			expected: ChainEqual,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CompareChains(tt.tipA, tt.tipB)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsBetterChain(t *testing.T) {
+	newTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+		BlockNumber: 50,
+	}
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
+		BlockNumber: 45,
+	}
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("equal")},
+		BlockNumber: 50,
+	}
+
+	assert.True(t, IsBetterChain(newTip, currentTip))
+	assert.False(t, IsBetterChain(currentTip, newTip))
+	assert.False(t, IsBetterChain(newTip, equalTip))
+}
+
+func TestIsSignificantlyBetter(t *testing.T) {
+	tests := []struct {
+		name         string
+		newTip       ochainsync.Tip
+		currentTip   ochainsync.Tip
+		minBlockDiff uint64
+		expected     bool
+	}{
+		{
+			name: "significantly better",
+			newTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+				BlockNumber: 55,
+			},
+			currentTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
+				BlockNumber: 50,
+			},
+			minBlockDiff: 5,
+			expected:     true,
+		},
+		{
+			name: "not significantly better - below threshold",
+			newTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+				BlockNumber: 52,
+			},
+			currentTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
+				BlockNumber: 50,
+			},
+			minBlockDiff: 5,
+			expected:     false,
+		},
+		{
+			name: "equal block numbers",
+			newTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+				BlockNumber: 50,
+			},
+			currentTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
+				BlockNumber: 50,
+			},
+			minBlockDiff: 1,
+			expected:     false,
+		},
+		{
+			name: "new tip worse",
+			newTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+				BlockNumber: 45,
+			},
+			currentTip: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
+				BlockNumber: 50,
+			},
+			minBlockDiff: 1,
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsSignificantlyBetter(
+				tt.newTip,
+				tt.currentTip,
+				tt.minBlockDiff,
+			)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+const (
+	PeerTipUpdateEventType  event.EventType = "chainselection.peer_tip_update"
+	ChainSwitchEventType    event.EventType = "chainselection.chain_switch"
+	ChainSelectionEventType event.EventType = "chainselection.selection"
+)
+
+// PeerTipUpdateEvent is published when a peer's chain tip is updated via
+// chainsync roll forward.
+type PeerTipUpdateEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	Tip          ochainsync.Tip
+}
+
+// ChainSwitchEvent is published when the chain selector decides to switch
+// to a different peer's chain.
+//
+// Fields:
+//   - PreviousConnectionId: The connection ID of the peer we were following.
+//   - NewConnectionId: The connection ID of the peer we are now following.
+//   - NewTip: The chain tip of the new peer.
+//   - PreviousTip: The chain tip of the previous peer at the time of the switch.
+type ChainSwitchEvent struct {
+	PreviousConnectionId ouroboros.ConnectionId
+	NewConnectionId      ouroboros.ConnectionId
+	NewTip               ochainsync.Tip
+	PreviousTip          ochainsync.Tip
+}
+
+// ChainSelectionEvent is published when chain selection evaluation completes.
+type ChainSelectionEvent struct {
+	BestConnectionId ouroboros.ConnectionId
+	BestTip          ochainsync.Tip
+	PeerCount        int
+	SwitchOccurred   bool
+}

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// PeerChainTip tracks the chain tip reported by a specific peer.
+type PeerChainTip struct {
+	ConnectionId ouroboros.ConnectionId
+	Tip          ochainsync.Tip
+	LastUpdated  time.Time
+}
+
+// NewPeerChainTip creates a new PeerChainTip with the given connection ID and
+// tip.
+func NewPeerChainTip(
+	connId ouroboros.ConnectionId,
+	tip ochainsync.Tip,
+) *PeerChainTip {
+	return &PeerChainTip{
+		ConnectionId: connId,
+		Tip:          tip,
+		LastUpdated:  time.Now(),
+	}
+}
+
+// UpdateTip updates the peer's chain tip and last updated timestamp.
+func (p *PeerChainTip) UpdateTip(tip ochainsync.Tip) {
+	p.Tip = tip
+	p.LastUpdated = time.Now()
+}
+
+// IsStale returns true if the peer's tip hasn't been updated within the given
+// duration.
+func (p *PeerChainTip) IsStale(threshold time.Duration) bool {
+	return time.Since(p.LastUpdated) > threshold
+}

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -1,0 +1,475 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+const (
+	defaultEvaluationInterval = 10 * time.Second
+	defaultStaleTipThreshold  = 60 * time.Second
+)
+
+// ChainSelectorConfig holds configuration for the ChainSelector.
+type ChainSelectorConfig struct {
+	Logger             *slog.Logger
+	EventBus           *event.EventBus
+	EvaluationInterval time.Duration
+	StaleTipThreshold  time.Duration
+}
+
+// ChainSelector tracks chain tips from multiple peers and selects the best
+// chain according to Ouroboros Praos rules.
+type ChainSelector struct {
+	config       ChainSelectorConfig
+	peerTips     map[ouroboros.ConnectionId]*PeerChainTip
+	bestPeerConn *ouroboros.ConnectionId
+	localTip     ochainsync.Tip
+	mutex        sync.RWMutex
+	ctx          context.Context
+	cancel       context.CancelFunc
+}
+
+// NewChainSelector creates a new ChainSelector with the given configuration.
+func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	cfg.Logger = cfg.Logger.With("component", "chainselection")
+	if cfg.EvaluationInterval == 0 {
+		cfg.EvaluationInterval = defaultEvaluationInterval
+	}
+	if cfg.StaleTipThreshold == 0 {
+		cfg.StaleTipThreshold = defaultStaleTipThreshold
+	}
+	return &ChainSelector{
+		config:   cfg,
+		peerTips: make(map[ouroboros.ConnectionId]*PeerChainTip),
+	}
+}
+
+// Start begins the chain selector's background evaluation loop and subscribes
+// to relevant events.
+func (cs *ChainSelector) Start(ctx context.Context) error {
+	cs.ctx, cs.cancel = context.WithCancel(ctx)
+	go cs.evaluationLoop()
+	return nil
+}
+
+// Stop stops the chain selector.
+func (cs *ChainSelector) Stop() {
+	if cs.cancel != nil {
+		cs.cancel()
+	}
+}
+
+// UpdatePeerTip updates the chain tip for a specific peer and triggers
+// evaluation if needed.
+func (cs *ChainSelector) UpdatePeerTip(
+	connId ouroboros.ConnectionId,
+	tip ochainsync.Tip,
+) {
+	shouldEvaluate := false
+
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+
+		if peerTip, exists := cs.peerTips[connId]; exists {
+			peerTip.UpdateTip(tip)
+		} else {
+			cs.peerTips[connId] = NewPeerChainTip(connId, tip)
+		}
+
+		cs.config.Logger.Debug(
+			"updated peer tip",
+			"connection_id", connId.String(),
+			"block_number", tip.BlockNumber,
+			"slot", tip.Point.Slot,
+		)
+
+		// Check if this peer's tip is better than the current best peer's tip
+		if cs.bestPeerConn != nil {
+			if bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]; ok {
+				if IsBetterChain(tip, bestPeerTip.Tip) {
+					shouldEvaluate = true
+				}
+			}
+		} else {
+			// No best peer yet, trigger evaluation
+			shouldEvaluate = true
+		}
+	}()
+
+	if shouldEvaluate {
+		cs.EvaluateAndSwitch()
+	}
+}
+
+// RemovePeer removes a peer from tracking.
+func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
+	var switchEvent *event.Event
+
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+
+		delete(cs.peerTips, connId)
+
+		if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
+			previousBest := *cs.bestPeerConn
+			cs.bestPeerConn = nil
+			cs.config.Logger.Info(
+				"best peer disconnected, selecting new best",
+				"connection_id", connId.String(),
+			)
+			// Immediately select a new best peer from remaining peers
+			newBest := cs.selectBestChainLocked()
+			cs.bestPeerConn = newBest
+
+			if newBest != nil {
+				cs.config.Logger.Info(
+					"selected new best peer after disconnect",
+					"connection_id", newBest.String(),
+				)
+				// Emit ChainSwitchEvent so subscribers know to switch connections
+				if cs.config.EventBus != nil {
+					newPeerTip := cs.peerTips[*newBest]
+					evt := event.NewEvent(
+						ChainSwitchEventType,
+						ChainSwitchEvent{
+							PreviousConnectionId: previousBest,
+							NewConnectionId:      *newBest,
+							NewTip:               newPeerTip.Tip,
+							// PreviousTip is zero value since the peer is removed
+						},
+					)
+					switchEvent = &evt
+				}
+			}
+		}
+	}()
+
+	// Publish event outside the lock to prevent deadlock if subscribers
+	// call back into ChainSelector
+	if switchEvent != nil {
+		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+	}
+}
+
+// SetLocalTip updates the local chain tip for comparison.
+func (cs *ChainSelector) SetLocalTip(tip ochainsync.Tip) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	cs.localTip = tip
+}
+
+// GetBestPeer returns the connection ID of the peer with the best chain, or
+// nil if no suitable peer is available.
+func (cs *ChainSelector) GetBestPeer() *ouroboros.ConnectionId {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return cs.bestPeerConn
+}
+
+// GetPeerTip returns the chain tip for a specific peer.
+func (cs *ChainSelector) GetPeerTip(
+	connId ouroboros.ConnectionId,
+) *PeerChainTip {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return cs.peerTips[connId]
+}
+
+// GetAllPeerTips returns a copy of all tracked peer tips.
+func (cs *ChainSelector) GetAllPeerTips() map[ouroboros.ConnectionId]*PeerChainTip {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	result := make(map[ouroboros.ConnectionId]*PeerChainTip, len(cs.peerTips))
+	for k, v := range cs.peerTips {
+		tipCopy := *v
+		result[k] = &tipCopy
+	}
+	return result
+}
+
+// PeerCount returns the number of peers being tracked.
+func (cs *ChainSelector) PeerCount() int {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return len(cs.peerTips)
+}
+
+// SelectBestChain evaluates all peer tips and returns the connection ID of
+// the peer with the best chain.
+func (cs *ChainSelector) SelectBestChain() *ouroboros.ConnectionId {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	return cs.selectBestChainLocked()
+}
+
+func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
+	if len(cs.peerTips) == 0 {
+		return nil
+	}
+
+	var bestConnId *ouroboros.ConnectionId
+	var bestTip ochainsync.Tip
+
+	for connId, peerTip := range cs.peerTips {
+		if peerTip.IsStale(cs.config.StaleTipThreshold) {
+			cs.config.Logger.Debug(
+				"skipping stale peer",
+				"connection_id", connId.String(),
+				"last_updated", peerTip.LastUpdated,
+			)
+			continue
+		}
+
+		if bestConnId == nil {
+			connIdCopy := connId
+			bestConnId = &connIdCopy
+			bestTip = peerTip.Tip
+			continue
+		}
+
+		comparison := CompareChains(peerTip.Tip, bestTip)
+		switch comparison {
+		case ChainABetter:
+			connIdCopy := connId
+			bestConnId = &connIdCopy
+			bestTip = peerTip.Tip
+		case ChainEqual:
+			// Deterministic tiebreaker: smaller connection ID string wins
+			if connId.String() < bestConnId.String() {
+				connIdCopy := connId
+				bestConnId = &connIdCopy
+				bestTip = peerTip.Tip
+			}
+		case ChainBBetter:
+			// Current best is better, no change needed
+		}
+	}
+
+	return bestConnId
+}
+
+// EvaluateAndSwitch evaluates all peer tips and switches to the best chain if
+// it differs from the current best. Returns true if a switch occurred.
+func (cs *ChainSelector) EvaluateAndSwitch() bool {
+	// Collect events to publish outside the lock to prevent deadlock
+	var switchEvent *event.Event
+	var selectionEvent *event.Event
+	switchOccurred := false
+
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+
+		newBest := cs.selectBestChainLocked()
+		if newBest == nil {
+			// Clear stale reference to avoid returning a disconnected peer
+			cs.bestPeerConn = nil
+			return
+		}
+
+		previousBest := cs.bestPeerConn
+
+		if previousBest == nil || *previousBest != *newBest {
+			newPeerTip, ok := cs.peerTips[*newBest]
+			if !ok {
+				return
+			}
+			newTip := newPeerTip.Tip
+			cs.bestPeerConn = newBest
+			switchOccurred = true
+
+			cs.config.Logger.Info(
+				"selected new best peer",
+				"connection_id", newBest.String(),
+				"block_number", newTip.BlockNumber,
+				"slot", newTip.Point.Slot,
+			)
+
+			if cs.config.EventBus != nil && previousBest != nil {
+				var previousTip ochainsync.Tip
+				if pt, ok := cs.peerTips[*previousBest]; ok {
+					previousTip = pt.Tip
+				}
+				evt := event.NewEvent(
+					ChainSwitchEventType,
+					ChainSwitchEvent{
+						PreviousConnectionId: *previousBest,
+						NewConnectionId:      *newBest,
+						NewTip:               newTip,
+						PreviousTip:          previousTip,
+					},
+				)
+				switchEvent = &evt
+			}
+		}
+
+		if cs.config.EventBus != nil && cs.bestPeerConn != nil {
+			bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]
+			if !ok {
+				return
+			}
+			bestTip := bestPeerTip.Tip
+			evt := event.NewEvent(
+				ChainSelectionEventType,
+				ChainSelectionEvent{
+					BestConnectionId: *cs.bestPeerConn,
+					BestTip:          bestTip,
+					PeerCount:        len(cs.peerTips),
+					SwitchOccurred:   switchOccurred,
+				},
+			)
+			selectionEvent = &evt
+		}
+	}()
+
+	// Publish events outside the lock to prevent deadlock if subscribers
+	// call back into ChainSelector
+	if cs.config.EventBus != nil {
+		if switchEvent != nil {
+			cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+		}
+		if selectionEvent != nil {
+			cs.config.EventBus.Publish(ChainSelectionEventType, *selectionEvent)
+		}
+	}
+
+	return switchOccurred
+}
+
+// HandlePeerTipUpdateEvent handles PeerTipUpdateEvent from the event bus.
+func (cs *ChainSelector) HandlePeerTipUpdateEvent(evt event.Event) {
+	e, ok := evt.Data.(PeerTipUpdateEvent)
+	if !ok {
+		cs.config.Logger.Warn(
+			"received unexpected event data type",
+			"expected", "PeerTipUpdateEvent",
+		)
+		return
+	}
+	cs.UpdatePeerTip(e.ConnectionId, e.Tip)
+}
+
+func (cs *ChainSelector) evaluationLoop() {
+	ticker := time.NewTicker(cs.config.EvaluationInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-cs.ctx.Done():
+			return
+		case <-ticker.C:
+			cs.runEvaluationTick()
+		}
+	}
+}
+
+// runEvaluationTick runs one evaluation tick with panic recovery.
+// If a panic occurs, it's logged and the loop continues.
+func (cs *ChainSelector) runEvaluationTick() {
+	defer func() {
+		if r := recover(); r != nil {
+			cs.config.Logger.Error(
+				"panic in evaluation tick, continuing",
+				"panic", r,
+			)
+		}
+	}()
+	cs.cleanupStalePeers()
+	cs.EvaluateAndSwitch()
+}
+
+func (cs *ChainSelector) cleanupStalePeers() {
+	var switchEvent *event.Event
+
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+
+		var previousBest *ouroboros.ConnectionId
+
+		for connId, peerTip := range cs.peerTips {
+			// Use 2x the stale threshold for "very stale" cleanup. Peers are
+			// skipped from selection after StaleTipThreshold, but we keep them
+			// tracked for an additional period in case they reconnect or update.
+			// After 2x the threshold, we consider them truly gone and remove them.
+			if peerTip.IsStale(cs.config.StaleTipThreshold * 2) {
+				cs.config.Logger.Debug(
+					"removing very stale peer",
+					"connection_id", connId.String(),
+					"last_updated", peerTip.LastUpdated,
+				)
+				delete(cs.peerTips, connId)
+				// Track if this was the best peer
+				if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
+					connIdCopy := connId
+					previousBest = &connIdCopy
+					cs.bestPeerConn = nil
+				}
+			}
+		}
+
+		// If the best peer was removed, select a new one and emit event
+		if previousBest != nil {
+			cs.config.Logger.Info(
+				"best peer became stale, selecting new best",
+				"connection_id", previousBest.String(),
+			)
+			newBest := cs.selectBestChainLocked()
+			cs.bestPeerConn = newBest
+
+			if newBest != nil {
+				cs.config.Logger.Info(
+					"selected new best peer after stale cleanup",
+					"connection_id", newBest.String(),
+				)
+				// Emit ChainSwitchEvent so subscribers know to switch connections
+				if cs.config.EventBus != nil {
+					newPeerTip := cs.peerTips[*newBest]
+					evt := event.NewEvent(
+						ChainSwitchEventType,
+						ChainSwitchEvent{
+							PreviousConnectionId: *previousBest,
+							NewConnectionId:      *newBest,
+							NewTip:               newPeerTip.Tip,
+							// PreviousTip is zero value since the peer is removed
+						},
+					)
+					switchEvent = &evt
+				}
+			}
+		}
+	}()
+
+	// Publish event outside the lock to prevent deadlock if subscribers
+	// call back into ChainSelector
+	if switchEvent != nil {
+		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+	}
+}

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -1,0 +1,384 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestConnectionId(n int) ouroboros.ConnectionId {
+	localAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:3001")
+	remoteAddr, _ := net.ResolveTCPAddr(
+		"tcp",
+		fmt.Sprintf("127.0.0.1:%d", n+10000),
+	)
+	return ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+}
+
+func TestChainSelectorUpdatePeerTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId := newTestConnectionId(1)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(connId, tip)
+
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, tip.BlockNumber, peerTip.Tip.BlockNumber)
+	assert.Equal(t, tip.Point.Slot, peerTip.Tip.Point.Slot)
+	assert.Equal(t, 1, cs.PeerCount())
+}
+
+func TestChainSelectorUpdateExistingPeerTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId := newTestConnectionId(1)
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test1")},
+		BlockNumber: 50,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 110, Hash: []byte("test2")},
+		BlockNumber: 55,
+	}
+
+	cs.UpdatePeerTip(connId, tip1)
+	cs.UpdatePeerTip(connId, tip2)
+
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, tip2.BlockNumber, peerTip.Tip.BlockNumber)
+	assert.Equal(t, tip2.Point.Slot, peerTip.Tip.Point.Slot)
+	assert.Equal(t, 1, cs.PeerCount())
+}
+
+func TestChainSelectorRemovePeer(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId := newTestConnectionId(1)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(connId, tip)
+	assert.Equal(t, 1, cs.PeerCount())
+
+	cs.RemovePeer(connId)
+	assert.Equal(t, 0, cs.PeerCount())
+	assert.Nil(t, cs.GetPeerTip(connId))
+}
+
+func TestChainSelectorRemoveBestPeer(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId := newTestConnectionId(1)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(connId, tip)
+	cs.EvaluateAndSwitch()
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId, *cs.GetBestPeer())
+
+	cs.RemovePeer(connId)
+	assert.Nil(t, cs.GetBestPeer())
+}
+
+func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus: eventBus,
+	})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 60, // Best peer
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	// Subscribe to ChainSwitchEvent before adding peers
+	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
+
+	cs.UpdatePeerTip(connId1, tip1)
+	cs.UpdatePeerTip(connId2, tip2)
+	cs.EvaluateAndSwitch()
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	// Drain any events from the initial selection
+	for len(evtCh) > 0 {
+		<-evtCh
+	}
+
+	// Remove the best peer - this should emit ChainSwitchEvent
+	cs.RemovePeer(connId1)
+
+	// Verify the new best peer is selected
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+
+	// Verify ChainSwitchEvent was emitted
+	select {
+	case evt := <-evtCh:
+		switchEvt, ok := evt.Data.(ChainSwitchEvent)
+		require.True(t, ok, "expected ChainSwitchEvent")
+		assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
+		assert.Equal(t, connId2, switchEvt.NewConnectionId)
+		assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected ChainSwitchEvent was not emitted")
+	}
+}
+
+func TestChainSelectorSelectBestChain(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+	connId3 := newTestConnectionId(3)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 40,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 95, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+	tip3 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip3")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(connId1, tip1)
+	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId3, tip3)
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, connId2, *bestPeer)
+}
+
+func TestChainSelectorSelectBestChainEmpty(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+	assert.Nil(t, cs.SelectBestChain())
+}
+
+func TestChainSelectorEvaluateAndSwitch(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 40,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	// UpdatePeerTip now automatically triggers evaluation when a better tip
+	// is received, so after adding the first peer, it should be selected
+	cs.UpdatePeerTip(connId1, tip1)
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	// Adding a peer with a better tip automatically triggers evaluation
+	cs.UpdatePeerTip(connId2, tip2)
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+
+	// Calling EvaluateAndSwitch again should return false since no change
+	switched := cs.EvaluateAndSwitch()
+	assert.False(t, switched)
+}
+
+func TestChainSelectorStalePeerFiltering(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		StaleTipThreshold: 100 * time.Millisecond,
+	})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 60,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(connId1, tip1)
+	time.Sleep(150 * time.Millisecond)
+	cs.UpdatePeerTip(connId2, tip2)
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, connId2, *bestPeer)
+}
+
+func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:          eventBus,
+		StaleTipThreshold: 50 * time.Millisecond,
+	})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 60, // Best peer
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	// Subscribe to ChainSwitchEvent before adding peers
+	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
+
+	cs.UpdatePeerTip(connId1, tip1)
+	cs.UpdatePeerTip(connId2, tip2)
+	cs.EvaluateAndSwitch()
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	// Drain any events from the initial selection
+	for len(evtCh) > 0 {
+		<-evtCh
+	}
+
+	// Wait for peer1 to become "very stale" (2x threshold)
+	time.Sleep(110 * time.Millisecond)
+
+	// Keep peer2 fresh
+	cs.UpdatePeerTip(connId2, tip2)
+
+	// Drain any events from tip update
+	for len(evtCh) > 0 {
+		<-evtCh
+	}
+
+	// Trigger cleanup - this should emit ChainSwitchEvent when best peer is
+	// removed
+	cs.cleanupStalePeers()
+
+	// Verify the new best peer is selected
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+
+	// Verify ChainSwitchEvent was emitted
+	select {
+	case evt := <-evtCh:
+		switchEvt, ok := evt.Data.(ChainSwitchEvent)
+		require.True(t, ok, "expected ChainSwitchEvent")
+		assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
+		assert.Equal(t, connId2, switchEvt.NewConnectionId)
+		assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected ChainSwitchEvent was not emitted")
+	}
+}
+
+func TestChainSelectorGetAllPeerTips(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 40,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 110, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(connId1, tip1)
+	cs.UpdatePeerTip(connId2, tip2)
+
+	allTips := cs.GetAllPeerTips()
+	assert.Len(t, allTips, 2)
+	assert.Contains(t, allTips, connId1)
+	assert.Contains(t, allTips, connId2)
+}
+
+func TestPeerChainTipIsStale(t *testing.T) {
+	connId := newTestConnectionId(1)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test")},
+		BlockNumber: 50,
+	}
+
+	peerTip := NewPeerChainTip(connId, tip)
+	assert.False(t, peerTip.IsStale(100*time.Millisecond))
+
+	time.Sleep(150 * time.Millisecond)
+	assert.True(t, peerTip.IsStale(100*time.Millisecond))
+}
+
+func TestPeerChainTipUpdateTip(t *testing.T) {
+	connId := newTestConnectionId(1)
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test1")},
+		BlockNumber: 50,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 110, Hash: []byte("test2")},
+		BlockNumber: 55,
+	}
+
+	peerTip := NewPeerChainTip(connId, tip1)
+	time.Sleep(50 * time.Millisecond)
+	oldTime := peerTip.LastUpdated
+
+	peerTip.UpdateTip(tip2)
+	assert.Equal(t, tip2.BlockNumber, peerTip.Tip.BlockNumber)
+	assert.True(t, peerTip.LastUpdated.After(oldTime))
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -264,6 +264,10 @@ const (
 // the node to shut down. The callback should trigger graceful shutdown.
 type FatalErrorFunc func(err error)
 
+// GetActiveConnectionFunc is a callback to retrieve the currently active
+// chainsync connection ID for chain selection purposes.
+type GetActiveConnectionFunc func() *ouroboros.ConnectionId
+
 type LedgerStateConfig struct {
 	PromRegistry               prometheus.Registerer
 	Logger                     *slog.Logger
@@ -272,6 +276,7 @@ type LedgerStateConfig struct {
 	EventBus                   *event.EventBus
 	CardanoNodeConfig          *cardano.CardanoNodeConfig
 	BlockfetchRequestRangeFunc BlockfetchRequestRangeFunc
+	GetActiveConnectionFunc    GetActiveConnectionFunc
 	FatalErrorFunc             FatalErrorFunc
 	ValidateHistorical         bool
 	ForgeBlocks                bool


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added multi-peer chain selection that tracks peer tips, picks the best chain using Praos rules, and automatically switches the active chainsync client to the best peer for more reliable syncing.

- **New Features**
  - New chainselection package: tip comparison (block number, then slot), peer tip tracking, and a background selector with stale-tip filtering and deterministic ties.
  - Event-driven integration: publishes peer tip updates on roll forward, and chain switch/selection events; selector runs on a timer and on better-tip updates.
  - Tests cover chain comparison, selector behavior, and stale handling.

- **Refactors**
  - Chainsync state now supports multiple clients and an “active” client; added helpers to add/remove/check tracked clients.
  - Ledger filters block header and rollback events from non-active connections when an active connection is provided via GetActiveConnectionFunc.
  - Node wires the selector, listens for switch events to set the active connection, removes disconnected peers, and stops the selector on shutdown.
  - Ouroboros starts up to 10 concurrent chainsync clients and relies on the selector to choose the active one.

<sup>Written for commit 2da4abbe0b24410db3b7ce44092e4b4c2cc853c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-peer chain selection with automatic evaluation and switching to the best chain
  * Peer tip tracking with stale-peer cleanup and peer update events
  * Active-client management for multiple chainsync connections and automatic active peer selection
  * Emitted events for chain switches and peer-tip updates to notify subscribers

* **Chores**
  * Event ordering adjustments and minor copyright year updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->