### PR TITLE
fix: handle nils for chain selection

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -410,10 +410,14 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 				"slot", newTip.Point.Slot,
 			)
 
-			if cs.config.EventBus != nil && previousBest != nil {
+			if cs.config.EventBus != nil {
 				var previousTip ochainsync.Tip
-				if pt, ok := cs.peerTips[*previousBest]; ok {
-					previousTip = pt.Tip
+				var previousConnId ouroboros.ConnectionId
+				if previousBest != nil {
+					previousConnId = *previousBest
+					if pt, ok := cs.peerTips[*previousBest]; ok {
+						previousTip = pt.Tip
+					}
 				}
 				// Compute comparison result and block difference
 				comparisonResult := CompareChains(newTip, previousTip)
@@ -424,7 +428,7 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 				evt := event.NewEvent(
 					ChainSwitchEventType,
 					ChainSwitchEvent{
-						PreviousConnectionId: *previousBest,
+						PreviousConnectionId: previousConnId,
 						NewConnectionId:      *newBest,
 						NewTip:               newTip,
 						PreviousTip:          previousTip,

--- a/node.go
+++ b/node.go
@@ -289,9 +289,14 @@ func (n *Node) Run(ctx context.Context) error {
 			if !ok {
 				return
 			}
+			prevConn := "(none)"
+			if e.PreviousConnectionId.LocalAddr != nil &&
+				e.PreviousConnectionId.RemoteAddr != nil {
+				prevConn = e.PreviousConnectionId.String()
+			}
 			n.config.logger.Info(
 				"chain switch: updating active connection",
-				"previous_connection", e.PreviousConnectionId.String(),
+				"previous_connection", prevConn,
 				"new_connection", e.NewConnectionId.String(),
 				"new_tip_block", e.NewTip.BlockNumber,
 				"new_tip_slot", e.NewTip.Point.Slot,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented nil dereferences during chain switches and made events and logs safe when there’s no previous connection. Chain switch events now emit on the first selection and logs show “(none)” when no previous connection exists.

- **Bug Fixes**
  - Always emit ChainSwitchEvent; use a zero-value PreviousConnectionId and include PreviousTip only when available.
  - In Node.Run, check LocalAddr/RemoteAddr before logging; show “(none)” if PreviousConnectionId is empty.

<sup>Written for commit 6c8871cd3770fbe62e8dcc8148ea833a492284a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chain switching events are now reliably emitted in all scenarios, including edge cases where no previous connection exists.
  * Logging has been improved to gracefully handle cases where connection information may be unavailable, preventing errors during startup or disconnection events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->