### PR TITLE
fix(ledger): removed blocking backpressure

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -38,8 +38,8 @@ func (o *Ouroboros) blockfetchClientConnOpts() []blockfetch.BlockFetchOptionFunc
 	return []blockfetch.BlockFetchOptionFunc{
 		blockfetch.WithBlockFunc(o.blockfetchClientBlock),
 		blockfetch.WithBatchDoneFunc(o.blockfetchClientBatchDone),
-		blockfetch.WithBatchStartTimeout(2 * time.Second),
-		blockfetch.WithBlockTimeout(2 * time.Second),
+		blockfetch.WithBatchStartTimeout(60 * time.Second),
+		blockfetch.WithBlockTimeout(60 * time.Second),
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed blocking backpressure in chainsync to keep headers flowing and prevent stalls. Added rollback loop detection, smarter active-connection switch handling, and longer blockfetch timeouts to improve sync stability.

- **Bug Fixes**
  - Removed the channel-based wait on blockfetch batches so header processing doesn’t pause.
  - Increased blockfetch start and per-block timeouts to 60s to avoid premature failures.

- **New Features**
  - Detect and skip rollback loops (3+ rollbacks to the same slot within 5 minutes).
  - Log active connection changes and reset dropped counters and rollback history.

<sup>Written for commit 42b732c9cb7525e252ec90b665489da37c85c31f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved rollback loop detection to avoid repeated rollbacks and reduce unnecessary reprocessing.
  * Better handling and logging when the active chain connection changes, with reset of related tracking.

* **Bug Fixes**
  * Increased block fetch timeouts to improve reliability under varying network conditions.
  * Reworked block synchronization flow from channel-based signaling to timer-based control for more stable coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->