### PR TITLE
feat: initial mini blockfrost

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+
+	"github.com/blinklabs-io/dingo/ledger"
+)
+
+// NodeAdapter wraps a real dingo Node's LedgerState to
+// implement the BlockfrostNode interface.
+type NodeAdapter struct {
+	ledgerState *ledger.LedgerState
+}
+
+// NewNodeAdapter creates a NodeAdapter that queries the
+// given LedgerState for blockchain data. Panics if ls is
+// nil.
+func NewNodeAdapter(
+	ls *ledger.LedgerState,
+) *NodeAdapter {
+	if ls == nil {
+		panic("NewNodeAdapter: LedgerState must not be nil")
+	}
+	return &NodeAdapter{ledgerState: ls}
+}
+
+// ChainTip returns the current chain tip from the ledger
+// state.
+func (a *NodeAdapter) ChainTip() (
+	ChainTipInfo, error,
+) {
+	tip := a.ledgerState.Tip()
+	return ChainTipInfo{
+		BlockHash: hex.EncodeToString(
+			tip.Point.Hash,
+		),
+		Slot:        tip.Point.Slot,
+		BlockNumber: tip.BlockNumber,
+	}, nil
+}
+
+// LatestBlock returns information about the latest block.
+func (a *NodeAdapter) LatestBlock() (
+	BlockInfo, error,
+) {
+	tip := a.ledgerState.Tip()
+	// TODO: Retrieve full block details (size, tx count,
+	// slot leader, previous block, epoch, epoch slot)
+	// from the database once block query methods are
+	// available.
+	return BlockInfo{
+		Hash: hex.EncodeToString(
+			tip.Point.Hash,
+		),
+		Slot:          tip.Point.Slot,
+		Height:        tip.BlockNumber,
+		Epoch:         0,
+		EpochSlot:     0,
+		Time:          0,
+		Size:          0,
+		TxCount:       0,
+		SlotLeader:    "",
+		PreviousBlock: "",
+		Confirmations: 0,
+	}, nil
+}
+
+// LatestBlockTxHashes returns transaction hashes from the
+// latest block.
+func (a *NodeAdapter) LatestBlockTxHashes() (
+	[]string, error,
+) {
+	// TODO: Query the database for transaction hashes
+	// in the latest block once the appropriate query
+	// methods are available.
+	return []string{}, nil
+}
+
+// CurrentEpoch returns information about the current
+// epoch.
+func (a *NodeAdapter) CurrentEpoch() (
+	EpochInfo, error,
+) {
+	// TODO: Retrieve full epoch details (epoch number,
+	// start/end time, block count, tx count) from the
+	// database once epoch query methods are available.
+	return EpochInfo{
+		Epoch:          0,
+		StartTime:      0,
+		EndTime:        0,
+		FirstBlockTime: 0,
+		LastBlockTime:  0,
+		BlockCount:     0,
+		TxCount:        0,
+	}, nil
+}
+
+// CurrentProtocolParams returns the current protocol
+// parameters.
+func (a *NodeAdapter) CurrentProtocolParams() (
+	ProtocolParamsInfo, error,
+) {
+	// TODO: Map real protocol parameter fields from
+	// GetCurrentPParams() once the gouroboros
+	// ProtocolParameters interface exposes the necessary
+	// getters. For now, return placeholder values.
+	return ProtocolParamsInfo{
+		Epoch:               0,
+		MinFeeA:             0,
+		MinFeeB:             0,
+		MaxBlockSize:        0,
+		MaxTxSize:           0,
+		MaxBlockHeaderSize:  0,
+		KeyDeposit:          "0",
+		PoolDeposit:         "0",
+		EMax:                0,
+		NOpt:                0,
+		A0:                  0,
+		Rho:                 0,
+		Tau:                 0,
+		ProtocolMajorVer:    0,
+		ProtocolMinorVer:    0,
+		MinPoolCost:         "0",
+		CoinsPerUtxoSize:    "0",
+		PriceMem:            0,
+		PriceStep:           0,
+		MaxTxExMem:          "0",
+		MaxTxExSteps:        "0",
+		MaxBlockExMem:       "0",
+		MaxBlockExSteps:     "0",
+		MaxValSize:          "0",
+		CollateralPercent:   0,
+		MaxCollateralInputs: 0,
+	}, nil
+}

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Blockfrost is the Blockfrost-compatible REST API server.
+type Blockfrost struct {
+	config     BlockfrostConfig
+	logger     *slog.Logger
+	node       BlockfrostNode
+	httpServer *http.Server
+	mu         sync.Mutex
+}
+
+// New creates a new Blockfrost API server instance.
+func New(
+	cfg BlockfrostConfig,
+	node BlockfrostNode,
+	logger *slog.Logger,
+) *Blockfrost {
+	if logger == nil {
+		logger = slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		)
+	}
+	logger = logger.With("component", "blockfrost")
+	if cfg.ListenAddress == "" {
+		cfg.ListenAddress = ":3000"
+	}
+	return &Blockfrost{
+		config: cfg,
+		logger: logger,
+		node:   node,
+	}
+}
+
+// Start starts the HTTP server in a background goroutine.
+func (b *Blockfrost) Start(
+	ctx context.Context,
+) error {
+	b.mu.Lock()
+	if b.httpServer != nil {
+		b.mu.Unlock()
+		return errors.New("server already started")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", b.handleRoot)
+	mux.HandleFunc("GET /health", b.handleHealth)
+	mux.HandleFunc(
+		"GET /api/v0/blocks/latest",
+		b.handleLatestBlock,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/blocks/latest/txs",
+		b.handleLatestBlockTxs,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/epochs/latest",
+		b.handleLatestEpoch,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/epochs/latest/parameters",
+		b.handleLatestEpochParams,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/network",
+		b.handleNetwork,
+	)
+
+	server := &http.Server{
+		Addr:              b.config.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 60 * time.Second,
+	}
+	b.httpServer = server
+	b.mu.Unlock()
+
+	// Start the server with deterministic error detection
+	if err := b.startServer(server); err != nil {
+		b.mu.Lock()
+		b.httpServer = nil
+		b.mu.Unlock()
+		return err
+	}
+
+	b.logger.Info(
+		"Blockfrost API listener started on " +
+			b.config.ListenAddress,
+	)
+
+	// Monitor context for cancellation
+	go func() {
+		<-ctx.Done()
+		b.mu.Lock()
+		srv := b.httpServer
+		b.httpServer = nil
+		b.mu.Unlock()
+
+		if srv != nil {
+			b.logger.Debug(
+				"context cancelled, shutting down " +
+					"Blockfrost API server",
+			)
+			//nolint:contextcheck
+			shutdownCtx, cancel := context.WithTimeout(
+				context.Background(),
+				30*time.Second,
+			)
+			defer cancel()
+			//nolint:contextcheck
+			if err := srv.Shutdown(
+				shutdownCtx,
+			); err != nil {
+				b.logger.Error(
+					"failed to shutdown Blockfrost "+
+						"API server on context "+
+						"cancellation",
+					"error", err,
+				)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully shuts down the HTTP server.
+func (b *Blockfrost) Stop(
+	ctx context.Context,
+) error {
+	b.mu.Lock()
+	srv := b.httpServer
+	b.httpServer = nil
+	b.mu.Unlock()
+
+	if srv != nil {
+		b.logger.Debug(
+			"shutting down Blockfrost API server",
+		)
+		if err := srv.Shutdown(ctx); err != nil {
+			return fmt.Errorf(
+				"failed to shutdown Blockfrost API "+
+					"server: %w",
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+// startServer starts the HTTP server with deterministic
+// error detection. It binds the listening socket first so
+// port conflicts are detected immediately, then serves in
+// a background goroutine.
+func (b *Blockfrost) startServer(
+	server *http.Server,
+) error {
+	ln, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to listen for Blockfrost API "+
+				"server: %w",
+			err,
+		)
+	}
+	go func() {
+		if err := server.Serve(ln); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) {
+			b.logger.Error(
+				"Blockfrost API server error",
+				"error", err,
+			)
+		}
+	}()
+	return nil
+}

--- a/blockfrost/blockfrost_compat_test.go
+++ b/blockfrost/blockfrost_compat_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"testing"
+
+	bfgo "github.com/blockfrost/blockfrost-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompatBlockResponse verifies that our BlockResponse
+// round-trips through blockfrost-go's Block type.
+func TestCompatBlockResponse(t *testing.T) {
+	output := "12345"
+	fees := "678"
+	blockVRF := "vrf_vk1abc"
+	opCert := "opcert123"
+	opCertCounter := "5"
+	nextBlock := "next_abc"
+
+	ours := BlockResponse{
+		Time:          1700000000,
+		Height:        67890,
+		Hash:          "abc123",
+		Slot:          12345,
+		Epoch:         100,
+		EpochSlot:     345,
+		SlotLeader:    "pool1xyz",
+		Size:          1024,
+		TxCount:       5,
+		Output:        &output,
+		Fees:          &fees,
+		BlockVRF:      &blockVRF,
+		OPCert:        &opCert,
+		OPCertCounter: &opCertCounter,
+		PreviousBlock: "prev123",
+		NextBlock:     &nextBlock,
+		Confirmations: 10,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Block
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1700000000, theirs.Time)
+	assert.Equal(t, 67890, theirs.Height)
+	assert.Equal(t, "abc123", theirs.Hash)
+	assert.Equal(t, 12345, theirs.Slot)
+	assert.Equal(t, 100, theirs.Epoch)
+	assert.Equal(t, 345, theirs.EpochSlot)
+	assert.Equal(t, "pool1xyz", theirs.SlotLeader)
+	assert.Equal(t, 1024, theirs.Size)
+	assert.Equal(t, 5, theirs.TxCount)
+	require.NotNil(t, theirs.Output)
+	assert.Equal(t, "12345", *theirs.Output)
+	require.NotNil(t, theirs.Fees)
+	assert.Equal(t, "678", *theirs.Fees)
+	require.NotNil(t, theirs.BlockVRF)
+	assert.Equal(t, "vrf_vk1abc", *theirs.BlockVRF)
+	require.NotNil(t, theirs.OPCert)
+	assert.Equal(t, "opcert123", *theirs.OPCert)
+	require.NotNil(t, theirs.OPCertCounter)
+	assert.Equal(t, "5", *theirs.OPCertCounter)
+	assert.Equal(t, "prev123", theirs.PreviousBlock)
+	require.NotNil(t, theirs.NextBlock)
+	assert.Equal(t, "next_abc", *theirs.NextBlock)
+	assert.Equal(t, 10, theirs.Confirmations)
+}
+
+// TestCompatBlockResponseNilFields verifies that null
+// pointer fields round-trip correctly.
+func TestCompatBlockResponseNilFields(t *testing.T) {
+	output := "0"
+	fees := "0"
+	ours := BlockResponse{
+		Hash:   "abc",
+		Output: &output,
+		Fees:   &fees,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Block
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Nil(t, theirs.BlockVRF)
+	assert.Nil(t, theirs.OPCert)
+	assert.Nil(t, theirs.OPCertCounter)
+	assert.Nil(t, theirs.NextBlock)
+}
+
+// TestCompatEpochResponse verifies that our
+// EpochResponse round-trips through blockfrost-go's
+// Epoch type.
+func TestCompatEpochResponse(t *testing.T) {
+	activeStake := "1000000"
+	ours := EpochResponse{
+		Epoch:          100,
+		StartTime:      1700000000,
+		EndTime:        1700432000,
+		FirstBlockTime: 1700000020,
+		LastBlockTime:  1700431980,
+		BlockCount:     21600,
+		TxCount:        50000,
+		Output:         "999",
+		Fees:           "123",
+		ActiveStake:    &activeStake,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Epoch
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, theirs.Epoch)
+	assert.Equal(t, 1700000000, theirs.StartTime)
+	assert.Equal(t, 1700432000, theirs.EndTime)
+	assert.Equal(t, 1700000020, theirs.FirstBlockTime)
+	assert.Equal(t, 1700431980, theirs.LastBlockTime)
+	assert.Equal(t, 21600, theirs.BlockCount)
+	assert.Equal(t, 50000, theirs.TxCount)
+	assert.Equal(t, "999", theirs.Output)
+	assert.Equal(t, "123", theirs.Fees)
+	require.NotNil(t, theirs.ActiveStake)
+	assert.Equal(t, "1000000", *theirs.ActiveStake)
+}
+
+// TestCompatProtocolParamsResponse verifies that our
+// ProtocolParamsResponse round-trips through
+// blockfrost-go's EpochParameters type.
+func TestCompatProtocolParamsResponse(t *testing.T) {
+	coinsPerUtxoSize := "4310"
+	priceMem := 0.0577
+	priceStep := 0.0000721
+	maxTxExMem := "10000000000"
+	maxTxExSteps := "10000000000000"
+	maxBlockExMem := "50000000000"
+	maxBlockExSteps := "40000000000000"
+	maxValSize := "5000"
+	collateralPercent := 150
+	maxCollateralInputs := 3
+
+	ours := ProtocolParamsResponse{
+		Epoch:                 100,
+		MinFeeA:               44,
+		MinFeeB:               155381,
+		MaxBlockSize:          65536,
+		MaxTxSize:             16384,
+		MaxBlockHeaderSize:    1100,
+		KeyDeposit:            "2000000",
+		PoolDeposit:           "500000000",
+		EMax:                  18,
+		NOpt:                  150,
+		A0:                    0.3,
+		Rho:                   0.003,
+		Tau:                   0.2,
+		DecentralisationParam: 0,
+		ExtraEntropy:          nil,
+		ProtocolMajorVer:      8,
+		ProtocolMinorVer:      0,
+		MinUtxo:               "0",
+		MinPoolCost:           "170000000",
+		Nonce:                 "abc123",
+		CoinsPerUtxoSize:      &coinsPerUtxoSize,
+		CoinsPerUtxoWord:      "4310",
+		CostModels:            nil,
+		PriceMem:              &priceMem,
+		PriceStep:             &priceStep,
+		MaxTxExMem:            &maxTxExMem,
+		MaxTxExSteps:          &maxTxExSteps,
+		MaxBlockExMem:         &maxBlockExMem,
+		MaxBlockExSteps:       &maxBlockExSteps,
+		MaxValSize:            &maxValSize,
+		CollateralPercent:     &collateralPercent,
+		MaxCollateralInputs:   &maxCollateralInputs,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.EpochParameters
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, theirs.Epoch)
+	assert.Equal(t, 44, theirs.MinFeeA)
+	assert.Equal(t, 155381, theirs.MinFeeB)
+	assert.Equal(t, 65536, theirs.MaxBlockSize)
+	assert.Equal(t, 16384, theirs.MaxTxSize)
+	assert.Equal(t, 1100, theirs.MaxBlockHeaderSize)
+	assert.Equal(t, "2000000", theirs.KeyDeposit)
+	assert.Equal(t, "500000000", theirs.PoolDeposit)
+	assert.Equal(t, 18, theirs.EMax)
+	assert.Equal(t, 150, theirs.NOpt)
+	assert.InDelta(t, 0.3, float64(theirs.A0), 0.001)
+	assert.InDelta(
+		t, 0.003, float64(theirs.Rho), 0.0001,
+	)
+	assert.InDelta(t, 0.2, float64(theirs.Tau), 0.001)
+	assert.Equal(t, 8, theirs.ProtocolMajorVer)
+	assert.Equal(t, 0, theirs.ProtocolMinorVer)
+	assert.Equal(t, "170000000", theirs.MinPoolCost)
+	assert.Equal(t, "abc123", theirs.Nonce)
+	require.NotNil(t, theirs.CoinsPerUTxOSize)
+	assert.Equal(t, "4310", *theirs.CoinsPerUTxOSize)
+	require.NotNil(t, theirs.PriceMem)
+	assert.InDelta(
+		t, 0.0577, float64(*theirs.PriceMem), 0.0001,
+	)
+	require.NotNil(t, theirs.PriceStep)
+	assert.InDelta(
+		t,
+		0.0000721,
+		float64(*theirs.PriceStep),
+		0.00001,
+	)
+	require.NotNil(t, theirs.MaxTxExMem)
+	assert.Equal(t, "10000000000", *theirs.MaxTxExMem)
+	require.NotNil(t, theirs.MaxTxExSteps)
+	assert.Equal(
+		t, "10000000000000", *theirs.MaxTxExSteps,
+	)
+	require.NotNil(t, theirs.MaxBlockExMem)
+	assert.Equal(
+		t, "50000000000", *theirs.MaxBlockExMem,
+	)
+	require.NotNil(t, theirs.MaxBlockExSteps)
+	assert.Equal(
+		t, "40000000000000", *theirs.MaxBlockExSteps,
+	)
+	// NOTE: blockfrost-go v0.3.0 has a tab in the
+	// MaxValSize JSON tag ("max_val_size\t"), so this
+	// field cannot round-trip. Skip assertion.
+	// See: blockfrost-go api_epochs.go:95
+	require.NotNil(t, theirs.CollateralPercent)
+	assert.Equal(t, 150, *theirs.CollateralPercent)
+	require.NotNil(t, theirs.MaxCollateralInputs)
+	assert.Equal(t, 3, *theirs.MaxCollateralInputs)
+}
+
+// TestCompatHealthResponse verifies that our
+// HealthResponse round-trips through blockfrost-go's
+// Health type.
+func TestCompatHealthResponse(t *testing.T) {
+	ours := HealthResponse{IsHealthy: true}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Health
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.True(t, theirs.IsHealthy)
+}
+
+// TestCompatRootResponse verifies that our
+// RootResponse round-trips through blockfrost-go's
+// Info type.
+func TestCompatRootResponse(t *testing.T) {
+	ours := RootResponse{
+		URL:     "https://blockfrost.io/",
+		Version: "0.1.0",
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Info
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t, "https://blockfrost.io/", theirs.Url,
+	)
+	assert.Equal(t, "0.1.0", theirs.Version)
+}
+
+// TestCompatNetworkResponse verifies that our
+// NetworkResponse round-trips through blockfrost-go's
+// NetworkInfo type.
+func TestCompatNetworkResponse(t *testing.T) {
+	ours := NetworkResponse{
+		Supply: NetworkSupply{
+			Max:         "45000000000000000",
+			Total:       "33000000000000000",
+			Circulating: "32000000000000000",
+			Locked:      "1000000000000",
+			Treasury:    "500000000000",
+			Reserves:    "12000000000000000",
+		},
+		Stake: NetworkStake{
+			Live:   "23000000000000000",
+			Active: "22000000000000000",
+		},
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.NetworkInfo
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t, "45000000000000000", theirs.Supply.Max,
+	)
+	assert.Equal(
+		t, "33000000000000000", theirs.Supply.Total,
+	)
+	assert.Equal(
+		t,
+		"32000000000000000",
+		theirs.Supply.Circulating,
+	)
+	assert.Equal(
+		t, "1000000000000", theirs.Supply.Locked,
+	)
+	assert.Equal(
+		t, "23000000000000000", theirs.Stake.Live,
+	)
+	assert.Equal(
+		t, "22000000000000000", theirs.Stake.Active,
+	)
+}

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -1,0 +1,454 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockNode implements BlockfrostNode for testing.
+type mockNode struct {
+	chainTip    ChainTipInfo
+	block       BlockInfo
+	txHashes    []string
+	epoch       EpochInfo
+	params      ProtocolParamsInfo
+	chainTipErr error
+	blockErr    error
+	txHashesErr error
+	epochErr    error
+	paramsErr   error
+}
+
+func (m *mockNode) ChainTip() (
+	ChainTipInfo, error,
+) {
+	return m.chainTip, m.chainTipErr
+}
+
+func (m *mockNode) LatestBlock() (
+	BlockInfo, error,
+) {
+	return m.block, m.blockErr
+}
+
+func (m *mockNode) LatestBlockTxHashes() (
+	[]string, error,
+) {
+	return m.txHashes, m.txHashesErr
+}
+
+func (m *mockNode) CurrentEpoch() (
+	EpochInfo, error,
+) {
+	return m.epoch, m.epochErr
+}
+
+func (m *mockNode) CurrentProtocolParams() (
+	ProtocolParamsInfo, error,
+) {
+	return m.params, m.paramsErr
+}
+
+func newTestBlockfrost(
+	node BlockfrostNode,
+) *Blockfrost {
+	return New(
+		BlockfrostConfig{
+			ListenAddress: ":0",
+		},
+		node,
+		slog.Default(),
+	)
+}
+
+func TestStartStop(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	err := b.Start(t.Context())
+	require.NoError(t, err)
+
+	// Verify server is running
+	b.mu.Lock()
+	assert.NotNil(t, b.httpServer)
+	b.mu.Unlock()
+
+	// Stop the server
+	stopCtx, stopCancel := context.WithTimeout(
+		context.Background(),
+		5*time.Second,
+	)
+	defer stopCancel()
+	err = b.Stop(stopCtx)
+	require.NoError(t, err)
+
+	// Verify server is stopped
+	b.mu.Lock()
+	assert.Nil(t, b.httpServer)
+	b.mu.Unlock()
+}
+
+func TestStartAlreadyStarted(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	ctx := t.Context()
+	err := b.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer stopCancel()
+		_ = b.Stop(stopCtx)
+	}()
+
+	// Starting again should error
+	err = b.Start(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+
+func TestHandleRoot(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/", nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleRoot(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(
+		t,
+		"application/json",
+		w.Header().Get("Content-Type"),
+	)
+
+	var resp RootResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://blockfrost.io/",
+		resp.URL,
+	)
+	assert.Equal(t, "0.1.0", resp.Version)
+}
+
+func TestHandleHealth(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/health", nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleHealth(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp HealthResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.True(t, resp.IsHealthy)
+}
+
+func TestHandleLatestBlock(t *testing.T) {
+	mock := &mockNode{
+		block: BlockInfo{
+			Hash:          "abc123",
+			Slot:          12345,
+			Epoch:         100,
+			EpochSlot:     345,
+			Height:        67890,
+			Time:          1700000000,
+			Size:          1024,
+			TxCount:       5,
+			SlotLeader:    "pool1xyz",
+			PreviousBlock: "prev123",
+			Confirmations: 10,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/blocks/latest",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestBlock(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp BlockResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", resp.Hash)
+	assert.Equal(t, uint64(12345), resp.Slot)
+	assert.Equal(t, uint64(100), resp.Epoch)
+	assert.Equal(t, uint64(345), resp.EpochSlot)
+	assert.Equal(t, uint64(67890), resp.Height)
+	assert.Equal(t, int64(1700000000), resp.Time)
+	assert.Equal(t, uint64(1024), resp.Size)
+	assert.Equal(t, 5, resp.TxCount)
+	assert.Equal(t, "pool1xyz", resp.SlotLeader)
+	assert.Equal(t, "prev123", resp.PreviousBlock)
+	assert.Equal(t, uint64(10), resp.Confirmations)
+}
+
+func TestHandleLatestBlockError(t *testing.T) {
+	mock := &mockNode{
+		blockErr: assert.AnError,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/blocks/latest",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestBlock(w, req)
+
+	assert.Equal(
+		t,
+		http.StatusInternalServerError,
+		w.Code,
+	)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, 500, resp.StatusCode)
+	assert.Equal(
+		t,
+		"Internal Server Error",
+		resp.Error,
+	)
+}
+
+func TestHandleLatestBlockTxs(t *testing.T) {
+	mock := &mockNode{
+		txHashes: []string{"tx1", "tx2", "tx3"},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/blocks/latest/txs",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestBlockTxs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []string
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		[]string{"tx1", "tx2", "tx3"},
+		resp,
+	)
+}
+
+func TestHandleLatestBlockTxsEmpty(t *testing.T) {
+	mock := &mockNode{
+		txHashes: nil,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/blocks/latest/txs",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestBlockTxs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []string
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	// Should return empty array, not null
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp)
+}
+
+func TestHandleLatestEpoch(t *testing.T) {
+	mock := &mockNode{
+		epoch: EpochInfo{
+			Epoch:          100,
+			StartTime:      1700000000,
+			EndTime:        1700432000,
+			FirstBlockTime: 1700000020,
+			LastBlockTime:  1700431980,
+			BlockCount:     21600,
+			TxCount:        50000,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/latest",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestEpoch(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp EpochResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), resp.Epoch)
+	assert.Equal(t, int64(1700000000), resp.StartTime)
+	assert.Equal(t, int64(1700432000), resp.EndTime)
+	assert.Equal(t, 21600, resp.BlockCount)
+	assert.Equal(t, 50000, resp.TxCount)
+}
+
+func TestHandleLatestEpochParams(t *testing.T) {
+	mock := &mockNode{
+		params: ProtocolParamsInfo{
+			Epoch:               100,
+			MinFeeA:             44,
+			MinFeeB:             155381,
+			MaxBlockSize:        65536,
+			MaxTxSize:           16384,
+			MaxBlockHeaderSize:  1100,
+			KeyDeposit:          "2000000",
+			PoolDeposit:         "500000000",
+			EMax:                18,
+			NOpt:                150,
+			A0:                  0.3,
+			Rho:                 0.003,
+			Tau:                 0.2,
+			ProtocolMajorVer:    8,
+			ProtocolMinorVer:    0,
+			MinPoolCost:         "170000000",
+			CoinsPerUtxoSize:    "4310",
+			PriceMem:            0.0577,
+			PriceStep:           0.0000721,
+			MaxTxExMem:          "10000000000",
+			MaxTxExSteps:        "10000000000000",
+			MaxBlockExMem:       "50000000000",
+			MaxBlockExSteps:     "40000000000000",
+			MaxValSize:          "5000",
+			CollateralPercent:   150,
+			MaxCollateralInputs: 3,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/latest/parameters",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestEpochParams(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ProtocolParamsResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), resp.Epoch)
+	assert.Equal(t, 44, resp.MinFeeA)
+	assert.Equal(t, 155381, resp.MinFeeB)
+	assert.Equal(t, 65536, resp.MaxBlockSize)
+	assert.Equal(t, "2000000", resp.KeyDeposit)
+	assert.Equal(t, "500000000", resp.PoolDeposit)
+	require.NotNil(t, resp.CollateralPercent)
+	assert.Equal(t, 150, *resp.CollateralPercent)
+	require.NotNil(t, resp.MaxCollateralInputs)
+	assert.Equal(t, 3, *resp.MaxCollateralInputs)
+}
+
+func TestHandleNetwork(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/network",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleNetwork(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp NetworkResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"45000000000000000",
+		resp.Supply.Max,
+	)
+	assert.NotEmpty(t, resp.Stake.Live)
+	assert.NotEmpty(t, resp.Stake.Active)
+}
+
+func TestStopIdempotent(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	// Stop without starting should not error
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		5*time.Second,
+	)
+	defer cancel()
+	err := b.Stop(ctx)
+	require.NoError(t, err)
+}
+
+func TestNilLogger(t *testing.T) {
+	b := New(
+		BlockfrostConfig{ListenAddress: ":0"},
+		&mockNode{},
+		nil,
+	)
+	assert.NotNil(t, b.logger)
+}
+
+func TestDefaultListenAddress(t *testing.T) {
+	b := New(
+		BlockfrostConfig{},
+		&mockNode{},
+		slog.Default(),
+	)
+	assert.Equal(t, ":3000", b.config.ListenAddress)
+}

--- a/blockfrost/config.go
+++ b/blockfrost/config.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+// BlockfrostConfig holds configuration for the Blockfrost
+// API server.
+type BlockfrostConfig struct {
+	// ListenAddress is the address to listen on.
+	// Defaults to ":3000".
+	ListenAddress string
+}

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const apiVersion = "0.1.0"
+
+// writeJSON writes a JSON response with the given status
+// code.
+func writeJSON(
+	w http.ResponseWriter,
+	status int,
+	v any,
+) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	//nolint:errcheck,errchkjson
+	json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes a Blockfrost-format error response.
+//
+//nolint:unparam
+func writeError(
+	w http.ResponseWriter,
+	status int,
+	errStr string,
+	message string,
+) {
+	writeJSON(w, status, ErrorResponse{
+		StatusCode: status,
+		Error:      errStr,
+		Message:    message,
+	})
+}
+
+// handleRoot handles GET / and returns API metadata.
+func (b *Blockfrost) handleRoot(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	writeJSON(w, http.StatusOK, RootResponse{
+		URL:     "https://blockfrost.io/",
+		Version: apiVersion,
+	})
+}
+
+// handleHealth handles GET /health and returns node health
+// status.
+func (b *Blockfrost) handleHealth(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	writeJSON(w, http.StatusOK, HealthResponse{
+		IsHealthy: true,
+	})
+}
+
+// handleLatestBlock handles GET /api/v0/blocks/latest and
+// returns the latest block.
+func (b *Blockfrost) handleLatestBlock(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	info, err := b.node.LatestBlock()
+	if err != nil {
+		b.logger.Error(
+			"failed to get latest block",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve latest block",
+		)
+		return
+	}
+	output := "0"
+	fees := "0"
+	writeJSON(w, http.StatusOK, BlockResponse{
+		Hash:          info.Hash,
+		Slot:          info.Slot,
+		Epoch:         info.Epoch,
+		EpochSlot:     info.EpochSlot,
+		Height:        info.Height,
+		Time:          info.Time,
+		Size:          info.Size,
+		TxCount:       info.TxCount,
+		SlotLeader:    info.SlotLeader,
+		PreviousBlock: info.PreviousBlock,
+		Confirmations: info.Confirmations,
+		Output:        &output,
+		Fees:          &fees,
+		BlockVRF:      nil,
+		NextBlock:     nil,
+	})
+}
+
+// handleLatestBlockTxs handles
+// GET /api/v0/blocks/latest/txs and returns transaction
+// hashes from the latest block.
+func (b *Blockfrost) handleLatestBlockTxs(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	hashes, err := b.node.LatestBlockTxHashes()
+	if err != nil {
+		b.logger.Error(
+			"failed to get latest block txs",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve latest block transactions",
+		)
+		return
+	}
+	if hashes == nil {
+		hashes = []string{}
+	}
+	writeJSON(w, http.StatusOK, hashes)
+}
+
+// handleLatestEpoch handles GET /api/v0/epochs/latest and
+// returns the current epoch info.
+func (b *Blockfrost) handleLatestEpoch(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	info, err := b.node.CurrentEpoch()
+	if err != nil {
+		b.logger.Error(
+			"failed to get current epoch",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve current epoch",
+		)
+		return
+	}
+	activeStake := "0"
+	writeJSON(w, http.StatusOK, EpochResponse{
+		Epoch:          info.Epoch,
+		StartTime:      info.StartTime,
+		EndTime:        info.EndTime,
+		FirstBlockTime: info.FirstBlockTime,
+		LastBlockTime:  info.LastBlockTime,
+		BlockCount:     info.BlockCount,
+		TxCount:        info.TxCount,
+		Output:         "0",
+		Fees:           "0",
+		ActiveStake:    &activeStake,
+	})
+}
+
+// handleLatestEpochParams handles
+// GET /api/v0/epochs/latest/parameters and returns the
+// current protocol parameters.
+func (b *Blockfrost) handleLatestEpochParams(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	info, err := b.node.CurrentProtocolParams()
+	if err != nil {
+		b.logger.Error(
+			"failed to get protocol params",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve protocol parameters",
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, ProtocolParamsResponse{
+		Epoch:                 info.Epoch,
+		MinFeeA:               info.MinFeeA,
+		MinFeeB:               info.MinFeeB,
+		MaxBlockSize:          info.MaxBlockSize,
+		MaxTxSize:             info.MaxTxSize,
+		MaxBlockHeaderSize:    info.MaxBlockHeaderSize,
+		KeyDeposit:            info.KeyDeposit,
+		PoolDeposit:           info.PoolDeposit,
+		EMax:                  info.EMax,
+		NOpt:                  info.NOpt,
+		A0:                    info.A0,
+		Rho:                   info.Rho,
+		Tau:                   info.Tau,
+		ProtocolMajorVer:      info.ProtocolMajorVer,
+		ProtocolMinorVer:      info.ProtocolMinorVer,
+		MinPoolCost:           info.MinPoolCost,
+		CoinsPerUtxoSize:      &info.CoinsPerUtxoSize,
+		CoinsPerUtxoWord:      info.CoinsPerUtxoSize,
+		PriceMem:              &info.PriceMem,
+		PriceStep:             &info.PriceStep,
+		MaxTxExMem:            &info.MaxTxExMem,
+		MaxTxExSteps:          &info.MaxTxExSteps,
+		MaxBlockExMem:         &info.MaxBlockExMem,
+		MaxBlockExSteps:       &info.MaxBlockExSteps,
+		MaxValSize:            &info.MaxValSize,
+		CollateralPercent:     &info.CollateralPercent,
+		MaxCollateralInputs:   &info.MaxCollateralInputs,
+		MinUtxo:               "0",
+		Nonce:                 "",
+		DecentralisationParam: 0,
+		ExtraEntropy:          nil,
+	})
+}
+
+// handleNetwork handles GET /api/v0/network and returns
+// network supply and stake information.
+func (b *Blockfrost) handleNetwork(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	// TODO: Wire to real supply/stake data when available
+	writeJSON(w, http.StatusOK, NetworkResponse{
+		Supply: NetworkSupply{
+			Max:         "45000000000000000",
+			Total:       "0",
+			Circulating: "0",
+			Locked:      "0",
+			Treasury:    "0",
+			Reserves:    "0",
+		},
+		Stake: NetworkStake{
+			Live:   "0",
+			Active: "0",
+		},
+	})
+}

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+// BlockfrostNode is the interface that the Blockfrost API
+// server uses to query the node for blockchain data. This
+// decouples the HTTP server from the concrete Node struct
+// and enables testing with mock implementations.
+type BlockfrostNode interface {
+	// ChainTip returns the current chain tip info.
+	ChainTip() (ChainTipInfo, error)
+
+	// LatestBlock returns information about the latest
+	// block on the chain.
+	LatestBlock() (BlockInfo, error)
+
+	// LatestBlockTxHashes returns the transaction hashes
+	// for the latest block.
+	LatestBlockTxHashes() ([]string, error)
+
+	// CurrentEpoch returns information about the current
+	// epoch.
+	CurrentEpoch() (EpochInfo, error)
+
+	// CurrentProtocolParams returns the current protocol
+	// parameters.
+	CurrentProtocolParams() (ProtocolParamsInfo, error)
+}
+
+// ChainTipInfo holds chain tip data needed by the API.
+type ChainTipInfo struct {
+	BlockHash   string
+	Slot        uint64
+	BlockNumber uint64
+}
+
+// BlockInfo holds block data needed by the API.
+type BlockInfo struct {
+	Hash          string
+	Slot          uint64
+	Epoch         uint64
+	EpochSlot     uint64
+	Height        uint64
+	Time          int64
+	Size          uint64
+	TxCount       int
+	SlotLeader    string
+	PreviousBlock string
+	Confirmations uint64
+}
+
+// EpochInfo holds epoch data needed by the API.
+type EpochInfo struct {
+	Epoch          uint64
+	StartTime      int64
+	EndTime        int64
+	FirstBlockTime int64
+	LastBlockTime  int64
+	BlockCount     int
+	TxCount        int
+}
+
+// ProtocolParamsInfo holds protocol parameter data needed
+// by the API.
+type ProtocolParamsInfo struct {
+	Epoch               uint64
+	MinFeeA             int
+	MinFeeB             int
+	MaxBlockSize        int
+	MaxTxSize           int
+	MaxBlockHeaderSize  int
+	KeyDeposit          string
+	PoolDeposit         string
+	EMax                int
+	NOpt                int
+	A0                  float64
+	Rho                 float64
+	Tau                 float64
+	ProtocolMajorVer    int
+	ProtocolMinorVer    int
+	MinPoolCost         string
+	CoinsPerUtxoSize    string
+	PriceMem            float64
+	PriceStep           float64
+	MaxTxExMem          string
+	MaxTxExSteps        string
+	MaxBlockExMem       string
+	MaxBlockExSteps     string
+	MaxValSize          string
+	CollateralPercent   int
+	MaxCollateralInputs int
+}

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+// RootResponse is returned by GET /.
+type RootResponse struct {
+	URL     string `json:"url"`
+	Version string `json:"version"`
+}
+
+// HealthResponse is returned by GET /health.
+type HealthResponse struct {
+	IsHealthy bool `json:"is_healthy"`
+}
+
+// BlockResponse represents a Blockfrost block object.
+type BlockResponse struct {
+	Time          int64   `json:"time"`
+	Height        uint64  `json:"height"`
+	Hash          string  `json:"hash"`
+	Slot          uint64  `json:"slot"`
+	Epoch         uint64  `json:"epoch"`
+	EpochSlot     uint64  `json:"epoch_slot"`
+	SlotLeader    string  `json:"slot_leader"`
+	Size          uint64  `json:"size"`
+	TxCount       int     `json:"tx_count"`
+	Output        *string `json:"output"`
+	Fees          *string `json:"fees"`
+	BlockVRF      *string `json:"block_vrf"`
+	OPCert        *string `json:"op_cert"`
+	OPCertCounter *string `json:"op_cert_counter"`
+	PreviousBlock string  `json:"previous_block"`
+	NextBlock     *string `json:"next_block"`
+	Confirmations uint64  `json:"confirmations"`
+}
+
+// EpochResponse represents a Blockfrost epoch object.
+type EpochResponse struct {
+	Epoch          uint64  `json:"epoch"`
+	StartTime      int64   `json:"start_time"`
+	EndTime        int64   `json:"end_time"`
+	FirstBlockTime int64   `json:"first_block_time"`
+	LastBlockTime  int64   `json:"last_block_time"`
+	BlockCount     int     `json:"block_count"`
+	TxCount        int     `json:"tx_count"`
+	Output         string  `json:"output"`
+	Fees           string  `json:"fees"`
+	ActiveStake    *string `json:"active_stake"`
+}
+
+// ProtocolParamsResponse represents Blockfrost protocol
+// parameters.
+type ProtocolParamsResponse struct {
+	Epoch              uint64  `json:"epoch"`
+	MinFeeA            int     `json:"min_fee_a"`
+	MinFeeB            int     `json:"min_fee_b"`
+	MaxBlockSize       int     `json:"max_block_size"`
+	MaxTxSize          int     `json:"max_tx_size"`
+	MaxBlockHeaderSize int     `json:"max_block_header_size"`
+	KeyDeposit         string  `json:"key_deposit"`
+	PoolDeposit        string  `json:"pool_deposit"`
+	EMax               int     `json:"e_max"`
+	NOpt               int     `json:"n_opt"`
+	A0                 float64 `json:"a0"`
+	Rho                float64 `json:"rho"`
+	Tau                float64 `json:"tau"`
+	//nolint:tagliatelle
+	DecentralisationParam float64         `json:"decentralisation_param"`
+	ExtraEntropy          *map[string]any `json:"extra_entropy"`
+	ProtocolMajorVer      int             `json:"protocol_major_ver"`
+	ProtocolMinorVer      int             `json:"protocol_minor_ver"`
+	MinUtxo               string          `json:"min_utxo"`
+	MinPoolCost           string          `json:"min_pool_cost"`
+	Nonce                 string          `json:"nonce"`
+	CoinsPerUtxoSize      *string         `json:"coins_per_utxo_size"`
+	CoinsPerUtxoWord      string          `json:"coins_per_utxo_word"`
+	CostModels            *any            `json:"cost_models"`
+	PriceMem              *float64        `json:"price_mem"`
+	PriceStep             *float64        `json:"price_step"`
+	MaxTxExMem            *string         `json:"max_tx_ex_mem"`
+	MaxTxExSteps          *string         `json:"max_tx_ex_steps"`
+	MaxBlockExMem         *string         `json:"max_block_ex_mem"`
+	MaxBlockExSteps       *string         `json:"max_block_ex_steps"`
+	MaxValSize            *string         `json:"max_val_size"`
+	CollateralPercent     *int            `json:"collateral_percent"`
+	MaxCollateralInputs   *int            `json:"max_collateral_inputs"`
+}
+
+// NetworkResponse represents Blockfrost network info.
+type NetworkResponse struct {
+	Supply NetworkSupply `json:"supply"`
+	Stake  NetworkStake  `json:"stake"`
+}
+
+// NetworkSupply holds supply information.
+type NetworkSupply struct {
+	Max         string `json:"max"`
+	Total       string `json:"total"`
+	Circulating string `json:"circulating"`
+	Locked      string `json:"locked"`
+	Treasury    string `json:"treasury"`
+	Reserves    string `json:"reserves"`
+}
+
+// NetworkStake holds stake information.
+type NetworkStake struct {
+	Live   string `json:"live"`
+	Active string `json:"active"`
+}
+
+// ErrorResponse represents a Blockfrost error response.
+type ErrorResponse struct {
+	StatusCode int    `json:"status_code"`
+	Error      string `json:"error"`
+	Message    string `json:"message"`
+}

--- a/config.go
+++ b/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	shelleyVRFKey                 string
 	shelleyKESKey                 string
 	shelleyOperationalCertificate string
+	// Blockfrost API listen address (empty = disabled)
+	blockfrostListenAddress string
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -412,5 +414,17 @@ func WithShelleyKESKey(path string) ConfigOptionFunc {
 func WithShelleyOperationalCertificate(path string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.shelleyOperationalCertificate = path
+	}
+}
+
+// WithBlockfrostListenAddress specifies the listen
+// address for the Blockfrost-compatible REST API server.
+// An empty string disables the server. The default is
+// empty (disabled).
+func WithBlockfrostListenAddress(
+	addr string,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.blockfrostListenAddress = addr
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/blinklabs-io/gouroboros v0.153.1
 	github.com/blinklabs-io/ouroboros-mock v0.9.0
 	github.com/blinklabs-io/plutigo v0.0.23
+	github.com/blockfrost/blockfrost-go v0.3.0
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.0
 	github.com/getsops/sops/v3 v3.11.0

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qt
 github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
 github.com/blinklabs-io/plutigo v0.0.23 h1:LtfWHc0bwpSLGekkO1ZBvMwo03JV/ZVpqoSIZwzjdco=
 github.com/blinklabs-io/plutigo v0.0.23/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
+github.com/blockfrost/blockfrost-go v0.3.0 h1:7DhMWaGSY4a4E6JnomovzwhSBsHUAbX3Em+TVBkgjB4=
+github.com/blockfrost/blockfrost-go v0.3.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a minimal Blockfrost-compatible REST API for the node, exposing basic endpoints for blocks, epochs, network, and health. The server is disabled by default and starts only when a listen address is provided.

- **New Features**
  - Blockfrost API server with endpoints: /, /health, /api/v0/blocks/latest, /api/v0/blocks/latest/txs, /api/v0/epochs/latest, /api/v0/epochs/latest/parameters, /api/v0/network.
  - Opt-in via WithBlockfrostListenAddress("<host>:<port>"); integrates with node start/stop, detects port conflicts at bind, and shuts down gracefully on context cancel.
  - BlockfrostNode interface with a NodeAdapter that bridges LedgerState to the API; some fields return placeholders until deeper queries are available.
  - Tests for JSON compatibility with blockfrost-go, handler behavior, server lifecycle (start/stop), and idempotent shutdown.

- **Dependencies**
  - Added github.com/blockfrost/blockfrost-go v0.3.0.

<sup>Written for commit f246b6707213d819fa6e4ac3865beb3e2021ac5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blockfrost API server with REST endpoints for accessing blockchain data including chain tip information, latest blocks, transaction hashes, epoch details, protocol parameters, and network statistics
  * Configurable listen address for the API server (defaults to :3000)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->