### PR TITLE
feat(chain): async chain rollback events

### DIFF
--- a/chain/event.go
+++ b/chain/event.go
@@ -30,7 +30,8 @@ type ChainBlockEvent struct {
 }
 
 type ChainRollbackEvent struct {
-	Point ocommon.Point
+	Point            ocommon.Point
+	RolledBackBlocks []models.Block // Blocks that were rolled back, in reverse order (newest first)
 }
 
 // ChainForkEvent is emitted when a chain fork is detected.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds asynchronous event publishing and enriches chain rollback events with the exact blocks that were rolled back. This reduces blocking and gives subscribers full context during rollbacks.

- **New Features**
  - EventBus async queue and worker pool with PublishAsync, publish timeout, backpressure, and drop metrics/logs.
  - ChainRollbackEvent now includes RolledBackBlocks (newest first).
  - ChainManager removeBlockByIndex returns the removed block for event payloads.

- **Refactors**
  - Simplified chain.blockByIndex signature (removed txn) and updated call sites.
  - EventBus Stop is idempotent, waits for workers, and reinitializes to allow reuse.

<sup>Written for commit e339ddc68f2f5faf4c67dfe24cff859617912b5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asynchronous event publishing capability with configurable worker pool sizes and queue management for improved system responsiveness and event throughput.
  * Chain rollback events now capture and include detailed information about all rolled-back blocks (ordered newest-first) for enhanced visibility and diagnostics.

* **Improvements**
  * Refined block management during rollback operations with improved event tracking and logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->