### PR TITLE
fix(chain): enforce rollback depth

### DIFF
--- a/chain/errors.go
+++ b/chain/errors.go
@@ -24,6 +24,9 @@ var (
 	ErrRollbackBeyondEphemeralChain = errors.New(
 		"cannot rollback ephemeral chain beyond memory buffer",
 	)
+	ErrRollbackExceedsSecurityParam = errors.New(
+		"rollback depth exceeds security parameter K",
+	)
 	ErrIteratorChainTip = errors.New(
 		"chain iterator is at chain tip",
 	)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces rollback depth by the ledger security parameter K on persistent chains to prevent deep, unsafe rollbacks. Rollbacks deeper than K are rejected with a new error; ephemeral chains and K=0 are exempt.

- **Bug Fixes**
  - Enforce K in Chain.Rollback for persistent chains; reject depth > K with ErrRollbackExceedsSecurityParam.
  - Skip the check for ephemeral chains and when K=0; rejection happens before any state change.
  - Add tests for over-K rejection, within-K allowed, K=0 allowed, and ephemeral-chain allowed; log a warning with fork depth, K, and rollback slot on rejection.

<sup>Written for commit f5d0c29061ec34905e59ae1a72009a47be74044b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rollback-depth validation for persistent chains, preventing rollbacks that exceed the configured security threshold and emitting a clear error when rejected; ephemeral forks remain unrestricted.
* **Tests**
  * Added comprehensive rollback and fork test coverage to validate behavior across different security-parameter scenarios and fork types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->