### PR TITLE
feat(database): make sops optional

### DIFF
--- a/database/sops/sops.go
+++ b/database/sops/sops.go
@@ -87,6 +87,14 @@ func Encrypt(data []byte) ([]byte, error) {
 	return encrypted, nil
 }
 
+// IsEnabled returns true if SOPS encryption is configured via environment
+// variables. SOPS is enabled when at least one of DINGO_GCP_KMS_RESOURCE_ID
+// or DINGO_AWS_KMS_KEY_ARNS is set.
+func IsEnabled() bool {
+	return os.Getenv("DINGO_GCP_KMS_RESOURCE_ID") != "" ||
+		os.Getenv("DINGO_AWS_KMS_KEY_ARNS") != ""
+}
+
 func getMasterKeyGroupsFromEnv() ([]sopsapi.KeyGroup, error) {
 	keyGroups := []sopsapi.KeyGroup{}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make SOPS encryption optional for commit timestamp blobs in S3 and GCS. If KMS env vars are not set, the timestamp is stored and read in plaintext, preserving compatibility with legacy data.

- **New Features**
  - Added sops.IsEnabled() that checks DINGO_GCP_KMS_RESOURCE_ID or DINGO_AWS_KMS_KEY_ARNS.
  - S3/GCS Get/SetCommitTimestamp read/write plaintext when SOPS is disabled; still decrypt/encrypt when enabled.
  - Keeps legacy plaintext fallback for existing timestamps and logs plaintext writes.

- **Migration**
  - To enable encryption, set DINGO_GCP_KMS_RESOURCE_ID or DINGO_AWS_KMS_KEY_ARNS.
  - No data migration required; plaintext values remain readable.

<sup>Written for commit 63a0f84051bba2628d515e81f40572a0429aebee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for plaintext timestamp storage when encryption is disabled.

* **Bug Fixes**
  * Improved handling of legacy plaintext timestamps with automatic migration to encrypted storage.
  * Added fast path for timestamp operations in non-encrypted mode, improving performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->