### PR TITLE
feat(ledger): detect hard fork transitions and emit events

### DIFF
--- a/event/hardfork.go
+++ b/event/hardfork.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package event
+
+// HardForkEventType is the event type for hard fork
+// (era transition) events
+const HardForkEventType = EventType("hardfork.transition")
+
+// HardForkEvent is emitted when a hard fork (era transition)
+// occurs at an epoch boundary due to a protocol version change
+type HardForkEvent struct {
+	// Slot is the slot at which the hard fork takes effect
+	Slot uint64
+	// EpochNo is the epoch number where the hard fork occurs
+	EpochNo uint64
+	// FromEra is the era ID before the hard fork
+	FromEra uint
+	// ToEra is the era ID after the hard fork
+	ToEra uint
+	// OldMajorVersion is the protocol major version before
+	OldMajorVersion uint
+	// OldMinorVersion is the protocol minor version before
+	OldMinorVersion uint
+	// NewMajorVersion is the protocol major version after
+	NewMajorVersion uint
+	// NewMinorVersion is the protocol minor version after
+	NewMinorVersion uint
+}

--- a/event/hardfork_test.go
+++ b/event/hardfork_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package event_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHardForkEventType(t *testing.T) {
+	assert.Equal(
+		t,
+		event.EventType("hardfork.transition"),
+		event.HardForkEventType,
+	)
+}
+
+func TestHardForkEventFields(t *testing.T) {
+	evt := event.HardForkEvent{
+		Slot:            432000,
+		EpochNo:         100,
+		FromEra:         5,
+		ToEra:           6,
+		OldMajorVersion: 8,
+		OldMinorVersion: 0,
+		NewMajorVersion: 9,
+		NewMinorVersion: 0,
+	}
+
+	assert.Equal(t, uint64(432000), evt.Slot)
+	assert.Equal(t, uint64(100), evt.EpochNo)
+	assert.Equal(t, uint(5), evt.FromEra)
+	assert.Equal(t, uint(6), evt.ToEra)
+	assert.Equal(t, uint(8), evt.OldMajorVersion)
+	assert.Equal(t, uint(0), evt.OldMinorVersion)
+	assert.Equal(t, uint(9), evt.NewMajorVersion)
+	assert.Equal(t, uint(0), evt.NewMinorVersion)
+}
+
+func TestHardForkEventPublishSubscribe(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	testEvent := event.HardForkEvent{
+		Slot:            432000,
+		EpochNo:         100,
+		FromEra:         5,
+		ToEra:           6,
+		OldMajorVersion: 8,
+		OldMinorVersion: 0,
+		NewMajorVersion: 9,
+		NewMinorVersion: 0,
+	}
+
+	_, subCh := eb.Subscribe(event.HardForkEventType)
+
+	eb.Publish(
+		event.HardForkEventType,
+		event.NewEvent(
+			event.HardForkEventType,
+			testEvent,
+		),
+	)
+
+	select {
+	case evt, ok := <-subCh:
+		require.True(
+			t,
+			ok,
+			"event channel closed unexpectedly",
+		)
+		require.Equal(
+			t,
+			event.HardForkEventType,
+			evt.Type,
+		)
+
+		hfEvent, ok := evt.Data.(event.HardForkEvent)
+		require.True(
+			t,
+			ok,
+			"event data was not HardForkEvent",
+		)
+
+		assert.Equal(t, uint64(432000), hfEvent.Slot)
+		assert.Equal(t, uint64(100), hfEvent.EpochNo)
+		assert.Equal(t, uint(5), hfEvent.FromEra)
+		assert.Equal(t, uint(6), hfEvent.ToEra)
+		assert.Equal(t, uint(8), hfEvent.OldMajorVersion)
+		assert.Equal(t, uint(0), hfEvent.OldMinorVersion)
+		assert.Equal(t, uint(9), hfEvent.NewMajorVersion)
+		assert.Equal(t, uint(0), hfEvent.NewMinorVersion)
+	case <-time.After(1 * time.Second):
+		t.Fatal(
+			"timeout waiting for hard fork event",
+		)
+	}
+}
+
+func TestHardForkEventSubscribeFunc(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	testEvent := event.HardForkEvent{
+		Slot:            86400,
+		EpochNo:         10,
+		FromEra:         4,
+		ToEra:           5,
+		OldMajorVersion: 6,
+		OldMinorVersion: 0,
+		NewMajorVersion: 7,
+		NewMinorVersion: 0,
+	}
+
+	receivedCh := make(chan event.HardForkEvent, 1)
+
+	eb.SubscribeFunc(
+		event.HardForkEventType,
+		func(evt event.Event) {
+			if hfEvent, ok := evt.Data.(event.HardForkEvent); ok {
+				receivedCh <- hfEvent
+			}
+		},
+	)
+
+	eb.Publish(
+		event.HardForkEventType,
+		event.NewEvent(
+			event.HardForkEventType,
+			testEvent,
+		),
+	)
+
+	select {
+	case received := <-receivedCh:
+		assert.Equal(
+			t,
+			testEvent.Slot,
+			received.Slot,
+		)
+		assert.Equal(
+			t,
+			testEvent.EpochNo,
+			received.EpochNo,
+		)
+		assert.Equal(
+			t,
+			testEvent.FromEra,
+			received.FromEra,
+		)
+		assert.Equal(
+			t,
+			testEvent.ToEra,
+			received.ToEra,
+		)
+		assert.Equal(
+			t,
+			testEvent.OldMajorVersion,
+			received.OldMajorVersion,
+		)
+		assert.Equal(
+			t,
+			testEvent.OldMinorVersion,
+			received.OldMinorVersion,
+		)
+		assert.Equal(
+			t,
+			testEvent.NewMajorVersion,
+			received.NewMajorVersion,
+		)
+		assert.Equal(
+			t,
+			testEvent.NewMinorVersion,
+			received.NewMinorVersion,
+		)
+	case <-time.After(1 * time.Second):
+		t.Fatal(
+			"timeout waiting for hard fork event " +
+				"via SubscribeFunc",
+		)
+	}
+}
+
+func TestHardForkEventZeroValues(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	testEvent := event.HardForkEvent{}
+
+	_, subCh := eb.Subscribe(event.HardForkEventType)
+
+	eb.Publish(
+		event.HardForkEventType,
+		event.NewEvent(
+			event.HardForkEventType,
+			testEvent,
+		),
+	)
+
+	select {
+	case evt, ok := <-subCh:
+		require.True(
+			t,
+			ok,
+			"event channel closed unexpectedly",
+		)
+		hfEvent, ok := evt.Data.(event.HardForkEvent)
+		require.True(
+			t,
+			ok,
+			"event data was not HardForkEvent",
+		)
+		assert.Equal(t, uint64(0), hfEvent.Slot)
+		assert.Equal(t, uint64(0), hfEvent.EpochNo)
+		assert.Equal(t, uint(0), hfEvent.FromEra)
+		assert.Equal(t, uint(0), hfEvent.ToEra)
+		assert.Equal(t, uint(0), hfEvent.OldMajorVersion)
+		assert.Equal(t, uint(0), hfEvent.OldMinorVersion)
+		assert.Equal(t, uint(0), hfEvent.NewMajorVersion)
+		assert.Equal(t, uint(0), hfEvent.NewMinorVersion)
+	case <-time.After(1 * time.Second):
+		t.Fatal(
+			"timeout waiting for zero-value " +
+				"hard fork event",
+		)
+	}
+}

--- a/ledger/protocol_version.go
+++ b/ledger/protocol_version.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// Compile-time check: allegra.AllegraProtocolParameters is
+// currently a type alias for shelley.ShelleyProtocolParameters
+// in gouroboros, so the Shelley case in GetProtocolVersion
+// handles Allegra as well. If this alias is ever changed to a
+// distinct type, this assignment will fail to compile,
+// reminding us to add an explicit Allegra case.
+var _ *shelley.ShelleyProtocolParameters = (*allegra.AllegraProtocolParameters)(nil)
+
+// ProtocolVersion represents the major and minor protocol
+// version numbers used in Cardano protocol parameters.
+type ProtocolVersion struct {
+	Major uint
+	Minor uint
+}
+
+// GetProtocolVersion extracts the protocol version from
+// protocol parameters. This works across all eras by type-
+// switching on the concrete pparams type.
+// Returns an error if the pparams type is not recognized or
+// nil.
+func GetProtocolVersion(
+	pparams lcommon.ProtocolParameters,
+) (ProtocolVersion, error) {
+	if pparams == nil {
+		return ProtocolVersion{}, errors.New("protocol parameters are nil")
+	}
+	switch pp := pparams.(type) {
+	case *shelley.ShelleyProtocolParameters:
+		// Also covers Allegra (protocol version 3):
+		// allegra.AllegraProtocolParameters is a type alias
+		// (=) for shelley.ShelleyProtocolParameters in
+		// gouroboros, so both resolve to this case. The
+		// compile-time assertion above guards against the
+		// alias being changed to a distinct type.
+		return ProtocolVersion{
+			Major: pp.ProtocolMajor,
+			Minor: pp.ProtocolMinor,
+		}, nil
+	case *mary.MaryProtocolParameters:
+		return ProtocolVersion{
+			Major: pp.ProtocolMajor,
+			Minor: pp.ProtocolMinor,
+		}, nil
+	case *alonzo.AlonzoProtocolParameters:
+		return ProtocolVersion{
+			Major: pp.ProtocolMajor,
+			Minor: pp.ProtocolMinor,
+		}, nil
+	case *babbage.BabbageProtocolParameters:
+		return ProtocolVersion{
+			Major: pp.ProtocolMajor,
+			Minor: pp.ProtocolMinor,
+		}, nil
+	case *conway.ConwayProtocolParameters:
+		return ProtocolVersion{
+			Major: pp.ProtocolVersion.Major,
+			Minor: pp.ProtocolVersion.Minor,
+		}, nil
+	default:
+		return ProtocolVersion{}, fmt.Errorf(
+			"unsupported protocol parameters type: %T",
+			pparams,
+		)
+	}
+}
+
+// EraForVersion returns the era ID for a given protocol
+// major version using the ProtocolMajorVersionToEra map in
+// ledger/eras/. Returns false if the version is not mapped.
+func EraForVersion(majorVersion uint) (uint, bool) {
+	eraDesc, ok := eras.ProtocolMajorVersionToEra[majorVersion]
+	if !ok {
+		return 0, false
+	}
+	return eraDesc.Id, true
+}
+
+// IsHardForkTransition returns true if the new protocol
+// version triggers an era change compared to the old version.
+func IsHardForkTransition(
+	oldVersion, newVersion ProtocolVersion,
+) bool {
+	oldEra, oldOk := EraForVersion(oldVersion.Major)
+	newEra, newOk := EraForVersion(newVersion.Major)
+	if !oldOk || !newOk {
+		return false
+	}
+	return newEra != oldEra
+}

--- a/ledger/protocol_version_test.go
+++ b/ledger/protocol_version_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProtocolVersion_Shelley(t *testing.T) {
+	pp := &shelley.ShelleyProtocolParameters{
+		ProtocolMajor: 2,
+		ProtocolMinor: 0,
+	}
+	pv, err := GetProtocolVersion(pp)
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), pv.Major)
+	assert.Equal(t, uint(0), pv.Minor)
+}
+
+func TestGetProtocolVersion_Allegra(t *testing.T) {
+	// allegra.AllegraProtocolParameters is a type alias for
+	// shelley.ShelleyProtocolParameters, so Allegra pparams
+	// are handled by the Shelley case in the type switch.
+	pp := &allegra.AllegraProtocolParameters{
+		ProtocolMajor: 3,
+		ProtocolMinor: 0,
+	}
+	pv, err := GetProtocolVersion(pp)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), pv.Major)
+	assert.Equal(t, uint(0), pv.Minor)
+}
+
+func TestGetProtocolVersion_Mary(t *testing.T) {
+	pp := &mary.MaryProtocolParameters{
+		ProtocolMajor: 4,
+		ProtocolMinor: 0,
+	}
+	pv, err := GetProtocolVersion(pp)
+	require.NoError(t, err)
+	assert.Equal(t, uint(4), pv.Major)
+	assert.Equal(t, uint(0), pv.Minor)
+}
+
+func TestGetProtocolVersion_Alonzo(t *testing.T) {
+	pp := &alonzo.AlonzoProtocolParameters{
+		ProtocolMajor: 6,
+		ProtocolMinor: 0,
+	}
+	pv, err := GetProtocolVersion(pp)
+	require.NoError(t, err)
+	assert.Equal(t, uint(6), pv.Major)
+	assert.Equal(t, uint(0), pv.Minor)
+}
+
+func TestGetProtocolVersion_Babbage(t *testing.T) {
+	pp := &babbage.BabbageProtocolParameters{
+		ProtocolMajor: 8,
+		ProtocolMinor: 0,
+	}
+	pv, err := GetProtocolVersion(pp)
+	require.NoError(t, err)
+	assert.Equal(t, uint(8), pv.Major)
+	assert.Equal(t, uint(0), pv.Minor)
+}
+
+func TestGetProtocolVersion_Conway(t *testing.T) {
+	pp := &conway.ConwayProtocolParameters{
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 9,
+			Minor: 0,
+		},
+	}
+	pv, err := GetProtocolVersion(pp)
+	require.NoError(t, err)
+	assert.Equal(t, uint(9), pv.Major)
+	assert.Equal(t, uint(0), pv.Minor)
+}
+
+func TestGetProtocolVersion_Nil(t *testing.T) {
+	_, err := GetProtocolVersion(nil)
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"protocol parameters are nil",
+	)
+}
+
+func TestEraForVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		majorVersion  uint
+		expectedEraId uint
+		expectedOk    bool
+	}{
+		{
+			name:          "Byron version 0",
+			majorVersion:  0,
+			expectedEraId: 0,
+			expectedOk:    true,
+		},
+		{
+			name:          "Byron version 1",
+			majorVersion:  1,
+			expectedEraId: 0,
+			expectedOk:    true,
+		},
+		{
+			name:          "Shelley version 2",
+			majorVersion:  2,
+			expectedEraId: 1,
+			expectedOk:    true,
+		},
+		{
+			name:          "Allegra version 3",
+			majorVersion:  3,
+			expectedEraId: 2,
+			expectedOk:    true,
+		},
+		{
+			name:          "Mary version 4",
+			majorVersion:  4,
+			expectedEraId: 3,
+			expectedOk:    true,
+		},
+		{
+			name:          "Alonzo version 5",
+			majorVersion:  5,
+			expectedEraId: 4,
+			expectedOk:    true,
+		},
+		{
+			name:          "Alonzo version 6",
+			majorVersion:  6,
+			expectedEraId: 4,
+			expectedOk:    true,
+		},
+		{
+			name:          "Babbage version 7",
+			majorVersion:  7,
+			expectedEraId: 5,
+			expectedOk:    true,
+		},
+		{
+			name:          "Babbage version 8",
+			majorVersion:  8,
+			expectedEraId: 5,
+			expectedOk:    true,
+		},
+		{
+			name:          "Conway version 9",
+			majorVersion:  9,
+			expectedEraId: 6,
+			expectedOk:    true,
+		},
+		{
+			name:          "Conway version 10",
+			majorVersion:  10,
+			expectedEraId: 6,
+			expectedOk:    true,
+		},
+		{
+			name:         "Unknown version 99",
+			majorVersion: 99,
+			expectedOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eraId, ok := EraForVersion(tt.majorVersion)
+			assert.Equal(t, tt.expectedOk, ok)
+			if tt.expectedOk {
+				assert.Equal(
+					t,
+					tt.expectedEraId,
+					eraId,
+				)
+			}
+		})
+	}
+}
+
+func TestIsHardForkTransition(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      ProtocolVersion
+		new      ProtocolVersion
+		expected bool
+	}{
+		{
+			name:     "same version no transition",
+			old:      ProtocolVersion{Major: 8, Minor: 0},
+			new:      ProtocolVersion{Major: 8, Minor: 0},
+			expected: false,
+		},
+		{
+			name:     "minor version change only",
+			old:      ProtocolVersion{Major: 8, Minor: 0},
+			new:      ProtocolVersion{Major: 8, Minor: 1},
+			expected: false,
+		},
+		{
+			name:     "Babbage to Conway transition",
+			old:      ProtocolVersion{Major: 8, Minor: 0},
+			new:      ProtocolVersion{Major: 9, Minor: 0},
+			expected: true,
+		},
+		{
+			name:     "Alonzo to Babbage transition",
+			old:      ProtocolVersion{Major: 6, Minor: 0},
+			new:      ProtocolVersion{Major: 7, Minor: 0},
+			expected: true,
+		},
+		{
+			name:     "intra-era Alonzo version bump",
+			old:      ProtocolVersion{Major: 5, Minor: 0},
+			new:      ProtocolVersion{Major: 6, Minor: 0},
+			expected: false,
+		},
+		{
+			name:     "intra-era Babbage version bump",
+			old:      ProtocolVersion{Major: 7, Minor: 0},
+			new:      ProtocolVersion{Major: 8, Minor: 0},
+			expected: false,
+		},
+		{
+			name:     "intra-era Conway version bump",
+			old:      ProtocolVersion{Major: 9, Minor: 0},
+			new:      ProtocolVersion{Major: 10, Minor: 0},
+			expected: false,
+		},
+		{
+			name:     "Shelley to Allegra transition",
+			old:      ProtocolVersion{Major: 2, Minor: 0},
+			new:      ProtocolVersion{Major: 3, Minor: 0},
+			expected: true,
+		},
+		{
+			name:     "unknown old version",
+			old:      ProtocolVersion{Major: 99, Minor: 0},
+			new:      ProtocolVersion{Major: 9, Minor: 0},
+			expected: false,
+		},
+		{
+			name:     "unknown new version",
+			old:      ProtocolVersion{Major: 9, Minor: 0},
+			new:      ProtocolVersion{Major: 99, Minor: 0},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsHardForkTransition(tt.old, tt.new)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detection and event emission for hard fork (era) transitions. Consumers can subscribe to hardfork.transition for slot, epoch, from/to era, and old/new protocol versions; duplicates are skipped when both pparam and block paths detect the same transition.

- **New Features**
  - Detect protocol major version changes at epoch rollover; map to eras and record via HardForkInfo.
  - Emit hardfork.transition events for epoch-rollover and block-led era changes (slot, epoch, from/to era, old/new major/minor); avoid duplicate emissions across paths.
  - Add GetProtocolVersion, EraForVersion, and IsHardForkTransition helpers with tests; define event type and publish/subscribe tests.

<sup>Written for commit 313dfd26ffefbf87bf09d2b62bb6dab1b797f492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and reports hard-fork transitions during epoch/era rollovers, including old/new protocol versions, era boundaries, slot and epoch context.
  * Emits structured hard-fork events on protocol updates and era changes so consumers can react to transitions.
  * Logs informative messages about detected transitions.

* **Tests**
  * Added comprehensive tests validating protocol version extraction, hard-fork detection, event emission, and publish/subscribe handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->