### PR TITLE
fix(database): remove stub block lru cache

### DIFF
--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -48,19 +48,6 @@ type CborCacheConfig struct {
 	BlockLRUEntries int   // Number of blocks in LRU cache
 }
 
-// BlockLRUCache is a placeholder for the block LRU cache that will be
-// implemented separately. For now, it provides stub functionality.
-type BlockLRUCache struct {
-	maxEntries int
-}
-
-// NewBlockLRUCache creates a new BlockLRUCache with the given maximum entries.
-func NewBlockLRUCache(maxEntries int) *BlockLRUCache {
-	return &BlockLRUCache{
-		maxEntries: maxEntries,
-	}
-}
-
 // TieredCborCache orchestrates the tiered cache system for CBOR data resolution.
 // It checks hot caches first, then falls back to block extraction.
 //


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the stubbed BlockLRUCache and its constructor from database/cbor_cache.go to clean up dead code. No functional changes.

<sup>Written for commit 8ddcb7b46ebc2ab7100cd6f1167f5421fcf71ee5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

