### PR TITLE
ci(publish): fix windows release tarball

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,9 @@ jobs:
     steps:
       - name: Set RELEASE_TAG
         run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+        shell: bash
       - run: git config --global --add safe.directory $PWD
+        shell: bash
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
         with:
           fetch-depth: 0


### PR DESCRIPTION
Closes #1286 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Windows release tarball creation by aligning shell usage in the publish workflow. Steps now run under bash, ensuring correct tag parsing and git config on Windows runners.

**Bug Fixes**
- Set shell: bash for RELEASE_TAG export and git safe.directory steps in publish.yml.
- Avoids PowerShell parsing issues with ${GITHUB_REF#refs/tags/} and $PWD, unblocking Windows tarball publishing.

<sup>Written for commit 77858c349c6fbba4050fc2bc51e5ef8a1b98c2ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

