### PR TITLE
feat(database): reduce duplicate logs

### DIFF
--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -725,7 +725,7 @@ func (d *BlobStoreS3) getInternal(
 		d.logger.Errorf("s3 read %q failed: %v", key, err)
 		return nil, err
 	}
-	d.logger.Infof("s3 get %q ok (%d bytes)", key, len(data))
+	d.logger.Debugf("s3 get %q ok (%d bytes)", key, len(data))
 	return data, nil
 }
 
@@ -740,7 +740,7 @@ func (d *BlobStoreS3) Put(ctx context.Context, key string, value []byte) error {
 		d.logger.Errorf("s3 put %q failed: %v", key, err)
 		return err
 	}
-	d.logger.Infof("s3 put %q ok (%d bytes)", key, len(value))
+	d.logger.Debugf("s3 put %q ok (%d bytes)", key, len(value))
 	return nil
 }
 

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -277,13 +277,19 @@ func (d *MetadataStoreMysql) Start() error {
 		return err
 	}
 	// Create table schemas
-	d.logger.Debug(fmt.Sprintf("creating table: %#v", &CommitTimestamp{}))
+	d.logger.Debug(
+		"creating table",
+		"model", fmt.Sprintf("%T", &CommitTimestamp{}),
+	)
 	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
 		return err
 	}
 
 	for _, model := range models.MigrateModels {
-		d.logger.Debug(fmt.Sprintf("creating table: %#v", model))
+		d.logger.Debug(
+			"creating table",
+			"model", fmt.Sprintf("%T", model),
+		)
 		if err := d.db.AutoMigrate(model); err != nil {
 			return err
 		}

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -236,12 +236,18 @@ func (d *MetadataStorePostgres) Start() error {
 		return err
 	}
 	// Create table schemas
-	d.logger.Debug(fmt.Sprintf("creating table: %#v", &CommitTimestamp{}))
+	d.logger.Debug(
+		"creating table",
+		"model", fmt.Sprintf("%T", &CommitTimestamp{}),
+	)
 	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
 		return err
 	}
 	for _, model := range models.MigrateModels {
-		d.logger.Debug(fmt.Sprintf("creating table: %#v", model))
+		d.logger.Debug(
+			"creating table",
+			"model", fmt.Sprintf("%T", model),
+		)
 		if err := d.db.AutoMigrate(model); err != nil {
 			return err
 		}

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -401,14 +401,16 @@ func (d *MetadataStoreSqlite) Start() error {
 	}
 	// Create table schemas (uses write connection)
 	d.logger.Debug(
-		fmt.Sprintf("creating table: %#v", &CommitTimestamp{}),
+		"creating table",
+		"model", fmt.Sprintf("%T", &CommitTimestamp{}),
 	)
 	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
 		return err
 	}
 	for _, model := range models.MigrateModels {
 		d.logger.Debug(
-			fmt.Sprintf("creating table: %#v", model),
+			"creating table",
+			"model", fmt.Sprintf("%T", model),
 		)
 		if err := d.db.AutoMigrate(model); err != nil {
 			return err

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -54,11 +54,9 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 		return err
 	}
 	logger.Debug(
-		fmt.Sprintf(
-			"cardano network config: %+v",
-			nodeCfg,
-		),
+		"cardano network config",
 		"component", "node",
+		"config", nodeCfg,
 	)
 	// Load database
 	dbConfig := &database.Config{
@@ -167,10 +165,8 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 		// Add block batch to chain
 		if err := c.AddBlocks(blockBatch); err != nil {
 			logger.Error(
-				fmt.Sprintf(
-					"failed to import block: %s",
-					err,
-				),
+				"failed to import block",
+				"error", err,
 			)
 			return nil
 		}
@@ -178,18 +174,14 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 		blockBatch = slices.Delete(blockBatch, 0, len(blockBatch))
 		if blocksCopied > 0 && blocksCopied%10000 == 0 {
 			logger.Info(
-				fmt.Sprintf(
-					"copying blocks from immutable DB (%d blocks copied)",
-					blocksCopied,
-				),
+				"copying blocks from immutable DB",
+				"blocks_copied", blocksCopied,
 			)
 		}
 	}
 	logger.Info(
-		fmt.Sprintf(
-			"finished copying %d blocks from immutable DB",
-			blocksCopied,
-		),
+		"finished copying blocks from immutable DB",
+		"blocks_copied", blocksCopied,
 	)
 	// Wait for ledger to catch up
 	for {
@@ -200,10 +192,8 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 		}
 	}
 	logger.Info(
-		fmt.Sprintf(
-			"finished processing %d blocks from immutable DB",
-			blocksCopied,
-		),
+		"finished processing blocks from immutable DB",
+		"blocks_copied", blocksCopied,
 	)
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduces noisy and duplicate logs across database plugins and node loading by switching success messages to debug and adopting structured key-value logging for clarity.

- **Refactors**
  - Use structured logs for node config, table creation, and block import; log model type names instead of full struct dumps.
  - Downgrade S3 get/put success logs from info to debug.
  - Log block copy progress every 10k blocks with "blocks_copied" and include final counts once.

<sup>Written for commit cba65a4b8a14882e0b308840846447116744fef9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

