### PR TITLE
feat: stake pool metrics

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1336,6 +1336,11 @@ func (ls *LedgerState) checkSlotBattle(
 		"local_won", localWon,
 	)
 
+	// Increment slot battle metric
+	if ls.config.SlotBattleRecorder != nil {
+		ls.config.SlotBattleRecorder.RecordSlotBattle()
+	}
+
 	if ls.config.EventBus != nil {
 		ls.config.EventBus.PublishAsync(
 			forging.SlotBattleEventType,

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -265,6 +265,17 @@ func (pc *PoolCredentials) GetOpCert() *OpCert {
 	}
 }
 
+// GetKESPeriod returns the current KES period of the loaded key.
+// Returns 0 if the KES key is not loaded.
+func (pc *PoolCredentials) GetKESPeriod() uint64 {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	if pc.kesSKey == nil {
+		return 0
+	}
+	return pc.kesSKey.Period
+}
+
 // IsLoaded returns true if all credentials have been loaded.
 func (pc *PoolCredentials) IsLoaded() bool {
 	pc.mu.RLock()

--- a/ledger/forging/metrics.go
+++ b/ledger/forging/metrics.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package forging
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// forgingMetrics holds Prometheus metrics for block forging and KES
+// lifecycle monitoring. Metric names match cardano-node where a
+// direct equivalent exists, enabling reuse of existing SPO
+// dashboards.
+type forgingMetrics struct {
+	// KES lifecycle (match cardano-node names)
+	currentKESPeriod    prometheus.Gauge
+	remainingKESPeriods prometheus.Gauge
+	opCertStartKES      prometheus.Gauge
+	opCertExpiryKES     prometheus.Gauge
+
+	// Forge outcomes (match cardano-node Forge_* names)
+	forgeAboutToLead  prometheus.Counter
+	forgeNodeIsLeader prometheus.Counter
+	forgeNotLeader    prometheus.Counter
+	forgeForged       prometheus.Counter
+	forgeAdopted      prometheus.Counter
+	forgeCouldNot     prometheus.Counter
+
+	// Dingo-specific (no cardano-node equivalent)
+	slotBattlesTotal prometheus.Counter
+	blockSizeBytes   prometheus.Histogram
+	blockTxCount     prometheus.Histogram
+}
+
+// initForgingMetrics initializes all forging metrics using the
+// provided Prometheus registerer.
+func initForgingMetrics(
+	reg prometheus.Registerer,
+) *forgingMetrics {
+	factory := promauto.With(reg)
+	m := &forgingMetrics{}
+
+	// KES lifecycle — names match cardano-node
+	m.currentKESPeriod = factory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_currentKESPeriod_int",
+			Help: "current KES period",
+		},
+	)
+	m.remainingKESPeriods = factory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_remainingKESPeriods_int",
+			Help: "KES periods remaining before OpCert expires",
+		},
+	)
+	m.opCertStartKES = factory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_operationalCertificateStartKESPeriod_int",
+			Help: "KES period when the operational certificate was issued",
+		},
+	)
+	m.opCertExpiryKES = factory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_operationalCertificateExpiryKESPeriod_int",
+			Help: "KES period when the operational certificate expires",
+		},
+	)
+
+	// Forge outcomes — names match cardano-node Forge_* counters
+	m.forgeAboutToLead = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_Forge_about_to_lead_int",
+			Help: "slots where this node checked leadership",
+		},
+	)
+	m.forgeNodeIsLeader = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_Forge_node_is_leader_int",
+			Help: "slots where this node was the slot leader",
+		},
+	)
+	m.forgeNotLeader = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_Forge_node_not_leader_int",
+			Help: "slots where this node was not the slot leader",
+		},
+	)
+	m.forgeForged = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_Forge_forged_int",
+			Help: "blocks successfully forged",
+		},
+	)
+	m.forgeAdopted = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_Forge_adopted_int",
+			Help: "forged blocks adopted onto the chain",
+		},
+	)
+	m.forgeCouldNot = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_Forge_could_not_forge_int",
+			Help: "slots where forging failed (syncing, build error, etc)",
+		},
+	)
+
+	// Dingo-specific metrics
+	m.slotBattlesTotal = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_slotBattlesTotal_int",
+			Help: "slot battles detected (competing blocks at same slot)",
+		},
+	)
+	m.blockSizeBytes = factory.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "cardano_node_metrics_forgedBlockSize_bytes",
+			Help: "size of forged block bodies in bytes",
+			Buckets: prometheus.ExponentialBuckets(
+				256, 2, 14,
+			), // 256B to ~2MB
+		},
+	)
+	m.blockTxCount = factory.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "cardano_node_metrics_forgedBlockTxCount_int",
+			Help: "number of transactions in forged blocks",
+			Buckets: prometheus.LinearBuckets(
+				0, 10, 20,
+			), // 0, 10, 20, ..., 190
+		},
+	)
+
+	return m
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -379,6 +379,12 @@ type ForgedBlockChecker interface {
 	WasForgedByUs(slot uint64) (blockHash []byte, ok bool)
 }
 
+// SlotBattleRecorder records slot battle events for metrics.
+type SlotBattleRecorder interface {
+	// RecordSlotBattle increments the slot battle counter.
+	RecordSlotBattle()
+}
+
 // ChainsyncResyncFunc describes a callback function used to trigger a
 // chainsync re-negotiation for the given connection. This is called when
 // the ledger detects a persistent chain fork that prevents syncing.
@@ -402,6 +408,7 @@ type LedgerStateConfig struct {
 	ConnectionSwitchFunc       ConnectionSwitchFunc
 	FatalErrorFunc             FatalErrorFunc
 	ForgedBlockChecker         ForgedBlockChecker
+	SlotBattleRecorder         SlotBattleRecorder
 	ValidateHistorical         bool
 	ForgeBlocks                bool
 	DatabaseWorkerPoolConfig   DatabaseWorkerPoolConfig
@@ -3138,6 +3145,17 @@ func (ls *LedgerState) SetForgedBlockChecker(checker ForgedBlockChecker) {
 	ls.Lock()
 	defer ls.Unlock()
 	ls.config.ForgedBlockChecker = checker
+}
+
+// SetSlotBattleRecorder sets the recorder used to increment the
+// slot battle metric. This is typically called after the block
+// forger is initialized.
+func (ls *LedgerState) SetSlotBattleRecorder(
+	recorder SlotBattleRecorder,
+) {
+	ls.Lock()
+	defer ls.Unlock()
+	ls.config.SlotBattleRecorder = recorder
 }
 
 // forgeBlock creates a conway block with transactions from mempool

--- a/node.go
+++ b/node.go
@@ -561,6 +561,9 @@ func (n *Node) Run(ctx context.Context) error {
 				n.blockForger.SlotTracker(),
 			)
 			n.ledgerState.SetForgingEnabled(true)
+			n.ledgerState.SetSlotBattleRecorder(
+				n.blockForger,
+			)
 		}
 		started = append(started, func() {
 			if n.blockForger != nil {
@@ -815,6 +818,7 @@ func (n *Node) initBlockForger(ctx context.Context) error {
 		BlockBuilder:     builder,
 		BlockBroadcaster: broadcaster,
 		SlotClock:        slotClock,
+		PromRegistry:     n.config.promRegistry,
 	})
 	if err != nil {
 		// Stop election to prevent goroutine leak


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Prometheus metrics for stake pool forging and slot battles using cardano-node metric names. Enables SPO dashboards for leadership checks, KES lifecycle, block outcomes, and block size/tx stats.

- New Features
  - Optional metrics via ForgerConfig.PromRegistry; Node passes the registry and sets the forger as LedgerState’s SlotBattleRecorder; ledger increments slotBattles on detection.
  - Forge_* counters: Forge_about_to_lead (every slot check), Forge_node_is_leader, Forge_node_not_leader, Forge_forged, Forge_adopted, Forge_could_not_forge (sync/build/broadcast failures).
  - KES gauges: currentKESPeriod, remainingKESPeriods, operationalCertificateStartKESPeriod, operationalCertificateExpiryKESPeriod; OpCert gauges set at startup and updated on KES evolution; added PoolCredentials.GetKESPeriod.
  - Extra metrics: slotBattlesTotal_int; forgedBlockSize_bytes and forgedBlockTxCount_int (histograms).

<sup>Written for commit bbfe1f73a2b13c6c67c4e9efa04ae24fa03995e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics for forging: leadership status, production attempts, forged/adopted counts, and failure tracking.
  * KES lifecycle monitoring: current period and remaining periods exposed.
  * Slot-battle tracking: recording and aggregate metric for detected slot conflicts.
  * New accessor to read current KES period and automatic wiring to enable metrics at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->