### PR TITLE
feat(config): cache config for tiered CBOR cache

### DIFF
--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -177,3 +177,25 @@ activePeersTopologyQuota: 0
 activePeersGossipQuota: 0
 # Active peer slots for ledger sources
 activePeersLedgerQuota: 0
+
+# Cache configuration for tiered CBOR cache system
+# This controls the in-memory caching of UTxO and transaction CBOR data
+cache:
+  # Number of entries in the hot UTxO cache (LFU eviction)
+  # Default: 50000
+  hotUtxoEntries: 50000
+  # Number of entries in the hot transaction cache (LFU eviction)
+  # Default: 10000
+  hotTxEntries: 10000
+  # Maximum memory in bytes for hot transaction cache
+  # Default: 268435456 (256 MB)
+  hotTxMaxBytes: 268435456
+  # Number of blocks to keep in the block LRU cache
+  # Default: 500
+  blockLruEntries: 500
+  # Number of recent blocks to warm up on startup
+  # Default: 1000
+  warmupBlocks: 1000
+  # Wait for cache warmup to complete before serving requests
+  # Default: true
+  warmupSync: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,34 @@ type databaseConfig struct {
 	Metadata map[string]any `yaml:"metadata,omitempty"`
 }
 
+// CacheConfig holds configuration for the tiered CBOR cache system.
+type CacheConfig struct {
+	// HotUtxoEntries is the maximum number of UTxO CBOR entries in the hot cache.
+	HotUtxoEntries int `yaml:"hotUtxoEntries" envconfig:"DINGO_CACHE_HOT_UTXO_ENTRIES"`
+	// HotTxEntries is the maximum number of transaction CBOR entries in the hot cache.
+	HotTxEntries int `yaml:"hotTxEntries" envconfig:"DINGO_CACHE_HOT_TX_ENTRIES"`
+	// HotTxMaxBytes is the maximum memory in bytes for the hot transaction cache.
+	HotTxMaxBytes int64 `yaml:"hotTxMaxBytes" envconfig:"DINGO_CACHE_HOT_TX_MAX_BYTES"`
+	// BlockLRUEntries is the maximum number of blocks in the LRU cache.
+	BlockLRUEntries int `yaml:"blockLruEntries" envconfig:"DINGO_CACHE_BLOCK_LRU_ENTRIES"`
+	// WarmupBlocks is the number of recent blocks to scan during cache warmup.
+	WarmupBlocks int `yaml:"warmupBlocks" envconfig:"DINGO_CACHE_WARMUP_BLOCKS"`
+	// WarmupSync blocks startup until cache warmup is complete when true.
+	WarmupSync bool `yaml:"warmupSync" envconfig:"DINGO_CACHE_WARMUP_SYNC"`
+}
+
+// DefaultCacheConfig returns the default cache configuration values.
+func DefaultCacheConfig() CacheConfig {
+	return CacheConfig{
+		HotUtxoEntries:  50000,
+		HotTxEntries:    10000,
+		HotTxMaxBytes:   268435456, // 256 MB
+		BlockLRUEntries: 500,
+		WarmupBlocks:    1000,
+		WarmupSync:      true,
+	}
+}
+
 type Config struct {
 	MetadataPlugin     string  `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
 	TlsKeyFilePath     string  `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
@@ -129,6 +157,9 @@ type Config struct {
 	ActivePeersTopologyQuota int `yaml:"activePeersTopologyQuota" envconfig:"DINGO_ACTIVE_PEERS_TOPOLOGY_QUOTA"`
 	ActivePeersGossipQuota   int `yaml:"activePeersGossipQuota"   envconfig:"DINGO_ACTIVE_PEERS_GOSSIP_QUOTA"`
 	ActivePeersLedgerQuota   int `yaml:"activePeersLedgerQuota"   envconfig:"DINGO_ACTIVE_PEERS_LEDGER_QUOTA"`
+
+	// Cache configuration for the tiered CBOR cache system
+	Cache CacheConfig `yaml:"cache"`
 }
 
 func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
@@ -212,6 +243,8 @@ var globalConfig = &Config{
 	// Defaults for database worker pool tuning
 	DatabaseWorkers:   5,
 	DatabaseQueueSize: 50,
+	// Cache configuration defaults
+	Cache: DefaultCacheConfig(),
 }
 
 func LoadConfig(configFile string) (*Config, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable settings for the tiered CBOR cache. Includes defaults, YAML fields, and env vars for hot UTxO/Tx caches, block LRU, and startup warmup behavior.

- **New Features**
  - New CacheConfig with defaults (HotUtxoEntries, HotTxEntries, HotTxMaxBytes, BlockLRUEntries, WarmupBlocks, WarmupSync).
  - Config now includes a Cache field; defaults loaded via DefaultCacheConfig.
  - dingo.yaml.example updated with a cache section and commented defaults.
  - Env overrides supported (e.g., DINGO_CACHE_HOT_TX_MAX_BYTES, DINGO_CACHE_WARMUP_SYNC).

- **Migration**
  - No changes required; defaults apply if cache is unset.
  - To tune, add the cache section to dingo.yaml or set the provided env vars.

<sup>Written for commit 4b985dcb7d644273f331160e163055a485644e86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a top-level cache configuration with tiered CBOR cache settings.
  * Add tunable hot UTxO and hot transaction cache limits (entries and size).
  * Add block LRU cache sizing, startup warmup controls, and a warmup synchronization flag.
  * All new settings include inline defaults and explanatory comments for easy tuning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->