### PR TITLE
fix: pparam update epoch handling

### DIFF
--- a/database/plugin/metadata/postgres/pparams.go
+++ b/database/plugin/metadata/postgres/pparams.go
@@ -40,7 +40,8 @@ func (d *MetadataStorePostgres) GetPParams(
 	return ret, nil
 }
 
-// GetPParamUpdates returns a list of protocol parameter updates for a given epoch
+// GetPParamUpdates returns a list of protocol parameter updates for a given epoch.
+// Updates are returned in descending order by ID (most recent first).
 func (d *MetadataStorePostgres) GetPParamUpdates(
 	epoch uint64,
 	txn types.Txn,
@@ -50,7 +51,15 @@ func (d *MetadataStorePostgres) GetPParamUpdates(
 	if err != nil {
 		return ret, err
 	}
-	result := db.Where("epoch = ?", epoch).Order("id DESC").Find(&ret)
+	// Query for updates targeting this epoch OR the previous epoch.
+	// This handles the case where updates are stored with a target epoch
+	// but we're applying them at the next epoch boundary.
+	// Guard against uint64 underflow when epoch is 0.
+	query := db.Where("epoch = ?", epoch)
+	if epoch > 0 {
+		query = query.Or("epoch = ?", epoch-1)
+	}
+	result := query.Order("id DESC").Find(&ret)
 	if result.Error != nil {
 		return ret, result.Error
 	}

--- a/database/pparams.go
+++ b/database/pparams.go
@@ -122,20 +122,22 @@ func (d *Database) ApplyPParamUpdates(
 	if err != nil {
 		return err
 	}
+	// Store params for the target epoch (epoch) where they take effect
 	return d.metadata.SetPParams(
 		pparamsCbor,
 		slot,
-		uint64(epoch+1),
+		epoch,
 		era,
 		txn.Metadata(),
 	)
 }
 
 // ComputeAndApplyPParamUpdates computes the new protocol parameters by applying
-// pending updates for the given epoch. Unlike ApplyPParamUpdates, this function
-// takes currentPParams as a value and returns the updated parameters without
-// mutating the input. This allows callers to capture the result in a transaction
-// and apply it to in-memory state after the transaction commits.
+// pending updates for the given target epoch. The epoch parameter should be the
+// epoch where updates take effect (currentEpoch + 1 during epoch rollover).
+// This function takes currentPParams as a value and returns the updated parameters
+// without mutating the input. This allows callers to capture the result in a
+// transaction and apply it to in-memory state after the transaction commits.
 func (d *Database) ComputeAndApplyPParamUpdates(
 	slot, epoch uint64,
 	era uint,
@@ -186,10 +188,11 @@ func (d *Database) ComputeAndApplyPParamUpdates(
 	if err != nil {
 		return nil, err
 	}
+	// Store params for the target epoch (epoch) where they take effect
 	err = d.metadata.SetPParams(
 		pparamsCbor,
 		slot,
-		uint64(epoch+1),
+		epoch,
 		era,
 		txn.Metadata(),
 	)

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -338,6 +338,7 @@ func (ls *LedgerState) createGenesisBlock() error {
 				len(byronGenesisUtxos),
 				len(shelleyGenesisUtxos),
 			),
+			"component", "ledger",
 		)
 
 		// Create genesis UTxOs directly using AddUtxos
@@ -533,9 +534,10 @@ func (ls *LedgerState) processEpochRollover(
 		return result, nil
 	}
 	// Apply pending pparam updates using the non-mutating version
+	// Updates target the next epoch, so we pass currentEpoch.EpochId + 1
 	newPParams, err := ls.db.ComputeAndApplyPParamUpdates(
 		epochStartSlot,
-		currentEpoch.EpochId,
+		currentEpoch.EpochId+1, // Target epoch for updates
 		currentEra.Id,
 		currentPParams,
 		currentEra.DecodePParamsUpdateFunc,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix protocol parameter update handling so updates target the correct epoch and apply cleanly at rollover. Prevents off-by-one issues by storing under the target epoch and querying both current and previous epochs.

- **Bug Fixes**
  - Query updates for epoch or epoch-1; order by ID DESC.
  - Store computed params under the target epoch (remove +1).
  - Apply rollover updates using currentEpoch + 1.
  - Add component="ledger" to genesis log.

<sup>Written for commit a16475779bde97b9b7f4dc02f1b727de16a4ae9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected when and how protocol parameter updates are stored and applied so they take effect at the intended epoch.
  * Retrieval of parameter updates now includes both the current and previous epoch and returns results in descending order for completeness.

* **Documentation**
  * Clarified comments describing epoch semantics and non-mutating parameter handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->