### PR TITLE
fix(ledger): builder revalidation

### DIFF
--- a/node.go
+++ b/node.go
@@ -644,6 +644,7 @@ func (n *Node) initBlockForger(ctx context.Context) error {
 		ChainTip:        n.chainManager.PrimaryChain(),
 		EpochNonce:      epochNonceAdapter,
 		Credentials:     creds,
+		TxValidator:     n.ledgerState,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create block builder: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds transaction re-validation at block assembly time and intra-block double-spend detection so stale or conflicting mempool transactions are not included in forged blocks. The node now wires the ledger state as the validator; validation can be disabled by omitting it in BlockBuilderConfig.

- **New Features**
  - Introduced TxValidator and BlockBuilderConfig.TxValidator; DefaultBlockBuilder validates each tx when provided.
  - Tracked consumed inputs to skip intra-block double-spends.
  - Node.initBlockForger passes n.ledgerState as TxValidator.

- **Bug Fixes**
  - Blocks no longer include transactions invalidated after mempool admission (spent inputs, protocol/state changes).
  - Only the first transaction spending a given UTxO is included in a block.

<sup>Written for commit 7f7ac8090760c8a00e23b24fedd88efbcda5adef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Enhanced Transaction Validation**
  * Added re-validation of transactions during block assembly to ensure they remain valid against current ledger state
  * Implemented double-spend detection to prevent transactions from reusing inputs already consumed within the same block

<!-- end of auto-generated comment: release notes by coderabbit.ai -->