### PR TITLE
fix(ouroboros): handle nil version data

### DIFF
--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -422,7 +422,7 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 
 	// Only start client protocols if the peer negotiated full duplex
 	_, versionData := conn.ProtocolVersion()
-	if versionData.DiffusionMode() != oprotocol.DiffusionModeInitiatorAndResponder {
+	if versionData == nil || versionData.DiffusionMode() != oprotocol.DiffusionModeInitiatorAndResponder {
 		o.config.Logger.Debug(
 			"inbound connection is not full-duplex, skipping client start",
 			"connection_id", connId.String(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a nil check for versionData in inbound connection handling to prevent nil pointer panics. Ensures client protocols are skipped when version data is missing or not full-duplex.

<sup>Written for commit 4fa943ddf7aeca86143230cb0dc9d53962617077. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

