### PR TITLE
feat(ledger): genesis stake pools + delegations

### DIFF
--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -1682,3 +1682,13 @@ func (d *MetadataStoreMysql) DeleteTransactionsAfterSlot(
 
 	return nil
 }
+
+// SetGenesisStaking is not implemented for the MySQL metadata plugin.
+func (d *MetadataStoreMysql) SetGenesisStaking(
+	_ map[string]lcommon.PoolRegistrationCertificate,
+	_ map[string]string,
+	_ []byte,
+	_ types.Txn,
+) error {
+	return errors.New("genesis staking not implemented for mysql")
+}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1660,3 +1660,13 @@ func (d *MetadataStorePostgres) DeleteTransactionsAfterSlot(
 
 	return nil
 }
+
+// SetGenesisStaking is not implemented for the PostgreSQL metadata plugin.
+func (d *MetadataStorePostgres) SetGenesisStaking(
+	_ map[string]lcommon.PoolRegistrationCertificate,
+	_ map[string]string,
+	_ []byte,
+	_ types.Txn,
+) error {
+	return errors.New("genesis staking not implemented for postgres")
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -279,6 +279,17 @@ type MetadataStore interface {
 		txn types.Txn,
 	) error
 
+	// SetGenesisStaking stores genesis pool registrations and stake
+	// delegations from the shelley-genesis.json staking section.
+	// pools maps pool key hash (hex) to its registration certificate.
+	// stakeDelegations maps staking credential hash (hex) to pool key hash (hex).
+	SetGenesisStaking(
+		pools map[string]lcommon.PoolRegistrationCertificate,
+		stakeDelegations map[string]string,
+		blockHash []byte,
+		txn types.Txn,
+	) error
+
 	// Helper methods
 
 	// DeleteBlockNoncesBeforeSlot removes block nonces older than the given slot.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -221,6 +221,36 @@ func (d *Database) SetGenesisTransaction(
 	return nil
 }
 
+// SetGenesisStaking stores genesis pool registrations and stake
+// delegations. This is metadata-only (no blob operations needed).
+func (d *Database) SetGenesisStaking(
+	pools map[string]lcommon.PoolRegistrationCertificate,
+	stakeDelegations map[string]string,
+	blockHash []byte,
+	txn *Txn,
+) error {
+	if txn == nil {
+		if err := d.metadata.SetGenesisStaking(
+			pools,
+			stakeDelegations,
+			blockHash,
+			nil,
+		); err != nil {
+			return fmt.Errorf("set genesis staking: %w", err)
+		}
+		return nil
+	}
+	if err := d.metadata.SetGenesisStaking(
+		pools,
+		stakeDelegations,
+		blockHash,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("set genesis staking: %w", err)
+	}
+	return nil
+}
+
 func (d *Database) GetTransactionByHash(
 	hash []byte,
 	txn *Txn,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -623,6 +623,31 @@ func (ls *LedgerState) createGenesisBlock() error {
 			"component", "ledger",
 		)
 
+		// Load genesis staking data (pool registrations + delegations)
+		genesisPools, _, err := shelleyGenesis.InitialPools()
+		if err != nil {
+			return fmt.Errorf("parse genesis staking: %w", err)
+		}
+		if len(genesisPools) > 0 ||
+			len(shelleyGenesis.Staking.Stake) > 0 {
+			ls.config.Logger.Info(
+				fmt.Sprintf(
+					"loading genesis staking: %d pools, %d delegations",
+					len(genesisPools),
+					len(shelleyGenesis.Staking.Stake),
+				),
+				"component", "ledger",
+			)
+			if err := ls.db.SetGenesisStaking(
+				genesisPools,
+				shelleyGenesis.Staking.Stake,
+				genesisHash[:],
+				txn,
+			); err != nil {
+				return fmt.Errorf("set genesis staking: %w", err)
+			}
+		}
+
 		return nil
 	})
 	return err

--- a/ledger/snapshot/calculator_test.go
+++ b/ledger/snapshot/calculator_test.go
@@ -58,7 +58,7 @@ func seedPoolAndDelegations(
 	sqliteStore *sqlite.MetadataStoreSqlite,
 	poolKeyHash []byte,
 	delegations []struct {
-		stakingKey []byte
+		stakingKey  []byte
 		utxoAmounts []types.Uint64
 	},
 	slot uint64,
@@ -325,7 +325,7 @@ func TestCalculateStakeDistribution_InactiveAccountsExcluded(t *testing.T) {
 		StakingKey: activeKey, Pool: poolHash, AddedSlot: 100, Active: true,
 	}).Error)
 	require.NoError(t, gormDB.Create(&models.Utxo{
-		TxId: []byte("tx_activ_567890123456789012345678901234"),
+		TxId:      []byte("tx_activ_567890123456789012345678901234"),
 		OutputIdx: 0, StakingKey: activeKey,
 		Amount: 7000000, AddedSlot: 100,
 	}).Error)
@@ -340,7 +340,7 @@ func TestCalculateStakeDistribution_InactiveAccountsExcluded(t *testing.T) {
 	require.NoError(t, gormDB.Create(&inactiveAcct).Error)
 	require.NoError(t, gormDB.Model(&inactiveAcct).Update("active", false).Error)
 	require.NoError(t, gormDB.Create(&models.Utxo{
-		TxId: []byte("tx_inact_567890123456789012345678901234"),
+		TxId:      []byte("tx_inact_567890123456789012345678901234"),
 		OutputIdx: 0, StakingKey: inactiveKey,
 		Amount: 15000000, AddedSlot: 100,
 	}).Error)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add genesis staking support. On bootstrap, we parse Shelley genesis and persist initial stake pools and delegations at slot 0 (SQLite only).

- **New Features**
  - Added MetadataStore.SetGenesisStaking and Database.SetGenesisStaking.
  - Ledger loads InitialPools and Staking.Stake during genesis block creation and persists them.
  - SQLite: creates/updates Pool and PoolRegistration; inserts Account (staking key → pool) with AddedSlot=0 and Active=true; stores owners, relays, metadata; handles existing pools/keys and ignores duplicate accounts.
  - MySQL/PostgreSQL: not implemented; SetGenesisStaking returns an explicit error (no persistence on these backends).

<sup>Written for commit 4843cb87edccf129155299a462560f19bfd54a2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genesis staking support across all database backends, enabling storage and processing of genesis-era pool registrations and stake delegations during blockchain initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->