### PR TITLE
fix(chain): limit header queue size

### DIFF
--- a/chain/errors.go
+++ b/chain/errors.go
@@ -19,6 +19,10 @@ import (
 	"fmt"
 )
 
+// DefaultMaxQueuedHeaders is the fallback header queue limit when the
+// security parameter is not yet available (e.g. before ledger is wired).
+const DefaultMaxQueuedHeaders = 10_000
+
 var (
 	ErrIntersectNotFound            = errors.New("chain intersect not found")
 	ErrRollbackBeyondEphemeralChain = errors.New(
@@ -26,6 +30,9 @@ var (
 	)
 	ErrIteratorChainTip = errors.New(
 		"chain iterator is at chain tip",
+	)
+	ErrHeaderQueueFull = errors.New(
+		"header queue at maximum capacity",
 	)
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a hard cap to the block header queue to prevent memory growth when peers send excessive headers. Extra headers are rejected to keep memory bounded.

- **Bug Fixes**
  - Enforce queue cap in AddBlockHeader: limit is securityParam*2 or DefaultMaxQueuedHeaders (10,000).
  - Return ErrHeaderQueueFull when the queue is full.
  - Add tests for default limit, security-param-derived limit, and acceptance within limit.

<sup>Written for commit aa53b170ab7185c1e7b62c68d27f9482d0cf4eaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

