### PR TITLE
fix(ledger): prevent divide by zero

### DIFF
--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -188,6 +188,12 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	lastEpoch := epochCacheCopy[len(epochCacheCopy)-1]
 	lastEpochEndSlot := lastEpoch.StartSlot + uint64(lastEpoch.LengthInSlots)
 
+	if lastEpoch.LengthInSlots == 0 {
+		return models.Epoch{}, errors.New(
+			"cannot project epoch: last known epoch has LengthInSlots=0",
+		)
+	}
+
 	// Calculate how many epochs past the last known epoch this slot is
 	slotsPastLastEpoch := slot - lastEpochEndSlot
 	epochsPastLast := slotsPastLastEpoch / uint64(lastEpoch.LengthInSlots)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix divide-by-zero in ledger SlotToEpoch by returning an error when the last known epoch has LengthInSlots=0. Prevents crashes and incorrect epoch projection in this edge case.

<sup>Written for commit 45d31f9227948c77e192de25662e4461ba937a6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced epoch projection error handling with additional validation to gracefully handle edge cases and prevent failures during slot calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->