### PR TITLE
feat(database): postgres plugin rollback support

### DIFF
--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -77,3 +77,624 @@ func (d *MetadataStorePostgres) SetAccount(
 	}
 	return nil
 }
+
+// certRecord holds common fields extracted from certificate records for
+// batch processing during account state restoration.
+// Includes certIndex for same-slot disambiguation.
+type certRecord struct {
+	pool      []byte
+	drep      []byte
+	addedSlot uint64
+	certIndex uint32
+}
+
+// isMoreRecent checks if this certificate is more recent than the other.
+// When slots are equal, certIndex determines order (higher = later in transaction).
+func (r certRecord) isMoreRecent(other certRecord) bool {
+	if r.addedSlot > other.addedSlot {
+		return true
+	}
+	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
+		return true
+	}
+	return false
+}
+
+// accountCertCache holds batch-fetched certificate data for all accounts
+// being restored. This eliminates N+1 queries by fetching all certificates
+// for all affected accounts in a small number of queries upfront.
+type accountCertCache struct {
+	// Maps staking key (as string) to the most recent registration
+	latestReg map[string]certRecord
+	hasReg    map[string]bool
+
+	// Maps staking key to the most recent deregistration
+	latestDereg map[string]certRecord
+	hasDereg    map[string]bool
+
+	// Maps staking key to the most recent pool delegation
+	poolDelegation map[string]certRecord
+
+	// Maps staking key to the most recent DRep delegation
+	drepDelegation map[string]certRecord
+}
+
+// newAccountCertCache creates an empty certificate cache.
+func newAccountCertCache(capacity int) *accountCertCache {
+	return &accountCertCache{
+		latestReg:      make(map[string]certRecord, capacity),
+		hasReg:         make(map[string]bool, capacity),
+		latestDereg:    make(map[string]certRecord, capacity),
+		hasDereg:       make(map[string]bool, capacity),
+		poolDelegation: make(map[string]certRecord, capacity),
+		drepDelegation: make(map[string]certRecord, capacity),
+	}
+}
+
+// updateReg updates the registration if this one is more recent.
+func (c *accountCertCache) updateReg(key string, rec certRecord) {
+	if !c.hasReg[key] || rec.isMoreRecent(c.latestReg[key]) {
+		c.latestReg[key] = rec
+		c.hasReg[key] = true
+	}
+}
+
+// updateDereg updates the deregistration if this one is more recent.
+func (c *accountCertCache) updateDereg(key string, rec certRecord) {
+	if !c.hasDereg[key] || rec.isMoreRecent(c.latestDereg[key]) {
+		c.latestDereg[key] = rec
+		c.hasDereg[key] = true
+	}
+}
+
+// updatePoolDelegation updates the pool delegation if this one is more recent.
+func (c *accountCertCache) updatePoolDelegation(key string, rec certRecord) {
+	existing, ok := c.poolDelegation[key]
+	if !ok || rec.isMoreRecent(existing) {
+		c.poolDelegation[key] = rec
+	}
+}
+
+// updateDrepDelegation updates the DRep delegation if this one is more recent.
+func (c *accountCertCache) updateDrepDelegation(key string, rec certRecord) {
+	existing, ok := c.drepDelegation[key]
+	if !ok || rec.isMoreRecent(existing) {
+		c.drepDelegation[key] = rec
+	}
+}
+
+// batchFetchCerts fetches all relevant certificates for the given staking keys
+// at or before the given slot. Uses one query per certificate table.
+func batchFetchCerts(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+) (*accountCertCache, error) {
+	cache := newAccountCertCache(len(stakingKeys))
+
+	// Registration certificates (5 types)
+	if err := batchFetchStakeRegistration(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+	if err := batchFetchStakeRegistrationDelegation(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+	if err := batchFetchStakeVoteRegistrationDelegation(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+	if err := batchFetchVoteRegistrationDelegation(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+	if err := batchFetchRegistration(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+
+	// Deregistration certificates (2 types)
+	if err := batchFetchStakeDeregistration(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+	if err := batchFetchDeregistration(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+
+	// Pool delegation certificates - StakeDelegation is pool-only
+	if err := batchFetchStakeDelegation(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+	// StakeVoteDelegation has both pool and DRep
+	if err := batchFetchStakeVoteDelegation(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+
+	// DRep delegation certificates - VoteDelegation is DRep-only
+	if err := batchFetchVoteDelegation(db, stakingKeys, slot, cache); err != nil {
+		return nil, err
+	}
+
+	return cache, nil
+}
+
+func batchFetchStakeRegistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	// Use ROW_NUMBER to fetch only the latest record per staking key
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_registration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateReg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{pool: r.PoolKeyHash, addedSlot: r.AddedSlot, certIndex: r.CertIndex}
+		cache.updateReg(key, rec)
+		cache.updatePoolDelegation(key, rec)
+	}
+	return nil
+}
+
+func batchFetchStakeVoteRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		Drep        []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_vote_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{pool: r.PoolKeyHash, drep: r.Drep, addedSlot: r.AddedSlot, certIndex: r.CertIndex}
+		cache.updateReg(key, rec)
+		cache.updatePoolDelegation(key, rec)
+		cache.updateDrepDelegation(key, certRecord{drep: r.Drep, addedSlot: r.AddedSlot, certIndex: r.CertIndex})
+	}
+	return nil
+}
+
+func batchFetchVoteRegistrationDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		Drep       []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM vote_registration_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		rec := certRecord{drep: r.Drep, addedSlot: r.AddedSlot, certIndex: r.CertIndex}
+		cache.updateReg(key, rec)
+		cache.updateDrepDelegation(key, rec)
+	}
+	return nil
+}
+
+func batchFetchRegistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM registration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateReg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeDeregistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_deregistration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDereg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchDeregistration(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM deregistration t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDereg(
+			string(r.StakingKey),
+			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updatePoolDelegation(
+			string(r.StakingKey),
+			certRecord{pool: r.PoolKeyHash, addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+func batchFetchStakeVoteDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey  []byte
+		PoolKeyHash []byte
+		Drep        []byte
+		AddedSlot   uint64
+		CertIndex   uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM stake_vote_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		key := string(r.StakingKey)
+		cache.updatePoolDelegation(key, certRecord{pool: r.PoolKeyHash, addedSlot: r.AddedSlot, certIndex: r.CertIndex})
+		cache.updateDrepDelegation(key, certRecord{drep: r.Drep, addedSlot: r.AddedSlot, certIndex: r.CertIndex})
+	}
+	return nil
+}
+
+func batchFetchVoteDelegation(
+	db *gorm.DB,
+	stakingKeys [][]byte,
+	slot uint64,
+	cache *accountCertCache,
+) error {
+	type result struct {
+		StakingKey []byte
+		Drep       []byte
+		AddedSlot  uint64
+		CertIndex  uint32
+	}
+	var records []result
+	query := `
+		WITH ranked AS (
+			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+				ROW_NUMBER() OVER (
+					PARTITION BY t.staking_key
+					ORDER BY t.added_slot DESC, c.cert_index DESC
+				) as rn
+			FROM vote_delegation t
+			INNER JOIN certs c ON c.id = t.certificate_id
+			WHERE t.staking_key IN ? AND t.added_slot <= ?
+		)
+		SELECT staking_key, drep, added_slot, cert_index
+		FROM ranked WHERE rn = 1`
+	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
+		return err
+	}
+	for _, r := range records {
+		cache.updateDrepDelegation(
+			string(r.StakingKey),
+			certRecord{drep: r.Drep, addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+		)
+	}
+	return nil
+}
+
+// RestoreAccountStateAtSlot reverts account delegation state to the given slot.
+// For accounts modified after the slot, this restores their Pool and Drep
+// delegations to the state they had at the given slot, or marks them inactive
+// if they were registered after that slot.
+//
+// This implementation uses batch fetching to avoid N+1 query patterns:
+// instead of querying certificates per-account, it fetches all relevant
+// certificates for all affected accounts upfront (one query per table),
+// then processes them in memory.
+func (d *MetadataStorePostgres) RestoreAccountStateAtSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Find all accounts that were modified after the rollback slot
+	var accountsToRestore []models.Account
+	if result := db.Where("added_slot > ?", slot).Find(&accountsToRestore); result.Error != nil {
+		return result.Error
+	}
+
+	if len(accountsToRestore) == 0 {
+		return nil
+	}
+
+	// Extract staking keys for batch fetching
+	stakingKeys := make([][]byte, len(accountsToRestore))
+	for i, account := range accountsToRestore {
+		stakingKeys[i] = account.StakingKey
+	}
+
+	// Batch-fetch all certificates for all affected accounts
+	cache, err := batchFetchCerts(db, stakingKeys, slot)
+	if err != nil {
+		return err
+	}
+
+	// Process each account using the cached certificate data
+	for _, account := range accountsToRestore {
+		key := string(account.StakingKey)
+
+		// Check if this account had any registration before the rollback slot
+		latestReg, hasReg := cache.latestReg[key], cache.hasReg[key]
+
+		if !hasReg {
+			// Account was registered after rollback slot, delete it
+			if result := db.Delete(&account); result.Error != nil {
+				return result.Error
+			}
+			continue
+		}
+
+		// Get pool delegation from cache
+		var pool []byte
+		var poolRec certRecord
+		if rec, ok := cache.poolDelegation[key]; ok {
+			pool = rec.pool
+			poolRec = rec
+		}
+
+		// Get DRep delegation from cache
+		var drep []byte
+		var drepRec certRecord
+		if rec, ok := cache.drepDelegation[key]; ok {
+			drep = rec.drep
+			drepRec = rec
+		}
+
+		// Get deregistration info from cache
+		latestDereg, hasDereg := cache.latestDereg[key], cache.hasDereg[key]
+
+		// Account is active if either:
+		// - There is no deregistration, or
+		// - The most recent registration is after the most recent deregistration
+		active := !hasDereg || latestReg.isMoreRecent(latestDereg)
+
+		// Compute the actual last modification slot as the max of all relevant events
+		lastModSlot := latestReg.addedSlot
+		if hasDereg && latestDereg.addedSlot > lastModSlot {
+			lastModSlot = latestDereg.addedSlot
+		}
+		// Only consider pool/drep slots if they were found in the cache
+		if _, hasPool := cache.poolDelegation[key]; hasPool && poolRec.addedSlot > lastModSlot {
+			lastModSlot = poolRec.addedSlot
+		}
+		if _, hasDrep := cache.drepDelegation[key]; hasDrep && drepRec.addedSlot > lastModSlot {
+			lastModSlot = drepRec.addedSlot
+		}
+
+		// Update the account with restored state
+		if result := db.Model(&account).Updates(map[string]any{
+			"pool":       pool,
+			"drep":       drep,
+			"active":     active,
+			"added_slot": lastModSlot,
+		}); result.Error != nil {
+			return result.Error
+		}
+	}
+
+	return nil
+}

--- a/database/plugin/metadata/postgres/certs.go
+++ b/database/plugin/metadata/postgres/certs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
 )
 
 // GetStakeRegistrations returns stake registration certificates
@@ -49,4 +50,93 @@ func (d *MetadataStorePostgres) GetStakeRegistrations(
 		ret = append(ret, tmpCert)
 	}
 	return ret, nil
+}
+
+// DeleteCertificatesAfterSlot removes all certificate records added after the given slot.
+// This is used during chain rollbacks to undo certificate state changes.
+// All deletions are performed atomically within a transaction to ensure consistency.
+func (d *MetadataStorePostgres) DeleteCertificatesAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Delete all specialized certificate tables.
+	// We explicitly delete child records for PoolRegistration (Owners, Relays) and
+	// MoveInstantaneousRewards (Rewards) before deleting their parents.
+	deleteCerts := func(tx *gorm.DB) error {
+		// Delete PoolRegistrationOwner and PoolRegistrationRelay records
+		// that belong to PoolRegistration records being deleted.
+		poolRegIDsSubquery := tx.Model(&models.PoolRegistration{}).
+			Select("id").
+			Where("added_slot > ?", slot)
+		if result := tx.Where(
+			"pool_registration_id IN (?)",
+			poolRegIDsSubquery,
+		).Delete(&models.PoolRegistrationOwner{}); result.Error != nil {
+			return result.Error
+		}
+		if result := tx.Where(
+			"pool_registration_id IN (?)",
+			poolRegIDsSubquery,
+		).Delete(&models.PoolRegistrationRelay{}); result.Error != nil {
+			return result.Error
+		}
+
+		// Delete MoveInstantaneousRewardsReward records that belong to
+		// MoveInstantaneousRewards records being deleted.
+		mirIDsSubquery := tx.Model(&models.MoveInstantaneousRewards{}).
+			Select("id").
+			Where("added_slot > ?", slot)
+		if result := tx.Where(
+			"mir_id IN (?)",
+			mirIDsSubquery,
+		).Delete(&models.MoveInstantaneousRewardsReward{}); result.Error != nil {
+			return result.Error
+		}
+
+		certTables := []any{
+			&models.StakeRegistration{},
+			&models.StakeDelegation{},
+			&models.StakeDeregistration{},
+			&models.StakeRegistrationDelegation{},
+			&models.StakeVoteDelegation{},
+			&models.StakeVoteRegistrationDelegation{},
+			&models.VoteDelegation{},
+			&models.VoteRegistrationDelegation{},
+			&models.Registration{},
+			&models.Deregistration{},
+			&models.PoolRegistration{},
+			&models.PoolRetirement{},
+			&models.RegistrationDrep{},
+			&models.DeregistrationDrep{},
+			&models.UpdateDrep{},
+			&models.AuthCommitteeHot{},
+			&models.ResignCommitteeCold{},
+			&models.MoveInstantaneousRewards{},
+		}
+
+		for _, table := range certTables {
+			if result := tx.Where("added_slot > ?", slot).Delete(table); result.Error != nil {
+				return result.Error
+			}
+		}
+
+		// Delete unified certificate records (Certificate table uses 'slot' not 'added_slot')
+		if result := tx.Where("slot > ?", slot).Delete(&models.Certificate{}); result.Error != nil {
+			return result.Error
+		}
+
+		return nil
+	}
+
+	// If caller provided a transaction, use it directly.
+	// Otherwise, wrap in a transaction for atomicity.
+	if txn != nil {
+		return deleteCerts(db)
+	}
+	return db.Transaction(deleteCerts)
 }

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -16,6 +16,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -78,5 +79,281 @@ func (d *MetadataStorePostgres) SetDrep(
 	if result := db.Clauses(onConflict).Create(&tmpItem); result.Error != nil {
 		return result.Error
 	}
+	return nil
+}
+
+// drepCertRecord holds fields from a DRep certificate for batch processing
+// during DRep state restoration.
+type drepCertRecord struct {
+	anchorUrl  string
+	anchorHash []byte
+	addedSlot  uint64
+	certIndex  uint32
+}
+
+// drepCertCache holds batch-fetched certificate data for all DReps being restored.
+type drepCertCache struct {
+	registration   map[string]drepCertRecord
+	hasReg         map[string]bool
+	deregistration map[string]drepCertRecord
+	hasDereg       map[string]bool
+	update         map[string]drepCertRecord
+	hasUpdate      map[string]bool
+}
+
+// batchFetchDrepCerts fetches all relevant certificates for the given DRep credentials
+// at or before the given slot.
+func batchFetchDrepCerts(
+	db *gorm.DB,
+	credentials [][]byte,
+	slot uint64,
+) (*drepCertCache, error) {
+	cache := &drepCertCache{
+		registration:   make(map[string]drepCertRecord, len(credentials)),
+		hasReg:         make(map[string]bool, len(credentials)),
+		deregistration: make(map[string]drepCertRecord, len(credentials)),
+		hasDereg:       make(map[string]bool, len(credentials)),
+		update:         make(map[string]drepCertRecord, len(credentials)),
+		hasUpdate:      make(map[string]bool, len(credentials)),
+	}
+
+	// Fetch registrations
+	{
+		type result struct {
+			DrepCredential []byte
+			AnchorUrl      string
+			AnchorHash     []byte
+			AddedSlot      uint64
+			CertIndex      uint32
+		}
+		var records []result
+		query := `
+			WITH ranked AS (
+				SELECT t.drep_credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
+					ROW_NUMBER() OVER (
+						PARTITION BY t.drep_credential
+						ORDER BY t.added_slot DESC, c.cert_index DESC
+					) as rn
+				FROM registration_drep t
+				INNER JOIN certs c ON c.id = t.certificate_id
+				WHERE t.drep_credential IN ? AND t.added_slot <= ?
+			)
+			SELECT drep_credential, anchor_url, anchor_hash, added_slot, cert_index
+			FROM ranked WHERE rn = 1`
+		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range records {
+			key := string(r.DrepCredential)
+			cache.registration[key] = drepCertRecord{
+				anchorUrl:  r.AnchorUrl,
+				anchorHash: r.AnchorHash,
+				addedSlot:  r.AddedSlot,
+				certIndex:  r.CertIndex,
+			}
+			cache.hasReg[key] = true
+		}
+	}
+
+	// Fetch deregistrations
+	{
+		type result struct {
+			DrepCredential []byte
+			AddedSlot      uint64
+			CertIndex      uint32
+		}
+		var records []result
+		query := `
+			WITH ranked AS (
+				SELECT t.drep_credential, t.added_slot, c.cert_index,
+					ROW_NUMBER() OVER (
+						PARTITION BY t.drep_credential
+						ORDER BY t.added_slot DESC, c.cert_index DESC
+					) as rn
+				FROM deregistration_drep t
+				INNER JOIN certs c ON c.id = t.certificate_id
+				WHERE t.drep_credential IN ? AND t.added_slot <= ?
+			)
+			SELECT drep_credential, added_slot, cert_index
+			FROM ranked WHERE rn = 1`
+		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range records {
+			key := string(r.DrepCredential)
+			cache.deregistration[key] = drepCertRecord{
+				addedSlot: r.AddedSlot,
+				certIndex: r.CertIndex,
+			}
+			cache.hasDereg[key] = true
+		}
+	}
+
+	// Fetch updates
+	{
+		type result struct {
+			Credential []byte
+			AnchorUrl  string
+			AnchorHash []byte
+			AddedSlot  uint64
+			CertIndex  uint32
+		}
+		var records []result
+		query := `
+			WITH ranked AS (
+				SELECT t.credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
+					ROW_NUMBER() OVER (
+						PARTITION BY t.credential
+						ORDER BY t.added_slot DESC, c.cert_index DESC
+					) as rn
+				FROM update_drep t
+				INNER JOIN certs c ON c.id = t.certificate_id
+				WHERE t.credential IN ? AND t.added_slot <= ?
+			)
+			SELECT credential, anchor_url, anchor_hash, added_slot, cert_index
+			FROM ranked WHERE rn = 1`
+		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range records {
+			key := string(r.Credential)
+			cache.update[key] = drepCertRecord{
+				anchorUrl:  r.AnchorUrl,
+				anchorHash: r.AnchorHash,
+				addedSlot:  r.AddedSlot,
+				certIndex:  r.CertIndex,
+			}
+			cache.hasUpdate[key] = true
+		}
+	}
+
+	return cache, nil
+}
+
+// RestoreDrepStateAtSlot reverts DRep state to the given slot.
+// DReps that have no registrations at or before the given slot are deleted.
+// DReps that have prior registrations have their Active status and anchor
+// data restored based on the most recent certificate at or before the slot.
+//
+// This implementation uses batch fetching to avoid N+1 query patterns:
+// instead of querying certificates per-DRep, it fetches all relevant
+// certificates for all affected DReps upfront (one query per table),
+// then processes them in memory.
+func (d *MetadataStorePostgres) RestoreDrepStateAtSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// Phase 1: Delete DReps that have no registration certificates at or before
+	// the rollback slot. These DReps were first registered after the rollback
+	// point and should not exist in the restored state.
+	drepsWithNoValidRegsSubquery := db.Model(&models.Drep{}).
+		Select("drep.id").
+		Where("added_slot > ?", slot).
+		Where(
+			"NOT EXISTS (?)",
+			db.Model(&models.RegistrationDrep{}).
+				Select("1").
+				Where("registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
+		)
+
+	if result := db.Where(
+		"id IN (?)",
+		drepsWithNoValidRegsSubquery,
+	).Delete(&models.Drep{}); result.Error != nil {
+		return result.Error
+	}
+
+	// Phase 2: Restore state for DReps that have at least one registration
+	// certificate at or before the rollback slot.
+	var drepsToRestore []models.Drep
+	if result := db.Where("added_slot > ?", slot).Find(&drepsToRestore); result.Error != nil {
+		return result.Error
+	}
+
+	if len(drepsToRestore) == 0 {
+		return nil
+	}
+
+	// Extract credentials for batch fetching
+	credentials := make([][]byte, len(drepsToRestore))
+	for i, drep := range drepsToRestore {
+		credentials[i] = drep.Credential
+	}
+
+	// Batch-fetch all certificates for all affected DReps
+	cache, err := batchFetchDrepCerts(db, credentials, slot)
+	if err != nil {
+		return err
+	}
+
+	// Process each DRep using the cached certificate data
+	for _, drep := range drepsToRestore {
+		key := string(drep.Credential)
+
+		// Get registration from cache (must exist due to Phase 1 deletion)
+		lastReg, hasRegAtSlot := cache.registration[key], cache.hasReg[key]
+		if !hasRegAtSlot {
+			// This indicates database inconsistency: Phase 1 should have deleted
+			// any DRep without a registration cert at or before the rollback slot.
+			return fmt.Errorf(
+				"DRep %x has no registration cert at or before slot %d but wasn't deleted in Phase 1",
+				drep.Credential,
+				slot,
+			)
+		}
+
+		// Determine the correct state by processing certificates in order.
+		// Start with registration state (DRep is active with registration's anchor data)
+		active := true
+		anchorUrl := lastReg.anchorUrl
+		anchorHash := lastReg.anchorHash
+		latestSlot := lastReg.addedSlot
+		latestCertIndex := lastReg.certIndex
+		latestWasDereg := false
+
+		// Apply deregistration if it's more recent than registration
+		if cache.hasDereg[key] {
+			lastDereg := cache.deregistration[key]
+			if lastDereg.addedSlot > latestSlot ||
+				(lastDereg.addedSlot == latestSlot && lastDereg.certIndex > latestCertIndex) {
+				active = false
+				latestSlot = lastDereg.addedSlot
+				latestCertIndex = lastDereg.certIndex
+				anchorUrl = ""
+				anchorHash = nil
+				latestWasDereg = true
+			}
+		}
+
+		// Apply update certificate only if it's the most recent event AND the
+		// DRep is still active. Per CIP-1694 and Cardano protocol rules, an update
+		// certificate is only valid for registered DReps. If a DRep deregisters,
+		// their update history is effectively cleared.
+		if cache.hasUpdate[key] && !latestWasDereg {
+			lastUpdate := cache.update[key]
+			if lastUpdate.addedSlot > latestSlot ||
+				(lastUpdate.addedSlot == latestSlot && lastUpdate.certIndex > latestCertIndex) {
+				anchorUrl = lastUpdate.anchorUrl
+				anchorHash = lastUpdate.anchorHash
+				latestSlot = lastUpdate.addedSlot
+			}
+		}
+
+		// Update the DRep with restored state
+		if result := db.Model(&drep).Updates(map[string]any{
+			"anchor_url":  anchorUrl,
+			"anchor_hash": anchorHash,
+			"active":      active,
+			"added_slot":  latestSlot,
+		}); result.Error != nil {
+			return result.Error
+		}
+	}
+
 	return nil
 }

--- a/database/plugin/metadata/postgres/pparams.go
+++ b/database/plugin/metadata/postgres/pparams.go
@@ -101,3 +101,33 @@ func (d *MetadataStorePostgres) SetPParamUpdate(
 	}
 	return nil
 }
+
+// DeletePParamsAfterSlot removes protocol parameter records added after the given slot.
+func (d *MetadataStorePostgres) DeletePParamsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Where("added_slot > ?", slot).Delete(&models.PParams{}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// DeletePParamUpdatesAfterSlot removes protocol parameter update records added after the given slot.
+func (d *MetadataStorePostgres) DeletePParamUpdatesAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Where("added_slot > ?", slot).Delete(&models.PParamUpdate{}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds rollback support to the Postgres metadata plugin. Lets us restore accounts, pools, and DReps to a target slot and remove data written after that slot.

- **New Features**
  - RestoreAccountStateAtSlot: restores pool/DRep delegations and active status at a slot; deletes accounts first registered after the slot.
  - RestorePoolStateAtSlot: deletes pools with no registration at/before the slot; restores denormalized fields from the latest valid registration.
  - RestoreDrepStateAtSlot: deletes DReps with no registration at/before the slot; restores active and anchor data based on registration/dereg/update order.
  - Delete after-slot helpers: transactions (clears UTXO refs and restores unspent), certificates (handles child tables, then unified certs), pparams and pparam updates.
  - Uses windowed queries with cert_index for deterministic ordering and batch fetching to avoid N+1. Includes tests covering delete and restore paths.

<sup>Written for commit dcd7686acf0f204f1260707e749cab5afb428d10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

