### PR TITLE
chore(deps): gouroboros 0.153.1

### DIFF
--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -162,6 +162,27 @@ func fetchPoolCertOrderInfo(
 	return regInfo, retInfo, nil
 }
 
+// GetPoolByVrfKeyHash retrieves an active pool by its VRF key hash.
+// Returns nil if no active pool uses this VRF key.
+func (d *MetadataStoreMysql) GetPoolByVrfKeyHash(
+	vrfKeyHash []byte,
+	txn types.Txn,
+) (*models.Pool, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var pool models.Pool
+	result := db.Where("vrf_key_hash = ?", vrfKeyHash).First(&pool)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &pool, nil
+}
+
 // GetPoolRegistrations returns pool registration certificates
 func (d *MetadataStoreMysql) GetPoolRegistrations(
 	pkh lcommon.PoolKeyHash,

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -209,6 +209,27 @@ func (d *MetadataStoreSqlite) GetPool(
 	return ret, nil
 }
 
+// GetPoolByVrfKeyHash retrieves an active pool by its VRF key hash.
+// Returns nil if no active pool uses this VRF key.
+func (d *MetadataStoreSqlite) GetPoolByVrfKeyHash(
+	vrfKeyHash []byte,
+	txn types.Txn,
+) (*models.Pool, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var pool models.Pool
+	result := db.Where("vrf_key_hash = ?", vrfKeyHash).First(&pool)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &pool, nil
+}
+
 // RestorePoolStateAtSlot reverts pool state to the given slot.
 //
 // This function handles two cases for pools:

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -64,6 +64,13 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Pool, error)
 
+	// GetPoolByVrfKeyHash retrieves an active pool by its VRF key hash.
+	// Returns nil if no active pool uses this VRF key.
+	GetPoolByVrfKeyHash(
+		[]byte, // vrfKeyHash
+		types.Txn,
+	) (*models.Pool, error)
+
 	// GetActivePoolRelays retrieves all relays from currently active pools.
 	// This is used for ledger peer discovery.
 	GetActivePoolRelays(types.Txn) ([]models.PoolRegistrationRelay, error)

--- a/database/pool.go
+++ b/database/pool.go
@@ -39,6 +39,19 @@ func (d *Database) GetPool(
 	return ret, nil
 }
 
+// GetPoolByVrfKeyHash retrieves an active pool by its VRF key hash.
+// Returns nil if no active pool uses this VRF key.
+func (d *Database) GetPoolByVrfKeyHash(
+	vrfKeyHash []byte,
+	txn *Txn,
+) (*models.Pool, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetPoolByVrfKeyHash(vrfKeyHash, txn.Metadata())
+}
+
 // GetActivePoolRelays returns all relays from currently active pools.
 // This is used for ledger peer discovery.
 func (d *Database) GetActivePoolRelays(

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.0
 	github.com/blinklabs-io/bursa v0.14.0
-	github.com/blinklabs-io/gouroboros v0.152.2
+	github.com/blinklabs-io/gouroboros v0.153.1
 	github.com/blinklabs-io/ouroboros-mock v0.9.0
 	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blinklabs-io/bursa v0.14.0 h1:e+RFfKty3sU0xcgXStg6dRSEIwiJhIKMENLcRlGOzxg=
 github.com/blinklabs-io/bursa v0.14.0/go.mod h1:T61tWWJCgoQd/fLbpPa1+64x8ANXx+fEc3CjVeAqbM4=
-github.com/blinklabs-io/gouroboros v0.152.2 h1:w2OPBrg+a8bGgk046WvkQNiyn4Yglql7AN5hdurhDFY=
-github.com/blinklabs-io/gouroboros v0.152.2/go.mod h1:BXTv7xGWb0fDpUuRunVLhSvrDrvd+pkSMBpOligo5Ew=
+github.com/blinklabs-io/gouroboros v0.153.1 h1:9Jj4hHFrVmmUbFAg4Jg8p8R07Cimb7rXJL5xrimGOi8=
+github.com/blinklabs-io/gouroboros v0.153.1/go.mod h1:MTwq+I/IMtzzWGN2Jd87uuryMfOD+3mQGYNFJn1PSFY=
 github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qtpU76eFeBKWeQ=
 github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
 github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=

--- a/internal/test/conformance/state_provider.go
+++ b/internal/test/conformance/state_provider.go
@@ -148,6 +148,14 @@ func (p *DingoStateProvider) IsPoolRegistered(
 	return retiring
 }
 
+// IsVrfKeyInUse checks if a VRF key hash is registered by another pool.
+// Conformance tests don't currently test VRF key uniqueness.
+func (p *DingoStateProvider) IsVrfKeyInUse(
+	vrfKeyHash common.Blake2b256,
+) (bool, common.PoolKeyHash, error) {
+	return false, common.PoolKeyHash{}, nil
+}
+
 // ========== common.RewardState ==========
 
 // CalculateRewards calculates rewards for the given epoch

--- a/ledger/eras/byron_test.go
+++ b/ledger/eras/byron_test.go
@@ -358,6 +358,12 @@ func (m *mockLedgerState) IsPoolRegistered(
 	return false
 }
 
+func (m *mockLedgerState) IsVrfKeyInUse(
+	_ lcommon.Blake2b256,
+) (bool, lcommon.PoolKeyHash, error) {
+	return false, lcommon.PoolKeyHash{}, nil
+}
+
 func (m *mockLedgerState) CalculateRewards(
 	_ lcommon.AdaPots,
 	_ lcommon.RewardSnapshot,

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -221,6 +221,26 @@ func (lv *LedgerView) IsPoolRegistered(pkh lcommon.PoolKeyHash) bool {
 	return reg != nil
 }
 
+// IsVrfKeyInUse checks if a VRF key hash is registered by another pool.
+// Returns (inUse, owningPoolId, error).
+func (lv *LedgerView) IsVrfKeyInUse(
+	vrfKeyHash lcommon.Blake2b256,
+) (bool, lcommon.PoolKeyHash, error) {
+	pool, err := lv.ls.db.GetPoolByVrfKeyHash(
+		vrfKeyHash.Bytes(),
+		lv.txn,
+	)
+	if err != nil {
+		return false, lcommon.PoolKeyHash{}, err
+	}
+	if pool == nil {
+		return false, lcommon.PoolKeyHash{}, nil
+	}
+	return true, lcommon.PoolKeyHash(
+		lcommon.NewBlake2b224(pool.PoolKeyHash),
+	), nil
+}
+
 // SlotToTime returns the current time for a given slot based on known epochs
 func (lv *LedgerView) SlotToTime(slot uint64) (time.Time, error) {
 	return lv.ls.SlotToTime(slot)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade to gouroboros v0.153.1 and add a VRF key hash lookup for stake pools. This enables checking VRF key uniqueness via LedgerView.

- **New Features**
  - Added GetPoolByVrfKeyHash to MetadataStore (MySQL/Postgres/SQLite) and Database.
  - Added LedgerView.IsVrfKeyInUse to report if a VRF key is registered and by which pool.
  - Updated conformance and test mocks to include IsVrfKeyInUse.

- **Dependencies**
  - Bumped github.com/blinklabs-io/gouroboros to v0.153.1.

<sup>Written for commit edccb8e2adcbd5f8614f86cbb34dbb40ff32ecfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

