### PR TITLE
ci(make): test-load-log target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' -X '$(GOMODULE)/internal/version.CommitHash=$(COMMIT_HASH)'"
 
-.PHONY: all build mod-tidy clean format golines test bench test-load test-load-profile
+.PHONY: all build mod-tidy clean format golines test bench test-load test-load-log test-load-profile
 
 # Default target
 all: format test build
@@ -54,6 +54,10 @@ bench: mod-tidy
 test-load: build
 	rm -rf .dingo
 	./dingo load database/immutable/testdata
+
+test-load-log: build
+	rm -rf .dingo dingo.log
+	./dingo load database/immutable/testdata 2>&1 | tee dingo.log
 
 test-load-profile: build
 	rm -rf .dingo


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a test-load-log Makefile target that runs the load test and saves combined stdout/stderr to dingo.log for easier debugging. It clears .dingo and any existing dingo.log before running and adds the target to .PHONY.

<sup>Written for commit 02bcb14347766b5c0b70794f31638e1530087386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

