### PR TITLE
feat(ledger): transaction events

### DIFF
--- a/chain/blockcache_test.go
+++ b/chain/blockcache_test.go
@@ -19,10 +19,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 func TestBlockCache_BasicOperations(t *testing.T) {

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -22,11 +22,12 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/chain"
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
 )
 
 func decodeHex(hexData string) []byte {

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -17,10 +17,11 @@ package chain
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/event"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 func TestIteratorCancelRemovesFromChain(t *testing.T) {

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -21,12 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 func newTestConnectionId(n int) ouroboros.ConnectionId {

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/chainsync"
-	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // newTestConnId creates a unique ConnectionId for testing by

--- a/config/cardano/node_test.go
+++ b/config/cardano/node_test.go
@@ -21,10 +21,9 @@ import (
 	"reflect"
 	"testing"
 
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 const (

--- a/connmanager/connection_manager_test.go
+++ b/connmanager/connection_manager_test.go
@@ -18,19 +18,18 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
-
-	"log/slog"
-
-	"github.com/blinklabs-io/dingo/connmanager"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/goleak"
+
+	"github.com/blinklabs-io/dingo/connmanager"
 )
 
 /*

--- a/database/block_indexer_test.go
+++ b/database/block_indexer_test.go
@@ -17,11 +17,12 @@ package database
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
 )
 
 func TestBlockIndexerComputeOffsets(t *testing.T) {

--- a/database/block_offset_test.go
+++ b/database/block_offset_test.go
@@ -17,12 +17,13 @@ package database
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
 )
 
 func TestExtractTransactionOffsets(t *testing.T) {

--- a/database/cbor_cache_test.go
+++ b/database/cbor_cache_test.go
@@ -17,10 +17,11 @@ package database
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 func TestNewTieredCborCache(t *testing.T) {

--- a/database/immutable/immutable_test.go
+++ b/database/immutable/immutable_test.go
@@ -18,8 +18,9 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/immutable"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
 )
 
 const (

--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin"
 )
 
 // TestTable is a simple table for testing concurrent transactions

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin"
 )
 
 // TestTable is a simple table for testing concurrent transactions

--- a/database/plugin/metadata/sqlite/concurrency_test.go
+++ b/database/plugin/metadata/sqlite/concurrency_test.go
@@ -21,9 +21,10 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 // setupFileBasedStore creates a file-based MetadataStoreSqlite in a

--- a/database/plugin/metadata/sqlite/governance_test.go
+++ b/database/plugin/metadata/sqlite/governance_test.go
@@ -17,9 +17,10 @@ package sqlite
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 func setupTestStore(t *testing.T) *MetadataStoreSqlite {

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -21,13 +21,14 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	pdata "github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 // --- Mock transaction input with consumed support ---

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 // setupTestDB creates and initializes a test SQLite database.

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -17,10 +17,11 @@ package sqlite
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 func setupStakeSnapshotTestStore(t *testing.T) *MetadataStoreSqlite {

--- a/event/block_test.go
+++ b/event/block_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 func TestBlockForgedEventType(t *testing.T) {

--- a/event/epoch_test.go
+++ b/event/epoch_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 func TestEpochTransitionEventType(t *testing.T) {

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -19,8 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 func TestEventBusSingleSubscriber(t *testing.T) {

--- a/event/hardfork_test.go
+++ b/event/hardfork_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 func TestHardForkEventType(t *testing.T) {

--- a/internal/integration/benchmark_test.go
+++ b/internal/integration/benchmark_test.go
@@ -21,13 +21,14 @@ import (
 	"strings"
 	"testing"
 
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	_ "github.com/blinklabs-io/dingo/database/plugin/blob/aws"
 	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
 	_ "github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
-	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // loadBlockData loads real block data from testdata chunks for benchmarking

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/blinklabs-io/dingo"
@@ -32,7 +33,6 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/internal/config"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestMain(m *testing.M) {

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -18,13 +18,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/gouroboros/ledger"
-	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
-	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Helper functions for benchmark seeding

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -15,6 +15,8 @@
 package ledger
 
 import (
+	"fmt"
+
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
@@ -28,6 +30,64 @@ func (ls *LedgerState) handleEventChainUpdate(evt event.Event) {
 	case chain.ChainRollbackEvent:
 		for _, blk := range data.RolledBackBlocks {
 			ls.publishBlockEvent(BlockActionUndo, blk)
+		}
+		// Emit per-transaction rollback events.
+		// Hold rollbackMu so Close cannot start Wait between our
+		// closed check and Add(1).
+		ls.rollbackMu.Lock()
+		if ls.closed.Load() {
+			ls.rollbackMu.Unlock()
+			return
+		}
+		ls.rollbackWG.Add(1)
+		ls.rollbackMu.Unlock()
+		go ls.emitTransactionRollbackEvents(data)
+	}
+}
+
+// emitTransactionRollbackEvents emits TransactionEvent for each transaction
+// in the rolled-back blocks, allowing subscribers to undo any state changes.
+func (ls *LedgerState) emitTransactionRollbackEvents(
+	rollbackEvt chain.ChainRollbackEvent,
+) {
+	defer ls.rollbackWG.Done()
+
+	if ls.config.EventBus == nil {
+		return
+	}
+
+	for _, block := range rollbackEvt.RolledBackBlocks {
+		blk, err := block.Decode()
+		if err != nil {
+			ls.config.Logger.Warn(
+				fmt.Sprintf(
+					"ledger: failed to decode block for undo events: %s",
+					err,
+				),
+			)
+			continue
+		}
+
+		blockPoint := ocommon.Point{
+			Slot: block.Slot,
+			Hash: block.Hash,
+		}
+
+		txs := blk.Transactions()
+		for i := len(txs) - 1; i >= 0; i-- {
+			ls.config.EventBus.PublishAsync(
+				TransactionEventType,
+				event.NewEvent(
+					TransactionEventType,
+					TransactionEvent{
+						Transaction: txs[i],
+						Point:       blockPoint,
+						BlockNumber: block.Number,
+						TxIndex:     uint32(i), //nolint:gosec
+						Rollback:    true,
+					},
+				),
+			)
 		}
 	}
 }

--- a/ledger/eras/eras_test.go
+++ b/ledger/eras/eras_test.go
@@ -17,8 +17,9 @@ package eras_test
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
 )
 
 func TestGetEraById(t *testing.T) {

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -28,6 +28,7 @@ const (
 	BlockEventType       event.EventType = "ledger.block"
 	ChainsyncEventType   event.EventType = "chainsync.event"
 	LedgerErrorEventType event.EventType = "ledger.error"
+	TransactionEventType event.EventType = "ledger.tx"
 )
 
 // It represents the direction a block is applied to the ledger.
@@ -72,4 +73,14 @@ type LedgerErrorEvent struct {
 	Error     error         // The actual error that occurred
 	Operation string        // The operation that failed (e.g., "block_header", "rollback")
 	Point     ocommon.Point // Chain point where the error occurred, if applicable
+}
+
+// TransactionEvent is emitted when a transaction is applied or rolled back.
+// Check the Rollback field to determine direction.
+type TransactionEvent struct {
+	Transaction ledger.Transaction
+	Point       ocommon.Point
+	BlockNumber uint64
+	TxIndex     uint32
+	Rollback    bool
 }

--- a/ledger/genesis_utxo_test.go
+++ b/ledger/genesis_utxo_test.go
@@ -21,12 +21,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/config/cardano"
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
 )
 
 func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {

--- a/ledger/governance_test.go
+++ b/ledger/governance_test.go
@@ -17,10 +17,11 @@ package ledger
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/models"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 func TestMapVoterType(t *testing.T) {

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 // electionTestNonce is a 32-byte epoch nonce for election tests.

--- a/ledger/slot_battle_test.go
+++ b/ledger/slot_battle_test.go
@@ -21,11 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/ledger/forging"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/forging"
 )
 
 // mockForgedBlockChecker is a test implementation of ForgedBlockChecker.

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -437,9 +437,21 @@ type LedgerState struct {
 	chainsyncBlockfetchReadyMutex sync.Mutex
 	chainsyncBlockfetchReadyChan  chan struct{}
 	checkpointWrittenForEpoch     bool
-	closed                        bool
+	closed                        atomic.Bool
 	inRecovery                    bool // guards against recursive recovery in SubmitAsyncDBTxn
-	validationEnabled             bool
+
+	// Subscription IDs for event bus unsubscribe on close
+	chainsyncSubID   event.EventSubscriberId
+	blockfetchSubID  event.EventSubscriberId
+	chainUpdateSubID event.EventSubscriberId
+
+	// rollbackMu serializes rollbackWG.Add with Close's rollbackWG.Wait
+	// to prevent Add-after-Wait panics from the TOCTOU race between
+	// closed.Load() and Add(1) in handleEventChainUpdate.
+	rollbackMu sync.Mutex
+	// rollbackWG tracks in-flight rollback event emission goroutines
+	rollbackWG        sync.WaitGroup
+	validationEnabled bool
 
 	// Sync progress reporting (Fix 4)
 	syncProgressLastLog  time.Time     // last time we logged sync progress
@@ -537,15 +549,15 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 
 	// Setup event handlers
 	if ls.config.EventBus != nil {
-		ls.config.EventBus.SubscribeFunc(
+		ls.chainsyncSubID = ls.config.EventBus.SubscribeFunc(
 			ChainsyncEventType,
 			ls.handleEventChainsync,
 		)
-		ls.config.EventBus.SubscribeFunc(
+		ls.blockfetchSubID = ls.config.EventBus.SubscribeFunc(
 			BlockfetchEventType,
 			ls.handleEventBlockfetch,
 		)
-		ls.config.EventBus.SubscribeFunc(
+		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFunc(
 			chain.ChainUpdateEventType,
 			ls.handleEventChainUpdate,
 		)
@@ -787,13 +799,32 @@ func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 }
 
 func (ls *LedgerState) Close() error {
-	ls.Lock()
-	if ls.closed {
-		ls.Unlock()
+	if !ls.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	ls.closed = true
-	ls.Unlock()
+
+	// Unsubscribe from event bus to stop receiving new events
+	if ls.config.EventBus != nil {
+		ls.config.EventBus.Unsubscribe(
+			ChainsyncEventType,
+			ls.chainsyncSubID,
+		)
+		ls.config.EventBus.Unsubscribe(
+			BlockfetchEventType,
+			ls.blockfetchSubID,
+		)
+		ls.config.EventBus.Unsubscribe(
+			chain.ChainUpdateEventType,
+			ls.chainUpdateSubID,
+		)
+	}
+
+	// Wait for in-flight rollback event emission goroutines.
+	// Hold rollbackMu so no new goroutine can Add(1) between our
+	// closed flag and this Wait.
+	ls.rollbackMu.Lock()
+	ls.rollbackWG.Wait()
+	ls.rollbackMu.Unlock()
 
 	// Stop slot clock
 	if ls.slotClock != nil {
@@ -2204,7 +2235,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 	intraBlockUtxos := make(map[string]lcommon.Utxo)
 	for i, tx := range block.Transactions() {
 		if delta == nil {
-			delta = NewLedgerDelta(point, uint(block.Era().Id))
+			delta = NewLedgerDelta(point, uint(block.Era().Id), block.BlockNumber())
 			delta.Offsets = offsets
 		}
 		// Validate transaction

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -26,13 +26,14 @@ import (
 	"testing"
 	"time"
 
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
-	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestCalculateStabilityWindow_ByronEra tests the stability window calculation for Byron era

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -23,13 +23,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database"
-	"github.com/blinklabs-io/dingo/database/immutable"
-	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 // TestUtxoStorageAndRetrieval tests that UTxOs from regular blocks are stored

--- a/ledger/validation_test.go
+++ b/ledger/validation_test.go
@@ -19,10 +19,11 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/ledger/eras"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
 )
 
 // mockTransaction implements lcommon.Transaction for

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
@@ -34,6 +33,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 // =============================================================================

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -21,11 +21,12 @@ import (
 	"net"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/event"
 	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/blinklabs-io/dingo/event"
 )
 
 // testConnId creates a ConnectionId with valid net.Addr values for testing.

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -24,14 +24,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/connmanager"
-	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/topology"
 )
 
 func newMockEventBus() *event.EventBus {

--- a/utxorpc/submit_test.go
+++ b/utxorpc/submit_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/mempool"
-	"github.com/stretchr/testify/require"
 )
 
 // TestWaitForTx_PendingSetTracking verifies the pending transaction tracking

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -16,14 +16,14 @@ package utxorpc
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
-	"io"
-	"log/slog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUtxorpc_StartStop(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-transaction ledger.tx events on apply and rollback so clients can react to each tx with block and index context, and add safe shutdown that unsubscribes and waits for in-flight rollback emissions.

- **New Features**
  - Publish ledger.tx for every transaction on apply (after processing succeeds) and on rollback.
  - Event fields: transaction, point, blockNumber, txIndex, rollback.
  - Rollback events are emitted per rolled-back block in reverse transaction order (async), and Close waits for emitters to finish.

- **Migration**
  - NewLedgerDelta now requires blockNumber: NewLedgerDelta(point, eraId, blockNumber).

<sup>Written for commit b248512541d7e2e44a06d69e1aec4ed8a7fecb94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction-level events are now emitted when transactions are applied or rolled back during chain operations
  * Each transaction event includes block number and position information for enhanced traceability

* **Chores**
  * Improved thread-safe state management and event subscription handling within the ledger system
  * Enhanced synchronization for concurrent ledger operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->