### PR TITLE
fix: resource leaks, silent failures, and panic recovery

### DIFF
--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -173,6 +173,7 @@ func (c *ConnectionManager) startListener(
 						err,
 					),
 				)
+				conn.Close()
 				continue
 			}
 			// Add to connection manager

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -82,6 +82,7 @@ func (c *ConnectionManager) CreateOutboundConn(
 		connOpts...,
 	)
 	if err != nil {
+		tmpConn.Close()
 		return nil, err
 	}
 	c.config.Logger.Info(

--- a/database/plugin/metadata/postgres/epoch.go
+++ b/database/plugin/metadata/postgres/epoch.go
@@ -25,14 +25,14 @@ func (d *MetadataStorePostgres) GetEpochsByEra(
 	eraId uint,
 	txn types.Txn,
 ) ([]models.Epoch, error) {
-	ret := []models.Epoch{}
+	var ret []models.Epoch
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, err
 	}
 	result := db.Where("era_id = ?", eraId).Order("epoch_id").Find(&ret)
 	if result.Error != nil {
-		return ret, result.Error
+		return nil, result.Error
 	}
 	return ret, nil
 }
@@ -41,14 +41,14 @@ func (d *MetadataStorePostgres) GetEpochsByEra(
 func (d *MetadataStorePostgres) GetEpochs(
 	txn types.Txn,
 ) ([]models.Epoch, error) {
-	ret := []models.Epoch{}
+	var ret []models.Epoch
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, err
 	}
 	result := db.Order("epoch_id").Find(&ret)
 	if result.Error != nil {
-		return ret, result.Error
+		return nil, result.Error
 	}
 	return ret, nil
 }

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -63,8 +63,10 @@ func (d *MetadataStoreSqlite) SetAccount(
 		Active:     active,
 	}
 	onConflict := clause.OnConflict{
-		Columns:   []clause.Column{{Name: "staking_key"}},
-		UpdateAll: true,
+		Columns: []clause.Column{{Name: "staking_key"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"added_slot", "pool", "drep", "active"},
+		),
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -63,8 +63,13 @@ func (d *MetadataStoreSqlite) SetDrep(
 		Active:     active,
 	}
 	onConflict := clause.OnConflict{
-		Columns:   []clause.Column{{Name: "credential"}},
-		UpdateAll: true,
+		Columns: []clause.Column{{Name: "credential"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"added_slot",
+			"anchor_url",
+			"anchor_hash",
+			"active",
+		}),
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {

--- a/database/plugin/metadata/sqlite/epoch.go
+++ b/database/plugin/metadata/sqlite/epoch.go
@@ -26,14 +26,14 @@ func (d *MetadataStoreSqlite) GetEpochsByEra(
 	eraId uint,
 	txn types.Txn,
 ) ([]models.Epoch, error) {
-	ret := []models.Epoch{}
+	var ret []models.Epoch
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, err
 	}
 	result := db.Where("era_id = ?", eraId).Order("epoch_id").Find(&ret)
 	if result.Error != nil {
-		return ret, result.Error
+		return nil, result.Error
 	}
 	return ret, nil
 }
@@ -42,14 +42,14 @@ func (d *MetadataStoreSqlite) GetEpochsByEra(
 func (d *MetadataStoreSqlite) GetEpochs(
 	txn types.Txn,
 ) ([]models.Epoch, error) {
-	ret := []models.Epoch{}
+	var ret []models.Epoch
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, err
 	}
 	result := db.Order("epoch_id").Find(&ret)
 	if result.Error != nil {
-		return ret, result.Error
+		return nil, result.Error
 	}
 	return ret, nil
 }
@@ -80,7 +80,7 @@ func (d *MetadataStoreSqlite) SetEpoch(
 	// (VACUUM during transaction causes lock contention)
 	if txn == nil {
 		if err := d.runVacuum(); err != nil {
-			d.logger.Error(
+			d.logger.Warn(
 				"failed to free space in metadata store",
 				"epoch", strconv.FormatUint(epoch, 10),
 				"error", err,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes node startup/shutdown and fixes leaks by reliably closing connections and resources, with explicit DB errors. Adds panic recovery for event handling to prevent crashes.

- **Bug Fixes**
  - Close rejected/failed connections in listener and outbound dial.
  - Improve metadata store correctness: explicit tip/epoch errors (SQLite/Postgres), safer upserts, relay port/IP handling.
  - Ensure DB, event bus, ledger store, and iterators are closed in loader; add a 30s startup timeout.
  - Guard WaitForTx event handler with type-checks and recover to avoid panics.

- **Refactors**
  - Track started components and perform reverse-order cleanup on failure or panic.
  - Stop services and close the DB during shutdown (connection manager, chain selector, peer governor, UTxO RPC).

<sup>Written for commit f21f3e2766f96b572b49559537ec052e49fc2f43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures network connections and DB resources are always closed on failure to prevent leaks.
  * Prevents crashes by guarding event handlers against unexpected data and panics.

* **Improvements**
  * Strengthens startup/shutdown by registering and running cleanup actions on failure.
  * Surface clearer errors for database lookups and relay port validation.
* **Behavior**
  * More conservative handling of missing records during initial sync.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->