### PR TITLE
fix(ledger): lock protection for reads

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1384,6 +1384,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			}
 		}
 		// Process batch in groups of batchSize to stay under DB txn limits
+		var tipForLog ochainsync.Tip
 		for i = 0; i < len(nextBatch); i += batchSize {
 			end = min(
 				len(nextBatch),
@@ -1547,6 +1548,8 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				}
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				ls.updateTipMetrics()
+				// Capture tip for logging while holding the lock
+				tipForLog = ls.currentTip
 				ls.Unlock()
 			}
 			if needsEpochRollover {
@@ -1557,8 +1560,8 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			ls.config.Logger.Info(
 				fmt.Sprintf(
 					"chain extended, new tip: %x at slot %d",
-					ls.currentTip.Point.Hash,
-					ls.currentTip.Point.Slot,
+					tipForLog.Point.Hash,
+					tipForLog.Point.Slot,
 				),
 				"component",
 				"ledger",


### PR DESCRIPTION
Closes #1217 
Closes #1233 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added read-lock protection for epochCache reads and captured tip values for logging to prevent data races and inconsistent outputs in slot/epoch conversions. Fixes issues reported in #1217 and #1233.

- **Bug Fixes**
  - SlotToTime, TimeToSlot, and SlotToEpoch read epochCache via a snapshot taken under RLock.
  - currentTip is copied under lock for logging; log happens after Unlock to avoid races.

<sup>Written for commit ac2fb06cc0b7d1c1f241d43b30615a72756e9b5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safety of concurrent data access operations to prevent potential race conditions that could impact system stability and data integrity.
  * Corrected logging accuracy for batch processing operations to ensure chain state values are properly captured and reported at the appropriate time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->