### PR TITLE
feat(database): align metastore implementations

### DIFF
--- a/database/plugin/metadata/mysql/certs.go
+++ b/database/plugin/metadata/mysql/certs.go
@@ -43,7 +43,8 @@ func (d *MetadataStoreMysql) GetStakeRegistrations(
 		tmpCert = lcommon.StakeRegistrationCertificate{
 			CertType: uint(lcommon.CertificateTypeStakeRegistration),
 			StakeCredential: lcommon.Credential{
-				CredType:   lcommon.CredentialTypeAddrKeyHash,
+				// TODO: determine correct type
+				// CredType: lcommon.CredentialTypeAddrKeyHash,
 				Credential: lcommon.CredentialHash(cert.StakingKey),
 			},
 		}

--- a/database/plugin/metadata/postgres/certs.go
+++ b/database/plugin/metadata/postgres/certs.go
@@ -43,7 +43,8 @@ func (d *MetadataStorePostgres) GetStakeRegistrations(
 		tmpCert = lcommon.StakeRegistrationCertificate{
 			CertType: uint(lcommon.CertificateTypeStakeRegistration),
 			StakeCredential: lcommon.Credential{
-				CredType:   lcommon.CredentialTypeAddrKeyHash,
+				// TODO: determine correct type
+				// CredType: lcommon.CredentialTypeAddrKeyHash,
 				Credential: lcommon.CredentialHash(cert.StakingKey),
 			},
 		}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -39,11 +39,13 @@ func (d *MetadataStorePostgres) GetPool(
 	result := db.
 		Preload(
 			"Registration",
-			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC").Limit(1) },
+			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC, id DESC").Limit(1) },
 		).
+		Preload("Registration.Owners").
+		Preload("Registration.Relays").
 		Preload(
 			"Retirement",
-			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC").Limit(1) },
+			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC, id DESC").Limit(1) },
 		).
 		First(
 			ret,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -241,7 +241,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}}, // unique txn hash
 		DoUpdates: clause.AssignmentColumns(
-			[]string{"block_hash", "block_index"},
+			[]string{"block_hash", "block_index", "slot"},
 		),
 	}).Create(tmpTx)
 	if result.Error != nil {

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -16,12 +16,18 @@ package postgres
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
+
+// postgresBatchChunkSize is the maximum number of UTXO refs to process in a single SQL statement.
+// Postgres can handle large batches efficiently.
+const postgresBatchChunkSize = 1000
 
 // GetUtxo returns a Utxo by reference
 func (d *MetadataStorePostgres) GetUtxo(
@@ -188,10 +194,20 @@ func (d *MetadataStorePostgres) DeleteUtxos(
 	if err != nil {
 		return err
 	}
-	// Delete each UTxO by tx_id and output_idx. Use a transaction-aware delete.
-	for _, u := range utxos {
-		result := db.Where("tx_id = ? AND output_idx = ?", u.Hash, u.Idx).
-			Delete(&models.Utxo{})
+	// Process in chunks for efficient batch deletion
+	for i := 0; i < len(utxos); i += postgresBatchChunkSize {
+		end := min(i+postgresBatchChunkSize, len(utxos))
+		chunk := utxos[i:end]
+
+		// Build batch delete with OR conditions for this chunk
+		conditions := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for _, u := range chunk {
+			conditions = append(conditions, "(tx_id = ? AND output_idx = ?)")
+			args = append(args, u.Hash, u.Idx)
+		}
+		query := strings.Join(conditions, " OR ")
+		result := db.Where(query, args...).Delete(&models.Utxo{})
 		if result.Error != nil {
 			return result.Error
 		}
@@ -220,18 +236,23 @@ func (d *MetadataStorePostgres) AddUtxos(
 	utxos []models.UtxoSlot,
 	txn types.Txn,
 ) error {
+	if len(utxos) == 0 {
+		return nil
+	}
+
 	items := make([]models.Utxo, 0, len(utxos))
 	for _, utxo := range utxos {
-		items = append(
-			items,
-			models.UtxoLedgerToModel(utxo.Utxo, utxo.Slot),
-		)
+		items = append(items, models.UtxoLedgerToModel(utxo.Utxo, utxo.Slot))
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return err
 	}
 	result := db.Session(&gorm.Session{FullSaveAssociations: true}).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
+			DoNothing: true,
+		}).
 		CreateInBatches(items, 1000)
 	if result.Error != nil {
 		return result.Error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns MySQL, Postgres, and SQLite metastore behavior to make rollbacks consistent, pool/DRep queries deterministic, and UTXO operations faster.

- **Bug Fixes**
  - MySQL: fix rollback deletes by plucking IDs before DELETE in DRep/Pool restore.
  - GetPool: order by added_slot DESC, id DESC and preload Owners/Relays for complete, stable results (MySQL/Postgres).
  - SQLite: correct UTXO address filter to require both credentials for base addresses.
  - Postgres: upsert now updates the slot in SetTransaction.
  - Certs: stop forcing stake registration CredType until type is known.

- **Refactors**
  - Batch UTXO deletions in MySQL/Postgres; process refs in chunks for efficiency.
  - Upsert UTXOs with ON CONFLICT DO NOTHING in Postgres/SQLite; batch inserts.
  - Tests use fixed-size 28/32-byte helpers for realistic hashes.

<sup>Written for commit cd5128b5ecc7c975d80652c4ce1c66c81bb9ec94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized UTXO deletion and insertion operations to use batch processing for improved efficiency.

* **Bug Fixes**
  * Enhanced transaction data consistency by including slot information in update operations.
  * Improved data integrity for pool and DRep state restoration with more reliable query logic.

* **Tests**
  * Strengthened test infrastructure with deterministic hash generation helpers and improved configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->