### PR TITLE
fix(ledger): consider native script and refs

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -211,6 +211,9 @@ func ValidateTxAlonzo(
 	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
 		scripts[tmpScript.Hash()] = tmpScript
 	}
+	for _, tmpScript := range tx.Witnesses().NativeScripts() {
+		scripts[tmpScript.Hash()] = tmpScript
+	}
 	// Evaluate scripts
 	var txInfoV1 script.TxInfo
 	txInfoV1, err = script.NewTxInfoV1FromTransaction(
@@ -343,6 +346,9 @@ func EvaluateTxAlonzo(
 		scripts[tmpScript.Hash()] = tmpScript
 	}
 	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	for _, tmpScript := range tx.Witnesses().NativeScripts() {
 		scripts[tmpScript.Hash()] = tmpScript
 	}
 	// Evaluate scripts

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -212,8 +212,9 @@ func ValidateTxConway(
 	}
 	// Build TX script map
 	scripts := make(map[lcommon.ScriptHash]lcommon.Script)
-	for _, refInput := range resolvedRefInputs {
-		tmpScript := refInput.Output.ScriptRef()
+	// Add script refs from all resolved UTxOs (both inputs and reference inputs)
+	for _, utxo := range slices.Concat(resolvedInputs, resolvedRefInputs) {
+		tmpScript := utxo.Output.ScriptRef()
 		if tmpScript == nil {
 			continue
 		}
@@ -226,6 +227,9 @@ func ValidateTxConway(
 		scripts[tmpScript.Hash()] = tmpScript
 	}
 	for _, tmpScript := range tx.Witnesses().PlutusV3Scripts() {
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	for _, tmpScript := range tx.Witnesses().NativeScripts() {
 		scripts[tmpScript.Hash()] = tmpScript
 	}
 	// Evaluate scripts
@@ -417,8 +421,9 @@ func EvaluateTxConway(
 	}
 	// Build TX script map
 	scripts := make(map[lcommon.ScriptHash]lcommon.Script)
-	for _, refInput := range resolvedRefInputs {
-		tmpScript := refInput.Output.ScriptRef()
+	// Add script refs from all resolved UTxOs (both inputs and reference inputs)
+	for _, utxo := range slices.Concat(resolvedInputs, resolvedRefInputs) {
+		tmpScript := utxo.Output.ScriptRef()
 		if tmpScript == nil {
 			continue
 		}
@@ -431,6 +436,9 @@ func EvaluateTxConway(
 		scripts[tmpScript.Hash()] = tmpScript
 	}
 	for _, tmpScript := range tx.Witnesses().PlutusV3Scripts() {
+		scripts[tmpScript.Hash()] = tmpScript
+	}
+	for _, tmpScript := range tx.Witnesses().NativeScripts() {
 		scripts[tmpScript.Hash()] = tmpScript
 	}
 	// Evaluate scripts


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix transaction script handling across Alonzo, Babbage, and Conway to correctly collect native scripts and script references, improving validation and evaluation. Adds a fallback Plutus V2 cost model during the Babbage hard fork when protocol params don’t include it.

- **Bug Fixes**
  - Include NativeScripts from witnesses in the script map (Alonzo, Babbage, Conway).
  - Read ScriptRef from both regular inputs and reference inputs in Babbage and Conway.
  - Set a default Plutus V2 cost model during the Babbage hard fork when missing.

<sup>Written for commit aa0b1f0b94961f7bffd543cd9a9d471453fa3737. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

