### PR TITLE
fix(connmanager): inbound connection limit

### DIFF
--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
-	pdata "github.com/blinklabs-io/plutigo/data"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	pdata "github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
@@ -977,25 +977,25 @@ func TestRollbackGovernanceProposalDeletion(t *testing.T) {
 	store := setupTestDB(t)
 
 	prop1 := &models.GovernanceProposal{
-		TxHash:       bytes.Repeat([]byte{0x90}, 32),
-		ActionIndex:  0,
-		ActionType:   1,
-		AddedSlot:    100,
-		ExpiresEpoch: 50,
-		AnchorUrl:    "https://example.com/prop1",
-		AnchorHash:   bytes.Repeat([]byte{0x92}, 32),
+		TxHash:        bytes.Repeat([]byte{0x90}, 32),
+		ActionIndex:   0,
+		ActionType:    1,
+		AddedSlot:     100,
+		ExpiresEpoch:  50,
+		AnchorUrl:     "https://example.com/prop1",
+		AnchorHash:    bytes.Repeat([]byte{0x92}, 32),
 		ReturnAddress: bytes.Repeat([]byte{0x93}, 29),
 	}
 	require.NoError(t, store.SetGovernanceProposal(prop1, nil))
 
 	prop2 := &models.GovernanceProposal{
-		TxHash:       bytes.Repeat([]byte{0x91}, 32),
-		ActionIndex:  0,
-		ActionType:   2,
-		AddedSlot:    300,
-		ExpiresEpoch: 70,
-		AnchorUrl:    "https://example.com/prop2",
-		AnchorHash:   bytes.Repeat([]byte{0x94}, 32),
+		TxHash:        bytes.Repeat([]byte{0x91}, 32),
+		ActionIndex:   0,
+		ActionType:    2,
+		AddedSlot:     300,
+		ExpiresEpoch:  70,
+		AnchorUrl:     "https://example.com/prop2",
+		AnchorHash:    bytes.Repeat([]byte{0x94}, 32),
 		ReturnAddress: bytes.Repeat([]byte{0x95}, 29),
 	}
 	require.NoError(t, store.SetGovernanceProposal(prop2, nil))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an atomic inbound connection limit with early rejection to prevent connection floods. Uses a reservation-based check to avoid races when multiple Accept calls run concurrently.

- **Bug Fixes**
  - Enforce limit before handshake with tryReserveInboundSlot; reject and close over-limit connections and log a warning; consume/release reservations on success/failure.
  - Add MaxInboundConns to ConnectionManagerConfig (0 defaults to 100); exclude outbound connections; expose InboundCount.
  - Add tests for reject-over-limit, accept-within-limit, defaulting, outbound exclusion, concurrent reservation correctness, and consume/release flow; plus minor sqlite rollback test cleanup (no functional changes).

<sup>Written for commit d99e8f7f8d72284d8ce330cdfc16d7f5d39d879d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

