### PR TITLE
feat(database): lock-free hot cache for cbor

### DIFF
--- a/database/hot_cache.go
+++ b/database/hot_cache.go
@@ -1,0 +1,301 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"maps"
+	"sort"
+	"sync/atomic"
+)
+
+// hotCacheData holds both entries and access counts together for atomic updates.
+// This ensures entries and accessCnt are always consistent.
+type hotCacheData struct {
+	entries   map[string][]byte
+	accessCnt map[string]uint64
+}
+
+// accessSampleRate controls how often access counts are updated on Get().
+// A value of 4 means ~25% of Gets trigger an access count update.
+// This trades LFU accuracy for performance by avoiding map copies on every read.
+const accessSampleRate = 4
+
+// HotCache provides a lock-free cache for frequently accessed CBOR data.
+// It uses copy-on-write semantics for thread-safe concurrent access without locks.
+// Eviction follows a Least-Frequently-Used (LFU) policy with probabilistic counting.
+type HotCache struct {
+	data      atomic.Pointer[hotCacheData] // combined entries + access counts
+	maxSize   int                          // max number of entries (0 = unlimited)
+	maxBytes  int64                        // max memory in bytes (0 = unlimited)
+	curBytes  atomic.Int64                 // current memory usage
+	evicting  atomic.Bool                  // eviction lock
+	sampleCnt atomic.Uint64                // counter for probabilistic access tracking
+}
+
+// NewHotCache creates a new HotCache with the given size and memory limits.
+// Set maxSize to 0 for unlimited entries (limited only by maxBytes).
+// Set maxBytes to 0 for unlimited memory (limited only by maxSize).
+func NewHotCache(maxSize int, maxBytes int64) *HotCache {
+	cache := &HotCache{
+		maxSize:  maxSize,
+		maxBytes: maxBytes,
+	}
+
+	// Initialize combined data structure
+	data := &hotCacheData{
+		entries:   make(map[string][]byte),
+		accessCnt: make(map[string]uint64),
+	}
+	cache.data.Store(data)
+
+	return cache
+}
+
+// Get retrieves a value from the cache by key.
+// Returns the value and true if found, nil and false otherwise.
+// This operation is lock-free and safe for concurrent use.
+// Access counts are updated probabilistically (1 in accessSampleRate calls)
+// to reduce overhead while maintaining approximate LFU behavior.
+func (c *HotCache) Get(key []byte) ([]byte, bool) {
+	data := c.data.Load()
+	if data == nil {
+		return nil, false
+	}
+
+	value, ok := data.entries[string(key)]
+	if ok {
+		// Probabilistic counting: only update access count 1 in accessSampleRate times
+		// This avoids expensive map copies on every read while maintaining approximate LFU
+		if c.sampleCnt.Add(1)%accessSampleRate == 0 {
+			c.incrementAccess(key)
+		}
+		// Return a copy to prevent callers from mutating cached data
+		return append([]byte(nil), value...), true
+	}
+	return nil, false
+}
+
+// Put adds or updates a value in the cache.
+// If maxBytes > 0 and the entry size exceeds maxBytes/10, the entry is skipped.
+// This operation uses copy-on-write semantics for thread safety.
+func (c *HotCache) Put(key []byte, cbor []byte) {
+	keyStr := string(key)
+	entrySize := int64(len(key) + len(cbor))
+
+	// Skip entries that are too large (> 10% of max memory)
+	if c.maxBytes > 0 && entrySize > c.maxBytes/10 {
+		return
+	}
+
+	// Copy-on-write: create new combined data with the update
+	for {
+		oldData := c.data.Load()
+
+		newEntries := make(map[string][]byte, len(oldData.entries)+1)
+		maps.Copy(newEntries, oldData.entries)
+
+		// Track memory change
+		var memDelta int64
+		if oldValue, exists := newEntries[keyStr]; exists {
+			memDelta = entrySize - int64(len(keyStr)+len(oldValue))
+		} else {
+			memDelta = entrySize
+		}
+
+		// Copy the value to prevent callers from mutating cached data
+		cborCopy := make([]byte, len(cbor))
+		copy(cborCopy, cbor)
+		newEntries[keyStr] = cborCopy
+
+		// Also update access count map
+		newAccessCnt := make(map[string]uint64, len(oldData.accessCnt)+1)
+		maps.Copy(newAccessCnt, oldData.accessCnt)
+		newAccessCnt[keyStr]++ // increment on put
+
+		newData := &hotCacheData{
+			entries:   newEntries,
+			accessCnt: newAccessCnt,
+		}
+
+		// Try to atomically update both maps together
+		if c.data.CompareAndSwap(oldData, newData) {
+			if c.maxBytes > 0 {
+				c.curBytes.Add(memDelta)
+			}
+			break
+		}
+		// CAS failed, retry with fresh data
+	}
+
+	c.maybeEvict()
+}
+
+// incrementAccess increments the access counter for a key.
+// Uses copy-on-write semantics for thread safety.
+// Only increments if the key still exists in entries to prevent orphan access counts.
+func (c *HotCache) incrementAccess(key []byte) {
+	keyStr := string(key)
+
+	for {
+		oldData := c.data.Load()
+		if oldData == nil {
+			return
+		}
+
+		// Check if key still exists in entries (may have been evicted)
+		if _, exists := oldData.entries[keyStr]; !exists {
+			return
+		}
+
+		// Copy and update access counts only - entries are unchanged so reuse them
+		newAccessCnt := make(map[string]uint64, len(oldData.accessCnt))
+		maps.Copy(newAccessCnt, oldData.accessCnt)
+		newAccessCnt[keyStr]++
+
+		newData := &hotCacheData{
+			entries:   oldData.entries, // reuse immutable entries map
+			accessCnt: newAccessCnt,
+		}
+
+		if c.data.CompareAndSwap(oldData, newData) {
+			return
+		}
+		// CAS failed, retry
+	}
+}
+
+// maybeEvict checks if eviction is needed and performs LFU eviction.
+// Uses atomic bool to ensure only one goroutine performs eviction at a time.
+func (c *HotCache) maybeEvict() {
+	// Check if eviction is needed
+	data := c.data.Load()
+	if data == nil {
+		return
+	}
+
+	currentSize := len(data.entries)
+	currentBytes := c.curBytes.Load()
+
+	needEvictBySize := c.maxSize > 0 && currentSize > c.maxSize
+	needEvictByBytes := c.maxBytes > 0 && currentBytes > c.maxBytes
+
+	if !needEvictBySize && !needEvictByBytes {
+		return
+	}
+
+	// Try to acquire eviction lock
+	if !c.evicting.CompareAndSwap(false, true) {
+		return // Another goroutine is already evicting
+	}
+	defer c.evicting.Store(false)
+
+	// Use CAS loop to atomically update while handling concurrent modifications
+	for {
+		oldData := c.data.Load()
+		if oldData == nil {
+			return
+		}
+
+		currentSize = len(oldData.entries)
+
+		// Calculate target size (evict ~25%, but keep at least 1 entry)
+		// Only computed when maxSize > 0; otherwise size-based eviction is disabled
+		var targetSize int
+		if c.maxSize > 0 {
+			targetSize = c.maxSize * 3 / 4
+			if targetSize < 1 {
+				targetSize = 1
+			}
+		}
+
+		var targetBytes int64
+		if c.maxBytes > 0 {
+			targetBytes = c.maxBytes * 3 / 4
+		}
+
+		// Build list of entries sorted by access count (ascending = least frequent first)
+		type entry struct {
+			key   string
+			count uint64
+			size  int64
+		}
+
+		entriesList := make([]entry, 0, currentSize)
+		for k, v := range oldData.entries {
+			count := oldData.accessCnt[k]
+			entriesList = append(entriesList, entry{
+				key:   k,
+				count: count,
+				size:  int64(len(k) + len(v)),
+			})
+		}
+
+		// Sort by access count ascending (least frequently used first)
+		sort.Slice(entriesList, func(i, j int) bool {
+			return entriesList[i].count < entriesList[j].count
+		})
+
+		// Determine which entries to keep
+		keysToRemove := make(map[string]bool)
+		keptSize := 0
+		var keptBytes int64
+
+		for i := len(entriesList) - 1; i >= 0; i-- {
+			e := entriesList[i]
+
+			wouldExceedSize := c.maxSize > 0 && keptSize >= targetSize
+			wouldExceedBytes := c.maxBytes > 0 && keptBytes+e.size > targetBytes
+
+			if wouldExceedSize || wouldExceedBytes {
+				keysToRemove[e.key] = true
+			} else {
+				keptSize++
+				keptBytes += e.size
+			}
+		}
+
+		if len(keysToRemove) == 0 {
+			return
+		}
+
+		// Create new maps without evicted entries
+		newEntries := make(map[string][]byte, keptSize)
+		newAccessCnt := make(map[string]uint64, keptSize)
+		var bytesRemoved int64
+
+		for k, v := range oldData.entries {
+			if keysToRemove[k] {
+				bytesRemoved += int64(len(k) + len(v))
+				continue
+			}
+			newEntries[k] = v
+			newAccessCnt[k] = oldData.accessCnt[k]
+		}
+
+		newData := &hotCacheData{
+			entries:   newEntries,
+			accessCnt: newAccessCnt,
+		}
+
+		// Try to atomically update
+		if c.data.CompareAndSwap(oldData, newData) {
+			if c.maxBytes > 0 {
+				c.curBytes.Add(-bytesRemoved)
+			}
+			return
+		}
+		// CAS failed, retry with fresh data
+	}
+}

--- a/database/hot_cache_test.go
+++ b/database/hot_cache_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHotCacheGetPut(t *testing.T) {
+	cache := NewHotCache(100, 0)
+
+	// Test Put and Get
+	key1 := []byte("key1")
+	value1 := []byte("value1")
+
+	cache.Put(key1, value1)
+
+	got, ok := cache.Get(key1)
+	require.True(t, ok, "expected key to be found")
+	assert.Equal(t, value1, got, "expected value to match")
+
+	// Test missing key
+	got, ok = cache.Get([]byte("nonexistent"))
+	assert.False(t, ok, "expected key not to be found")
+	assert.Nil(t, got, "expected nil value for missing key")
+
+	// Test overwrite
+	value2 := []byte("value2")
+	cache.Put(key1, value2)
+
+	got, ok = cache.Get(key1)
+	require.True(t, ok, "expected key to be found after overwrite")
+	assert.Equal(t, value2, got, "expected updated value")
+
+	// Test multiple keys
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := []byte(fmt.Sprintf("value%d", i))
+		cache.Put(key, value)
+	}
+
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		expectedValue := []byte(fmt.Sprintf("value%d", i))
+		got, ok := cache.Get(key)
+		require.True(t, ok, "expected key%d to be found", i)
+		assert.Equal(t, expectedValue, got, "expected value%d to match", i)
+	}
+}
+
+func TestHotCacheConcurrent(t *testing.T) {
+	cache := NewHotCache(1000, 0)
+
+	const numGoroutines = 100
+	const numOperations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2)
+
+	// Writers
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				key := []byte(fmt.Sprintf("key-%d-%d", id, j))
+				value := []byte(fmt.Sprintf("value-%d-%d", id, j))
+				cache.Put(key, value)
+			}
+		}(i)
+	}
+
+	// Readers
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				key := []byte(fmt.Sprintf("key-%d-%d", id, j))
+				cache.Get(key)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify some entries are still accessible
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("key-%d-%d", i, numOperations-1))
+		got, ok := cache.Get(key)
+		if ok {
+			expected := []byte(fmt.Sprintf("value-%d-%d", i, numOperations-1))
+			assert.Equal(t, expected, got, "value mismatch for concurrent key")
+		}
+	}
+}
+
+func TestHotCacheEviction(t *testing.T) {
+	maxSize := 10
+	cache := NewHotCache(maxSize, 0)
+
+	// Add entries up to maxSize
+	for i := 0; i < maxSize; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := []byte(fmt.Sprintf("value%d", i))
+		cache.Put(key, value)
+	}
+
+	// Access some keys to increase their frequency
+	frequentKeys := [][]byte{
+		[]byte("key0"),
+		[]byte("key1"),
+		[]byte("key2"),
+	}
+	for _, key := range frequentKeys {
+		for j := 0; j < 10; j++ {
+			cache.Get(key)
+		}
+	}
+
+	// Add more entries to trigger eviction
+	for i := maxSize; i < maxSize+10; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := []byte(fmt.Sprintf("value%d", i))
+		cache.Put(key, value)
+	}
+
+	// Frequently accessed keys should still be present
+	for _, key := range frequentKeys {
+		_, ok := cache.Get(key)
+		assert.True(
+			t,
+			ok,
+			"frequently accessed key %s should still be present",
+			string(key),
+		)
+	}
+
+	// Verify cache size is controlled (may be slightly over due to concurrent ops)
+	data := cache.data.Load()
+	assert.LessOrEqual(
+		t,
+		len(data.entries),
+		maxSize+5,
+		"cache should be close to maxSize after eviction",
+	)
+}
+
+func TestHotCacheMemoryLimit(t *testing.T) {
+	maxBytes := int64(1000)
+	cache := NewHotCache(1000, maxBytes)
+
+	// Add entries that together exceed maxBytes
+	valueSize := 100
+	for i := 0; i < 20; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := make([]byte, valueSize)
+		for j := range value {
+			value[j] = byte(i)
+		}
+		cache.Put(key, value)
+	}
+
+	// Memory usage should be controlled
+	assert.LessOrEqual(
+		t,
+		cache.curBytes.Load(),
+		maxBytes+int64(valueSize*3),
+		"memory should be close to maxBytes after eviction",
+	)
+
+	// Test that oversized entries are rejected
+	// Entry > maxBytes/10 should be skipped
+	oversizedKey := []byte("oversized")
+	oversizedValue := make([]byte, maxBytes/10+1)
+	cache.Put(oversizedKey, oversizedValue)
+
+	_, ok := cache.Get(oversizedKey)
+	assert.False(t, ok, "oversized entry should not be stored")
+}
+
+func TestHotCacheLFUEviction(t *testing.T) {
+	maxSize := 5
+	cache := NewHotCache(maxSize, 0)
+
+	// Add initial entries
+	for i := 0; i < maxSize; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := []byte(fmt.Sprintf("value%d", i))
+		cache.Put(key, value)
+	}
+
+	// Access key0 many times to make it frequently used
+	for i := 0; i < 50; i++ {
+		cache.Get([]byte("key0"))
+	}
+
+	// Access key1 a moderate number of times
+	for i := 0; i < 20; i++ {
+		cache.Get([]byte("key1"))
+	}
+
+	// key2, key3, key4 have access count of 1 from the Put operation only
+
+	// Add new entries to force eviction
+	for i := maxSize; i < maxSize+5; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := []byte(fmt.Sprintf("value%d", i))
+		cache.Put(key, value)
+	}
+
+	// key0 (most frequent) should still be present
+	_, ok := cache.Get([]byte("key0"))
+	assert.True(t, ok, "most frequently accessed key should survive eviction")
+
+	// key1 (moderately frequent) should likely still be present
+	_, ok = cache.Get([]byte("key1"))
+	assert.True(t, ok, "moderately accessed key should survive eviction")
+}
+
+func TestHotCacheEmptyCache(t *testing.T) {
+	cache := NewHotCache(10, 0)
+
+	// Get from empty cache
+	got, ok := cache.Get([]byte("nonexistent"))
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestHotCacheNilKey(t *testing.T) {
+	cache := NewHotCache(10, 0)
+
+	// Put with nil key
+	cache.Put(nil, []byte("value"))
+
+	// Should be retrievable with empty key
+	got, ok := cache.Get(nil)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("value"), got)
+}
+
+func TestHotCacheZeroMaxSize(t *testing.T) {
+	// Zero maxSize means unlimited by count
+	cache := NewHotCache(0, 1000)
+
+	for i := 0; i < 100; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+		value := []byte(fmt.Sprintf("value%d", i))
+		cache.Put(key, value)
+	}
+
+	// All entries should be present (limited only by bytes)
+	count := 0
+	data := cache.data.Load()
+	if data != nil {
+		count = len(data.entries)
+	}
+	assert.Greater(t, count, 0, "cache should have entries")
+}
+
+func TestHotCacheSmallMaxSize(t *testing.T) {
+	// Test that maxSize=1 works correctly (edge case for eviction)
+	cache := NewHotCache(1, 0)
+
+	// Add first entry
+	cache.Put([]byte("key1"), []byte("value1"))
+	val, ok := cache.Get([]byte("key1"))
+	assert.True(t, ok, "first entry should be retrievable")
+	assert.Equal(t, []byte("value1"), val)
+
+	// Add second entry - should trigger eviction but keep at least 1
+	cache.Put([]byte("key2"), []byte("value2"))
+
+	// At least one entry should exist (either key1 or key2)
+	data := cache.data.Load()
+	assert.NotNil(t, data)
+	assert.GreaterOrEqual(
+		t,
+		len(data.entries),
+		1,
+		"cache with maxSize=1 should keep at least 1 entry",
+	)
+	assert.LessOrEqual(
+		t,
+		len(data.entries),
+		2,
+		"cache with maxSize=1 should have at most 2 entries",
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lock-free, copy-on-write hot cache for CBOR with LFU eviction to speed up reads and control memory usage. Includes tests for concurrency, eviction behavior, and memory limits.

- **New Features**
  - HotCache with Get/Put using atomic CAS; reads are lock-free with sampled access counts.
  - LFU eviction trims to ~75% when size or bytes exceed limits.
  - Supports max entries and max bytes; tracks memory usage.
  - Skips oversized entries (>10% of maxBytes).
  - Tests cover concurrency, LFU eviction, memory limits, and edge cases.

<sup>Written for commit 5d7c70d5f8a75d2918f09275b8c69031064b6a03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a high-performance, lock-free in-memory cache with configurable item and memory limits for faster data access and probabilistic frequency tracking.
  * Automatic frequency-aware eviction that deterministically retains hot items while reducing cache usage when limits are exceeded.

* **Tests**
  * Added extensive tests covering basic operations, concurrency, eviction behavior, memory bounds, and edge cases to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->