### PR TITLE
fix(ledger): simplify fee calculation

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -449,7 +449,7 @@ func EvaluateTxAlonzo(
 	if tmpPparams.ExecutionCosts.StepPrice != nil {
 		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
 	}
-	fee, err := CalculateMinFee(
+	fee := CalculateMinFee(
 		txSize,
 		retTotalExUnits,
 		tmpPparams.MinFeeA,
@@ -457,8 +457,5 @@ func EvaluateTxAlonzo(
 		pricesMem,
 		pricesSteps,
 	)
-	if err != nil {
-		return 0, lcommon.ExUnits{}, nil, err
-	}
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -613,7 +613,7 @@ func EvaluateTxBabbage(
 	if tmpPparams.ExecutionCosts.StepPrice != nil {
 		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
 	}
-	fee, err := CalculateMinFee(
+	fee := CalculateMinFee(
 		txSize,
 		retTotalExUnits,
 		tmpPparams.MinFeeA,
@@ -621,8 +621,5 @@ func EvaluateTxBabbage(
 		pricesMem,
 		pricesSteps,
 	)
-	if err != nil {
-		return 0, lcommon.ExUnits{}, nil, err
-	}
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -616,7 +616,7 @@ func EvaluateTxConway(
 	if tmpPparams.ExecutionCosts.StepPrice != nil {
 		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
 	}
-	fee, err := CalculateMinFee(
+	fee := CalculateMinFee(
 		txSize,
 		retTotalExUnits,
 		tmpPparams.MinFeeA,
@@ -624,8 +624,5 @@ func EvaluateTxConway(
 		pricesMem,
 		pricesSteps,
 	)
-	if err != nil {
-		return 0, lcommon.ExUnits{}, nil, err
-	}
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -415,15 +415,22 @@ func TestCeilMul(t *testing.T) {
 			value:    big.NewInt(14000001),
 			expected: 807801,
 		},
+		{
+			// Result exceeds uint64 range: saturate at MaxUint64.
+			name:     "overflow saturates at MaxUint64",
+			num:      new(big.Int).SetUint64(math.MaxUint64),
+			denom:    big.NewInt(1),
+			value:    big.NewInt(2),
+			expected: math.MaxUint64,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := CeilMul(
+			result := CeilMul(
 				tc.num,
 				tc.denom,
 				tc.value,
 			)
-			require.NoError(t, err)
 			assert.Equal(
 				t,
 				tc.expected,
@@ -686,7 +693,7 @@ func TestCalculateMinFee(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fee, err := CalculateMinFee(
+			fee := CalculateMinFee(
 				tc.txSize,
 				tc.exUnits,
 				tc.minFeeA,
@@ -694,7 +701,6 @@ func TestCalculateMinFee(t *testing.T) {
 				tc.pricesMem,
 				tc.pricesSteps,
 			)
-			require.NoError(t, err)
 			assert.Equal(
 				t,
 				tc.expected,
@@ -715,7 +721,7 @@ func TestCalculateMinFee_ScriptFeeAddsCorrectly(t *testing.T) {
 	pricesSteps := big.NewRat(721, 10000000)
 
 	// Fee with no scripts
-	feeNoScripts, err := CalculateMinFee(
+	feeNoScripts := CalculateMinFee(
 		txSize,
 		lcommon.ExUnits{Memory: 0, Steps: 0},
 		minFeeA,
@@ -723,10 +729,9 @@ func TestCalculateMinFee_ScriptFeeAddsCorrectly(t *testing.T) {
 		pricesMem,
 		pricesSteps,
 	)
-	require.NoError(t, err)
 
 	// Fee with scripts
-	feeWithScripts, err := CalculateMinFee(
+	feeWithScripts := CalculateMinFee(
 		txSize,
 		lcommon.ExUnits{
 			Memory: 1000000,
@@ -737,7 +742,6 @@ func TestCalculateMinFee_ScriptFeeAddsCorrectly(t *testing.T) {
 		pricesMem,
 		pricesSteps,
 	)
-	require.NoError(t, err)
 
 	assert.Greater(
 		t,
@@ -785,7 +789,7 @@ func TestCalculateMinFee_MultipleScriptsSum(t *testing.T) {
 	require.Equal(t, int64(600000), totalExUnits.Memory)
 	require.Equal(t, int64(200000000), totalExUnits.Steps)
 
-	fee, err := CalculateMinFee(
+	fee := CalculateMinFee(
 		txSize,
 		totalExUnits,
 		minFeeA,
@@ -793,7 +797,6 @@ func TestCalculateMinFee_MultipleScriptsSum(t *testing.T) {
 		pricesMem,
 		pricesSteps,
 	)
-	require.NoError(t, err)
 
 	// baseFee = 44*400 + 155381 = 172981
 	// memFee = ceil(577*600000/10000) = 34620
@@ -806,7 +809,7 @@ func TestCalculateMinFee_NilPricesIgnoresExUnits(t *testing.T) {
 	// When prices are nil, even non-zero ExUnits should
 	// not contribute to the fee. This can happen in
 	// pre-Alonzo eras where there are no execution costs.
-	fee, err := CalculateMinFee(
+	fee := CalculateMinFee(
 		200,
 		lcommon.ExUnits{
 			Memory: 1000000,
@@ -817,7 +820,6 @@ func TestCalculateMinFee_NilPricesIgnoresExUnits(t *testing.T) {
 		nil,
 		nil,
 	)
-	require.NoError(t, err)
 	baseFee := uint64(44*200 + 155381)
 	assert.Equal(
 		t,
@@ -830,7 +832,7 @@ func TestCalculateMinFee_NilPricesIgnoresExUnits(t *testing.T) {
 func TestCalculateMinFee_OnePriceNilIgnoresExUnits(t *testing.T) {
 	// When only one price is nil, both should be
 	// ignored (the function requires both to be non-nil).
-	fee1, err := CalculateMinFee(
+	fee1 := CalculateMinFee(
 		200,
 		lcommon.ExUnits{
 			Memory: 1000000,
@@ -841,8 +843,7 @@ func TestCalculateMinFee_OnePriceNilIgnoresExUnits(t *testing.T) {
 		big.NewRat(577, 10000),
 		nil,
 	)
-	require.NoError(t, err)
-	fee2, err := CalculateMinFee(
+	fee2 := CalculateMinFee(
 		200,
 		lcommon.ExUnits{
 			Memory: 1000000,
@@ -853,7 +854,6 @@ func TestCalculateMinFee_OnePriceNilIgnoresExUnits(t *testing.T) {
 		nil,
 		big.NewRat(721, 10000000),
 	)
-	require.NoError(t, err)
 	baseFee := uint64(44*200 + 155381)
 	assert.Equal(t, baseFee, fee1,
 		"nil step price should ignore script fees",
@@ -866,12 +866,11 @@ func TestCalculateMinFee_OnePriceNilIgnoresExUnits(t *testing.T) {
 func TestCeilMul_ExactMultiples(t *testing.T) {
 	// When num*value is exactly divisible by denom,
 	// ceiling should equal the exact quotient.
-	result, err := CeilMul(
+	result := CeilMul(
 		big.NewInt(3),
 		big.NewInt(1),
 		big.NewInt(5),
 	)
-	require.NoError(t, err)
 	assert.Equal(t, uint64(15), result)
 }
 
@@ -879,20 +878,18 @@ func TestCeilMul_LargeValues(t *testing.T) {
 	// Test with values near the practical maximum for
 	// Cardano mainnet. Max memory is 14M, max steps
 	// is 10B. Price rationals are small fractions.
-	memResult, err := CeilMul(
+	memResult := CeilMul(
 		big.NewInt(577),
 		big.NewInt(10000),
 		big.NewInt(14000000),
 	)
-	require.NoError(t, err)
 	assert.Equal(t, uint64(807800), memResult)
 
-	stepResult, err := CeilMul(
+	stepResult := CeilMul(
 		big.NewInt(721),
 		big.NewInt(10000000),
 		big.NewInt(10000000000),
 	)
-	require.NoError(t, err)
 	assert.Equal(t, uint64(721000), stepResult)
 }
 
@@ -900,13 +897,22 @@ func TestCeilMul_MaxInt64Values(t *testing.T) {
 	// Test with max int64 to ensure no overflow in
 	// big.Int arithmetic.
 	maxVal := big.NewInt(math.MaxInt64)
-	result, err := CeilMul(
+	result := CeilMul(
 		big.NewInt(1),
 		big.NewInt(1),
 		maxVal,
 	)
-	require.NoError(t, err)
 	assert.Equal(t, uint64(math.MaxInt64), result)
+}
+
+func TestCeilMul_ZeroDenomPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		CeilMul(
+			big.NewInt(1),
+			big.NewInt(0),
+			big.NewInt(1),
+		)
+	}, "CeilMul should panic on zero denominator")
 }
 
 func TestDeclaredExUnits(t *testing.T) {
@@ -1648,120 +1654,11 @@ func TestValidateTxFee_ErrorMessageIncludesFees(
 	assert.Contains(t, err.Error(), "168581")
 }
 
-func TestCeilMul_ZeroDenominator(t *testing.T) {
-	// A zero denominator must return an error instead
-	// of panicking with a division-by-zero.
-	_, err := CeilMul(
-		big.NewInt(577),
-		big.NewInt(0),
-		big.NewInt(1000000),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errZeroDenominator)
-}
-
-func TestCeilMul_OverflowUint64(t *testing.T) {
-	// When the result exceeds MaxUint64, CeilMul must
-	// return errFeeOverflow instead of silently
-	// truncating via big.Int.Uint64().
-	maxU64 := new(big.Int).SetUint64(math.MaxUint64)
-	_, err := CeilMul(
-		new(big.Int).Mul(maxU64, big.NewInt(2)),
-		big.NewInt(1),
-		big.NewInt(1),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errFeeOverflow)
-}
-
-func TestCalculateMinFee_OverflowMultiplication(
-	t *testing.T,
-) {
-	// minFeeA * txSize overflows uint64 when both
-	// values are large.
-	_, err := CalculateMinFee(
-		math.MaxUint64,
-		lcommon.ExUnits{},
-		2,
-		0,
-		nil,
-		nil,
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errFeeOverflow)
-}
-
-func TestCalculateMinFee_OverflowBaseFeeAddition(
-	t *testing.T,
-) {
-	// baseFee = (minFeeA * txSize) + minFeeB overflows
-	// when the product is near MaxUint64.
-	// Use txSize (uint64) to drive overflow portably across
-	// 32-bit and 64-bit platforms.
-	_, err := CalculateMinFee(
-		math.MaxUint64,
-		lcommon.ExUnits{},
-		1,
-		1,
-		nil,
-		nil,
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errFeeOverflow)
-}
-
-func TestCalculateMinFee_OverflowScriptFeeAddition(
-	t *testing.T,
-) {
-	// memFee + stepFee overflows when both are large.
-	// Use prices that produce near-max uint64 values.
-	// pricesMem = MaxUint64/1 applied to mem=1
-	//   => memFee = MaxUint64
-	// pricesSteps = 1/1 applied to steps=1
-	//   => stepFee = 1
-	// memFee + stepFee wraps around.
-	bigNum := new(big.Int).SetUint64(math.MaxUint64)
-	_, err := CalculateMinFee(
-		0,
-		lcommon.ExUnits{
-			Memory: 1,
-			Steps:  1,
-		},
-		0,
-		0,
-		new(big.Rat).SetFrac(bigNum, big.NewInt(1)),
-		big.NewRat(1, 1),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errFeeOverflow)
-}
-
-func TestCalculateMinFee_OverflowTotalAddition(
-	t *testing.T,
-) {
-	// baseFee + scriptFee overflows when both are near
-	// MaxUint64. Use txSize to produce a large baseFee
-	// portably across 32-bit and 64-bit platforms.
-	_, err := CalculateMinFee(
-		math.MaxUint64,
-		lcommon.ExUnits{
-			Memory: 1,
-			Steps:  0,
-		},
-		1,
-		0,
-		big.NewRat(1, 1),
-		big.NewRat(1, 1),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errFeeOverflow)
-}
-
 func TestCalculateMinFee_NormalValuesNoOverflow(
 	t *testing.T,
 ) {
 	// Mainnet-like parameters should still work.
-	fee, err := CalculateMinFee(
+	fee := CalculateMinFee(
 		300,
 		lcommon.ExUnits{
 			Memory: 1000000,
@@ -1772,6 +1669,23 @@ func TestCalculateMinFee_NormalValuesNoOverflow(
 		big.NewRat(577, 10000),
 		big.NewRat(721, 10000000),
 	)
-	require.NoError(t, err)
 	assert.Equal(t, uint64(240701), fee)
+}
+
+func TestCalculateMinFee_OverflowSaturates(t *testing.T) {
+	// Force an overflow: huge num/denom ratio with large ExUnits.
+	fee := CalculateMinFee(
+		math.MaxUint64,
+		lcommon.ExUnits{
+			Memory: math.MaxInt64,
+			Steps:  math.MaxInt64,
+		},
+		44,
+		155381,
+		big.NewRat(math.MaxInt64, 1),
+		big.NewRat(math.MaxInt64, 1),
+	)
+	assert.Equal(t, uint64(math.MaxUint64), fee,
+		"overflow should saturate at MaxUint64",
+	)
 }

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -60,9 +60,9 @@ func ValidateTxExUnits(
 //	scriptFee = ceil(pricesMem * exUnits.Memory)
 //	          + ceil(pricesSteps * exUnits.Steps)
 //
-// All arithmetic uses integer math (big.Int) to match
-// the Haskell reference implementation. Returns an error
-// if any intermediate result overflows uint64.
+// All arithmetic uses big.Int to match the Haskell
+// reference implementation. Overflow is impossible
+// with Cardano protocol parameters.
 func CalculateMinFee(
 	txSize uint64,
 	exUnits lcommon.ExUnits,
@@ -70,7 +70,7 @@ func CalculateMinFee(
 	minFeeB uint,
 	pricesMem *big.Rat,
 	pricesSteps *big.Rat,
-) (uint64, error) {
+) uint64 {
 	return eras.CalculateMinFee(
 		txSize,
 		exUnits,

--- a/ledger/validation_test.go
+++ b/ledger/validation_test.go
@@ -460,7 +460,7 @@ func TestCalculateMinFee(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fee, err := CalculateMinFee(
+			fee := CalculateMinFee(
 				tc.txSize,
 				tc.exUnits,
 				tc.minFeeA,
@@ -468,7 +468,6 @@ func TestCalculateMinFee(t *testing.T) {
 				tc.pricesMem,
 				tc.pricesSteps,
 			)
-			require.NoError(t, err)
 			assert.Equal(
 				t,
 				tc.expected,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified fee calculation by making CalculateMinFee return a uint64 with saturating overflow and no errors. Updated era evaluators, fee validation, comments, and tests to match the new behavior.

- **Refactors**
  - CeilMul now returns uint64, saturates at MaxUint64 on overflow, and panics on zero denominators.
  - CalculateMinFee uses big.Int for script fees and saturating uint64 for base/total; updated wrapper in ledger/validation.go to the new signature and doc comments.
  - Alonzo/Babbage/Conway EvaluateTx* and ValidateTxFee updated to remove error handling.
  - Tests updated: removed error-based cases; added coverage for saturation (including end-to-end fee saturation) and zero-denominator panic; kept fee correctness checks.

<sup>Written for commit 9e07833514885202934a1f7b8bc1d70fca54ab12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed error returns from fee calculation and validation APIs; callers now receive a single fee value and no error paths.
  * Arithmetic now saturates on overflow (caps at max value) instead of returning errors.

* **Behavior**
  * Division-by-zero in the internal ceil-multiply now triggers a panic rather than an error return.

* **Tests**
  * Updated and added tests to reflect simplified signatures, saturation behavior, and new panic case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->