### PR TITLE
fix(database): return lru slice copy

### DIFF
--- a/database/block_lru_cache.go
+++ b/database/block_lru_cache.go
@@ -42,8 +42,10 @@ type CachedBlock struct {
 	OutputIndex map[OutputKey]Location
 }
 
-// Extract returns a slice of RawBytes from offset to offset+length.
+// Extract returns a copy of RawBytes from offset to offset+length.
 // Returns nil if the range is out of bounds.
+// The returned slice is a defensive copy so callers may freely modify it
+// without corrupting the cached block data.
 func (cb *CachedBlock) Extract(offset, length uint32) []byte {
 	dataLen := len(cb.RawBytes)
 	// Check offset doesn't exceed data length
@@ -55,7 +57,9 @@ func (cb *CachedBlock) Extract(offset, length uint32) []byte {
 	if end > uint64(dataLen) {
 		return nil
 	}
-	return cb.RawBytes[offset : offset+length]
+	result := make([]byte, length)
+	copy(result, cb.RawBytes[offset:offset+length])
+	return result
 }
 
 // blockKey is the composite key for cache entries.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return a defensive copy from CachedBlock.Extract to prevent callers from mutating and corrupting cached block data. Adds a test to lock in this behavior.

- **Bug Fixes**
  - Extract now allocates and copies the requested range instead of returning a subslice.
  - Added TestCachedBlockExtractReturnsCopy to ensure mutations to the returned slice do not affect RawBytes.

<sup>Written for commit 551f0a19e62486f99b700e64bc7389ce8d0113b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache data safety by returning defensive copies of extracted data instead of direct references, preventing unintended modifications by callers.
  * Enhanced boundary checking for out-of-bounds access scenarios.

* **Tests**
  * Added test coverage to verify defensive data copying behavior and cached data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->