### PR TITLE
fix(connmanager): track goroutines with wait group for clean shutdown

### DIFF
--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -105,7 +105,9 @@ func (c *ConnectionManager) startListener(
 		defaultConnOpts,
 		l.ConnectionOpts...,
 	)
+	c.goroutineWg.Add(1)
 	go func() {
+		defer c.goroutineWg.Done()
 		for {
 			// Accept connection
 			conn, err := l.Listener.Accept()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Track listener and error-watcher goroutines with a WaitGroup to ensure clean shutdown. Stop() now waits for goroutines and respects context timeouts, preventing leaks.

- **Bug Fixes**
  - Added goroutineWg to track listener and connection error-watcher goroutines; increment on start, decrement on exit.
  - Updated Stop() to close connections, then wait on the WaitGroup; return early on context timeout with clear logs.
  - Added goleak-based test to verify no goroutine leaks with multiple connections.

<sup>Written for commit df4c00dc60c10505e4dc9e5f6b0b4350170d6df9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

