### PR TITLE
feat(ledger): era-1 transaction compatibility

### DIFF
--- a/ledger/eras/eras.go
+++ b/ledger/eras/eras.go
@@ -72,3 +72,39 @@ func GetEraById(eraId uint) *EraDesc {
 	}
 	return nil
 }
+
+// IsCompatibleEra checks if a transaction era is valid
+// for the current ledger era. Cardano allows transactions
+// from the current era and the immediately previous era
+// (era - 1) after a hard fork. The previous era is
+// determined by the ordering of the Eras slice, not by
+// numeric ID arithmetic.
+//
+// Returns true if txEraId matches the ledgerEraId or if
+// txEraId is the era immediately preceding ledgerEraId
+// in the known era sequence. Returns false for unknown
+// era IDs that don't match, future eras, or eras more
+// than one step back.
+func IsCompatibleEra(txEraId, ledgerEraId uint) bool {
+	if txEraId == ledgerEraId {
+		return true
+	}
+	// Find the ledger era's index in the Eras slice
+	ledgerIdx := -1
+	for i := range Eras {
+		if Eras[i].Id == ledgerEraId {
+			ledgerIdx = i
+			break
+		}
+	}
+	// Unknown ledger era: only exact match is valid
+	// (already handled above)
+	if ledgerIdx < 0 {
+		return false
+	}
+	// Check if txEraId is the immediately previous era
+	if ledgerIdx > 0 && Eras[ledgerIdx-1].Id == txEraId {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Closes #476 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds era-1 transaction compatibility so the ledger accepts current- and previous-era transactions, validates/evaluates with the right era rules and protocol parameters, and rejects future or too-old eras with clear errors. Also snapshots era/slot/params during validation and block ingestion to prevent races.

- **New Features**
  - Added eras.IsCompatibleEra and public helpers (ValidateTxEra, IsCompatibleEra), plus resolveValidationEra; errors include TX hash and era names/IDs.
  - Updated block processing, ValidateTx, and EvaluateTx to pick the right era’s Validate/Evaluate funcs and protocol params, using prevEraPParams across hard forks and at startup; added tests for all adjacent era pairs and future/unknown/too-old cases.

<sup>Written for commit f7e72daf099284a69c741ae11260357f2b8bebc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept transactions from the immediately preceding era and surface explicit era-compatibility checks with clearer error messages.
  * Validation now uses the correct era context, preserving prior-era protocol parameters when needed.

* **Bug Fixes**
  * Reject unknown/future or too-old-era transactions; propagate validation resolution errors to abort processing and release resources.
  * Preserve pre-hard-fork parameters for accurate legacy-era validation.

* **Tests**
  * Added unit tests covering era compatibility and validation error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->