### PR TITLE
feat: mesh (rosetta) API

### DIFF
--- a/config.go
+++ b/config.go
@@ -85,6 +85,8 @@ type Config struct {
 	// Chainsync multi-client configuration
 	chainsyncMaxClients   int
 	chainsyncStallTimeout time.Duration
+	// Mesh API listen address (empty = disabled)
+	meshListenAddress string
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -450,5 +452,17 @@ func WithChainsyncStallTimeout(
 ) ConfigOptionFunc {
 	return func(c *Config) {
 		c.chainsyncStallTimeout = timeout
+	}
+}
+
+// WithMeshListenAddress specifies the listen address
+// for the Mesh (Coinbase Rosetta) compatible REST API
+// server. An empty string disables the server. The
+// default is empty (disabled).
+func WithMeshListenAddress(
+	addr string,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.meshListenAddress = addr
 	}
 }

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -118,6 +118,39 @@ func (d *MetadataStoreMysql) GetUtxosDeletedBeforeSlot(
 	return ret, nil
 }
 
+// addressWhereClause builds a GORM Where clause for matching
+// UTxOs by payment key, staking key, or both. Returns nil if
+// the address has neither key.
+func addressWhereClause(
+	db *gorm.DB,
+	addr lcommon.Address,
+) *gorm.DB {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	hasPayment := addr.PaymentKeyHash() != zeroHash
+	hasStake := addr.StakeKeyHash() != zeroHash
+
+	switch {
+	case hasPayment && hasStake:
+		return db.Where(
+			"payment_key = ? AND staking_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		)
+	case hasPayment:
+		return db.Where(
+			"payment_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+		)
+	case hasStake:
+		return db.Where(
+			"staking_key = ?",
+			addr.StakeKeyHash().Bytes(),
+		)
+	default:
+		return nil
+	}
+}
+
 // GetUtxosByAddress returns a list of Utxos
 func (d *MetadataStoreMysql) GetUtxosByAddress(
 	addr ledger.Address,
@@ -128,25 +161,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-
-	hasPaymentKey := addr.PaymentKeyHash() != ledger.NewBlake2b224(nil)
-	hasStakeKey := addr.StakeKeyHash() != ledger.NewBlake2b224(nil)
-
-	// Build sub-query for address
-	var addrQuery *gorm.DB
-	if hasPaymentKey && hasStakeKey {
-		// Base address: both credentials must match (AND)
-		addrQuery = db.Where(
-			"payment_key = ? AND staking_key = ?",
-			addr.PaymentKeyHash().Bytes(),
-			addr.StakeKeyHash().Bytes(),
-		)
-	} else if hasPaymentKey {
-		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
-	} else if hasStakeKey {
-		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
-	}
-
+	addrQuery := addressWhereClause(db, addr)
 	if addrQuery == nil {
 		return ret, nil
 	}
@@ -161,7 +176,8 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	return ret, nil
 }
 
-// GetUtxosByAddressAtSlot returns UTxOs for an address that existed at a specific slot
+// GetUtxosByAddressAtSlot returns UTxOs for an address
+// that existed at a specific slot.
 func (d *MetadataStoreMysql) GetUtxosByAddressAtSlot(
 	addr lcommon.Address,
 	slot uint64,
@@ -172,25 +188,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-
-	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
-	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
-
-	// Build sub-query for address
-	var addrQuery *gorm.DB
-	if hasPaymentKey && hasStakeKey {
-		// Base address: both credentials must match (AND)
-		addrQuery = db.Where(
-			"payment_key = ? AND staking_key = ?",
-			addr.PaymentKeyHash().Bytes(),
-			addr.StakeKeyHash().Bytes(),
-		)
-	} else if hasPaymentKey {
-		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
-	} else if hasStakeKey {
-		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
-	}
-
+	addrQuery := addressWhereClause(db, addr)
 	if addrQuery == nil {
 		return ret, nil
 	}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -63,6 +63,38 @@ func (d *MetadataStorePostgres) resolveDB(txn types.Txn) (*gorm.DB, error) {
 	return db, nil
 }
 
+// addressSQLCondition builds a raw SQL WHERE fragment and
+// bind args for matching UTxO rows by payment/staking key.
+// The prefix is the table alias (e.g. "u"). Returns an
+// empty condition if the address has neither key.
+func addressSQLCondition(
+	addr lcommon.Address,
+	prefix string,
+) (string, []any) {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	hasPayment := addr.PaymentKeyHash() != zeroHash
+	hasStake := addr.StakeKeyHash() != zeroHash
+
+	switch {
+	case hasPayment && hasStake:
+		return fmt.Sprintf(
+				"%s.payment_key = ? AND %s.staking_key = ?",
+				prefix, prefix,
+			), []any{
+				addr.PaymentKeyHash().Bytes(),
+				addr.StakeKeyHash().Bytes(),
+			}
+	case hasPayment:
+		return prefix + ".payment_key = ?",
+			[]any{addr.PaymentKeyHash().Bytes()}
+	case hasStake:
+		return prefix + ".staking_key = ?",
+			[]any{addr.StakeKeyHash().Bytes()}
+	default:
+		return "", nil
+	}
+}
+
 // GetTransactionByHash returns a transaction by its hash
 func (d *MetadataStorePostgres) GetTransactionByHash(
 	hash []byte,
@@ -114,7 +146,8 @@ func (d *MetadataStorePostgres) GetTransactionsByBlockHash(
 	return ret, nil
 }
 
-// GetTransactionsByAddress returns transactions associated with an address
+// GetTransactionsByAddress returns transactions associated
+// with an address.
 func (d *MetadataStorePostgres) GetTransactionsByAddress(
 	addr lcommon.Address,
 	limit int,
@@ -127,38 +160,25 @@ func (d *MetadataStorePostgres) GetTransactionsByAddress(
 		return nil, err
 	}
 
-	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
-	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
-
-	var addrCondition string
-	var addrArgs []any
-	if hasPaymentKey && hasStakeKey {
-		addrCondition = "u.payment_key = ? AND u.staking_key = ?"
-		addrArgs = []any{
-			addr.PaymentKeyHash().Bytes(),
-			addr.StakeKeyHash().Bytes(),
-		}
-	} else if hasPaymentKey {
-		addrCondition = "u.payment_key = ?"
-		addrArgs = []any{addr.PaymentKeyHash().Bytes()}
-	} else if hasStakeKey {
-		addrCondition = "u.staking_key = ?"
-		addrArgs = []any{addr.StakeKeyHash().Bytes()}
-	} else {
+	cond, args := addressSQLCondition(addr, "u")
+	if cond == "" {
 		return ret, nil
 	}
 
 	subQuery := fmt.Sprintf(
 		"id IN ("+
-			"SELECT DISTINCT t.id FROM transaction t "+
-			"JOIN utxo u ON (u.transaction_id = t.id OR u.spent_at_tx_id = t.hash) "+
+			"SELECT DISTINCT t.id "+
+			"FROM transaction t "+
+			"JOIN utxo u ON "+
+			"(u.transaction_id = t.id "+
+			"OR u.spent_at_tx_id = t.hash) "+
 			"WHERE %s"+
 			")",
-		addrCondition,
+		cond,
 	)
 
 	query := db.
-		Where(subQuery, addrArgs...).
+		Where(subQuery, args...).
 		Order("slot DESC").
 		Preload(clause.Associations).
 		Preload("Inputs.Assets").
@@ -175,7 +195,9 @@ func (d *MetadataStorePostgres) GetTransactionsByAddress(
 
 	result := query.Find(&ret)
 	if result.Error != nil {
-		return nil, fmt.Errorf("get txs by address: %w", result.Error)
+		return nil, fmt.Errorf(
+			"get txs by address: %w", result.Error,
+		)
 	}
 	return ret, nil
 }
@@ -309,6 +331,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 		Type:       tx.Type(),
 		BlockHash:  point.Hash,
 		BlockIndex: idx,
+		Slot:       point.Slot,
 		Fee:        types.Uint64(feeUint),
 		TTL:        types.Uint64(tx.TTL()),
 		Valid:      tx.IsValid(),
@@ -994,6 +1017,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					}
 
 					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
@@ -1032,6 +1056,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					}
 
 					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
@@ -1058,6 +1083,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
@@ -1084,6 +1110,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
@@ -1112,6 +1139,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
 					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -118,6 +118,39 @@ func (d *MetadataStorePostgres) GetUtxosDeletedBeforeSlot(
 	return ret, nil
 }
 
+// addressWhereClause builds a GORM Where clause for matching
+// UTxOs by payment key, staking key, or both. Returns nil if
+// the address has neither key.
+func addressWhereClause(
+	db *gorm.DB,
+	addr lcommon.Address,
+) *gorm.DB {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	hasPayment := addr.PaymentKeyHash() != zeroHash
+	hasStake := addr.StakeKeyHash() != zeroHash
+
+	switch {
+	case hasPayment && hasStake:
+		return db.Where(
+			"payment_key = ? AND staking_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(),
+		)
+	case hasPayment:
+		return db.Where(
+			"payment_key = ?",
+			addr.PaymentKeyHash().Bytes(),
+		)
+	case hasStake:
+		return db.Where(
+			"staking_key = ?",
+			addr.StakeKeyHash().Bytes(),
+		)
+	default:
+		return nil
+	}
+}
+
 // GetUtxosByAddress returns a list of Utxos
 func (d *MetadataStorePostgres) GetUtxosByAddress(
 	addr ledger.Address,
@@ -128,25 +161,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-
-	hasPaymentKey := addr.PaymentKeyHash() != ledger.NewBlake2b224(nil)
-	hasStakeKey := addr.StakeKeyHash() != ledger.NewBlake2b224(nil)
-
-	// Build sub-query for address
-	var addrQuery *gorm.DB
-	if hasPaymentKey && hasStakeKey {
-		// Base address: both credentials must match (AND)
-		addrQuery = db.Where(
-			"payment_key = ? AND staking_key = ?",
-			addr.PaymentKeyHash().Bytes(),
-			addr.StakeKeyHash().Bytes(),
-		)
-	} else if hasPaymentKey {
-		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
-	} else if hasStakeKey {
-		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
-	}
-
+	addrQuery := addressWhereClause(db, addr)
 	if addrQuery == nil {
 		return ret, nil
 	}
@@ -161,7 +176,8 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 	return ret, nil
 }
 
-// GetUtxosByAddressAtSlot returns UTxOs for an address that existed at a specific slot
+// GetUtxosByAddressAtSlot returns UTxOs for an address
+// that existed at a specific slot.
 func (d *MetadataStorePostgres) GetUtxosByAddressAtSlot(
 	addr lcommon.Address,
 	slot uint64,
@@ -172,25 +188,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-
-	hasPaymentKey := addr.PaymentKeyHash() != lcommon.NewBlake2b224(nil)
-	hasStakeKey := addr.StakeKeyHash() != lcommon.NewBlake2b224(nil)
-
-	// Build sub-query for address
-	var addrQuery *gorm.DB
-	if hasPaymentKey && hasStakeKey {
-		// Base address: both credentials must match (AND)
-		addrQuery = db.Where(
-			"payment_key = ? AND staking_key = ?",
-			addr.PaymentKeyHash().Bytes(),
-			addr.StakeKeyHash().Bytes(),
-		)
-	} else if hasPaymentKey {
-		addrQuery = db.Where("payment_key = ?", addr.PaymentKeyHash().Bytes())
-	} else if hasStakeKey {
-		addrQuery = db.Where("staking_key = ?", addr.StakeKeyHash().Bytes())
-	}
-
+	addrQuery := addressWhereClause(db, addr)
 	if addrQuery == nil {
 		return ret, nil
 	}

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
-	pdata "github.com/blinklabs-io/plutigo/data"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	pdata "github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
@@ -977,25 +977,25 @@ func TestRollbackGovernanceProposalDeletion(t *testing.T) {
 	store := setupTestDB(t)
 
 	prop1 := &models.GovernanceProposal{
-		TxHash:       bytes.Repeat([]byte{0x90}, 32),
-		ActionIndex:  0,
-		ActionType:   1,
-		AddedSlot:    100,
-		ExpiresEpoch: 50,
-		AnchorUrl:    "https://example.com/prop1",
-		AnchorHash:   bytes.Repeat([]byte{0x92}, 32),
+		TxHash:        bytes.Repeat([]byte{0x90}, 32),
+		ActionIndex:   0,
+		ActionType:    1,
+		AddedSlot:     100,
+		ExpiresEpoch:  50,
+		AnchorUrl:     "https://example.com/prop1",
+		AnchorHash:    bytes.Repeat([]byte{0x92}, 32),
 		ReturnAddress: bytes.Repeat([]byte{0x93}, 29),
 	}
 	require.NoError(t, store.SetGovernanceProposal(prop1, nil))
 
 	prop2 := &models.GovernanceProposal{
-		TxHash:       bytes.Repeat([]byte{0x91}, 32),
-		ActionIndex:  0,
-		ActionType:   2,
-		AddedSlot:    300,
-		ExpiresEpoch: 70,
-		AnchorUrl:    "https://example.com/prop2",
-		AnchorHash:   bytes.Repeat([]byte{0x94}, 32),
+		TxHash:        bytes.Repeat([]byte{0x91}, 32),
+		ActionIndex:   0,
+		ActionType:    2,
+		AddedSlot:     300,
+		ExpiresEpoch:  70,
+		AnchorUrl:     "https://example.com/prop2",
+		AnchorHash:    bytes.Repeat([]byte{0x94}, 32),
 		ReturnAddress: bytes.Repeat([]byte{0x95}, 29),
 	}
 	require.NoError(t, store.SetGovernanceProposal(prop2, nil))

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -173,11 +173,8 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Utxo, error)
 
-	// GetUtxoIncludingSpent retrieves a transaction output by transaction ID
-	// and index, including outputs that have already been consumed (spent).
-	// Unlike GetUtxo, this does not filter on deleted_slot = 0, so it can
-	// resolve inputs that have already been consumed. This is needed for
-	// APIs that must display the source address and amount of spent inputs.
+	// GetUtxoIncludingSpent retrieves a transaction output by
+	// transaction ID and index, including spent outputs.
 	GetUtxoIncludingSpent(
 		[]byte, // txId
 		uint32, // idx
@@ -190,19 +187,15 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Transaction, error)
 
-	// GetTransactionsByBlockHash retrieves all transactions for a given
-	// block hash, ordered by block_index (position within the block).
-	// Associations (Inputs, Outputs, Certificates) and nested Assets
-	// are preloaded.
+	// GetTransactionsByBlockHash retrieves all transactions
+	// for a given block hash, ordered by block_index.
 	GetTransactionsByBlockHash(
 		[]byte, // blockHash
 		types.Txn,
 	) ([]models.Transaction, error)
 
-	// GetTransactionsByAddress retrieves transactions that involve the
-	// given address, either as a sender (input) or receiver (output).
-	// Results are ordered by slot descending, with limit and offset for
-	// pagination.
+	// GetTransactionsByAddress retrieves transactions involving
+	// the given address, ordered by slot descending.
 	GetTransactionsByAddress(
 		lcommon.Address,
 		int, // limit

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -108,7 +108,12 @@ func (d *Database) SetTransaction(
 		// Store offset reference
 		offsetData := EncodeUtxoOffset(&offset)
 		if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
-			return fmt.Errorf("set utxo offset %x#%d: %w", txId[:8], outputIdx, err)
+			return fmt.Errorf(
+				"set utxo offset %x#%d: %w",
+				txId[:8],
+				outputIdx,
+				err,
+			)
 		}
 	}
 
@@ -175,13 +180,22 @@ func (d *Database) SetGenesisTransaction(
 
 		offset, ok := offsets[ref]
 		if !ok {
-			return fmt.Errorf("missing offset for genesis utxo %x:%d", txId[:8], outputIdx)
+			return fmt.Errorf(
+				"missing offset for genesis utxo %x:%d",
+				txId[:8],
+				outputIdx,
+			)
 		}
 
 		// Store offset reference
 		offsetData := EncodeUtxoOffset(&offset)
 		if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
-			return fmt.Errorf("set genesis utxo offset %x#%d: %w", txId[:8], outputIdx, err)
+			return fmt.Errorf(
+				"set genesis utxo offset %x#%d: %w",
+				txId[:8],
+				outputIdx,
+				err,
+			)
 		}
 
 		// Build model for metadata store
@@ -239,7 +253,9 @@ func (d *Database) GetTransactionsByBlockHash(
 		txn.Metadata(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("get txs by block %x: %w", blockHash, err)
+		return nil, fmt.Errorf(
+			"get txs by block hash: %w", err,
+		)
 	}
 	return txs, nil
 }
@@ -346,7 +362,10 @@ func (d *Database) TransactionsDeleteRolledback(
 	}
 
 	// Get transaction hashes that will be deleted
-	txHashes, err := d.metadata.GetTransactionHashesAfterSlot(slot, txn.Metadata())
+	txHashes, err := d.metadata.GetTransactionHashesAfterSlot(
+		slot,
+		txn.Metadata(),
+	)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to get transaction hashes after slot %d: %w",

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -180,10 +180,8 @@ func (d *Database) UtxoByRef(
 	return utxo, nil
 }
 
-// UtxoByRefIncludingSpent returns a Utxo by reference, including spent
-// (consumed) UTxOs. Unlike UtxoByRef, this does not filter on
-// deleted_slot, making it suitable for resolving transaction inputs
-// that have already been consumed.
+// UtxoByRefIncludingSpent returns a Utxo by reference,
+// including spent (consumed) UTxOs.
 func (d *Database) UtxoByRefIncludingSpent(
 	txId []byte,
 	outputIdx uint32,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,9 @@ type Config struct {
 	ShelleyVRFKey                 string `yaml:"shelleyVrfKey"                 envconfig:"SHELLEY_VRF_KEY"`
 	ShelleyKESKey                 string `yaml:"shelleyKesKey"                 envconfig:"SHELLEY_KES_KEY"`
 	ShelleyOperationalCertificate string `yaml:"shelleyOperationalCertificate" envconfig:"SHELLEY_OPERATIONAL_CERTIFICATE"`
+
+	// Mesh (Coinbase Rosetta) API listen address (empty = disabled)
+	MeshListenAddress string `yaml:"meshListenAddress" envconfig:"DINGO_MESH_LISTEN_ADDRESS"`
 }
 
 func (c *Config) ParseCmdlineArgs(programName string, args []string) error {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -187,6 +187,9 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithChainsyncStallTimeout(
 				chainsyncStallTimeout,
 			),
+			dingo.WithMeshListenAddress(
+				cfg.MeshListenAddress,
+			),
 		),
 	)
 	if err != nil {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2747,6 +2747,8 @@ func (ls *LedgerState) UtxosByAddress(
 	return ret, nil
 }
 
+// UtxosByAddressAtSlot returns all UTxOs belonging to the
+// specified address that existed at the given slot.
 func (ls *LedgerState) UtxosByAddressAtSlot(
 	addr lcommon.Address,
 	slot uint64,

--- a/mesh/account.go
+++ b/mesh/account.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"cmp"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// handleAccountBalance handles POST /account/balance.
+func (s *Server) handleAccountBalance(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req AccountBalanceRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	addr, meshErr := s.parseAccountAddress(
+		req.AccountIdentifier,
+	)
+	if meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	utxos, err := s.config.LedgerState.UtxosByAddress(
+		addr,
+	)
+	if err != nil {
+		s.logger.Error(
+			"failed to query UTxOs for account",
+			"address",
+			req.AccountIdentifier.Address,
+			"error", err,
+		)
+		writeError(w, wrapErr(ErrInternal, err))
+		return
+	}
+
+	balances := aggregateBalances(utxos)
+	tip := s.config.Chain.Tip()
+
+	writeJSON(w, http.StatusOK, &AccountBalanceResponse{
+		BlockIdentifier: s.tipBlockID(tip),
+		Balances:        balances,
+	})
+}
+
+// handleAccountCoins handles POST /account/coins.
+func (s *Server) handleAccountCoins(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req AccountCoinsRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	addr, meshErr := s.parseAccountAddress(
+		req.AccountIdentifier,
+	)
+	if meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	utxos, err := s.config.LedgerState.UtxosByAddress(
+		addr,
+	)
+	if err != nil {
+		s.logger.Error(
+			"failed to query UTxOs for account",
+			"address",
+			req.AccountIdentifier.Address,
+			"error", err,
+		)
+		writeError(w, wrapErr(ErrInternal, err))
+		return
+	}
+
+	coins := utxosToCoins(utxos)
+	tip := s.config.Chain.Tip()
+
+	writeJSON(w, http.StatusOK, &AccountCoinsResponse{
+		BlockIdentifier: s.tipBlockID(tip),
+		Coins:           coins,
+	})
+}
+
+// parseAccountAddress validates the account identifier
+// and parses the Cardano address.
+func (s *Server) parseAccountAddress(
+	acct *AccountIdentifier,
+) (ledger.Address, *Error) {
+	if acct == nil || acct.Address == "" {
+		return ledger.Address{},
+			ErrInvalidRequest
+	}
+	addr, err := ledger.NewAddress(acct.Address)
+	if err != nil {
+		return ledger.Address{},
+			wrapErr(ErrInvalidRequest, err)
+	}
+	return addr, nil
+}
+
+// aggregateBalances sums ADA and native asset amounts
+// across all UTxOs into Mesh Amount entries.
+func aggregateBalances(utxos []models.Utxo) []*Amount {
+	var totalLovelace uint64
+	type assetKey struct {
+		policyHex string
+		nameHex   string
+	}
+	assetTotals := make(map[assetKey]uint64)
+
+	for i := range utxos {
+		totalLovelace += uint64(utxos[i].Amount)
+		for j := range utxos[i].Assets {
+			asset := &utxos[i].Assets[j]
+			key := assetKey{
+				policyHex: hex.EncodeToString(
+					asset.PolicyId,
+				),
+				nameHex: hex.EncodeToString(
+					asset.Name,
+				),
+			}
+			assetTotals[key] += uint64(asset.Amount)
+		}
+	}
+
+	balances := make(
+		[]*Amount, 1, 1+len(assetTotals),
+	)
+	balances[0] = convertAmount(totalLovelace)
+
+	// Sort asset keys for deterministic ordering.
+	keys := make([]assetKey, 0, len(assetTotals))
+	for k := range assetTotals {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, func(a, b assetKey) int {
+		if c := cmp.Compare(
+			a.policyHex, b.policyHex,
+		); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.nameHex, b.nameHex)
+	})
+	for _, key := range keys {
+		balances = append(balances, &Amount{
+			Value: strconv.FormatUint(
+				assetTotals[key], 10,
+			),
+			Currency: nativeAssetCurrency(
+				key.policyHex,
+				key.nameHex,
+			),
+		})
+	}
+	return balances
+}
+
+// utxosToCoins converts UTxOs to Mesh Coin entries,
+// including separate entries for each native asset.
+func utxosToCoins(utxos []models.Utxo) []*Coin {
+	coins := make([]*Coin, 0, len(utxos))
+	for i := range utxos {
+		utxo := &utxos[i]
+		baseCoinID := fmt.Sprintf(
+			"%s:%d",
+			hex.EncodeToString(utxo.TxId),
+			utxo.OutputIdx,
+		)
+		coins = append(coins, &Coin{
+			CoinIdentifier: &CoinIdentifier{
+				Identifier: baseCoinID,
+			},
+			Amount: convertAmount(
+				uint64(utxo.Amount),
+			),
+		})
+		for j := range utxo.Assets {
+			asset := &utxo.Assets[j]
+			policyHex := hex.EncodeToString(
+				asset.PolicyId,
+			)
+			nameHex := hex.EncodeToString(
+				asset.Name,
+			)
+			assetCoinID := fmt.Sprintf(
+				"%s:%s:%s",
+				baseCoinID, policyHex, nameHex,
+			)
+			coins = append(coins, &Coin{
+				CoinIdentifier: &CoinIdentifier{
+					Identifier: assetCoinID,
+				},
+				Amount: convertAssetAmount(
+					asset.PolicyId,
+					asset.Name,
+					uint64(asset.Amount),
+				),
+			})
+		}
+	}
+	return coins
+}

--- a/mesh/block.go
+++ b/mesh/block.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"net/http"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// handleBlock handles POST /block.
+func (s *Server) handleBlock(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req BlockRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	if req.BlockIdentifier == nil {
+		writeError(w, ErrInvalidRequest)
+		return
+	}
+
+	block, meshErr := s.lookupBlock(
+		req.BlockIdentifier,
+	)
+	if meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	txs, err := s.config.Database.
+		GetTransactionsByBlockHash(
+			block.Hash, nil,
+		)
+	if err != nil {
+		s.logger.Error(
+			"failed to get block transactions",
+			"error", err,
+		)
+		writeError(w, wrapErr(ErrInternal, err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, &BlockResponse{
+		Block: convertBlock(
+			block, txs,
+			s.addrNetworkID,
+			s.slotToTimestamp,
+		),
+	})
+}
+
+// handleBlockTransaction handles
+// POST /block/transaction.
+func (s *Server) handleBlockTransaction(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req BlockTransactionRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	if req.TransactionIdentifier == nil ||
+		req.TransactionIdentifier.Hash == "" {
+		writeError(w, ErrInvalidRequest)
+		return
+	}
+	if req.BlockIdentifier == nil ||
+		req.BlockIdentifier.Hash == "" {
+		writeError(w, wrapErr(
+			ErrInvalidRequest,
+			errors.New(
+				"block_identifier with hash "+
+					"is required",
+			),
+		))
+		return
+	}
+
+	hashBytes, err := hex.DecodeString(
+		req.TransactionIdentifier.Hash,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidRequest, err,
+		))
+		return
+	}
+
+	tx, err := s.config.Database.GetTransactionByHash(
+		hashBytes, nil,
+	)
+	if err != nil {
+		s.logger.Error(
+			"failed to look up transaction",
+			"error", err,
+		)
+		writeError(w, wrapErr(ErrInternal, err))
+		return
+	}
+	if tx == nil {
+		writeError(w, ErrTransactionNotFound)
+		return
+	}
+
+	// Verify the transaction belongs to the requested
+	// block to prevent cross-block ambiguity.
+	blockHashBytes, err := hex.DecodeString(
+		req.BlockIdentifier.Hash,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidRequest, err,
+		))
+		return
+	}
+	if !bytes.Equal(tx.BlockHash, blockHashBytes) {
+		writeError(w, ErrTransactionNotFound)
+		return
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&BlockTransactionResponse{
+			Transaction: convertTransaction(
+				*tx, s.addrNetworkID,
+			),
+		},
+	)
+}
+
+// lookupBlock resolves a PartialBlockIdentifier to a
+// database Block by hash or index.
+func (s *Server) lookupBlock(
+	id *PartialBlockIdentifier,
+) (models.Block, *Error) {
+	var (
+		block models.Block
+		err   error
+	)
+
+	switch {
+	case id.Hash != nil && *id.Hash != "":
+		hashBytes, decErr := hex.DecodeString(
+			*id.Hash,
+		)
+		if decErr != nil {
+			return block, wrapErr(
+				ErrInvalidRequest, decErr,
+			)
+		}
+		block, err = database.BlockByHash(
+			s.config.Database, hashBytes,
+		)
+	case id.Index != nil:
+		if *id.Index < 0 {
+			return block, ErrInvalidRequest
+		}
+		// #nosec G115 -- validated non-negative
+		block, err = s.config.Database.BlockByIndex(
+			uint64(*id.Index), nil,
+		)
+	default:
+		return block, ErrInvalidRequest
+	}
+
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return block, ErrBlockNotFound
+		}
+		s.logger.Error(
+			"failed to look up block",
+			"error", err,
+		)
+		return block, wrapErr(ErrInternal, err)
+	}
+	return block, nil
+}

--- a/mesh/construction.go
+++ b/mesh/construction.go
@@ -1,0 +1,934 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"golang.org/x/crypto/blake2b"
+)
+
+const (
+	// avgTxSize is the average transaction size in bytes,
+	// used to estimate the suggested fee.
+	avgTxSize = 300
+)
+
+// handleConstructionDerive derives an account identifier
+// (address) from a public key.
+func (s *Server) handleConstructionDerive(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionDeriveRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	if req.PublicKey == nil {
+		writeError(w, wrapErr(
+			ErrInvalidPublicKey,
+			errors.New("public_key is required"),
+		))
+		return
+	}
+	if req.PublicKey.CurveType != Edwards25519 {
+		writeError(w, wrapErr(
+			ErrInvalidPublicKey,
+			fmt.Errorf(
+				"unsupported curve type: %s",
+				req.PublicKey.CurveType,
+			),
+		))
+		return
+	}
+
+	pubKeyBytes, err := hex.DecodeString(
+		req.PublicKey.HexBytes,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidPublicKey,
+			fmt.Errorf("hex decode: %w", err),
+		))
+		return
+	}
+	if len(pubKeyBytes) != 32 {
+		writeError(w, wrapErr(
+			ErrInvalidPublicKey,
+			fmt.Errorf(
+				"expected 32 bytes, got %d",
+				len(pubKeyBytes),
+			),
+		))
+		return
+	}
+
+	keyHash := lcommon.Blake2b224Hash(pubKeyBytes)
+
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		s.addrNetworkID,
+		keyHash[:],
+		nil,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInternal,
+			fmt.Errorf("build address: %w", err),
+		))
+		return
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionDeriveResponse{
+			AccountIdentifier: &AccountIdentifier{
+				Address: addr.String(),
+			},
+		},
+	)
+}
+
+// handleConstructionHash computes the transaction hash
+// for a signed transaction.
+func (s *Server) handleConstructionHash(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionHashRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	tx, meshErr := decodeTxCbor(req.SignedTransaction)
+	if meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionHashResponse{
+			TransactionIdentifier: &TransactionIdentifier{
+				Hash: tx.Hash().String(),
+			},
+		},
+	)
+}
+
+// handleConstructionParse parses a signed or unsigned
+// transaction and returns the operations within it.
+func (s *Server) handleConstructionParse(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionParseRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	if req.Signed {
+		s.parseSignedTransaction(w, req.Transaction)
+	} else {
+		s.parseUnsignedTransaction(w, req.Transaction)
+	}
+}
+
+// parseSignedTransaction decodes a full signed TX and
+// returns its operations and signers.
+func (s *Server) parseSignedTransaction(
+	w http.ResponseWriter,
+	txHex string,
+) {
+	tx, meshErr := decodeTxCbor(txHex)
+	if meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	ops, signers := convertParsedTransaction(tx, true)
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionParseResponse{
+			Operations:               ops,
+			AccountIdentifierSigners: signers,
+		},
+	)
+}
+
+// parseUnsignedTransaction decodes an unsigned TX body
+// CBOR (as produced by /construction/payloads) and
+// returns its operations. DetermineTransactionType only
+// works on signed TXs (CBOR arrays), so unsigned bodies
+// (CBOR maps) are decoded directly as ConwayTransactionBody.
+func (s *Server) parseUnsignedTransaction(
+	w http.ResponseWriter,
+	bodyHex string,
+) {
+	bodyBytes, err := hex.DecodeString(bodyHex)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("hex decode: %w", err),
+		))
+		return
+	}
+
+	var body conway.ConwayTransactionBody
+	if _, err := cbor.Decode(bodyBytes, &body); err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("decode body: %w", err),
+		))
+		return
+	}
+
+	// Compute the body hash for output coin IDs.
+	bodyHash := blake2b.Sum256(bodyBytes)
+	txHash := hex.EncodeToString(bodyHash[:])
+
+	ops := convertBodyToOps(
+		body.Inputs(), body.Outputs(),
+		body.Certificates(), body.Withdrawals(),
+		txHash,
+	)
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionParseResponse{
+			Operations: ops,
+		},
+	)
+}
+
+// handleConstructionPreprocess is called prior to
+// /construction/payloads to construct a request for any
+// metadata needed for transaction construction.
+func (s *Server) handleConstructionPreprocess(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionPreprocessRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	var inputRefs []string
+	var requiredKeys []*AccountIdentifier
+	for _, op := range req.Operations {
+		if op.Type != OpInput {
+			continue
+		}
+		if op.CoinChange != nil &&
+			op.CoinChange.CoinIdentifier != nil {
+			inputRefs = append(
+				inputRefs,
+				op.CoinChange.CoinIdentifier.Identifier,
+			)
+		}
+		if op.Account != nil &&
+			op.Account.Address != "" {
+			requiredKeys = append(
+				requiredKeys,
+				&AccountIdentifier{
+					Address: op.Account.Address,
+				},
+			)
+		}
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionPreprocessResponse{
+			Options: map[string]any{
+				"input_refs": inputRefs,
+			},
+			RequiredPublicKeys: requiredKeys,
+		},
+	)
+}
+
+// handleConstructionMetadata returns metadata required
+// for transaction construction.
+func (s *Server) handleConstructionMetadata(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionMetadataRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	pparams := s.config.LedgerState.GetCurrentPParams()
+	if pparams == nil {
+		writeError(w, wrapErr(
+			ErrUnavailable,
+			errors.New(
+				"protocol parameters not available",
+			),
+		))
+		return
+	}
+
+	pp, err := pparams.Utxorpc()
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInternal,
+			fmt.Errorf(
+				"convert protocol params: %w", err,
+			),
+		))
+		return
+	}
+	if pp == nil {
+		writeError(w, wrapErr(
+			ErrUnavailable,
+			errors.New(
+				"protocol parameters conversion "+
+					"returned nil",
+			),
+		))
+		return
+	}
+
+	var coefficient, constant int64
+	if c := pp.GetMinFeeCoefficient(); c != nil {
+		coefficient = c.GetInt()
+	}
+	if c := pp.GetMinFeeConstant(); c != nil {
+		constant = c.GetInt()
+	}
+	suggestedFee := coefficient*avgTxSize + constant
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionMetadataResponse{
+			Metadata: map[string]any{
+				"min_fee_coefficient": coefficient,
+				"min_fee_constant":    constant,
+			},
+			SuggestedFee: []*Amount{
+				{
+					Value: strconv.FormatInt(
+						suggestedFee, 10,
+					),
+					Currency: adaCurrency(),
+				},
+			},
+		},
+	)
+}
+
+// handleConstructionPayloads generates an unsigned
+// transaction and signing payloads from operations.
+func (s *Server) handleConstructionPayloads(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionPayloadsRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	var inputs []shelley.ShelleyTransactionInput
+	type outputEntry struct {
+		addr   lcommon.Address
+		amount mary.MaryTransactionOutputValue
+	}
+	outputMap := make(map[int]outputEntry)
+	var maxOutputIdx int
+
+	for _, op := range req.Operations {
+		switch op.Type {
+		case OpInput:
+			if op.CoinChange == nil ||
+				op.CoinChange.CoinIdentifier == nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					errors.New(
+						"input op missing coin_change",
+					),
+				))
+				return
+			}
+			parts := strings.SplitN(
+				op.CoinChange.CoinIdentifier.Identifier,
+				":", 2,
+			)
+			if len(parts) != 2 {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid coin ID: %s",
+						op.CoinChange.CoinIdentifier.Identifier,
+					),
+				))
+				return
+			}
+			// Validate hex and length before calling
+			// NewShelleyTransactionInput, which panics
+			// on invalid input.
+			hashBytes, err := hex.DecodeString(
+				parts[0],
+			)
+			if err != nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid tx hash hex: %w",
+						err,
+					),
+				))
+				return
+			}
+			if len(hashBytes) != 32 {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"tx hash must be 32 bytes, "+
+							"got %d",
+						len(hashBytes),
+					),
+				))
+				return
+			}
+			idx, err := strconv.Atoi(parts[1])
+			if err != nil || idx < 0 {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid output index: %s",
+						parts[1],
+					),
+				))
+				return
+			}
+			inputs = append(
+				inputs,
+				shelley.NewShelleyTransactionInput(
+					parts[0], idx,
+				),
+			)
+		case OpOutput:
+			if op.Account == nil || op.Amount == nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					errors.New(
+						"output op missing account "+
+							"or amount",
+					),
+				))
+				return
+			}
+			if op.OperationIdentifier == nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					errors.New(
+						"output op missing "+
+							"operation_identifier",
+					),
+				))
+				return
+			}
+			if op.OperationIdentifier.Index < 0 ||
+				op.OperationIdentifier.Index > 10000 {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"operation index out "+
+							"of range: %d",
+						op.OperationIdentifier.Index,
+					),
+				))
+				return
+			}
+			outIdx := int(
+				op.OperationIdentifier.Index,
+			)
+			if _, exists := outputMap[outIdx]; exists {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"duplicate output index: %d",
+						outIdx,
+					),
+				))
+				return
+			}
+			addr, err := lcommon.NewAddress(
+				op.Account.Address,
+			)
+			if err != nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid address: %w",
+						err,
+					),
+				))
+				return
+			}
+			var entry outputEntry
+			entry.addr = addr
+			if op.Amount.Currency == nil ||
+				op.Amount.Currency.Symbol != "ADA" {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					errors.New(
+						"only ADA outputs "+
+							"supported in "+
+							"construction",
+					),
+				))
+				return
+			}
+			val, err := strconv.ParseUint(
+				op.Amount.Value, 10, 64,
+			)
+			if err != nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid amount: %w",
+						err,
+					),
+				))
+				return
+			}
+			entry.amount.Amount = val
+			outputMap[outIdx] = entry
+			if outIdx > maxOutputIdx {
+				maxOutputIdx = outIdx
+			}
+		default:
+			writeError(w, wrapErr(
+				ErrInvalidRequest,
+				fmt.Errorf(
+					"unsupported operation type: %s",
+					op.Type,
+				),
+			))
+			return
+		}
+	}
+
+	// Build outputs in insertion order by iterating
+	// up to the maximum index seen.
+	outputs := make(
+		[]babbage.BabbageTransactionOutput, 0,
+		len(outputMap),
+	)
+	for i := range maxOutputIdx + 1 {
+		entry, ok := outputMap[i]
+		if !ok {
+			continue
+		}
+		outputs = append(
+			outputs,
+			babbage.BabbageTransactionOutput{
+				OutputAddress: entry.addr,
+				OutputAmount:  entry.amount,
+			},
+		)
+	}
+
+	// Fee from metadata (required for valid TX)
+	feeStr, ok := req.Metadata["fee"].(string)
+	if !ok || feeStr == "" {
+		writeError(w, wrapErr(
+			ErrInvalidRequest,
+			errors.New(
+				"metadata must include \"fee\"",
+			),
+		))
+		return
+	}
+	fee, err := strconv.ParseUint(feeStr, 10, 64)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidRequest,
+			fmt.Errorf("invalid fee: %w", err),
+		))
+		return
+	}
+
+	// TTL from metadata (optional)
+	var ttl uint64
+	if ttlVal, ok := req.Metadata["ttl"]; ok {
+		switch v := ttlVal.(type) {
+		case string:
+			var err error
+			ttl, err = strconv.ParseUint(v, 10, 64)
+			if err != nil {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid ttl: %w", err,
+					),
+				))
+				return
+			}
+		case float64:
+			if v < 0 || v != float64(uint64(v)) {
+				writeError(w, wrapErr(
+					ErrInvalidRequest,
+					fmt.Errorf(
+						"invalid ttl: %v "+
+							"(must be a non-negative "+
+							"integer)", v,
+					),
+				))
+				return
+			}
+			ttl = uint64(v) // #nosec G115
+		default:
+			writeError(w, wrapErr(
+				ErrInvalidRequest,
+				fmt.Errorf(
+					"unsupported ttl type: %T", v,
+				),
+			))
+			return
+		}
+	}
+
+	body := conway.ConwayTransactionBody{
+		TxInputs: conway.NewConwayTransactionInputSet(
+			inputs,
+		),
+		TxOutputs: outputs,
+		TxFee:     fee,
+		Ttl:       ttl,
+	}
+
+	bodyCbor, err := cbor.Encode(&body)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInternal,
+			fmt.Errorf("encode body: %w", err),
+		))
+		return
+	}
+
+	bodyHash := blake2b.Sum256(bodyCbor)
+	bodyHashHex := hex.EncodeToString(bodyHash[:])
+
+	// Build one SigningPayload per unique signer.
+	// When public keys are provided, derive the
+	// address for each to set AccountIdentifier.
+	var payloads []*SigningPayload
+	if len(req.PublicKeys) > 0 {
+		seen := make(map[string]struct{})
+		for _, pk := range req.PublicKeys {
+			if _, dup := seen[pk.HexBytes]; dup {
+				continue
+			}
+			seen[pk.HexBytes] = struct{}{}
+			pkBytes, pkErr := hex.DecodeString(
+				pk.HexBytes,
+			)
+			if pkErr != nil || len(pkBytes) != 32 {
+				writeError(w, wrapErr(
+					ErrInvalidPublicKey,
+					fmt.Errorf(
+						"invalid public key: %s",
+						pk.HexBytes,
+					),
+				))
+				return
+			}
+			keyHash := lcommon.Blake2b224Hash(
+				pkBytes,
+			)
+			addr, addrErr := lcommon.NewAddressFromParts(
+				lcommon.AddressTypeKeyNone,
+				s.addrNetworkID,
+				keyHash[:], nil,
+			)
+			if addrErr != nil {
+				writeError(w, wrapErr(
+					ErrInternal, addrErr,
+				))
+				return
+			}
+			payloads = append(payloads,
+				&SigningPayload{
+					AccountIdentifier: &AccountIdentifier{
+						Address: addr.String(),
+					},
+					HexBytes:      bodyHashHex,
+					SignatureType: Ed25519,
+				},
+			)
+		}
+	} else {
+		// No public keys — single payload without
+		// AccountIdentifier.
+		payloads = []*SigningPayload{
+			{
+				HexBytes:      bodyHashHex,
+				SignatureType: Ed25519,
+			},
+		}
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionPayloadsResponse{
+			UnsignedTransaction: hex.EncodeToString(
+				bodyCbor,
+			),
+			Payloads: payloads,
+		},
+	)
+}
+
+// handleConstructionCombine combines an unsigned
+// transaction with signatures to produce a signed
+// transaction.
+func (s *Server) handleConstructionCombine(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionCombineRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	bodyBytes, err := hex.DecodeString(
+		req.UnsignedTransaction,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("hex decode body: %w", err),
+		))
+		return
+	}
+
+	witnesses := make(
+		[]lcommon.VkeyWitness, 0, len(req.Signatures),
+	)
+	for _, sig := range req.Signatures {
+		if sig.PublicKey == nil {
+			writeError(w, wrapErr(
+				ErrInvalidPublicKey,
+				errors.New(
+					"signature missing public_key",
+				),
+			))
+			return
+		}
+		vkeyBytes, err := hex.DecodeString(
+			sig.PublicKey.HexBytes,
+		)
+		if err != nil {
+			writeError(w, wrapErr(
+				ErrInvalidPublicKey,
+				fmt.Errorf(
+					"hex decode public key: %w", err,
+				),
+			))
+			return
+		}
+		if len(vkeyBytes) != 32 {
+			writeError(w, wrapErr(
+				ErrInvalidPublicKey,
+				fmt.Errorf(
+					"public key must be 32 bytes, "+
+						"got %d",
+					len(vkeyBytes),
+				),
+			))
+			return
+		}
+		sigBytes, err := hex.DecodeString(sig.HexBytes)
+		if err != nil {
+			writeError(w, wrapErr(
+				ErrInvalidTransaction,
+				fmt.Errorf(
+					"hex decode signature: %w", err,
+				),
+			))
+			return
+		}
+		if len(sigBytes) != 64 {
+			writeError(w, wrapErr(
+				ErrInvalidTransaction,
+				fmt.Errorf(
+					"signature must be 64 bytes, "+
+						"got %d",
+					len(sigBytes),
+				),
+			))
+			return
+		}
+		witnesses = append(
+			witnesses,
+			lcommon.VkeyWitness{
+				Vkey:      vkeyBytes,
+				Signature: sigBytes,
+			},
+		)
+	}
+
+	// Build signed TX as CBOR 4-element array:
+	// [body, witness_set, is_valid, auxiliary_data]
+	// Use RawMessage for body to preserve exact bytes.
+	witnessMap := map[int]any{
+		0: witnesses,
+	}
+	signedTx := []any{
+		cbor.RawMessage(bodyBytes),
+		witnessMap,
+		true,
+		nil,
+	}
+
+	signedCbor, err := cbor.Encode(signedTx)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInternal,
+			fmt.Errorf(
+				"encode signed tx: %w", err,
+			),
+		))
+		return
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionCombineResponse{
+			SignedTransaction: hex.EncodeToString(
+				signedCbor,
+			),
+		},
+	)
+}
+
+// handleConstructionSubmit submits a signed transaction
+// to the network via the mempool.
+func (s *Server) handleConstructionSubmit(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req ConstructionSubmitRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	txBytes, err := hex.DecodeString(
+		req.SignedTransaction,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("hex decode: %w", err),
+		))
+		return
+	}
+
+	txType, err := gledger.DetermineTransactionType(
+		txBytes,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf(
+				"determine tx type: %w", err,
+			),
+		))
+		return
+	}
+
+	tx, err := gledger.NewTransactionFromCbor(
+		txType, txBytes,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("decode tx: %w", err),
+		))
+		return
+	}
+
+	if err := s.config.Mempool.AddTransaction(
+		txType, txBytes,
+	); err != nil {
+		writeError(w, wrapErr(
+			ErrSubmitFailed,
+			fmt.Errorf(
+				"mempool submit: %w", err,
+			),
+		))
+		return
+	}
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&ConstructionSubmitResponse{
+			TransactionIdentifier: &TransactionIdentifier{
+				Hash: tx.Hash().String(),
+			},
+		},
+	)
+}

--- a/mesh/convert.go
+++ b/mesh/convert.go
@@ -1,0 +1,610 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// adaCurrency returns the ADA currency descriptor.
+// 1 ADA = 1,000,000 lovelace (6 decimals).
+func adaCurrency() *Currency {
+	return &Currency{
+		Symbol:   "ADA",
+		Decimals: 6,
+	}
+}
+
+// nativeAssetCurrency returns a Currency for a Cardano
+// native asset identified by hex-encoded policy ID and
+// asset name.
+func nativeAssetCurrency(
+	policyHex, nameHex string,
+) *Currency {
+	return &Currency{
+		Symbol:   nameHex,
+		Decimals: 0,
+		Metadata: map[string]any{
+			"policyId":  policyHex,
+			"assetName": nameHex,
+		},
+	}
+}
+
+// convertBlock converts a database block model and its
+// transactions into a Mesh Block.
+func convertBlock(
+	block models.Block,
+	txs []models.Transaction,
+	addrNetworkID uint8,
+	slotToTimestamp func(uint64) int64,
+) *Block {
+	meshTxs := make([]*Transaction, 0, len(txs))
+	for i := range txs {
+		meshTxs = append(
+			meshTxs,
+			convertTransaction(txs[i], addrNetworkID),
+		)
+	}
+
+	blockHash := hex.EncodeToString(block.Hash)
+
+	// Per Mesh spec, genesis block's parent is itself.
+	var parentID *BlockIdentifier
+	if block.Number == 0 {
+		parentID = &BlockIdentifier{
+			Index: 0,
+			Hash:  blockHash,
+		}
+	} else {
+		parentID = &BlockIdentifier{
+			// #nosec G115
+			Index: int64(block.Number - 1),
+			Hash: hex.EncodeToString(
+				block.PrevHash,
+			),
+		}
+	}
+
+	return &Block{
+		BlockIdentifier: &BlockIdentifier{
+			Index: int64(block.Number), // #nosec G115
+			Hash:  blockHash,
+		},
+		ParentBlockIdentifier: parentID,
+		Timestamp:             slotToTimestamp(block.Slot),
+		Transactions:          meshTxs,
+	}
+}
+
+// convertTransaction converts a database transaction
+// into a Mesh Transaction with input/output operations.
+func convertTransaction(
+	tx models.Transaction,
+	addrNetworkID uint8,
+) *Transaction {
+	txHash := hex.EncodeToString(tx.Hash)
+	status := txStatus(tx.Valid)
+
+	ops := make(
+		[]*Operation,
+		0,
+		len(tx.Inputs)+len(tx.Outputs),
+	)
+	var opIdx int64
+
+	// Track only the primary ADA operation index for
+	// each input (not native asset sub-operations).
+	// Per Mesh spec, outputs reference the spent coin
+	// operations, not individual asset movements.
+	inputOpIDs := make(
+		[]*OperationIdentifier, 0, len(tx.Inputs),
+	)
+
+	for i := range tx.Inputs {
+		input := &tx.Inputs[i]
+		coinID := fmt.Sprintf(
+			"%s:%d",
+			hex.EncodeToString(input.TxId),
+			input.OutputIdx,
+		)
+		inputOpIDs = append(inputOpIDs,
+			&OperationIdentifier{Index: opIdx},
+		)
+		opIdx = appendUtxoOps(
+			&ops, opIdx, status,
+			utxoAddress(input, addrNetworkID),
+			coinID, uint64(input.Amount),
+			input.Assets,
+			OpInput, CoinSpent, true, nil,
+		)
+	}
+
+	for i := range tx.Outputs {
+		output := &tx.Outputs[i]
+		coinID := fmt.Sprintf(
+			"%s:%d", txHash, output.OutputIdx,
+		)
+		opIdx = appendUtxoOps(
+			&ops, opIdx, status,
+			utxoAddress(output, addrNetworkID),
+			coinID, uint64(output.Amount),
+			output.Assets,
+			OpOutput, CoinCreated, false,
+			inputOpIDs,
+		)
+	}
+
+	return &Transaction{
+		TransactionIdentifier: &TransactionIdentifier{
+			Hash: txHash,
+		},
+		Operations: ops,
+	}
+}
+
+// txStatus returns the operation status string pointer
+// for a transaction's validity.
+func txStatus(valid bool) *string {
+	if valid {
+		s := StatusSuccess
+		return &s
+	}
+	s := StatusInvalid
+	return &s
+}
+
+// utxoAddress reconstructs a bech32 Cardano address from
+// the payment and staking key hashes stored in the
+// metadata DB. The address type depends on which keys
+// are present:
+//
+//   - PaymentKey + StakingKey → AddressTypeKeyKey
+//   - PaymentKey only        → AddressTypeKeyNone
+//   - Neither (Byron-era)    → "byron:<txId hex>"
+//
+// The networkID determines the address prefix
+// (addr / addr_test1).
+func utxoAddress(
+	utxo *models.Utxo,
+	networkID uint8,
+) string {
+	if len(utxo.PaymentKey) == 0 {
+		// Byron-era or unresolvable — return a
+		// distinguishable placeholder so the address
+		// field is never empty (Mesh spec requires
+		// it).
+		return "byron:" +
+			hex.EncodeToString(utxo.TxId)
+	}
+
+	var addrType uint8
+	var stakingKey []byte
+	if len(utxo.StakingKey) > 0 {
+		addrType = lcommon.AddressTypeKeyKey
+		stakingKey = utxo.StakingKey
+	} else {
+		addrType = lcommon.AddressTypeKeyNone
+	}
+
+	addr, err := lcommon.NewAddressFromParts(
+		addrType, networkID,
+		utxo.PaymentKey, stakingKey,
+	)
+	if err != nil {
+		// Fallback: should not happen with valid
+		// 28-byte key hashes, but don't panic.
+		return hex.EncodeToString(utxo.PaymentKey)
+	}
+	return addr.String()
+}
+
+// appendUtxoOps appends an ADA operation and any native
+// asset operations for a single UTxO to the ops slice.
+// When negate is true, the ADA value is prefixed with "-"
+// (for inputs). relatedOps, if non-nil, is attached to
+// each operation (used for outputs to reference inputs).
+// Returns the next operation index.
+func appendUtxoOps(
+	ops *[]*Operation,
+	opIdx int64,
+	status *string,
+	address string,
+	coinID string,
+	lovelace uint64,
+	assets []models.Asset,
+	opType string,
+	coinAction string,
+	negate bool,
+	relatedOps []*OperationIdentifier,
+) int64 {
+	acct := &AccountIdentifier{Address: address}
+	coinChange := &CoinChange{
+		CoinIdentifier: &CoinIdentifier{
+			Identifier: coinID,
+		},
+		CoinAction: coinAction,
+	}
+
+	value := strconv.FormatUint(lovelace, 10)
+	if negate {
+		value = "-" + value
+	}
+
+	*ops = append(*ops, &Operation{
+		OperationIdentifier: &OperationIdentifier{
+			Index: opIdx,
+		},
+		RelatedOperations: relatedOps,
+		Type:              opType,
+		Status:            status,
+		Account:           acct,
+		Amount: &Amount{
+			Value:    value,
+			Currency: adaCurrency(),
+		},
+		CoinChange: coinChange,
+	})
+	opIdx++
+
+	for i := range assets {
+		asset := &assets[i]
+		assetValue := strconv.FormatUint(
+			uint64(asset.Amount), 10,
+		)
+		if negate {
+			assetValue = "-" + assetValue
+		}
+		policyHex := hex.EncodeToString(
+			asset.PolicyId,
+		)
+		nameHex := hex.EncodeToString(
+			asset.Name,
+		)
+		assetCoinID := fmt.Sprintf(
+			"%s:%s:%s",
+			coinID, policyHex, nameHex,
+		)
+		*ops = append(*ops, &Operation{
+			OperationIdentifier: &OperationIdentifier{
+				Index: opIdx,
+			},
+			RelatedOperations: relatedOps,
+			Type:              opType,
+			Status:            status,
+			Account:           acct,
+			Amount: &Amount{
+				Value: assetValue,
+				Currency: nativeAssetCurrency(
+					policyHex,
+					nameHex,
+				),
+			},
+			CoinChange: &CoinChange{
+				CoinIdentifier: &CoinIdentifier{
+					Identifier: assetCoinID,
+				},
+				CoinAction: coinAction,
+			},
+		})
+		opIdx++
+	}
+
+	return opIdx
+}
+
+// convertAmount converts a lovelace value to a Mesh
+// Amount with ADA currency.
+func convertAmount(lovelace uint64) *Amount {
+	return &Amount{
+		Value:    strconv.FormatUint(lovelace, 10),
+		Currency: adaCurrency(),
+	}
+}
+
+// convertAssetAmount converts a native asset to a Mesh
+// Amount with currency metadata.
+func convertAssetAmount(
+	policyID []byte,
+	assetName []byte,
+	amount uint64,
+) *Amount {
+	return &Amount{
+		Value: strconv.FormatUint(amount, 10),
+		Currency: nativeAssetCurrency(
+			hex.EncodeToString(policyID),
+			hex.EncodeToString(assetName),
+		),
+	}
+}
+
+// decodeTxCbor hex-decodes a transaction string and
+// parses it into a gouroboros Transaction. Shared by
+// hash, parse, and combine endpoints.
+func decodeTxCbor(
+	hexStr string,
+) (gledger.Transaction, *Error) {
+	txBytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return nil, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("hex decode: %w", err),
+		)
+	}
+	txType, err := gledger.DetermineTransactionType(
+		txBytes,
+	)
+	if err != nil {
+		return nil, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf(
+				"determine tx type: %w", err,
+			),
+		)
+	}
+	tx, err := gledger.NewTransactionFromCbor(
+		txType, txBytes,
+	)
+	if err != nil {
+		return nil, wrapErr(
+			ErrInvalidTransaction,
+			fmt.Errorf("decode tx: %w", err),
+		)
+	}
+	return tx, nil
+}
+
+// convertParsedTransaction converts a gouroboros
+// Transaction to Mesh operations and signer accounts.
+// When signed is true, VKey witnesses are hashed to
+// produce signer identifiers.
+func convertParsedTransaction(
+	tx gledger.Transaction,
+	signed bool,
+) ([]*Operation, []*AccountIdentifier) {
+	txHash := tx.Hash().String()
+	ops := convertBodyToOps(
+		tx.Inputs(), tx.Outputs(),
+		tx.Certificates(), tx.Withdrawals(),
+		txHash,
+	)
+
+	// Signers from VKey witnesses
+	var signers []*AccountIdentifier
+	if signed {
+		witnesses := tx.Witnesses()
+		for _, vkw := range witnesses.Vkey() {
+			keyHash := lcommon.Blake2b224Hash(
+				vkw.Vkey,
+			)
+			signers = append(
+				signers,
+				&AccountIdentifier{
+					Address: hex.EncodeToString(
+						keyHash[:],
+					),
+				},
+			)
+		}
+	}
+
+	return ops, signers
+}
+
+// convertBodyToOps builds Mesh operations from
+// transaction body components. Used by both signed TX
+// parsing and unsigned body parsing. The txHash is used
+// to construct output coin identifiers; pass empty
+// string if unknown.
+func convertBodyToOps(
+	inputs []gledger.TransactionInput,
+	outputs []gledger.TransactionOutput,
+	certs []gledger.Certificate,
+	withdrawals map[*lcommon.Address]*big.Int,
+	txHash string,
+) []*Operation {
+	var ops []*Operation
+	var opIdx int64
+
+	// Inputs — no Account since we don't have UTxO
+	// lookup in the construction flow (standard for
+	// Cardano Mesh implementations).
+	for _, input := range inputs {
+		coinID := fmt.Sprintf(
+			"%s:%d",
+			input.Id().String(),
+			input.Index(),
+		)
+		ops = append(ops, &Operation{
+			OperationIdentifier: &OperationIdentifier{
+				Index: opIdx,
+			},
+			Type: OpInput,
+			CoinChange: &CoinChange{
+				CoinIdentifier: &CoinIdentifier{
+					Identifier: coinID,
+				},
+				CoinAction: CoinSpent,
+			},
+		})
+		opIdx++
+	}
+
+	// Outputs
+	for i, output := range outputs {
+		addr := output.Address().String()
+		amount := output.Amount()
+		coinID := fmt.Sprintf("%s:%d", txHash, i)
+
+		ops = append(ops, &Operation{
+			OperationIdentifier: &OperationIdentifier{
+				Index: opIdx,
+			},
+			Type: OpOutput,
+			Account: &AccountIdentifier{
+				Address: addr,
+			},
+			Amount: &Amount{
+				Value:    amount.String(),
+				Currency: adaCurrency(),
+			},
+			CoinChange: &CoinChange{
+				CoinIdentifier: &CoinIdentifier{
+					Identifier: coinID,
+				},
+				CoinAction: CoinCreated,
+			},
+		})
+		opIdx++
+
+		// Native assets
+		assets := output.Assets()
+		if assets != nil {
+			for _, policyID := range assets.Policies() {
+				for _, name := range assets.Assets(
+					policyID,
+				) {
+					val := assets.Asset(policyID, name)
+					pHex := hex.EncodeToString(
+						policyID[:],
+					)
+					nHex := hex.EncodeToString(name)
+					assetCoinID := fmt.Sprintf(
+						"%s:%s:%s",
+						coinID, pHex, nHex,
+					)
+					ops = append(ops, &Operation{
+						OperationIdentifier: &OperationIdentifier{
+							Index: opIdx,
+						},
+						Type: OpOutput,
+						Account: &AccountIdentifier{
+							Address: addr,
+						},
+						Amount: &Amount{
+							Value: val.String(),
+							Currency: nativeAssetCurrency(
+								pHex, nHex,
+							),
+						},
+						CoinChange: &CoinChange{
+							CoinIdentifier: &CoinIdentifier{
+								Identifier: assetCoinID,
+							},
+							CoinAction: CoinCreated,
+						},
+					})
+					opIdx++
+				}
+			}
+		}
+	}
+
+	// Certificates
+	for _, cert := range certs {
+		opType := certToOpType(cert)
+		if opType == "" {
+			continue
+		}
+		ops = append(ops, &Operation{
+			OperationIdentifier: &OperationIdentifier{
+				Index: opIdx,
+			},
+			Type: opType,
+		})
+		opIdx++
+	}
+
+	// Withdrawals — sort by address for deterministic
+	// operation indices.
+	type withdrawal struct {
+		addr   string
+		amount *big.Int
+	}
+	wdrls := make([]withdrawal, 0, len(withdrawals))
+	for addr, amount := range withdrawals {
+		wdrls = append(wdrls, withdrawal{
+			addr:   addr.String(),
+			amount: amount,
+		})
+	}
+	slices.SortFunc(wdrls, func(a, b withdrawal) int {
+		return strings.Compare(a.addr, b.addr)
+	})
+	for _, w := range wdrls {
+		ops = append(ops, &Operation{
+			OperationIdentifier: &OperationIdentifier{
+				Index: opIdx,
+			},
+			Type: OpWithdrawal,
+			Account: &AccountIdentifier{
+				Address: w.addr,
+			},
+			Amount: &Amount{
+				Value:    w.amount.String(),
+				Currency: adaCurrency(),
+			},
+		})
+		opIdx++
+	}
+
+	return ops
+}
+
+// certToOpType maps a gouroboros Certificate type to a
+// Mesh operation type string.
+func certToOpType(
+	cert gledger.Certificate,
+) string {
+	switch lcommon.CertificateType(cert.Type()) {
+	case lcommon.CertificateTypeStakeRegistration,
+		lcommon.CertificateTypeRegistration:
+		return OpStakeKeyRegistration
+	case lcommon.CertificateTypeStakeDeregistration,
+		lcommon.CertificateTypeDeregistration:
+		return OpStakeKeyDeregistration
+	case lcommon.CertificateTypeStakeDelegation:
+		return OpStakeDelegation
+	case lcommon.CertificateTypePoolRegistration:
+		return OpPoolRegistration
+	case lcommon.CertificateTypePoolRetirement:
+		return OpPoolRetirement
+	case lcommon.CertificateTypeVoteDelegation:
+		return OpVoteDRepDelegation
+	case lcommon.CertificateTypeGenesisKeyDelegation,
+		lcommon.CertificateTypeMoveInstantaneousRewards,
+		lcommon.CertificateTypeStakeVoteDelegation,
+		lcommon.CertificateTypeStakeRegistrationDelegation,
+		lcommon.CertificateTypeVoteRegistrationDelegation,
+		lcommon.CertificateTypeStakeVoteRegistrationDelegation,
+		lcommon.CertificateTypeAuthCommitteeHot,
+		lcommon.CertificateTypeResignCommitteeCold,
+		lcommon.CertificateTypeRegistrationDrep,
+		lcommon.CertificateTypeDeregistrationDrep,
+		lcommon.CertificateTypeUpdateDrep,
+		lcommon.CertificateTypeLeiosEb:
+		return ""
+	}
+	return ""
+}

--- a/mesh/errors.go
+++ b/mesh/errors.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+// Error represents a Mesh API error response.
+type Error struct {
+	Code        int32          `json:"code"`
+	Message     string         `json:"message"`
+	Description string         `json:"description,omitempty"`
+	Retriable   bool           `json:"retriable"`
+	Details     map[string]any `json:"details,omitempty"`
+}
+
+// Standard Mesh API error codes following the specification.
+var (
+	ErrNetworkNotSupported = &Error{
+		Code:    1,
+		Message: "network not supported",
+		Description: "The requested network is not supported " +
+			"by this server.",
+		Retriable: false,
+	}
+	ErrBlockNotFound = &Error{
+		Code:        2,
+		Message:     "block not found",
+		Description: "The requested block could not be found.",
+		Retriable:   false,
+	}
+	ErrTransactionNotFound = &Error{
+		Code:    3,
+		Message: "transaction not found",
+		Description: "The requested transaction could " +
+			"not be found.",
+		Retriable: false,
+	}
+	ErrAccountNotFound = &Error{
+		Code:    4,
+		Message: "account not found",
+		Description: "The requested account could not " +
+			"be found.",
+		Retriable: false,
+	}
+	ErrInvalidRequest = &Error{
+		Code:        5,
+		Message:     "invalid request",
+		Description: "The request was invalid or malformed.",
+		Retriable:   false,
+	}
+	ErrInternal = &Error{
+		Code:        6,
+		Message:     "internal error",
+		Description: "An internal server error occurred.",
+		Retriable:   true,
+	}
+	ErrNotImplemented = &Error{
+		Code:        7,
+		Message:     "not implemented",
+		Description: "This endpoint is not yet implemented.",
+		Retriable:   false,
+	}
+	ErrInvalidPublicKey = &Error{
+		Code:        8,
+		Message:     "invalid public key",
+		Description: "The provided public key is invalid.",
+		Retriable:   false,
+	}
+	ErrInvalidTransaction = &Error{
+		Code:    9,
+		Message: "invalid transaction",
+		Description: "The provided transaction is " +
+			"invalid or malformed.",
+		Retriable: false,
+	}
+	ErrSubmitFailed = &Error{
+		Code:    10,
+		Message: "transaction submit failed",
+		Description: "The transaction could not be " +
+			"submitted to the network.",
+		Retriable: true,
+	}
+	ErrUnavailable = &Error{
+		Code:    11,
+		Message: "service unavailable",
+		Description: "The service is temporarily " +
+			"unavailable. Please retry.",
+		Retriable: true,
+	}
+)
+
+// AllErrors returns all defined error types for the
+// /network/options response.
+func AllErrors() []*Error {
+	return []*Error{
+		ErrNetworkNotSupported,
+		ErrBlockNotFound,
+		ErrTransactionNotFound,
+		ErrAccountNotFound,
+		ErrInvalidRequest,
+		ErrInternal,
+		ErrNotImplemented,
+		ErrInvalidPublicKey,
+		ErrInvalidTransaction,
+		ErrSubmitFailed,
+		ErrUnavailable,
+	}
+}
+
+// wrapErr creates a new Error with additional details.
+func wrapErr(base *Error, detail error) *Error {
+	if detail == nil {
+		return base
+	}
+	return &Error{
+		Code:        base.Code,
+		Message:     base.Message,
+		Description: base.Description,
+		Retriable:   base.Retriable,
+		Details: map[string]any{
+			"error": detail.Error(),
+		},
+	}
+}

--- a/mesh/mempool_api.go
+++ b/mesh/mempool_api.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// handleMempool handles POST /mempool.
+func (s *Server) handleMempool(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req NetworkRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	txs := s.config.Mempool.Transactions()
+	txIDs := make(
+		[]*TransactionIdentifier, len(txs),
+	)
+	for i := range txs {
+		txIDs[i] = &TransactionIdentifier{
+			Hash: txs[i].Hash,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, &MempoolResponse{
+		TransactionIdentifiers: txIDs,
+	})
+}
+
+// handleMempoolTransaction handles
+// POST /mempool/transaction.
+func (s *Server) handleMempoolTransaction(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req MempoolTransactionRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	if req.TransactionIdentifier == nil ||
+		req.TransactionIdentifier.Hash == "" {
+		writeError(w, wrapErr(
+			ErrInvalidRequest,
+			errors.New(
+				"transaction_identifier is required",
+			),
+		))
+		return
+	}
+
+	mempoolTx, exists := s.config.Mempool.GetTransaction(
+		req.TransactionIdentifier.Hash,
+	)
+	if !exists {
+		writeError(w, ErrTransactionNotFound)
+		return
+	}
+
+	tx, err := gledger.NewTransactionFromCbor(
+		mempoolTx.Type, mempoolTx.Cbor,
+	)
+	if err != nil {
+		writeError(w, wrapErr(
+			ErrInternal,
+			fmt.Errorf("decode mempool tx: %w", err),
+		))
+		return
+	}
+
+	ops, _ := convertParsedTransaction(tx, true)
+
+	writeJSON(
+		w,
+		http.StatusOK,
+		&MempoolTransactionResponse{
+			Transaction: &Transaction{
+				TransactionIdentifier: &TransactionIdentifier{
+					Hash: tx.Hash().String(),
+				},
+				Operations: ops,
+			},
+		},
+	)
+}

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -1,0 +1,463 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/mempool"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+const (
+	// rosettaVersion is pinned to 1.4.15 for
+	// compatibility with existing Mesh/Rosetta tooling
+	// (mesh-cli, exchanges). Upgrading to 1.7.x is
+	// tracked for a future release.
+	rosettaVersion    = "1.4.15"
+	nodeVersion       = "0.1.0"
+	blockchain        = "cardano"
+	defaultListenAddr = ":8080"
+	maxRequestBody    = 1 << 20 // 1 MB
+
+	// mainnetMagic is the network magic for Cardano
+	// mainnet, used to determine the address network.
+	mainnetMagic = 764824073
+)
+
+// ServerConfig holds configuration for the Mesh API server.
+type ServerConfig struct {
+	Logger        *slog.Logger
+	EventBus      *event.EventBus
+	LedgerState   *ledger.LedgerState
+	Database      *database.Database
+	Chain         *chain.Chain
+	Mempool       *mempool.Mempool
+	ListenAddress string
+	Network       string
+	NetworkMagic  uint32
+	// GenesisHash is the Byron genesis block hash
+	// (hex-encoded).
+	GenesisHash string
+	// GenesisStartTimeSec is the Unix timestamp (seconds)
+	// of slot 0 for the configured network. Used to
+	// convert slot numbers to absolute timestamps.
+	GenesisStartTimeSec int64
+}
+
+// Server is the Mesh-compatible REST API server.
+type Server struct {
+	config              ServerConfig
+	logger              *slog.Logger
+	networkID           *NetworkIdentifier
+	genesisID           *BlockIdentifier
+	genesisStartTimeSec int64
+	addrNetworkID       uint8
+	httpServer          *http.Server
+	mu                  sync.Mutex
+}
+
+// NewServer creates a new Mesh API server instance.
+// Returns an error if required configuration fields are
+// missing.
+func NewServer(cfg ServerConfig) (*Server, error) {
+	if cfg.Chain == nil {
+		return nil, errors.New(
+			"mesh: Chain is required",
+		)
+	}
+	if cfg.Database == nil {
+		return nil, errors.New(
+			"mesh: Database is required",
+		)
+	}
+	if cfg.LedgerState == nil {
+		return nil, errors.New(
+			"mesh: LedgerState is required",
+		)
+	}
+	if cfg.Mempool == nil {
+		return nil, errors.New(
+			"mesh: Mempool is required",
+		)
+	}
+	if cfg.Network == "" {
+		return nil, errors.New(
+			"mesh: Network is required",
+		)
+	}
+	if cfg.GenesisHash == "" {
+		return nil, errors.New(
+			"mesh: GenesisHash is required",
+		)
+	}
+	if _, err := hex.DecodeString(
+		cfg.GenesisHash,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"mesh: invalid GenesisHash: %w", err,
+		)
+	}
+	if cfg.GenesisStartTimeSec <= 0 {
+		return nil, errors.New(
+			"mesh: GenesisStartTimeSec must be " +
+				"positive",
+		)
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		)
+	}
+	logger := cfg.Logger.With("component", "mesh")
+	if cfg.ListenAddress == "" {
+		cfg.ListenAddress = defaultListenAddr
+	}
+
+	var addrNetID uint8 = lcommon.AddressNetworkTestnet
+	if cfg.NetworkMagic == mainnetMagic {
+		addrNetID = lcommon.AddressNetworkMainnet
+	}
+
+	networkID := &NetworkIdentifier{
+		Blockchain: blockchain,
+		Network:    cfg.Network,
+	}
+
+	genesisID := &BlockIdentifier{
+		Index: 0,
+		Hash:  cfg.GenesisHash,
+	}
+
+	return &Server{
+		config:              cfg,
+		logger:              logger,
+		networkID:           networkID,
+		genesisID:           genesisID,
+		genesisStartTimeSec: cfg.GenesisStartTimeSec,
+		addrNetworkID:       addrNetID,
+	}, nil
+}
+
+// Start starts the HTTP server in a background goroutine.
+func (s *Server) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.httpServer != nil {
+		s.mu.Unlock()
+		return errors.New("server already started")
+	}
+
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	server := &http.Server{
+		Addr:              s.config.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 60 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	s.httpServer = server
+
+	// Launch context monitor before unlocking so there
+	// is no window where Stop() could race with the
+	// goroutine not yet existing.
+	go func() {
+		<-ctx.Done()
+		s.mu.Lock()
+		srv := s.httpServer
+		s.httpServer = nil
+		s.mu.Unlock()
+
+		if srv != nil {
+			s.logger.Debug(
+				"context cancelled, shutting down " +
+					"Mesh API server",
+			)
+			//nolint:contextcheck
+			shutdownCtx, cancel := context.WithTimeout(
+				context.Background(),
+				30*time.Second,
+			)
+			defer cancel()
+			//nolint:contextcheck
+			if err := srv.Shutdown(
+				shutdownCtx,
+			); err != nil {
+				s.logger.Error(
+					"failed to shutdown Mesh API "+
+						"server on context "+
+						"cancellation",
+					"error", err,
+				)
+			}
+		}
+	}()
+
+	s.mu.Unlock()
+
+	if err := s.startServer(server); err != nil {
+		s.mu.Lock()
+		s.httpServer = nil
+		s.mu.Unlock()
+		return err
+	}
+
+	s.logger.Info(
+		"Mesh API listener started on " +
+			s.config.ListenAddress,
+	)
+
+	return nil
+}
+
+// Stop gracefully shuts down the HTTP server.
+func (s *Server) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	srv := s.httpServer
+	s.httpServer = nil
+	s.mu.Unlock()
+
+	if srv != nil {
+		s.logger.Debug("shutting down Mesh API server")
+		if err := srv.Shutdown(ctx); err != nil {
+			return fmt.Errorf(
+				"failed to shutdown Mesh API server: %w",
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+// startServer starts the HTTP server with deterministic
+// error detection.
+func (s *Server) startServer(
+	server *http.Server,
+) error {
+	ln, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to listen for Mesh API server: %w",
+			err,
+		)
+	}
+	go func() {
+		if err := server.Serve(ln); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error(
+				"Mesh API server error",
+				"error", err,
+			)
+		}
+	}()
+	return nil
+}
+
+// registerRoutes registers all Mesh API endpoints.
+func (s *Server) registerRoutes(mux *http.ServeMux) {
+	// Network API
+	mux.HandleFunc(
+		"POST /network/list",
+		s.handleNetworkList,
+	)
+	mux.HandleFunc(
+		"POST /network/options",
+		s.handleNetworkOptions,
+	)
+	mux.HandleFunc(
+		"POST /network/status",
+		s.handleNetworkStatus,
+	)
+
+	// Block API
+	mux.HandleFunc("POST /block", s.handleBlock)
+	mux.HandleFunc(
+		"POST /block/transaction",
+		s.handleBlockTransaction,
+	)
+
+	// Account API
+	mux.HandleFunc(
+		"POST /account/balance",
+		s.handleAccountBalance,
+	)
+	mux.HandleFunc(
+		"POST /account/coins",
+		s.handleAccountCoins,
+	)
+
+	// Mempool API
+	mux.HandleFunc("POST /mempool", s.handleMempool)
+	mux.HandleFunc(
+		"POST /mempool/transaction",
+		s.handleMempoolTransaction,
+	)
+
+	// Construction API
+	mux.HandleFunc(
+		"POST /construction/derive",
+		s.handleConstructionDerive,
+	)
+	mux.HandleFunc(
+		"POST /construction/preprocess",
+		s.handleConstructionPreprocess,
+	)
+	mux.HandleFunc(
+		"POST /construction/metadata",
+		s.handleConstructionMetadata,
+	)
+	mux.HandleFunc(
+		"POST /construction/payloads",
+		s.handleConstructionPayloads,
+	)
+	mux.HandleFunc(
+		"POST /construction/combine",
+		s.handleConstructionCombine,
+	)
+	mux.HandleFunc(
+		"POST /construction/parse",
+		s.handleConstructionParse,
+	)
+	mux.HandleFunc(
+		"POST /construction/hash",
+		s.handleConstructionHash,
+	)
+	mux.HandleFunc(
+		"POST /construction/submit",
+		s.handleConstructionSubmit,
+	)
+}
+
+// networkRequest is implemented by request types that
+// carry a NetworkIdentifier for validation.
+type networkRequest interface {
+	networkID() *NetworkIdentifier
+}
+
+// decodeAndValidate decodes a JSON request body and
+// validates the network identifier. Returns a non-nil
+// *Error if decoding or validation fails.
+func (s *Server) decodeAndValidate(
+	w http.ResponseWriter,
+	r *http.Request,
+	dst networkRequest,
+) *Error {
+	if err := decodeRequest(w, r, dst); err != nil {
+		return wrapErr(ErrInvalidRequest, err)
+	}
+	id := dst.networkID()
+	if id == nil {
+		return ErrInvalidRequest
+	}
+	if id.Blockchain != s.networkID.Blockchain ||
+		id.Network != s.networkID.Network {
+		return ErrNetworkNotSupported
+	}
+	return nil
+}
+
+// slotToTimestamp converts a slot number to a Unix
+// timestamp in milliseconds. It delegates to
+// LedgerState.SlotToTime which handles Byron-to-Shelley
+// slot duration transitions via the epoch cache. Falls
+// back to simple 1s-per-slot calculation if the epoch
+// cache is not yet populated.
+func (s *Server) slotToTimestamp(slot uint64) int64 {
+	t, err := s.config.LedgerState.SlotToTime(slot)
+	if err == nil {
+		return t.UnixMilli()
+	}
+	// Fallback: assume 1s slots (Shelley+).
+	// #nosec G115 -- slot fits in int64
+	return (s.genesisStartTimeSec +
+		int64(slot)) * 1000
+}
+
+// tipBlockID returns a BlockIdentifier for the given
+// chain tip.
+func (s *Server) tipBlockID(
+	tip ochainsync.Tip,
+) *BlockIdentifier {
+	return &BlockIdentifier{
+		Index: int64(tip.BlockNumber), // #nosec G115
+		Hash:  hex.EncodeToString(tip.Point.Hash),
+	}
+}
+
+// writeJSON writes a JSON response.
+func writeJSON(
+	w http.ResponseWriter,
+	status int,
+	v any,
+) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Default().Error(
+			"failed to encode JSON response",
+			"error", err,
+		)
+	}
+}
+
+// writeError writes a Mesh error response.
+func writeError(w http.ResponseWriter, meshErr *Error) {
+	status := http.StatusInternalServerError
+	switch meshErr.Code {
+	case ErrNetworkNotSupported.Code,
+		ErrBlockNotFound.Code,
+		ErrTransactionNotFound.Code,
+		ErrAccountNotFound.Code:
+		status = http.StatusNotFound
+	case ErrInvalidRequest.Code,
+		ErrInvalidPublicKey.Code,
+		ErrInvalidTransaction.Code,
+		ErrSubmitFailed.Code:
+		status = http.StatusBadRequest
+	case ErrNotImplemented.Code:
+		status = http.StatusNotImplemented
+	case ErrUnavailable.Code:
+		status = http.StatusServiceUnavailable
+	}
+	writeJSON(w, status, meshErr)
+}
+
+// decodeRequest decodes a JSON request body into dst.
+func decodeRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	dst any,
+) error {
+	body := http.MaxBytesReader(w, r.Body, maxRequestBody)
+	defer body.Close()
+	decoder := json.NewDecoder(body)
+	return decoder.Decode(dst)
+}

--- a/mesh/network.go
+++ b/mesh/network.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"net/http"
+)
+
+// handleNetworkList handles POST /network/list.
+func (s *Server) handleNetworkList(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req MetadataRequest
+	if err := decodeRequest(w, r, &req); err != nil {
+		writeError(w, ErrInvalidRequest)
+		return
+	}
+
+	resp := &NetworkListResponse{
+		NetworkIdentifiers: []*NetworkIdentifier{
+			{
+				Blockchain: blockchain,
+				Network:    s.networkID.Network,
+			},
+		},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleNetworkOptions handles POST /network/options.
+func (s *Server) handleNetworkOptions(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req NetworkRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	resp := &NetworkOptionsResponse{
+		Version: &Version{
+			RosettaVersion: rosettaVersion,
+			NodeVersion:    nodeVersion,
+		},
+		Allow: &Allow{
+			OperationStatuses:       OperationStatuses(),
+			OperationTypes:          OperationTypes(),
+			Errors:                  AllErrors(),
+			HistoricalBalanceLookup: false,
+			MempoolCoins:            false,
+		},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleNetworkStatus handles POST /network/status.
+func (s *Server) handleNetworkStatus(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	var req NetworkRequest
+	if meshErr := s.decodeAndValidate(
+		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	tip := s.config.Chain.Tip()
+	tipTimestamp := s.slotToTimestamp(tip.Point.Slot)
+	synced := true
+
+	resp := &NetworkStatusResponse{
+		CurrentBlockIdentifier: s.tipBlockID(tip),
+		CurrentBlockTimestamp:  tipTimestamp,
+		GenesisBlockIdentifier: s.genesisID,
+		SyncStatus: &SyncStatus{
+			Synced: &synced,
+		},
+		Peers: []*Peer{},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/mesh/operations.go
+++ b/mesh/operations.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+// Operation type constants matching the Cardano Foundation's
+// cardano-rosetta-java implementation.
+const (
+	OpInput                    = "input"
+	OpOutput                   = "output"
+	OpStakeKeyRegistration     = "stakeKeyRegistration"
+	OpStakeKeyDeregistration   = "stakeKeyDeregistration"
+	OpStakeDelegation          = "stakeDelegation"
+	OpWithdrawal               = "withdrawal"
+	OpPoolRegistration         = "poolRegistration"
+	OpPoolRegistrationWithCert = "poolRegistrationWithCert"
+	OpPoolRetirement           = "poolRetirement"
+	OpVoteDRepDelegation       = "dRepVoteDelegation"
+	OpPoolGovernanceVote       = "poolGovernanceVote"
+)
+
+// Operation status constants.
+const (
+	StatusSuccess = "success"
+	StatusInvalid = "invalid"
+)
+
+// OperationTypes returns all supported operation types.
+func OperationTypes() []string {
+	return []string{
+		OpInput,
+		OpOutput,
+		OpStakeKeyRegistration,
+		OpStakeKeyDeregistration,
+		OpStakeDelegation,
+		OpWithdrawal,
+		OpPoolRegistration,
+		OpPoolRegistrationWithCert,
+		OpPoolRetirement,
+		OpVoteDRepDelegation,
+		OpPoolGovernanceVote,
+	}
+}
+
+// OperationStatuses returns the supported operation statuses.
+func OperationStatuses() []*OperationStatus {
+	return []*OperationStatus{
+		{Status: StatusSuccess, Successful: true},
+		{Status: StatusInvalid, Successful: false},
+	}
+}

--- a/mesh/types.go
+++ b/mesh/types.go
@@ -1,0 +1,434 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+// Mesh API types following the Coinbase Mesh specification v1.4.15.
+// These types are defined manually to avoid the broken mesh-sdk-go
+// module path issue. They implement the JSON wire format expected by
+// mesh-cli and other Mesh-compatible tooling.
+
+// NetworkIdentifier identifies a blockchain network.
+type NetworkIdentifier struct {
+	Blockchain string `json:"blockchain"`
+	Network    string `json:"network"`
+}
+
+// BlockIdentifier uniquely identifies a block.
+type BlockIdentifier struct {
+	Index int64  `json:"index"`
+	Hash  string `json:"hash"`
+}
+
+// PartialBlockIdentifier is used in requests
+// where either index or hash may be specified.
+type PartialBlockIdentifier struct {
+	Index *int64  `json:"index,omitempty"`
+	Hash  *string `json:"hash,omitempty"`
+}
+
+// TransactionIdentifier uniquely identifies a transaction.
+type TransactionIdentifier struct {
+	Hash string `json:"hash"`
+}
+
+// AccountIdentifier uniquely identifies an account.
+type AccountIdentifier struct {
+	Address    string                `json:"address"`
+	SubAccount *SubAccountIdentifier `json:"sub_account,omitempty"`
+}
+
+// SubAccountIdentifier identifies a sub-account.
+type SubAccountIdentifier struct {
+	Address string `json:"address"`
+}
+
+// CoinIdentifier uniquely identifies a UTXO coin.
+type CoinIdentifier struct {
+	Identifier string `json:"identifier"`
+}
+
+// Currency represents a currency with symbol and decimals.
+type Currency struct {
+	Symbol   string         `json:"symbol"`
+	Decimals int32          `json:"decimals"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// Amount represents a value in a specific currency.
+type Amount struct {
+	Value    string    `json:"value"`
+	Currency *Currency `json:"currency"`
+}
+
+// Operation describes a single mutation to state.
+type Operation struct {
+	OperationIdentifier *OperationIdentifier   `json:"operation_identifier"`
+	RelatedOperations   []*OperationIdentifier `json:"related_operations,omitempty"`
+	Type                string                 `json:"type"`
+	Status              *string                `json:"status,omitempty"`
+	Account             *AccountIdentifier     `json:"account,omitempty"`
+	Amount              *Amount                `json:"amount,omitempty"`
+	CoinChange          *CoinChange            `json:"coin_change,omitempty"`
+	Metadata            map[string]any         `json:"metadata,omitempty"`
+}
+
+// OperationIdentifier uniquely identifies an operation.
+type OperationIdentifier struct {
+	Index        int64  `json:"index"`
+	NetworkIndex *int64 `json:"network_index,omitempty"`
+}
+
+// CoinChange describes the change to a coin (created or spent).
+type CoinChange struct {
+	CoinIdentifier *CoinIdentifier `json:"coin_identifier"`
+	CoinAction     string          `json:"coin_action"`
+}
+
+// Coin represents a UTXO.
+type Coin struct {
+	CoinIdentifier *CoinIdentifier `json:"coin_identifier"`
+	Amount         *Amount         `json:"amount"`
+}
+
+// Transaction represents a blockchain transaction.
+type Transaction struct {
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+	Operations            []*Operation           `json:"operations"`
+	RelatedTransactions   []*RelatedTransaction  `json:"related_transactions,omitempty"`
+	Metadata              map[string]any         `json:"metadata,omitempty"`
+}
+
+// RelatedTransaction identifies a related transaction.
+type RelatedTransaction struct {
+	NetworkIdentifier     *NetworkIdentifier     `json:"network_identifier,omitempty"`
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+	Direction             string                 `json:"direction"`
+}
+
+// Block represents a blockchain block.
+type Block struct {
+	BlockIdentifier       *BlockIdentifier `json:"block_identifier"`
+	ParentBlockIdentifier *BlockIdentifier `json:"parent_block_identifier"`
+	Timestamp             int64            `json:"timestamp"`
+	Transactions          []*Transaction   `json:"transactions"`
+	Metadata              map[string]any   `json:"metadata,omitempty"`
+}
+
+// Peer represents a network peer.
+type Peer struct {
+	PeerID   string         `json:"peer_id"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// SyncStatus describes the sync state.
+type SyncStatus struct {
+	CurrentIndex *int64  `json:"current_index,omitempty"`
+	TargetIndex  *int64  `json:"target_index,omitempty"`
+	Stage        *string `json:"stage,omitempty"`
+	Synced       *bool   `json:"synced,omitempty"`
+}
+
+// Version describes software version info.
+type Version struct {
+	RosettaVersion    string         `json:"rosetta_version"`
+	NodeVersion       string         `json:"node_version"`
+	MiddlewareVersion *string        `json:"middleware_version,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+}
+
+// Allow specifies what the server supports.
+type Allow struct {
+	OperationStatuses       []*OperationStatus  `json:"operation_statuses"`
+	OperationTypes          []string            `json:"operation_types"`
+	Errors                  []*Error            `json:"errors"`
+	HistoricalBalanceLookup bool                `json:"historical_balance_lookup"`
+	CallMethods             []string            `json:"call_methods,omitempty"`
+	BalanceExemptions       []*BalanceExemption `json:"balance_exemptions,omitempty"`
+	MempoolCoins            bool                `json:"mempool_coins"`
+	BlockHashCase           *string             `json:"block_hash_case,omitempty"`
+	TransactionHashCase     *string             `json:"transaction_hash_case,omitempty"`
+}
+
+// OperationStatus describes the status of an operation.
+type OperationStatus struct {
+	Status     string `json:"status"`
+	Successful bool   `json:"successful"`
+}
+
+// BalanceExemption allows operations to change
+// balances without affecting account balances.
+type BalanceExemption struct {
+	SubAccountAddress string    `json:"sub_account_address,omitempty"`
+	Currency          *Currency `json:"currency,omitempty"`
+	ExemptionType     string    `json:"exemption_type,omitempty"`
+}
+
+// SigningPayload is the payload to be signed.
+type SigningPayload struct {
+	AccountIdentifier *AccountIdentifier `json:"account_identifier,omitempty"`
+	HexBytes          string             `json:"hex_bytes"`
+	SignatureType     string             `json:"signature_type,omitempty"`
+}
+
+// Signature is a signed payload.
+type Signature struct {
+	SigningPayload *SigningPayload `json:"signing_payload"`
+	PublicKey      *PublicKey      `json:"public_key"`
+	SignatureType  string          `json:"signature_type"`
+	HexBytes       string          `json:"hex_bytes"`
+}
+
+// PublicKey represents a public key.
+type PublicKey struct {
+	HexBytes  string `json:"hex_bytes"`
+	CurveType string `json:"curve_type"`
+}
+
+// CoinAction constants.
+const (
+	CoinCreated = "coin_created"
+	CoinSpent   = "coin_spent"
+)
+
+// Signature type constants.
+const (
+	Ed25519 = "ed25519"
+)
+
+// Curve type constants.
+const (
+	Edwards25519 = "edwards25519"
+)
+
+// --- Request types ---
+
+// MetadataRequest is used for network list.
+type MetadataRequest struct {
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// networkIdentifierField is embedded by request types
+// that carry a NetworkIdentifier, satisfying the
+// networkRequest interface.
+type networkIdentifierField struct {
+	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
+}
+
+func (f *networkIdentifierField) networkID() *NetworkIdentifier {
+	return f.NetworkIdentifier
+}
+
+// NetworkRequest identifies the target network.
+type NetworkRequest struct {
+	networkIdentifierField
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// BlockRequest identifies a block to fetch.
+type BlockRequest struct {
+	networkIdentifierField
+	BlockIdentifier *PartialBlockIdentifier `json:"block_identifier"`
+}
+
+// BlockTransactionRequest identifies a tx in a block.
+type BlockTransactionRequest struct {
+	networkIdentifierField
+	BlockIdentifier       *BlockIdentifier       `json:"block_identifier"`
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+}
+
+// AccountBalanceRequest is for balance lookups.
+type AccountBalanceRequest struct {
+	networkIdentifierField
+	AccountIdentifier *AccountIdentifier      `json:"account_identifier"`
+	BlockIdentifier   *PartialBlockIdentifier `json:"block_identifier,omitempty"`
+	Currencies        []*Currency             `json:"currencies,omitempty"`
+}
+
+// AccountCoinsRequest is for UTXO lookups.
+type AccountCoinsRequest struct {
+	networkIdentifierField
+	AccountIdentifier *AccountIdentifier `json:"account_identifier"`
+	IncludeMempool    bool               `json:"include_mempool"`
+	Currencies        []*Currency        `json:"currencies,omitempty"`
+}
+
+// MempoolTransactionRequest identifies a mempool tx.
+type MempoolTransactionRequest struct {
+	networkIdentifierField
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+}
+
+// ConstructionDeriveRequest derives an address.
+type ConstructionDeriveRequest struct {
+	networkIdentifierField
+	PublicKey *PublicKey     `json:"public_key"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// ConstructionPreprocessRequest preprocesses operations.
+type ConstructionPreprocessRequest struct {
+	networkIdentifierField
+	Operations []*Operation   `json:"operations"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+// ConstructionMetadataRequest fetches tx metadata.
+type ConstructionMetadataRequest struct {
+	networkIdentifierField
+	Options    map[string]any `json:"options,omitempty"`
+	PublicKeys []*PublicKey   `json:"public_keys,omitempty"`
+}
+
+// ConstructionPayloadsRequest creates unsigned tx.
+type ConstructionPayloadsRequest struct {
+	networkIdentifierField
+	Operations []*Operation   `json:"operations"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	PublicKeys []*PublicKey   `json:"public_keys,omitempty"`
+}
+
+// ConstructionCombineRequest combines unsigned tx + sigs.
+type ConstructionCombineRequest struct {
+	networkIdentifierField
+	UnsignedTransaction string       `json:"unsigned_transaction"`
+	Signatures          []*Signature `json:"signatures"`
+}
+
+// ConstructionParseRequest parses a transaction.
+type ConstructionParseRequest struct {
+	networkIdentifierField
+	Signed      bool   `json:"signed"`
+	Transaction string `json:"transaction"`
+}
+
+// ConstructionHashRequest computes a tx hash.
+type ConstructionHashRequest struct {
+	networkIdentifierField
+	SignedTransaction string `json:"signed_transaction"`
+}
+
+// ConstructionSubmitRequest submits a signed tx.
+type ConstructionSubmitRequest struct {
+	networkIdentifierField
+	SignedTransaction string `json:"signed_transaction"`
+}
+
+// --- Response types ---
+
+// NetworkListResponse lists supported networks.
+type NetworkListResponse struct {
+	NetworkIdentifiers []*NetworkIdentifier `json:"network_identifiers"`
+}
+
+// NetworkOptionsResponse describes network options.
+type NetworkOptionsResponse struct {
+	Version *Version `json:"version"`
+	Allow   *Allow   `json:"allow"`
+}
+
+// NetworkStatusResponse describes network status.
+type NetworkStatusResponse struct {
+	CurrentBlockIdentifier *BlockIdentifier `json:"current_block_identifier"`
+	CurrentBlockTimestamp  int64            `json:"current_block_timestamp"`
+	GenesisBlockIdentifier *BlockIdentifier `json:"genesis_block_identifier"`
+	OldestBlockIdentifier  *BlockIdentifier `json:"oldest_block_identifier,omitempty"`
+	SyncStatus             *SyncStatus      `json:"sync_status,omitempty"`
+	Peers                  []*Peer          `json:"peers"`
+}
+
+// BlockResponse returns a block.
+type BlockResponse struct {
+	Block             *Block                   `json:"block,omitempty"`
+	OtherTransactions []*TransactionIdentifier `json:"other_transactions,omitempty"`
+}
+
+// BlockTransactionResponse returns a transaction.
+type BlockTransactionResponse struct {
+	Transaction *Transaction `json:"transaction"`
+}
+
+// AccountBalanceResponse returns balances.
+type AccountBalanceResponse struct {
+	BlockIdentifier *BlockIdentifier `json:"block_identifier"`
+	Balances        []*Amount        `json:"balances"`
+	Metadata        map[string]any   `json:"metadata,omitempty"`
+}
+
+// AccountCoinsResponse returns UTXOs.
+type AccountCoinsResponse struct {
+	BlockIdentifier *BlockIdentifier `json:"block_identifier"`
+	Coins           []*Coin          `json:"coins"`
+	Metadata        map[string]any   `json:"metadata,omitempty"`
+}
+
+// MempoolResponse lists mempool transactions.
+type MempoolResponse struct {
+	TransactionIdentifiers []*TransactionIdentifier `json:"transaction_identifiers"`
+}
+
+// MempoolTransactionResponse returns a mempool tx.
+type MempoolTransactionResponse struct {
+	Transaction *Transaction   `json:"transaction"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// ConstructionDeriveResponse returns a derived address.
+type ConstructionDeriveResponse struct {
+	AccountIdentifier *AccountIdentifier `json:"account_identifier,omitempty"`
+	Metadata          map[string]any     `json:"metadata,omitempty"`
+}
+
+// ConstructionPreprocessResponse returns options.
+type ConstructionPreprocessResponse struct {
+	Options            map[string]any       `json:"options,omitempty"`
+	RequiredPublicKeys []*AccountIdentifier `json:"required_public_keys,omitempty"`
+}
+
+// ConstructionMetadataResponse returns tx metadata.
+type ConstructionMetadataResponse struct {
+	Metadata     map[string]any `json:"metadata"`
+	SuggestedFee []*Amount      `json:"suggested_fee,omitempty"`
+}
+
+// ConstructionPayloadsResponse returns unsigned tx.
+type ConstructionPayloadsResponse struct {
+	UnsignedTransaction string            `json:"unsigned_transaction"`
+	Payloads            []*SigningPayload `json:"payloads"`
+}
+
+// ConstructionCombineResponse returns signed tx.
+type ConstructionCombineResponse struct {
+	SignedTransaction string `json:"signed_transaction"`
+}
+
+// ConstructionParseResponse returns parsed operations.
+type ConstructionParseResponse struct {
+	Operations               []*Operation         `json:"operations"`
+	AccountIdentifierSigners []*AccountIdentifier `json:"account_identifier_signers,omitempty"`
+	Metadata                 map[string]any       `json:"metadata,omitempty"`
+}
+
+// ConstructionHashResponse returns a tx hash.
+type ConstructionHashResponse struct {
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+	Metadata              map[string]any         `json:"metadata,omitempty"`
+}
+
+// ConstructionSubmitResponse returns submit result.
+type ConstructionSubmitResponse struct {
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+	Metadata              map[string]any         `json:"metadata,omitempty"`
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Mesh (Coinbase Rosetta) compatible REST API for Cardano covering network, blocks, accounts, mempool, and full construction (build, hash, submit). This lets Mesh/Rosetta tools query the node and submit signed transactions.

- **New Features**
  - Endpoints: network (/network/list, /options, /status), blocks (/block, /block/transaction), accounts (/account/balance, /account/coins), mempool (/mempool, /mempool/transaction), construction (/construction/derive, /preprocess, /metadata, /payloads, /combine, /parse, /hash, /submit).
  - Converts DB/ledger data to Mesh blocks/transactions; aggregates balances (ADA and native assets).
  - Transaction submit via mempool with automatic hash calculation and mempool listing/lookup.
  - Consistent Mesh errors and operation types/statuses.
  - Address filtering by payment/stake key across MySQL/Postgres/SQLite; added UTxOs-by-address-at-slot helper.

- **Migration**
  - New config to enable the server (disabled by default):
    - YAML: meshListenAddress
    - Env: DINGO_MESH_LISTEN_ADDRESS
    - Programmatic: WithMeshListenAddress(addr)
  - When set, the node starts the server and wires in Chain, LedgerState, Database, and Mempool.
  - Ensure Byron genesis hash and Shelley genesis start time are in cardanoNodeConfig for network identifiers and status.

<sup>Written for commit 53a2451e6411c3bd8fddbd0b543464996f5e4fc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mesh API server: Rosetta-compatible REST endpoints for network, block, account, mempool and full construction workflows (derive/parse/payloads/combine/hash/submit)
  * Account balance/coins, block & transaction lookups, mempool listing and per-transaction views, and transaction submission
  * Full Mesh data models, operation types/statuses, and standardized Mesh error responses
  * Configurable Mesh API listen address (enable/disable)

* **Other**
  * Ledger helper to query UTxOs by address at a specific slot
<!-- end of auto-generated comment: release notes by coderabbit.ai -->