### PR TITLE
feat: key management and keystore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/crypto v0.47.0
 	golang.org/x/net v0.49.0
 	golang.org/x/sys v0.40.0
 	google.golang.org/api v0.264.0
@@ -193,7 +194,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,6 +160,17 @@ type Config struct {
 
 	// Cache configuration for the tiered CBOR cache system
 	Cache CacheConfig `yaml:"cache"`
+
+	// KES (Key Evolving Signature) configuration for block production
+	// SlotsPerKESPeriod is the number of slots in a KES period.
+	// After this many slots, the KES key must be evolved to the next period.
+	// Default: 129600 (mainnet value = 1.5 days at 1 second per slot)
+	SlotsPerKESPeriod uint64 `yaml:"slotsPerKESPeriod" envconfig:"DINGO_SLOTS_PER_KES_PERIOD"`
+	// MaxKESEvolutions is the maximum number of times a KES key can evolve.
+	// For Cardano's KES depth of 6, this is 2^6 - 2 = 62 evolutions.
+	// After this many evolutions, a new operational certificate must be issued.
+	// Default: 62
+	MaxKESEvolutions uint64 `yaml:"maxKESEvolutions" envconfig:"DINGO_MAX_KES_EVOLUTIONS"`
 }
 
 func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
@@ -245,6 +256,9 @@ var globalConfig = &Config{
 	DatabaseQueueSize: 50,
 	// Cache configuration defaults
 	Cache: DefaultCacheConfig(),
+	// KES configuration defaults (mainnet values)
+	SlotsPerKESPeriod: 129600, // 1.5 days at 1 second per slot
+	MaxKESEvolutions:  62,     // 2^6 - 2 for KES depth 6
 }
 
 func LoadConfig(configFile string) (*Config, error) {

--- a/keystore/evolution.go
+++ b/keystore/evolution.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keystore
+
+import "time"
+
+// KES (Key Evolving Signature) constants for Cardano.
+// These values are defined in the Shelley genesis configuration and
+// determine how often KES keys must be evolved.
+// Default values are for the preview network (Dingo's default network).
+const (
+	// DefaultSlotsPerKESPeriod is the number of slots in a KES period on preview.
+	// After this many slots, the KES key must be evolved to the next period.
+	// Preview value: 129600 slots = 1.5 days (at 1 second per slot)
+	DefaultSlotsPerKESPeriod = 129600
+
+	// DefaultMaxKESEvolutions is the maximum number of times a KES key can evolve.
+	// For Cardano's KES depth of 6, this is 2^6 - 2 = 62 evolutions.
+	// After this many evolutions, a new operational certificate must be issued.
+	DefaultMaxKESEvolutions = 62
+
+	// DefaultSlotDuration is the default slot duration on preview (1 second).
+	DefaultSlotDuration = time.Second
+)
+
+// KESPeriodDuration returns the approximate wall-clock duration of a KES period.
+// This is useful for calculating when the next evolution will occur.
+func KESPeriodDuration(slotsPerPeriod uint64, slotDuration time.Duration) time.Duration {
+	//nolint:gosec // G115: slotsPerPeriod is bounded by protocol params, will not overflow
+	return time.Duration(slotsPerPeriod) * slotDuration
+}
+
+// DefaultKESPeriodDuration returns the KES period duration using preview defaults.
+// This is approximately 1.5 days.
+func DefaultKESPeriodDuration() time.Duration {
+	return KESPeriodDuration(DefaultSlotsPerKESPeriod, DefaultSlotDuration)
+}
+
+// OpCertLifetimeSlots returns the total number of slots an OpCert is valid for.
+func OpCertLifetimeSlots(slotsPerPeriod, maxEvolutions uint64) uint64 {
+	return slotsPerPeriod * maxEvolutions
+}
+
+// DefaultOpCertLifetimeSlots returns the OpCert lifetime using preview defaults.
+// This is approximately 93 days (62 periods * 1.5 days per period).
+func DefaultOpCertLifetimeSlots() uint64 {
+	return OpCertLifetimeSlots(DefaultSlotsPerKESPeriod, DefaultMaxKESEvolutions)
+}
+
+// OpCertLifetimeDuration returns the approximate wall-clock duration an OpCert is valid.
+func OpCertLifetimeDuration(
+	slotsPerPeriod, maxEvolutions uint64,
+	slotDuration time.Duration,
+) time.Duration {
+	//nolint:gosec // G115: these values are bounded by protocol params, will not overflow
+	return time.Duration(slotsPerPeriod*maxEvolutions) * slotDuration
+}
+
+// DefaultOpCertLifetimeDuration returns the OpCert lifetime using preview defaults.
+func DefaultOpCertLifetimeDuration() time.Duration {
+	return OpCertLifetimeDuration(
+		DefaultSlotsPerKESPeriod,
+		DefaultMaxKESEvolutions,
+		DefaultSlotDuration,
+	)
+}
+
+// SlotToKESPeriod converts a slot number to a KES period.
+// Returns 0 if slotsPerPeriod is 0 to avoid division by zero.
+func SlotToKESPeriod(slot, slotsPerPeriod uint64) uint64 {
+	if slotsPerPeriod == 0 {
+		return 0
+	}
+	return slot / slotsPerPeriod
+}
+
+// KESPeriodStartSlot returns the first slot of the given KES period.
+func KESPeriodStartSlot(period, slotsPerPeriod uint64) uint64 {
+	return period * slotsPerPeriod
+}
+
+// KESPeriodEndSlot returns the last slot of the given KES period.
+// Returns 0 if slotsPerPeriod is 0 to avoid underflow.
+func KESPeriodEndSlot(period, slotsPerPeriod uint64) uint64 {
+	if slotsPerPeriod == 0 {
+		return 0
+	}
+	return (period+1)*slotsPerPeriod - 1
+}
+
+// ExpiryWarningThresholds defines warning thresholds for OpCert expiry.
+// These are the number of KES periods remaining before expiry.
+type ExpiryWarningThresholds struct {
+	// Critical: OpCert is about to expire, cannot produce blocks soon
+	Critical uint64
+	// Warning: OpCert should be renewed soon
+	Warning uint64
+	// Info: OpCert expiry is approaching
+	Info uint64
+}
+
+// DefaultExpiryWarningThresholds returns the default warning thresholds.
+func DefaultExpiryWarningThresholds() ExpiryWarningThresholds {
+	return ExpiryWarningThresholds{
+		Critical: 3,  // ~4.5 days remaining
+		Warning:  7,  // ~10.5 days remaining
+		Info:     14, // ~21 days remaining
+	}
+}

--- a/keystore/keyfile.go
+++ b/keystore/keyfile.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keystore
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/vrf"
+)
+
+// keyFileEnvelope represents the JSON structure of a cardano-cli key file.
+type keyFileEnvelope struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	CborHex     string `json:"cborHex"`
+}
+
+// loadedKey holds the parsed contents of a key file.
+type loadedKey struct {
+	Type        string
+	Description string
+	RawCBOR     []byte
+	VKey        []byte
+	SKey        []byte
+	// OpCert fields (only populated for NodeOperationalCertificate type)
+	OpCertIssueNumber uint64
+	OpCertKesPeriod   uint64
+	OpCertSignature   []byte
+	OpCertColdVKey    []byte
+}
+
+// loadKeyFromFile loads a key from a file path (cardano-cli format).
+// Supports VRF, KES, and operational certificates.
+func loadKeyFromFile(path string) (*loadedKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file %q: %w", path, err)
+	}
+	key, err := parseKeyEnvelope(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse key file %q: %w", path, err)
+	}
+	return key, nil
+}
+
+// parseKeyEnvelope parses a cardano-cli format key file.
+func parseKeyEnvelope(fileBytes []byte) (*loadedKey, error) {
+	var env keyFileEnvelope
+	if err := json.Unmarshal(fileBytes, &env); err != nil {
+		return nil, fmt.Errorf("could not parse key file envelope: %w", err)
+	}
+
+	cborData, err := hex.DecodeString(env.CborHex)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode key from hex: %w", err)
+	}
+
+	lk := &loadedKey{
+		Type:        env.Type,
+		Description: env.Description,
+		RawCBOR:     cborData,
+	}
+
+	// Decode cbor encoded key bytes based on type
+	switch env.Type {
+	// VRF keys
+	case "VrfSigningKey_PraosVRF", "VRFSigningKey_PraosVRF":
+		sk, vk, err := decodeVRFSKey(cborData)
+		if err != nil {
+			return nil, err
+		}
+		lk.SKey, lk.VKey = sk, vk
+		return lk, nil
+
+	// KES keys
+	case "KesSigningKey_ed25519_kes_2^6", "KESSigningKey_PraosV2":
+		sk, vk, err := decodeKESSKey(cborData)
+		if err != nil {
+			return nil, err
+		}
+		lk.SKey, lk.VKey = sk, vk
+		return lk, nil
+
+	// Operational Certificate
+	case "NodeOperationalCertificate":
+		kesVkey, issueNumber, kesPeriod, signature, coldVkey, err := decodeOpCert(
+			cborData,
+		)
+		if err != nil {
+			return nil, err
+		}
+		lk.VKey = kesVkey
+		lk.OpCertIssueNumber = issueNumber
+		lk.OpCertKesPeriod = kesPeriod
+		lk.OpCertSignature = signature
+		lk.OpCertColdVKey = coldVkey
+		return lk, nil
+
+	default:
+		return nil, fmt.Errorf("unknown key type: %s", env.Type)
+	}
+}
+
+// decodeVRFSKey decodes a VRF signing key from CBOR.
+func decodeVRFSKey(skeyBytes []byte) ([]byte, []byte, error) {
+	var keyBytes []byte
+	if _, err := cbor.Decode(skeyBytes, &keyBytes); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal VRF skey CBOR: %w", err)
+	}
+
+	switch len(keyBytes) {
+	case vrf.SeedSize:
+		// Just the seed - generate public key
+		pubKey, _, err := vrf.KeyGen(keyBytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to derive VRF public key: %w", err)
+		}
+		return keyBytes, pubKey, nil
+	case vrf.SeedSize + vrf.PublicKeySize:
+		// Seed + public key (cardano-cli format)
+		// Derive pubkey from seed rather than trusting file contents
+		seed := keyBytes[:vrf.SeedSize]
+		pubKey, _, err := vrf.KeyGen(seed)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to derive VRF public key: %w", err)
+		}
+		return seed, pubKey, nil
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid VRF skey bytes: expected %d or %d, got %d",
+			vrf.SeedSize,
+			vrf.SeedSize+vrf.PublicKeySize,
+			len(keyBytes),
+		)
+	}
+}
+
+// decodeKESSKey decodes a KES signing key from CBOR.
+func decodeKESSKey(skeyBytes []byte) ([]byte, []byte, error) {
+	var keyBytes []byte
+	if _, err := cbor.Decode(skeyBytes, &keyBytes); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal KES skey CBOR: %w", err)
+	}
+	if len(keyBytes) != kes.CardanoKesSecretKeySize {
+		return nil, nil, fmt.Errorf(
+			"invalid KES skey bytes: expected %d, got %d",
+			kes.CardanoKesSecretKeySize,
+			len(keyBytes),
+		)
+	}
+	// Create a SecretKey struct to extract the public key
+	sk := &kes.SecretKey{
+		Depth:  kes.CardanoKesDepth,
+		Period: 0, // Period is not encoded in the key file
+		Data:   keyBytes,
+	}
+	pubKey := kes.PublicKey(sk)
+	return keyBytes, pubKey, nil
+}
+
+// decodeOpCert decodes an operational certificate from CBOR.
+// OpCert CBOR format: [[kes_vkey, issue_number, kes_period, signature], cold_vkey]
+func decodeOpCert(
+	certBytes []byte,
+) ([]byte, uint64, uint64, []byte, []byte, error) {
+	var outerData []any
+	if _, err := cbor.Decode(certBytes, &outerData); err != nil {
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"failed to unmarshal OpCert CBOR: %w",
+			err,
+		)
+	}
+	if len(outerData) != 2 {
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: expected 2-element outer array, got %d",
+			len(outerData),
+		)
+	}
+
+	// Extract inner certificate array
+	certData, ok := outerData[0].([]any)
+	if !ok {
+		return nil, 0, 0, nil, nil, errors.New(
+			"invalid OpCert: first element is not an array",
+		)
+	}
+	if len(certData) != 4 {
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: expected 4-element cert array, got %d",
+			len(certData),
+		)
+	}
+
+	// Extract cold vkey
+	coldVkey, ok := outerData[1].([]byte)
+	if !ok {
+		return nil, 0, 0, nil, nil, errors.New(
+			"invalid OpCert: cold_vkey is not bytes",
+		)
+	}
+	if len(coldVkey) != 32 {
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: cold_vkey expected 32 bytes, got %d",
+			len(coldVkey),
+		)
+	}
+
+	// Extract KES vkey from inner array
+	kesVkey, ok := certData[0].([]byte)
+	if !ok {
+		return nil, 0, 0, nil, nil, errors.New(
+			"invalid OpCert: kes_vkey is not bytes",
+		)
+	}
+	if len(kesVkey) != 32 {
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: kes_vkey expected 32 bytes, got %d",
+			len(kesVkey),
+		)
+	}
+
+	// Extract issue number (can be uint64 or int64 depending on CBOR encoding)
+	var issueNumber uint64
+	switch v := certData[1].(type) {
+	case uint64:
+		issueNumber = v
+	case int64:
+		if v < 0 {
+			return nil, 0, 0, nil, nil, errors.New(
+				"invalid OpCert: issue_number cannot be negative",
+			)
+		}
+		issueNumber = uint64(v) //nolint:gosec // G115: validated non-negative above
+	default:
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: issue_number has unexpected type %T",
+			certData[1],
+		)
+	}
+
+	// Extract KES period
+	var kesPeriod uint64
+	switch v := certData[2].(type) {
+	case uint64:
+		kesPeriod = v
+	case int64:
+		if v < 0 {
+			return nil, 0, 0, nil, nil, errors.New(
+				"invalid OpCert: kes_period cannot be negative",
+			)
+		}
+		kesPeriod = uint64(v) //nolint:gosec // G115: validated non-negative above
+	default:
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: kes_period has unexpected type %T",
+			certData[2],
+		)
+	}
+
+	// Extract cold signature
+	signature, ok := certData[3].([]byte)
+	if !ok {
+		return nil, 0, 0, nil, nil, errors.New(
+			"invalid OpCert: cold_signature is not bytes",
+		)
+	}
+	if len(signature) != 64 {
+		return nil, 0, 0, nil, nil, fmt.Errorf(
+			"invalid OpCert: cold_signature expected 64 bytes, got %d",
+			len(signature),
+		)
+	}
+
+	return kesVkey, issueNumber, kesPeriod, signature, coldVkey, nil
+}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -1,0 +1,614 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package keystore provides key management for Cardano stake pool operators.
+// It wraps pool credentials (VRF, KES, OpCert) and handles KES key evolution
+// as the blockchain progresses through KES periods.
+package keystore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/blinklabs-io/gouroboros/kes"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/vrf"
+)
+
+// Common errors returned by KeyStore operations.
+var (
+	ErrKeysNotLoaded    = errors.New("keys not loaded")
+	ErrVRFKeyNotLoaded  = errors.New("VRF key not loaded")
+	ErrKESKeyNotLoaded  = errors.New("KES key not loaded")
+	ErrOpCertNotLoaded  = errors.New("operational certificate not loaded")
+	ErrAlreadyRunning   = errors.New("keystore already running")
+	ErrNotRunning       = errors.New("keystore not running")
+	ErrInsecureFileMode = errors.New("insecure file permissions")
+)
+
+// OpCert represents an operational certificate that binds a KES key to a pool.
+type OpCert struct {
+	KESVKey     []byte // KES verification key (32 bytes)
+	IssueNumber uint64 // Certificate sequence number
+	KESPeriod   uint64 // KES period when certificate was created
+	Signature   []byte // Cold key signature (64 bytes)
+	ColdVKey    []byte // Cold verification key (32 bytes)
+}
+
+// VRFSigner provides VRF signing capabilities for leader election.
+type VRFSigner interface {
+	// Prove generates a VRF proof for the given input.
+	// Returns (proof, output, error).
+	Prove(alpha []byte) ([]byte, []byte, error)
+	// VKey returns the VRF verification key.
+	VKey() []byte
+}
+
+// KESSigner provides KES signing capabilities for block production.
+type KESSigner interface {
+	// Sign signs a message at the specified KES period.
+	Sign(period uint64, message []byte) ([]byte, error)
+	// VKey returns the KES verification key.
+	VKey() []byte
+	// CurrentPeriod returns the current KES period the key is evolved to.
+	CurrentPeriod() uint64
+}
+
+// KeyStoreConfig holds configuration for the KeyStore.
+type KeyStoreConfig struct {
+	// VRFSKeyPath is the path to the VRF signing key file.
+	VRFSKeyPath string
+	// KESSKeyPath is the path to the KES signing key file.
+	KESSKeyPath string
+	// OpCertPath is the path to the operational certificate file.
+	OpCertPath string
+	// SlotsPerKESPeriod is the number of slots in a KES period.
+	// Default: 129600 (preview network value)
+	SlotsPerKESPeriod uint64
+	// MaxKESEvolutions is the maximum number of KES evolutions.
+	// Default: 62 (for KES depth 6)
+	MaxKESEvolutions uint64
+	// Logger for keystore events.
+	Logger *slog.Logger
+}
+
+// DefaultKeyStoreConfig returns the default configuration.
+func DefaultKeyStoreConfig() KeyStoreConfig {
+	return KeyStoreConfig{
+		SlotsPerKESPeriod: DefaultSlotsPerKESPeriod,
+		MaxKESEvolutions:  DefaultMaxKESEvolutions,
+	}
+}
+
+// KeyStore manages pool credentials and KES key evolution.
+type KeyStore struct {
+	config KeyStoreConfig
+	logger *slog.Logger
+
+	// Credentials
+	poolID  lcommon.PoolId // Blake2b-224 hash of cold verification key
+	hasPool bool           // true if poolID has been set
+	vrfSKey []byte         // VRF secret key (seed)
+	vrfVKey []byte         // VRF verification key
+	kesSKey *kes.SecretKey // KES secret key
+	kesVKey []byte         // KES verification key
+	opCert  *OpCert        // Operational certificate
+
+	// State
+	mu      sync.RWMutex
+	running bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// NewKeyStore creates a new KeyStore with the given configuration.
+func NewKeyStore(config KeyStoreConfig) *KeyStore {
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+	if config.SlotsPerKESPeriod == 0 {
+		config.SlotsPerKESPeriod = DefaultSlotsPerKESPeriod
+	}
+	if config.MaxKESEvolutions == 0 {
+		config.MaxKESEvolutions = DefaultMaxKESEvolutions
+	}
+	return &KeyStore{
+		config: config,
+		logger: config.Logger.With("component", "keystore"),
+	}
+}
+
+// LoadFromFiles loads all pool credentials from the configured file paths.
+// Parses cardano-cli format key files.
+// Security: Verifies file permissions are not world-readable.
+func (ks *KeyStore) LoadFromFiles() error {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	// Check file permissions for all key files
+	paths := []string{
+		ks.config.VRFSKeyPath,
+		ks.config.KESSKeyPath,
+		ks.config.OpCertPath,
+	}
+	for _, path := range paths {
+		if err := checkKeyFilePermissions(path); err != nil {
+			return fmt.Errorf("security check failed for %s: %w", path, err)
+		}
+	}
+
+	// Load VRF signing key
+	vrfKey, err := loadKeyFromFile(ks.config.VRFSKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load VRF signing key: %w", err)
+	}
+	if len(vrfKey.SKey) != vrf.SeedSize {
+		return fmt.Errorf(
+			"invalid VRF key size: expected %d, got %d",
+			vrf.SeedSize,
+			len(vrfKey.SKey),
+		)
+	}
+	ks.vrfSKey = vrfKey.SKey
+	ks.vrfVKey = vrfKey.VKey
+
+	// Load KES signing key
+	kesKey, err := loadKeyFromFile(ks.config.KESSKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load KES signing key: %w", err)
+	}
+	if len(kesKey.SKey) != kes.CardanoKesSecretKeySize {
+		return fmt.Errorf(
+			"invalid KES key size: expected %d, got %d",
+			kes.CardanoKesSecretKeySize,
+			len(kesKey.SKey),
+		)
+	}
+	ks.kesSKey = &kes.SecretKey{
+		Depth:  kes.CardanoKesDepth,
+		Period: 0, // Will be evolved during Start()
+		Data:   kesKey.SKey,
+	}
+	ks.kesVKey = kesKey.VKey
+
+	// Load operational certificate
+	opCertKey, err := loadKeyFromFile(ks.config.OpCertPath)
+	if err != nil {
+		return fmt.Errorf("failed to load operational certificate: %w", err)
+	}
+	ks.opCert = &OpCert{
+		KESVKey:     opCertKey.VKey,
+		IssueNumber: opCertKey.OpCertIssueNumber,
+		KESPeriod:   opCertKey.OpCertKesPeriod,
+		Signature:   opCertKey.OpCertSignature,
+		ColdVKey:    opCertKey.OpCertColdVKey,
+	}
+
+	// Verify KES verification key in OpCert matches loaded KES key
+	if !bytes.Equal(ks.kesVKey, ks.opCert.KESVKey) {
+		return errors.New(
+			"opCert KES vkey does not match loaded KES key: " +
+				"ensure the operational certificate was generated for this KES key",
+		)
+	}
+
+	// Derive pool ID from cold verification key (Blake2b-224 hash)
+	ks.poolID = lcommon.PoolId(lcommon.Blake2b224Hash(ks.opCert.ColdVKey))
+	ks.hasPool = true
+
+	ks.logger.Info(
+		"pool credentials loaded",
+		"pool_id", ks.poolID.String(),
+		"opcert_issue", ks.opCert.IssueNumber,
+		"opcert_kes_period", ks.opCert.KESPeriod,
+	)
+
+	return nil
+}
+
+// SlotClock provides slot information for KES evolution monitoring.
+type SlotClock interface {
+	// CurrentSlot returns the current slot number.
+	CurrentSlot() (uint64, error)
+	// Subscribe returns a channel that receives slot tick notifications.
+	Subscribe() <-chan SlotTick
+	// Unsubscribe removes a subscriber channel.
+	Unsubscribe(ch <-chan SlotTick)
+}
+
+// SlotTick represents a slot boundary notification (minimal interface).
+type SlotTick struct {
+	Slot uint64
+}
+
+// Start begins KES evolution monitoring using the provided slot clock.
+// The keystore will automatically evolve the KES key when the period advances.
+func (ks *KeyStore) Start(ctx context.Context, slotClock SlotClock) error {
+	ks.mu.Lock()
+	if ks.running {
+		ks.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	if !ks.isLoadedUnsafe() {
+		ks.mu.Unlock()
+		return ErrKeysNotLoaded
+	}
+
+	// Get current slot and evolve to current period
+	currentSlot, err := slotClock.CurrentSlot()
+	if err != nil {
+		ks.mu.Unlock()
+		return fmt.Errorf("failed to get current slot: %w", err)
+	}
+	currentPeriod := ks.slotToKESPeriod(currentSlot)
+
+	// Evolve KES key to current period
+	if err := ks.evolveKESToUnsafe(currentPeriod); err != nil {
+		ks.mu.Unlock()
+		return fmt.Errorf("failed to evolve KES to current period: %w", err)
+	}
+
+	// Check OpCert expiry
+	ks.checkOpCertExpiryUnsafe(currentPeriod)
+
+	ks.running = true
+	ctx, ks.cancel = context.WithCancel(ctx)
+	ks.mu.Unlock()
+
+	// Start monitoring goroutine
+	ks.wg.Add(1)
+	go ks.monitorSlots(ctx, slotClock)
+
+	ks.logger.Info(
+		"keystore started",
+		"current_slot", currentSlot,
+		"current_kes_period", currentPeriod,
+	)
+
+	return nil
+}
+
+// Stop halts KES evolution monitoring and cleans up resources.
+func (ks *KeyStore) Stop() error {
+	ks.mu.Lock()
+	if !ks.running {
+		ks.mu.Unlock()
+		return ErrNotRunning
+	}
+	ks.running = false
+	if ks.cancel != nil {
+		ks.cancel()
+	}
+	ks.mu.Unlock()
+
+	// Wait for monitoring goroutine to exit
+	ks.wg.Wait()
+
+	ks.logger.Info("keystore stopped")
+	return nil
+}
+
+// VRFSigner returns a VRF signer for leader election.
+// Returns nil if VRF key is not loaded.
+func (ks *KeyStore) VRFSigner() VRFSigner {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	if ks.vrfSKey == nil {
+		return nil
+	}
+	// Use defensive copies to prevent modification of internal state
+	return &vrfSignerImpl{
+		skey: bytes.Clone(ks.vrfSKey),
+		vkey: bytes.Clone(ks.vrfVKey),
+	}
+}
+
+// KESSigner returns a KES signer for block signing.
+// Returns nil if KES key is not loaded.
+func (ks *KeyStore) KESSigner() KESSigner {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	if ks.kesSKey == nil {
+		return nil
+	}
+	return &kesSignerImpl{
+		ks: ks,
+	}
+}
+
+// OpCert returns a copy of the operational certificate.
+// Returns nil if not loaded.
+func (ks *KeyStore) OpCert() *OpCert {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	if ks.opCert == nil {
+		return nil
+	}
+	// Return a defensive copy to prevent callers from modifying internal state
+	return &OpCert{
+		KESVKey:     bytes.Clone(ks.opCert.KESVKey),
+		IssueNumber: ks.opCert.IssueNumber,
+		KESPeriod:   ks.opCert.KESPeriod,
+		Signature:   bytes.Clone(ks.opCert.Signature),
+		ColdVKey:    bytes.Clone(ks.opCert.ColdVKey),
+	}
+}
+
+// PoolID returns the pool ID (Blake2b-224 of cold vkey).
+// Returns nil if not loaded.
+func (ks *KeyStore) PoolID() *lcommon.PoolId {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	if !ks.hasPool {
+		return nil
+	}
+	result := ks.poolID // copy the array
+	return &result
+}
+
+// IsLoaded returns true if all credentials have been loaded.
+func (ks *KeyStore) IsLoaded() bool {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	return ks.isLoadedUnsafe()
+}
+
+func (ks *KeyStore) isLoadedUnsafe() bool {
+	return ks.vrfSKey != nil && ks.kesSKey != nil && ks.opCert != nil
+}
+
+// ValidateOpCert validates that the operational certificate matches the KES key.
+func (ks *KeyStore) ValidateOpCert() error {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	if ks.opCert == nil {
+		return ErrOpCertNotLoaded
+	}
+	if ks.kesVKey == nil {
+		return ErrKESKeyNotLoaded
+	}
+
+	// Verify KES public key matches OpCert's hot vkey
+	if !bytes.Equal(ks.kesVKey, ks.opCert.KESVKey) {
+		return errors.New(
+			"KES verification key mismatch: loaded key does not match OpCert.KESVKey",
+		)
+	}
+
+	return nil
+}
+
+// OpCertExpiryPeriod returns the KES period at which the OpCert expires.
+func (ks *KeyStore) OpCertExpiryPeriod() uint64 {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	return ks.opCertExpiryPeriodUnsafe()
+}
+
+func (ks *KeyStore) opCertExpiryPeriodUnsafe() uint64 {
+	if ks.opCert == nil {
+		return 0
+	}
+	return ks.opCert.KESPeriod + ks.config.MaxKESEvolutions
+}
+
+// PeriodsRemaining returns how many KES periods remain before expiry.
+func (ks *KeyStore) PeriodsRemaining(currentPeriod uint64) uint64 {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	return ks.periodsRemainingUnsafe(currentPeriod)
+}
+
+func (ks *KeyStore) periodsRemainingUnsafe(currentPeriod uint64) uint64 {
+	expiryPeriod := ks.opCertExpiryPeriodUnsafe()
+	if currentPeriod >= expiryPeriod {
+		return 0
+	}
+	return expiryPeriod - currentPeriod
+}
+
+// CurrentKESPeriod returns the current KES period the key is evolved to.
+func (ks *KeyStore) CurrentKESPeriod() uint64 {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	if ks.kesSKey == nil {
+		return 0
+	}
+	return ks.kesSKey.Period
+}
+
+// EvolveKESTo evolves the KES key to the specified period.
+func (ks *KeyStore) EvolveKESTo(targetPeriod uint64) error {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	return ks.evolveKESToUnsafe(targetPeriod)
+}
+
+func (ks *KeyStore) evolveKESToUnsafe(targetPeriod uint64) error {
+	if ks.kesSKey == nil {
+		return ErrKESKeyNotLoaded
+	}
+
+	for ks.kesSKey.Period < targetPeriod {
+		newKey, err := kes.Update(ks.kesSKey)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to evolve KES key to period %d: %w",
+				targetPeriod,
+				err,
+			)
+		}
+		ks.kesSKey = newKey
+		ks.logger.Debug(
+			"KES key evolved",
+			"new_period", ks.kesSKey.Period,
+		)
+	}
+
+	return nil
+}
+
+// slotToKESPeriod converts a slot number to a KES period.
+// Returns 0 if SlotsPerKESPeriod is 0 to avoid division by zero.
+func (ks *KeyStore) slotToKESPeriod(slot uint64) uint64 {
+	if ks.config.SlotsPerKESPeriod == 0 {
+		return 0
+	}
+	return slot / ks.config.SlotsPerKESPeriod
+}
+
+// checkOpCertExpiryUnsafe logs warnings if OpCert expiry is approaching.
+// Caller must hold ks.mu (read or write lock).
+func (ks *KeyStore) checkOpCertExpiryUnsafe(currentPeriod uint64) {
+	if ks.opCert == nil {
+		return
+	}
+
+	remaining := ks.periodsRemainingUnsafe(currentPeriod)
+
+	if remaining == 0 {
+		ks.logger.Error(
+			"OpCert has EXPIRED! Cannot produce blocks",
+			"opcert_kes_period", ks.opCert.KESPeriod,
+			"current_period", currentPeriod,
+		)
+		return
+	}
+
+	// Warn at various thresholds
+	switch {
+	case remaining <= 3:
+		ks.logger.Error(
+			"OpCert expiry CRITICAL - renew immediately",
+			"periods_remaining", remaining,
+			"current_period", currentPeriod,
+		)
+	case remaining <= 7:
+		ks.logger.Warn(
+			"OpCert expiry WARNING - renew soon",
+			"periods_remaining", remaining,
+			"current_period", currentPeriod,
+		)
+	case remaining <= 14:
+		ks.logger.Info(
+			"OpCert expiry approaching",
+			"periods_remaining", remaining,
+			"current_period", currentPeriod,
+		)
+	}
+}
+
+// monitorSlots watches the slot clock and evolves KES key when period changes.
+func (ks *KeyStore) monitorSlots(ctx context.Context, slotClock SlotClock) {
+	defer ks.wg.Done()
+
+	ch := slotClock.Subscribe()
+	defer slotClock.Unsubscribe(ch)
+
+	var lastPeriod uint64
+	ks.mu.RLock()
+	if ks.kesSKey != nil {
+		lastPeriod = ks.kesSKey.Period
+	}
+	ks.mu.RUnlock()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case tick, ok := <-ch:
+			if !ok {
+				return
+			}
+
+			currentPeriod := ks.slotToKESPeriod(tick.Slot)
+			if currentPeriod > lastPeriod {
+				ks.logger.Info(
+					"KES period changed, evolving key",
+					"old_period", lastPeriod,
+					"new_period", currentPeriod,
+					"slot", tick.Slot,
+				)
+
+				if err := ks.EvolveKESTo(currentPeriod); err != nil {
+					ks.logger.Error(
+						"failed to evolve KES key",
+						"error", err,
+						"target_period", currentPeriod,
+					)
+					continue
+				}
+
+				// Check OpCert expiry after evolution
+				ks.mu.RLock()
+				ks.checkOpCertExpiryUnsafe(currentPeriod)
+				ks.mu.RUnlock()
+
+				lastPeriod = currentPeriod
+			}
+		}
+	}
+}
+
+// vrfSignerImpl implements VRFSigner.
+type vrfSignerImpl struct {
+	skey []byte
+	vkey []byte
+}
+
+func (v *vrfSignerImpl) Prove(alpha []byte) ([]byte, []byte, error) {
+	return vrf.Prove(v.skey, alpha)
+}
+
+func (v *vrfSignerImpl) VKey() []byte {
+	return bytes.Clone(v.vkey)
+}
+
+// kesSignerImpl implements KESSigner.
+type kesSignerImpl struct {
+	ks *KeyStore
+}
+
+func (k *kesSignerImpl) Sign(period uint64, message []byte) ([]byte, error) {
+	k.ks.mu.RLock()
+	defer k.ks.mu.RUnlock()
+
+	if k.ks.kesSKey == nil {
+		return nil, ErrKESKeyNotLoaded
+	}
+
+	return kes.Sign(k.ks.kesSKey, period, message)
+}
+
+func (k *kesSignerImpl) VKey() []byte {
+	k.ks.mu.RLock()
+	defer k.ks.mu.RUnlock()
+	return bytes.Clone(k.ks.kesVKey)
+}
+
+func (k *kesSignerImpl) CurrentPeriod() uint64 {
+	k.ks.mu.RLock()
+	defer k.ks.mu.RUnlock()
+	if k.ks.kesSKey == nil {
+		return 0
+	}
+	return k.ks.kesSKey.Period
+}

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -1,0 +1,469 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keystore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/vrf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Sample test keys from config/cardano/devnet/keys/
+const (
+	testVRFSKeyJSON = `{
+    "type": "VrfSigningKey_PraosVRF",
+    "description": "VRF Signing Key",
+    "cborHex": "5840899795b70e9f34b737159fe21a6170568d6031e187f0cc84555c712b7c29b45cb882007593ef70f86e5c0948561a3b8e8851529a4f98975f2b24e768dda38ce2"
+}`
+
+	testKESSKeyJSON = `{
+    "type": "KesSigningKey_ed25519_kes_2^6",
+    "description": "KES Signing Key",
+    "cborHex": "590260a199f16b11da6c7f5c1e0f1eb0b9bbe278d3d8f35bfd50d0951c2ff94d0344cd57df5f64c9bac1dd60b4482f9c636168f40737d526625a2ec82f22ec0c72de0013f86ef743a7bba0286db6ddf3d85bf8e49ddbf14d9d3b7ee22f4857c77b740948f84f2e72f6bcf91f405e34ea50a2c53fa4876b43cfce2bcfe87c06a903de8bb33d968ca7930b67d0c23f5cb2d74e422d773ba80e388de384691000d6ba8a9b4dc7d3187f76048fbef9a52b72d80d835bb76eced7c0e0cdc5b58869b73c095dffa01db4ff51765afcead565395a5ed1cf74e5f2134d61076fece21aacd080bbbfaab94125401d7bbc74eafc7e7e3a2235f59dc03d6e332e53d558493a1e22213b92c77b1328ff1b83855da704fc366bf4415490602481d1939136eeaf252c65184912a779d9d94a90e32b72c1877ef60b6d79e707ce5a762acb4bed46436efe4fe62aae50b39068cc508a09427c92791cbcbea44318529cc68d297ca24e1b73b2394c385ec63fcd85ed56eec3de48860a1ec950aad4f91cbf741dbd7bf1d3c278875bd20e31ff5372339f6aa5280ad9b8bf3514889ac44600fe57ca0b535d6dc6b0b981e079595aad186ee0be9b07e837391ab165e4ca406601c876a86e246a3f53311e21199cccc0b080f28d18f4dc6987731e10e4ade00df7c6921c5ef3022b6f49a29ba307a2c8f4bd2ba42fcfa0aad68a2f0ad31fff69a99d3471f9036d3f5817a3edfeff7fc3c14e1151d767aaa043481cfd1a6ee55e8e5d7853ecdaf9da2bb36c716beae8d706bc648a790d4697e1d044a11a49f305ab8bc64a094bd81bda7395fe6f77dd5557c39919dd9bb9cf22a87fe47408ae3ec2247007d015a5"
+}`
+
+	testOpCertJSON = `{
+    "type": "NodeOperationalCertificate",
+    "description": "",
+    "cborHex": "828458204cd49bb05e9885142fe7af1481107995298771fd1a24e72b506a4d600ee2b3120000584089fc9e9f551b2ea873bf31643659d049152d5c8e8de86be4056370bccc5fa62dd12e3f152f1664e614763e46eaa7a17ed366b5cef19958773d1ab96941442e0b58205a3d778e76741a009e29d23093cfe046131808d34d7c864967b515e98dfc3583"
+}`
+)
+
+func setupTestKeys(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	// On Windows, bypass ACL checks since they're not implemented.
+	// Tests verify key loading functionality, not Windows ACL verification.
+	if runtime.GOOS == "windows" {
+		t.Setenv("DINGO_ALLOW_INSECURE_KEY_PERMS", "true")
+	}
+
+	tmpDir := t.TempDir()
+
+	vrfPath := filepath.Join(tmpDir, "vrf.skey")
+	kesPath := filepath.Join(tmpDir, "kes.skey")
+	opCertPath := filepath.Join(tmpDir, "opcert.cert")
+
+	require.NoError(t, os.WriteFile(vrfPath, []byte(testVRFSKeyJSON), 0o600))
+	require.NoError(t, os.WriteFile(kesPath, []byte(testKESSKeyJSON), 0o600))
+	require.NoError(t, os.WriteFile(opCertPath, []byte(testOpCertJSON), 0o600))
+
+	return vrfPath, kesPath, opCertPath
+}
+
+func TestKeyStoreLoadFromFiles(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath: vrfPath,
+		KESSKeyPath: kesPath,
+		OpCertPath:  opCertPath,
+	}
+
+	ks := NewKeyStore(config)
+	err := ks.LoadFromFiles()
+	require.NoError(t, err)
+
+	// Verify VRF keys
+	assert.True(t, ks.IsLoaded())
+	vrfSigner := ks.VRFSigner()
+	require.NotNil(t, vrfSigner)
+	assert.Equal(t, vrf.PublicKeySize, len(vrfSigner.VKey()))
+
+	// Verify KES keys
+	kesSigner := ks.KESSigner()
+	require.NotNil(t, kesSigner)
+	assert.Equal(t, 32, len(kesSigner.VKey()))
+	assert.Equal(t, uint64(0), kesSigner.CurrentPeriod())
+
+	// Verify OpCert
+	opCert := ks.OpCert()
+	require.NotNil(t, opCert)
+	assert.Equal(t, uint64(0), opCert.IssueNumber)
+	assert.Equal(t, uint64(0), opCert.KESPeriod)
+	assert.Equal(t, 64, len(opCert.Signature))
+	assert.Equal(t, 32, len(opCert.ColdVKey))
+
+	// Verify pool ID is derived from cold key
+	poolID := ks.PoolID()
+	require.NotNil(t, poolID)
+	assert.Equal(t, 28, len(*poolID))
+}
+
+func TestVRFSigner(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath: vrfPath,
+		KESSKeyPath: kesPath,
+		OpCertPath:  opCertPath,
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	vrfSigner := ks.VRFSigner()
+	require.NotNil(t, vrfSigner)
+
+	// Generate VRF proof for a sample slot
+	epochNonce := make([]byte, 32) // All zeros for test
+	alpha := vrf.MkInputVrf(1000, epochNonce)
+
+	proof, output, err := vrfSigner.Prove(alpha)
+	require.NoError(t, err)
+
+	assert.Equal(t, vrf.ProofSize, len(proof))
+	assert.Equal(t, vrf.OutputSize, len(output))
+
+	// Verify the proof
+	ok, err := vrf.Verify(vrfSigner.VKey(), proof, output, alpha)
+	require.NoError(t, err)
+	assert.True(t, ok, "VRF proof verification failed")
+}
+
+func TestKESSigner(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath: vrfPath,
+		KESSKeyPath: kesPath,
+		OpCertPath:  opCertPath,
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	kesSigner := ks.KESSigner()
+	require.NotNil(t, kesSigner)
+
+	// Sign a test message at period 0
+	message := []byte("test block header data")
+	signature, err := kesSigner.Sign(0, message)
+	require.NoError(t, err)
+
+	// KES signature for depth 6 is 448 bytes
+	assert.Equal(t, kes.CardanoKesSignatureSize, len(signature))
+
+	// Verify the signature
+	ok := kes.VerifySignedKES(kesSigner.VKey(), 0, message, signature)
+	assert.True(t, ok, "KES signature verification failed")
+}
+
+func TestKESEvolution(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath: vrfPath,
+		KESSKeyPath: kesPath,
+		OpCertPath:  opCertPath,
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	// Initial period should be 0
+	assert.Equal(t, uint64(0), ks.CurrentKESPeriod())
+
+	// Evolve to period 1
+	err := ks.EvolveKESTo(1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), ks.CurrentKESPeriod())
+
+	// Sign at period 1
+	kesSigner := ks.KESSigner()
+	require.NotNil(t, kesSigner)
+	message := []byte("test message for period 1")
+	signature, err := kesSigner.Sign(1, message)
+	require.NoError(t, err)
+
+	// Verify the signature at period 1
+	ok := kes.VerifySignedKES(kesSigner.VKey(), 1, message, signature)
+	assert.True(t, ok, "KES signature verification failed at period 1")
+
+	// Evolve to period 3 (skipping 2)
+	err = ks.EvolveKESTo(3)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3), ks.CurrentKESPeriod())
+}
+
+func TestOpCertValidation(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath:      vrfPath,
+		KESSKeyPath:      kesPath,
+		OpCertPath:       opCertPath,
+		MaxKESEvolutions: 64, // Depth 6
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	// Validate OpCert - should pass since keys match
+	err := ks.ValidateOpCert()
+	require.NoError(t, err)
+
+	// Check expiry period
+	expiryPeriod := ks.OpCertExpiryPeriod()
+	// For depth 6, max periods = 64, starting at period 0
+	assert.Equal(t, uint64(64), expiryPeriod)
+
+	// Check periods remaining
+	remaining := ks.PeriodsRemaining(0)
+	assert.Equal(t, uint64(64), remaining)
+
+	remaining = ks.PeriodsRemaining(32)
+	assert.Equal(t, uint64(32), remaining)
+
+	remaining = ks.PeriodsRemaining(64)
+	assert.Equal(t, uint64(0), remaining)
+
+	remaining = ks.PeriodsRemaining(100)
+	assert.Equal(t, uint64(0), remaining)
+}
+
+func TestSecurityFilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file with secure permissions (0600)
+	securePath := filepath.Join(tmpDir, "secure.key")
+	require.NoError(t, os.WriteFile(securePath, []byte("test"), 0o600))
+
+	if runtime.GOOS == "windows" {
+		// On Windows, ACL verification is not implemented, so it fails-closed.
+		// Test that it fails by default and passes with the bypass env var.
+		err := checkKeyFilePermissions(securePath)
+		assert.ErrorIs(t, err, ErrInsecureFileMode, "Windows should fail-closed without env var")
+
+		// Test that the bypass env var works
+		t.Setenv("DINGO_ALLOW_INSECURE_KEY_PERMS", "true")
+		err = checkKeyFilePermissions(securePath)
+		assert.NoError(t, err, "Windows should pass with bypass env var")
+		return
+	}
+
+	// Unix permission checks
+	err := checkKeyFilePermissions(securePath)
+	assert.NoError(t, err, "secure file should pass permission check")
+
+	// Create a file with insecure permissions (world-readable)
+	insecurePath := filepath.Join(tmpDir, "insecure.key")
+	require.NoError(t, os.WriteFile(insecurePath, []byte("test"), 0o644))
+
+	err = checkKeyFilePermissions(insecurePath)
+	assert.Error(t, err, "insecure file should fail permission check")
+	assert.ErrorIs(t, err, ErrInsecureFileMode)
+}
+
+// mockSlotClock implements SlotClock for testing.
+type mockSlotClock struct {
+	mu          sync.RWMutex
+	currentSlot uint64
+	subscribers []chan SlotTick
+}
+
+func newMockSlotClock(initialSlot uint64) *mockSlotClock {
+	return &mockSlotClock{
+		currentSlot: initialSlot,
+		subscribers: make([]chan SlotTick, 0),
+	}
+}
+
+func (m *mockSlotClock) CurrentSlot() (uint64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.currentSlot, nil
+}
+
+func (m *mockSlotClock) Subscribe() <-chan SlotTick {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan SlotTick, 1)
+	m.subscribers = append(m.subscribers, ch)
+	return ch
+}
+
+func (m *mockSlotClock) Unsubscribe(ch <-chan SlotTick) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, sub := range m.subscribers {
+		if sub == ch {
+			// Don't close the channel here - AdvanceSlot may be concurrently
+			// sending to a copy of the subscribers slice after releasing the lock.
+			// Just remove from slice; the channel will be garbage collected.
+			m.subscribers = append(m.subscribers[:i], m.subscribers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (m *mockSlotClock) AdvanceSlot(slot uint64) {
+	m.mu.Lock()
+	m.currentSlot = slot
+	subs := make([]chan SlotTick, len(m.subscribers))
+	copy(subs, m.subscribers)
+	m.mu.Unlock()
+
+	tick := SlotTick{Slot: slot}
+	for _, ch := range subs {
+		select {
+		case ch <- tick:
+		default:
+		}
+	}
+}
+
+func (m *mockSlotClock) HasSubscribers() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.subscribers) > 0
+}
+
+func TestKeyStoreStartStop(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath:       vrfPath,
+		KESSKeyPath:       kesPath,
+		OpCertPath:        opCertPath,
+		SlotsPerKESPeriod: 100, // Small value for testing
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	// Create a mock slot clock starting at slot 50 (period 0)
+	slotClock := newMockSlotClock(50)
+
+	// Start the keystore
+	ctx := context.Background()
+	err := ks.Start(ctx, slotClock)
+	require.NoError(t, err)
+
+	// Starting again should fail
+	err = ks.Start(ctx, slotClock)
+	assert.ErrorIs(t, err, ErrAlreadyRunning)
+
+	// Stop the keystore
+	err = ks.Stop()
+	require.NoError(t, err)
+
+	// Stopping again should fail
+	err = ks.Stop()
+	assert.ErrorIs(t, err, ErrNotRunning)
+}
+
+func TestKeyStoreKESEvolutionOnPeriodChange(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath:       vrfPath,
+		KESSKeyPath:       kesPath,
+		OpCertPath:        opCertPath,
+		SlotsPerKESPeriod: 100, // Small value for testing
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	// Create a mock slot clock starting at slot 50 (period 0)
+	slotClock := newMockSlotClock(50)
+
+	// Start the keystore
+	ctx := context.Background()
+	err := ks.Start(ctx, slotClock)
+	require.NoError(t, err)
+	defer func() { _ = ks.Stop() }()
+
+	// Wait for monitor goroutine to subscribe to slot clock
+	require.Eventually(t, func() bool {
+		return slotClock.HasSubscribers()
+	}, time.Second, 10*time.Millisecond, "monitor should subscribe to slot clock")
+
+	// Initial period should be 0
+	assert.Equal(t, uint64(0), ks.CurrentKESPeriod())
+
+	// Advance to slot 150 (period 1)
+	slotClock.AdvanceSlot(150)
+
+	// Wait for evolution to period 1
+	require.Eventually(t, func() bool {
+		return ks.CurrentKESPeriod() == 1
+	}, time.Second, 10*time.Millisecond, "KES period should evolve to 1")
+
+	// Advance to slot 350 (period 3)
+	slotClock.AdvanceSlot(350)
+
+	// Wait for evolution to period 3
+	require.Eventually(t, func() bool {
+		return ks.CurrentKESPeriod() == 3
+	}, time.Second, 10*time.Millisecond, "KES period should evolve to 3")
+}
+
+func TestKeyStoreNotLoadedError(t *testing.T) {
+	config := KeyStoreConfig{}
+	ks := NewKeyStore(config)
+
+	// Not loaded
+	assert.False(t, ks.IsLoaded())
+	assert.Nil(t, ks.VRFSigner())
+	assert.Nil(t, ks.KESSigner())
+	assert.Nil(t, ks.OpCert())
+	assert.Nil(t, ks.PoolID())
+
+	// Cannot start without loading
+	slotClock := newMockSlotClock(0)
+	err := ks.Start(context.Background(), slotClock)
+	assert.ErrorIs(t, err, ErrKeysNotLoaded)
+}
+
+func TestEvolutionConstants(t *testing.T) {
+	// Test slot to KES period conversion
+	assert.Equal(t, uint64(0), SlotToKESPeriod(0, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(0), SlotToKESPeriod(129599, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(1), SlotToKESPeriod(129600, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(1), SlotToKESPeriod(259199, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(2), SlotToKESPeriod(259200, DefaultSlotsPerKESPeriod))
+
+	// Test period start/end slots
+	assert.Equal(t, uint64(0), KESPeriodStartSlot(0, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(129599), KESPeriodEndSlot(0, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(129600), KESPeriodStartSlot(1, DefaultSlotsPerKESPeriod))
+	assert.Equal(t, uint64(259199), KESPeriodEndSlot(1, DefaultSlotsPerKESPeriod))
+
+	// Test KES period duration
+	duration := DefaultKESPeriodDuration()
+	assert.Equal(t, time.Duration(DefaultSlotsPerKESPeriod)*time.Second, duration)
+
+	// Test OpCert lifetime
+	lifetimeSlots := DefaultOpCertLifetimeSlots()
+	assert.Equal(t, uint64(DefaultSlotsPerKESPeriod*DefaultMaxKESEvolutions), lifetimeSlots)
+}
+
+func TestExpiryWarningThresholds(t *testing.T) {
+	thresholds := DefaultExpiryWarningThresholds()
+	assert.Equal(t, uint64(3), thresholds.Critical)
+	assert.Equal(t, uint64(7), thresholds.Warning)
+	assert.Equal(t, uint64(14), thresholds.Info)
+}

--- a/keystore/permissions_unix.go
+++ b/keystore/permissions_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keystore
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkKeyFilePermissions verifies a key file has secure permissions.
+// Returns an error if the file is not exactly 0600 (owner read/write only).
+func checkKeyFilePermissions(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	mode := info.Mode().Perm()
+	// Enforce exactly 0600: owner read+write only, no group/world/execute
+	if mode != 0o600 {
+		return fmt.Errorf(
+			"%w: %o (key files must be 0600, owner read/write only)",
+			ErrInsecureFileMode,
+			mode,
+		)
+	}
+
+	return nil
+}

--- a/keystore/permissions_windows.go
+++ b/keystore/permissions_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keystore
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Environment variable to bypass Windows ACL checks.
+// Set DINGO_ALLOW_INSECURE_KEY_PERMS=true to skip permission verification.
+// WARNING: Only use this in development/testing environments where you have
+// manually verified the key file ACLs are properly restricted.
+const envAllowInsecureKeyPerms = "DINGO_ALLOW_INSECURE_KEY_PERMS"
+
+// checkKeyFilePermissions on Windows verifies file permissions.
+// Windows uses ACLs which require platform-specific APIs to check properly.
+// By default, this function fails-closed (returns an error) since ACL
+// verification is not implemented. Set DINGO_ALLOW_INSECURE_KEY_PERMS=true
+// to bypass this check after manually verifying file ACLs.
+func checkKeyFilePermissions(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	// Check for explicit override
+	if allowInsecure := os.Getenv(envAllowInsecureKeyPerms); strings.EqualFold(allowInsecure, "true") {
+		slog.Warn(
+			"Windows ACL verification bypassed via environment variable; "+
+				"ensure key file has restrictive permissions manually",
+			"path", path,
+			"env_var", envAllowInsecureKeyPerms,
+		)
+		return nil
+	}
+
+	// Fail-closed: Windows ACL checking requires platform-specific APIs
+	// (e.g., GetFileSecurity, GetSecurityDescriptorDacl from golang.org/x/sys/windows).
+	// Until proper ACL checks are implemented, reject by default for security.
+	return fmt.Errorf(
+		"%w: Windows ACL verification not implemented; "+
+			"set %s=true to bypass after manually verifying file permissions",
+		ErrInsecureFileMode,
+		envAllowInsecureKeyPerms,
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a keystore for Cardano stake pool operators that loads VRF/KES/OpCert keys, derives the pool ID, and automatically evolves KES keys based on the current slot. Adds KES period and evolution config with sane defaults and expiry warnings.

- **New Features**
  - keystore package with VRF and KES signer interfaces and OpCert validation.
  - Loads cardano-cli JSON key files (VRF, KES, OpCert) and derives pool ID via blake2b-224.
  - Automatic KES evolution using a SlotClock; logs expiry warnings as OpCert nears end of life.
  - KES utilities for period math and durations.
  - Secure key file checks (0600 on Unix; on Windows, ACL checks fail-closed unless DINGO_ALLOW_INSECURE_KEY_PERMS=true).
  - Config: slotsPerKESPeriod and maxKESEvolutions with defaults (129600, 62) and env support (DINGO_SLOTS_PER_KES_PERIOD, DINGO_MAX_KES_EVOLUTIONS).

- **Migration**
  - Set VRF, KES, and OpCert file paths in KeyStoreConfig; ensure files are 0600 on Unix.
  - Initialize keystore, call LoadFromFiles, then Start(ctx, slotClock); call Stop() on shutdown.
  - Optionally override KES settings via config or env (DINGO_SLOTS_PER_KES_PERIOD, DINGO_MAX_KES_EVOLUTIONS).
  - On Windows, set DINGO_ALLOW_INSECURE_KEY_PERMS=true to bypass ACL verification after locking down file ACLs.

<sup>Written for commit 021bbb8e153c43b6af5d52a9ac9c9b7d67630603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keystore for loading/managing VRF, KES and operational certificate credentials; pool identity derivation; lifecycle (start/stop) and signer access.

* **Configuration**
  * New KES-related configuration options with sensible defaults for period and max evolutions.

* **Security**
  * Platform-specific key-file permission checks with enforced secure defaults and Windows advisory bypass behavior.

* **Tests**
  * Extensive keystore tests covering loading, signing, evolution, expiry and lifecycle.

* **Dependencies**
  * Promoted crypto dependency to a direct requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->