### PR TITLE
fix(ledger): enforce positive scheduler period

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1674,7 +1674,13 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				interval := time.Duration(
 					rolloverResult.SchedulerIntervalMs,
 				) * time.Millisecond
-				ls.Scheduler.ChangeInterval(interval)
+				if err := ls.Scheduler.ChangeInterval(interval); err != nil {
+					ls.config.Logger.Warn(
+						"failed to update scheduler interval",
+						"error", err,
+						"interval", interval,
+					)
+				}
 			}
 
 			// Emit epoch transition event (coordinated with slot clock)

--- a/ledger/timer.go
+++ b/ledger/timer.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -192,11 +193,19 @@ func (st *Scheduler) Register(
 }
 
 // ChangeInterval updates the tick interval of the Scheduler at runtime.
-func (st *Scheduler) ChangeInterval(newInterval time.Duration) {
+// It returns an error if newInterval is not positive.
+func (st *Scheduler) ChangeInterval(newInterval time.Duration) error {
+	if newInterval <= 0 {
+		return fmt.Errorf(
+			"scheduler: interval must be positive, got %v",
+			newInterval,
+		)
+	}
 	select {
 	case st.updateIntervalChan <- newInterval:
 	default:
 	}
+	return nil
 }
 
 // Stop the timer (terminates)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforce positive durations for Scheduler.ChangeInterval and return errors for zero or negative values. Log a warning in ledger when interval updates fail and add tests for invalid and valid durations.

- **Migration**
  - Handle the returned error at all ChangeInterval call sites (ledgerProcessBlocks updated here).
  - No behavior changes for valid positive intervals.

<sup>Written for commit 52064ef72067548c3123f1f7843887cd87f62821. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler interval validation with proper error handling. The system now verifies that intervals are positive and logs warnings when invalid values are attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->