### PR TITLE
fix: rename metrics to match Haskell node

### DIFF
--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -28,6 +28,8 @@ type stateMetrics struct {
 	forks               prometheus.Gauge
 	blocksForgedTotal   prometheus.Counter
 	blockForgingLatency prometheus.Histogram
+	forgingEnabled      prometheus.Gauge
+	nodeStartTime       prometheus.Gauge
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -66,6 +68,18 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 			Name:    "cardano_node_metrics_blockForgingLatency_seconds",
 			Help:    "latency of block forging from slot start to block completion",
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms to ~16s
+		},
+	)
+	m.forgingEnabled = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_forging_enabled",
+			Help: "whether block forging is enabled (0 or 1)",
+		},
+	)
+	m.nodeStartTime = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_nodeStartTime_int",
+			Help: "unix timestamp when the node started",
 		},
 	)
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -545,6 +545,9 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	ls.ctx = ctx
 	// Init metrics
 	ls.metrics.init(ls.config.PromRegistry)
+	ls.metrics.nodeStartTime.Set(
+		float64(time.Now().Unix()),
+	)
 
 	// Initialize database worker pool for async operations
 	if !ls.config.DatabaseWorkerPoolConfig.Disabled {
@@ -3116,6 +3119,16 @@ func (ls *LedgerState) EvaluateTx(
 // Sets the mempool for accessing transactions
 func (ls *LedgerState) SetMempool(mempool MempoolProvider) {
 	ls.mempool = mempool
+}
+
+// SetForgingEnabled sets the forging_enabled metric gauge. Call with
+// true after the block forger has been initialised successfully.
+func (ls *LedgerState) SetForgingEnabled(enabled bool) {
+	if enabled {
+		ls.metrics.forgingEnabled.Set(1)
+	} else {
+		ls.metrics.forgingEnabled.Set(0)
+	}
 }
 
 // SetForgedBlockChecker sets the forged block checker used for slot

--- a/node.go
+++ b/node.go
@@ -559,6 +559,7 @@ func (n *Node) Run(ctx context.Context) error {
 			n.ledgerState.SetForgedBlockChecker(
 				n.blockForger.SlotTracker(),
 			)
+			n.ledgerState.SetForgingEnabled(true)
 		}
 		started = append(started, func() {
 			if n.blockForger != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns metrics with the Haskell node so existing dashboards and alerts work. Adds Prometheus gauges for forging status and node start time and updates them at startup and forger init.

- **New Features**
  - Adds cardano_node_metrics_forging_enabled gauge; set to 1 after the block forger initializes (via LedgerState.SetForgingEnabled).
  - Adds cardano_node_metrics_nodeStartTime_int gauge; set once at node start to the current Unix timestamp.

<sup>Written for commit 56ed09c032fb262e579e7c5d0362defaca0da8d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new monitoring metrics for block forging status and node startup time, enhancing observability and diagnostics for node operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->