### PR TITLE
chore(deps): plutigo 0.0.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/blinklabs-io/bursa v0.14.0
 	github.com/blinklabs-io/gouroboros v0.153.1
 	github.com/blinklabs-io/ouroboros-mock v0.9.0
-	github.com/blinklabs-io/plutigo v0.0.22
+	github.com/blinklabs-io/plutigo v0.0.23
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.0
 	github.com/getsops/sops/v3 v3.11.0

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/blinklabs-io/gouroboros v0.153.1 h1:9Jj4hHFrVmmUbFAg4Jg8p8R07Cimb7rXJ
 github.com/blinklabs-io/gouroboros v0.153.1/go.mod h1:MTwq+I/IMtzzWGN2Jd87uuryMfOD+3mQGYNFJn1PSFY=
 github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qtpU76eFeBKWeQ=
 github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
-github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=
-github.com/blinklabs-io/plutigo v0.0.22/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
+github.com/blinklabs-io/plutigo v0.0.23 h1:LtfWHc0bwpSLGekkO1ZBvMwo03JV/ZVpqoSIZwzjdco=
+github.com/blinklabs-io/plutigo v0.0.23/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update github.com/blinklabs-io/plutigo to v0.0.23 to keep dependencies current. Only go.mod and go.sum changed; no code changes.

<sup>Written for commit eb573f7d9a24112d17cf0e0d6ac0756f894e6a27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

