### PR TITLE
fix(ledger): byron genesis block hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
-	golang.org/x/crypto v0.47.0
 	golang.org/x/net v0.49.0
 	golang.org/x/sys v0.40.0
 	google.golang.org/api v0.264.0
@@ -194,6 +193,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/ledger/genesis_utxo_test.go
+++ b/ledger/genesis_utxo_test.go
@@ -91,6 +91,10 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 			utxo.Id.Id().Bytes()[:8], utxo.Id.Index(), len(cborData))
 	}
 
+	// Get the Byron genesis hash to use as the synthetic block hash
+	genesisHash, err := GenesisBlockHash(nodeCfg)
+	require.NoError(t, err)
+
 	// Create a transaction to store genesis UTxOs
 	txn := db.Transaction(true)
 	err = txn.Do(func(txn *database.Txn) error {
@@ -129,7 +133,7 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 
 			utxoOffsets[ref] = database.CborOffset{
 				BlockSlot:  0,
-				BlockHash:  GenesisBlockHash,
+				BlockHash:  genesisHash,
 				ByteOffset: offset,
 				ByteLength: uint32(len(outputCbor)),
 			}
@@ -140,7 +144,7 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 
 		// Store the genesis block CBOR
 		t.Logf("Storing genesis block CBOR: %d bytes", len(blockCbor))
-		if err := db.SetGenesisCbor(0, GenesisBlockHash[:], blockCbor, txn); err != nil {
+		if err := db.SetGenesisCbor(0, genesisHash[:], blockCbor, txn); err != nil {
 			return err
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the Byron genesis hash from node config as the synthetic genesis block hash for genesis UTxO storage, replacing the hardcoded value. This keeps CBOR offsets and lookups aligned with the actual network configuration.

- **Bug Fixes**
  - Added GenesisBlockHash(cfg) to decode and validate the 32-byte Byron genesis hash; used in createGenesisBlock and buildGenesisBlockCbor.
  - Updated genesis UTxO storage and tests to use the config-provided hash with SetGenesisCbor and UTxO offsets.

- **Dependencies**
  - Marked golang.org/x/crypto as indirect.

<sup>Written for commit 66e14e1912b960b6dccf61f6677df6218091c4ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Genesis block hash is now dynamically configured from node settings instead of using a static value, enabling flexible genesis block creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->