### PR TITLE
fix(chain): lru block cache

### DIFF
--- a/chain/blockcache.go
+++ b/chain/blockcache.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// DefaultBlockCacheCapacity is the default maximum number of blocks to cache.
+// At ~20KB per block, 10K blocks uses ~200MB of memory.
+const DefaultBlockCacheCapacity = 10000
+
+// blockCache is an LRU cache for blocks keyed by block hash.
+// It is used to cache rolled-back blocks that may still be needed by
+// non-primary chains during reconciliation.
+// All methods are thread-safe.
+type blockCache struct {
+	mu       sync.Mutex
+	capacity int
+	items    map[string]*list.Element
+	order    *list.List // front = most recently used, back = least recently used
+}
+
+type blockCacheEntry struct {
+	hash  string
+	block models.Block
+}
+
+// newBlockCache creates a new block cache with the given capacity.
+// If capacity is <= 0, DefaultBlockCacheCapacity is used.
+func newBlockCache(capacity int) *blockCache {
+	if capacity <= 0 {
+		capacity = DefaultBlockCacheCapacity
+	}
+	return &blockCache{
+		capacity: capacity,
+		items:    make(map[string]*list.Element),
+		order:    list.New(),
+	}
+}
+
+// Get retrieves a block from the cache by its hash.
+// Returns the block and true if found, or an empty block and false if not found.
+// Accessing a block moves it to the front of the LRU list.
+func (c *blockCache) Get(hash string) (models.Block, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, ok := c.items[hash]; ok {
+		c.order.MoveToFront(elem)
+		return elem.Value.(*blockCacheEntry).block, true
+	}
+	return models.Block{}, false
+}
+
+// Put adds or updates a block in the cache.
+// If the cache is at capacity, the least recently used block is evicted.
+func (c *blockCache) Put(block models.Block) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	hash := string(block.Hash)
+
+	// If already in cache, update and move to front
+	if elem, ok := c.items[hash]; ok {
+		c.order.MoveToFront(elem)
+		elem.Value.(*blockCacheEntry).block = block
+		return
+	}
+
+	// Evict if at capacity
+	if c.order.Len() >= c.capacity {
+		c.evictOldest()
+	}
+
+	// Add new entry at front
+	entry := &blockCacheEntry{
+		hash:  hash,
+		block: block,
+	}
+	elem := c.order.PushFront(entry)
+	c.items[hash] = elem
+}
+
+// evictOldest removes the least recently used entry from the cache.
+func (c *blockCache) evictOldest() {
+	if elem := c.order.Back(); elem != nil {
+		c.order.Remove(elem)
+		entry := elem.Value.(*blockCacheEntry)
+		delete(c.items, entry.hash)
+	}
+}
+
+// Len returns the number of blocks in the cache.
+func (c *blockCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}

--- a/chain/blockcache_test.go
+++ b/chain/blockcache_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockCache_BasicOperations(t *testing.T) {
+	cache := newBlockCache(3)
+
+	// Test empty cache
+	_, ok := cache.Get("nonexistent")
+	assert.False(t, ok)
+	assert.Equal(t, 0, cache.Len())
+
+	// Add a block
+	block1 := models.Block{Hash: []byte("hash1"), Slot: 100}
+	cache.Put(block1)
+	assert.Equal(t, 1, cache.Len())
+
+	// Retrieve it
+	got, ok := cache.Get("hash1")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(100), got.Slot)
+}
+
+func TestBlockCache_LRUEviction(t *testing.T) {
+	cache := newBlockCache(3)
+
+	// Add 3 blocks
+	block1 := models.Block{Hash: []byte("hash1"), Slot: 1}
+	block2 := models.Block{Hash: []byte("hash2"), Slot: 2}
+	block3 := models.Block{Hash: []byte("hash3"), Slot: 3}
+
+	cache.Put(block1)
+	cache.Put(block2)
+	cache.Put(block3)
+	assert.Equal(t, 3, cache.Len())
+
+	// All should be present
+	_, ok1 := cache.Get("hash1")
+	_, ok2 := cache.Get("hash2")
+	_, ok3 := cache.Get("hash3")
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+	assert.True(t, ok3)
+
+	// Add a 4th block, should evict hash1 (least recently used)
+	// Note: after the Gets above, order is hash3, hash2, hash1 (most to least recent)
+	// So hash1 should be evicted
+	block4 := models.Block{Hash: []byte("hash4"), Slot: 4}
+	cache.Put(block4)
+	assert.Equal(t, 3, cache.Len())
+
+	// hash1 should be evicted
+	_, ok1 = cache.Get("hash1")
+	assert.False(t, ok1)
+
+	// Others should still be present
+	_, ok2 = cache.Get("hash2")
+	_, ok3 = cache.Get("hash3")
+	_, ok4 := cache.Get("hash4")
+	assert.True(t, ok2)
+	assert.True(t, ok3)
+	assert.True(t, ok4)
+}
+
+func TestBlockCache_UpdateExisting(t *testing.T) {
+	cache := newBlockCache(3)
+
+	// Add a block
+	block1 := models.Block{Hash: []byte("hash1"), Slot: 100}
+	cache.Put(block1)
+
+	// Update it
+	block1Updated := models.Block{Hash: []byte("hash1"), Slot: 200}
+	cache.Put(block1Updated)
+
+	// Should still have only 1 entry
+	assert.Equal(t, 1, cache.Len())
+
+	// Should have updated slot
+	got, ok := cache.Get("hash1")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(200), got.Slot)
+}
+
+func TestBlockCache_AccessMovesToFront(t *testing.T) {
+	cache := newBlockCache(3)
+
+	// Add 3 blocks in order
+	block1 := models.Block{Hash: []byte("hash1"), Slot: 1}
+	block2 := models.Block{Hash: []byte("hash2"), Slot: 2}
+	block3 := models.Block{Hash: []byte("hash3"), Slot: 3}
+
+	cache.Put(block1)
+	cache.Put(block2)
+	cache.Put(block3)
+
+	// Access hash1, moving it to front
+	cache.Get("hash1")
+
+	// Add block4 - should evict hash2 (now least recently used)
+	block4 := models.Block{Hash: []byte("hash4"), Slot: 4}
+	cache.Put(block4)
+
+	// hash1 should still be present (was accessed)
+	_, ok1 := cache.Get("hash1")
+	assert.True(t, ok1)
+
+	// hash2 should be evicted
+	_, ok2 := cache.Get("hash2")
+	assert.False(t, ok2)
+
+	// hash3 and hash4 should be present
+	_, ok3 := cache.Get("hash3")
+	_, ok4 := cache.Get("hash4")
+	assert.True(t, ok3)
+	assert.True(t, ok4)
+}
+
+func TestBlockCache_DefaultCapacity(t *testing.T) {
+	// Test that 0 capacity uses default
+	cache := newBlockCache(0)
+	assert.Equal(t, DefaultBlockCacheCapacity, cache.capacity)
+
+	// Test that negative capacity uses default
+	cache = newBlockCache(-1)
+	assert.Equal(t, DefaultBlockCacheCapacity, cache.capacity)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced ChainManager’s in-memory block map with a bounded LRU block cache to prevent unbounded memory growth and keep recently rolled-back blocks available for reconciliation. Updated block lookups and add/remove paths to use the cache and added unit tests for eviction, updates, and access ordering.

<sup>Written for commit 23a793acd0acb7d1b9a24aa81affefa8af25724b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory LRU cache for blockchain blocks (default capacity: 10,000) to improve retrieval performance and memory usage; least-recently-used entries are evicted when full.

* **Tests**
  * Added comprehensive unit tests covering basic operations, LRU eviction behavior, entry updates, access-ordering, and default-capacity handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->