### PR TITLE
feat(ledger): stake snapshot capture logic

### DIFF
--- a/database/plugin/metadata/mysql/stake_snapshot.go
+++ b/database/plugin/metadata/mysql/stake_snapshot.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -199,9 +200,41 @@ func (d *MetadataStoreMysql) DeletePoolStakeSnapshotsAfterEpoch(
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsAfterEpoch: resolve db: %w",
+			err,
+		)
 	}
-	return db.Where("epoch > ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error
+	if err := db.Where("epoch > ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsAfterEpoch: failed to delete snapshots after epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
+}
+
+// DeletePoolStakeSnapshotsBeforeEpoch deletes all pool stake snapshots before a given epoch.
+func (d *MetadataStoreMysql) DeletePoolStakeSnapshotsBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsBeforeEpoch: resolve db: %w",
+			err,
+		)
+	}
+	if err := db.Where("epoch < ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsBeforeEpoch: failed to delete snapshots before epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
 }
 
 // DeleteEpochSummariesAfterEpoch deletes all epoch summaries after a given epoch.
@@ -212,7 +245,39 @@ func (d *MetadataStoreMysql) DeleteEpochSummariesAfterEpoch(
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"DeleteEpochSummariesAfterEpoch: resolve db: %w",
+			err,
+		)
 	}
-	return db.Where("epoch > ?", epoch).Delete(&models.EpochSummary{}).Error
+	if err := db.Where("epoch > ?", epoch).Delete(&models.EpochSummary{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesAfterEpoch: failed to delete summaries after epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
+}
+
+// DeleteEpochSummariesBeforeEpoch deletes all epoch summaries before a given epoch.
+func (d *MetadataStoreMysql) DeleteEpochSummariesBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesBeforeEpoch: resolve db: %w",
+			err,
+		)
+	}
+	if err := db.Where("epoch < ?", epoch).Delete(&models.EpochSummary{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesBeforeEpoch: failed to delete summaries before epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
 }

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -378,3 +378,153 @@ func (d *MetadataStorePostgres) RestorePoolStateAtSlot(
 
 	return nil
 }
+
+// GetActivePoolKeyHashes retrieves the key hashes of all currently active pools.
+// A pool is active if it has a registration and either no retirement or
+// the retirement epoch is in the future.
+func (d *MetadataStorePostgres) GetActivePoolKeyHashes(
+	txn types.Txn,
+) ([][]byte, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetActivePoolKeyHashes: resolve db: %w", err)
+	}
+
+	// Get the current epoch from the tip
+	var tmpTip models.Tip
+	if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashes: get tip: %w",
+			res.Error,
+		)
+	}
+
+	var curEpoch models.Epoch
+	if res := db.Where(
+		"start_slot <= ?",
+		tmpTip.Slot,
+	).Order("start_slot DESC").First(&curEpoch); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashes: get epoch: %w",
+			res.Error,
+		)
+	}
+
+	// Query all pools with their registrations and retirements
+	var pools []models.Pool
+	result := db.
+		Preload("Registration", func(db *gorm.DB) *gorm.DB {
+			return db.Order("added_slot DESC, id DESC")
+		}).
+		Preload("Retirement", func(db *gorm.DB) *gorm.DB {
+			return db.Order("added_slot DESC, id DESC")
+		}).
+		Find(&pools)
+	if result.Error != nil {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashes: query pools: %w",
+			result.Error,
+		)
+	}
+
+	// Filter active pools and collect their key hashes
+	poolKeyHashes := make([][]byte, 0, len(pools))
+	for _, pool := range pools {
+		if len(pool.Registration) == 0 {
+			continue
+		}
+
+		latestReg := pool.Registration[0]
+
+		// Check if pool is retired
+		if len(pool.Retirement) > 0 {
+			latestRet := pool.Retirement[0]
+			if latestRet.AddedSlot > latestReg.AddedSlot &&
+				latestRet.Epoch <= curEpoch.EpochId {
+				continue // Pool is retired
+			}
+		}
+
+		// Pool is active
+		poolKeyHashes = append(poolKeyHashes, pool.PoolKeyHash)
+	}
+
+	return poolKeyHashes, nil
+}
+
+// GetStakeByPool returns the total delegated stake and delegator count for a pool.
+func (d *MetadataStorePostgres) GetStakeByPool(
+	poolKeyHash []byte,
+	txn types.Txn,
+) (uint64, uint64, error) {
+	stakes, delegators, err := d.GetStakeByPools([][]byte{poolKeyHash}, txn)
+	if err != nil {
+		return 0, 0, err
+	}
+	return stakes[string(poolKeyHash)], delegators[string(poolKeyHash)], nil
+}
+
+// GetStakeByPools returns delegated stake for multiple pools in a single query.
+func (d *MetadataStorePostgres) GetStakeByPools(
+	poolKeyHashes [][]byte,
+	txn types.Txn,
+) (map[string]uint64, map[string]uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetStakeByPools: resolve db: %w", err)
+	}
+
+	// Initialize maps - stakeMap returns zeros since stake calculation
+	// requires UTxO aggregation which is not yet implemented
+	stakeMap := make(map[string]uint64, len(poolKeyHashes))
+	delegatorMap := make(map[string]uint64, len(poolKeyHashes))
+
+	// Initialize all pools with zero
+	for _, hash := range poolKeyHashes {
+		stakeMap[string(hash)] = 0
+		delegatorMap[string(hash)] = 0
+	}
+
+	if len(poolKeyHashes) == 0 {
+		return stakeMap, delegatorMap, nil
+	}
+
+	// Query accounts delegated to these pools and count
+	type poolStakeResult struct {
+		Pool           []byte
+		DelegatorCount int64
+	}
+
+	var results []poolStakeResult
+	if err := db.Model(&models.Account{}).
+		Select("pool, COUNT(*) as delegator_count").
+		Where("pool IN ? AND active = ?", poolKeyHashes, true).
+		Group("pool").
+		Scan(&results).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetStakeByPools: query accounts: %w",
+			err,
+		)
+	}
+
+	// Update delegator counts from query results
+	for _, r := range results {
+		if r.DelegatorCount >= 0 {
+			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount)
+		}
+	}
+
+	// TODO: Implement full stake calculation. This requires:
+	// 1. Get all staking_keys for accounts delegated to pools
+	// 2. Query UTxOs by stake credential
+	// 3. Sum values per pool
+	// For now, stakeMap returns zeros - stake values are placeholders.
+
+	return stakeMap, delegatorMap, nil
+}

--- a/database/plugin/metadata/postgres/stake_snapshot.go
+++ b/database/plugin/metadata/postgres/stake_snapshot.go
@@ -16,6 +16,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -199,9 +200,41 @@ func (d *MetadataStorePostgres) DeletePoolStakeSnapshotsAfterEpoch(
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsAfterEpoch: resolve db: %w",
+			err,
+		)
 	}
-	return db.Where("epoch > ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error
+	if err := db.Where("epoch > ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsAfterEpoch: failed to delete snapshots after epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
+}
+
+// DeletePoolStakeSnapshotsBeforeEpoch deletes all pool stake snapshots before a given epoch.
+func (d *MetadataStorePostgres) DeletePoolStakeSnapshotsBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsBeforeEpoch: resolve db: %w",
+			err,
+		)
+	}
+	if err := db.Where("epoch < ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsBeforeEpoch: failed to delete snapshots before epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
 }
 
 // DeleteEpochSummariesAfterEpoch deletes all epoch summaries after a given epoch.
@@ -212,7 +245,39 @@ func (d *MetadataStorePostgres) DeleteEpochSummariesAfterEpoch(
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"DeleteEpochSummariesAfterEpoch: resolve db: %w",
+			err,
+		)
 	}
-	return db.Where("epoch > ?", epoch).Delete(&models.EpochSummary{}).Error
+	if err := db.Where("epoch > ?", epoch).Delete(&models.EpochSummary{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesAfterEpoch: failed to delete summaries after epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
+}
+
+// DeleteEpochSummariesBeforeEpoch deletes all epoch summaries before a given epoch.
+func (d *MetadataStorePostgres) DeleteEpochSummariesBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesBeforeEpoch: resolve db: %w",
+			err,
+		)
+	}
+	if err := db.Where("epoch < ?", epoch).Delete(&models.EpochSummary{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesBeforeEpoch: failed to delete summaries before epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
 }

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -506,3 +506,154 @@ func (d *MetadataStoreSqlite) GetActivePoolRelays(
 
 	return relays, nil
 }
+
+// GetActivePoolKeyHashes retrieves the key hashes of all currently active pools.
+// A pool is active if it has a registration and either no retirement or
+// the retirement epoch is in the future.
+func (d *MetadataStoreSqlite) GetActivePoolKeyHashes(
+	txn types.Txn,
+) ([][]byte, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetActivePoolKeyHashes: resolve db: %w", err)
+	}
+
+	// Get the current epoch from the tip
+	var tmpTip models.Tip
+	if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashes: get tip: %w",
+			res.Error,
+		)
+	}
+
+	var curEpoch models.Epoch
+	if res := db.Where(
+		"start_slot <= ?",
+		tmpTip.Slot,
+	).Order("start_slot DESC").First(&curEpoch); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashes: get epoch: %w",
+			res.Error,
+		)
+	}
+
+	// Query all pools with their registrations and retirements
+	var pools []models.Pool
+	result := db.
+		Preload("Registration", func(db *gorm.DB) *gorm.DB {
+			return db.Order("added_slot DESC, id DESC")
+		}).
+		Preload("Retirement", func(db *gorm.DB) *gorm.DB {
+			return db.Order("added_slot DESC, id DESC")
+		}).
+		Find(&pools)
+	if result.Error != nil {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashes: query pools: %w",
+			result.Error,
+		)
+	}
+
+	// Filter active pools and collect their key hashes
+	poolKeyHashes := make([][]byte, 0, len(pools))
+	for _, pool := range pools {
+		if len(pool.Registration) == 0 {
+			continue
+		}
+
+		latestReg := pool.Registration[0]
+
+		// Check if pool is retired
+		if len(pool.Retirement) > 0 {
+			latestRet := pool.Retirement[0]
+			if latestRet.AddedSlot > latestReg.AddedSlot &&
+				latestRet.Epoch <= curEpoch.EpochId {
+				continue // Pool is retired
+			}
+		}
+
+		// Pool is active
+		poolKeyHashes = append(poolKeyHashes, pool.PoolKeyHash)
+	}
+
+	return poolKeyHashes, nil
+}
+
+// GetStakeByPool returns the total delegated stake and delegator count for a pool.
+func (d *MetadataStoreSqlite) GetStakeByPool(
+	poolKeyHash []byte,
+	txn types.Txn,
+) (uint64, uint64, error) {
+	stakes, delegators, err := d.GetStakeByPools([][]byte{poolKeyHash}, txn)
+	if err != nil {
+		return 0, 0, err
+	}
+	return stakes[string(poolKeyHash)], delegators[string(poolKeyHash)], nil
+}
+
+// GetStakeByPools returns delegated stake for multiple pools in a single query.
+func (d *MetadataStoreSqlite) GetStakeByPools(
+	poolKeyHashes [][]byte,
+	txn types.Txn,
+) (map[string]uint64, map[string]uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetStakeByPools: resolve db: %w", err)
+	}
+
+	// Initialize maps - stakeMap returns zeros since stake calculation
+	// requires UTxO aggregation which is not yet implemented
+	stakeMap := make(map[string]uint64, len(poolKeyHashes))
+	delegatorMap := make(map[string]uint64, len(poolKeyHashes))
+
+	// Initialize all pools with zero
+	for _, hash := range poolKeyHashes {
+		stakeMap[string(hash)] = 0
+		delegatorMap[string(hash)] = 0
+	}
+
+	if len(poolKeyHashes) == 0 {
+		return stakeMap, delegatorMap, nil
+	}
+
+	// Query accounts delegated to these pools and count/sum
+	// The Account table has a Pool field containing the pool key hash
+	type poolStakeResult struct {
+		Pool           []byte
+		DelegatorCount int64
+	}
+
+	var results []poolStakeResult
+	if err := db.Model(&models.Account{}).
+		Select("pool, COUNT(*) as delegator_count").
+		Where("pool IN ? AND active = ?", poolKeyHashes, true).
+		Group("pool").
+		Scan(&results).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetStakeByPools: query accounts: %w",
+			err,
+		)
+	}
+
+	// Update delegator counts from query results
+	for _, r := range results {
+		if r.DelegatorCount >= 0 {
+			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount)
+		}
+	}
+
+	// TODO: Implement full stake calculation. This requires:
+	// 1. Get all staking_keys for accounts delegated to pools
+	// 2. Query UTxOs by stake credential
+	// 3. Sum values per pool
+	// For now, stakeMap returns zeros - stake values are placeholders.
+
+	return stakeMap, delegatorMap, nil
+}

--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -199,9 +200,41 @@ func (d *MetadataStoreSqlite) DeletePoolStakeSnapshotsAfterEpoch(
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsAfterEpoch: resolve db: %w",
+			err,
+		)
 	}
-	return db.Where("epoch > ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error
+	if err := db.Where("epoch > ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsAfterEpoch: failed to delete snapshots after epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
+}
+
+// DeletePoolStakeSnapshotsBeforeEpoch deletes all pool stake snapshots before a given epoch.
+func (d *MetadataStoreSqlite) DeletePoolStakeSnapshotsBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsBeforeEpoch: resolve db: %w",
+			err,
+		)
+	}
+	if err := db.Where("epoch < ?", epoch).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeletePoolStakeSnapshotsBeforeEpoch: failed to delete snapshots before epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
 }
 
 // DeleteEpochSummariesAfterEpoch deletes all epoch summaries after a given epoch.
@@ -212,7 +245,39 @@ func (d *MetadataStoreSqlite) DeleteEpochSummariesAfterEpoch(
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"DeleteEpochSummariesAfterEpoch: resolve db: %w",
+			err,
+		)
 	}
-	return db.Where("epoch > ?", epoch).Delete(&models.EpochSummary{}).Error
+	if err := db.Where("epoch > ?", epoch).Delete(&models.EpochSummary{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesAfterEpoch: failed to delete summaries after epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
+}
+
+// DeleteEpochSummariesBeforeEpoch deletes all epoch summaries before a given epoch.
+func (d *MetadataStoreSqlite) DeleteEpochSummariesBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesBeforeEpoch: resolve db: %w",
+			err,
+		)
+	}
+	if err := db.Where("epoch < ?", epoch).Delete(&models.EpochSummary{}).Error; err != nil {
+		return fmt.Errorf(
+			"DeleteEpochSummariesBeforeEpoch: failed to delete summaries before epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	return nil
 }

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -338,7 +338,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	}
 
 	// Add Inputs to Transaction - batch fetch all input UTXOs
-	var inputRefs []UtxoRef
+	inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
 	for _, input := range tx.Inputs() {
 		inputRefs = append(inputRefs, UtxoRef{
 			TxId:      input.Id().Bytes(),
@@ -369,7 +369,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	}
 	// Add Collateral to Transaction - batch fetch all collateral UTXOs
 	if len(tx.Collateral()) > 0 {
-		var collateralRefs []UtxoRef
+		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
 		for _, input := range tx.Collateral() {
 			collateralRefs = append(collateralRefs, UtxoRef{
 				TxId:      input.Id().Bytes(),

--- a/ledger/snapshot/calculator.go
+++ b/ledger/snapshot/calculator.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Calculator calculates stake distribution from the current ledger state.
+type Calculator struct {
+	db *database.Database
+}
+
+// NewCalculator creates a new stake calculator.
+func NewCalculator(db *database.Database) *Calculator {
+	return &Calculator{db: db}
+}
+
+// StakeDistribution represents the stake distribution at a point in time.
+// Uses ledger types for interoperability between database and ledger layers.
+type StakeDistribution struct {
+	Slot           uint64                         // Slot at which distribution was captured
+	PoolStakes     map[lcommon.PoolKeyHash]uint64 // pool key hash -> total stake
+	DelegatorCount map[lcommon.PoolKeyHash]uint64 // pool key hash -> delegator count
+	TotalStake     uint64                         // Sum of all pool stakes
+	TotalPools     uint64                         // Number of active pools
+}
+
+// CalculateStakeDistribution calculates the stake distribution at a given slot.
+// This aggregates all delegated stake by pool from the account and UTxO tables.
+func (c *Calculator) CalculateStakeDistribution(
+	ctx context.Context,
+	slot uint64,
+) (*StakeDistribution, error) {
+	dist := &StakeDistribution{
+		Slot:           slot,
+		PoolStakes:     make(map[lcommon.PoolKeyHash]uint64),
+		DelegatorCount: make(map[lcommon.PoolKeyHash]uint64),
+	}
+
+	// Get all active accounts with their delegations
+	// We query accounts that were active at or before the given slot
+	txn := c.db.Transaction(false) // read-only transaction
+	defer func() { _ = txn.Commit() }()
+
+	err := c.calculateFromAccounts(ctx, txn, slot, dist)
+	if err != nil {
+		return nil, fmt.Errorf("calculate from accounts: %w", err)
+	}
+
+	// Count total pools
+	dist.TotalPools = uint64(len(dist.PoolStakes))
+
+	return dist, nil
+}
+
+// calculateFromAccounts aggregates stake by querying accounts and their UTxOs.
+// Uses batched queries to avoid N+1 database patterns.
+func (c *Calculator) calculateFromAccounts(
+	ctx context.Context,
+	txn *database.Txn,
+	slot uint64,
+	dist *StakeDistribution,
+) error {
+	meta := c.db.Metadata()
+	metaTxn := (*txn).Metadata()
+
+	// Get all active pools at the given slot
+	pools, err := c.getActivePoolsAtSlot(ctx, meta, metaTxn, slot)
+	if err != nil {
+		return fmt.Errorf("get active pools: %w", err)
+	}
+
+	// If no pools found, return empty distribution (not an error)
+	if len(pools) == 0 {
+		return nil
+	}
+
+	// Batch fetch delegated stake for all pools in a single query
+	stakeMap, delegatorMap, err := c.getBatchPoolsDelegatedStake(
+		ctx,
+		meta,
+		metaTxn,
+		pools,
+	)
+	if err != nil {
+		return fmt.Errorf("get batch pools delegated stake: %w", err)
+	}
+
+	// Populate distribution from the batched results
+	for _, poolHash := range pools {
+		delegators := delegatorMap[poolHash]
+		if delegators > 0 {
+			// Record pool with delegators
+			stake := stakeMap[poolHash]
+			dist.PoolStakes[poolHash] = stake
+			dist.DelegatorCount[poolHash] = delegators
+			dist.TotalStake += stake
+		}
+	}
+
+	return nil
+}
+
+// getActivePoolsAtSlot returns all pool key hashes that were active at the slot.
+// A pool is active if it has a registration with added_slot <= slot and either
+// no retirement or retirement.epoch > epoch at slot.
+//
+// TODO: The slot parameter is currently unused - this returns the current active
+// pools from meta.GetActivePoolKeyHashes() rather than pools active at the
+// requested slot. For proper snapshot capture (e.g., evt.SnapshotSlot), implement
+// slot-aware filtering by querying historical pool registrations/retirements
+// against the provided slot, or add a GetActivePoolKeyHashesAtSlot method to
+// the MetadataStore interface.
+func (c *Calculator) getActivePoolsAtSlot(
+	_ context.Context,
+	meta metadata.MetadataStore,
+	metaTxn types.Txn,
+	_ uint64, // slot - unused, see TODO above
+) ([]lcommon.PoolKeyHash, error) {
+	// Query active pool key hashes from the metadata store
+	poolKeyHashBytes, err := meta.GetActivePoolKeyHashes(metaTxn)
+	if err != nil {
+		return nil, fmt.Errorf("get active pool key hashes: %w", err)
+	}
+
+	// Convert [][]byte to []lcommon.PoolKeyHash
+	pools := make([]lcommon.PoolKeyHash, 0, len(poolKeyHashBytes))
+	for _, hashBytes := range poolKeyHashBytes {
+		if len(hashBytes) != 28 {
+			// Skip invalid pool key hashes (must be 28 bytes)
+			continue
+		}
+		var poolHash lcommon.PoolKeyHash
+		copy(poolHash[:], hashBytes)
+		pools = append(pools, poolHash)
+	}
+
+	return pools, nil
+}
+
+// getBatchPoolsDelegatedStake calculates stake for all pools in a single batch query.
+// Returns maps of pool hash -> total stake and pool hash -> delegator count.
+// Note: stake values are currently zeros (placeholder) until UTxO aggregation is implemented.
+func (c *Calculator) getBatchPoolsDelegatedStake(
+	_ context.Context,
+	meta metadata.MetadataStore,
+	metaTxn types.Txn,
+	pools []lcommon.PoolKeyHash,
+) (map[lcommon.PoolKeyHash]uint64, map[lcommon.PoolKeyHash]uint64, error) {
+	// Initialize result maps
+	stakeMap := make(map[lcommon.PoolKeyHash]uint64, len(pools))
+	delegatorMap := make(map[lcommon.PoolKeyHash]uint64, len(pools))
+
+	if len(pools) == 0 {
+		return stakeMap, delegatorMap, nil
+	}
+
+	// Convert pool key hashes to [][]byte for the metadata store query
+	poolKeyHashBytes := make([][]byte, len(pools))
+	for i, poolHash := range pools {
+		hashCopy := make([]byte, 28)
+		copy(hashCopy, poolHash[:])
+		poolKeyHashBytes[i] = hashCopy
+	}
+
+	// Batch query delegator counts for all pools
+	stakes, delegators, err := meta.GetStakeByPools(poolKeyHashBytes, metaTxn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get stake by pools: %w", err)
+	}
+
+	// Convert back to lcommon.PoolKeyHash keys
+	for _, poolHash := range pools {
+		stakeMap[poolHash] = stakes[string(poolHash[:])]
+		delegatorMap[poolHash] = delegators[string(poolHash[:])]
+	}
+
+	return stakeMap, delegatorMap, nil
+}

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package snapshot provides stake snapshot management for Ouroboros Praos
+// leader election. It captures stake distribution at epoch boundaries and
+// maintains the Mark/Set/Go snapshot rotation model.
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// Manager handles stake snapshot capture and rotation at epoch boundaries.
+// It subscribes to EpochTransitionEvents and orchestrates the snapshot
+// lifecycle according to the Ouroboros Praos specification.
+type Manager struct {
+	db       *database.Database
+	eventBus *event.EventBus
+	logger   *slog.Logger
+
+	mu             sync.RWMutex
+	running        bool
+	cancel         context.CancelFunc
+	subscriptionId event.EventSubscriberId
+}
+
+// NewManager creates a new snapshot manager.
+func NewManager(
+	db *database.Database,
+	eventBus *event.EventBus,
+	logger *slog.Logger,
+) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Manager{
+		db:       db,
+		eventBus: eventBus,
+		logger:   logger,
+	}
+}
+
+// Start begins listening for epoch transitions and capturing snapshots.
+func (m *Manager) Start() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running {
+		return nil
+	}
+
+	// Guard against nil dependencies to avoid panics
+	if m.db == nil {
+		return errors.New("snapshot manager: nil database")
+	}
+	if m.eventBus == nil {
+		return errors.New("snapshot manager: nil event bus")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.running = true
+
+	// Subscribe to epoch transitions
+	m.subscriptionId = m.eventBus.SubscribeFunc(
+		event.EpochTransitionEventType,
+		func(evt event.Event) {
+			epochEvent, ok := evt.Data.(event.EpochTransitionEvent)
+			if !ok {
+				m.logger.Error(
+					"invalid event data for epoch transition",
+					"component", "snapshot",
+				)
+				return
+			}
+			if err := m.handleEpochTransition(ctx, epochEvent); err != nil {
+				m.logger.Error(
+					"failed to handle epoch transition",
+					"component", "snapshot",
+					"epoch", epochEvent.NewEpoch,
+					"error", err,
+				)
+			}
+		},
+	)
+
+	m.logger.Info("snapshot manager started", "component", "snapshot")
+	return nil
+}
+
+// Stop stops the snapshot manager.
+func (m *Manager) Stop() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return nil
+	}
+
+	if m.cancel != nil {
+		m.cancel()
+	}
+	if m.subscriptionId != 0 {
+		m.eventBus.Unsubscribe(
+			event.EpochTransitionEventType,
+			m.subscriptionId,
+		)
+		m.subscriptionId = 0
+	}
+	m.running = false
+
+	m.logger.Info("snapshot manager stopped", "component", "snapshot")
+	return nil
+}
+
+// handleEpochTransition processes an epoch boundary event.
+func (m *Manager) handleEpochTransition(
+	ctx context.Context,
+	evt event.EpochTransitionEvent,
+) error {
+	m.logger.Info(
+		"handling epoch transition",
+		"component", "snapshot",
+		"previous_epoch", evt.PreviousEpoch,
+		"new_epoch", evt.NewEpoch,
+		"boundary_slot", evt.BoundarySlot,
+		"snapshot_slot", evt.SnapshotSlot,
+	)
+
+	// 1. Capture new Mark snapshot (current stake distribution)
+	if err := m.captureMarkSnapshot(ctx, evt); err != nil {
+		return fmt.Errorf("capture mark snapshot: %w", err)
+	}
+
+	// 2. Rotate snapshots (Mark→Set→Go)
+	m.rotateSnapshots(ctx, evt.NewEpoch)
+
+	// 3. Cleanup old snapshots (keep last 3 epochs)
+	if err := m.cleanupOldSnapshots(ctx, evt.NewEpoch); err != nil {
+		return fmt.Errorf("cleanup old snapshots: %w", err)
+	}
+
+	m.logger.Info(
+		"epoch transition complete",
+		"component", "snapshot",
+		"epoch", evt.NewEpoch,
+	)
+
+	return nil
+}
+
+// captureMarkSnapshot captures the stake distribution as a Mark snapshot.
+func (m *Manager) captureMarkSnapshot(
+	ctx context.Context,
+	evt event.EpochTransitionEvent,
+) error {
+	calculator := NewCalculator(m.db)
+
+	// Calculate stake distribution at the snapshot slot
+	distribution, err := calculator.CalculateStakeDistribution(
+		ctx,
+		evt.SnapshotSlot,
+	)
+	if err != nil {
+		return fmt.Errorf("calculate stake distribution: %w", err)
+	}
+
+	// Save as Mark snapshot for the new epoch
+	if err := m.saveSnapshot(
+		ctx,
+		evt.NewEpoch,
+		"mark",
+		distribution,
+		evt,
+	); err != nil {
+		return fmt.Errorf("save mark snapshot: %w", err)
+	}
+
+	m.logger.Info(
+		"captured mark snapshot",
+		"component", "snapshot",
+		"epoch", evt.NewEpoch,
+		"total_pools", len(distribution.PoolStakes),
+		"total_stake", distribution.TotalStake,
+	)
+
+	return nil
+}

--- a/ledger/snapshot/rotation.go
+++ b/ledger/snapshot/rotation.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/event"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// saveSnapshot saves a stake distribution as a snapshot of the given type.
+func (m *Manager) saveSnapshot(
+	ctx context.Context,
+	epoch uint64,
+	snapshotType string,
+	distribution *StakeDistribution,
+	evt event.EpochTransitionEvent,
+) error {
+	_ = ctx
+	txn := m.db.Transaction(true) // read-write transaction
+	defer func() { _ = txn.Rollback() }()
+
+	meta := m.db.Metadata()
+	metaTxn := txn.Metadata()
+
+	// Save pool stake snapshots
+	snapshots := make([]*models.PoolStakeSnapshot, 0, len(distribution.PoolStakes))
+	for poolKeyHash, stake := range distribution.PoolStakes {
+		delegators := distribution.DelegatorCount[poolKeyHash]
+		snapshots = append(snapshots, &models.PoolStakeSnapshot{
+			Epoch:          epoch,
+			SnapshotType:   snapshotType,
+			PoolKeyHash:    poolKeyHash[:], // Convert [28]byte to []byte
+			TotalStake:     types.Uint64(stake),
+			DelegatorCount: delegators,
+			CapturedSlot:   distribution.Slot,
+		})
+	}
+
+	if err := meta.SavePoolStakeSnapshots(snapshots, metaTxn); err != nil {
+		return fmt.Errorf("save pool snapshots: %w", err)
+	}
+
+	// Save epoch summary
+	summary := &models.EpochSummary{
+		Epoch:            epoch,
+		TotalActiveStake: types.Uint64(distribution.TotalStake),
+		TotalPoolCount:   distribution.TotalPools,
+		TotalDelegators:  sumDelegators(distribution.DelegatorCount),
+		EpochNonce:       evt.EpochNonce,
+		BoundarySlot:     evt.BoundarySlot,
+		SnapshotReady:    true,
+	}
+
+	if err := meta.SaveEpochSummary(summary, metaTxn); err != nil {
+		return fmt.Errorf("save epoch summary: %w", err)
+	}
+
+	return txn.Commit()
+}
+
+// rotateSnapshots promotes Mark→Set→Go for the new epoch.
+func (m *Manager) rotateSnapshots(ctx context.Context, newEpoch uint64) {
+	_ = ctx
+	// Snapshot rotation in Ouroboros Praos:
+	// - The Mark snapshot from epoch N-1 becomes Set for epoch N
+	// - The Set snapshot from epoch N-1 becomes Go for epoch N
+	// - We only need to track the type metadata, not copy data
+
+	// In practice, we store snapshots with their epoch and type.
+	// The "Go" snapshot used for leader election in epoch N is the
+	// "Mark" snapshot captured at the end of epoch N-2.
+
+	// For simplicity, we don't physically rotate - we query by epoch offset:
+	// - Go snapshot for epoch N = data from epoch N-2
+	// - Set snapshot for epoch N = data from epoch N-1
+	// - Mark snapshot for epoch N = data captured at epoch N boundary
+
+	goEpoch := uint64(0)
+	setEpoch := uint64(0)
+	if newEpoch > 1 {
+		goEpoch = newEpoch - 2
+	}
+	if newEpoch > 0 {
+		setEpoch = newEpoch - 1
+	}
+
+	m.logger.Debug(
+		"snapshot rotation conceptual",
+		"component", "snapshot",
+		"epoch", newEpoch,
+		"go_epoch", goEpoch,
+		"set_epoch", setEpoch,
+	)
+}
+
+// cleanupOldSnapshots removes snapshots older than needed for the rotation model.
+// We keep 3 epochs of snapshots (current, current-1, current-2 for Go).
+func (m *Manager) cleanupOldSnapshots(
+	ctx context.Context,
+	currentEpoch uint64,
+) error {
+	_ = ctx
+	// Keep snapshots for epochs: currentEpoch, currentEpoch-1, currentEpoch-2
+	// Delete anything older than currentEpoch-2 (i.e., epoch < currentEpoch-2)
+	if currentEpoch < 2 {
+		return nil // Not enough history to clean
+	}
+
+	deleteBeforeEpoch := currentEpoch - 2
+
+	txn := m.db.Transaction(true) // read-write transaction
+	defer func() { _ = txn.Rollback() }()
+
+	meta := m.db.Metadata()
+	metaTxn := txn.Metadata()
+
+	// Delete old pool stake snapshots
+	// For cleaning up old data, we want to delete epochs < deleteBeforeEpoch
+	if err := meta.DeletePoolStakeSnapshotsBeforeEpoch(
+		deleteBeforeEpoch,
+		metaTxn,
+	); err != nil {
+		return fmt.Errorf("cleanup pool snapshots: %w", err)
+	}
+
+	// Delete old epoch summaries
+	if err := meta.DeleteEpochSummariesBeforeEpoch(
+		deleteBeforeEpoch,
+		metaTxn,
+	); err != nil {
+		return fmt.Errorf("cleanup epoch summaries: %w", err)
+	}
+
+	m.logger.Debug(
+		"cleaned up old snapshots",
+		"component", "snapshot",
+		"before_epoch", deleteBeforeEpoch,
+	)
+
+	return txn.Commit()
+}
+
+// sumDelegators totals all delegator counts.
+func sumDelegators(counts map[lcommon.PoolKeyHash]uint64) uint64 {
+	var total uint64
+	for _, count := range counts {
+		total += count
+	}
+	return total
+}

--- a/peergov/topology.go
+++ b/peergov/topology.go
@@ -41,7 +41,7 @@ func (p *PeerGovernor) LoadTopologyConfig(
 		normalized string
 	}
 
-	var bootstrapResolved []resolvedPeer
+	bootstrapResolved := make([]resolvedPeer, 0, len(topologyConfig.BootstrapPeers))
 	for _, bootstrapPeer := range topologyConfig.BootstrapPeers {
 		tmpAddress := net.JoinHostPort(
 			bootstrapPeer.Address,
@@ -59,9 +59,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 		valency     uint
 		warmValency uint
 	}
-	var localRootsResolved []resolvedLocalRoot
+	localRootsResolved := make([]resolvedLocalRoot, 0, len(topologyConfig.LocalRoots))
 	for _, localRoot := range topologyConfig.LocalRoots {
-		var peers []resolvedPeer
+		peers := make([]resolvedPeer, 0, len(localRoot.AccessPoints))
 		for _, ap := range localRoot.AccessPoints {
 			tmpAddress := net.JoinHostPort(
 				ap.Address,
@@ -86,9 +86,9 @@ func (p *PeerGovernor) LoadTopologyConfig(
 		valency     uint
 		warmValency uint
 	}
-	var publicRootsResolved []resolvedPublicRoot
+	publicRootsResolved := make([]resolvedPublicRoot, 0, len(topologyConfig.PublicRoots))
 	for _, publicRoot := range topologyConfig.PublicRoots {
-		var peers []resolvedPeer
+		peers := make([]resolvedPeer, 0, len(publicRoot.AccessPoints))
 		for _, ap := range publicRoot.AccessPoints {
 			tmpAddress := net.JoinHostPort(
 				ap.Address,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stake snapshot capture and rotation at epoch boundaries to support Ouroboros Praos leader election. Introduces a snapshot manager, calculator, and database APIs to persist Mark/Set/Go snapshots and epoch summaries.

- **New Features**
  - Snapshot Manager listens to epoch transition events, captures Mark at the snapshot slot, rotates snapshots, and cleans old data.
  - Rotation uses epoch offsets: Go = N-2, Set = N-1, Mark = N; keeps only the last 3 epochs.
  - Stake Calculator aggregates delegated stake by pool at a slot using batched queries; currently records delegator counts (stake sum stubbed pending UTxO integration).
  - MetadataStore adds active pool/stake APIs (GetActivePoolKeyHashes, GetStakeByPool(s)), CRUD for pool stake snapshots and epoch summaries, total active stake queries, and before/after-epoch cleanup helpers with improved errors.

<sup>Written for commit 477a550253cdc2ded0ce960ba4f73a7f72cb8fb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end stake snapshot system: capture, rotation, retention, epoch summaries, and a stake distribution calculator with lifecycle management.
  * Pool stake APIs to list active pools and fetch per-pool / multi-pool stake and delegator counts.

* **Data Management**
  * New persistence and deletion operations for pool stake snapshots and epoch summaries, including before/after-epoch pruning.

* **Bug Fixes**
  * Improved contextual error reporting for snapshot-related DB operations.

* **Performance**
  * Reduced allocations by preallocating slices in hot paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->