### PR TITLE
fix: buffer max, error check, return tip copy

### DIFF
--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -91,9 +91,14 @@ func (b *Blockfrost) Start(
 		b.handleNetwork,
 	)
 
+	// Wrap handler with a request body size limit (1 MB)
+	// as defense-in-depth against oversized payloads.
+	const maxRequestBodyBytes int64 = 1 << 20 // 1 MB
+	handler := http.MaxBytesHandler(mux, maxRequestBodyBytes)
+
 	server := &http.Server{
 		Addr:              b.config.ListenAddress,
-		Handler:           mux,
+		Handler:           handler,
 		ReadHeaderTimeout: 60 * time.Second,
 	}
 	b.httpServer = server

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -177,8 +177,8 @@ func main() {
 	// Initialize CPU profiling (starts immediately, stops on exit)
 	if cpuprofile != "" {
 		cpuprofile = filepath.Clean(cpuprofile)
-		fmt.Fprintf(os.Stderr, "Starting CPU profiling to %q\n", cpuprofile) //nolint:gosec // stderr output, no XSS risk
-		f, err := os.Create(cpuprofile)                                      //nolint:gosec // user-specified profiling output path
+		fmt.Fprintf(os.Stderr, "Starting CPU profiling to %q\n", cpuprofile)         //nolint:gosec // stderr output, no XSS risk
+		f, err := os.OpenFile(cpuprofile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // user-specified profiling output path
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not create CPU profile: %v\n", err)
 			os.Exit(1)
@@ -298,7 +298,7 @@ func main() {
 	// Finalize memory profiling before exit
 	if memprofile != "" {
 		memprofile = filepath.Clean(memprofile)
-		f, err := os.Create(memprofile) //nolint:gosec // user-specified profiling output path
+		f, err := os.OpenFile(memprofile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // user-specified profiling output path
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not create memory profile: %v\n", err)
 		} else {

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -161,14 +161,14 @@ func (c *ConnectionManager) startListener(
 						consecutiveErrors,
 					),
 				)
-				// Sleep with cancellation awareness
-				c.listenersMutex.Lock()
-				isClosing = c.closing
-				c.listenersMutex.Unlock()
-				if isClosing {
+				// Backoff with cancellation awareness
+				timer := time.NewTimer(backoff)
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					timer.Stop()
 					return
 				}
-				time.Sleep(backoff)
 				continue
 			}
 			// Successful accept - reset consecutive error count

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -198,7 +198,7 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 				return nil, fmt.Errorf("failed to read data dir: %w", err)
 			}
 			// Create data directory
-			if err := os.MkdirAll(db.dataDir, 0o755); err != nil {
+			if err := os.MkdirAll(db.dataDir, 0o700); err != nil {
 				return nil, fmt.Errorf("failed to create data dir: %w", err)
 			}
 		}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -153,6 +153,14 @@ func NewMempool(config MempoolConfig) *Mempool {
 	} else {
 		m.logger = config.Logger
 	}
+	if config.MempoolCapacity <= 0 {
+		m.logger.Warn(
+			"mempool capacity is zero or negative; "+
+				"all transactions will be rejected",
+			"component", "mempool",
+			"capacity", config.MempoolCapacity,
+		)
+	}
 	// Init metrics before launching goroutines that reference them
 	promautoFactory := promauto.With(config.PromRegistry)
 	m.metrics.txsProcessedNum = promautoFactory.NewCounter(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens network and storage paths and improves shutdown behavior. Adds a 1 MB request limit, stricter file perms, safer peer tip reads, and better logging.

- **Bug Fixes**
  - Blockfrost: cap request body to 1 MB and log JSON encode errors.
  - Profiling/storage perms: use 0600 for CPU/mem profile files and 0700 for Badger data dir.
  - ChainSelector: GetPeerTip and GetAllPeerTips return deep copies; nil when peer not tracked.
  - ConnectionManager: backoff now uses a cancel-aware timer for faster shutdowns.
  - Mempool: warn when capacity <= 0 to flag misconfiguration.

<sup>Written for commit 6a59eadf8a497fa7ae9b2c0d3a0029e15c71bf51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

