### PR TITLE
build(make): append .exe on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,5 @@ $(BINARIES): mod-tidy $(GO_FILES)
 	CGO_ENABLED=0 \
 	go build \
 		$(GO_LDFLAGS) \
-		-o $(@) \
+		-o $(@)$(if $(filter windows,$(GOOS)),.exe,)  \
 		./cmd/$(@)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Append .exe to built binaries when GOOS=windows so Windows builds produce correctly named executables. No changes for non-Windows builds.

<sup>Written for commit 0540f966472aeb2f11b1477443b84c461f95068a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed build process to correctly append `.exe` extension for Windows binaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->