### PR TITLE
feat(mempool): watermark-based eviction and rejection thresholds

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,6 +53,8 @@ type Config struct {
 	intersectPoints          []ocommon.Point
 	listeners                []ListenerConfig
 	mempoolCapacity          int64
+	evictionWatermark        float64
+	rejectionWatermark       float64
 	outboundSourcePort       uint
 	utxorpcPort              uint
 	networkMagic             uint32
@@ -304,6 +306,30 @@ func WithShutdownTimeout(timeout time.Duration) ConfigOptionFunc {
 func WithMempoolCapacity(capacity int64) ConfigOptionFunc {
 	return func(c *Config) {
 		c.mempoolCapacity = capacity
+	}
+}
+
+// WithEvictionWatermark sets the mempool eviction watermark
+// as a fraction of capacity (0.0-1.0). When a new TX would
+// push the mempool past this fraction, oldest TXs are evicted
+// to make room. Default is 0.90 (90%).
+func WithEvictionWatermark(
+	watermark float64,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.evictionWatermark = watermark
+	}
+}
+
+// WithRejectionWatermark sets the mempool rejection watermark
+// as a fraction of capacity (0.0-1.0). New TXs are rejected
+// when the mempool would exceed this fraction even after
+// eviction. Default is 0.95 (95%).
+func WithRejectionWatermark(
+	watermark float64,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.rejectionWatermark = watermark
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,8 +49,10 @@ func FromContext(ctx context.Context) *Config {
 }
 
 const (
-	DefaultBlobPlugin     = "badger"
-	DefaultMetadataPlugin = "sqlite"
+	DefaultBlobPlugin         = "badger"
+	DefaultMetadataPlugin     = "sqlite"
+	DefaultEvictionWatermark  = 0.90
+	DefaultRejectionWatermark = 0.95
 )
 
 // ErrPluginListRequested is returned when the user requests to list available plugins
@@ -136,6 +138,8 @@ type Config struct {
 	ShutdownTimeout    string  `yaml:"shutdownTimeout"                                               split_words:"true"`
 	Network            string  `yaml:"network"`
 	MempoolCapacity    int64   `yaml:"mempoolCapacity"                                               split_words:"true"`
+	EvictionWatermark  float64 `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
+	RejectionWatermark float64 `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
 	PrivatePort        uint    `yaml:"privatePort"                                                   split_words:"true"`
 	RelayPort          uint    `yaml:"relayPort"          envconfig:"port"`
 	UtxorpcPort        uint    `yaml:"utxorpcPort"                                                   split_words:"true"`
@@ -239,6 +243,8 @@ func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
 
 var globalConfig = &Config{
 	MempoolCapacity:    1048576,
+	EvictionWatermark:  DefaultEvictionWatermark,
+	RejectionWatermark: DefaultRejectionWatermark,
 	BindAddr:           "0.0.0.0",
 	CardanoConfig:      "", // Will be set dynamically based on network
 	DatabasePath:       ".dingo",
@@ -456,6 +462,38 @@ func LoadConfig(configFile string) (*Config, error) {
 				missing,
 			)
 		}
+	}
+
+	// Default unset watermarks. In Go, unset float64 fields are 0,
+	// which is indistinguishable from an explicit 0. We default 0 to
+	// the standard value; the subsequent validation rejects any value
+	// that ends up <= 0 after defaulting.
+	if globalConfig.EvictionWatermark == 0 {
+		globalConfig.EvictionWatermark = DefaultEvictionWatermark
+	}
+	if globalConfig.RejectionWatermark == 0 {
+		globalConfig.RejectionWatermark = DefaultRejectionWatermark
+	}
+	if globalConfig.EvictionWatermark <= 0 ||
+		globalConfig.EvictionWatermark >= 1.0 {
+		return nil, fmt.Errorf(
+			"invalid evictionWatermark: %f (must be in range (0, 1))",
+			globalConfig.EvictionWatermark,
+		)
+	}
+	if globalConfig.RejectionWatermark <= 0 ||
+		globalConfig.RejectionWatermark > 1.0 {
+		return nil, fmt.Errorf(
+			"invalid rejectionWatermark: %f (must be in range (0, 1])",
+			globalConfig.RejectionWatermark,
+		)
+	}
+	if globalConfig.EvictionWatermark >= globalConfig.RejectionWatermark {
+		return nil, fmt.Errorf(
+			"evictionWatermark (%f) must be less than rejectionWatermark (%f)",
+			globalConfig.EvictionWatermark,
+			globalConfig.RejectionWatermark,
+		)
 	}
 
 	// Set default CardanoConfig path based on network if not provided by user

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -134,6 +134,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithBlobPlugin(cfg.BlobPlugin),
 			dingo.WithMetadataPlugin(cfg.MetadataPlugin),
 			dingo.WithMempoolCapacity(cfg.MempoolCapacity),
+			dingo.WithEvictionWatermark(cfg.EvictionWatermark),
+			dingo.WithRejectionWatermark(cfg.RejectionWatermark),
 			dingo.WithNetwork(cfg.Network),
 			dingo.WithCardanoNodeConfig(nodeCfg),
 			dingo.WithListeners(listeners...),

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1577,6 +1577,375 @@ func TestMempool_NextTxIdx_RaceCondition(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// Eviction Tests
+// =============================================================================
+
+// newTestMempoolWithCapacity creates a mempool with the given
+// byte capacity and watermarks for eviction testing.
+func newTestMempoolWithCapacity(
+	t *testing.T,
+	capacity int64,
+	evictionWM float64,
+	rejectionWM float64,
+) *Mempool {
+	t.Helper()
+	return NewMempool(MempoolConfig{
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    capacity,
+		EvictionWatermark:  evictionWM,
+		RejectionWatermark: rejectionWM,
+	})
+}
+
+// addMockTransactionsOfSize adds mock transactions with CBOR
+// data of exactly the given byte size.
+func addMockTransactionsOfSize(
+	t *testing.T,
+	m *Mempool,
+	count int,
+	sizeBytes int,
+) []*MempoolTransaction {
+	t.Helper()
+	txs := make([]*MempoolTransaction, count)
+	m.Lock()
+	m.consumersMutex.Lock()
+	for i := range count {
+		cbor := make([]byte, sizeBytes)
+		tx := &MempoolTransaction{
+			Hash: fmt.Sprintf(
+				"tx-sized-%d", i,
+			),
+			Cbor:     cbor,
+			Type:     uint(conway.EraIdConway),
+			LastSeen: time.Now(),
+		}
+		txs[i] = tx
+		m.transactions = append(m.transactions, tx)
+		m.txByHash[tx.Hash] = tx
+		m.currentSizeBytes += int64(sizeBytes)
+		m.metrics.txsInMempool.Inc()
+		m.metrics.mempoolBytes.Add(
+			float64(sizeBytes),
+		)
+	}
+	m.consumersMutex.Unlock()
+	m.Unlock()
+	return txs
+}
+
+func TestMempool_Eviction_TriggersAtWatermark(t *testing.T) {
+	// Capacity=1000, eviction=0.50, rejection=0.90
+	// Each TX is 100 bytes. Add 5 TXs = 500 bytes (50%).
+	// Adding a 6th TX: newSize = 600 > 500 (eviction).
+	// Eviction target = 500 - 100 = 400 bytes.
+	// Should evict 1 TX (500 -> 400), then add new one.
+	m := newTestMempoolWithCapacity(t, 1000, 0.50, 0.90)
+	defer m.Stop(context.Background())
+
+	addMockTransactionsOfSize(t, m, 5, 100)
+
+	m.RLock()
+	require.Equal(
+		t, 5, len(m.transactions),
+		"should start with 5 TXs",
+	)
+	require.Equal(
+		t, int64(500), m.currentSizeBytes,
+		"should start with 500 bytes",
+	)
+	m.RUnlock()
+
+	// Add a 6th TX of 100 bytes directly to trigger eviction
+	// We add it via internal path to skip CBOR decode
+	m.Lock()
+	m.consumersMutex.Lock()
+	txSize := int64(100)
+	newSize := m.currentSizeBytes + txSize
+	evictionThreshold := int64(
+		float64(m.config.MempoolCapacity) *
+			m.evictionWatermark,
+	)
+	require.Greater(
+		t, newSize, evictionThreshold,
+		"new size should exceed eviction threshold",
+	)
+
+	// Trigger eviction
+	targetBytes := evictionThreshold - txSize
+	m.evictOldest(targetBytes)
+
+	// Verify first TX was evicted
+	require.Equal(
+		t, 4, len(m.transactions),
+		"should have 4 TXs after eviction",
+	)
+	require.Equal(
+		t, int64(400), m.currentSizeBytes,
+		"should have 400 bytes after eviction",
+	)
+	// Oldest TX (tx-sized-0) should be gone
+	_, exists := m.txByHash["tx-sized-0"]
+	require.False(
+		t, exists,
+		"oldest TX should be evicted",
+	)
+	// Second TX should still exist
+	_, exists = m.txByHash["tx-sized-1"]
+	require.True(
+		t, exists,
+		"second TX should still be present",
+	)
+	m.consumersMutex.Unlock()
+	m.Unlock()
+}
+
+func TestMempool_Eviction_OldestTxsEvictedFirst(t *testing.T) {
+	// Capacity=1000, eviction=0.50, rejection=0.90
+	// Add 5 TXs of 100 bytes = 500 bytes (50%).
+	// Evict to targetBytes=200 -> should evict 3 TXs.
+	m := newTestMempoolWithCapacity(t, 1000, 0.50, 0.90)
+	defer m.Stop(context.Background())
+
+	addMockTransactionsOfSize(t, m, 5, 100)
+
+	m.Lock()
+	m.consumersMutex.Lock()
+	m.evictOldest(200)
+
+	// Should have evicted tx-sized-0, tx-sized-1, tx-sized-2
+	require.Equal(
+		t, 2, len(m.transactions),
+		"should have 2 TXs after eviction",
+	)
+	require.Equal(
+		t, int64(200), m.currentSizeBytes,
+		"should have 200 bytes",
+	)
+	// Remaining should be the newest TXs
+	assert.Equal(
+		t, "tx-sized-3", m.transactions[0].Hash,
+	)
+	assert.Equal(
+		t, "tx-sized-4", m.transactions[1].Hash,
+	)
+	m.consumersMutex.Unlock()
+	m.Unlock()
+}
+
+func TestMempool_Rejection_AboveRejectionWatermark(
+	t *testing.T,
+) {
+	// Capacity=1000, eviction=0.50, rejection=0.80
+	// Add 8 TXs of 100 bytes = 800 bytes (80%).
+	// Adding a 9th TX of 100 bytes: newSize = 900 > 800.
+	// 800 = 1000 * 0.80, so the rejection threshold is 800.
+	// newSize 900 > 800 => rejected.
+	m := newTestMempoolWithCapacity(t, 1000, 0.50, 0.80)
+	defer m.Stop(context.Background())
+
+	addMockTransactionsOfSize(t, m, 8, 100)
+
+	// Try to add a TX via the internal path
+	m.Lock()
+	m.consumersMutex.Lock()
+	txSize := int64(100)
+	newSize := m.currentSizeBytes + txSize
+	rejectionThreshold := int64(
+		float64(m.config.MempoolCapacity) *
+			m.rejectionWatermark,
+	)
+	assert.Greater(
+		t, newSize, rejectionThreshold,
+		"new size should exceed rejection threshold",
+	)
+	m.consumersMutex.Unlock()
+	m.Unlock()
+
+	// Verify through AddTransaction with real TX that the
+	// mempool rejects when above rejection watermark.
+	// First, fill to rejection level with appropriately
+	// sized direct adds.
+	// The real test TX is ~171 bytes. With capacity 200
+	// and rejection at 0.80 (160 bytes), a single TX of
+	// 171 bytes already exceeds the threshold.
+	m2 := newTestMempoolWithCapacity(t, 200, 0.50, 0.80)
+	defer m2.Stop(context.Background())
+
+	txBytes := getTestTxBytes(t)
+	err := m2.AddTransaction(
+		uint(conway.EraIdConway), txBytes,
+	)
+	require.Error(
+		t, err,
+		"should reject TX above rejection watermark",
+	)
+	var fullErr *MempoolFullError
+	assert.ErrorAs(
+		t, err, &fullErr,
+		"should be MempoolFullError",
+	)
+}
+
+func TestMempool_Eviction_CounterIncrements(t *testing.T) {
+	m := newTestMempoolWithCapacity(t, 1000, 0.50, 0.90)
+	defer m.Stop(context.Background())
+
+	addMockTransactionsOfSize(t, m, 5, 100)
+
+	// Initial evicted counter should be 0
+	evictedBefore := testutil.ToFloat64(
+		m.metrics.txsEvicted,
+	)
+	assert.Equal(
+		t, float64(0), evictedBefore,
+		"evicted counter should start at 0",
+	)
+
+	// Evict 3 TXs
+	m.Lock()
+	m.consumersMutex.Lock()
+	m.evictOldest(200)
+	m.consumersMutex.Unlock()
+	m.Unlock()
+
+	evictedAfter := testutil.ToFloat64(
+		m.metrics.txsEvicted,
+	)
+	assert.Equal(
+		t, float64(3), evictedAfter,
+		"evicted counter should be 3",
+	)
+}
+
+func TestMempool_DefaultWatermarkValues(t *testing.T) {
+	m := NewMempool(MempoolConfig{
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		EventBus:        event.NewEventBus(nil, nil),
+		PromRegistry:    prometheus.NewRegistry(),
+		Validator:       newMockValidator(),
+		MempoolCapacity: 1024 * 1024,
+	})
+	defer m.Stop(context.Background())
+
+	assert.Equal(
+		t,
+		DefaultEvictionWatermark,
+		m.evictionWatermark,
+		"default eviction watermark should be 0.90",
+	)
+	assert.Equal(
+		t,
+		DefaultRejectionWatermark,
+		m.rejectionWatermark,
+		"default rejection watermark should be 0.95",
+	)
+}
+
+func TestMempool_CustomWatermarkValues(t *testing.T) {
+	m := NewMempool(MempoolConfig{
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    1024 * 1024,
+		EvictionWatermark:  0.75,
+		RejectionWatermark: 0.85,
+	})
+	defer m.Stop(context.Background())
+
+	assert.Equal(
+		t,
+		0.75,
+		m.evictionWatermark,
+		"custom eviction watermark should be 0.75",
+	)
+	assert.Equal(
+		t,
+		0.85,
+		m.rejectionWatermark,
+		"custom rejection watermark should be 0.85",
+	)
+}
+
+func TestMempool_Eviction_NoEvictionBelowWatermark(
+	t *testing.T,
+) {
+	// Capacity=1000, eviction=0.90, rejection=0.95
+	// Add 5 TXs of 100 bytes = 500 bytes (50%).
+	// This is below eviction watermark, so no eviction.
+	m := newTestMempoolWithCapacity(t, 1000, 0.90, 0.95)
+	defer m.Stop(context.Background())
+
+	addMockTransactionsOfSize(t, m, 5, 100)
+
+	m.RLock()
+	require.Equal(
+		t, 5, len(m.transactions),
+	)
+	m.RUnlock()
+
+	// Adding another 100 byte TX: newSize = 600 bytes.
+	// Eviction threshold = 900 bytes.
+	// 600 < 900, so no eviction should happen.
+	m.Lock()
+	m.consumersMutex.Lock()
+	tx := &MempoolTransaction{
+		Hash:     "tx-no-evict",
+		Cbor:     make([]byte, 100),
+		Type:     uint(conway.EraIdConway),
+		LastSeen: time.Now(),
+	}
+	m.transactions = append(m.transactions, tx)
+	m.txByHash[tx.Hash] = tx
+	m.currentSizeBytes += 100
+	m.consumersMutex.Unlock()
+	m.Unlock()
+
+	m.RLock()
+	assert.Equal(
+		t, 6, len(m.transactions),
+		"all TXs should remain (no eviction needed)",
+	)
+	assert.Equal(
+		t, int64(600), m.currentSizeBytes,
+	)
+	m.RUnlock()
+
+	evicted := testutil.ToFloat64(m.metrics.txsEvicted)
+	assert.Equal(
+		t, float64(0), evicted,
+		"no TXs should have been evicted",
+	)
+}
+
+func TestMempool_Eviction_EmptyMempoolSafe(t *testing.T) {
+	// Calling evictOldest on an empty mempool should not panic
+	m := newTestMempoolWithCapacity(t, 1000, 0.50, 0.90)
+	defer m.Stop(context.Background())
+
+	m.Lock()
+	m.consumersMutex.Lock()
+	m.evictOldest(0)
+	m.consumersMutex.Unlock()
+	m.Unlock()
+
+	m.RLock()
+	assert.Equal(
+		t, 0, len(m.transactions),
+	)
+	m.RUnlock()
+}
+
 // TestMempool_RemoveTransaction_ConsumerIndexAdjustment verifies that consumer
 // nextTxIdx is properly adjusted when transactions are removed
 func TestMempool_RemoveTransaction_ConsumerIndexAdjustment(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -229,11 +229,13 @@ func (n *Node) Run(ctx context.Context) error {
 	started = append(started, func() { _ = n.snapshotMgr.Stop() })
 	// Initialize mempool
 	n.mempool = mempool.NewMempool(mempool.MempoolConfig{
-		MempoolCapacity: n.config.mempoolCapacity,
-		Logger:          n.config.logger,
-		EventBus:        n.eventBus,
-		PromRegistry:    n.config.promRegistry,
-		Validator:       n.ledgerState,
+		MempoolCapacity:    n.config.mempoolCapacity,
+		EvictionWatermark:  n.config.evictionWatermark,
+		RejectionWatermark: n.config.rejectionWatermark,
+		Logger:             n.config.logger,
+		EventBus:           n.eventBus,
+		PromRegistry:       n.config.promRegistry,
+		Validator:          n.ledgerState,
 	},
 	)
 	started = append(started, func() { //nolint:contextcheck


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds watermark-based mempool control: evict oldest transactions when near capacity and reject new ones above a higher threshold. Ships safe defaults (0.90/0.95), full config wiring, validation, and a new eviction metric.

- **New Features**
  - Watermarks: evict oldest TXs when a new TX pushes usage past eviction watermark; reject when above rejection watermark. Eviction is batched, publishes remove events, and safely adjusts consumer indexes.
  - Defaults and config: eviction at 0.90, rejection at 0.95; set via YAML (evictionWatermark, rejectionWatermark), env (DINGO_MEMPOOL_EVICTION_WATERMARK, DINGO_MEMPOOL_REJECTION_WATERMARK), or code (WithEvictionWatermark, WithRejectionWatermark). Validates eviction in (0,1), rejection in (0,1], and eviction < rejection; applies defaults when unset.
  - Metrics: added Prometheus counter cardano_node_metrics_txsEvictedNum_int.

- **Migration**
  - No breaking changes; defaults preserve current behavior.
  - To tune, set evictionWatermark/rejectionWatermark via config or env.
  - Optionally add the new eviction metric to dashboards.

<sup>Written for commit 7ce76257bafd0feec24d5dc6c40b134befc3d13f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

