### PR TITLE
fix(database): set slot during transaction save in mysql

### DIFF
--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -212,6 +212,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 		Type:       tx.Type(),
 		BlockHash:  point.Hash,
 		BlockIndex: idx,
+		Slot:       point.Slot,
 		Fee:        types.Uint64(feeUint),
 		TTL:        types.Uint64(tx.TTL()),
 		Valid:      tx.IsValid(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist the transaction slot when saving to MySQL metadata to ensure slot is stored alongside hash and index. Fixes missing slot values that could break ordering and lookups that depend on slot.

<sup>Written for commit 986b11a6cd22d65c5dda9b50577aadf19feeb29f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction data storage with an additional attribute for improved transaction tracking and record-keeping capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->