### PR TITLE
fix(database): use correct hash sizes in models

### DIFF
--- a/database/models/account.go
+++ b/database/models/account.go
@@ -25,9 +25,9 @@ import (
 var ErrAccountNotFound = errors.New("account not found")
 
 type Account struct {
-	StakingKey    []byte `gorm:"uniqueIndex;size:32"`
-	Pool          []byte `gorm:"index;size:32"`
-	Drep          []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"uniqueIndex;size:28"`
+	Pool          []byte `gorm:"index;size:28"`
+	Drep          []byte `gorm:"index;size:28"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
@@ -58,7 +58,7 @@ func (a *Account) String() (string, error) {
 }
 
 type Deregistration struct {
-	StakingKey    []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -70,7 +70,7 @@ func (Deregistration) TableName() string {
 }
 
 type Registration struct {
-	StakingKey    []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -82,8 +82,8 @@ func (Registration) TableName() string {
 }
 
 type StakeDelegation struct {
-	StakingKey    []byte `gorm:"index;size:32"`
-	PoolKeyHash   []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
+	PoolKeyHash   []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -94,7 +94,7 @@ func (StakeDelegation) TableName() string {
 }
 
 type StakeDeregistration struct {
-	StakingKey    []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -105,7 +105,7 @@ func (StakeDeregistration) TableName() string {
 }
 
 type StakeRegistration struct {
-	StakingKey    []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -117,8 +117,8 @@ func (StakeRegistration) TableName() string {
 }
 
 type StakeRegistrationDelegation struct {
-	StakingKey    []byte `gorm:"index;size:32"`
-	PoolKeyHash   []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
+	PoolKeyHash   []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -130,9 +130,9 @@ func (StakeRegistrationDelegation) TableName() string {
 }
 
 type StakeVoteDelegation struct {
-	StakingKey    []byte `gorm:"index;size:32"`
-	PoolKeyHash   []byte `gorm:"index;size:32"`
-	Drep          []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
+	PoolKeyHash   []byte `gorm:"index;size:28"`
+	Drep          []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -143,9 +143,9 @@ func (StakeVoteDelegation) TableName() string {
 }
 
 type StakeVoteRegistrationDelegation struct {
-	StakingKey    []byte `gorm:"index;size:32"`
-	PoolKeyHash   []byte `gorm:"index;size:32"`
-	Drep          []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
+	PoolKeyHash   []byte `gorm:"index;size:28"`
+	Drep          []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -157,8 +157,8 @@ func (StakeVoteRegistrationDelegation) TableName() string {
 }
 
 type VoteDelegation struct {
-	StakingKey    []byte `gorm:"index;size:32"`
-	Drep          []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
+	Drep          []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -169,8 +169,8 @@ func (VoteDelegation) TableName() string {
 }
 
 type VoteRegistrationDelegation struct {
-	StakingKey    []byte `gorm:"index;size:32"`
-	Drep          []byte `gorm:"index;size:32"`
+	StakingKey    []byte `gorm:"index;size:28"`
+	Drep          []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`

--- a/database/models/asset.go
+++ b/database/models/asset.go
@@ -23,9 +23,9 @@ import (
 
 type Asset struct {
 	Name        []byte       `gorm:"index;size:32"`
-	NameHex     []byte       `gorm:"index;size:32"`
-	PolicyId    []byte       `gorm:"index;size:32"`
-	Fingerprint []byte       `gorm:"index;size:32"`
+	NameHex     []byte       `gorm:"index;size:64"`
+	PolicyId    []byte       `gorm:"index;size:28"`
+	Fingerprint []byte       `gorm:"index;size:48"`
 	ID          uint         `gorm:"primaryKey"`
 	UtxoID      uint         `gorm:"index"`
 	Amount      types.Uint64 `gorm:"index"`

--- a/database/models/auth_committee_hot.go
+++ b/database/models/auth_committee_hot.go
@@ -15,8 +15,8 @@
 package models
 
 type AuthCommitteeHot struct {
-	ColdCredential []byte `gorm:"index;size:32"`
-	HostCredential []byte `gorm:"index;size:32"`
+	ColdCredential []byte `gorm:"index;size:28"`
+	HostCredential []byte `gorm:"index;size:28"`
 	ID             uint   `gorm:"primarykey"`
 	CertificateID  uint   `gorm:"index"`
 	AddedSlot      uint64 `gorm:"index"`

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -24,7 +24,7 @@ var ErrDrepNotFound = errors.New("drep not found")
 
 type Drep struct {
 	AnchorUrl  string
-	Credential []byte `gorm:"uniqueIndex;size:32"`
+	Credential []byte `gorm:"uniqueIndex;size:28"`
 	AnchorHash []byte
 	ID         uint   `gorm:"primarykey"`
 	AddedSlot  uint64 `gorm:"index"`
@@ -36,7 +36,7 @@ func (d *Drep) TableName() string {
 }
 
 type DeregistrationDrep struct {
-	DrepCredential []byte `gorm:"index;size:32"`
+	DrepCredential []byte `gorm:"index;size:28"`
 	CertificateID  uint   `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
 	AddedSlot      uint64 `gorm:"index"`
@@ -49,7 +49,7 @@ func (DeregistrationDrep) TableName() string {
 
 type RegistrationDrep struct {
 	AnchorUrl      string
-	DrepCredential []byte `gorm:"index;size:32"`
+	DrepCredential []byte `gorm:"index;size:28"`
 	AnchorHash     []byte
 	CertificateID  uint   `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
@@ -63,7 +63,7 @@ func (RegistrationDrep) TableName() string {
 
 type UpdateDrep struct {
 	AnchorUrl     string
-	Credential    []byte `gorm:"index;size:32"`
+	Credential    []byte `gorm:"index;size:28"`
 	AnchorHash    []byte
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`

--- a/database/models/pool.go
+++ b/database/models/pool.go
@@ -26,7 +26,7 @@ var ErrPoolNotFound = errors.New("pool not found")
 // Error 1170 (42000): BLOB/TEXT column 'staking_key' used in key specification without a key length
 type Pool struct {
 	Margin        *types.Rat
-	PoolKeyHash   []byte `gorm:"uniqueIndex;size:32"`
+	PoolKeyHash   []byte `gorm:"uniqueIndex;size:28"`
 	VrfKeyHash    []byte
 	RewardAccount []byte
 	// Owners and Relays are query-only associations (no CASCADE).
@@ -50,7 +50,7 @@ type PoolRegistration struct {
 	Pool          *Pool // Belongs-to relationship; CASCADE is defined on Pool.Registration
 	MetadataUrl   string
 	VrfKeyHash    []byte
-	PoolKeyHash   []byte `gorm:"index;size:32"`
+	PoolKeyHash   []byte `gorm:"index;size:28"`
 	RewardAccount []byte
 	MetadataHash  []byte
 	Owners        []PoolRegistrationOwner `gorm:"foreignKey:PoolRegistrationID;constraint:OnDelete:CASCADE"`
@@ -94,7 +94,7 @@ func (PoolRegistrationRelay) TableName() string {
 }
 
 type PoolRetirement struct {
-	PoolKeyHash   []byte `gorm:"index;size:32"`
+	PoolKeyHash   []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	PoolID        uint   `gorm:"index"`

--- a/database/models/resign_committee_cold.go
+++ b/database/models/resign_committee_cold.go
@@ -16,7 +16,7 @@ package models
 
 type ResignCommitteeCold struct {
 	AnchorUrl      string
-	ColdCredential []byte `gorm:"index;size:32"`
+	ColdCredential []byte `gorm:"index;size:28"`
 	AnchorHash     []byte
 	ID             uint   `gorm:"primarykey"`
 	CertificateID  uint   `gorm:"index"`

--- a/database/models/script.go
+++ b/database/models/script.go
@@ -18,7 +18,7 @@ package models
 // This avoids storing duplicate script data when the same script appears
 // in multiple transactions
 type Script struct {
-	Hash        []byte `gorm:"index;unique;size:32"`
+	Hash        []byte `gorm:"index;unique;size:28"`
 	Content     []byte
 	ID          uint `gorm:"primaryKey"`
 	CreatedSlot uint64

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -25,8 +25,8 @@ type Utxo struct {
 	TransactionID           *uint        `gorm:"index"`
 	CollateralReturnForTxID *uint        `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
 	TxId                    []byte       `gorm:"uniqueIndex:tx_id_output_idx;size:32"`
-	PaymentKey              []byte       `gorm:"index;size:32"`
-	StakingKey              []byte       `gorm:"index;size:32"`
+	PaymentKey              []byte       `gorm:"index;size:28"`
+	StakingKey              []byte       `gorm:"index;size:28"`
 	Assets                  []Asset      `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
 	Cbor                    []byte       `gorm:"-"` // This is here for convenience but not represented in the metadata DB
 	SpentAtTxId             []byte       `gorm:"index;size:32"`

--- a/database/models/witness_script.go
+++ b/database/models/witness_script.go
@@ -25,7 +25,7 @@ package models
 // transactions, we store only the script hash here. The actual script content
 // is stored separately in Script table, indexed by hash.
 type WitnessScripts struct {
-	ScriptHash    []byte `gorm:"index;size:32"`
+	ScriptHash    []byte `gorm:"index;size:28"`
 	ID            uint   `gorm:"primaryKey"`
 	TransactionID uint   `gorm:"index"`
 	Type          uint8  `gorm:"index"`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected hash sizes across database models to match Cardano types (28-byte key/script hashes, proper asset field lengths). This fixes index definitions and avoids storage inconsistencies.

- **Bug Fixes**
  - Standardized staking/pool/DRep/script hashes to 28 bytes across models (Account, Pool, Drep, Utxo, Script, WitnessScripts).
  - Updated asset field sizes: NameHex 64, PolicyId 28, Fingerprint 48.

- **Migration**
  - Run database migrations to apply the column size changes.

<sup>Written for commit b8be41907ebf92ceb460088de0ff5cc4ae679dd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted database field size constraints: reduced index sizes for staking keys, pool keys, drep/cold/host credentials, scripts, witness and UTXO keys to narrow storage footprint.
  * Updated asset index sizes: increased asset name hex and fingerprint length (and adjusted policy id constraint).
  * No functional or behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->