### PR TITLE
fix(ledger): enable TX validation error returns

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1679,7 +1679,8 @@ func (ls *LedgerState) ledgerProcessBlock(
 						"aux_cbor_hex",
 						auxCborHex,
 					)
-					// return fmt.Errorf("TX validation failure: %w", err)
+					delta.Release()
+					return nil, fmt.Errorf("TX validation failure: %w", err)
 				}
 			}
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable transaction validation errors to bubble up from ledgerProcessBlock. We now release the delta and return an error when validation fails, preventing silent failures and potential resource leaks.

<sup>Written for commit 98a94076c43b29e5967d8217d4fd5a6b302d9d69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

