### PR TITLE
fix(ledger): prevent double-close on channel

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -693,6 +693,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	// Cancel our blockfetch timeout watcher
 	if ls.chainsyncBlockfetchBatchDoneChan != nil {
 		close(ls.chainsyncBlockfetchBatchDoneChan)
+		ls.chainsyncBlockfetchBatchDoneChan = nil
 	}
 	// Process pending block events
 	if err := ls.processBlockEvents(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent double-close of the chainsync blockfetch batch done channel by setting it to nil after closing. This avoids potential panics and ensures safe cleanup when a blockfetch batch completes.

<sup>Written for commit 58626deba35b50701822663e47091d065a6094c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code robustness by ensuring proper cleanup of internal state management, reducing potential for edge-case issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->