### PR TITLE
fix(ledger): exunits overflow

### DIFF
--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"math"
 
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -206,20 +207,36 @@ func (b *DefaultBlockBuilder) BuildBlock(
 		}
 
 		// Pull ExUnits from redeemers in the witness set
-		var txMemory, txSteps int64
+		var estimatedTxExUnits lcommon.ExUnits
+		var exUnitsErr error
 		for _, redeemer := range fullTx.WitnessSet.Redeemers().Iter() {
-			txMemory += redeemer.ExUnits.Memory
-			txSteps += redeemer.ExUnits.Steps
+			estimatedTxExUnits, exUnitsErr = eras.SafeAddExUnits(
+				estimatedTxExUnits,
+				redeemer.ExUnits,
+			)
+			if exUnitsErr != nil {
+				b.logger.Debug(
+					"skipping transaction - ExUnits overflow",
+					"component", "forging",
+					"error", exUnitsErr,
+				)
+				break
+			}
 		}
-		estimatedTxExUnits := lcommon.ExUnits{
-			Memory: txMemory,
-			Steps:  txSteps,
+		if exUnitsErr != nil {
+			continue
 		}
 
 		// Check MaxExUnits limit - skip this tx but continue trying
-		// smaller ones, matching the MaxTxSize behavior above
-		if totalExUnits.Memory+estimatedTxExUnits.Memory > maxExUnits.Memory ||
-			totalExUnits.Steps+estimatedTxExUnits.Steps > maxExUnits.Steps {
+		// smaller ones, matching the MaxTxSize behavior above.
+		// Use SafeAddExUnits to avoid overflow in the comparison.
+		candidateExUnits, addErr := eras.SafeAddExUnits(
+			totalExUnits,
+			estimatedTxExUnits,
+		)
+		if addErr != nil ||
+			candidateExUnits.Memory > maxExUnits.Memory ||
+			candidateExUnits.Steps > maxExUnits.Steps {
 			b.logger.Debug(
 				"tx exceeds remaining ex units budget, skipping",
 				"component", "forging",
@@ -265,8 +282,10 @@ func (b *DefaultBlockBuilder) BuildBlock(
 			transactionMetadataSet[uint(len(transactionBodies))-1] = metadataCbor
 		}
 		blockSize += txSize
-		totalExUnits.Memory += estimatedTxExUnits.Memory
-		totalExUnits.Steps += estimatedTxExUnits.Steps
+		// Safe to assign: overflow was already checked
+		// via SafeAddExUnits when computing
+		// candidateExUnits above.
+		totalExUnits = candidateExUnits
 
 		b.logger.Debug(
 			"added transaction to block candidate lists",

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -82,10 +82,11 @@ func CalculateMinFee(
 
 // DeclaredExUnits returns the total execution units
 // declared across all redeemers in a transaction's
-// witness set.
+// witness set. Returns an error if the summation
+// would overflow int64.
 func DeclaredExUnits(
 	tx lcommon.Transaction,
-) lcommon.ExUnits {
+) (lcommon.ExUnits, error) {
 	return eras.DeclaredExUnits(tx)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes int64 overflow when summing execution units by adding overflow-safe addition and wiring it through fee validation and block building. Transactions that overflow or contain negative ex units are now skipped instead of crashing.

- **Bug Fixes**
  - Added SafeAddExUnits with overflow and negative-value detection, plus ErrExUnitsOverflow.
  - DeclaredExUnits now uses SafeAddExUnits and returns an error; ValidateTxFee propagates it.
  - Block builder uses SafeAddExUnits for per-tx and cumulative checks; compares candidateExUnits to limits and skips txs on overflow or budget exceed.
  - Expanded tests for overflow, negative values, and the helper.

- **Migration**
  - DeclaredExUnits now returns (ExUnits, error). Update callers to handle errors.

<sup>Written for commit 79644a0e292a92211580a49c38675a369cbc6c03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

