### PR TITLE
feat(database): tiered cbor cache orchestrator

### DIFF
--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/binary"
+	"errors"
+	"sync/atomic"
+)
+
+// ErrNotImplemented is returned when functionality is not yet implemented.
+var ErrNotImplemented = errors.New("not implemented")
+
+// UtxoRef represents a reference to a UTxO by transaction ID and output index.
+type UtxoRef struct {
+	TxId      [32]byte
+	OutputIdx uint32
+}
+
+// CacheMetrics holds atomic counters for cache performance monitoring.
+type CacheMetrics struct {
+	UtxoHotHits     atomic.Uint64
+	UtxoHotMisses   atomic.Uint64
+	TxHotHits       atomic.Uint64
+	TxHotMisses     atomic.Uint64
+	BlockLRUHits    atomic.Uint64
+	BlockLRUMisses  atomic.Uint64
+	ColdExtractions atomic.Uint64
+}
+
+// CborCacheConfig holds configuration for the TieredCborCache.
+type CborCacheConfig struct {
+	HotUtxoEntries  int   // Number of UTxO CBOR entries in hot cache
+	HotTxEntries    int   // Number of TX CBOR entries in hot cache
+	HotTxMaxBytes   int64 // Memory limit for TX hot cache (0 = no limit)
+	BlockLRUEntries int   // Number of blocks in LRU cache
+}
+
+// BlockLRUCache is a placeholder for the block LRU cache that will be
+// implemented separately. For now, it provides stub functionality.
+type BlockLRUCache struct {
+	maxEntries int
+}
+
+// NewBlockLRUCache creates a new BlockLRUCache with the given maximum entries.
+func NewBlockLRUCache(maxEntries int) *BlockLRUCache {
+	return &BlockLRUCache{
+		maxEntries: maxEntries,
+	}
+}
+
+// TieredCborCache orchestrates the tiered cache system for CBOR data resolution.
+// It checks hot caches first, then falls back to block extraction.
+//
+// Cache tiers:
+//   - Tier 1: Hot caches (hotUtxo for UTxO CBOR, hotTx for transaction CBOR)
+//   - Tier 2: Block LRU cache (shared block cache with pre-computed indexes)
+//   - Tier 3: Cold extraction from blob store (not yet wired up)
+type TieredCborCache struct {
+	hotUtxo  *HotCache      // Tier 1: frequently accessed UTxO CBOR
+	hotTx    *HotCache      // Tier 1: frequently accessed transaction CBOR
+	blockLRU *BlockLRUCache // Tier 2: recent blocks with index (shared)
+	metrics  *CacheMetrics
+}
+
+// NewTieredCborCache creates a new TieredCborCache with the given configuration.
+func NewTieredCborCache(config CborCacheConfig) *TieredCborCache {
+	return &TieredCborCache{
+		hotUtxo:  NewHotCache(config.HotUtxoEntries, 0),
+		hotTx:    NewHotCache(config.HotTxEntries, config.HotTxMaxBytes),
+		blockLRU: NewBlockLRUCache(config.BlockLRUEntries),
+		metrics:  &CacheMetrics{},
+	}
+}
+
+// ResolveUtxoCbor resolves UTxO CBOR data by transaction ID and output index.
+// It first checks the hot UTxO cache. On cache miss, it returns ErrNotImplemented
+// since the cold path (fetching offsets and extracting from blocks) is not yet wired up.
+func (c *TieredCborCache) ResolveUtxoCbor(
+	txId []byte,
+	outputIdx uint32,
+) ([]byte, error) {
+	key := makeUtxoKey(txId, outputIdx)
+
+	// Tier 1: Hot cache check
+	if cbor, ok := c.hotUtxo.Get(key); ok {
+		c.metrics.UtxoHotHits.Add(1)
+		return cbor, nil
+	}
+
+	// Hot cache miss
+	c.metrics.UtxoHotMisses.Add(1)
+
+	// TODO: Implement cold path
+	// 1. Get offset from blob store: db.GetUtxoOffset(txId, outputIdx, nil)
+	// 2. Check block LRU cache
+	// 3. If miss, fetch block from blob store and extract CBOR
+	// 4. Populate hot cache with extracted CBOR
+
+	return nil, ErrNotImplemented
+}
+
+// ResolveTxCbor resolves transaction CBOR data by transaction hash.
+// It first checks the hot TX cache. On cache miss, it returns ErrNotImplemented
+// since the cold path (fetching offsets and extracting from blocks) is not yet wired up.
+func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
+	// Tier 1: Hot cache check
+	if cbor, ok := c.hotTx.Get(txHash); ok {
+		c.metrics.TxHotHits.Add(1)
+		return cbor, nil
+	}
+
+	// Hot cache miss
+	c.metrics.TxHotMisses.Add(1)
+
+	// TODO: Implement cold path
+	// 1. Get offset from blob store: db.GetTxOffset(txHash, nil)
+	// 2. Check block LRU cache
+	// 3. If miss, fetch block from blob store and extract CBOR
+	// 4. Populate hot cache with extracted CBOR
+
+	return nil, ErrNotImplemented
+}
+
+// ResolveUtxoCborBatch resolves multiple UTxO CBOR entries in a single batch.
+// This is a stub that returns ErrNotImplemented. The full implementation will
+// group requests by block to minimize blob store fetches.
+func (c *TieredCborCache) ResolveUtxoCborBatch(
+	refs []UtxoRef,
+) (map[UtxoRef][]byte, error) {
+	// TODO: Implement batch resolution
+	// 1. Check hot cache for each ref, collect misses
+	// 2. Look up offset structs for all misses
+	// 3. Group misses by (block_slot, block_hash)
+	// 4. Fetch each unique block once
+	// 5. Extract all items from each block
+	// 6. Populate hot cache and return combined results
+	_ = refs // unused for now
+	return nil, ErrNotImplemented
+}
+
+// Metrics returns the cache metrics for monitoring and observability.
+func (c *TieredCborCache) Metrics() *CacheMetrics {
+	return c.metrics
+}
+
+// makeUtxoKey creates a cache key from transaction ID and output index.
+// The key is 36 bytes: 32 bytes for txId + 4 bytes for outputIdx (big-endian).
+func makeUtxoKey(txId []byte, outputIdx uint32) []byte {
+	key := make([]byte, 36)
+	copy(key[:32], txId)
+	binary.BigEndian.PutUint32(key[32:36], outputIdx)
+	return key
+}

--- a/database/cbor_cache_test.go
+++ b/database/cbor_cache_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTieredCborCache(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  1000,
+		HotTxEntries:    500,
+		HotTxMaxBytes:   1024 * 1024, // 1 MB
+		BlockLRUEntries: 100,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	require.NotNil(t, cache)
+	require.NotNil(t, cache.hotUtxo)
+	require.NotNil(t, cache.hotTx)
+	require.NotNil(t, cache.blockLRU)
+	require.NotNil(t, cache.metrics)
+}
+
+func TestTieredCborCacheHotHitUtxo(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  100,
+		HotTxEntries:    100,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 10,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	// Create a test key and CBOR data
+	var txId [32]byte
+	copy(txId[:], []byte("test-tx-id-0000000000000000000"))
+	outputIdx := uint32(0)
+	testCbor := []byte{0x82, 0x01, 0x02} // Simple CBOR array [1, 2]
+
+	// Manually populate the hot cache
+	key := makeUtxoKey(txId[:], outputIdx)
+	cache.hotUtxo.Put(key, testCbor)
+
+	// Resolve should hit the hot cache
+	result, err := cache.ResolveUtxoCbor(txId[:], outputIdx)
+
+	require.NoError(t, err)
+	assert.Equal(t, testCbor, result)
+
+	// Verify metrics show a hot hit
+	metrics := cache.Metrics()
+	assert.Equal(t, uint64(1), metrics.UtxoHotHits.Load())
+	assert.Equal(t, uint64(0), metrics.UtxoHotMisses.Load())
+}
+
+func TestTieredCborCacheHotHitTx(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  100,
+		HotTxEntries:    100,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 10,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	// Create a test key and CBOR data
+	var txHash [32]byte
+	copy(txHash[:], []byte("test-tx-hash-000000000000000000"))
+	testCbor := []byte{0x82, 0x01, 0x02} // Simple CBOR array [1, 2]
+
+	// Manually populate the hot cache
+	cache.hotTx.Put(txHash[:], testCbor)
+
+	// Resolve should hit the hot cache
+	result, err := cache.ResolveTxCbor(txHash[:])
+
+	require.NoError(t, err)
+	assert.Equal(t, testCbor, result)
+
+	// Verify metrics show a hot hit
+	metrics := cache.Metrics()
+	assert.Equal(t, uint64(1), metrics.TxHotHits.Load())
+	assert.Equal(t, uint64(0), metrics.TxHotMisses.Load())
+}
+
+func TestTieredCborCacheHotMissUtxo(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  100,
+		HotTxEntries:    100,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 10,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	// Create a test key that is NOT in the cache
+	var txId [32]byte
+	copy(txId[:], []byte("missing-tx-id-0000000000000000"))
+	outputIdx := uint32(5)
+
+	// Resolve should miss the hot cache and return ErrNotImplemented
+	// (since cold path is not wired up yet)
+	result, err := cache.ResolveUtxoCbor(txId[:], outputIdx)
+
+	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.Nil(t, result)
+
+	// Verify metrics show a hot miss
+	metrics := cache.Metrics()
+	assert.Equal(t, uint64(0), metrics.UtxoHotHits.Load())
+	assert.Equal(t, uint64(1), metrics.UtxoHotMisses.Load())
+}
+
+func TestTieredCborCacheHotMissTx(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  100,
+		HotTxEntries:    100,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 10,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	// Create a test key that is NOT in the cache
+	var txHash [32]byte
+	copy(txHash[:], []byte("missing-tx-hash-00000000000000"))
+
+	// Resolve should miss the hot cache and return ErrNotImplemented
+	result, err := cache.ResolveTxCbor(txHash[:])
+
+	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.Nil(t, result)
+
+	// Verify metrics show a hot miss
+	metrics := cache.Metrics()
+	assert.Equal(t, uint64(0), metrics.TxHotHits.Load())
+	assert.Equal(t, uint64(1), metrics.TxHotMisses.Load())
+}
+
+func TestTieredCborCacheMetrics(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  100,
+		HotTxEntries:    100,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 10,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	// Initial metrics should all be zero
+	metrics := cache.Metrics()
+	assert.Equal(t, uint64(0), metrics.UtxoHotHits.Load())
+	assert.Equal(t, uint64(0), metrics.UtxoHotMisses.Load())
+	assert.Equal(t, uint64(0), metrics.TxHotHits.Load())
+	assert.Equal(t, uint64(0), metrics.TxHotMisses.Load())
+	assert.Equal(t, uint64(0), metrics.BlockLRUHits.Load())
+	assert.Equal(t, uint64(0), metrics.BlockLRUMisses.Load())
+	assert.Equal(t, uint64(0), metrics.ColdExtractions.Load())
+
+	// Populate some UTxO entries
+	var txId1 [32]byte
+	copy(txId1[:], []byte("tx-id-1-00000000000000000000000"))
+	cache.hotUtxo.Put(makeUtxoKey(txId1[:], 0), []byte{0x01})
+
+	var txId2 [32]byte
+	copy(txId2[:], []byte("tx-id-2-00000000000000000000000"))
+	// txId2 is NOT in cache
+
+	// Perform some hits and misses
+	_, _ = cache.ResolveUtxoCbor(txId1[:], 0) // hit
+	_, _ = cache.ResolveUtxoCbor(txId1[:], 0) // hit
+	_, _ = cache.ResolveUtxoCbor(txId2[:], 0) // miss
+
+	// Verify counts
+	assert.Equal(t, uint64(2), metrics.UtxoHotHits.Load())
+	assert.Equal(t, uint64(1), metrics.UtxoHotMisses.Load())
+
+	// Populate some TX entries
+	var txHash1 [32]byte
+	copy(txHash1[:], []byte("tx-hash-1-000000000000000000000"))
+	cache.hotTx.Put(txHash1[:], []byte{0x02})
+
+	var txHash2 [32]byte
+	copy(txHash2[:], []byte("tx-hash-2-000000000000000000000"))
+	// txHash2 is NOT in cache
+
+	// Perform some hits and misses
+	_, _ = cache.ResolveTxCbor(txHash1[:]) // hit
+	_, _ = cache.ResolveTxCbor(txHash2[:]) // miss
+	_, _ = cache.ResolveTxCbor(txHash2[:]) // miss
+
+	// Verify counts
+	assert.Equal(t, uint64(1), metrics.TxHotHits.Load())
+	assert.Equal(t, uint64(2), metrics.TxHotMisses.Load())
+}
+
+func TestTieredCborCacheBatchStub(t *testing.T) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  100,
+		HotTxEntries:    100,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 10,
+	}
+
+	cache := NewTieredCborCache(config)
+
+	// Create some test refs
+	refs := []UtxoRef{
+		{TxId: [32]byte{1}, OutputIdx: 0},
+		{TxId: [32]byte{2}, OutputIdx: 1},
+	}
+
+	// Batch resolution returns ErrNotImplemented for now
+	result, err := cache.ResolveUtxoCborBatch(refs)
+
+	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.Nil(t, result)
+}
+
+func TestUtxoRefEquality(t *testing.T) {
+	// Test that UtxoRef works correctly as map keys
+	ref1 := UtxoRef{TxId: [32]byte{1, 2, 3}, OutputIdx: 5}
+	ref2 := UtxoRef{TxId: [32]byte{1, 2, 3}, OutputIdx: 5}
+	ref3 := UtxoRef{TxId: [32]byte{1, 2, 3}, OutputIdx: 6}
+	ref4 := UtxoRef{TxId: [32]byte{1, 2, 4}, OutputIdx: 5}
+
+	assert.Equal(t, ref1, ref2)
+	assert.NotEqual(t, ref1, ref3)
+	assert.NotEqual(t, ref1, ref4)
+
+	// Test map usage
+	m := make(map[UtxoRef][]byte)
+	m[ref1] = []byte{0x01}
+
+	_, exists := m[ref2]
+	assert.True(t, exists, "ref2 should match ref1 as map key")
+
+	_, exists = m[ref3]
+	assert.False(t, exists, "ref3 should not match ref1")
+}
+
+func TestMakeUtxoKey(t *testing.T) {
+	var txId [32]byte
+	for i := range txId {
+		txId[i] = byte(i)
+	}
+	outputIdx := uint32(12345)
+
+	key := makeUtxoKey(txId[:], outputIdx)
+
+	// Key should be 36 bytes: 32 (txId) + 4 (outputIdx big-endian)
+	assert.Len(t, key, 36)
+
+	// First 32 bytes should be the txId
+	assert.Equal(t, txId[:], key[:32])
+
+	// Last 4 bytes should be outputIdx in big-endian
+	assert.Equal(t, byte(0x00), key[32])
+	assert.Equal(t, byte(0x00), key[33])
+	assert.Equal(t, byte(0x30), key[34]) // 12345 = 0x3039
+	assert.Equal(t, byte(0x39), key[35])
+}
+
+func TestCborCacheConfigDefaults(t *testing.T) {
+	// Test with zero config
+	config := CborCacheConfig{}
+
+	cache := NewTieredCborCache(config)
+
+	require.NotNil(t, cache)
+	require.NotNil(t, cache.hotUtxo)
+	require.NotNil(t, cache.hotTx)
+	require.NotNil(t, cache.blockLRU)
+	require.NotNil(t, cache.metrics)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce a tiered CBOR cache orchestrator that checks hot UTxO and transaction caches first and tracks cache metrics. The block LRU and cold extraction paths are stubbed for now; misses return ErrNotImplemented.

- **New Features**
  - TieredCborCache with hot UTxO and TX caches, plus BlockLRUCache placeholder; configured via CborCacheConfig.
  - ResolveUtxoCbor and ResolveTxCbor return hot hits; on miss, increment metrics and return ErrNotImplemented.
  - CacheMetrics with atomic counters and Metrics() accessor; UtxoRef and makeUtxoKey for stable keys.
  - Batch API ResolveUtxoCborBatch added as a stub (returns ErrNotImplemented) and comprehensive unit tests for hits/misses, metrics, key derivation, and defaults.

<sup>Written for commit 4ad335c0fc2545175c8d95e6eaf28151bf6be14c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

