### PR TITLE
fix(ledger): drain loop for epoch transitions

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	EventQueueSize       = 20
+	EventQueueSize       = 1000
 	AsyncQueueSize       = 1000
 	AsyncWorkerPoolSize  = 4
 	RemoteDeliverTimeout = 5 * time.Second

--- a/ledger/snapshot/calculator_test.go
+++ b/ledger/snapshot/calculator_test.go
@@ -58,7 +58,7 @@ func seedPoolAndDelegations(
 	sqliteStore *sqlite.MetadataStoreSqlite,
 	poolKeyHash []byte,
 	delegations []struct {
-		stakingKey []byte
+		stakingKey  []byte
 		utxoAmounts []types.Uint64
 	},
 	slot uint64,
@@ -325,7 +325,7 @@ func TestCalculateStakeDistribution_InactiveAccountsExcluded(t *testing.T) {
 		StakingKey: activeKey, Pool: poolHash, AddedSlot: 100, Active: true,
 	}).Error)
 	require.NoError(t, gormDB.Create(&models.Utxo{
-		TxId: []byte("tx_activ_567890123456789012345678901234"),
+		TxId:      []byte("tx_activ_567890123456789012345678901234"),
 		OutputIdx: 0, StakingKey: activeKey,
 		Amount: 7000000, AddedSlot: 100,
 	}).Error)
@@ -340,7 +340,7 @@ func TestCalculateStakeDistribution_InactiveAccountsExcluded(t *testing.T) {
 	require.NoError(t, gormDB.Create(&inactiveAcct).Error)
 	require.NoError(t, gormDB.Model(&inactiveAcct).Update("active", false).Error)
 	require.NoError(t, gormDB.Create(&models.Utxo{
-		TxId: []byte("tx_inact_567890123456789012345678901234"),
+		TxId:      []byte("tx_inact_567890123456789012345678901234"),
 		OutputIdx: 0, StakingKey: inactiveKey,
 		Amount: 15000000, AddedSlot: 100,
 	}).Error)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a drain loop for epoch transition events and move to channel-based subscriptions so only the latest epoch is processed. This avoids redundant leader schedule refreshes and snapshot work during rapid sync (e.g., 500ms epochs) and reduces backlog.

- **Bug Fixes**
  - Leader election and snapshot manager now read epoch events from a channel and drain stale items; snapshot manager fast-forwards and logs skipped epochs.
  - Increased EventQueueSize from 20 to 1000 and added context-based shutdown and warnings when the event bus is unavailable to improve stability under fast epochs.

<sup>Written for commit 3d9e5e619d457b1427edb8ce5f5415a8155418d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased in-memory event buffer capacity to support higher throughput.
  * Optimized epoch transition processing to reduce computational overhead and improve system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->