### PR TITLE
fix(ledger): validation fixes from devnet testing

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -82,11 +82,14 @@ func (c *Chain) headerTip() ochainsync.Tip {
 	}
 }
 
-// maxQueuedHeaders returns the maximum number of headers that may be
+// MaxQueuedHeaders returns the maximum number of headers that may be
 // queued. When the security parameter is available (securityParam > 0),
 // the limit is securityParam * 2. Otherwise, DefaultMaxQueuedHeaders is
 // used as a safe fallback.
-func (c *Chain) maxQueuedHeaders() int {
+func (c *Chain) MaxQueuedHeaders() int {
+	if c == nil || c.manager == nil {
+		return DefaultMaxQueuedHeaders
+	}
 	if sp := c.manager.securityParam; sp > 0 {
 		return sp * 2
 	}
@@ -101,7 +104,7 @@ func (c *Chain) AddBlockHeader(header ledger.BlockHeader) error {
 	defer c.mutex.Unlock()
 	// Reject headers when the queue is at capacity to prevent
 	// unbounded memory growth from a malicious peer.
-	if len(c.headers) >= c.maxQueuedHeaders() {
+	if len(c.headers) >= c.MaxQueuedHeaders() {
 		return ErrHeaderQueueFull
 	}
 	// Make sure header fits on chain tip

--- a/database/txn.go
+++ b/database/txn.go
@@ -17,6 +17,7 @@ package database
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -131,6 +132,7 @@ func (t *Txn) Do(fn func(*Txn) error) error {
 			t.db.logger.Error(
 				"panic in transaction function, ensuring rollback",
 				"panic", fmt.Sprintf("%v", r),
+				"stack", string(debug.Stack()),
 			)
 			// Attempt rollback to ensure transaction is cleaned up
 			if err := t.Rollback(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.1
 	github.com/blinklabs-io/bursa v0.15.0
-	github.com/blinklabs-io/gouroboros v0.159.0
+	github.com/blinklabs-io/gouroboros v0.159.2
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.25
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/blinklabs-io/bursa v0.15.0 h1:kRgoX+i9duRVXDHEDJXbrEHiLeLRA4TyqatAOfo
 github.com/blinklabs-io/bursa v0.15.0/go.mod h1:84ZHhG8pjOjjN6mGveeDrQHhRhDkbixdvR3mZ2BOr/k=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.159.0 h1:oec/KxMOkBXmk5T19PeePrifW9nL40eDxEQFHflG/oQ=
-github.com/blinklabs-io/gouroboros v0.159.0/go.mod h1:OuKGQEmPF7O/uf0OX8jrdTZBl8qIkuI9ti4t++JV65Y=
+github.com/blinklabs-io/gouroboros v0.159.2 h1:igIFQSMEDAXa0vSGKoz+65ytWOBFMN1ucEvrfxww0+4=
+github.com/blinklabs-io/gouroboros v0.159.2/go.mod h1:OuKGQEmPF7O/uf0OX8jrdTZBl8qIkuI9ti4t++JV65Y=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.25 h1:0FIsUPnuL9O/YLYC7ZhwHW3wpubLjPNwX/FZgj5b0Nw=

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -24,6 +24,11 @@
 #   docker compose up -d       # Start all services
 #   docker compose down -v     # Stop and remove volumes
 #
+# Host port overrides (set in environment or .env file):
+#   DEVNET_DINGO_PORT     - Dingo producer host port    (default: 3010)
+#   DEVNET_CARDANO_PORT   - Cardano producer host port  (default: 3011)
+#   DEVNET_RELAY_PORT     - Cardano relay host port     (default: 3012)
+#
 # The configurator service runs first (via depends_on) to generate unique
 # key sets and genesis files for each pool from testnet.yaml.
 
@@ -64,7 +69,7 @@ services:
       - dingo-producer-data:/data/db
       - dingo-producer-ipc:/ipc
     ports:
-      - "3010:3001"
+      - "${DEVNET_DINGO_PORT:-3010}:3001"
     networks:
       devnet:
         ipv4_address: 172.20.0.10
@@ -108,7 +113,7 @@ services:
       - cardano-producer-data:/data/db
       - cardano-producer-ipc:/ipc
     ports:
-      - "3011:3001"
+      - "${DEVNET_CARDANO_PORT:-3011}:3001"
     networks:
       devnet:
         ipv4_address: 172.20.0.11
@@ -145,7 +150,7 @@ services:
       - cardano-relay-data:/data/db
       - cardano-relay-ipc:/ipc
     ports:
-      - "3012:3001"
+      - "${DEVNET_RELAY_PORT:-3012}:3001"
     networks:
       devnet:
         ipv4_address: 172.20.0.12

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -441,7 +441,7 @@ func EvaluateTxAlonzo(
 		}
 	}
 	// Calculate fee based on TX size and calculated ExUnits
-	txSize := TxBodySize(tx)
+	txSize := TxSizeForFee(tx)
 	var pricesMem, pricesSteps *big.Rat
 	if tmpPparams.ExecutionCosts.MemPrice != nil {
 		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -605,7 +605,7 @@ func EvaluateTxBabbage(
 		}
 	}
 	// Calculate fee based on TX size and calculated ExUnits
-	txSize := TxBodySize(tx)
+	txSize := TxSizeForFee(tx)
 	var pricesMem, pricesSteps *big.Rat
 	if tmpPparams.ExecutionCosts.MemPrice != nil {
 		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -608,7 +608,7 @@ func EvaluateTxConway(
 		}
 	}
 	// Calculate fee based on TX size and calculated ExUnits
-	txSize := TxBodySize(tx)
+	txSize := TxSizeForFee(tx)
 	var pricesMem, pricesSteps *big.Rat
 	if tmpPparams.ExecutionCosts.MemPrice != nil {
 		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -22,10 +22,15 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
-// TxBodySize returns the CBOR-serialized size of a
-// transaction in bytes.
+// TxSizeForFee computes the transaction size used in
+// the Cardano fee formula. See eras.TxSizeForFee.
+func TxSizeForFee(tx lcommon.Transaction) uint64 {
+	return eras.TxSizeForFee(tx)
+}
+
+// TxBodySize is a deprecated alias for TxSizeForFee.
 func TxBodySize(tx lcommon.Transaction) uint64 {
-	return eras.TxBodySize(tx)
+	return eras.TxSizeForFee(tx)
 }
 
 // ValidateTxSize checks that the transaction size does

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -389,8 +389,11 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 			// already running. The active goroutine's defer
 			// cleanup in createOutboundConnection will clear
 			// Reconnecting when it exits.
+			// Do NOT set Reconnecting here — createOutboundConnection
+			// sets it itself after acquiring the lock. Setting it
+			// here would cause the goroutine to see it as already
+			// active and immediately return.
 			if !peer.Reconnecting {
-				peer.Reconnecting = true
 				go p.createOutboundConnection(peer)
 			}
 		}

--- a/peergov/peer_cap_test.go
+++ b/peergov/peer_cap_test.go
@@ -36,14 +36,14 @@ func TestAddPeer_RejectsGossipPeersAtCap(t *testing.T) {
 
 	// Fill peer list to exactly the cap with gossip peers
 	for i := range cap {
-		addr := fmt.Sprintf("10.0.%d.%d:%d", i/256, i%256, 3000)
+		addr := fmt.Sprintf("44.0.%d.%d:%d", i/256, i%256, 3000)
 		err := pg.AddPeer(addr, PeerSourceP2PGossip)
 		require.NoError(t, err, "peer %d should be accepted", i)
 	}
 	require.Len(t, pg.GetPeers(), cap)
 
 	// The next gossip peer should be rejected
-	err := pg.AddPeer("10.99.99.99:3000", PeerSourceP2PGossip)
+	err := pg.AddPeer("44.99.99.99:3000", PeerSourceP2PGossip)
 	assert.ErrorIs(t, err, ErrPeerListFull)
 
 	// Peer count should not have increased
@@ -59,13 +59,13 @@ func TestAddPeer_RejectsLedgerPeersAtCap(t *testing.T) {
 
 	// Fill peer list to the cap
 	for i := range cap {
-		addr := fmt.Sprintf("10.0.%d.%d:%d", i/256, i%256, 3000)
+		addr := fmt.Sprintf("44.0.%d.%d:%d", i/256, i%256, 3000)
 		err := pg.AddPeer(addr, PeerSourceP2PGossip)
 		require.NoError(t, err)
 	}
 
 	// Ledger peers should also be rejected at cap
-	err := pg.AddPeer("10.99.99.99:3000", PeerSourceP2PLedger)
+	err := pg.AddPeer("44.99.99.99:3000", PeerSourceP2PLedger)
 	assert.ErrorIs(t, err, ErrPeerListFull)
 	assert.Len(t, pg.GetPeers(), cap)
 }
@@ -79,7 +79,7 @@ func TestAddPeer_AcceptsTopologyPeersAtCap(t *testing.T) {
 
 	// Fill peer list to the cap
 	for i := range cap {
-		addr := fmt.Sprintf("10.0.%d.%d:%d", i/256, i%256, 3000)
+		addr := fmt.Sprintf("44.0.%d.%d:%d", i/256, i%256, 3000)
 		err := pg.AddPeer(addr, PeerSourceP2PGossip)
 		require.NoError(t, err)
 	}
@@ -110,13 +110,15 @@ func TestAddPeer_NormalOperationWithinCap(t *testing.T) {
 		TargetNumberOfKnownPeers: 5,
 	})
 
-	// Add a mix of peer sources, well under cap
+	// Add a mix of peer sources, well under cap.
+	// Gossip and ledger peers use routable IPs; inbound and topology
+	// peers may use private IPs since they are exempt from routing checks.
 	sources := []struct {
 		addr   string
 		source PeerSource
 	}{
-		{"10.0.0.1:3000", PeerSourceP2PGossip},
-		{"10.0.0.2:3000", PeerSourceP2PLedger},
+		{"44.0.0.1:3000", PeerSourceP2PGossip},
+		{"44.0.0.2:3000", PeerSourceP2PLedger},
 		{"10.0.0.3:3000", PeerSourceInboundConn},
 		{"10.0.0.4:3000", PeerSourceTopologyLocalRoot},
 		{"10.0.0.5:3000", PeerSourceTopologyPublicRoot},
@@ -154,13 +156,13 @@ func TestAddPeer_InboundRejectedAtCap(t *testing.T) {
 
 	// Fill peer list to the cap
 	for i := range cap {
-		addr := fmt.Sprintf("10.0.%d.%d:%d", i/256, i%256, 3000)
+		addr := fmt.Sprintf("44.0.%d.%d:%d", i/256, i%256, 3000)
 		err := pg.AddPeer(addr, PeerSourceP2PGossip)
 		require.NoError(t, err)
 	}
 
 	// Inbound connection peer should also be rejected at cap
-	err := pg.AddPeer("10.99.99.99:3000", PeerSourceInboundConn)
+	err := pg.AddPeer("44.99.99.99:3000", PeerSourceInboundConn)
 	assert.ErrorIs(t, err, ErrPeerListFull)
 	assert.Len(t, pg.GetPeers(), cap)
 }
@@ -174,13 +176,13 @@ func TestAddLedgerPeer_RejectedAtCap(t *testing.T) {
 
 	// Fill peer list to the cap via AddPeer
 	for i := range cap {
-		addr := fmt.Sprintf("10.0.%d.%d:%d", i/256, i%256, 3000)
+		addr := fmt.Sprintf("44.0.%d.%d:%d", i/256, i%256, 3000)
 		err := pg.AddPeer(addr, PeerSourceP2PGossip)
 		require.NoError(t, err)
 	}
 
 	// addLedgerPeer should return false when at cap
-	added := pg.addLedgerPeer("10.99.99.99:3000")
+	added := pg.addLedgerPeer("44.99.99.99:3000")
 	assert.False(t, added, "ledger peer should be rejected at cap")
 	assert.Len(t, pg.GetPeers(), cap)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns fee and epoch nonce validation with the Cardano ledger and hardens DevNet, snapshots, and peer connectivity. Tx sizes/fees and nonces now match ledger semantics; DevNet tests and networking are more reliable.

- **Bug Fixes**
  - Fees: use fee‑relevant TX size (exclude Alonzo+ IsValid) and a single ceiling over combined script costs; tests updated.
  - Epoch nonce: candidate = Shelley genesis; combine with boundary block PrevHash via blake2b_256; store evolving nonce on snapshot import; safer genesis detection and idempotent genesis creation (auto‑create when missing after Mithril).
  - Networking: cap chainsync headers to chain.MaxQueuedHeaders; reject non‑routable gossip/ledger peers while allowing topology/inbound; auto‑connect peers added at runtime; fix reconnection race.
  - Leader schedule: validate ActiveSlotCoeff and guard Threshold against invalid inputs.
  - Database: detect any genesis CBOR at a slot; log stack traces on transaction panics.

- **New Features**
  - DevNet/test harness: host port overrides propagated to Go tests, TEST_TIMEOUT (default 5m), shorter failure logs (tail 100), and always teardown with volumes.
  - Dependency: bumped gouroboros to v0.159.2.

<sup>Written for commit 41b70f563dcd504b26eda2a9721a5d2ce7da8e2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate fee and script-cost rounding; fee validation/messages updated.
  * Genesis handling is idempotent and stricter on hash mismatches.
  * Header fetching now respects runtime queue capacity.
  * Stronger validation for leader-schedule inputs.

* **Chores**
  * Dependency version bumped.

* **Devops**
  * Dev environment ports configurable via environment variables.
  * Teardown always removes volumes; test timeout support and smaller failure log tails.

* **Networking**
  * Non-routable peer addresses rejected; new peers can trigger outbound connects automatically.

* **State & Snapshots**
  * Snapshots/imports now track evolving and epoch nonces for correct restores.

* **Database**
  * Detect presence of any genesis CBOR at a slot.

* **Logging**
  * Enhanced logging and panic stack traces.

* **Tests**
  * Extensive tests added/updated for era-specific size/fee behavior and routable-address policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->