### PR TITLE
fix(database): use upsert for stake snapshots and genesis staking

### DIFF
--- a/database/plugin/metadata/mysql/stake_snapshot.go
+++ b/database/plugin/metadata/mysql/stake_snapshot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Pool Stake Snapshot Operations
@@ -49,7 +50,7 @@ func (d *MetadataStoreMysql) SavePoolStakeSnapshots(
 	if err != nil {
 		return err
 	}
-	return db.Create(snapshots).Error
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(snapshots).Error
 }
 
 // GetPoolStakeSnapshot retrieves a specific pool's stake snapshot
@@ -132,7 +133,7 @@ func (d *MetadataStoreMysql) SaveEpochSummary(
 	if err != nil {
 		return err
 	}
-	return db.Create(summary).Error
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(summary).Error
 }
 
 // GetEpochSummary retrieves an epoch summary by epoch number

--- a/database/plugin/metadata/postgres/stake_snapshot.go
+++ b/database/plugin/metadata/postgres/stake_snapshot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Pool Stake Snapshot Operations
@@ -49,7 +50,7 @@ func (d *MetadataStorePostgres) SavePoolStakeSnapshots(
 	if err != nil {
 		return err
 	}
-	return db.Create(snapshots).Error
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(snapshots).Error
 }
 
 // GetPoolStakeSnapshot retrieves a specific pool's stake snapshot
@@ -132,7 +133,7 @@ func (d *MetadataStorePostgres) SaveEpochSummary(
 	if err != nil {
 		return err
 	}
-	return db.Create(summary).Error
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(summary).Error
 }
 
 // GetEpochSummary retrieves an epoch summary by epoch number

--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -50,7 +50,7 @@ func (d *MetadataStoreSqlite) SavePoolStakeSnapshots(
 	if err != nil {
 		return err
 	}
-	return db.Create(snapshots).Error
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(snapshots).Error
 }
 
 // GetPoolStakeSnapshot retrieves a specific pool's stake snapshot

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1767,7 +1767,7 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 			tmpReg.Relays[i].PoolID = tmpPool.ID
 		}
 
-		result := db.Create(&tmpReg)
+		result := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&tmpReg)
 		if result.Error != nil {
 			return fmt.Errorf(
 				"create genesis pool registration: %w",
@@ -1802,7 +1802,7 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 		}
 		result := db.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "staking_key"}},
-			DoNothing: true,
+			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace direct inserts with upserts for stake snapshots and genesis staking. This avoids duplicate insert errors and updates existing staking accounts during re-imports.

- **Bug Fixes**
  - Stake snapshot inserts now use upsert (DoNothing) across MySQL, Postgres, and SQLite.
  - Epoch summary inserts use upsert (DoNothing) to prevent duplicates.
  - Genesis pool registrations (SQLite) ignore duplicates via upsert.
  - Genesis staking accounts upsert on staking_key and update pool and active fields.

<sup>Written for commit 5575ed4474f6b2e10b7e33f6ed2e6d24e36386c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

