### PR TITLE
feat(ledger): leader election for block production

### DIFF
--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leader
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/snapshot"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// StakeDistributionProvider provides stake distribution data for leader election.
+type StakeDistributionProvider interface {
+	// GetStakeDistribution returns the stake distribution for the given epoch.
+	// For leader election, this should return the "Go" snapshot (epoch - 2).
+	GetStakeDistribution(epoch uint64) (*snapshot.StakeDistribution, error)
+
+	// GetPoolStake returns the stake for a specific pool in the given epoch.
+	GetPoolStake(epoch uint64, poolKeyHash []byte) (uint64, error)
+
+	// GetTotalActiveStake returns the total active stake for the given epoch.
+	GetTotalActiveStake(epoch uint64) (uint64, error)
+}
+
+// EpochInfoProvider provides epoch-related information.
+type EpochInfoProvider interface {
+	// CurrentEpoch returns the current epoch number.
+	CurrentEpoch() uint64
+
+	// EpochNonce returns the nonce for the given epoch.
+	EpochNonce(epoch uint64) []byte
+
+	// SlotsPerEpoch returns the number of slots in an epoch.
+	SlotsPerEpoch() uint64
+
+	// ActiveSlotCoeff returns the active slot coefficient (f parameter).
+	ActiveSlotCoeff() float64
+}
+
+// Election manages leader election for a stake pool.
+// It maintains the current epoch's schedule and refreshes it on epoch transitions.
+type Election struct {
+	poolId      lcommon.PoolKeyHash
+	poolVrfSkey []byte
+
+	stakeProvider StakeDistributionProvider
+	epochProvider EpochInfoProvider
+	eventBus      *event.EventBus
+	logger        *slog.Logger
+
+	mu             sync.RWMutex
+	schedule       *Schedule
+	running        bool
+	cancel         context.CancelFunc
+	subscriptionId event.EventSubscriberId
+}
+
+// NewElection creates a new leader election manager for a stake pool.
+func NewElection(
+	poolId lcommon.PoolKeyHash,
+	poolVrfSkey []byte,
+	stakeProvider StakeDistributionProvider,
+	epochProvider EpochInfoProvider,
+	eventBus *event.EventBus,
+	logger *slog.Logger,
+) *Election {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Election{
+		poolId:        poolId,
+		poolVrfSkey:   poolVrfSkey,
+		stakeProvider: stakeProvider,
+		epochProvider: epochProvider,
+		eventBus:      eventBus,
+		logger:        logger,
+	}
+}
+
+// Start begins listening for epoch transitions and maintaining the schedule.
+func (e *Election) Start() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.running {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	e.cancel = cancel
+	e.running = true
+
+	// Calculate initial schedule
+	if err := e.refreshScheduleUnsafe(ctx); err != nil {
+		e.logger.Warn(
+			"failed to calculate initial schedule",
+			"component", "leader",
+			"error", err,
+		)
+	}
+
+	// Subscribe to epoch transitions
+	e.subscriptionId = e.eventBus.SubscribeFunc(
+		event.EpochTransitionEventType,
+		func(evt event.Event) {
+			epochEvent, ok := evt.Data.(event.EpochTransitionEvent)
+			if !ok {
+				return
+			}
+			e.logger.Info(
+				"epoch transition, refreshing leader schedule",
+				"component", "leader",
+				"new_epoch", epochEvent.NewEpoch,
+			)
+			if err := e.RefreshSchedule(ctx); err != nil {
+				e.logger.Error(
+					"failed to refresh schedule",
+					"component", "leader",
+					"epoch", epochEvent.NewEpoch,
+					"error", err,
+				)
+			}
+		},
+	)
+
+	e.logger.Info(
+		"leader election started",
+		"component", "leader",
+		"pool_id", hex.EncodeToString(e.poolId[:]),
+	)
+
+	return nil
+}
+
+// Stop stops the leader election manager.
+func (e *Election) Stop() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.running {
+		return nil
+	}
+
+	if e.cancel != nil {
+		e.cancel()
+	}
+	if e.subscriptionId != 0 {
+		e.eventBus.Unsubscribe(
+			event.EpochTransitionEventType,
+			e.subscriptionId,
+		)
+		e.subscriptionId = 0
+	}
+	e.running = false
+	e.schedule = nil
+
+	e.logger.Info("leader election stopped", "component", "leader")
+	return nil
+}
+
+// RefreshSchedule recalculates the leader schedule for the current epoch.
+func (e *Election) RefreshSchedule(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.refreshScheduleUnsafe(ctx)
+}
+
+// refreshScheduleUnsafe recalculates the schedule without locking.
+// Caller must hold e.mu.
+func (e *Election) refreshScheduleUnsafe(ctx context.Context) error {
+	// Check for context cancellation
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	currentEpoch := e.epochProvider.CurrentEpoch()
+
+	// Leader election uses the Go snapshot (epoch - 2)
+	if currentEpoch < 2 {
+		e.logger.Debug(
+			"no Go snapshot available yet",
+			"component", "leader",
+			"epoch", currentEpoch,
+		)
+		e.schedule = nil
+		return nil
+	}
+
+	snapshotEpoch := currentEpoch - 2
+
+	// Get pool stake from Go snapshot
+	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
+	if err != nil {
+		return fmt.Errorf("get pool stake: %w", err)
+	}
+
+	if poolStake == 0 {
+		e.logger.Debug(
+			"pool has no stake in Go snapshot",
+			"component", "leader",
+			"epoch", currentEpoch,
+			"snapshot_epoch", snapshotEpoch,
+		)
+		e.schedule = nil
+		return nil
+	}
+
+	// Get total stake from Go snapshot
+	totalStake, err := e.stakeProvider.GetTotalActiveStake(snapshotEpoch)
+	if err != nil {
+		return fmt.Errorf("get total stake: %w", err)
+	}
+
+	if totalStake == 0 {
+		return fmt.Errorf("total stake is zero for epoch %d", snapshotEpoch)
+	}
+
+	// Get epoch nonce
+	epochNonce := e.epochProvider.EpochNonce(currentEpoch)
+
+	// Create calculator with protocol parameters
+	calc := NewCalculator(
+		e.epochProvider.ActiveSlotCoeff(),
+		e.epochProvider.SlotsPerEpoch(),
+	)
+
+	// Calculate schedule
+	schedule, err := calc.CalculateSchedule(
+		currentEpoch,
+		e.poolId,
+		e.poolVrfSkey,
+		poolStake,
+		totalStake,
+		epochNonce,
+	)
+	if err != nil {
+		return fmt.Errorf("calculate schedule: %w", err)
+	}
+
+	e.schedule = schedule
+
+	e.logger.Info(
+		"leader schedule calculated",
+		"component", "leader",
+		"epoch", currentEpoch,
+		"pool_stake", poolStake,
+		"total_stake", totalStake,
+		"stake_ratio", schedule.StakeRatio(),
+		"leader_slots", schedule.SlotCount(),
+	)
+
+	return nil
+}
+
+// ShouldProduceBlock returns true if this pool should produce a block for the slot.
+func (e *Election) ShouldProduceBlock(slot uint64) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if e.schedule == nil {
+		return false
+	}
+	return e.schedule.IsLeaderForSlot(slot)
+}
+
+// CurrentSchedule returns the current leader schedule, or nil if not available.
+func (e *Election) CurrentSchedule() *Schedule {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.schedule
+}
+
+// NextLeaderSlot returns the next slot where this pool is leader, starting from
+// the given slot. Returns 0 and false if no leader slot is found.
+func (e *Election) NextLeaderSlot(fromSlot uint64) (uint64, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if e.schedule == nil {
+		return 0, false
+	}
+
+	for _, slot := range e.schedule.LeaderSlots {
+		if slot >= fromSlot {
+			return slot, true
+		}
+	}
+	return 0, false
+}

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -1,0 +1,397 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leader
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/snapshot"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStakeProvider implements StakeDistributionProvider for testing
+type mockStakeProvider struct {
+	stakeDistribution *snapshot.StakeDistribution
+	poolStakes        map[string]uint64
+	totalStake        uint64
+	err               error
+}
+
+func newMockStakeProvider() *mockStakeProvider {
+	return &mockStakeProvider{
+		poolStakes: make(map[string]uint64),
+	}
+}
+
+func (m *mockStakeProvider) GetStakeDistribution(
+	epoch uint64,
+) (*snapshot.StakeDistribution, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.stakeDistribution, nil
+}
+
+func (m *mockStakeProvider) GetPoolStake(
+	epoch uint64,
+	poolKeyHash []byte,
+) (uint64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return m.poolStakes[string(poolKeyHash)], nil
+}
+
+func (m *mockStakeProvider) GetTotalActiveStake(epoch uint64) (uint64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return m.totalStake, nil
+}
+
+// mockEpochProvider implements EpochInfoProvider for testing
+type mockEpochProvider struct {
+	currentEpoch    uint64
+	epochNonce      []byte
+	slotsPerEpoch   uint64
+	activeSlotCoeff float64
+}
+
+func newMockEpochProvider() *mockEpochProvider {
+	return &mockEpochProvider{
+		currentEpoch:    10,
+		epochNonce:      []byte("testnonce"),
+		slotsPerEpoch:   432000,
+		activeSlotCoeff: 0.05,
+	}
+}
+
+func (m *mockEpochProvider) CurrentEpoch() uint64 {
+	return m.currentEpoch
+}
+
+func (m *mockEpochProvider) EpochNonce(epoch uint64) []byte {
+	return m.epochNonce
+}
+
+func (m *mockEpochProvider) SlotsPerEpoch() uint64 {
+	return m.slotsPerEpoch
+}
+
+func (m *mockEpochProvider) ActiveSlotCoeff() float64 {
+	return m.activeSlotCoeff
+}
+
+func TestNewElection(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+	vrfKey := []byte("vrfsecretkey")
+
+	stakeProvider := newMockStakeProvider()
+	epochProvider := newMockEpochProvider()
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		vrfKey,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		nil, // nil logger uses default
+	)
+
+	require.NotNil(t, election)
+	assert.Equal(t, poolId, election.poolId)
+	assert.Equal(t, vrfKey, election.poolVrfSkey)
+	assert.NotNil(t, election.logger)
+}
+
+func TestElectionStartStop(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	epochProvider := newMockEpochProvider()
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	// Start should succeed
+	err := election.Start()
+	require.NoError(t, err)
+
+	// Start again should be idempotent
+	err = election.Start()
+	require.NoError(t, err)
+
+	// Stop should succeed
+	err = election.Stop()
+	require.NoError(t, err)
+
+	// Stop again should be idempotent
+	err = election.Stop()
+	require.NoError(t, err)
+}
+
+func TestElectionScheduleEarlyEpochs(t *testing.T) {
+	// Test behavior when epoch < 2 (no Go snapshot available)
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch = 1 // Too early for Go snapshot
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start()
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	// Schedule should be nil for early epochs
+	assert.Nil(t, election.CurrentSchedule())
+	assert.False(t, election.ShouldProduceBlock(100))
+}
+
+func TestElectionZeroPoolStake(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	// No pool stake set (zero)
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch = 10
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start()
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	// Schedule should be nil when pool has no stake
+	assert.Nil(t, election.CurrentSchedule())
+}
+
+func TestElectionShouldProduceBlock(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch = 10
+	epochProvider.slotsPerEpoch = 10 // Small for testing
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start()
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	// With placeholder isSlotLeader returning false, no slots are leader slots
+	schedule := election.CurrentSchedule()
+	require.NotNil(t, schedule)
+	assert.Equal(t, 0, schedule.SlotCount())
+
+	// ShouldProduceBlock should return false for all slots
+	assert.False(t, election.ShouldProduceBlock(100))
+	assert.False(t, election.ShouldProduceBlock(101))
+}
+
+func TestElectionNextLeaderSlot(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch = 10
+	epochProvider.slotsPerEpoch = 10
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	// No schedule - should return 0, false
+	slot, found := election.NextLeaderSlot(0)
+	assert.Equal(t, uint64(0), slot)
+	assert.False(t, found)
+
+	err := election.Start()
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	// With placeholder returning no leader slots, should return 0, false
+	slot, found = election.NextLeaderSlot(0)
+	assert.Equal(t, uint64(0), slot)
+	assert.False(t, found)
+}
+
+func TestElectionEpochTransition(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch = 10
+	epochProvider.slotsPerEpoch = 10
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start()
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	// Verify initial schedule
+	schedule := election.CurrentSchedule()
+	require.NotNil(t, schedule)
+	assert.Equal(t, uint64(10), schedule.Epoch)
+
+	// Simulate epoch transition by updating provider and sending event
+	epochProvider.currentEpoch = 11
+
+	// Publish epoch transition event
+	eventBus.Publish(
+		event.EpochTransitionEventType,
+		event.NewEvent(
+			event.EpochTransitionEventType,
+			event.EpochTransitionEvent{
+				PreviousEpoch: 10,
+				NewEpoch:      11,
+				BoundarySlot:  110,
+				EpochNonce:    []byte("newepochnonce"),
+			},
+		),
+	)
+
+	// Poll for event to be processed with timeout
+	require.Eventually(t, func() bool {
+		schedule := election.CurrentSchedule()
+		return schedule != nil && schedule.Epoch == 11
+	}, 2*time.Second, 10*time.Millisecond, "schedule should update to epoch 11")
+
+	// Schedule should be updated to new epoch
+	schedule = election.CurrentSchedule()
+	require.NotNil(t, schedule)
+	assert.Equal(t, uint64(11), schedule.Epoch)
+}
+
+func TestElectionConcurrentAccess(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch = 10
+	epochProvider.slotsPerEpoch = 10
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		nil,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start()
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	// Concurrent reads and operations
+	done := make(chan bool)
+	for i := range 20 {
+		go func(slot int) {
+			_ = election.ShouldProduceBlock(uint64(slot))
+			_ = election.CurrentSchedule()
+			_, _ = election.NextLeaderSlot(uint64(slot))
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for range 20 {
+		<-done
+	}
+}

--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package leader provides Ouroboros Praos leader election functionality
+// for block production. It determines which slots a stake pool is eligible
+// to produce blocks based on the stake distribution snapshot.
+package leader
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"sync"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Schedule represents the leader schedule for a stake pool in an epoch.
+// It contains the slots where the pool is eligible to produce blocks.
+type Schedule struct {
+	Epoch       uint64              // Epoch this schedule is for
+	PoolId      lcommon.PoolKeyHash // Pool key hash
+	PoolStake   uint64              // Pool's stake from Go snapshot
+	TotalStake  uint64              // Total active stake from Go snapshot
+	EpochNonce  []byte              // Epoch nonce for VRF
+	LeaderSlots []uint64            // Slots where pool is leader
+
+	mu sync.RWMutex
+}
+
+// NewSchedule creates a new empty schedule for an epoch.
+func NewSchedule(
+	epoch uint64,
+	poolId lcommon.PoolKeyHash,
+	poolStake uint64,
+	totalStake uint64,
+	epochNonce []byte,
+) *Schedule {
+	return &Schedule{
+		Epoch:       epoch,
+		PoolId:      poolId,
+		PoolStake:   poolStake,
+		TotalStake:  totalStake,
+		EpochNonce:  epochNonce,
+		LeaderSlots: make([]uint64, 0),
+	}
+}
+
+// AddLeaderSlot adds a slot where this pool is the leader.
+func (s *Schedule) AddLeaderSlot(slot uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.LeaderSlots = append(s.LeaderSlots, slot)
+}
+
+// IsLeaderForSlot returns true if the pool is leader for the given slot.
+func (s *Schedule) IsLeaderForSlot(slot uint64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return slices.Contains(s.LeaderSlots, slot)
+}
+
+// SlotCount returns the number of slots where this pool is leader.
+func (s *Schedule) SlotCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.LeaderSlots)
+}
+
+// StakeRatio returns the pool's stake as a fraction of total stake.
+func (s *Schedule) StakeRatio() float64 {
+	if s.TotalStake == 0 {
+		return 0
+	}
+	return float64(s.PoolStake) / float64(s.TotalStake)
+}
+
+// Calculator computes leader schedules using VRF and stake distribution.
+type Calculator struct {
+	// ActiveSlotCoeff (f) determines block production rate.
+	// For mainnet, f = 0.05 (5% of slots have blocks on average)
+	ActiveSlotCoeff float64
+
+	// SlotsPerEpoch is the number of slots in an epoch.
+	SlotsPerEpoch uint64
+}
+
+// NewCalculator creates a calculator with the given protocol parameters.
+func NewCalculator(activeSlotCoeff float64, slotsPerEpoch uint64) *Calculator {
+	return &Calculator{
+		ActiveSlotCoeff: activeSlotCoeff,
+		SlotsPerEpoch:   slotsPerEpoch,
+	}
+}
+
+// CalculateSchedule computes which slots a pool leads in the given epoch.
+// This uses the certified VRF to determine leader eligibility per slot.
+//
+// The leader check for each slot uses:
+// - Pool's relative stake (sigma = poolStake / totalStake)
+// - Active slot coefficient (f)
+// - VRF output for the slot
+//
+// A pool is leader if: VRF_output < threshold(sigma)
+func (c *Calculator) CalculateSchedule(
+	epoch uint64,
+	poolId lcommon.PoolKeyHash,
+	poolVrfSkey []byte,
+	poolStake uint64,
+	totalStake uint64,
+	epochNonce []byte,
+) (*Schedule, error) {
+	if totalStake == 0 {
+		return nil, errors.New("total stake cannot be zero")
+	}
+
+	schedule := NewSchedule(epoch, poolId, poolStake, totalStake, epochNonce)
+
+	// Calculate epoch slot range
+	epochStartSlot := epoch * c.SlotsPerEpoch
+	epochEndSlot := epochStartSlot + c.SlotsPerEpoch
+
+	// Check each slot in the epoch
+	for slot := epochStartSlot; slot < epochEndSlot; slot++ {
+		isLeader, err := c.isSlotLeader(
+			slot,
+			poolVrfSkey,
+			poolStake,
+			totalStake,
+			epochNonce,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("check slot %d: %w", slot, err)
+		}
+		if isLeader {
+			schedule.AddLeaderSlot(slot)
+		}
+	}
+
+	return schedule, nil
+}
+
+// isSlotLeader determines if the pool is leader for a specific slot.
+// This is a placeholder - the actual implementation requires:
+// 1. VRF computation with the pool's VRF secret key
+// 2. Comparison against the leadership threshold
+//
+// TODO: Integrate with gouroboros consensus.IsSlotLeader() when available
+func (c *Calculator) isSlotLeader(
+	slot uint64,
+	poolVrfSkey []byte,
+	poolStake uint64,
+	totalStake uint64,
+	epochNonce []byte,
+) (bool, error) {
+	// The actual leader check requires:
+	// 1. Compute VRF proof for the slot seed (epochNonce || slot)
+	// 2. Convert VRF output to a value in [0, 1)
+	// 3. Compute threshold for the stake ratio
+	// 4. Pool is leader if VRF output < threshold
+
+	// For now, return false - actual VRF implementation needed
+	// This will be integrated with gouroboros/consensus when ready
+	_ = slot
+	_ = poolVrfSkey
+	_ = poolStake
+	_ = totalStake
+	_ = epochNonce
+
+	return false, nil
+}
+
+// Threshold calculates the leadership threshold for a given stake ratio.
+// threshold(sigma) = 1 - (1-f)^sigma
+// where f is the active slot coefficient and sigma is the relative stake.
+func (c *Calculator) Threshold(stakeRatio float64) float64 {
+	if stakeRatio <= 0 {
+		return 0
+	}
+	if stakeRatio >= 1 {
+		return c.ActiveSlotCoeff
+	}
+	// threshold(sigma) = 1 - (1-f)^sigma
+	return 1 - math.Pow(1-c.ActiveSlotCoeff, stakeRatio)
+}

--- a/ledger/leader/schedule_test.go
+++ b/ledger/leader/schedule_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leader
+
+import (
+	"math"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSchedule(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("pool1234567890123456"))
+
+	schedule := NewSchedule(
+		10,     // epoch
+		poolId, // pool ID
+		1000,   // pool stake
+		10000,  // total stake
+		[]byte("nonce"),
+	)
+
+	assert.NotNil(t, schedule)
+	assert.Equal(t, uint64(10), schedule.Epoch)
+	assert.Equal(t, poolId, schedule.PoolId)
+	assert.Equal(t, uint64(1000), schedule.PoolStake)
+	assert.Equal(t, uint64(10000), schedule.TotalStake)
+	assert.Equal(t, []byte("nonce"), schedule.EpochNonce)
+	assert.Empty(t, schedule.LeaderSlots)
+}
+
+func TestScheduleAddLeaderSlot(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	schedule := NewSchedule(10, poolId, 1000, 10000, nil)
+
+	schedule.AddLeaderSlot(100)
+	schedule.AddLeaderSlot(200)
+	schedule.AddLeaderSlot(300)
+
+	assert.Len(t, schedule.LeaderSlots, 3)
+	assert.Contains(t, schedule.LeaderSlots, uint64(100))
+	assert.Contains(t, schedule.LeaderSlots, uint64(200))
+	assert.Contains(t, schedule.LeaderSlots, uint64(300))
+}
+
+func TestScheduleIsLeaderForSlot(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	schedule := NewSchedule(10, poolId, 1000, 10000, nil)
+
+	schedule.AddLeaderSlot(100)
+	schedule.AddLeaderSlot(200)
+
+	assert.True(t, schedule.IsLeaderForSlot(100))
+	assert.True(t, schedule.IsLeaderForSlot(200))
+	assert.False(t, schedule.IsLeaderForSlot(150))
+	assert.False(t, schedule.IsLeaderForSlot(0))
+}
+
+func TestScheduleSlotCount(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	schedule := NewSchedule(10, poolId, 1000, 10000, nil)
+
+	assert.Equal(t, 0, schedule.SlotCount())
+
+	schedule.AddLeaderSlot(100)
+	assert.Equal(t, 1, schedule.SlotCount())
+
+	schedule.AddLeaderSlot(200)
+	schedule.AddLeaderSlot(300)
+	assert.Equal(t, 3, schedule.SlotCount())
+}
+
+func TestScheduleStakeRatio(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+
+	tests := []struct {
+		name       string
+		poolStake  uint64
+		totalStake uint64
+		expected   float64
+	}{
+		{
+			name:       "10% stake",
+			poolStake:  1000,
+			totalStake: 10000,
+			expected:   0.1,
+		},
+		{
+			name:       "50% stake",
+			poolStake:  5000,
+			totalStake: 10000,
+			expected:   0.5,
+		},
+		{
+			name:       "100% stake",
+			poolStake:  10000,
+			totalStake: 10000,
+			expected:   1.0,
+		},
+		{
+			name:       "zero total stake",
+			poolStake:  1000,
+			totalStake: 0,
+			expected:   0,
+		},
+		{
+			name:       "zero pool stake",
+			poolStake:  0,
+			totalStake: 10000,
+			expected:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule := NewSchedule(10, poolId, tt.poolStake, tt.totalStake, nil)
+			assert.InDelta(t, tt.expected, schedule.StakeRatio(), 0.0001)
+		})
+	}
+}
+
+func TestNewCalculator(t *testing.T) {
+	calc := NewCalculator(0.05, 432000)
+
+	assert.Equal(t, 0.05, calc.ActiveSlotCoeff)
+	assert.Equal(t, uint64(432000), calc.SlotsPerEpoch)
+}
+
+func TestCalculatorThreshold(t *testing.T) {
+	// Mainnet parameters: f = 0.05
+	calc := NewCalculator(0.05, 432000)
+
+	tests := []struct {
+		name       string
+		stakeRatio float64
+		expected   float64
+	}{
+		{
+			name:       "zero stake",
+			stakeRatio: 0,
+			expected:   0,
+		},
+		{
+			name:       "small stake (1%)",
+			stakeRatio: 0.01,
+			// threshold = 1 - (1-0.05)^0.01 = 1 - 0.95^0.01
+			expected: 1 - math.Pow(0.95, 0.01),
+		},
+		{
+			name:       "10% stake",
+			stakeRatio: 0.1,
+			// threshold = 1 - (1-0.05)^0.1 = 1 - 0.95^0.1
+			expected: 1 - math.Pow(0.95, 0.1),
+		},
+		{
+			name:       "100% stake",
+			stakeRatio: 1.0,
+			// threshold = 1 - (1-0.05)^1 = 1 - 0.95 = 0.05
+			expected: 0.05,
+		},
+		{
+			name:       "greater than 100%",
+			stakeRatio: 1.5,
+			// Capped at f (active slot coefficient)
+			expected: 0.05,
+		},
+		{
+			name:       "negative stake",
+			stakeRatio: -0.1,
+			expected:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calc.Threshold(tt.stakeRatio)
+			assert.InDelta(t, tt.expected, result, 0.0001)
+		})
+	}
+}
+
+func TestCalculateScheduleZeroTotalStake(t *testing.T) {
+	calc := NewCalculator(0.05, 432000)
+	poolId := lcommon.PoolKeyHash{}
+
+	_, err := calc.CalculateSchedule(
+		10,     // epoch
+		poolId, // pool ID
+		nil,    // VRF key (not used in placeholder)
+		1000,   // pool stake
+		0,      // zero total stake
+		nil,    // epoch nonce
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "total stake cannot be zero")
+}
+
+func TestCalculateScheduleReturnsSchedule(t *testing.T) {
+	// Note: With the placeholder isSlotLeader that returns false,
+	// the schedule will have no leader slots. This test verifies
+	// the basic structure is correct.
+	calc := NewCalculator(0.05, 10) // Small epoch for testing
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	schedule, err := calc.CalculateSchedule(
+		5,      // epoch
+		poolId, // pool ID
+		nil,    // VRF key
+		1000,   // pool stake
+		10000,  // total stake
+		[]byte("nonce"),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, schedule)
+
+	assert.Equal(t, uint64(5), schedule.Epoch)
+	assert.Equal(t, poolId, schedule.PoolId)
+	assert.Equal(t, uint64(1000), schedule.PoolStake)
+	assert.Equal(t, uint64(10000), schedule.TotalStake)
+	assert.Equal(t, []byte("nonce"), schedule.EpochNonce)
+
+	// With placeholder returning false, no leader slots
+	assert.Empty(t, schedule.LeaderSlots)
+}
+
+func TestScheduleConcurrentAccess(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	schedule := NewSchedule(10, poolId, 1000, 10000, nil)
+
+	// Concurrent writes
+	done := make(chan bool)
+	for i := range 10 {
+		go func(slot int) {
+			schedule.AddLeaderSlot(uint64(slot * 100))
+			done <- true
+		}(i)
+	}
+
+	// Wait for all writes
+	for range 10 {
+		<-done
+	}
+
+	// Concurrent reads
+	for range 10 {
+		go func() {
+			_ = schedule.SlotCount()
+			_ = schedule.IsLeaderForSlot(100)
+			_ = schedule.StakeRatio()
+			done <- true
+		}()
+	}
+
+	// Wait for all reads
+	for range 10 {
+		<-done
+	}
+
+	assert.Equal(t, 10, schedule.SlotCount())
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Ouroboros Praos leader election for block production with per-epoch schedules based on the “Go” (epoch − 2) stake snapshot. Introduces an event-driven Election manager and a Calculator; VRF leader check is stubbed for now.

- **New Features**
  - Election manager: builds the schedule at start and on epoch transitions via EventBus; thread-safe APIs (Start/Stop, RefreshSchedule, ShouldProduceBlock, CurrentSchedule, NextLeaderSlot).
  - Schedule: stores epoch, pool stake/total stake, nonce, and leader slots; helpers for stake ratio, slot count, and slot checks.
  - Calculator: computes thresholds using active slot coeff and slots/epoch; iterates slots to build schedules; isSlotLeader is a placeholder (no leader slots until VRF integration).
  - Uses providers: StakeDistributionProvider and EpochInfoProvider; reads Go snapshot (epoch − 2) for pool/total stake and current epoch nonce.

- **Migration**
  - No breaking changes.
  - To use: implement the two providers, pass poolId and VRF skey, create Election, call Start, then query ShouldProduceBlock/NextLeaderSlot.
  - Note: schedules will be empty until VRF leader check is implemented.

<sup>Written for commit 4ec63b66ed51ded3ded2b47a13ba6eac60348859. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

