### PR TITLE
fix(chain): mutate state under lock

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -17,6 +17,7 @@ package chain
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"slices"
 	"sync"
@@ -127,6 +128,26 @@ func (c *Chain) AddBlock(
 	if c == nil {
 		return errors.New("chain is nil")
 	}
+	// Perform all state mutations under locks, collect event to publish
+	// outside locks to prevent deadlock if subscribers access chain state.
+	pendingEvent, err := c.addBlockLocked(block, txn)
+	if err != nil {
+		return err
+	}
+	// Publish event outside locks to prevent deadlock if subscribers
+	// call back into chain or manager state
+	if c.eventBus != nil && pendingEvent != nil {
+		c.eventBus.Publish(pendingEvent.Type, *pendingEvent)
+	}
+	return nil
+}
+
+// addBlockLocked performs AddBlock state mutations under locks and returns
+// any event that should be published after locks are released.
+func (c *Chain) addBlockLocked(
+	block ledger.Block,
+	txn *database.Txn,
+) (*event.Event, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	// We get a write lock on the manager to cover the integrity checks and adding the block below
@@ -134,13 +155,13 @@ func (c *Chain) AddBlock(
 	defer c.manager.mutex.Unlock()
 	// Verify chain integrity
 	if err := c.reconcile(); err != nil {
-		return err
+		return nil, fmt.Errorf("reconcile chain: %w", err)
 	}
 	// Check that the new block matches our first header, if any
 	if len(c.headers) > 0 {
 		firstHeader := c.headers[0]
 		if block.Hash().String() != firstHeader.Hash().String() {
-			return NewBlockNotMatchHeaderError(
+			return nil, NewBlockNotMatchHeaderError(
 				block.Hash().String(),
 				firstHeader.Hash().String(),
 			)
@@ -149,7 +170,7 @@ func (c *Chain) AddBlock(
 	// Check that this block fits on the current chain tip
 	if c.tipBlockIndex >= initialBlockIndex {
 		if string(block.PrevHash().Bytes()) != string(c.currentTip.Point.Hash) {
-			return NewBlockNotFitChainTipError(
+			return nil, NewBlockNotFitChainTipError(
 				block.Hash().String(),
 				block.PrevHash().String(),
 				hex.EncodeToString(c.currentTip.Point.Hash),
@@ -172,7 +193,7 @@ func (c *Chain) AddBlock(
 		Cbor:     block.Cbor(),
 	}
 	if err := c.manager.addBlock(tmpBlock, txn, c.persistent); err != nil {
-		return err
+		return nil, fmt.Errorf("store block: %w", err)
 	}
 	if !c.persistent {
 		c.blocks = append(c.blocks, tmpPoint)
@@ -194,20 +215,18 @@ func (c *Chain) AddBlock(
 		c.waitingChan = nil
 	}
 	c.waitingChanMutex.Unlock()
-	// Generate event
+	// Build event for deferred publication
 	if c.eventBus != nil {
-		c.eventBus.Publish(
+		evt := event.NewEvent(
 			ChainUpdateEventType,
-			event.NewEvent(
-				ChainUpdateEventType,
-				ChainBlockEvent{
-					Point: tmpPoint,
-					Block: tmpBlock,
-				},
-			),
+			ChainBlockEvent{
+				Point: tmpPoint,
+				Block: tmpBlock,
+			},
 		)
+		return &evt, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (c *Chain) AddBlocks(blocks []ledger.Block) error {
@@ -224,17 +243,34 @@ func (c *Chain) AddBlocks(blocks []ledger.Block) error {
 		if batchSize == 0 {
 			break
 		}
+		// Collect events inside the transaction callback and
+		// publish them only after the transaction commits
+		// successfully. This prevents subscribers from reacting
+		// to events whose underlying data has not yet been
+		// persisted.
+		var pendingEvents []event.Event
 		txn := c.manager.db.BlobTxn(true)
 		err := txn.Do(func(txn *database.Txn) error {
+			pendingEvents = pendingEvents[:0]
 			for _, tmpBlock := range blocks[batchOffset : batchOffset+batchSize] {
-				if err := c.AddBlock(tmpBlock, txn); err != nil {
+				evt, err := c.addBlockLocked(tmpBlock, txn)
+				if err != nil {
 					return err
+				}
+				if evt != nil {
+					pendingEvents = append(pendingEvents, *evt)
 				}
 			}
 			return nil
 		})
 		if err != nil {
 			return err
+		}
+		// Publish events after the transaction has committed
+		if c.eventBus != nil {
+			for _, evt := range pendingEvents {
+				c.eventBus.Publish(evt.Type, evt)
+			}
 		}
 		batchOffset += batchSize
 	}
@@ -245,6 +281,27 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	if c == nil {
 		return errors.New("chain is nil")
 	}
+	// Perform all state mutations under locks, collect events to publish
+	// outside locks to prevent deadlock if subscribers access chain state.
+	pendingEvents, err := c.rollbackLocked(point)
+	if err != nil {
+		return err
+	}
+	// Publish events outside locks to prevent deadlock if subscribers
+	// call back into chain or manager state
+	if c.eventBus != nil {
+		for _, evt := range pendingEvents {
+			c.eventBus.Publish(evt.Type, evt)
+		}
+	}
+	return nil
+}
+
+// rollbackLocked performs Rollback state mutations under locks and returns
+// any events that should be published after locks are released.
+func (c *Chain) rollbackLocked(
+	point ocommon.Point,
+) ([]event.Event, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	// We get a write lock on the manager to cover the integrity checks and block deletions
@@ -252,7 +309,7 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	defer c.manager.mutex.Unlock()
 	// Verify chain integrity
 	if err := c.reconcile(); err != nil {
-		return err
+		return nil, fmt.Errorf("reconcile chain: %w", err)
 	}
 	// Check headers for rollback point
 	if len(c.headers) > 0 {
@@ -267,10 +324,10 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 			}
 			if header.SlotNumber() == point.Slot &&
 				string(header.Hash().Bytes()) == string(point.Hash) {
-				return nil
+				return nil, nil
 			}
 			if header.SlotNumber() < point.Slot {
-				return models.ErrBlockNotFound
+				return nil, models.ErrBlockNotFound
 			}
 		}
 	}
@@ -281,9 +338,19 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 		var err error
 		tmpBlock, err = c.manager.blockByPoint(point, nil)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf(
+				"lookup rollback point: %w", err,
+			)
 		}
 		rollbackBlockIndex = tmpBlock.ID
+	}
+	// Guard against uint64 underflow from corrupt/stale data
+	if rollbackBlockIndex > c.tipBlockIndex {
+		return nil, fmt.Errorf(
+			"rollback block index %d exceeds tip block index %d",
+			rollbackBlockIndex,
+			c.tipBlockIndex,
+		)
 	}
 	// Calculate fork depth before deleting blocks
 	forkDepth := c.tipBlockIndex - rollbackBlockIndex
@@ -302,7 +369,7 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 			"security_param", securityParam,
 			"rollback_slot", point.Slot,
 		)
-		return ErrRollbackExceedsSecurityParam
+		return nil, ErrRollbackExceedsSecurityParam
 	}
 	// Capture old tip for fork event before we modify it
 	oldTip := c.currentTip
@@ -313,7 +380,9 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 			// Remove block from persistent store, returns the removed block
 			block, err := c.manager.removeBlockByIndex(i)
 			if err != nil {
-				return err
+				return nil, fmt.Errorf(
+					"remove block at index %d: %w", i, err,
+				)
 			}
 			if c.eventBus != nil {
 				rolledBackBlocks = append(rolledBackBlocks, block)
@@ -365,11 +434,12 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 			iter.needsRollback = true
 		}
 	}
-	// Generate events
-	if c.eventBus != nil {
-		// Rollback event (existing)
-		c.eventBus.Publish(
-			ChainUpdateEventType,
+	// Build events for deferred publication
+	var pendingEvents []event.Event
+	if c.eventBus != nil && len(rolledBackBlocks) > 0 {
+		// Rollback event — only emit when blocks were actually removed
+		pendingEvents = append(
+			pendingEvents,
 			event.NewEvent(
 				ChainUpdateEventType,
 				ChainRollbackEvent{
@@ -378,10 +448,10 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 				},
 			),
 		)
-		// Fork event (new) - only emit if we actually rolled back blocks
+		// Fork event - only emit if we actually rolled back blocks
 		if forkDepth > 0 {
-			c.eventBus.Publish(
-				ChainForkEventType,
+			pendingEvents = append(
+				pendingEvents,
 				event.NewEvent(
 					ChainForkEventType,
 					ChainForkEvent{
@@ -394,7 +464,7 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 			)
 		}
 	}
-	return nil
+	return pendingEvents, nil
 }
 
 // ClearHeaders removes all queued block headers. This is used when


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Chain state changes under locks and defer event publication until after unlocking and transaction commit to prevent races, deadlocks, and premature notifications. Enforces security parameter K for persistent rollbacks and adds extra safety checks.

- **Bug Fixes**
  - Perform all state mutations under chain/manager locks via addBlockLocked and rollbackLocked.
  - Build events while locked; publish after unlocking and, for AddBlocks, only after the transaction commits.
  - Enforce security parameter K on persistent rollbacks; return ErrRollbackExceedsSecurityParam (ephemeral chains are not limited).
  - Emit rollback/fork events only when blocks were actually removed and guard against invalid rollback indices to prevent underflow.

<sup>Written for commit 787c3ff9dcd1045c68849837e00906b3096a1701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling and synchronization mechanisms within the blockchain chain management system to enhance reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->