### PR TITLE
fix(ledger): improved block processing locking

### DIFF
--- a/ledger/chainsync_test.go
+++ b/ledger/chainsync_test.go
@@ -66,7 +66,7 @@ func TestCalculateEpochNonce_ByronEra(t *testing.T) {
 	}
 
 	// Byron era should return nil nonce
-	nonce, err := ls.calculateEpochNonce(nil, 0)
+	nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestCalculateEpochNonce_InitialEpochWithoutNonce(t *testing.T) {
 	}
 
 	// Initial epoch should return genesis hash
-	nonce, err := ls.calculateEpochNonce(nil, 0)
+	nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestCalculateEpochNonce_InvalidGenesisHash(t *testing.T) {
 		},
 	}
 
-	_, err := ls.calculateEpochNonce(nil, 0)
+	_, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err == nil {
 		t.Fatal("expected error for invalid genesis hash, got nil")
 	}
@@ -204,7 +204,7 @@ func TestCalculateEpochNonce_MissingShelleyGenesis(t *testing.T) {
 		},
 	}
 
-	_, err := ls.calculateEpochNonce(nil, 86400)
+	_, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
 	if err == nil {
 		t.Fatal("expected error for missing Shelley genesis, got nil")
 	}
@@ -248,7 +248,7 @@ func TestCalculateEpochNonce_NegativeSecurityParam(t *testing.T) {
 
 	// Test will depend on whether the genesis loads successfully
 	// If it loads, we expect an error about negative k
-	_, err := ls.calculateEpochNonce(nil, 86400)
+	_, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
 	// Either genesis loading fails or calculateEpochNonce catches negative k
 	if err == nil {
 		t.Log("Note: negative k may be caught during genesis loading")
@@ -323,7 +323,7 @@ func TestCalculateEpochNonce_ShelleyEraDifferentParams(t *testing.T) {
 			}
 
 			// Initial epoch should return genesis hash
-			nonce, err := ls.calculateEpochNonce(nil, 0)
+			nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 			if err != nil {
 				t.Fatalf("%s: unexpected error: %v", tc.description, err)
 			}
@@ -449,7 +449,7 @@ func TestCalculateEpochNonce_StabilityWindowCalculation(t *testing.T) {
 
 			// Test for Byron era - should return nil
 			if tc.era.Id == 0 {
-				nonce, err := ls.calculateEpochNonce(nil, 0)
+				nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -463,7 +463,7 @@ func TestCalculateEpochNonce_StabilityWindowCalculation(t *testing.T) {
 			}
 
 			// For non-Byron eras, test initial epoch returns genesis hash
-			nonce, err := ls.calculateEpochNonce(nil, 0)
+			nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -514,7 +514,7 @@ func TestCalculateEpochNonce_IntegerArithmeticPrecision(t *testing.T) {
 	}
 
 	// Should handle fractional coefficients correctly using integer arithmetic
-	nonce, err := ls.calculateEpochNonce(nil, 0)
+	nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error with fractional coefficient: %v", err)
 	}
@@ -662,7 +662,7 @@ func TestCalculateEpochNonce_AllEras(t *testing.T) {
 				},
 			}
 
-			nonce, err := ls.calculateEpochNonce(nil, 0)
+			nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 			if err != nil {
 				t.Fatalf("%s: unexpected error: %v", tc.description, err)
 			}
@@ -713,7 +713,7 @@ func TestCalculateEpochNonce_MissingByronGenesisInByronEra(t *testing.T) {
 	}
 
 	// Byron era returns nil nonce immediately without genesis validation
-	nonce, err := ls.calculateEpochNonce(nil, 86400)
+	nonce, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error for Byron era: %v", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit locking to in-memory updates across rollback, loadTip, block processing, and epoch/era transitions to avoid deadlocks during DB transactions and reduce contention. Guard Tip() with a read lock to prevent data races.

<sup>Written for commit c7ce5bca94f8a5d7b7ded9d4be66e8919066bef2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency and locking to avoid deadlocks and races; in-memory state (tip, nonce, checkpoint) is updated only after successful commits.
  * Read-lock snapshots added for startup/load and epoch transitions to prevent contention with recovery paths.

* **New Features**
  * Non-mutating era and epoch transition results allow computing changes inside transactions and applying them post-commit.
  * Batch/block processing now validates previous-block hashes and tracks per-batch nonces.

* **Tests**
  * Added comprehensive tests for era transitions, epoch rollovers, concurrency, and deadlock scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->