### PR TITLE
fix(utxorpc): add request size limits and context cancellation propagation

### DIFF
--- a/utxorpc/query.go
+++ b/utxorpc/query.go
@@ -215,6 +215,19 @@ func (s *queryServiceServer) ReadUtxos(
 	s.utxorpc.config.Logger.Info(
 		fmt.Sprintf("Got a ReadUtxos request with keys %v", keys),
 	)
+
+	// Enforce request size limit
+	if len(keys) > s.utxorpc.config.MaxUtxoKeys {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			fmt.Errorf(
+				"too many UTxO keys: %d exceeds maximum of %d",
+				len(keys),
+				s.utxorpc.config.MaxUtxoKeys,
+			),
+		)
+	}
+
 	resp := &query.ReadUtxosResponse{}
 
 	// Get UTxOs from ledger
@@ -448,6 +461,19 @@ func (s *queryServiceServer) ReadData(
 			fieldMask,
 		),
 	)
+
+	// Enforce request size limit
+	if len(keys) > s.utxorpc.config.MaxDataKeys {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			fmt.Errorf(
+				"too many data keys: %d exceeds maximum of %d",
+				len(keys),
+				s.utxorpc.config.MaxDataKeys,
+			),
+		)
+	}
+
 	resp := &query.ReadDataResponse{}
 
 	for _, key := range keys {

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -38,6 +38,15 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
+// Default request size limits to prevent denial-of-service via
+// unbounded request arrays.
+const (
+	DefaultMaxBlockRefs    = 100
+	DefaultMaxUtxoKeys     = 1000
+	DefaultMaxHistoryItems = 10000
+	DefaultMaxDataKeys     = 1000
+)
+
 type Utxorpc struct {
 	server *http.Server
 	config UtxorpcConfig
@@ -53,6 +62,12 @@ type UtxorpcConfig struct {
 	TlsKeyFilePath  string
 	Host            string
 	Port            uint
+
+	// Request size limits (0 = use default)
+	MaxBlockRefs    int
+	MaxUtxoKeys     int
+	MaxHistoryItems int
+	MaxDataKeys     int
 }
 
 func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
@@ -65,6 +80,18 @@ func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
 	}
 	if cfg.Port == 0 {
 		cfg.Port = 9090
+	}
+	if cfg.MaxBlockRefs <= 0 {
+		cfg.MaxBlockRefs = DefaultMaxBlockRefs
+	}
+	if cfg.MaxUtxoKeys <= 0 {
+		cfg.MaxUtxoKeys = DefaultMaxUtxoKeys
+	}
+	if cfg.MaxHistoryItems <= 0 {
+		cfg.MaxHistoryItems = DefaultMaxHistoryItems
+	}
+	if cfg.MaxDataKeys <= 0 {
+		cfg.MaxDataKeys = DefaultMaxDataKeys
 	}
 	return &Utxorpc{
 		config: cfg,

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -26,6 +26,92 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 )
 
+func TestNewUtxorpc_DefaultLimits(t *testing.T) {
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil, nil),
+	})
+	require.Equal(
+		t,
+		DefaultMaxBlockRefs,
+		u.config.MaxBlockRefs,
+		"MaxBlockRefs should default",
+	)
+	require.Equal(
+		t,
+		DefaultMaxUtxoKeys,
+		u.config.MaxUtxoKeys,
+		"MaxUtxoKeys should default",
+	)
+	require.Equal(
+		t,
+		DefaultMaxHistoryItems,
+		u.config.MaxHistoryItems,
+		"MaxHistoryItems should default",
+	)
+	require.Equal(
+		t,
+		DefaultMaxDataKeys,
+		u.config.MaxDataKeys,
+		"MaxDataKeys should default",
+	)
+}
+
+func TestNewUtxorpc_CustomLimits(t *testing.T) {
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:        event.NewEventBus(nil, nil),
+		MaxBlockRefs:    50,
+		MaxUtxoKeys:     500,
+		MaxHistoryItems: 5000,
+		MaxDataKeys:     200,
+	})
+	require.Equal(t, 50, u.config.MaxBlockRefs)
+	require.Equal(t, 500, u.config.MaxUtxoKeys)
+	require.Equal(t, 5000, u.config.MaxHistoryItems)
+	require.Equal(t, 200, u.config.MaxDataKeys)
+}
+
+// TestRequestLimitConstants verifies that the default limit constants
+// are reasonable values for preventing DoS while allowing normal use.
+func TestRequestLimitConstants(t *testing.T) {
+	require.Equal(t, 100, DefaultMaxBlockRefs)
+	require.Equal(t, 1000, DefaultMaxUtxoKeys)
+	require.Equal(t, 10000, DefaultMaxHistoryItems)
+	require.Equal(t, 1000, DefaultMaxDataKeys)
+}
+
+// TestRequestLimitEnforcement_Pattern verifies the limit enforcement
+// pattern used in FetchBlock, ReadUtxos, DumpHistory, and ReadData.
+// This tests the comparison logic in isolation, since calling the
+// actual gRPC handlers requires a full LedgerState.
+func TestRequestLimitEnforcement_Pattern(t *testing.T) {
+	tests := []struct {
+		name      string
+		count     int
+		limit     int
+		shouldErr bool
+	}{
+		{"at limit", 100, 100, false},
+		{"below limit", 50, 100, false},
+		{"above limit", 101, 100, true},
+		{"zero items", 0, 100, false},
+		{"single item", 1, 100, false},
+		{"way above limit", 10000, 100, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exceeds := tc.count > tc.limit
+			require.Equal(
+				t,
+				tc.shouldErr,
+				exceeds,
+				"limit enforcement mismatch",
+			)
+		})
+	}
+}
+
 func TestUtxorpc_StartStop(t *testing.T) {
 	// Start server on ephemeral port by setting Port to 0
 	u := NewUtxorpc(UtxorpcConfig{


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add request size limits and propagate stream context cancellation to iterators. This prevents oversized request DoS and ensures streams close promptly on client disconnect.

- **New Features**
  - Added default limits with overrides: MaxBlockRefs=100, MaxUtxoKeys=1000, MaxHistoryItems=10000, MaxDataKeys=1000.
  - Enforce limits in FetchBlock, ReadUtxos, DumpHistory, and ReadData with InvalidArgument errors when exceeded.

- **Bug Fixes**
  - FollowTip and WatchTx now cancel the chain iterator when the stream context ends, unblocking Next(true) immediately and logging disconnects.
  - Added tests for default/custom limits, limit enforcement logic, and the stream cancellation pattern.

<sup>Written for commit 4a97605edcbbeb59a083d34ca4d0ec5d61d8e7e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

