### PR TITLE
perf(database): bulk load optimizations

### DIFF
--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -15,6 +15,7 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -96,6 +97,9 @@ type MetadataStorePostgres struct {
 	sslMode  string
 	timeZone string
 	dsn      string // Data source name (postgres connection string)
+
+	poolMaxIdle int // saved pool max idle connections
+	poolMaxOpen int // saved pool max open connections
 }
 
 // New creates a new database
@@ -227,8 +231,10 @@ func (d *MetadataStorePostgres) Start() error {
 	if err != nil {
 		return err
 	}
-	sqlDB.SetMaxIdleConns(10)
-	sqlDB.SetMaxOpenConns(100)
+	d.poolMaxIdle = 10
+	d.poolMaxOpen = 100
+	sqlDB.SetMaxOpenConns(d.poolMaxOpen)
+	sqlDB.SetMaxIdleConns(d.poolMaxIdle)
 	sqlDB.SetConnMaxLifetime(time.Hour)
 
 	if err := d.init(); err != nil {
@@ -319,6 +325,83 @@ func (d *MetadataStorePostgres) BeginTxn() (types.Txn, error) {
 		return newFailedPostgresTxn(db.Error), db.Error
 	}
 	return newPostgresTxn(db), nil
+}
+
+// SetBulkLoadPragmas configures PostgreSQL session settings for high-throughput bulk inserts.
+// It pins the connection pool to a single connection so SET statements apply to all queries.
+func (d *MetadataStorePostgres) SetBulkLoadPragmas() error {
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		return fmt.Errorf("failed to get sql.DB handle: %w", err)
+	}
+	// Pin to single connection so session-level SET statements apply to all queries
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	for _, stmt := range []string{
+		"SET synchronous_commit = OFF",
+		"SET work_mem = '256MB'",
+		"SET maintenance_work_mem = '256MB'",
+	} {
+		if result := d.db.Exec(stmt); result.Error != nil {
+			// Rollback any already-applied pragmas before returning
+			if restoreErr := d.RestoreNormalPragmas(); restoreErr != nil {
+				d.logger.Error(
+					"failed to restore pragmas after partial bulk-load failure",
+					"error", restoreErr,
+				)
+			}
+			return fmt.Errorf(
+				"failed to set bulk-load pragma %q: %w",
+				stmt,
+				result.Error,
+			)
+		}
+	}
+	d.logger.Info("postgres bulk-load pragmas enabled")
+	return nil
+}
+
+// RestoreNormalPragmas restores PostgreSQL session settings to server defaults
+// and restores the connection pool size.
+func (d *MetadataStorePostgres) RestoreNormalPragmas() error {
+	var errs []error
+	for _, stmt := range []string{
+		"RESET synchronous_commit",
+		"RESET work_mem",
+		"RESET maintenance_work_mem",
+	} {
+		if result := d.db.Exec(stmt); result.Error != nil {
+			errs = append(
+				errs,
+				fmt.Errorf(
+					"failed to restore normal pragma %q: %w",
+					stmt,
+					result.Error,
+				),
+			)
+		}
+	}
+	// Always restore connection pool settings
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		errs = append(
+			errs,
+			fmt.Errorf("failed to get sql.DB handle: %w", err),
+		)
+		return errors.Join(errs...)
+	}
+	sqlDB.SetMaxOpenConns(d.poolMaxOpen)
+	sqlDB.SetMaxIdleConns(d.poolMaxIdle)
+	if len(errs) > 0 {
+		d.logger.Warn(
+			"postgres normal pragmas partially restored",
+			"error",
+			errors.Join(errs...),
+		)
+	} else {
+		d.logger.Info("postgres normal pragmas restored")
+	}
+	return errors.Join(errs...)
 }
 
 // Where constrains a DB query

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -524,3 +524,65 @@ func (d *MetadataStoreSqlite) Where(
 ) *gorm.DB {
 	return d.DB().Where(query, args...)
 }
+
+// SetBulkLoadPragmas configures SQLite PRAGMAs optimized for bulk loading.
+// These settings trade crash safety for speed, which is acceptable because
+// immutable chunk data can always be reloaded.
+func (d *MetadataStoreSqlite) SetBulkLoadPragmas() error {
+	pragmas := []string{
+		"PRAGMA synchronous = OFF",
+		"PRAGMA cache_size = -200000", // 200MB cache (4x default)
+		"PRAGMA temp_store = MEMORY",
+		"PRAGMA wal_autocheckpoint = 10000", // Reduce checkpoint frequency
+	}
+	for _, pragma := range pragmas {
+		if result := d.DB().Exec(pragma); result.Error != nil {
+			// Rollback any already-applied pragmas before returning
+			if restoreErr := d.RestoreNormalPragmas(); restoreErr != nil {
+				d.logger.Error(
+					"failed to restore pragmas after partial bulk-load failure",
+					"error", restoreErr,
+				)
+			}
+			return fmt.Errorf("set pragma %q: %w", pragma, result.Error)
+		}
+	}
+	d.logger.Info(
+		"set bulk-load PRAGMAs (synchronous=OFF, cache=200MB, temp=MEMORY)",
+	)
+	return nil
+}
+
+// RestoreNormalPragmas restores SQLite PRAGMAs to production settings
+// after bulk loading is complete.
+func (d *MetadataStoreSqlite) RestoreNormalPragmas() error {
+	pragmas := []string{
+		"PRAGMA synchronous = NORMAL",
+		"PRAGMA cache_size = -50000", // Restore default 50MB
+		"PRAGMA temp_store = DEFAULT",
+		"PRAGMA wal_autocheckpoint = 1000", // Restore default
+	}
+	var errs []error
+	for _, pragma := range pragmas {
+		if result := d.DB().Exec(pragma); result.Error != nil {
+			errs = append(
+				errs,
+				fmt.Errorf(
+					"restore pragma %q: %w",
+					pragma,
+					result.Error,
+				),
+			)
+		}
+	}
+	if len(errs) > 0 {
+		d.logger.Warn(
+			"partially restored normal PRAGMAs",
+			"error",
+			errors.Join(errs...),
+		)
+		return errors.Join(errs...)
+	}
+	d.logger.Info("restored normal PRAGMAs")
+	return nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -504,6 +504,14 @@ type MetadataStore interface {
 	DeletePParamUpdatesAfterSlot(uint64, types.Txn) error
 }
 
+// BulkLoadOptimizer is an optional interface that metadata stores can
+// implement to provide optimized settings for bulk loading operations.
+// The load command checks for this interface and uses it when available.
+type BulkLoadOptimizer interface {
+	SetBulkLoadPragmas() error
+	RestoreNormalPragmas() error
+}
+
 // New creates a new metadata store instance using the specified plugin
 func New(pluginName string) (MetadataStore, error) {
 	// Get and start the plugin


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up bulk imports and catch-up sync by temporarily tuning DB/session settings and pinning the pool to a single connection during bulk load or when validation is off. Adds a 500ms catch-up poller with a 30-minute timeout.

- **New Features**
  - Added BulkLoadOptimizer interface with SetBulkLoadPragmas and RestoreNormalPragmas.
  - MySQL/Postgres: pin pool to 1, apply fast-insert session params (MySQL: innodb_flush_log_at_trx_commit=0, unique/foreign_key_checks=0; Postgres: synchronous_commit OFF, work_mem/maintenance_work_mem 256MB), and save/restore original pool sizes.
  - SQLite: bulk-load PRAGMAs (synchronous OFF, 200MB cache, temp MEMORY, WAL autocheckpoint 10k) with restore to normal settings.
  - Load command auto-enables/restores optimizations; ledger enables them only when validation is disabled and restores on validation enable or exit.

<sup>Written for commit acf8171cccfcdf04503fbbe70a6f041cd600d615. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional bulk-load optimizations for metadata stores (MySQL, Postgres, SQLite): session/PRAGMA tuning, connection pinning, and automatic enable/disable with logging.

* **Refactor**
  * Connection pool sizes are now saved and restored rather than using fixed values.

* **Improvements**
  * Replaced endless wait with a timed polling loop for block-copy progress; added logging around bulk-load enable/restore and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->