### PR TITLE
fix(database): partial commit handling

### DIFF
--- a/database/types/types.go
+++ b/database/types/types.go
@@ -91,6 +91,10 @@ var ErrNoStoreAvailable = errors.New("no store available")
 // ErrBlobStoreUnavailable is returned when blob store cannot be accessed
 var ErrBlobStoreUnavailable = errors.New("blob store unavailable")
 
+// ErrPartialCommit is returned when blob commits but metadata fails,
+// leaving the database in an inconsistent state that requires recovery.
+var ErrPartialCommit = errors.New("partial commit: blob committed but metadata failed")
+
 // BlobItem represents a value returned by an iterator
 type BlobItem interface {
 	Key() []byte


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust handling for partial commits where blobs commit but metadata fails. Returns a typed error and automatically triggers recovery to restore consistency.

- **Bug Fixes**
  - Introduced PartialCommitError that matches types.ErrPartialCommit and carries the commit timestamp.
  - Added types.ErrPartialCommit sentinel for detection with errors.Is.
  - Tracked commitTimestamp during commit and improved logging; rolled back metadata on failure.
  - LedgerState detects partial commits in SubmitAsyncDBTxn, guards against nested recovery, attempts RecoverCommitTimestampConflict, joins errors on recovery failure, and returns a retryable non-partial error on recovery success.

<sup>Written for commit 1cc873e801882d9fbcb550752d580a90cab5b0d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect and report partial commits with the commit timestamp to aid recovery.
  * Ensure both stores are rolled back if timestamp updates fail; improve rollback when metadata commits fail.
  * Add automated recovery attempts and richer logging/diagnostics for partial-commit scenarios to improve troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->