### PR TITLE
chore: gouroboros 0.157.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.0
 	github.com/blinklabs-io/bursa v0.14.0
-	github.com/blinklabs-io/gouroboros v0.154.0
+	github.com/blinklabs-io/gouroboros v0.157.0
 	github.com/blinklabs-io/ouroboros-mock v0.9.0
 	github.com/blinklabs-io/plutigo v0.0.23
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blinklabs-io/bursa v0.14.0 h1:e+RFfKty3sU0xcgXStg6dRSEIwiJhIKMENLcRlGOzxg=
 github.com/blinklabs-io/bursa v0.14.0/go.mod h1:T61tWWJCgoQd/fLbpPa1+64x8ANXx+fEc3CjVeAqbM4=
-github.com/blinklabs-io/gouroboros v0.154.0 h1:wwn5AU3t/43ztJv1Puns0XCWk3tku0jqXQLJjBGMm3k=
-github.com/blinklabs-io/gouroboros v0.154.0/go.mod h1:oD41po6mrWc4GkUta5TupkLLdUOA14ovLebuZHEKzt8=
+github.com/blinklabs-io/gouroboros v0.157.0 h1:UNDo9OCvpb39goH7Ag8IvLmAA4Jf05hkj7g2dbmfEFg=
+github.com/blinklabs-io/gouroboros v0.157.0/go.mod h1:oD41po6mrWc4GkUta5TupkLLdUOA14ovLebuZHEKzt8=
 github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qtpU76eFeBKWeQ=
 github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
 github.com/blinklabs-io/plutigo v0.0.23 h1:LtfWHc0bwpSLGekkO1ZBvMwo03JV/ZVpqoSIZwzjdco=

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -566,9 +566,6 @@ func makeMinimalTxCbor(t *testing.T, txID byte, padding int) []byte {
 
 	// Conway transaction body: {0: inputs, 2: fee}
 	// Inputs are encoded as a tagged set (tag 258)
-	input := cbor.NewConstructor(0, cbor.IndefLengthList{})
-	_ = input // not used directly; we encode manually below
-
 	bodyMap := map[uint]any{
 		0: cbor.Tag{
 			Number:  258,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade github.com/blinklabs-io/gouroboros from v0.154.0 to v0.157.0, updating go.mod and go.sum. Removed an unused variable in ledger/forging/builder_test.go to clean up the test.

<sup>Written for commit bbc10769a85b7f017fc0faaace2d3aa842077998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

