### PR TITLE
perf(ledger): replace blockfetch polling goroutine with timer

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -389,28 +389,26 @@ type MempoolProvider interface {
 	Transactions() []mempool.MempoolTransaction
 }
 type LedgerState struct {
-	metrics                          stateMetrics
-	currentEra                       eras.EraDesc
-	config                           LedgerStateConfig
-	chainsyncBlockfetchBusyTimeMutex sync.Mutex // protects chainsyncBlockfetchBusyTime
-	chainsyncBlockfetchBusyTime      time.Time
-	currentPParams                   lcommon.ProtocolParameters
-	mempool                          MempoolProvider
-	chainsyncBlockfetchBatchDoneChan chan struct{}
-	timerCleanupConsumedUtxos        *time.Timer
-	Scheduler                        *Scheduler
-	chain                            *chain.Chain
-	chainsyncBlockfetchReadyMutex    sync.Mutex
-	chainsyncBlockfetchReadyChan     chan struct{}
-	db                               *database.Database
-	chainsyncState                   ChainsyncState
-	currentTipBlockNonce             []byte
-	chainsyncBlockEvents             []BlockfetchEvent
-	epochCache                       []models.Epoch
-	currentTip                       ochainsync.Tip
-	currentEpoch                     models.Epoch
-	dbWorkerPool                     *DatabaseWorkerPool
-	ctx                              context.Context
+	metrics                         stateMetrics
+	currentEra                      eras.EraDesc
+	config                          LedgerStateConfig
+	chainsyncBlockfetchTimeoutTimer *time.Timer // timeout timer for blockfetch operations
+	currentPParams                  lcommon.ProtocolParameters
+	mempool                         MempoolProvider
+	timerCleanupConsumedUtxos       *time.Timer
+	Scheduler                       *Scheduler
+	chain                           *chain.Chain
+	chainsyncBlockfetchReadyMutex   sync.Mutex
+	chainsyncBlockfetchReadyChan    chan struct{}
+	db                              *database.Database
+	chainsyncState                  ChainsyncState
+	currentTipBlockNonce            []byte
+	chainsyncBlockEvents            []BlockfetchEvent
+	epochCache                      []models.Epoch
+	currentTip                      ochainsync.Tip
+	currentEpoch                    models.Epoch
+	dbWorkerPool                    *DatabaseWorkerPool
+	ctx                             context.Context
 	sync.RWMutex
 	chainsyncMutex             sync.Mutex
 	chainsyncBlockfetchMutex   sync.Mutex


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the blockfetch timeout polling goroutine with a single timer that resets on each received block. This reduces CPU overhead, simplifies synchronization, and makes timeouts more reliable.

- **Refactors**
  - Use time.AfterFunc for blockfetch timeout; callback runs cleanup and logs.
  - Reset the timer in handleEventBlockfetchBlock; stop it on batch done and cleanup.
  - Remove chainsyncBlockfetchBusyTime, its mutex, and chainsyncBlockfetchBatchDoneChan.
  - Add chainsyncBlockfetchTimeoutTimer to LedgerState; protect cleanup with chainsyncBlockfetchMutex.

<sup>Written for commit 8742cdf21dcbe92a9f9648926ead30309c0cc952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced manual polling and busy-time tracking with a unified timer-based timeout mechanism for block synchronization, improving reliability of timeout detection and recovery.
  * Reorganized internal state to support the new timeout approach and cleaner event/buffer cleanup.
  * Removed legacy timing primitives and simplified batch completion handling for clearer lifecycle management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->