### PR TITLE
fix(mempool): race in next consumer

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -383,9 +383,11 @@ func (m *Mempool) removeTransactionByIndex(txIdx int) bool {
 	m.consumersMutex.Lock()
 	for _, consumer := range m.consumers {
 		// Decrement consumer index if the consumer has reached the removed TX
+		consumer.nextTxIdxMu.Lock()
 		if consumer.nextTxIdx > txIdx {
 			consumer.nextTxIdx--
 		}
+		consumer.nextTxIdxMu.Unlock()
 	}
 	m.consumersMutex.Unlock()
 	// Generate event


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in MempoolConsumer’s nextTxIdx to prevent skipped or duplicated transactions and occasional out-of-bounds panics. NextTx is now consistent under concurrent access, blocks until new transactions arrive, and cleanly unblocks on shutdown.

- **Bug Fixes**
  - Added nextTxIdxMu to guard reads/writes of nextTxIdx.
  - Reworked NextTx to lock around index updates, update cache outside locks, and block on add events; now unblocks on shutdown.
  - Guarded consumer index changes on removal with nextTxIdxMu to keep positions in sync.

<sup>Written for commit ea6496e0672d30580d74d0c7cff26249e5da5d25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consumer-side transaction retrieval to reduce lock contention and make waits event-driven for better concurrency.

* **Bug Fixes**
  * Fixed rare races and ensured blocking retrieval unblocks cleanly during shutdown, improving stability under load.

* **Tests**
  * Added tests verifying that blocking transaction retrieval unblocks on shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->