### PR TITLE
fix(ledger): bounds check output slices before use

### DIFF
--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -213,6 +213,9 @@ func (ls *LedgerState) queryShelleyUtxoByAddress(
 	addrs []ledger.Address,
 ) (any, error) {
 	ret := make(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	if len(addrs) == 0 {
+		return []any{ret}, nil
+	}
 	// TODO: support multiple addresses (#391)
 	utxos, err := ls.db.UtxosByAddress(addrs[0], nil)
 	if err != nil {
@@ -236,6 +239,9 @@ func (ls *LedgerState) queryShelleyUtxoByTxIn(
 	txIns []ledger.ShelleyTransactionInput,
 ) (any, error) {
 	ret := make(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	if len(txIns) == 0 {
+		return []any{ret}, nil
+	}
 	// TODO: support multiple TxIns (#392)
 	utxo, err := ls.db.UtxoByRef(
 		txIns[0].Id().Bytes(),

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryShelleyUtxoByAddress_EmptySlice(t *testing.T) {
+	ls := &LedgerState{}
+	result, err := ls.queryShelleyUtxoByAddress(nil)
+	require.NoError(t, err)
+	// Should return []any{empty map}
+	arr, ok := result.([]any)
+	require.True(t, ok, "expected []any result")
+	require.Len(t, arr, 1)
+	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	require.True(t, ok, "expected UtxoId map")
+	require.Empty(t, m)
+}
+
+func TestQueryShelleyUtxoByTxIn_EmptySlice(t *testing.T) {
+	ls := &LedgerState{}
+	result, err := ls.queryShelleyUtxoByTxIn(nil)
+	require.NoError(t, err)
+	// Should return []any{empty map}
+	arr, ok := result.([]any)
+	require.True(t, ok, "expected []any result")
+	require.Len(t, arr, 1)
+	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	require.True(t, ok, "expected UtxoId map")
+	require.Empty(t, m)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent index-out-of-range panics in Shelley UTXO queries by handling empty input slices. When no addresses or tx-ins are given, we return []any with an empty UTXO map and add tests to verify this shape.

- **Bug Fixes**
  - queryShelleyUtxoByAddress: return []any{empty UTXO map} when addrs is empty.
  - queryShelleyUtxoByTxIn: return []any{empty UTXO map} when txIns is empty.
  - Added unit tests for both empty-input cases.

<sup>Written for commit 10e9efc8e13998ef80b630eeda85b7098cd35bd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced query functions with defensive input validation to safely handle empty and null inputs, preventing potential downstream access errors and maintaining consistent return behavior across all conditions.

* **Tests**
  * Added comprehensive unit test coverage validating that query functions correctly handle edge case scenarios with empty and null inputs, ensuring appropriate return values and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->