### PR TITLE
fix(ledger): typed slot errors

### DIFF
--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -194,7 +194,13 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 					uint64(tmpEpoch.LengthInSlots),
 				)
 				if slotErr != nil {
-					return nil, slotErr
+					return nil, fmt.Errorf(
+						"epoch %d (start=%d, length=%d): %w",
+						tmpEpoch.EpochId,
+						tmpEpoch.StartSlot,
+						tmpEpoch.LengthInSlots,
+						slotErr,
+					)
 				}
 				tmpEnd = []any{
 					new(big.Int).Set(timespan),

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -395,6 +395,9 @@ func (sc *SlotClock) run() {
 		actualNow := sc.nowFunc()
 		actualSlot, err := sc.provider.TimeToSlot(actualNow)
 		if err != nil {
+			if errors.Is(err, ErrBeforeGenesis) {
+				continue
+			}
 			logger.Error("failed to verify slot after wake", "error", err)
 			continue
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved slot error handling in the ledger to reduce noise and add context. Epoch-to-slot calculation errors now include epoch details, and SlotClock skips ErrBeforeGenesis instead of logging.

- **Bug Fixes**
  - Wrap epoch slot errors with epoch ID, start slot, and length for clearer diagnostics.
  - Ignore ErrBeforeGenesis in SlotClock wake checks to avoid noisy logs before genesis.

<sup>Written for commit efaa9dddc99e63f6c76712834018adee77a3d24d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

