### PR TITLE
feat: full-duplex inbound connections

### DIFF
--- a/node.go
+++ b/node.go
@@ -405,6 +405,10 @@ func (n *Node) Run(ctx context.Context) error {
 		peergov.OutboundConnectionEventType,
 		n.ouroboros.HandleOutboundConnEvent,
 	)
+	n.eventBus.SubscribeFunc(
+		connmanager.InboundConnectionEventType,
+		n.ouroboros.HandleInboundConnEvent,
+	)
 	if n.config.topologyConfig != nil {
 		n.peerGov.LoadTopologyConfig(n.config.topologyConfig)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables full‑duplex inbound connections so one TCP connection can run both client and server mini‑protocols. Starts client protocols on eligible inbound connections and skips redundant outbound dials, matching cardano-node behavior.

- **New Features**
  - Node-to-node listeners use full duplex and keep-alive; client+server opts enabled for peer sharing, chainsync, blockfetch, and txsubmission.
  - Added HandleInboundConnEvent to start chainsync and txsubmission clients when InitiatorAndResponder is negotiated.
  - ConnectionManager.HasFullDuplexInbound checks for an existing full‑duplex inbound from a peer.
  - PeerGovernor skips creating an outbound connection if a full‑duplex inbound exists.
  - Node subscribes to inbound connection events to trigger client startup.

<sup>Written for commit 71e401b2efe58859c3bdcaa973f9d4f1aef1ecef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

