### PR TITLE
feat(database): extract raw bytes from blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Order("added_slot DESC, cert_index DESC")
 - Use `TransactionEvent.Rollback` field to detect undo operations
 
 ### CBOR Storage
-- UTxOs/TXs stored as 48-byte `CborOffset` (slot + hash + offset + length)
+- UTxOs/TXs stored as 52-byte `CborOffset` (magic "DOFF" + slot + hash + offset + length)
 - `TieredCborCache` resolves: hot cache → block LRU → cold extraction
 
 ### Stake Snapshots

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -287,10 +287,11 @@ Instead of storing full CBOR data redundantly, Dingo uses offset-based reference
 
 ### CborOffset Structure
 
-Each CBOR reference is a fixed 48-byte `CborOffset` struct:
+Each CBOR reference is a fixed 52-byte `CborOffset` struct with magic prefix:
 
 | Field | Size | Purpose |
 |-------|------|---------|
+| Magic | 4 bytes | "DOFF" prefix to identify offset storage |
 | BlockSlot | 8 bytes | Block slot number |
 | BlockHash | 32 bytes | Block hash |
 | ByteOffset | 4 bytes | Offset within block CBOR |

--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ For Windows, download the appropriate binary from the [Mithril releases page](ht
 Bootstrapping requires temporary disk space for both the downloaded snapshot and the Dingo database:
 
 | Network | Snapshot Size | Dingo DB | Total Needed |
-|---------|---------------|----------|--------------|
-| mainnet | ~180 GB | ~200+ GB | ~400 GB |
-| preprod | ~60 GB | ~80 GB | ~150 GB |
-| preview | ~15 GB | ~25 GB | ~50 GB |
+|---------|--------------|----------|--------------|
+| mainnet |      ~180 GB | ~200+ GB |      ~400 GB |
+| preprod |       ~60 GB |   ~80 GB |      ~150 GB |
+| preview |       ~15 GB |   ~25 GB |       ~50 GB |
 
 **Note**: These are approximate values that grow over time. The snapshot can be deleted after import, but you need sufficient space for both during the load process.
 
 ### Bootstrap Workflow
 
-**Step 1: Download the snapshot**
+#### Step 1: Download the snapshot
 
 Set the aggregator endpoint for your network and download:
 
@@ -143,7 +143,7 @@ export AGGREGATOR_ENDPOINT=https://aggregator.release-mainnet.api.mithril.networ
 mithril-client cardano-db download --download-dir /path/to/download
 ```
 
-**Step 2: Load into Dingo**
+#### Step 2: Load into Dingo
 
 ```bash
 # Load the immutable DB into Dingo
@@ -152,7 +152,7 @@ mithril-client cardano-db download --download-dir /path/to/download
 
 The load process will import all blocks from the snapshot. Progress is logged as blocks are processed.
 
-**Step 3: Start Dingo**
+#### Step 3: Start Dingo
 
 After loading completes, start Dingo normally and it will sync the remaining blocks from the network:
 
@@ -160,7 +160,7 @@ After loading completes, start Dingo normally and it will sync the remaining blo
 CARDANO_NETWORK=mainnet ./dingo
 ```
 
-**Step 4: Clean up (optional)**
+#### Step 4: Clean up (optional)
 
 Once Dingo is running and synced, you can delete the downloaded snapshot to reclaim disk space:
 

--- a/database/block_indexer.go
+++ b/database/block_indexer.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// safeIntToUint32 converts an int to uint32, clamping to math.MaxUint32 on overflow.
+// This is safe because we use this for byte offsets/lengths within blocks that
+// are bounded by Cardano's protocol limits (~90KB max block body).
+func safeIntToUint32(n int) uint32 {
+	if n < 0 {
+		return 0
+	}
+	if n > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(n) // #nosec G115: bounds checked above
+}
+
+// BlockIngestionResult contains pre-computed offsets for all items in a block.
+// This is computed during block ingestion and used to store offset references
+// instead of duplicating CBOR data.
+type BlockIngestionResult struct {
+	// TxOffsets maps transaction hash to its CborOffset within the block.
+	// This stores only the transaction body offset for backward compatibility.
+	TxOffsets map[[32]byte]CborOffset
+
+	// TxParts maps transaction hash to all 4 component offsets within the block.
+	// This enables byte-perfect reconstruction of complete standalone transaction
+	// CBOR from the source block by extracting and reassembling:
+	// body, witness, is_valid, and metadata (optional).
+	TxParts map[[32]byte]TxCborParts
+
+	// UtxoOffsets maps UTxO reference to its CborOffset within the block
+	UtxoOffsets map[UtxoRef]CborOffset
+
+	// DatumOffsets maps datum hash to its CborOffset within the block
+	DatumOffsets map[[32]byte]CborOffset
+
+	// RedeemerOffsets maps redeemer key to its CborOffset within the block
+	RedeemerOffsets map[common.RedeemerKey]CborOffset
+
+	// ScriptOffsets maps script hash to its CborOffset within the block
+	ScriptOffsets map[[32]byte]CborOffset
+}
+
+// BlockIndexer computes byte offsets for all items within a block.
+// It uses gouroboros's ExtractTransactionOffsets for efficient offset extraction.
+type BlockIndexer struct {
+	blockSlot uint64
+	blockHash [32]byte
+}
+
+// NewBlockIndexer creates a new BlockIndexer for the given block.
+func NewBlockIndexer(slot uint64, hash []byte) *BlockIndexer {
+	bi := &BlockIndexer{
+		blockSlot: slot,
+	}
+	copy(bi.blockHash[:], hash)
+	return bi
+}
+
+// ComputeOffsets extracts byte offsets for all transactions, UTxOs, datums,
+// redeemers, and scripts within the block CBOR.
+func (bi *BlockIndexer) ComputeOffsets(
+	blockCbor []byte,
+	block ledger.Block,
+) (*BlockIngestionResult, error) {
+	if block == nil {
+		return nil, errors.New("block cannot be nil")
+	}
+
+	result := &BlockIngestionResult{
+		TxOffsets:       make(map[[32]byte]CborOffset),
+		TxParts:         make(map[[32]byte]TxCborParts),
+		UtxoOffsets:     make(map[UtxoRef]CborOffset),
+		DatumOffsets:    make(map[[32]byte]CborOffset),
+		RedeemerOffsets: make(map[common.RedeemerKey]CborOffset),
+		ScriptOffsets:   make(map[[32]byte]CborOffset),
+	}
+
+	// Extract transaction-level offsets from block CBOR
+	txOffsets, err := common.ExtractTransactionOffsets(blockCbor)
+	if err != nil {
+		return nil, fmt.Errorf("extract transaction offsets: %w", err)
+	}
+
+	// Get transactions from the parsed block
+	txs := block.Transactions()
+	if len(txs) == 0 {
+		return result, nil
+	}
+
+	// Verify we have offsets for all transactions
+	if len(txOffsets.Transactions) < len(txs) {
+		return nil, fmt.Errorf(
+			"transaction count mismatch: block has %d transactions but only %d offsets extracted",
+			len(txs), len(txOffsets.Transactions),
+		)
+	}
+
+	// Process each transaction
+	for txIdx, tx := range txs {
+		txLoc := txOffsets.Transactions[txIdx]
+		txHash := tx.Hash()
+		var txHashArray [32]byte
+		copy(txHashArray[:], txHash.Bytes())
+
+		// Store transaction body offset for backward compatibility.
+		result.TxOffsets[txHashArray] = CborOffset{
+			BlockSlot:  bi.blockSlot,
+			BlockHash:  bi.blockHash,
+			ByteOffset: txLoc.Body.Offset,
+			ByteLength: txLoc.Body.Length,
+		}
+
+		// Store all 4 transaction components for complete CBOR reconstruction.
+		//
+		// Cardano blocks store transaction components in separate arrays:
+		//   [header, [bodies...], [witnesses...], {aux_data_map}, [invalid_txs]]
+		//
+		// TxParts stores offsets for each component so they can be extracted
+		// from the block and reassembled into a complete standalone transaction
+		// CBOR: [body, witness, is_valid, aux_data]
+		result.TxParts[txHashArray] = TxCborParts{
+			BlockSlot:      bi.blockSlot,
+			BlockHash:      bi.blockHash,
+			BodyOffset:     txLoc.Body.Offset,
+			BodyLength:     txLoc.Body.Length,
+			WitnessOffset:  txLoc.Witness.Offset,
+			WitnessLength:  txLoc.Witness.Length,
+			MetadataOffset: txLoc.Metadata.Offset,
+			MetadataLength: txLoc.Metadata.Length,
+			IsValid:        tx.IsValid(),
+		}
+
+		// Extract UTxO output offsets from transaction body
+		if err := bi.extractOutputOffsets(blockCbor, txLoc, tx, result); err != nil {
+			return nil, fmt.Errorf("extract output offsets for tx %s: %w", txHash.String(), err)
+		}
+
+		// Store datum offsets from witness set
+		for datumHash, loc := range txLoc.Datums {
+			var hashArray [32]byte
+			copy(hashArray[:], datumHash[:])
+			result.DatumOffsets[hashArray] = CborOffset{
+				BlockSlot:  bi.blockSlot,
+				BlockHash:  bi.blockHash,
+				ByteOffset: loc.Offset,
+				ByteLength: loc.Length,
+			}
+		}
+
+		// Store redeemer offsets from witness set
+		for redeemerKey, loc := range txLoc.Redeemers {
+			result.RedeemerOffsets[redeemerKey] = CborOffset{
+				BlockSlot:  bi.blockSlot,
+				BlockHash:  bi.blockHash,
+				ByteOffset: loc.Offset,
+				ByteLength: loc.Length,
+			}
+		}
+
+		// Store script offsets from witness set
+		for scriptHash, loc := range txLoc.Scripts {
+			var hashArray [32]byte
+			copy(hashArray[:], scriptHash[:])
+			result.ScriptOffsets[hashArray] = CborOffset{
+				BlockSlot:  bi.blockSlot,
+				BlockHash:  bi.blockHash,
+				ByteOffset: loc.Offset,
+				ByteLength: loc.Length,
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// extractOutputOffsets extracts byte offsets for each transaction output.
+// Uses pre-computed output offsets from gouroboros when available,
+// with fallback to byte searching for compatibility.
+// Returns an error if offsets cannot be computed for any output.
+func (bi *BlockIndexer) extractOutputOffsets(
+	blockCbor []byte,
+	txLoc common.TransactionLocation,
+	tx common.Transaction,
+	result *BlockIngestionResult,
+) error {
+	txHash := tx.Hash()
+	var txHashArray [32]byte
+	copy(txHashArray[:], txHash.Bytes())
+
+	// Get produced UTxOs (includes both regular outputs and collateral return)
+	produced := tx.Produced()
+	if len(produced) == 0 {
+		return nil
+	}
+
+	// Use pre-computed output offsets from gouroboros if available
+	// This is much faster than byte searching
+	if len(txLoc.Outputs) > 0 {
+		allOffsetsFound := true
+		for _, utxo := range produced {
+			outputIdx := int(utxo.Id.Index())
+
+			// For valid transactions, output index maps directly to Outputs array
+			// For invalid transactions with collateral return, the index is len(Outputs)
+			// which means we need to handle this case specially
+			if outputIdx < len(txLoc.Outputs) {
+				loc := txLoc.Outputs[outputIdx]
+				ref := UtxoRef{
+					TxId:      txHashArray,
+					OutputIdx: utxo.Id.Index(),
+				}
+				result.UtxoOffsets[ref] = CborOffset{
+					BlockSlot:  bi.blockSlot,
+					BlockHash:  bi.blockHash,
+					ByteOffset: loc.Offset,
+					ByteLength: loc.Length,
+				}
+			} else {
+				// Output index not in pre-computed offsets
+				allOffsetsFound = false
+			}
+		}
+		// Only return early if ALL outputs had pre-computed offsets
+		if allOffsetsFound {
+			return nil
+		}
+		// Fall through to byte searching for missing outputs
+	}
+
+	// Fallback: search for output CBOR within the body (slower but always works)
+	// Returns error if offset cannot be computed for any output.
+	// We need to track how many times we've seen each unique CBOR pattern
+	// to handle duplicate outputs (which are valid in Cardano).
+	seenCborCounts := make(map[string]int)
+
+	for _, utxo := range produced {
+		ref := UtxoRef{
+			TxId:      txHashArray,
+			OutputIdx: utxo.Id.Index(),
+		}
+
+		outputCbor := utxo.Output.Cbor()
+
+		// Skip if we already have an offset for this output, but still
+		// increment seenCborCounts so subsequent duplicate outputs resolve
+		// to the correct occurrence
+		if _, ok := result.UtxoOffsets[ref]; ok {
+			if len(outputCbor) > 0 {
+				seenCborCounts[string(outputCbor)]++
+			}
+			continue
+		}
+		if len(outputCbor) == 0 {
+			return fmt.Errorf(
+				"output %d has no CBOR data - cannot compute offset",
+				utxo.Id.Index(),
+			)
+		}
+
+		bodyStart := txLoc.Body.Offset
+		bodyEnd := txLoc.Body.Offset + txLoc.Body.Length
+		if bodyEnd > safeIntToUint32(len(blockCbor)) {
+			return fmt.Errorf(
+				"output %d: body end (%d) exceeds block size (%d)",
+				utxo.Id.Index(),
+				bodyEnd,
+				len(blockCbor),
+			)
+		}
+
+		bodyBytes := blockCbor[bodyStart:bodyEnd]
+
+		// Track which occurrence of this CBOR pattern we need
+		cborKey := string(outputCbor)
+		targetOccurrence := seenCborCounts[cborKey]
+		seenCborCounts[cborKey]++
+
+		// Find the nth occurrence of this CBOR pattern
+		offset := findNthCborOccurrence(bodyBytes, outputCbor, targetOccurrence)
+		if offset < 0 {
+			return fmt.Errorf(
+				"output %d: CBOR occurrence %d not found in transaction body",
+				utxo.Id.Index(),
+				targetOccurrence,
+			)
+		}
+
+		result.UtxoOffsets[ref] = CborOffset{
+			BlockSlot:  bi.blockSlot,
+			BlockHash:  bi.blockHash,
+			ByteOffset: bodyStart + safeIntToUint32(offset),
+			ByteLength: safeIntToUint32(len(outputCbor)),
+		}
+	}
+
+	return nil
+}
+
+// findNthCborOccurrence finds the nth (0-indexed) occurrence of a CBOR byte
+// sequence within a larger byte slice. Returns the offset if found, -1 otherwise.
+// This handles transactions with duplicate outputs (identical CBOR).
+func findNthCborOccurrence(data, target []byte, n int) int {
+	if len(target) == 0 || len(data) < len(target) || n < 0 {
+		return -1
+	}
+
+	count := 0
+	for i := 0; i <= len(data)-len(target); i++ {
+		match := true
+		for j := 0; j < len(target); j++ {
+			if data[i+j] != target[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			if count == n {
+				return i
+			}
+			count++
+			// Skip past this match to find non-overlapping occurrences
+			i += len(target) - 1
+		}
+	}
+	return -1
+}

--- a/database/block_indexer_test.go
+++ b/database/block_indexer_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockIndexerComputeOffsets(t *testing.T) {
+	// Load blocks from immutable test data
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err, "failed to open immutable database")
+
+	// Get an iterator starting from the beginning
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: []byte{}})
+	require.NoError(t, err, "failed to create block iterator")
+	defer iter.Close()
+
+	// Test offset computation on multiple blocks
+	blocksWithTx := 0
+	maxBlocksToTest := 500
+
+	for i := 0; i < maxBlocksToTest; i++ {
+		immBlock, err := iter.Next()
+		if err != nil {
+			t.Fatalf("unexpected error reading block %d: %s", i, err)
+		}
+		if immBlock == nil {
+			break // End of chain
+		}
+
+		// Parse the block
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		if err != nil {
+			// Skip blocks that can't be parsed (e.g., Byron EBB)
+			continue
+		}
+
+		// Skip blocks without transactions
+		txs := block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+
+		blocksWithTx++
+
+		// Create indexer and compute offsets
+		indexer := NewBlockIndexer(immBlock.Slot, immBlock.Hash)
+		result, err := indexer.ComputeOffsets(immBlock.Cbor, block)
+		require.NoError(t, err, "failed to compute offsets for block %d (slot %d)",
+			i, immBlock.Slot)
+
+		// Verify we got transaction offsets
+		assert.Equal(t, len(txs), len(result.TxOffsets),
+			"transaction count mismatch for block %d (slot %d)", i, immBlock.Slot)
+
+		// Verify each transaction offset
+		for _, tx := range txs {
+			txHash := tx.Hash()
+			var txHashArray [32]byte
+			copy(txHashArray[:], txHash.Bytes())
+
+			offset, ok := result.TxOffsets[txHashArray]
+			assert.True(t, ok, "missing offset for tx %x in block %d", txHash[:8], i)
+
+			if ok {
+				// Verify offset is within block bounds
+				end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
+				assert.LessOrEqual(t, end, uint64(len(immBlock.Cbor)),
+					"tx offset out of bounds for tx %x in block %d", txHash[:8], i)
+
+				// Verify block slot and hash match
+				assert.Equal(t, immBlock.Slot, offset.BlockSlot,
+					"block slot mismatch in offset")
+				var expectedHash [32]byte
+				copy(expectedHash[:], immBlock.Hash)
+				assert.Equal(t, expectedHash, offset.BlockHash,
+					"block hash mismatch in offset")
+			}
+		}
+
+		// Verify UTxO offsets
+		for _, tx := range txs {
+			produced := tx.Produced()
+			for _, utxo := range produced {
+				txHash := tx.Hash()
+				var txHashArray [32]byte
+				copy(txHashArray[:], txHash.Bytes())
+
+				ref := UtxoRef{
+					TxId:      txHashArray,
+					OutputIdx: utxo.Id.Index(),
+				}
+
+				offset, ok := result.UtxoOffsets[ref]
+				if ok {
+					// Verify offset is within block bounds
+					end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
+					assert.LessOrEqual(t, end, uint64(len(immBlock.Cbor)),
+						"utxo offset out of bounds for ref %x:%d in block %d",
+						txHash[:8], utxo.Id.Index(), i)
+
+					// Verify extracted bytes match the UTxO CBOR
+					if end <= uint64(len(immBlock.Cbor)) {
+						extracted := immBlock.Cbor[offset.ByteOffset : offset.ByteOffset+offset.ByteLength]
+						expectedCbor := utxo.Output.Cbor()
+						if len(expectedCbor) > 0 {
+							assert.Equal(t, expectedCbor, extracted,
+								"extracted CBOR mismatch for utxo %x:%d in block %d",
+								txHash[:8], utxo.Id.Index(), i)
+						}
+					}
+				}
+			}
+		}
+
+		// Stop after testing some blocks with transactions
+		if blocksWithTx >= 20 {
+			break
+		}
+	}
+
+	assert.Greater(t, blocksWithTx, 0, "no blocks with transactions were tested")
+	t.Logf("Successfully tested %d blocks with transactions", blocksWithTx)
+}
+
+func TestBlockIndexerEmptyBlock(t *testing.T) {
+	// Test with a block that has no transactions
+	indexer := NewBlockIndexer(0, make([]byte, 32))
+
+	// Test nil block returns error
+	result, err := indexer.ComputeOffsets([]byte{}, nil)
+	assert.Error(t, err, "expected error for nil block")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "block cannot be nil")
+}
+
+// findCborInBytes searches for a CBOR byte sequence within a larger byte slice.
+// Returns the offset if found, -1 otherwise.
+func findCborInBytes(data, target []byte) int {
+	if len(target) == 0 || len(data) < len(target) {
+		return -1
+	}
+
+	for i := 0; i <= len(data)-len(target); i++ {
+		match := true
+		for j := 0; j < len(target); j++ {
+			if data[i+j] != target[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestFindCborInBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		target   []byte
+		expected int
+	}{
+		{
+			name:     "found at start",
+			data:     []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			target:   []byte{0x01, 0x02},
+			expected: 0,
+		},
+		{
+			name:     "found in middle",
+			data:     []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			target:   []byte{0x02, 0x03},
+			expected: 1,
+		},
+		{
+			name:     "found at end",
+			data:     []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			target:   []byte{0x04, 0x05},
+			expected: 3,
+		},
+		{
+			name:     "not found",
+			data:     []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			target:   []byte{0x06, 0x07},
+			expected: -1,
+		},
+		{
+			name:     "empty target",
+			data:     []byte{0x01, 0x02, 0x03},
+			target:   []byte{},
+			expected: -1,
+		},
+		{
+			name:     "target larger than data",
+			data:     []byte{0x01, 0x02},
+			target:   []byte{0x01, 0x02, 0x03},
+			expected: -1,
+		},
+		{
+			name:     "exact match",
+			data:     []byte{0x01, 0x02, 0x03},
+			target:   []byte{0x01, 0x02, 0x03},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findCborInBytes(tt.data, tt.target)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/database/block_offset_test.go
+++ b/database/block_offset_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTransactionOffsets(t *testing.T) {
+	// Load blocks from immutable test data
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err, "failed to open immutable database")
+
+	// Get an iterator starting from the beginning
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: []byte{}})
+	require.NoError(t, err, "failed to create block iterator")
+	defer iter.Close()
+
+	// Test offset extraction on multiple blocks
+	blocksWithTx := 0
+	maxBlocksToTest := 500
+
+	for i := 0; i < maxBlocksToTest; i++ {
+		immBlock, err := iter.Next()
+		if err != nil {
+			t.Fatalf("unexpected error reading block %d: %s", i, err)
+		}
+		if immBlock == nil {
+			break // End of chain
+		}
+
+		// Parse the block
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		if err != nil {
+			// Skip blocks that can't be parsed (e.g., Byron EBB)
+			continue
+		}
+
+		// Skip blocks without transactions (e.g., Byron EBB or empty blocks)
+		txs := block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+
+		blocksWithTx++
+
+		// Extract offsets
+		offsets, err := common.ExtractTransactionOffsets(immBlock.Cbor)
+		require.NoError(t, err, "failed to extract offsets from block %d (slot %d)",
+			i, immBlock.Slot)
+
+		// Verify we got offsets for all transactions
+		assert.Equal(t, len(txs), len(offsets.Transactions),
+			"transaction count mismatch for block %d (slot %d)", i, immBlock.Slot)
+
+		// Verify each offset points to valid data
+		for txIdx, tx := range txs {
+			if txIdx >= len(offsets.Transactions) {
+				continue
+			}
+
+			loc := offsets.Transactions[txIdx]
+
+			// Verify body offset is within block bounds
+			bodyEnd := uint64(loc.Body.Offset) + uint64(loc.Body.Length)
+			assert.LessOrEqual(t, bodyEnd, uint64(len(immBlock.Cbor)),
+				"body offset out of bounds for tx %d in block %d", txIdx, i)
+
+			// Extract body CBOR and verify it matches transaction body
+			if loc.Body.Offset > 0 && loc.Body.Length > 0 && bodyEnd <= uint64(len(immBlock.Cbor)) {
+				extractedBody := immBlock.Cbor[loc.Body.Offset : loc.Body.Offset+loc.Body.Length]
+
+				// The extracted data should be valid CBOR (basic sanity check)
+				assert.Greater(t, len(extractedBody), 0,
+					"extracted body is empty for tx %d in block %d", txIdx, i)
+
+				// Compare with transaction's stored CBOR if available
+				txCbor := tx.Cbor()
+				if len(txCbor) > 0 {
+					// Transaction CBOR includes both body and witnesses,
+					// so extracted body should be a prefix or we need to
+					// compare differently based on era
+					assert.LessOrEqual(t, len(extractedBody), len(txCbor)+1000,
+						"extracted body unexpectedly larger than tx cbor for tx %d in block %d",
+						txIdx, i)
+				}
+			}
+
+			// Verify witness offset is within block bounds
+			witnessEnd := uint64(loc.Witness.Offset) + uint64(loc.Witness.Length)
+			assert.LessOrEqual(t, witnessEnd, uint64(len(immBlock.Cbor)),
+				"witness offset out of bounds for tx %d in block %d", txIdx, i)
+
+			// Verify datum, redeemer, and script offsets if present
+			for hash, datumLoc := range loc.Datums {
+				datumEnd := uint64(datumLoc.Offset) + uint64(datumLoc.Length)
+				assert.LessOrEqual(t, datumEnd, uint64(len(immBlock.Cbor)),
+					"datum offset out of bounds for hash %x in tx %d block %d",
+					hash[:8], txIdx, i)
+			}
+
+			for key, redeemerLoc := range loc.Redeemers {
+				redeemerEnd := uint64(redeemerLoc.Offset) + uint64(redeemerLoc.Length)
+				assert.LessOrEqual(t, redeemerEnd, uint64(len(immBlock.Cbor)),
+					"redeemer offset out of bounds for key (%d,%d) in tx %d block %d",
+					key.Tag, key.Index, txIdx, i)
+			}
+
+			for hash, scriptLoc := range loc.Scripts {
+				scriptEnd := uint64(scriptLoc.Offset) + uint64(scriptLoc.Length)
+				assert.LessOrEqual(t, scriptEnd, uint64(len(immBlock.Cbor)),
+					"script offset out of bounds for hash %x in tx %d block %d",
+					hash[:8], txIdx, i)
+			}
+		}
+
+		// Stop after testing some blocks with transactions
+		if blocksWithTx >= 20 {
+			break
+		}
+	}
+
+	assert.Greater(t, blocksWithTx, 0, "no blocks with transactions were tested")
+	t.Logf("Successfully tested %d blocks with transactions", blocksWithTx)
+}
+
+func TestExtractTransactionOffsetsEmptyBlock(t *testing.T) {
+	// Test that the function handles blocks with empty/minimal structure
+	// Byron EBB blocks have a different structure
+
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err, "failed to open immutable database")
+
+	// Get first block (typically Byron genesis or EBB)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: []byte{}})
+	require.NoError(t, err, "failed to create block iterator")
+	defer iter.Close()
+
+	immBlock, err := iter.Next()
+	require.NoError(t, err, "failed to get first block")
+	require.NotNil(t, immBlock, "expected at least one block")
+
+	// Should not panic on Byron blocks
+	offsets, err := common.ExtractTransactionOffsets(immBlock.Cbor)
+	// Error is acceptable for unsupported block formats
+	if err == nil {
+		assert.NotNil(t, offsets, "offsets should not be nil when no error")
+	}
+}

--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -17,7 +17,13 @@ package database
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"sync"
 	"sync/atomic"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // ErrNotImplemented is returned when functionality is not yet implemented.
@@ -38,6 +44,122 @@ type CacheMetrics struct {
 	BlockLRUHits    atomic.Uint64
 	BlockLRUMisses  atomic.Uint64
 	ColdExtractions atomic.Uint64
+
+	// Prometheus metrics (nil until Register is called)
+	utxoHotHitsCounter     prometheus.Counter
+	utxoHotMissesCounter   prometheus.Counter
+	txHotHitsCounter       prometheus.Counter
+	txHotMissesCounter     prometheus.Counter
+	blockLRUHitsCounter    prometheus.Counter
+	blockLRUMissesCounter  prometheus.Counter
+	coldExtractionsCounter prometheus.Counter
+
+	// registerOnce ensures Prometheus metrics are only registered once
+	registerOnce sync.Once
+}
+
+// Register registers Prometheus metrics with the given registry.
+// If registry is nil, this is a no-op. This method is idempotent;
+// subsequent calls after the first successful registration are no-ops.
+func (m *CacheMetrics) Register(registry prometheus.Registerer) {
+	if registry == nil {
+		return
+	}
+
+	m.registerOnce.Do(func() {
+		factory := promauto.With(registry)
+
+		m.utxoHotHitsCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_utxo_hot_hits_total",
+			Help: "Total number of UTxO CBOR hot cache hits",
+		})
+
+		m.utxoHotMissesCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_utxo_hot_misses_total",
+			Help: "Total number of UTxO CBOR hot cache misses",
+		})
+
+		m.txHotHitsCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_tx_hot_hits_total",
+			Help: "Total number of TX CBOR hot cache hits",
+		})
+
+		m.txHotMissesCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_tx_hot_misses_total",
+			Help: "Total number of TX CBOR hot cache misses",
+		})
+
+		m.blockLRUHitsCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_block_lru_hits_total",
+			Help: "Total number of block LRU cache hits",
+		})
+
+		m.blockLRUMissesCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_block_lru_misses_total",
+			Help: "Total number of block LRU cache misses",
+		})
+
+		m.coldExtractionsCounter = factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_cbor_cache_cold_extractions_total",
+			Help: "Total number of cold CBOR extractions from blob store",
+		})
+	})
+}
+
+// IncUtxoHotHit increments the UTxO hot cache hit counter.
+func (m *CacheMetrics) IncUtxoHotHit() {
+	m.UtxoHotHits.Add(1)
+	if m.utxoHotHitsCounter != nil {
+		m.utxoHotHitsCounter.Inc()
+	}
+}
+
+// IncUtxoHotMiss increments the UTxO hot cache miss counter.
+func (m *CacheMetrics) IncUtxoHotMiss() {
+	m.UtxoHotMisses.Add(1)
+	if m.utxoHotMissesCounter != nil {
+		m.utxoHotMissesCounter.Inc()
+	}
+}
+
+// IncTxHotHit increments the TX hot cache hit counter.
+func (m *CacheMetrics) IncTxHotHit() {
+	m.TxHotHits.Add(1)
+	if m.txHotHitsCounter != nil {
+		m.txHotHitsCounter.Inc()
+	}
+}
+
+// IncTxHotMiss increments the TX hot cache miss counter.
+func (m *CacheMetrics) IncTxHotMiss() {
+	m.TxHotMisses.Add(1)
+	if m.txHotMissesCounter != nil {
+		m.txHotMissesCounter.Inc()
+	}
+}
+
+// IncBlockLRUHit increments the block LRU cache hit counter.
+func (m *CacheMetrics) IncBlockLRUHit() {
+	m.BlockLRUHits.Add(1)
+	if m.blockLRUHitsCounter != nil {
+		m.blockLRUHitsCounter.Inc()
+	}
+}
+
+// IncBlockLRUMiss increments the block LRU cache miss counter.
+func (m *CacheMetrics) IncBlockLRUMiss() {
+	m.BlockLRUMisses.Add(1)
+	if m.blockLRUMissesCounter != nil {
+		m.blockLRUMissesCounter.Inc()
+	}
+}
+
+// IncColdExtraction increments the cold extraction counter.
+func (m *CacheMetrics) IncColdExtraction() {
+	m.ColdExtractions.Add(1)
+	if m.coldExtractionsCounter != nil {
+		m.coldExtractionsCounter.Inc()
+	}
 }
 
 // CborCacheConfig holds configuration for the TieredCborCache.
@@ -54,8 +176,9 @@ type CborCacheConfig struct {
 // Cache tiers:
 //   - Tier 1: Hot caches (hotUtxo for UTxO CBOR, hotTx for transaction CBOR)
 //   - Tier 2: Block LRU cache (shared block cache with pre-computed indexes)
-//   - Tier 3: Cold extraction from blob store (not yet wired up)
+//   - Tier 3: Cold extraction from blob store
 type TieredCborCache struct {
+	db       *Database      // Database for blob store access
 	hotUtxo  *HotCache      // Tier 1: frequently accessed UTxO CBOR
 	hotTx    *HotCache      // Tier 1: frequently accessed transaction CBOR
 	blockLRU *BlockLRUCache // Tier 2: recent blocks with index (shared)
@@ -63,8 +186,10 @@ type TieredCborCache struct {
 }
 
 // NewTieredCborCache creates a new TieredCborCache with the given configuration.
-func NewTieredCborCache(config CborCacheConfig) *TieredCborCache {
+// The db parameter provides access to the blob store for cold path resolution.
+func NewTieredCborCache(config CborCacheConfig, db *Database) *TieredCborCache {
 	return &TieredCborCache{
+		db:       db,
 		hotUtxo:  NewHotCache(config.HotUtxoEntries, 0),
 		hotTx:    NewHotCache(config.HotTxEntries, config.HotTxMaxBytes),
 		blockLRU: NewBlockLRUCache(config.BlockLRUEntries),
@@ -73,69 +198,492 @@ func NewTieredCborCache(config CborCacheConfig) *TieredCborCache {
 }
 
 // ResolveUtxoCbor resolves UTxO CBOR data by transaction ID and output index.
-// It first checks the hot UTxO cache. On cache miss, it returns ErrNotImplemented
-// since the cold path (fetching offsets and extracting from blocks) is not yet wired up.
+// It checks caches in order: hot UTxO cache, block LRU cache, then blob store.
+// An optional blob transaction can be provided to see uncommitted writes within
+// the same transaction (important for intra-batch UTxO lookups during validation).
 func (c *TieredCborCache) ResolveUtxoCbor(
 	txId []byte,
 	outputIdx uint32,
+	blobTxn ...types.Txn,
 ) ([]byte, error) {
 	key := makeUtxoKey(txId, outputIdx)
 
 	// Tier 1: Hot cache check
 	if cbor, ok := c.hotUtxo.Get(key); ok {
-		c.metrics.UtxoHotHits.Add(1)
+		c.metrics.IncUtxoHotHit()
 		return cbor, nil
 	}
 
 	// Hot cache miss
-	c.metrics.UtxoHotMisses.Add(1)
+	c.metrics.IncUtxoHotMiss()
 
-	// TODO: Implement cold path
-	// 1. Get offset from blob store: db.GetUtxoOffset(txId, outputIdx, nil)
-	// 2. Check block LRU cache
-	// 3. If miss, fetch block from blob store and extract CBOR
-	// 4. Populate hot cache with extracted CBOR
+	// Tier 3: Cold path - fetch from blob store
+	if c.db == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
 
-	return nil, ErrNotImplemented
+	blob := c.db.Blob()
+	if blob == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
+
+	// Use provided transaction if available, otherwise create a new one
+	var txn types.Txn
+	var ownedTxn bool
+	if len(blobTxn) > 0 && blobTxn[0] != nil {
+		txn = blobTxn[0]
+	} else {
+		txn = blob.NewTransaction(false)
+		ownedTxn = true
+		defer func() {
+			if ownedTxn {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+
+	utxoData, err := blob.GetUtxo(txn, txId, outputIdx)
+	if err != nil {
+		return nil, fmt.Errorf("get utxo from blob: %w", err)
+	}
+
+	// Check if this is offset-based storage
+	if !IsUtxoOffsetStorage(utxoData) {
+		// Legacy format: raw CBOR data - populate hot cache and return
+		c.hotUtxo.Put(key, utxoData)
+		return utxoData, nil
+	}
+
+	// Decode the offset reference
+	offset, err := DecodeUtxoOffset(utxoData)
+	if err != nil {
+		return nil, fmt.Errorf("decode utxo offset: %w", err)
+	}
+
+	// Tier 2: Check block LRU cache
+	if cachedBlock, ok := c.blockLRU.Get(offset.BlockSlot, offset.BlockHash); ok {
+		c.metrics.IncBlockLRUHit()
+		cbor := cachedBlock.Extract(offset.ByteOffset, offset.ByteLength)
+		if cbor != nil {
+			// Populate hot cache
+			c.hotUtxo.Put(key, cbor)
+			return cbor, nil
+		}
+	}
+
+	// Block LRU miss
+	c.metrics.IncBlockLRUMiss()
+
+	// Fetch block from blob store
+	blockCbor, _, err := blob.GetBlock(txn, offset.BlockSlot, offset.BlockHash[:])
+	if err != nil {
+		return nil, fmt.Errorf("get block for utxo extraction: %w", err)
+	}
+
+	c.metrics.IncColdExtraction()
+
+	// Create cached block and add to LRU
+	cachedBlock := newCachedBlock(blockCbor)
+	c.blockLRU.Put(offset.BlockSlot, offset.BlockHash, cachedBlock)
+
+	// Extract the UTxO CBOR from the block
+	cbor := cachedBlock.Extract(offset.ByteOffset, offset.ByteLength)
+	if cbor == nil {
+		return nil, fmt.Errorf(
+			"utxo offset out of bounds: offset=%d, length=%d, block_size=%d",
+			offset.ByteOffset,
+			offset.ByteLength,
+			len(blockCbor),
+		)
+	}
+
+	// Populate hot cache
+	c.hotUtxo.Put(key, cbor)
+	return cbor, nil
 }
 
-// ResolveTxCbor resolves transaction CBOR data by transaction hash.
-// It first checks the hot TX cache. On cache miss, it returns ErrNotImplemented
-// since the cold path (fetching offsets and extracting from blocks) is not yet wired up.
+// ResolveTxCbor resolves transaction body CBOR data by transaction hash.
+// It checks caches in order: hot TX cache, block LRU cache, then blob store.
+//
+// NOTE: This returns only the transaction BODY CBOR, not a complete standalone
+// transaction. Cardano blocks store bodies and witnesses in separate arrays,
+// so reconstructing a complete transaction ([body, witness, is_valid, aux_data])
+// would require fetching multiple components. Use tx.Cbor() from the parsed
+// block if you need complete transaction CBOR for decoding.
 func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
 	// Tier 1: Hot cache check
 	if cbor, ok := c.hotTx.Get(txHash); ok {
-		c.metrics.TxHotHits.Add(1)
+		c.metrics.IncTxHotHit()
 		return cbor, nil
 	}
 
 	// Hot cache miss
-	c.metrics.TxHotMisses.Add(1)
+	c.metrics.IncTxHotMiss()
 
-	// TODO: Implement cold path
-	// 1. Get offset from blob store: db.GetTxOffset(txHash, nil)
-	// 2. Check block LRU cache
-	// 3. If miss, fetch block from blob store and extract CBOR
-	// 4. Populate hot cache with extracted CBOR
+	// Tier 3: Cold path - fetch from blob store
+	if c.db == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
 
-	return nil, ErrNotImplemented
+	blob := c.db.Blob()
+	if blob == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
+
+	// Get TX offset data from blob store
+	txn := blob.NewTransaction(false)
+	defer txn.Rollback() //nolint:errcheck
+
+	txData, err := blob.GetTx(txn, txHash)
+	if err != nil {
+		return nil, fmt.Errorf("get tx from blob: %w", err)
+	}
+
+	// Check if this is offset-based storage
+	if !IsTxOffsetStorage(txData) {
+		// Legacy format: raw CBOR data - populate hot cache and return
+		c.hotTx.Put(txHash, txData)
+		return txData, nil
+	}
+
+	// Decode the offset reference
+	offset, err := DecodeTxOffset(txData)
+	if err != nil {
+		return nil, fmt.Errorf("decode tx offset: %w", err)
+	}
+
+	// Tier 2: Check block LRU cache
+	if cachedBlock, ok := c.blockLRU.Get(offset.BlockSlot, offset.BlockHash); ok {
+		c.metrics.IncBlockLRUHit()
+		cbor := cachedBlock.Extract(offset.ByteOffset, offset.ByteLength)
+		if cbor != nil {
+			// Populate hot cache
+			c.hotTx.Put(txHash, cbor)
+			return cbor, nil
+		}
+	}
+
+	// Block LRU miss
+	c.metrics.IncBlockLRUMiss()
+
+	// Fetch block from blob store
+	blockCbor, _, err := blob.GetBlock(txn, offset.BlockSlot, offset.BlockHash[:])
+	if err != nil {
+		return nil, fmt.Errorf("get block for tx extraction: %w", err)
+	}
+
+	c.metrics.IncColdExtraction()
+
+	// Create cached block and add to LRU
+	cachedBlock := newCachedBlock(blockCbor)
+	c.blockLRU.Put(offset.BlockSlot, offset.BlockHash, cachedBlock)
+
+	// Extract the TX CBOR from the block
+	cbor := cachedBlock.Extract(offset.ByteOffset, offset.ByteLength)
+	if cbor == nil {
+		return nil, fmt.Errorf(
+			"tx offset out of bounds: offset=%d, length=%d, block_size=%d",
+			offset.ByteOffset,
+			offset.ByteLength,
+			len(blockCbor),
+		)
+	}
+
+	// Populate hot cache
+	c.hotTx.Put(txHash, cbor)
+	return cbor, nil
 }
 
 // ResolveUtxoCborBatch resolves multiple UTxO CBOR entries in a single batch.
-// This is a stub that returns ErrNotImplemented. The full implementation will
-// group requests by block to minimize blob store fetches.
+// It groups requests by block to minimize blob store fetches.
 func (c *TieredCborCache) ResolveUtxoCborBatch(
 	refs []UtxoRef,
 ) (map[UtxoRef][]byte, error) {
-	// TODO: Implement batch resolution
-	// 1. Check hot cache for each ref, collect misses
-	// 2. Look up offset structs for all misses
-	// 3. Group misses by (block_slot, block_hash)
-	// 4. Fetch each unique block once
-	// 5. Extract all items from each block
-	// 6. Populate hot cache and return combined results
-	_ = refs // unused for now
-	return nil, ErrNotImplemented
+	result := make(map[UtxoRef][]byte, len(refs))
+
+	if len(refs) == 0 {
+		return result, nil
+	}
+
+	// Phase 1: Check hot cache for each ref, collect misses
+	var misses []UtxoRef
+	for _, ref := range refs {
+		key := makeUtxoKey(ref.TxId[:], ref.OutputIdx)
+		if cbor, ok := c.hotUtxo.Get(key); ok {
+			c.metrics.IncUtxoHotHit()
+			result[ref] = cbor
+		} else {
+			c.metrics.IncUtxoHotMiss()
+			misses = append(misses, ref)
+		}
+	}
+
+	if len(misses) == 0 {
+		return result, nil
+	}
+
+	// Check database availability
+	if c.db == nil {
+		return result, types.ErrBlobStoreUnavailable
+	}
+
+	blob := c.db.Blob()
+	if blob == nil {
+		return result, types.ErrBlobStoreUnavailable
+	}
+
+	txn := blob.NewTransaction(false)
+	defer txn.Rollback() //nolint:errcheck
+
+	// Phase 2: Look up offset structs for all misses, group by block
+	type blockGroup struct {
+		slot uint64
+		hash [32]byte
+		refs []struct {
+			ref    UtxoRef
+			offset CborOffset
+		}
+	}
+	blockGroups := make(map[blockKey]*blockGroup)
+
+	for _, ref := range misses {
+		utxoData, err := blob.GetUtxo(txn, ref.TxId[:], ref.OutputIdx)
+		if err != nil {
+			// Skip UTxOs that can't be found, propagate other errors
+			if errors.Is(err, types.ErrBlobKeyNotFound) {
+				continue
+			}
+			return result, fmt.Errorf(
+				"get utxo %x#%d: %w",
+				ref.TxId[:8],
+				ref.OutputIdx,
+				err,
+			)
+		}
+
+		// Check if this is offset-based storage
+		if !IsUtxoOffsetStorage(utxoData) {
+			// Legacy format: raw CBOR data
+			key := makeUtxoKey(ref.TxId[:], ref.OutputIdx)
+			c.hotUtxo.Put(key, utxoData)
+			result[ref] = utxoData
+			continue
+		}
+
+		// Decode the offset reference
+		offset, err := DecodeUtxoOffset(utxoData)
+		if err != nil {
+			return result, fmt.Errorf(
+				"decode utxo offset %x#%d: %w",
+				ref.TxId[:8],
+				ref.OutputIdx,
+				err,
+			)
+		}
+
+		// Group by block
+		bk := blockKey{slot: offset.BlockSlot, hash: offset.BlockHash}
+		if blockGroups[bk] == nil {
+			blockGroups[bk] = &blockGroup{
+				slot: offset.BlockSlot,
+				hash: offset.BlockHash,
+			}
+		}
+		blockGroups[bk].refs = append(blockGroups[bk].refs, struct {
+			ref    UtxoRef
+			offset CborOffset
+		}{ref: ref, offset: *offset})
+	}
+
+	// Phase 3: Fetch each unique block once and extract all items
+	for bk, group := range blockGroups {
+		// Check block LRU cache first
+		cachedBlock, ok := c.blockLRU.Get(group.slot, group.hash)
+		if ok {
+			c.metrics.IncBlockLRUHit()
+		} else {
+			c.metrics.IncBlockLRUMiss()
+
+			// Fetch block from blob store
+			blockCbor, _, err := blob.GetBlock(txn, group.slot, group.hash[:])
+			if err != nil {
+				return nil, fmt.Errorf(
+					"get block for utxo batch extraction (slot=%d, hash=%x): %w",
+					group.slot,
+					group.hash,
+					err,
+				)
+			}
+
+			c.metrics.IncColdExtraction()
+
+			// Create cached block and add to LRU
+			cachedBlock = newCachedBlock(blockCbor)
+			c.blockLRU.Put(bk.slot, bk.hash, cachedBlock)
+		}
+
+		// Extract all UTxOs from this block
+		for _, item := range group.refs {
+			cbor := cachedBlock.Extract(item.offset.ByteOffset, item.offset.ByteLength)
+			if cbor == nil {
+				return nil, fmt.Errorf(
+					"utxo batch extraction failed: offset out of bounds "+
+						"(slot=%d, hash=%x, offset=%d, length=%d)",
+					group.slot,
+					group.hash,
+					item.offset.ByteOffset,
+					item.offset.ByteLength,
+				)
+			}
+
+			// Populate hot cache
+			key := makeUtxoKey(item.ref.TxId[:], item.ref.OutputIdx)
+			c.hotUtxo.Put(key, cbor)
+			result[item.ref] = cbor
+		}
+	}
+
+	return result, nil
+}
+
+// ResolveTxCborBatch resolves multiple transaction CBOR entries in a single batch.
+// It groups requests by block to minimize blob store fetches.
+func (c *TieredCborCache) ResolveTxCborBatch(
+	txHashes [][32]byte,
+) (map[[32]byte][]byte, error) {
+	result := make(map[[32]byte][]byte, len(txHashes))
+
+	if len(txHashes) == 0 {
+		return result, nil
+	}
+
+	// Phase 1: Check hot cache for each hash, collect misses
+	var misses [][32]byte
+	for _, txHash := range txHashes {
+		if cbor, ok := c.hotTx.Get(txHash[:]); ok {
+			c.metrics.IncTxHotHit()
+			result[txHash] = cbor
+		} else {
+			c.metrics.IncTxHotMiss()
+			misses = append(misses, txHash)
+		}
+	}
+
+	if len(misses) == 0 {
+		return result, nil
+	}
+
+	// Check database availability
+	if c.db == nil {
+		return result, types.ErrBlobStoreUnavailable
+	}
+
+	blob := c.db.Blob()
+	if blob == nil {
+		return result, types.ErrBlobStoreUnavailable
+	}
+
+	txn := blob.NewTransaction(false)
+	defer txn.Rollback() //nolint:errcheck
+
+	// Phase 2: Look up offset structs for all misses, group by block
+	type txItem struct {
+		hash   [32]byte
+		offset CborOffset
+	}
+	type blockGroup struct {
+		slot uint64
+		hash [32]byte
+		txs  []txItem
+	}
+	blockGroups := make(map[blockKey]*blockGroup)
+
+	for _, txHash := range misses {
+		txData, err := blob.GetTx(txn, txHash[:])
+		if err != nil {
+			// Skip TXs that can't be found, propagate other errors
+			if errors.Is(err, types.ErrBlobKeyNotFound) {
+				continue
+			}
+			return result, fmt.Errorf("get tx %x: %w", txHash[:8], err)
+		}
+
+		// Check if this is offset-based storage
+		if !IsTxOffsetStorage(txData) {
+			// Legacy format: raw CBOR data
+			c.hotTx.Put(txHash[:], txData)
+			result[txHash] = txData
+			continue
+		}
+
+		// Decode the offset reference
+		offset, err := DecodeTxOffset(txData)
+		if err != nil {
+			return result, fmt.Errorf("decode tx offset %x: %w", txHash[:8], err)
+		}
+
+		// Group by block
+		bk := blockKey{slot: offset.BlockSlot, hash: offset.BlockHash}
+		if blockGroups[bk] == nil {
+			blockGroups[bk] = &blockGroup{
+				slot: offset.BlockSlot,
+				hash: offset.BlockHash,
+			}
+		}
+		blockGroups[bk].txs = append(blockGroups[bk].txs, txItem{
+			hash:   txHash,
+			offset: *offset,
+		})
+	}
+
+	// Phase 3: Fetch each unique block once and extract all items
+	for bk, group := range blockGroups {
+		// Check block LRU cache first
+		cachedBlock, ok := c.blockLRU.Get(group.slot, group.hash)
+		if ok {
+			c.metrics.IncBlockLRUHit()
+		} else {
+			c.metrics.IncBlockLRUMiss()
+
+			// Fetch block from blob store
+			blockCbor, _, err := blob.GetBlock(txn, group.slot, group.hash[:])
+			if err != nil {
+				return nil, fmt.Errorf(
+					"get block for tx batch extraction (slot=%d, hash=%x): %w",
+					group.slot,
+					group.hash,
+					err,
+				)
+			}
+
+			c.metrics.IncColdExtraction()
+
+			// Create cached block and add to LRU
+			cachedBlock = newCachedBlock(blockCbor)
+			c.blockLRU.Put(bk.slot, bk.hash, cachedBlock)
+		}
+
+		// Extract all TXs from this block
+		for _, item := range group.txs {
+			cbor := cachedBlock.Extract(item.offset.ByteOffset, item.offset.ByteLength)
+			if cbor == nil {
+				return nil, fmt.Errorf(
+					"tx batch extraction failed: offset out of bounds "+
+						"(slot=%d, hash=%x, offset=%d, length=%d)",
+					group.slot,
+					group.hash,
+					item.offset.ByteOffset,
+					item.offset.ByteLength,
+				)
+			}
+
+			// Populate hot cache
+			c.hotTx.Put(item.hash[:], cbor)
+			result[item.hash] = cbor
+		}
+	}
+
+	return result, nil
 }
 
 // Metrics returns the cache metrics for monitoring and observability.
@@ -150,4 +698,14 @@ func makeUtxoKey(txId []byte, outputIdx uint32) []byte {
 	copy(key[:32], txId)
 	binary.BigEndian.PutUint32(key[32:36], outputIdx)
 	return key
+}
+
+// newCachedBlock creates a new CachedBlock with the given raw CBOR data.
+// The TxIndex and OutputIndex maps are initialized empty for later population.
+func newCachedBlock(rawBytes []byte) *CachedBlock {
+	return &CachedBlock{
+		RawBytes:    rawBytes,
+		TxIndex:     make(map[[32]byte]Location),
+		OutputIndex: make(map[OutputKey]Location),
+	}
 }

--- a/database/cbor_cache_bench_test.go
+++ b/database/cbor_cache_bench_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// BenchmarkHotCacheGet measures hot cache read performance
+func BenchmarkHotCacheGet(b *testing.B) {
+	cache := NewHotCache(10000, 0)
+
+	// Pre-populate cache
+	key := make([]byte, 36)
+	rand.Read(key) //nolint:errcheck
+	cbor := make([]byte, 100)
+	rand.Read(cbor) //nolint:errcheck
+	cache.Put(key, cbor)
+
+	b.ResetTimer()
+	for b.Loop() {
+		cache.Get(key)
+	}
+}
+
+// BenchmarkHotCachePut measures hot cache write performance
+func BenchmarkHotCachePut(b *testing.B) {
+	cache := NewHotCache(10000, 0)
+
+	key := make([]byte, 36)
+	cbor := make([]byte, 100)
+	rand.Read(cbor) //nolint:errcheck
+
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		// Use different keys to avoid overwriting
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[2] = byte(i >> 16)
+		key[3] = byte(i >> 24)
+		cache.Put(key, cbor)
+	}
+}
+
+// BenchmarkHotCacheGetMiss measures hot cache miss performance
+func BenchmarkHotCacheGetMiss(b *testing.B) {
+	cache := NewHotCache(10000, 0)
+
+	key := make([]byte, 36)
+
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		// Use different keys that are not in cache
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[2] = byte(i >> 16)
+		key[3] = byte(i >> 24)
+		cache.Get(key)
+	}
+}
+
+// BenchmarkHotCacheParallelGet measures concurrent read performance
+func BenchmarkHotCacheParallelGet(b *testing.B) {
+	cache := NewHotCache(10000, 0)
+
+	// Pre-populate with many entries
+	for i := 0; i < 1000; i++ {
+		key := make([]byte, 36)
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		cbor := make([]byte, 100)
+		cache.Put(key, cbor)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		key := make([]byte, 36)
+		i := 0
+		for pb.Next() {
+			key[0] = byte(i % 1000)
+			key[1] = byte((i % 1000) >> 8)
+			cache.Get(key)
+			i++
+		}
+	})
+}
+
+// BenchmarkBlockLRUCacheGet measures block LRU cache hit performance
+func BenchmarkBlockLRUCacheGet(b *testing.B) {
+	cache := NewBlockLRUCache(100)
+
+	// Pre-populate cache
+	var hash [32]byte
+	rand.Read(hash[:]) //nolint:errcheck
+	block := &CachedBlock{
+		RawBytes:    make([]byte, 100000),
+		TxIndex:     make(map[[32]byte]Location),
+		OutputIndex: make(map[OutputKey]Location),
+	}
+	cache.Put(12345, hash, block)
+
+	b.ResetTimer()
+	for b.Loop() {
+		cache.Get(12345, hash)
+	}
+}
+
+// BenchmarkBlockLRUCachePut measures block LRU cache write performance
+func BenchmarkBlockLRUCachePut(b *testing.B) {
+	cache := NewBlockLRUCache(100)
+
+	var hash [32]byte
+	block := &CachedBlock{
+		RawBytes:    make([]byte, 100000),
+		TxIndex:     make(map[[32]byte]Location),
+		OutputIndex: make(map[OutputKey]Location),
+	}
+
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		hash[0] = byte(i)
+		hash[1] = byte(i >> 8)
+		cache.Put(uint64(i), hash, block)
+	}
+}
+
+// BenchmarkCachedBlockExtract measures CBOR extraction from cached block
+func BenchmarkCachedBlockExtract(b *testing.B) {
+	block := &CachedBlock{
+		RawBytes:    make([]byte, 200000),
+		TxIndex:     make(map[[32]byte]Location),
+		OutputIndex: make(map[OutputKey]Location),
+	}
+	rand.Read(block.RawBytes) //nolint:errcheck
+
+	b.ResetTimer()
+	for b.Loop() {
+		block.Extract(1000, 256)
+	}
+}
+
+// BenchmarkCborOffsetEncode measures offset encoding performance
+func BenchmarkCborOffsetEncode(b *testing.B) {
+	offset := &CborOffset{
+		BlockSlot:  12345678,
+		BlockHash:  [32]byte{1, 2, 3, 4, 5},
+		ByteOffset: 1000,
+		ByteLength: 256,
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		offset.Encode()
+	}
+}
+
+// BenchmarkCborOffsetDecode measures offset decoding performance
+func BenchmarkCborOffsetDecode(b *testing.B) {
+	offset := &CborOffset{
+		BlockSlot:  12345678,
+		BlockHash:  [32]byte{1, 2, 3, 4, 5},
+		ByteOffset: 1000,
+		ByteLength: 256,
+	}
+	encoded := offset.Encode()
+
+	b.ResetTimer()
+	for b.Loop() {
+		DecodeUtxoOffset(encoded) //nolint:errcheck
+	}
+}
+
+// BenchmarkTieredCacheHotHit measures tiered cache hot path performance
+func BenchmarkTieredCacheHotHit(b *testing.B) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  10000,
+		HotTxEntries:    1000,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 100,
+	}
+	cache := NewTieredCborCache(config, nil)
+
+	// Pre-populate hot cache
+	var txId [32]byte
+	rand.Read(txId[:]) //nolint:errcheck
+	cbor := make([]byte, 100)
+	rand.Read(cbor) //nolint:errcheck
+	cache.hotUtxo.Put(makeUtxoKey(txId[:], 0), cbor)
+
+	b.ResetTimer()
+	for b.Loop() {
+		cache.ResolveUtxoCbor(txId[:], 0) //nolint:errcheck
+	}
+}
+
+// BenchmarkMakeUtxoKey measures key generation performance
+func BenchmarkMakeUtxoKey(b *testing.B) {
+	var txId [32]byte
+	rand.Read(txId[:]) //nolint:errcheck
+
+	b.ResetTimer()
+	for b.Loop() {
+		makeUtxoKey(txId[:], 12345)
+	}
+}
+
+// BenchmarkMetricsIncrement measures metric increment performance
+func BenchmarkMetricsIncrement(b *testing.B) {
+	metrics := &CacheMetrics{}
+
+	b.ResetTimer()
+	for b.Loop() {
+		metrics.IncUtxoHotHit()
+	}
+}
+
+// BenchmarkMetricsIncrementWithPrometheus measures metric increment with
+// Prometheus counters registered. This benchmarks the path where counters
+// are non-nil and Prometheus Inc() is called on each increment.
+func BenchmarkMetricsIncrementWithPrometheus(b *testing.B) {
+	metrics := &CacheMetrics{}
+
+	// Register with a local registry to exercise the Prometheus increment path
+	registry := prometheus.NewRegistry()
+	metrics.Register(registry)
+
+	b.ResetTimer()
+	for b.Loop() {
+		metrics.IncUtxoHotHit()
+	}
+}
+
+// BenchmarkBatchResolutionHotHits measures batch resolution with all hot hits
+func BenchmarkBatchResolutionHotHits(b *testing.B) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  10000,
+		HotTxEntries:    1000,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 100,
+	}
+	cache := NewTieredCborCache(config, nil)
+
+	// Pre-populate hot cache with 100 entries
+	refs := make([]UtxoRef, 100)
+	for i := 0; i < 100; i++ {
+		refs[i] = UtxoRef{OutputIdx: uint32(i)}
+		refs[i].TxId[0] = byte(i)
+		refs[i].TxId[1] = byte(i >> 8)
+
+		cbor := make([]byte, 100)
+		cache.hotUtxo.Put(makeUtxoKey(refs[i].TxId[:], refs[i].OutputIdx), cbor)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		cache.ResolveUtxoCborBatch(refs) //nolint:errcheck
+	}
+}
+
+// BenchmarkTxBatchResolutionHotHits measures TX batch resolution with all hot hits
+func BenchmarkTxBatchResolutionHotHits(b *testing.B) {
+	config := CborCacheConfig{
+		HotUtxoEntries:  10000,
+		HotTxEntries:    1000,
+		HotTxMaxBytes:   1024 * 1024,
+		BlockLRUEntries: 100,
+	}
+	cache := NewTieredCborCache(config, nil)
+
+	// Pre-populate hot cache with 100 TX entries
+	hashes := make([][32]byte, 100)
+	for i := 0; i < 100; i++ {
+		hashes[i][0] = byte(i)
+		hashes[i][1] = byte(i >> 8)
+
+		cbor := make([]byte, 500) // TX CBOR is typically larger than UTxO
+		cache.hotTx.Put(hashes[i][:], cbor)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		cache.ResolveTxCborBatch(hashes) //nolint:errcheck
+	}
+}

--- a/database/cbor_offset.go
+++ b/database/cbor_offset.go
@@ -16,12 +16,18 @@ package database
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 )
 
+// offsetMagic is a 4-byte prefix that identifies offset-based storage.
+// This prevents misidentifying legacy CBOR that happens to be the same size.
+// Using a fixed-size array makes it immutable (unlike a slice).
+var offsetMagic = [4]byte{'D', 'O', 'F', 'F'} // "DOFF" = Dingo OFFset
+
 // CborOffsetSize is the size in bytes of an encoded CborOffset.
-// Layout: BlockSlot (8) + BlockHash (32) + ByteOffset (4) + ByteLength (4) = 48
-const CborOffsetSize = 48
+// Layout: Magic (4) + BlockSlot (8) + BlockHash (32) + ByteOffset (4) + ByteLength (4) = 52
+const CborOffsetSize = 52
 
 // CborOffset represents a reference to CBOR data within a block.
 // Instead of storing duplicate CBOR data, we store an offset reference
@@ -33,32 +39,36 @@ type CborOffset struct {
 	ByteLength uint32   // Length of the CBOR data in bytes
 }
 
-// Encode serializes the CborOffset to a 48-byte big-endian encoded slice.
+// Encode serializes the CborOffset to a 52-byte big-endian encoded slice.
 // Layout:
-//   - bytes 0-7:   BlockSlot (big-endian uint64)
-//   - bytes 8-39:  BlockHash (32 bytes)
-//   - bytes 40-43: ByteOffset (big-endian uint32)
-//   - bytes 44-47: ByteLength (big-endian uint32)
+//   - bytes 0-3:   Magic "DOFF" (identifies offset storage)
+//   - bytes 4-11:  BlockSlot (big-endian uint64)
+//   - bytes 12-43: BlockHash (32 bytes)
+//   - bytes 44-47: ByteOffset (big-endian uint32)
+//   - bytes 48-51: ByteLength (big-endian uint32)
 func (c *CborOffset) Encode() []byte {
 	buf := make([]byte, CborOffsetSize)
 
-	// Encode BlockSlot (bytes 0-7)
-	binary.BigEndian.PutUint64(buf[0:8], c.BlockSlot)
+	// Magic prefix (bytes 0-3)
+	copy(buf[0:4], offsetMagic[:])
 
-	// Copy BlockHash (bytes 8-39)
-	copy(buf[8:40], c.BlockHash[:])
+	// Encode BlockSlot (bytes 4-11)
+	binary.BigEndian.PutUint64(buf[4:12], c.BlockSlot)
 
-	// Encode ByteOffset (bytes 40-43)
-	binary.BigEndian.PutUint32(buf[40:44], c.ByteOffset)
+	// Copy BlockHash (bytes 12-43)
+	copy(buf[12:44], c.BlockHash[:])
 
-	// Encode ByteLength (bytes 44-47)
-	binary.BigEndian.PutUint32(buf[44:48], c.ByteLength)
+	// Encode ByteOffset (bytes 44-47)
+	binary.BigEndian.PutUint32(buf[44:48], c.ByteOffset)
+
+	// Encode ByteLength (bytes 48-51)
+	binary.BigEndian.PutUint32(buf[48:52], c.ByteLength)
 
 	return buf
 }
 
-// DecodeCborOffset deserializes a 48-byte big-endian encoded slice into a CborOffset.
-// Returns an error if the input data is not exactly 48 bytes.
+// DecodeCborOffset deserializes a 52-byte big-endian encoded slice into a CborOffset.
+// Returns an error if the input data is not exactly 52 bytes or has wrong magic.
 func DecodeCborOffset(data []byte) (*CborOffset, error) {
 	if len(data) != CborOffsetSize {
 		return nil, fmt.Errorf(
@@ -68,19 +78,306 @@ func DecodeCborOffset(data []byte) (*CborOffset, error) {
 		)
 	}
 
+	// Verify magic prefix
+	if data[0] != offsetMagic[0] || data[1] != offsetMagic[1] ||
+		data[2] != offsetMagic[2] || data[3] != offsetMagic[3] {
+		return nil, errors.New("invalid CborOffset magic: expected DOFF")
+	}
+
 	offset := &CborOffset{}
 
-	// Decode BlockSlot (bytes 0-7)
-	offset.BlockSlot = binary.BigEndian.Uint64(data[0:8])
+	// Decode BlockSlot (bytes 4-11)
+	offset.BlockSlot = binary.BigEndian.Uint64(data[4:12])
 
-	// Copy BlockHash (bytes 8-39)
-	copy(offset.BlockHash[:], data[8:40])
+	// Copy BlockHash (bytes 12-43)
+	copy(offset.BlockHash[:], data[12:44])
 
-	// Decode ByteOffset (bytes 40-43)
-	offset.ByteOffset = binary.BigEndian.Uint32(data[40:44])
+	// Decode ByteOffset (bytes 44-47)
+	offset.ByteOffset = binary.BigEndian.Uint32(data[44:48])
 
-	// Decode ByteLength (bytes 44-47)
-	offset.ByteLength = binary.BigEndian.Uint32(data[44:48])
+	// Decode ByteLength (bytes 48-51)
+	offset.ByteLength = binary.BigEndian.Uint32(data[48:52])
 
 	return offset, nil
+}
+
+// EncodeUtxoOffset encodes a CborOffset for UTxO storage.
+// Returns a 52-byte encoded offset with magic prefix.
+func EncodeUtxoOffset(offset *CborOffset) []byte {
+	return offset.Encode()
+}
+
+// IsUtxoOffsetStorage checks if the data is offset-based UTxO storage.
+// Returns true if data has the correct size and magic prefix.
+func IsUtxoOffsetStorage(data []byte) bool {
+	if len(data) != CborOffsetSize {
+		return false
+	}
+	return data[0] == offsetMagic[0] && data[1] == offsetMagic[1] &&
+		data[2] == offsetMagic[2] && data[3] == offsetMagic[3]
+}
+
+// DecodeUtxoOffset decodes offset-based UTxO storage data.
+// Returns an error if the data is not exactly 52 bytes or has wrong magic.
+func DecodeUtxoOffset(data []byte) (*CborOffset, error) {
+	return DecodeCborOffset(data)
+}
+
+// EncodeTxOffset encodes a CborOffset for transaction storage.
+// Returns a 52-byte encoded offset with magic prefix.
+func EncodeTxOffset(offset *CborOffset) []byte {
+	return offset.Encode()
+}
+
+// IsTxOffsetStorage checks if the data is offset-based transaction storage.
+// Returns true if data has the correct size and magic prefix.
+func IsTxOffsetStorage(data []byte) bool {
+	if len(data) != CborOffsetSize {
+		return false
+	}
+	return data[0] == offsetMagic[0] && data[1] == offsetMagic[1] &&
+		data[2] == offsetMagic[2] && data[3] == offsetMagic[3]
+}
+
+// DecodeTxOffset decodes offset-based transaction storage data.
+// Returns an error if the data is not exactly 52 bytes or has wrong magic.
+func DecodeTxOffset(data []byte) (*CborOffset, error) {
+	return DecodeCborOffset(data)
+}
+
+// txPartsMagic identifies TxCborParts storage (complete transaction components).
+var txPartsMagic = [4]byte{'D', 'T', 'X', 'P'} // "DTXP" = Dingo TX Parts
+
+// TxCborPartsSize is the size in bytes of an encoded TxCborParts.
+// Layout: Magic (4) + BlockSlot (8) + BlockHash (32) +
+//
+//	BodyOffset (4) + BodyLength (4) +
+//	WitnessOffset (4) + WitnessLength (4) +
+//	MetadataOffset (4) + MetadataLength (4) +
+//	IsValid (1) = 69
+const TxCborPartsSize = 69
+
+// TxCborParts stores byte offsets for all 4 components of a Cardano transaction.
+// This enables byte-perfect reconstruction of standalone transaction CBOR
+// from the source block.
+//
+// A complete standalone transaction has the CBOR structure:
+//
+//	[body, witness, is_valid, metadata]
+//
+// However, in Cardano blocks, these components are stored in separate arrays:
+//
+//	[header, [bodies...], [witnesses...], {metadata_map}, [invalid_txs]]
+//
+// TxCborParts stores the location of each component so they can be extracted
+// and reassembled into a complete transaction.
+type TxCborParts struct {
+	BlockSlot      uint64   // Slot number of the block containing the transaction
+	BlockHash      [32]byte // Hash of the block containing the transaction
+	BodyOffset     uint32   // Byte offset of transaction body within block CBOR
+	BodyLength     uint32   // Length of transaction body in bytes
+	WitnessOffset  uint32   // Byte offset of witness set within block CBOR
+	WitnessLength  uint32   // Length of witness set in bytes
+	MetadataOffset uint32   // Byte offset of metadata within block CBOR (0 if none)
+	MetadataLength uint32   // Length of metadata in bytes (0 if none)
+	IsValid        bool     // True if transaction is valid (not in invalid_txs)
+}
+
+// Encode serializes TxCborParts to a 69-byte big-endian encoded slice.
+// Layout:
+//   - bytes 0-3:   Magic "DTXP"
+//   - bytes 4-11:  BlockSlot (big-endian uint64)
+//   - bytes 12-43: BlockHash (32 bytes)
+//   - bytes 44-47: BodyOffset (big-endian uint32)
+//   - bytes 48-51: BodyLength (big-endian uint32)
+//   - bytes 52-55: WitnessOffset (big-endian uint32)
+//   - bytes 56-59: WitnessLength (big-endian uint32)
+//   - bytes 60-63: MetadataOffset (big-endian uint32)
+//   - bytes 64-67: MetadataLength (big-endian uint32)
+//   - byte 68:     IsValid (0 = false, 1 = true)
+func (t *TxCborParts) Encode() []byte {
+	buf := make([]byte, TxCborPartsSize)
+
+	// Magic prefix (bytes 0-3)
+	copy(buf[0:4], txPartsMagic[:])
+
+	// Encode BlockSlot (bytes 4-11)
+	binary.BigEndian.PutUint64(buf[4:12], t.BlockSlot)
+
+	// Copy BlockHash (bytes 12-43)
+	copy(buf[12:44], t.BlockHash[:])
+
+	// Encode body offset/length (bytes 44-51)
+	binary.BigEndian.PutUint32(buf[44:48], t.BodyOffset)
+	binary.BigEndian.PutUint32(buf[48:52], t.BodyLength)
+
+	// Encode witness offset/length (bytes 52-59)
+	binary.BigEndian.PutUint32(buf[52:56], t.WitnessOffset)
+	binary.BigEndian.PutUint32(buf[56:60], t.WitnessLength)
+
+	// Encode metadata offset/length (bytes 60-67)
+	binary.BigEndian.PutUint32(buf[60:64], t.MetadataOffset)
+	binary.BigEndian.PutUint32(buf[64:68], t.MetadataLength)
+
+	// Encode IsValid (byte 68)
+	if t.IsValid {
+		buf[68] = 1
+	} else {
+		buf[68] = 0
+	}
+
+	return buf
+}
+
+// DecodeTxCborParts deserializes a 69-byte big-endian encoded slice into TxCborParts.
+// Returns an error if the input data is not exactly 69 bytes or has wrong magic.
+func DecodeTxCborParts(data []byte) (*TxCborParts, error) {
+	if len(data) != TxCborPartsSize {
+		return nil, fmt.Errorf(
+			"invalid TxCborParts data size: expected %d bytes, got %d",
+			TxCborPartsSize,
+			len(data),
+		)
+	}
+
+	// Verify magic prefix
+	if data[0] != txPartsMagic[0] || data[1] != txPartsMagic[1] ||
+		data[2] != txPartsMagic[2] || data[3] != txPartsMagic[3] {
+		return nil, errors.New("invalid TxCborParts magic: expected DTXP")
+	}
+
+	parts := &TxCborParts{}
+
+	// Decode BlockSlot (bytes 4-11)
+	parts.BlockSlot = binary.BigEndian.Uint64(data[4:12])
+
+	// Copy BlockHash (bytes 12-43)
+	copy(parts.BlockHash[:], data[12:44])
+
+	// Decode body offset/length (bytes 44-51)
+	parts.BodyOffset = binary.BigEndian.Uint32(data[44:48])
+	parts.BodyLength = binary.BigEndian.Uint32(data[48:52])
+
+	// Decode witness offset/length (bytes 52-59)
+	parts.WitnessOffset = binary.BigEndian.Uint32(data[52:56])
+	parts.WitnessLength = binary.BigEndian.Uint32(data[56:60])
+
+	// Decode metadata offset/length (bytes 60-67)
+	parts.MetadataOffset = binary.BigEndian.Uint32(data[60:64])
+	parts.MetadataLength = binary.BigEndian.Uint32(data[64:68])
+
+	// Decode IsValid (byte 68)
+	parts.IsValid = data[68] != 0
+
+	return parts, nil
+}
+
+// IsTxCborPartsStorage checks if the data is TxCborParts storage.
+// Returns true if data has the correct size and magic prefix.
+func IsTxCborPartsStorage(data []byte) bool {
+	if len(data) != TxCborPartsSize {
+		return false
+	}
+	return data[0] == txPartsMagic[0] && data[1] == txPartsMagic[1] &&
+		data[2] == txPartsMagic[2] && data[3] == txPartsMagic[3]
+}
+
+// HasMetadata returns true if the transaction has metadata.
+func (t *TxCborParts) HasMetadata() bool {
+	return t.MetadataLength > 0
+}
+
+// ReassembleTxCbor extracts all transaction components from the block CBOR
+// and reassembles them into a complete standalone transaction CBOR.
+//
+// The returned CBOR has the structure: [body, witness, is_valid, metadata]
+// where metadata is null if the transaction has no auxiliary data.
+//
+// This produces byte-perfect output when the original transaction had this
+// exact structure. Note that Cardano blocks store components in separate
+// arrays, so the reassembled CBOR may differ from tx.Cbor() which may use
+// a different encoding order or structure.
+func (t *TxCborParts) ReassembleTxCbor(blockCbor []byte) ([]byte, error) {
+	// Safe conversion: Cardano blocks are limited to ~90KB, well within uint32 range.
+	blockLen := uint32(len(blockCbor)) // #nosec G115: bounded by Cardano protocol limits
+
+	// Validate body bounds (overflow-safe: check offset first, then remaining space)
+	if t.BodyOffset > blockLen || t.BodyLength > blockLen-t.BodyOffset {
+		return nil, fmt.Errorf(
+			"body range [%d:%d] exceeds block size %d",
+			t.BodyOffset, t.BodyOffset+t.BodyLength, blockLen,
+		)
+	}
+
+	// Validate witness bounds (overflow-safe)
+	if t.WitnessOffset > blockLen || t.WitnessLength > blockLen-t.WitnessOffset {
+		return nil, fmt.Errorf(
+			"witness range [%d:%d] exceeds block size %d",
+			t.WitnessOffset, t.WitnessOffset+t.WitnessLength, blockLen,
+		)
+	}
+
+	// Validate metadata bounds if present (overflow-safe)
+	if t.HasMetadata() && (t.MetadataOffset > blockLen || t.MetadataLength > blockLen-t.MetadataOffset) {
+		return nil, fmt.Errorf(
+			"metadata range [%d:%d] exceeds block size %d",
+			t.MetadataOffset, t.MetadataOffset+t.MetadataLength, blockLen,
+		)
+	}
+
+	// Extract components
+	bodyCbor := blockCbor[t.BodyOffset : t.BodyOffset+t.BodyLength]
+	witnessCbor := blockCbor[t.WitnessOffset : t.WitnessOffset+t.WitnessLength]
+
+	var metadataCbor []byte
+	if t.HasMetadata() {
+		metadataCbor = blockCbor[t.MetadataOffset : t.MetadataOffset+t.MetadataLength]
+	}
+
+	// Build the complete transaction CBOR array: [body, witness, is_valid, metadata]
+	// Using CBOR indefinite-length array encoding for flexibility
+	return buildTxCborArray(bodyCbor, witnessCbor, t.IsValid, metadataCbor), nil
+}
+
+// buildTxCborArray constructs a CBOR array containing the transaction components.
+// Format: [body, witness, is_valid, metadata_or_null]
+func buildTxCborArray(body, witness []byte, isValid bool, metadata []byte) []byte {
+	// Calculate total size needed
+	// CBOR array header (1 byte for 4-element array: 0x84)
+	// + body bytes + witness bytes
+	// + is_valid (1 byte: 0xF5 for true, 0xF4 for false)
+	// + metadata bytes (or 0xF6 for null)
+	size := 1 + len(body) + len(witness) + 1
+	if len(metadata) > 0 {
+		size += len(metadata)
+	} else {
+		size++ // null takes 1 byte
+	}
+
+	result := make([]byte, 0, size)
+
+	// CBOR array header: 4-element array
+	result = append(result, 0x84)
+
+	// Body (already CBOR-encoded)
+	result = append(result, body...)
+
+	// Witness (already CBOR-encoded)
+	result = append(result, witness...)
+
+	// is_valid boolean
+	if isValid {
+		result = append(result, 0xf5) // CBOR true
+	} else {
+		result = append(result, 0xf4) // CBOR false
+	}
+
+	// Metadata or null
+	if len(metadata) > 0 {
+		result = append(result, metadata...)
+	} else {
+		result = append(result, 0xf6) // CBOR null
+	}
+
+	return result
 }

--- a/database/cbor_offset_test.go
+++ b/database/cbor_offset_test.go
@@ -257,15 +257,22 @@ func TestCborOffsetEncodeFormat(t *testing.T) {
 
 	encoded := offset.Encode()
 
-	// Verify BlockSlot bytes 0-7 (big-endian)
+	// Verify Magic prefix bytes 0-3
+	assert.True(
+		t,
+		bytes.Equal(encoded[0:4], offsetMagic[:]),
+		"Magic prefix mismatch",
+	)
+
+	// Verify BlockSlot bytes 4-11 (big-endian)
 	expectedSlotBytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	assert.True(
 		t,
-		bytes.Equal(encoded[0:8], expectedSlotBytes),
+		bytes.Equal(encoded[4:12], expectedSlotBytes),
 		"BlockSlot encoding mismatch",
 	)
 
-	// Verify BlockHash bytes 8-39
+	// Verify BlockHash bytes 12-43
 	expectedHashBytes := []byte{
 		0x10,
 		0x11,
@@ -302,23 +309,23 @@ func TestCborOffsetEncodeFormat(t *testing.T) {
 	}
 	assert.True(
 		t,
-		bytes.Equal(encoded[8:40], expectedHashBytes),
+		bytes.Equal(encoded[12:44], expectedHashBytes),
 		"BlockHash encoding mismatch",
 	)
 
-	// Verify ByteOffset bytes 40-43 (big-endian)
+	// Verify ByteOffset bytes 44-47 (big-endian)
 	expectedOffsetBytes := []byte{0x30, 0x31, 0x32, 0x33}
 	assert.True(
 		t,
-		bytes.Equal(encoded[40:44], expectedOffsetBytes),
+		bytes.Equal(encoded[44:48], expectedOffsetBytes),
 		"ByteOffset encoding mismatch",
 	)
 
-	// Verify ByteLength bytes 44-47 (big-endian)
+	// Verify ByteLength bytes 48-51 (big-endian)
 	expectedLengthBytes := []byte{0x40, 0x41, 0x42, 0x43}
 	assert.True(
 		t,
-		bytes.Equal(encoded[44:48], expectedLengthBytes),
+		bytes.Equal(encoded[48:52], expectedLengthBytes),
 		"ByteLength encoding mismatch",
 	)
 }
@@ -337,12 +344,12 @@ func TestDecodeCborOffsetInvalidSize(t *testing.T) {
 			data: []byte{0x01},
 		},
 		{
-			name: "too short - 47 bytes",
-			data: make([]byte, 47),
+			name: "too short - 51 bytes",
+			data: make([]byte, 51),
 		},
 		{
-			name: "too long - 49 bytes",
-			data: make([]byte, 49),
+			name: "too long - 53 bytes",
+			data: make([]byte, 53),
 		},
 		{
 			name: "too long - 100 bytes",
@@ -358,16 +365,36 @@ func TestDecodeCborOffsetInvalidSize(t *testing.T) {
 			assert.Contains(
 				t,
 				err.Error(),
-				"48",
+				"52",
 				"error message should mention expected size",
 			)
 		})
 	}
 }
 
+func TestDecodeCborOffsetInvalidMagic(t *testing.T) {
+	// Valid size but wrong magic
+	data := make([]byte, CborOffsetSize)
+	data[0] = 'X' // Wrong magic
+	data[1] = 'O'
+	data[2] = 'F'
+	data[3] = 'F'
+
+	decoded, err := DecodeCborOffset(data)
+	assert.Error(t, err, "decode should return error for invalid magic")
+	assert.Nil(t, decoded, "decoded should be nil on error")
+	assert.Contains(
+		t,
+		err.Error(),
+		"magic",
+		"error message should mention magic",
+	)
+}
+
 func TestCborOffsetSizeConstant(t *testing.T) {
 	// Verify the constant matches expected value
-	assert.Equal(t, 48, CborOffsetSize, "CborOffsetSize should be 48")
+	// Layout: Magic (4) + BlockSlot (8) + BlockHash (32) + ByteOffset (4) + ByteLength (4) = 52
+	assert.Equal(t, 52, CborOffsetSize, "CborOffsetSize should be 52")
 
 	// Verify encoded size matches constant
 	offset := CborOffset{}
@@ -378,4 +405,558 @@ func TestCborOffsetSizeConstant(t *testing.T) {
 		CborOffsetSize,
 		"encoded size should match CborOffsetSize constant",
 	)
+}
+
+func TestEncodeUtxoOffset(t *testing.T) {
+	offset := &CborOffset{
+		BlockSlot:  12345,
+		BlockHash:  [32]byte{0x01, 0x02, 0x03},
+		ByteOffset: 100,
+		ByteLength: 200,
+	}
+
+	encoded := EncodeUtxoOffset(offset)
+	assert.Len(t, encoded, CborOffsetSize, "encoded should be 52 bytes")
+
+	// Verify magic prefix
+	assert.True(t, bytes.Equal(encoded[0:4], offsetMagic[:]), "should have DOFF magic prefix")
+
+	// Verify it decodes correctly
+	decoded, err := DecodeUtxoOffset(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, offset.BlockSlot, decoded.BlockSlot)
+	assert.Equal(t, offset.BlockHash, decoded.BlockHash)
+	assert.Equal(t, offset.ByteOffset, decoded.ByteOffset)
+	assert.Equal(t, offset.ByteLength, decoded.ByteLength)
+}
+
+func TestIsUtxoOffsetStorage(t *testing.T) {
+	// Create a valid offset-encoded data
+	validOffset := make([]byte, CborOffsetSize)
+	copy(validOffset[0:4], offsetMagic[:])
+
+	tests := []struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{
+			name:     "valid 52 bytes with magic",
+			data:     validOffset,
+			expected: true,
+		},
+		{
+			name:     "52 bytes but wrong magic",
+			data:     make([]byte, 52), // zeros, no DOFF magic
+			expected: false,
+		},
+		{
+			name:     "too short - 51 bytes",
+			data:     make([]byte, 51),
+			expected: false,
+		},
+		{
+			name:     "too long - 53 bytes",
+			data:     make([]byte, 53),
+			expected: false,
+		},
+		{
+			name:     "empty",
+			data:     []byte{},
+			expected: false,
+		},
+		{
+			name:     "typical CBOR size",
+			data:     make([]byte, 100),
+			expected: false,
+		},
+		{
+			name:     "48 bytes (legacy size) should not match",
+			data:     make([]byte, 48),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsUtxoOffsetStorage(tc.data)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDecodeUtxoOffsetError(t *testing.T) {
+	// Invalid sizes should error
+	_, err := DecodeUtxoOffset(make([]byte, 51))
+	assert.Error(t, err)
+
+	_, err = DecodeUtxoOffset(make([]byte, 53))
+	assert.Error(t, err)
+
+	// Valid size but wrong magic should error
+	wrongMagic := make([]byte, 52)
+	_, err = DecodeUtxoOffset(wrongMagic)
+	assert.Error(t, err)
+
+	// Valid size with correct magic should succeed
+	validData := make([]byte, 52)
+	copy(validData[0:4], offsetMagic[:])
+	_, err = DecodeUtxoOffset(validData)
+	assert.NoError(t, err)
+}
+
+func TestEncodeTxOffset(t *testing.T) {
+	offset := &CborOffset{
+		BlockSlot:  12345,
+		BlockHash:  [32]byte{0x01, 0x02, 0x03},
+		ByteOffset: 100,
+		ByteLength: 200,
+	}
+
+	encoded := EncodeTxOffset(offset)
+	assert.Len(t, encoded, CborOffsetSize, "encoded should be 52 bytes")
+
+	// Verify magic prefix
+	assert.True(t, bytes.Equal(encoded[0:4], offsetMagic[:]), "should have DOFF magic prefix")
+
+	// Verify it decodes correctly
+	decoded, err := DecodeTxOffset(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, offset.BlockSlot, decoded.BlockSlot)
+	assert.Equal(t, offset.BlockHash, decoded.BlockHash)
+	assert.Equal(t, offset.ByteOffset, decoded.ByteOffset)
+	assert.Equal(t, offset.ByteLength, decoded.ByteLength)
+}
+
+func TestIsTxOffsetStorage(t *testing.T) {
+	// Create a valid offset-encoded data
+	validOffset := make([]byte, CborOffsetSize)
+	copy(validOffset[0:4], offsetMagic[:])
+
+	tests := []struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{
+			name:     "valid 52 bytes with magic",
+			data:     validOffset,
+			expected: true,
+		},
+		{
+			name:     "52 bytes but wrong magic",
+			data:     make([]byte, 52), // zeros, no DOFF magic
+			expected: false,
+		},
+		{
+			name:     "too short - 51 bytes",
+			data:     make([]byte, 51),
+			expected: false,
+		},
+		{
+			name:     "too long - 53 bytes",
+			data:     make([]byte, 53),
+			expected: false,
+		},
+		{
+			name:     "empty",
+			data:     []byte{},
+			expected: false,
+		},
+		{
+			name:     "typical CBOR size",
+			data:     make([]byte, 100),
+			expected: false,
+		},
+		{
+			name:     "48 bytes (legacy size) should not match",
+			data:     make([]byte, 48),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsTxOffsetStorage(tc.data)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDecodeTxOffsetError(t *testing.T) {
+	// Invalid sizes should error
+	_, err := DecodeTxOffset(make([]byte, 51))
+	assert.Error(t, err)
+
+	_, err = DecodeTxOffset(make([]byte, 53))
+	assert.Error(t, err)
+
+	// Valid size but wrong magic should error
+	wrongMagic := make([]byte, 52)
+	_, err = DecodeTxOffset(wrongMagic)
+	assert.Error(t, err)
+
+	// Valid size with correct magic should succeed
+	validData := make([]byte, 52)
+	copy(validData[0:4], offsetMagic[:])
+	_, err = DecodeTxOffset(validData)
+	assert.NoError(t, err)
+}
+
+func TestTxCborPartsEncodeDecode(t *testing.T) {
+	testCases := []struct {
+		name           string
+		blockSlot      uint64
+		blockHash      [32]byte
+		bodyOffset     uint32
+		bodyLength     uint32
+		witnessOffset  uint32
+		witnessLength  uint32
+		metadataOffset uint32
+		metadataLength uint32
+		isValid        bool
+	}{
+		{
+			name:           "zero values",
+			blockSlot:      0,
+			blockHash:      [32]byte{},
+			bodyOffset:     0,
+			bodyLength:     0,
+			witnessOffset:  0,
+			witnessLength:  0,
+			metadataOffset: 0,
+			metadataLength: 0,
+			isValid:        false,
+		},
+		{
+			name:           "typical valid transaction",
+			blockSlot:      12345678,
+			blockHash:      [32]byte{0x01, 0x02, 0x03, 0x04},
+			bodyOffset:     100,
+			bodyLength:     500,
+			witnessOffset:  1000,
+			witnessLength:  200,
+			metadataOffset: 2000,
+			metadataLength: 50,
+			isValid:        true,
+		},
+		{
+			name:           "invalid transaction no metadata",
+			blockSlot:      99999,
+			blockHash:      [32]byte{0xff, 0xee, 0xdd},
+			bodyOffset:     200,
+			bodyLength:     300,
+			witnessOffset:  800,
+			witnessLength:  150,
+			metadataOffset: 0,
+			metadataLength: 0,
+			isValid:        false,
+		},
+		{
+			name:      "max values",
+			blockSlot: math.MaxUint64,
+			blockHash: [32]byte{
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			},
+			bodyOffset:     math.MaxUint32,
+			bodyLength:     math.MaxUint32,
+			witnessOffset:  math.MaxUint32,
+			witnessLength:  math.MaxUint32,
+			metadataOffset: math.MaxUint32,
+			metadataLength: math.MaxUint32,
+			isValid:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := TxCborParts{
+				BlockSlot:      tc.blockSlot,
+				BlockHash:      tc.blockHash,
+				BodyOffset:     tc.bodyOffset,
+				BodyLength:     tc.bodyLength,
+				WitnessOffset:  tc.witnessOffset,
+				WitnessLength:  tc.witnessLength,
+				MetadataOffset: tc.metadataOffset,
+				MetadataLength: tc.metadataLength,
+				IsValid:        tc.isValid,
+			}
+
+			// Test encode
+			encoded := original.Encode()
+			require.Len(
+				t,
+				encoded,
+				TxCborPartsSize,
+				"encoded size should be %d bytes",
+				TxCborPartsSize,
+			)
+
+			// Verify magic prefix
+			assert.True(
+				t,
+				bytes.Equal(encoded[0:4], txPartsMagic[:]),
+				"should have DTXP magic prefix",
+			)
+
+			// Test decode
+			decoded, err := DecodeTxCborParts(encoded)
+			require.NoError(t, err, "decode should not error")
+			require.NotNil(t, decoded, "decoded should not be nil")
+
+			// Verify round-trip
+			assert.Equal(t, original.BlockSlot, decoded.BlockSlot, "BlockSlot mismatch")
+			assert.Equal(t, original.BlockHash, decoded.BlockHash, "BlockHash mismatch")
+			assert.Equal(t, original.BodyOffset, decoded.BodyOffset, "BodyOffset mismatch")
+			assert.Equal(t, original.BodyLength, decoded.BodyLength, "BodyLength mismatch")
+			assert.Equal(t, original.WitnessOffset, decoded.WitnessOffset, "WitnessOffset mismatch")
+			assert.Equal(t, original.WitnessLength, decoded.WitnessLength, "WitnessLength mismatch")
+			assert.Equal(t, original.MetadataOffset, decoded.MetadataOffset, "MetadataOffset mismatch")
+			assert.Equal(t, original.MetadataLength, decoded.MetadataLength, "MetadataLength mismatch")
+			assert.Equal(t, original.IsValid, decoded.IsValid, "IsValid mismatch")
+		})
+	}
+}
+
+func TestTxCborPartsSizeConstant(t *testing.T) {
+	// Verify the constant matches expected value
+	// Layout: Magic (4) + BlockSlot (8) + BlockHash (32) +
+	//         BodyOffset (4) + BodyLength (4) +
+	//         WitnessOffset (4) + WitnessLength (4) +
+	//         MetadataOffset (4) + MetadataLength (4) +
+	//         IsValid (1) = 69
+	assert.Equal(t, 69, TxCborPartsSize, "TxCborPartsSize should be 69")
+
+	// Verify encoded size matches constant
+	parts := TxCborParts{}
+	encoded := parts.Encode()
+	assert.Len(
+		t,
+		encoded,
+		TxCborPartsSize,
+		"encoded size should match TxCborPartsSize constant",
+	)
+}
+
+func TestDecodeTxCborPartsInvalidSize(t *testing.T) {
+	testCases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty data", data: []byte{}},
+		{name: "too short - 1 byte", data: []byte{0x01}},
+		{name: "too short - 68 bytes", data: make([]byte, 68)},
+		{name: "too long - 70 bytes", data: make([]byte, 70)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded, err := DecodeTxCborParts(tc.data)
+			assert.Error(t, err, "decode should return error for invalid size")
+			assert.Nil(t, decoded, "decoded should be nil on error")
+			assert.Contains(t, err.Error(), "69", "error message should mention expected size")
+		})
+	}
+}
+
+func TestDecodeTxCborPartsInvalidMagic(t *testing.T) {
+	// Valid size but wrong magic
+	data := make([]byte, TxCborPartsSize)
+	data[0] = 'X' // Wrong magic
+	data[1] = 'T'
+	data[2] = 'X'
+	data[3] = 'P'
+
+	decoded, err := DecodeTxCborParts(data)
+	assert.Error(t, err, "decode should return error for invalid magic")
+	assert.Nil(t, decoded, "decoded should be nil on error")
+	assert.Contains(t, err.Error(), "magic", "error message should mention magic")
+}
+
+func TestIsTxCborPartsStorage(t *testing.T) {
+	// Create valid TxCborParts data
+	validData := make([]byte, TxCborPartsSize)
+	copy(validData[0:4], txPartsMagic[:])
+
+	tests := []struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{name: "valid 69 bytes with magic", data: validData, expected: true},
+		{name: "69 bytes but wrong magic", data: make([]byte, 69), expected: false},
+		{name: "too short - 68 bytes", data: make([]byte, 68), expected: false},
+		{name: "too long - 70 bytes", data: make([]byte, 70), expected: false},
+		{name: "empty", data: []byte{}, expected: false},
+		{name: "52 bytes (CborOffset size)", data: make([]byte, 52), expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsTxCborPartsStorage(tc.data)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestTxCborPartsHasMetadata(t *testing.T) {
+	// With metadata
+	withMeta := TxCborParts{MetadataLength: 100}
+	assert.True(t, withMeta.HasMetadata())
+
+	// Without metadata
+	noMeta := TxCborParts{MetadataLength: 0}
+	assert.False(t, noMeta.HasMetadata())
+}
+
+func TestTxCborPartsReassembleTxCbor(t *testing.T) {
+	// Create a mock block CBOR with embedded components
+	// Body: simple CBOR map {0: 1}
+	bodyCbor := []byte{0xa1, 0x00, 0x01}
+	// Witness: simple CBOR array [1, 2]
+	witnessCbor := []byte{0x82, 0x01, 0x02}
+	// Metadata: simple CBOR map {1: "test"}
+	metadataCbor := []byte{0xa1, 0x01, 0x64, 0x74, 0x65, 0x73, 0x74}
+
+	// Build mock block with components at different offsets
+	blockCbor := make([]byte, 100)
+	copy(blockCbor[10:], bodyCbor)     // body at offset 10
+	copy(blockCbor[30:], witnessCbor)  // witness at offset 30
+	copy(blockCbor[50:], metadataCbor) // metadata at offset 50
+
+	t.Run("valid transaction with metadata", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset:     10,
+			BodyLength:     uint32(len(bodyCbor)),
+			WitnessOffset:  30,
+			WitnessLength:  uint32(len(witnessCbor)),
+			MetadataOffset: 50,
+			MetadataLength: uint32(len(metadataCbor)),
+			IsValid:        true,
+		}
+
+		result, err := parts.ReassembleTxCbor(blockCbor)
+		require.NoError(t, err)
+
+		// Verify structure: 0x84 (4-element array) + body + witness + true + metadata
+		assert.Equal(t, byte(0x84), result[0], "should be 4-element array")
+		// Body should follow array header
+		assert.True(t, bytes.Equal(result[1:1+len(bodyCbor)], bodyCbor), "body mismatch")
+		// Witness should follow body
+		witnessStart := 1 + len(bodyCbor)
+		assert.True(t, bytes.Equal(result[witnessStart:witnessStart+len(witnessCbor)], witnessCbor), "witness mismatch")
+		// IsValid (true = 0xf5) should follow witness
+		isValidIdx := witnessStart + len(witnessCbor)
+		assert.Equal(t, byte(0xf5), result[isValidIdx], "is_valid should be true (0xf5)")
+		// Metadata should follow is_valid
+		metaStart := isValidIdx + 1
+		assert.True(t, bytes.Equal(result[metaStart:], metadataCbor), "metadata mismatch")
+	})
+
+	t.Run("invalid transaction without metadata", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset:     10,
+			BodyLength:     uint32(len(bodyCbor)),
+			WitnessOffset:  30,
+			WitnessLength:  uint32(len(witnessCbor)),
+			MetadataOffset: 0,
+			MetadataLength: 0,
+			IsValid:        false,
+		}
+
+		result, err := parts.ReassembleTxCbor(blockCbor)
+		require.NoError(t, err)
+
+		// Verify structure: 0x84 + body + witness + false + null
+		assert.Equal(t, byte(0x84), result[0], "should be 4-element array")
+		// IsValid (false = 0xf4)
+		isValidIdx := 1 + len(bodyCbor) + len(witnessCbor)
+		assert.Equal(t, byte(0xf4), result[isValidIdx], "is_valid should be false (0xf4)")
+		// Null (0xf6) for no metadata
+		assert.Equal(t, byte(0xf6), result[isValidIdx+1], "metadata should be null (0xf6)")
+	})
+
+	t.Run("body out of bounds", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset: 90,
+			BodyLength: 20, // Would exceed block size
+		}
+
+		_, err := parts.ReassembleTxCbor(blockCbor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "body")
+	})
+
+	t.Run("witness out of bounds", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset:    10,
+			BodyLength:    3,
+			WitnessOffset: 95,
+			WitnessLength: 10, // Would exceed block size
+		}
+
+		_, err := parts.ReassembleTxCbor(blockCbor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "witness")
+	})
+
+	t.Run("metadata out of bounds", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset:     10,
+			BodyLength:     3,
+			WitnessOffset:  30,
+			WitnessLength:  3,
+			MetadataOffset: 98,
+			MetadataLength: 10, // Would exceed block size
+		}
+
+		_, err := parts.ReassembleTxCbor(blockCbor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "metadata")
+	})
+
+	t.Run("uint32 overflow in body bounds check", func(t *testing.T) {
+		// Test that overflow in offset+length is caught
+		// 0xFFFFFFF0 + 0x20 = 0x10 (wraps), which is < 100
+		// Without overflow protection, this would pass the check but panic on slice
+		parts := TxCborParts{
+			BodyOffset: 0xFFFFFFF0,
+			BodyLength: 0x20,
+		}
+
+		_, err := parts.ReassembleTxCbor(blockCbor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "body")
+	})
+
+	t.Run("uint32 overflow in witness bounds check", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset:    10,
+			BodyLength:    3,
+			WitnessOffset: 0xFFFFFFE0,
+			WitnessLength: 0x30,
+		}
+
+		_, err := parts.ReassembleTxCbor(blockCbor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "witness")
+	})
+
+	t.Run("uint32 overflow in metadata bounds check", func(t *testing.T) {
+		parts := TxCborParts{
+			BodyOffset:     10,
+			BodyLength:     3,
+			WitnessOffset:  30,
+			WitnessLength:  3,
+			MetadataOffset: 0xFFFFFF00,
+			MetadataLength: 0x200,
+		}
+
+		_, err := parts.ReassembleTxCbor(blockCbor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "metadata")
+	})
 }

--- a/database/plugin/blob/store.go
+++ b/database/plugin/blob/store.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,6 +74,11 @@ type BlobStore interface {
 	SetUtxo(txn types.Txn, txId []byte, outputIdx uint32, cbor []byte) error
 	GetUtxo(txn types.Txn, txId []byte, outputIdx uint32) ([]byte, error)
 	DeleteUtxo(txn types.Txn, txId []byte, outputIdx uint32) error
+
+	// Transaction operations
+	SetTx(txn types.Txn, txHash []byte, offsetData []byte) error
+	GetTx(txn types.Txn, txHash []byte) ([]byte, error)
+	DeleteTx(txn types.Txn, txHash []byte) error
 }
 
 // New returns the started blob plugin selected by name

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1375,6 +1375,64 @@ func (d *MetadataStoreMysql) SetTransaction(
 	return nil
 }
 
+// SetGenesisTransaction stores a genesis transaction record.
+// Genesis transactions have no inputs, witnesses, or fees - just outputs.
+func (d *MetadataStoreMysql) SetGenesisTransaction(
+	hash []byte,
+	blockHash []byte,
+	outputs []models.Utxo,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	tmpTx := &models.Transaction{
+		Hash:      hash,
+		Type:      0, // Byron era type
+		BlockHash: blockHash,
+		Slot:      0, // Genesis slot
+		Valid:     true,
+	}
+
+	result := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "hash"}},
+		DoNothing: true,
+	}).Create(tmpTx)
+	if result.Error != nil {
+		return fmt.Errorf("create genesis transaction %x: %w", hash, result.Error)
+	}
+
+	// Fetch ID if it was an existing record
+	if tmpTx.ID == 0 {
+		var existing struct{ ID uint }
+		if err := db.Model(&models.Transaction{}).
+			Select("id").
+			Where("hash = ?", hash).
+			Take(&existing).Error; err != nil {
+			return fmt.Errorf("fetch genesis transaction ID: %w", err)
+		}
+		tmpTx.ID = existing.ID
+	}
+
+	// Create UTxO records for genesis outputs
+	for i := range outputs {
+		outputs[i].TransactionID = &tmpTx.ID
+	}
+	if len(outputs) > 0 {
+		result := db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
+			DoNothing: true,
+		}).Create(&outputs)
+		if result.Error != nil {
+			return fmt.Errorf("create genesis utxos: %w", result.Error)
+		}
+	}
+
+	return nil
+}
+
 // Traverse each utxo and check for inline datum & calls storeDatum
 func (d *MetadataStoreMysql) storeTransactionDatums(
 	tx lcommon.Transaction,
@@ -1422,6 +1480,27 @@ func (d *MetadataStoreMysql) storeDatum(
 	}
 	datumHash := lcommon.Blake2b256Hash(rawDatum)
 	return d.SetDatum(datumHash, rawDatum, slot, txn)
+}
+
+// GetTransactionHashesAfterSlot returns transaction hashes for transactions added after the given slot.
+// This is used for blob cleanup during rollback/truncation.
+func (d *MetadataStoreMysql) GetTransactionHashesAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) ([][]byte, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	var txHashes [][]byte
+	if result := db.Model(&models.Transaction{}).
+		Where("slot > ?", slot).
+		Pluck("hash", &txHashes); result.Error != nil {
+		return nil, fmt.Errorf("query transaction hashes: %w", result.Error)
+	}
+
+	return txHashes, nil
 }
 
 // DeleteTransactionsAfterSlot removes transaction records added after the given slot.

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -214,6 +214,15 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// SetGenesisTransaction stores a genesis transaction record.
+	// Genesis transactions have no inputs, witnesses, or fees - just outputs.
+	SetGenesisTransaction(
+		hash []byte,
+		blockHash []byte,
+		outputs []models.Utxo,
+		txn types.Txn,
+	) error
+
 	// Helper methods
 
 	// DeleteBlockNoncesBeforeSlot removes block nonces older than the given slot.
@@ -341,6 +350,14 @@ type MetadataStore interface {
 
 	// DeleteEpochSummariesBeforeEpoch deletes all epoch summaries before a given epoch.
 	DeleteEpochSummariesBeforeEpoch(uint64, types.Txn) error
+
+	// GetTransactionHashesAfterSlot returns transaction hashes for transactions added after the given slot.
+	// This is used for blob cleanup during rollback/truncation.
+	GetTransactionHashesAfterSlot(uint64, types.Txn) ([][]byte, error)
+
+	// DeleteTransactionsAfterSlot removes transaction records added after the given slot.
+	// Child records are automatically removed via CASCADE constraints.
+	DeleteTransactionsAfterSlot(uint64, types.Txn) error
 }
 
 // New creates a new metadata store instance using the specified plugin

--- a/database/types/keys.go
+++ b/database/types/keys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ const (
 	BlockBlobIndexKeyPrefix    = "bi"
 	BlockBlobMetadataKeySuffix = "_metadata"
 	UtxoBlobKeyPrefix          = "u"
+	TxBlobKeyPrefix            = "t"
 )
 
 func BlockBlobKeyUint64ToBytes(input uint64) []byte {
@@ -60,5 +61,13 @@ func UtxoBlobKey(txId []byte, outputIdx uint32) []byte {
 	idxBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(idxBytes, outputIdx)
 	key = append(key, idxBytes...)
+	return key
+}
+
+// TxBlobKey creates a key for storing transaction offset data.
+// Key format: 't' + txHash (32 bytes)
+func TxBlobKey(txHash []byte) []byte {
+	key := []byte(TxBlobKeyPrefix)
+	key = append(key, txHash...)
 	return key
 }

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.0
-	github.com/blinklabs-io/gouroboros v0.151.1
-	github.com/blinklabs-io/ouroboros-mock v0.5.1
+	github.com/blinklabs-io/gouroboros v0.152.1
+	github.com/blinklabs-io/ouroboros-mock v0.7.0
 	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.0

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,10 @@ github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoG
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blinklabs-io/gouroboros v0.151.1 h1:FYVdlF6Dtejizeibap+bQyf+hQlWznPHCgBMQZAiBDI=
-github.com/blinklabs-io/gouroboros v0.151.1/go.mod h1:TvYUUtyOOW/D518NIAo/4TzllN51sQKMzTVYpuW6mHE=
-github.com/blinklabs-io/ouroboros-mock v0.5.1 h1:maGW79vo+okLAHCkM65PKNZvnV3Chuvqfmes3oZAIUk=
-github.com/blinklabs-io/ouroboros-mock v0.5.1/go.mod h1:NtHOSbznmZ5CChTvAmMH8v85lgCiknumUoSJw8fdAkA=
+github.com/blinklabs-io/gouroboros v0.152.1 h1:wySqy6coBwbrc/3j94GNz062c39zGb2kpGKWHhun2AE=
+github.com/blinklabs-io/gouroboros v0.152.1/go.mod h1:BXTv7xGWb0fDpUuRunVLhSvrDrvd+pkSMBpOligo5Ew=
+github.com/blinklabs-io/ouroboros-mock v0.7.0 h1:IbBzOHAtjzh1PWIXy9tMB6wAS6/+HLMVtNtTFSTN4VM=
+github.com/blinklabs-io/ouroboros-mock v0.7.0/go.mod h1:ODwZJTTyonyId1hFeFjxvGGnlhvRZ+5IKBYAka0XWhE=
 github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=
 github.com/blinklabs-io/plutigo v0.0.22/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -15,9 +15,11 @@
 package ledger
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"time"
 
@@ -311,6 +313,15 @@ func (ls *LedgerState) processBlockEvents() error {
 	return nil
 }
 
+// GenesisBlockHash is a well-known hash for the synthetic genesis block.
+// This block holds genesis UTxO data and allows offset-based storage.
+var GenesisBlockHash = [32]byte{
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x47, 0x45, 0x4e, 0x45, 0x53, 0x49, 0x53, 0x00, // "GENESIS\0"
+}
+
 func (ls *LedgerState) createGenesisBlock() error {
 	if ls.currentTip.Point.Slot > 0 {
 		return nil
@@ -332,7 +343,7 @@ func (ls *LedgerState) createGenesisBlock() error {
 		if len(byronGenesisUtxos)+len(shelleyGenesisUtxos) == 0 {
 			return errors.New("failed to generate genesis UTxOs")
 		}
-		ls.config.Logger.Debug(
+		ls.config.Logger.Info(
 			fmt.Sprintf("creating %d genesis UTxOs (%d Byron, %d Shelley)",
 				len(byronGenesisUtxos)+len(shelleyGenesisUtxos),
 				len(byronGenesisUtxos),
@@ -341,10 +352,14 @@ func (ls *LedgerState) createGenesisBlock() error {
 			"component", "ledger",
 		)
 
-		// Create genesis UTxOs directly using AddUtxos
+		// Group genesis UTxOs by transaction hash
 		genesisUtxos := slices.Concat(byronGenesisUtxos, shelleyGenesisUtxos)
-		utxoSlots := make([]models.UtxoSlot, len(genesisUtxos))
+		txUtxos := make(map[[32]byte][]lcommon.Utxo)
 		for i := range genesisUtxos {
+			txHash := genesisUtxos[i].Id.Id()
+			var txHashArray [32]byte
+			copy(txHashArray[:], txHash.Bytes())
+
 			// Generate CBOR for genesis UTxO outputs since they don't have original CBOR
 			cborData, err := cbor.Encode(genesisUtxos[i].Output)
 			if err != nil {
@@ -352,7 +367,6 @@ func (ls *LedgerState) createGenesisBlock() error {
 			}
 
 			// Create a new Utxo with CBOR-encoded output
-			// We need to create a new output object with CBOR set
 			var newOutput lcommon.TransactionOutput
 			switch output := genesisUtxos[i].Output.(type) {
 			case byron.ByronTransactionOutput:
@@ -367,22 +381,222 @@ func (ls *LedgerState) createGenesisBlock() error {
 				return fmt.Errorf("unsupported genesis UTxO output type: %T", genesisUtxos[i].Output)
 			}
 
-			utxoSlots[i] = models.UtxoSlot{
-				Utxo: lcommon.Utxo{
-					Id:     genesisUtxos[i].Id,
-					Output: newOutput,
-				},
-				Slot: 0, // genesis slot
+			txUtxos[txHashArray] = append(txUtxos[txHashArray], lcommon.Utxo{
+				Id:     genesisUtxos[i].Id,
+				Output: newOutput,
+			})
+		}
+
+		// Build synthetic genesis block with proper structure:
+		// Block -> Transactions -> Outputs (UTxOs)
+		//
+		// CBOR structure:
+		// [                                    // block: array of transactions
+		//   {0: tx_hash, 1: [output, ...]},    // transaction 1
+		//   {0: tx_hash, 1: [output, ...]},    // transaction 2
+		//   ...
+		// ]
+		//
+		// We track byte offsets for each output within this structure.
+		utxoOffsets := make(map[database.UtxoRef]database.CborOffset)
+
+		// Sort transaction hashes for deterministic ordering
+		txHashes := make([][32]byte, 0, len(txUtxos))
+		for txHash := range txUtxos {
+			txHashes = append(txHashes, txHash)
+		}
+		slices.SortFunc(txHashes, func(a, b [32]byte) int {
+			return bytes.Compare(a[:], b[:])
+		})
+
+		// Build the block structure manually to track exact byte offsets
+		// We need to know where each output CBOR starts within the block
+		blockCbor, err := buildGenesisBlockCbor(txHashes, txUtxos, utxoOffsets)
+		if err != nil {
+			return fmt.Errorf("build genesis block cbor: %w", err)
+		}
+
+		// Store synthetic genesis block CBOR.
+		// We use SetGenesisCbor to avoid creating a block index entry that
+		// would cause the chain iterator to include it (genesis is already
+		// handled separately during initialization).
+		if err := ls.db.SetGenesisCbor(0, GenesisBlockHash[:], blockCbor, txn); err != nil {
+			return fmt.Errorf("store genesis cbor: %w", err)
+		}
+
+		// Store each genesis transaction with its UTxOs
+		for txHashArray, utxos := range txUtxos {
+			if err := ls.db.SetGenesisTransaction(
+				txHashArray[:],
+				GenesisBlockHash[:],
+				utxos,
+				utxoOffsets,
+				txn,
+			); err != nil {
+				return fmt.Errorf("set genesis transaction %x: %w", txHashArray[:8], err)
 			}
 		}
 
-		if err := ls.db.AddUtxos(utxoSlots, txn); err != nil {
-			return fmt.Errorf("add genesis UTxOs: %w", err)
-		}
+		ls.config.Logger.Info(
+			fmt.Sprintf("stored %d genesis transactions with %d total UTxOs",
+				len(txUtxos),
+				len(genesisUtxos),
+			),
+			"component", "ledger",
+		)
 
 		return nil
 	})
 	return err
+}
+
+// buildGenesisBlockCbor creates a CBOR structure representing a synthetic
+// genesis block containing transactions with outputs. The structure is:
+//
+//	[                                    // block: array of transactions
+//	  {0: tx_hash, 1: [output, ...]},    // transaction 1
+//	  {0: tx_hash, 1: [output, ...]},    // transaction 2
+//	  ...
+//	]
+//
+// It populates utxoOffsets with the byte offset of each output within the block.
+// Unlike a search-based approach, this function tracks exact byte positions during
+// CBOR construction to avoid any possibility of false matches.
+func buildGenesisBlockCbor(
+	txHashes [][32]byte,
+	txUtxos map[[32]byte][]lcommon.Utxo,
+	utxoOffsets map[database.UtxoRef]database.CborOffset,
+) ([]byte, error) {
+	var buf bytes.Buffer
+
+	// Write outer array header for transactions
+	writeCborArrayHeader(&buf, len(txHashes))
+
+	for _, txHash := range txHashes {
+		utxos := txUtxos[txHash]
+
+		// Sort outputs by index for deterministic ordering
+		slices.SortFunc(utxos, func(a, b lcommon.Utxo) int {
+			ai, bi := uint64(a.Id.Index()), uint64(b.Id.Index())
+			if ai < bi {
+				return -1
+			} else if ai > bi {
+				return 1
+			}
+			return 0
+		})
+
+		// Write map header with 2 entries: {0: txhash, 1: outputs}
+		writeCborMapHeader(&buf, 2)
+
+		// Key 0: tx hash
+		writeCborUint(&buf, 0)
+		writeCborBytes(&buf, txHash[:])
+
+		// Key 1: outputs array
+		writeCborUint(&buf, 1)
+		writeCborArrayHeader(&buf, len(utxos))
+
+		// Write each output, tracking offsets
+		for _, utxo := range utxos {
+			outputCbor := utxo.Output.Cbor()
+			if len(outputCbor) == 0 {
+				var err error
+				outputCbor, err = cbor.Encode(utxo.Output)
+				if err != nil {
+					return nil, fmt.Errorf("encode output: %w", err)
+				}
+			}
+
+			// Record offset BEFORE writing the output
+			offset := buf.Len()
+			outputLen := len(outputCbor)
+
+			// Validate sizes fit in uint32 (fail fast instead of silent truncation)
+			if offset > math.MaxUint32 {
+				return nil, fmt.Errorf(
+					"genesis CBOR offset %d exceeds uint32 max",
+					offset,
+				)
+			}
+			if outputLen > math.MaxUint32 {
+				return nil, fmt.Errorf(
+					"genesis output CBOR length %d exceeds uint32 max",
+					outputLen,
+				)
+			}
+
+			buf.Write(outputCbor)
+
+			ref := database.UtxoRef{
+				TxId:      txHash,
+				OutputIdx: utxo.Id.Index(),
+			}
+			utxoOffsets[ref] = database.CborOffset{
+				BlockSlot:  0,
+				BlockHash:  GenesisBlockHash,
+				ByteOffset: uint32(offset),    // #nosec G115: bounds checked above
+				ByteLength: uint32(outputLen), // #nosec G115: bounds checked above
+			}
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// writeCborArrayHeader writes a CBOR array header for n elements.
+func writeCborArrayHeader(buf *bytes.Buffer, n int) {
+	writeCborMajorType(buf, 4, n) // Major type 4 = array
+}
+
+// writeCborMapHeader writes a CBOR map header for n pairs.
+func writeCborMapHeader(buf *bytes.Buffer, n int) {
+	writeCborMajorType(buf, 5, n) // Major type 5 = map
+}
+
+// writeCborBytes writes a CBOR byte string.
+func writeCborBytes(buf *bytes.Buffer, data []byte) {
+	writeCborMajorType(buf, 2, len(data)) // Major type 2 = byte string
+	buf.Write(data)
+}
+
+// writeCborUint writes a CBOR unsigned integer.
+func writeCborUint(buf *bytes.Buffer, n int) {
+	writeCborMajorType(buf, 0, n) // Major type 0 = unsigned int
+}
+
+// writeCborMajorType writes a CBOR header with the given major type and value.
+func writeCborMajorType(buf *bytes.Buffer, majorType, n int) {
+	header := byte(majorType << 5)
+	switch {
+	case n < 24:
+		buf.WriteByte(header | byte(n))
+	case n < 256:
+		buf.WriteByte(header | 24)
+		buf.WriteByte(byte(n))
+	case n < 65536:
+		buf.WriteByte(header | 25)
+		buf.WriteByte(byte(n >> 8))
+		buf.WriteByte(byte(n))
+	case n < 4294967296:
+		buf.WriteByte(header | 26)
+		buf.WriteByte(byte(n >> 24))
+		buf.WriteByte(byte(n >> 16))
+		buf.WriteByte(byte(n >> 8))
+		buf.WriteByte(byte(n))
+	default:
+		// 8-byte encoding for values >= 2^32
+		buf.WriteByte(header | 27)
+		val := uint64(n)
+		buf.WriteByte(byte(val >> 56))
+		buf.WriteByte(byte(val >> 48))
+		buf.WriteByte(byte(val >> 40))
+		buf.WriteByte(byte(val >> 32))
+		buf.WriteByte(byte(val >> 24))
+		buf.WriteByte(byte(val >> 16))
+		buf.WriteByte(byte(val >> 8))
+		buf.WriteByte(byte(val))
+	}
 }
 
 func (ls *LedgerState) calculateEpochNonce(

--- a/ledger/genesis_utxo_test.go
+++ b/ledger/genesis_utxo_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
+	// Create temp directory for database
+	tmpDir, err := os.MkdirTemp("", "genesis_utxo_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Create database
+	dbConfig := &database.Config{
+		DataDir:        tmpDir,
+		Logger:         logger,
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	}
+	db, err := database.New(dbConfig)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Load cardano config from embedded preview network
+	nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
+		"preview/config.json",
+		"preview",
+		cardano.EmbeddedConfigPreviewNetworkFS,
+	)
+	require.NoError(t, err)
+
+	// Get genesis UTxOs
+	byronGenesis := nodeCfg.ByronGenesis()
+	require.NotNil(t, byronGenesis)
+
+	byronGenesisUtxos, err := byronGenesis.GenesisUtxos()
+	require.NoError(t, err)
+	t.Logf("Found %d Byron genesis UTxOs", len(byronGenesisUtxos))
+
+	if len(byronGenesisUtxos) == 0 {
+		t.Skip("No Byron genesis UTxOs to test")
+	}
+
+	// First, encode the genesis outputs to CBOR (like createGenesisBlock does)
+	encodedUtxos := make([]lcommon.Utxo, len(byronGenesisUtxos))
+	for i, utxo := range byronGenesisUtxos {
+		// Encode the output to CBOR
+		cborData, err := cbor.Encode(utxo.Output)
+		require.NoError(t, err, "Failed to encode output %d", i)
+
+		// Create a new Utxo with CBOR-encoded output
+		switch output := utxo.Output.(type) {
+		case byron.ByronTransactionOutput:
+			newOutput := output
+			(&newOutput).SetCbor(cborData)
+			encodedUtxos[i] = lcommon.Utxo{
+				Id:     utxo.Id,
+				Output: newOutput,
+			}
+		default:
+			t.Fatalf("Unexpected output type: %T", utxo.Output)
+		}
+		t.Logf("Encoded UTxO %x#%d: %d bytes",
+			utxo.Id.Id().Bytes()[:8], utxo.Id.Index(), len(cborData))
+	}
+
+	// Create a transaction to store genesis UTxOs
+	txn := db.Transaction(true)
+	err = txn.Do(func(txn *database.Txn) error {
+		// Build and store genesis block CBOR
+		utxoOffsets := make(map[database.UtxoRef]database.CborOffset)
+
+		// Build synthetic genesis block CBOR (simplified version)
+		// First, encode each UTxO to get its CBOR
+		var blockCbor []byte
+
+		// Track offsets as we build the block
+		for _, utxo := range encodedUtxos {
+			txId := utxo.Id.Id().Bytes()
+			outputIdx := utxo.Id.Index()
+
+			// Get the output CBOR
+			outputCbor := utxo.Output.Cbor()
+			if len(outputCbor) == 0 {
+				return fmt.Errorf(
+					"UTxO %x#%d still has no CBOR after encoding",
+					txId[:8], outputIdx,
+				)
+			}
+
+			var txHashArray [32]byte
+			copy(txHashArray[:], txId)
+
+			ref := database.UtxoRef{
+				TxId:      txHashArray,
+				OutputIdx: outputIdx,
+			}
+
+			// Track offset within block (simplified: just concatenate)
+			offset := uint32(len(blockCbor))
+			blockCbor = append(blockCbor, outputCbor...)
+
+			utxoOffsets[ref] = database.CborOffset{
+				BlockSlot:  0,
+				BlockHash:  GenesisBlockHash,
+				ByteOffset: offset,
+				ByteLength: uint32(len(outputCbor)),
+			}
+
+			t.Logf("UTxO %x#%d: offset=%d, length=%d",
+				txId[:8], outputIdx, offset, len(outputCbor))
+		}
+
+		// Store the genesis block CBOR
+		t.Logf("Storing genesis block CBOR: %d bytes", len(blockCbor))
+		if err := db.SetGenesisCbor(0, GenesisBlockHash[:], blockCbor, txn); err != nil {
+			return err
+		}
+
+		// Now store each genesis transaction
+		for _, utxo := range encodedUtxos {
+			txId := utxo.Id.Id().Bytes()
+			outputIdx := utxo.Id.Index()
+
+			var txHashArray [32]byte
+			copy(txHashArray[:], txId)
+
+			ref := database.UtxoRef{
+				TxId:      txHashArray,
+				OutputIdx: outputIdx,
+			}
+
+			offset, ok := utxoOffsets[ref]
+			if !ok {
+				return fmt.Errorf(
+					"no offset for UTxO %x#%d after building block",
+					txId[:8], outputIdx,
+				)
+			}
+
+			// Store the offset
+			offsetData := database.EncodeUtxoOffset(&offset)
+			t.Logf("Storing UTxO offset: %s", hex.EncodeToString(offsetData[:20]))
+
+			blob := db.Blob()
+			if blob == nil {
+				return fmt.Errorf("blob store is nil")
+			}
+			blobTxn := txn.Blob()
+			if blobTxn == nil {
+				return fmt.Errorf("blob transaction is nil")
+			}
+
+			if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Now try to retrieve each genesis UTxO
+	t.Log("Retrieving genesis UTxOs...")
+	for _, utxo := range byronGenesisUtxos {
+		txId := utxo.Id.Id().Bytes()
+		outputIdx := utxo.Id.Index()
+
+		// Try to get the UTxO from blob store
+		readTxn := db.Transaction(false)
+		blob := db.Blob()
+		require.NotNil(t, blob)
+		blobTxn := readTxn.Blob()
+		require.NotNil(t, blobTxn)
+
+		data, err := blob.GetUtxo(blobTxn, txId, outputIdx)
+		if err != nil {
+			t.Errorf("Failed to get UTxO %s#%d from blob: %v",
+				hex.EncodeToString(txId[:8]), outputIdx, err)
+			readTxn.Rollback() //nolint:errcheck
+			continue
+		}
+
+		t.Logf("Retrieved data for %x#%d: %d bytes, first bytes: %s",
+			txId[:8], outputIdx, len(data), hex.EncodeToString(data[:min(20, len(data))]))
+
+		// Check if it's an offset
+		if database.IsUtxoOffsetStorage(data) {
+			t.Logf("Data is offset storage (has DOFF magic)")
+
+			// Decode the offset
+			offset, err := database.DecodeUtxoOffset(data)
+			require.NoError(t, err, "Failed to decode offset for %x#%d", txId[:8], outputIdx)
+
+			t.Logf("Offset: slot=%d, hash=%x, offset=%d, length=%d",
+				offset.BlockSlot, offset.BlockHash[:8], offset.ByteOffset, offset.ByteLength)
+
+			// Try to get the block
+			blockCbor, _, err := blob.GetBlock(blobTxn, offset.BlockSlot, offset.BlockHash[:])
+			if err != nil {
+				t.Errorf("Failed to get block for offset: slot=%d, hash=%x, error=%v",
+					offset.BlockSlot, offset.BlockHash[:8], err)
+				readTxn.Rollback() //nolint:errcheck
+				continue
+			}
+
+			t.Logf("Got block: %d bytes", len(blockCbor))
+
+			// Extract the UTxO CBOR
+			end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
+			if end > uint64(len(blockCbor)) {
+				t.Errorf("Offset out of bounds: offset=%d, length=%d, block_size=%d",
+					offset.ByteOffset, offset.ByteLength, len(blockCbor))
+			} else {
+				utxoCbor := blockCbor[offset.ByteOffset:end]
+				t.Logf("Extracted UTxO CBOR: %d bytes, first bytes: %s",
+					len(utxoCbor), hex.EncodeToString(utxoCbor[:min(20, len(utxoCbor))]))
+			}
+		} else {
+			t.Logf("Data is raw CBOR (legacy format)")
+		}
+
+		readTxn.Rollback() //nolint:errcheck
+	}
+}

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUtxoStorageAndRetrieval tests that UTxOs from regular blocks are stored
+// and retrieved correctly using the offset-based storage system.
+func TestUtxoStorageAndRetrieval(t *testing.T) {
+	// Create temp directory for database
+	tmpDir, err := os.MkdirTemp("", "utxo_storage_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Create database
+	dbConfig := &database.Config{
+		DataDir:        tmpDir,
+		Logger:         logger,
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	}
+	db, err := database.New(dbConfig)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Load blocks from immutable testdata
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+
+	// Start from genesis and process a few blocks
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var storedUtxos []struct {
+		txId      []byte
+		outputIdx uint32
+		slot      uint64
+	}
+
+	blocksProcessed := 0
+	maxBlocks := 10 // Process a few blocks to find some UTxOs
+
+	for blocksProcessed < maxBlocks {
+		immBlock, err := iter.Next()
+		if err != nil {
+			// io.EOF or equivalent signals end of iteration
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+				break
+			}
+			t.Fatalf("unexpected iterator error: %v", err)
+		}
+		if immBlock == nil {
+			break
+		}
+
+		// Decode block using gouroboros
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+
+		point := ocommon.Point{
+			Slot: block.SlotNumber(),
+			Hash: block.Hash().Bytes(),
+		}
+
+		t.Logf("Processing block at slot %d with %d transactions",
+			point.Slot, len(block.Transactions()))
+
+		// Skip blocks with no transactions
+		if len(block.Transactions()) == 0 {
+			blocksProcessed++
+			continue
+		}
+
+		// First, store the block
+		txn := db.Transaction(true)
+		err = txn.Do(func(txn *database.Txn) error {
+			// Store block CBOR
+			blockRecord := models.Block{
+				Slot:     point.Slot,
+				Hash:     point.Hash,
+				Number:   block.BlockNumber(),
+				Type:     uint(block.Type()),
+				PrevHash: block.PrevHash().Bytes(),
+				Cbor:     block.Cbor(),
+			}
+			if err := db.BlockCreate(blockRecord, txn); err != nil {
+				return err
+			}
+
+			// Compute offsets - offsets MUST be available
+			indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+			offsets, err := indexer.ComputeOffsets(block.Cbor(), block)
+			if err != nil {
+				return fmt.Errorf("compute offsets for block %d: %w", point.Slot, err)
+			}
+
+			// Process each transaction
+			for txIdx, tx := range block.Transactions() {
+				txHash := tx.Hash()
+				var txHashArray [32]byte
+				copy(txHashArray[:], txHash.Bytes())
+
+				t.Logf("  TX %d: %s with %d outputs",
+					txIdx, txHash.String(), len(tx.Outputs()))
+
+				// Verify offsets exist for this transaction
+				if txOff, ok := offsets.TxOffsets[txHashArray]; ok {
+					t.Logf("    TX offset: slot=%d, offset=%d, length=%d",
+						txOff.BlockSlot, txOff.ByteOffset, txOff.ByteLength)
+				} else {
+					return fmt.Errorf("TX offset not found for %s", txHash.String())
+				}
+
+				// Store the transaction - offsets MUST be available
+				err := db.SetTransaction(
+					tx,
+					point,
+					uint32(txIdx),
+					0,
+					nil,
+					nil,
+					&database.BlockIngestionResult{
+						TxOffsets:   offsets.TxOffsets,
+						UtxoOffsets: offsets.UtxoOffsets,
+					},
+					txn,
+				)
+				if err != nil {
+					return err
+				}
+
+				// Track outputs for later verification
+				for _, utxo := range tx.Produced() {
+					txId := utxo.Id.Id().Bytes()
+					outputIdx := utxo.Id.Index()
+
+					// Verify offset was computed
+					ref := database.UtxoRef{
+						TxId:      txHashArray,
+						OutputIdx: outputIdx,
+					}
+					if utxoOff, ok := offsets.UtxoOffsets[ref]; ok {
+						t.Logf("    Output %d offset: slot=%d, offset=%d, length=%d",
+							outputIdx, utxoOff.BlockSlot, utxoOff.ByteOffset, utxoOff.ByteLength)
+					} else {
+						return fmt.Errorf("output %d offset not found", outputIdx)
+					}
+
+					storedUtxos = append(storedUtxos, struct {
+						txId      []byte
+						outputIdx uint32
+						slot      uint64
+					}{
+						txId:      txId,
+						outputIdx: outputIdx,
+						slot:      point.Slot,
+					})
+				}
+			}
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		blocksProcessed++
+	}
+
+	t.Logf("\n=== Stored %d UTxOs from %d blocks ===\n", len(storedUtxos), blocksProcessed)
+
+	// Now try to retrieve each stored UTxO
+	var retrievalErrors int
+	var metadataErrors int
+	var blobErrors int
+	var successCount int
+
+	for _, utxoRef := range storedUtxos {
+		txn := db.Transaction(false)
+
+		// Step 1: Check if metadata exists
+		metaTxn := txn.Metadata()
+		utxoMeta, err := db.Metadata().GetUtxo(utxoRef.txId, utxoRef.outputIdx, metaTxn)
+		if err != nil {
+			t.Logf("Metadata error for %s#%d: %v",
+				hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx, err)
+			metadataErrors++
+			txn.Release()
+			continue
+		}
+		if utxoMeta == nil {
+			t.Logf("Metadata MISSING for %s#%d (slot %d)",
+				hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx, utxoRef.slot)
+			metadataErrors++
+			txn.Release()
+			continue
+		}
+
+		// Step 2: Check if blob data exists
+		blob := db.Blob()
+		blobTxn := txn.Blob()
+		blobData, err := blob.GetUtxo(blobTxn, utxoRef.txId, utxoRef.outputIdx)
+		if err != nil {
+			t.Logf("Blob error for %s#%d: %v",
+				hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx, err)
+			blobErrors++
+			txn.Release()
+			continue
+		}
+
+		// Step 3: Check blob data type
+		if database.IsUtxoOffsetStorage(blobData) {
+			// Decode offset
+			offset, err := database.DecodeUtxoOffset(blobData)
+			if err != nil {
+				t.Logf("Offset decode error for %s#%d: %v",
+					hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx, err)
+				blobErrors++
+				txn.Release()
+				continue
+			}
+
+			// Try to get block CBOR
+			blockCbor, _, err := blob.GetBlock(blobTxn, offset.BlockSlot, offset.BlockHash[:])
+			if err != nil {
+				t.Logf("Block retrieval error for %s#%d: slot=%d, hash=%x, err=%v",
+					hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx,
+					offset.BlockSlot, offset.BlockHash[:8], err)
+				blobErrors++
+				txn.Release()
+				continue
+			}
+
+			// Extract UTxO CBOR
+			end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
+			if end > uint64(len(blockCbor)) {
+				t.Logf("Offset out of bounds for %s#%d: offset=%d, length=%d, block_size=%d",
+					hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx,
+					offset.ByteOffset, offset.ByteLength, len(blockCbor))
+				blobErrors++
+				txn.Release()
+				continue
+			}
+
+			// Success!
+			successCount++
+		} else {
+			// Raw CBOR storage
+			if len(blobData) > 0 {
+				successCount++
+			} else {
+				t.Logf("Empty blob data for %s#%d",
+					hex.EncodeToString(utxoRef.txId[:8]), utxoRef.outputIdx)
+				blobErrors++
+			}
+		}
+
+		txn.Release()
+	}
+
+	retrievalErrors = metadataErrors + blobErrors
+
+	t.Logf("\n=== RESULTS ===")
+	t.Logf("Total UTxOs: %d", len(storedUtxos))
+	t.Logf("Successful retrievals: %d", successCount)
+	t.Logf("Metadata errors: %d", metadataErrors)
+	t.Logf("Blob errors: %d", blobErrors)
+	t.Logf("Total retrieval errors: %d", retrievalErrors)
+
+	// Require all UTxOs to be retrievable
+	require.Equal(t, 0, retrievalErrors, "Some UTxOs could not be retrieved")
+	require.Equal(t, len(storedUtxos), successCount, "Not all UTxOs were retrieved successfully")
+}
+
+// TestUtxoByRefAfterSetTransaction verifies that UtxoByRef works immediately
+// after SetTransaction within the same transaction.
+func TestUtxoByRefAfterSetTransaction(t *testing.T) {
+	// Create temp directory for database
+	tmpDir, err := os.MkdirTemp("", "utxo_byref_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Create database
+	dbConfig := &database.Config{
+		DataDir:        tmpDir,
+		Logger:         logger,
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	}
+	db, err := database.New(dbConfig)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Load blocks from immutable testdata
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+
+	// Start from genesis
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Find a block with transactions
+	var block lcommon.Block
+	var blockCbor []byte
+	for {
+		immBlock, err := iter.Next()
+		require.NoError(t, err)
+		if immBlock == nil {
+			t.Skip("No blocks with transactions found")
+		}
+
+		block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+
+		if len(block.Transactions()) > 0 {
+			blockCbor = immBlock.Cbor
+			break
+		}
+	}
+
+	point := ocommon.Point{
+		Slot: block.SlotNumber(),
+		Hash: block.Hash().Bytes(),
+	}
+
+	t.Logf("Using block at slot %d with %d transactions", point.Slot, len(block.Transactions()))
+
+	// Store block and verify UTxO retrieval in same transaction
+	txn := db.Transaction(true)
+	err = txn.Do(func(txn *database.Txn) error {
+		// Store block CBOR
+		blockRecord := models.Block{
+			Slot:     point.Slot,
+			Hash:     point.Hash,
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     blockCbor,
+		}
+		if err := db.BlockCreate(blockRecord, txn); err != nil {
+			return err
+		}
+
+		// Compute offsets - offsets MUST be available
+		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+		offsets, err := indexer.ComputeOffsets(blockCbor, block)
+		if err != nil {
+			return fmt.Errorf("compute offsets: %w", err)
+		}
+
+		// Process first transaction - offsets MUST be available
+		tx := block.Transactions()[0]
+		err = db.SetTransaction(
+			tx,
+			point,
+			0,
+			0,
+			nil,
+			nil,
+			&database.BlockIngestionResult{
+				TxOffsets:   offsets.TxOffsets,
+				UtxoOffsets: offsets.UtxoOffsets,
+			},
+			txn,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Try to retrieve UTxOs immediately (within same transaction)
+		for _, utxo := range tx.Produced() {
+			txId := utxo.Id.Id().Bytes()
+			outputIdx := utxo.Id.Index()
+
+			t.Logf("Attempting to retrieve %s#%d within same transaction...",
+				hex.EncodeToString(txId[:8]), outputIdx)
+
+			retrieved, err := db.UtxoByRef(txId, outputIdx, txn)
+			if err != nil {
+				t.Errorf("Failed to retrieve %s#%d: %v",
+					hex.EncodeToString(txId[:8]), outputIdx, err)
+				continue
+			}
+
+			t.Logf("Successfully retrieved %s#%d: CBOR len=%d",
+				hex.EncodeToString(txId[:8]), outputIdx, len(retrieved.Cbor))
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -26,6 +26,9 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// ErrNilDecodedOutput is returned when a decoded UTxO output is nil.
+var ErrNilDecodedOutput = errors.New("nil decoded output")
+
 type LedgerView struct {
 	ls  *LedgerState
 	txn *database.Txn
@@ -68,6 +71,14 @@ func (lv *LedgerView) UtxoById(
 	tmpOutput, err := utxo.Decode()
 	if err != nil {
 		return lcommon.Utxo{}, err
+	}
+	if tmpOutput == nil {
+		return lcommon.Utxo{}, fmt.Errorf(
+			"decoded output is nil for utxo %s#%d: %w",
+			utxoId.Id().String(),
+			utxoId.Index(),
+			ErrNilDecodedOutput,
+		)
 	}
 	return lcommon.Utxo{
 		Id:     utxoId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds offset-based CBOR extraction from blocks to store and retrieve raw bytes for transactions and UTxOs, reducing storage and speeding reads. Integrates a tiered CBOR cache with Prometheus metrics and adds safe handling for genesis CBOR.

- **New Features**
  - BlockIndexer computes per-transaction/UTxO CBOR byte offsets and lengths.
  - Offset-based storage with DOFF magic (52-byte CborOffset) to avoid CBOR duplication.
  - Blob stores support transaction offsets (SetTx/GetTx/DeleteTx).
  - TieredCborCache wired into Database for hot UTxO/tx reads and cold block-byte extraction.
  - Prometheus counters for cache hits/misses; added benchmarks and tests.
  - Ledger sync computes offsets during ingestion; rollback removes offset data; genesis CBOR stored without creating a block entry.

- **Dependencies**
  - Updated gouroboros to v0.152.1 and ouroboros-mock to v0.7.0.

<sup>Written for commit 382617f9092d293d20cdbbebec4d52b29c155c47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiered CBOR cache with hot/cold and batch resolution for faster data retrieval
  * Genesis transactions and synthetic genesis block storage for reliable startup and lookup
  * Transaction-offset storage enabling offset-based UTxO/TX retrieval

* **Documentation**
  * Expanded bootstrap workflow with clearer, network-specific commands and examples

* **Tests**
  * Large expansion of unit tests and benchmarks covering offsets, cache paths, and end-to-end storage

* **Chores**
  * Dependency updates and metadata year bumps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->