### PR TITLE
test(ledger): conformance tests from ouroboros-mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.0
-	github.com/blinklabs-io/gouroboros v0.152.1
-	github.com/blinklabs-io/ouroboros-mock v0.7.0
+	github.com/blinklabs-io/gouroboros v0.152.2
+	github.com/blinklabs-io/ouroboros-mock v0.9.0
 	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.0

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,10 @@ github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoG
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blinklabs-io/gouroboros v0.152.1 h1:wySqy6coBwbrc/3j94GNz062c39zGb2kpGKWHhun2AE=
-github.com/blinklabs-io/gouroboros v0.152.1/go.mod h1:BXTv7xGWb0fDpUuRunVLhSvrDrvd+pkSMBpOligo5Ew=
-github.com/blinklabs-io/ouroboros-mock v0.7.0 h1:IbBzOHAtjzh1PWIXy9tMB6wAS6/+HLMVtNtTFSTN4VM=
-github.com/blinklabs-io/ouroboros-mock v0.7.0/go.mod h1:ODwZJTTyonyId1hFeFjxvGGnlhvRZ+5IKBYAka0XWhE=
+github.com/blinklabs-io/gouroboros v0.152.2 h1:w2OPBrg+a8bGgk046WvkQNiyn4Yglql7AN5hdurhDFY=
+github.com/blinklabs-io/gouroboros v0.152.2/go.mod h1:BXTv7xGWb0fDpUuRunVLhSvrDrvd+pkSMBpOligo5Ew=
+github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qtpU76eFeBKWeQ=
+github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
 github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=
 github.com/blinklabs-io/plutigo v0.0.22/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/internal/test/conformance/conformance_test.go
+++ b/internal/test/conformance/conformance_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRulesConformanceVectors runs the Amaru ledger rules conformance test vectors
+// using Dingo's ledger implementation via the shared harness from ouroboros-mock/conformance.
+//
+// The test vectors exercise Conway era ledger rules including:
+// - UTxO validation (inputs, outputs, fees, collateral)
+// - Certificate processing (stake, pool, DRep, committee)
+// - Governance (proposals, voting, enactment)
+// - Script execution (native scripts, Plutus V1/V2/V3)
+//
+// Test vectors are embedded in the ouroboros-mock module and extracted at test time.
+func TestRulesConformanceVectors(t *testing.T) {
+	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	sm, err := NewDingoStateManager()
+	require.NoError(t, err)
+	defer sm.Close()
+
+	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
+		TestdataRoot: testdataRoot,
+		Debug:        testing.Verbose(),
+	})
+
+	harness.RunAllVectors(t)
+}
+
+// TestRulesConformanceVectorsWithResults runs the conformance tests and reports
+// detailed statistics. This is useful for tracking implementation progress.
+func TestRulesConformanceVectorsWithResults(t *testing.T) {
+	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	sm, err := NewDingoStateManager()
+	require.NoError(t, err)
+	defer sm.Close()
+
+	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
+		TestdataRoot: testdataRoot,
+		Debug:        false,
+	})
+
+	results, err := harness.RunAllVectorsWithResults()
+	if err != nil {
+		t.Fatalf("failed to run vectors: %v", err)
+	}
+
+	var successes, failures int
+	for _, result := range results {
+		if result.Success {
+			successes++
+		} else {
+			failures++
+		}
+	}
+
+	t.Logf("Conformance Test Results:")
+	t.Logf("  Total vectors: %d", len(results))
+	t.Logf("  Passed: %d", successes)
+	t.Logf("  Failed: %d", failures)
+	if len(results) > 0 {
+		t.Logf(
+			"  Pass rate: %.1f%%",
+			float64(successes)/float64(len(results))*100,
+		)
+	}
+
+	if failures > 0 && testing.Verbose() {
+		t.Log("First failures:")
+		failCount := 0
+		for _, result := range results {
+			if !result.Success && failCount < 5 {
+				t.Logf("  %s: %v", result.Title, result.Error)
+				failCount++
+			}
+		}
+		if failures > 5 {
+			t.Logf("  ... and %d more failures", failures-5)
+		}
+	}
+}

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -1,0 +1,1051 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package conformance provides a DingoStateManager that implements the
+// ouroboros-mock conformance.StateManager interface using dingo's database
+// and ledger packages with an in-memory SQLite database.
+package conformance
+
+import (
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/glebarez/sqlite"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// DingoStateManager implements conformance.StateManager using dingo's database
+// with an in-memory SQLite backend for testing.
+type DingoStateManager struct {
+	// db is the GORM database connection
+	db *gorm.DB
+
+	// protocolParams holds the current protocol parameters
+	protocolParams common.ProtocolParameters
+
+	// govState tracks governance-related state
+	govState *conformance.GovernanceState
+
+	// currentEpoch tracks the current epoch
+	currentEpoch uint64
+
+	// utxos stores UTxOs by their ID string for fast lookup
+	utxos map[string]common.Utxo
+
+	// stakeRegistrations tracks registered stake credentials and their balances
+	stakeRegistrations map[common.Blake2b224]uint64
+
+	// poolRegistrations tracks registered pools
+	poolRegistrations map[common.Blake2b224]bool
+
+	// drepRegistrations tracks registered DReps
+	drepRegistrations map[common.Blake2b224]bool
+
+	// committeeMembers tracks committee members (cold key -> expiry epoch)
+	committeeMembers map[common.Blake2b224]uint64
+
+	// hotKeyAuthorizations tracks hot key authorizations (cold key -> hot key)
+	hotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
+}
+
+// NewDingoStateManager creates a new DingoStateManager with an in-memory SQLite database.
+func NewDingoStateManager() (*DingoStateManager, error) {
+	// Open in-memory SQLite database
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open in-memory database: %w", err)
+	}
+
+	// Run migrations for all models
+	if err := db.AutoMigrate(models.MigrateModels...); err != nil {
+		return nil, fmt.Errorf("failed to migrate database: %w", err)
+	}
+
+	return &DingoStateManager{
+		db:                   db,
+		govState:             conformance.NewGovernanceState(),
+		utxos:                make(map[string]common.Utxo),
+		stakeRegistrations:   make(map[common.Blake2b224]uint64),
+		poolRegistrations:    make(map[common.Blake2b224]bool),
+		drepRegistrations:    make(map[common.Blake2b224]bool),
+		committeeMembers:     make(map[common.Blake2b224]uint64),
+		hotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
+	}, nil
+}
+
+// LoadInitialState implements conformance.StateManager.LoadInitialState.
+func (m *DingoStateManager) LoadInitialState(
+	state *conformance.ParsedInitialState,
+	pp common.ProtocolParameters,
+) error {
+	m.protocolParams = pp
+	m.currentEpoch = state.CurrentEpoch
+
+	// Clear existing state
+	m.utxos = make(map[string]common.Utxo)
+	m.stakeRegistrations = make(map[common.Blake2b224]uint64)
+	m.poolRegistrations = make(map[common.Blake2b224]bool)
+	m.drepRegistrations = make(map[common.Blake2b224]bool)
+	m.committeeMembers = make(map[common.Blake2b224]uint64)
+	m.hotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
+
+	// Clear database tables
+	if err := m.clearDatabaseTables(); err != nil {
+		return fmt.Errorf("failed to clear database: %w", err)
+	}
+
+	// Load stake registrations with reward balances
+	for hash, registered := range state.StakeRegistrations {
+		if registered {
+			balance := state.RewardAccounts[hash]
+			m.stakeRegistrations[hash] = balance
+
+			// Insert into database
+			account := models.Account{
+				StakingKey: hash[:],
+				AddedSlot:  0,
+				Active:     true,
+			}
+			if err := m.db.Create(&account).Error; err != nil {
+				return fmt.Errorf("failed to insert account: %w", err)
+			}
+		}
+	}
+
+	// Load pool registrations
+	for hash, registered := range state.PoolRegistrations {
+		if registered {
+			m.poolRegistrations[hash] = true
+
+			// Insert into database
+			pool := models.Pool{
+				PoolKeyHash: hash[:],
+			}
+			if err := m.db.Create(&pool).Error; err != nil {
+				return fmt.Errorf("failed to insert pool: %w", err)
+			}
+		}
+	}
+
+	// Load DRep registrations
+	for _, hash := range state.DRepRegistrations {
+		m.drepRegistrations[hash] = true
+
+		// Insert into database
+		drep := models.Drep{
+			Credential: hash[:],
+			AddedSlot:  0,
+			Active:     true,
+		}
+		if err := m.db.Create(&drep).Error; err != nil {
+			return fmt.Errorf("failed to insert drep: %w", err)
+		}
+	}
+
+	// Load committee members
+	maps.Copy(m.committeeMembers, state.CommitteeMembers)
+
+	// Load hot key authorizations
+	maps.Copy(m.hotKeyAuthorizations, state.HotKeyAuthorizations)
+
+	// Insert hot key auths into database
+	for coldKey, hotKey := range state.HotKeyAuthorizations {
+		auth := models.AuthCommitteeHot{
+			ColdCredential: coldKey[:],
+			HostCredential: hotKey[:],
+			AddedSlot:      0,
+		}
+		if err := m.db.Create(&auth).Error; err != nil {
+			return fmt.Errorf("failed to insert auth_committee_hot: %w", err)
+		}
+	}
+
+	// Load governance state
+	m.govState = conformance.NewGovernanceState()
+	m.govState.LoadFromParsedState(state)
+
+	// Insert governance proposals into database
+	for id, proposal := range state.Proposals {
+		govProposal := m.proposalToModel(id, proposal)
+		if err := m.db.Create(&govProposal).Error; err != nil {
+			return fmt.Errorf("failed to insert governance proposal: %w", err)
+		}
+	}
+
+	// Populate UTxOs from parsed state using the fully decoded Output
+	for utxoId, parsedUtxo := range state.Utxos {
+		// Create a mock transaction input for the UTxO ID
+		var txHash common.Blake2b256
+		copy(txHash[:], parsedUtxo.TxHash)
+
+		mockInput := &dingoTransactionInput{
+			txId:  txHash,
+			index: parsedUtxo.Index,
+		}
+
+		// Use the decoded Output directly
+		m.utxos[utxoId] = common.Utxo{
+			Id:     mockInput,
+			Output: parsedUtxo.Output,
+		}
+
+		// Insert into database
+		utxoModel := models.Utxo{
+			TxId:      parsedUtxo.TxHash,
+			OutputIdx: parsedUtxo.Index,
+			AddedSlot: 0,
+		}
+		if parsedUtxo.Output != nil {
+			utxoModel.Cbor = parsedUtxo.Output.Cbor()
+		}
+		if err := m.db.Create(&utxoModel).Error; err != nil {
+			return fmt.Errorf("failed to insert utxo: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ApplyTransaction implements conformance.StateManager.ApplyTransaction.
+func (m *DingoStateManager) ApplyTransaction(
+	tx common.Transaction,
+	slot uint64,
+) error {
+	// For phase-2 invalid transactions (IsValid=false), only consume collateral
+	// and add collateral return output if present
+	if !tx.IsValid() {
+		// Consume collateral inputs
+		for _, input := range tx.Collateral() {
+			inputId := input.Id()
+			inputIdx := input.Index()
+			utxoId := fmt.Sprintf(
+				"%s#%d",
+				hex.EncodeToString(inputId.Bytes()),
+				inputIdx,
+			)
+			delete(m.utxos, utxoId)
+
+			// Mark as spent in database
+			m.db.Model(&models.Utxo{}).
+				Where("tx_id = ? AND output_idx = ?", inputId.Bytes(), inputIdx).
+				Update("deleted_slot", slot)
+		}
+
+		// Add collateral return output if present
+		if collateralReturn := tx.CollateralReturn(); collateralReturn != nil {
+			txHash := tx.Hash()
+			txHashStr := hex.EncodeToString(txHash.Bytes())
+			//nolint:gosec // output count bounded by protocol max tx size
+			returnIdx := uint32(len(tx.Outputs()))
+			utxoId := fmt.Sprintf("%s#%d", txHashStr, returnIdx)
+
+			mockInput := &dingoTransactionInput{
+				txId:  txHash,
+				index: returnIdx,
+			}
+			m.utxos[utxoId] = common.Utxo{
+				Id:     mockInput,
+				Output: collateralReturn,
+			}
+
+			// Insert into database
+			utxoModel := models.Utxo{
+				TxId:      txHash.Bytes(),
+				OutputIdx: returnIdx,
+				AddedSlot: slot,
+				Cbor:      collateralReturn.Cbor(),
+			}
+			if err := m.db.Create(&utxoModel).Error; err != nil {
+				return fmt.Errorf("failed to insert collateral return utxo: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	// Get tx hash as string
+	txHash := tx.Hash()
+	txHashStr := hex.EncodeToString(txHash.Bytes())
+
+	// Process consumed UTxOs (inputs)
+	inputs := tx.Inputs()
+	for _, input := range inputs {
+		inputId := input.Id()
+		inputIdx := input.Index()
+		utxoId := fmt.Sprintf(
+			"%s#%d",
+			hex.EncodeToString(inputId.Bytes()),
+			inputIdx,
+		)
+		delete(m.utxos, utxoId)
+
+		// Mark as spent in database
+		m.db.Model(&models.Utxo{}).
+			Where("tx_id = ? AND output_idx = ?", inputId.Bytes(), inputIdx).
+			Update("deleted_slot", slot)
+	}
+
+	// Process produced UTxOs (outputs)
+	outputs := tx.Outputs()
+	for idx, output := range outputs {
+		utxoId := fmt.Sprintf("%s#%d", txHashStr, idx)
+
+		// Create a mock transaction input for the UTxO ID
+		mockInput := &dingoTransactionInput{
+			txId:  txHash,
+			index: uint32(idx), //nolint:gosec // idx bounded by tx outputs
+		}
+
+		m.utxos[utxoId] = common.Utxo{
+			Id:     mockInput,
+			Output: output,
+		}
+
+		// Insert into database
+		utxoModel := models.Utxo{
+			TxId:      txHash.Bytes(),
+			OutputIdx: uint32(idx), //nolint:gosec // idx bounded by tx outputs
+			AddedSlot: slot,
+			Cbor:      output.Cbor(),
+		}
+		if err := m.db.Create(&utxoModel).Error; err != nil {
+			return fmt.Errorf("failed to insert utxo: %w", err)
+		}
+	}
+
+	// Process certificates
+	certs := tx.Certificates()
+	for _, cert := range certs {
+		m.processCertificate(cert, slot)
+	}
+
+	// Process governance proposals
+	proposals := tx.ProposalProcedures()
+	for idx, proposal := range proposals {
+		govActionId := fmt.Sprintf("%s#%d", txHashStr, idx)
+		action := proposal.GovAction()
+		if action != nil {
+			// Get govActionLifetime from protocol parameters
+			var govActionLifetime uint64 = 6 // Default fallback
+			if conwayPP, ok := m.protocolParams.(*conway.ConwayProtocolParameters); ok {
+				govActionLifetime = conwayPP.GovActionValidityPeriod
+			}
+
+			info := conformance.GovActionInfo{
+				ActionType:      getActionType(action),
+				ExpiresAfter:    m.currentEpoch + govActionLifetime,
+				SubmittedEpoch:  m.currentEpoch,
+				ProposedMembers: make(map[common.Blake2b224]uint64),
+			}
+
+			// Extract action-specific data including parent action ID
+			extractActionSpecificData(action, &info)
+
+			m.govState.AddProposal(govActionId, info)
+
+			// Insert into database
+			govProposal := m.proposalToModel(govActionId, info)
+			govProposal.AddedSlot = slot
+			m.db.Create(&govProposal)
+		}
+	}
+
+	// Process voting procedures
+	votes := tx.VotingProcedures()
+	for voter, voteMap := range votes {
+		for govActionId, votingProc := range voteMap {
+			actionKey := fmt.Sprintf(
+				"%s#%d",
+				hex.EncodeToString(govActionId.TransactionId[:]),
+				govActionId.GovActionIdx,
+			)
+			proposal := m.govState.GetProposal(actionKey)
+			if proposal == nil {
+				continue
+			}
+			if proposal.Votes == nil {
+				proposal.Votes = make(map[string]uint8)
+			}
+			// Store vote as "voterType:credHash" -> vote value
+			voterKey := fmt.Sprintf(
+				"%d:%s",
+				voter.Type,
+				hex.EncodeToString(voter.Hash[:]),
+			)
+			proposal.Votes[voterKey] = votingProc.Vote
+		}
+	}
+
+	return nil
+}
+
+// processCertificate processes a single certificate and updates state.
+func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uint64) {
+	certType := common.CertificateType(cert.Type())
+
+	//exhaustive:ignore
+	switch certType {
+	case common.CertificateTypeStakeRegistration:
+		if regCert, ok := cert.(*common.StakeRegistrationCertificate); ok {
+			credential := regCert.StakeCredential.Credential
+			m.stakeRegistrations[credential] = 0
+			m.govState.RegisterStake(credential)
+
+			// Insert into database
+			account := models.Account{
+				StakingKey: credential[:],
+				AddedSlot:  slot,
+				Active:     true,
+			}
+			m.db.Create(&account)
+		}
+
+	case common.CertificateTypeRegistration:
+		if regCert, ok := cert.(*common.RegistrationCertificate); ok {
+			credential := regCert.StakeCredential.Credential
+			m.stakeRegistrations[credential] = 0
+			m.govState.RegisterStake(credential)
+
+			// Insert into database
+			account := models.Account{
+				StakingKey: credential[:],
+				AddedSlot:  slot,
+				Active:     true,
+			}
+			m.db.Create(&account)
+		}
+
+	case common.CertificateTypeStakeRegistrationDelegation:
+		if regCert, ok := cert.(*common.StakeRegistrationDelegationCertificate); ok {
+			credential := regCert.StakeCredential.Credential
+			m.stakeRegistrations[credential] = 0
+			m.govState.RegisterStake(credential)
+
+			// Insert into database
+			account := models.Account{
+				StakingKey: credential[:],
+				AddedSlot:  slot,
+				Active:     true,
+			}
+			m.db.Create(&account)
+		}
+
+	case common.CertificateTypeVoteRegistrationDelegation:
+		if regCert, ok := cert.(*common.VoteRegistrationDelegationCertificate); ok {
+			credential := regCert.StakeCredential.Credential
+			m.stakeRegistrations[credential] = 0
+			m.govState.RegisterStake(credential)
+
+			// Insert into database
+			account := models.Account{
+				StakingKey: credential[:],
+				AddedSlot:  slot,
+				Active:     true,
+			}
+			m.db.Create(&account)
+		}
+
+	case common.CertificateTypeStakeVoteRegistrationDelegation:
+		if regCert, ok := cert.(*common.StakeVoteRegistrationDelegationCertificate); ok {
+			credential := regCert.StakeCredential.Credential
+			m.stakeRegistrations[credential] = 0
+			m.govState.RegisterStake(credential)
+
+			// Insert into database
+			account := models.Account{
+				StakingKey: credential[:],
+				AddedSlot:  slot,
+				Active:     true,
+			}
+			m.db.Create(&account)
+		}
+
+	case common.CertificateTypeStakeDeregistration:
+		if deregCert, ok := cert.(*common.StakeDeregistrationCertificate); ok {
+			credential := deregCert.StakeCredential.Credential
+			delete(m.stakeRegistrations, credential)
+			m.govState.DeregisterStake(credential)
+
+			// Update database
+			m.db.Model(&models.Account{}).
+				Where("staking_key = ?", credential[:]).
+				Update("active", false)
+		}
+
+	case common.CertificateTypeDeregistration:
+		if deregCert, ok := cert.(*common.DeregistrationCertificate); ok {
+			credential := deregCert.StakeCredential.Credential
+			delete(m.stakeRegistrations, credential)
+			m.govState.DeregisterStake(credential)
+
+			// Update database
+			m.db.Model(&models.Account{}).
+				Where("staking_key = ?", credential[:]).
+				Update("active", false)
+		}
+
+	case common.CertificateTypePoolRegistration:
+		if poolCert, ok := cert.(*common.PoolRegistrationCertificate); ok {
+			poolId := poolCert.Operator
+			m.poolRegistrations[poolId] = true
+			m.govState.RegisterPool(poolId)
+
+			// Insert or update database
+			var pool models.Pool
+			result := m.db.Where("pool_key_hash = ?", poolId[:]).First(&pool)
+			if result.Error != nil {
+				pool = models.Pool{PoolKeyHash: poolId[:]}
+				m.db.Create(&pool)
+			}
+		}
+
+	case common.CertificateTypePoolRetirement:
+		if retireCert, ok := cert.(*common.PoolRetirementCertificate); ok {
+			poolId := retireCert.PoolKeyHash
+			retireEpoch := retireCert.Epoch
+			m.govState.RetirePool(poolId, retireEpoch)
+
+			// Insert retirement record
+			var pool models.Pool
+			if m.db.Where("pool_key_hash = ?", poolId[:]).First(&pool).Error == nil {
+				retirement := models.PoolRetirement{
+					PoolKeyHash: poolId[:],
+					PoolID:      pool.ID,
+					Epoch:       retireEpoch,
+					AddedSlot:   slot,
+				}
+				m.db.Create(&retirement)
+			}
+		}
+
+	case common.CertificateTypeRegistrationDrep:
+		if drepCert, ok := cert.(*common.RegistrationDrepCertificate); ok {
+			credential := drepCert.DrepCredential.Credential
+			m.drepRegistrations[credential] = true
+			m.govState.RegisterDRep(credential)
+
+			// Insert into database
+			drep := models.Drep{
+				Credential: credential[:],
+				AddedSlot:  slot,
+				Active:     true,
+			}
+			m.db.Create(&drep)
+		}
+
+	case common.CertificateTypeDeregistrationDrep:
+		if drepCert, ok := cert.(*common.DeregistrationDrepCertificate); ok {
+			credential := drepCert.DrepCredential.Credential
+			delete(m.drepRegistrations, credential)
+			m.govState.DeregisterDRep(credential)
+
+			// Update database
+			m.db.Model(&models.Drep{}).
+				Where("credential = ?", credential[:]).
+				Update("active", false)
+		}
+
+	case common.CertificateTypeAuthCommitteeHot:
+		if authCert, ok := cert.(*common.AuthCommitteeHotCertificate); ok {
+			coldKey := authCert.ColdCredential.Credential
+			hotKey := authCert.HotCredential.Credential
+			m.hotKeyAuthorizations[coldKey] = hotKey
+			m.govState.AuthorizeHotKey(coldKey, hotKey)
+
+			// Insert into database
+			auth := models.AuthCommitteeHot{
+				ColdCredential: coldKey[:],
+				HostCredential: hotKey[:],
+				AddedSlot:      slot,
+			}
+			m.db.Create(&auth)
+		}
+
+	case common.CertificateTypeResignCommitteeCold:
+		if resignCert, ok := cert.(*common.ResignCommitteeColdCertificate); ok {
+			coldKey := resignCert.ColdCredential.Credential
+			delete(m.hotKeyAuthorizations, coldKey)
+			m.govState.ResignCommitteeMember(coldKey)
+
+			// Insert into database
+			resign := models.ResignCommitteeCold{
+				ColdCredential: coldKey[:],
+				AddedSlot:      slot,
+			}
+			m.db.Create(&resign)
+		}
+
+	default:
+		// Other certificate types not relevant for state tracking
+	}
+}
+
+// ProcessEpochBoundary implements conformance.StateManager.ProcessEpochBoundary.
+func (m *DingoStateManager) ProcessEpochBoundary(newEpoch uint64) error {
+	m.currentEpoch = newEpoch
+	m.govState.CurrentEpoch = newEpoch
+
+	// Snapshot pool retirements before processing
+	retirementsSnapshot := maps.Clone(m.govState.PoolRetirements)
+
+	// Process pool retirements in governance state
+	m.govState.ProcessPoolRetirements(newEpoch)
+
+	// Update local pool registrations using the snapshot
+	for poolId, retireEpoch := range retirementsSnapshot {
+		if newEpoch >= retireEpoch {
+			delete(m.poolRegistrations, poolId)
+
+			// Delete from database
+			m.db.Where("pool_key_hash = ?", poolId[:]).Delete(&models.Pool{})
+		}
+	}
+
+	// Phase 1: Enact proposals that were ratified in previous epochs
+	var toEnact []string
+	for id, proposal := range m.govState.Proposals {
+		if proposal == nil {
+			continue
+		}
+		if proposal.RatifiedEpoch != nil && newEpoch > *proposal.RatifiedEpoch {
+			toEnact = append(toEnact, id)
+		}
+	}
+
+	// Enact collected proposals
+	for _, id := range toEnact {
+		proposal := m.govState.Proposals[id]
+		if proposal == nil {
+			continue
+		}
+		// Info proposals cannot be enacted
+		if proposal.ActionType == common.GovActionTypeInfo {
+			continue
+		}
+		m.enactProposal(id, proposal)
+	}
+
+	// Phase 2: Ratify proposals that meet threshold requirements
+	m.ratifyProposals(newEpoch)
+
+	// Phase 3: Expire old proposals
+	for id, proposal := range m.govState.Proposals {
+		if proposal == nil {
+			continue
+		}
+		if newEpoch > proposal.ExpiresAfter {
+			delete(m.govState.Proposals, id)
+
+			// Update database
+			m.db.Model(&models.GovernanceProposal{}).
+				Where("tx_hash = ?", parseProposalTxHash(id)).
+				Update("deleted_slot", newEpoch*432000) // Approximate slot
+		}
+	}
+
+	return nil
+}
+
+// ratifyProposals performs simplified proposal ratification.
+func (m *DingoStateManager) ratifyProposals(currentEpoch uint64) {
+	for id, proposal := range m.govState.Proposals {
+		// Skip already-ratified proposals
+		if proposal.RatifiedEpoch != nil {
+			continue
+		}
+
+		// Require at least 1 epoch between submission and ratification
+		if currentEpoch <= proposal.SubmittedEpoch {
+			continue
+		}
+
+		// Info proposals are auto-ratified
+		if proposal.ActionType == common.GovActionTypeInfo {
+			epoch := currentEpoch
+			proposal.RatifiedEpoch = &epoch
+			m.govState.Proposals[id] = proposal
+
+			// Update database
+			m.db.Model(&models.GovernanceProposal{}).
+				Where("tx_hash = ?", parseProposalTxHash(id)).
+				Update("ratified_epoch", currentEpoch)
+			continue
+		}
+
+		// Skip proposals that haven't been voted on
+		if len(proposal.Votes) == 0 {
+			continue
+		}
+
+		// Count YES votes by voter type
+		voterTypesWithYes := make(map[uint8]bool)
+		for voterKey, voteValue := range proposal.Votes {
+			if voteValue != 1 {
+				continue
+			}
+			if len(voterKey) > 0 {
+				voterType := voterKey[0] - '0'
+				voterTypesWithYes[voterType] = true
+			}
+		}
+
+		// Check if required voter types have voted YES
+		hasCC := voterTypesWithYes[0] || voterTypesWithYes[1]
+		hasDRep := voterTypesWithYes[2] || voterTypesWithYes[3]
+		hasSPO := voterTypesWithYes[4] || voterTypesWithYes[5]
+
+		var meetsRequirements bool
+		//exhaustive:ignore
+		switch proposal.ActionType {
+		case common.GovActionTypeNoConfidence,
+			common.GovActionTypeHardForkInitiation:
+			meetsRequirements = hasCC && hasDRep && hasSPO
+		case common.GovActionTypeUpdateCommittee,
+			common.GovActionTypeNewConstitution,
+			common.GovActionTypeParameterChange,
+			common.GovActionTypeTreasuryWithdrawal:
+			meetsRequirements = hasCC && hasDRep
+		default:
+			meetsRequirements = len(voterTypesWithYes) >= 2
+		}
+
+		if !meetsRequirements {
+			continue
+		}
+
+		// Ratify
+		epoch := currentEpoch
+		proposal.RatifiedEpoch = &epoch
+		m.govState.Proposals[id] = proposal
+
+		// Update database
+		m.db.Model(&models.GovernanceProposal{}).
+			Where("tx_hash = ?", parseProposalTxHash(id)).
+			Update("ratified_epoch", currentEpoch)
+	}
+}
+
+// enactProposal processes a ratified proposal.
+func (m *DingoStateManager) enactProposal(
+	id string,
+	proposal *conformance.ProposalState,
+) {
+	//exhaustive:ignore
+	switch proposal.ActionType {
+	case common.GovActionTypeNewConstitution:
+		m.govState.Roots.Constitution = &id
+		if m.govState.Constitution == nil {
+			m.govState.Constitution = &conformance.ConstitutionInfo{}
+		}
+		if len(proposal.PolicyHash) > 0 {
+			m.govState.Constitution.PolicyHash = make(
+				[]byte,
+				len(proposal.PolicyHash),
+			)
+			copy(m.govState.Constitution.PolicyHash, proposal.PolicyHash)
+		} else {
+			m.govState.Constitution.PolicyHash = nil
+		}
+	case common.GovActionTypeParameterChange:
+		m.govState.Roots.ProtocolParameters = &id
+		if proposal.ParameterUpdate != nil {
+			if conwayPP, ok := m.protocolParams.(*conway.ConwayProtocolParameters); ok {
+				conwayPP.Update(proposal.ParameterUpdate)
+			}
+		}
+	case common.GovActionTypeHardForkInitiation:
+		m.govState.Roots.HardFork = &id
+	case common.GovActionTypeNoConfidence, common.GovActionTypeUpdateCommittee:
+		m.govState.Roots.ConstitutionalCommittee = &id
+		if proposal.ActionType == common.GovActionTypeUpdateCommittee {
+			for coldKey, expiry := range proposal.ProposedMembers {
+				m.govState.CommitteeMembers[coldKey] = &conformance.CommitteeMemberInfo{
+					ColdKey:     coldKey,
+					ExpiryEpoch: expiry,
+				}
+				m.committeeMembers[coldKey] = expiry
+			}
+		}
+	}
+
+	// Mark as enacted
+	m.govState.EnactedProposals[id] = true
+	delete(m.govState.Proposals, id)
+
+	// Update database
+	m.db.Model(&models.GovernanceProposal{}).
+		Where("tx_hash = ?", parseProposalTxHash(id)).
+		Update("enacted_epoch", m.currentEpoch)
+}
+
+// GetStateProvider implements conformance.StateManager.GetStateProvider.
+func (m *DingoStateManager) GetStateProvider() conformance.StateProvider {
+	return NewDingoStateProvider(m)
+}
+
+// GetGovernanceState implements conformance.StateManager.GetGovernanceState.
+func (m *DingoStateManager) GetGovernanceState() *conformance.GovernanceState {
+	return m.govState
+}
+
+// SetRewardBalances implements conformance.StateManager.SetRewardBalances.
+func (m *DingoStateManager) SetRewardBalances(
+	balances map[common.Blake2b224]uint64,
+) {
+	for cred, balance := range balances {
+		if _, exists := m.stakeRegistrations[cred]; exists {
+			m.stakeRegistrations[cred] = balance
+		}
+	}
+	if m.govState != nil {
+		for cred, balance := range balances {
+			if m.govState.StakeRegistrations[cred] {
+				m.govState.RewardAccounts[cred] = balance
+			}
+		}
+	}
+}
+
+// GetProtocolParameters implements conformance.StateManager.GetProtocolParameters.
+func (m *DingoStateManager) GetProtocolParameters() common.ProtocolParameters {
+	return m.protocolParams
+}
+
+// Reset implements conformance.StateManager.Reset.
+func (m *DingoStateManager) Reset() error {
+	m.protocolParams = nil
+	m.currentEpoch = 0
+	m.utxos = make(map[string]common.Utxo)
+	m.stakeRegistrations = make(map[common.Blake2b224]uint64)
+	m.poolRegistrations = make(map[common.Blake2b224]bool)
+	m.drepRegistrations = make(map[common.Blake2b224]bool)
+	m.committeeMembers = make(map[common.Blake2b224]uint64)
+	m.hotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
+	m.govState = conformance.NewGovernanceState()
+
+	// Clear database tables
+	return m.clearDatabaseTables()
+}
+
+// clearDatabaseTables clears all relevant database tables.
+func (m *DingoStateManager) clearDatabaseTables() error {
+	tables := []string{
+		"utxo",
+		"account",
+		"pool",
+		"pool_registration",
+		"pool_retirement",
+		"drep",
+		"auth_committee_hot",
+		"resign_committee_cold",
+		"governance_proposal",
+	}
+	for _, table := range tables {
+		if err := m.db.Exec("DELETE FROM " + table).Error; err != nil {
+			// Table might not exist, which is fine
+			continue
+		}
+	}
+	return nil
+}
+
+// proposalToModel converts a governance proposal to a database model.
+func (m *DingoStateManager) proposalToModel(
+	id string,
+	info conformance.GovActionInfo,
+) models.GovernanceProposal {
+	txHash := parseProposalTxHash(id)
+	actionIdx := parseProposalActionIdx(id)
+
+	proposal := models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   actionIdx,
+		ActionType:    uint8(info.ActionType), //nolint:gosec // GovActionType is 0-6
+		ProposedEpoch: info.SubmittedEpoch,
+		ExpiresEpoch:  info.ExpiresAfter,
+		PolicyHash:    info.PolicyHash,
+	}
+
+	if info.ParentActionId != nil {
+		parentTxHash := parseProposalTxHash(*info.ParentActionId)
+		parentIdx := parseProposalActionIdx(*info.ParentActionId)
+		proposal.ParentTxHash = parentTxHash
+		proposal.ParentActionIdx = &parentIdx
+	}
+
+	if info.RatifiedEpoch != nil {
+		proposal.RatifiedEpoch = info.RatifiedEpoch
+	}
+
+	return proposal
+}
+
+// Helper functions
+
+func parseProposalTxHash(id string) []byte {
+	if len(id) < 64 {
+		return nil
+	}
+	hashStr := id[:64]
+	hashBytes, _ := hex.DecodeString(hashStr)
+	return hashBytes
+}
+
+func parseProposalActionIdx(id string) uint32 {
+	if len(id) < 66 {
+		return 0
+	}
+	idxStr := id[65:]
+	var idx uint32
+	_, _ = fmt.Sscanf(idxStr, "%d", &idx)
+	return idx
+}
+
+func getActionType(action common.GovAction) common.GovActionType {
+	switch action.(type) {
+	case *common.HardForkInitiationGovAction:
+		return common.GovActionTypeHardForkInitiation
+	case *common.TreasuryWithdrawalGovAction:
+		return common.GovActionTypeTreasuryWithdrawal
+	case *common.NoConfidenceGovAction:
+		return common.GovActionTypeNoConfidence
+	case *common.UpdateCommitteeGovAction:
+		return common.GovActionTypeUpdateCommittee
+	case *common.NewConstitutionGovAction:
+		return common.GovActionTypeNewConstitution
+	case *common.InfoGovAction:
+		return common.GovActionTypeInfo
+	default:
+		return common.GovActionTypeParameterChange
+	}
+}
+
+func extractActionSpecificData(action common.GovAction, info *conformance.GovActionInfo) {
+	switch ga := action.(type) {
+	case *common.UpdateCommitteeGovAction:
+		if ga.ActionId != nil {
+			key := fmt.Sprintf(
+				"%x#%d",
+				ga.ActionId.TransactionId[:],
+				ga.ActionId.GovActionIdx,
+			)
+			info.ParentActionId = &key
+		}
+		for cred, epoch := range ga.CredEpochs {
+			if cred != nil {
+				info.ProposedMembers[cred.Credential] = uint64(epoch)
+			}
+		}
+	case *common.NoConfidenceGovAction:
+		if ga.ActionId != nil {
+			key := fmt.Sprintf(
+				"%x#%d",
+				ga.ActionId.TransactionId[:],
+				ga.ActionId.GovActionIdx,
+			)
+			info.ParentActionId = &key
+		}
+	case *common.HardForkInitiationGovAction:
+		if ga.ActionId != nil {
+			key := fmt.Sprintf(
+				"%x#%d",
+				ga.ActionId.TransactionId[:],
+				ga.ActionId.GovActionIdx,
+			)
+			info.ParentActionId = &key
+		}
+		info.ProtocolVersion = &conformance.ProtocolVersionInfo{
+			Major: ga.ProtocolVersion.Major,
+			Minor: ga.ProtocolVersion.Minor,
+		}
+	case *common.NewConstitutionGovAction:
+		if ga.ActionId != nil {
+			key := fmt.Sprintf(
+				"%x#%d",
+				ga.ActionId.TransactionId[:],
+				ga.ActionId.GovActionIdx,
+			)
+			info.ParentActionId = &key
+		}
+		if len(ga.Constitution.ScriptHash) > 0 {
+			info.PolicyHash = make([]byte, len(ga.Constitution.ScriptHash))
+			copy(info.PolicyHash, ga.Constitution.ScriptHash)
+		}
+	case *conway.ConwayParameterChangeGovAction:
+		if ga.ActionId != nil {
+			key := fmt.Sprintf(
+				"%x#%d",
+				ga.ActionId.TransactionId[:],
+				ga.ActionId.GovActionIdx,
+			)
+			info.ParentActionId = &key
+		}
+		info.ParameterUpdate = &ga.ParamUpdate
+	}
+}
+
+// dingoTransactionInput implements common.TransactionInput for mock UTxOs.
+type dingoTransactionInput struct {
+	txId  common.Blake2b256
+	index uint32
+}
+
+func (d *dingoTransactionInput) Id() common.Blake2b256 {
+	return d.txId
+}
+
+func (d *dingoTransactionInput) Index() uint32 {
+	return d.index
+}
+
+func (d *dingoTransactionInput) String() string {
+	return fmt.Sprintf("%x#%d", d.txId[:], d.index)
+}
+
+func (d *dingoTransactionInput) Utxorpc() (*utxorpc.TxInput, error) {
+	return &utxorpc.TxInput{
+		TxHash:      d.txId[:],
+		OutputIndex: d.index,
+	}, nil
+}
+
+func (d *dingoTransactionInput) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0,
+		data.NewByteString(d.txId[:]),
+		data.NewInteger(big.NewInt(int64(d.index))),
+	)
+}
+
+// Close closes the database connection.
+func (m *DingoStateManager) Close() error {
+	sqlDB, err := m.db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
+}
+
+// Compile-time interface check
+var _ conformance.StateManager = (*DingoStateManager)(nil)

--- a/internal/test/conformance/state_provider.go
+++ b/internal/test/conformance/state_provider.go
@@ -1,0 +1,382 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+)
+
+// ErrNotFound is returned when a requested item is not found
+var ErrNotFound = errors.New("conformance: not found")
+
+// DingoStateProvider implements conformance.StateProvider by wrapping
+// DingoStateManager to satisfy all gouroboros state interfaces.
+type DingoStateProvider struct {
+	manager *DingoStateManager
+}
+
+// NewDingoStateProvider creates a new DingoStateProvider.
+func NewDingoStateProvider(manager *DingoStateManager) *DingoStateProvider {
+	return &DingoStateProvider{manager: manager}
+}
+
+// ========== common.LedgerState ==========
+
+// NetworkId returns the network identifier
+func (p *DingoStateProvider) NetworkId() uint {
+	// Default to testnet (0) for conformance tests
+	return 0
+}
+
+// CostModels returns the current cost models for Plutus scripts
+func (p *DingoStateProvider) CostModels() map[common.PlutusLanguage]common.CostModel {
+	if p.manager.protocolParams == nil {
+		return make(map[common.PlutusLanguage]common.CostModel)
+	}
+	return extractCostModels(p.manager.protocolParams)
+}
+
+// ========== common.UtxoState ==========
+
+// UtxoById looks up a UTxO by transaction input
+func (p *DingoStateProvider) UtxoById(
+	id common.TransactionInput,
+) (common.Utxo, error) {
+	if id == nil {
+		return common.Utxo{}, ErrNotFound
+	}
+
+	inputId := id.Id()
+	inputIdx := id.Index()
+	utxoId := fmt.Sprintf("%x#%d", inputId.Bytes(), inputIdx)
+
+	if utxo, ok := p.manager.utxos[utxoId]; ok {
+		return utxo, nil
+	}
+	return common.Utxo{}, ErrNotFound
+}
+
+// ========== common.CertState ==========
+
+// StakeRegistration looks up stake registrations by staking key
+func (p *DingoStateProvider) StakeRegistration(
+	stakingKey []byte,
+) ([]common.StakeRegistrationCertificate, error) {
+	// For conformance testing, we track registrations by credential hash
+	// Return empty slice if not found
+	return []common.StakeRegistrationCertificate{}, nil
+}
+
+// IsStakeCredentialRegistered checks if a stake credential is currently registered
+func (p *DingoStateProvider) IsStakeCredentialRegistered(
+	cred common.Credential,
+) bool {
+	_, exists := p.manager.stakeRegistrations[cred.Credential]
+	return exists
+}
+
+// ========== common.SlotState ==========
+
+// SlotToTime converts a slot number to a time
+func (p *DingoStateProvider) SlotToTime(slot uint64) (time.Time, error) {
+	// For conformance testing, use a simple epoch-based calculation
+	// assuming slot 0 = Unix epoch and 1 second per slot
+	//nolint:gosec // G115: slot values in tests won't overflow int64
+	return time.Unix(int64(slot), 0), nil
+}
+
+// TimeToSlot converts a time to a slot number
+func (p *DingoStateProvider) TimeToSlot(t time.Time) (uint64, error) {
+	//nolint:gosec // G115: Unix timestamps won't be negative in tests
+	return uint64(t.Unix()), nil
+}
+
+// ========== common.PoolState ==========
+
+// PoolCurrentState returns the current state of a pool
+func (p *DingoStateProvider) PoolCurrentState(
+	poolKeyHash common.PoolKeyHash,
+) (*common.PoolRegistrationCertificate, *uint64, error) {
+	if p.manager.poolRegistrations[poolKeyHash] {
+		// Check if pool has pending retirement
+		if retireEpoch, retiring := p.manager.govState.PoolRetirements[poolKeyHash]; retiring {
+			return &common.PoolRegistrationCertificate{
+				Operator: poolKeyHash,
+			}, &retireEpoch, nil
+		}
+		return &common.PoolRegistrationCertificate{
+			Operator: poolKeyHash,
+		}, nil, nil
+	}
+	// Also check if pool is pending retirement
+	if retireEpoch, retiring := p.manager.govState.PoolRetirements[poolKeyHash]; retiring {
+		return &common.PoolRegistrationCertificate{
+			Operator: poolKeyHash,
+		}, &retireEpoch, nil
+	}
+	return nil, nil, nil
+}
+
+// IsPoolRegistered checks if a pool is currently registered
+func (p *DingoStateProvider) IsPoolRegistered(
+	poolKeyHash common.PoolKeyHash,
+) bool {
+	if p.manager.poolRegistrations[poolKeyHash] {
+		return true
+	}
+	// Also check pending retirements (pool is still registered until retirement)
+	_, retiring := p.manager.govState.PoolRetirements[poolKeyHash]
+	return retiring
+}
+
+// ========== common.RewardState ==========
+
+// CalculateRewards calculates rewards for the given epoch
+func (p *DingoStateProvider) CalculateRewards(
+	pots common.AdaPots,
+	snapshot common.RewardSnapshot,
+	params common.RewardParameters,
+) (*common.RewardCalculationResult, error) {
+	return common.CalculateRewards(pots, snapshot, params)
+}
+
+// GetAdaPots returns the current ADA pots
+func (p *DingoStateProvider) GetAdaPots() common.AdaPots {
+	return common.AdaPots{}
+}
+
+// UpdateAdaPots updates the ADA pots
+func (p *DingoStateProvider) UpdateAdaPots(pots common.AdaPots) error {
+	return nil
+}
+
+// GetRewardSnapshot returns the stake snapshot for reward calculation
+func (p *DingoStateProvider) GetRewardSnapshot(
+	epoch uint64,
+) (common.RewardSnapshot, error) {
+	return common.RewardSnapshot{}, nil
+}
+
+// IsRewardAccountRegistered checks if a reward account is registered
+func (p *DingoStateProvider) IsRewardAccountRegistered(
+	cred common.Credential,
+) bool {
+	return p.IsStakeCredentialRegistered(cred)
+}
+
+// RewardAccountBalance returns the current reward balance for a stake credential
+func (p *DingoStateProvider) RewardAccountBalance(
+	cred common.Credential,
+) (*uint64, error) {
+	balance, exists := p.manager.stakeRegistrations[cred.Credential]
+	if !exists {
+		return nil, nil
+	}
+	return &balance, nil
+}
+
+// ========== common.GovState ==========
+
+// CommitteeMember looks up a constitutional committee member by credential hash
+func (p *DingoStateProvider) CommitteeMember(
+	coldKey common.Blake2b224,
+) (*common.CommitteeMember, error) {
+	// Check current members first
+	if expiry, ok := p.manager.committeeMembers[coldKey]; ok {
+		member := &common.CommitteeMember{
+			ColdKey:     coldKey,
+			ExpiryEpoch: expiry,
+		}
+		// Add hot key if authorized
+		if hotKey, hasHot := p.manager.hotKeyAuthorizations[coldKey]; hasHot {
+			member.HotKey = &hotKey
+		}
+		return member, nil
+	}
+
+	// Check proposed members from governance state
+	if memberInfo := p.manager.govState.GetCommitteeMember(coldKey); memberInfo != nil {
+		member := &common.CommitteeMember{
+			ColdKey:     coldKey,
+			ExpiryEpoch: memberInfo.ExpiryEpoch,
+			Resigned:    memberInfo.Resigned,
+		}
+		if memberInfo.HotKey != nil {
+			member.HotKey = memberInfo.HotKey
+		}
+		return member, nil
+	}
+
+	// Check if member is proposed in a pending UpdateCommittee action
+	if p.manager.govState.IsProposedCommitteeMember(coldKey) {
+		// Get the expiry from the proposal
+		for _, proposal := range p.manager.govState.Proposals {
+			if proposal.ActionType == common.GovActionTypeUpdateCommittee {
+				if expiry, ok := proposal.ProposedMembers[coldKey]; ok {
+					return &common.CommitteeMember{
+						ColdKey:     coldKey,
+						ExpiryEpoch: expiry,
+					}, nil
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// CommitteeMembers returns all committee members
+func (p *DingoStateProvider) CommitteeMembers() ([]common.CommitteeMember, error) {
+	var members []common.CommitteeMember
+
+	// Add current members
+	for coldKey, expiry := range p.manager.committeeMembers {
+		member := common.CommitteeMember{
+			ColdKey:     coldKey,
+			ExpiryEpoch: expiry,
+		}
+		if hotKey, hasHot := p.manager.hotKeyAuthorizations[coldKey]; hasHot {
+			member.HotKey = &hotKey
+		}
+		members = append(members, member)
+	}
+
+	// Add members from governance state
+	for coldKey, memberInfo := range p.manager.govState.CommitteeMembers {
+		// Skip if already added
+		found := false
+		for _, m := range members {
+			if m.ColdKey == coldKey {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		member := common.CommitteeMember{
+			ColdKey:     coldKey,
+			ExpiryEpoch: memberInfo.ExpiryEpoch,
+			Resigned:    memberInfo.Resigned,
+		}
+		if memberInfo.HotKey != nil {
+			member.HotKey = memberInfo.HotKey
+		}
+		members = append(members, member)
+	}
+
+	return members, nil
+}
+
+// DRepRegistration looks up a DRep registration by credential hash
+func (p *DingoStateProvider) DRepRegistration(
+	credential common.Blake2b224,
+) (*common.DRepRegistration, error) {
+	if p.manager.drepRegistrations[credential] {
+		return &common.DRepRegistration{
+			Credential: credential,
+		}, nil
+	}
+	return nil, nil
+}
+
+// DRepRegistrations returns all DRep registrations
+func (p *DingoStateProvider) DRepRegistrations() ([]common.DRepRegistration, error) {
+	dreps := make([]common.DRepRegistration, 0, len(p.manager.drepRegistrations))
+	for cred := range p.manager.drepRegistrations {
+		dreps = append(dreps, common.DRepRegistration{
+			Credential: cred,
+		})
+	}
+	return dreps, nil
+}
+
+// Constitution returns the current constitution
+func (p *DingoStateProvider) Constitution() (*common.Constitution, error) {
+	return &common.Constitution{}, nil
+}
+
+// TreasuryValue returns the current treasury value
+func (p *DingoStateProvider) TreasuryValue() (uint64, error) {
+	return 0, nil
+}
+
+// GovActionById looks up a governance action by its ID
+func (p *DingoStateProvider) GovActionById(
+	id common.GovActionId,
+) (*common.GovActionState, error) {
+	key := fmt.Sprintf(
+		"%s#%d",
+		hex.EncodeToString(id.TransactionId[:]),
+		id.GovActionIdx,
+	)
+	proposal := p.manager.govState.GetProposal(key)
+	if proposal == nil {
+		return nil, nil
+	}
+	return &common.GovActionState{
+		ActionId:   id,
+		ActionType: proposal.ActionType,
+		ExpirySlot: proposal.ExpiresAfter * 432000, // Approximate: epoch * slots per epoch
+	}, nil
+}
+
+// GovActionExists checks if a governance action exists
+func (p *DingoStateProvider) GovActionExists(id common.GovActionId) bool {
+	state, _ := p.GovActionById(id)
+	return state != nil
+}
+
+// extractCostModels extracts cost models from protocol parameters.
+func extractCostModels(
+	pp common.ProtocolParameters,
+) map[common.PlutusLanguage]common.CostModel {
+	if pp == nil {
+		return nil
+	}
+
+	// Try to get cost models from the protocol parameters
+	type costModelsProvider interface {
+		GetCostModels() map[uint][]int64
+	}
+
+	if provider, ok := pp.(costModelsProvider); ok {
+		models := provider.GetCostModels()
+		if models == nil {
+			return nil
+		}
+		result := make(map[common.PlutusLanguage]common.CostModel)
+		for version := range models {
+			if version > 2 {
+				continue
+			}
+			//nolint:gosec // G115: version is bounds checked above (0-2)
+			plutusLang := common.PlutusLanguage(version + 1)
+			result[plutusLang] = common.CostModel{}
+		}
+		return result
+	}
+
+	return nil
+}
+
+// Compile-time interface check
+var _ conformance.StateProvider = (*DingoStateProvider)(nil)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Amaru ledger rules conformance tests using ouroboros-mock and a new in-memory state manager/provider to exercise UTxO, certificates, and governance flows. Updates dependencies to the latest gouroboros and ouroboros-mock for test vector support.

- **New Features**
  - Added conformance test suite that runs all embedded vectors and an optional summary run.
  - Implemented DingoStateManager (in-memory SQLite) to load initial state, apply transactions (including collateral-only paths), process certificates, proposals, and epoch boundaries.
  - Implemented DingoStateProvider to satisfy ledger state lookups (UTxO, pools, committee, DRep, gov actions), basic reward balance reads, cost models, and slot/time conversions.
  - Persist test state to dingo models (UTxO, accounts, pools, DReps, committee auth, governance proposals) with updates on spends, creations, ratify/enact, and expirations.

- **Dependencies**
  - Upgraded github.com/blinklabs-io/gouroboros to v0.152.2 and github.com/blinklabs-io/ouroboros-mock to v0.9.0.

<sup>Written for commit e183acd83d05a06b242f75d0380a7470a8ec64dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: gouroboros (v0.152.1 → v0.152.2) and ouroboros-mock (v0.7.0 → v0.9.0)

* **Tests**
  * Added conformance testing framework with state management and transaction validation capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->