### PR TITLE
fix: genesis snapshot

### DIFF
--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Pool Stake Snapshot Operations
@@ -132,7 +133,10 @@ func (d *MetadataStoreSqlite) SaveEpochSummary(
 	if err != nil {
 		return err
 	}
-	return db.Create(summary).Error
+	// Use ON CONFLICT DO NOTHING so duplicate epoch events (from both
+	// slot-clock and block-based transitions) are idempotent.
+	return db.Clauses(clause.OnConflict{DoNothing: true}).
+		Create(summary).Error
 }
 
 // GetEpochSummary retrieves an epoch summary by epoch number


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Captures the genesis stake snapshot at epoch 0 so the “Go” snapshot is available by epoch 2 for leader election, and makes epoch summary writes idempotent to avoid duplicates.

- **Bug Fixes**
  - Added CaptureGenesisSnapshot to save the epoch 0 mark snapshot per Cardano spec.
  - Used ON CONFLICT DO NOTHING when saving epoch summaries to prevent duplicates from overlapping transition events.
  - Improved epoch transition handling: skip intermediate events and downgrade logs when epoch data isn’t synced.

<sup>Written for commit d0b756d1db0b41a06e78c9656f06ffa9abcf620d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genesis snapshot capture to compute stake distribution at epoch 0.
  * Enhanced epoch transition handling with improved error detection and logging for skipped epochs.
  * Added context cancellation checks for prompter event processing interruption.

* **Bug Fixes**
  * Fixed duplicate key errors in epoch summary operations through idempotent insert behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->