### PR TITLE
feat(ledger): tx size validation and exunit budgets

### DIFF
--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"slices"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
@@ -203,6 +204,10 @@ func ValidateTxBabbage(
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
+	}
+	// Validate transaction size against protocol limit
+	if err = ValidateTxSize(tx, tmpPparams.MaxTxSize); err != nil {
+		return err
 	}
 	// Skip script evaluation if TX is marked as not valid
 	if !tx.IsValid() {
@@ -582,6 +587,22 @@ func EvaluateTxBabbage(
 			return 0, lcommon.ExUnits{}, nil, fmt.Errorf("unimplemented script type: %T", tmpScript)
 		}
 	}
-	// TODO: calculate fee based on current TX and calculated ExUnits
-	return 0, retTotalExUnits, retRedeemerExUnits, nil
+	// Calculate fee based on TX size and calculated ExUnits
+	txSize := TxBodySize(tx)
+	var pricesMem, pricesSteps *big.Rat
+	if tmpPparams.ExecutionCosts.MemPrice != nil {
+		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()
+	}
+	if tmpPparams.ExecutionCosts.StepPrice != nil {
+		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
+	}
+	fee := CalculateMinFee(
+		txSize,
+		retTotalExUnits,
+		tmpPparams.MinFeeA,
+		tmpPparams.MinFeeB,
+		pricesMem,
+		pricesSteps,
+	)
+	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"slices"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
@@ -181,6 +182,10 @@ func ValidateTxConway(
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
+	}
+	// Validate transaction size against protocol limit
+	if err = ValidateTxSize(tx, tmpPparams.MaxTxSize); err != nil {
+		return err
 	}
 	// Skip script evaluation if TX is marked as not valid
 	if !tx.IsValid() {
@@ -585,6 +590,22 @@ func EvaluateTxConway(
 			return 0, lcommon.ExUnits{}, nil, fmt.Errorf("unimplemented script type: %T", tmpScript)
 		}
 	}
-	// TODO: calculate fee based on current TX and calculated ExUnits
-	return 0, retTotalExUnits, retRedeemerExUnits, nil
+	// Calculate fee based on TX size and calculated ExUnits
+	txSize := TxBodySize(tx)
+	var pricesMem, pricesSteps *big.Rat
+	if tmpPparams.ExecutionCosts.MemPrice != nil {
+		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()
+	}
+	if tmpPparams.ExecutionCosts.StepPrice != nil {
+		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
+	}
+	fee := CalculateMinFee(
+		txSize,
+		retTotalExUnits,
+		tmpPparams.MinFeeA,
+		tmpPparams.MinFeeB,
+		pricesMem,
+		pricesSteps,
+	)
+	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eras
+
+import (
+	"fmt"
+	"math/big"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// TxBodySize returns the CBOR-serialized size of a
+// transaction in bytes.
+func TxBodySize(tx lcommon.Transaction) uint64 {
+	return uint64(len(tx.Cbor()))
+}
+
+// ValidateTxSize checks that the transaction size does
+// not exceed the protocol parameter maximum.
+func ValidateTxSize(
+	tx lcommon.Transaction,
+	maxTxSize uint,
+) error {
+	size := TxBodySize(tx)
+	if size > uint64(maxTxSize) {
+		return fmt.Errorf(
+			"transaction size %d exceeds maximum %d",
+			size,
+			maxTxSize,
+		)
+	}
+	return nil
+}
+
+// ValidateTxExUnits checks that total execution units
+// do not exceed the protocol parameter per-transaction
+// limits.
+func ValidateTxExUnits(
+	totalExUnits lcommon.ExUnits,
+	maxTxExUnits lcommon.ExUnits,
+) error {
+	if totalExUnits.Memory > maxTxExUnits.Memory {
+		return fmt.Errorf(
+			"transaction memory %d exceeds maximum %d",
+			totalExUnits.Memory,
+			maxTxExUnits.Memory,
+		)
+	}
+	if totalExUnits.Steps > maxTxExUnits.Steps {
+		return fmt.Errorf(
+			"transaction steps %d exceeds maximum %d",
+			totalExUnits.Steps,
+			maxTxExUnits.Steps,
+		)
+	}
+	return nil
+}
+
+// CeilMul computes ceil(rat * value) using integer
+// arithmetic. The rational is represented as num/denom.
+// This avoids floating-point imprecision.
+func CeilMul(num, denom, value *big.Int) uint64 {
+	// product = num * value
+	product := new(big.Int).Mul(num, value)
+	// ceil(product / denom) = (product + denom - 1) / denom
+	one := big.NewInt(1)
+	denomMinusOne := new(big.Int).Sub(denom, one)
+	product.Add(product, denomMinusOne)
+	product.Div(product, denom)
+	return product.Uint64()
+}
+
+// CalculateMinFee computes the minimum fee for a
+// transaction using the Cardano fee formula:
+//
+//	fee = (minFeeA * txSize) + minFeeB + scriptFee
+//
+// where:
+//
+//	scriptFee = ceil(pricesMem * exUnits.Memory)
+//	          + ceil(pricesSteps * exUnits.Steps)
+//
+// All arithmetic uses integer math (big.Int) to match
+// the Haskell reference implementation.
+func CalculateMinFee(
+	txSize uint64,
+	exUnits lcommon.ExUnits,
+	minFeeA uint,
+	minFeeB uint,
+	pricesMem *big.Rat,
+	pricesSteps *big.Rat,
+) uint64 {
+	baseFee := uint64(minFeeA)*txSize + uint64(minFeeB)
+	var scriptFee uint64
+	if pricesMem != nil && pricesSteps != nil {
+		memFee := CeilMul(
+			pricesMem.Num(),
+			pricesMem.Denom(),
+			big.NewInt(exUnits.Memory),
+		)
+		stepFee := CeilMul(
+			pricesSteps.Num(),
+			pricesSteps.Denom(),
+			big.NewInt(exUnits.Steps),
+		)
+		scriptFee = memFee + stepFee
+	}
+	return baseFee + scriptFee
+}

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// TxBodySize returns the CBOR-serialized size of a
+// transaction in bytes.
+func TxBodySize(tx lcommon.Transaction) uint64 {
+	return eras.TxBodySize(tx)
+}
+
+// ValidateTxSize checks that the transaction size does
+// not exceed the protocol parameter maximum.
+func ValidateTxSize(
+	tx lcommon.Transaction,
+	maxTxSize uint,
+) error {
+	return eras.ValidateTxSize(tx, maxTxSize)
+}
+
+// ValidateTxExUnits checks that total execution units
+// do not exceed the protocol parameter per-transaction
+// limits.
+func ValidateTxExUnits(
+	totalExUnits lcommon.ExUnits,
+	maxTxExUnits lcommon.ExUnits,
+) error {
+	return eras.ValidateTxExUnits(
+		totalExUnits,
+		maxTxExUnits,
+	)
+}
+
+// CalculateMinFee computes the minimum fee for a
+// transaction using the Cardano fee formula:
+//
+//	fee = (minFeeA * txSize) + minFeeB + scriptFee
+//
+// where:
+//
+//	scriptFee = ceil(pricesMem * exUnits.Memory)
+//	          + ceil(pricesSteps * exUnits.Steps)
+//
+// All arithmetic uses integer math (big.Int) to match
+// the Haskell reference implementation.
+func CalculateMinFee(
+	txSize uint64,
+	exUnits lcommon.ExUnits,
+	minFeeA uint,
+	minFeeB uint,
+	pricesMem *big.Rat,
+	pricesSteps *big.Rat,
+) uint64 {
+	return eras.CalculateMinFee(
+		txSize,
+		exUnits,
+		minFeeA,
+		minFeeB,
+		pricesMem,
+		pricesSteps,
+	)
+}

--- a/ledger/validation_test.go
+++ b/ledger/validation_test.go
@@ -1,0 +1,382 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"math/big"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTransaction implements lcommon.Transaction for
+// testing. Only the Cbor() method is needed for our
+// validation functions.
+type mockTransaction struct {
+	lcommon.Transaction
+	cbor []byte
+}
+
+func (m *mockTransaction) Cbor() []byte {
+	return m.cbor
+}
+
+func TestTxBodySize(t *testing.T) {
+	tests := []struct {
+		name     string
+		cbor     []byte
+		expected uint64
+	}{
+		{
+			name:     "empty cbor",
+			cbor:     []byte{},
+			expected: 0,
+		},
+		{
+			name:     "small transaction",
+			cbor:     make([]byte, 256),
+			expected: 256,
+		},
+		{
+			name:     "typical transaction",
+			cbor:     make([]byte, 4096),
+			expected: 4096,
+		},
+		{
+			name:     "large transaction",
+			cbor:     make([]byte, 16384),
+			expected: 16384,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := &mockTransaction{cbor: tc.cbor}
+			size := TxBodySize(tx)
+			assert.Equal(
+				t,
+				tc.expected,
+				size,
+			)
+		})
+	}
+}
+
+func TestValidateTxSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		txSize    int
+		maxSize   uint
+		expectErr bool
+	}{
+		{
+			name:      "within limit",
+			txSize:    1000,
+			maxSize:   16384,
+			expectErr: false,
+		},
+		{
+			name:      "exactly at limit",
+			txSize:    16384,
+			maxSize:   16384,
+			expectErr: false,
+		},
+		{
+			name:      "one byte over limit",
+			txSize:    16385,
+			maxSize:   16384,
+			expectErr: true,
+		},
+		{
+			name:      "well over limit",
+			txSize:    32768,
+			maxSize:   16384,
+			expectErr: true,
+		},
+		{
+			name:      "zero size transaction",
+			txSize:    0,
+			maxSize:   16384,
+			expectErr: false,
+		},
+		{
+			name:      "zero max size",
+			txSize:    1,
+			maxSize:   0,
+			expectErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := &mockTransaction{
+				cbor: make([]byte, tc.txSize),
+			}
+			err := ValidateTxSize(tx, tc.maxSize)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(
+					t,
+					err.Error(),
+					"exceeds maximum",
+				)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateTxExUnits(t *testing.T) {
+	tests := []struct {
+		name      string
+		total     lcommon.ExUnits
+		max       lcommon.ExUnits
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "within both limits",
+			total: lcommon.ExUnits{
+				Memory: 100,
+				Steps:  200,
+			},
+			max: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			expectErr: false,
+		},
+		{
+			name: "exactly at both limits",
+			total: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			max: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			expectErr: false,
+		},
+		{
+			name: "memory exceeds limit",
+			total: lcommon.ExUnits{
+				Memory: 1001,
+				Steps:  2000,
+			},
+			max: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			expectErr: true,
+			errMsg:    "memory",
+		},
+		{
+			name: "steps exceeds limit",
+			total: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2001,
+			},
+			max: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			expectErr: true,
+			errMsg:    "steps",
+		},
+		{
+			name: "both exceed limits",
+			total: lcommon.ExUnits{
+				Memory: 1001,
+				Steps:  2001,
+			},
+			max: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			expectErr: true,
+			errMsg:    "memory",
+		},
+		{
+			name: "zero usage",
+			total: lcommon.ExUnits{
+				Memory: 0,
+				Steps:  0,
+			},
+			max: lcommon.ExUnits{
+				Memory: 1000,
+				Steps:  2000,
+			},
+			expectErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTxExUnits(tc.total, tc.max)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(
+					t,
+					err.Error(),
+					tc.errMsg,
+				)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCalculateMinFee(t *testing.T) {
+	tests := []struct {
+		name        string
+		txSize      uint64
+		exUnits     lcommon.ExUnits
+		minFeeA     uint
+		minFeeB     uint
+		pricesMem   *big.Rat
+		pricesSteps *big.Rat
+		expected    uint64
+	}{
+		{
+			name:   "base fee only, no scripts",
+			txSize: 200,
+			exUnits: lcommon.ExUnits{
+				Memory: 0,
+				Steps:  0,
+			},
+			minFeeA:     44,
+			minFeeB:     155381,
+			pricesMem:   nil,
+			pricesSteps: nil,
+			expected:    44*200 + 155381,
+		},
+		{
+			name:   "base fee with zero exunits",
+			txSize: 300,
+			exUnits: lcommon.ExUnits{
+				Memory: 0,
+				Steps:  0,
+			},
+			minFeeA:     44,
+			minFeeB:     155381,
+			pricesMem:   big.NewRat(577, 10000),
+			pricesSteps: big.NewRat(721, 10000000),
+			expected:    44*300 + 155381,
+		},
+		{
+			// Mainnet-like parameters:
+			// minFeeA = 44, minFeeB = 155381
+			// pricesMem = 577/10000 = 0.0577
+			// pricesSteps = 721/10000000 = 0.0000721
+			// txSize = 300, mem = 1000000, steps = 200000000
+			// baseFee = 44*300 + 155381 = 13200 + 155381 = 168581
+			// memFee = ceil(577/10000 * 1000000)
+			//        = ceil(577000000/10000) = ceil(57700) = 57700
+			// stepFee = ceil(721/10000000 * 200000000)
+			//         = ceil(144200000000/10000000)
+			//         = ceil(14420) = 14420
+			// scriptFee = 57700 + 14420 = 72120
+			// total = 168581 + 72120 = 240701
+			name:   "mainnet-like parameters",
+			txSize: 300,
+			exUnits: lcommon.ExUnits{
+				Memory: 1000000,
+				Steps:  200000000,
+			},
+			minFeeA:     44,
+			minFeeB:     155381,
+			pricesMem:   big.NewRat(577, 10000),
+			pricesSteps: big.NewRat(721, 10000000),
+			expected:    240701,
+		},
+		{
+			// Test ceiling behavior:
+			// pricesMem = 1/3, mem = 1
+			// ceil(1/3 * 1) = ceil(1/3) = 1
+			// pricesSteps = 1/3, steps = 1
+			// ceil(1/3 * 1) = ceil(1/3) = 1
+			// scriptFee = 1 + 1 = 2
+			// baseFee = 0*0 + 0 = 0
+			// total = 2
+			name:   "ceiling rounding",
+			txSize: 0,
+			exUnits: lcommon.ExUnits{
+				Memory: 1,
+				Steps:  1,
+			},
+			minFeeA:     0,
+			minFeeB:     0,
+			pricesMem:   big.NewRat(1, 3),
+			pricesSteps: big.NewRat(1, 3),
+			expected:    2,
+		},
+		{
+			// Exact division, no ceiling needed:
+			// pricesMem = 1/2, mem = 4
+			// ceil(1/2 * 4) = ceil(2) = 2
+			// pricesSteps = 1/4, steps = 8
+			// ceil(1/4 * 8) = ceil(2) = 2
+			// scriptFee = 2 + 2 = 4
+			// baseFee = 10*100 + 500 = 1500
+			// total = 1504
+			name:   "exact division",
+			txSize: 100,
+			exUnits: lcommon.ExUnits{
+				Memory: 4,
+				Steps:  8,
+			},
+			minFeeA:     10,
+			minFeeB:     500,
+			pricesMem:   big.NewRat(1, 2),
+			pricesSteps: big.NewRat(1, 4),
+			expected:    1504,
+		},
+		{
+			// Test with zero minFeeA:
+			// baseFee = 0*300 + 155381 = 155381
+			name:   "zero minFeeA",
+			txSize: 300,
+			exUnits: lcommon.ExUnits{
+				Memory: 0,
+				Steps:  0,
+			},
+			minFeeA:     0,
+			minFeeB:     155381,
+			pricesMem:   nil,
+			pricesSteps: nil,
+			expected:    155381,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fee := CalculateMinFee(
+				tc.txSize,
+				tc.exUnits,
+				tc.minFeeA,
+				tc.minFeeB,
+				tc.pricesMem,
+				tc.pricesSteps,
+			)
+			assert.Equal(
+				t,
+				tc.expected,
+				fee,
+				"fee mismatch",
+			)
+		})
+	}
+}


### PR DESCRIPTION
Closes #642 
Closes #641 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds transaction size validation and implements minimum fee calculation based on tx size and execution units for Alonzo, Babbage, and Conway. Introduces shared helpers for size and ex-unit checks with correct integer rounding.

- **New Features**
  - ValidateTx now rejects transactions that exceed protocol MaxTxSize (all three eras).
  - EvaluateTx computes and returns the minimum fee using TxBodySize, minFeeA/B, and execution cost prices (big.Rat) with integer ceil rounding.
  - New helpers: TxBodySize, ValidateTxSize, ValidateTxExUnits, CalculateMinFee (exposed via ledger package).
  - Added unit tests for size limits and fee calculation.

<sup>Written for commit 3ed4ceed86de7a8557e4b61b8d9d842f64a58439. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction size validation now enforced against protocol-defined limits
  * Minimum fee calculations improved to account for transaction size and script execution costs

* **Tests**
  * Added comprehensive unit tests for transaction validation and fee calculation across multiple scenarios and boundary conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->