### PR TITLE
fix(event): subscribe func panic

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -269,10 +269,32 @@ func (e *EventBus) SubscribeFunc(
 			if !ok {
 				return
 			}
-			handlerFunc(evt)
+			e.safeHandlerCall(handlerFunc, evt)
 		}
 	}(chSub.ch, handlerFunc)
 	return subId
+}
+
+// safeHandlerCall invokes a SubscribeFunc handler with panic recovery so that
+// a misbehaving handler cannot crash the node.
+func (e *EventBus) safeHandlerCall(
+	handlerFunc EventHandlerFunc,
+	evt Event,
+) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger := e.Logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.Error(
+				"SubscribeFunc handler panicked",
+				"event_type", evt.Type,
+				"panic", r,
+			)
+		}
+	}()
+	handlerFunc(evt)
 }
 
 // Unsubscribe stops delivery of events for a particular type for an existing subscriber


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents node crashes when a SubscribeFunc handler panics by recovering and logging the error, ensuring the event bus keeps delivering events.

- **Bug Fixes**
  - Wrapped handler execution with panic recovery (safeHandlerCall) and error logging, falling back to slog.Default when no logger is set.
  - Added TestSubscribeFuncPanicRecovery to verify the handler survives a panic and continues processing subsequent events.

<sup>Written for commit da01baf29fb3c9a6a0d4b4665a2c996c8d94ddba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

