### PR TITLE
fix: lower pipeline sizes

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -46,10 +46,14 @@ func (o *Ouroboros) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 	return []ochainsync.ChainSyncOptionFunc{
 		ochainsync.WithRollForwardFunc(o.chainsyncClientRollForward),
 		ochainsync.WithRollBackwardFunc(o.chainsyncClientRollBackward),
-		// Enable pipelining of RequestNext messages to speed up chainsync
-		ochainsync.WithPipelineLimit(50),
-		// Set the recv queue size to 2x our pipeline limit
-		ochainsync.WithRecvQueueSize(100),
+		// Pipeline enough headers to keep one blockfetch batch (500
+		// blocks) ready while the previous batch processes. A depth
+		// of 10 is sufficient; higher values flood the header queue
+		// and waste CPU parsing headers that are immediately dropped.
+		ochainsync.WithPipelineLimit(10),
+		// Recv queue at 2x pipeline limit to absorb bursts without
+		// blocking the protocol goroutine.
+		ochainsync.WithRecvQueueSize(20),
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduced chainsync pipeline and recv queue sizes to stabilize bulk sync and lower CPU usage. Added safe handling for full header queues to stop error log spam.

- **Bug Fixes**
  - Set pipeline limit to 10 and recv queue size to 20 to avoid flooding the header queue.
  - Log ErrHeaderQueueFull at DEBUG and return, preventing repeated error logs during bulk sync.

<sup>Written for commit ce33936ead4df706803b7348a57b51b0feb37deb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain synchronization error handling by treating full header queue conditions as expected during bulk syncing, reducing error log spam and unnecessary error propagation.

* **Performance**
  * Optimized chain sync pipeline configuration with reduced buffering depth to prevent header queue flooding and excessive CPU parsing during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->