### PR TITLE
feat(database): sqlite plugin rollback support

### DIFF
--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -23,6 +23,579 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// certRecord holds common fields extracted from certificate records for
+// batch processing during account state restoration.
+// Includes certIndex for same-slot disambiguation.
+type certRecord struct {
+	pool      []byte
+	drep      []byte
+	addedSlot uint64
+	certIndex uint32
+}
+
+// isMoreRecent checks if this certificate is more recent than the other.
+// When slots are equal, certIndex determines order (higher = later in transaction).
+func (r certRecord) isMoreRecent(other certRecord) bool {
+	if r.addedSlot > other.addedSlot {
+		return true
+	}
+	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
+		return true
+	}
+	return false
+}
+
+// accountCertCache holds batch-fetched certificate data for all accounts
+// being restored. This eliminates N+1 queries by fetching all certificates
+// for all affected accounts in a small number of queries upfront.
+type accountCertCache struct {
+	// Maps staking key (as string) to the most recent registration
+	latestReg map[string]certRecord
+	hasReg    map[string]bool
+
+	// Maps staking key to the most recent deregistration
+	latestDereg map[string]certRecord
+	hasDereg    map[string]bool
+
+	// Maps staking key to the most recent pool delegation
+	poolDelegation map[string]certRecord
+
+	// Maps staking key to the most recent DRep delegation
+	drepDelegation map[string]certRecord
+}
+
+// newAccountCertCache creates an empty certificate cache.
+func newAccountCertCache(capacity int) *accountCertCache {
+	return &accountCertCache{
+		latestReg:      make(map[string]certRecord, capacity),
+		hasReg:         make(map[string]bool, capacity),
+		latestDereg:    make(map[string]certRecord, capacity),
+		hasDereg:       make(map[string]bool, capacity),
+		poolDelegation: make(map[string]certRecord, capacity),
+		drepDelegation: make(map[string]certRecord, capacity),
+	}
+}
+
+// updateReg updates the registration if this one is more recent.
+func (c *accountCertCache) updateReg(key string, rec certRecord) {
+	if !c.hasReg[key] || rec.isMoreRecent(c.latestReg[key]) {
+		c.latestReg[key] = rec
+		c.hasReg[key] = true
+	}
+}
+
+// updateDereg updates the deregistration if this one is more recent.
+func (c *accountCertCache) updateDereg(key string, rec certRecord) {
+	if !c.hasDereg[key] || rec.isMoreRecent(c.latestDereg[key]) {
+		c.latestDereg[key] = rec
+		c.hasDereg[key] = true
+	}
+}
+
+// updatePoolDelegation updates the pool delegation if this one is more recent.
+func (c *accountCertCache) updatePoolDelegation(key string, rec certRecord) {
+	existing, ok := c.poolDelegation[key]
+	if !ok || rec.isMoreRecent(existing) {
+		c.poolDelegation[key] = rec
+	}
+}
+
+// updateDrepDelegation updates the DRep delegation if this one is more recent.
+func (c *accountCertCache) updateDrepDelegation(key string, rec certRecord) {
+	existing, ok := c.drepDelegation[key]
+	if !ok || rec.isMoreRecent(existing) {
+		c.drepDelegation[key] = rec
+	}
+}
+
+// batchFetchCerts fetches all relevant certificates for the given staking keys
+// at or before the given slot. Uses one query per certificate table. Chunks
+// queries to avoid exceeding SQLite bind variable limits.
+func batchFetchCerts(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+) (*accountCertCache, error) {
+	cache := newAccountCertCache(len(stakingKeys))
+
+	// Process staking keys in chunks to avoid SQLite bind variable limits
+	for start := 0; start < len(stakingKeys); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(stakingKeys))
+		keyChunk := stakingKeys[start:end]
+
+		// Registration certificates (5 types)
+		if err := batchFetchStakeRegistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeRegistrationDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeVoteRegistrationDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchVoteRegistrationDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchRegistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+
+		// Deregistration certificates (2 types)
+		if err := batchFetchStakeDeregistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		if err := batchFetchDeregistration(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+
+		// Pool delegation certificates - StakeDelegation is pool-only
+		if err := batchFetchStakeDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+		// StakeVoteDelegation has both pool and DRep
+		if err := batchFetchStakeVoteDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+
+		// DRep delegation certificates - VoteDelegation is DRep-only
+		if err := batchFetchVoteDelegation(db, keyChunk, slot, cache); err != nil {
+			return nil, err
+		}
+	}
+
+	return cache, nil
+}
+
+func batchFetchStakeRegistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_registration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateReg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{
+			pool:      r.PoolKeyHash,
+			addedSlot: r.AddedSlot,
+			certIndex: r.CertIndex,
+		}
+		cache.updateReg(key, rec)
+		cache.updatePoolDelegation(key, rec)
+	}
+	return nil
+}
+
+func batchFetchStakeVoteRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		Drep        []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_vote_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{
+			pool:      r.PoolKeyHash,
+			drep:      r.Drep,
+			addedSlot: r.AddedSlot,
+			certIndex: r.CertIndex,
+		}
+		cache.updateReg(key, rec)
+		cache.updatePoolDelegation(key, rec)
+		cache.updateDrepDelegation(
+			key,
+			certRecord{
+				drep:      r.Drep,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
+func batchFetchVoteRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		Drep       []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM vote_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{
+			drep:      r.Drep,
+			addedSlot: r.AddedSlot,
+			certIndex: r.CertIndex,
+		}
+		cache.updateReg(key, rec)
+		cache.updateDrepDelegation(key, rec)
+	}
+	return nil
+}
+
+func batchFetchRegistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM registration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateReg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeDeregistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_deregistration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDereg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchDeregistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM deregistration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDereg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updatePoolDelegation(
+			string(r.StakingKey),
+			certRecord{
+				pool:      r.PoolKeyHash,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
+func batchFetchVoteDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		Drep       []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM vote_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDrepDelegation(
+			string(r.StakingKey),
+			certRecord{
+				drep:      r.Drep,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeVoteDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		Drep        []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_vote_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		cache.updatePoolDelegation(
+			key,
+			certRecord{
+				pool:      r.PoolKeyHash,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+		cache.updateDrepDelegation(
+			key,
+			certRecord{
+				drep:      r.Drep,
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			},
+		)
+	}
+	return nil
+}
+
 // GetAccount gets an account
 func (d *MetadataStoreSqlite) GetAccount(
 	stakeKey []byte,
@@ -75,5 +648,111 @@ func (d *MetadataStoreSqlite) SetAccount(
 	if result := db.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 		return result.Error
 	}
+	return nil
+}
+
+// RestoreAccountStateAtSlot reverts account delegation state to the given slot.
+// For accounts modified after the slot, this restores their Pool and Drep
+// delegations to the state they had at the given slot, or deletes them
+// if they were registered after that slot.
+//
+// This implementation uses batch fetching to avoid N+1 query patterns:
+// instead of querying certificates per-account, it fetches all relevant
+// certificates for all affected accounts upfront (one query per table),
+// then processes them in memory.
+func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Find all accounts that were modified after the rollback slot
+	var accountsToRestore []models.Account
+	if result := db.Where("added_slot > ?", slot).Find(&accountsToRestore); result.Error != nil {
+		return result.Error
+	}
+
+	if len(accountsToRestore) == 0 {
+		return nil
+	}
+
+	// Extract staking keys for batch fetching
+	stakingKeys := make([][]byte, len(accountsToRestore))
+	for i, account := range accountsToRestore {
+		stakingKeys[i] = account.StakingKey
+	}
+
+	// Batch-fetch all certificates for all affected accounts
+	cache, err := batchFetchCerts(db, stakingKeys, slot)
+	if err != nil {
+		return err
+	}
+
+	// Process each account using the cached certificate data
+	for _, account := range accountsToRestore {
+		key := string(account.StakingKey)
+
+		// Check if this account had any registration before the rollback slot
+		latestReg, hasReg := cache.latestReg[key], cache.hasReg[key]
+
+		if !hasReg {
+			// Account was registered after rollback slot, delete it
+			if result := db.Delete(&account); result.Error != nil {
+				return result.Error
+			}
+			continue
+		}
+
+		// Get pool delegation from cache
+		var pool []byte
+		var poolRec certRecord
+		if rec, ok := cache.poolDelegation[key]; ok {
+			pool = rec.pool
+			poolRec = rec
+		}
+
+		// Get DRep delegation from cache
+		var drep []byte
+		var drepRec certRecord
+		if rec, ok := cache.drepDelegation[key]; ok {
+			drep = rec.drep
+			drepRec = rec
+		}
+
+		// Get deregistration info from cache
+		latestDereg, hasDereg := cache.latestDereg[key], cache.hasDereg[key]
+
+		// Account is active if either:
+		// - There is no deregistration, or
+		// - The most recent registration is after the most recent deregistration
+		active := !hasDereg || latestReg.isMoreRecent(latestDereg)
+
+		// Compute the actual last modification slot as the max of all relevant events
+		lastModSlot := latestReg.addedSlot
+		if hasDereg && latestDereg.addedSlot > lastModSlot {
+			lastModSlot = latestDereg.addedSlot
+		}
+		// Only consider pool/drep slots if they were found in the cache
+		if _, hasPool := cache.poolDelegation[key]; hasPool && poolRec.addedSlot > lastModSlot {
+			lastModSlot = poolRec.addedSlot
+		}
+		if _, hasDrep := cache.drepDelegation[key]; hasDrep && drepRec.addedSlot > lastModSlot {
+			lastModSlot = drepRec.addedSlot
+		}
+
+		// Update the account with restored state
+		if result := db.Model(&account).Updates(map[string]any{
+			"pool":       pool,
+			"drep":       drep,
+			"active":     active,
+			"added_slot": lastModSlot,
+		}); result.Error != nil {
+			return result.Error
+		}
+	}
+
 	return nil
 }

--- a/database/plugin/metadata/sqlite/datum.go
+++ b/database/plugin/metadata/sqlite/datum.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -68,7 +69,7 @@ func (d *MetadataStoreSqlite) SetDatum(
 	}
 	result := db.Clauses(onConflict).Create(&tmpItem)
 	if result.Error != nil {
-		return result.Error
+		return fmt.Errorf("create datum: %w", result.Error)
 	}
 	return nil
 }

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -16,12 +16,167 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+// drepCertRecord holds certificate data for batch processing during DRep restoration.
+// Includes cert_index for same-slot disambiguation.
+type drepCertRecord struct {
+	addedSlot  uint64
+	certIndex  uint32
+	anchorUrl  string
+	anchorHash []byte
+}
+
+// isMoreRecent checks if this certificate is more recent than the other.
+// When slots are equal, cert_index determines order (higher = later in transaction).
+func (r drepCertRecord) isMoreRecent(other drepCertRecord) bool {
+	if r.addedSlot > other.addedSlot {
+		return true
+	}
+	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
+		return true
+	}
+	return false
+}
+
+// drepCertCache holds batch-fetched certificate data for all DReps being restored.
+type drepCertCache struct {
+	// Maps credential (as string) to the most recent registration
+	registration map[string]drepCertRecord
+	hasReg       map[string]bool
+
+	// Maps credential to the most recent deregistration
+	deregistration map[string]drepCertRecord
+	hasDereg       map[string]bool
+
+	// Maps credential to the most recent update
+	update    map[string]drepCertRecord
+	hasUpdate map[string]bool
+}
+
+// newDrepCertCache creates an empty DRep certificate cache.
+func newDrepCertCache(capacity int) *drepCertCache {
+	return &drepCertCache{
+		registration:   make(map[string]drepCertRecord, capacity),
+		hasReg:         make(map[string]bool, capacity),
+		deregistration: make(map[string]drepCertRecord, capacity),
+		hasDereg:       make(map[string]bool, capacity),
+		update:         make(map[string]drepCertRecord, capacity),
+		hasUpdate:      make(map[string]bool, capacity),
+	}
+}
+
+// batchFetchDrepCerts fetches all relevant certificates for the given credentials
+// at or before the given slot. Uses one query per certificate table with JOIN
+// to get cert_index for same-slot disambiguation. Chunks queries to avoid
+// exceeding SQLite bind variable limits.
+func batchFetchDrepCerts(
+	db *gorm.DB,
+	credentials [][]byte,
+	slot uint64,
+) (*drepCertCache, error) {
+	cache := newDrepCertCache(len(credentials))
+
+	// Process credentials in chunks to avoid SQLite bind variable limits
+	for start := 0; start < len(credentials); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(credentials))
+		credChunk := credentials[start:end]
+
+		// Fetch registration certificates with cert_index
+		type regResult struct {
+			DrepCredential []byte
+			AddedSlot      uint64
+			CertIndex      uint32
+			AnchorUrl      string
+			AnchorHash     []byte
+		}
+		var regRecords []regResult
+		if err := db.Table("registration_drep").
+			Select("registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, certs.cert_index").
+			Joins("INNER JOIN certs ON certs.id = registration_drep.certificate_id").
+			Where("drep_credential IN ? AND registration_drep.added_slot <= ?", credChunk, slot).
+			Find(&regRecords).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range regRecords {
+			key := string(r.DrepCredential)
+			rec := drepCertRecord{
+				addedSlot:  r.AddedSlot,
+				certIndex:  r.CertIndex,
+				anchorUrl:  r.AnchorUrl,
+				anchorHash: r.AnchorHash,
+			}
+			if !cache.hasReg[key] || rec.isMoreRecent(cache.registration[key]) {
+				cache.registration[key] = rec
+				cache.hasReg[key] = true
+			}
+		}
+
+		// Fetch deregistration certificates with cert_index
+		type deregResult struct {
+			DrepCredential []byte
+			AddedSlot      uint64
+			CertIndex      uint32
+		}
+		var deregRecords []deregResult
+		if err := db.Table("deregistration_drep").
+			Select("deregistration_drep.drep_credential, deregistration_drep.added_slot, certs.cert_index").
+			Joins("INNER JOIN certs ON certs.id = deregistration_drep.certificate_id").
+			Where("drep_credential IN ? AND deregistration_drep.added_slot <= ?", credChunk, slot).
+			Find(&deregRecords).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range deregRecords {
+			key := string(r.DrepCredential)
+			rec := drepCertRecord{
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			}
+			if !cache.hasDereg[key] || rec.isMoreRecent(cache.deregistration[key]) {
+				cache.deregistration[key] = rec
+				cache.hasDereg[key] = true
+			}
+		}
+
+		// Fetch update certificates with cert_index
+		type updateResult struct {
+			Credential []byte
+			AddedSlot  uint64
+			CertIndex  uint32
+			AnchorUrl  string
+			AnchorHash []byte
+		}
+		var updateRecords []updateResult
+		if err := db.Table("update_drep").
+			Select("update_drep.credential, update_drep.added_slot, update_drep.anchor_url, update_drep.anchor_hash, certs.cert_index").
+			Joins("INNER JOIN certs ON certs.id = update_drep.certificate_id").
+			Where("credential IN ? AND update_drep.added_slot <= ?", credChunk, slot).
+			Find(&updateRecords).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range updateRecords {
+			key := string(r.Credential)
+			rec := drepCertRecord{
+				addedSlot:  r.AddedSlot,
+				certIndex:  r.CertIndex,
+				anchorUrl:  r.AnchorUrl,
+				anchorHash: r.AnchorHash,
+			}
+			if !cache.hasUpdate[key] || rec.isMoreRecent(cache.update[key]) {
+				cache.update[key] = rec
+				cache.hasUpdate[key] = true
+			}
+		}
+	}
+
+	return cache, nil
+}
 
 // GetDrep gets a drep
 func (d *MetadataStoreSqlite) GetDrep(
@@ -44,6 +199,148 @@ func (d *MetadataStoreSqlite) GetDrep(
 		return nil, result.Error
 	}
 	return &drep, nil
+}
+
+// RestoreDrepStateAtSlot reverts DRep state to the given slot.
+//
+// This function handles two cases for DReps modified after the rollback slot:
+//  1. DReps with no registration certificates at or before the slot are deleted
+//     (they didn't exist at that point in the chain).
+//  2. DReps with prior registrations have their state restored by examining
+//     all relevant certificates (registration, deregistration, update) and
+//     determining the correct Active status and anchor data.
+//
+// The Active status follows these rules:
+//   - A registration certificate activates a DRep
+//   - A deregistration certificate deactivates a DRep
+//   - An update certificate can modify anchor data but cannot reactivate a
+//     deregistered DRep (per Cardano protocol rules)
+//
+// The added_slot field is set to the slot of the most recent effective
+// certificate that modified the DRep's state at or before the rollback slot.
+//
+// This implementation uses batch fetching to avoid N+1 query patterns:
+// instead of querying certificates per-DRep, it fetches all relevant
+// certificates for all affected DReps upfront (one query per table),
+// then processes them in memory.
+func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Phase 1: Delete DReps that have no registration certificates at or before
+	// the rollback slot. These DReps were first registered after the rollback
+	// point and should not exist in the restored state.
+	drepsWithNoValidRegsSubquery := db.Model(&models.Drep{}).
+		Select("drep.id").
+		Where("added_slot > ?", slot).
+		Where(
+			"NOT EXISTS (?)",
+			db.Model(&models.RegistrationDrep{}).
+				Select("1").
+				Where("registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
+		)
+
+	if result := db.Where(
+		"id IN (?)",
+		drepsWithNoValidRegsSubquery,
+	).Delete(&models.Drep{}); result.Error != nil {
+		return result.Error
+	}
+
+	// Phase 2: Restore state for DReps that have at least one registration
+	// certificate at or before the rollback slot.
+	var drepsToRestore []models.Drep
+	if result := db.Where("added_slot > ?", slot).Find(&drepsToRestore); result.Error != nil {
+		return result.Error
+	}
+
+	if len(drepsToRestore) == 0 {
+		return nil
+	}
+
+	// Extract credentials for batch fetching
+	credentials := make([][]byte, len(drepsToRestore))
+	for i, drep := range drepsToRestore {
+		credentials[i] = drep.Credential
+	}
+
+	// Batch-fetch all certificates for all affected DReps
+	cache, err := batchFetchDrepCerts(db, credentials, slot)
+	if err != nil {
+		return err
+	}
+
+	// Process each DRep using the cached certificate data
+	for _, drep := range drepsToRestore {
+		key := string(drep.Credential)
+
+		// Get registration from cache (must exist due to Phase 1 deletion)
+		lastReg, hasRegAtSlot := cache.registration[key], cache.hasReg[key]
+		if !hasRegAtSlot {
+			// This indicates database inconsistency: Phase 1 should have deleted
+			// any DRep without a registration cert at or before the rollback slot.
+			return fmt.Errorf(
+				"DRep %x has no registration cert at or before slot %d but wasn't deleted in Phase 1",
+				drep.Credential,
+				slot,
+			)
+		}
+
+		// Determine the correct state by processing certificates in order.
+		// Start with registration state (DRep is active with registration's anchor data)
+		active := true
+		anchorUrl := lastReg.anchorUrl
+		anchorHash := lastReg.anchorHash
+		latestSlot := lastReg.addedSlot
+		latestCertIndex := lastReg.certIndex
+		latestWasDereg := false
+
+		// Apply deregistration if it's more recent than registration
+		if cache.hasDereg[key] {
+			lastDereg := cache.deregistration[key]
+			if lastDereg.addedSlot > latestSlot ||
+				(lastDereg.addedSlot == latestSlot && lastDereg.certIndex > latestCertIndex) {
+				active = false
+				latestSlot = lastDereg.addedSlot
+				latestCertIndex = lastDereg.certIndex
+				anchorUrl = ""
+				anchorHash = nil
+				latestWasDereg = true
+			}
+		}
+
+		// Apply update certificate only if it's the most recent event AND the
+		// DRep is still active. Per CIP-1694 and Cardano protocol rules, an update
+		// certificate is only valid for registered DReps. If a DRep deregisters,
+		// any subsequent update certificates are ignored - the DRep must re-register
+		// to become active again. Therefore, we skip updates when latestWasDereg is true.
+		if cache.hasUpdate[key] && !latestWasDereg {
+			lastUpdate := cache.update[key]
+			if lastUpdate.addedSlot > latestSlot ||
+				(lastUpdate.addedSlot == latestSlot && lastUpdate.certIndex > latestCertIndex) {
+				anchorUrl = lastUpdate.anchorUrl
+				anchorHash = lastUpdate.anchorHash
+				latestSlot = lastUpdate.addedSlot
+			}
+		}
+
+		// Update the DRep record with the restored state.
+		if result := db.Model(&drep).Updates(map[string]any{
+			"active":      active,
+			"anchor_url":  anchorUrl,
+			"anchor_hash": anchorHash,
+			"added_slot":  latestSlot,
+		}); result.Error != nil {
+			return result.Error
+		}
+	}
+
+	return nil
 }
 
 // SetDrep saves a drep

--- a/database/plugin/metadata/sqlite/pparams.go
+++ b/database/plugin/metadata/sqlite/pparams.go
@@ -101,3 +101,33 @@ func (d *MetadataStoreSqlite) SetPParamUpdate(
 	}
 	return nil
 }
+
+// DeletePParamsAfterSlot removes protocol parameter records added after the given slot.
+func (d *MetadataStoreSqlite) DeletePParamsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Where("added_slot > ?", slot).Delete(&models.PParams{}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// DeletePParamUpdatesAfterSlot removes protocol parameter update records added after the given slot.
+func (d *MetadataStoreSqlite) DeletePParamUpdatesAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Where("added_slot > ?", slot).Delete(&models.PParamUpdate{}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -32,8 +32,8 @@ type TestTable struct {
 }
 
 type mockTransaction struct {
-	hash         lcommon.Blake2b256
 	certificates []lcommon.Certificate
+	hash         lcommon.Blake2b256
 	isValid      bool
 }
 
@@ -167,6 +167,27 @@ func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
 
 func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
 	return lcommon.Blake2b256{}
+}
+
+// createTestTransaction creates a Transaction record for testing with foreign key constraints.
+func createTestTransaction(db *gorm.DB, id uint, slot uint64) error {
+	tx := models.Transaction{
+		Hash:       []byte{byte(id), byte(id >> 8), byte(id >> 16), byte(id >> 24)},
+		Slot:       slot,
+		Valid:      true,
+		Type:       0,
+		BlockIndex: 0,
+	}
+	// Use raw SQL to insert with specific ID
+	return db.Exec(
+		"INSERT INTO \"transaction\" (id, hash, slot, valid, type, block_index) VALUES (?, ?, ?, ?, ?, ?)",
+		id,
+		tx.Hash,
+		tx.Slot,
+		tx.Valid,
+		tx.Type,
+		tx.BlockIndex,
+	).Error
 }
 
 // TestInMemorySqliteMultipleTransaction tests that our sqlite connection allows multiple
@@ -405,4 +426,2386 @@ func TestUnifiedCertificateCreation(t *testing.T) {
 			authUnified.ID,
 		)
 	}
+}
+
+// TestDeleteCertificatesAfterSlot tests that certificates added after a given slot are deleted
+func TestDeleteCertificatesAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create Transaction records for foreign key constraints
+	if err := createTestTransaction(sqliteStore.DB(), 1, 1000); err != nil {
+		t.Fatalf("failed to create transaction 1: %v", err)
+	}
+	if err := createTestTransaction(sqliteStore.DB(), 2, 2000); err != nil {
+		t.Fatalf("failed to create transaction 2: %v", err)
+	}
+
+	// Create certificate at slot 1000 directly
+	cert1 := models.Certificate{
+		Slot: 1000,
+		BlockHash: []byte(
+			"block_hash_1000_12345678901234567890123456789012",
+		),
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		TransactionID: 1,
+		CertIndex:     0,
+	}
+	if result := sqliteStore.DB().Create(&cert1); result.Error != nil {
+		t.Fatalf("failed to create cert1: %v", result.Error)
+	}
+
+	stakeReg1 := models.StakeDelegation{
+		CertificateID: cert1.ID,
+		StakingKey:    []byte("stake_key_1_1234567890123456789012345678"),
+		PoolKeyHash:   []byte("pool_hash_1_12345678901234567890123456789012"),
+		AddedSlot:     1000,
+	}
+	if result := sqliteStore.DB().Create(&stakeReg1); result.Error != nil {
+		t.Fatalf("failed to create stakeReg1: %v", result.Error)
+	}
+
+	// Create certificate at slot 2000
+	cert2 := models.Certificate{
+		Slot: 2000,
+		BlockHash: []byte(
+			"block_hash_2000_12345678901234567890123456789012",
+		),
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		TransactionID: 2,
+		CertIndex:     0,
+	}
+	if result := sqliteStore.DB().Create(&cert2); result.Error != nil {
+		t.Fatalf("failed to create cert2: %v", result.Error)
+	}
+
+	stakeReg2 := models.StakeDelegation{
+		CertificateID: cert2.ID,
+		StakingKey:    []byte("stake_key_2_1234567890123456789012345678"),
+		PoolKeyHash:   []byte("pool_hash_2_12345678901234567890123456789012"),
+		AddedSlot:     2000,
+	}
+	if result := sqliteStore.DB().Create(&stakeReg2); result.Error != nil {
+		t.Fatalf("failed to create stakeReg2: %v", result.Error)
+	}
+
+	// Verify we have 2 certificates
+	var countBefore int64
+	sqliteStore.DB().Model(&models.Certificate{}).Count(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf("expected 2 certificates before rollback, got %d", countBefore)
+	}
+
+	// Delete certificates after slot 1500 (should delete the one at slot 2000)
+	if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete certificates: %v", err)
+	}
+
+	// Verify only 1 certificate remains
+	var countAfter int64
+	sqliteStore.DB().Model(&models.Certificate{}).Count(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 certificate after rollback, got %d", countAfter)
+	}
+
+	// Verify the remaining certificate is at slot 1000
+	var remainingCert models.Certificate
+	if result := sqliteStore.DB().First(&remainingCert); result.Error != nil {
+		t.Fatalf("failed to query remaining certificate: %v", result.Error)
+	}
+	if remainingCert.Slot != 1000 {
+		t.Errorf(
+			"expected remaining certificate at slot 1000, got %d",
+			remainingCert.Slot,
+		)
+	}
+
+	// Verify specialized delegation record was also deleted
+	var delegationCount int64
+	sqliteStore.DB().Model(&models.StakeDelegation{}).Count(&delegationCount)
+	if delegationCount != 1 {
+		t.Errorf(
+			"expected 1 delegation after rollback, got %d",
+			delegationCount,
+		)
+	}
+}
+
+// TestRestoreAccountStateAtSlot tests that account delegation state is correctly restored
+func TestRestoreAccountStateAtSlot(t *testing.T) {
+	t.Run("account delegation is restored to prior pool", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		// Run auto-migration
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		// Create Transaction records for foreign key constraints
+		for i := uint(1); i <= 3; i++ {
+			if err := createTestTransaction(sqliteStore.DB(), i, uint64(i*500)); err != nil {
+				t.Fatalf("failed to create transaction %d: %v", i, err)
+			}
+		}
+
+		stakingKey := []byte("staking_key_test_1234567890123456789012345678")
+		poolHash1 := []byte("pool_hash_1_12345678901234567890123456789012")
+		poolHash2 := []byte("pool_hash_2_12345678901234567890123456789012")
+
+		// Create an account with delegation to pool2 at slot 2000
+		// (simulating current state after delegation change)
+		account := models.Account{
+			StakingKey: stakingKey,
+			Pool:       poolHash2,
+			AddedSlot:  2000,
+			Active:     true,
+		}
+		if result := sqliteStore.DB().Create(&account); result.Error != nil {
+			t.Fatalf("failed to create account: %v", result.Error)
+		}
+
+		// Create stake registration certificate at slot 500 (registration must exist before delegation)
+		regCert := models.Certificate{
+			Slot: 500,
+			BlockHash: []byte(
+				"block_500_1234567890123456789012345678901234",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+			TransactionID: 1,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&regCert); result.Error != nil {
+			t.Fatalf("failed to create regCert: %v", result.Error)
+		}
+
+		stakeReg := models.StakeRegistration{
+			CertificateID: regCert.ID,
+			StakingKey:    stakingKey,
+			AddedSlot:     500,
+		}
+		if result := sqliteStore.DB().Create(&stakeReg); result.Error != nil {
+			t.Fatalf("failed to create stakeReg: %v", result.Error)
+		}
+
+		// Create initial stake delegation certificate at slot 1000 (to pool1)
+		cert1 := models.Certificate{
+			Slot: 1000,
+			BlockHash: []byte(
+				"block_1000_12345678901234567890123456789012",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+			TransactionID: 2,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&cert1); result.Error != nil {
+			t.Fatalf("failed to create cert1: %v", result.Error)
+		}
+
+		delegation1 := models.StakeDelegation{
+			CertificateID: cert1.ID,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolHash1,
+			AddedSlot:     1000,
+		}
+		if result := sqliteStore.DB().Create(&delegation1); result.Error != nil {
+			t.Fatalf("failed to create delegation1: %v", result.Error)
+		}
+
+		// Create stake delegation certificate at slot 2000 (to pool2)
+		cert2 := models.Certificate{
+			Slot: 2000,
+			BlockHash: []byte(
+				"block_2000_12345678901234567890123456789012",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+			TransactionID: 3,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&cert2); result.Error != nil {
+			t.Fatalf("failed to create cert2: %v", result.Error)
+		}
+
+		delegation2 := models.StakeDelegation{
+			CertificateID: cert2.ID,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolHash2,
+			AddedSlot:     2000,
+		}
+		if result := sqliteStore.DB().Create(&delegation2); result.Error != nil {
+			t.Fatalf("failed to create delegation2: %v", result.Error)
+		}
+
+		// Delete certificates after slot 1500 (removes cert2 and delegation2)
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+
+		// Restore account state to slot 1500
+		if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore account state: %v", err)
+		}
+
+		// Verify account is delegated back to pool1
+		var restoredAccount models.Account
+		if result := sqliteStore.DB().First(&restoredAccount); result.Error != nil {
+			t.Fatalf("failed to query restored account: %v", result.Error)
+		}
+		if string(restoredAccount.Pool) != string(poolHash1) {
+			t.Errorf(
+				"expected account delegated to pool1, got %x",
+				restoredAccount.Pool,
+			)
+		}
+	})
+
+	t.Run(
+		"account deregistered after rollback slot is restored to active",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create Transaction records for foreign key constraints
+			for i := uint(1); i <= 2; i++ {
+				if err := createTestTransaction(sqliteStore.DB(), i, uint64(i*1000)); err != nil {
+					t.Fatalf("failed to create transaction %d: %v", i, err)
+				}
+			}
+
+			stakingKey := []byte("staking_key_active_test_12345678901234567890")
+
+			// Create an account that is currently inactive (deregistered at slot 2000)
+			account := models.Account{
+				StakingKey: stakingKey,
+				AddedSlot:  2000,
+				Active:     false, // Currently inactive due to deregistration
+			}
+			if result := sqliteStore.DB().Create(&account); result.Error != nil {
+				t.Fatalf("failed to create account: %v", result.Error)
+			}
+
+			// Create stake registration certificate at slot 1000
+			regCert := models.Certificate{
+				Slot: 1000,
+				BlockHash: []byte(
+					"block_1000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+				TransactionID: 1,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&regCert); result.Error != nil {
+				t.Fatalf("failed to create regCert: %v", result.Error)
+			}
+
+			stakeReg := models.StakeRegistration{
+				CertificateID: regCert.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     1000,
+			}
+			if result := sqliteStore.DB().Create(&stakeReg); result.Error != nil {
+				t.Fatalf("failed to create stakeReg: %v", result.Error)
+			}
+
+			// Create stake deregistration certificate at slot 2000 (after rollback point)
+			deregCert := models.Certificate{
+				Slot: 2000,
+				BlockHash: []byte(
+					"block_2000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeDeregistration),
+				TransactionID: 2,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&deregCert); result.Error != nil {
+				t.Fatalf("failed to create deregCert: %v", result.Error)
+			}
+
+			stakeDereg := models.StakeDeregistration{
+				CertificateID: deregCert.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     2000,
+			}
+			if result := sqliteStore.DB().Create(&stakeDereg); result.Error != nil {
+				t.Fatalf("failed to create stakeDereg: %v", result.Error)
+			}
+
+			// Delete certificates after slot 1500 (removes deregistration)
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+
+			// Restore account state to slot 1500
+			if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore account state: %v", err)
+			}
+
+			// Verify account is now active (deregistration was rolled back)
+			var restoredAccount models.Account
+			if result := sqliteStore.DB().First(&restoredAccount); result.Error != nil {
+				t.Fatalf("failed to query restored account: %v", result.Error)
+			}
+			if !restoredAccount.Active {
+				t.Error(
+					"expected account to be active after rolling back deregistration",
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"account deregistered before rollback slot remains inactive",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create Transaction records for foreign key constraints
+			for i := uint(1); i <= 3; i++ {
+				if err := createTestTransaction(sqliteStore.DB(), i, uint64(i*500)); err != nil {
+					t.Fatalf("failed to create transaction %d: %v", i, err)
+				}
+			}
+
+			stakingKey := []byte("staking_key_inactive_test_123456789012345678")
+
+			// Create an account that was re-registered at slot 2000 (currently active)
+			account := models.Account{
+				StakingKey: stakingKey,
+				AddedSlot:  2000,
+				Active:     true,
+			}
+			if result := sqliteStore.DB().Create(&account); result.Error != nil {
+				t.Fatalf("failed to create account: %v", result.Error)
+			}
+
+			// Create stake registration certificate at slot 500
+			regCert1 := models.Certificate{
+				Slot: 500,
+				BlockHash: []byte(
+					"block_500_1234567890123456789012345678901234",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+				TransactionID: 1,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&regCert1); result.Error != nil {
+				t.Fatalf("failed to create regCert1: %v", result.Error)
+			}
+
+			stakeReg1 := models.StakeRegistration{
+				CertificateID: regCert1.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     500,
+			}
+			if result := sqliteStore.DB().Create(&stakeReg1); result.Error != nil {
+				t.Fatalf("failed to create stakeReg1: %v", result.Error)
+			}
+
+			// Create stake deregistration certificate at slot 1000 (before rollback point)
+			deregCert := models.Certificate{
+				Slot: 1000,
+				BlockHash: []byte(
+					"block_1000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeDeregistration),
+				TransactionID: 2,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&deregCert); result.Error != nil {
+				t.Fatalf("failed to create deregCert: %v", result.Error)
+			}
+
+			stakeDereg := models.StakeDeregistration{
+				CertificateID: deregCert.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     1000,
+			}
+			if result := sqliteStore.DB().Create(&stakeDereg); result.Error != nil {
+				t.Fatalf("failed to create stakeDereg: %v", result.Error)
+			}
+
+			// Create re-registration certificate at slot 2000 (after rollback point)
+			regCert2 := models.Certificate{
+				Slot: 2000,
+				BlockHash: []byte(
+					"block_2000_12345678901234567890123456789012",
+				),
+				CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+				TransactionID: 3,
+				CertIndex:     0,
+			}
+			if result := sqliteStore.DB().Create(&regCert2); result.Error != nil {
+				t.Fatalf("failed to create regCert2: %v", result.Error)
+			}
+
+			stakeReg2 := models.StakeRegistration{
+				CertificateID: regCert2.ID,
+				StakingKey:    stakingKey,
+				AddedSlot:     2000,
+			}
+			if result := sqliteStore.DB().Create(&stakeReg2); result.Error != nil {
+				t.Fatalf("failed to create stakeReg2: %v", result.Error)
+			}
+
+			// Delete certificates after slot 1500 (removes re-registration at slot 2000)
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+
+			// Restore account state to slot 1500
+			if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore account state: %v", err)
+			}
+
+			// Verify account is inactive (deregistration at slot 1000 is more recent than registration at slot 500)
+			var restoredAccount models.Account
+			if result := sqliteStore.DB().First(&restoredAccount); result.Error != nil {
+				t.Fatalf("failed to query restored account: %v", result.Error)
+			}
+			if restoredAccount.Active {
+				t.Error(
+					"expected account to be inactive (deregistered before rollback slot)",
+				)
+			}
+		},
+	)
+
+	t.Run("account with no prior registration is deleted", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		// Create Transaction for foreign key constraints
+		if err := createTestTransaction(sqliteStore.DB(), 1, 2000); err != nil {
+			t.Fatalf("failed to create transaction: %v", err)
+		}
+
+		stakingKey := []byte("staking_key_test_1234567890123456789012345678")
+
+		// Create an account registered at slot 2000 (after rollback point)
+		account := models.Account{
+			StakingKey: stakingKey,
+			AddedSlot:  2000,
+			Active:     true,
+		}
+		if result := sqliteStore.DB().Create(&account); result.Error != nil {
+			t.Fatalf("failed to create account: %v", result.Error)
+		}
+
+		// Create stake registration certificate at slot 2000 (after rollback point)
+		regCert := models.Certificate{
+			Slot: 2000,
+			BlockHash: []byte(
+				"block_2000_12345678901234567890123456789012",
+			),
+			CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+			TransactionID: 1,
+			CertIndex:     0,
+		}
+		if result := sqliteStore.DB().Create(&regCert); result.Error != nil {
+			t.Fatalf("failed to create regCert: %v", result.Error)
+		}
+
+		stakeReg := models.StakeRegistration{
+			CertificateID: regCert.ID,
+			StakingKey:    stakingKey,
+			AddedSlot:     2000,
+		}
+		if result := sqliteStore.DB().Create(&stakeReg); result.Error != nil {
+			t.Fatalf("failed to create stakeReg: %v", result.Error)
+		}
+
+		// Delete certificates after slot 1500 (removes registration)
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+
+		// Restore account state to slot 1500
+		if err := sqliteStore.RestoreAccountStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore account state: %v", err)
+		}
+
+		// Verify account is deleted (no registration before rollback slot)
+		var count int64
+		sqliteStore.DB().Model(&models.Account{}).Count(&count)
+		if count != 0 {
+			t.Errorf("expected 0 accounts after rollback, got %d", count)
+		}
+	})
+}
+
+// TestDeletePParamsAfterSlot tests that protocol parameters after a slot are deleted
+func TestDeletePParamsAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create pparams at slot 1000
+	pparams1 := models.PParams{
+		AddedSlot: 1000,
+		Epoch:     100,
+		Cbor:      []byte("pparams_cbor_1"),
+	}
+	if result := sqliteStore.DB().Create(&pparams1); result.Error != nil {
+		t.Fatalf("failed to create pparams1: %v", result.Error)
+	}
+
+	// Create pparams at slot 2000
+	pparams2 := models.PParams{
+		AddedSlot: 2000,
+		Epoch:     101,
+		Cbor:      []byte("pparams_cbor_2"),
+	}
+	if result := sqliteStore.DB().Create(&pparams2); result.Error != nil {
+		t.Fatalf("failed to create pparams2: %v", result.Error)
+	}
+
+	// Verify we have 2 pparams
+	var countBefore int64
+	sqliteStore.DB().Model(&models.PParams{}).Count(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf("expected 2 pparams before rollback, got %d", countBefore)
+	}
+
+	// Delete pparams after slot 1500
+	if err := sqliteStore.DeletePParamsAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete pparams: %v", err)
+	}
+
+	// Verify only 1 remains
+	var countAfter int64
+	sqliteStore.DB().Model(&models.PParams{}).Count(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 pparams after rollback, got %d", countAfter)
+	}
+}
+
+// TestDeletePParamUpdatesAfterSlot tests that protocol parameter updates after a slot are deleted
+func TestDeletePParamUpdatesAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create pparam update at slot 1000
+	update1 := models.PParamUpdate{
+		AddedSlot:   1000,
+		Epoch:       100,
+		GenesisHash: []byte("genesis_hash_1"),
+		Cbor:        []byte("update_cbor_1"),
+	}
+	if result := sqliteStore.DB().Create(&update1); result.Error != nil {
+		t.Fatalf("failed to create update1: %v", result.Error)
+	}
+
+	// Create pparam update at slot 2000
+	update2 := models.PParamUpdate{
+		AddedSlot:   2000,
+		Epoch:       101,
+		GenesisHash: []byte("genesis_hash_2"),
+		Cbor:        []byte("update_cbor_2"),
+	}
+	if result := sqliteStore.DB().Create(&update2); result.Error != nil {
+		t.Fatalf("failed to create update2: %v", result.Error)
+	}
+
+	// Verify we have 2 updates
+	var countBefore int64
+	sqliteStore.DB().Model(&models.PParamUpdate{}).Count(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf(
+			"expected 2 pparam updates before rollback, got %d",
+			countBefore,
+		)
+	}
+
+	// Delete updates after slot 1500
+	if err := sqliteStore.DeletePParamUpdatesAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete pparam updates: %v", err)
+	}
+
+	// Verify only 1 remains
+	var countAfter int64
+	sqliteStore.DB().Model(&models.PParamUpdate{}).Count(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 pparam update after rollback, got %d", countAfter)
+	}
+}
+
+// TestDeleteTransactionsAfterSlot tests that transactions and their child records are deleted
+func TestDeleteTransactionsAfterSlot(t *testing.T) {
+	sqliteStore, err := New("", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := sqliteStore.Start(); err != nil {
+		t.Fatalf("unexpected error starting store: %s", err)
+	}
+	defer sqliteStore.Close() //nolint:errcheck
+
+	// Run auto-migration
+	if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+		t.Fatalf("failed to auto-migrate: %v", err)
+	}
+
+	// Create transaction at slot 1000 (should be kept)
+	tx1 := models.Transaction{
+		Hash:       []byte("tx_hash_1_123456789012345678901234567890123456"),
+		BlockHash:  []byte("block_1000_12345678901234567890123456789012"),
+		Slot:       1000,
+		BlockIndex: 0,
+	}
+	if result := sqliteStore.DB().Create(&tx1); result.Error != nil {
+		t.Fatalf("failed to create tx1: %v", result.Error)
+	}
+
+	// Create child records for tx1
+	kw1 := models.KeyWitness{TransactionID: tx1.ID, Type: 1}
+	if result := sqliteStore.DB().Create(&kw1); result.Error != nil {
+		t.Fatalf("failed to create key witness for tx1: %v", result.Error)
+	}
+
+	// Create transaction at slot 2000 (should be deleted)
+	tx2 := models.Transaction{
+		Hash:       []byte("tx_hash_2_123456789012345678901234567890123456"),
+		BlockHash:  []byte("block_2000_12345678901234567890123456789012"),
+		Slot:       2000,
+		BlockIndex: 0,
+	}
+	if result := sqliteStore.DB().Create(&tx2); result.Error != nil {
+		t.Fatalf("failed to create tx2: %v", result.Error)
+	}
+
+	// Create child records for tx2
+	kw2 := models.KeyWitness{TransactionID: tx2.ID, Type: 1}
+	if result := sqliteStore.DB().Create(&kw2); result.Error != nil {
+		t.Fatalf("failed to create key witness for tx2: %v", result.Error)
+	}
+	ws2 := models.WitnessScripts{TransactionID: tx2.ID, Type: 1}
+	if result := sqliteStore.DB().Create(&ws2); result.Error != nil {
+		t.Fatalf("failed to create witness script for tx2: %v", result.Error)
+	}
+	rd2 := models.Redeemer{TransactionID: tx2.ID}
+	if result := sqliteStore.DB().Create(&rd2); result.Error != nil {
+		t.Fatalf("failed to create redeemer for tx2: %v", result.Error)
+	}
+	pd2 := models.PlutusData{TransactionID: tx2.ID}
+	if result := sqliteStore.DB().Create(&pd2); result.Error != nil {
+		t.Fatalf("failed to create plutus data for tx2: %v", result.Error)
+	}
+
+	// Verify we have 2 transactions and their child records
+	var txCountBefore int64
+	sqliteStore.DB().Model(&models.Transaction{}).Count(&txCountBefore)
+	if txCountBefore != 2 {
+		t.Fatalf(
+			"expected 2 transactions before rollback, got %d",
+			txCountBefore,
+		)
+	}
+
+	var kwCountBefore int64
+	sqliteStore.DB().Model(&models.KeyWitness{}).Count(&kwCountBefore)
+	if kwCountBefore != 2 {
+		t.Fatalf(
+			"expected 2 key witnesses before rollback, got %d",
+			kwCountBefore,
+		)
+	}
+
+	// Delete transactions after slot 1500
+	if err := sqliteStore.DeleteTransactionsAfterSlot(1500, nil); err != nil {
+		t.Fatalf("failed to delete transactions: %v", err)
+	}
+
+	// Verify only tx1 remains
+	var txCountAfter int64
+	sqliteStore.DB().Model(&models.Transaction{}).Count(&txCountAfter)
+	if txCountAfter != 1 {
+		t.Errorf("expected 1 transaction after rollback, got %d", txCountAfter)
+	}
+
+	// Verify only kw1 remains (child record of tx1)
+	var kwCountAfter int64
+	sqliteStore.DB().Model(&models.KeyWitness{}).Count(&kwCountAfter)
+	if kwCountAfter != 1 {
+		t.Errorf("expected 1 key witness after rollback, got %d", kwCountAfter)
+	}
+
+	// Verify all other child records of tx2 are deleted
+	var wsCountAfter int64
+	sqliteStore.DB().Model(&models.WitnessScripts{}).Count(&wsCountAfter)
+	if wsCountAfter != 0 {
+		t.Errorf(
+			"expected 0 witness scripts after rollback, got %d",
+			wsCountAfter,
+		)
+	}
+
+	var rdCountAfter int64
+	sqliteStore.DB().Model(&models.Redeemer{}).Count(&rdCountAfter)
+	if rdCountAfter != 0 {
+		t.Errorf("expected 0 redeemers after rollback, got %d", rdCountAfter)
+	}
+
+	var pdCountAfter int64
+	sqliteStore.DB().Model(&models.PlutusData{}).Count(&pdCountAfter)
+	if pdCountAfter != 0 {
+		t.Errorf("expected 0 plutus data after rollback, got %d", pdCountAfter)
+	}
+}
+
+// TestRestorePoolStateAtSlot tests that pool state is correctly restored during rollback
+func TestRestorePoolStateAtSlot(t *testing.T) {
+	t.Run("pool with no prior registrations is deleted", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+		// Create a pool with registration after rollback point
+		pool := models.Pool{PoolKeyHash: poolHash}
+		if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+			t.Fatalf("failed to create pool: %v", result.Error)
+		}
+
+		poolReg := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   2000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
+			t.Fatalf("failed to create pool registration: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestorePoolStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore pool state: %v", err)
+		}
+
+		// Pool should be deleted
+		var count int64
+		sqliteStore.DB().Model(&models.Pool{}).Count(&count)
+		if count != 0 {
+			t.Errorf("expected 0 pools after rollback, got %d", count)
+		}
+	})
+
+	t.Run("pool with prior registration is kept", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+		// Create a pool with registration BEFORE rollback point
+		pool := models.Pool{PoolKeyHash: poolHash}
+		if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+			t.Fatalf("failed to create pool: %v", result.Error)
+		}
+
+		// Registration at slot 1000 (before rollback)
+		poolReg1 := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   1000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg1); result.Error != nil {
+			t.Fatalf("failed to create pool registration 1: %v", result.Error)
+		}
+
+		// Registration at slot 2000 (after rollback)
+		poolReg2 := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   2000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg2); result.Error != nil {
+			t.Fatalf("failed to create pool registration 2: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestorePoolStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore pool state: %v", err)
+		}
+
+		// Pool should still exist (has registration before rollback)
+		var count int64
+		sqliteStore.DB().Model(&models.Pool{}).Count(&count)
+		if count != 1 {
+			t.Errorf("expected 1 pool after rollback, got %d", count)
+		}
+
+		// Only one registration should remain
+		var regCount int64
+		sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+		if regCount != 1 {
+			t.Errorf(
+				"expected 1 pool registration after rollback, got %d",
+				regCount,
+			)
+		}
+	})
+
+	t.Run("pool with retirement after rollback has retirement undone", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+		// Create a pool with registration BEFORE rollback point
+		pool := models.Pool{PoolKeyHash: poolHash}
+		if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+			t.Fatalf("failed to create pool: %v", result.Error)
+		}
+
+		// Registration at slot 1000 (before rollback)
+		poolReg := models.PoolRegistration{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   1000,
+		}
+		if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
+			t.Fatalf("failed to create pool registration: %v", result.Error)
+		}
+
+		// Retirement at slot 2000 (after rollback)
+		poolRetirement := models.PoolRetirement{
+			PoolID:      pool.ID,
+			PoolKeyHash: poolHash,
+			AddedSlot:   2000,
+			Epoch:       100,
+		}
+		if result := sqliteStore.DB().Create(&poolRetirement); result.Error != nil {
+			t.Fatalf("failed to create pool retirement: %v", result.Error)
+		}
+
+		// Verify pool has retirement before rollback
+		var retirementCountBefore int64
+		sqliteStore.DB().Model(&models.PoolRetirement{}).Count(&retirementCountBefore)
+		if retirementCountBefore != 1 {
+			t.Fatalf(
+				"expected 1 retirement before rollback, got %d",
+				retirementCountBefore,
+			)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestorePoolStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore pool state: %v", err)
+		}
+
+		// Pool should still exist
+		var count int64
+		sqliteStore.DB().Model(&models.Pool{}).Count(&count)
+		if count != 1 {
+			t.Errorf("expected 1 pool after rollback, got %d", count)
+		}
+
+		// Retirement should be removed (CASCADE from DeleteCertificatesAfterSlot)
+		var retirementCountAfter int64
+		sqliteStore.DB().Model(&models.PoolRetirement{}).Count(&retirementCountAfter)
+		if retirementCountAfter != 0 {
+			t.Errorf(
+				"expected 0 retirements after rollback, got %d",
+				retirementCountAfter,
+			)
+		}
+
+		// Registration should still exist
+		var regCount int64
+		sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+		if regCount != 1 {
+			t.Errorf(
+				"expected 1 pool registration after rollback, got %d",
+				regCount,
+			)
+		}
+	})
+}
+
+// TestRestoreDrepStateAtSlot tests that DRep state is correctly restored during rollback
+func TestRestoreDrepStateAtSlot(t *testing.T) {
+	t.Run("DRep with no prior registrations is deleted", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		drepCredential := []byte("drep_credential_12345678901234567890123456")
+
+		// Create a DRep registered at slot 2000 (after rollback point)
+		drep := models.Drep{
+			Credential: drepCredential,
+			Active:     true,
+			AddedSlot:  2000,
+		}
+		if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+			t.Fatalf("failed to create drep: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore DRep state: %v", err)
+		}
+
+		// DRep should be deleted
+		var count int64
+		sqliteStore.DB().Model(&models.Drep{}).Count(&count)
+		if count != 0 {
+			t.Errorf("expected 0 DReps after rollback, got %d", count)
+		}
+	})
+
+	t.Run(
+		"DRep with prior registration has state restored",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep1"
+			anchorHash1 := []byte("anchor_hash_1_1234567890123456789012345678")
+			anchorUrl2 := "https://example.com/drep2"
+			anchorHash2 := []byte("anchor_hash_2_1234567890123456789012345678")
+
+			// Create a DRep with current state at slot 2000
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl2,
+				AnchorHash: anchorHash2,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records for proper JOIN support
+			tx1 := models.Transaction{Hash: []byte("tx_hash_1000"), Slot: 1000}
+			if result := sqliteStore.DB().Create(&tx1); result.Error != nil {
+				t.Fatalf("failed to create tx1: %v", result.Error)
+			}
+			cert1 := models.Certificate{
+				Slot:          1000,
+				CertIndex:     0,
+				TransactionID: tx1.ID,
+			}
+			if result := sqliteStore.DB().Create(&cert1); result.Error != nil {
+				t.Fatalf("failed to create cert1: %v", result.Error)
+			}
+			tx2 := models.Transaction{Hash: []byte("tx_hash_2000"), Slot: 2000}
+			if result := sqliteStore.DB().Create(&tx2); result.Error != nil {
+				t.Fatalf("failed to create tx2: %v", result.Error)
+			}
+			cert2 := models.Certificate{
+				Slot:          2000,
+				CertIndex:     0,
+				TransactionID: tx2.ID,
+			}
+			if result := sqliteStore.DB().Create(&cert2); result.Error != nil {
+				t.Fatalf("failed to create cert2: %v", result.Error)
+			}
+
+			// Registration at slot 1000 (before rollback) with original anchor data
+			reg1 := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      1000,
+				CertificateID:  cert1.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg1); result.Error != nil {
+				t.Fatalf("failed to create registration 1: %v", result.Error)
+			}
+
+			// Registration at slot 2000 (after rollback) with new anchor data
+			reg2 := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl2,
+				AnchorHash:     anchorHash2,
+				AddedSlot:      2000,
+				CertificateID:  cert2.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg2); result.Error != nil {
+				t.Fatalf("failed to create registration 2: %v", result.Error)
+			}
+
+			// Delete certificates and restore state
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should still exist with original anchor data
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.AnchorUrl != anchorUrl1 {
+				t.Errorf(
+					"expected anchor URL %s, got %s",
+					anchorUrl1,
+					restoredDrep.AnchorUrl,
+				)
+			}
+			if string(restoredDrep.AnchorHash) != string(anchorHash1) {
+				t.Errorf("expected anchor hash to be restored")
+			}
+			if !restoredDrep.Active {
+				t.Errorf("expected DRep to be active")
+			}
+		},
+	)
+
+	t.Run("DRep deregistered before rollback is inactive", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		drepCredential := []byte("drep_credential_12345678901234567890123456")
+
+		// DRep is currently active (re-registered at slot 2000)
+		drep := models.Drep{
+			Credential: drepCredential,
+			Active:     true,
+			AddedSlot:  2000,
+		}
+		if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+			t.Fatalf("failed to create drep: %v", result.Error)
+		}
+
+		// Create Transaction and Certificate records for proper JOIN support
+		txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+		if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+			t.Fatalf("failed to create txReg: %v", result.Error)
+		}
+		certReg := models.Certificate{
+			Slot:          500,
+			CertIndex:     0,
+			TransactionID: txReg.ID,
+		}
+		if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+			t.Fatalf("failed to create certReg: %v", result.Error)
+		}
+		txDereg := models.Transaction{Hash: []byte("tx_hash_1000"), Slot: 1000}
+		if result := sqliteStore.DB().Create(&txDereg); result.Error != nil {
+			t.Fatalf("failed to create txDereg: %v", result.Error)
+		}
+		certDereg := models.Certificate{
+			Slot:          1000,
+			CertIndex:     0,
+			TransactionID: txDereg.ID,
+		}
+		if result := sqliteStore.DB().Create(&certDereg); result.Error != nil {
+			t.Fatalf("failed to create certDereg: %v", result.Error)
+		}
+		txReg2 := models.Transaction{Hash: []byte("tx_hash_2000"), Slot: 2000}
+		if result := sqliteStore.DB().Create(&txReg2); result.Error != nil {
+			t.Fatalf("failed to create txReg2: %v", result.Error)
+		}
+		certReg2 := models.Certificate{
+			Slot:          2000,
+			CertIndex:     0,
+			TransactionID: txReg2.ID,
+		}
+		if result := sqliteStore.DB().Create(&certReg2); result.Error != nil {
+			t.Fatalf("failed to create certReg2: %v", result.Error)
+		}
+
+		// Registration at slot 500
+		reg := models.RegistrationDrep{
+			DrepCredential: drepCredential,
+			AddedSlot:      500,
+			CertificateID:  certReg.ID,
+		}
+		if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+			t.Fatalf("failed to create registration: %v", result.Error)
+		}
+
+		// Deregistration at slot 1000 (before rollback)
+		dereg := models.DeregistrationDrep{
+			DrepCredential: drepCredential,
+			AddedSlot:      1000,
+			CertificateID:  certDereg.ID,
+		}
+		if result := sqliteStore.DB().Create(&dereg); result.Error != nil {
+			t.Fatalf("failed to create deregistration: %v", result.Error)
+		}
+
+		// Re-registration at slot 2000 (after rollback)
+		reg2 := models.RegistrationDrep{
+			DrepCredential: drepCredential,
+			AddedSlot:      2000,
+			CertificateID:  certReg2.ID,
+		}
+		if result := sqliteStore.DB().Create(&reg2); result.Error != nil {
+			t.Fatalf("failed to create re-registration: %v", result.Error)
+		}
+
+		// Delete certificates and restore state
+		if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+			t.Fatalf("failed to delete certificates: %v", err)
+		}
+		if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+			t.Fatalf("failed to restore DRep state: %v", err)
+		}
+
+		// DRep should exist but be inactive (deregistered at slot 1000)
+		var restoredDrep models.Drep
+		if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+			t.Fatalf("failed to query restored DRep: %v", result.Error)
+		}
+		if restoredDrep.Active {
+			t.Errorf(
+				"expected DRep to be inactive after rollback (was deregistered at slot 1000)",
+			)
+		}
+	})
+
+	t.Run(
+		"DRep with update certificate has anchor restored",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep_initial"
+			anchorHash1 := []byte("anchor_hash_initial_123456789012345678901")
+			anchorUrl2 := "https://example.com/drep_updated"
+			anchorHash2 := []byte("anchor_hash_updated_123456789012345678901")
+			anchorUrl3 := "https://example.com/drep_final"
+			anchorHash3 := []byte("anchor_hash_final_12345678901234567890123")
+
+			// DRep currently has final anchor data
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl3,
+				AnchorHash: anchorHash3,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records for proper JOIN support
+			txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+			if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+				t.Fatalf("failed to create txReg: %v", result.Error)
+			}
+			certReg := models.Certificate{
+				Slot:          500,
+				CertIndex:     0,
+				TransactionID: txReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+				t.Fatalf("failed to create certReg: %v", result.Error)
+			}
+			txUpdate1 := models.Transaction{
+				Hash: []byte("tx_hash_1000"),
+				Slot: 1000,
+			}
+			if result := sqliteStore.DB().Create(&txUpdate1); result.Error != nil {
+				t.Fatalf("failed to create txUpdate1: %v", result.Error)
+			}
+			certUpdate1 := models.Certificate{
+				Slot:          1000,
+				CertIndex:     0,
+				TransactionID: txUpdate1.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate1); result.Error != nil {
+				t.Fatalf("failed to create certUpdate1: %v", result.Error)
+			}
+			txUpdate2 := models.Transaction{
+				Hash: []byte("tx_hash_2000"),
+				Slot: 2000,
+			}
+			if result := sqliteStore.DB().Create(&txUpdate2); result.Error != nil {
+				t.Fatalf("failed to create txUpdate2: %v", result.Error)
+			}
+			certUpdate2 := models.Certificate{
+				Slot:          2000,
+				CertIndex:     0,
+				TransactionID: txUpdate2.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate2); result.Error != nil {
+				t.Fatalf("failed to create certUpdate2: %v", result.Error)
+			}
+
+			// Registration at slot 500
+			reg := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      500,
+				CertificateID:  certReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+				t.Fatalf("failed to create registration: %v", result.Error)
+			}
+
+			// Update at slot 1000 (before rollback)
+			update := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl2,
+				AnchorHash:    anchorHash2,
+				AddedSlot:     1000,
+				CertificateID: certUpdate1.ID,
+			}
+			if result := sqliteStore.DB().Create(&update); result.Error != nil {
+				t.Fatalf("failed to create update: %v", result.Error)
+			}
+
+			// Update at slot 2000 (after rollback)
+			update2 := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl3,
+				AnchorHash:    anchorHash3,
+				AddedSlot:     2000,
+				CertificateID: certUpdate2.ID,
+			}
+			if result := sqliteStore.DB().Create(&update2); result.Error != nil {
+				t.Fatalf("failed to create update 2: %v", result.Error)
+			}
+
+			// Delete certificates and restore state
+			if err := sqliteStore.DeleteCertificatesAfterSlot(1500, nil); err != nil {
+				t.Fatalf("failed to delete certificates: %v", err)
+			}
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should have anchor data from slot 1000 update
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.AnchorUrl != anchorUrl2 {
+				t.Errorf(
+					"expected anchor URL %s, got %s",
+					anchorUrl2,
+					restoredDrep.AnchorUrl,
+				)
+			}
+			if string(restoredDrep.AnchorHash) != string(anchorHash2) {
+				t.Errorf("expected anchor hash from update at slot 1000")
+			}
+			if !restoredDrep.Active {
+				t.Errorf("expected DRep to be active")
+			}
+		},
+	)
+
+	t.Run(
+		"DRep with update after deregistration stays inactive",
+		func(t *testing.T) {
+			// This test verifies that an update certificate does NOT reactivate
+			// a deregistered DRep. Per CIP-1694, update certificates only modify
+			// anchor data and cannot change the active status.
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep_reg"
+			anchorHash1 := []byte("anchor_hash_reg_123456789012345678901234")
+			anchorUrl2 := "https://example.com/drep_update"
+			anchorHash2 := []byte("anchor_hash_update_1234567890123456789012")
+
+			// DRep currently shows as active at slot 2000 (after rollback point)
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl2,
+				AnchorHash: anchorHash2,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records
+			txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+			if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+				t.Fatalf("failed to create txReg: %v", result.Error)
+			}
+			certReg := models.Certificate{
+				Slot:          500,
+				CertIndex:     0,
+				TransactionID: txReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+				t.Fatalf("failed to create certReg: %v", result.Error)
+			}
+
+			txDereg := models.Transaction{Hash: []byte("tx_hash_1000"), Slot: 1000}
+			if result := sqliteStore.DB().Create(&txDereg); result.Error != nil {
+				t.Fatalf("failed to create txDereg: %v", result.Error)
+			}
+			certDereg := models.Certificate{
+				Slot:          1000,
+				CertIndex:     0,
+				TransactionID: txDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certDereg); result.Error != nil {
+				t.Fatalf("failed to create certDereg: %v", result.Error)
+			}
+
+			txUpdate := models.Transaction{Hash: []byte("tx_hash_1200"), Slot: 1200}
+			if result := sqliteStore.DB().Create(&txUpdate); result.Error != nil {
+				t.Fatalf("failed to create txUpdate: %v", result.Error)
+			}
+			certUpdate := models.Certificate{
+				Slot:          1200,
+				CertIndex:     0,
+				TransactionID: txUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate); result.Error != nil {
+				t.Fatalf("failed to create certUpdate: %v", result.Error)
+			}
+
+			// Registration at slot 500
+			reg := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      500,
+				CertificateID:  certReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+				t.Fatalf("failed to create registration: %v", result.Error)
+			}
+
+			// Deregistration at slot 1000
+			dereg := models.DeregistrationDrep{
+				DrepCredential: drepCredential,
+				AddedSlot:      1000,
+				CertificateID:  certDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&dereg); result.Error != nil {
+				t.Fatalf("failed to create deregistration: %v", result.Error)
+			}
+
+			// Update at slot 1200 (AFTER deregistration - should be ignored per protocol)
+			update := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl2,
+				AnchorHash:    anchorHash2,
+				AddedSlot:     1200,
+				CertificateID: certUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&update); result.Error != nil {
+				t.Fatalf("failed to create update: %v", result.Error)
+			}
+
+			// Rollback to slot 1500 (all certs are within the rollback window)
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should be INACTIVE because:
+			// - Registered at 500 (active)
+			// - Deregistered at 1000 (inactive)
+			// - Update at 1200 should NOT reactivate (update only changes anchor, not status)
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.Active {
+				t.Errorf(
+					"expected DRep to be inactive (update after deregistration should not reactivate)",
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"DRep update as latest event does not reactivate deregistered DRep",
+		func(t *testing.T) {
+			// This test verifies the specific bug scenario where the update
+			// certificate is the chronologically latest event. The DRep should
+			// remain inactive because updates cannot change active status.
+			//
+			// Scenario: Reg(500) -> Dereg(600) -> Update(700) (update is latest)
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			drepCredential := []byte(
+				"drep_credential_12345678901234567890123456",
+			)
+			anchorUrl1 := "https://example.com/drep_reg"
+			anchorHash1 := []byte("anchor_hash_reg_123456789012345678901234")
+			anchorUrl2 := "https://example.com/drep_update"
+			anchorHash2 := []byte("anchor_hash_update_1234567890123456789012")
+
+			// DRep currently shows as active at slot 2000 (after rollback point)
+			drep := models.Drep{
+				Credential: drepCredential,
+				Active:     true,
+				AnchorUrl:  anchorUrl2,
+				AnchorHash: anchorHash2,
+				AddedSlot:  2000,
+			}
+			if result := sqliteStore.DB().Create(&drep); result.Error != nil {
+				t.Fatalf("failed to create drep: %v", result.Error)
+			}
+
+			// Create Transaction and Certificate records
+			txReg := models.Transaction{Hash: []byte("tx_hash_500"), Slot: 500}
+			if result := sqliteStore.DB().Create(&txReg); result.Error != nil {
+				t.Fatalf("failed to create txReg: %v", result.Error)
+			}
+			certReg := models.Certificate{
+				Slot:          500,
+				CertIndex:     0,
+				TransactionID: txReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certReg); result.Error != nil {
+				t.Fatalf("failed to create certReg: %v", result.Error)
+			}
+
+			txDereg := models.Transaction{Hash: []byte("tx_hash_600"), Slot: 600}
+			if result := sqliteStore.DB().Create(&txDereg); result.Error != nil {
+				t.Fatalf("failed to create txDereg: %v", result.Error)
+			}
+			certDereg := models.Certificate{
+				Slot:          600,
+				CertIndex:     0,
+				TransactionID: txDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&certDereg); result.Error != nil {
+				t.Fatalf("failed to create certDereg: %v", result.Error)
+			}
+
+			// Update is at slot 700 - the latest event chronologically
+			txUpdate := models.Transaction{Hash: []byte("tx_hash_700"), Slot: 700}
+			if result := sqliteStore.DB().Create(&txUpdate); result.Error != nil {
+				t.Fatalf("failed to create txUpdate: %v", result.Error)
+			}
+			certUpdate := models.Certificate{
+				Slot:          700,
+				CertIndex:     0,
+				TransactionID: txUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&certUpdate); result.Error != nil {
+				t.Fatalf("failed to create certUpdate: %v", result.Error)
+			}
+
+			// Registration at slot 500
+			reg := models.RegistrationDrep{
+				DrepCredential: drepCredential,
+				AnchorUrl:      anchorUrl1,
+				AnchorHash:     anchorHash1,
+				AddedSlot:      500,
+				CertificateID:  certReg.ID,
+			}
+			if result := sqliteStore.DB().Create(&reg); result.Error != nil {
+				t.Fatalf("failed to create registration: %v", result.Error)
+			}
+
+			// Deregistration at slot 600
+			dereg := models.DeregistrationDrep{
+				DrepCredential: drepCredential,
+				AddedSlot:      600,
+				CertificateID:  certDereg.ID,
+			}
+			if result := sqliteStore.DB().Create(&dereg); result.Error != nil {
+				t.Fatalf("failed to create deregistration: %v", result.Error)
+			}
+
+			// Update at slot 700 - the latest event (AFTER deregistration)
+			update := models.UpdateDrep{
+				Credential:    drepCredential,
+				AnchorUrl:     anchorUrl2,
+				AnchorHash:    anchorHash2,
+				AddedSlot:     700,
+				CertificateID: certUpdate.ID,
+			}
+			if result := sqliteStore.DB().Create(&update); result.Error != nil {
+				t.Fatalf("failed to create update: %v", result.Error)
+			}
+
+			// Rollback to slot 1500 (all certs are within the rollback window)
+			if err := sqliteStore.RestoreDrepStateAtSlot(1500, nil); err != nil {
+				t.Fatalf("failed to restore DRep state: %v", err)
+			}
+
+			// DRep should be INACTIVE because:
+			// - Registered at 500 (active)
+			// - Deregistered at 600 (inactive)
+			// - Update at 700 should NOT reactivate (update only changes anchor, not status)
+			var restoredDrep models.Drep
+			if result := sqliteStore.DB().First(&restoredDrep); result.Error != nil {
+				t.Fatalf("failed to query restored DRep: %v", result.Error)
+			}
+			if restoredDrep.Active {
+				t.Errorf(
+					"expected DRep to be inactive (update as latest event should not reactivate)",
+				)
+			}
+		},
+	)
+}
+
+// TestPoolCascadeDelete tests that Pool deletion cascades correctly to child records
+func TestPoolCascadeDelete(t *testing.T) {
+	t.Run(
+		"pool deletion cascades to registrations, owners, relays",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+			// Create a pool
+			pool := models.Pool{PoolKeyHash: poolHash}
+			if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+				t.Fatalf("failed to create pool: %v", result.Error)
+			}
+
+			// Create a registration with owners and relays
+			poolReg := models.PoolRegistration{
+				PoolID:      pool.ID,
+				PoolKeyHash: poolHash,
+				AddedSlot:   1000,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: []byte("owner1"), PoolID: pool.ID},
+					{KeyHash: []byte("owner2"), PoolID: pool.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: "relay1.example.com", PoolID: pool.ID},
+				},
+			}
+			if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
+				t.Fatalf("failed to create pool registration: %v", result.Error)
+			}
+
+			// Verify records exist
+			var regCount, ownerCount, relayCount int64
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 1 || ownerCount != 2 || relayCount != 1 {
+				t.Fatalf(
+					"expected 1 reg, 2 owners, 1 relay; got %d, %d, %d",
+					regCount,
+					ownerCount,
+					relayCount,
+				)
+			}
+
+			// Delete the pool
+			if result := sqliteStore.DB().Delete(&pool); result.Error != nil {
+				t.Fatalf("failed to delete pool: %v", result.Error)
+			}
+
+			// All related records should be deleted via cascade
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 0 {
+				t.Errorf(
+					"expected 0 registrations after pool delete, got %d",
+					regCount,
+				)
+			}
+			if ownerCount != 0 {
+				t.Errorf(
+					"expected 0 owners after pool delete, got %d",
+					ownerCount,
+				)
+			}
+			if relayCount != 0 {
+				t.Errorf(
+					"expected 0 relays after pool delete, got %d",
+					relayCount,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"registration deletion cascades to its owners/relays only",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			poolHash := []byte("pool_key_hash_1234567890123456789012345678")
+
+			// Create a pool
+			pool := models.Pool{PoolKeyHash: poolHash}
+			if result := sqliteStore.DB().Create(&pool); result.Error != nil {
+				t.Fatalf("failed to create pool: %v", result.Error)
+			}
+
+			// Create first registration with owners and relays
+			poolReg1 := models.PoolRegistration{
+				PoolID:      pool.ID,
+				PoolKeyHash: poolHash,
+				AddedSlot:   1000,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: []byte("owner1_reg1"), PoolID: pool.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: "relay1_reg1.example.com", PoolID: pool.ID},
+				},
+			}
+			if result := sqliteStore.DB().Create(&poolReg1); result.Error != nil {
+				t.Fatalf(
+					"failed to create pool registration 1: %v",
+					result.Error,
+				)
+			}
+
+			// Create second registration with different owners and relays
+			poolReg2 := models.PoolRegistration{
+				PoolID:      pool.ID,
+				PoolKeyHash: poolHash,
+				AddedSlot:   2000,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: []byte("owner1_reg2"), PoolID: pool.ID},
+					{KeyHash: []byte("owner2_reg2"), PoolID: pool.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: "relay1_reg2.example.com", PoolID: pool.ID},
+				},
+			}
+			if result := sqliteStore.DB().Create(&poolReg2); result.Error != nil {
+				t.Fatalf(
+					"failed to create pool registration 2: %v",
+					result.Error,
+				)
+			}
+
+			// Verify initial counts
+			var regCount, ownerCount, relayCount int64
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 2 || ownerCount != 3 || relayCount != 2 {
+				t.Fatalf(
+					"expected 2 regs, 3 owners, 2 relays; got %d, %d, %d",
+					regCount,
+					ownerCount,
+					relayCount,
+				)
+			}
+
+			// Delete the second registration only
+			if result := sqliteStore.DB().Delete(&poolReg2); result.Error != nil {
+				t.Fatalf(
+					"failed to delete pool registration 2: %v",
+					result.Error,
+				)
+			}
+
+			// Pool should still exist
+			var poolCount int64
+			sqliteStore.DB().Model(&models.Pool{}).Count(&poolCount)
+			if poolCount != 1 {
+				t.Errorf(
+					"expected pool to still exist, got %d pools",
+					poolCount,
+				)
+			}
+
+			// First registration and its owners/relays should still exist
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if regCount != 1 {
+				t.Errorf(
+					"expected 1 registration after deleting one, got %d",
+					regCount,
+				)
+			}
+			if ownerCount != 1 {
+				t.Errorf(
+					"expected 1 owner from first registration, got %d",
+					ownerCount,
+				)
+			}
+			if relayCount != 1 {
+				t.Errorf(
+					"expected 1 relay from first registration, got %d",
+					relayCount,
+				)
+			}
+		},
+	)
+}
+
+// TestPoolCrossPoolOwnerRelay tests that owners/relays with the same key hash
+// across different pools are stored as separate records and don't affect each other
+func TestPoolCrossPoolOwnerRelay(t *testing.T) {
+	t.Run(
+		"same owner key hash in different pools are independent records",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create two different pools
+			poolA := models.Pool{
+				PoolKeyHash: []byte("pool_A_hash_123456789012345678901234"),
+			}
+			if result := sqliteStore.DB().Create(&poolA); result.Error != nil {
+				t.Fatalf("failed to create pool A: %v", result.Error)
+			}
+			poolB := models.Pool{
+				PoolKeyHash: []byte("pool_B_hash_123456789012345678901234"),
+			}
+			if result := sqliteStore.DB().Create(&poolB); result.Error != nil {
+				t.Fatalf("failed to create pool B: %v", result.Error)
+			}
+
+			// Both pools use the SAME owner key hash and relay hostname
+			sharedOwnerHash := []byte("shared_owner_key_hash_1234567890123")
+			sharedRelayHost := "shared-relay.example.com"
+
+			// Create registration for Pool A
+			regA := models.PoolRegistration{
+				PoolID:      poolA.ID,
+				PoolKeyHash: poolA.PoolKeyHash,
+				AddedSlot:   500,
+				Owners: []models.PoolRegistrationOwner{
+					{KeyHash: sharedOwnerHash, PoolID: poolA.ID},
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{Hostname: sharedRelayHost, PoolID: poolA.ID, Port: 3001},
+				},
+			}
+			if result := sqliteStore.DB().Create(&regA); result.Error != nil {
+				t.Fatalf("failed to create registration A: %v", result.Error)
+			}
+
+			// Create registration for Pool B with SAME owner hash and relay
+			regB := models.PoolRegistration{
+				PoolID:      poolB.ID,
+				PoolKeyHash: poolB.PoolKeyHash,
+				AddedSlot:   1000,
+				Owners: []models.PoolRegistrationOwner{
+					{
+						KeyHash: sharedOwnerHash,
+						PoolID:  poolB.ID,
+					}, // Same key hash!
+				},
+				Relays: []models.PoolRegistrationRelay{
+					{
+						Hostname: sharedRelayHost,
+						PoolID:   poolB.ID,
+						Port:     3001,
+					}, // Same relay!
+				},
+			}
+			if result := sqliteStore.DB().Create(&regB); result.Error != nil {
+				t.Fatalf("failed to create registration B: %v", result.Error)
+			}
+
+			// Verify we have 2 owner records and 2 relay records (separate records, same data)
+			var ownerCount, relayCount int64
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if ownerCount != 2 {
+				t.Fatalf("expected 2 owner records, got %d", ownerCount)
+			}
+			if relayCount != 2 {
+				t.Fatalf("expected 2 relay records, got %d", relayCount)
+			}
+
+			// Delete Pool B - this should only delete Pool B's records
+			if result := sqliteStore.DB().Delete(&poolB); result.Error != nil {
+				t.Fatalf("failed to delete pool B: %v", result.Error)
+			}
+
+			// Pool A should still exist with its registration, owner, and relay
+			var poolCount int64
+			sqliteStore.DB().Model(&models.Pool{}).Count(&poolCount)
+			if poolCount != 1 {
+				t.Errorf("expected 1 pool remaining, got %d", poolCount)
+			}
+
+			var regCount int64
+			sqliteStore.DB().Model(&models.PoolRegistration{}).Count(&regCount)
+			if regCount != 1 {
+				t.Errorf("expected 1 registration remaining, got %d", regCount)
+			}
+
+			// Verify Pool A's owner and relay still exist
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationOwner{}).
+				Count(&ownerCount)
+			sqliteStore.DB().
+				Model(&models.PoolRegistrationRelay{}).
+				Count(&relayCount)
+			if ownerCount != 1 {
+				t.Errorf(
+					"expected 1 owner remaining (Pool A's), got %d",
+					ownerCount,
+				)
+			}
+			if relayCount != 1 {
+				t.Errorf(
+					"expected 1 relay remaining (Pool A's), got %d",
+					relayCount,
+				)
+			}
+
+			// Verify the remaining records belong to Pool A
+			var remainingOwner models.PoolRegistrationOwner
+			sqliteStore.DB().First(&remainingOwner)
+			if remainingOwner.PoolID != poolA.ID {
+				t.Errorf("remaining owner should belong to Pool A")
+			}
+		},
+	)
+}
+
+// TestUtxoCascadeDelete tests that Utxo deletion cascades correctly to Asset records
+func TestUtxoCascadeDelete(t *testing.T) {
+	t.Run("utxo deletion cascades to assets", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		txId := []byte("tx_hash_1234567890123456789012345678901234567890")
+
+		// Create a Utxo with multiple assets
+		utxo := models.Utxo{
+			TxId:       txId,
+			OutputIdx:  0,
+			AddedSlot:  1000,
+			PaymentKey: []byte("payment_key_123456789012345678901234567890"),
+			Amount:     1000000,
+			Assets: []models.Asset{
+				{
+					PolicyId: []byte(
+						"policy_id_1234567890123456789012345678901234",
+					),
+					Name:   []byte("asset_name_1"),
+					Amount: 100,
+				},
+				{
+					PolicyId: []byte(
+						"policy_id_1234567890123456789012345678901234",
+					),
+					Name:   []byte("asset_name_2"),
+					Amount: 200,
+				},
+			},
+		}
+		if result := sqliteStore.DB().Create(&utxo); result.Error != nil {
+			t.Fatalf("failed to create utxo: %v", result.Error)
+		}
+
+		// Verify records exist
+		var utxoCount, assetCount int64
+		sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+		sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+		if utxoCount != 1 || assetCount != 2 {
+			t.Fatalf(
+				"expected 1 utxo, 2 assets; got %d, %d",
+				utxoCount,
+				assetCount,
+			)
+		}
+
+		// Delete the utxo
+		if result := sqliteStore.DB().Delete(&utxo); result.Error != nil {
+			t.Fatalf("failed to delete utxo: %v", result.Error)
+		}
+
+		// All related assets should be deleted via cascade
+		sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+		sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+		if utxoCount != 0 {
+			t.Errorf("expected 0 utxos after delete, got %d", utxoCount)
+		}
+		if assetCount != 0 {
+			t.Errorf(
+				"expected 0 assets after utxo delete (cascade), got %d",
+				assetCount,
+			)
+		}
+	})
+
+	t.Run(
+		"deleting one utxo does not affect assets of other utxos",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create first utxo with asset
+			utxo1 := models.Utxo{
+				TxId: []byte(
+					"tx_hash_1111111111111111111111111111111111111111",
+				),
+				OutputIdx: 0,
+				AddedSlot: 1000,
+				PaymentKey: []byte(
+					"payment_key_123456789012345678901234567890",
+				),
+				Amount: 1000000,
+				Assets: []models.Asset{
+					{
+						PolicyId: []byte(
+							"policy_id_1234567890123456789012345678901234",
+						),
+						Name:   []byte("asset_utxo1"),
+						Amount: 100,
+					},
+				},
+			}
+			if result := sqliteStore.DB().Create(&utxo1); result.Error != nil {
+				t.Fatalf("failed to create utxo1: %v", result.Error)
+			}
+
+			// Create second utxo with asset
+			utxo2 := models.Utxo{
+				TxId: []byte(
+					"tx_hash_2222222222222222222222222222222222222222",
+				),
+				OutputIdx: 0,
+				AddedSlot: 1000,
+				PaymentKey: []byte(
+					"payment_key_123456789012345678901234567890",
+				),
+				Amount: 2000000,
+				Assets: []models.Asset{
+					{
+						PolicyId: []byte(
+							"policy_id_1234567890123456789012345678901234",
+						),
+						Name:   []byte("asset_utxo2"),
+						Amount: 200,
+					},
+				},
+			}
+			if result := sqliteStore.DB().Create(&utxo2); result.Error != nil {
+				t.Fatalf("failed to create utxo2: %v", result.Error)
+			}
+
+			// Verify initial counts
+			var utxoCount, assetCount int64
+			sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+			sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+			if utxoCount != 2 || assetCount != 2 {
+				t.Fatalf(
+					"expected 2 utxos, 2 assets; got %d, %d",
+					utxoCount,
+					assetCount,
+				)
+			}
+
+			// Delete only the first utxo
+			if result := sqliteStore.DB().Delete(&utxo1); result.Error != nil {
+				t.Fatalf("failed to delete utxo1: %v", result.Error)
+			}
+
+			// Second utxo and its asset should still exist
+			sqliteStore.DB().Model(&models.Utxo{}).Count(&utxoCount)
+			sqliteStore.DB().Model(&models.Asset{}).Count(&assetCount)
+			if utxoCount != 1 {
+				t.Errorf(
+					"expected 1 utxo after deleting one, got %d",
+					utxoCount,
+				)
+			}
+			if assetCount != 1 {
+				t.Errorf(
+					"expected 1 asset from remaining utxo, got %d",
+					assetCount,
+				)
+			}
+
+			// Verify the remaining asset belongs to utxo2
+			var remainingAsset models.Asset
+			if result := sqliteStore.DB().First(&remainingAsset); result.Error != nil {
+				t.Fatalf("failed to query remaining asset: %v", result.Error)
+			}
+			if string(remainingAsset.Name) != "asset_utxo2" {
+				t.Errorf(
+					"expected remaining asset to be 'asset_utxo2', got '%s'",
+					string(remainingAsset.Name),
+				)
+			}
+		},
+	)
+}
+
+// TestCollateralReturnUniqueConstraint verifies that CollateralReturnForTxID has a unique constraint:
+//   - Multiple UTXOs with NULL CollateralReturnForTxID are allowed (regular outputs)
+//   - Two UTXOs with the same non-NULL CollateralReturnForTxID are rejected (per Cardano protocol,
+//     a transaction has at most one collateral return output)
+func TestCollateralReturnUniqueConstraint(t *testing.T) {
+	t.Run("multiple NULL CollateralReturnForTxID allowed", func(t *testing.T) {
+		sqliteStore, err := New("", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := sqliteStore.Start(); err != nil {
+			t.Fatalf("unexpected error starting store: %s", err)
+		}
+		defer sqliteStore.Close() //nolint:errcheck
+
+		if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+			t.Fatalf("failed to auto-migrate: %v", err)
+		}
+
+		// Create multiple UTXOs with NULL CollateralReturnForTxID (normal outputs)
+		utxo1 := models.Utxo{
+			TxId: []byte(
+				"tx_hash_1111111111111111111111111111111111111111",
+			),
+			OutputIdx: 0,
+			AddedSlot: 1000,
+			Amount:    1000000,
+			// CollateralReturnForTxID is nil (NULL)
+		}
+		if result := sqliteStore.DB().Create(&utxo1); result.Error != nil {
+			t.Fatalf("failed to create utxo1: %v", result.Error)
+		}
+
+		utxo2 := models.Utxo{
+			TxId: []byte(
+				"tx_hash_2222222222222222222222222222222222222222",
+			),
+			OutputIdx: 0,
+			AddedSlot: 1000,
+			Amount:    2000000,
+			// CollateralReturnForTxID is nil (NULL)
+		}
+		if result := sqliteStore.DB().Create(&utxo2); result.Error != nil {
+			t.Fatalf("failed to create utxo2: %v", result.Error)
+		}
+
+		// Both should exist
+		var count int64
+		sqliteStore.DB().Model(&models.Utxo{}).Count(&count)
+		if count != 2 {
+			t.Errorf(
+				"expected 2 UTXOs with NULL CollateralReturnForTxID, got %d",
+				count,
+			)
+		}
+	})
+
+	t.Run(
+		"duplicate non-NULL CollateralReturnForTxID rejected",
+		func(t *testing.T) {
+			sqliteStore, err := New("", nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := sqliteStore.Start(); err != nil {
+				t.Fatalf("unexpected error starting store: %s", err)
+			}
+			defer sqliteStore.Close() //nolint:errcheck
+
+			if err := sqliteStore.DB().AutoMigrate(models.MigrateModels...); err != nil {
+				t.Fatalf("failed to auto-migrate: %v", err)
+			}
+
+			// Create a transaction first (needed for FK)
+			tx := models.Transaction{
+				Hash: []byte(
+					"tx_hash_for_collateral_test_1234567890123456",
+				),
+				Slot:       1000,
+				BlockIndex: 0,
+				Valid:      false, // Invalid tx that used collateral
+			}
+			if result := sqliteStore.DB().Create(&tx); result.Error != nil {
+				t.Fatalf("failed to create transaction: %v", result.Error)
+			}
+
+			// Create first UTXO with CollateralReturnForTxID pointing to tx
+			txID := tx.ID
+			utxo1 := models.Utxo{
+				TxId: []byte(
+					"collateral_return_1111111111111111111111111111111",
+				),
+				OutputIdx:               0,
+				AddedSlot:               1000,
+				Amount:                  1000000,
+				CollateralReturnForTxID: &txID,
+			}
+			if result := sqliteStore.DB().Create(&utxo1); result.Error != nil {
+				t.Fatalf(
+					"failed to create first collateral return: %v",
+					result.Error,
+				)
+			}
+
+			// Try to create second UTXO with same CollateralReturnForTxID - should fail
+			utxo2 := models.Utxo{
+				TxId: []byte(
+					"collateral_return_2222222222222222222222222222222",
+				),
+				OutputIdx:               1,
+				AddedSlot:               1000,
+				Amount:                  2000000,
+				CollateralReturnForTxID: &txID, // Same transaction ID - violates unique constraint
+			}
+			result := sqliteStore.DB().Create(&utxo2)
+			if result.Error == nil {
+				t.Fatal(
+					"expected unique constraint violation for duplicate CollateralReturnForTxID, but insert succeeded",
+				)
+			}
+			// Verify only one UTXO with this CollateralReturnForTxID exists
+			var count int64
+			sqliteStore.DB().
+				Model(&models.Utxo{}).
+				Where("collateral_return_for_tx_id = ?", txID).
+				Count(&count)
+			if count != 1 {
+				t.Errorf(
+					"expected exactly 1 UTXO with CollateralReturnForTxID=%d, got %d",
+					txID,
+					count,
+				)
+			}
+		},
+	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds rollback support to the SQLite metadata plugin to safely restore state after chain rollbacks. Handles certificates, protocol params, and account/pool/DRep state with deterministic ordering and strong FK enforcement.

- **New Features**
  - Rollback APIs to delete records after a given slot: certificates, protocol params, and param updates.
  - Deterministic restoration using slot/blockIndex/certIndex ordering; batch caches for accounts, pools, and DReps to avoid N+1 queries.
  - Batch UTXO fetch (GetUtxosBatch) with safe chunking under SQLite bind limits.
  - Large test suite covering rollbacks and edge cases.

- **Refactors**
  - Enforce SQLite foreign keys via DSN (_pragma=foreign_keys(1)); add sqliteBindVarLimit for safe IN clauses.
  - Race-safe account creation pattern; clearer errors/logging.

<sup>Written for commit 132a89fad6f02a0ba331ec8cbe322a91aaac722c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

