### PR TITLE
feat(chainsync): multi-peer client registry with failover and dedupe

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -15,66 +15,195 @@
 package chainsync
 
 import (
+	"bytes"
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/connection"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
+// DefaultMaxClients is the default maximum number of concurrent
+// chainsync clients.
+const DefaultMaxClients = 3
+
+// DefaultStallTimeout is the default duration after which a
+// client with no activity is considered stalled. This value
+// must stay in sync with config.DefaultChainsyncConfig() and
+// the fallback in internal/node/node.go.
+const DefaultStallTimeout = 30 * time.Second
+
+// ClientStatus represents the sync status of a chainsync client.
+type ClientStatus int
+
+const (
+	// ClientStatusSyncing indicates the client is actively
+	// receiving headers.
+	ClientStatusSyncing ClientStatus = iota
+	// ClientStatusSynced indicates the client has reached the
+	// upstream chain tip.
+	ClientStatusSynced
+	// ClientStatusStalled indicates the client has not received
+	// activity within the stall timeout.
+	ClientStatusStalled
+	// ClientStatusFailed indicates the client encountered an
+	// error.
+	ClientStatusFailed
+)
+
+// String returns a human-readable name for the ClientStatus.
+func (s ClientStatus) String() string {
+	switch s {
+	case ClientStatusSyncing:
+		return "syncing"
+	case ClientStatusSynced:
+		return "synced"
+	case ClientStatusStalled:
+		return "stalled"
+	case ClientStatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// ChainsyncClientState holds per-connection state for a
+// chainsync server-side client (node-to-client connections).
 type ChainsyncClientState struct {
 	ChainIter            *chain.ChainIterator
 	Cursor               ocommon.Point
 	NeedsInitialRollback bool
 }
 
+// TrackedClient holds per-connection state for a tracked
+// chainsync client (outbound node-to-node connections).
+type TrackedClient struct {
+	ConnId       ouroboros.ConnectionId
+	Cursor       ocommon.Point
+	Tip          ochainsync.Tip
+	Status       ClientStatus
+	LastActivity time.Time
+	HeadersRecv  uint64
+	// TODO: BytesRecv needs to be wired to the underlying
+	// connection's byte counter. Currently unused.
+	BytesRecv uint64
+}
+
+// Config holds configuration for the chainsync State.
+type Config struct {
+	MaxClients   int
+	StallTimeout time.Duration
+}
+
+// DefaultConfig returns the default chainsync configuration.
+func DefaultConfig() Config {
+	return Config{
+		MaxClients:   DefaultMaxClients,
+		StallTimeout: DefaultStallTimeout,
+	}
+}
+
+// State manages chainsync client connections and header
+// tracking for both server-side (N2C) and outbound (N2N)
+// connections.
 type State struct {
-	eventBus           *event.EventBus
-	ledgerState        *ledger.LedgerState
-	clients            map[ouroboros.ConnectionId]*ChainsyncClientState
-	trackedClients     map[ouroboros.ConnectionId]struct{}
+	eventBus    *event.EventBus
+	ledgerState *ledger.LedgerState
+	config      Config
+
+	// Server-side clients (node-to-client connections)
+	clients map[ouroboros.ConnectionId]*ChainsyncClientState
+
+	// Tracked outbound clients (node-to-node connections)
+	trackedClients     map[ouroboros.ConnectionId]*TrackedClient
 	activeClientConnId *ouroboros.ConnectionId
 	clientConnIdMutex  sync.RWMutex
+
+	// Header deduplication: maps slot -> list of distinct
+	// block hashes seen at that slot
+	seenHeaders      map[uint64][]headerRecord
+	seenHeadersMutex sync.Mutex
+
 	sync.Mutex
 }
 
+// headerRecord tracks a block hash and the connection that
+// first reported it for a given slot.
+type headerRecord struct {
+	hash   []byte
+	connId ouroboros.ConnectionId
+}
+
+// NewState creates a new chainsync State with the given
+// event bus and ledger state using default configuration.
 func NewState(
 	eventBus *event.EventBus,
 	ledgerState *ledger.LedgerState,
 ) *State {
+	return NewStateWithConfig(eventBus, ledgerState, DefaultConfig())
+}
+
+// NewStateWithConfig creates a new chainsync State with the
+// given event bus, ledger state, and configuration.
+func NewStateWithConfig(
+	eventBus *event.EventBus,
+	ledgerState *ledger.LedgerState,
+	cfg Config,
+) *State {
+	if cfg.MaxClients <= 0 {
+		cfg.MaxClients = DefaultMaxClients
+	}
+	if cfg.StallTimeout <= 0 {
+		cfg.StallTimeout = DefaultStallTimeout
+	}
 	s := &State{
 		eventBus:       eventBus,
 		ledgerState:    ledgerState,
+		config:         cfg,
 		clients:        make(map[ouroboros.ConnectionId]*ChainsyncClientState),
-		trackedClients: make(map[ouroboros.ConnectionId]struct{}),
+		trackedClients: make(map[ouroboros.ConnectionId]*TrackedClient),
+		seenHeaders:    make(map[uint64][]headerRecord),
 	}
 	return s
 }
 
+// AddClient registers a server-side (N2C) chainsync client.
 func (s *State) AddClient(
 	connId connection.ConnectionId,
 	intersectPoint ocommon.Point,
 ) (*ChainsyncClientState, error) {
 	s.Lock()
 	defer s.Unlock()
-	// Create initial chainsync state for connection
-	chainIter, err := s.ledgerState.GetChainFromPoint(intersectPoint, false)
-	if err != nil {
-		return nil, err
+	// Return existing client state if already registered
+	if existing, ok := s.clients[connId]; ok {
+		return existing, nil
 	}
-	if _, ok := s.clients[connId]; !ok {
-		s.clients[connId] = &ChainsyncClientState{
-			Cursor:               intersectPoint,
-			ChainIter:            chainIter,
-			NeedsInitialRollback: true,
-		}
+	// Create initial chainsync state for connection
+	chainIter, err := s.ledgerState.GetChainFromPoint(
+		intersectPoint,
+		false,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetChainFromPoint failed: %w", err,
+		)
+	}
+	s.clients[connId] = &ChainsyncClientState{
+		Cursor:               intersectPoint,
+		ChainIter:            chainIter,
+		NeedsInitialRollback: true,
 	}
 	return s.clients[connId], nil
 }
 
+// RemoveClient unregisters a server-side (N2C) chainsync
+// client.
 func (s *State) RemoveClient(connId connection.ConnectionId) {
 	s.Lock()
 	defer s.Unlock()
@@ -87,80 +216,159 @@ func (s *State) RemoveClient(connId connection.ConnectionId) {
 	delete(s.clients, connId)
 }
 
-// GetClientConnId returns the active chainsync client connection ID.
-// This is the connection that should be used for block fetching.
+// GetClientConnId returns the active chainsync client
+// connection ID. This is the connection that should be used
+// for block fetching.
 func (s *State) GetClientConnId() *ouroboros.ConnectionId {
 	s.clientConnIdMutex.RLock()
 	defer s.clientConnIdMutex.RUnlock()
 	return s.activeClientConnId
 }
 
-// SetClientConnId sets the active chainsync client connection ID.
-// This is used when chain selection determines a new best peer.
+// SetClientConnId sets the active chainsync client connection
+// ID. This is used when chain selection determines a new best
+// peer.
 func (s *State) SetClientConnId(connId ouroboros.ConnectionId) {
 	s.clientConnIdMutex.Lock()
 	defer s.clientConnIdMutex.Unlock()
 	s.activeClientConnId = &connId
 }
 
-// RemoveClientConnId removes a connection from tracking. If this was the
-// active client, selects a fallback from remaining tracked clients.
-func (s *State) RemoveClientConnId(connId ouroboros.ConnectionId) {
+// RemoveClientConnId removes a connection from tracking. If
+// this was the active client, promotes the client with the
+// highest tip slot as the new primary.
+func (s *State) RemoveClientConnId(
+	connId ouroboros.ConnectionId,
+) {
 	s.clientConnIdMutex.Lock()
 	defer s.clientConnIdMutex.Unlock()
+	wasPrimary := s.activeClientConnId != nil &&
+		*s.activeClientConnId == connId
 	delete(s.trackedClients, connId)
-	if s.activeClientConnId != nil && *s.activeClientConnId == connId {
+	if wasPrimary {
 		s.activeClientConnId = nil
-		// Select fallback from remaining tracked clients
-		for fallbackId := range s.trackedClients {
-			s.activeClientConnId = &fallbackId
-			break
-		}
+		s.promoteBestClientLocked()
+	}
+	// Emit client removed event
+	if s.eventBus != nil {
+		s.eventBus.PublishAsync(
+			ClientRemovedEventType,
+			event.NewEvent(
+				ClientRemovedEventType,
+				ClientRemovedEvent{
+					ConnId:       connId,
+					TotalClients: len(s.trackedClients),
+					WasPrimary:   wasPrimary,
+				},
+			),
+		)
 	}
 }
 
-// AddClientConnId adds a connection ID to the set of tracked chainsync clients.
-// If no active client exists, this connection is automatically set as the active
-// client. This ensures there is always an active client when at least one is tracked.
-func (s *State) AddClientConnId(connId ouroboros.ConnectionId) {
-	s.clientConnIdMutex.Lock()
-	defer s.clientConnIdMutex.Unlock()
-	s.trackedClients[connId] = struct{}{}
+// promoteBestClientLocked selects the tracked client with the
+// highest tip slot as the new active client. Only healthy
+// (syncing or synced) clients are considered. If no healthy
+// client exists, activeClientConnId is set to nil so that
+// callers do not route work to a known-bad peer.
+// Caller must hold clientConnIdMutex.
+func (s *State) promoteBestClientLocked() {
+	var bestId *ouroboros.ConnectionId
+	var bestSlot uint64
+	for id, tc := range s.trackedClients {
+		if tc.Status == ClientStatusFailed ||
+			tc.Status == ClientStatusStalled {
+			continue
+		}
+		if bestId == nil || tc.Tip.Point.Slot > bestSlot {
+			idCopy := id
+			bestId = &idCopy
+			bestSlot = tc.Tip.Point.Slot
+		}
+	}
+	s.activeClientConnId = bestId
+}
+
+// addTrackedClientLocked registers a new tracked client. It
+// initialises the TrackedClient, sets it as active if none
+// exists, and emits a ClientAddedEvent.
+// Caller must hold clientConnIdMutex.
+func (s *State) addTrackedClientLocked(
+	connId ouroboros.ConnectionId,
+) {
+	s.trackedClients[connId] = &TrackedClient{
+		ConnId:       connId,
+		Status:       ClientStatusSyncing,
+		LastActivity: time.Now(),
+	}
 	// Set as active if there's no active client
 	if s.activeClientConnId == nil {
 		s.activeClientConnId = &connId
 	}
+	// Emit client added event
+	if s.eventBus != nil {
+		s.eventBus.PublishAsync(
+			ClientAddedEventType,
+			event.NewEvent(
+				ClientAddedEventType,
+				ClientAddedEvent{
+					ConnId:       connId,
+					TotalClients: len(s.trackedClients),
+				},
+			),
+		)
+	}
 }
 
-// HasClientConnId returns true if the connection ID is being tracked.
-func (s *State) HasClientConnId(connId ouroboros.ConnectionId) bool {
+// AddClientConnId adds a connection ID to the set of tracked
+// chainsync clients, enforcing the configured MaxClients limit.
+// Returns true if the client was added, false if rejected
+// (already tracked or at capacity). If no active client exists,
+// this connection is automatically set as the active client.
+func (s *State) AddClientConnId(
+	connId ouroboros.ConnectionId,
+) bool {
+	return s.TryAddClientConnId(connId, s.config.MaxClients)
+}
+
+// HasClientConnId returns true if the connection ID is being
+// tracked.
+func (s *State) HasClientConnId(
+	connId ouroboros.ConnectionId,
+) bool {
 	s.clientConnIdMutex.RLock()
 	defer s.clientConnIdMutex.RUnlock()
 	_, exists := s.trackedClients[connId]
 	return exists
 }
 
-// GetClientConnIds returns all tracked chainsync client connection IDs.
+// GetClientConnIds returns all tracked chainsync client
+// connection IDs.
 func (s *State) GetClientConnIds() []ouroboros.ConnectionId {
 	s.clientConnIdMutex.RLock()
 	defer s.clientConnIdMutex.RUnlock()
-	connIds := make([]ouroboros.ConnectionId, 0, len(s.trackedClients))
+	connIds := make(
+		[]ouroboros.ConnectionId,
+		0,
+		len(s.trackedClients),
+	)
 	for connId := range s.trackedClients {
 		connIds = append(connIds, connId)
 	}
 	return connIds
 }
 
-// ClientConnCount returns the number of tracked chainsync clients.
+// ClientConnCount returns the number of tracked chainsync
+// clients.
 func (s *State) ClientConnCount() int {
 	s.clientConnIdMutex.RLock()
 	defer s.clientConnIdMutex.RUnlock()
 	return len(s.trackedClients)
 }
 
-// TryAddClientConnId atomically checks if a connection can be added (not
-// already tracked and under maxClients limit) and adds it if allowed.
-// Returns true if the connection was added, false otherwise.
+// TryAddClientConnId atomically checks if a connection can be
+// added (not already tracked and under maxClients limit) and
+// adds it if allowed. Returns true if the connection was added,
+// false otherwise.
 func (s *State) TryAddClientConnId(
 	connId ouroboros.ConnectionId,
 	maxClients int,
@@ -175,11 +383,241 @@ func (s *State) TryAddClientConnId(
 	if len(s.trackedClients) >= maxClients {
 		return false
 	}
-	// Add the client
-	s.trackedClients[connId] = struct{}{}
-	// Set as active if there's no active client
-	if s.activeClientConnId == nil {
-		s.activeClientConnId = &connId
+	s.addTrackedClientLocked(connId)
+	return true
+}
+
+// UpdateClientTip updates the cursor, tip, and activity
+// tracking for a tracked client. Returns true if the header at
+// this point is new (not a duplicate).
+func (s *State) UpdateClientTip(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+	tip ochainsync.Tip,
+) bool {
+	s.clientConnIdMutex.Lock()
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		s.clientConnIdMutex.Unlock()
+		return true
+	}
+	tc.Cursor = point
+	tc.Tip = tip
+	tc.LastActivity = time.Now()
+	tc.HeadersRecv++
+	if tc.Status == ClientStatusStalled {
+		tc.Status = ClientStatusSyncing
+	}
+	s.clientConnIdMutex.Unlock()
+
+	// Header deduplication and fork detection
+	return s.processHeader(connId, point)
+}
+
+// processHeader checks whether the header at the given point
+// has already been seen. If another client reported a different
+// hash at the same slot, a fork detection event is emitted.
+// Returns true if this is a new (non-duplicate) header.
+func (s *State) processHeader(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+) bool {
+	s.seenHeadersMutex.Lock()
+	defer s.seenHeadersMutex.Unlock()
+	records := s.seenHeaders[point.Slot]
+	// Check if any existing record matches this hash
+	for _, rec := range records {
+		if bytes.Equal(rec.hash, point.Hash) {
+			// Duplicate header, same hash
+			return false
+		}
+	}
+	// New hash at this slot; record it.
+	// Clone the hash to avoid aliasing the caller's buffer.
+	hashClone := cloneBytes(point.Hash)
+	newRec := headerRecord{
+		hash:   hashClone,
+		connId: connId,
+	}
+	s.seenHeaders[point.Slot] = append(records, newRec)
+	// If there was already a different hash at this slot,
+	// emit a fork detection event against the first record.
+	// Clone the Point.Hash to avoid aliasing the caller's
+	// buffer in the event payload.
+	if len(records) > 0 {
+		if s.eventBus != nil {
+			clonedPoint := ocommon.NewPoint(
+				point.Slot,
+				cloneBytes(point.Hash),
+			)
+			s.eventBus.PublishAsync(
+				ForkDetectedEventType,
+				event.NewEvent(
+					ForkDetectedEventType,
+					ForkDetectedEvent{
+						Slot:    point.Slot,
+						HashA:   records[0].hash,
+						HashB:   hashClone,
+						ConnIdA: records[0].connId,
+						ConnIdB: connId,
+						Point:   clonedPoint,
+					},
+				),
+			)
+		}
 	}
 	return true
+}
+
+// MarkClientSynced marks a tracked client as synced (at chain
+// tip).
+func (s *State) MarkClientSynced(
+	connId ouroboros.ConnectionId,
+) {
+	s.clientConnIdMutex.Lock()
+	tc, exists := s.trackedClients[connId]
+	var changed bool
+	if exists && tc.Status != ClientStatusSynced {
+		tc.Status = ClientStatusSynced
+		tc.LastActivity = time.Now()
+		changed = true
+	}
+	var slot uint64
+	if exists {
+		slot = tc.Tip.Point.Slot
+	}
+	s.clientConnIdMutex.Unlock()
+	if changed && s.eventBus != nil {
+		s.eventBus.PublishAsync(
+			ClientSyncedEventType,
+			event.NewEvent(
+				ClientSyncedEventType,
+				ClientSyncedEvent{
+					ConnId: connId,
+					Slot:   slot,
+				},
+			),
+		)
+	}
+}
+
+// CheckStalledClients scans all tracked clients and marks any
+// that have exceeded the stall timeout. If the primary client
+// is stalled, a failover to the next best client is triggered.
+// Returns the list of connection IDs that were newly marked as
+// stalled.
+func (s *State) CheckStalledClients() []ouroboros.ConnectionId {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+
+	now := time.Now()
+	var stalled []ouroboros.ConnectionId
+	for id, tc := range s.trackedClients {
+		if tc.Status == ClientStatusStalled ||
+			tc.Status == ClientStatusFailed {
+			continue
+		}
+		if now.Sub(tc.LastActivity) > s.config.StallTimeout {
+			tc.Status = ClientStatusStalled
+			stalled = append(stalled, id)
+			if s.eventBus != nil {
+				s.eventBus.PublishAsync(
+					ClientStalledEventType,
+					event.NewEvent(
+						ClientStalledEventType,
+						ClientStalledEvent{
+							ConnId: id,
+							Slot:   tc.Tip.Point.Slot,
+						},
+					),
+				)
+			}
+		}
+	}
+
+	// Check if the primary client was stalled
+	if len(stalled) > 0 && s.activeClientConnId != nil {
+		for _, id := range stalled {
+			if *s.activeClientConnId == id {
+				s.activeClientConnId = nil
+				s.promoteBestClientLocked()
+				break
+			}
+		}
+	}
+
+	return stalled
+}
+
+// GetTrackedClient returns a deep copy of the TrackedClient
+// for the given connection ID, or nil if not found. Byte
+// slices inside Point.Hash are cloned so the caller cannot
+// race with concurrent UpdateClientTip calls.
+func (s *State) GetTrackedClient(
+	connId ouroboros.ConnectionId,
+) *TrackedClient {
+	s.clientConnIdMutex.RLock()
+	defer s.clientConnIdMutex.RUnlock()
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		return nil
+	}
+	// Return a deep copy to avoid races on byte slices
+	result := *tc
+	result.Cursor.Hash = cloneBytes(tc.Cursor.Hash)
+	result.Tip.Point.Hash = cloneBytes(tc.Tip.Point.Hash)
+	return &result
+}
+
+// GetTrackedClients returns deep copies of all tracked
+// clients.
+func (s *State) GetTrackedClients() []TrackedClient {
+	s.clientConnIdMutex.RLock()
+	defer s.clientConnIdMutex.RUnlock()
+	result := make([]TrackedClient, 0, len(s.trackedClients))
+	for _, tc := range s.trackedClients {
+		cpy := *tc
+		cpy.Cursor.Hash = cloneBytes(tc.Cursor.Hash)
+		cpy.Tip.Point.Hash = cloneBytes(tc.Tip.Point.Hash)
+		result = append(result, cpy)
+	}
+	return result
+}
+
+// MaxClients returns the configured maximum number of chainsync
+// clients.
+func (s *State) MaxClients() int {
+	return s.config.MaxClients
+}
+
+// ClearSeenHeaders removes all entries from the header
+// deduplication cache. This should be called on rollback to
+// avoid stale entries.
+func (s *State) ClearSeenHeaders() {
+	s.seenHeadersMutex.Lock()
+	defer s.seenHeadersMutex.Unlock()
+	s.seenHeaders = make(map[uint64][]headerRecord)
+}
+
+// cloneBytes returns a copy of the byte slice, or nil if the
+// input is nil.
+func cloneBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	c := make([]byte, len(b))
+	copy(c, b)
+	return c
+}
+
+// PruneSeenHeaders removes entries from the header
+// deduplication cache for slots older than the given slot.
+func (s *State) PruneSeenHeaders(beforeSlot uint64) {
+	s.seenHeadersMutex.Lock()
+	defer s.seenHeadersMutex.Unlock()
+	for slot := range s.seenHeaders {
+		if slot < beforeSlot {
+			delete(s.seenHeaders, slot)
+		}
+	}
 }

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1,0 +1,942 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync_test
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestConnId creates a unique ConnectionId for testing by
+// using the id as the remote port number.
+func newTestConnId(id uint) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 3001,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: int(id),
+		},
+	}
+}
+
+func newTestEventBus(t *testing.T) *event.EventBus {
+	t.Helper()
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	return bus
+}
+
+func newTestState(
+	t *testing.T,
+	bus *event.EventBus,
+	cfg chainsync.Config,
+) *chainsync.State {
+	t.Helper()
+	return chainsync.NewStateWithConfig(bus, nil, cfg)
+}
+
+// --- Client registry tests ---
+
+func TestAddAndRemoveClientConnId(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+
+	s.AddClientConnId(connA)
+	require.True(t, s.HasClientConnId(connA))
+	require.Equal(t, 1, s.ClientConnCount())
+
+	s.AddClientConnId(connB)
+	require.True(t, s.HasClientConnId(connB))
+	require.Equal(t, 2, s.ClientConnCount())
+
+	// First added should be active (primary)
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connA, *active)
+
+	// Remove first client; second should become active
+	s.RemoveClientConnId(connA)
+	require.False(t, s.HasClientConnId(connA))
+	require.Equal(t, 1, s.ClientConnCount())
+
+	active = s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connB, *active)
+}
+
+func TestTryAddClientConnId_LimitEnforced(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.Config{
+		MaxClients:   2,
+		StallTimeout: 30 * time.Second,
+	})
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	connC := newTestConnId(3)
+
+	require.True(t, s.TryAddClientConnId(connA, 2))
+	require.True(t, s.TryAddClientConnId(connB, 2))
+	// Third should be rejected
+	require.False(t, s.TryAddClientConnId(connC, 2))
+	require.Equal(t, 2, s.ClientConnCount())
+}
+
+func TestTryAddClientConnId_DuplicateRejected(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	require.True(t, s.TryAddClientConnId(conn, 10))
+	require.False(t, s.TryAddClientConnId(conn, 10))
+	require.Equal(t, 1, s.ClientConnCount())
+}
+
+func TestAddClientConnId_DuplicatePreservesState(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+
+	// Update tip so the client has meaningful state
+	point := ocommon.NewPoint(500, []byte("block_hash"))
+	tip := ochainsync.Tip{
+		Point:       point,
+		BlockNumber: 42,
+	}
+	s.UpdateClientTip(conn, point, tip)
+
+	// Re-adding should be a no-op and preserve state
+	s.AddClientConnId(conn)
+	require.Equal(t, 1, s.ClientConnCount())
+
+	tc := s.GetTrackedClient(conn)
+	require.NotNil(t, tc)
+	require.Equal(
+		t, uint64(500), tc.Cursor.Slot,
+		"cursor should be preserved",
+	)
+	require.Equal(
+		t, uint64(1), tc.HeadersRecv,
+		"headers counter should be preserved",
+	)
+}
+
+func TestPromoteBestClient_NoHealthyClients(t *testing.T) {
+	bus := newTestEventBus(t)
+	cfg := chainsync.Config{
+		MaxClients:   5,
+		StallTimeout: 50 * time.Millisecond,
+	}
+	s := newTestState(t, bus, cfg)
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	// Set A as primary
+	s.SetClientConnId(connA)
+
+	// Update tips so both have data
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("ha")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("ha")),
+		})
+	s.UpdateClientTip(connB,
+		ocommon.NewPoint(200, []byte("hb")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(200, []byte("hb")),
+		})
+
+	// Wait for stall timeout to elapse for both clients.
+	// Use a map to deduplicate connection IDs across
+	// polling iterations.
+	stalledSet := make(
+		map[ouroboros.ConnectionId]struct{},
+	)
+	require.Eventually(t, func() bool {
+		for _, id := range s.CheckStalledClients() {
+			stalledSet[id] = struct{}{}
+		}
+		return len(stalledSet) >= 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"both clients should become stalled",
+	)
+	require.Len(t, stalledSet, 2)
+
+	// Remove primary; only stalled clients remain so
+	// active should be nil (no fallback to bad peers).
+	s.RemoveClientConnId(connA)
+	active := s.GetClientConnId()
+	require.Nil(
+		t, active,
+		"should not promote stalled client",
+	)
+}
+
+func TestGetClientConnIds(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	ids := s.GetClientConnIds()
+	require.Len(t, ids, 2)
+	require.Contains(t, ids, connA)
+	require.Contains(t, ids, connB)
+}
+
+func TestSetClientConnId(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	// Override active client
+	s.SetClientConnId(connB)
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connB, *active)
+}
+
+// --- Failover tests ---
+
+func TestFailover_PrimaryDisconnects(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	connC := newTestConnId(3)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+	s.AddClientConnId(connC)
+
+	// Update tips so B is the best
+	s.UpdateClientTip(connA, ocommon.NewPoint(100, []byte("aa")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("aa"))})
+	s.UpdateClientTip(connB, ocommon.NewPoint(300, []byte("bb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(300, []byte("bb"))})
+	s.UpdateClientTip(connC, ocommon.NewPoint(200, []byte("cc")),
+		ochainsync.Tip{Point: ocommon.NewPoint(200, []byte("cc"))})
+
+	// Set A as primary, then remove it
+	s.SetClientConnId(connA)
+	s.RemoveClientConnId(connA)
+
+	// B should be promoted (highest tip)
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connB, *active)
+}
+
+func TestFailover_PromotesNonStalledClient(t *testing.T) {
+	bus := newTestEventBus(t)
+	cfg := chainsync.Config{
+		MaxClients:   5,
+		StallTimeout: 50 * time.Millisecond,
+	}
+	s := newTestState(t, bus, cfg)
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	connC := newTestConnId(3)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+	s.AddClientConnId(connC)
+
+	// Give B a higher tip
+	s.UpdateClientTip(connA, ocommon.NewPoint(100, []byte("aa")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("aa"))})
+	s.UpdateClientTip(connB, ocommon.NewPoint(300, []byte("bb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(300, []byte("bb"))})
+	s.UpdateClientTip(connC, ocommon.NewPoint(200, []byte("cc")),
+		ochainsync.Tip{Point: ocommon.NewPoint(200, []byte("cc"))})
+
+	// Set A as primary
+	s.SetClientConnId(connA)
+
+	// Poll until B's stall timeout elapses, refreshing A
+	// and C on each iteration to keep them active. Use a
+	// map to deduplicate IDs across polling iterations.
+	stalledSet := make(
+		map[ouroboros.ConnectionId]struct{},
+	)
+	require.Eventually(t, func() bool {
+		s.UpdateClientTip(connA,
+			ocommon.NewPoint(101, []byte("a2")),
+			ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					101, []byte("a2"),
+				),
+			})
+		s.UpdateClientTip(connC,
+			ocommon.NewPoint(201, []byte("c2")),
+			ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					201, []byte("c2"),
+				),
+			})
+		for _, id := range s.CheckStalledClients() {
+			stalledSet[id] = struct{}{}
+		}
+		return len(stalledSet) >= 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"B should become stalled",
+	)
+	require.Contains(t, stalledSet, connB)
+
+	// Remove A (primary)
+	s.RemoveClientConnId(connA)
+
+	// C should be promoted because B is stalled
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connC, *active)
+}
+
+// --- Header deduplication tests ---
+
+func TestHeaderDeduplication_NewHeader(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	s.AddClientConnId(connA)
+
+	isNew := s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("hash1")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("hash1"))})
+	require.True(t, isNew)
+}
+
+func TestHeaderDeduplication_DuplicateHeader(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	point := ocommon.NewPoint(100, []byte("same_hash"))
+	tip := ochainsync.Tip{Point: point}
+
+	// First report is new
+	isNew := s.UpdateClientTip(connA, point, tip)
+	require.True(t, isNew)
+
+	// Second report of same hash is duplicate
+	isNew = s.UpdateClientTip(connB, point, tip)
+	require.False(t, isNew)
+}
+
+// --- Fork detection tests ---
+
+func TestForkDetection(t *testing.T) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ForkDetectedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	// Client A reports hash1 at slot 100
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("hash_a")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("hash_a")),
+		})
+
+	// Client B reports hash2 at slot 100 (fork)
+	isNew := s.UpdateClientTip(connB,
+		ocommon.NewPoint(100, []byte("hash_b")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("hash_b")),
+		})
+	require.True(t, isNew, "fork header should be treated as new")
+
+	// Verify fork detection event was emitted
+	evt := testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected fork detection event",
+	)
+	forkEvt, ok := evt.Data.(chainsync.ForkDetectedEvent)
+	require.True(t, ok)
+	require.Equal(t, uint64(100), forkEvt.Slot)
+	require.Equal(t, []byte("hash_a"), forkEvt.HashA)
+	require.Equal(t, []byte("hash_b"), forkEvt.HashB)
+	require.Equal(t, connA, forkEvt.ConnIdA)
+	require.Equal(t, connB, forkEvt.ConnIdB)
+}
+
+func TestForkDetection_DuplicateForkHashDeduplicated(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ForkDetectedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	connC := newTestConnId(3)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+	s.AddClientConnId(connC)
+
+	// A reports hash_a at slot 100
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("hash_a")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("hash_a")),
+		})
+
+	// B reports hash_b at slot 100 (fork)
+	isNew := s.UpdateClientTip(connB,
+		ocommon.NewPoint(100, []byte("hash_b")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("hash_b")),
+		})
+	require.True(t, isNew)
+
+	// Consume the fork event
+	_ = testutil.RequireReceive(
+		t, ch, 2*time.Second,
+		"expected fork detection event",
+	)
+
+	// C reports hash_b (same as B) -- should be
+	// deduplicated, NOT trigger another fork event
+	isNew = s.UpdateClientTip(connC,
+		ocommon.NewPoint(100, []byte("hash_b")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("hash_b")),
+		})
+	require.False(t, isNew,
+		"duplicate fork hash should be deduplicated",
+	)
+
+	// No additional fork event should be emitted
+	testutil.RequireNoReceive(
+		t, ch, 50*time.Millisecond,
+		"no duplicate fork event expected",
+	)
+}
+
+// --- Stall detection tests ---
+
+func TestStallDetection(t *testing.T) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ClientStalledEventType)
+	cfg := chainsync.Config{
+		MaxClients:   5,
+		StallTimeout: 50 * time.Millisecond,
+	}
+	s := newTestState(t, bus, cfg)
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	// Update both initially
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("ha")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("ha"))})
+	s.UpdateClientTip(connB,
+		ocommon.NewPoint(200, []byte("hb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(200, []byte("hb"))})
+
+	// Wait for stall timeout to elapse. Use a map to
+	// deduplicate connection IDs across polling iterations.
+	stalledSet := make(
+		map[ouroboros.ConnectionId]struct{},
+	)
+	require.Eventually(t, func() bool {
+		for _, id := range s.CheckStalledClients() {
+			stalledSet[id] = struct{}{}
+		}
+		return len(stalledSet) >= 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"both clients should become stalled",
+	)
+	require.Len(t, stalledSet, 2)
+
+	// Verify stall events emitted
+	evt1 := testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected first stall event",
+	)
+	stalledEvt := evt1.Data.(chainsync.ClientStalledEvent)
+	require.Contains(t,
+		[]ouroboros.ConnectionId{connA, connB},
+		stalledEvt.ConnId,
+	)
+}
+
+func TestStallDetection_RecoveryOnActivity(t *testing.T) {
+	bus := newTestEventBus(t)
+	cfg := chainsync.Config{
+		MaxClients:   5,
+		StallTimeout: 50 * time.Millisecond,
+	}
+	s := newTestState(t, bus, cfg)
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+	s.UpdateClientTip(conn,
+		ocommon.NewPoint(100, []byte("h1")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("h1"))})
+
+	// Wait for stall timeout to elapse. Use a map to
+	// deduplicate connection IDs across polling iterations.
+	stalledSet := make(
+		map[ouroboros.ConnectionId]struct{},
+	)
+	require.Eventually(t, func() bool {
+		for _, id := range s.CheckStalledClients() {
+			stalledSet[id] = struct{}{}
+		}
+		return len(stalledSet) >= 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"client should become stalled",
+	)
+	require.Len(t, stalledSet, 1)
+
+	// Verify stalled status
+	tc := s.GetTrackedClient(conn)
+	require.NotNil(t, tc)
+	require.Equal(t, chainsync.ClientStatusStalled, tc.Status)
+
+	// Activity should recover the client
+	s.UpdateClientTip(conn,
+		ocommon.NewPoint(101, []byte("h2")),
+		ochainsync.Tip{Point: ocommon.NewPoint(101, []byte("h2"))})
+	tc = s.GetTrackedClient(conn)
+	require.NotNil(t, tc)
+	require.Equal(t, chainsync.ClientStatusSyncing, tc.Status)
+}
+
+func TestStallDetection_PrimaryFailover(t *testing.T) {
+	bus := newTestEventBus(t)
+	cfg := chainsync.Config{
+		MaxClients:   5,
+		StallTimeout: 50 * time.Millisecond,
+	}
+	s := newTestState(t, bus, cfg)
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	// Set A as primary with a high tip
+	s.SetClientConnId(connA)
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(500, []byte("ha")),
+		ochainsync.Tip{Point: ocommon.NewPoint(500, []byte("ha"))})
+	s.UpdateClientTip(connB,
+		ocommon.NewPoint(400, []byte("hb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(400, []byte("hb"))})
+
+	// Poll until A's stall timeout elapses, keeping B
+	// active. Use a map to deduplicate IDs across polling
+	// iterations.
+	stalledSet := make(
+		map[ouroboros.ConnectionId]struct{},
+	)
+	require.Eventually(t, func() bool {
+		s.UpdateClientTip(connB,
+			ocommon.NewPoint(401, []byte("hb2")),
+			ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					401, []byte("hb2"),
+				),
+			})
+		for _, id := range s.CheckStalledClients() {
+			stalledSet[id] = struct{}{}
+		}
+		return len(stalledSet) >= 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"A should become stalled",
+	)
+	require.Contains(t, stalledSet, connA)
+
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connB, *active)
+}
+
+// --- Client synced tests ---
+
+func TestMarkClientSynced(t *testing.T) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ClientSyncedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+	s.UpdateClientTip(conn,
+		ocommon.NewPoint(100, []byte("h1")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("h1"))})
+
+	s.MarkClientSynced(conn)
+
+	tc := s.GetTrackedClient(conn)
+	require.NotNil(t, tc)
+	require.Equal(t, chainsync.ClientStatusSynced, tc.Status)
+
+	evt := testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected synced event",
+	)
+	syncEvt := evt.Data.(chainsync.ClientSyncedEvent)
+	require.Equal(t, conn, syncEvt.ConnId)
+	require.Equal(t, uint64(100), syncEvt.Slot)
+}
+
+func TestMarkClientSynced_IdempotentNoDoubleEvent(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ClientSyncedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+	s.UpdateClientTip(conn,
+		ocommon.NewPoint(100, []byte("h1")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(100, []byte("h1")),
+		})
+
+	// First call should emit event
+	s.MarkClientSynced(conn)
+	_ = testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected synced event",
+	)
+
+	// Second call should NOT emit another event
+	s.MarkClientSynced(conn)
+	testutil.RequireNoReceive(
+		t, ch, 50*time.Millisecond,
+		"no duplicate synced event expected",
+	)
+}
+
+// --- Client events tests ---
+
+func TestClientAddedEvent(t *testing.T) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ClientAddedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+
+	evt := testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected client added event",
+	)
+	addedEvt := evt.Data.(chainsync.ClientAddedEvent)
+	require.Equal(t, conn, addedEvt.ConnId)
+	require.Equal(t, 1, addedEvt.TotalClients)
+}
+
+func TestClientRemovedEvent(t *testing.T) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ClientRemovedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+	s.RemoveClientConnId(conn)
+
+	evt := testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected client removed event",
+	)
+	removedEvt := evt.Data.(chainsync.ClientRemovedEvent)
+	require.Equal(t, conn, removedEvt.ConnId)
+	require.Equal(t, 0, removedEvt.TotalClients)
+	require.True(t, removedEvt.WasPrimary)
+}
+
+func TestClientRemovedEvent_NonPrimary(t *testing.T) {
+	bus := newTestEventBus(t)
+	_, ch := bus.Subscribe(chainsync.ClientRemovedEventType)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA) // becomes primary
+	s.AddClientConnId(connB)
+	s.RemoveClientConnId(connB) // not primary
+
+	evt := testutil.RequireReceive(
+		t, ch, 2*time.Second, "expected client removed event",
+	)
+	removedEvt := evt.Data.(chainsync.ClientRemovedEvent)
+	require.Equal(t, connB, removedEvt.ConnId)
+	require.False(t, removedEvt.WasPrimary)
+}
+
+// --- Tracked client state tests ---
+
+func TestGetTrackedClient(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+	s.UpdateClientTip(conn,
+		ocommon.NewPoint(42, []byte("xyz")),
+		ochainsync.Tip{
+			Point:       ocommon.NewPoint(42, []byte("xyz")),
+			BlockNumber: 10,
+		})
+
+	tc := s.GetTrackedClient(conn)
+	require.NotNil(t, tc)
+	require.Equal(t, conn, tc.ConnId)
+	require.Equal(t, uint64(42), tc.Cursor.Slot)
+	require.Equal(t, uint64(1), tc.HeadersRecv)
+	require.Equal(t, chainsync.ClientStatusSyncing, tc.Status)
+}
+
+func TestGetTrackedClient_NotFound(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	tc := s.GetTrackedClient(newTestConnId(999))
+	require.Nil(t, tc)
+}
+
+func TestGetTrackedClients(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	s.AddClientConnId(newTestConnId(1))
+	s.AddClientConnId(newTestConnId(2))
+	s.AddClientConnId(newTestConnId(3))
+
+	clients := s.GetTrackedClients()
+	require.Len(t, clients, 3)
+}
+
+// --- Seen headers cache tests ---
+
+func TestClearSeenHeaders(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+
+	s.UpdateClientTip(conn,
+		ocommon.NewPoint(100, []byte("h1")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("h1"))})
+
+	s.ClearSeenHeaders()
+
+	// Same header should now be treated as new
+	isNew := s.UpdateClientTip(conn,
+		ocommon.NewPoint(100, []byte("h1")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("h1"))})
+	require.True(t, isNew)
+}
+
+func TestPruneSeenHeaders(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	// Add headers at slots 50 and 150
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(50, []byte("old")),
+		ochainsync.Tip{Point: ocommon.NewPoint(50, []byte("old"))})
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(150, []byte("new")),
+		ochainsync.Tip{Point: ocommon.NewPoint(150, []byte("new"))})
+
+	// Prune headers before slot 100
+	s.PruneSeenHeaders(100)
+
+	// Slot 50 should be treated as new again
+	isNew := s.UpdateClientTip(connB,
+		ocommon.NewPoint(50, []byte("old")),
+		ochainsync.Tip{Point: ocommon.NewPoint(50, []byte("old"))})
+	require.True(t, isNew)
+
+	// Slot 150 should still be a duplicate
+	isNew = s.UpdateClientTip(connB,
+		ocommon.NewPoint(150, []byte("new")),
+		ochainsync.Tip{Point: ocommon.NewPoint(150, []byte("new"))})
+	require.False(t, isNew)
+}
+
+// --- Config tests ---
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := chainsync.DefaultConfig()
+	require.Equal(t, chainsync.DefaultMaxClients, cfg.MaxClients)
+	require.Equal(t, chainsync.DefaultStallTimeout, cfg.StallTimeout)
+}
+
+func TestNewStateWithConfig_InvalidDefaults(t *testing.T) {
+	bus := newTestEventBus(t)
+	// Zero/negative values should be replaced with defaults
+	s := chainsync.NewStateWithConfig(bus, nil, chainsync.Config{
+		MaxClients:   -1,
+		StallTimeout: 0,
+	})
+	require.Equal(t, chainsync.DefaultMaxClients, s.MaxClients())
+}
+
+// --- ClientStatus string tests ---
+
+func TestClientStatus_String(t *testing.T) {
+	require.Equal(t, "syncing", chainsync.ClientStatusSyncing.String())
+	require.Equal(t, "synced", chainsync.ClientStatusSynced.String())
+	require.Equal(t, "stalled", chainsync.ClientStatusStalled.String())
+	require.Equal(t, "failed", chainsync.ClientStatusFailed.String())
+	require.Equal(t, "unknown", chainsync.ClientStatus(99).String())
+}
+
+// --- NewState backward compatibility ---
+
+func TestNewState_BackwardCompatible(t *testing.T) {
+	bus := newTestEventBus(t)
+	// NewState (no config) should still work
+	s := chainsync.NewState(bus, nil)
+	require.NotNil(t, s)
+	require.Equal(t, chainsync.DefaultMaxClients, s.MaxClients())
+
+	// Single client should work exactly as before
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+	require.True(t, s.HasClientConnId(conn))
+
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, conn, *active)
+
+	s.RemoveClientConnId(conn)
+	require.False(t, s.HasClientConnId(conn))
+	require.Equal(t, 0, s.ClientConnCount())
+}
+
+// --- UpdateClientTip for untracked connection ---
+
+func TestUpdateClientTip_UntrackedConnection(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	// Updating an untracked connection should return true
+	// (treat as new) and not panic
+	isNew := s.UpdateClientTip(newTestConnId(999),
+		ocommon.NewPoint(100, []byte("h1")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("h1"))})
+	require.True(t, isNew)
+}
+
+// --- Concurrent access test ---
+
+func TestConcurrentAccess(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.Config{
+		MaxClients:   50,
+		StallTimeout: 30 * time.Second,
+	})
+
+	var wg sync.WaitGroup
+	// Spawn goroutines that add, update, and remove clients
+	for i := range 20 {
+		wg.Add(1)
+		go func(id uint) {
+			defer wg.Done()
+			conn := newTestConnId(id)
+			s.AddClientConnId(conn)
+			for j := range 10 {
+				s.UpdateClientTip(conn,
+					ocommon.NewPoint(
+						uint64(j),
+						[]byte{byte(id), byte(j)},
+					),
+					ochainsync.Tip{
+						Point: ocommon.NewPoint(
+							uint64(j),
+							[]byte{byte(id), byte(j)},
+						),
+					})
+			}
+			_ = s.GetClientConnId()
+			_ = s.GetClientConnIds()
+			_ = s.ClientConnCount()
+			_ = s.GetTrackedClient(conn)
+			_ = s.GetTrackedClients()
+			s.CheckStalledClients()
+			s.RemoveClientConnId(conn)
+		}(uint(i))
+	}
+	wg.Wait()
+}
+
+// --- Remove all clients leaves nil active ---
+
+func TestRemoveAllClients_NilActive(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	s.RemoveClientConnId(connA)
+	s.RemoveClientConnId(connB)
+
+	active := s.GetClientConnId()
+	require.Nil(t, active)
+	require.Equal(t, 0, s.ClientConnCount())
+}

--- a/chainsync/event.go
+++ b/chainsync/event.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	// ClientAddedEventType is emitted when a new chainsync
+	// client is registered.
+	ClientAddedEventType event.EventType = "chainsync.client_added"
+
+	// ClientRemovedEventType is emitted when a chainsync client
+	// is unregistered (e.g. on disconnect).
+	ClientRemovedEventType event.EventType = "chainsync.client_removed"
+
+	// ClientSyncedEventType is emitted when a chainsync client
+	// reaches the upstream chain tip.
+	ClientSyncedEventType event.EventType = "chainsync.client_synced"
+
+	// ClientStalledEventType is emitted when a chainsync client
+	// has not received any headers within the stall timeout.
+	ClientStalledEventType event.EventType = "chainsync.client_stalled"
+
+	// ForkDetectedEventType is emitted when two clients report
+	// different block hashes for the same slot.
+	ForkDetectedEventType event.EventType = "chainsync.fork_detected"
+)
+
+// ClientAddedEvent contains details about a newly registered
+// chainsync client.
+type ClientAddedEvent struct {
+	ConnId       ouroboros.ConnectionId
+	TotalClients int
+}
+
+// ClientRemovedEvent contains details about a removed chainsync
+// client.
+type ClientRemovedEvent struct {
+	ConnId       ouroboros.ConnectionId
+	TotalClients int
+	WasPrimary   bool
+}
+
+// ClientSyncedEvent is published when a client reaches the
+// upstream chain tip.
+type ClientSyncedEvent struct {
+	ConnId ouroboros.ConnectionId
+	Slot   uint64
+}
+
+// ClientStalledEvent is published when a client exceeds the
+// stall timeout.
+type ClientStalledEvent struct {
+	ConnId ouroboros.ConnectionId
+	Slot   uint64
+}
+
+// ForkDetectedEvent is published when two clients report
+// different block hashes at the same slot.
+type ForkDetectedEvent struct {
+	Slot    uint64
+	HashA   []byte
+	HashB   []byte
+	ConnIdA ouroboros.ConnectionId
+	ConnIdB ouroboros.ConnectionId
+	Point   ocommon.Point
+}

--- a/config.go
+++ b/config.go
@@ -82,6 +82,9 @@ type Config struct {
 	shelleyOperationalCertificate string
 	// Blockfrost API listen address (empty = disabled)
 	blockfrostListenAddress string
+	// Chainsync multi-client configuration
+	chainsyncMaxClients   int
+	chainsyncStallTimeout time.Duration
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -426,5 +429,26 @@ func WithBlockfrostListenAddress(
 ) ConfigOptionFunc {
 	return func(c *Config) {
 		c.blockfrostListenAddress = addr
+	}
+}
+
+// WithChainsyncMaxClients specifies the maximum number of
+// concurrent chainsync client connections. Default is 3.
+func WithChainsyncMaxClients(
+	maxClients int,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.chainsyncMaxClients = maxClients
+	}
+}
+
+// WithChainsyncStallTimeout specifies the duration after
+// which a chainsync client with no activity is considered
+// stalled. Default is 30 seconds.
+func WithChainsyncStallTimeout(
+	timeout time.Duration,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.chainsyncStallTimeout = timeout
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,27 @@ type databaseConfig struct {
 	Metadata map[string]any `yaml:"metadata,omitempty"`
 }
 
+// ChainsyncConfig holds configuration for the multi-client chainsync
+// subsystem.
+type ChainsyncConfig struct {
+	// MaxClients is the maximum number of concurrent chainsync client
+	// connections. Default: 3.
+	MaxClients int `yaml:"maxClients"   envconfig:"DINGO_CHAINSYNC_MAX_CLIENTS"`
+	// StallTimeout is the duration after which a client with no
+	// activity is considered stalled. Default: "30s".
+	StallTimeout string `yaml:"stallTimeout" envconfig:"DINGO_CHAINSYNC_STALL_TIMEOUT"`
+}
+
+// DefaultChainsyncConfig returns the default chainsync configuration.
+// StallTimeout must match chainsync.DefaultStallTimeout and the
+// fallback in internal/node/node.go.
+func DefaultChainsyncConfig() ChainsyncConfig {
+	return ChainsyncConfig{
+		MaxClients:   3,
+		StallTimeout: "30s",
+	}
+}
+
 // CacheConfig holds configuration for the tiered CBOR cache system.
 type CacheConfig struct {
 	// HotUtxoEntries is the maximum number of UTxO CBOR entries in the hot cache.
@@ -129,23 +150,23 @@ type Config struct {
 	TlsKeyFilePath     string  `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
 	Topology           string  `yaml:"topology"`
 	CardanoConfig      string  `yaml:"cardanoConfig"      envconfig:"config"`
-	DatabasePath       string  `yaml:"databasePath"                                                  split_words:"true"`
-	SocketPath         string  `yaml:"socketPath"                                                    split_words:"true"`
+	DatabasePath       string  `yaml:"databasePath"                                                     split_words:"true"`
+	SocketPath         string  `yaml:"socketPath"                                                       split_words:"true"`
 	TlsCertFilePath    string  `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr           string  `yaml:"bindAddr"                                                      split_words:"true"`
+	BindAddr           string  `yaml:"bindAddr"                                                         split_words:"true"`
 	BlobPlugin         string  `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
-	PrivateBindAddr    string  `yaml:"privateBindAddr"                                               split_words:"true"`
-	ShutdownTimeout    string  `yaml:"shutdownTimeout"                                               split_words:"true"`
+	PrivateBindAddr    string  `yaml:"privateBindAddr"                                                  split_words:"true"`
+	ShutdownTimeout    string  `yaml:"shutdownTimeout"                                                  split_words:"true"`
 	Network            string  `yaml:"network"`
-	MempoolCapacity    int64   `yaml:"mempoolCapacity"                                               split_words:"true"`
+	MempoolCapacity    int64   `yaml:"mempoolCapacity"                                                  split_words:"true"`
 	EvictionWatermark  float64 `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
 	RejectionWatermark float64 `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
-	PrivatePort        uint    `yaml:"privatePort"                                                   split_words:"true"`
+	PrivatePort        uint    `yaml:"privatePort"                                                      split_words:"true"`
 	RelayPort          uint    `yaml:"relayPort"          envconfig:"port"`
-	UtxorpcPort        uint    `yaml:"utxorpcPort"                                                   split_words:"true"`
-	MetricsPort        uint    `yaml:"metricsPort"                                                   split_words:"true"`
-	IntersectTip       bool    `yaml:"intersectTip"                                                  split_words:"true"`
-	ValidateHistorical bool    `yaml:"validateHistorical"                                            split_words:"true"`
+	UtxorpcPort        uint    `yaml:"utxorpcPort"                                                      split_words:"true"`
+	MetricsPort        uint    `yaml:"metricsPort"                                                      split_words:"true"`
+	IntersectTip       bool    `yaml:"intersectTip"                                                     split_words:"true"`
+	ValidateHistorical bool    `yaml:"validateHistorical"                                               split_words:"true"`
 	RunMode            RunMode `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
 	ImmutableDbPath    string  `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
 	// Database worker pool tuning (worker count and task queue size)
@@ -165,6 +186,9 @@ type Config struct {
 	// Cache configuration for the tiered CBOR cache system
 	Cache CacheConfig `yaml:"cache"`
 
+	// Chainsync configuration for multi-client support
+	Chainsync ChainsyncConfig `yaml:"chainsync"`
+
 	// KES (Key Evolving Signature) configuration for block production
 	// SlotsPerKESPeriod is the number of slots in a KES period.
 	// After this many slots, the KES key must be evolved to the next period.
@@ -174,14 +198,14 @@ type Config struct {
 	// For Cardano's KES depth of 6, this is 2^6 - 2 = 62 evolutions.
 	// After this many evolutions, a new operational certificate must be issued.
 	// Default: 62
-	MaxKESEvolutions uint64 `yaml:"maxKESEvolutions" envconfig:"DINGO_MAX_KES_EVOLUTIONS"`
+	MaxKESEvolutions uint64 `yaml:"maxKESEvolutions"  envconfig:"DINGO_MAX_KES_EVOLUTIONS"`
 
 	// Block production configuration (SPO mode)
 	// Environment variables match cardano-node naming convention for compatibility
 	// Note: envconfig.Process("cardano", ...) adds "CARDANO_" prefix automatically
-	BlockProducer                 bool   `yaml:"blockProducer"       envconfig:"BLOCK_PRODUCER"`
-	ShelleyVRFKey                 string `yaml:"shelleyVrfKey"       envconfig:"SHELLEY_VRF_KEY"`
-	ShelleyKESKey                 string `yaml:"shelleyKesKey"       envconfig:"SHELLEY_KES_KEY"`
+	BlockProducer                 bool   `yaml:"blockProducer"                 envconfig:"BLOCK_PRODUCER"`
+	ShelleyVRFKey                 string `yaml:"shelleyVrfKey"                 envconfig:"SHELLEY_VRF_KEY"`
+	ShelleyKESKey                 string `yaml:"shelleyKesKey"                 envconfig:"SHELLEY_KES_KEY"`
 	ShelleyOperationalCertificate string `yaml:"shelleyOperationalCertificate" envconfig:"SHELLEY_OPERATIONAL_CERTIFICATE"`
 }
 
@@ -270,6 +294,8 @@ var globalConfig = &Config{
 	DatabaseQueueSize: 50,
 	// Cache configuration defaults
 	Cache: DefaultCacheConfig(),
+	// Chainsync configuration defaults
+	Chainsync: DefaultChainsyncConfig(),
 	// KES configuration defaults (mainnet values)
 	SlotsPerKESPeriod: 129600, // 1.5 days at 1 second per slot
 	MaxKESEvolutions:  62,     // 2^6 - 2 for KES depth 6


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-peer chainsync client registry with automatic failover, stall detection, and cross-peer header deduplication to boost resilience and prevent duplicate processing. Ouroboros skips duplicate headers while still driving chain selection and metrics; if chainsync negotiation fails, txsubmission is not started on that connection.

- **New Features**
  - Track outbound clients (status, cursor/tip, last activity, counters); enforce MaxClients; getters: GetTrackedClient(s), MaxClients.
  - Failover promotes the highest-tip healthy client when the primary disconnects or stalls; stalled clients recover on activity.
  - UpdateClientTip returns isNew; dedupes headers by slot+hash and emits fork_detected on diverging hashes; ClearSeenHeaders/PruneSeenHeaders; getters return deep copies.
  - Events: chainsync.client_added, chainsync.client_removed (includes WasPrimary), chainsync.client_synced, chainsync.client_stalled, chainsync.fork_detected.
  - Ouroboros skips ledger processing for duplicate headers but still emits PeerTipUpdate and updates metrics.

- **Configuration**
  - YAML: chainsync.maxClients (default 3), chainsync.stallTimeout (default "30s"); env DINGO_CHAINSYNC_MAX_CLIENTS, DINGO_CHAINSYNC_STALL_TIMEOUT.
  - Node options: WithChainsyncMaxClients, WithChainsyncStallTimeout; sensible defaults applied in node startup.
  - Ouroboros uses ChainsyncState.MaxClients; fallback matches the default (3) when unavailable.

<sup>Written for commit 2a5f1286ca95b59d1cd0bd3a39b4d84509d97b38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-client chain synchronization with header deduplication, fork detection (emits fork events), automatic failover and client lifecycle events.

* **Configuration**
  * Added configurable max clients (default: 3) and stall timeout (default: 30s).

* **Improvements**
  * Better peer liveness/status tracking, promotion of best peers, safer concurrent state handling and connection management.

* **Tests**
  * Comprehensive test suite for registry, failover, dedupe, forks, stalls, events, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->