### PR TITLE
feat(add-workflow): update-closed-issues

### DIFF
--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,0 +1,19 @@
+name: Test Issue Close Trigger
+permissions:
+  contents: read
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print closed issue info
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          echo "Issue Number: $ISSUE_NUMBER"
+          echo "Title: $ISSUE_TITLE"
+          echo "Workflow triggered successfully when issue was closed."

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,0 +1,39 @@
+name: Set Project Closed Date
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+
+env:
+  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
+  CLOSED_DATE_FIELD: "Closed Date"
+
+jobs:
+  set-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve closed date
+        id: when
+        shell: bash
+        run: |
+          ts='${{ github.event.issue.closed_at }}'
+          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
+            d=$(date -u +%F)
+          else
+            d=$(date -u -d "$ts" +%F)
+          fi
+          echo "date=$d" >> "$GITHUB_OUTPUT"
+          echo "Closed date -> $d"
+
+      # Update the "Closed Date" field on that project item
+      - name: Update Closed Date field
+        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.ORG_PROJECT_PAT }}
+          field-name: ${{ env.CLOSED_DATE_FIELD }}
+          field-value: ${{ steps.when.outputs.date }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two GitHub Actions that run when an issue is closed: one updates the Project “Closed Date” field, and one verifies the trigger. This helps track closure dates automatically on the org project.

- **New Features**
  - Set Project Closed Date workflow: reads issue.closed_at (falls back to UTC today) and updates the “Closed Date” field on Project 11 via nipe0324/update-project-v2-item-field (pinned SHA).
  - Test workflow: logs closed issue number and title to confirm the trigger.

- **Migration**
  - Add org secret ORG_PROJECT_PAT with write access to Projects and Issues.
  - Ensure Project 11 has a “Closed Date” field and that issues are added to this project.

<sup>Written for commit e5dda2ac6bd63e1053bba19d6c44232d0f16b327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

