### PR TITLE
fix(ledger): database double-close

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -554,7 +554,10 @@ func (ls *LedgerState) Close() error {
 		ls.dbWorkerPool.Shutdown()
 	}
 
-	return ls.db.Close()
+	// Note: We don't close the database here because LedgerState doesn't own it.
+	// The database is passed in via LedgerStateConfig and should be closed by
+	// the owner (typically Node.shutdown()).
+	return nil
 }
 
 func (ls *LedgerState) initScheduler() error {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop closing the database in LedgerState.Close() to prevent double-close. The database is owned by the caller (e.g., Node.shutdown) and is closed there.

<sup>Written for commit ebadb22fce310ce586d125ec64efb75a84e5e5e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Close function to properly handle database connection management and worker pool shutdown with correct ownership delegation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->