### PR TITLE
feat(database): indexes and foreign keys for rollback

### DIFF
--- a/database/models/account.go
+++ b/database/models/account.go
@@ -29,9 +29,9 @@ type Account struct {
 	Pool          []byte `gorm:"index"`
 	Drep          []byte `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
-	CertificateID uint `gorm:"index"`
-	Active        bool `gorm:"default:true"`
+	AddedSlot     uint64 `gorm:"index"`
+	CertificateID uint   `gorm:"index"`
+	Active        bool   `gorm:"default:true"`
 }
 
 func (a *Account) TableName() string {
@@ -61,7 +61,7 @@ type Deregistration struct {
 	StakingKey    []byte `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	Amount        types.Uint64
 }
 
@@ -73,7 +73,7 @@ type Registration struct {
 	StakingKey    []byte `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -86,7 +86,7 @@ type StakeDelegation struct {
 	PoolKeyHash   []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (StakeDelegation) TableName() string {
@@ -97,7 +97,7 @@ type StakeDeregistration struct {
 	StakingKey    []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (StakeDeregistration) TableName() string {
@@ -108,7 +108,7 @@ type StakeRegistration struct {
 	StakingKey    []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -121,7 +121,7 @@ type StakeRegistrationDelegation struct {
 	PoolKeyHash   []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -135,7 +135,7 @@ type StakeVoteDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (StakeVoteDelegation) TableName() string {
@@ -148,7 +148,7 @@ type StakeVoteRegistrationDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 
@@ -161,7 +161,7 @@ type VoteDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (VoteDelegation) TableName() string {
@@ -173,7 +173,7 @@ type VoteRegistrationDelegation struct {
 	Drep          []byte `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
-	AddedSlot     uint64
+	AddedSlot     uint64 `gorm:"index"`
 	DepositAmount types.Uint64
 }
 

--- a/database/models/account_test.go
+++ b/database/models/account_test.go
@@ -26,11 +26,11 @@ import (
 func TestAccount_String(t *testing.T) {
 	tests := []struct {
 		name         string
+		wantErrMsg   string
+		expectedHRP  string
 		stakingKey   []byte
 		wantErr      bool
-		wantErrMsg   string
 		validateAddr bool
-		expectedHRP  string
 	}{
 		{
 			name: "valid staking key - 28 bytes",

--- a/database/models/auth_committee_hot.go
+++ b/database/models/auth_committee_hot.go
@@ -19,7 +19,7 @@ type AuthCommitteeHot struct {
 	HostCredential []byte `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
 	CertificateID  uint   `gorm:"index"`
-	AddedSlot      uint64
+	AddedSlot      uint64 `gorm:"index"`
 }
 
 func (AuthCommitteeHot) TableName() string {

--- a/database/models/certs.go
+++ b/database/models/certs.go
@@ -22,7 +22,7 @@ package models
 type Certificate struct {
 	BlockHash     []byte `gorm:"index"`
 	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"index;uniqueIndex:uniq_tx_cert;constraint:OnDelete:CASCADE"`
+	TransactionID uint   `gorm:"index;uniqueIndex:uniq_tx_cert"`
 	CertificateID uint   `gorm:"index"` // Polymorphic FK to certificate table based on CertType. Not DB-enforced.
 	Slot          uint64 `gorm:"index"`
 	CertIndex     uint   `gorm:"column:cert_index;uniqueIndex:uniq_tx_cert"`

--- a/database/models/datum.go
+++ b/database/models/datum.go
@@ -18,7 +18,7 @@ type Datum struct {
 	Hash      []byte `gorm:"index;not null;unique"`
 	RawDatum  []byte `gorm:"not null"`
 	ID        uint   `gorm:"primarykey"`
-	AddedSlot uint64 `gorm:"not null"`
+	AddedSlot uint64 `gorm:"index;not null"`
 }
 
 func (Datum) TableName() string {
@@ -27,10 +27,10 @@ func (Datum) TableName() string {
 
 // PlutusData represents a Plutus data value in the witness set
 type PlutusData struct {
+	Transaction   *Transaction `gorm:"foreignKey:TransactionID"`
+	Data          []byte
 	ID            uint `gorm:"primaryKey"`
 	TransactionID uint `gorm:"index"`
-	Data          []byte
-	Transaction   *Transaction
 }
 
 func (PlutusData) TableName() string {

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -23,13 +23,12 @@ import (
 var ErrDrepNotFound = errors.New("drep not found")
 
 type Drep struct {
-	AnchorUrl     string
-	Credential    []byte `gorm:"uniqueIndex"`
-	AnchorHash    []byte
-	CertificateID uint `gorm:"index"`
-	ID            uint `gorm:"primarykey"`
-	AddedSlot     uint64
-	Active        bool `gorm:"default:true"`
+	AnchorUrl  string
+	Credential []byte `gorm:"uniqueIndex"`
+	AnchorHash []byte
+	ID         uint   `gorm:"primarykey"`
+	AddedSlot  uint64 `gorm:"index"`
+	Active     bool   `gorm:"default:true"`
 }
 
 func (d *Drep) TableName() string {
@@ -40,7 +39,7 @@ type DeregistrationDrep struct {
 	DrepCredential []byte `gorm:"index"`
 	CertificateID  uint   `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
-	AddedSlot      uint64
+	AddedSlot      uint64 `gorm:"index"`
 	DepositAmount  types.Uint64
 }
 
@@ -52,9 +51,9 @@ type RegistrationDrep struct {
 	AnchorUrl      string
 	DrepCredential []byte `gorm:"index"`
 	AnchorHash     []byte
-	CertificateID  uint `gorm:"index"`
-	ID             uint `gorm:"primarykey"`
-	AddedSlot      uint64
+	CertificateID  uint   `gorm:"index"`
+	ID             uint   `gorm:"primarykey"`
+	AddedSlot      uint64 `gorm:"index"`
 	DepositAmount  types.Uint64
 }
 
@@ -66,9 +65,9 @@ type UpdateDrep struct {
 	AnchorUrl     string
 	Credential    []byte `gorm:"index"`
 	AnchorHash    []byte
-	CertificateID uint `gorm:"index"`
-	ID            uint `gorm:"primarykey"`
-	AddedSlot     uint64
+	CertificateID uint   `gorm:"index"`
+	ID            uint   `gorm:"primarykey"`
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (UpdateDrep) TableName() string {

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -17,10 +17,11 @@ package models
 import "github.com/blinklabs-io/dingo/database/types"
 
 type MoveInstantaneousRewards struct {
-	Pot           uint `gorm:"index"`
-	CertificateID uint `gorm:"index"`
-	ID            uint `gorm:"primarykey"`
-	AddedSlot     uint64
+	Rewards       []MoveInstantaneousRewardsReward `gorm:"foreignKey:MIRID;constraint:OnDelete:CASCADE"`
+	Pot           uint                             `gorm:"index"`
+	CertificateID uint                             `gorm:"index"`
+	ID            uint                             `gorm:"primarykey"`
+	AddedSlot     uint64                           `gorm:"index"`
 }
 
 func (MoveInstantaneousRewards) TableName() string {
@@ -31,7 +32,7 @@ type MoveInstantaneousRewardsReward struct {
 	Credential []byte
 	Amount     types.Uint64
 	ID         uint `gorm:"primarykey"`
-	MIRID      uint `gorm:"index;constraint:OnDelete:CASCADE"`
+	MIRID      uint `gorm:"index"`
 }
 
 func (MoveInstantaneousRewardsReward) TableName() string {

--- a/database/models/pparams.go
+++ b/database/models/pparams.go
@@ -16,8 +16,8 @@ package models
 
 type PParams struct {
 	Cbor      []byte
-	ID        uint `gorm:"primarykey"`
-	AddedSlot uint64
+	ID        uint   `gorm:"primarykey"`
+	AddedSlot uint64 `gorm:"index"`
 	Epoch     uint64
 	EraId     uint
 }
@@ -29,8 +29,8 @@ func (PParams) TableName() string {
 type PParamUpdate struct {
 	GenesisHash []byte
 	Cbor        []byte
-	ID          uint `gorm:"primarykey"`
-	AddedSlot   uint64
+	ID          uint   `gorm:"primarykey"`
+	AddedSlot   uint64 `gorm:"index"`
 	Epoch       uint64
 }
 

--- a/database/models/redeemer.go
+++ b/database/models/redeemer.go
@@ -16,13 +16,13 @@ package models
 
 // Redeemer represents a redeemer in the witness set
 type Redeemer struct {
-	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"index"`
-	Tag           uint8  `gorm:"index"` // Redeemer tag
-	Index         uint32 `gorm:"index"`
-	Data          []byte // Plutus data
+	Data          []byte
+	ID            uint `gorm:"primaryKey"`
+	TransactionID uint `gorm:"index"`
 	ExUnitsMemory uint64
 	ExUnitsCPU    uint64
+	Index         uint32 `gorm:"index"`
+	Tag           uint8  `gorm:"index"`
 }
 
 func (Redeemer) TableName() string {

--- a/database/models/resign_committee_cold.go
+++ b/database/models/resign_committee_cold.go
@@ -18,9 +18,9 @@ type ResignCommitteeCold struct {
 	AnchorUrl      string
 	ColdCredential []byte `gorm:"index"`
 	AnchorHash     []byte
-	ID             uint `gorm:"primarykey"`
-	CertificateID  uint `gorm:"index"`
-	AddedSlot      uint64
+	ID             uint   `gorm:"primarykey"`
+	CertificateID  uint   `gorm:"index"`
+	AddedSlot      uint64 `gorm:"index"`
 }
 
 func (ResignCommitteeCold) TableName() string {

--- a/database/models/script.go
+++ b/database/models/script.go
@@ -18,11 +18,11 @@ package models
 // This avoids storing duplicate script data when the same script appears
 // in multiple transactions
 type Script struct {
-	ID          uint   `gorm:"primaryKey"`
-	Hash        []byte `gorm:"index;unique"` // Script hash
-	Type        uint8  `gorm:"index"`        // Script type
-	Content     []byte // Script content
-	CreatedSlot uint64 // Slot when this script was first seen
+	Hash        []byte `gorm:"index;unique"`
+	Content     []byte
+	ID          uint `gorm:"primaryKey"`
+	CreatedSlot uint64
+	Type        uint8 `gorm:"index"`
 }
 
 func (Script) TableName() string {

--- a/database/models/transaction.go
+++ b/database/models/transaction.go
@@ -18,23 +18,28 @@ import "github.com/blinklabs-io/dingo/database/types"
 
 // Transaction represents a transaction record
 type Transaction struct {
+	// CollateralReturn uses a separate FK (CollateralReturnForTxID) to distinguish
+	// from regular Outputs which use TransactionID. This allows GORM to load each
+	// association correctly without ambiguity.
+	CollateralReturn *Utxo            `gorm:"foreignKey:CollateralReturnForTxID;references:ID;constraint:OnDelete:CASCADE"`
+	PlutusData       []PlutusData     `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	Certificates     []Certificate    `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	Outputs          []Utxo           `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
 	Hash             []byte           `gorm:"uniqueIndex"`
-	BlockHash        []byte           `gorm:"index"`
-	Inputs           []Utxo           `gorm:"foreignKey:SpentAtTxId;references:Hash"`
-	Outputs          []Utxo           `gorm:"foreignKey:TransactionID;references:ID"`
-	ReferenceInputs  []Utxo           `gorm:"foreignKey:ReferencedByTxId;references:Hash"`
 	Collateral       []Utxo           `gorm:"foreignKey:CollateralByTxId;references:Hash"`
-	CollateralReturn *Utxo            `gorm:"foreignKey:TransactionID;references:ID"`
-	KeyWitnesses     []KeyWitness     `gorm:"foreignKey:TransactionID;references:ID"`
-	WitnessScripts   []WitnessScripts `gorm:"foreignKey:TransactionID;references:ID"`
-	Redeemers        []Redeemer       `gorm:"foreignKey:TransactionID;references:ID"`
-	PlutusData       []PlutusData     `gorm:"foreignKey:TransactionID;references:ID"`
-	ID               uint             `gorm:"primaryKey"`
-	Type             int
-	BlockIndex       uint32
+	BlockHash        []byte           `gorm:"index"`
+	KeyWitnesses     []KeyWitness     `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	WitnessScripts   []WitnessScripts `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	Inputs           []Utxo           `gorm:"foreignKey:SpentAtTxId;references:Hash"`
+	Redeemers        []Redeemer       `gorm:"foreignKey:TransactionID;references:ID;constraint:OnDelete:CASCADE"`
+	ReferenceInputs  []Utxo           `gorm:"foreignKey:ReferencedByTxId;references:Hash"`
 	Metadata         []byte
+	Slot             uint64 `gorm:"index"`
+	Type             int
+	ID               uint `gorm:"primaryKey"`
 	Fee              types.Uint64
 	TTL              types.Uint64
+	BlockIndex       uint32
 	Valid            bool
 }
 

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -22,20 +22,21 @@ import (
 
 // Utxo represents an unspent transaction output
 type Utxo struct {
-	TransactionID    *uint  `gorm:"index"`
-	TxId             []byte `gorm:"uniqueIndex:tx_id_output_idx"`
-	PaymentKey       []byte `gorm:"index"`
-	StakingKey       []byte `gorm:"index"`
-	Assets           []Asset
-	Cbor             []byte       `gorm:"-"` // This is here for convenience but not represented in the metadata DB
-	SpentAtTxId      []byte       `gorm:"index"`
-	ReferencedByTxId []byte       `gorm:"index"`
-	CollateralByTxId []byte       `gorm:"index"`
-	ID               uint         `gorm:"primarykey"`
-	AddedSlot        uint64       `gorm:"index"`
-	DeletedSlot      uint64       `gorm:"index"`
-	Amount           types.Uint64 `gorm:"index"`
-	OutputIdx        uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
+	TransactionID           *uint        `gorm:"index"`
+	CollateralReturnForTxID *uint        `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
+	TxId                    []byte       `gorm:"uniqueIndex:tx_id_output_idx"`
+	PaymentKey              []byte       `gorm:"index"`
+	StakingKey              []byte       `gorm:"index"`
+	Assets                  []Asset      `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
+	Cbor                    []byte       `gorm:"-"` // This is here for convenience but not represented in the metadata DB
+	SpentAtTxId             []byte       `gorm:"index"`
+	ReferencedByTxId        []byte       `gorm:"index"`
+	CollateralByTxId        []byte       `gorm:"index"`
+	ID                      uint         `gorm:"primarykey"`
+	AddedSlot               uint64       `gorm:"index"`
+	DeletedSlot             uint64       `gorm:"index"`
+	Amount                  types.Uint64 `gorm:"index"`
+	OutputIdx               uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
 }
 
 func (u *Utxo) TableName() string {

--- a/database/models/witness.go
+++ b/database/models/witness.go
@@ -24,14 +24,14 @@ const (
 // KeyWitness represents a key witness entry (Vkey or Bootstrap)
 // Type: KeyWitnessTypeVkey = VkeyWitness, KeyWitnessTypeBootstrap = BootstrapWitness
 type KeyWitness struct {
-	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"index"`
-	Type          uint8  `gorm:"index"` // See KeyWitnessType* constants
-	Vkey          []byte // Vkey witness key
-	Signature     []byte // Witness signature
-	PublicKey     []byte // For Bootstrap witness
-	ChainCode     []byte // For Bootstrap witness
-	Attributes    []byte // For Bootstrap witness
+	Vkey          []byte
+	Signature     []byte
+	PublicKey     []byte
+	ChainCode     []byte
+	Attributes    []byte
+	ID            uint  `gorm:"primaryKey"`
+	TransactionID uint  `gorm:"index"`
+	Type          uint8 `gorm:"index"`
 }
 
 func (KeyWitness) TableName() string {

--- a/database/models/witness_script.go
+++ b/database/models/witness_script.go
@@ -25,10 +25,10 @@ package models
 // transactions, we store only the script hash here. The actual script content
 // is stored separately in Script table, indexed by hash.
 type WitnessScripts struct {
+	ScriptHash    []byte `gorm:"index"`
 	ID            uint   `gorm:"primaryKey"`
 	TransactionID uint   `gorm:"index"`
-	Type          uint8  `gorm:"index"` // Script type
-	ScriptHash    []byte `gorm:"index"` // Hash of the script
+	Type          uint8  `gorm:"index"`
 }
 
 func (WitnessScripts) TableName() string {

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -133,7 +133,10 @@ type Txn interface {
 	Rollback() error
 }
 
-// BlockMetadata contains metadata for a block stored in blob
+// BlockMetadata contains metadata for a block stored in blob.
+// IMPORTANT: Field order must remain [ID, Type, Height, PrevHash] because
+// cbor.StructAsArray encodes/decodes by position. Changing the order would
+// break deserialization of existing stored data.
 type BlockMetadata struct {
 	cbor.StructAsArray
 	ID       uint64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add indexes and foreign keys across models to support efficient rollback by slot and safe cascading deletes. This makes rollback faster and ensures related records are cleaned up consistently.

- **Refactors**
  - Indexed AddedSlot (and Transaction.Slot) across models for fast rollback queries.
  - Added explicit associations with OnDelete:CASCADE (transactions → outputs/certificates/redeemers/plutus data/witnesses, utxos → assets, pools → registrations/retirements → owners/relays, MIR → rewards).
  - Introduced a unique FK for collateral return outputs (CollateralReturnForTxID) and separated it from regular outputs.
  - Shifted cascade responsibility to parent relations (e.g., Transaction → Certificate) and removed redundant constraints.
  - Minor consistency updates: PlutusData FK, WitnessScripts ScriptHash index, and other small index/association fixes.

<sup>Written for commit 80de3763219a9d2651656ccde3e73d5c031c8309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized database query performance through strategic indexing improvements.
  * Enhanced data integrity with relationship refinements and cascading constraints across multiple data models.
  * Internal structural improvements to support system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->