### PR TITLE
fix(chain): interator deregistration

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -416,6 +416,19 @@ func (c *Chain) FromPoint(
 	return iter, nil
 }
 
+// removeIterator removes an iterator from the chain's iterator list.
+// This is called when an iterator is cancelled to prevent memory leaks.
+func (c *Chain) removeIterator(iter *ChainIterator) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	for i, it := range c.iterators {
+		if it == iter {
+			c.iterators = slices.Delete(c.iterators, i, i+1)
+			return
+		}
+	}
+}
+
 func (c *Chain) BlockByPoint(
 	point ocommon.Point,
 	txn *database.Txn,

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -74,4 +74,8 @@ func (ci *ChainIterator) Cancel() {
 	if ci.cancel != nil {
 		ci.cancel()
 	}
+	// Remove from chain's iterator list to prevent memory leak
+	if ci.chain != nil {
+		ci.chain.removeIterator(ci)
+	}
 }

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIteratorCancelRemovesFromChain(t *testing.T) {
+	// Create a chain manager without a database (in-memory only)
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := NewManager(nil, eventBus)
+	require.NoError(t, err)
+
+	// Get the primary chain
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	// Initially no iterators
+	c.mutex.RLock()
+	initialLen := len(c.iterators)
+	c.mutex.RUnlock()
+	assert.Equal(t, 0, initialLen)
+
+	// Create an iterator
+	iter, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+	require.NotNil(t, iter)
+
+	// Should have one iterator now
+	c.mutex.RLock()
+	afterCreateLen := len(c.iterators)
+	c.mutex.RUnlock()
+	assert.Equal(t, 1, afterCreateLen)
+
+	// Cancel the iterator
+	iter.Cancel()
+
+	// Iterator should be removed
+	c.mutex.RLock()
+	afterCancelLen := len(c.iterators)
+	c.mutex.RUnlock()
+	assert.Equal(t, 0, afterCancelLen)
+}
+
+func TestIteratorCancelMultiple(t *testing.T) {
+	// Create a chain manager without a database (in-memory only)
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := NewManager(nil, eventBus)
+	require.NoError(t, err)
+
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	// Create multiple iterators
+	iter1, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+	iter2, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+	iter3, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+
+	// Should have 3 iterators
+	c.mutex.RLock()
+	assert.Equal(t, 3, len(c.iterators))
+	c.mutex.RUnlock()
+
+	// Cancel the middle one
+	iter2.Cancel()
+
+	// Should have 2 iterators, and iter2 should not be in the list
+	c.mutex.RLock()
+	assert.Equal(t, 2, len(c.iterators))
+	for _, it := range c.iterators {
+		assert.NotEqual(t, iter2, it)
+	}
+	c.mutex.RUnlock()
+
+	// Cancel remaining
+	iter1.Cancel()
+	iter3.Cancel()
+
+	c.mutex.RLock()
+	assert.Equal(t, 0, len(c.iterators))
+	c.mutex.RUnlock()
+}
+
+func TestIteratorCancelIdempotent(t *testing.T) {
+	// Create a chain manager without a database (in-memory only)
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := NewManager(nil, eventBus)
+	require.NoError(t, err)
+
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	// Create an iterator
+	iter, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+
+	// Cancel multiple times should not panic
+	iter.Cancel()
+	iter.Cancel()
+	iter.Cancel()
+
+	c.mutex.RLock()
+	assert.Equal(t, 0, len(c.iterators))
+	c.mutex.RUnlock()
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed iterator deregistration in Chain so cancelled iterators are removed from the active list, preventing memory leaks. Added tests to verify removal and idempotent cancellation.

- **Bug Fixes**
  - Added Chain.removeIterator with mutex-protected deletion.
  - Updated ChainIterator.Cancel() to remove itself from the chain.
  - Added tests for single removal, multiple iterators, and idempotent cancel.

<sup>Written for commit 39f8a47b86cfa43bace8684c3a76fc9986ad5798. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory leaks caused by iterators not being properly cleaned up upon cancellation.

* **Tests**
  * Added tests for iterator cancellation behavior to ensure proper cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->