### PR TITLE
feat(database): delete epoch after slot

### DIFF
--- a/database/epoch.go
+++ b/database/epoch.go
@@ -45,6 +45,19 @@ func (d *Database) GetEpochs(txn *Txn) ([]models.Epoch, error) {
 	return txn.db.metadata.GetEpochs(txn.Metadata())
 }
 
+func (d *Database) DeleteEpochsAfterSlot(
+	slot uint64,
+	txn *Txn,
+) error {
+	if txn == nil {
+		return d.metadata.DeleteEpochsAfterSlot(slot, nil)
+	}
+	return txn.db.metadata.DeleteEpochsAfterSlot(
+		slot,
+		txn.Metadata(),
+	)
+}
+
 func (d *Database) SetEpoch(
 	slot, epoch uint64,
 	nonce []byte,

--- a/database/plugin/metadata/mysql/epoch.go
+++ b/database/plugin/metadata/mysql/epoch.go
@@ -76,6 +76,20 @@ func (d *MetadataStoreMysql) GetEpochs(
 	return ret, nil
 }
 
+// DeleteEpochsAfterSlot removes all epoch entries whose start slot
+// is after the given slot.
+func (d *MetadataStoreMysql) DeleteEpochsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Where("start_slot > ?", slot).Delete(&models.Epoch{})
+	return result.Error
+}
+
 // SetEpoch saves an epoch
 func (d *MetadataStoreMysql) SetEpoch(
 	slot, epoch uint64,

--- a/database/plugin/metadata/postgres/epoch.go
+++ b/database/plugin/metadata/postgres/epoch.go
@@ -76,6 +76,20 @@ func (d *MetadataStorePostgres) GetEpochs(
 	return ret, nil
 }
 
+// DeleteEpochsAfterSlot removes all epoch entries whose start slot
+// is after the given slot.
+func (d *MetadataStorePostgres) DeleteEpochsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Where("start_slot > ?", slot).Delete(&models.Epoch{})
+	return result.Error
+}
+
 // SetEpoch saves an epoch
 func (d *MetadataStorePostgres) SetEpoch(
 	slot, epoch uint64,

--- a/database/plugin/metadata/sqlite/epoch.go
+++ b/database/plugin/metadata/sqlite/epoch.go
@@ -76,6 +76,20 @@ func (d *MetadataStoreSqlite) GetEpochs(
 	return ret, nil
 }
 
+// DeleteEpochsAfterSlot removes all epoch entries whose start slot
+// is after the given slot.
+func (d *MetadataStoreSqlite) DeleteEpochsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	result := db.Where("start_slot > ?", slot).Delete(&models.Epoch{})
+	return result.Error
+}
+
 // SetEpoch saves an epoch
 func (d *MetadataStoreSqlite) SetEpoch(
 	slot, epoch uint64,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -321,6 +321,11 @@ type MetadataStore interface {
 	// GetEpochs retrieves all epochs.
 	GetEpochs(types.Txn) ([]models.Epoch, error)
 
+	// DeleteEpochsAfterSlot removes all epoch entries whose start slot
+	// is after the given slot. Used during chain rollback to discard
+	// epoch nonces that were computed from rolled-back blocks.
+	DeleteEpochsAfterSlot(uint64, types.Txn) error
+
 	// GetUtxosAddedAfterSlot retrieves all UTxOs added after the given slot.
 	GetUtxosAddedAfterSlot(uint64, types.Txn) ([]models.Utxo, error)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds DeleteEpochsAfterSlot to metadata stores and uses it during ledger rollbacks to delete epochs starting after the rollback slot, then reloads the epoch cache. This prevents stale epoch nonces and keeps epoch/era state consistent.

- **Bug Fixes**
  - Drops nonces derived from rolled-back blocks so they’re recomputed on re-sync.
  - Keeps EpochNonce() and next-epoch detection accurate after rollback.

<sup>Written for commit f8b1dd4067b8c780635c9762e709809a7490ea83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chain rollback reliability by properly cleaning up stale epoch records and reloading updated data. This ensures correct epoch nonce computation after blockchain reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->