### PR TITLE
fix(ledger): log account get errors except not found

### DIFF
--- a/ledger/view.go
+++ b/ledger/view.go
@@ -82,6 +82,14 @@ func (lv *LedgerView) IsStakeCredentialRegistered(
 ) bool {
 	account, err := lv.ls.db.GetAccount(cred.Credential[:], false, lv.txn)
 	if err != nil {
+		if !errors.Is(err, models.ErrAccountNotFound) {
+			lv.ls.config.Logger.Error(
+				"failed to get account for stake credential",
+				"component", "ledger",
+				"credential", cred.Hash().String(),
+				"error", err,
+			)
+		}
 		return false
 	}
 	return account != nil && account.Active
@@ -233,6 +241,14 @@ func (lv *LedgerView) IsRewardAccountRegistered(
 ) bool {
 	account, err := lv.ls.db.GetAccount(cred.Credential[:], false, lv.txn)
 	if err != nil {
+		if !errors.Is(err, models.ErrAccountNotFound) {
+			lv.ls.config.Logger.Error(
+				"failed to get account for reward account",
+				"component", "ledger",
+				"credential", cred.Hash().String(),
+				"error", err,
+			)
+		}
 		return false
 	}
 	return account != nil && account.Active


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add error logging for account lookup failures in ledger view, excluding not-found cases. Improves observability during stake and reward credential checks without noisy logs.

- **Bug Fixes**
  - Log unexpected GetAccount errors in IsStakeCredentialRegistered and IsRewardAccountRegistered; skip logging for ErrAccountNotFound.

<sup>Written for commit 6bb7cf62157f785971a42ee37e0c6d2a8a08e106. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostic logging for account registration checks to better assist with troubleshooting when operations encounter unexpected issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->