### PR TITLE
fix(connmanager): match inbound by IP to prevent collision

### DIFF
--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -67,6 +67,7 @@ const (
 	initialReconnectDelay  = 1 * time.Second
 	maxReconnectDelay      = 128 * time.Second
 	reconnectBackoffFactor = 2
+	inboundCheckDelay      = 30 * time.Second
 )
 
 // Peer source priority values for removal decisions.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent TCP 4-tuple collisions when OutboundSourcePort is reused by matching inbound connections by host IP and deferring outbound attempts while that inbound exists.

- **Bug Fixes**
  - Introduce HasInboundFromHost (replaces HasFullDuplexInbound): compare by host IP (handles IPv6 forms), ignoring port/DiffusionMode; only active when OutboundSourcePort is set.
  - PeerGovernor now polls every 30s and proceeds once the inbound clears; updated log message to reflect waiting.

<sup>Written for commit 74933d8dda4ae3f82540c96c81d7890fbffb8da7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved peer connection detection to identify inbound connections from the same host, enabling more flexible connection management across different port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->