### PR TITLE
feat(ledger): stake distribution query interface

### DIFF
--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -568,4 +568,3 @@ func TestSnapshotTypesMarkSetGo(t *testing.T) {
 		)
 	}
 }
-

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -252,6 +252,36 @@ type MetadataStore interface {
 
 	// SetUtxosNotDeletedAfterSlot marks all UTxOs created after the given slot as not deleted.
 	SetUtxosNotDeletedAfterSlot(uint64, types.Txn) error
+
+	// Stake snapshot methods
+
+	// GetPoolStakeSnapshot retrieves a specific pool's stake snapshot for an epoch.
+	GetPoolStakeSnapshot(
+		uint64, // epoch
+		string, // snapshotType ("mark", "set", or "go")
+		[]byte, // poolKeyHash
+		types.Txn,
+	) (*models.PoolStakeSnapshot, error)
+
+	// GetPoolStakeSnapshotsByEpoch retrieves all pool stake snapshots for an epoch.
+	GetPoolStakeSnapshotsByEpoch(
+		uint64, // epoch
+		string, // snapshotType
+		types.Txn,
+	) ([]*models.PoolStakeSnapshot, error)
+
+	// GetTotalActiveStake returns the sum of all pool stakes for an epoch.
+	GetTotalActiveStake(
+		uint64, // epoch
+		string, // snapshotType
+		types.Txn,
+	) (uint64, error)
+
+	// GetEpochSummary retrieves the summary for a specific epoch.
+	GetEpochSummary(
+		uint64, // epoch
+		types.Txn,
+	) (*models.EpochSummary, error)
 }
 
 // New creates a new metadata store instance using the specified plugin


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds stake distribution queries to support Ouroboros leader election. Uses the "go" snapshot (stake from 2 epochs ago) for accurate epoch-boundary data.

- **New Features**
  - MetadataStore: GetPoolStakeSnapshot, GetPoolStakeSnapshotsByEpoch, GetTotalActiveStake, GetEpochSummary.
  - LedgerView: GetStakeDistribution(epoch), GetPoolStake(epoch, poolKeyHash), GetTotalActiveStake(epoch); StakeDistribution returns per-pool stakes (pool key hash hex) and total stake.

<sup>Written for commit 1961ff290e8f84576daf3d12bace25663fce7640. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stake distribution support with new query methods for pool stake snapshots and epoch summaries
  * Introduced stake distribution data structure to retrieve per-pool and total stake information by epoch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->