### PR TITLE
fix: data races in timers

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -392,26 +392,27 @@ type MempoolProvider interface {
 	Transactions() []mempool.MempoolTransaction
 }
 type LedgerState struct {
-	metrics                         stateMetrics
-	currentEra                      eras.EraDesc
-	config                          LedgerStateConfig
-	chainsyncBlockfetchTimeoutTimer *time.Timer // timeout timer for blockfetch operations
-	currentPParams                  lcommon.ProtocolParameters
-	mempool                         MempoolProvider
-	timerCleanupConsumedUtxos       *time.Timer
-	Scheduler                       *Scheduler
-	chain                           *chain.Chain
-	chainsyncBlockfetchReadyMutex   sync.Mutex
-	chainsyncBlockfetchReadyChan    chan struct{}
-	db                              *database.Database
-	chainsyncState                  ChainsyncState
-	currentTipBlockNonce            []byte
-	chainsyncBlockEvents            []BlockfetchEvent
-	epochCache                      []models.Epoch
-	currentTip                      ochainsync.Tip
-	currentEpoch                    models.Epoch
-	dbWorkerPool                    *DatabaseWorkerPool
-	ctx                             context.Context
+	metrics                            stateMetrics
+	currentEra                         eras.EraDesc
+	config                             LedgerStateConfig
+	chainsyncBlockfetchTimeoutTimer    *time.Timer // timeout timer for blockfetch operations
+	chainsyncBlockfetchTimerGeneration uint64      // generation counter to detect stale timer callbacks
+	currentPParams                     lcommon.ProtocolParameters
+	mempool                            MempoolProvider
+	timerCleanupConsumedUtxos          *time.Timer
+	Scheduler                          *Scheduler
+	chain                              *chain.Chain
+	chainsyncBlockfetchReadyMutex      sync.Mutex
+	chainsyncBlockfetchReadyChan       chan struct{}
+	db                                 *database.Database
+	chainsyncState                     ChainsyncState
+	currentTipBlockNonce               []byte
+	chainsyncBlockEvents               []BlockfetchEvent
+	epochCache                         []models.Epoch
+	currentTip                         ochainsync.Tip
+	currentEpoch                       models.Epoch
+	dbWorkerPool                       *DatabaseWorkerPool
+	ctx                                context.Context
 	sync.RWMutex
 	chainsyncMutex             sync.Mutex
 	chainsyncBlockfetchMutex   sync.Mutex


### PR DESCRIPTION
Closes #1218 
Closes #1234 
Closes #1235 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data races in chainsync blockfetch timers to prevent stale callbacks and spurious timeouts during range requests.

- **Bug Fixes**
  - Stop an existing blockfetch timeout timer before creating a new one.
  - Add a generation counter (chainsyncBlockfetchTimerGeneration) and validate it in timer callbacks to ignore stale timers.
  - Increment the generation and clear timers on cleanup and batch-done paths for safe invalidation.
  - Closes #1218, #1234, #1235.

<sup>Written for commit 519fc7ab0ea18de3e9406ed04a353360539e1364. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential race condition in block synchronization timer handling that could trigger stale callbacks.

* **Refactor**
  * Improved internal state tracking for block fetch operations, checkpoint management, and ledger lifecycle monitoring to enhance system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->