### PR TITLE
fix(database): split sqlite reads/writes

### DIFF
--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -603,7 +603,7 @@ func (d *MetadataStoreSqlite) GetAccount(
 	txn types.Txn,
 ) (*models.Account, error) {
 	ret := &models.Account{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/asset.go
+++ b/database/plugin/metadata/sqlite/asset.go
@@ -32,7 +32,7 @@ func (d *MetadataStoreSqlite) GetAssetByPolicyAndName(
 	var asset models.Asset
 	var result *gorm.DB
 
-	query, err := d.resolveDB(txn)
+	query, err := d.resolveReadDB(txn)
 	if err != nil {
 		return models.Asset{}, err
 	}
@@ -56,7 +56,7 @@ func (d *MetadataStoreSqlite) GetAssetsByPolicy(
 	var assets []models.Asset
 	var result *gorm.DB
 
-	query, err := d.resolveDB(txn)
+	query, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (d *MetadataStoreSqlite) GetAssetsByUTxO(
 	var assets []models.Asset
 	var result *gorm.DB
 
-	query, err := d.resolveDB(txn)
+	query, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/block_nonce.go
+++ b/database/plugin/metadata/sqlite/block_nonce.go
@@ -57,7 +57,7 @@ func (d *MetadataStoreSqlite) GetBlockNonce(
 	txn types.Txn,
 ) ([]byte, error) {
 	ret := models.BlockNonce{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/certs.go
+++ b/database/plugin/metadata/sqlite/certs.go
@@ -28,7 +28,7 @@ func (d *MetadataStoreSqlite) GetStakeRegistrations(
 ) ([]lcommon.StakeRegistrationCertificate, error) {
 	ret := []lcommon.StakeRegistrationCertificate{}
 	certs := []models.StakeRegistration{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return ret, err
 	}

--- a/database/plugin/metadata/sqlite/commit_timestamp.go
+++ b/database/plugin/metadata/sqlite/commit_timestamp.go
@@ -39,7 +39,7 @@ func (CommitTimestamp) TableName() string {
 func (d *MetadataStoreSqlite) GetCommitTimestamp() (int64, error) {
 	// Get value from sqlite
 	var tmpCommitTimestamp CommitTimestamp
-	result := d.DB().First(&tmpCommitTimestamp)
+	result := d.ReadDB().First(&tmpCommitTimestamp)
 	if result.Error != nil {
 		// It's not an error if there's no records found
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {

--- a/database/plugin/metadata/sqlite/committee.go
+++ b/database/plugin/metadata/sqlite/committee.go
@@ -29,7 +29,7 @@ func (d *MetadataStoreSqlite) GetCommitteeMember(
 	txn types.Txn,
 ) (*models.AuthCommitteeHot, error) {
 	var member models.AuthCommitteeHot
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (d *MetadataStoreSqlite) GetActiveCommitteeMembers(
 	txn types.Txn,
 ) ([]*models.AuthCommitteeHot, error) {
 	var members []*models.AuthCommitteeHot
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (d *MetadataStoreSqlite) IsCommitteeMemberResigned(
 	coldKey []byte,
 	txn types.Txn,
 ) (bool, error) {
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return false, err
 	}

--- a/database/plugin/metadata/sqlite/concurrency_test.go
+++ b/database/plugin/metadata/sqlite/concurrency_test.go
@@ -1,0 +1,458 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlite
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupFileBasedStore creates a file-based MetadataStoreSqlite in a
+// temp directory. This exercises the separate read/write connection
+// pools used in production.
+func setupFileBasedStore(
+	t *testing.T,
+) *MetadataStoreSqlite {
+	t.Helper()
+	tmpDir := t.TempDir()
+	store, err := NewWithOptions(
+		WithDataDir(tmpDir),
+		WithMaxConnections(DefaultMaxConnections),
+	)
+	require.NoError(t, err, "failed to create store")
+	require.NoError(t, store.Start(), "failed to start store")
+	return store
+}
+
+// TestConcurrentReadsDuringWrites verifies that concurrent reads
+// do not produce SQLITE_BUSY errors while writes are in progress.
+// This is the core scenario the read/write pool separation fixes.
+func TestConcurrentReadsDuringWrites(t *testing.T) {
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const (
+		numWriters   = 3
+		numReaders   = 5
+		opsPerWorker = 20
+	)
+
+	var (
+		writeErrors atomic.Int64
+		readErrors  atomic.Int64
+		wg          sync.WaitGroup
+	)
+
+	// Seed some initial data so reads have something to find
+	for i := range 10 {
+		snapshot := &models.PoolStakeSnapshot{
+			Epoch:          1,
+			SnapshotType:   "go",
+			PoolKeyHash:    []byte(fmt.Sprintf("pool_%028d", i)),
+			TotalStake:     1000000,
+			DelegatorCount: 100,
+			CapturedSlot:   1000,
+		}
+		require.NoError(
+			t,
+			store.SavePoolStakeSnapshot(snapshot, nil),
+		)
+	}
+
+	// Start concurrent writers
+	for w := range numWriters {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for i := range opsPerWorker {
+				snapshot := &models.PoolStakeSnapshot{
+					Epoch:        uint64(writerID*1000 + i + 2),
+					SnapshotType: "go",
+					PoolKeyHash: []byte(
+						fmt.Sprintf(
+							"pool_w%d_%023d",
+							writerID,
+							i,
+						),
+					),
+					TotalStake:     1000000,
+					DelegatorCount: 100,
+					CapturedSlot:   uint64(writerID*1000 + i),
+				}
+				if err := store.SavePoolStakeSnapshot(
+					snapshot, nil,
+				); err != nil {
+					writeErrors.Add(1)
+					t.Logf(
+						"writer %d op %d error: %v",
+						writerID, i, err,
+					)
+				}
+			}
+		}(w)
+	}
+
+	// Start concurrent readers
+	for r := range numReaders {
+		wg.Add(1)
+		go func(readerID int) {
+			defer wg.Done()
+			for range opsPerWorker {
+				_, err := store.GetPoolStakeSnapshotsByEpoch(
+					1, "go", nil,
+				)
+				if err != nil {
+					readErrors.Add(1)
+					t.Logf(
+						"reader %d error: %v",
+						readerID, err,
+					)
+				}
+			}
+		}(r)
+	}
+
+	wg.Wait()
+
+	assert.Equal(
+		t,
+		int64(0),
+		writeErrors.Load(),
+		"expected zero write errors (SQLITE_BUSY)",
+	)
+	assert.Equal(
+		t,
+		int64(0),
+		readErrors.Load(),
+		"expected zero read errors (SQLITE_BUSY)",
+	)
+}
+
+// TestConcurrentWriteTransactions verifies that multiple
+// goroutines can perform write transactions without SQLITE_BUSY
+// errors. With a single-writer connection pool, writes serialize
+// naturally at the Go connection pool level.
+func TestConcurrentWriteTransactions(t *testing.T) {
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const (
+		numWriters   = 5
+		opsPerWriter = 10
+	)
+
+	var (
+		errors atomic.Int64
+		wg     sync.WaitGroup
+	)
+
+	for w := range numWriters {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for i := range opsPerWriter {
+				txn := store.Transaction()
+
+				snapshot := &models.PoolStakeSnapshot{
+					Epoch: uint64(
+						writerID*1000 + i + 1,
+					),
+					SnapshotType: "go",
+					PoolKeyHash: []byte(
+						fmt.Sprintf(
+							"pool_tw%d_%022d",
+							writerID,
+							i,
+						),
+					),
+					TotalStake:     1000000,
+					DelegatorCount: 100,
+					CapturedSlot: uint64(
+						writerID*1000 + i,
+					),
+				}
+				if err := store.SavePoolStakeSnapshot(
+					snapshot, txn,
+				); err != nil {
+					errors.Add(1)
+					t.Logf(
+						"writer %d op %d save error: %v",
+						writerID, i, err,
+					)
+					_ = txn.Rollback()
+					continue
+				}
+				if err := txn.Commit(); err != nil {
+					errors.Add(1)
+					t.Logf(
+						"writer %d op %d commit error: %v",
+						writerID, i, err,
+					)
+					_ = txn.Rollback()
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	assert.Equal(
+		t,
+		int64(0),
+		errors.Load(),
+		"expected zero transaction errors",
+	)
+}
+
+// TestReadWritePoolSeparation verifies that the file-based store
+// has separate read and write database handles.
+func TestReadWritePoolSeparation(t *testing.T) {
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	// For file-based stores, ReadDB should be a different handle
+	// than DB (write handle)
+	assert.NotNil(t, store.DB(), "write DB should not be nil")
+	assert.NotNil(t, store.ReadDB(), "read DB should not be nil")
+
+	// The read and write handles should be different objects for
+	// file-based stores
+	writeDB := store.DB()
+	readDB := store.ReadDB()
+	assert.NotSame(
+		t,
+		writeDB,
+		readDB,
+		"file-based store should have separate read/write pools",
+	)
+}
+
+// TestInMemorySharedPool verifies that the in-memory store shares
+// a single pool for reads and writes.
+func TestInMemorySharedPool(t *testing.T) {
+	store, err := New("", nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, store.Start())
+	defer store.Close() //nolint:errcheck
+
+	// For in-memory stores, ReadDB and DB should be the same
+	assert.Same(
+		t,
+		store.DB(),
+		store.ReadDB(),
+		"in-memory store should share read/write pool",
+	)
+}
+
+// TestHighContentionReadWrite exercises a high-contention scenario
+// with many goroutines performing mixed read/write operations. This
+// is a stress test to verify the fix under load.
+func TestHighContentionReadWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const (
+		numGoroutines = 20
+		opsPerRoutine = 50
+	)
+
+	var (
+		busyErrors atomic.Int64
+		otherErrs  atomic.Int64
+		wg         sync.WaitGroup
+	)
+
+	// Seed data
+	for i := range 5 {
+		summary := &models.EpochSummary{
+			Epoch:            uint64(i + 1),
+			TotalActiveStake: 30000000000000000,
+			TotalPoolCount:   3000,
+			TotalDelegators:  1200000,
+			BoundarySlot:     uint64(i * 43200),
+			SnapshotReady:    true,
+		}
+		require.NoError(t, store.SaveEpochSummary(summary, nil))
+	}
+
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range opsPerRoutine {
+				var err error
+				if id%2 == 0 {
+					// Writer
+					summary := &models.EpochSummary{
+						Epoch: uint64(
+							id*10000 + i + 100,
+						),
+						TotalActiveStake: 30000000000000000,
+						TotalPoolCount:   3000,
+						TotalDelegators:  1200000,
+						BoundarySlot: uint64(
+							id*10000 + i,
+						),
+						SnapshotReady: true,
+					}
+					err = store.SaveEpochSummary(
+						summary, nil,
+					)
+				} else {
+					// Reader
+					_, err = store.GetEpochSummary(
+						uint64(i%5+1), nil,
+					)
+				}
+				if err != nil {
+					errMsg := err.Error()
+					if strings.Contains(
+						errMsg,
+						"SQLITE_BUSY",
+					) || strings.Contains(
+						errMsg,
+						"database is locked",
+					) {
+						busyErrors.Add(1)
+					} else {
+						otherErrs.Add(1)
+					}
+					t.Logf(
+						"goroutine %d op %d error: %v",
+						id, i, err,
+					)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	assert.Equal(
+		t,
+		int64(0),
+		busyErrors.Load(),
+		"expected zero SQLITE_BUSY errors",
+	)
+	assert.Equal(
+		t,
+		int64(0),
+		otherErrs.Load(),
+		"expected zero database errors",
+	)
+}
+
+// TestWritePoolSingleConnection verifies that the write pool has
+// exactly 1 max open connection for file-based databases.
+func TestWritePoolSingleConnection(t *testing.T) {
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	writeSqlDB, err := store.DB().DB()
+	require.NoError(t, err)
+
+	stats := writeSqlDB.Stats()
+	assert.Equal(
+		t,
+		1,
+		stats.MaxOpenConnections,
+		"write pool should have exactly 1 max open connection",
+	)
+}
+
+// TestReadPoolMultipleConnections verifies that the read pool
+// allows multiple connections for file-based databases.
+func TestReadPoolMultipleConnections(t *testing.T) {
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	readSqlDB, err := store.ReadDB().DB()
+	require.NoError(t, err)
+
+	stats := readSqlDB.Stats()
+	assert.Equal(
+		t,
+		DefaultMaxConnections,
+		stats.MaxOpenConnections,
+		"read pool should have DefaultMaxConnections open conns",
+	)
+}
+
+// TestConcurrentReadsDontBlock verifies that many concurrent reads
+// complete quickly and don't block each other.
+func TestConcurrentReadsDontBlock(t *testing.T) {
+	store := setupFileBasedStore(t)
+	defer store.Close() //nolint:errcheck
+
+	// Seed a small amount of data
+	for i := range 10 {
+		snapshot := &models.PoolStakeSnapshot{
+			Epoch:          1,
+			SnapshotType:   "go",
+			PoolKeyHash:    []byte(fmt.Sprintf("pool_%028d", i)),
+			TotalStake:     1000000,
+			DelegatorCount: 100,
+			CapturedSlot:   1000,
+		}
+		require.NoError(
+			t,
+			store.SavePoolStakeSnapshot(snapshot, nil),
+		)
+	}
+
+	const numReaders = 10
+
+	var (
+		wg     sync.WaitGroup
+		errors atomic.Int64
+	)
+
+	for range numReaders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				_, err := store.GetPoolStakeSnapshotsByEpoch(
+					1, "go", nil,
+				)
+				if err != nil {
+					errors.Add(1)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify no errors occurred - the key metric is zero
+	// errors, not raw speed (race detector adds overhead).
+	assert.Equal(
+		t,
+		int64(0),
+		errors.Load(),
+		"concurrent reads should not produce errors",
+	)
+}

--- a/database/plugin/metadata/sqlite/constitution.go
+++ b/database/plugin/metadata/sqlite/constitution.go
@@ -30,9 +30,9 @@ func (d *MetadataStoreSqlite) GetConstitution(
 	txn types.Txn,
 ) (*models.Constitution, error) {
 	var constitution models.Constitution
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
-		return nil, fmt.Errorf("resolveDB failed in GetConstitution: %w", err)
+		return nil, fmt.Errorf("resolveReadDB failed in GetConstitution: %w", err)
 	}
 	// Get the most recent non-deleted constitution by added_slot
 	if result := db.Where("deleted_slot IS NULL").Order("added_slot DESC").First(&constitution); result.Error != nil {

--- a/database/plugin/metadata/sqlite/datum.go
+++ b/database/plugin/metadata/sqlite/datum.go
@@ -31,7 +31,7 @@ func (d *MetadataStoreSqlite) GetDatum(
 	txn types.Txn,
 ) (*models.Datum, error) {
 	ret := &models.Datum{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -186,7 +186,7 @@ func (d *MetadataStoreSqlite) GetDrep(
 	txn types.Txn,
 ) (*models.Drep, error) {
 	var drep models.Drep
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/epoch.go
+++ b/database/plugin/metadata/sqlite/epoch.go
@@ -27,7 +27,7 @@ func (d *MetadataStoreSqlite) GetEpochsByEra(
 	txn types.Txn,
 ) ([]models.Epoch, error) {
 	var ret []models.Epoch
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (d *MetadataStoreSqlite) GetEpochs(
 	txn types.Txn,
 ) ([]models.Epoch, error) {
 	var ret []models.Epoch
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/governance.go
+++ b/database/plugin/metadata/sqlite/governance.go
@@ -31,7 +31,7 @@ func (d *MetadataStoreSqlite) GetGovernanceProposal(
 	txn types.Txn,
 ) (*models.GovernanceProposal, error) {
 	var proposal models.GovernanceProposal
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (d *MetadataStoreSqlite) GetActiveGovernanceProposals(
 	txn types.Txn,
 ) ([]*models.GovernanceProposal, error) {
 	var proposals []*models.GovernanceProposal
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (d *MetadataStoreSqlite) GetGovernanceVotes(
 	txn types.Txn,
 ) ([]*models.GovernanceVote, error) {
 	var votes []*models.GovernanceVote
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -138,7 +138,7 @@ func (d *MetadataStoreSqlite) GetPool(
 	txn types.Txn,
 ) (*models.Pool, error) {
 	ret := &models.Pool{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +319,7 @@ func (d *MetadataStoreSqlite) GetPoolRegistrations(
 ) ([]lcommon.PoolRegistrationCertificate, error) {
 	ret := []lcommon.PoolRegistrationCertificate{}
 	certs := []models.PoolRegistration{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return ret, err
 	}
@@ -434,7 +434,7 @@ func (d *MetadataStoreSqlite) GetPoolRegistrations(
 func (d *MetadataStoreSqlite) GetActivePoolRelays(
 	txn types.Txn,
 ) ([]models.PoolRegistrationRelay, error) {
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +513,7 @@ func (d *MetadataStoreSqlite) GetActivePoolRelays(
 func (d *MetadataStoreSqlite) GetActivePoolKeyHashes(
 	txn types.Txn,
 ) ([][]byte, error) {
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf("GetActivePoolKeyHashes: resolve db: %w", err)
 	}
@@ -603,7 +603,7 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 	poolKeyHashes [][]byte,
 	txn types.Txn,
 ) (map[string]uint64, map[string]uint64, error) {
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("GetStakeByPools: resolve db: %w", err)
 	}

--- a/database/plugin/metadata/sqlite/pparams.go
+++ b/database/plugin/metadata/sqlite/pparams.go
@@ -26,7 +26,7 @@ func (d *MetadataStoreSqlite) GetPParams(
 	txn types.Txn,
 ) ([]models.PParams, error) {
 	ret := []models.PParams{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return ret, err
 	}
@@ -47,7 +47,7 @@ func (d *MetadataStoreSqlite) GetPParamUpdates(
 	txn types.Txn,
 ) ([]models.PParamUpdate, error) {
 	ret := []models.PParamUpdate{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return ret, err
 	}

--- a/database/plugin/metadata/sqlite/script.go
+++ b/database/plugin/metadata/sqlite/script.go
@@ -29,7 +29,7 @@ func (d *MetadataStoreSqlite) GetScript(
 	txn types.Txn,
 ) (*models.Script, error) {
 	ret := &models.Script{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -60,7 +60,7 @@ func (d *MetadataStoreSqlite) GetPoolStakeSnapshot(
 	txn types.Txn,
 ) (*models.PoolStakeSnapshot, error) {
 	var snapshot models.PoolStakeSnapshot
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (d *MetadataStoreSqlite) GetPoolStakeSnapshotsByEpoch(
 	txn types.Txn,
 ) ([]*models.PoolStakeSnapshot, error) {
 	var snapshots []*models.PoolStakeSnapshot
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (d *MetadataStoreSqlite) GetTotalActiveStake(
 	txn types.Txn,
 ) (uint64, error) {
 	var total uint64
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return 0, err
 	}
@@ -141,7 +141,7 @@ func (d *MetadataStoreSqlite) GetEpochSummary(
 	txn types.Txn,
 ) (*models.EpochSummary, error) {
 	var summary models.EpochSummary
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (d *MetadataStoreSqlite) GetLatestEpochSummary(
 	txn types.Txn,
 ) (*models.EpochSummary, error) {
 	var summary models.EpochSummary
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/tip.go
+++ b/database/plugin/metadata/sqlite/tip.go
@@ -35,7 +35,7 @@ func (d *MetadataStoreSqlite) GetTip(
 ) (ocommon.Tip, error) {
 	ret := ocommon.Tip{}
 	tmpTip := models.Tip{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return ret, err
 	}

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -39,7 +39,7 @@ func (d *MetadataStoreSqlite) GetUtxo(
 	txn types.Txn,
 ) (*models.Utxo, error) {
 	ret := &models.Utxo{}
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (d *MetadataStoreSqlite) GetUtxosBatch(
 		return make(map[string]*models.Utxo), nil
 	}
 
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (d *MetadataStoreSqlite) GetUtxosAddedAfterSlot(
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (d *MetadataStoreSqlite) GetUtxosDeletedBeforeSlot(
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAssets(
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
-	db, err := d.resolveDB(txn)
+	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split SQLite reads from writes by introducing a dedicated read-only pool and routing all read queries to it. This removes SQLITE_BUSY under load and improves concurrent read throughput.

- **Bug Fixes**
  - File-based DBs: 1 write connection (_txlock=immediate) and a read-only pool (mode=ro) with DefaultMaxConnections; enable WAL, busy_timeout, synchronous=NORMAL, cache_size, mmap_size, foreign_keys.
  - Added ReadDB() and resolveReadDB(); switched read paths to the read pool; enabled tracing on both pools.
  - In-memory DBs: single shared pool with cache=shared.
  - Clean shutdown of both pools; added concurrency tests covering zero SQLITE_BUSY under mixed load, transaction serialization (1 writer), read/write pool separation, in-memory sharing, high-contention stress, and pool size assertions.

<sup>Written for commit 3c4bf33ffe0ef7b34753edb0ccefc5b7cc67a196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Read and write database paths were separated so read operations use a dedicated read pool, reducing contention and improving concurrent read performance and reliability.

* **Tests**
  * Added a comprehensive concurrency test suite validating stability under mixed read/write load, high contention, and pool-separation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->