### PR TITLE
fix(ledger): use header count for blockfetch range cleanup

### DIFF
--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -32,7 +32,10 @@ func (ls *LedgerState) handleEventChainUpdate(evt event.Event) {
 	}
 }
 
-func (ls *LedgerState) publishBlockEvent(action BlockAction, block models.Block) {
+func (ls *LedgerState) publishBlockEvent(
+	action BlockAction,
+	block models.Block,
+) {
 	if ls.config.EventBus == nil {
 		return
 	}

--- a/ledger/genesis_utxo_test.go
+++ b/ledger/genesis_utxo_test.go
@@ -35,7 +35,12 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := slog.New(
+		slog.NewTextHandler(
+			os.Stdout,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
 
 	// Create database
 	dbConfig := &database.Config{
@@ -171,7 +176,10 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 
 			// Store the offset
 			offsetData := database.EncodeUtxoOffset(&offset)
-			t.Logf("Storing UTxO offset: %s", hex.EncodeToString(offsetData[:20]))
+			t.Logf(
+				"Storing UTxO offset: %s",
+				hex.EncodeToString(offsetData[:20]),
+			)
 
 			blob := db.Blob()
 			if blob == nil {
@@ -212,8 +220,13 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 			continue
 		}
 
-		t.Logf("Retrieved data for %x#%d: %d bytes, first bytes: %s",
-			txId[:8], outputIdx, len(data), hex.EncodeToString(data[:min(20, len(data))]))
+		t.Logf(
+			"Retrieved data for %x#%d: %d bytes, first bytes: %s",
+			txId[:8],
+			outputIdx,
+			len(data),
+			hex.EncodeToString(data[:min(20, len(data))]),
+		)
 
 		// Check if it's an offset
 		if database.IsUtxoOffsetStorage(data) {
@@ -221,16 +234,35 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 
 			// Decode the offset
 			offset, err := database.DecodeUtxoOffset(data)
-			require.NoError(t, err, "Failed to decode offset for %x#%d", txId[:8], outputIdx)
+			require.NoError(
+				t,
+				err,
+				"Failed to decode offset for %x#%d",
+				txId[:8],
+				outputIdx,
+			)
 
-			t.Logf("Offset: slot=%d, hash=%x, offset=%d, length=%d",
-				offset.BlockSlot, offset.BlockHash[:8], offset.ByteOffset, offset.ByteLength)
+			t.Logf(
+				"Offset: slot=%d, hash=%x, offset=%d, length=%d",
+				offset.BlockSlot,
+				offset.BlockHash[:8],
+				offset.ByteOffset,
+				offset.ByteLength,
+			)
 
 			// Try to get the block
-			blockCbor, _, err := blob.GetBlock(blobTxn, offset.BlockSlot, offset.BlockHash[:])
+			blockCbor, _, err := blob.GetBlock(
+				blobTxn,
+				offset.BlockSlot,
+				offset.BlockHash[:],
+			)
 			if err != nil {
-				t.Errorf("Failed to get block for offset: slot=%d, hash=%x, error=%v",
-					offset.BlockSlot, offset.BlockHash[:8], err)
+				t.Errorf(
+					"Failed to get block for offset: slot=%d, hash=%x, error=%v",
+					offset.BlockSlot,
+					offset.BlockHash[:8],
+					err,
+				)
 				readTxn.Rollback() //nolint:errcheck
 				continue
 			}
@@ -240,8 +272,12 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 			// Extract the UTxO CBOR
 			end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
 			if end > uint64(len(blockCbor)) {
-				t.Errorf("Offset out of bounds: offset=%d, length=%d, block_size=%d",
-					offset.ByteOffset, offset.ByteLength, len(blockCbor))
+				t.Errorf(
+					"Offset out of bounds: offset=%d, length=%d, block_size=%d",
+					offset.ByteOffset,
+					offset.ByteLength,
+					len(blockCbor),
+				)
 			} else {
 				utxoCbor := blockCbor[offset.ByteOffset:end]
 				t.Logf("Extracted UTxO CBOR: %d bytes, first bytes: %s",

--- a/ledger/governance.go
+++ b/ledger/governance.go
@@ -47,7 +47,9 @@ func processGovernanceProposals(
 	txHash := tx.Hash().Bytes()
 
 	for i, proposal := range proposals {
-		actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(proposal.GovAction())
+		actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
+			proposal.GovAction(),
+		)
 		if err != nil {
 			return fmt.Errorf(
 				"proposal %d in tx %x: %w",

--- a/ledger/governance_test.go
+++ b/ledger/governance_test.go
@@ -75,7 +75,9 @@ func TestExtractGovActionInfo_ParameterChange(t *testing.T) {
 		PolicyHash: []byte{0xAB, 0xCD},
 	}
 
-	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -92,7 +94,9 @@ func TestExtractGovActionInfo_ParameterChange(t *testing.T) {
 func TestExtractGovActionInfo_ParameterChangeNoParent(t *testing.T) {
 	action := &conway.ConwayParameterChangeGovAction{}
 
-	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -114,7 +118,9 @@ func TestExtractGovActionInfo_HardForkInitiation(t *testing.T) {
 		ActionId: parentId,
 	}
 
-	actionType, parentTxHash, parentActionIdx, _, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, _, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -132,7 +138,9 @@ func TestExtractGovActionInfo_TreasuryWithdrawal(t *testing.T) {
 		PolicyHash: []byte{0x01, 0x02, 0x03},
 	}
 
-	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -154,7 +162,9 @@ func TestExtractGovActionInfo_NoConfidence(t *testing.T) {
 		ActionId: parentId,
 	}
 
-	actionType, parentTxHash, parentActionIdx, _, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, _, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -170,7 +180,9 @@ func TestExtractGovActionInfo_NoConfidence(t *testing.T) {
 func TestExtractGovActionInfo_UpdateCommittee(t *testing.T) {
 	action := &lcommon.UpdateCommitteeGovAction{}
 
-	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -192,7 +204,9 @@ func TestExtractGovActionInfo_NewConstitution(t *testing.T) {
 		ActionId: parentId,
 	}
 
-	actionType, parentTxHash, parentActionIdx, _, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, _, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -208,7 +222,9 @@ func TestExtractGovActionInfo_NewConstitution(t *testing.T) {
 func TestExtractGovActionInfo_Info(t *testing.T) {
 	action := &lcommon.InfoGovAction{}
 
-	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(action)
+	actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
+		action,
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint8(lcommon.GovActionTypeInfo), actionType)

--- a/ledger/leader/schedule_test.go
+++ b/ledger/leader/schedule_test.go
@@ -140,7 +140,13 @@ func TestScheduleStakeRatio(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			schedule := NewSchedule(10, poolId, tt.poolStake, tt.totalStake, nil)
+			schedule := NewSchedule(
+				10,
+				poolId,
+				tt.poolStake,
+				tt.totalStake,
+				nil,
+			)
 			assert.InDelta(t, tt.expected, schedule.StakeRatio(), 0.0001)
 		})
 	}
@@ -211,11 +217,11 @@ func TestCalculateScheduleZeroTotalStake(t *testing.T) {
 	poolId := lcommon.PoolKeyHash{}
 
 	_, err := calc.CalculateSchedule(
-		10,            // epoch
-		poolId,        // pool ID
-		testVRFSeed,   // VRF key
-		1000,          // pool stake
-		0,             // zero total stake
+		10,             // epoch
+		poolId,         // pool ID
+		testVRFSeed,    // VRF key
+		1000,           // pool stake
+		0,              // zero total stake
 		testEpochNonce, // epoch nonce
 	)
 
@@ -232,12 +238,12 @@ func TestCalculateSchedulePoolWithStakeGetsSlots(t *testing.T) {
 	copy(poolId[:], []byte("testpool1234567890123"))
 
 	schedule, err := calc.CalculateSchedule(
-		5,               // epoch
-		poolId,          // pool ID
-		testVRFSeed,     // VRF key (32-byte seed)
-		1_000_000,       // pool stake = 100% of total
-		1_000_000,       // total stake
-		testEpochNonce,  // epoch nonce (32 bytes)
+		5,              // epoch
+		poolId,         // pool ID
+		testVRFSeed,    // VRF key (32-byte seed)
+		1_000_000,      // pool stake = 100% of total
+		1_000_000,      // total stake
+		testEpochNonce, // epoch nonce (32 bytes)
 	)
 
 	require.NoError(t, err)
@@ -285,12 +291,12 @@ func TestCalculateScheduleFullStakeApproxRate(t *testing.T) {
 	copy(poolId[:], []byte("testpool1234567890123"))
 
 	schedule, err := calc.CalculateSchedule(
-		3,               // epoch
-		poolId,          // pool ID
-		testVRFSeed,     // VRF key
-		10_000_000,      // pool stake = 100% of total
-		10_000_000,      // total stake
-		testEpochNonce,  // epoch nonce
+		3,              // epoch
+		poolId,         // pool ID
+		testVRFSeed,    // VRF key
+		10_000_000,     // pool stake = 100% of total
+		10_000_000,     // total stake
+		testEpochNonce, // epoch nonce
 	)
 
 	require.NoError(t, err)

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -61,9 +61,11 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		Name: "cardano_node_metrics_blocksForgedNum_int",
 		Help: "total number of blocks forged by this node",
 	})
-	m.blockForgingLatency = promautoFactory.NewHistogram(prometheus.HistogramOpts{
-		Name:    "cardano_node_metrics_blockForgingLatency_seconds",
-		Help:    "latency of block forging from slot start to block completion",
-		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms to ~16s
-	})
+	m.blockForgingLatency = promautoFactory.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "cardano_node_metrics_blockForgingLatency_seconds",
+			Help:    "latency of block forging from slot start to block completion",
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms to ~16s
+		},
+	)
 }

--- a/ledger/protocol_version.go
+++ b/ledger/protocol_version.go
@@ -34,7 +34,9 @@ import (
 // handles Allegra as well. If this alias is ever changed to a
 // distinct type, this assignment will fail to compile,
 // reminding us to add an explicit Allegra case.
-var _ *shelley.ShelleyProtocolParameters = (*allegra.AllegraProtocolParameters)(nil)
+var _ *shelley.ShelleyProtocolParameters = (*allegra.AllegraProtocolParameters)(
+	nil,
+)
 
 // ProtocolVersion represents the major and minor protocol
 // version numbers used in Cardano protocol parameters.

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -170,7 +170,9 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	// Guard: reject slots before the first known epoch
 	firstEpoch := epochCacheCopy[0]
 	if slot < firstEpoch.StartSlot {
-		return models.Epoch{}, errors.New("slot is before the first known epoch")
+		return models.Epoch{}, errors.New(
+			"slot is before the first known epoch",
+		)
 	}
 
 	for _, epoch := range epochCacheCopy {
@@ -196,9 +198,12 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	projectedStartSlot := lastEpochEndSlot + (epochsPastLast * uint64(lastEpoch.LengthInSlots))
 
 	// Verify our calculation is correct (slot should be within the projected epoch)
-	if slot < projectedStartSlot || slot >= projectedStartSlot+uint64(lastEpoch.LengthInSlots) {
+	if slot < projectedStartSlot ||
+		slot >= projectedStartSlot+uint64(lastEpoch.LengthInSlots) {
 		// This shouldn't happen, but return error if our math is wrong
-		return models.Epoch{}, errors.New("internal error: projected epoch calculation mismatch")
+		return models.Epoch{}, errors.New(
+			"internal error: projected epoch calculation mismatch",
+		)
 	}
 	_ = slotInProjectedEpoch // Used only for verification
 

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -103,7 +103,10 @@ type SlotClock struct {
 }
 
 // NewSlotClock creates a new SlotClock with the given provider and configuration
-func NewSlotClock(provider SlotTimeProvider, config SlotClockConfig) *SlotClock {
+func NewSlotClock(
+	provider SlotTimeProvider,
+	config SlotClockConfig,
+) *SlotClock {
 	if config.Logger == nil {
 		config.Logger = slog.Default()
 	}
@@ -331,7 +334,13 @@ func (sc *SlotClock) run() {
 		nextSlot := currentSlot + 1
 		nextSlotTime, err := sc.provider.SlotToTime(nextSlot)
 		if err != nil {
-			logger.Error("failed to get next slot time", "error", err, "slot", nextSlot)
+			logger.Error(
+				"failed to get next slot time",
+				"error",
+				err,
+				"slot",
+				nextSlot,
+			)
 			select {
 			case <-sc.ctx.Done():
 				return
@@ -371,7 +380,13 @@ func (sc *SlotClock) run() {
 		// Emit tick for the slot we're at (might have skipped some if drift is large)
 		tick, err := sc.buildSlotTick(actualSlot, actualNow)
 		if err != nil {
-			logger.Error("failed to build slot tick", "error", err, "slot", actualSlot)
+			logger.Error(
+				"failed to build slot tick",
+				"error",
+				err,
+				"slot",
+				actualSlot,
+			)
 			continue
 		}
 
@@ -380,7 +395,10 @@ func (sc *SlotClock) run() {
 }
 
 // buildSlotTick creates a SlotTick for the given slot
-func (sc *SlotClock) buildSlotTick(slot uint64, slotStart time.Time) (SlotTick, error) {
+func (sc *SlotClock) buildSlotTick(
+	slot uint64,
+	slotStart time.Time,
+) (SlotTick, error) {
 	epochInfo, err := sc.provider.SlotToEpoch(slot)
 	if err != nil {
 		return SlotTick{}, err

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -133,8 +133,20 @@ func TestSlotClockGetEpochForSlot(t *testing.T) {
 	for _, tc := range testCases {
 		epochInfo, err := clock.GetEpochForSlot(tc.slot)
 		require.NoError(t, err)
-		assert.Equal(t, tc.expectedEpoch, epochInfo.EpochId, "epoch mismatch for slot %d", tc.slot)
-		assert.Equal(t, tc.expectedStart, epochInfo.StartSlot, "start slot mismatch for slot %d", tc.slot)
+		assert.Equal(
+			t,
+			tc.expectedEpoch,
+			epochInfo.EpochId,
+			"epoch mismatch for slot %d",
+			tc.slot,
+		)
+		assert.Equal(
+			t,
+			tc.expectedStart,
+			epochInfo.StartSlot,
+			"start slot mismatch for slot %d",
+			tc.slot,
+		)
 	}
 }
 
@@ -205,7 +217,13 @@ func TestSlotClockIsEpochBoundary(t *testing.T) {
 	for _, tc := range testCases {
 		isBoundary, err := clock.IsEpochBoundary(tc.slot)
 		require.NoError(t, err)
-		assert.Equal(t, tc.isBoundary, isBoundary, "boundary check failed for slot %d", tc.slot)
+		assert.Equal(
+			t,
+			tc.isBoundary,
+			isBoundary,
+			"boundary check failed for slot %d",
+			tc.slot,
+		)
 	}
 }
 
@@ -363,14 +381,38 @@ func TestSlotTickSlotsUntilEpoch(t *testing.T) {
 		expectedRemain  uint64
 		expectedIsStart bool
 	}{
-		{slot: 0, expectedRemain: 100, expectedIsStart: true},   // Start of epoch 0
-		{slot: 1, expectedRemain: 99, expectedIsStart: false},   // Near start
-		{slot: 50, expectedRemain: 50, expectedIsStart: false},  // Middle
-		{slot: 99, expectedRemain: 1, expectedIsStart: false},   // Last slot of epoch 0
-		{slot: 100, expectedRemain: 100, expectedIsStart: true}, // Start of epoch 1
-		{slot: 150, expectedRemain: 50, expectedIsStart: false}, // Middle of epoch 1
-		{slot: 199, expectedRemain: 1, expectedIsStart: false},  // Last slot of epoch 1
-		{slot: 200, expectedRemain: 100, expectedIsStart: true}, // Start of epoch 2
+		{
+			slot:            0,
+			expectedRemain:  100,
+			expectedIsStart: true,
+		}, // Start of epoch 0
+		{slot: 1, expectedRemain: 99, expectedIsStart: false},  // Near start
+		{slot: 50, expectedRemain: 50, expectedIsStart: false}, // Middle
+		{
+			slot:            99,
+			expectedRemain:  1,
+			expectedIsStart: false,
+		}, // Last slot of epoch 0
+		{
+			slot:            100,
+			expectedRemain:  100,
+			expectedIsStart: true,
+		}, // Start of epoch 1
+		{
+			slot:            150,
+			expectedRemain:  50,
+			expectedIsStart: false,
+		}, // Middle of epoch 1
+		{
+			slot:            199,
+			expectedRemain:  1,
+			expectedIsStart: false,
+		}, // Last slot of epoch 1
+		{
+			slot:            200,
+			expectedRemain:  100,
+			expectedIsStart: true,
+		}, // Start of epoch 2
 	}
 
 	for _, tc := range testCases {
@@ -378,8 +420,20 @@ func TestSlotTickSlotsUntilEpoch(t *testing.T) {
 			slotTime, _ := provider.SlotToTime(tc.slot)
 			tick, err := clock.buildSlotTick(tc.slot, slotTime)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedRemain, tick.SlotsUntilEpoch, "slots until epoch mismatch for slot %d", tc.slot)
-			assert.Equal(t, tc.expectedIsStart, tick.IsEpochStart, "epoch start mismatch for slot %d", tc.slot)
+			assert.Equal(
+				t,
+				tc.expectedRemain,
+				tick.SlotsUntilEpoch,
+				"slots until epoch mismatch for slot %d",
+				tc.slot,
+			)
+			assert.Equal(
+				t,
+				tc.expectedIsStart,
+				tick.IsEpochStart,
+				"epoch start mismatch for slot %d",
+				tc.slot,
+			)
 		})
 	}
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -431,13 +431,14 @@ type LedgerState struct {
 	slotTickChan                       <-chan SlotTick
 	ctx                                context.Context
 	sync.RWMutex
-	chainsyncMutex             sync.Mutex
-	chainsyncBlockfetchMutex   sync.Mutex
-	chainsyncBlockfetchWaiting bool
-	checkpointWrittenForEpoch  bool
-	closed                     bool
-	inRecovery                 bool // guards against recursive recovery in SubmitAsyncDBTxn
-	validationEnabled          bool
+	chainsyncMutex                sync.Mutex
+	chainsyncBlockfetchMutex      sync.Mutex
+	chainsyncBlockfetchReadyMutex sync.Mutex
+	chainsyncBlockfetchReadyChan  chan struct{}
+	checkpointWrittenForEpoch     bool
+	closed                        bool
+	inRecovery                    bool // guards against recursive recovery in SubmitAsyncDBTxn
+	validationEnabled             bool
 
 	// Sync progress reporting (Fix 4)
 	syncProgressLastLog  time.Time     // last time we logged sync progress

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -135,8 +135,11 @@ func createTestBlock(
 				copy(k[:], coldPubKey)
 				return k
 			}(),
-			VrfKey:        vrfPk,
-			VrfResult:     lcommon.VrfResult{Output: vrfOutput, Proof: vrfProof},
+			VrfKey: vrfPk,
+			VrfResult: lcommon.VrfResult{
+				Output: vrfOutput,
+				Proof:  vrfProof,
+			},
 			BlockBodySize: 1024,
 			BlockBodyHash: func() lcommon.Blake2b256 {
 				var h lcommon.Blake2b256


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chainsync/blockfetch coordination to use header count for range cleanup and continuation, preventing stalls and deadlocks when headers accumulate. Cleans up the fetch lifecycle and adds clearer debug logs.

- **Bug Fixes**
  - Continue blockfetch in batches while headers remain; stop only when header count is zero.
  - Replace the waiting flag with a ready channel; cleanup stops the timer, clears pending events, closes the channel, and signals completion (including timeout path).
  - Skip starting a new blockfetch if one is in progress (ready channel set), guarded by a mutex to avoid races.
  - Add targeted debug logs for header handling, accumulation, blockfetch start, batch completion, and next-range requests.

<sup>Written for commit 75788fae0d91064adb57bce14fa5cf56b7ca3077. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved blockfetch readiness and synchronization flow with enhanced debug logging for better reliability and observability
  * Standardized method signatures and call formatting across ledger modules

* **Style**
  * Applied consistent code and logging formatting across multiple ledger components

* **Tests**
  * Reformatted test assertions and logging initialization for consistency and clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->