### PR TITLE
feat: sync progress

### DIFF
--- a/node.go
+++ b/node.go
@@ -382,6 +382,7 @@ func (n *Node) Run(ctx context.Context) error {
 			ActivePeersTopologyQuota:       n.config.activePeersTopologyQuota,
 			ActivePeersGossipQuota:         n.config.activePeersGossipQuota,
 			ActivePeersLedgerQuota:         n.config.activePeersLedgerQuota,
+			SyncProgressProvider:           n.ledgerState,
 		},
 	)
 	n.ouroboros.PeerGov = n.peerGov
@@ -792,7 +793,9 @@ func (a *stakeDistributionAdapter) GetPoolStake(
 	return stake, err
 }
 
-func (a *stakeDistributionAdapter) GetTotalActiveStake(epoch uint64) (uint64, error) {
+func (a *stakeDistributionAdapter) GetTotalActiveStake(
+	epoch uint64,
+) (uint64, error) {
 	txn := a.ledgerState.Database().Transaction(false)
 	var stake uint64
 	err := txn.Do(func(txn *database.Txn) error {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose ledger sync progress to the PeerGovernor so it can exit bootstrap based on real progress. Reduce sync log noise by lowering a few warnings.

- **New Features**
  - Added LedgerState.SyncProgress() returning 0.0–1.0 based on current tip vs upstream tip (capped at 1.0).
  - Wired ledgerState as SyncProgressProvider when initializing PeerGovernor.

- **Refactors**
  - Lowered log levels: rollback and blockfetch timeout to info; stale header to debug.
  - Minor cleanups in CBOR offset comments and a wrapped function signature (no behavior changes).

<sup>Written for commit 4a0bdf38ce113f403dbe006c31411e7609c9b05f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

