### PR TITLE
fix(ouroboros): set chainsync timeouts

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -39,6 +39,15 @@ func (o *Ouroboros) chainsyncServerConnOpts() []ochainsync.ChainSyncOptionFunc {
 	return []ochainsync.ChainSyncOptionFunc{
 		ochainsync.WithFindIntersectFunc(o.chainsyncServerFindIntersect),
 		ochainsync.WithRequestNextFunc(o.chainsyncServerRequestNext),
+		// Increase intersect timeout from the 10s default. Downstream
+		// peers may send FindIntersect with many points during initial
+		// sync, and processing can be slow under load.
+		ochainsync.WithIntersectTimeout(30 * time.Second),
+		// Set idle timeout to 1 hour. The spec default (3673s per
+		// Table 3.8) is similar, but we set it explicitly to keep
+		// server connections alive during periods of low block
+		// production (e.g. DevNets with low activeSlotsCoeff).
+		ochainsync.WithIdleTimeout(1 * time.Hour),
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase ChainSync server timeouts to improve reliability during initial sync and quiet periods. Prevents disconnects when peers send many intersect points or when block production is sparse.

- **Bug Fixes**
  - Set intersect timeout to 30s to handle large FindIntersect requests under load.
  - Set idle timeout to 1h to keep connections alive on low-traffic networks (e.g., DevNets).

<sup>Written for commit 942e2325361d382dde92bcc383c846cd3af2c718. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

