### PR TITLE
fix(chain): convert recursive iterNext to for loop

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -512,78 +512,83 @@ func (c *Chain) iterNext(
 	iter *ChainIterator,
 	blocking bool,
 ) (*ChainIteratorResult, error) {
-	c.mutex.Lock()
-	// We get a read lock on the manager for the integrity check and initial block lookup
-	c.manager.mutex.RLock()
-	// Verify chain integrity
-	if err := c.reconcile(); err != nil {
-		c.mutex.Unlock()
-		c.manager.mutex.RUnlock()
-		return nil, err
-	}
-	// Check for pending rollback
-	if iter.needsRollback {
-		ret := &ChainIteratorResult{}
-		ret.Point = iter.rollbackPoint
-		ret.Rollback = true
-		iter.lastPoint = iter.rollbackPoint
-		iter.needsRollback = false
-		if iter.rollbackPoint.Slot > 0 {
-			// Lookup block index for rollback point
-			tmpBlock, err := c.manager.blockByPoint(iter.rollbackPoint, nil)
-			if err != nil {
-				c.mutex.Unlock()
-				c.manager.mutex.RUnlock()
-				return nil, err
+	for {
+		c.mutex.Lock()
+		// We get a read lock on the manager for the integrity check and initial block lookup
+		c.manager.mutex.RLock()
+		// Verify chain integrity
+		if err := c.reconcile(); err != nil {
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return nil, err
+		}
+		// Check for pending rollback
+		if iter.needsRollback {
+			ret := &ChainIteratorResult{}
+			ret.Point = iter.rollbackPoint
+			ret.Rollback = true
+			iter.lastPoint = iter.rollbackPoint
+			iter.needsRollback = false
+			if iter.rollbackPoint.Slot > 0 {
+				// Lookup block index for rollback point
+				tmpBlock, err := c.manager.blockByPoint(
+					iter.rollbackPoint,
+					nil,
+				)
+				if err != nil {
+					c.mutex.Unlock()
+					c.manager.mutex.RUnlock()
+					return nil, err
+				}
+				iter.nextBlockIndex = tmpBlock.ID + 1
 			}
-			iter.nextBlockIndex = tmpBlock.ID + 1
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return ret, nil
+		}
+		ret := &ChainIteratorResult{}
+		// Lookup next block in metadata DB
+		tmpBlock, err := c.blockByIndex(iter.nextBlockIndex)
+		// Return immedidately if a block is found
+		if err == nil {
+			ret.Point = ocommon.NewPoint(tmpBlock.Slot, tmpBlock.Hash)
+			ret.Block = tmpBlock
+			iter.nextBlockIndex++
+			iter.lastPoint = ret.Point
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return ret, nil
+		}
+		// Return any actual error
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return ret, err
+		}
+		// Return immediately if we're not blocking
+		if !blocking {
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return nil, ErrIteratorChainTip
 		}
 		c.mutex.Unlock()
 		c.manager.mutex.RUnlock()
-		return ret, nil
-	}
-	ret := &ChainIteratorResult{}
-	// Lookup next block in metadata DB
-	tmpBlock, err := c.blockByIndex(iter.nextBlockIndex)
-	// Return immedidately if a block is found
-	if err == nil {
-		ret.Point = ocommon.NewPoint(tmpBlock.Slot, tmpBlock.Hash)
-		ret.Block = tmpBlock
-		iter.nextBlockIndex++
-		iter.lastPoint = ret.Point
-		c.mutex.Unlock()
-		c.manager.mutex.RUnlock()
-		return ret, nil
-	}
-	// Return any actual error
-	if !errors.Is(err, models.ErrBlockNotFound) {
-		c.mutex.Unlock()
-		c.manager.mutex.RUnlock()
-		return ret, err
-	}
-	// Return immediately if we're not blocking
-	if !blocking {
-		c.mutex.Unlock()
-		c.manager.mutex.RUnlock()
-		return nil, ErrIteratorChainTip
-	}
-	c.mutex.Unlock()
-	c.manager.mutex.RUnlock()
-	// Wait for chain update
-	c.waitingChanMutex.Lock()
-	if c.waitingChan == nil {
-		c.waitingChan = make(chan struct{})
-	}
-	waitChan := c.waitingChan
-	c.waitingChanMutex.Unlock()
+		// Wait for chain update
+		c.waitingChanMutex.Lock()
+		if c.waitingChan == nil {
+			c.waitingChan = make(chan struct{})
+		}
+		waitChan := c.waitingChan
+		c.waitingChanMutex.Unlock()
 
-	select {
-	case <-waitChan:
-		// Call ourselves again now that we should have new data
-		return c.iterNext(iter, blocking)
-	case <-iter.ctx.Done():
-		// Iterator was cancelled
-		return nil, iter.ctx.Err()
+		select {
+		case <-waitChan:
+			// Loop again now that we should have new data
+			continue
+		case <-iter.ctx.Done():
+			// Iterator was cancelled
+			return nil, iter.ctx.Err()
+		}
 	}
 }
 

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -16,6 +16,7 @@ package chain
 
 import (
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/event"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -123,4 +124,100 @@ func TestIteratorCancelIdempotent(t *testing.T) {
 	c.mutex.RLock()
 	assert.Equal(t, 0, len(c.iterators))
 	c.mutex.RUnlock()
+}
+
+// TestIterNextSpuriousWakeups verifies that the blocking
+// iterator survives many spurious wake-ups (channel closes
+// with no new block available) without stack overflow.
+//
+// Before the fix, iterNext called itself recursively on each
+// wake-up. With thousands of spurious signals, this would
+// overflow the goroutine stack. The iterative loop fix makes
+// this safe regardless of wake-up count.
+func TestIterNextSpuriousWakeups(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := NewManager(nil, eventBus)
+	require.NoError(t, err)
+
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	// Create a blocking iterator from origin
+	iter, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+	defer iter.Cancel()
+
+	// Channel to receive the iterator result from the
+	// blocking goroutine.
+	type iterResult struct {
+		result *ChainIteratorResult
+		err    error
+	}
+	resultCh := make(chan iterResult, 1)
+
+	// Start a goroutine that calls Next(blocking=true).
+	// It will block until a block is available.
+	go func() {
+		res, err := iter.Next(true)
+		resultCh <- iterResult{result: res, err: err}
+	}()
+
+	// Fire many spurious wake-ups. Each wake-up closes the
+	// waitingChan without adding a block, forcing the
+	// iterator to loop again. With the old recursive code,
+	// 10 000 wake-ups would overflow the stack.
+	const spuriousCount = 10_000
+	for i := range spuriousCount {
+		// Give the iterator goroutine a moment to register
+		// its wait channel before we close it.
+		require.Eventually(t, func() bool {
+			c.waitingChanMutex.Lock()
+			defer c.waitingChanMutex.Unlock()
+			return c.waitingChan != nil
+		}, 2*time.Second, time.Millisecond,
+			"iterator should create waitingChan "+
+				"(wake-up %d)", i,
+		)
+
+		// Close the waiting channel (spurious wake-up)
+		c.waitingChanMutex.Lock()
+		close(c.waitingChan)
+		c.waitingChan = nil
+		c.waitingChanMutex.Unlock()
+	}
+
+	// Verify the iterator has not returned yet (still
+	// blocking because no block was added).
+	select {
+	case r := <-resultCh:
+		t.Fatalf(
+			"iterator should still be blocking "+
+				"after spurious wake-ups, got: %+v",
+			r,
+		)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: still blocking
+	}
+
+	// Now cancel the iterator to unblock the goroutine.
+	iter.Cancel()
+
+	// The blocked Next() should return a context
+	// cancellation error.
+	require.Eventually(t, func() bool {
+		select {
+		case r := <-resultCh:
+			resultCh <- r // put it back for final assertion
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, time.Millisecond,
+		"iterator should return after cancel",
+	)
+
+	r := <-resultCh
+	require.Error(t, r.err,
+		"cancelled iterator should return an error",
+	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Convert recursive iterNext to a loop to prevent stack overflow under repeated spurious wake-ups while keeping iterator behavior unchanged. Adds a stress test to confirm blocking behavior and graceful cancellation.

- **Bug Fixes**
  - Replace recursive wake-up handling with an iterative loop; preserves lock order and blocking semantics, eliminates stack growth on repeated signals.
  - Add TestIterNextSpuriousWakeups (10,000 spurious signals) to verify Next remains blocked without new blocks and returns on cancel.

<sup>Written for commit cf44c5dc98f18467c9e27f041f0be0837b9b60e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

