### PR TITLE
fix(database): collateral return index

### DIFF
--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -226,30 +226,12 @@ func (d *MetadataStorePostgres) SetTransaction(
 		tmpTx.Metadata = tmpMetadata
 	}
 	collateralReturn := tx.CollateralReturn()
-	// For invalid transactions with collateral returns, fix indices via CBOR matching
-	// since Produced() uses enumerated indices rather than real transaction indices
-	var realIndexMap map[lcommon.Blake2b256]uint32
-	if !tx.IsValid() && collateralReturn != nil {
-		realIndexMap = make(map[lcommon.Blake2b256]uint32)
-		for idx, out := range tx.Outputs() {
-			if out != nil && idx <= int(^uint32(0)) {
-				// Hash CBOR for efficient map key
-				outputHash := lcommon.NewBlake2b256(out.Cbor())
-				//nolint:gosec // G115: idx bounds already checked above
-				realIndexMap[outputHash] = uint32(idx)
-			}
-		}
-	}
+	// Store all produced UTxOs - tx.Produced() returns correct indices for both
+	// valid transactions (regular outputs at indices 0, 1, ...) and invalid
+	// transactions (collateral return at index len(Outputs()))
 	for _, utxo := range tx.Produced() {
 		if collateralReturn != nil && utxo.Output == collateralReturn {
 			m := models.UtxoLedgerToModel(utxo, point.Slot)
-			// Fix collateral return index for invalid transactions
-			if realIndexMap != nil && m.Cbor != nil {
-				outputHash := lcommon.NewBlake2b256(m.Cbor)
-				if realIdx, ok := realIndexMap[outputHash]; ok {
-					m.OutputIdx = realIdx
-				}
-			}
 			tmpTx.CollateralReturn = &m
 			continue
 		}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -250,30 +250,12 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		tmpTx.Metadata = tmpMetadata
 	}
 	collateralReturn := tx.CollateralReturn()
-	// For invalid transactions with collateral returns, fix indices via CBOR matching
-	// since Produced() uses enumerated indices rather than real transaction indices
-	var realIndexMap map[lcommon.Blake2b256]uint32
-	if !tx.IsValid() && collateralReturn != nil {
-		realIndexMap = make(map[lcommon.Blake2b256]uint32)
-		for idx, out := range tx.Outputs() {
-			if out != nil && idx <= int(^uint32(0)) {
-				// Hash CBOR for efficient map key
-				outputHash := lcommon.NewBlake2b256(out.Cbor())
-				//nolint:gosec // G115: idx bounds already checked above
-				realIndexMap[outputHash] = uint32(idx)
-			}
-		}
-	}
+	// Store all produced UTxOs - tx.Produced() returns correct indices for both
+	// valid transactions (regular outputs at indices 0, 1, ...) and invalid
+	// transactions (collateral return at index len(Outputs()))
 	for _, utxo := range tx.Produced() {
 		if collateralReturn != nil && utxo.Output == collateralReturn {
 			m := models.UtxoLedgerToModel(utxo, point.Slot)
-			// Fix collateral return index for invalid transactions
-			if realIndexMap != nil && m.Cbor != nil {
-				outputHash := lcommon.NewBlake2b256(m.Cbor)
-				if realIdx, ok := realIndexMap[outputHash]; ok {
-					m.OutputIdx = realIdx
-				}
-			}
 			tmpTx.CollateralReturn = &m
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1
 	github.com/aws/smithy-go v1.24.0
-	github.com/blinklabs-io/gouroboros v0.151.0
+	github.com/blinklabs-io/gouroboros v0.151.1
 	github.com/blinklabs-io/ouroboros-mock v0.4.0
 	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoG
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blinklabs-io/gouroboros v0.151.0 h1:0SriwNQ5e/6p38Tgtp/nzMU/YPhv1ECaNICV1QRMhds=
-github.com/blinklabs-io/gouroboros v0.151.0/go.mod h1:TvYUUtyOOW/D518NIAo/4TzllN51sQKMzTVYpuW6mHE=
+github.com/blinklabs-io/gouroboros v0.151.1 h1:FYVdlF6Dtejizeibap+bQyf+hQlWznPHCgBMQZAiBDI=
+github.com/blinklabs-io/gouroboros v0.151.1/go.mod h1:TvYUUtyOOW/D518NIAo/4TzllN51sQKMzTVYpuW6mHE=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
 github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect UTxO indexing for collateral return outputs by using tx.Produced() indices. Removes CBOR-based remapping and ensures correct indices for invalid transactions across Postgres, SQLite, and blob storage.

- **Bug Fixes**
  - Use tx.Produced() indices for both valid and invalid transactions (collateral return at len(Outputs())).
  - Store UTxOs with utxo.Id.Index() and remove CBOR hash remap logic.

- **Dependencies**
  - Bump blinklabs-io/gouroboros to v0.151.1.

<sup>Written for commit 3e44d2b25f8cc917dcc0ec51f517898708051612. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined transaction processing and index management across database implementations, reducing code complexity and improving system reliability. The changes simplify collateral handling during invalid transaction processing by eliminating unnecessary remapping, resulting in cleaner and more maintainable code paths.
* **Chores**
  * Updated dependencies to incorporate latest improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->