### PR TITLE
test: replace sleeps

### DIFF
--- a/connmanager/connection_manager_test.go
+++ b/connmanager/connection_manager_test.go
@@ -126,8 +126,15 @@ func TestConnectionManagerConnError(t *testing.T) {
 				tmpConn.Close()
 			}
 		}
-		// TODO: actually wait for shutdown
-		time.Sleep(5 * time.Second)
+		// Wait for clean shutdown using Stop instead of fixed sleep
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(),
+			10*time.Second,
+		)
+		defer stopCancel()
+		if err := connManager.Stop(stopCtx); err != nil {
+			t.Logf("warning: connection manager stop returned error: %s", err)
+		}
 		return
 	case <-time.After(10 * time.Second):
 		t.Fatalf("did not receive error within timeout")
@@ -181,8 +188,15 @@ func TestConnectionManagerConnClosed(t *testing.T) {
 	)
 	select {
 	case <-doneChan:
-		// TODO: actually wait for shutdown
-		time.Sleep(5 * time.Second)
+		// Wait for clean shutdown using Stop instead of fixed sleep
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(),
+			10*time.Second,
+		)
+		defer stopCancel()
+		if err := connManager.Stop(stopCtx); err != nil {
+			t.Logf("warning: connection manager stop returned error: %s", err)
+		}
 		return
 	case <-time.After(10 * time.Second):
 		t.Fatalf("did not receive error within timeout")

--- a/internal/test/testutil/testutil.go
+++ b/internal/test/testutil/testutil.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides common test helper utilities for the Dingo project.
+// It replaces ad-hoc time.Sleep patterns with deterministic synchronization
+// helpers that make tests faster and more reliable.
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WaitForCondition polls the given condition function until it returns true
+// or the timeout expires. This replaces the common pattern of
+// time.Sleep followed by an assertion check.
+func WaitForCondition(
+	t *testing.T,
+	condition func() bool,
+	timeout time.Duration,
+	msg string,
+) {
+	t.Helper()
+	require.Eventually(
+		t,
+		condition,
+		timeout,
+		10*time.Millisecond,
+		msg,
+	)
+}
+
+// WaitForConditionWithInterval is like WaitForCondition but allows specifying
+// a custom polling interval.
+func WaitForConditionWithInterval(
+	t *testing.T,
+	condition func() bool,
+	timeout time.Duration,
+	interval time.Duration,
+	msg string,
+) {
+	t.Helper()
+	require.Eventually(
+		t,
+		condition,
+		timeout,
+		interval,
+		msg,
+	)
+}
+
+// RequireReceive waits for a value on the given channel or fails the test
+// if the timeout expires. This replaces the common pattern of
+// time.Sleep followed by reading a channel.
+func RequireReceive[T any](
+	t *testing.T,
+	ch <-chan T,
+	timeout time.Duration,
+	msg string,
+) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(timeout):
+		t.Fatalf("timeout waiting for channel receive: %s", msg)
+		var zero T
+		return zero // unreachable
+	}
+}
+
+// RequireNoReceive verifies that no value is received on the given channel
+// within the specified duration. This replaces the pattern of
+// time.Sleep followed by a non-blocking channel read to confirm
+// that nothing was sent.
+func RequireNoReceive[T any](
+	t *testing.T,
+	ch <-chan T,
+	duration time.Duration,
+	msg string,
+) {
+	t.Helper()
+	select {
+	case v := <-ch:
+		t.Fatalf(
+			"unexpected value received on channel: %v: %s",
+			v,
+			msg,
+		)
+	case <-time.After(duration):
+		// Expected: nothing received
+	}
+}

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -775,8 +775,10 @@ func TestDatabaseWorkerPoolInFlightOperations(t *testing.T) {
 		}(resultChan)
 	}
 
-	// Give operations time to queue
-	time.Sleep(20 * time.Millisecond)
+	// Wait for at least one operation to start processing
+	require.Eventually(t, func() bool {
+		return completedCount.Load() > 0
+	}, 5*time.Second, 5*time.Millisecond, "at least one operation should start")
 
 	// Shutdown the pool - this should wait for all operations to complete
 	pool.Shutdown()

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUtxorpc_StartStop(t *testing.T) {
@@ -33,14 +34,13 @@ func TestUtxorpc_StartStop(t *testing.T) {
 		Host:     "127.0.0.1",
 		Port:     0,
 	})
-	if err := u.Start(context.Background()); err != nil {
-		t.Fatalf("failed to start utxorpc: %v", err)
-	}
-	// Brief delay to ensure server is listening
-	time.Sleep(100 * time.Millisecond)
+	err := u.Start(context.Background())
+	require.NoError(t, err, "failed to start utxorpc")
+
+	// Server is already listening after Start returns successfully
+	// (startServer waits internally for startup or error)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := u.Stop(ctx); err != nil {
-		t.Fatalf("failed to stop utxorpc: %v", err)
-	}
+	err = u.Stop(ctx)
+	require.NoError(t, err, "failed to stop utxorpc")
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced fixed sleeps in tests with deterministic waits to reduce flakiness and speed up runs. Introduces shared test helpers and updates tests across subsystems to use polling and clean shutdowns.

- **New Features**
  - Added internal/test/testutil with WaitForCondition, WaitForConditionWithInterval, RequireReceive, and RequireNoReceive.

- **Refactors**
  - Replaced time.Sleep with require.Eventually or channel helpers in chainselection, connmanager, listener, ledger, timer, mempool, peergov, and utxorpc tests.
  - Used Stop(ctx) for connection manager shutdowns instead of fixed delays.
  - Tests now wait for observable conditions (e.g., accept count, event delivery, staleness) before asserting.

<sup>Written for commit 0fa28e2e96a311be9efaff7379247a1a2b0b8017. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by replacing arbitrary timing-based waits with deterministic polling mechanisms across multiple test suites.
  * Introduced standardized test utilities for synchronization and channel assertions, reducing test flakiness and improving consistency.

* **Chores**
  * Improved test infrastructure to support more robust and stable testing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->