### PR TITLE
feat(chain): clear header queue on peer switch

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -364,6 +364,18 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	return nil
 }
 
+// ClearHeaders removes all queued block headers. This is used when
+// the active peer changes and stale headers from the previous peer's
+// chainsync session no longer fit the current chain tip.
+func (c *Chain) ClearHeaders() {
+	if c == nil {
+		return
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.headers = c.headers[:0]
+}
+
 func (c *Chain) HeaderCount() int {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -47,6 +47,18 @@ func NewBlockNotFitChainTipError(
 	}
 }
 
+func (e BlockNotFitChainTipError) BlockHash() string {
+	return e.blockHash
+}
+
+func (e BlockNotFitChainTipError) BlockPrevHash() string {
+	return e.blockPrevHash
+}
+
+func (e BlockNotFitChainTipError) TipHash() string {
+	return e.tipHash
+}
+
 func (e BlockNotFitChainTipError) Error() string {
 	return fmt.Sprintf(
 		"block %s with prev hash %s does not fit on current chain tip %s",

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -2099,7 +2099,7 @@ func TestGetActivePoolKeyHashesAtSlot(t *testing.T) {
 				PoolID:        pool.ID,
 				PoolKeyHash:   poolHash,
 				AddedSlot:     1000,
-				Epoch:         10, // Current epoch, so retirement is effective
+				Epoch:         10,  // Current epoch, so retirement is effective
 				CertificateID: 200, // References cert with higher cert_index
 			}
 			if result := sqliteStore.DB().Create(&poolRet); result.Error != nil {

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -35,10 +35,10 @@ import (
 type tamperOption int
 
 const (
-	tamperNone       tamperOption = iota
-	tamperKESSig                  // Flip bits in the KES signature
-	tamperVRFProof                // Flip bits in the VRF proof
-	tamperOpCertSig               // Flip bits in the OpCert cold-key signature
+	tamperNone      tamperOption = iota
+	tamperKESSig                 // Flip bits in the KES signature
+	tamperVRFProof               // Flip bits in the VRF proof
+	tamperOpCertSig              // Flip bits in the OpCert cold-key signature
 )
 
 // testBlockResult holds a constructed test block and the parameters needed


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears queued block headers on peer switch to prevent mismatched headers from stalling ChainSync, improving sync stability. Adds rate-limited drop logs (events and rollbacks) with suppression counts and periodic progress reporting; increases blockfetch busy timeout to 30s.

- **Bug Fixes**
  - Clear the header queue on BlockNotFitChainTip via Chain.ClearHeaders; continue cleanly and warn with prev/tip hashes.

- **New Features**
  - Rate-limit “non-active connection” drop logs for events and rollbacks; include suppressed counts.
  - Log periodic sync progress (current slot, upstream tip, % complete, slots/sec).
  - Increase blockfetch busy timeout from 5s to 30s.

<sup>Written for commit 0ca0a1bdc0716fab19243f1a41271c3e9923eda6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced chain synchronization logging with periodic progress updates and rate-limited messages to reduce log spam
  * Increased block fetch timeout from 5s to 30s for improved reliability during network congestion
  * Improved error handling when chain headers don't align with chain tip by automatically clearing stale headers

* **Refactor**
  * Added internal methods for better error information tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->