### PR TITLE
feat(ledger): Byron era transaction validation

### DIFF
--- a/ledger/eras/byron.go
+++ b/ledger/eras/byron.go
@@ -16,15 +16,19 @@ package eras
 
 import (
 	"errors"
+	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 var ByronEraDesc = EraDesc{
 	Id:              byron.EraIdByron,
 	Name:            byron.EraNameByron,
 	EpochLengthFunc: EpochLengthByron,
+	ValidateTxFunc:  ValidateTxByron,
 }
 
 func EpochLengthByron(
@@ -39,4 +43,277 @@ func EpochLengthByron(
 	return uint(byronGenesis.BlockVersionData.SlotDuration),
 		uint(byronGenesis.ProtocolConsts.K * 10),
 		nil
+}
+
+// Byron validation error types
+
+// InputSetEmptyByronError is returned when a Byron transaction
+// has no inputs.
+type InputSetEmptyByronError struct{}
+
+func (InputSetEmptyByronError) Error() string {
+	return "transaction has no inputs"
+}
+
+// OutputSetEmptyByronError is returned when a Byron transaction
+// has no outputs.
+type OutputSetEmptyByronError struct{}
+
+func (OutputSetEmptyByronError) Error() string {
+	return "transaction has no outputs"
+}
+
+// OutputNotPositiveByronError is returned when a Byron transaction
+// output has a non-positive value.
+type OutputNotPositiveByronError struct {
+	Index  int
+	Amount *big.Int
+}
+
+func (e OutputNotPositiveByronError) Error() string {
+	return fmt.Sprintf(
+		"output %d has non-positive value: %s",
+		e.Index,
+		e.Amount.String(),
+	)
+}
+
+// DuplicateInputByronError is returned when a Byron transaction
+// contains duplicate inputs.
+type DuplicateInputByronError struct {
+	TxId  string
+	Index uint32
+}
+
+func (e DuplicateInputByronError) Error() string {
+	return fmt.Sprintf(
+		"duplicate input: %s#%d",
+		e.TxId,
+		e.Index,
+	)
+}
+
+// BadInputsByronError is returned when a Byron transaction
+// references inputs that do not exist in the UTxO set.
+type BadInputsByronError struct {
+	Inputs []lcommon.TransactionInput
+}
+
+func (e BadInputsByronError) Error() string {
+	return fmt.Sprintf(
+		"inputs not found in UTxO set: %d bad input(s)",
+		len(e.Inputs),
+	)
+}
+
+// ValueNotConservedByronError is returned when a Byron
+// transaction's consumed value does not equal its produced
+// value plus fee (sum of inputs != sum of outputs + fee).
+type ValueNotConservedByronError struct {
+	Consumed *big.Int
+	Produced *big.Int
+}
+
+func (e ValueNotConservedByronError) Error() string {
+	return fmt.Sprintf(
+		"value not conserved: consumed %s != produced %s",
+		e.Consumed.String(),
+		e.Produced.String(),
+	)
+}
+
+// ValidateTxByron performs structural and UTxO-aware
+// validation on Byron transactions. Structural rules always
+// run. UTxO-aware rules (input existence, value conservation,
+// witness signatures) run when a LedgerState is provided.
+func ValidateTxByron(
+	tx lcommon.Transaction,
+	slot uint64,
+	ls lcommon.LedgerState,
+	pp lcommon.ProtocolParameters,
+) error {
+	errs := make([]error, 0)
+	// Structural rules (no ledger state needed)
+	for _, validationFunc := range byronValidationRules {
+		errs = append(
+			errs,
+			validationFunc(tx),
+		)
+	}
+	// UTxO-aware rules (require ledger state)
+	if ls != nil {
+		for _, validationFunc := range byronUtxoValidationRules {
+			errs = append(
+				errs,
+				validationFunc(tx, slot, ls, pp),
+			)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// byronValidationRuleFunc is a function that validates a Byron
+// transaction against a specific structural rule.
+type byronValidationRuleFunc func(tx lcommon.Transaction) error
+
+var byronValidationRules = []byronValidationRuleFunc{
+	byronValidateInputsNotEmpty,
+	byronValidateOutputsNotEmpty,
+	byronValidateOutputsPositive,
+	byronValidateNoDuplicateInputs,
+}
+
+// byronUtxoValidationRules require ledger state and run only
+// when a LedgerState is provided.
+var byronUtxoValidationRules = []lcommon.UtxoValidationRuleFunc{
+	byronValidateBadInputs,
+	byronValidateValueConserved,
+	byronValidateWitnesses,
+}
+
+// byronValidateInputsNotEmpty ensures that the transaction has at
+// least one input.
+func byronValidateInputsNotEmpty(
+	tx lcommon.Transaction,
+) error {
+	if len(tx.Inputs()) == 0 {
+		return InputSetEmptyByronError{}
+	}
+	return nil
+}
+
+// byronValidateOutputsNotEmpty ensures that the transaction has at
+// least one output.
+func byronValidateOutputsNotEmpty(
+	tx lcommon.Transaction,
+) error {
+	if len(tx.Outputs()) == 0 {
+		return OutputSetEmptyByronError{}
+	}
+	return nil
+}
+
+// byronValidateOutputsPositive ensures that all outputs have
+// positive values.
+func byronValidateOutputsPositive(
+	tx lcommon.Transaction,
+) error {
+	zero := new(big.Int)
+	for i, output := range tx.Outputs() {
+		amount := output.Amount()
+		if amount == nil || amount.Cmp(zero) <= 0 {
+			if amount == nil {
+				amount = new(big.Int)
+			}
+			return OutputNotPositiveByronError{
+				Index:  i,
+				Amount: amount,
+			}
+		}
+	}
+	return nil
+}
+
+// byronValidateNoDuplicateInputs ensures that there are no
+// duplicate inputs in the transaction.
+func byronValidateNoDuplicateInputs(
+	tx lcommon.Transaction,
+) error {
+	seen := make(map[string]struct{})
+	for _, input := range tx.Inputs() {
+		key := fmt.Sprintf("%s#%d", input.Id(), input.Index())
+		if _, exists := seen[key]; exists {
+			return DuplicateInputByronError{
+				TxId:  input.Id().String(),
+				Index: input.Index(),
+			}
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+// byronValidateBadInputs ensures that all inputs reference
+// UTxOs that exist in the ledger state.
+func byronValidateBadInputs(
+	tx lcommon.Transaction,
+	_ uint64,
+	ls lcommon.LedgerState,
+	_ lcommon.ProtocolParameters,
+) error {
+	var badInputs []lcommon.TransactionInput
+	for _, input := range tx.Inputs() {
+		if _, err := ls.UtxoById(input); err != nil {
+			badInputs = append(badInputs, input)
+		}
+	}
+	if len(badInputs) == 0 {
+		return nil
+	}
+	return BadInputsByronError{Inputs: badInputs}
+}
+
+// byronValidateValueConserved ensures that the consumed value
+// (sum of input UTxO amounts) equals the produced value (sum
+// of output amounts). In Byron the fee is implicit: it is the
+// difference between consumed and produced. We verify that
+// consumed >= produced (i.e. the implicit fee is non-negative).
+func byronValidateValueConserved(
+	tx lcommon.Transaction,
+	_ uint64,
+	ls lcommon.LedgerState,
+	_ lcommon.ProtocolParameters,
+) error {
+	consumed := new(big.Int)
+	for _, input := range tx.Inputs() {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			// Bad inputs are caught by byronValidateBadInputs
+			continue
+		}
+		if utxo.Output == nil {
+			continue
+		}
+		if amount := utxo.Output.Amount(); amount != nil {
+			consumed.Add(consumed, amount)
+		}
+	}
+	produced := new(big.Int)
+	for _, output := range tx.Outputs() {
+		if amount := output.Amount(); amount != nil {
+			produced.Add(produced, amount)
+		}
+	}
+	// In Byron the fee is implicit (consumed - produced).
+	// Consumed must be >= produced for a valid transaction.
+	if consumed.Cmp(produced) < 0 {
+		return ValueNotConservedByronError{
+			Consumed: consumed,
+			Produced: produced,
+		}
+	}
+	return nil
+}
+
+// byronValidateWitnesses verifies the cryptographic
+// signatures on vkey and bootstrap witnesses.
+func byronValidateWitnesses(
+	tx lcommon.Transaction,
+	_ uint64,
+	ls lcommon.LedgerState,
+	_ lcommon.ProtocolParameters,
+) error {
+	// Verify vkey witness signatures
+	if err := lcommon.ValidateVKeyWitnesses(tx); err != nil {
+		return err
+	}
+	// Verify bootstrap witness signatures
+	if err := lcommon.ValidateBootstrapWitnesses(tx); err != nil {
+		return err
+	}
+	// Verify each input has a matching witness
+	if err := lcommon.ValidateInputVKeyWitnesses(tx, ls); err != nil {
+		return err
+	}
+	return nil
 }

--- a/ledger/eras/byron_test.go
+++ b/ledger/eras/byron_test.go
@@ -1,0 +1,693 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// testInput implements lcommon.TransactionInput for testing.
+type testInput struct {
+	txId  lcommon.Blake2b256
+	index uint32
+}
+
+func (i testInput) Id() lcommon.Blake2b256             { return i.txId }
+func (i testInput) Index() uint32                      { return i.index }
+func (i testInput) String() string                     { return fmt.Sprintf("%s#%d", i.txId, i.index) }
+func (i testInput) MarshalJSON() ([]byte, error)       { return []byte(`"` + i.String() + `"`), nil }
+func (i testInput) Utxorpc() (*utxorpc.TxInput, error) { return &utxorpc.TxInput{}, nil }
+func (i testInput) ToPlutusData() data.PlutusData      { return data.NewConstr(0) }
+
+// testOutput implements lcommon.TransactionOutput for testing.
+type testOutput struct {
+	amount *big.Int
+}
+
+func (o testOutput) Address() lcommon.Address                                  { return lcommon.Address{} }
+func (o testOutput) Amount() *big.Int                                          { return o.amount }
+func (o testOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] { return nil }
+func (o testOutput) Datum() *lcommon.Datum                                     { return nil }
+func (o testOutput) DatumHash() *lcommon.Blake2b256                            { return nil }
+func (o testOutput) Cbor() []byte                                              { return nil }
+func (o testOutput) Utxorpc() (*utxorpc.TxOutput, error)                       { return &utxorpc.TxOutput{}, nil }
+func (o testOutput) ScriptRef() lcommon.Script                                 { return nil }
+func (o testOutput) ToPlutusData() data.PlutusData                             { return data.NewConstr(0) }
+func (o testOutput) String() string                                            { return "testOutput" }
+
+func newTestInput(hashByte byte, index uint32) testInput {
+	var hash lcommon.Blake2b256
+	hash[0] = hashByte
+	return testInput{txId: hash, index: index}
+}
+
+func newTestOutput(amount uint64) testOutput {
+	return testOutput{amount: new(big.Int).SetUint64(amount)}
+}
+
+// testByronTx wraps byron.ByronTransaction to override
+// Inputs() and Outputs() for testing.
+type testByronTx struct {
+	byron.ByronTransaction
+	inputs  []lcommon.TransactionInput
+	outputs []lcommon.TransactionOutput
+}
+
+func (t *testByronTx) Inputs() []lcommon.TransactionInput {
+	return t.inputs
+}
+
+func (t *testByronTx) Outputs() []lcommon.TransactionOutput {
+	return t.outputs
+}
+
+func TestValidateTxByron_ValidTransaction(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxByron_ValidMultipleInputsOutputs(
+	t *testing.T,
+) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+			newTestInput(0x02, 0),
+			newTestInput(0x03, 1),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(500_000),
+			newTestOutput(300_000),
+			newTestOutput(200_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxByron_EmptyInputs(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &InputSetEmptyByronError{})
+	assert.Contains(t, err.Error(), "no inputs")
+}
+
+func TestValidateTxByron_NilInputs(t *testing.T) {
+	tx := &testByronTx{
+		inputs: nil,
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &InputSetEmptyByronError{})
+}
+
+func TestValidateTxByron_EmptyOutputs(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &OutputSetEmptyByronError{})
+	assert.Contains(t, err.Error(), "no outputs")
+}
+
+func TestValidateTxByron_NilOutputs(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: nil,
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &OutputSetEmptyByronError{})
+}
+
+func TestValidateTxByron_ZeroValueOutput(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(0),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &OutputNotPositiveByronError{})
+	assert.Contains(t, err.Error(), "non-positive value")
+}
+
+func TestValidateTxByron_NegativeValueOutput(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			testOutput{amount: big.NewInt(-100)},
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &OutputNotPositiveByronError{})
+}
+
+func TestValidateTxByron_NilAmountOutput(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			testOutput{amount: nil},
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &OutputNotPositiveByronError{})
+}
+
+func TestValidateTxByron_DuplicateInputs(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+			newTestInput(0x01, 0), // duplicate
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &DuplicateInputByronError{})
+	assert.Contains(t, err.Error(), "duplicate input")
+}
+
+func TestValidateTxByron_SameTxDifferentIndex(t *testing.T) {
+	// Same transaction hash but different output indices
+	// should be valid
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+			newTestInput(0x01, 1),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxByron_MultipleErrors(t *testing.T) {
+	// Empty inputs AND empty outputs should both be reported
+	tx := &testByronTx{
+		inputs:  []lcommon.TransactionInput{},
+		outputs: []lcommon.TransactionOutput{},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &InputSetEmptyByronError{})
+	assert.ErrorAs(t, err, &OutputSetEmptyByronError{})
+}
+
+func TestValidateTxByron_SecondOutputZeroValue(t *testing.T) {
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+			newTestOutput(0), // second output is zero
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &OutputNotPositiveByronError{})
+}
+
+func TestByronEraDesc_HasValidateTxFunc(t *testing.T) {
+	assert.NotNil(
+		t,
+		ByronEraDesc.ValidateTxFunc,
+		"ByronEraDesc should have ValidateTxFunc set",
+	)
+}
+
+// --- Mock LedgerState for UTxO-aware tests ---
+
+// errUtxoNotFound is returned when a UTxO is not found in the
+// mock ledger state.
+var errUtxoNotFound = errors.New("UTxO not found")
+
+// mockLedgerState implements lcommon.LedgerState for testing
+// UTxO-aware Byron validation rules.
+type mockLedgerState struct {
+	utxos     map[string]lcommon.Utxo
+	networkId uint
+}
+
+func newMockLedgerState() *mockLedgerState {
+	return &mockLedgerState{
+		utxos: make(map[string]lcommon.Utxo),
+	}
+}
+
+func (m *mockLedgerState) addUtxo(
+	input lcommon.TransactionInput,
+	output lcommon.TransactionOutput,
+) {
+	key := fmt.Sprintf("%s#%d", input.Id(), input.Index())
+	m.utxos[key] = lcommon.Utxo{
+		Id:     input,
+		Output: output,
+	}
+}
+
+func (m *mockLedgerState) UtxoById(
+	input lcommon.TransactionInput,
+) (lcommon.Utxo, error) {
+	key := fmt.Sprintf("%s#%d", input.Id(), input.Index())
+	utxo, ok := m.utxos[key]
+	if !ok {
+		return lcommon.Utxo{}, errUtxoNotFound
+	}
+	return utxo, nil
+}
+
+func (m *mockLedgerState) NetworkId() uint { return m.networkId }
+
+// Stub implementations for the remaining LedgerState
+// interface methods. These are unused by Byron validation.
+
+func (m *mockLedgerState) StakeRegistration(
+	_ []byte,
+) ([]lcommon.StakeRegistrationCertificate, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) IsStakeCredentialRegistered(
+	_ lcommon.Credential,
+) bool {
+	return false
+}
+
+func (m *mockLedgerState) SlotToTime(
+	_ uint64,
+) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (m *mockLedgerState) TimeToSlot(
+	_ time.Time,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (m *mockLedgerState) PoolCurrentState(
+	_ lcommon.PoolKeyHash,
+) (*lcommon.PoolRegistrationCertificate, *uint64, error) {
+	return nil, nil, nil
+}
+
+func (m *mockLedgerState) IsPoolRegistered(
+	_ lcommon.PoolKeyHash,
+) bool {
+	return false
+}
+
+func (m *mockLedgerState) CalculateRewards(
+	_ lcommon.AdaPots,
+	_ lcommon.RewardSnapshot,
+	_ lcommon.RewardParameters,
+) (*lcommon.RewardCalculationResult, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) GetAdaPots() lcommon.AdaPots {
+	return lcommon.AdaPots{}
+}
+
+func (m *mockLedgerState) UpdateAdaPots(
+	_ lcommon.AdaPots,
+) error {
+	return nil
+}
+
+func (m *mockLedgerState) GetRewardSnapshot(
+	_ uint64,
+) (lcommon.RewardSnapshot, error) {
+	return lcommon.RewardSnapshot{}, nil
+}
+
+func (m *mockLedgerState) IsRewardAccountRegistered(
+	_ lcommon.Credential,
+) bool {
+	return false
+}
+
+func (m *mockLedgerState) RewardAccountBalance(
+	_ lcommon.Credential,
+) (*uint64, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) CommitteeMember(
+	_ lcommon.Blake2b224,
+) (*lcommon.CommitteeMember, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) CommitteeMembers() (
+	[]lcommon.CommitteeMember,
+	error,
+) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) DRepRegistration(
+	_ lcommon.Blake2b224,
+) (*lcommon.DRepRegistration, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) DRepRegistrations() (
+	[]lcommon.DRepRegistration,
+	error,
+) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) Constitution() (
+	*lcommon.Constitution,
+	error,
+) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) TreasuryValue() (uint64, error) {
+	return 0, nil
+}
+
+func (m *mockLedgerState) GovActionById(
+	_ lcommon.GovActionId,
+) (*lcommon.GovActionState, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerState) GovActionExists(
+	_ lcommon.GovActionId,
+) bool {
+	return false
+}
+
+func (m *mockLedgerState) CostModels() map[lcommon.PlutusLanguage]lcommon.CostModel {
+	return nil
+}
+
+// --- Tests for UTxO-aware Byron validation rules ---
+
+func TestByronValidateBadInputs_AllInputsExist(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	input2 := newTestInput(0x02, 0)
+	ls.addUtxo(input1, newTestOutput(1_000_000))
+	ls.addUtxo(input2, newTestOutput(2_000_000))
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1, input2},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(2_500_000),
+		},
+	}
+	err := byronValidateBadInputs(tx, 0, ls, nil)
+	assert.NoError(t, err)
+}
+
+func TestByronValidateBadInputs_MissingInput(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(1_000_000))
+
+	missingInput := newTestInput(0xFF, 0)
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			input1,
+			missingInput,
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(500_000),
+		},
+	}
+	err := byronValidateBadInputs(tx, 0, ls, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &BadInputsByronError{})
+	assert.Contains(t, err.Error(), "bad input")
+}
+
+func TestByronValidateBadInputs_AllMissing(t *testing.T) {
+	ls := newMockLedgerState()
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+			newTestInput(0x02, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(500_000),
+		},
+	}
+	err := byronValidateBadInputs(tx, 0, ls, nil)
+	require.Error(t, err)
+	var badErr BadInputsByronError
+	require.ErrorAs(t, err, &badErr)
+	assert.Len(t, badErr.Inputs, 2)
+}
+
+func TestByronValidateValueConserved_Valid(t *testing.T) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(3_000_000))
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(2_800_000), // 200k implicit fee
+		},
+	}
+	err := byronValidateValueConserved(tx, 0, ls, nil)
+	assert.NoError(t, err)
+}
+
+func TestByronValidateValueConserved_ExactMatch(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(1_000_000))
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000), // zero fee is valid
+		},
+	}
+	err := byronValidateValueConserved(tx, 0, ls, nil)
+	assert.NoError(t, err)
+}
+
+func TestByronValidateValueConserved_OutputExceedsInput(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(1_000_000))
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(2_000_000), // outputs > inputs
+		},
+	}
+	err := byronValidateValueConserved(tx, 0, ls, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &ValueNotConservedByronError{})
+	assert.Contains(t, err.Error(), "value not conserved")
+}
+
+func TestByronValidateValueConserved_MultipleInputsOutputs(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	input2 := newTestInput(0x02, 0)
+	ls.addUtxo(input1, newTestOutput(5_000_000))
+	ls.addUtxo(input2, newTestOutput(3_000_000))
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1, input2},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(4_000_000),
+			newTestOutput(3_500_000),
+		},
+	}
+	// Consumed=8M, Produced=7.5M, fee=0.5M -- valid
+	err := byronValidateValueConserved(tx, 0, ls, nil)
+	assert.NoError(t, err)
+}
+
+func TestByronValidateValueConserved_SkipsMissingInputs(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(2_000_000))
+	// input2 is not in UTxO set -- skipped in value calc
+	input2 := newTestInput(0x02, 0)
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1, input2},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	// Only input1 counted: 2M consumed vs 1M produced -> ok
+	err := byronValidateValueConserved(tx, 0, ls, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxByron_WithLedgerState_Valid(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(5_000_000))
+
+	tx := &testByronTx{
+		inputs:  []lcommon.TransactionInput{input1},
+		outputs: []lcommon.TransactionOutput{newTestOutput(4_800_000)},
+	}
+	err := ValidateTxByron(tx, 0, ls, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxByron_WithLedgerState_BadInput(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	// Do not add any UTxO -- input will be bad
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, ls, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &BadInputsByronError{})
+}
+
+func TestValidateTxByron_WithLedgerState_ValueNotConserved(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	input1 := newTestInput(0x01, 0)
+	ls.addUtxo(input1, newTestOutput(500_000))
+
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{input1},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, ls, nil)
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &ValueNotConservedByronError{})
+}
+
+func TestValidateTxByron_NilLedgerState_SkipsUtxoRules(
+	t *testing.T,
+) {
+	// With nil LedgerState, only structural rules run.
+	// A valid structural TX passes even though we can't
+	// check inputs against the UTxO set.
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			newTestInput(0x01, 0),
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateTxByron_CombinedStructuralAndUtxoErrors(
+	t *testing.T,
+) {
+	ls := newMockLedgerState()
+	// Duplicate inputs AND bad inputs
+	input1 := newTestInput(0x01, 0)
+	tx := &testByronTx{
+		inputs: []lcommon.TransactionInput{
+			input1,
+			input1, // duplicate
+		},
+		outputs: []lcommon.TransactionOutput{
+			newTestOutput(1_000_000),
+		},
+	}
+	err := ValidateTxByron(tx, 0, ls, nil)
+	require.Error(t, err)
+	// Both structural and UTxO errors should be reported
+	assert.ErrorAs(t, err, &DuplicateInputByronError{})
+	assert.ErrorAs(t, err, &BadInputsByronError{})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Byron era transaction validation and wire it into EraDesc. It checks transaction structure and, when ledger state is provided, validates UTxOs, value conservation, and witnesses.

- **New Features**
  - Structural rules: at least one input and output, outputs must be positive, no duplicate inputs.
  - UTxO-aware rules: reject missing inputs, enforce consumed ≥ produced (implicit fee), verify vkey and bootstrap witnesses (including per-input matching), and return specific error types with joined errors.

<sup>Written for commit fea8b7e6df250f52542a329fe01278251ef6c1ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

