### PR TITLE
feat(ledger): BlockEvent from ledger

### DIFF
--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+func (ls *LedgerState) handleEventChainUpdate(evt event.Event) {
+	switch data := evt.Data.(type) {
+	case chain.ChainBlockEvent:
+		ls.publishBlockEvent(BlockActionApply, data.Block)
+	case chain.ChainRollbackEvent:
+		for _, blk := range data.RolledBackBlocks {
+			ls.publishBlockEvent(BlockActionUndo, blk)
+		}
+	}
+}
+
+func (ls *LedgerState) publishBlockEvent(action BlockAction, block models.Block) {
+	if ls.config.EventBus == nil {
+		return
+	}
+	evt := BlockEvent{
+		Action: action,
+		Block:  block,
+		Point: ocommon.Point{
+			Slot: block.Slot,
+			Hash: block.Hash,
+		},
+	}
+	ls.config.EventBus.Publish(
+		BlockEventType,
+		event.NewEvent(BlockEventType, evt),
+	)
+}

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -24,9 +25,25 @@ import (
 
 const (
 	BlockfetchEventType  event.EventType = "blockfetch.event"
+	BlockEventType       event.EventType = "ledger.block"
 	ChainsyncEventType   event.EventType = "chainsync.event"
 	LedgerErrorEventType event.EventType = "ledger.error"
 )
+
+// It represents the direction a block is applied to the ledger.
+type BlockAction string
+
+const (
+	BlockActionApply BlockAction = "Apply"
+	BlockActionUndo  BlockAction = "Undo"
+)
+
+// It represents a persisted block apply or rollback action.
+type BlockEvent struct {
+	Action BlockAction
+	Block  models.Block
+	Point  ocommon.Point
+}
 
 // BlockfetchEvent represents either a Block or BatchDone blockfetch event. We use
 // a single event type for both to make synchronization easier.

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -499,6 +499,10 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 			BlockfetchEventType,
 			ls.handleEventBlockfetch,
 		)
+		ls.config.EventBus.SubscribeFunc(
+			chain.ChainUpdateEventType,
+			ls.handleEventChainUpdate,
+		)
 	}
 	// Schedule periodic process to purge consumed UTxOs outside of the rollback window
 	ls.scheduleCleanupConsumedUtxos()


### PR DESCRIPTION
1. Added ledger.block event with apply/undo actions emitted when blocks are persisted or rolled back.
2. Subscribe ledger to chain update and re-emit block events from chain persistence.

Closes #1188 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ledger.block event that emits Apply/Undo when blocks are persisted or rolled back. Subscribes the ledger to chain update events and re-emits block changes, fulfilling Linear #1188.

- **New Features**
  - New event type: ledger.block with actions Apply and Undo.
  - Payload includes models.Block and Point (slot, hash).
  - Ledger subscribes to chain.ChainUpdateEventType and publishes on apply/rollback.

<sup>Written for commit e0ab94798677dabceee25dbbf7c5f5083668ac0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Block events now published: external systems can subscribe to block changes, receiving notifications when blocks are applied or rolled back, including block details and action information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->