### PR TITLE
fix(ledger): fee calculation overflow

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -449,7 +449,7 @@ func EvaluateTxAlonzo(
 	if tmpPparams.ExecutionCosts.StepPrice != nil {
 		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
 	}
-	fee := CalculateMinFee(
+	fee, err := CalculateMinFee(
 		txSize,
 		retTotalExUnits,
 		tmpPparams.MinFeeA,
@@ -457,5 +457,8 @@ func EvaluateTxAlonzo(
 		pricesMem,
 		pricesSteps,
 	)
+	if err != nil {
+		return 0, lcommon.ExUnits{}, nil, err
+	}
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -613,7 +613,7 @@ func EvaluateTxBabbage(
 	if tmpPparams.ExecutionCosts.StepPrice != nil {
 		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
 	}
-	fee := CalculateMinFee(
+	fee, err := CalculateMinFee(
 		txSize,
 		retTotalExUnits,
 		tmpPparams.MinFeeA,
@@ -621,5 +621,8 @@ func EvaluateTxBabbage(
 		pricesMem,
 		pricesSteps,
 	)
+	if err != nil {
+		return 0, lcommon.ExUnits{}, nil, err
+	}
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -616,7 +616,7 @@ func EvaluateTxConway(
 	if tmpPparams.ExecutionCosts.StepPrice != nil {
 		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
 	}
-	fee := CalculateMinFee(
+	fee, err := CalculateMinFee(
 		txSize,
 		retTotalExUnits,
 		tmpPparams.MinFeeA,
@@ -624,5 +624,8 @@ func EvaluateTxConway(
 		pricesMem,
 		pricesSteps,
 	)
+	if err != nil {
+		return 0, lcommon.ExUnits{}, nil, err
+	}
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -74,6 +74,16 @@ func SafeAddExUnits(
 	}, nil
 }
 
+// errFeeOverflow is returned when fee arithmetic
+// overflows uint64.
+var errFeeOverflow = errors.New("fee calculation overflow")
+
+// errZeroDenominator is returned when CeilMul receives
+// a zero denominator.
+var errZeroDenominator = errors.New(
+	"CeilMul: zero denominator",
+)
+
 // TxBodySize returns the CBOR-serialized size of a
 // transaction in bytes.
 func TxBodySize(tx lcommon.Transaction) uint64 {
@@ -123,8 +133,14 @@ func ValidateTxExUnits(
 
 // CeilMul computes ceil(rat * value) using integer
 // arithmetic. The rational is represented as num/denom.
-// This avoids floating-point imprecision.
-func CeilMul(num, denom, value *big.Int) uint64 {
+// This avoids floating-point imprecision. Returns an
+// error if denom is zero.
+func CeilMul(
+	num, denom, value *big.Int,
+) (uint64, error) {
+	if denom.Sign() == 0 {
+		return 0, errZeroDenominator
+	}
 	// product = num * value
 	product := new(big.Int).Mul(num, value)
 	// ceil(product / denom) = (product + denom - 1) / denom
@@ -132,7 +148,10 @@ func CeilMul(num, denom, value *big.Int) uint64 {
 	denomMinusOne := new(big.Int).Sub(denom, one)
 	product.Add(product, denomMinusOne)
 	product.Div(product, denom)
-	return product.Uint64()
+	if !product.IsUint64() {
+		return 0, errFeeOverflow
+	}
+	return product.Uint64(), nil
 }
 
 // CalculateMinFee computes the minimum fee for a
@@ -146,7 +165,8 @@ func CeilMul(num, denom, value *big.Int) uint64 {
 //	          + ceil(pricesSteps * exUnits.Steps)
 //
 // All arithmetic uses integer math (big.Int) to match
-// the Haskell reference implementation.
+// the Haskell reference implementation. Returns an error
+// if any intermediate result overflows uint64.
 func CalculateMinFee(
 	txSize uint64,
 	exUnits lcommon.ExUnits,
@@ -154,23 +174,56 @@ func CalculateMinFee(
 	minFeeB uint,
 	pricesMem *big.Rat,
 	pricesSteps *big.Rat,
-) uint64 {
-	baseFee := uint64(minFeeA)*txSize + uint64(minFeeB)
+) (uint64, error) {
+	// baseFee = minFeeA * txSize + minFeeB
+	a := uint64(minFeeA)
+	product := a * txSize
+	if txSize != 0 && product/txSize != a {
+		return 0, fmt.Errorf(
+			"%w: minFeeA * txSize", errFeeOverflow,
+		)
+	}
+	baseFee := product + uint64(minFeeB)
+	if baseFee < product {
+		return 0, fmt.Errorf(
+			"%w: baseFee + minFeeB", errFeeOverflow,
+		)
+	}
+
 	var scriptFee uint64
 	if pricesMem != nil && pricesSteps != nil {
-		memFee := CeilMul(
+		memFee, err := CeilMul(
 			pricesMem.Num(),
 			pricesMem.Denom(),
 			big.NewInt(exUnits.Memory),
 		)
-		stepFee := CeilMul(
+		if err != nil {
+			return 0, fmt.Errorf("memFee: %w", err)
+		}
+		stepFee, err := CeilMul(
 			pricesSteps.Num(),
 			pricesSteps.Denom(),
 			big.NewInt(exUnits.Steps),
 		)
+		if err != nil {
+			return 0, fmt.Errorf("stepFee: %w", err)
+		}
 		scriptFee = memFee + stepFee
+		if scriptFee < memFee {
+			return 0, fmt.Errorf(
+				"%w: memFee + stepFee",
+				errFeeOverflow,
+			)
+		}
 	}
-	return baseFee + scriptFee
+
+	total := baseFee + scriptFee
+	if total < baseFee {
+		return 0, fmt.Errorf(
+			"%w: baseFee + scriptFee", errFeeOverflow,
+		)
+	}
+	return total, nil
 }
 
 // DeclaredExUnits returns the total execution units
@@ -231,7 +284,7 @@ func ValidateTxFee(
 			err,
 		)
 	}
-	minFee := CalculateMinFee(
+	minFee, err := CalculateMinFee(
 		txSize,
 		declaredEU,
 		minFeeA,
@@ -239,6 +292,11 @@ func ValidateTxFee(
 		pricesMem,
 		pricesSteps,
 	)
+	if err != nil {
+		return fmt.Errorf(
+			"calculating minimum fee: %w", err,
+		)
+	}
 	txFee := tx.Fee()
 	if txFee == nil {
 		txFee = new(big.Int)

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -61,7 +61,8 @@ func ValidateTxExUnits(
 //	          + ceil(pricesSteps * exUnits.Steps)
 //
 // All arithmetic uses integer math (big.Int) to match
-// the Haskell reference implementation.
+// the Haskell reference implementation. Returns an error
+// if any intermediate result overflows uint64.
 func CalculateMinFee(
 	txSize uint64,
 	exUnits lcommon.ExUnits,
@@ -69,7 +70,7 @@ func CalculateMinFee(
 	minFeeB uint,
 	pricesMem *big.Rat,
 	pricesSteps *big.Rat,
-) uint64 {
+) (uint64, error) {
 	return eras.CalculateMinFee(
 		txSize,
 		exUnits,

--- a/ledger/validation_test.go
+++ b/ledger/validation_test.go
@@ -459,7 +459,7 @@ func TestCalculateMinFee(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fee := CalculateMinFee(
+			fee, err := CalculateMinFee(
 				tc.txSize,
 				tc.exUnits,
 				tc.minFeeA,
@@ -467,6 +467,7 @@ func TestCalculateMinFee(t *testing.T) {
 				tc.pricesMem,
 				tc.pricesSteps,
 			)
+			require.NoError(t, err)
 			assert.Equal(
 				t,
 				tc.expected,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uint64 overflow in fee calculation with safe integer math and explicit errors. Prevents wraparound in base/script/total fees and enforces zero‑denominator checks in CeilMul.

- **Bug Fixes**
  - CalculateMinFee checks overflow for minFeeA*txSize, base+minFeeB, memFee+stepFee, and baseFee+scriptFee; returns errFeeOverflow on failure.
  - CeilMul now returns errors for zero denominators and results that don’t fit in uint64.
  - Errors are propagated through EvaluateTx for Alonzo/Babbage/Conway and ValidateTxFee; era evaluators return early on fee errors.
  - Added tests for overflow scenarios, zero denominators, and normal mainnet-like values.

- **Migration**
  - CalculateMinFee (and ledger.CalculateMinFee wrapper) now return (uint64, error). Update call sites to handle errors.
  - Treat errFeeOverflow and errZeroDenominator as validation failures; behavior is unchanged for normal inputs.

<sup>Written for commit 0b03e0b74691b21e9099f236e33c9f6c7ef3b8d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction fee calculations with explicit error propagation for arithmetic issues and invalid inputs; failures are now surfaced instead of being ignored.
  * Added overflow and edge-case checks to prevent silently incorrect fee results and ensure invalid fee conditions are reported.

* **Tests**
  * Expanded tests to cover new error paths, overflow scenarios, invalid inputs, and end-to-end fee validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->