### PR TITLE
feat(chainselection): vrf tie breaker

### DIFF
--- a/chain/event.go
+++ b/chain/event.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	ChainUpdateEventType = "chain.update"
+	ChainForkEventType   = "chain.fork-detected"
 )
 
 type ChainBlockEvent struct {
@@ -30,4 +31,17 @@ type ChainBlockEvent struct {
 
 type ChainRollbackEvent struct {
 	Point ocommon.Point
+}
+
+// ChainForkEvent is emitted when a chain fork is detected.
+// This allows subscribers to monitor fork activity for alerting and metrics.
+type ChainForkEvent struct {
+	// ForkPoint is the common ancestor where the chains diverge
+	ForkPoint ocommon.Point
+	// ForkDepth is the number of blocks rolled back from the canonical chain
+	ForkDepth uint64
+	// AlternateHead is the tip of the competing chain
+	AlternateHead ocommon.Point
+	// CanonicalHead is the tip of the current canonical chain
+	CanonicalHead ocommon.Point
 }

--- a/chainselection/comparison_test.go
+++ b/chainselection/comparison_test.go
@@ -203,3 +203,194 @@ func TestIsSignificantlyBetter(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareChainsWithDensity(t *testing.T) {
+	tests := []struct {
+		name            string
+		tipA            ochainsync.Tip
+		tipB            ochainsync.Tip
+		blocksInWindowA uint64
+		blocksInWindowB uint64
+		expected        ChainComparisonResult
+	}{
+		{
+			name: "higher block number wins regardless of density",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 40,
+			},
+			blocksInWindowA: 10,
+			blocksInWindowB: 20, // B has higher density but lower block number
+			expected:        ChainABetter,
+		},
+		{
+			name: "lower block number loses regardless of density",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 40,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			blocksInWindowA: 20, // A has higher density but lower block number
+			blocksInWindowB: 10,
+			expected:        ChainBBetter,
+		},
+		{
+			name: "equal block number higher density wins",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			blocksInWindowA: 25,
+			blocksInWindowB: 20,
+			expected:        ChainABetter,
+		},
+		{
+			name: "equal block number lower density loses",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			blocksInWindowA: 20,
+			blocksInWindowB: 25,
+			expected:        ChainBBetter,
+		},
+		{
+			name: "equal block number and density lower slot wins",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			blocksInWindowA: 20,
+			blocksInWindowB: 20,
+			expected:        ChainABetter,
+		},
+		{
+			name: "equal block number and density higher slot loses",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 90, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			blocksInWindowA: 20,
+			blocksInWindowB: 20,
+			expected:        ChainBBetter,
+		},
+		{
+			name: "completely equal chains",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
+				BlockNumber: 50,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
+				BlockNumber: 50,
+			},
+			blocksInWindowA: 20,
+			blocksInWindowB: 20,
+			expected:        ChainEqual,
+		},
+		{
+			name: "origin tips with zero density",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 0, Hash: nil},
+				BlockNumber: 0,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 0, Hash: nil},
+				BlockNumber: 0,
+			},
+			blocksInWindowA: 0,
+			blocksInWindowB: 0,
+			expected:        ChainEqual,
+		},
+		{
+			name: "density matters only at equal block number",
+			tipA: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 1000, Hash: []byte("a")},
+				BlockNumber: 100,
+			},
+			tipB: ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 900, Hash: []byte("b")},
+				BlockNumber: 100,
+			},
+			blocksInWindowA: 50,
+			blocksInWindowB: 40,
+			expected:        ChainABetter,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CompareChainsWithDensity(
+				tt.tipA,
+				tt.tipB,
+				tt.blocksInWindowA,
+				tt.blocksInWindowB,
+			)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsBetterChainWithDensity(t *testing.T) {
+	newTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+		BlockNumber: 50,
+	}
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
+		BlockNumber: 45,
+	}
+	equalBlockTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("equal")},
+		BlockNumber: 50,
+	}
+
+	// New tip has higher block number - wins regardless of density
+	assert.True(
+		t,
+		IsBetterChainWithDensity(newTip, currentTip, 10, 20),
+	)
+	assert.False(
+		t,
+		IsBetterChainWithDensity(currentTip, newTip, 20, 10),
+	)
+
+	// Equal block numbers - density decides
+	assert.True(
+		t,
+		IsBetterChainWithDensity(newTip, equalBlockTip, 25, 20),
+	)
+	assert.False(
+		t,
+		IsBetterChainWithDensity(newTip, equalBlockTip, 20, 25),
+	)
+
+	// Equal block numbers and density - slot decides
+	assert.False(
+		t,
+		IsBetterChainWithDensity(newTip, equalBlockTip, 20, 20),
+	)
+}

--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -31,6 +31,7 @@ const (
 type PeerTipUpdateEvent struct {
 	ConnectionId ouroboros.ConnectionId
 	Tip          ochainsync.Tip
+	VRFOutput    []byte // VRF output from block header for tie-breaking
 }
 
 // ChainSwitchEvent is published when the chain selector decides to switch
@@ -41,11 +42,15 @@ type PeerTipUpdateEvent struct {
 //   - NewConnectionId: The connection ID of the peer we are now following.
 //   - NewTip: The chain tip of the new peer.
 //   - PreviousTip: The chain tip of the previous peer at the time of the switch.
+//   - ComparisonResult: Why the new chain is better than the previous chain.
+//   - BlockDifference: NewTip.BlockNumber - PreviousTip.BlockNumber.
 type ChainSwitchEvent struct {
 	PreviousConnectionId ouroboros.ConnectionId
 	NewConnectionId      ouroboros.ConnectionId
 	NewTip               ochainsync.Tip
 	PreviousTip          ochainsync.Tip
+	ComparisonResult     ChainComparisonResult
+	BlockDifference      int64
 }
 
 // ChainSelectionEvent is published when chain selection evaluation completes.

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -25,25 +25,29 @@ import (
 type PeerChainTip struct {
 	ConnectionId ouroboros.ConnectionId
 	Tip          ochainsync.Tip
+	VRFOutput    []byte // VRF output from tip block for tie-breaking
 	LastUpdated  time.Time
 }
 
-// NewPeerChainTip creates a new PeerChainTip with the given connection ID and
-// tip.
+// NewPeerChainTip creates a new PeerChainTip with the given connection ID,
+// tip, and VRF output.
 func NewPeerChainTip(
 	connId ouroboros.ConnectionId,
 	tip ochainsync.Tip,
+	vrfOutput []byte,
 ) *PeerChainTip {
 	return &PeerChainTip{
 		ConnectionId: connId,
 		Tip:          tip,
+		VRFOutput:    vrfOutput,
 		LastUpdated:  time.Now(),
 	}
 }
 
-// UpdateTip updates the peer's chain tip and last updated timestamp.
-func (p *PeerChainTip) UpdateTip(tip ochainsync.Tip) {
+// UpdateTip updates the peer's chain tip, VRF output, and last updated timestamp.
+func (p *PeerChainTip) UpdateTip(tip ochainsync.Tip, vrfOutput []byte) {
 	p.Tip = tip
+	p.VRFOutput = vrfOutput
 	p.LastUpdated = time.Now()
 }
 

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -49,7 +49,7 @@ func TestChainSelectorUpdatePeerTip(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	cs.UpdatePeerTip(connId, tip)
+	cs.UpdatePeerTip(connId, tip, nil)
 
 	peerTip := cs.GetPeerTip(connId)
 	require.NotNil(t, peerTip)
@@ -71,8 +71,8 @@ func TestChainSelectorUpdateExistingPeerTip(t *testing.T) {
 		BlockNumber: 55,
 	}
 
-	cs.UpdatePeerTip(connId, tip1)
-	cs.UpdatePeerTip(connId, tip2)
+	cs.UpdatePeerTip(connId, tip1, nil)
+	cs.UpdatePeerTip(connId, tip2, nil)
 
 	peerTip := cs.GetPeerTip(connId)
 	require.NotNil(t, peerTip)
@@ -90,7 +90,7 @@ func TestChainSelectorRemovePeer(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	cs.UpdatePeerTip(connId, tip)
+	cs.UpdatePeerTip(connId, tip, nil)
 	assert.Equal(t, 1, cs.PeerCount())
 
 	cs.RemovePeer(connId)
@@ -107,7 +107,7 @@ func TestChainSelectorRemoveBestPeer(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	cs.UpdatePeerTip(connId, tip)
+	cs.UpdatePeerTip(connId, tip, nil)
 	cs.EvaluateAndSwitch()
 
 	require.NotNil(t, cs.GetBestPeer())
@@ -138,8 +138,8 @@ func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
 	// Subscribe to ChainSwitchEvent before adding peers
 	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
 
-	cs.UpdatePeerTip(connId1, tip1)
-	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId1, tip1, nil)
+	cs.UpdatePeerTip(connId2, tip2, nil)
 	cs.EvaluateAndSwitch()
 
 	require.NotNil(t, cs.GetBestPeer())
@@ -190,9 +190,9 @@ func TestChainSelectorSelectBestChain(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	cs.UpdatePeerTip(connId1, tip1)
-	cs.UpdatePeerTip(connId2, tip2)
-	cs.UpdatePeerTip(connId3, tip3)
+	cs.UpdatePeerTip(connId1, tip1, nil)
+	cs.UpdatePeerTip(connId2, tip2, nil)
+	cs.UpdatePeerTip(connId3, tip3, nil)
 
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
@@ -221,11 +221,11 @@ func TestChainSelectorEvaluateAndSwitch(t *testing.T) {
 
 	// UpdatePeerTip now automatically triggers evaluation when a better tip
 	// is received, so after adding the first peer, it should be selected
-	cs.UpdatePeerTip(connId1, tip1)
+	cs.UpdatePeerTip(connId1, tip1, nil)
 	assert.Equal(t, connId1, *cs.GetBestPeer())
 
 	// Adding a peer with a better tip automatically triggers evaluation
-	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId2, tip2, nil)
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 
 	// Calling EvaluateAndSwitch again should return false since no change
@@ -250,9 +250,9 @@ func TestChainSelectorStalePeerFiltering(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	cs.UpdatePeerTip(connId1, tip1)
+	cs.UpdatePeerTip(connId1, tip1, nil)
 	time.Sleep(150 * time.Millisecond)
-	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId2, tip2, nil)
 
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
@@ -281,8 +281,8 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 	// Subscribe to ChainSwitchEvent before adding peers
 	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
 
-	cs.UpdatePeerTip(connId1, tip1)
-	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId1, tip1, nil)
+	cs.UpdatePeerTip(connId2, tip2, nil)
 	cs.EvaluateAndSwitch()
 
 	require.NotNil(t, cs.GetBestPeer())
@@ -297,7 +297,7 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 	time.Sleep(110 * time.Millisecond)
 
 	// Keep peer2 fresh
-	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId2, tip2, nil)
 
 	// Drain any events from tip update
 	for len(evtCh) > 0 {
@@ -340,8 +340,8 @@ func TestChainSelectorGetAllPeerTips(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	cs.UpdatePeerTip(connId1, tip1)
-	cs.UpdatePeerTip(connId2, tip2)
+	cs.UpdatePeerTip(connId1, tip1, nil)
+	cs.UpdatePeerTip(connId2, tip2, nil)
 
 	allTips := cs.GetAllPeerTips()
 	assert.Len(t, allTips, 2)
@@ -356,7 +356,7 @@ func TestPeerChainTipIsStale(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	peerTip := NewPeerChainTip(connId, tip)
+	peerTip := NewPeerChainTip(connId, tip, nil)
 	assert.False(t, peerTip.IsStale(100*time.Millisecond))
 
 	time.Sleep(150 * time.Millisecond)
@@ -374,11 +374,141 @@ func TestPeerChainTipUpdateTip(t *testing.T) {
 		BlockNumber: 55,
 	}
 
-	peerTip := NewPeerChainTip(connId, tip1)
+	peerTip := NewPeerChainTip(connId, tip1, nil)
 	time.Sleep(50 * time.Millisecond)
 	oldTime := peerTip.LastUpdated
 
-	peerTip.UpdateTip(tip2)
+	peerTip.UpdateTip(tip2, nil)
 	assert.Equal(t, tip2.BlockNumber, peerTip.Tip.BlockNumber)
 	assert.True(t, peerTip.LastUpdated.After(oldTime))
+}
+
+func TestChainSelectorVRFTiebreaker(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	// Two peers with identical tips (same block number and slot)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("same")},
+		BlockNumber: 50,
+	}
+
+	// VRF outputs: lower wins (per Ouroboros Praos)
+	vrfLower := []byte{0x00, 0x00, 0x00, 0x01}
+	vrfHigher := []byte{0x00, 0x00, 0x00, 0x02}
+
+	// Add peer with higher VRF first
+	cs.UpdatePeerTip(connId1, tip, vrfHigher)
+	// Add peer with lower VRF second
+	cs.UpdatePeerTip(connId2, tip, vrfLower)
+
+	// The peer with lower VRF should win
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, connId2, *bestPeer, "peer with lower VRF should win")
+}
+
+func TestChainSelectorVRFTiebreakerWithNilVRF(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	// Two peers with identical tips
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("same")},
+		BlockNumber: 50,
+	}
+
+	// One peer has VRF, one doesn't
+	vrf := []byte{0x00, 0x01, 0x02, 0x03}
+
+	cs.UpdatePeerTip(connId1, tip, vrf)
+	cs.UpdatePeerTip(connId2, tip, nil)
+
+	// When VRF comparison returns equal (due to nil), fall back to connection ID
+	// connId1 vs connId2 - the one with lexicographically smaller string wins
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	// Since VRF comparison returns ChainEqual when one is nil,
+	// it falls back to connection ID comparison
+	assert.Equal(t, connId1, *bestPeer, "should fall back to connection ID ordering when one peer has nil VRF")
+}
+
+func TestChainSelectorVRFDoesNotOverrideBlockNumber(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	// Peer 1: lower block number but lower VRF
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 40,
+	}
+	// Peer 2: higher block number but higher VRF
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	vrfLower := []byte{0x00, 0x00, 0x00, 0x01}
+	vrfHigher := []byte{0xFF, 0xFF, 0xFF, 0xFF}
+
+	cs.UpdatePeerTip(connId1, tip1, vrfLower)
+	cs.UpdatePeerTip(connId2, tip2, vrfHigher)
+
+	// Block number takes precedence - peer 2 should win despite higher VRF
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, connId2, *bestPeer, "higher block number should win over lower VRF")
+}
+
+func TestChainSelectorVRFDoesNotOverrideSlot(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	// Both have same block number
+	// Peer 1: higher slot (less dense) but lower VRF
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 110, Hash: []byte("tip1")},
+		BlockNumber: 50,
+	}
+	// Peer 2: lower slot (more dense) but higher VRF
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	vrfLower := []byte{0x00, 0x00, 0x00, 0x01}
+	vrfHigher := []byte{0xFF, 0xFF, 0xFF, 0xFF}
+
+	cs.UpdatePeerTip(connId1, tip1, vrfLower)
+	cs.UpdatePeerTip(connId2, tip2, vrfHigher)
+
+	// Slot takes precedence - peer 2 (lower slot) should win despite higher VRF
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, connId2, *bestPeer, "lower slot should win over lower VRF")
+}
+
+func TestPeerChainTipVRFOutputStored(t *testing.T) {
+	connId := newTestConnectionId(1)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test")},
+		BlockNumber: 50,
+	}
+	vrf := []byte{0x01, 0x02, 0x03, 0x04}
+
+	peerTip := NewPeerChainTip(connId, tip, vrf)
+	assert.Equal(t, vrf, peerTip.VRFOutput)
+
+	// Update with new VRF
+	newVRF := []byte{0x05, 0x06, 0x07, 0x08}
+	peerTip.UpdateTip(tip, newVRF)
+	assert.Equal(t, newVRF, peerTip.VRFOutput)
 }

--- a/chainselection/vrf.go
+++ b/chainselection/vrf.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"bytes"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// VRFOutputSize is the expected size of a VRF output in bytes.
+const VRFOutputSize = 64
+
+// GetVRFOutput extracts the VRF output from a block header.
+// Returns nil if the header type is not supported or doesn't contain VRF data.
+//
+// The VRF output is used for tie-breaking in chain selection when two chains
+// have equal block numbers and equal density. The chain with the LOWER VRF
+// output (lexicographically) wins.
+func GetVRFOutput(header ledger.BlockHeader) []byte {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *allegra.AllegraBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *mary.MaryBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *alonzo.AlonzoBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *babbage.BabbageBlockHeader:
+		return h.Body.VrfResult.Output
+	case *conway.ConwayBlockHeader:
+		return h.Body.VrfResult.Output
+	default:
+		return nil
+	}
+}
+
+// CompareVRFOutputs compares two VRF outputs for chain selection tie-breaking.
+// Returns:
+//   - ChainABetter (1) if vrfA is lower (A wins)
+//   - ChainBBetter (-1) if vrfB is lower (B wins)
+//   - ChainEqual (0) if equal or either is nil
+//
+// Per Ouroboros Praos: the chain with the LOWER VRF output wins the tie-break.
+func CompareVRFOutputs(vrfA, vrfB []byte) ChainComparisonResult {
+	// Can't compare if either is nil
+	if vrfA == nil || vrfB == nil {
+		return ChainEqual
+	}
+
+	// Lower VRF output wins
+	cmp := bytes.Compare(vrfA, vrfB)
+	if cmp < 0 {
+		return ChainABetter // vrfA is lower, A wins
+	}
+	if cmp > 0 {
+		return ChainBBetter // vrfB is lower, B wins
+	}
+	return ChainEqual
+}
+
+// CompareHeaders compares two block headers for chain selection tie-breaking
+// using their VRF outputs. This is a convenience wrapper around GetVRFOutput
+// and CompareVRFOutputs.
+func CompareHeaders(headerA, headerB ledger.BlockHeader) ChainComparisonResult {
+	vrfA := GetVRFOutput(headerA)
+	vrfB := GetVRFOutput(headerB)
+	return CompareVRFOutputs(vrfA, vrfB)
+}

--- a/chainselection/vrf_test.go
+++ b/chainselection/vrf_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"testing"
+
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareVRFOutputs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		vrfA     []byte
+		vrfB     []byte
+		expected ChainComparisonResult
+	}{
+		{
+			name:     "vrfA lower - A wins",
+			vrfA:     []byte{0x00, 0x00, 0x00, 0x01},
+			vrfB:     []byte{0x00, 0x00, 0x00, 0x02},
+			expected: ChainABetter,
+		},
+		{
+			name:     "vrfB lower - B wins",
+			vrfA:     []byte{0x00, 0x00, 0x00, 0x02},
+			vrfB:     []byte{0x00, 0x00, 0x00, 0x01},
+			expected: ChainBBetter,
+		},
+		{
+			name:     "equal VRF outputs",
+			vrfA:     []byte{0x01, 0x02, 0x03, 0x04},
+			vrfB:     []byte{0x01, 0x02, 0x03, 0x04},
+			expected: ChainEqual,
+		},
+		{
+			name:     "vrfA nil - equal",
+			vrfA:     nil,
+			vrfB:     []byte{0x01, 0x02, 0x03, 0x04},
+			expected: ChainEqual,
+		},
+		{
+			name:     "vrfB nil - equal",
+			vrfA:     []byte{0x01, 0x02, 0x03, 0x04},
+			vrfB:     nil,
+			expected: ChainEqual,
+		},
+		{
+			name:     "both nil - equal",
+			vrfA:     nil,
+			vrfB:     nil,
+			expected: ChainEqual,
+		},
+		{
+			name:     "first byte different - A lower wins",
+			vrfA:     []byte{0x00, 0xFF, 0xFF, 0xFF},
+			vrfB:     []byte{0xFF, 0x00, 0x00, 0x00},
+			expected: ChainABetter,
+		},
+		{
+			name:     "first byte different - B lower wins",
+			vrfA:     []byte{0xFF, 0x00, 0x00, 0x00},
+			vrfB:     []byte{0x00, 0xFF, 0xFF, 0xFF},
+			expected: ChainBBetter,
+		},
+		{
+			name: "full 64-byte VRF - A lower",
+			vrfA: make64ByteVRF(0x00),
+			vrfB: make64ByteVRF(0x01),
+			expected: ChainABetter,
+		},
+		{
+			name: "full 64-byte VRF - B lower",
+			vrfA: make64ByteVRF(0x01),
+			vrfB: make64ByteVRF(0x00),
+			expected: ChainBBetter,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CompareVRFOutputs(tc.vrfA, tc.vrfB)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestCompareChainsWithVRF(t *testing.T) {
+	testCases := []struct {
+		name            string
+		tipA            ochainsync.Tip
+		tipB            ochainsync.Tip
+		blocksInWindowA uint64
+		blocksInWindowB uint64
+		vrfA            []byte
+		vrfB            []byte
+		expected        ChainComparisonResult
+	}{
+		{
+			name:            "higher block number wins regardless of VRF",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 40},
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            make64ByteVRF(0xFF), // Higher VRF
+			vrfB:            make64ByteVRF(0x00), // Lower VRF
+			expected:        ChainABetter, // Block number wins over VRF
+		},
+		{
+			name:            "equal block number - higher density wins regardless of VRF",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			blocksInWindowA: 100, // Higher density
+			blocksInWindowB: 80,  // Lower density
+			vrfA:            make64ByteVRF(0xFF), // Higher VRF
+			vrfB:            make64ByteVRF(0x00), // Lower VRF
+			expected:        ChainABetter, // Density wins over VRF
+		},
+		{
+			name:            "equal block number and density - VRF tie-breaker A wins",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            make64ByteVRF(0x00), // Lower VRF wins
+			vrfB:            make64ByteVRF(0xFF),
+			expected:        ChainABetter,
+		},
+		{
+			name:            "equal block number and density - VRF tie-breaker B wins",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            make64ByteVRF(0xFF), // Higher VRF loses
+			vrfB:            make64ByteVRF(0x00), // Lower VRF wins
+			expected:        ChainBBetter,
+		},
+		{
+			name:            "equal VRF - falls back to slot comparison A wins",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 90}, BlockNumber: 50},  // Lower slot
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50}, // Higher slot
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            make64ByteVRF(0x50),
+			vrfB:            make64ByteVRF(0x50), // Equal VRF
+			expected:        ChainABetter, // Lower slot wins
+		},
+		{
+			name:            "nil VRF - falls back to slot comparison",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 90}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            nil,
+			vrfB:            nil,
+			expected:        ChainABetter, // Lower slot wins as fallback
+		},
+		{
+			name:            "one nil VRF - falls back to slot comparison",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 90}, BlockNumber: 50},
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            make64ByteVRF(0x00), // Has VRF but B is nil
+			vrfB:            nil,
+			expected:        ChainBBetter, // B has lower slot, VRF comparison skipped
+		},
+		{
+			name:            "completely equal chains",
+			tipA:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			tipB:            ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50},
+			blocksInWindowA: 100,
+			blocksInWindowB: 100,
+			vrfA:            make64ByteVRF(0x50),
+			vrfB:            make64ByteVRF(0x50),
+			expected:        ChainEqual,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CompareChainsWithVRF(
+				tc.tipA, tc.tipB,
+				tc.blocksInWindowA, tc.blocksInWindowB,
+				tc.vrfA, tc.vrfB,
+			)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsBetterChainWithVRF(t *testing.T) {
+	// Test that IsBetterChainWithVRF correctly wraps CompareChainsWithVRF
+	newTip := ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50}
+	currentTip := ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50}
+
+	// New chain has lower VRF - should be better
+	assert.True(t, IsBetterChainWithVRF(
+		newTip, currentTip,
+		100, 100, // Equal density
+		make64ByteVRF(0x00), make64ByteVRF(0xFF), // New has lower VRF
+	))
+
+	// New chain has higher VRF - should not be better
+	assert.False(t, IsBetterChainWithVRF(
+		newTip, currentTip,
+		100, 100, // Equal density
+		make64ByteVRF(0xFF), make64ByteVRF(0x00), // New has higher VRF
+	))
+}
+
+// Helper function to create a 64-byte VRF output filled with a specific value
+func make64ByteVRF(fill byte) []byte {
+	vrf := make([]byte, VRFOutputSize)
+	for i := range vrf {
+		vrf[i] = fill
+	}
+	return vrf
+}

--- a/node.go
+++ b/node.go
@@ -221,6 +221,23 @@ func (n *Node) Run(ctx context.Context) error {
 			n.chainsyncState.SetClientConnId(e.NewConnectionId)
 		},
 	)
+	// Subscribe to chain fork events for monitoring
+	n.eventBus.SubscribeFunc(
+		chain.ChainForkEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(chain.ChainForkEvent)
+			if !ok {
+				return
+			}
+			n.config.logger.Warn(
+				"chain fork detected",
+				"fork_point_slot", e.ForkPoint.Slot,
+				"fork_depth", e.ForkDepth,
+				"alternate_head_slot", e.AlternateHead.Slot,
+				"canonical_head_slot", e.CanonicalHead.Slot,
+			)
+		},
+	)
 	// Subscribe to connection closed events to remove peers from chain selector
 	n.eventBus.SubscribeFunc(
 		connmanager.ConnectionClosedEventType,

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -267,6 +267,8 @@ func (o *Ouroboros) chainsyncClientRollForward(
 	case gledger.BlockHeader:
 		blockSlot := v.SlotNumber()
 		blockHash := v.Hash().Bytes()
+		// Extract VRF output from block header for chain selection tie-breaking
+		vrfOutput := chainselection.GetVRFOutput(v)
 		// Publish peer tip update for chain selection
 		o.EventBus.Publish(
 			chainselection.PeerTipUpdateEventType,
@@ -275,6 +277,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				chainselection.PeerTipUpdateEvent{
 					ConnectionId: ctx.ConnectionId,
 					Tip:          tip,
+					VRFOutput:    vrfOutput,
 				},
 			),
 		)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add VRF-based tie-breaker to Ouroboros Praos chain selection and emit detailed fork detection events to improve correctness and observability.

- **New Features**
  - Implement VRF tie-breaker when block number and density are equal (CompareChainsWithVRF, CompareVRFOutputs, GetVRFOutput).
  - Add density-based comparison helpers for 3k/f window (CompareChainsWithDensity).
  - Emit chain.fork-detected events on rollback with fork point, depth, and heads.
  - Extend ChainSwitchEvent with ComparisonResult and BlockDifference.
  - Add SecurityParam to ChainSelectorConfig and SetSecurityParam for dynamic updates.
  - Node subscribes to fork events and logs warnings with fork details.
  - Comprehensive tests for VRF and density selection.

<sup>Written for commit 3c3fad5db95fc60b0d0ed90202da2c83b81eb190. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fork detection now emits detailed fork events with fork point, depth, alternate and canonical head metadata; node logs these fork warnings.
  * Chain selection enhanced with density-based and VRF-based tie-breaking; VRF outputs are extracted and propagated to selection logic.
  * Chain switch events now include comparison results and block-difference info.
  * Security parameter made runtime-configurable.

* **Tests**
  * Added comprehensive tests for density- and VRF-based chain comparison and tie-breaking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->