### PR TITLE
feat(ouroboros): txsubmission rate limiter

### DIFF
--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -58,6 +58,8 @@ type Ouroboros struct {
 	// ChainSync measurement tracking for peer scoring
 	chainsyncStats map[ouroboros.ConnectionId]*chainsyncPeerStats
 	chainsyncMutex sync.Mutex
+	// Per-peer rate limiter for TxSubmission server
+	txSubmissionRateLimiter *txSubmissionRateLimiter
 }
 
 // chainsyncPeerStats tracks ChainSync performance metrics per peer connection.
@@ -75,6 +77,11 @@ type OuroborosConfig struct {
 	PeerSharing     bool
 	IntersectTip    bool
 	PromRegistry    prometheus.Registerer
+	// MaxTxSubmissionsPerSecond is the maximum number of transaction
+	// submissions accepted per peer per second via the TxSubmission
+	// mini-protocol. A value of 0 uses DefaultMaxTxSubmissionsPerSecond.
+	// A negative value disables rate limiting.
+	MaxTxSubmissionsPerSecond int
 }
 
 type blockfetchMetrics struct {
@@ -101,6 +108,19 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		ConnManager:      cfg.ConnManager,
 		blockFetchStarts: make(map[ouroboros.ConnectionId]time.Time),
 		chainsyncStats:   make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
+	}
+	// Initialize per-peer TxSubmission rate limiter
+	txRate := cfg.MaxTxSubmissionsPerSecond
+	if txRate == 0 {
+		txRate = DefaultMaxTxSubmissionsPerSecond
+	}
+	if txRate > 0 {
+		// Burst allows small batches: 2x the per-second rate
+		burst := float64(txRate) * 2
+		o.txSubmissionRateLimiter = newTxSubmissionRateLimiter(
+			float64(txRate),
+			burst,
+		)
 	}
 	if cfg.PromRegistry != nil {
 		o.initMetrics()
@@ -283,6 +303,10 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	o.chainsyncMutex.Lock()
 	delete(o.chainsyncStats, connId)
 	o.chainsyncMutex.Unlock()
+	// Clean up TxSubmission rate limiter state
+	if o.txSubmissionRateLimiter != nil {
+		o.txSubmissionRateLimiter.RemovePeer(connId)
+	}
 }
 
 func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {

--- a/ouroboros/txsubmission_rate_limiter.go
+++ b/ouroboros/txsubmission_rate_limiter.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"sync"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+)
+
+// DefaultMaxTxSubmissionsPerSecond is the default maximum number of
+// transaction submissions accepted per peer per second.
+const DefaultMaxTxSubmissionsPerSecond = 30
+
+// tokenBucket implements a simple token bucket rate limiter.
+// Tokens are replenished at a fixed rate up to a maximum burst.
+type tokenBucket struct {
+	mu         sync.Mutex
+	tokens     float64
+	maxTokens  float64
+	refillRate float64   // tokens per second
+	lastRefill time.Time // last time tokens were refilled
+}
+
+// newTokenBucket creates a new token bucket with the given rate
+// (tokens per second) and burst size.
+func newTokenBucket(
+	rate float64,
+	burst float64,
+	now time.Time,
+) *tokenBucket {
+	return &tokenBucket{
+		tokens:     burst,
+		maxTokens:  burst,
+		refillRate: rate,
+		lastRefill: now,
+	}
+}
+
+// refill replenishes tokens based on elapsed time. Must be called
+// with tb.mu held.
+func (tb *tokenBucket) refill(now time.Time) {
+	elapsed := now.Sub(tb.lastRefill).Seconds()
+	if elapsed > 0 {
+		tb.tokens += elapsed * tb.refillRate
+		if tb.tokens > tb.maxTokens {
+			tb.tokens = tb.maxTokens
+		}
+		tb.lastRefill = now
+	}
+}
+
+// allow checks whether n tokens can be consumed. It refills tokens
+// based on elapsed time and then attempts to consume n tokens.
+// Returns true if the tokens were consumed, false if rate limited.
+func (tb *tokenBucket) allow(n float64, now time.Time) bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	tb.refill(now)
+
+	// Check if enough tokens are available
+	if tb.tokens < n {
+		return false
+	}
+	tb.tokens -= n
+	return true
+}
+
+// waitDuration returns how long to wait before n tokens will be
+// available. Returns 0 if tokens are already available.
+func (tb *tokenBucket) waitDuration(
+	n float64,
+	now time.Time,
+) time.Duration {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	tb.refill(now)
+
+	if tb.tokens >= n {
+		return 0
+	}
+	deficit := n - tb.tokens
+	seconds := deficit / tb.refillRate
+	return time.Duration(seconds * float64(time.Second))
+}
+
+// txSubmissionRateLimiter manages per-peer rate limiting for
+// the TxSubmission mini-protocol.
+type txSubmissionRateLimiter struct {
+	mu      sync.Mutex
+	peers   map[ouroboros.ConnectionId]*tokenBucket
+	rate    float64 // tokens per second per peer
+	burst   float64 // max burst per peer
+	nowFunc func() time.Time
+}
+
+// newTxSubmissionRateLimiter creates a new per-peer rate limiter.
+// rate is the sustained transactions per second allowed per peer.
+// burst is the maximum burst size (typically 2x-3x the rate to
+// allow small batches).
+func newTxSubmissionRateLimiter(
+	rate float64,
+	burst float64,
+) *txSubmissionRateLimiter {
+	return &txSubmissionRateLimiter{
+		peers:   make(map[ouroboros.ConnectionId]*tokenBucket),
+		rate:    rate,
+		burst:   burst,
+		nowFunc: time.Now,
+	}
+}
+
+// Allow checks whether n transaction submissions from the given
+// peer are allowed. Returns true if the submissions are within
+// the rate limit, false if they should be rejected.
+func (rl *txSubmissionRateLimiter) Allow(
+	connId ouroboros.ConnectionId,
+	n int,
+) bool {
+	rl.mu.Lock()
+	bucket, ok := rl.peers[connId]
+	if !ok {
+		bucket = newTokenBucket(rl.rate, rl.burst, rl.nowFunc())
+		rl.peers[connId] = bucket
+	}
+	rl.mu.Unlock()
+
+	return bucket.allow(float64(n), rl.nowFunc())
+}
+
+// WaitDuration returns how long to wait before n transactions from
+// the given peer will be allowed.
+func (rl *txSubmissionRateLimiter) WaitDuration(
+	connId ouroboros.ConnectionId,
+	n int,
+) time.Duration {
+	rl.mu.Lock()
+	bucket, ok := rl.peers[connId]
+	rl.mu.Unlock()
+
+	if !ok {
+		return 0
+	}
+	return bucket.waitDuration(float64(n), rl.nowFunc())
+}
+
+// RemovePeer removes rate limiting state for the given connection.
+// This should be called when a connection is closed.
+func (rl *txSubmissionRateLimiter) RemovePeer(
+	connId ouroboros.ConnectionId,
+) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	delete(rl.peers, connId)
+}

--- a/ouroboros/txsubmission_rate_limiter_test.go
+++ b/ouroboros/txsubmission_rate_limiter_test.go
@@ -1,0 +1,537 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testConnIdWithPort creates a ConnectionId with a unique remote port
+// for testing.
+func testConnIdWithPort(
+	port int,
+) ouroboros_conn.ConnectionId {
+	return ouroboros_conn.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 3001,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: port,
+		},
+	}
+}
+
+func TestTokenBucket_BasicAllow(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(10, 20, now)
+
+	// Should allow up to burst size
+	assert.True(
+		t,
+		tb.allow(10, now),
+		"should allow 10 tokens from burst of 20",
+	)
+	assert.True(
+		t,
+		tb.allow(10, now),
+		"should allow another 10 tokens from burst of 20",
+	)
+	// Burst exhausted
+	assert.False(
+		t,
+		tb.allow(1, now),
+		"should reject when tokens exhausted",
+	)
+}
+
+func TestTokenBucket_Refill(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(10, 20, now)
+
+	// Exhaust all tokens
+	assert.True(t, tb.allow(20, now), "should allow burst")
+	assert.False(
+		t,
+		tb.allow(1, now),
+		"should reject when exhausted",
+	)
+
+	// Advance time by 1 second: refill 10 tokens
+	later := now.Add(1 * time.Second)
+	assert.True(
+		t,
+		tb.allow(10, later),
+		"should allow 10 tokens after 1s refill",
+	)
+	assert.False(
+		t,
+		tb.allow(1, later),
+		"should reject after consuming refilled tokens",
+	)
+}
+
+func TestTokenBucket_RefillCap(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(10, 20, now)
+
+	// Exhaust all tokens
+	assert.True(t, tb.allow(20, now), "should allow burst")
+
+	// Advance time by 10 seconds: refill would be 100 but capped
+	// at 20
+	later := now.Add(10 * time.Second)
+	assert.True(
+		t,
+		tb.allow(20, later),
+		"should allow max burst after long refill",
+	)
+	assert.False(
+		t,
+		tb.allow(1, later),
+		"should reject since bucket only holds burst",
+	)
+}
+
+func TestTokenBucket_PartialConsumption(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(10, 20, now)
+
+	// Consume some tokens
+	assert.True(t, tb.allow(5, now), "should allow 5 of 20")
+	assert.True(t, tb.allow(5, now), "should allow another 5")
+	assert.True(t, tb.allow(5, now), "should allow another 5")
+	assert.True(t, tb.allow(5, now), "should allow last 5")
+	assert.False(t, tb.allow(1, now), "should reject at 0 tokens")
+}
+
+func TestTxSubmissionRateLimiter_NormalRate(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(30, 60)
+	peer := testConnIdWithPort(4001)
+
+	// Normal submission rate: 10 txs at a time, well within burst
+	assert.True(
+		t,
+		rl.Allow(peer, 10),
+		"normal batch of 10 should be allowed",
+	)
+	assert.True(
+		t,
+		rl.Allow(peer, 10),
+		"second batch of 10 should be allowed",
+	)
+	assert.True(
+		t,
+		rl.Allow(peer, 10),
+		"third batch of 10 should be allowed",
+	)
+}
+
+func TestTxSubmissionRateLimiter_ExcessiveRate(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(10, 20)
+	// Override time function for deterministic testing
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+
+	peer := testConnIdWithPort(4001)
+
+	// Exhaust the burst
+	assert.True(
+		t,
+		rl.Allow(peer, 10),
+		"first batch should be allowed",
+	)
+	assert.True(
+		t,
+		rl.Allow(peer, 10),
+		"second batch should be allowed (burst=20)",
+	)
+	// Now the bucket is empty
+	assert.False(
+		t,
+		rl.Allow(peer, 1),
+		"should reject when rate limit exceeded",
+	)
+}
+
+func TestTxSubmissionRateLimiter_PerPeerIsolation(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(10, 20)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+
+	peerA := testConnIdWithPort(4001)
+	peerB := testConnIdWithPort(4002)
+
+	// Exhaust peer A's bucket
+	assert.True(t, rl.Allow(peerA, 20), "peer A burst allowed")
+	assert.False(
+		t,
+		rl.Allow(peerA, 1),
+		"peer A should be rate limited",
+	)
+
+	// Peer B should still have a full bucket
+	assert.True(
+		t,
+		rl.Allow(peerB, 20),
+		"peer B should be unaffected by peer A",
+	)
+	assert.False(
+		t,
+		rl.Allow(peerB, 1),
+		"peer B should now be rate limited",
+	)
+}
+
+func TestTxSubmissionRateLimiter_Recovery(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(10, 20)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mu := sync.Mutex{}
+	rl.nowFunc = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	peer := testConnIdWithPort(4001)
+
+	// Exhaust the bucket
+	assert.True(t, rl.Allow(peer, 20), "burst allowed")
+	assert.False(
+		t,
+		rl.Allow(peer, 1),
+		"should be rate limited",
+	)
+
+	// Advance time: tokens should refill
+	mu.Lock()
+	now = now.Add(2 * time.Second) // +20 tokens at rate=10/s
+	mu.Unlock()
+
+	assert.True(
+		t,
+		rl.Allow(peer, 10),
+		"should allow after refill",
+	)
+}
+
+func TestTxSubmissionRateLimiter_RemovePeer(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(10, 20)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+
+	peer := testConnIdWithPort(4001)
+
+	// Exhaust the bucket
+	assert.True(t, rl.Allow(peer, 20), "burst allowed")
+	assert.False(
+		t,
+		rl.Allow(peer, 1),
+		"should be rate limited",
+	)
+
+	// Remove peer and verify a new bucket is created
+	rl.RemovePeer(peer)
+	assert.True(
+		t,
+		rl.Allow(peer, 20),
+		"should have fresh bucket after removal",
+	)
+}
+
+func TestTxSubmissionRateLimiter_ConcurrentAccess(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(1000, 2000)
+	peer := testConnIdWithPort(4001)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Just exercise the rate limiter concurrently;
+			// we don't assert results since timing varies
+			rl.Allow(peer, 1)
+		}()
+	}
+	wg.Wait()
+	// If the test reaches here without data races (with -race),
+	// the concurrent access is safe
+}
+
+func TestNewOuroboros_DefaultRateLimit(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+
+	require.NotNil(
+		t,
+		o.txSubmissionRateLimiter,
+		"rate limiter should be initialized with default config",
+	)
+	assert.Equal(
+		t,
+		float64(DefaultMaxTxSubmissionsPerSecond),
+		o.txSubmissionRateLimiter.rate,
+		"rate should use default",
+	)
+	assert.Equal(
+		t,
+		float64(DefaultMaxTxSubmissionsPerSecond)*2,
+		o.txSubmissionRateLimiter.burst,
+		"burst should be 2x default rate",
+	)
+}
+
+func TestNewOuroboros_CustomRateLimit(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:                    logger,
+		EventBus:                  event.NewEventBus(nil, logger),
+		MaxTxSubmissionsPerSecond: 50,
+	})
+
+	require.NotNil(t, o.txSubmissionRateLimiter)
+	assert.Equal(
+		t,
+		float64(50),
+		o.txSubmissionRateLimiter.rate,
+		"rate should use custom value",
+	)
+	assert.Equal(
+		t,
+		float64(100),
+		o.txSubmissionRateLimiter.burst,
+		"burst should be 2x custom rate",
+	)
+}
+
+func TestNewOuroboros_DisabledRateLimit(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:                    logger,
+		EventBus:                  event.NewEventBus(nil, logger),
+		MaxTxSubmissionsPerSecond: -1,
+	})
+
+	assert.Nil(
+		t,
+		o.txSubmissionRateLimiter,
+		"rate limiter should be nil when disabled",
+	)
+}
+
+func TestHandleConnClosedEvent_CleansUpRateLimiter(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+
+	peer := testConnIdWithPort(4001)
+
+	// Create rate limiter state for this peer
+	o.txSubmissionRateLimiter.Allow(peer, 1)
+
+	// Verify the peer exists in the rate limiter
+	o.txSubmissionRateLimiter.mu.Lock()
+	_, exists := o.txSubmissionRateLimiter.peers[peer]
+	o.txSubmissionRateLimiter.mu.Unlock()
+	require.True(t, exists, "peer should exist in rate limiter")
+
+	// Simulate a connection closed event through the actual handler
+	evt := event.NewEvent(
+		connmanager.ConnectionClosedEventType,
+		connmanager.ConnectionClosedEvent{
+			ConnectionId: peer,
+		},
+	)
+	o.HandleConnClosedEvent(evt)
+
+	// Verify cleanup
+	o.txSubmissionRateLimiter.mu.Lock()
+	_, exists = o.txSubmissionRateLimiter.peers[peer]
+	o.txSubmissionRateLimiter.mu.Unlock()
+	assert.False(
+		t,
+		exists,
+		"peer should be removed from rate limiter after connection closed event",
+	)
+}
+
+func TestTxSubmissionRateLimiter_CustomRatePlumbing(t *testing.T) {
+	// Verify that a custom MaxTxSubmissionsPerSecond value is
+	// correctly plumbed through to the rate limiter with the
+	// expected rate and burst (2x rate).
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:                    logger,
+		EventBus:                  event.NewEventBus(nil, logger),
+		MaxTxSubmissionsPerSecond: 10,
+	})
+
+	require.NotNil(t, o.txSubmissionRateLimiter)
+	assert.Equal(
+		t,
+		float64(10),
+		o.txSubmissionRateLimiter.rate,
+		"rate should match custom config value",
+	)
+	assert.Equal(
+		t,
+		float64(20),
+		o.txSubmissionRateLimiter.burst,
+		"burst should be 2x the custom rate",
+	)
+}
+
+func TestTokenBucket_ZeroTokenRequest(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(10, 20, now)
+
+	// Zero tokens should always be allowed
+	assert.True(
+		t,
+		tb.allow(0, now),
+		"zero tokens should always be allowed",
+	)
+
+	// Exhaust the bucket
+	assert.True(t, tb.allow(20, now), "consume all tokens")
+
+	// Zero tokens should still be allowed even when bucket is empty
+	assert.True(
+		t,
+		tb.allow(0, now),
+		"zero tokens should be allowed even when empty",
+	)
+}
+
+func TestTokenBucket_WaitDuration(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := newTokenBucket(10, 20, now)
+
+	// Tokens available - no wait needed
+	assert.Equal(
+		t,
+		time.Duration(0),
+		tb.waitDuration(10, now),
+		"should not wait when tokens are available",
+	)
+
+	// Exhaust the bucket
+	assert.True(t, tb.allow(20, now), "consume all tokens")
+
+	// Need 10 tokens at rate 10/s = 1 second wait
+	assert.Equal(
+		t,
+		1*time.Second,
+		tb.waitDuration(10, now),
+		"should wait 1s for 10 tokens at rate 10/s",
+	)
+
+	// Need 20 tokens at rate 10/s = 2 second wait
+	assert.Equal(
+		t,
+		2*time.Second,
+		tb.waitDuration(20, now),
+		"should wait 2s for 20 tokens at rate 10/s",
+	)
+}
+
+func TestTxSubmissionRateLimiter_WaitDuration(t *testing.T) {
+	rl := newTxSubmissionRateLimiter(10, 20)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+
+	peer := testConnIdWithPort(4001)
+
+	// Unknown peer returns zero wait
+	assert.Equal(
+		t,
+		time.Duration(0),
+		rl.WaitDuration(peer, 10),
+		"unknown peer should return zero wait",
+	)
+
+	// Create peer and exhaust tokens
+	assert.True(t, rl.Allow(peer, 20), "consume all tokens")
+
+	// Should report wait duration
+	assert.True(
+		t,
+		rl.WaitDuration(peer, 10) > 0,
+		"should report positive wait when exhausted",
+	)
+}
+
+func TestTxSubmissionRateLimiter_MultiplePeersIndependent(
+	t *testing.T,
+) {
+	rl := newTxSubmissionRateLimiter(10, 20)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mu := sync.Mutex{}
+	rl.nowFunc = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	// Create 5 peers
+	peers := make([]ouroboros_conn.ConnectionId, 5)
+	for i := range peers {
+		peers[i] = testConnIdWithPort(5000 + i)
+	}
+
+	// Each peer should have their own independent bucket
+	for i, peer := range peers {
+		assert.True(
+			t,
+			rl.Allow(peer, 20),
+			"peer %d should have full burst", i,
+		)
+		assert.False(
+			t,
+			rl.Allow(peer, 1),
+			"peer %d should be rate limited", i,
+		)
+	}
+
+	// Advance time and verify all peers recover independently
+	mu.Lock()
+	now = now.Add(1 * time.Second) // +10 tokens for each peer
+	mu.Unlock()
+
+	for i, peer := range peers {
+		assert.True(
+			t,
+			rl.Allow(peer, 10),
+			"peer %d should recover after refill", i,
+		)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-peer rate limiting to the TxSubmission mini-protocol to prevent flooding and smooth bursts. Enabled by default and configurable via OuroborosConfig.

- **New Features**
  - Per-peer token-bucket limiter (default 30 tx/s, 2× burst).
  - When over limit, the server waits for tokens (logs a warning) and then processes the batch to avoid tight-loop spinning.
  - Config: MaxTxSubmissionsPerSecond (0 uses default; negative disables); limiter state is removed on connection close.
  - Tests cover per-peer isolation, recovery, concurrent access, default/custom/disabled config, and wait timing.

<sup>Written for commit 12358d1893499697a56105bc91ef38de670bcb9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-peer transaction submission rate limiting with configurable thresholds to prevent resource exhaustion and manage throughput
  * New configuration option to set maximum transactions per second, with automatic cleanup on connection closure

* **Tests**
  * Comprehensive test coverage for rate limiting scenarios, including per-peer isolation, concurrent access, and recovery patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->