### PR TITLE
feat(forging): slot-aligned forge loop with sync guards and genesis snapshot

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -189,6 +189,13 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithMeshListenAddress(
 				cfg.MeshListenAddress,
 			),
+			// Block production (SPO mode)
+			dingo.WithBlockProducer(cfg.BlockProducer),
+			dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),
+			dingo.WithShelleyKESKey(cfg.ShelleyKESKey),
+			dingo.WithShelleyOperationalCertificate(
+				cfg.ShelleyOperationalCertificate,
+			),
 		),
 	)
 	if err != nil {

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -359,9 +359,16 @@ func (e *Election) computeSchedule(
 		return nil, fmt.Errorf("get pool stake: %w", err)
 	}
 
+	e.logger.Info(
+		"pool stake from Go snapshot",
+		"component", "leader",
+		"epoch", currentEpoch,
+		"snapshot_epoch", snapshotEpoch,
+		"pool_stake", poolStake,
+	)
 	if poolStake == 0 {
-		e.logger.Debug(
-			"pool has no stake in Go snapshot",
+		e.logger.Info(
+			"pool has no stake in Go snapshot, skipping schedule computation",
 			"component", "leader",
 			"epoch", currentEpoch,
 			"snapshot_epoch", snapshotEpoch,
@@ -375,6 +382,13 @@ func (e *Election) computeSchedule(
 		return nil, fmt.Errorf("get total stake: %w", err)
 	}
 
+	e.logger.Info(
+		"total active stake from Go snapshot",
+		"component", "leader",
+		"epoch", currentEpoch,
+		"snapshot_epoch", snapshotEpoch,
+		"total_stake", totalStake,
+	)
 	if totalStake == 0 {
 		return nil, fmt.Errorf(
 			"total stake is zero for epoch %d", snapshotEpoch,
@@ -466,6 +480,12 @@ func (e *Election) ShouldProduceBlock(slot uint64) bool {
 	if schedule == nil {
 		// Schedule not yet computed for this epoch.
 		// Request background computation (non-blocking).
+		e.logger.Debug(
+			"no leader schedule for epoch, requesting computation",
+			"component", "leader",
+			"slot", slot,
+			"epoch", slotEpoch,
+		)
 		if computeCh != nil {
 			select {
 			case computeCh <- slotEpoch:

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -284,12 +284,19 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	}
 
 	if distribution.TotalPools == 0 {
-		m.logger.Debug(
-			"no genesis pools, skipping genesis snapshot",
+		m.logger.Warn(
+			"no pools found in genesis stake distribution; leader election will not produce blocks until pool stake is registered",
 			"component", "snapshot",
 		)
 		return nil
 	}
+
+	m.logger.Info(
+		"genesis stake distribution calculated",
+		"component", "snapshot",
+		"total_pools", distribution.TotalPools,
+		"total_stake", distribution.TotalStake,
+	)
 
 	evt := event.EpochTransitionEvent{
 		NewEpoch:     0,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2678,6 +2678,19 @@ func (ls *LedgerState) Tip() ochainsync.Tip {
 	return ls.currentTip
 }
 
+// ChainTipSlot returns the slot number of the current chain tip.
+func (ls *LedgerState) ChainTipSlot() uint64 {
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.currentTip.Point.Slot
+}
+
+// UpstreamTipSlot returns the latest known tip slot from upstream peers.
+// Returns 0 if no upstream tip is known yet.
+func (ls *LedgerState) UpstreamTipSlot() uint64 {
+	return ls.syncUpstreamTipSlot.Load()
+}
+
 // GetCurrentPParams returns the currentPParams value
 func (ls *LedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
 	return ls.currentPParams
@@ -2788,6 +2801,14 @@ func (ls *LedgerState) CurrentSlot() (uint64, error) {
 		return 0, errors.New("slot clock not initialized")
 	}
 	return ls.slotClock.CurrentSlot()
+}
+
+// NextSlotTime returns the wall-clock time when the next slot begins.
+func (ls *LedgerState) NextSlotTime() (time.Time, error) {
+	if ls.slotClock == nil {
+		return time.Time{}, errors.New("slot clock not initialized")
+	}
+	return ls.slotClock.NextSlotTime()
 }
 
 // NewView creates a new LedgerView for querying ledger state within a transaction.

--- a/node.go
+++ b/node.go
@@ -227,6 +227,13 @@ func (n *Node) Run(ctx context.Context) error {
 		n.eventBus,
 		n.config.logger,
 	)
+	// Capture genesis stake snapshot (epoch 0) so leader election works at epoch 2
+	if err := n.snapshotMgr.CaptureGenesisSnapshot(ctx); err != nil {
+		n.config.logger.Warn(
+			"failed to capture genesis snapshot",
+			"error", err,
+		)
+	}
 	if err := n.snapshotMgr.Start(); err != nil { //nolint:contextcheck
 		return fmt.Errorf("failed to start snapshot manager: %w", err)
 	}
@@ -914,6 +921,18 @@ func (a *slotClockAdapter) CurrentSlot() (uint64, error) {
 
 func (a *slotClockAdapter) SlotsPerKESPeriod() uint64 {
 	return a.ledgerState.SlotsPerKESPeriod()
+}
+
+func (a *slotClockAdapter) ChainTipSlot() uint64 {
+	return a.ledgerState.ChainTipSlot()
+}
+
+func (a *slotClockAdapter) NextSlotTime() (time.Time, error) {
+	return a.ledgerState.NextSlotTime()
+}
+
+func (a *slotClockAdapter) UpstreamTipSlot() uint64 {
+	return a.ledgerState.UpstreamTipSlot()
 }
 
 // epochNonceAdapter adapts ledger.LedgerState to forging.EpochNonceProvider.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns block forging to slot boundaries and adds sync guards to prevent slot battles and forging while catching up. Captures a genesis stake snapshot at startup so leader election works from epoch 2.

- **New Features**
  - Slot-aligned forge loop in production (wakes at next slot boundary).
  - Sync guards: skip forging if tip already has a block at the slot, or if upstream tip is >100 slots ahead.
  - Genesis stake snapshot on boot with stake totals; warns if no pools so leader election won’t produce until stake is registered.
  - SPO mode wiring: BlockProducer flag + Shelley VRF/KES keys and operational cert.
  - More observability: leader checks and schedule requests logged; produced block logs include hash.

- **Migration**
  - Set BlockProducer=true and provide ShelleyVRFKey, ShelleyKESKey, and ShelleyOperationalCertificate in config.
  - No manual steps for genesis snapshot; it runs automatically at startup.

<sup>Written for commit 9a717fe3a0dcc58c7960efa0cb658e92f5fe343f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Stake Pool Operator (SPO) mode support, enabling block production with Shelley key and certificate configuration
  * Implemented slot-aligned block forging for synchronized production timing
  * Added upstream synchronization checks to prevent forging when significantly out of sync

* **Improvements**
  * Enhanced logging visibility for stake information and genesis configuration issues
  * Improved block production success messages with additional metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->