### PR TITLE
feat: Plutus V1/V2 contract evaluation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1
 	github.com/aws/smithy-go v1.24.0
-	github.com/blinklabs-io/gouroboros v0.150.0
+	github.com/blinklabs-io/gouroboros v0.151.0
 	github.com/blinklabs-io/ouroboros-mock v0.4.0
-	github.com/blinklabs-io/plutigo v0.0.21
+	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.0
 	github.com/getsops/sops/v3 v3.11.0

--- a/go.sum
+++ b/go.sum
@@ -126,12 +126,12 @@ github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoG
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blinklabs-io/gouroboros v0.150.0 h1:85pjIds96ufojJT7q4wmHaH4YnSsM9yZUoH7AMDHpDw=
-github.com/blinklabs-io/gouroboros v0.150.0/go.mod h1:Op+E43dmFywqyvDc9id/wqh08muGfdeM4lERR1aRe5s=
+github.com/blinklabs-io/gouroboros v0.151.0 h1:0SriwNQ5e/6p38Tgtp/nzMU/YPhv1ECaNICV1QRMhds=
+github.com/blinklabs-io/gouroboros v0.151.0/go.mod h1:TvYUUtyOOW/D518NIAo/4TzllN51sQKMzTVYpuW6mHE=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
-github.com/blinklabs-io/plutigo v0.0.21 h1:+corf01GABIs8dKQowlYgBk5RFfj0wrficxG1LVF3Qw=
-github.com/blinklabs-io/plutigo v0.0.21/go.mod h1:JwWJQOXVc3Bbb5ot05MUZOACysxTU8TsyDZ9IAJgKeA=
+github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=
+github.com/blinklabs-io/plutigo v0.0.22/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -18,13 +18,18 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/plutigo/cek"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/blinklabs-io/plutigo/lang"
 )
 
 var AlonzoEraDesc = EraDesc{
@@ -38,6 +43,7 @@ var AlonzoEraDesc = EraDesc{
 	CalculateEtaVFunc:       CalculateEtaVAlonzo,
 	CertDepositFunc:         CertDepositAlonzo,
 	ValidateTxFunc:          ValidateTxAlonzo,
+	EvaluateTxFunc:          EvaluateTxAlonzo,
 }
 
 func DecodePParamsAlonzo(data []byte) (lcommon.ProtocolParameters, error) {
@@ -147,12 +153,263 @@ func ValidateTxAlonzo(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	errs := make([]error, 0, len(alonzo.UtxoValidationRules))
+	tmpPparams, ok := pp.(*alonzo.AlonzoProtocolParameters)
+	if !ok {
+		return ErrIncompatibleProtocolParams
+	}
+	errs := []error{}
+	var err error
 	for _, validationFunc := range alonzo.UtxoValidationRules {
-		errs = append(
-			errs,
-			validationFunc(tx, slot, ls, pp),
+		err = validationFunc(tx, slot, ls, pp)
+		if err != nil {
+			errs = append(
+				errs,
+				err,
+			)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	// Skip script evaluation if TX is marked as not valid
+	if !tx.IsValid() {
+		return nil
+	}
+	// Resolve inputs
+	resolvedInputs := []lcommon.Utxo{}
+	for _, tmpInput := range tx.Inputs() {
+		tmpUtxo, err := ls.UtxoById(tmpInput)
+		if err != nil {
+			return err
+		}
+		resolvedInputs = append(
+			resolvedInputs,
+			tmpUtxo,
 		)
 	}
-	return errors.Join(errs...)
+	// Resolve reference inputs
+	resolvedRefInputs := []lcommon.Utxo{}
+	for _, tmpRefInput := range tx.ReferenceInputs() {
+		tmpUtxo, err := ls.UtxoById(tmpRefInput)
+		if err != nil {
+			return err
+		}
+		resolvedRefInputs = append(
+			resolvedRefInputs,
+			tmpUtxo,
+		)
+	}
+	// Build TX script map
+	scripts := make(map[lcommon.ScriptHash]lcommon.Script)
+	for _, refInput := range resolvedRefInputs {
+		tmpScript := refInput.Output.ScriptRef()
+		if tmpScript == nil {
+			continue
+		}
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	// Evaluate scripts
+	var txInfoV1 script.TxInfo
+	txInfoV1, err = script.NewTxInfoV1FromTransaction(
+		ls,
+		tx,
+		slices.Concat(resolvedInputs, resolvedRefInputs),
+	)
+	if err != nil {
+		return err
+	}
+	for _, redeemerPair := range txInfoV1.(script.TxInfoV1).Redeemers {
+		purpose := redeemerPair.Key
+		if purpose == nil {
+			return errors.New("script purpose is nil")
+		}
+		redeemer := redeemerPair.Value
+		// Lookup script from redeemer purpose
+		tmpScript := scripts[purpose.ScriptHash()]
+		if tmpScript == nil {
+			return fmt.Errorf(
+				"could not find script with hash %s",
+				purpose.ScriptHash().String(),
+			)
+		}
+		switch s := tmpScript.(type) {
+		case lcommon.PlutusV1Script:
+			// Get spent UTxO datum
+			var datum data.PlutusData
+			if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
+				datum = tmp.Datum
+			}
+			sc := script.NewScriptContextV1V2(txInfoV1, purpose)
+			evalContext, err := cek.NewEvalContext(
+				lang.LanguageVersionV1,
+				cek.ProtoVersion{
+					Major: tmpPparams.ProtocolMajor,
+					Minor: tmpPparams.ProtocolMinor,
+				},
+				tmpPparams.CostModels[0],
+			)
+			if err != nil {
+				return fmt.Errorf("build evaluation context: %w", err)
+			}
+			_, err = s.Evaluate(
+				datum,
+				redeemer.Data,
+				sc.ToPlutusData(),
+				redeemer.ExUnits,
+				evalContext,
+			)
+			if err != nil {
+				/*
+					fmt.Printf("TX ID: %s\n", tx.Hash().String())
+					fmt.Printf("purpose = %#v, redeemer = %#v\n", purpose, redeemer)
+					scriptHash := s.Hash()
+					fmt.Printf("scriptHash = %s\n", scriptHash.String())
+					fmt.Printf("tx = %x\n", tx.Cbor())
+					// Build inputs/outputs strings that can be plugged into Aiken script_context tests for comparison
+					var tmpInputs []lcommon.TransactionInput
+					var tmpOutputs []lcommon.TransactionOutput
+					for _, input := range slices.Concat(resolvedInputs, resolvedRefInputs) {
+						tmpInputs = append(tmpInputs, input.Id)
+						tmpOutputs = append(tmpOutputs, input.Output)
+					}
+					tmpInputsCbor, err2 := cbor.Encode(tmpInputs)
+					if err2 != nil {
+						return err2
+					}
+					fmt.Printf("tmpInputs = %x\n", tmpInputsCbor)
+					tmpOutputsCbor, err2 := cbor.Encode(tmpOutputs)
+					if err2 != nil {
+						return err2
+					}
+					fmt.Printf("tmpOutputs = %x\n", tmpOutputsCbor)
+					scCbor, err2 := data.Encode(sc.ToPlutusData())
+					if err2 != nil {
+						return err2
+					}
+					fmt.Printf("scCbor = %x\n", scCbor)
+				*/
+				return err
+			}
+		default:
+			return fmt.Errorf("unimplemented script type: %T", tmpScript)
+		}
+	}
+	return nil
+}
+
+func EvaluateTxAlonzo(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+	pp lcommon.ProtocolParameters,
+) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error) {
+	tmpPparams, ok := pp.(*alonzo.AlonzoProtocolParameters)
+	if !ok {
+		return 0, lcommon.ExUnits{}, nil, ErrIncompatibleProtocolParams
+	}
+	// Resolve inputs
+	resolvedInputs := []lcommon.Utxo{}
+	for _, tmpInput := range tx.Inputs() {
+		tmpUtxo, err := ls.UtxoById(tmpInput)
+		if err != nil {
+			return 0, lcommon.ExUnits{}, nil, err
+		}
+		resolvedInputs = append(
+			resolvedInputs,
+			tmpUtxo,
+		)
+	}
+	// Resolve reference inputs
+	resolvedRefInputs := []lcommon.Utxo{}
+	for _, tmpRefInput := range tx.ReferenceInputs() {
+		tmpUtxo, err := ls.UtxoById(tmpRefInput)
+		if err != nil {
+			return 0, lcommon.ExUnits{}, nil, err
+		}
+		resolvedRefInputs = append(
+			resolvedRefInputs,
+			tmpUtxo,
+		)
+	}
+	// Build TX script map
+	scripts := make(map[lcommon.ScriptHash]lcommon.Script)
+	for _, refInput := range resolvedRefInputs {
+		tmpScript := refInput.Output.ScriptRef()
+		if tmpScript == nil {
+			continue
+		}
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	// Evaluate scripts
+	var retTotalExUnits lcommon.ExUnits
+	retRedeemerExUnits := make(map[lcommon.RedeemerKey]lcommon.ExUnits)
+	var txInfoV1 script.TxInfo
+	var err error
+	txInfoV1, err = script.NewTxInfoV1FromTransaction(
+		ls,
+		tx,
+		slices.Concat(resolvedInputs, resolvedRefInputs),
+	)
+	if err != nil {
+		return 0, lcommon.ExUnits{}, nil, err
+	}
+	for _, redeemerPair := range txInfoV1.(script.TxInfoV1).Redeemers {
+		purpose := redeemerPair.Key
+		if purpose == nil {
+			return 0, lcommon.ExUnits{}, nil, errors.New("script purpose is nil")
+		}
+		redeemer := redeemerPair.Value
+		// Lookup script from redeemer purpose
+		tmpScript := scripts[purpose.ScriptHash()]
+		if tmpScript == nil {
+			return 0, lcommon.ExUnits{}, nil, errors.New(
+				"could not find needed script",
+			)
+		}
+		switch s := tmpScript.(type) {
+		case lcommon.PlutusV1Script:
+			// Get spent UTxO datum
+			var datum data.PlutusData
+			if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
+				datum = tmp.Datum
+			}
+			sc := script.NewScriptContextV1V2(txInfoV1, purpose)
+			evalContext, err := cek.NewEvalContext(
+				lang.LanguageVersionV1,
+				cek.ProtoVersion{
+					Major: tmpPparams.ProtocolMajor,
+					Minor: tmpPparams.ProtocolMinor,
+				},
+				tmpPparams.CostModels[0],
+			)
+			if err != nil {
+				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
+			}
+			usedBudget, err := s.Evaluate(
+				datum,
+				redeemer.Data,
+				sc.ToPlutusData(),
+				tmpPparams.MaxTxExUnits,
+				evalContext,
+			)
+			if err != nil {
+				return 0, lcommon.ExUnits{}, nil, err
+			}
+			retTotalExUnits.Steps += usedBudget.Steps
+			retTotalExUnits.Memory += usedBudget.Memory
+			retRedeemerExUnits[lcommon.RedeemerKey{
+				Tag:   redeemer.Tag,
+				Index: redeemer.Index,
+			}] = usedBudget
+		default:
+			return 0, lcommon.ExUnits{}, nil, fmt.Errorf("unimplemented script type: %T", tmpScript)
+		}
+	}
+	// TODO: calculate fee based on current TX and calculated ExUnits
+	return 0, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/eras.go
+++ b/ledger/eras/eras.go
@@ -33,7 +33,7 @@ type EraDesc struct {
 	CalculateEtaVFunc       func(*cardano.CardanoNodeConfig, []byte, ledger.Block) ([]byte, error)
 	CertDepositFunc         func(lcommon.Certificate, lcommon.ProtocolParameters) (uint64, error)
 	ValidateTxFunc          func(lcommon.Transaction, uint64, lcommon.LedgerState, lcommon.ProtocolParameters) error
-	EvaluateTxFunc          func(tx lcommon.Transaction, ls lcommon.LedgerState, pp lcommon.ProtocolParameters) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error)
+	EvaluateTxFunc          func(lcommon.Transaction, lcommon.LedgerState, lcommon.ProtocolParameters) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error)
 	Name                    string
 	Id                      uint
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Plutus V1 and V2 script evaluation for Alonzo and Babbage, and exposes EvaluateTx for both eras to return total and per-redeemer ExUnits. Also unifies script evaluation across eras using plutigo’s CEK EvalContext.

- **New Features**
  - ValidateTx now evaluates scripts when tx.IsValid, resolving inputs and reference inputs and loading witnesses/ref scripts.
  - Alonzo supports Plutus V1; Babbage supports Plutus V1 and V2; Conway now evaluates V1/V2/V3 using the same EvalContext.
  - Added EvaluateTx for Alonzo and Babbage, returning total and per-redeemer ExUnits with clear errors for missing/unsupported scripts.

- **Dependencies**
  - github.com/blinklabs-io/gouroboros v0.151.0
  - github.com/blinklabs-io/plutigo v0.0.22

<sup>Written for commit 26c958393e97e621b39000e67e2d9eddc1e65d5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Plutus script validation and per-redeemer execution-unit estimation across Alonzo, Babbage, and Conway eras, improving transaction script verification and cost accounting.
  * Expanded Conway era to support multiple Plutus script versions with clearer error reporting.

* **Chores**
  * Bumped dependency versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->