### PR TITLE
fix: dingo load context timeout

### DIFF
--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -106,9 +106,10 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := ls.Start(ctx); err != nil {
+	// Use a long-running context for the ledger state - the 30s timeout is only for
+	// the Start() initialization, not for the entire ledger processing lifetime.
+	// The load operation can take much longer than 30 seconds to process all blocks.
+	if err := ls.Start(context.Background()); err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
 	defer ls.Close()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes dingo load timeouts caused by a 30s context on ledger state startup. Now uses a background context so long-running block processing can complete.

<sup>Written for commit cdbe10da4a7b93060ba2adfe6496ac7e01d7cc18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed initialization timeout limitation to allow extended startup procedures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->