### PR TITLE
refactor: use labeled break vs goto

### DIFF
--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -208,12 +208,13 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	timeout := time.After(30 * time.Minute)
+waitLoop:
 	for {
 		select {
 		case <-ticker.C:
 			tip := ls.Tip()
 			if tip.Point.Slot >= immutableTip.Slot {
-				goto done
+				break waitLoop
 			}
 		case <-timeout:
 			return fmt.Errorf(
@@ -223,7 +224,6 @@ func Load(cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 			)
 		}
 	}
-done:
 	logger.Info(
 		"finished processing blocks from immutable DB",
 		"blocks_copied", blocksCopied,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced a goto with a labeled break in Load to simplify control flow and improve readability without changing behavior.

- **Refactors**
  - Added waitLoop label and used break waitLoop instead of goto.
  - Removed done label; timeout and logging behavior unchanged.

<sup>Written for commit b8387360de0aefde8913f4581efe696a72689324. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

