### PR TITLE
feat(ledger): slot clock

### DIFF
--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -568,4 +568,3 @@ func TestSnapshotTypesMarkSetGo(t *testing.T) {
 		)
 	}
 }
-

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -1,0 +1,457 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// SlotTick represents a notification that a slot boundary has been reached
+type SlotTick struct {
+	// Slot is the current slot number
+	Slot uint64
+	// SlotStart is the time when this slot started
+	SlotStart time.Time
+	// Epoch is the current epoch number
+	Epoch uint64
+	// EpochSlot is the slot number within the current epoch (0-indexed)
+	EpochSlot uint64
+	// IsEpochStart indicates whether this is the first slot of a new epoch
+	IsEpochStart bool
+	// SlotsUntilEpoch is the number of slots until the next epoch boundary
+	SlotsUntilEpoch uint64
+}
+
+// SlotClockConfig holds configuration for the SlotClock
+type SlotClockConfig struct {
+	// Logger for slot clock events
+	Logger *slog.Logger
+	// ClockTolerance is the maximum drift allowed when waking at slot boundaries.
+	// If we wake up more than this much after the slot boundary, we log a warning.
+	// Default: 100ms
+	ClockTolerance time.Duration
+}
+
+// DefaultSlotClockConfig returns the default configuration
+func DefaultSlotClockConfig() SlotClockConfig {
+	return SlotClockConfig{
+		ClockTolerance: 100 * time.Millisecond,
+	}
+}
+
+// SlotTimeProvider defines the interface for slot/time conversion
+// This allows testing with mock time
+type SlotTimeProvider interface {
+	SlotToTime(slot uint64) (time.Time, error)
+	TimeToSlot(t time.Time) (uint64, error)
+	SlotToEpoch(slot uint64) (EpochInfo, error)
+}
+
+// EpochInfo contains epoch boundary information
+type EpochInfo struct {
+	EpochId       uint64
+	StartSlot     uint64
+	LengthInSlots uint
+}
+
+// EndSlot returns the first slot of the next epoch (one past the last slot of this epoch)
+func (e EpochInfo) EndSlot() uint64 {
+	return e.StartSlot + uint64(e.LengthInSlots)
+}
+
+// SlotClock provides slot-boundary-aware timing for the Cardano node.
+// It ticks at each slot boundary and notifies subscribers, enabling
+// time-based operations like epoch transitions and block production
+// that don't depend on incoming blocks.
+//
+// The SlotClock provides two categories of functionality:
+//  1. Query methods (CurrentSlot, CurrentEpoch, GetEpochForSlot, etc.) that work
+//     in all modes (catch up, load, synced) and can be called anytime.
+//  2. Tick notifications that fire at real-time slot boundaries, useful for
+//     leader election and proactive epoch detection when synced to tip.
+type SlotClock struct {
+	provider    SlotTimeProvider
+	config      SlotClockConfig
+	subscribers []chan SlotTick
+	mu          sync.RWMutex
+	cancel      context.CancelFunc
+	ctx         context.Context
+	running     bool
+	wg          sync.WaitGroup
+
+	// Track last emitted epoch to avoid duplicates and detect discrepancies
+	lastEmittedEpoch uint64
+	epochEmitMu      sync.Mutex
+
+	// For testing: allow injection of custom time source
+	nowFunc func() time.Time
+}
+
+// NewSlotClock creates a new SlotClock with the given provider and configuration
+func NewSlotClock(provider SlotTimeProvider, config SlotClockConfig) *SlotClock {
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+	if config.ClockTolerance == 0 {
+		config.ClockTolerance = DefaultSlotClockConfig().ClockTolerance
+	}
+	return &SlotClock{
+		provider:    provider,
+		config:      config,
+		subscribers: make([]chan SlotTick, 0),
+		nowFunc:     time.Now,
+	}
+}
+
+// Start begins the slot clock ticking loop.
+// The clock will emit SlotTick notifications at each slot boundary.
+// Returns immediately; the tick loop runs in a goroutine.
+func (sc *SlotClock) Start(ctx context.Context) {
+	sc.mu.Lock()
+	if sc.running {
+		sc.mu.Unlock()
+		return
+	}
+	sc.running = true
+	sc.ctx, sc.cancel = context.WithCancel(ctx)
+	sc.mu.Unlock()
+
+	sc.wg.Add(1)
+	go sc.run()
+}
+
+// Stop halts the slot clock and waits for the tick loop to exit.
+// All subscriber channels will be closed, causing any goroutines blocked
+// on receiving from them to exit cleanly.
+func (sc *SlotClock) Stop() {
+	sc.mu.Lock()
+	if !sc.running {
+		sc.mu.Unlock()
+		return
+	}
+	sc.running = false
+	if sc.cancel != nil {
+		sc.cancel()
+	}
+	// Close all subscriber channels to unblock any goroutines waiting on them
+	for _, ch := range sc.subscribers {
+		close(ch)
+	}
+	sc.subscribers = nil
+	sc.mu.Unlock()
+
+	sc.wg.Wait()
+}
+
+// Subscribe returns a channel that will receive SlotTick notifications.
+// The channel is buffered to prevent blocking the clock loop.
+// Call Unsubscribe to stop receiving notifications and close the channel.
+func (sc *SlotClock) Subscribe() <-chan SlotTick {
+	ch := make(chan SlotTick, 1)
+	sc.mu.Lock()
+	sc.subscribers = append(sc.subscribers, ch)
+	sc.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel from the notification list.
+// The channel will be closed after this call.
+func (sc *SlotClock) Unsubscribe(ch <-chan SlotTick) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	for i, sub := range sc.subscribers {
+		if sub == ch {
+			// Close the channel
+			close(sub)
+			// Remove from slice
+			sc.subscribers = append(sc.subscribers[:i], sc.subscribers[i+1:]...)
+			return
+		}
+	}
+}
+
+// =============================================================================
+// Query Methods - These work in all modes (catch up, load, synced)
+// =============================================================================
+
+// CurrentSlot returns the current slot number based on wall-clock time.
+// This works regardless of sync state and can be called during catch up or load.
+func (sc *SlotClock) CurrentSlot() (uint64, error) {
+	return sc.provider.TimeToSlot(sc.nowFunc())
+}
+
+// CurrentEpoch returns the current epoch based on wall-clock time.
+// This works regardless of sync state and can be called during catch up or load.
+func (sc *SlotClock) CurrentEpoch() (EpochInfo, error) {
+	slot, err := sc.CurrentSlot()
+	if err != nil {
+		return EpochInfo{}, err
+	}
+	return sc.provider.SlotToEpoch(slot)
+}
+
+// GetEpochForSlot returns epoch information for the given slot.
+// This works regardless of sync state and can be called during catch up or load.
+func (sc *SlotClock) GetEpochForSlot(slot uint64) (EpochInfo, error) {
+	return sc.provider.SlotToEpoch(slot)
+}
+
+// SlotToTime returns the time when the given slot starts.
+// This works regardless of sync state and can be called during catch up or load.
+func (sc *SlotClock) SlotToTime(slot uint64) (time.Time, error) {
+	return sc.provider.SlotToTime(slot)
+}
+
+// NextSlotTime returns the time when the next slot will start
+func (sc *SlotClock) NextSlotTime() (time.Time, error) {
+	currentSlot, err := sc.CurrentSlot()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return sc.provider.SlotToTime(currentSlot + 1)
+}
+
+// TimeUntilNextEpoch returns the duration until the next epoch boundary.
+// This works regardless of sync state and can be called during catch up or load.
+func (sc *SlotClock) TimeUntilNextEpoch() (time.Duration, error) {
+	epochInfo, err := sc.CurrentEpoch()
+	if err != nil {
+		return 0, err
+	}
+	epochEndSlot := epochInfo.EndSlot()
+	epochEndTime, err := sc.provider.SlotToTime(epochEndSlot)
+	if err != nil {
+		return 0, err
+	}
+	return epochEndTime.Sub(sc.nowFunc()), nil
+}
+
+// TimeUntilSlot returns the duration until the given slot starts.
+// Returns negative duration if the slot is in the past.
+func (sc *SlotClock) TimeUntilSlot(slot uint64) (time.Duration, error) {
+	slotTime, err := sc.provider.SlotToTime(slot)
+	if err != nil {
+		return 0, err
+	}
+	return slotTime.Sub(sc.nowFunc()), nil
+}
+
+// IsEpochBoundary returns true if the given slot is the first slot of an epoch.
+func (sc *SlotClock) IsEpochBoundary(slot uint64) (bool, error) {
+	epochInfo, err := sc.provider.SlotToEpoch(slot)
+	if err != nil {
+		return false, err
+	}
+	return slot == epochInfo.StartSlot, nil
+}
+
+// =============================================================================
+// Epoch Event Tracking
+// =============================================================================
+
+// MarkEpochEmitted records that an epoch transition event was emitted for the
+// given epoch. This is used to coordinate between slot-based and block-based
+// epoch detection to avoid duplicate events.
+// Returns true if this is a new epoch (not previously emitted), false if duplicate.
+func (sc *SlotClock) MarkEpochEmitted(epoch uint64) bool {
+	sc.epochEmitMu.Lock()
+	defer sc.epochEmitMu.Unlock()
+
+	if epoch <= sc.lastEmittedEpoch {
+		return false
+	}
+	sc.lastEmittedEpoch = epoch
+	return true
+}
+
+// LastEmittedEpoch returns the last epoch for which an event was emitted.
+func (sc *SlotClock) LastEmittedEpoch() uint64 {
+	sc.epochEmitMu.Lock()
+	defer sc.epochEmitMu.Unlock()
+	return sc.lastEmittedEpoch
+}
+
+// SetLastEmittedEpoch sets the last emitted epoch. Used during startup to
+// initialize the tracker based on stored state.
+func (sc *SlotClock) SetLastEmittedEpoch(epoch uint64) {
+	sc.epochEmitMu.Lock()
+	defer sc.epochEmitMu.Unlock()
+	sc.lastEmittedEpoch = epoch
+}
+
+// =============================================================================
+// Internal tick loop
+// =============================================================================
+
+// run is the main tick loop
+func (sc *SlotClock) run() {
+	defer sc.wg.Done()
+
+	logger := sc.config.Logger.With("component", "slot_clock")
+
+	for {
+		// Check context first
+		select {
+		case <-sc.ctx.Done():
+			return
+		default:
+		}
+
+		// Calculate current slot and next slot boundary
+		now := sc.nowFunc()
+		currentSlot, err := sc.provider.TimeToSlot(now)
+		if err != nil {
+			logger.Error("failed to get current slot", "error", err)
+			// Sleep briefly and retry
+			select {
+			case <-sc.ctx.Done():
+				return
+			case <-time.After(100 * time.Millisecond):
+				continue
+			}
+		}
+
+		// Get the time for the next slot
+		nextSlot := currentSlot + 1
+		nextSlotTime, err := sc.provider.SlotToTime(nextSlot)
+		if err != nil {
+			logger.Error("failed to get next slot time", "error", err, "slot", nextSlot)
+			select {
+			case <-sc.ctx.Done():
+				return
+			case <-time.After(100 * time.Millisecond):
+				continue
+			}
+		}
+
+		// Sleep until the next slot boundary
+		sleepDuration := nextSlotTime.Sub(now)
+		if sleepDuration > 0 {
+			select {
+			case <-sc.ctx.Done():
+				return
+			case <-time.After(sleepDuration):
+			}
+		}
+
+		// Verify we're at the correct slot (handle clock drift)
+		actualNow := sc.nowFunc()
+		actualSlot, err := sc.provider.TimeToSlot(actualNow)
+		if err != nil {
+			logger.Error("failed to verify slot after wake", "error", err)
+			continue
+		}
+
+		// Check for drift
+		drift := actualNow.Sub(nextSlotTime)
+		if drift > sc.config.ClockTolerance {
+			logger.Warn("slot clock drift detected",
+				"expected_slot", nextSlot,
+				"actual_slot", actualSlot,
+				"drift", drift,
+			)
+		}
+
+		// Emit tick for the slot we're at (might have skipped some if drift is large)
+		tick, err := sc.buildSlotTick(actualSlot, actualNow)
+		if err != nil {
+			logger.Error("failed to build slot tick", "error", err, "slot", actualSlot)
+			continue
+		}
+
+		sc.emitTick(tick)
+	}
+}
+
+// buildSlotTick creates a SlotTick for the given slot
+func (sc *SlotClock) buildSlotTick(slot uint64, slotStart time.Time) (SlotTick, error) {
+	epochInfo, err := sc.provider.SlotToEpoch(slot)
+	if err != nil {
+		return SlotTick{}, err
+	}
+
+	epochSlot := slot - epochInfo.StartSlot
+	slotsUntilEpoch := epochInfo.EndSlot() - slot
+
+	// Check if this is the first slot of an epoch
+	isEpochStart := slot == epochInfo.StartSlot
+
+	return SlotTick{
+		Slot:            slot,
+		SlotStart:       slotStart,
+		Epoch:           epochInfo.EpochId,
+		EpochSlot:       epochSlot,
+		IsEpochStart:    isEpochStart,
+		SlotsUntilEpoch: slotsUntilEpoch,
+	}, nil
+}
+
+// emitTick sends the tick to all subscribers
+func (sc *SlotClock) emitTick(tick SlotTick) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	for _, ch := range sc.subscribers {
+		select {
+		case ch <- tick:
+		default:
+			// Channel is full, subscriber is slow - skip to avoid blocking
+			sc.config.Logger.Debug("slot tick dropped for slow subscriber",
+				"slot", tick.Slot,
+			)
+		}
+	}
+}
+
+// =============================================================================
+// LedgerState adapter
+// =============================================================================
+
+// ledgerStateSlotProvider adapts LedgerState to the SlotTimeProvider interface.
+type ledgerStateSlotProvider struct {
+	ls *LedgerState
+}
+
+// newLedgerStateSlotProvider creates a new adapter wrapping the given LedgerState
+func newLedgerStateSlotProvider(ls *LedgerState) *ledgerStateSlotProvider {
+	return &ledgerStateSlotProvider{ls: ls}
+}
+
+// SlotToTime delegates to LedgerState.SlotToTime
+func (p *ledgerStateSlotProvider) SlotToTime(slot uint64) (time.Time, error) {
+	return p.ls.SlotToTime(slot)
+}
+
+// TimeToSlot delegates to LedgerState.TimeToSlot
+func (p *ledgerStateSlotProvider) TimeToSlot(t time.Time) (uint64, error) {
+	return p.ls.TimeToSlot(t)
+}
+
+// SlotToEpoch delegates to LedgerState.SlotToEpoch and converts the result
+func (p *ledgerStateSlotProvider) SlotToEpoch(slot uint64) (EpochInfo, error) {
+	epoch, err := p.ls.SlotToEpoch(slot)
+	if err != nil {
+		return EpochInfo{}, err
+	}
+	return EpochInfo{
+		EpochId:       epoch.EpochId,
+		StartSlot:     epoch.StartSlot,
+		LengthInSlots: epoch.LengthInSlots,
+	}, nil
+}

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -1,0 +1,642 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSlotTimeProvider implements SlotTimeProvider for testing
+type mockSlotTimeProvider struct {
+	systemStart   time.Time
+	slotLength    time.Duration
+	epochLength   uint // slots per epoch
+	currentEpoch  uint64
+	epochStartMap map[uint64]uint64 // epoch -> startSlot
+	mu            sync.RWMutex
+}
+
+func newMockSlotTimeProvider(
+	systemStart time.Time,
+	slotLength time.Duration,
+	epochLength uint,
+) *mockSlotTimeProvider {
+	return &mockSlotTimeProvider{
+		systemStart:   systemStart,
+		slotLength:    slotLength,
+		epochLength:   epochLength,
+		epochStartMap: make(map[uint64]uint64),
+	}
+}
+
+func (m *mockSlotTimeProvider) SlotToTime(slot uint64) (time.Time, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.systemStart.Add(time.Duration(slot) * m.slotLength), nil
+}
+
+func (m *mockSlotTimeProvider) TimeToSlot(t time.Time) (uint64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if t.Before(m.systemStart) {
+		return 0, nil
+	}
+	elapsed := t.Sub(m.systemStart)
+	return uint64(elapsed / m.slotLength), nil
+}
+
+func (m *mockSlotTimeProvider) SlotToEpoch(slot uint64) (EpochInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	epochId := slot / uint64(m.epochLength)
+	startSlot := epochId * uint64(m.epochLength)
+	return EpochInfo{
+		EpochId:       epochId,
+		StartSlot:     startSlot,
+		LengthInSlots: m.epochLength,
+	}, nil
+}
+
+func TestSlotClockCreation(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+	require.NotNil(t, clock)
+	assert.NotNil(t, clock.provider)
+	assert.Equal(t, 100*time.Millisecond, clock.config.ClockTolerance)
+}
+
+func TestSlotClockCurrentSlot(t *testing.T) {
+	systemStart := time.Now().Add(-10 * time.Second)
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	slot, err := clock.CurrentSlot()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, slot, uint64(9))
+	assert.LessOrEqual(t, slot, uint64(11))
+}
+
+func TestSlotClockCurrentEpoch(t *testing.T) {
+	// Start 150 seconds ago with 1 second slots and 100 slot epochs
+	// Should be in epoch 1 (slots 100-199)
+	systemStart := time.Now().Add(-150 * time.Second)
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	epochInfo, err := clock.CurrentEpoch()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), epochInfo.EpochId)
+	assert.Equal(t, uint64(100), epochInfo.StartSlot)
+	assert.Equal(t, uint(100), epochInfo.LengthInSlots)
+}
+
+func TestSlotClockGetEpochForSlot(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	testCases := []struct {
+		slot          uint64
+		expectedEpoch uint64
+		expectedStart uint64
+	}{
+		{slot: 0, expectedEpoch: 0, expectedStart: 0},
+		{slot: 50, expectedEpoch: 0, expectedStart: 0},
+		{slot: 99, expectedEpoch: 0, expectedStart: 0},
+		{slot: 100, expectedEpoch: 1, expectedStart: 100},
+		{slot: 150, expectedEpoch: 1, expectedStart: 100},
+		{slot: 200, expectedEpoch: 2, expectedStart: 200},
+	}
+
+	for _, tc := range testCases {
+		epochInfo, err := clock.GetEpochForSlot(tc.slot)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expectedEpoch, epochInfo.EpochId, "epoch mismatch for slot %d", tc.slot)
+		assert.Equal(t, tc.expectedStart, epochInfo.StartSlot, "start slot mismatch for slot %d", tc.slot)
+	}
+}
+
+func TestSlotClockNextSlotTime(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	nextTime, err := clock.NextSlotTime()
+	require.NoError(t, err)
+	assert.True(t, nextTime.After(time.Now()))
+}
+
+func TestSlotClockTimeUntilNextEpoch(t *testing.T) {
+	// Start 50 seconds ago, 1 second slots, 100 slot epochs
+	// We should be around slot 50, with ~50 seconds until epoch boundary
+	systemStart := time.Now().Add(-50 * time.Second)
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	duration, err := clock.TimeUntilNextEpoch()
+	require.NoError(t, err)
+	// Should be approximately 50 seconds (give or take a second)
+	assert.Greater(t, duration, 48*time.Second)
+	assert.Less(t, duration, 52*time.Second)
+}
+
+func TestSlotClockTimeUntilSlot(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Time until slot 10 (10 seconds in the future)
+	duration, err := clock.TimeUntilSlot(10)
+	require.NoError(t, err)
+	assert.Greater(t, duration, 9*time.Second)
+	assert.Less(t, duration, 11*time.Second)
+
+	// Time until slot in the past
+	systemStart2 := time.Now().Add(-20 * time.Second)
+	provider2 := newMockSlotTimeProvider(systemStart2, time.Second, 100)
+	clock2 := NewSlotClock(provider2, DefaultSlotClockConfig())
+
+	duration2, err := clock2.TimeUntilSlot(5)
+	require.NoError(t, err)
+	assert.Less(t, duration2, time.Duration(0)) // Negative = in the past
+}
+
+func TestSlotClockIsEpochBoundary(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	testCases := []struct {
+		slot       uint64
+		isBoundary bool
+	}{
+		{slot: 0, isBoundary: true},
+		{slot: 1, isBoundary: false},
+		{slot: 99, isBoundary: false},
+		{slot: 100, isBoundary: true},
+		{slot: 101, isBoundary: false},
+		{slot: 200, isBoundary: true},
+	}
+
+	for _, tc := range testCases {
+		isBoundary, err := clock.IsEpochBoundary(tc.slot)
+		require.NoError(t, err)
+		assert.Equal(t, tc.isBoundary, isBoundary, "boundary check failed for slot %d", tc.slot)
+	}
+}
+
+func TestEpochInfoEndSlot(t *testing.T) {
+	epochInfo := EpochInfo{
+		EpochId:       5,
+		StartSlot:     500,
+		LengthInSlots: 100,
+	}
+	assert.Equal(t, uint64(600), epochInfo.EndSlot())
+}
+
+func TestSlotClockSubscribeUnsubscribe(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Subscribe
+	ch := clock.Subscribe()
+	require.NotNil(t, ch)
+
+	clock.mu.RLock()
+	assert.Len(t, clock.subscribers, 1)
+	clock.mu.RUnlock()
+
+	// Unsubscribe
+	clock.Unsubscribe(ch)
+
+	clock.mu.RLock()
+	assert.Len(t, clock.subscribers, 0)
+	clock.mu.RUnlock()
+}
+
+func TestSlotClockMultipleSubscribers(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Subscribe multiple times
+	ch1 := clock.Subscribe()
+	ch2 := clock.Subscribe()
+	ch3 := clock.Subscribe()
+
+	clock.mu.RLock()
+	assert.Len(t, clock.subscribers, 3)
+	clock.mu.RUnlock()
+
+	// Unsubscribe middle one
+	clock.Unsubscribe(ch2)
+
+	clock.mu.RLock()
+	assert.Len(t, clock.subscribers, 2)
+	clock.mu.RUnlock()
+
+	// Unsubscribe all
+	clock.Unsubscribe(ch1)
+	clock.Unsubscribe(ch3)
+
+	clock.mu.RLock()
+	assert.Len(t, clock.subscribers, 0)
+	clock.mu.RUnlock()
+}
+
+func TestSlotClockStartStop(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, 100*time.Millisecond, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ctx := context.Background()
+
+	// Start
+	clock.Start(ctx)
+	clock.mu.RLock()
+	assert.True(t, clock.running)
+	clock.mu.RUnlock()
+
+	// Double start should be no-op
+	clock.Start(ctx)
+	clock.mu.RLock()
+	assert.True(t, clock.running)
+	clock.mu.RUnlock()
+
+	// Stop
+	clock.Stop()
+	clock.mu.RLock()
+	assert.False(t, clock.running)
+	clock.mu.RUnlock()
+
+	// Double stop should be no-op
+	clock.Stop()
+	clock.mu.RLock()
+	assert.False(t, clock.running)
+	clock.mu.RUnlock()
+}
+
+func TestSlotClockReceivesTicks(t *testing.T) {
+	// Use short slot length for faster test
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, 50*time.Millisecond, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ch := clock.Subscribe()
+	ctx := t.Context()
+
+	clock.Start(ctx)
+	defer clock.Stop()
+
+	// Wait for a tick
+	select {
+	case tick := <-ch:
+		assert.GreaterOrEqual(t, tick.Slot, uint64(0))
+		assert.False(t, tick.SlotStart.IsZero())
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for slot tick")
+	}
+}
+
+func TestSlotClockEpochBoundary(t *testing.T) {
+	// Set up so we're close to an epoch boundary
+	// Epoch length = 10 slots, slot length = 20ms
+	systemStart := time.Now().Add(-9 * 20 * time.Millisecond) // Start at slot 9
+	provider := newMockSlotTimeProvider(systemStart, 20*time.Millisecond, 10)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ch := clock.Subscribe()
+	ctx := t.Context()
+
+	clock.Start(ctx)
+	defer clock.Stop()
+
+	// Collect ticks until we see an epoch boundary
+	var sawEpochStart bool
+	timeout := time.After(500 * time.Millisecond)
+	for !sawEpochStart {
+		select {
+		case tick := <-ch:
+			if tick.IsEpochStart {
+				sawEpochStart = true
+				assert.Equal(t, uint64(0), tick.EpochSlot)
+			}
+		case <-timeout:
+			t.Fatal("timeout waiting for epoch boundary tick")
+		}
+	}
+}
+
+func TestSlotTickSlotsUntilEpoch(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Test at various points in epoch
+	testCases := []struct {
+		slot            uint64
+		expectedRemain  uint64
+		expectedIsStart bool
+	}{
+		{slot: 0, expectedRemain: 100, expectedIsStart: true},   // Start of epoch 0
+		{slot: 1, expectedRemain: 99, expectedIsStart: false},   // Near start
+		{slot: 50, expectedRemain: 50, expectedIsStart: false},  // Middle
+		{slot: 99, expectedRemain: 1, expectedIsStart: false},   // Last slot of epoch 0
+		{slot: 100, expectedRemain: 100, expectedIsStart: true}, // Start of epoch 1
+		{slot: 150, expectedRemain: 50, expectedIsStart: false}, // Middle of epoch 1
+		{slot: 199, expectedRemain: 1, expectedIsStart: false},  // Last slot of epoch 1
+		{slot: 200, expectedRemain: 100, expectedIsStart: true}, // Start of epoch 2
+	}
+
+	for _, tc := range testCases {
+		t.Run("slot_"+string(rune(tc.slot)), func(t *testing.T) {
+			slotTime, _ := provider.SlotToTime(tc.slot)
+			tick, err := clock.buildSlotTick(tc.slot, slotTime)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedRemain, tick.SlotsUntilEpoch, "slots until epoch mismatch for slot %d", tc.slot)
+			assert.Equal(t, tc.expectedIsStart, tick.IsEpochStart, "epoch start mismatch for slot %d", tc.slot)
+		})
+	}
+}
+
+func TestSlotClockConcurrentSubscribers(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, 20*time.Millisecond, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ctx := t.Context()
+
+	clock.Start(ctx)
+	defer clock.Stop()
+
+	// Create many concurrent subscribers
+	const numSubscribers = 10
+	var wg sync.WaitGroup
+	wg.Add(numSubscribers)
+
+	for range numSubscribers {
+		go func() {
+			defer wg.Done()
+			ch := clock.Subscribe()
+			defer clock.Unsubscribe(ch)
+
+			// Wait for at least one tick
+			select {
+			case <-ch:
+				// Got a tick
+			case <-time.After(100 * time.Millisecond):
+				// Timeout is ok, just testing concurrency safety
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestSlotClockContextCancellation(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, 100*time.Millisecond, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	clock.Start(ctx)
+
+	// Cancel context
+	cancel()
+
+	// Wait briefly for goroutine to exit
+	done := make(chan struct{})
+	go func() {
+		clock.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good, clock stopped
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("clock did not stop after context cancellation")
+	}
+}
+
+func TestBuildSlotTick(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	slotTime, _ := provider.SlotToTime(150)
+	tick, err := clock.buildSlotTick(150, slotTime)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(150), tick.Slot)
+	assert.Equal(t, slotTime, tick.SlotStart)
+	assert.Equal(t, uint64(1), tick.Epoch)
+	assert.Equal(t, uint64(50), tick.EpochSlot)
+	assert.False(t, tick.IsEpochStart)
+	assert.Equal(t, uint64(50), tick.SlotsUntilEpoch)
+}
+
+func TestEmitTickToSubscribers(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ch1 := clock.Subscribe()
+	ch2 := clock.Subscribe()
+
+	tick := SlotTick{
+		Slot:      42,
+		SlotStart: time.Now(),
+		Epoch:     0,
+	}
+
+	clock.emitTick(tick)
+
+	// Both channels should receive the tick
+	select {
+	case received := <-ch1:
+		assert.Equal(t, uint64(42), received.Slot)
+	default:
+		t.Fatal("ch1 did not receive tick")
+	}
+
+	select {
+	case received := <-ch2:
+		assert.Equal(t, uint64(42), received.Slot)
+	default:
+		t.Fatal("ch2 did not receive tick")
+	}
+}
+
+func TestSlotClockDropsTickForSlowSubscriber(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Subscribe but don't read from channel
+	ch := clock.Subscribe()
+
+	// Fill the buffer
+	tick1 := SlotTick{Slot: 1}
+	clock.emitTick(tick1)
+
+	// This should be dropped (buffer is full)
+	tick2 := SlotTick{Slot: 2}
+	clock.emitTick(tick2)
+
+	// Only first tick should be in the channel
+	select {
+	case received := <-ch:
+		assert.Equal(t, uint64(1), received.Slot)
+	default:
+		t.Fatal("expected tick 1 in channel")
+	}
+
+	// Channel should be empty now
+	select {
+	case <-ch:
+		t.Fatal("unexpected second tick in channel")
+	default:
+		// Expected
+	}
+}
+
+// =============================================================================
+// Epoch Event Coordination Tests
+// =============================================================================
+
+func TestMarkEpochEmitted(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// First call should succeed
+	assert.True(t, clock.MarkEpochEmitted(5))
+	assert.Equal(t, uint64(5), clock.LastEmittedEpoch())
+
+	// Same epoch should fail (duplicate)
+	assert.False(t, clock.MarkEpochEmitted(5))
+
+	// Earlier epoch should fail
+	assert.False(t, clock.MarkEpochEmitted(3))
+
+	// Later epoch should succeed
+	assert.True(t, clock.MarkEpochEmitted(7))
+	assert.Equal(t, uint64(7), clock.LastEmittedEpoch())
+}
+
+func TestSetLastEmittedEpoch(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Initialize with epoch 10
+	clock.SetLastEmittedEpoch(10)
+	assert.Equal(t, uint64(10), clock.LastEmittedEpoch())
+
+	// Trying to emit epoch 5 should fail (already past)
+	assert.False(t, clock.MarkEpochEmitted(5))
+
+	// Trying to emit epoch 11 should succeed
+	assert.True(t, clock.MarkEpochEmitted(11))
+}
+
+func TestMarkEpochEmittedConcurrent(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	// Try to emit the same epoch from multiple goroutines
+	// Only one should succeed
+	const numGoroutines = 10
+	successCount := 0
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+			if clock.MarkEpochEmitted(100) {
+				mu.Lock()
+				successCount++
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, 1, successCount, "exactly one goroutine should succeed")
+}
+
+func TestSlotClockSlotToTime(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	slotTime, err := clock.SlotToTime(10)
+	require.NoError(t, err)
+
+	expected := systemStart.Add(10 * time.Second)
+	assert.Equal(t, expected, slotTime)
+}
+
+func TestSlotClockStopClosesSubscriberChannels(t *testing.T) {
+	systemStart := time.Now()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+
+	ch := clock.Subscribe()
+	ctx := context.Background()
+	clock.Start(ctx)
+
+	// Start a goroutine that blocks on the channel
+	done := make(chan struct{})
+	go func() {
+		for range ch {
+			// Drain the channel
+		}
+		close(done)
+	}()
+
+	// Stop should close the channel, unblocking the goroutine
+	clock.Stop()
+
+	// The goroutine should exit within a reasonable time
+	select {
+	case <-done:
+		// Good, channel was closed and goroutine exited
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber goroutine did not exit after Stop")
+	}
+
+	// Verify subscribers list is cleared
+	clock.mu.RLock()
+	assert.Nil(t, clock.subscribers)
+	clock.mu.RUnlock()
+}

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -751,7 +751,7 @@ func TestDatabaseWorkerPoolInFlightOperations(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Submit multiple operations
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		resultChan := make(chan DatabaseResult, 1)
 
@@ -804,7 +804,7 @@ func TestDatabaseWorkerPoolShutdownWithErrors(t *testing.T) {
 	var completedCount atomic.Int32
 
 	// Submit operations, some will error
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		resultChan := make(chan DatabaseResult, 1)
 		operationIndex := i
 
@@ -850,7 +850,7 @@ func TestDatabaseWorkerPoolQueueFull(t *testing.T) {
 	pool := NewDatabaseWorkerPool(nil, config)
 
 	// Submit some operations
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		resultChan := make(chan DatabaseResult, 1)
 		pool.Submit(DatabaseOperation{
 			OpFunc: func(db *database.Database) error {
@@ -911,7 +911,7 @@ func TestDatabaseWorkerPoolConcurrency(t *testing.T) {
 
 	// Submit many operations
 	numOperations := 20
-	for i := 0; i < numOperations; i++ {
+	for range numOperations {
 		resultChan := make(chan DatabaseResult, 1)
 
 		pool.Submit(DatabaseOperation{
@@ -972,7 +972,7 @@ func TestDatabaseWorkerPoolResultChannelFull(t *testing.T) {
 	var completedCount atomic.Int32
 
 	// Submit operations
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		resultChan := make(chan DatabaseResult, 1)
 
 		pool.Submit(DatabaseOperation{
@@ -1564,7 +1564,7 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 	}()
 
 	// Start multiple reader goroutines that try to read during the transaction
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1573,7 +1573,7 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 			<-txnStarted
 
 			// Try to read multiple times during the transaction
-			for j := 0; j < 10; j++ {
+			for range 10 {
 				select {
 				case <-txnDone:
 					return


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a slot-based clock that emits ticks at slot boundaries and integrate it with LedgerState to drive proactive epoch transitions and leader election independent of block arrival. Coordinates with block-based detection to avoid duplicate epoch events and only emits when the node is synced.

- **New Features**
  - Introduced SlotClock with subscribe/unsubscribe, drift tolerance (default 100ms), and query helpers (CurrentSlot/Epoch, SlotToTime, TimeUntilNextEpoch, IsEpochBoundary).
  - Wired SlotClock into LedgerState: start/stop lifecycle, slot tick handler that emits EpochTransitionEvent at epoch boundaries only when validationEnabled; uses MarkEpochEmitted to de-duplicate with block-based path and initializes last-emitted epoch on startup.
  - Added comprehensive tests for ticking, epoch boundaries, concurrency, and coordination; minor test cleanups.

<sup>Written for commit ede0223f9d97adc04c117f00785dc823791a9631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

