### PR TITLE
fix(ledger): handle empty chain intersect

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2577,6 +2577,13 @@ func (ls *LedgerState) GetIntersectPoint(
 	ls.RLock()
 	tip := ls.currentTip
 	ls.RUnlock()
+	// When the chain is empty (tip at origin), origin is the only
+	// valid intersect regardless of what points the peer sends.
+	// This allows peers to start chainsync before we have blocks.
+	if tip.Point.Slot == 0 && len(tip.Point.Hash) == 0 {
+		var ret ocommon.Point
+		return &ret, nil
+	}
 	var ret ocommon.Point
 	var tmpBlock models.Block
 	var err error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return origin as the intersect point when the ledger tip is at origin (empty chain). This prevents failed intersects and allows peers to start chainsync before any blocks exist.

<sup>Written for commit 397c1e553486a70d46f95be20fc44e90250de8f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

