### PR TITLE
build(deps): gouroboros 0.158.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.0
 	github.com/blinklabs-io/bursa v0.14.0
-	github.com/blinklabs-io/gouroboros v0.157.0
+	github.com/blinklabs-io/gouroboros v0.158.0
 	github.com/blinklabs-io/ouroboros-mock v0.9.0
-	github.com/blinklabs-io/plutigo v0.0.23
+	github.com/blinklabs-io/plutigo v0.0.24
 	github.com/blockfrost/blockfrost-go v0.3.0
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.1

--- a/go.sum
+++ b/go.sum
@@ -128,12 +128,12 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blinklabs-io/bursa v0.14.0 h1:e+RFfKty3sU0xcgXStg6dRSEIwiJhIKMENLcRlGOzxg=
 github.com/blinklabs-io/bursa v0.14.0/go.mod h1:T61tWWJCgoQd/fLbpPa1+64x8ANXx+fEc3CjVeAqbM4=
-github.com/blinklabs-io/gouroboros v0.157.0 h1:UNDo9OCvpb39goH7Ag8IvLmAA4Jf05hkj7g2dbmfEFg=
-github.com/blinklabs-io/gouroboros v0.157.0/go.mod h1:oD41po6mrWc4GkUta5TupkLLdUOA14ovLebuZHEKzt8=
+github.com/blinklabs-io/gouroboros v0.158.0 h1:TlphslsMwR/FoCmro4VmAEmmEng6KesLlC8qi1O6cek=
+github.com/blinklabs-io/gouroboros v0.158.0/go.mod h1:gQ54NMsab6+XUEZQOS4CUZBNtZImW1FlqTtA+D1HxQs=
 github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qtpU76eFeBKWeQ=
 github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
-github.com/blinklabs-io/plutigo v0.0.23 h1:LtfWHc0bwpSLGekkO1ZBvMwo03JV/ZVpqoSIZwzjdco=
-github.com/blinklabs-io/plutigo v0.0.23/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
+github.com/blinklabs-io/plutigo v0.0.24 h1:v/4GjyHortriqVy5nZo6vlZ7ftI8LSUL5pX7aW/IUcs=
+github.com/blinklabs-io/plutigo v0.0.24/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/blockfrost/blockfrost-go v0.3.0 h1:7DhMWaGSY4a4E6JnomovzwhSBsHUAbX3Em+TVBkgjB4=
 github.com/blockfrost/blockfrost-go v0.3.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -563,6 +563,20 @@ func computeBlockBodyHash(
 	metadataSet lcommon.TransactionMetadataSet,
 	invalidTxs []uint,
 ) (lcommon.Blake2b256, uint64, error) {
+	// Normalize nil slices to empty so CBOR encodes as 0x80 (empty
+	// array) rather than 0xf6 (null). This must match the encoding
+	// in ConwayBlock.MarshalCBOR, which applies the same
+	// normalization before serializing the block.
+	if txBodies == nil {
+		txBodies = []conway.ConwayTransactionBody{}
+	}
+	if witnessSets == nil {
+		witnessSets = []conway.ConwayTransactionWitnessSet{}
+	}
+	if invalidTxs == nil {
+		invalidTxs = []uint{}
+	}
+
 	var bodyHashes []byte
 	var totalSize uint64
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade gouroboros to 0.158.0 and align block body hash computation with CBOR encoding by normalizing nil slices to empty arrays. This prevents hash mismatches with ConwayBlock.MarshalCBOR.

- **Bug Fixes**
  - Normalize nil tx bodies, witness sets, and invalidTxs to empty slices in computeBlockBodyHash so CBOR encodes empty arrays (0x80) instead of null (0xf6), matching ConwayBlock.MarshalCBOR.

- **Dependencies**
  - gouroboros: 0.157.0 → 0.158.0
  - plutigo: 0.0.23 → 0.0.24

<sup>Written for commit bc6a0ac59d2356df6f816869255b6f624689df24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest versions
  * Improved internal block encoding consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->