### PR TITLE
fix(ledger): use mark snapshot for stake distribution

### DIFF
--- a/ledger/view.go
+++ b/ledger/view.go
@@ -570,13 +570,14 @@ type StakeDistribution struct {
 }
 
 // GetStakeDistribution returns the stake distribution for leader election.
-// Uses the "go" snapshot which represents stake from 2 epochs ago.
+// Uses the "mark" snapshot at the given epoch. Callers pass currentEpoch-2
+// so the epoch offset already accounts for the Mark→Set→Go rotation.
 func (lv *LedgerView) GetStakeDistribution(
 	epoch uint64,
 ) (*StakeDistribution, error) {
 	snapshots, err := lv.ls.db.Metadata().GetPoolStakeSnapshotsByEpoch(
 		epoch,
-		"go",
+		"mark",
 		(*lv.txn).Metadata(),
 	)
 	if err != nil {
@@ -598,15 +599,16 @@ func (lv *LedgerView) GetStakeDistribution(
 	return dist, nil
 }
 
-// GetPoolStake returns the stake for a specific pool from the "go" snapshot.
-// Returns 0 if the pool has no stake in the snapshot.
+// GetPoolStake returns the stake for a specific pool from the snapshot.
+// Returns 0 if the pool has no stake in the snapshot. Callers pass
+// currentEpoch-2 so the epoch offset accounts for Mark→Set→Go rotation.
 func (lv *LedgerView) GetPoolStake(
 	epoch uint64,
 	poolKeyHash []byte,
 ) (uint64, error) {
 	snapshot, err := lv.ls.db.Metadata().GetPoolStakeSnapshot(
 		epoch,
-		"go",
+		"mark",
 		poolKeyHash,
 		(*lv.txn).Metadata(),
 	)
@@ -619,11 +621,12 @@ func (lv *LedgerView) GetPoolStake(
 	return uint64(snapshot.TotalStake), nil
 }
 
-// GetTotalActiveStake returns the total active stake from the "go" snapshot.
+// GetTotalActiveStake returns the total active stake from the snapshot.
+// Callers pass currentEpoch-2 so the epoch offset accounts for rotation.
 func (lv *LedgerView) GetTotalActiveStake(epoch uint64) (uint64, error) {
 	return lv.ls.db.Metadata().GetTotalActiveStake(
 		epoch,
-		"go",
+		"mark",
 		(*lv.txn).Metadata(),
 	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the "mark" snapshot for stake distribution and stake lookups to fix epoch alignment for leader election. Callers already pass currentEpoch-2, matching the Mark→Set→Go rotation.

- **Bug Fixes**
  - Switched snapshot key from "go" to "mark" in GetStakeDistribution, GetPoolStake, and GetTotalActiveStake.
  - Updated comments to document the epoch offset expectation.
  - Ensures leader selection and totals use the correct snapshot at the given epoch.

<sup>Written for commit 5f3656a71892a0447180bb3c1dc84ff5b8358064. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

