### PR TITLE
ci: mysql container for integration tests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  # Linux job with Postgres service for integration tests
+  # Linux job with Postgres and MySQL services for integration tests
   go-test-linux:
     name: go-test (Linux)
     strategy:
@@ -33,12 +33,31 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_DATABASE: dingo_test
+        options: >-
+          --health-cmd "sh -c 'mysqladmin ping -h 127.0.0.1 -u root -p$MYSQL_ROOT_PASSWORD'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
     env:
       POSTGRES_HOST: localhost
       POSTGRES_PORT: '5432'
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DATABASE: dingo_test
+      MYSQL_HOST: localhost
+      MYSQL_PORT: '3306'
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_DATABASE: dingo_test
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a MySQL 8 service to the GitHub Actions go-test (Linux) workflow to run MySQL integration tests alongside Postgres. Includes container health checks, exposes port 3306, and sets MYSQL_* env vars for reliable test connections.

<sup>Written for commit 5773162f5d520b1ade09f85e2e491abbdaf6f6f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added MySQL to the Linux test environment: included service configuration, environment variables for connection, credentials, port mapping, and health checks to expand database coverage and improve test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->