### PR TITLE
fix(chainselection): validate vrf length

### DIFF
--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -412,8 +412,9 @@ func TestChainSelectorVRFTiebreaker(t *testing.T) {
 	}
 
 	// VRF outputs: lower wins (per Ouroboros Praos)
-	vrfLower := []byte{0x00, 0x00, 0x00, 0x01}
-	vrfHigher := []byte{0x00, 0x00, 0x00, 0x02}
+	// Must be exactly VRFOutputSize (64 bytes) to be valid
+	vrfLower := make64ByteVRF(0x00)
+	vrfHigher := make64ByteVRF(0x01)
 
 	// Add peer with higher VRF first
 	cs.UpdatePeerTip(connId1, tip, vrfHigher)
@@ -439,7 +440,7 @@ func TestChainSelectorVRFTiebreakerWithNilVRF(t *testing.T) {
 	}
 
 	// One peer has VRF, one doesn't
-	vrf := []byte{0x00, 0x01, 0x02, 0x03}
+	vrf := make64ByteVRF(0x01)
 
 	cs.UpdatePeerTip(connId1, tip, vrf)
 	cs.UpdatePeerTip(connId2, tip, nil)
@@ -475,8 +476,8 @@ func TestChainSelectorVRFDoesNotOverrideBlockNumber(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	vrfLower := []byte{0x00, 0x00, 0x00, 0x01}
-	vrfHigher := []byte{0xFF, 0xFF, 0xFF, 0xFF}
+	vrfLower := make64ByteVRF(0x00)
+	vrfHigher := make64ByteVRF(0xFF)
 
 	cs.UpdatePeerTip(connId1, tip1, vrfLower)
 	cs.UpdatePeerTip(connId2, tip2, vrfHigher)
@@ -510,8 +511,8 @@ func TestChainSelectorVRFDoesNotOverrideSlot(t *testing.T) {
 		BlockNumber: 50,
 	}
 
-	vrfLower := []byte{0x00, 0x00, 0x00, 0x01}
-	vrfHigher := []byte{0xFF, 0xFF, 0xFF, 0xFF}
+	vrfLower := make64ByteVRF(0x00)
+	vrfHigher := make64ByteVRF(0xFF)
 
 	cs.UpdatePeerTip(connId1, tip1, vrfLower)
 	cs.UpdatePeerTip(connId2, tip2, vrfHigher)

--- a/chainselection/vrf.go
+++ b/chainselection/vrf.go
@@ -58,12 +58,14 @@ func GetVRFOutput(header ledger.BlockHeader) []byte {
 // Returns:
 //   - ChainABetter (1) if vrfA is lower (A wins)
 //   - ChainBBetter (-1) if vrfB is lower (B wins)
-//   - ChainEqual (0) if equal or either is nil
+//   - ChainEqual (0) if equal, either is nil, or either has invalid length
 //
 // Per Ouroboros Praos: the chain with the LOWER VRF output wins the tie-break.
+// Both outputs must be exactly VRFOutputSize (64) bytes; outputs of any other
+// length are treated the same as nil to prevent truncated values from winning.
 func CompareVRFOutputs(vrfA, vrfB []byte) ChainComparisonResult {
-	// Can't compare if either is nil
-	if vrfA == nil || vrfB == nil {
+	// Can't compare if either is nil or has invalid length
+	if len(vrfA) != VRFOutputSize || len(vrfB) != VRFOutputSize {
 		return ChainEqual
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate VRF output length in chain selection so tie-breaks run only when both outputs are exactly 64 bytes; otherwise the result is treated as equal to prevent truncated values winning.
Updated tests to use 64-byte helpers and added cases for short, empty, and oversized inputs.

<sup>Written for commit 9a70a120b1c7ef422cf338180b3481a9efff74a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

