### PR TITLE
perf(ledger): reduce lock scope in cleanupConsumedUtxos

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -596,13 +596,14 @@ func (ls *LedgerState) cleanupConsumedUtxos() {
 	)
 	if tipSlot > cleanupConsumedUtxosSlotWindow {
 		for {
-			ls.Lock()
+			// No lock needed here - the database handles its own consistency
+			// and we're not accessing any in-memory LedgerState fields.
+			// The tipSlot was captured above with a read lock.
 			count, err := ls.db.UtxosDeleteConsumed(
 				tipSlot-cleanupConsumedUtxosSlotWindow,
 				10000,
 				nil,
 			)
-			ls.Unlock()
 			if count == 0 {
 				break
 			}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce lock scope in cleanupConsumedUtxos to avoid holding the LedgerState mutex during batch deletes. This cuts contention and speeds up cleanup while the database ensures consistency.

- **Refactors**
  - Removed mutex around UtxosDeleteConsumed loop; rely on DB for consistency.
  - tipSlot is captured under a read lock; no in-memory fields touched in the loop.
  - No functional changes; performance improvement under load.

<sup>Written for commit 0280b893c925abbb866b35e87109364c64330327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced database consistency in UTXO cleanup operations through improved synchronization handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->