### PR TITLE
fix(chainselection): peer tracking limit

### DIFF
--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -24,6 +24,7 @@ const (
 	PeerTipUpdateEventType  event.EventType = "chainselection.peer_tip_update"
 	ChainSwitchEventType    event.EventType = "chainselection.chain_switch"
 	ChainSelectionEventType event.EventType = "chainselection.selection"
+	PeerEvictedEventType    event.EventType = "chainselection.peer_evicted"
 )
 
 // PeerTipUpdateEvent is published when a peer's chain tip is updated via
@@ -59,4 +60,11 @@ type ChainSelectionEvent struct {
 	BestTip          ochainsync.Tip
 	PeerCount        int
 	SwitchOccurred   bool
+}
+
+// PeerEvictedEvent is published when a tracked peer is evicted from the
+// chain selector to make room for a new peer. Subscribers (e.g. connection
+// manager) can use this to close the evicted peer's connection.
+type PeerEvictedEvent struct {
+	ConnectionId ouroboros.ConnectionId
 }

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -30,6 +30,13 @@ import (
 const (
 	defaultEvaluationInterval = 10 * time.Second
 	defaultStaleTipThreshold  = 60 * time.Second
+
+	// DefaultMaxTrackedPeers is the maximum number of peers tracked by
+	// the ChainSelector. When a new peer is added and the limit is reached,
+	// the least-recently-updated peer is evicted. This bounds memory usage
+	// and CPU cost of chain selection, preventing Sybil-based resource
+	// exhaustion.
+	DefaultMaxTrackedPeers = 200
 )
 
 // safeBlockDiff computes the difference between two block numbers as int64,
@@ -64,19 +71,21 @@ type ChainSelectorConfig struct {
 	EvaluationInterval time.Duration
 	StaleTipThreshold  time.Duration
 	SecurityParam      uint64
+	MaxTrackedPeers    int // 0 means use DefaultMaxTrackedPeers
 }
 
 // ChainSelector tracks chain tips from multiple peers and selects the best
 // chain according to Ouroboros Praos rules.
 type ChainSelector struct {
-	config        ChainSelectorConfig
-	securityParam uint64
-	peerTips      map[ouroboros.ConnectionId]*PeerChainTip
-	bestPeerConn  *ouroboros.ConnectionId
-	localTip      ochainsync.Tip
-	mutex         sync.RWMutex
-	ctx           context.Context
-	cancel        context.CancelFunc
+	config          ChainSelectorConfig
+	securityParam   uint64
+	maxTrackedPeers int
+	peerTips        map[ouroboros.ConnectionId]*PeerChainTip
+	bestPeerConn    *ouroboros.ConnectionId
+	localTip        ochainsync.Tip
+	mutex           sync.RWMutex
+	ctx             context.Context
+	cancel          context.CancelFunc
 }
 
 // NewChainSelector creates a new ChainSelector with the given configuration.
@@ -91,10 +100,15 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 	if cfg.StaleTipThreshold == 0 {
 		cfg.StaleTipThreshold = defaultStaleTipThreshold
 	}
+	maxPeers := cfg.MaxTrackedPeers
+	if maxPeers <= 0 {
+		maxPeers = DefaultMaxTrackedPeers
+	}
 	return &ChainSelector{
-		config:        cfg,
-		securityParam: cfg.SecurityParam,
-		peerTips:      make(map[ouroboros.ConnectionId]*PeerChainTip),
+		config:          cfg,
+		securityParam:   cfg.SecurityParam,
+		maxTrackedPeers: maxPeers,
+		peerTips:        make(map[ouroboros.ConnectionId]*PeerChainTip),
 	}
 }
 
@@ -130,6 +144,7 @@ func (cs *ChainSelector) UpdatePeerTip(
 ) bool {
 	shouldEvaluate := false
 	accepted := true
+	var evictedConn *ouroboros.ConnectionId
 
 	func() {
 		cs.mutex.Lock()
@@ -160,6 +175,20 @@ func (cs *ChainSelector) UpdatePeerTip(
 		if peerTip, exists := cs.peerTips[connId]; exists {
 			peerTip.UpdateTip(tip, vrfOutput)
 		} else {
+			// Evict the least-recently-updated peer if at capacity
+			if len(cs.peerTips) >= cs.maxTrackedPeers {
+				evictedConn = cs.evictLeastRecentPeerLocked()
+				if evictedConn == nil {
+					cs.config.Logger.Warn(
+						"cannot accept new peer: at capacity and best peer is the only tracked peer",
+						"connection_id", connId.String(),
+						"peer_count", len(cs.peerTips),
+						"max_tracked_peers", cs.maxTrackedPeers,
+					)
+					accepted = false
+					return
+				}
+			}
 			cs.peerTips[connId] = NewPeerChainTip(connId, tip, vrfOutput)
 		}
 
@@ -183,6 +212,15 @@ func (cs *ChainSelector) UpdatePeerTip(
 		}
 	}()
 
+	// Publish eviction event outside the lock to prevent deadlock
+	if evictedConn != nil && cs.config.EventBus != nil {
+		evt := event.NewEvent(
+			PeerEvictedEventType,
+			PeerEvictedEvent{ConnectionId: *evictedConn},
+		)
+		cs.config.EventBus.Publish(PeerEvictedEventType, evt)
+	}
+
 	if !accepted {
 		return false
 	}
@@ -192,6 +230,65 @@ func (cs *ChainSelector) UpdatePeerTip(
 	}
 
 	return true
+}
+
+// evictLeastRecentPeerLocked removes the peer with the oldest LastUpdated
+// timestamp from the peerTips map. It never evicts the current best peer.
+// When multiple peers share the same LastUpdated timestamp (common on
+// Windows where clock resolution is ~15ms), the peer with the lowest
+// block number is evicted first. If block numbers also tie, the
+// connection ID string is used as a final deterministic tie-breaker.
+// Returns a pointer to the evicted connection ID, or nil if no eviction
+// was possible (e.g. the only tracked peer is the best peer).
+// Must be called with cs.mutex held.
+func (cs *ChainSelector) evictLeastRecentPeerLocked() *ouroboros.ConnectionId {
+	var oldestConn ouroboros.ConnectionId
+	var oldestTip *PeerChainTip
+	found := false
+
+	for connId, peerTip := range cs.peerTips {
+		// Never evict the current best peer
+		if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
+			continue
+		}
+		if !found {
+			oldestConn = connId
+			oldestTip = peerTip
+			found = true
+			continue
+		}
+		// Primary: oldest LastUpdated wins eviction
+		if peerTip.LastUpdated.Before(oldestTip.LastUpdated) {
+			oldestConn = connId
+			oldestTip = peerTip
+		} else if peerTip.LastUpdated.Equal(oldestTip.LastUpdated) {
+			// Tie-break on block number: evict the peer with
+			// the lower block number (less useful chain)
+			if peerTip.Tip.BlockNumber < oldestTip.Tip.BlockNumber {
+				oldestConn = connId
+				oldestTip = peerTip
+			} else if peerTip.Tip.BlockNumber == oldestTip.Tip.BlockNumber {
+				// Final tie-break: deterministic by connection ID
+				if connId.String() < oldestConn.String() {
+					oldestConn = connId
+					oldestTip = peerTip
+				}
+			}
+		}
+	}
+
+	if found {
+		cs.config.Logger.Debug(
+			"evicting least-recent peer due to tracking limit",
+			"connection_id", oldestConn.String(),
+			"last_updated", oldestTip.LastUpdated,
+			"peer_count", len(cs.peerTips),
+			"max_tracked_peers", cs.maxTrackedPeers,
+		)
+		delete(cs.peerTips, oldestConn)
+		return &oldestConn
+	}
+	return nil
 }
 
 // RemovePeer removes a peer from tracking.

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -762,3 +762,379 @@ func TestUpdatePeerTipSpoofedPeerDoesNotBecomesBest(t *testing.T) {
 		"legitimate peer should remain best peer",
 	)
 }
+
+func TestChainSelectorMaxTrackedPeersDefault(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+	assert.Equal(
+		t,
+		DefaultMaxTrackedPeers,
+		cs.maxTrackedPeers,
+		"default max tracked peers should be applied",
+	)
+}
+
+func TestChainSelectorMaxTrackedPeersCustom(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: 50,
+	})
+	assert.Equal(
+		t,
+		50,
+		cs.maxTrackedPeers,
+		"custom max tracked peers should be applied",
+	)
+}
+
+func TestChainSelectorPeerEvictionAtCapacity(t *testing.T) {
+	const maxPeers = 5
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: maxPeers,
+	})
+
+	// Pre-create connection IDs so the same pointers are reused for
+	// map lookups (ConnectionId contains net.Addr interface fields).
+	connIds := make([]ouroboros.ConnectionId, maxPeers+1)
+	for i := range connIds {
+		connIds[i] = newTestConnectionId(i)
+	}
+
+	// Fill to capacity with peers. Each peer gets a slightly higher slot
+	// to ensure different LastUpdated timestamps (they are added
+	// sequentially so time.Now() progresses).
+	for i := 0; i < maxPeers; i++ {
+		tip := ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: uint64(100 + i),
+				Hash: []byte(fmt.Sprintf("tip%d", i)),
+			},
+			BlockNumber: uint64(50 + i),
+		}
+		cs.UpdatePeerTip(connIds[i], tip, nil)
+	}
+	assert.Equal(t, maxPeers, cs.PeerCount(), "should be at capacity")
+
+	// Peer 0 was added first and has the oldest LastUpdated.
+	// It may or may not be the best peer (peer maxPeers-1 has highest
+	// block number and becomes best via auto-evaluation). Verify peer 0
+	// exists before we trigger eviction.
+	require.NotNil(
+		t,
+		cs.GetPeerTip(connIds[0]),
+		"peer 0 should exist before eviction",
+	)
+
+	// Add one more peer beyond the limit
+	newTip := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: uint64(100 + maxPeers),
+			Hash: []byte("new"),
+		},
+		BlockNumber: uint64(50 + maxPeers),
+	}
+	cs.UpdatePeerTip(connIds[maxPeers], newTip, nil)
+
+	// Count should still be at the limit
+	assert.Equal(
+		t,
+		maxPeers,
+		cs.PeerCount(),
+		"peer count should not exceed max",
+	)
+
+	// The new peer should be present
+	require.NotNil(
+		t,
+		cs.GetPeerTip(connIds[maxPeers]),
+		"new peer should be tracked",
+	)
+
+	// The oldest peer (peer 0) should have been evicted since it is not
+	// the best peer (peer maxPeers-1 has the highest block number).
+	assert.Nil(
+		t,
+		cs.GetPeerTip(connIds[0]),
+		"oldest peer should have been evicted",
+	)
+
+	// Peers 1 through maxPeers-1 should still be present
+	for i := 1; i < maxPeers; i++ {
+		assert.NotNil(
+			t,
+			cs.GetPeerTip(connIds[i]),
+			"peer %d should still be tracked",
+			i,
+		)
+	}
+}
+
+func TestChainSelectorUpdateExistingPeerDoesNotEvict(t *testing.T) {
+	const maxPeers = 3
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: maxPeers,
+	})
+
+	// Pre-create connection IDs so the same pointers are reused
+	connIds := make([]ouroboros.ConnectionId, maxPeers)
+	for i := range connIds {
+		connIds[i] = newTestConnectionId(i)
+	}
+
+	// Fill to capacity
+	for i := 0; i < maxPeers; i++ {
+		tip := ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: uint64(100 + i),
+				Hash: []byte(fmt.Sprintf("tip%d", i)),
+			},
+			BlockNumber: uint64(50 + i),
+		}
+		cs.UpdatePeerTip(connIds[i], tip, nil)
+	}
+	assert.Equal(t, maxPeers, cs.PeerCount())
+
+	// Update an existing peer (peer 1) with a new tip
+	updatedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("updated")},
+		BlockNumber: 100,
+	}
+	cs.UpdatePeerTip(connIds[1], updatedTip, nil)
+
+	// Count should remain the same -- no eviction for existing peer updates
+	assert.Equal(
+		t,
+		maxPeers,
+		cs.PeerCount(),
+		"updating existing peer should not change count",
+	)
+
+	// All original peers should still be present
+	for i := 0; i < maxPeers; i++ {
+		assert.NotNil(
+			t,
+			cs.GetPeerTip(connIds[i]),
+			"peer %d should still be tracked after existing peer update",
+			i,
+		)
+	}
+
+	// Verify the update was applied
+	peerTip := cs.GetPeerTip(connIds[1])
+	require.NotNil(t, peerTip)
+	assert.Equal(
+		t,
+		updatedTip.BlockNumber,
+		peerTip.Tip.BlockNumber,
+		"existing peer tip should be updated",
+	)
+}
+
+func TestChainSelectorEvictionPreservesBestPeer(t *testing.T) {
+	const maxPeers = 3
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: maxPeers,
+	})
+
+	// Pre-create connection IDs so the same pointers are reused
+	connIds := make([]ouroboros.ConnectionId, maxPeers+1)
+	for i := range connIds {
+		connIds[i] = newTestConnectionId(i)
+	}
+
+	// Add peer 0 first (oldest) with the BEST tip
+	bestTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("best")},
+		BlockNumber: 999, // Highest block number = best chain
+	}
+	cs.UpdatePeerTip(connIds[0], bestTip, nil)
+
+	// Trigger evaluation so peer 0 becomes the best peer
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connIds[0], *cs.GetBestPeer())
+
+	// Add peers 1 and 2 (at capacity now)
+	for i := 1; i < maxPeers; i++ {
+		tip := ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: uint64(100 + i),
+				Hash: []byte(fmt.Sprintf("tip%d", i)),
+			},
+			BlockNumber: uint64(50 + i),
+		}
+		cs.UpdatePeerTip(connIds[i], tip, nil)
+	}
+	assert.Equal(t, maxPeers, cs.PeerCount())
+
+	// Add a new peer beyond the limit. Peer 0 is oldest but is the best
+	// peer, so peer 1 (next oldest) should be evicted instead.
+	newTip := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: uint64(100 + maxPeers),
+			Hash: []byte("new"),
+		},
+		BlockNumber: uint64(50 + maxPeers),
+	}
+	cs.UpdatePeerTip(connIds[maxPeers], newTip, nil)
+
+	assert.Equal(t, maxPeers, cs.PeerCount())
+
+	// Best peer (peer 0) must NOT have been evicted
+	assert.NotNil(
+		t,
+		cs.GetPeerTip(connIds[0]),
+		"best peer must not be evicted",
+	)
+
+	// One of the non-best peers (1 or 2) should have been evicted.
+	// We don't assert which one because eviction among peers with equal
+	// timestamps depends on map iteration order, which is non-deterministic.
+	evictedCount := 0
+	for i := 1; i < maxPeers; i++ {
+		if cs.GetPeerTip(connIds[i]) == nil {
+			evictedCount++
+		}
+	}
+	assert.Equal(
+		t,
+		1,
+		evictedCount,
+		"exactly one non-best peer should be evicted",
+	)
+
+	// New peer should be present
+	assert.NotNil(
+		t,
+		cs.GetPeerTip(connIds[maxPeers]),
+		"new peer should be tracked",
+	)
+}
+
+func TestChainSelectorEvictionEmitsPeerEvictedEvent(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	const maxPeers = 2
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: maxPeers,
+		EventBus:        eb,
+	})
+
+	evictedCh := make(chan PeerEvictedEvent, 1)
+	eb.SubscribeFunc(PeerEvictedEventType, func(evt event.Event) {
+		e, ok := evt.Data.(PeerEvictedEvent)
+		if ok {
+			evictedCh <- e
+		}
+	})
+
+	connIds := make([]ouroboros.ConnectionId, maxPeers+1)
+	for i := range connIds {
+		connIds[i] = newTestConnectionId(i)
+	}
+
+	// Fill to capacity
+	for i := 0; i < maxPeers; i++ {
+		tip := ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: uint64(100 + i),
+				Hash: []byte(fmt.Sprintf("tip%d", i)),
+			},
+			BlockNumber: uint64(50 + i),
+		}
+		cs.UpdatePeerTip(connIds[i], tip, nil)
+	}
+
+	// Add one more peer to trigger eviction
+	newTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("new")},
+		BlockNumber: 60,
+	}
+	cs.UpdatePeerTip(connIds[maxPeers], newTip, nil)
+
+	// Should receive a PeerEvictedEvent
+	select {
+	case evt := <-evictedCh:
+		// The evicted peer should be one of the original peers
+		assert.True(
+			t,
+			evt.ConnectionId == connIds[0] || evt.ConnectionId == connIds[1],
+			"evicted peer should be one of the original peers",
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected PeerEvictedEvent but none received")
+	}
+}
+
+func TestChainSelectorEvictionFailsWhenOnlyBestPeer(t *testing.T) {
+	// When maxTrackedPeers=1 and the sole peer is best, eviction cannot
+	// proceed. The new peer should be rejected rather than exceeding the cap.
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: 1,
+	})
+
+	bestConn := newTestConnectionId(0)
+	bestTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("best")},
+		BlockNumber: 999,
+	}
+	cs.UpdatePeerTip(bestConn, bestTip, nil)
+	cs.EvaluateAndSwitch()
+
+	require.Equal(t, 1, cs.PeerCount())
+	require.NotNil(t, cs.GetBestPeer())
+
+	// Try to add a second peer — should be rejected
+	newConn := newTestConnectionId(1)
+	newTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("new")},
+		BlockNumber: 50,
+	}
+	accepted := cs.UpdatePeerTip(newConn, newTip, nil)
+
+	assert.False(t, accepted, "new peer should be rejected when eviction fails")
+	assert.Equal(t, 1, cs.PeerCount(), "peer count must not exceed max")
+	assert.Nil(t, cs.GetPeerTip(newConn), "rejected peer should not be tracked")
+	assert.NotNil(t, cs.GetPeerTip(bestConn), "best peer must remain")
+}
+
+func TestChainSelectorNormalOperationWithinLimit(t *testing.T) {
+	const maxPeers = 10
+	cs := NewChainSelector(ChainSelectorConfig{
+		MaxTrackedPeers: maxPeers,
+	})
+
+	expectedCount := maxPeers - 3
+
+	// Pre-create connection IDs so the same pointers are reused
+	connIds := make([]ouroboros.ConnectionId, expectedCount)
+	for i := range connIds {
+		connIds[i] = newTestConnectionId(i)
+	}
+
+	// Add fewer peers than the limit
+	for i := 0; i < expectedCount; i++ {
+		tip := ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: uint64(100 + i),
+				Hash: []byte(fmt.Sprintf("tip%d", i)),
+			},
+			BlockNumber: uint64(50 + i),
+		}
+		cs.UpdatePeerTip(connIds[i], tip, nil)
+	}
+
+	assert.Equal(
+		t,
+		expectedCount,
+		cs.PeerCount(),
+		"all peers should be tracked when below limit",
+	)
+
+	// All peers should be present
+	for i := 0; i < expectedCount; i++ {
+		assert.NotNil(
+			t,
+			cs.GetPeerTip(connIds[i]),
+			"peer %d should be tracked",
+			i,
+		)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a peer tracking limit to ChainSelector to prevent resource exhaustion and stabilize selection under Sybil attacks. At capacity, it evicts the least-recently-updated peer (with deterministic tie-breakers) while preserving the current best; evictions publish a PeerEvicted event, and if eviction isn’t possible, new peers are rejected.

- **Bug Fixes**
  - Enforce a cap with DefaultMaxTrackedPeers=200; configurable via MaxTrackedPeers.
  - Evict least-recently-updated peer (never the current best); reject new peers when only the best is tracked.
  - Emit PeerEvicted event for subscriber cleanup; tests cover defaults, custom limits, eviction ordering/ties, best preservation, existing-peer updates, event emission, rejection at limit, and normal operation under the cap.

<sup>Written for commit 7e6d86cc9fd13b0579ac576c1d2f20c89942ccc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable max tracked peers with a sensible default; when capacity is reached the least-recently-updated peer is evicted (current best is preserved) and an eviction event is published for observability. New behavior rejects adding a new peer if only the best peer would remain.

* **Tests**
  * Added comprehensive tests covering defaults, custom limits, eviction mechanics, best-peer preservation, edge cases, and event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->