### PR TITLE
feat(ouroboros): genesis hash, blockfetch range validation

### DIFF
--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// testConnId creates a ConnectionId with valid net.Addr values for testing.
+func testConnId() ouroboros_conn.ConnectionId {
+	return ouroboros_conn.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
+	}
+}
+
+func TestBlockfetchServerRequestRange_StartAfterEnd(t *testing.T) {
+	// When start slot > end slot, blockfetchServerRequestRange should
+	// log a warning and attempt to send NoBlocks. Since we don't have a
+	// real protocol server wired up, the NoBlocks call will panic on the
+	// nil server. We use assert.Panics to catch that, and then verify the
+	// warning was logged BEFORE the NoBlocks call, proving the range check
+	// was reached (not GetChainFromPoint, which would be a different panic).
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	// LedgerState is intentionally nil - if the range check works,
+	// we never reach GetChainFromPoint and avoid a nil dereference on
+	// LedgerState.
+
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(50, []byte{0x02})
+	ctx := blockfetch.CallbackContext{
+		ConnectionId: testConnId(),
+		// Server is nil, so NoBlocks() will panic after the log.
+	}
+
+	assert.Panics(t, func() {
+		_ = o.blockfetchServerRequestRange(ctx, start, end)
+	}, "expected panic from nil Server.NoBlocks()")
+
+	// Verify the warning was logged before the panic
+	logOutput := logBuf.String()
+	assert.Contains(
+		t,
+		logOutput,
+		"start after end",
+		"expected log message about start after end",
+	)
+}
+
+func TestBlockfetchServerRequestRange_EqualPoints(t *testing.T) {
+	// When start == end (same slot), this is a valid single-block range
+	// and should NOT trigger the "start after end" check.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	// LedgerState is nil, so GetChainFromPoint will panic.
+	// This verifies the range check does NOT reject equal slots.
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(100, []byte{0x01})
+
+	// We expect a panic from nil LedgerState (not from range validation),
+	// which proves that equal slots pass the range check.
+	assert.Panics(t, func() {
+		_ = o.blockfetchServerRequestRange(
+			blockfetch.CallbackContext{
+				ConnectionId: testConnId(),
+			},
+			start,
+			end,
+		)
+	}, "equal slot range should pass validation and reach LedgerState call")
+}


### PR DESCRIPTION
Closes #397 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add genesis hash verification for Cardano configs and enforce valid BlockFetch request ranges. Reject mismatched genesis files and invalid ranges, with clearer logs and tests for both paths.

- **New Features**
  - Validate Byron/Shelley/Alonzo/Conway genesis hashes on load; skip if expected hash is empty; fail with "<Era> genesis hash mismatch".
  - BlockFetch: send NoBlocks when start.slot > end.slot or the start point isn’t on our chain; warn with connection ID and slot range.
  - Add contextual error logs for StartBatch, SendBlockToPeer, and BatchDone (include connection ID and start/end slots).

<sup>Written for commit 37822171557d1439c4af3f08b2f8a03157a9fb06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling in block synchronization logic with enhanced contextual logging.
  * Genesis hash validation now provides clearer error messaging for configuration mismatches.

* **Tests**
  * Added comprehensive test coverage for genesis hash validation across multiple eras.
  * New tests for block synchronization edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->