### PR TITLE
fix(ledger): track quorum for genesis keys

### DIFF
--- a/database/pparams.go
+++ b/database/pparams.go
@@ -17,6 +17,7 @@ package database
 import (
 	"fmt"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -77,25 +78,58 @@ func (d *Database) SetPParams(
 func (d *Database) ApplyPParamUpdates(
 	slot, epoch uint64,
 	era uint,
+	quorum int,
 	currentPParams *lcommon.ProtocolParameters,
 	decodeFunc func([]byte) (any, error),
 	updateFunc func(lcommon.ProtocolParameters, any) (lcommon.ProtocolParameters, error),
 	txn *Txn,
 ) error {
+	// Handle nil transaction by creating a read-only transaction
+	if txn == nil {
+		tmpTxn := d.Transaction(false)
+		defer tmpTxn.Release()
+		txn = tmpTxn
+	}
 	// Check for pparam updates that apply at the end of the epoch
 	pparamUpdates, err := d.metadata.GetPParamUpdates(epoch, txn.Metadata())
 	if err != nil {
-		return err
+		return fmt.Errorf("get pparam updates for epoch %d: %w", epoch, err)
 	}
 	if len(pparamUpdates) == 0 {
 		// nothing to do
 		return nil
 	}
-	// We only want the latest for the epoch
-	pparamUpdate := pparamUpdates[0]
-	tmpPParamUpdate, err := decodeFunc(pparamUpdate.Cbor)
+	// Filter to only updates targeting this specific epoch and count
+	// unique genesis key delegates
+	uniqueGenesis := make(map[string]struct{})
+	var latestUpdate *models.PParamUpdate
+	for i := range pparamUpdates {
+		if pparamUpdates[i].Epoch != epoch {
+			continue
+		}
+		genesisKey := string(pparamUpdates[i].GenesisHash)
+		uniqueGenesis[genesisKey] = struct{}{}
+		if latestUpdate == nil {
+			latestUpdate = &pparamUpdates[i]
+		}
+	}
+	// Check quorum: need at least 'quorum' unique genesis key delegates
+	if len(uniqueGenesis) < quorum {
+		d.logger.Debug(
+			"pparam update quorum not met, skipping",
+			"epoch", epoch,
+			"uniqueProposals", len(uniqueGenesis),
+			"quorum", quorum,
+		)
+		return nil
+	}
+	if latestUpdate == nil {
+		// No updates for this specific epoch
+		return nil
+	}
+	tmpPParamUpdate, err := decodeFunc(latestUpdate.Cbor)
 	if err != nil {
-		return err
+		return fmt.Errorf("decode pparam update: %w", err)
 	}
 	// Update current pparams
 	if *currentPParams == nil {
@@ -109,18 +143,20 @@ func (d *Database) ApplyPParamUpdates(
 		tmpPParamUpdate,
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("apply pparam update: %w", err)
 	}
 	*currentPParams = newPParams
 	d.logger.Debug(
 		"updated protocol params",
-		"pparams",
-		fmt.Sprintf("%#v", currentPParams),
+		"epoch", epoch,
+		"uniqueProposals", len(uniqueGenesis),
+		"quorum", quorum,
+		"pparams", fmt.Sprintf("%#v", currentPParams),
 	)
 	// Write pparams update to DB
 	pparamsCbor, err := cbor.Encode(&currentPParams)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode updated pparams: %w", err)
 	}
 	// Store params for the target epoch (epoch) where they take effect
 	return d.metadata.SetPParams(
@@ -135,12 +171,16 @@ func (d *Database) ApplyPParamUpdates(
 // ComputeAndApplyPParamUpdates computes the new protocol parameters by applying
 // pending updates for the given target epoch. The epoch parameter should be the
 // epoch where updates take effect (currentEpoch + 1 during epoch rollover).
+// The quorum parameter specifies the minimum number of unique genesis key
+// delegates that must have submitted update proposals for the update to be
+// applied (from shelley-genesis.json updateQuorum).
 // This function takes currentPParams as a value and returns the updated parameters
 // without mutating the input. This allows callers to capture the result in a
 // transaction and apply it to in-memory state after the transaction commits.
 func (d *Database) ComputeAndApplyPParamUpdates(
 	slot, epoch uint64,
 	era uint,
+	quorum int,
 	currentPParams lcommon.ProtocolParameters,
 	decodeFunc func([]byte) (any, error),
 	updateFunc func(
@@ -149,20 +189,56 @@ func (d *Database) ComputeAndApplyPParamUpdates(
 	) (lcommon.ProtocolParameters, error),
 	txn *Txn,
 ) (lcommon.ProtocolParameters, error) {
+	// Handle nil transaction by creating a read-only transaction
+	if txn == nil {
+		tmpTxn := d.Transaction(false)
+		defer tmpTxn.Release()
+		txn = tmpTxn
+	}
 	// Check for pparam updates that apply at the end of the epoch
 	pparamUpdates, err := d.metadata.GetPParamUpdates(epoch, txn.Metadata())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"get pparam updates for epoch %d: %w",
+			epoch,
+			err,
+		)
 	}
 	if len(pparamUpdates) == 0 {
 		// nothing to do, return current params unchanged
 		return currentPParams, nil
 	}
-	// We only want the latest for the epoch
-	pparamUpdate := pparamUpdates[0]
-	tmpPParamUpdate, err := decodeFunc(pparamUpdate.Cbor)
+	// Filter to only updates targeting this specific epoch and count
+	// unique genesis key delegates
+	uniqueGenesis := make(map[string]struct{})
+	var latestUpdate *models.PParamUpdate
+	for i := range pparamUpdates {
+		if pparamUpdates[i].Epoch != epoch {
+			continue
+		}
+		genesisKey := string(pparamUpdates[i].GenesisHash)
+		uniqueGenesis[genesisKey] = struct{}{}
+		if latestUpdate == nil {
+			latestUpdate = &pparamUpdates[i]
+		}
+	}
+	// Check quorum: need at least 'quorum' unique genesis key delegates
+	if len(uniqueGenesis) < quorum {
+		d.logger.Debug(
+			"pparam update quorum not met, skipping",
+			"epoch", epoch,
+			"uniqueProposals", len(uniqueGenesis),
+			"quorum", quorum,
+		)
+		return currentPParams, nil
+	}
+	if latestUpdate == nil {
+		// No updates for this specific epoch
+		return currentPParams, nil
+	}
+	tmpPParamUpdate, err := decodeFunc(latestUpdate.Cbor)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode pparam update: %w", err)
 	}
 	// Compute updated pparams
 	if currentPParams == nil {
@@ -176,17 +252,19 @@ func (d *Database) ComputeAndApplyPParamUpdates(
 		tmpPParamUpdate,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("apply pparam update: %w", err)
 	}
 	d.logger.Debug(
 		"computed updated protocol params",
-		"pparams",
-		fmt.Sprintf("%#v", newPParams),
+		"epoch", epoch,
+		"uniqueProposals", len(uniqueGenesis),
+		"quorum", quorum,
+		"pparams", fmt.Sprintf("%#v", newPParams),
 	)
 	// Write pparams update to DB
 	pparamsCbor, err := cbor.Encode(&newPParams)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode updated pparams: %w", err)
 	}
 	// Store params for the target epoch (epoch) where they take effect
 	err = d.metadata.SetPParams(
@@ -197,7 +275,7 @@ func (d *Database) ComputeAndApplyPParamUpdates(
 		txn.Metadata(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("set pparams: %w", err)
 	}
 	return newPParams, nil
 }

--- a/database/pparams_test.go
+++ b/database/pparams_test.go
@@ -1,0 +1,384 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeAndApplyPParamUpdates_QuorumNotMet(
+	t *testing.T,
+) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	txn := db.Transaction(true)
+	defer txn.Commit() //nolint:errcheck
+
+	// Store 3 pparam updates from 3 different genesis keys
+	// targeting epoch 4
+	genesisKeys := [][]byte{
+		{0x01, 0x02, 0x03},
+		{0x04, 0x05, 0x06},
+		{0x07, 0x08, 0x09},
+	}
+	minFeeA := uint(100)
+	updateCbor, err := cbor.Encode(
+		&shelley.ShelleyProtocolParameterUpdate{
+			MinFeeA: &minFeeA,
+		},
+	)
+	require.NoError(t, err)
+
+	for i, gk := range genesisKeys {
+		err := db.SetPParamUpdate(
+			gk,
+			updateCbor,
+			uint64(300+i), // slot
+			4,             // epoch
+			txn,
+		)
+		require.NoError(t, err)
+	}
+
+	// Set current pparams so we have something to start with
+	currentPParams := &shelley.ShelleyProtocolParameters{
+		MinFeeA: 44,
+	}
+	currentPParamsCbor, err := cbor.Encode(currentPParams)
+	require.NoError(t, err)
+	err = db.SetPParams(currentPParamsCbor, 0, 3, 2, txn)
+	require.NoError(t, err)
+
+	// Decode and update functions
+	decodeFunc := func(data []byte) (any, error) {
+		var update shelley.ShelleyProtocolParameterUpdate
+		_, err := cbor.Decode(data, &update)
+		return update, err
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		// For test: just return current unchanged to
+		// verify the update is skipped
+		return current, nil
+	}
+
+	// Try to apply with quorum = 5 (only 3 proposals, below
+	// quorum)
+	result, err := db.ComputeAndApplyPParamUpdates(
+		400, // slot
+		4,   // epoch
+		2,   // era
+		5,   // quorum - 5 required, only 3 present
+		currentPParams,
+		decodeFunc,
+		updateFunc,
+		txn,
+	)
+	require.NoError(t, err)
+	// Should return current params unchanged since quorum not met
+	assert.Equal(
+		t,
+		currentPParams,
+		result,
+		"params should be unchanged when quorum not met",
+	)
+}
+
+func TestComputeAndApplyPParamUpdates_QuorumMet(
+	t *testing.T,
+) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	txn := db.Transaction(true)
+	defer txn.Commit() //nolint:errcheck
+
+	// Store 5 pparam updates from 5 different genesis keys
+	// targeting epoch 4
+	genesisKeys := [][]byte{
+		{0x01}, {0x02}, {0x03}, {0x04}, {0x05},
+	}
+	minFeeA := uint(100)
+	updateCbor, err := cbor.Encode(
+		&shelley.ShelleyProtocolParameterUpdate{
+			MinFeeA: &minFeeA,
+		},
+	)
+	require.NoError(t, err)
+
+	for i, gk := range genesisKeys {
+		err := db.SetPParamUpdate(
+			gk,
+			updateCbor,
+			uint64(300+i),
+			4, // epoch
+			txn,
+		)
+		require.NoError(t, err)
+	}
+
+	currentPParams := &shelley.ShelleyProtocolParameters{
+		MinFeeA: 44,
+	}
+	currentPParamsCbor, err := cbor.Encode(currentPParams)
+	require.NoError(t, err)
+	err = db.SetPParams(currentPParamsCbor, 0, 3, 2, txn)
+	require.NoError(t, err)
+
+	updateApplied := false
+	decodeFunc := func(data []byte) (any, error) {
+		var update shelley.ShelleyProtocolParameterUpdate
+		_, err := cbor.Decode(data, &update)
+		return update, err
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		updateApplied = true
+		return current, nil
+	}
+
+	// Apply with quorum = 5 (exactly 5 proposals, meets quorum)
+	_, err = db.ComputeAndApplyPParamUpdates(
+		400,
+		4,
+		2,
+		5, // quorum met
+		currentPParams,
+		decodeFunc,
+		updateFunc,
+		txn,
+	)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		updateApplied,
+		"update should be applied when quorum is met",
+	)
+}
+
+func TestComputeAndApplyPParamUpdates_FiltersEpoch(
+	t *testing.T,
+) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	txn := db.Transaction(true)
+	defer txn.Commit() //nolint:errcheck
+
+	// Store 3 updates for epoch 3 and 5 updates for epoch 4.
+	// When querying for epoch 4, GetPParamUpdates returns
+	// both (epoch=4 OR epoch=3). The quorum check should only
+	// count epoch 4 records.
+	for i := 0; i < 3; i++ {
+		err := db.SetPParamUpdate(
+			[]byte{byte(i)},
+			[]byte{0x80}, // minimal CBOR
+			uint64(200+i),
+			3, // epoch 3
+			txn,
+		)
+		require.NoError(t, err)
+	}
+	for i := 0; i < 5; i++ {
+		innerMinFeeA := uint(100)
+		updateCbor, innerErr := cbor.Encode(
+			&shelley.ShelleyProtocolParameterUpdate{
+				MinFeeA: &innerMinFeeA,
+			},
+		)
+		require.NoError(t, innerErr)
+		err := db.SetPParamUpdate(
+			[]byte{byte(10 + i)},
+			updateCbor,
+			uint64(300+i),
+			4, // epoch 4
+			txn,
+		)
+		require.NoError(t, err)
+	}
+
+	currentPParams := &shelley.ShelleyProtocolParameters{
+		MinFeeA: 44,
+	}
+	currentPParamsCbor, err := cbor.Encode(currentPParams)
+	require.NoError(t, err)
+	err = db.SetPParams(currentPParamsCbor, 0, 3, 2, txn)
+	require.NoError(t, err)
+
+	updateApplied := false
+	decodeFunc := func(data []byte) (any, error) {
+		var update shelley.ShelleyProtocolParameterUpdate
+		_, err := cbor.Decode(data, &update)
+		return update, err
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		updateApplied = true
+		return current, nil
+	}
+
+	// Quorum = 5: epoch 4 has 5 proposals (meets quorum),
+	// epoch 3 has 3 (below quorum). Only epoch 4 should count.
+	_, err = db.ComputeAndApplyPParamUpdates(
+		400,
+		4,
+		2,
+		5, // quorum
+		currentPParams,
+		decodeFunc,
+		updateFunc,
+		txn,
+	)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		updateApplied,
+		"update should be applied: epoch 4 has 5 proposals meeting quorum",
+	)
+}
+
+func TestComputeAndApplyPParamUpdates_NoUpdates(
+	t *testing.T,
+) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	txn := db.Transaction(true)
+	defer txn.Commit() //nolint:errcheck
+
+	currentPParams := &shelley.ShelleyProtocolParameters{
+		MinFeeA: 44,
+	}
+
+	decodeFunc := func(data []byte) (any, error) {
+		return nil, nil
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		t.Fatal("update function should not be called")
+		return current, nil
+	}
+
+	result, err := db.ComputeAndApplyPParamUpdates(
+		400, 4, 2, 5,
+		currentPParams,
+		decodeFunc, updateFunc,
+		txn,
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		currentPParams,
+		result,
+		"should return current params when no updates exist",
+	)
+}
+
+func TestComputeAndApplyPParamUpdates_DuplicateGenesis(
+	t *testing.T,
+) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	txn := db.Transaction(true)
+	defer txn.Commit() //nolint:errcheck
+
+	// Store 5 updates but from only 2 unique genesis keys
+	// (duplicates should not count toward quorum)
+	genesisKeys := [][]byte{
+		{0x01}, {0x02}, {0x01}, {0x02}, {0x01},
+	}
+	for i, gk := range genesisKeys {
+		innerMinFeeA := uint(100)
+		updateCbor, innerErr := cbor.Encode(
+			&shelley.ShelleyProtocolParameterUpdate{
+				MinFeeA: &innerMinFeeA,
+			},
+		)
+		require.NoError(t, innerErr)
+		err := db.SetPParamUpdate(
+			gk,
+			updateCbor,
+			uint64(300+i),
+			4,
+			txn,
+		)
+		require.NoError(t, err)
+	}
+
+	currentPParams := &shelley.ShelleyProtocolParameters{
+		MinFeeA: 44,
+	}
+	currentPParamsCbor, err := cbor.Encode(currentPParams)
+	require.NoError(t, err)
+	err = db.SetPParams(currentPParamsCbor, 0, 3, 2, txn)
+	require.NoError(t, err)
+
+	decodeFunc := func(data []byte) (any, error) {
+		var update shelley.ShelleyProtocolParameterUpdate
+		_, err := cbor.Decode(data, &update)
+		return update, err
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		t.Fatal(
+			"update function should not be called " +
+				"with duplicate genesis keys",
+		)
+		return current, nil
+	}
+
+	// Only 2 unique genesis keys, quorum is 5
+	result, err := db.ComputeAndApplyPParamUpdates(
+		400, 4, 2, 5,
+		currentPParams,
+		decodeFunc, updateFunc,
+		txn,
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		currentPParams,
+		result,
+		"should not apply: only 2 unique genesis keys, need 5",
+	)
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -789,10 +789,16 @@ func (ls *LedgerState) processEpochRollover(
 	}
 	// Apply pending pparam updates using the non-mutating version
 	// Updates target the next epoch, so we pass currentEpoch.EpochId + 1
+	// The quorum threshold comes from shelley-genesis.json updateQuorum
+	updateQuorum := 0
+	if shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis(); shelleyGenesis != nil {
+		updateQuorum = shelleyGenesis.UpdateQuorum
+	}
 	newPParams, err := ls.db.ComputeAndApplyPParamUpdates(
 		epochStartSlot,
 		currentEpoch.EpochId+1, // Target epoch for updates
 		currentEra.Id,
+		updateQuorum,
 		currentPParams,
 		currentEra.DecodePParamsUpdateFunc,
 		currentEra.PParamsUpdateFunc,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Count unique genesis key delegates and only apply protocol parameter updates at epoch rollover when updateQuorum is met.

- **Bug Fixes**
  - Database: ApplyPParamUpdates and ComputeAndApplyPParamUpdates now accept a quorum, filter to the target epoch, dedupe by genesis key, skip apply when quorum isn’t met, handle nil txn safely, and add clear debug logs.
  - Ledger: Read updateQuorum from shelley-genesis.json and pass it to ComputeAndApplyPParamUpdates during epoch rollover.
  - Tests: Added cases for quorum met/not met, epoch filtering, no updates, and duplicate genesis keys.

<sup>Written for commit 7c05d31de885645fde8041a964b4e051ffb3cc96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Protocol parameter updates now enforce quorum-based validation, requiring approval from a minimum threshold of genesis delegates before updates are applied to the network. This ensures governance changes meet consensus requirements and maintain network integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->