### PR TITLE
fix: genesis hash validation

### DIFF
--- a/database/block.go
+++ b/database/block.go
@@ -120,6 +120,21 @@ func (d *Database) SetGenesisCbor(slot uint64, hash []byte, cborData []byte, txn
 	return nil
 }
 
+// HasGenesisCbor checks whether genesis CBOR data exists at the expected
+// blob key for the given slot and hash. This is used to validate that
+// existing chain data matches the current genesis configuration.
+func (d *Database) HasGenesisCbor(slot uint64, hash []byte) bool {
+	blob := d.Blob()
+	if blob == nil {
+		return false
+	}
+	txn := d.BlobTxn(false)
+	defer txn.Rollback() //nolint:errcheck
+	key := types.BlockBlobKey(slot, hash)
+	_, err := blob.Get(txn.Blob(), key)
+	return err == nil
+}
+
 func BlockDeleteTxn(txn *Txn, block models.Block) error {
 	if txn == nil {
 		return types.ErrNilTxn

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -567,15 +567,26 @@ func GenesisBlockHash(cfg *cardano.CardanoNodeConfig) ([32]byte, error) {
 }
 
 func (ls *LedgerState) createGenesisBlock() error {
-	if ls.currentTip.Point.Slot > 0 {
-		return nil
-	}
-
 	// Get the Byron genesis hash to use as the synthetic block hash.
 	// This mirrors how the Shelley epoch nonce uses the Shelley genesis hash.
 	genesisHash, err := GenesisBlockHash(ls.config.CardanoNodeConfig)
 	if err != nil {
 		return fmt.Errorf("get genesis block hash: %w", err)
+	}
+
+	if ls.currentTip.Point.Slot > 0 {
+		// Validate existing chain data matches the current genesis config.
+		// If the blob store does not contain genesis CBOR at the expected
+		// key, the database was created with a different genesis.
+		if !ls.db.HasGenesisCbor(0, genesisHash[:]) {
+			return fmt.Errorf(
+				"genesis hash mismatch: database contains chain data "+
+					"from a different genesis (expected Byron genesis "+
+					"hash %x); delete the database directory to start fresh",
+				genesisHash,
+			)
+		}
+		return nil
 	}
 
 	txn := ls.db.Transaction(true)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate the database’s genesis against the node config to prevent syncing on a different network. Adds a blob check for genesis CBOR and fails fast with a clear error if mismatched.

- **Bug Fixes**
  - Added Database.HasGenesisCbor(slot, hash) to check for genesis CBOR at the expected blob key.
  - In createGenesisBlock, when a chain already exists (slot > 0), verify genesis CBOR for slot 0 and the computed Byron genesis hash; return a clear mismatch error otherwise.

- **Migration**
  - If you see “genesis hash mismatch” on startup, delete the database directory and resync.

<sup>Written for commit 7bd6cb00b4bd7f67e2987e1c11ef3bc59e81c585. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

