### PR TITLE
fix: update for latest golangci-lint

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"strings"
 
@@ -84,7 +85,7 @@ func listPlugins(
 		buf.WriteString("Available blob plugins:\n")
 		blobPlugins := plugin.GetPlugins(plugin.PluginTypeBlob)
 		for _, p := range blobPlugins {
-			buf.WriteString(fmt.Sprintf("  %s: %s\n", p.Name, p.Description))
+			fmt.Fprintf(&buf, "  %s: %s\n", p.Name, p.Description)
 		}
 		listed = true
 	}
@@ -96,7 +97,7 @@ func listPlugins(
 		buf.WriteString("Available metadata plugins:\n")
 		metadataPlugins := plugin.GetPlugins(plugin.PluginTypeMetadata)
 		for _, p := range metadataPlugins {
-			buf.WriteString(fmt.Sprintf("  %s: %s\n", p.Name, p.Description))
+			fmt.Fprintf(&buf, "  %s: %s\n", p.Name, p.Description)
 		}
 		listed = true
 	}
@@ -114,13 +115,13 @@ func listAllPlugins() string {
 	buf.WriteString("Blob Storage Plugins:\n")
 	blobPlugins := plugin.GetPlugins(plugin.PluginTypeBlob)
 	for _, p := range blobPlugins {
-		buf.WriteString(fmt.Sprintf("  %s: %s\n", p.Name, p.Description))
+		fmt.Fprintf(&buf, "  %s: %s\n", p.Name, p.Description)
 	}
 
 	buf.WriteString("\nMetadata Storage Plugins:\n")
 	metadataPlugins := plugin.GetPlugins(plugin.PluginTypeMetadata)
 	for _, p := range metadataPlugins {
-		buf.WriteString(fmt.Sprintf("  %s: %s\n", p.Name, p.Description))
+		fmt.Fprintf(&buf, "  %s: %s\n", p.Name, p.Description)
 	}
 
 	return buf.String()
@@ -175,8 +176,9 @@ func main() {
 
 	// Initialize CPU profiling (starts immediately, stops on exit)
 	if cpuprofile != "" {
-		fmt.Fprintf(os.Stderr, "Starting CPU profiling to %s\n", cpuprofile)
-		f, err := os.Create(cpuprofile)
+		cpuprofile = filepath.Clean(cpuprofile)
+		fmt.Fprintf(os.Stderr, "Starting CPU profiling to %q\n", cpuprofile) //nolint:gosec // stderr output, no XSS risk
+		f, err := os.Create(cpuprofile)                                      //nolint:gosec // user-specified profiling output path
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not create CPU profile: %v\n", err)
 			os.Exit(1)
@@ -295,7 +297,8 @@ func main() {
 
 	// Finalize memory profiling before exit
 	if memprofile != "" {
-		f, err := os.Create(memprofile)
+		memprofile = filepath.Clean(memprofile)
+		f, err := os.Create(memprofile) //nolint:gosec // user-specified profiling output path
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not create memory profile: %v\n", err)
 		} else {

--- a/connmanager/listener_unix.go
+++ b/connmanager/listener_unix.go
@@ -29,7 +29,7 @@ func socketControl(network, address string, c syscall.RawConn) error {
 	var innerErr error
 	err := c.Control(func(fd uintptr) {
 		err := unix.SetsockoptInt(
-			int(fd),
+			int(fd), //nolint:gosec // fd fits in int on all supported platforms
 			unix.SOL_SOCKET,
 			unix.SO_REUSEADDR,
 			1,
@@ -39,7 +39,7 @@ func socketControl(network, address string, c syscall.RawConn) error {
 			return
 		}
 		err = unix.SetsockoptInt(
-			int(fd),
+			int(fd), //nolint:gosec // fd fits in int on all supported platforms
 			unix.SOL_SOCKET,
 			unix.SO_REUSEPORT,
 			1,

--- a/connmanager/unix.go
+++ b/connmanager/unix.go
@@ -46,7 +46,7 @@ func NewUnixConn(conn net.Conn) (*UnixConn, error) {
 	}
 	err = rawConn.Control(
 		func(fd uintptr) {
-			fdNum = int(fd)
+			fdNum = int(fd) //nolint:gosec // fd fits in int on all supported platforms
 		},
 	)
 	if err != nil {

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -807,7 +807,7 @@ func (d *MetadataStoreMysql) GetStakeByPools(
 
 	for _, r := range delegatorResults {
 		if r.DelegatorCount >= 0 {
-			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount)
+			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount) //nolint:gosec // guarded by >= 0 check
 		}
 	}
 

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -624,7 +624,7 @@ func (d *MetadataStorePostgres) GetStakeByPools(
 
 	for _, r := range delegatorResults {
 		if r.DelegatorCount >= 0 {
-			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount)
+			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount) //nolint:gosec // guarded by >= 0 check
 		}
 	}
 

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -844,7 +844,7 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 
 	for _, r := range delegatorResults {
 		if r.DelegatorCount >= 0 {
-			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount)
+			delegatorMap[string(r.Pool)] = uint64(r.DelegatorCount) //nolint:gosec // guarded by >= 0 check
 		}
 	}
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -772,6 +772,8 @@ func writeCborUint(buf *bytes.Buffer, n int) {
 }
 
 // writeCborMajorType writes a CBOR header with the given major type and value.
+//
+//nolint:gosec // Intentional byte truncation for CBOR encoding of individual octets.
 func writeCborMajorType(buf *bytes.Buffer, majorType, n int) {
 	header := byte(majorType << 5)
 	switch {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update code to pass the latest golangci-lint checks, mainly gosec rules. No behavior changes.

- **Refactors**
  - Use fmt.Fprintf for buffer writes in plugin listing.
  - Clean profiling paths with filepath.Clean and quote them in stderr output; add gosec nolint on os.Create.
  - Add gosec nolint for fd casts to int in Unix socket code.
  - Annotate safe uint64 casts of non-negative delegator counts.
  - Add gosec nolint for intentional byte truncation in CBOR major type writer.

<sup>Written for commit 01c0ed82237116d7a50ae4ec455a2639166c96d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CPU and memory profiling output path handling with automatic path normalization to ensure consistent file paths across different systems.

* **Chores**
  * Added internal code security annotations and linter directives for improved code quality and safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->