### PR TITLE
fix: resolve data race in handleEventBlockfetchBatchDone

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -643,13 +643,17 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 	go func() {
 		for {
 			ls.chainsyncBlockfetchBatchDoneMutex.Lock()
-			tmpChainsyncBlockFetchBatchDoneChan := ls.chainsyncBlockfetchBatchDoneChan
+			tmpChainsyncBlockfetchBatchDoneChan := ls.chainsyncBlockfetchBatchDoneChan
 			ls.chainsyncBlockfetchBatchDoneMutex.Unlock()
-			select {
-			case <-tmpChainsyncBlockFetchBatchDoneChan:
-				return
-			case <-time.After(500 * time.Millisecond):
+
+			if tmpChainsyncBlockfetchBatchDoneChan != nil {
+				select {
+				case <-tmpChainsyncBlockfetchBatchDoneChan:
+					return
+				case <-time.After(500 * time.Millisecond):
+				}
 			}
+
 			// Clear blockfetch busy flag on timeout
 			ls.chainsyncBlockfetchBusyTimeMutex.Lock()
 			busyTime := ls.chainsyncBlockfetchBusyTime

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -341,28 +341,29 @@ type MempoolProvider interface {
 	Transactions() []mempool.MempoolTransaction
 }
 type LedgerState struct {
-	metrics                          stateMetrics
-	currentEra                       eras.EraDesc
-	config                           LedgerStateConfig
-	chainsyncBlockfetchBusyTimeMutex sync.Mutex // protects chainsyncBlockfetchBusyTime
-	chainsyncBlockfetchBusyTime      time.Time
-	currentPParams                   lcommon.ProtocolParameters
-	mempool                          MempoolProvider
-	chainsyncBlockfetchBatchDoneChan chan struct{}
-	timerCleanupConsumedUtxos        *time.Timer
-	Scheduler                        *Scheduler
-	chain                            *chain.Chain
-	chainsyncBlockfetchReadyMutex    sync.Mutex
-	chainsyncBlockfetchReadyChan     chan struct{}
-	db                               *database.Database
-	chainsyncState                   ChainsyncState
-	currentTipBlockNonce             []byte
-	chainsyncBlockEvents             []BlockfetchEvent
-	epochCache                       []models.Epoch
-	currentTip                       ochainsync.Tip
-	currentEpoch                     models.Epoch
-	dbWorkerPool                     *DatabaseWorkerPool
-	ctx                              context.Context
+	metrics                           stateMetrics
+	currentEra                        eras.EraDesc
+	config                            LedgerStateConfig
+	chainsyncBlockfetchBusyTimeMutex  sync.Mutex // protects chainsyncBlockfetchBusyTime
+	chainsyncBlockfetchBusyTime       time.Time
+	currentPParams                    lcommon.ProtocolParameters
+	mempool                           MempoolProvider
+	chainsyncBlockfetchBatchDoneMutex sync.Mutex // protects chainsyncBlockfetchBatchDoneChan
+	chainsyncBlockfetchBatchDoneChan  chan struct{}
+	timerCleanupConsumedUtxos         *time.Timer
+	Scheduler                         *Scheduler
+	chain                             *chain.Chain
+	chainsyncBlockfetchReadyMutex     sync.Mutex // protects chainsyncBlockfetchReadyChan
+	chainsyncBlockfetchReadyChan      chan struct{}
+	db                                *database.Database
+	chainsyncState                    ChainsyncState
+	currentTipBlockNonce              []byte
+	chainsyncBlockEvents              []BlockfetchEvent
+	epochCache                        []models.Epoch
+	currentTip                        ochainsync.Tip
+	currentEpoch                      models.Epoch
+	dbWorkerPool                      *DatabaseWorkerPool
+	ctx                               context.Context
 	sync.RWMutex
 	chainsyncMutex             sync.Mutex
 	chainsyncBlockfetchMutex   sync.Mutex


### PR DESCRIPTION
closes #1235 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved a data race in blockfetch batch completion handling by synchronizing access to chainsyncBlockfetchBatchDoneChan. Prevents rare panics and ensures the timeout watcher exits cleanly.

- **Bug Fixes**
  - Added chainsyncBlockfetchBatchDoneMutex and used it to create, read, and close the batch-done channel.
  - Updated the timeout goroutine to snapshot the channel under lock and only select when it’s non-nil, removing races and avoiding waits on a nil channel.

<sup>Written for commit 9fab226585b7568f113a1f05d9b1fa5ab06ffeca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency handling to reduce rare race conditions, crashes, and hangs during block synchronization and fetching, enhancing stability.

* **Refactor**
  * Internal synchronization reorganized with explicit locking and guarded signaling to clarify and harden concurrent workflows; no changes to public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->