### PR TITLE
feat(database): more transaction and utxo lookup funcs

### DIFF
--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -16,11 +16,13 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -41,12 +43,35 @@ func (d *MetadataStoreMysql) GetUtxo(
 		return nil, err
 	}
 	result := db.Where("deleted_slot = 0").
+		Preload("Assets").
 		First(ret, "tx_id = ? AND output_idx = ?", txId, idx)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, result.Error
+		return nil, fmt.Errorf("get utxo %x#%d: %w", txId, idx, result.Error)
+	}
+	return ret, nil
+}
+
+// GetUtxoIncludingSpent returns a Utxo by reference, including spent UTxOs
+func (d *MetadataStoreMysql) GetUtxoIncludingSpent(
+	txId []byte,
+	idx uint32,
+	txn types.Txn,
+) (*models.Utxo, error) {
+	ret := &models.Utxo{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Preload("Assets").
+		First(ret, "tx_id = ? AND output_idx = ?", txId, idx)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get utxo including spent %x#%d: %w", txId, idx, result.Error)
 	}
 	return ret, nil
 }
@@ -128,6 +153,52 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	result := db.
 		Where("deleted_slot = 0").
 		Where(addrQuery).
+		Preload("Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// GetUtxosByAddressAtSlot returns UTxOs for an address that existed at a specific slot
+func (d *MetadataStoreMysql) GetUtxosByAddressAtSlot(
+	addr lcommon.Address,
+	slot uint64,
+	txn types.Txn,
+) ([]models.Utxo, error) {
+	var ret []models.Utxo
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
+	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
+
+	// Build sub-query for address
+	var addrQuery *gorm.DB
+	if hasPaymentKey && hasStakeKey {
+		// Base address: both credentials must match (AND)
+		addrQuery = db.Where(
+			"payment_key = ? AND staking_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		)
+	} else if hasPaymentKey {
+		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
+	} else if hasStakeKey {
+		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
+	}
+
+	if addrQuery == nil {
+		return ret, nil
+	}
+	result := db.
+		Where("added_slot <= ?", slot).
+		Where("(deleted_slot = 0 OR deleted_slot > ?)", slot).
+		Where(addrQuery).
+		Preload("Assets").
 		Find(&ret)
 	if result.Error != nil {
 		return nil, result.Error

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -75,12 +75,107 @@ func (d *MetadataStorePostgres) GetTransactionByHash(
 	}
 	result := db.
 		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
 		First(ret, "hash = ?", hash)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// GetTransactionsByBlockHash returns all transactions in a block, ordered by index
+func (d *MetadataStorePostgres) GetTransactionsByBlockHash(
+	blockHash []byte,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where("block_hash = ?", blockHash).
+		Order("block_index ASC").
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by block %x: %w", blockHash, result.Error)
+	}
+	return ret, nil
+}
+
+// GetTransactionsByAddress returns transactions associated with an address
+func (d *MetadataStorePostgres) GetTransactionsByAddress(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
+	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
+
+	var addrCondition string
+	var addrArgs []any
+	if hasPaymentKey && hasStakeKey {
+		addrCondition = "u.payment_key = ? AND u.staking_key = ?"
+		addrArgs = []any{
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		}
+	} else if hasPaymentKey {
+		addrCondition = "u.payment_key = ?"
+		addrArgs = []any{addr.PaymentKeyHash().Bytes()}
+	} else if hasStakeKey {
+		addrCondition = "u.staking_key = ?"
+		addrArgs = []any{addr.StakeKeyHash().Bytes()}
+	} else {
+		return ret, nil
+	}
+
+	subQuery := fmt.Sprintf(
+		"id IN ("+
+			"SELECT DISTINCT t.id FROM transaction t "+
+			"JOIN utxo u ON (u.transaction_id = t.id OR u.spent_at_tx_id = t.hash) "+
+			"WHERE %s"+
+			")",
+		addrCondition,
+	)
+
+	query := db.
+		Where(subQuery, addrArgs...).
+		Order("slot DESC").
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if offset > 0 {
+		query = query.Offset(offset)
+	}
+
+	result := query.Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by address: %w", result.Error)
 	}
 	return ret, nil
 }

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -16,11 +16,13 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -41,12 +43,35 @@ func (d *MetadataStorePostgres) GetUtxo(
 		return nil, err
 	}
 	result := db.Where("deleted_slot = 0").
+		Preload("Assets").
 		First(ret, "tx_id = ? AND output_idx = ?", txId, idx)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, result.Error
+		return nil, fmt.Errorf("get utxo %x#%d: %w", txId, idx, result.Error)
+	}
+	return ret, nil
+}
+
+// GetUtxoIncludingSpent returns a Utxo by reference, including spent UTxOs
+func (d *MetadataStorePostgres) GetUtxoIncludingSpent(
+	txId []byte,
+	idx uint32,
+	txn types.Txn,
+) (*models.Utxo, error) {
+	ret := &models.Utxo{}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.Preload("Assets").
+		First(ret, "tx_id = ? AND output_idx = ?", txId, idx)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get utxo including spent %x#%d: %w", txId, idx, result.Error)
 	}
 	return ret, nil
 }
@@ -128,6 +153,52 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 	result := db.
 		Where("deleted_slot = 0").
 		Where(addrQuery).
+		Preload("Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// GetUtxosByAddressAtSlot returns UTxOs for an address that existed at a specific slot
+func (d *MetadataStorePostgres) GetUtxosByAddressAtSlot(
+	addr lcommon.Address,
+	slot uint64,
+	txn types.Txn,
+) ([]models.Utxo, error) {
+	var ret []models.Utxo
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
+	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
+
+	// Build sub-query for address
+	var addrQuery *gorm.DB
+	if hasPaymentKey && hasStakeKey {
+		// Base address: both credentials must match (AND)
+		addrQuery = db.Where(
+			"payment_key = ? AND staking_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		)
+	} else if hasPaymentKey {
+		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
+	} else if hasStakeKey {
+		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
+	}
+
+	if addrQuery == nil {
+		return ret, nil
+	}
+	result := db.
+		Where("added_slot <= ?", slot).
+		Where("(deleted_slot = 0 OR deleted_slot > ?)", slot).
+		Where(addrQuery).
+		Preload("Assets").
 		Find(&ret)
 	if result.Error != nil {
 		return nil, result.Error

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -107,12 +107,113 @@ func (d *MetadataStoreSqlite) GetTransactionByHash(
 	}
 	result := db.
 		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
 		First(ret, "hash = ?", hash)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, result.Error
+	}
+	return ret, nil
+}
+
+// GetTransactionsByBlockHash returns all transactions for a given
+// block hash, ordered by their position within the block.
+func (d *MetadataStoreSqlite) GetTransactionsByBlockHash(
+	blockHash []byte,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where("block_hash = ?", blockHash).
+		Order("block_index ASC").
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by block %x: %w", blockHash, result.Error)
+	}
+	return ret, nil
+}
+
+// GetTransactionsByAddress returns transactions that involve a given
+// address as either a sender (input) or receiver (output). Results
+// are ordered by slot descending with pagination support.
+func (d *MetadataStoreSqlite) GetTransactionsByAddress(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
+	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
+
+	// Build address condition for UTXO matching
+	var addrCondition string
+	var addrArgs []any
+	if hasPaymentKey && hasStakeKey {
+		addrCondition = "u.payment_key = ? AND u.staking_key = ?"
+		addrArgs = []any{
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		}
+	} else if hasPaymentKey {
+		addrCondition = "u.payment_key = ?"
+		addrArgs = []any{addr.PaymentKeyHash().Bytes()}
+	} else if hasStakeKey {
+		addrCondition = "u.staking_key = ?"
+		addrArgs = []any{addr.StakeKeyHash().Bytes()}
+	} else {
+		return ret, nil
+	}
+
+	// Find transactions that either created or consumed UTxOs
+	// at the given address using a subquery
+	subQuery := fmt.Sprintf(
+		"id IN ("+
+			"SELECT DISTINCT t.id FROM transaction t "+
+			"JOIN utxo u ON (u.transaction_id = t.id OR u.spent_at_tx_id = t.hash) "+
+			"WHERE %s"+
+			")",
+		addrCondition,
+	)
+
+	query := db.
+		Where(subQuery, addrArgs...).
+		Order("slot DESC").
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if offset > 0 {
+		query = query.Offset(offset)
+	}
+
+	result := query.Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by address: %w", result.Error)
 	}
 	return ret, nil
 }

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -173,11 +173,42 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Utxo, error)
 
+	// GetUtxoIncludingSpent retrieves a transaction output by transaction ID
+	// and index, including outputs that have already been consumed (spent).
+	// Unlike GetUtxo, this does not filter on deleted_slot = 0, so it can
+	// resolve inputs that have already been consumed. This is needed for
+	// APIs that must display the source address and amount of spent inputs.
+	GetUtxoIncludingSpent(
+		[]byte, // txId
+		uint32, // idx
+		types.Txn,
+	) (*models.Utxo, error)
+
 	// GetTransactionByHash retrieves a transaction by its hash.
 	GetTransactionByHash(
 		[]byte, // hash
 		types.Txn,
 	) (*models.Transaction, error)
+
+	// GetTransactionsByBlockHash retrieves all transactions for a given
+	// block hash, ordered by block_index (position within the block).
+	// Associations (Inputs, Outputs, Certificates) and nested Assets
+	// are preloaded.
+	GetTransactionsByBlockHash(
+		[]byte, // blockHash
+		types.Txn,
+	) ([]models.Transaction, error)
+
+	// GetTransactionsByAddress retrieves transactions that involve the
+	// given address, either as a sender (input) or receiver (output).
+	// Results are ordered by slot descending, with limit and offset for
+	// pagination.
+	GetTransactionsByAddress(
+		lcommon.Address,
+		int, // limit
+		int, // offset
+		types.Txn,
+	) ([]models.Transaction, error)
 
 	// GetScript retrieves a script by its hash.
 	GetScript(
@@ -291,6 +322,9 @@ type MetadataStore interface {
 
 	// GetUtxosByAddress retrieves all UTxOs for a given address.
 	GetUtxosByAddress(ledger.Address, types.Txn) ([]models.Utxo, error)
+
+	// GetUtxosByAddressAtSlot retrieves all UTxOs for a given address at a specific slot.
+	GetUtxosByAddressAtSlot(lcommon.Address, uint64, types.Txn) ([]models.Utxo, error)
 
 	// GetUtxosByAssets retrieves all UTxOs that contain the specified assets.
 	// Pass nil for assetName to match all assets under the policy, or empty []byte{} to match assets with empty names.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -221,6 +221,58 @@ func (d *Database) GetTransactionByHash(
 	return d.metadata.GetTransactionByHash(hash, txn.Metadata())
 }
 
+// GetTransactionsByBlockHash returns all transactions for a given
+// block hash, ordered by their position within the block.
+func (d *Database) GetTransactionsByBlockHash(
+	blockHash []byte,
+	txn *Txn,
+) ([]models.Transaction, error) {
+	if len(blockHash) == 0 {
+		return nil, nil
+	}
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	txs, err := d.metadata.GetTransactionsByBlockHash(
+		blockHash,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get txs by block %x: %w", blockHash, err)
+	}
+	return txs, nil
+}
+
+// GetTransactionsByAddress returns transactions that involve a given
+// address as either a sender (input) or receiver (output).
+func (d *Database) GetTransactionsByAddress(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+	txn *Txn,
+) ([]models.Transaction, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	txs, err := d.metadata.GetTransactionsByAddress(
+		addr,
+		limit,
+		offset,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get txs by address limit=%d offset=%d: %w",
+			limit,
+			offset,
+			err,
+		)
+	}
+	return txs, nil
+}
+
 // deleteTxBlobs attempts to delete blob data for the given transaction hashes.
 // This is a best-effort operation; metadata remains the source of truth. If the
 // provided transaction does not include a blob handle, a temporary blob-only

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 var ErrUtxoNotFound = errors.New("utxo not found")
@@ -179,38 +180,79 @@ func (d *Database) UtxoByRef(
 	return utxo, nil
 }
 
+// UtxoByRefIncludingSpent returns a Utxo by reference, including spent
+// (consumed) UTxOs. Unlike UtxoByRef, this does not filter on
+// deleted_slot, making it suitable for resolving transaction inputs
+// that have already been consumed.
+func (d *Database) UtxoByRefIncludingSpent(
+	txId []byte,
+	outputIdx uint32,
+	txn *Txn,
+) (*models.Utxo, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	utxo, err := d.metadata.GetUtxoIncludingSpent(
+		txId,
+		outputIdx,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if utxo == nil {
+		return nil, nil
+	}
+	if err := loadCbor(utxo, txn); err != nil {
+		return nil, err
+	}
+	return utxo, nil
+}
+
 func (d *Database) UtxosByAddress(
 	addr ledger.Address,
 	txn *Txn,
 ) ([]models.Utxo, error) {
-	ret := []models.Utxo{}
-	tmpUtxo := models.Utxo{}
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
 	utxos, err := d.metadata.GetUtxosByAddress(addr, txn.Metadata())
 	if err != nil {
-		return ret, err
+		return nil, err
 	}
-	for _, utxo := range utxos {
-		tmpUtxo = models.Utxo{
-			ID:          utxo.ID,
-			TxId:        utxo.TxId,
-			OutputIdx:   utxo.OutputIdx,
-			AddedSlot:   utxo.AddedSlot,
-			DeletedSlot: utxo.DeletedSlot,
-			PaymentKey:  utxo.PaymentKey,
-			StakingKey:  utxo.StakingKey,
-			Amount:      utxo.Amount,
-			Assets:      utxo.Assets,
+	for i := range utxos {
+		if err := loadCbor(&utxos[i], txn); err != nil {
+			return nil, err
 		}
-		if err := loadCbor(&tmpUtxo, txn); err != nil {
-			return ret, err
-		}
-		ret = append(ret, tmpUtxo)
 	}
-	return ret, nil
+	return utxos, nil
+}
+
+func (d *Database) UtxosByAddressAtSlot(
+	addr lcommon.Address,
+	slot uint64,
+	txn *Txn,
+) ([]models.Utxo, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	utxos, err := d.metadata.GetUtxosByAddressAtSlot(
+		addr,
+		slot,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	for i := range utxos {
+		if err := loadCbor(&utxos[i], txn); err != nil {
+			return nil, err
+		}
+	}
+	return utxos, nil
 }
 
 // UtxosByAssets returns UTxOs that contain the specified assets
@@ -221,8 +263,6 @@ func (d *Database) UtxosByAssets(
 	assetName []byte,
 	txn *Txn,
 ) ([]models.Utxo, error) {
-	ret := []models.Utxo{}
-	tmpUtxo := models.Utxo{}
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
@@ -233,26 +273,14 @@ func (d *Database) UtxosByAssets(
 		txn.Metadata(),
 	)
 	if err != nil {
-		return ret, err
+		return nil, err
 	}
-	for _, utxo := range utxos {
-		tmpUtxo = models.Utxo{
-			ID:          utxo.ID,
-			TxId:        utxo.TxId,
-			OutputIdx:   utxo.OutputIdx,
-			AddedSlot:   utxo.AddedSlot,
-			DeletedSlot: utxo.DeletedSlot,
-			PaymentKey:  utxo.PaymentKey,
-			StakingKey:  utxo.StakingKey,
-			Amount:      utxo.Amount,
-			Assets:      utxo.Assets,
+	for i := range utxos {
+		if err := loadCbor(&utxos[i], txn); err != nil {
+			return nil, err
 		}
-		if err := loadCbor(&tmpUtxo, txn); err != nil {
-			return ret, err
-		}
-		ret = append(ret, tmpUtxo)
 	}
-	return ret, nil
+	return utxos, nil
 }
 
 func (d *Database) UtxosDeleteConsumed(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2747,6 +2747,41 @@ func (ls *LedgerState) UtxosByAddress(
 	return ret, nil
 }
 
+func (ls *LedgerState) UtxosByAddressAtSlot(
+	addr lcommon.Address,
+	slot uint64,
+) ([]models.Utxo, error) {
+	return ls.db.UtxosByAddressAtSlot(addr, slot, nil)
+}
+
+// UtxoByRefIncludingSpent returns a UTxO by reference, including
+// spent outputs. This is needed for APIs that must resolve consumed
+// inputs to display source address and amount.
+func (ls *LedgerState) UtxoByRefIncludingSpent(
+	txId []byte,
+	outputIdx uint32,
+) (*models.Utxo, error) {
+	return ls.db.UtxoByRefIncludingSpent(txId, outputIdx, nil)
+}
+
+// GetTransactionsByBlockHash returns all transactions for a given
+// block hash.
+func (ls *LedgerState) GetTransactionsByBlockHash(
+	blockHash []byte,
+) ([]models.Transaction, error) {
+	return ls.db.GetTransactionsByBlockHash(blockHash, nil)
+}
+
+// GetTransactionsByAddress returns transactions involving the given
+// address.
+func (ls *LedgerState) GetTransactionsByAddress(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+) ([]models.Transaction, error) {
+	return ls.db.GetTransactionsByAddress(addr, limit, offset, nil)
+}
+
 // resolveValidationEra determines the appropriate era descriptor for
 // validating a transaction. It returns the current era if the transaction
 // matches, the previous era if compatible (era-1), or an error if the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds richer transaction and UTxO lookup APIs for block and address queries, and for resolving spent inputs. All backends preload assets/associations, and Database/LedgerState expose the new methods.

- **New Features**
  - GetTransactionsByBlockHash: ordered by block_index with Inputs/Outputs/Collateral/ReferenceInputs and nested Assets preloaded.
  - GetTransactionsByAddress: address activity (inputs or outputs), paginated, ordered by slot desc.
  - GetUtxoIncludingSpent: fetches UTxOs even if already consumed.
  - GetUtxosByAddressAtSlot: snapshot UTxOs at a given slot with correct added/deleted slot filtering.
  - UTxO/Transaction lookups now preload Assets; CBOR loading done in-place for returned UTxOs.

- **Migration**
  - If you implement MetadataStore, add implementations for:
    - GetUtxoIncludingSpent
    - GetTransactionsByBlockHash
    - GetTransactionsByAddress
    - GetUtxosByAddressAtSlot
  - No schema changes.

<sup>Written for commit f282568e93de3a7ddccd6346cd685e9bc1474160. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended transaction retrieval capabilities including block-based and address-based lookups with pagination support.
  * Enhanced UTXO (unspent transaction output) data access with slot-aware queries and spent output resolution.
  * Improved data loading with preloaded asset associations across transaction and UTXO queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->