### PR TITLE
feat(ledger): slot battle detection

### DIFF
--- a/ledger/forging/slot_tracker.go
+++ b/ledger/forging/slot_tracker.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import "sync"
+
+const (
+	// defaultMaxTrackedSlots is the maximum number of recently forged
+	// slots to keep in memory. Once this limit is reached, the oldest
+	// entry is evicted.
+	defaultMaxTrackedSlots = 100
+)
+
+// ForgedBlockRecord stores the hash of a block we forged for a given slot.
+type ForgedBlockRecord struct {
+	BlockHash []byte
+}
+
+// SlotTracker is a thread-safe tracker for recently forged block
+// slots and their hashes. It allows chainsync to detect slot
+// battles when an incoming block from a peer occupies a slot for
+// which the local node has already forged a block.
+type SlotTracker struct {
+	mu       sync.RWMutex
+	forged   map[uint64]ForgedBlockRecord
+	order    []uint64 // insertion order for eviction
+	maxSlots int
+}
+
+// NewSlotTracker creates a new SlotTracker with the default capacity.
+func NewSlotTracker() *SlotTracker {
+	return NewSlotTrackerWithCapacity(defaultMaxTrackedSlots)
+}
+
+// NewSlotTrackerWithCapacity creates a new SlotTracker with the
+// given maximum capacity.
+func NewSlotTrackerWithCapacity(maxSlots int) *SlotTracker {
+	if maxSlots <= 0 {
+		maxSlots = defaultMaxTrackedSlots
+	}
+	return &SlotTracker{
+		forged:   make(map[uint64]ForgedBlockRecord, maxSlots),
+		order:    make([]uint64, 0, maxSlots),
+		maxSlots: maxSlots,
+	}
+}
+
+// RecordForgedBlock records that the local node forged a block with
+// the given hash at the given slot. If the tracker is at capacity,
+// the oldest entry is evicted.
+func (st *SlotTracker) RecordForgedBlock(slot uint64, blockHash []byte) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	// If we already have an entry for this slot, update it
+	if _, exists := st.forged[slot]; exists {
+		hashCopy := make([]byte, len(blockHash))
+		copy(hashCopy, blockHash)
+		st.forged[slot] = ForgedBlockRecord{BlockHash: hashCopy}
+		return
+	}
+
+	// Evict oldest entry if at capacity
+	if len(st.order) >= st.maxSlots {
+		oldest := st.order[0]
+		st.order = st.order[1:]
+		delete(st.forged, oldest)
+	}
+
+	// Store a copy of the hash to avoid aliasing
+	hashCopy := make([]byte, len(blockHash))
+	copy(hashCopy, blockHash)
+
+	st.forged[slot] = ForgedBlockRecord{BlockHash: hashCopy}
+	st.order = append(st.order, slot)
+}
+
+// WasForgedByUs checks whether the local node forged a block for
+// the given slot. If so, it returns the block hash and true.
+// Otherwise it returns nil, false.
+func (st *SlotTracker) WasForgedByUs(
+	slot uint64,
+) (blockHash []byte, ok bool) {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	record, exists := st.forged[slot]
+	if !exists {
+		return nil, false
+	}
+	hashCopy := make([]byte, len(record.BlockHash))
+	copy(hashCopy, record.BlockHash)
+	return hashCopy, true
+}
+
+// Len returns the number of tracked forged slots.
+func (st *SlotTracker) Len() int {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	return len(st.forged)
+}

--- a/ledger/forging/slot_tracker_test.go
+++ b/ledger/forging/slot_tracker_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlotTrackerRecordAndLookup(t *testing.T) {
+	st := NewSlotTracker()
+
+	hash := []byte{0x01, 0x02, 0x03}
+	st.RecordForgedBlock(1000, hash)
+
+	got, ok := st.WasForgedByUs(1000)
+	require.True(t, ok, "slot 1000 should be tracked")
+	assert.Equal(t, hash, got)
+}
+
+func TestSlotTrackerLookupMissing(t *testing.T) {
+	st := NewSlotTracker()
+
+	got, ok := st.WasForgedByUs(999)
+	assert.False(t, ok, "untracked slot should return false")
+	assert.Nil(t, got)
+}
+
+func TestSlotTrackerDoesNotAlias(t *testing.T) {
+	st := NewSlotTracker()
+
+	hash := []byte{0x01, 0x02, 0x03}
+	st.RecordForgedBlock(1000, hash)
+
+	// Mutate the original slice
+	hash[0] = 0xFF
+
+	got, ok := st.WasForgedByUs(1000)
+	require.True(t, ok)
+	assert.Equal(t, byte(0x01), got[0],
+		"tracker should store a copy, not alias the original slice")
+}
+
+func TestSlotTrackerEvictsOldestWhenFull(t *testing.T) {
+	st := NewSlotTrackerWithCapacity(3)
+
+	st.RecordForgedBlock(1, []byte{0x01})
+	st.RecordForgedBlock(2, []byte{0x02})
+	st.RecordForgedBlock(3, []byte{0x03})
+	assert.Equal(t, 3, st.Len())
+
+	// Adding a 4th entry should evict slot 1
+	st.RecordForgedBlock(4, []byte{0x04})
+	assert.Equal(t, 3, st.Len())
+
+	_, ok := st.WasForgedByUs(1)
+	assert.False(t, ok, "slot 1 should have been evicted")
+
+	got, ok := st.WasForgedByUs(4)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0x04}, got)
+
+	// Slots 2 and 3 should still be present
+	_, ok = st.WasForgedByUs(2)
+	assert.True(t, ok)
+	_, ok = st.WasForgedByUs(3)
+	assert.True(t, ok)
+}
+
+func TestSlotTrackerUpdateExistingSlot(t *testing.T) {
+	st := NewSlotTrackerWithCapacity(3)
+
+	st.RecordForgedBlock(1, []byte{0x01})
+	st.RecordForgedBlock(1, []byte{0xFF})
+
+	got, ok := st.WasForgedByUs(1)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0xFF}, got,
+		"updating an existing slot should overwrite the hash")
+	assert.Equal(t, 1, st.Len(),
+		"updating should not increase size")
+}
+
+func TestSlotTrackerConcurrency(t *testing.T) {
+	st := NewSlotTracker()
+	const goroutines = 50
+	const slotsPerGoroutine = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2) // writers + readers
+
+	// Writers
+	for g := range goroutines {
+		go func(base uint64) {
+			defer wg.Done()
+			for i := range slotsPerGoroutine {
+				slot := base*slotsPerGoroutine + uint64(i)
+				st.RecordForgedBlock(slot, []byte{byte(slot % 256)})
+			}
+		}(uint64(g))
+	}
+
+	// Readers
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for i := range slotsPerGoroutine {
+				st.WasForgedByUs(uint64(i))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Just verify no panics and the tracker has a reasonable size
+	assert.LessOrEqual(t, st.Len(), defaultMaxTrackedSlots)
+}
+
+func TestSlotTrackerZeroCapacity(t *testing.T) {
+	// Zero/negative capacity should fall back to default
+	st := NewSlotTrackerWithCapacity(0)
+	assert.NotNil(t, st)
+
+	st.RecordForgedBlock(1, []byte{0x01})
+	_, ok := st.WasForgedByUs(1)
+	assert.True(t, ok)
+}

--- a/ledger/slot_battle_test.go
+++ b/ledger/slot_battle_test.go
@@ -1,0 +1,294 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/forging"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockForgedBlockChecker is a test implementation of ForgedBlockChecker.
+type mockForgedBlockChecker struct {
+	forgedSlots map[uint64][]byte
+}
+
+func (m *mockForgedBlockChecker) WasForgedByUs(
+	slot uint64,
+) ([]byte, bool) {
+	hash, ok := m.forgedSlots[slot]
+	return hash, ok
+}
+
+func TestCheckSlotBattle_DetectsConflict(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	localHash := []byte{0x01, 0x02, 0x03, 0x04}
+	remoteHash := []byte{0x0A, 0x0B, 0x0C, 0x0D}
+
+	checker := &mockForgedBlockChecker{
+		forgedSlots: map[uint64][]byte{
+			1000: localHash,
+		},
+	}
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus:           eventBus,
+			ForgedBlockChecker: checker,
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	// Subscribe to slot battle events
+	_, evtCh := eventBus.Subscribe(forging.SlotBattleEventType)
+
+	// Simulate an incoming block at slot 1000 with a different hash.
+	// Pass a non-nil error to indicate the remote block was rejected
+	// (local block stays on chain, so local won).
+	e := BlockfetchEvent{
+		Point: ocommon.Point{
+			Slot: 1000,
+			Hash: remoteHash,
+		},
+	}
+	ls.checkSlotBattle(e, errors.New("block rejected"))
+
+	// Verify the event was emitted
+	select {
+	case evt := <-evtCh:
+		battle, ok := evt.Data.(forging.SlotBattleEvent)
+		require.True(t, ok, "event data should be SlotBattleEvent")
+		assert.Equal(t, uint64(1000), battle.Slot)
+		assert.Equal(t, localHash, battle.LocalBlockHash)
+		assert.Equal(t, remoteHash, battle.RemoteBlockHash)
+		assert.True(t, battle.Won,
+			"local should win when remote block is rejected")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for SlotBattleEvent")
+	}
+}
+
+func TestCheckSlotBattle_RemoteWinsWhenAccepted(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	localHash := []byte{0x01, 0x02, 0x03, 0x04}
+	remoteHash := []byte{0x0A, 0x0B, 0x0C, 0x0D}
+
+	checker := &mockForgedBlockChecker{
+		forgedSlots: map[uint64][]byte{
+			1000: localHash,
+		},
+	}
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus:           eventBus,
+			ForgedBlockChecker: checker,
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	_, evtCh := eventBus.Subscribe(forging.SlotBattleEventType)
+
+	// Pass nil error to indicate the remote block was accepted
+	// (remote won, our block is replaced).
+	e := BlockfetchEvent{
+		Point: ocommon.Point{
+			Slot: 1000,
+			Hash: remoteHash,
+		},
+	}
+	ls.checkSlotBattle(e, nil)
+
+	select {
+	case evt := <-evtCh:
+		battle, ok := evt.Data.(forging.SlotBattleEvent)
+		require.True(t, ok)
+		assert.Equal(t, uint64(1000), battle.Slot)
+		assert.False(t, battle.Won,
+			"local should lose when remote block is accepted")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for SlotBattleEvent")
+	}
+}
+
+func TestCheckSlotBattle_NoConflictDifferentSlot(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	checker := &mockForgedBlockChecker{
+		forgedSlots: map[uint64][]byte{
+			1000: {0x01, 0x02, 0x03, 0x04},
+		},
+	}
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus:           eventBus,
+			ForgedBlockChecker: checker,
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	_, evtCh := eventBus.Subscribe(forging.SlotBattleEventType)
+
+	// Incoming block is at slot 2000, not a slot we forged
+	e := BlockfetchEvent{
+		Point: ocommon.Point{
+			Slot: 2000,
+			Hash: []byte{0x0A, 0x0B, 0x0C, 0x0D},
+		},
+	}
+	ls.checkSlotBattle(e, nil)
+
+	// Verify no event was emitted
+	select {
+	case evt := <-evtCh:
+		t.Fatalf("unexpected SlotBattleEvent: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no event emitted
+	}
+}
+
+func TestCheckSlotBattle_SameHashIsNotBattle(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	blockHash := []byte{0x01, 0x02, 0x03, 0x04}
+
+	checker := &mockForgedBlockChecker{
+		forgedSlots: map[uint64][]byte{
+			1000: blockHash,
+		},
+	}
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus:           eventBus,
+			ForgedBlockChecker: checker,
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	_, evtCh := eventBus.Subscribe(forging.SlotBattleEventType)
+
+	// Incoming block has the same hash (it's our own block echoed back)
+	e := BlockfetchEvent{
+		Point: ocommon.Point{
+			Slot: 1000,
+			Hash: blockHash,
+		},
+	}
+	ls.checkSlotBattle(e, nil)
+
+	select {
+	case evt := <-evtCh:
+		t.Fatalf("same-hash block should not trigger slot battle: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no event for same-hash block
+	}
+}
+
+func TestCheckSlotBattle_NilCheckerSkips(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus:           eventBus,
+			ForgedBlockChecker: nil, // No checker configured
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	_, evtCh := eventBus.Subscribe(forging.SlotBattleEventType)
+
+	e := BlockfetchEvent{
+		Point: ocommon.Point{
+			Slot: 1000,
+			Hash: []byte{0x0A, 0x0B, 0x0C, 0x0D},
+		},
+	}
+	ls.checkSlotBattle(e, nil)
+
+	select {
+	case evt := <-evtCh:
+		t.Fatalf("nil checker should not emit events: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no event when checker is nil
+	}
+}
+
+func TestCheckSlotBattle_NilEventBus(t *testing.T) {
+	localHash := []byte{0x01, 0x02, 0x03, 0x04}
+	remoteHash := []byte{0x0A, 0x0B, 0x0C, 0x0D}
+
+	checker := &mockForgedBlockChecker{
+		forgedSlots: map[uint64][]byte{
+			1000: localHash,
+		},
+	}
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus:           nil, // No event bus
+			ForgedBlockChecker: checker,
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	// Should not panic with nil event bus
+	e := BlockfetchEvent{
+		Point: ocommon.Point{
+			Slot: 1000,
+			Hash: remoteHash,
+		},
+	}
+	ls.checkSlotBattle(e, errors.New("rejected"))
+}
+
+func TestSetForgedBlockChecker(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	assert.Nil(t, ls.config.ForgedBlockChecker)
+
+	checker := &mockForgedBlockChecker{
+		forgedSlots: map[uint64][]byte{
+			1000: {0x01},
+		},
+	}
+	ls.SetForgedBlockChecker(checker)
+
+	assert.NotNil(t, ls.config.ForgedBlockChecker)
+
+	hash, ok := ls.config.ForgedBlockChecker.WasForgedByUs(1000)
+	assert.True(t, ok)
+	assert.Equal(t, []byte{0x01}, hash)
+}

--- a/node.go
+++ b/node.go
@@ -422,6 +422,14 @@ func (n *Node) Run(ctx context.Context) error {
 		if err := n.initBlockForger(n.ctx); err != nil {
 			return fmt.Errorf("failed to initialize block forger: %w", err)
 		}
+		// Wire forger's slot tracker into ledger state for slot
+		// battle detection. The forger is created after the ledger
+		// state, so we use the late-binding setter.
+		if n.blockForger != nil {
+			n.ledgerState.SetForgedBlockChecker(
+				n.blockForger.SlotTracker(),
+			)
+		}
 		started = append(started, func() {
 			if n.blockForger != nil {
 				n.blockForger.Stop()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds slot battle detection to the ledger. We track locally forged slots and detect when a peer’s block for the same slot arrives, log the winner, and emit an event.

- **New Features**
  - Forger keeps a recent slots tracker (default 100, evicts oldest) and exposes it; Node injects it into LedgerState as a ForgedBlockChecker.
  - ChainSync checks incoming blocks against tracked slots; skips same-hash, decides winner from AddBlock result (nil=remote won), logs details, and publishes forging.SlotBattleEvent (slot, local/remote hashes, won).
  - Added ForgedBlockChecker interface and LedgerState.SetForgedBlockChecker; tests for the tracker and slot-battle flow.

<sup>Written for commit 83cf2d223557ddb02ad69e83dfe24e381fe5fc25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added slot battle detection to identify and track conflicts when locally forged blocks compete with incoming remote blocks for the same consensus slot.
* Slot battle events are now published when conflicts are detected, providing visibility into slot information and conflict resolution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->