### PR TITLE
fix(database): update tx slot on conflict in mysql

### DIFF
--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -258,7 +258,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}}, // unique txn hash
 		DoUpdates: clause.AssignmentColumns(
-			[]string{"block_hash", "block_index"},
+			[]string{"block_hash", "block_index", "slot"},
 		),
 	}).Create(tmpTx)
 	if result.Error != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the MySQL transaction upsert to also update slot when the hash already exists. This prevents stale slot values during re-indexing and keeps transaction metadata consistent.

<sup>Written for commit fc16836e938e8cde5e15f1d161a8daac7949e0ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

