### PR TITLE
fix(ledger): query races

### DIFF
--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -70,15 +70,21 @@ func (ls *LedgerState) querySystemStart() (any, error) {
 }
 
 func (ls *LedgerState) queryChainBlockNo() (any, error) {
+	ls.RLock()
+	blockNumber := ls.currentTip.BlockNumber
+	ls.RUnlock()
 	ret := []any{
 		1, // TODO: figure out what this value is (#393)
-		ls.currentTip.BlockNumber,
+		blockNumber,
 	}
 	return ret, nil
 }
 
 func (ls *LedgerState) queryChainPoint() (any, error) {
-	return ls.currentTip.Point, nil
+	ls.RLock()
+	point := ls.currentTip.Point
+	ls.RUnlock()
+	return point, nil
 }
 
 func (ls *LedgerState) queryHardFork(
@@ -86,7 +92,10 @@ func (ls *LedgerState) queryHardFork(
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.HardForkCurrentEraQuery:
-		return ls.currentEra.Id, nil
+		ls.RLock()
+		eraId := ls.currentEra.Id
+		ls.RUnlock()
+		return eraId, nil
 	case *olocalstatequery.HardForkEraHistoryQuery:
 		return ls.queryHardForkEraHistory()
 	default:
@@ -170,9 +179,15 @@ func (ls *LedgerState) queryShelley(
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.ShelleyEpochNoQuery:
-		return []any{ls.currentEpoch.EpochId}, nil
+		ls.RLock()
+		epochId := ls.currentEpoch.EpochId
+		ls.RUnlock()
+		return []any{epochId}, nil
 	case *olocalstatequery.ShelleyCurrentProtocolParamsQuery:
-		return []any{ls.currentPParams}, nil
+		ls.RLock()
+		pparams := ls.currentPParams
+		ls.RUnlock()
+		return []any{pparams}, nil
 	case *olocalstatequery.ShelleyGenesisConfigQuery:
 		return ls.queryShelleyGenesisConfig()
 	case *olocalstatequery.ShelleyUtxoByAddressQuery:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes data races in ledger query handlers by reading shared state under RLock/RUnlock to ensure consistent results during concurrent updates.

- **Bug Fixes**
  - Added read locks to: queryChainBlockNo, queryChainPoint, HardForkCurrentEraQuery, ShelleyEpochNoQuery, ShelleyCurrentProtocolParamsQuery (copy values under lock before returning).

<sup>Written for commit 9ef93133a8803d327eb0f24428195eeb5168bcd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

