### PR TITLE
feat(database): block lru cache

### DIFF
--- a/database/block_lru_cache.go
+++ b/database/block_lru_cache.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"container/list"
+	"sync"
+)
+
+// Location represents a byte range within the block's raw CBOR data.
+type Location struct {
+	Offset uint32
+	Length uint32
+}
+
+// OutputKey uniquely identifies a transaction output within a block.
+type OutputKey struct {
+	TxIndex     uint16
+	OutputIndex uint16
+}
+
+// CachedBlock holds a block's raw CBOR data along with pre-computed indexes
+// for fast extraction of transactions and UTxO outputs.
+type CachedBlock struct {
+	// RawBytes contains the block's raw CBOR data.
+	RawBytes []byte
+	// TxIndex maps transaction hashes to their location in RawBytes.
+	TxIndex map[[32]byte]Location
+	// OutputIndex maps UTxO output keys to their location in RawBytes.
+	OutputIndex map[OutputKey]Location
+}
+
+// Extract returns a slice of RawBytes from offset to offset+length.
+// Returns nil if the range is out of bounds.
+func (cb *CachedBlock) Extract(offset, length uint32) []byte {
+	dataLen := len(cb.RawBytes)
+	// Check offset doesn't exceed data length
+	if uint64(offset) > uint64(dataLen) {
+		return nil
+	}
+	// Check end doesn't exceed data length (using uint64 to avoid overflow)
+	end := uint64(offset) + uint64(length)
+	if end > uint64(dataLen) {
+		return nil
+	}
+	return cb.RawBytes[offset : offset+length]
+}
+
+// blockKey is the composite key for cache entries.
+type blockKey struct {
+	slot uint64
+	hash [32]byte
+}
+
+// cacheEntry holds a cached block and its key for LRU tracking.
+type cacheEntry struct {
+	key   blockKey
+	block *CachedBlock
+}
+
+// BlockLRUCache is a thread-safe LRU cache for recently accessed blocks.
+// Blocks are keyed by (slot, hash) and evicted in LRU order when the cache
+// exceeds maxEntries.
+type BlockLRUCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	cache      map[blockKey]*list.Element
+	lruList    *list.List
+}
+
+// NewBlockLRUCache creates a new BlockLRUCache with the specified maximum
+// number of entries. If maxEntries is negative, it is treated as zero
+// (cache disabled).
+func NewBlockLRUCache(maxEntries int) *BlockLRUCache {
+	if maxEntries < 0 {
+		maxEntries = 0
+	}
+	return &BlockLRUCache{
+		maxEntries: maxEntries,
+		cache:      make(map[blockKey]*list.Element),
+		lruList:    list.New(),
+	}
+}
+
+// Get retrieves a cached block by slot and hash.
+// Returns the block and true if found, or nil and false if not found.
+// Accessing a block moves it to the front of the LRU list.
+func (c *BlockLRUCache) Get(slot uint64, hash [32]byte) (*CachedBlock, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := blockKey{slot: slot, hash: hash}
+	elem, ok := c.cache[key]
+	if !ok {
+		return nil, false
+	}
+
+	// Move to front (most recently used)
+	c.lruList.MoveToFront(elem)
+
+	entry := elem.Value.(*cacheEntry)
+	return entry.block, true
+}
+
+// Put adds or updates a block in the cache.
+// The block is moved to the front of the LRU list.
+// If the cache exceeds maxEntries, the least recently used block is evicted.
+func (c *BlockLRUCache) Put(slot uint64, hash [32]byte, block *CachedBlock) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := blockKey{slot: slot, hash: hash}
+
+	// Check if entry already exists
+	if elem, ok := c.cache[key]; ok {
+		// Update existing entry
+		c.lruList.MoveToFront(elem)
+		entry := elem.Value.(*cacheEntry)
+		entry.block = block
+		return
+	}
+
+	// Add new entry
+	entry := &cacheEntry{key: key, block: block}
+	elem := c.lruList.PushFront(entry)
+	c.cache[key] = elem
+
+	// Evict if over capacity
+	for c.lruList.Len() > c.maxEntries {
+		c.evictOldest()
+	}
+}
+
+// evictOldest removes the least recently used entry from the cache.
+// Must be called with the mutex held.
+func (c *BlockLRUCache) evictOldest() {
+	elem := c.lruList.Back()
+	if elem == nil {
+		return
+	}
+
+	entry := elem.Value.(*cacheEntry)
+	delete(c.cache, entry.key)
+	c.lruList.Remove(elem)
+}

--- a/database/block_lru_cache_test.go
+++ b/database/block_lru_cache_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockLRUCacheGetPut(t *testing.T) {
+	cache := NewBlockLRUCache(10)
+	require.NotNil(t, cache)
+
+	// Create a test block
+	hash1 := [32]byte{1, 2, 3}
+	block1 := &CachedBlock{
+		RawBytes: []byte("test block data"),
+		TxIndex: map[[32]byte]Location{
+			{0xaa}: {Offset: 0, Length: 5},
+		},
+		OutputIndex: map[OutputKey]Location{
+			{TxIndex: 0, OutputIndex: 0}: {Offset: 5, Length: 10},
+		},
+	}
+
+	// Test Put and Get
+	cache.Put(100, hash1, block1)
+
+	got, ok := cache.Get(100, hash1)
+	require.True(t, ok)
+	assert.Equal(t, block1.RawBytes, got.RawBytes)
+	assert.Equal(t, block1.TxIndex, got.TxIndex)
+	assert.Equal(t, block1.OutputIndex, got.OutputIndex)
+
+	// Test Get for non-existent block
+	hash2 := [32]byte{4, 5, 6}
+	got, ok = cache.Get(100, hash2)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+
+	// Test Get with wrong slot but correct hash
+	got, ok = cache.Get(101, hash1)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+
+	// Test overwriting existing entry
+	block1Updated := &CachedBlock{
+		RawBytes: []byte("updated block data"),
+		TxIndex:  map[[32]byte]Location{},
+	}
+	cache.Put(100, hash1, block1Updated)
+
+	got, ok = cache.Get(100, hash1)
+	require.True(t, ok)
+	assert.Equal(t, block1Updated.RawBytes, got.RawBytes)
+}
+
+func TestBlockLRUCacheEviction(t *testing.T) {
+	cache := NewBlockLRUCache(3)
+
+	// Add 3 blocks - LRU order after: 3, 2, 1 (3 is most recent)
+	hash1 := [32]byte{1}
+	hash2 := [32]byte{2}
+	hash3 := [32]byte{3}
+
+	cache.Put(1, hash1, &CachedBlock{RawBytes: []byte("block1")})
+	cache.Put(2, hash2, &CachedBlock{RawBytes: []byte("block2")})
+	cache.Put(3, hash3, &CachedBlock{RawBytes: []byte("block3")})
+
+	// Add a 4th block - should evict block1 (least recently used)
+	// LRU order after: 4, 3, 2
+	hash4 := [32]byte{4}
+	cache.Put(4, hash4, &CachedBlock{RawBytes: []byte("block4")})
+
+	// block1 should be evicted
+	_, ok := cache.Get(1, hash1)
+	assert.False(t, ok, "block1 should have been evicted")
+
+	// block2, block3, block4 should still be present
+	// Note: these Gets change LRU order to: 4, 3, 2 -> 2, 4, 3 -> 3, 2, 4 -> 4, 3, 2
+	_, ok = cache.Get(2, hash2)
+	assert.True(t, ok, "block2 should still be present")
+	_, ok = cache.Get(3, hash3)
+	assert.True(t, ok, "block3 should still be present")
+	_, ok = cache.Get(4, hash4)
+	assert.True(t, ok, "block4 should still be present")
+	// After these gets, LRU order is: 4, 3, 2 (4 most recent, 2 least recent)
+
+	// Add another block - should evict block2 (least recently used)
+	hash5 := [32]byte{5}
+	cache.Put(5, hash5, &CachedBlock{RawBytes: []byte("block5")})
+
+	_, ok = cache.Get(2, hash2)
+	assert.False(t, ok, "block2 should have been evicted")
+
+	// block3, block4, block5 should still be present
+	_, ok = cache.Get(3, hash3)
+	assert.True(t, ok, "block3 should still be present")
+	_, ok = cache.Get(4, hash4)
+	assert.True(t, ok, "block4 should still be present")
+	_, ok = cache.Get(5, hash5)
+	assert.True(t, ok, "block5 should still be present")
+}
+
+func TestCachedBlockExtract(t *testing.T) {
+	block := &CachedBlock{
+		RawBytes: []byte("0123456789abcdef"),
+	}
+
+	// Test normal extraction
+	result := block.Extract(0, 5)
+	assert.Equal(t, []byte("01234"), result)
+
+	// Test extraction from middle
+	result = block.Extract(5, 5)
+	assert.Equal(t, []byte("56789"), result)
+
+	// Test extraction at end
+	result = block.Extract(10, 6)
+	assert.Equal(t, []byte("abcdef"), result)
+
+	// Test single byte extraction
+	result = block.Extract(0, 1)
+	assert.Equal(t, []byte("0"), result)
+
+	// Test zero length extraction
+	result = block.Extract(5, 0)
+	assert.Equal(t, []byte{}, result)
+
+	// Test extraction beyond bounds returns nil
+	result = block.Extract(20, 5)
+	assert.Nil(t, result)
+
+	// Test extraction that would overflow returns nil
+	result = block.Extract(14, 5)
+	assert.Nil(t, result)
+}
+
+func TestBlockLRUCacheConcurrent(t *testing.T) {
+	cache := NewBlockLRUCache(100)
+	var wg sync.WaitGroup
+	numGoroutines := 50
+	numOperations := 100
+
+	// Spawn multiple goroutines doing concurrent puts and gets
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := range numOperations {
+				slot := uint64((id*numOperations + j) % 200)
+				hash := [32]byte{byte(id), byte(j)}
+
+				// Put
+				block := &CachedBlock{
+					RawBytes: []byte{byte(id), byte(j)},
+					TxIndex:  map[[32]byte]Location{},
+				}
+				cache.Put(slot, hash, block)
+
+				// Get
+				_, _ = cache.Get(slot, hash)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify cache is still functional after concurrent access
+	hash := [32]byte{0xff}
+	block := &CachedBlock{RawBytes: []byte("final")}
+	cache.Put(999, hash, block)
+
+	got, ok := cache.Get(999, hash)
+	assert.True(t, ok)
+	assert.Equal(t, block.RawBytes, got.RawBytes)
+}
+
+func TestBlockLRUCacheLRUOrdering(t *testing.T) {
+	cache := NewBlockLRUCache(3)
+
+	hash1 := [32]byte{1}
+	hash2 := [32]byte{2}
+	hash3 := [32]byte{3}
+
+	// Add blocks in order: 1, 2, 3
+	cache.Put(1, hash1, &CachedBlock{RawBytes: []byte("block1")})
+	cache.Put(2, hash2, &CachedBlock{RawBytes: []byte("block2")})
+	cache.Put(3, hash3, &CachedBlock{RawBytes: []byte("block3")})
+
+	// Access order: 3, 1, 2
+	// This makes LRU order (most to least recent): 2, 1, 3
+	cache.Get(3, hash3)
+	cache.Get(1, hash1)
+	cache.Get(2, hash2)
+
+	// Adding a new block should evict block3 (least recently used)
+	hash4 := [32]byte{4}
+	cache.Put(4, hash4, &CachedBlock{RawBytes: []byte("block4")})
+
+	_, ok := cache.Get(3, hash3)
+	assert.False(t, ok, "block3 should have been evicted as LRU")
+
+	// Others should still be present
+	_, ok = cache.Get(1, hash1)
+	assert.True(t, ok)
+	_, ok = cache.Get(2, hash2)
+	assert.True(t, ok)
+	_, ok = cache.Get(4, hash4)
+	assert.True(t, ok)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a thread-safe LRU cache for block data to speed up repeated reads and bound memory usage. Caches raw CBOR plus precomputed indexes so transactions and UTxOs can be sliced quickly by offset/length.

- **New Features**
  - BlockLRUCache with Get/Put, keyed by (slot, hash), evicts least-recently-used when over capacity.
  - CachedBlock stores RawBytes and indexes (TxIndex, OutputIndex) with a safe Extract method for byte ranges.
  - Concurrency-safe access using a mutex; Get updates LRU order, Put updates or inserts.
  - Tests cover get/put, eviction order, concurrent access, and Extract bounds.

<sup>Written for commit f1e7a704b4e1e9ca1cc4bea749979452d7dc7655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented efficient block data caching mechanism with thread-safe concurrent access
  * Added automatic least-recently-used eviction policy for cache management
  
* **Tests**
  * Comprehensive test coverage for cache operations, boundary conditions, and concurrent scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->