### PR TITLE
feat(ledger): configurable forging tolerances

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -247,6 +247,9 @@ func (cs *ChainSelector) evictLeastRecentPeerLocked() *ouroboros.ConnectionId {
 	found := false
 
 	for connId, peerTip := range cs.peerTips {
+		if peerTip == nil {
+			continue
+		}
 		// Never evict the current best peer
 		if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
 			continue

--- a/config.go
+++ b/config.go
@@ -110,6 +110,9 @@ type Config struct {
 	shelleyVRFKey                 string
 	shelleyKESKey                 string
 	shelleyOperationalCertificate string
+	// Forging tolerances (0 = use defaults)
+	forgeSyncToleranceSlots     uint64
+	forgeStaleGapThresholdSlots uint64
 	// Blockfrost API port (0 = disabled)
 	blockfrostPort uint
 	// Chainsync multi-client configuration
@@ -487,6 +490,22 @@ func WithShelleyKESKey(path string) ConfigOptionFunc {
 func WithShelleyOperationalCertificate(path string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.shelleyOperationalCertificate = path
+	}
+}
+
+// WithForgeSyncToleranceSlots sets the slot gap tolerated before forging is skipped.
+// Use 0 to fall back to the built-in default.
+func WithForgeSyncToleranceSlots(slots uint64) ConfigOptionFunc {
+	return func(c *Config) {
+		c.forgeSyncToleranceSlots = slots
+	}
+}
+
+// WithForgeStaleGapThresholdSlots sets the slot gap threshold for stale database warnings.
+// Use 0 to fall back to the built-in default.
+func WithForgeStaleGapThresholdSlots(slots uint64) ConfigOptionFunc {
+	return func(c *Config) {
+		c.forgeStaleGapThresholdSlots = slots
 	}
 }
 

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -167,6 +167,9 @@ meshPort: 0
 #   shelleyVrfKey: "/keys/vrf.skey"
 #   shelleyKesKey: "/keys/kes.skey"
 #   shelleyOperationalCertificate: "/keys/opcert.cert"
+#   # Optional forging tolerances (0 = defaults)
+#   forgeSyncToleranceSlots: 0
+#   forgeStaleGapThresholdSlots: 0
 #
 # Dev mode (isolated, forge blocks, no outbound):
 #   runMode: "dev"
@@ -180,6 +183,13 @@ intersectTip: false
 # Transactions exceeding this limit will be rejected.
 # Default: 1048576 (1 MB)
 mempoolCapacity: 1048576
+
+# Forging tolerances (0 = defaults)
+# forgeSyncToleranceSlots controls how far the local chain can lag the upstream
+# tip before forging is skipped. forgeStaleGapThresholdSlots controls when to
+# log an error if the chain tip is far ahead of the slot clock.
+forgeSyncToleranceSlots: 0
+forgeStaleGapThresholdSlots: 0
 
 # Operational mode: "serve" (default), "load", or "dev"
 # - serve: Full node with network connectivity (default)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,32 +24,34 @@ import (
 
 func resetGlobalConfig() {
 	globalConfig = &Config{
-		MempoolCapacity:      1048576,
-		EvictionWatermark:    0.90,
-		RejectionWatermark:   0.95,
-		BindAddr:             "0.0.0.0",
-		CardanoConfig:        "", // Will be set dynamically based on network
-		DatabasePath:         ".dingo",
-		SocketPath:           "dingo.socket",
-		IntersectTip:         false,
-		ValidateHistorical:   false,
-		Network:              "preview",
-		MetricsPort:          12798,
-		PrivateBindAddr:      "127.0.0.1",
-		PrivatePort:          3002,
-		RelayPort:            3001,
-		UtxorpcPort:          0,
-		Topology:             "",
-		TlsCertFilePath:      "",
-		TlsKeyFilePath:       "",
-		BlobPlugin:           DefaultBlobPlugin,
-		MetadataPlugin:       DefaultMetadataPlugin,
-		RunMode:              RunModeServe,
-		ImmutableDbPath:      "",
-		ShutdownTimeout:      DefaultShutdownTimeout,
-		LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
-		DatabaseWorkers:      5,
-		DatabaseQueueSize:    50,
+		MempoolCapacity:             1048576,
+		EvictionWatermark:           0.90,
+		RejectionWatermark:          0.95,
+		BindAddr:                    "0.0.0.0",
+		CardanoConfig:               "", // Will be set dynamically based on network
+		DatabasePath:                ".dingo",
+		SocketPath:                  "dingo.socket",
+		IntersectTip:                false,
+		ValidateHistorical:          false,
+		Network:                     "preview",
+		MetricsPort:                 12798,
+		PrivateBindAddr:             "127.0.0.1",
+		PrivatePort:                 3002,
+		RelayPort:                   3001,
+		UtxorpcPort:                 0,
+		Topology:                    "",
+		TlsCertFilePath:             "",
+		TlsKeyFilePath:              "",
+		BlobPlugin:                  DefaultBlobPlugin,
+		MetadataPlugin:              DefaultMetadataPlugin,
+		RunMode:                     RunModeServe,
+		ImmutableDbPath:             "",
+		ShutdownTimeout:             DefaultShutdownTimeout,
+		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
+		DatabaseWorkers:             5,
+		DatabaseQueueSize:           50,
+		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
+		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
 			Enabled:            true,
 			CleanupAfterLoad:   true,
@@ -74,13 +76,27 @@ privateBindAddr: "127.0.0.1"
 privatePort: 8000
 relayPort: 4000
 utxorpcPort: 9940
+databaseWorkers: 11
+databaseQueueSize: 77
+immutableDbPath: "/tmp/immutable"
+shutdownTimeout: "45s"
+ledgerCatchupTimeout: "90m"
 topology: ""
 tlsCertFilePath: "cert1.pem"
 tlsKeyFilePath: "key1.pem"
+mithril:
+  enabled: false
+  aggregatorUrl: "https://mithril.example.net"
+  downloadDir: "/tmp/mithril"
+  cleanupAfterLoad: false
+  verifyCertificates: false
 `
 
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "test-dingo.yaml")
+
+	t.Setenv("DINGO_FORGE_SYNC_TOLERANCE_SLOTS", "321")
+	t.Setenv("DINGO_FORGE_STALE_GAP_THRESHOLD_SLOTS", "654")
 
 	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
 	if err != nil {
@@ -89,36 +105,40 @@ tlsKeyFilePath: "key1.pem"
 	defer os.Remove(tmpFile)
 
 	expected := &Config{
-		MempoolCapacity:      2097152,
-		EvictionWatermark:    0.90,
-		RejectionWatermark:   0.95,
-		BindAddr:             "127.0.0.1",
-		CardanoConfig:        "./cardano/preview/config.json",
-		DatabasePath:         ".dingo",
-		SocketPath:           "env.socket",
-		IntersectTip:         true,
-		ValidateHistorical:   false,
-		Network:              "preview",
-		MetricsPort:          8088,
-		PrivateBindAddr:      "127.0.0.1",
-		PrivatePort:          8000,
-		RelayPort:            4000,
-		UtxorpcPort:          9940, // explicit override from YAML
-		Topology:             "",
-		TlsCertFilePath:      "cert1.pem",
-		TlsKeyFilePath:       "key1.pem",
-		BlobPlugin:           DefaultBlobPlugin,
-		MetadataPlugin:       DefaultMetadataPlugin,
-		RunMode:              RunModeServe,
-		ImmutableDbPath:      "",
-		ShutdownTimeout:      DefaultShutdownTimeout,
-		LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
-		DatabaseWorkers:      5,
-		DatabaseQueueSize:    50,
+		MempoolCapacity:             2097152,
+		EvictionWatermark:           0.90,
+		RejectionWatermark:          0.95,
+		BindAddr:                    "127.0.0.1",
+		CardanoConfig:               "./cardano/preview/config.json",
+		DatabasePath:                ".dingo",
+		SocketPath:                  "env.socket",
+		IntersectTip:                true,
+		ValidateHistorical:          false,
+		Network:                     "preview",
+		MetricsPort:                 8088,
+		PrivateBindAddr:             "127.0.0.1",
+		PrivatePort:                 8000,
+		RelayPort:                   4000,
+		UtxorpcPort:                 9940, // explicit override from YAML
+		Topology:                    "",
+		TlsCertFilePath:             "cert1.pem",
+		TlsKeyFilePath:              "key1.pem",
+		BlobPlugin:                  DefaultBlobPlugin,
+		MetadataPlugin:              DefaultMetadataPlugin,
+		RunMode:                     RunModeServe,
+		ImmutableDbPath:             "/tmp/immutable",
+		ShutdownTimeout:             "45s",
+		LedgerCatchupTimeout:        "90m",
+		DatabaseWorkers:             11,
+		DatabaseQueueSize:           77,
+		ForgeSyncToleranceSlots:     321,
+		ForgeStaleGapThresholdSlots: 654,
 		Mithril: MithrilConfig{
-			Enabled:            true,
-			CleanupAfterLoad:   true,
-			VerifyCertificates: true,
+			Enabled:            false,
+			AggregatorURL:      "https://mithril.example.net",
+			DownloadDir:        "/tmp/mithril",
+			CleanupAfterLoad:   false,
+			VerifyCertificates: false,
 		},
 	}
 
@@ -146,32 +166,34 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 
 	// Expected is the updated default values from globalConfig
 	expected := &Config{
-		MempoolCapacity:      1048576,
-		EvictionWatermark:    0.90,
-		RejectionWatermark:   0.95,
-		BindAddr:             "0.0.0.0",
-		CardanoConfig:        "preview/config.json", // Set dynamically based on network
-		DatabasePath:         ".dingo",
-		SocketPath:           "dingo.socket",
-		IntersectTip:         false,
-		ValidateHistorical:   false,
-		Network:              "preview",
-		MetricsPort:          12798,
-		PrivateBindAddr:      "127.0.0.1",
-		PrivatePort:          3002,
-		RelayPort:            3001,
-		UtxorpcPort:          0,
-		Topology:             "",
-		TlsCertFilePath:      "",
-		TlsKeyFilePath:       "",
-		BlobPlugin:           DefaultBlobPlugin,
-		MetadataPlugin:       DefaultMetadataPlugin,
-		RunMode:              RunModeServe,
-		ImmutableDbPath:      "",
-		ShutdownTimeout:      DefaultShutdownTimeout,
-		LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
-		DatabaseWorkers:      5,
-		DatabaseQueueSize:    50,
+		MempoolCapacity:             1048576,
+		EvictionWatermark:           0.90,
+		RejectionWatermark:          0.95,
+		BindAddr:                    "0.0.0.0",
+		CardanoConfig:               "preview/config.json", // Set dynamically based on network
+		DatabasePath:                ".dingo",
+		SocketPath:                  "dingo.socket",
+		IntersectTip:                false,
+		ValidateHistorical:          false,
+		Network:                     "preview",
+		MetricsPort:                 12798,
+		PrivateBindAddr:             "127.0.0.1",
+		PrivatePort:                 3002,
+		RelayPort:                   3001,
+		UtxorpcPort:                 0,
+		Topology:                    "",
+		TlsCertFilePath:             "",
+		TlsKeyFilePath:              "",
+		BlobPlugin:                  DefaultBlobPlugin,
+		MetadataPlugin:              DefaultMetadataPlugin,
+		RunMode:                     RunModeServe,
+		ImmutableDbPath:             "",
+		ShutdownTimeout:             DefaultShutdownTimeout,
+		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
+		DatabaseWorkers:             5,
+		DatabaseQueueSize:           50,
+		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
+		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
 			Enabled:            true,
 			CleanupAfterLoad:   true,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -229,6 +229,12 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithShelleyOperationalCertificate(
 				cfg.ShelleyOperationalCertificate,
 			),
+			dingo.WithForgeSyncToleranceSlots(
+				cfg.ForgeSyncToleranceSlots,
+			),
+			dingo.WithForgeStaleGapThresholdSlots(
+				cfg.ForgeStaleGapThresholdSlots,
+			),
 		),
 	)
 	if err != nil {

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -74,6 +74,9 @@ func (ls *LedgerState) emitTransactionRollbackEvents(
 		}
 
 		txs := blk.Transactions()
+		if txs == nil {
+			continue
+		}
 		for i := len(txs) - 1; i >= 0; i-- {
 			ls.config.EventBus.PublishAsync(
 				TransactionEventType,

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -73,6 +73,10 @@ type BlockForger struct {
 	// Prometheus metrics
 	metrics *forgingMetrics
 
+	// Configurable forging tolerances
+	forgeSyncToleranceSlots     uint64
+	forgeStaleGapThresholdSlots uint64
+
 	// State
 	mu      sync.RWMutex
 	running bool
@@ -129,6 +133,13 @@ type ForgerConfig struct {
 	BlockBroadcaster BlockBroadcaster
 	SlotClock        SlotClockProvider
 
+	// ForgeSyncToleranceSlots controls how far the local chain can lag the
+	// upstream tip before forging is skipped. Zero uses the default.
+	ForgeSyncToleranceSlots uint64
+	// ForgeStaleGapThresholdSlots controls when to log an error if the
+	// chain tip is far ahead of the slot clock. Zero uses the default.
+	ForgeStaleGapThresholdSlots uint64
+
 	// Prometheus metrics registry (optional)
 	PromRegistry prometheus.Registerer
 }
@@ -154,6 +165,14 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		slotClock:        cfg.SlotClock,
 		slotTracker:      NewSlotTracker(),
 	}
+	if cfg.ForgeSyncToleranceSlots == 0 {
+		cfg.ForgeSyncToleranceSlots = forgeSyncToleranceSlots
+	}
+	if cfg.ForgeStaleGapThresholdSlots == 0 {
+		cfg.ForgeStaleGapThresholdSlots = forgeStaleGapThresholdSlots
+	}
+	f.forgeSyncToleranceSlots = cfg.ForgeSyncToleranceSlots
+	f.forgeStaleGapThresholdSlots = cfg.ForgeStaleGapThresholdSlots
 
 	if cfg.Mode == ModeProduction {
 		if cfg.Credentials == nil || !cfg.Credentials.IsLoaded() {
@@ -268,6 +287,9 @@ func (f *BlockForger) runLoopSlotAligned(ctx context.Context) {
 		nextSlot, err := f.slotClock.NextSlotTime()
 		if err != nil {
 			retries++
+			if f.metrics != nil {
+				f.metrics.slotClockErrors.Inc()
+			}
 			// Log warning periodically so operators see why forger is stuck
 			if retries%50 == 1 {
 				f.logger.Warn(
@@ -356,6 +378,7 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// Forge.about_to_lead)
 	if f.metrics != nil {
 		f.metrics.forgeAboutToLead.Inc()
+		f.metrics.tipGapSlots.Set(0)
 	}
 
 	if currentSlot <= tipSlot {
@@ -364,7 +387,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		// Use subtraction (safe here since tipSlot >= currentSlot from
 		// the outer check) to avoid uint64 overflow on the addition.
 		gap := tipSlot - currentSlot
-		if gap > forgeStaleGapThresholdSlots {
+		if f.metrics != nil {
+			f.metrics.tipGapSlots.Set(float64(gap))
+		}
+		if gap > f.forgeStaleGapThresholdSlots {
 			f.logger.Error(
 				"chain tip is far ahead of slot clock; database may contain data from a different genesis",
 				"current_slot", currentSlot,
@@ -390,7 +416,13 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	upstreamTip := f.slotClock.UpstreamTipSlot()
 	if upstreamTip > 0 &&
 		upstreamTip > tipSlot &&
-		upstreamTip-tipSlot > forgeSyncToleranceSlots {
+		upstreamTip-tipSlot > f.forgeSyncToleranceSlots {
+		if f.metrics != nil {
+			f.metrics.forgeSyncSkip.Inc()
+			f.metrics.tipGapSlots.Set(
+				float64(upstreamTip - tipSlot),
+			)
+		}
 		f.logger.Debug(
 			"chain syncing from peer, skipping forge",
 			"current_slot", currentSlot,

--- a/ledger/forging/metrics.go
+++ b/ledger/forging/metrics.go
@@ -42,6 +42,9 @@ type forgingMetrics struct {
 	slotBattlesTotal prometheus.Counter
 	blockSizeBytes   prometheus.Histogram
 	blockTxCount     prometheus.Histogram
+	forgeSyncSkip    prometheus.Counter
+	slotClockErrors  prometheus.Counter
+	tipGapSlots      prometheus.Gauge
 }
 
 // initForgingMetrics initializes all forging metrics using the
@@ -139,6 +142,24 @@ func initForgingMetrics(
 			Buckets: prometheus.LinearBuckets(
 				0, 10, 20,
 			), // 0, 10, 20, ..., 190
+		},
+	)
+	m.forgeSyncSkip = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_forge_sync_skip_total",
+			Help: "forging attempts skipped because upstream tip is ahead",
+		},
+	)
+	m.slotClockErrors = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_forge_slot_clock_errors_total",
+			Help: "errors reading slot clock for forging",
+		},
+	)
+	m.tipGapSlots = factory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "dingo_forge_tip_gap_slots",
+			Help: "latest observed tip gap in slots",
 		},
 	)
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1765,7 +1765,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				bulkOptimizer = opt
 				bulkLoadActive = true
 				defer func() {
-					if bulkLoadActive {
+					if bulkLoadActive && bulkOptimizer != nil {
 						if restoreErr := bulkOptimizer.RestoreNormalPragmas(); restoreErr != nil {
 							ls.config.Logger.Error(
 								"failed to restore normal pragmas on exit",
@@ -2350,7 +2350,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				checker = ls.config.ForgedBlockChecker
 				ls.Unlock()
 				// Restore normal DB options outside the lock after validation is enabled
-				if wantEnableValidation && bulkLoadActive {
+				if wantEnableValidation && bulkLoadActive && bulkOptimizer != nil {
 					if restoreErr := bulkOptimizer.RestoreNormalPragmas(); restoreErr != nil {
 						ls.config.Logger.Error(
 							"failed to restore normal pragmas",

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -355,6 +355,9 @@ type costModelsProvider interface {
 func extractCostModelsFromPParams(
 	pp lcommon.ProtocolParameters,
 ) map[lcommon.PlutusLanguage]lcommon.CostModel {
+	if pp == nil {
+		return map[lcommon.PlutusLanguage]lcommon.CostModel{}
+	}
 	rawModels := extractRawCostModels(pp)
 	if rawModels == nil {
 		return map[lcommon.PlutusLanguage]lcommon.CostModel{}

--- a/node.go
+++ b/node.go
@@ -559,8 +559,12 @@ func (n *Node) Run(ctx context.Context) error {
 
 	// Initialize block forger if production mode is enabled
 	if n.config.blockProducer {
+		creds, err := n.validateBlockProducerStartup()
+		if err != nil {
+			return fmt.Errorf("block producer startup validation failed: %w", err)
+		}
 		//nolint:contextcheck // n.ctx is the node's lifecycle context, correct parent for forger
-		if err := n.initBlockForger(n.ctx); err != nil {
+		if err := n.initBlockForger(n.ctx, creds); err != nil {
 			return fmt.Errorf("failed to initialize block forger: %w", err)
 		}
 		// Wire forger's slot tracker into ledger state for slot
@@ -734,30 +738,35 @@ func (n *Node) shutdown() error {
 	return err
 }
 
-// initBlockForger initializes the block forger for production mode.
-// This requires VRF, KES, and OpCert key files to be configured.
-func (n *Node) initBlockForger(ctx context.Context) error {
-	// Load pool credentials from configured key files
+func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) {
 	creds := forging.NewPoolCredentials()
 	if err := creds.LoadFromFiles(
 		n.config.shelleyVRFKey,
 		n.config.shelleyKESKey,
 		n.config.shelleyOperationalCertificate,
 	); err != nil {
-		return fmt.Errorf("failed to load pool credentials: %w", err)
+		return nil, fmt.Errorf("load pool credentials: %w", err)
 	}
-
-	// Validate the operational certificate matches the KES key
 	if err := creds.ValidateOpCert(); err != nil {
-		return fmt.Errorf("invalid operational certificate: %w", err)
+		return nil, fmt.Errorf("validate operational certificate: %w", err)
 	}
-
 	n.config.logger.Info(
-		"loaded pool credentials for block production",
+		"block producer credentials validated",
 		"pool_id", creds.GetPoolID().String(),
 		"opcert_expiry_period", creds.OpCertExpiryPeriod(),
 	)
+	return creds, nil
+}
 
+// initBlockForger initializes the block forger for production mode.
+// This requires VRF, KES, and OpCert key files to be configured.
+func (n *Node) initBlockForger(
+	ctx context.Context,
+	creds *forging.PoolCredentials,
+) error {
+	if creds == nil {
+		return errors.New("nil pool credentials")
+	}
 	// Create mempool adapter for the forging package
 	mempoolAdapter := &mempoolAdapter{mempool: n.mempool}
 
@@ -821,14 +830,16 @@ func (n *Node) initBlockForger(ctx context.Context) error {
 
 	// Create the block forger with the real leader election
 	forger, err := forging.NewBlockForger(forging.ForgerConfig{
-		Mode:             forging.ModeProduction,
-		Logger:           n.config.logger,
-		Credentials:      creds,
-		LeaderChecker:    election,
-		BlockBuilder:     builder,
-		BlockBroadcaster: broadcaster,
-		SlotClock:        slotClock,
-		PromRegistry:     n.config.promRegistry,
+		Mode:                        forging.ModeProduction,
+		Logger:                      n.config.logger,
+		Credentials:                 creds,
+		LeaderChecker:               election,
+		BlockBuilder:                builder,
+		BlockBroadcaster:            broadcaster,
+		SlotClock:                   slotClock,
+		ForgeSyncToleranceSlots:     n.config.forgeSyncToleranceSlots,
+		ForgeStaleGapThresholdSlots: n.config.forgeStaleGapThresholdSlots,
+		PromRegistry:                n.config.promRegistry,
 	})
 	if err != nil {
 		// Stop election to prevent goroutine leak


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make forging tolerances configurable and observable to control when we skip forging during sync and when we warn about a stale tip. Adds sensible defaults, config wiring, Prometheus metrics, and stricter startup validation.

- **New Features**
  - Added forgeSyncToleranceSlots and forgeStaleGapThresholdSlots (0 = use defaults).
  - Defaults: 100 slots (sync tolerance), 1000 slots (stale gap).
  - Configurable via YAML and env vars:
    - DINGO_FORGE_SYNC_TOLERANCE_SLOTS
    - DINGO_FORGE_STALE_GAP_THRESHOLD_SLOTS
  - Wired through internal config, node startup, and forger config.
  - New Prometheus metrics:
    - dingo_forge_sync_skip_total
    - dingo_forge_slot_clock_errors_total
    - dingo_forge_tip_gap_slots
  - Node validates pool credentials (VRF/KES/OpCert) on startup and logs pool ID and opcert expiry.

- **Bug Fixes**
  - Avoid nil derefs: skip nil peer tips, nil block transactions, and nil protocol parameters.
  - Guard DB pragma restore when optimizer is nil.
  - Count slot clock read errors to aid debugging.

<sup>Written for commit bf96a62ca4361aff9627f39d7282b9a7e3ef4cca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable forging tolerance settings with sensible defaults and example config entries.
  * Block-producer startup validation for credentials and improved forger initialization.
  * New forging observability metrics for diagnostics and performance.

* **Bug Fixes**
  * Prevented nil-related crashes in peer eviction, transaction rollback processing, and protocol-parameter handling.
  * Strengthened guards around bulk-optimizer restoration and configuration defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->