### PR TITLE
perf(mempool): tx lookup by hash

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -139,6 +139,7 @@ func addMockTransactions(
 		}
 		txs[i] = tx
 		m.transactions = append(m.transactions, tx)
+		m.txByHash[tx.Hash] = tx
 		m.metrics.txsInMempool.Inc()
 		m.metrics.mempoolBytes.Add(float64(len(tx.Cbor)))
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speed up mempool operations by adding O(1) transaction lookup by hash and caching total mempool size in bytes. This removes linear scans on adds, gets, and removes, improving performance at scale.

- **Refactors**
  - Added txByHash map for direct lookups; updated add/remove/stop paths to maintain it.
  - Cached currentSizeBytes; used in capacity checks and kept in sync on add/remove/stop.
  - Updated tests to populate the new hash index.

<sup>Written for commit b520e046386d1362dd7b6b3d5c25ad5d597ef69e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

