### PR TITLE
fix(event): prevent publishWithTimeout goroutine leak

### DIFF
--- a/event/delivery_test.go
+++ b/event/delivery_test.go
@@ -3,6 +3,7 @@ package event
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 // mockSubscriber returns an error on Deliver to simulate a failing remote client.
@@ -41,5 +42,77 @@ func TestDeliverFailureUnregisters(t *testing.T) {
 		t.Fatalf(
 			"expected subscriber Close() to be called after deliver failure",
 		)
+	}
+}
+
+// TestChannelSubscriberDeliverNonBlocking verifies that channelSubscriber.Deliver
+// does not block when the channel buffer is full. This is the core fix for the
+// MEM-06 goroutine leak: previously, Deliver used a blocking send which caused
+// goroutines spawned by publishWithTimeout to leak.
+func TestChannelSubscriberDeliverNonBlocking(t *testing.T) {
+	const bufferSize = 5
+	sub := newChannelSubscriber(bufferSize, nil)
+
+	// Fill the buffer completely
+	for i := range bufferSize {
+		err := sub.Deliver(NewEvent("test", i))
+		if err != nil {
+			t.Fatalf("unexpected error on buffered deliver: %v", err)
+		}
+	}
+
+	// Deliver to the full buffer should return immediately without blocking.
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Deliver(NewEvent("test", "overflow"))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error on non-blocking deliver: %v", err)
+		}
+		// Good: Deliver returned without blocking
+	case <-time.After(1 * time.Second):
+		t.Fatal("Deliver blocked on full channel buffer; expected non-blocking drop")
+	}
+
+	// Verify the original buffered events are still present
+	for range bufferSize {
+		select {
+		case <-sub.ch:
+			// Expected
+		default:
+			t.Fatal("expected buffered event not found")
+		}
+	}
+
+	// Verify no extra event was inserted (the overflow should have been dropped)
+	select {
+	case evt := <-sub.ch:
+		t.Fatalf("unexpected extra event in channel: %v", evt)
+	default:
+		// Good: buffer only contains the original events
+	}
+}
+
+// TestChannelSubscriberDeliverAfterClose verifies that Deliver to a closed
+// subscriber returns nil (not a panic) and does not block.
+func TestChannelSubscriberDeliverAfterClose(t *testing.T) {
+	sub := newChannelSubscriber(5, nil)
+	sub.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Deliver(NewEvent("test", "after-close"))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Deliver after Close should return nil, got: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Deliver blocked after Close")
 	}
 }

--- a/event/event.go
+++ b/event/event.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	EventQueueSize      = 20
-	AsyncQueueSize      = 1000
-	AsyncWorkerPoolSize = 4
-	AsyncPublishTimeout = 5 * time.Second // Timeout for async Publish calls to prevent worker deadlock
+	EventQueueSize       = 20
+	AsyncQueueSize       = 1000
+	AsyncWorkerPoolSize  = 4
+	RemoteDeliverTimeout = 5 * time.Second
 )
 
 type EventType string
@@ -106,39 +106,12 @@ func (e *EventBus) asyncWorker() {
 			if !ok {
 				return
 			}
-			// Use bounded/watched Publish to prevent blocking forever on slow subscribers
-			e.publishWithTimeout(ae.eventType, ae.event)
+			// Publish directly — channelSubscriber.Deliver uses non-blocking
+			// sends so this cannot block forever on in-memory subscribers.
+			// Remote subscribers are time-bounded by deliverWithTimeout in
+			// Publish, so async workers cannot be stalled indefinitely.
+			e.Publish(ae.eventType, ae.event)
 		}
-	}
-}
-
-// publishWithTimeout wraps Publish with a timeout to prevent asyncWorker from
-// blocking forever on slow subscribers. If Publish doesn't complete within
-// AsyncPublishTimeout, the call is abandoned (the goroutine will complete
-// eventually, but the worker proceeds).
-func (e *EventBus) publishWithTimeout(eventType EventType, evt Event) {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		e.Publish(eventType, evt)
-	}()
-
-	select {
-	case <-done:
-		// Publish completed successfully
-	case <-time.After(AsyncPublishTimeout):
-		// Publish is taking too long, log and continue
-		// The goroutine will complete eventually
-		if e.Logger != nil {
-			e.Logger.Warn(
-				"async publish timeout exceeded",
-				"type", eventType,
-				"timeout", AsyncPublishTimeout,
-			)
-		}
-	case <-e.stopCh:
-		// EventBus is stopping, exit immediately
-		// The goroutine will complete eventually
 	}
 }
 
@@ -342,6 +315,58 @@ func (e *EventBus) Unsubscribe(eventType EventType, subId EventSubscriberId) {
 	}
 }
 
+// deliverWithTimeout calls sub.Deliver with a timeout for non-channel
+// subscribers. channelSubscriber.Deliver is already non-blocking, so it
+// is called directly. For other (e.g. network-backed) implementations,
+// the call is bounded by RemoteDeliverTimeout to prevent worker stalls.
+//
+// Bounded goroutine leak on timeout: when the timeout fires, the
+// goroutine running sub.Deliver remains alive until Deliver returns.
+// Because the done channel is buffered (size 1), the goroutine will
+// not block when it eventually writes its result -- it will complete
+// and be reclaimed. The caller (Publish) unsubscribes the slow
+// subscriber immediately after a timeout, preventing any further
+// goroutine spawns for that subscriber. Therefore at most one
+// goroutine can be outstanding per timed-out subscriber.
+//
+// True cancellation would require adding context support to the
+// Subscriber interface, which is out of scope for this change.
+func (e *EventBus) deliverWithTimeout(
+	sub Subscriber,
+	evt Event,
+) error {
+	// Fast path: in-memory channel subscribers are non-blocking.
+	if _, ok := sub.(*channelSubscriber); ok {
+		return sub.Deliver(evt)
+	}
+
+	// Slow path: bound remote Deliver calls with a timeout.
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				done <- fmt.Errorf("subscriber deliver panic: %v", r)
+			}
+		}()
+		done <- sub.Deliver(evt)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(RemoteDeliverTimeout):
+		if e.metrics != nil {
+			e.metrics.deliveryTimeouts.WithLabelValues(
+				string(evt.Type),
+			).Inc()
+		}
+		return fmt.Errorf(
+			"subscriber deliver timeout after %s",
+			RemoteDeliverTimeout,
+		)
+	}
+}
+
 // Publish allows a producer to send an event of a particular type to all subscribers
 func (e *EventBus) Publish(eventType EventType, evt Event) {
 	// Build list of channels inside read lock to avoid map race condition
@@ -358,7 +383,8 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 		}
 	}
 	e.mu.RUnlock()
-	// Send event on gathered subscribers (preserving per-subscriber blocking semantics)
+	// Send event on gathered subscribers (non-blocking for channel
+	// subscribers, time-bounded for remote subscribers via deliverWithTimeout)
 	for _, item := range subList {
 		// Protect against panics inside subscriber Deliver implementations.
 		var deliverErr error
@@ -368,7 +394,7 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 					deliverErr = fmt.Errorf("subscriber deliver panic: %v", r)
 				}
 			}()
-			deliverErr = item.sub.Deliver(evt)
+			deliverErr = e.deliverWithTimeout(item.sub, evt)
 		}()
 
 		if deliverErr != nil {

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -15,6 +15,7 @@
 package event_test
 
 import (
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -218,4 +219,137 @@ func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond,
 		"handler should continue processing events after a panic",
 	)
+}
+
+// TestPublishNoGoroutineLeak verifies that publishing to a slow or blocked
+// subscriber does not leak goroutines. This is a regression test for MEM-06
+// where publishWithTimeout spawned goroutines that could never complete when
+// a subscriber's channel buffer was full.
+func TestPublishNoGoroutineLeak(t *testing.T) {
+	const testEvtType event.EventType = "test.leak"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	// Subscribe but never read from the channel, simulating a blocked subscriber.
+	_, _ = eb.Subscribe(testEvtType)
+
+	// Allow the runtime to settle (async workers, etc.)
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	goroutinesBefore := runtime.NumGoroutine()
+
+	// Publish many more events than the channel buffer can hold (buffer = 20).
+	// With the old publishWithTimeout approach, each publish beyond the buffer
+	// would spawn a goroutine that could never complete.
+	const eventCount = 200
+	for i := range eventCount {
+		eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
+	}
+
+	// Give any hypothetical leaked goroutines a moment to accumulate
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	goroutinesAfter := runtime.NumGoroutine()
+
+	// With the fix, Publish returns immediately via non-blocking send.
+	// Allow a small margin (5) for normal runtime variation.
+	require.InDelta(
+		t,
+		goroutinesBefore,
+		goroutinesAfter,
+		5,
+		"goroutine count should not grow significantly after publishing to a blocked subscriber (before=%d, after=%d)",
+		goroutinesBefore,
+		goroutinesAfter,
+	)
+}
+
+// TestPublishAsyncNoGoroutineLeak verifies that PublishAsync with a slow
+// subscriber does not leak goroutines. The async workers call Publish
+// internally, which previously used publishWithTimeout.
+func TestPublishAsyncNoGoroutineLeak(t *testing.T) {
+	const testEvtType event.EventType = "test.async.leak"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	// Subscribe but never read from the channel.
+	_, _ = eb.Subscribe(testEvtType)
+
+	// Allow the runtime to settle
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	goroutinesBefore := runtime.NumGoroutine()
+
+	// PublishAsync many events; async workers will attempt to deliver them
+	// to the blocked subscriber via Publish -> Deliver.
+	const eventCount = 200
+	for i := range eventCount {
+		eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i))
+	}
+
+	// Wait for async workers to process the queued events
+	require.Eventually(t, func() bool {
+		// Publish one more and check if the queue has capacity (workers drained it)
+		return eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, -1))
+	}, 5*time.Second, 10*time.Millisecond, "async workers should drain the queue")
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	goroutinesAfter := runtime.NumGoroutine()
+
+	require.InDelta(
+		t,
+		goroutinesBefore,
+		goroutinesAfter,
+		5,
+		"goroutine count should not grow after async publishing to a blocked subscriber (before=%d, after=%d)",
+		goroutinesBefore,
+		goroutinesAfter,
+	)
+}
+
+// TestPublishDropsEventsOnFullBuffer verifies that when a subscriber's channel
+// buffer is full, Publish drops events gracefully instead of blocking.
+func TestPublishDropsEventsOnFullBuffer(t *testing.T) {
+	const testEvtType event.EventType = "test.drop"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	// Subscribe but never consume events.
+	_, subCh := eb.Subscribe(testEvtType)
+
+	// Fill the buffer (EventQueueSize = 20)
+	for i := range event.EventQueueSize {
+		eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
+	}
+
+	// Publish should return immediately even though the buffer is full.
+	// Use a timeout to ensure Publish doesn't block.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 50 {
+			eb.Publish(
+				testEvtType,
+				event.NewEvent(testEvtType, event.EventQueueSize+i),
+			)
+		}
+	}()
+
+	select {
+	case <-done:
+		// Good: Publish returned promptly
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish blocked on full subscriber channel buffer")
+	}
+
+	// Verify the subscriber still received the first EventQueueSize events.
+	for range event.EventQueueSize {
+		select {
+		case _, ok := <-subCh:
+			require.True(t, ok, "channel should not be closed")
+		case <-time.After(1 * time.Second):
+			t.Fatal("expected buffered event not received")
+		}
+	}
 }

--- a/event/metrics.go
+++ b/event/metrics.go
@@ -20,9 +20,10 @@ import (
 )
 
 type eventMetrics struct {
-	eventsTotal    *prometheus.CounterVec
-	subscribers    *prometheus.GaugeVec
-	deliveryErrors *prometheus.CounterVec
+	eventsTotal      *prometheus.CounterVec
+	subscribers      *prometheus.GaugeVec
+	deliveryErrors   *prometheus.CounterVec
+	deliveryTimeouts *prometheus.CounterVec
 }
 
 func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
@@ -48,5 +49,12 @@ func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
 			Help: "total delivery errors by event type and kind",
 		},
 		[]string{"type", "kind"},
+	)
+	e.metrics.deliveryTimeouts = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_delivery_timeouts_total",
+			Help: "total remote subscriber delivery timeouts by event type",
+		},
+		[]string{"type"},
 	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a goroutine leak in async event publishing by making channel delivery non-blocking and time-bounding remote deliveries. Slow or blocked subscribers no longer stall workers; overflow events are dropped safely.

- **Bug Fixes**
  - Removed publishWithTimeout/AsyncPublishTimeout; async workers call Publish directly. Remote subscribers are bounded via deliverWithTimeout (RemoteDeliverTimeout) with timeouts tracked by a new deliveryTimeouts metric.
  - Made channelSubscriber.Deliver non-blocking; drops when the buffer is full; Deliver after Close returns nil.
  - Added regression tests for goroutine leaks (Publish/PublishAsync), non-blocking Deliver with full buffers, and safe dropping on full buffers.

<sup>Written for commit c7cca446d921a8847626af3fbb4d07ae0aafb61f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

