### PR TITLE
fix(database): update sqlite to prevent dead locking

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -38,6 +38,7 @@ type Config struct {
 	BlobPlugin     string
 	DataDir        string
 	MetadataPlugin string
+	MaxConnections int // Connection pool size for metadata plugin (should match DatabaseWorkers)
 }
 
 // Database represents our data storage services
@@ -158,6 +159,18 @@ func New(
 	)
 	if err != nil {
 		return nil, err
+	}
+	// Set max-connections if configured (for SQLite plugin)
+	if configCopy.MaxConnections > 0 {
+		err = plugin.SetPluginOption(
+			plugin.PluginTypeMetadata,
+			configCopy.MetadataPlugin,
+			"max-connections",
+			configCopy.MaxConnections,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	blobDb, err := blob.New(
 		configCopy.BlobPlugin,

--- a/database/plugin/metadata/sqlite/options.go
+++ b/database/plugin/metadata/sqlite/options.go
@@ -44,3 +44,12 @@ func WithDataDir(dataDir string) SqliteOptionFunc {
 		m.dataDir = dataDir
 	}
 }
+
+// WithMaxConnections specifies the maximum number of database connections.
+// This should match the DatabaseWorkers configuration to avoid connection
+// pool exhaustion or unnecessary contention on SQLite's lock infrastructure.
+func WithMaxConnections(maxConnections int) SqliteOptionFunc {
+	return func(m *MetadataStoreSqlite) {
+		m.maxConnections = maxConnections
+	}
+}

--- a/database/plugin/metadata/sqlite/options_test.go
+++ b/database/plugin/metadata/sqlite/options_test.go
@@ -55,3 +55,33 @@ func TestWithPromRegistry(t *testing.T) {
 		t.Errorf("Expected promRegistry to be set")
 	}
 }
+
+func TestWithMaxConnections(t *testing.T) {
+	m := &MetadataStoreSqlite{}
+	option := WithMaxConnections(10)
+
+	option(m)
+
+	if m.maxConnections != 10 {
+		t.Errorf("Expected maxConnections to be 10, got %d", m.maxConnections)
+	}
+}
+
+func TestWithMaxConnections_DefaultUsed(t *testing.T) {
+	// Test that DefaultMaxConnections is used when maxConnections is 0
+	m := &MetadataStoreSqlite{}
+	// Don't set maxConnections, leave it at 0
+
+	if m.maxConnections != 0 {
+		t.Errorf("Expected initial maxConnections to be 0, got %d", m.maxConnections)
+	}
+
+	// The default should be applied during Start(), not here
+	// This test just verifies the option works
+	option := WithMaxConnections(DefaultMaxConnections)
+	option(m)
+
+	if m.maxConnections != DefaultMaxConnections {
+		t.Errorf("Expected maxConnections to be %d, got %d", DefaultMaxConnections, m.maxConnections)
+	}
+}

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -67,6 +67,7 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 		PromRegistry:   nil,
 		BlobPlugin:     cfg.BlobPlugin,
 		MetadataPlugin: cfg.MetadataPlugin,
+		MaxConnections: cfg.DatabaseWorkers,
 	}
 	db, err := database.New(dbConfig)
 	if err != nil {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -1055,9 +1055,9 @@ func TestTransitionToEra_ReturnsResultWithoutMutating(t *testing.T) {
 		result, err := ls.transitionToEra(
 			txn,
 			eras.ShelleyEraDesc.Id,
-			0,    // startEpoch
-			0,    // addedSlot
-			nil,  // currentPParams (Byron has none)
+			0,   // startEpoch
+			0,   // addedSlot
+			nil, // currentPParams (Byron has none)
 		)
 		if err != nil {
 			return err
@@ -1513,8 +1513,8 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 					return
 				default:
 					ls.RLock()
-					_ = ls.currentEra    // Read era
-					_ = ls.currentEpoch  // Read epoch
+					_ = ls.currentEra   // Read era
+					_ = ls.currentEpoch // Read epoch
 					readCount.Add(1)
 					ls.RUnlock()
 					time.Sleep(5 * time.Millisecond)

--- a/node.go
+++ b/node.go
@@ -108,6 +108,7 @@ func (n *Node) Run(ctx context.Context) error {
 		PromRegistry:   n.config.promRegistry,
 		BlobPlugin:     n.config.blobPlugin,
 		MetadataPlugin: n.config.metadataPlugin,
+		MaxConnections: n.config.DatabaseWorkerPoolConfig.WorkerPoolSize,
 	}
 	db, err := database.New(dbConfig)
 	if db == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SQLite configuration to prevent deadlocks under concurrent writes by enabling WAL mode, using immediate transaction locks, and aligning the connection pool size with DatabaseWorkers. In-memory DB for tests keeps shared cache with a busy timeout; file-based DB drops shared cache.

- **Bug Fixes**
  - File DB DSN: enable WAL, set synchronous NORMAL, cache_size -50000, busy_timeout 30s, and _txlock=immediate; remove cache=shared to avoid SQLITE_LOCKED.
  - In-memory DSN: keep cache=shared for tests and add busy_timeout 30s.
  - Connection pool: set max open/idle to DatabaseWorkers (default 5) and reuse connections indefinitely to reduce lock contention.

<sup>Written for commit d177341d5963cb0ee763940108b974ba8ef89749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved SQLite runtime configuration: updated connection pooling, timeouts, and transaction/journal settings for both in-memory and file-backed modes.
  * Added a configurable MaxConnections setting with a sensible default and option API to tune pool size.
  * Added unit tests for the new option and tidied test formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->