### PR TITLE
feat(database): get utxos by assets

### DIFF
--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -131,7 +131,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 
 // GetUtxosByAssets returns a list of Utxos that contain the specified assets
 // policyId: the policy ID of the asset (required)
-// assetName: the asset name (optional, pass nil to match all assets under the policy)
+// assetName: the asset name (pass nil to match all assets under the policy, or empty []byte{} to match assets with empty names)
 func (d *MetadataStorePostgres) GetUtxosByAssets(
 	policyId []byte,
 	assetName []byte,
@@ -145,7 +145,7 @@ func (d *MetadataStorePostgres) GetUtxosByAssets(
 
 	// Build the asset query
 	assetQuery := db.Table("asset").Select("utxo_id").Where("policy_id = ?", policyId)
-	if len(assetName) > 0 {
+	if assetName != nil {
 		assetQuery = assetQuery.Where("name = ?", assetName)
 	}
 

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -127,7 +127,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 
 // GetUtxosByAssets returns a list of Utxos that contain the specified assets
 // policyId: the policy ID of the asset (required)
-// assetName: the asset name (optional, pass nil to match all assets under the policy)
+// assetName: the asset name (pass nil to match all assets under the policy, or empty []byte{} to match assets with empty names)
 func (d *MetadataStoreSqlite) GetUtxosByAssets(
 	policyId []byte,
 	assetName []byte,
@@ -141,7 +141,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAssets(
 
 	// Build the asset query
 	assetQuery := db.Table("asset").Select("utxo_id").Where("policy_id = ?", policyId)
-	if len(assetName) > 0 {
+	if assetName != nil {
 		assetQuery = assetQuery.Where("name = ?", assetName)
 	}
 

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -229,7 +229,7 @@ type MetadataStore interface {
 	GetUtxosByAddress(ledger.Address, types.Txn) ([]models.Utxo, error)
 
 	// GetUtxosByAssets retrieves all UTxOs that contain the specified assets.
-	// If assetName is empty, returns all UTxOs containing any asset with the given policyId.
+	// Pass nil for assetName to match all assets under the policy, or empty []byte{} to match assets with empty names.
 	GetUtxosByAssets(policyId []byte, assetName []byte, txn types.Txn) ([]models.Utxo, error)
 
 	// GetUtxosDeletedBeforeSlot retrieves UTxOs deleted before the given slot, up to the specified limit.

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -210,7 +210,7 @@ func (d *Database) UtxosByAddress(
 
 // UtxosByAssets returns UTxOs that contain the specified assets
 // policyId: the policy ID of the asset (required)
-// assetName: the asset name (optional, pass nil or empty slice to match all assets under the policy)
+// assetName: the asset name (pass nil to match all assets under the policy, or empty []byte{} to match assets with empty names)
 func (d *Database) UtxosByAssets(
 	policyId []byte,
 	assetName []byte,


### PR DESCRIPTION
closes #1222 
This pull request adds support for querying UTxOs (Unspent Transaction Outputs) by asset, enabling retrieval of UTxOs that contain a specific asset policy ID and optionally an asset name. The changes span the database interface, Postgres and Sqlite implementations, and the main database logic.

**New UTxO asset query functionality:**

* Added a new method `GetUtxosByAssets` to the `MetadataStore` interface, allowing retrieval of UTxOs by asset policy ID and optional asset name.
* Implemented `GetUtxosByAssets` for both Postgres (`metadata/postgres/utxo.go`) and Sqlite (`metadata/sqlite/utxo.go`) backends, supporting flexible asset queries. [

**Database API extension:**

* Added a public method `UtxosByAssets` to the main `Database` struct, which wraps the new metadata store functionality and handles transaction management and CBOR loading.