### PR TITLE
fix: replace context.TODO() with real propagation

### DIFF
--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -26,11 +26,12 @@ import (
 )
 
 func (c *ConnectionManager) CreateOutboundConn(
+	ctx context.Context,
 	address string,
 ) (*ouroboros.Connection, error) {
 	t := otel.Tracer("")
 	if t != nil {
-		_, span := t.Start(context.TODO(), "create outbound connection")
+		_, span := t.Start(ctx, "create outbound connection")
 		defer span.End()
 		span.SetAttributes(
 			attribute.String("peer.address", address),
@@ -55,7 +56,7 @@ func (c *ConnectionManager) CreateOutboundConn(
 		"establishing TCP connection to: "+address,
 		"role", "client",
 	)
-	tmpConn, err := dialer.Dial("tcp", address)
+	tmpConn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return nil, err
 	}

--- a/node.go
+++ b/node.go
@@ -72,7 +72,7 @@ func New(cfg Config) (*Node, error) {
 func (n *Node) Run(ctx context.Context) error {
 	// Configure tracing
 	if n.config.tracing {
-		if err := n.setupTracing(); err != nil { //nolint:contextcheck
+		if err := n.setupTracing(ctx); err != nil {
 			return err
 		}
 	}

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -88,7 +88,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		}
 		p.mu.Unlock()
 
-		conn, err := p.config.ConnManager.CreateOutboundConn(peer.Address)
+		conn, err := p.config.ConnManager.CreateOutboundConn(p.ctx, peer.Address)
 		if err == nil {
 			connId := conn.Id()
 			p.mu.Lock()
@@ -372,7 +372,7 @@ func (p *PeerGovernor) TestPeer(address string) (bool, error) {
 		testErr = p.config.PeerTestFunc(address)
 	} else if p.config.ConnManager != nil {
 		// Default: attempt connection via ConnManager
-		conn, err := p.config.ConnManager.CreateOutboundConn(address)
+		conn, err := p.config.ConnManager.CreateOutboundConn(p.ctx, address)
 		if err != nil {
 			testErr = err
 		} else {

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -85,6 +85,7 @@ type PeerGovernor struct {
 	gossipChurnTicker     *time.Ticker
 	publicRootChurnTicker *time.Ticker
 	stopCh                chan struct{}
+	ctx                   context.Context      // Context for cancellation
 	denyList              map[string]time.Time // address -> expiry time
 	peers                 []*Peer
 	config                PeerGovernorConfig
@@ -282,6 +283,7 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 	publicRootChurnTicker := time.NewTicker(p.config.PublicRootChurnInterval)
 
 	p.mu.Lock()
+	p.ctx = ctx
 	p.reconcileTicker = ticker
 	p.gossipChurnTicker = gossipChurnTicker
 	p.publicRootChurnTicker = publicRootChurnTicker

--- a/tracing.go
+++ b/tracing.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
-func (n *Node) setupTracing() error {
+func (n *Node) setupTracing(ctx context.Context) error {
 	// Set up propagator.
 	otel.SetTextMapPropagator(
 		propagation.NewCompositeTextMapPropagator(
@@ -43,7 +43,7 @@ func (n *Node) setupTracing() error {
 		)
 	} else {
 		// TODO: make options configurable (#387)
-		traceExporter, err = otlptracehttp.New(context.TODO())
+		traceExporter, err = otlptracehttp.New(ctx)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Propagates real context through outbound connections and tracing so cancellations, timeouts, and spans are properly linked. Replaces context.TODO() with the caller’s ctx across Node, PeerGovernor, and ConnectionManager.

- **Bug Fixes**
  - ConnectionManager.CreateOutboundConn now accepts ctx, starts spans with it, and uses DialContext.
  - PeerGovernor stores ctx on Start and passes it to connection attempts and TestPeer.
  - Node.Run passes ctx to setupTracing; tracing uses ctx when creating the OTLP HTTP exporter.

<sup>Written for commit 7f786048af73d0a328cd80d1e80d1f1c253aa4e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced context propagation across core network and connection management components to improve system reliability and cancellation handling throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->