### PR TITLE
feat(ledger): block propagation

### DIFF
--- a/event/block.go
+++ b/event/block.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import "time"
+
+// BlockForgedEventType is the event type for locally forged blocks
+const BlockForgedEventType = EventType("block.forged")
+
+// BlockForgedEvent is emitted when the node successfully forges a new block.
+// This event is published after the block has been added to the local chain
+// via chain.AddBlock(), which triggers automatic propagation to connected peers.
+type BlockForgedEvent struct {
+	// Slot is the slot number where the block was forged
+	Slot uint64
+	// BlockNumber is the block height in the chain
+	BlockNumber uint64
+	// BlockHash is the hash of the forged block
+	BlockHash []byte
+	// TxCount is the number of transactions included in the block
+	TxCount uint
+	// BlockSize is the size of the block in bytes
+	BlockSize uint
+	// Timestamp is when the block was forged
+	Timestamp time.Time
+}

--- a/event/block_test.go
+++ b/event/block_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockForgedEventType(t *testing.T) {
+	assert.Equal(
+		t,
+		event.EventType("block.forged"),
+		event.BlockForgedEventType,
+	)
+}
+
+func TestBlockForgedEventPublishSubscribe(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	now := time.Now()
+	testEvent := event.BlockForgedEvent{
+		Slot:        12345,
+		BlockNumber: 100,
+		BlockHash:   []byte{0xab, 0xcd, 0xef},
+		TxCount:     5,
+		BlockSize:   1024,
+		Timestamp:   now,
+	}
+
+	_, subCh := eb.Subscribe(event.BlockForgedEventType)
+
+	eb.Publish(
+		event.BlockForgedEventType,
+		event.NewEvent(event.BlockForgedEventType, testEvent),
+	)
+
+	select {
+	case evt, ok := <-subCh:
+		require.True(t, ok, "event channel closed unexpectedly")
+		require.Equal(t, event.BlockForgedEventType, evt.Type)
+
+		blockEvent, ok := evt.Data.(event.BlockForgedEvent)
+		require.True(t, ok, "event data was not BlockForgedEvent")
+
+		assert.Equal(t, uint64(12345), blockEvent.Slot)
+		assert.Equal(t, uint64(100), blockEvent.BlockNumber)
+		assert.Equal(t, []byte{0xab, 0xcd, 0xef}, blockEvent.BlockHash)
+		assert.Equal(t, uint(5), blockEvent.TxCount)
+		assert.Equal(t, uint(1024), blockEvent.BlockSize)
+		assert.Equal(t, now, blockEvent.Timestamp)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for block forged event")
+	}
+}
+
+func TestBlockForgedEventSubscribeFunc(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	now := time.Now()
+	testEvent := event.BlockForgedEvent{
+		Slot:        67890,
+		BlockNumber: 200,
+		BlockHash:   []byte{0x01, 0x02},
+		TxCount:     10,
+		BlockSize:   2048,
+		Timestamp:   now,
+	}
+
+	receivedCh := make(chan event.BlockForgedEvent, 1)
+
+	eb.SubscribeFunc(event.BlockForgedEventType, func(evt event.Event) {
+		if blockEvent, ok := evt.Data.(event.BlockForgedEvent); ok {
+			receivedCh <- blockEvent
+		}
+	})
+
+	eb.Publish(
+		event.BlockForgedEventType,
+		event.NewEvent(event.BlockForgedEventType, testEvent),
+	)
+
+	select {
+	case received := <-receivedCh:
+		assert.Equal(t, testEvent.Slot, received.Slot)
+		assert.Equal(t, testEvent.BlockNumber, received.BlockNumber)
+		assert.Equal(t, testEvent.BlockHash, received.BlockHash)
+		assert.Equal(t, testEvent.TxCount, received.TxCount)
+		assert.Equal(t, testEvent.BlockSize, received.BlockSize)
+		assert.Equal(t, testEvent.Timestamp, received.Timestamp)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for block forged event via SubscribeFunc")
+	}
+}
+
+func TestBlockForgedEventMultipleSubscribers(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	testEvent := event.BlockForgedEvent{
+		Slot:        11111,
+		BlockNumber: 50,
+		BlockHash:   []byte{0xff},
+		TxCount:     3,
+		BlockSize:   512,
+		Timestamp:   time.Now(),
+	}
+
+	_, sub1Ch := eb.Subscribe(event.BlockForgedEventType)
+	_, sub2Ch := eb.Subscribe(event.BlockForgedEventType)
+
+	eb.Publish(
+		event.BlockForgedEventType,
+		event.NewEvent(event.BlockForgedEventType, testEvent),
+	)
+
+	var gotSub1, gotSub2 bool
+	timeout := time.After(1 * time.Second)
+
+	for !gotSub1 || !gotSub2 {
+		select {
+		case evt, ok := <-sub1Ch:
+			require.True(t, ok, "sub1 channel closed unexpectedly")
+			blockEvent, ok := evt.Data.(event.BlockForgedEvent)
+			require.True(t, ok, "sub1 event data was not BlockForgedEvent")
+			assert.Equal(t, testEvent.Slot, blockEvent.Slot)
+			gotSub1 = true
+		case evt, ok := <-sub2Ch:
+			require.True(t, ok, "sub2 channel closed unexpectedly")
+			blockEvent, ok := evt.Data.(event.BlockForgedEvent)
+			require.True(t, ok, "sub2 event data was not BlockForgedEvent")
+			assert.Equal(t, testEvent.Slot, blockEvent.Slot)
+			gotSub2 = true
+		case <-timeout:
+			t.Fatal("timeout waiting for events from multiple subscribers")
+		}
+	}
+}
+
+func TestBlockForgedEventZeroValues(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	testEvent := event.BlockForgedEvent{
+		Slot:        0,
+		BlockNumber: 0,
+		BlockHash:   nil,
+		TxCount:     0,
+		BlockSize:   0,
+		Timestamp:   time.Time{},
+	}
+
+	_, subCh := eb.Subscribe(event.BlockForgedEventType)
+
+	eb.Publish(
+		event.BlockForgedEventType,
+		event.NewEvent(event.BlockForgedEventType, testEvent),
+	)
+
+	select {
+	case evt, ok := <-subCh:
+		require.True(t, ok, "event channel closed unexpectedly")
+		blockEvent, ok := evt.Data.(event.BlockForgedEvent)
+		require.True(t, ok, "event data was not BlockForgedEvent")
+		assert.Equal(t, uint64(0), blockEvent.Slot)
+		assert.Equal(t, uint64(0), blockEvent.BlockNumber)
+		assert.Nil(t, blockEvent.BlockHash)
+		assert.Equal(t, uint(0), blockEvent.TxCount)
+		assert.Equal(t, uint(0), blockEvent.BlockSize)
+		assert.True(t, blockEvent.Timestamp.IsZero())
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for zero-value block forged event")
+	}
+}

--- a/ledger/forging/events.go
+++ b/ledger/forging/events.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package forging contains types and utilities for block production.
+//
+// # Block Propagation
+//
+// Block propagation to peers is handled automatically by the chain package.
+// When a forged block is added via chain.AddBlock(), the method closes
+// the chain's waitingChan (see chain/chain.go lines 174-180), which signals
+// any blocking ChainIterators. The ouroboros chainsync server (see
+// ouroboros/chainsync.go chainsyncServerRequestNext) waits on these iterators
+// via ChainIterator.Next(true), which blocks on waitingChan when at chain tip.
+// When the channel is closed, iterators wake up and deliver the new block
+// to connected peers via RollForward messages.
+//
+// This means there is no need for explicit propagation logic when forging
+// blocks - adding the block to the chain automatically triggers delivery
+// to all subscribed chainsync clients.
+package forging
+
+import "github.com/blinklabs-io/dingo/event"
+
+// SlotBattleEventType is the event type for slot battles (competing blocks)
+const SlotBattleEventType = event.EventType("forging.slot-battle")
+
+// SlotBattleEvent is emitted when the node detects competing blocks for the
+// same slot, either from receiving an external block while preparing to forge
+// or when detecting a fork at the same slot height.
+type SlotBattleEvent struct {
+	// Slot is the slot number where the battle occurred
+	Slot uint64
+	// LocalBlockHash is the hash of our locally forged block (if any)
+	LocalBlockHash []byte
+	// RemoteBlockHash is the hash of the competing block from peers
+	RemoteBlockHash []byte
+	// Won indicates whether our local block was selected for the chain
+	Won bool
+}

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -20,12 +20,14 @@ import (
 )
 
 type stateMetrics struct {
-	blockNum    prometheus.Gauge
-	density     prometheus.Gauge
-	epochNum    prometheus.Gauge
-	slotInEpoch prometheus.Gauge
-	slotNum     prometheus.Gauge
-	forks       prometheus.Gauge
+	blockNum            prometheus.Gauge
+	density             prometheus.Gauge
+	epochNum            prometheus.Gauge
+	slotInEpoch         prometheus.Gauge
+	slotNum             prometheus.Gauge
+	forks               prometheus.Gauge
+	blocksForgedTotal   prometheus.Counter
+	blockForgingLatency prometheus.Histogram
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -54,5 +56,14 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	m.forks = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_forks_int",
 		Help: "number of forks seen",
+	})
+	m.blocksForgedTotal = promautoFactory.NewCounter(prometheus.CounterOpts{
+		Name: "cardano_node_metrics_blocksForgedNum_int",
+		Help: "total number of blocks forged by this node",
+	})
+	m.blockForgingLatency = promautoFactory.NewHistogram(prometheus.HistogramOpts{
+		Name:    "cardano_node_metrics_blockForgingLatency_seconds",
+		Help:    "latency of block forging from slot start to block completion",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms to ~16s
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a BlockForgedEvent to announce locally forged blocks; propagation to peers happens automatically once the block is added to the chain. Also adds a SlotBattleEvent and Prometheus metrics for total blocks forged and forging latency.

- **New Features**
  - Publish/subscribe support for BlockForgedEvent with tests.
  - SlotBattleEvent for reporting competing blocks in the same slot.
  - Prometheus metrics: cardano_node_metrics_blocksForgedNum_int (counter) and cardano_node_metrics_blockForgingLatency_seconds (histogram).

<sup>Written for commit 56c35b26c59bbd7c89432ad5007f7a3209e665e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added block forging event tracking capturing slot, block number, block hash, transaction count, size, and timestamp.
  * Introduced slot battle event to monitor competing blocks for the same slot.
  * Added metrics for total blocks forged and block forging latency measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->