### PR TITLE
fix: resolve txsubmission timeouts

### DIFF
--- a/ledger/snapshot/calculator_test.go
+++ b/ledger/snapshot/calculator_test.go
@@ -58,7 +58,7 @@ func seedPoolAndDelegations(
 	sqliteStore *sqlite.MetadataStoreSqlite,
 	poolKeyHash []byte,
 	delegations []struct {
-		stakingKey []byte
+		stakingKey  []byte
 		utxoAmounts []types.Uint64
 	},
 	slot uint64,
@@ -325,7 +325,7 @@ func TestCalculateStakeDistribution_InactiveAccountsExcluded(t *testing.T) {
 		StakingKey: activeKey, Pool: poolHash, AddedSlot: 100, Active: true,
 	}).Error)
 	require.NoError(t, gormDB.Create(&models.Utxo{
-		TxId: []byte("tx_activ_567890123456789012345678901234"),
+		TxId:      []byte("tx_activ_567890123456789012345678901234"),
 		OutputIdx: 0, StakingKey: activeKey,
 		Amount: 7000000, AddedSlot: 100,
 	}).Error)
@@ -340,7 +340,7 @@ func TestCalculateStakeDistribution_InactiveAccountsExcluded(t *testing.T) {
 	require.NoError(t, gormDB.Create(&inactiveAcct).Error)
 	require.NoError(t, gormDB.Model(&inactiveAcct).Update("active", false).Error)
 	require.NoError(t, gormDB.Create(&models.Utxo{
-		TxId: []byte("tx_inact_567890123456789012345678901234"),
+		TxId:      []byte("tx_inact_567890123456789012345678901234"),
 		OutputIdx: 0, StakingKey: inactiveKey,
 		Amount: 15000000, AddedSlot: 100,
 	}).Error)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent tx-submission timeouts when the mempool is empty by adding a 90s wait limit and cleaning up consumer goroutines on disconnect or shutdown. This keeps peer connections alive during initial sync and stops stuck NextTx calls.

- **Bug Fixes**
  - Add a 90s timeout for blocking tx-submission requests; return empty before the 120s protocol timeout and log the event.
  - Introduce MempoolConsumer Close() with a done channel; NextTx exits on close or mempool shutdown and unsubscribes.
  - Call Close() in RemoveConsumer and Stop to signal and drain blocked goroutines.

<sup>Written for commit fa01d8b061bd13ee1156983bddef61c7b9d323b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safe consumer lifecycle control to ensure blocked requests are woken and resources are cleaned up on shutdown.
  * Updated transaction submission blocking behavior to use a 90-second timeout, preventing protocol timeouts during initial sync and returning promptly if no transactions arrive.
  * Ensured consumers are closed before cache clearing to improve shutdown reliability and prevent goroutine leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->