### PR TITLE
fix(ledger): harden leader schedule cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules/
 # IDEs
 .idea/
 .vscode/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened the leader schedule cache to avoid races during start/stop and improved leader slot lookup near epoch boundaries to reduce false negatives.

- **Bug Fixes**
  - Made scheduleComputeLoop consume a passed computeCh and set e.computeCh to nil on Stop to prevent sends after shutdown.
  - Guarded compute/store paths to no-op when the election is not running.
  - Fixed NextLeaderSlot to handle missing schedules safely and check the next epoch’s cache when near boundaries.
  - Stabilized tests by using atomic currentEpoch and waiting for the initial schedule.
  - Added .worktrees to .gitignore.

<sup>Written for commit f5c9e8fb59079f23283436a0803b8cdc8dc874ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

