### PR TITLE
fix(ledger): pool current state tie breaker

### DIFF
--- a/ledger/view.go
+++ b/ledger/view.go
@@ -139,9 +139,13 @@ func (lv *LedgerView) PoolCurrentState(
 	if len(pool.Registration) > 0 {
 		var latestIdx int
 		var latestSlot uint64
+		var latestCertID uint
 		for i, reg := range pool.Registration {
-			if reg.AddedSlot >= latestSlot {
+			// Use CertificateID for deterministic disambiguation when slots are equal
+			if reg.AddedSlot > latestSlot ||
+				(reg.AddedSlot == latestSlot && reg.CertificateID > latestCertID) {
 				latestSlot = reg.AddedSlot
+				latestCertID = reg.CertificateID
 				latestIdx = i
 			}
 		}
@@ -163,13 +167,13 @@ func (lv *LedgerView) PoolCurrentState(
 		tmp.RewardAccount = lcommon.AddrKeyHash(
 			lcommon.NewBlake2b224(pool.RewardAccount),
 		)
-		for _, owner := range pool.Owners {
+		for _, owner := range reg.Owners {
 			tmp.PoolOwners = append(
 				tmp.PoolOwners,
 				lcommon.AddrKeyHash(lcommon.NewBlake2b224(owner.KeyHash)),
 			)
 		}
-		for _, relay := range pool.Relays {
+		for _, relay := range reg.Relays {
 			r := lcommon.PoolRelay{}
 			if relay.Port != 0 {
 				port := uint32(relay.Port) // #nosec G115


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make PoolCurrentState deterministic and accurate by adding a CertificateID tie-breaker for equal AddedSlot values and by pulling owners/relays from the selected registration. This prevents inconsistent pool state and mismatched owner/relay data.

- **Bug Fixes**
  - Pick latest registration by AddedSlot, then by CertificateID when slots are equal.
  - Use reg.Owners and reg.Relays from the chosen registration instead of pool-level fields.

<sup>Written for commit 43d8750bba3d0ee8bd1b74013b64ed3ccfcbfb8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

