### PR TITLE
feat(chain): lru cache metrics

### DIFF
--- a/chain/blockcache_test.go
+++ b/chain/blockcache_test.go
@@ -15,14 +15,18 @@
 package chain
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBlockCache_BasicOperations(t *testing.T) {
-	cache := newBlockCache(3)
+	cache := newBlockCache(3, nil)
 
 	// Test empty cache
 	_, ok := cache.Get("nonexistent")
@@ -30,7 +34,10 @@ func TestBlockCache_BasicOperations(t *testing.T) {
 	assert.Equal(t, 0, cache.Len())
 
 	// Add a block
-	block1 := models.Block{Hash: []byte("hash1"), Slot: 100}
+	block1 := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 100,
+	}
 	cache.Put(block1)
 	assert.Equal(t, 1, cache.Len())
 
@@ -41,12 +48,21 @@ func TestBlockCache_BasicOperations(t *testing.T) {
 }
 
 func TestBlockCache_LRUEviction(t *testing.T) {
-	cache := newBlockCache(3)
+	cache := newBlockCache(3, nil)
 
 	// Add 3 blocks
-	block1 := models.Block{Hash: []byte("hash1"), Slot: 1}
-	block2 := models.Block{Hash: []byte("hash2"), Slot: 2}
-	block3 := models.Block{Hash: []byte("hash3"), Slot: 3}
+	block1 := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 1,
+	}
+	block2 := models.Block{
+		Hash: []byte("hash2"),
+		Slot: 2,
+	}
+	block3 := models.Block{
+		Hash: []byte("hash3"),
+		Slot: 3,
+	}
 
 	cache.Put(block1)
 	cache.Put(block2)
@@ -61,10 +77,13 @@ func TestBlockCache_LRUEviction(t *testing.T) {
 	assert.True(t, ok2)
 	assert.True(t, ok3)
 
-	// Add a 4th block, should evict hash1 (least recently used)
-	// Note: after the Gets above, order is hash3, hash2, hash1 (most to least recent)
-	// So hash1 should be evicted
-	block4 := models.Block{Hash: []byte("hash4"), Slot: 4}
+	// Add a 4th block, should evict hash1 (least recently
+	// used). After the Gets above, order is hash3, hash2,
+	// hash1 (most to least recent), so hash1 is evicted.
+	block4 := models.Block{
+		Hash: []byte("hash4"),
+		Slot: 4,
+	}
 	cache.Put(block4)
 	assert.Equal(t, 3, cache.Len())
 
@@ -82,14 +101,20 @@ func TestBlockCache_LRUEviction(t *testing.T) {
 }
 
 func TestBlockCache_UpdateExisting(t *testing.T) {
-	cache := newBlockCache(3)
+	cache := newBlockCache(3, nil)
 
 	// Add a block
-	block1 := models.Block{Hash: []byte("hash1"), Slot: 100}
+	block1 := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 100,
+	}
 	cache.Put(block1)
 
 	// Update it
-	block1Updated := models.Block{Hash: []byte("hash1"), Slot: 200}
+	block1Updated := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 200,
+	}
 	cache.Put(block1Updated)
 
 	// Should still have only 1 entry
@@ -102,12 +127,21 @@ func TestBlockCache_UpdateExisting(t *testing.T) {
 }
 
 func TestBlockCache_AccessMovesToFront(t *testing.T) {
-	cache := newBlockCache(3)
+	cache := newBlockCache(3, nil)
 
 	// Add 3 blocks in order
-	block1 := models.Block{Hash: []byte("hash1"), Slot: 1}
-	block2 := models.Block{Hash: []byte("hash2"), Slot: 2}
-	block3 := models.Block{Hash: []byte("hash3"), Slot: 3}
+	block1 := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 1,
+	}
+	block2 := models.Block{
+		Hash: []byte("hash2"),
+		Slot: 2,
+	}
+	block3 := models.Block{
+		Hash: []byte("hash3"),
+		Slot: 3,
+	}
 
 	cache.Put(block1)
 	cache.Put(block2)
@@ -116,8 +150,12 @@ func TestBlockCache_AccessMovesToFront(t *testing.T) {
 	// Access hash1, moving it to front
 	cache.Get("hash1")
 
-	// Add block4 - should evict hash2 (now least recently used)
-	block4 := models.Block{Hash: []byte("hash4"), Slot: 4}
+	// Add block4 - should evict hash2 (now least recently
+	// used)
+	block4 := models.Block{
+		Hash: []byte("hash4"),
+		Slot: 4,
+	}
 	cache.Put(block4)
 
 	// hash1 should still be present (was accessed)
@@ -137,10 +175,179 @@ func TestBlockCache_AccessMovesToFront(t *testing.T) {
 
 func TestBlockCache_DefaultCapacity(t *testing.T) {
 	// Test that 0 capacity uses default
-	cache := newBlockCache(0)
-	assert.Equal(t, DefaultBlockCacheCapacity, cache.capacity)
+	cache := newBlockCache(0, nil)
+	assert.Equal(
+		t,
+		DefaultBlockCacheCapacity,
+		cache.capacity,
+	)
 
 	// Test that negative capacity uses default
-	cache = newBlockCache(-1)
-	assert.Equal(t, DefaultBlockCacheCapacity, cache.capacity)
+	cache = newBlockCache(-1, nil)
+	assert.Equal(
+		t,
+		DefaultBlockCacheCapacity,
+		cache.capacity,
+	)
+}
+
+func TestBlockCache_Delete(t *testing.T) {
+	cache := newBlockCache(5, nil)
+
+	// Add blocks
+	block1 := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 1,
+	}
+	block2 := models.Block{
+		Hash: []byte("hash2"),
+		Slot: 2,
+	}
+	block3 := models.Block{
+		Hash: []byte("hash3"),
+		Slot: 3,
+	}
+	cache.Put(block1)
+	cache.Put(block2)
+	cache.Put(block3)
+	assert.Equal(t, 3, cache.Len())
+
+	// Delete middle block
+	cache.Delete("hash2")
+	assert.Equal(t, 2, cache.Len())
+
+	// Deleted block should not be found
+	_, ok := cache.Get("hash2")
+	assert.False(t, ok)
+
+	// Other blocks should still be present
+	_, ok1 := cache.Get("hash1")
+	_, ok3 := cache.Get("hash3")
+	assert.True(t, ok1)
+	assert.True(t, ok3)
+
+	// Deleting a non-existent key should be a no-op
+	cache.Delete("nonexistent")
+	assert.Equal(t, 2, cache.Len())
+}
+
+func TestBlockCache_ConcurrentAccess(t *testing.T) {
+	cache := newBlockCache(100, nil)
+	const goroutines = 10
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 3) // Put, Get, Delete goroutines
+
+	// Concurrent Put operations
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for i := range opsPerGoroutine {
+				hash := fmt.Sprintf(
+					"hash-%d-%d",
+					id,
+					i,
+				)
+				block := models.Block{
+					Hash: []byte(hash),
+					Slot: uint64(
+						id*opsPerGoroutine + i,
+					),
+				}
+				cache.Put(block)
+			}
+		}(g)
+	}
+
+	// Concurrent Get operations
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for i := range opsPerGoroutine {
+				hash := fmt.Sprintf(
+					"hash-%d-%d",
+					id,
+					i,
+				)
+				cache.Get(hash)
+			}
+		}(g)
+	}
+
+	// Concurrent Delete operations
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for i := range opsPerGoroutine {
+				hash := fmt.Sprintf(
+					"hash-%d-%d",
+					id,
+					i,
+				)
+				cache.Delete(hash)
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	// Cache should be in a consistent state
+	cacheLen := cache.Len()
+	require.GreaterOrEqual(t, cacheLen, 0)
+	require.LessOrEqual(t, cacheLen, 100)
+}
+
+func TestBlockCache_PrometheusMetric(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	cache := newBlockCache(5, registry)
+
+	// Add blocks and verify metric is registered
+	block1 := models.Block{
+		Hash: []byte("hash1"),
+		Slot: 1,
+	}
+	block2 := models.Block{
+		Hash: []byte("hash2"),
+		Slot: 2,
+	}
+	cache.Put(block1)
+	cache.Put(block2)
+
+	// Gather metrics from the registry
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Find our metric
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == "dingo_chain_manager_cached_blocks" {
+			found = true
+			require.Len(t, mf.GetMetric(), 1)
+			assert.Equal(
+				t,
+				float64(2),
+				mf.GetMetric()[0].GetGauge().GetValue(),
+			)
+		}
+	}
+	require.True(
+		t,
+		found,
+		"dingo_chain_manager_cached_blocks metric not found",
+	)
+
+	// Delete a block and verify metric updates
+	cache.Delete("hash1")
+	metrics, err = registry.Gather()
+	require.NoError(t, err)
+	for _, mf := range metrics {
+		if mf.GetName() == "dingo_chain_manager_cached_blocks" {
+			assert.Equal(
+				t,
+				float64(1),
+				mf.GetMetric()[0].GetGauge().GetValue(),
+			)
+		}
+	}
 }

--- a/node.go
+++ b/node.go
@@ -155,6 +155,7 @@ func (n *Node) Run(ctx context.Context) error {
 	cm, err := chain.NewManager(
 		n.db,
 		n.eventBus,
+		n.config.promRegistry,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to load chain manager: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Prometheus metrics to the chain LRU block cache and wires optional registry injection through ChainManager and Node. Also adds a Delete operation and improves test coverage for concurrency and metrics.

- **New Features**
  - Exposes a Prometheus gauge: dingo_chain_manager_cached_blocks (current cached block count).
  - ChainManager.NewManager now accepts an optional prometheus.Registerer; Node passes config.promRegistry.
  - New Delete(hash) on the block cache; metrics update on put/delete/eviction.
  - Expanded tests: concurrency, delete behavior, and metric assertions.

- **Migration**
  - No action needed. To enable metrics, pass a prometheus.Registerer to chain.NewManager; if nil, metrics are not registered.

<sup>Written for commit 950e3593f7c2d317638959bdff3e864ef4998309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Block cache now supports deletion operations for managing cached blocks
  * Integrated Prometheus metrics for real-time monitoring of cache size and state

* **Tests**
  * Added comprehensive tests for concurrent cache operations
  * Added metrics validation tests for Prometheus integration accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->