### PR TITLE
fix: guard nil pointers

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -243,7 +243,8 @@ func (cs *ChainSelector) UpdatePeerTip(
 // Must be called with cs.mutex held.
 func (cs *ChainSelector) evictLeastRecentPeerLocked() *ouroboros.ConnectionId {
 	var oldestConn ouroboros.ConnectionId
-	var oldestTip *PeerChainTip
+	var oldestUpdated time.Time
+	var oldestBlockNumber uint64
 	found := false
 
 	for connId, peerTip := range cs.peerTips {
@@ -256,25 +257,29 @@ func (cs *ChainSelector) evictLeastRecentPeerLocked() *ouroboros.ConnectionId {
 		}
 		if !found {
 			oldestConn = connId
-			oldestTip = peerTip
+			oldestUpdated = peerTip.LastUpdated
+			oldestBlockNumber = peerTip.Tip.BlockNumber
 			found = true
 			continue
 		}
 		// Primary: oldest LastUpdated wins eviction
-		if peerTip.LastUpdated.Before(oldestTip.LastUpdated) {
+		if peerTip.LastUpdated.Before(oldestUpdated) {
 			oldestConn = connId
-			oldestTip = peerTip
-		} else if peerTip.LastUpdated.Equal(oldestTip.LastUpdated) {
+			oldestUpdated = peerTip.LastUpdated
+			oldestBlockNumber = peerTip.Tip.BlockNumber
+		} else if peerTip.LastUpdated.Equal(oldestUpdated) {
 			// Tie-break on block number: evict the peer with
 			// the lower block number (less useful chain)
-			if peerTip.Tip.BlockNumber < oldestTip.Tip.BlockNumber {
+			if peerTip.Tip.BlockNumber < oldestBlockNumber {
 				oldestConn = connId
-				oldestTip = peerTip
-			} else if peerTip.Tip.BlockNumber == oldestTip.Tip.BlockNumber {
+				oldestUpdated = peerTip.LastUpdated
+				oldestBlockNumber = peerTip.Tip.BlockNumber
+			} else if peerTip.Tip.BlockNumber == oldestBlockNumber {
 				// Final tie-break: deterministic by connection ID
 				if connId.String() < oldestConn.String() {
 					oldestConn = connId
-					oldestTip = peerTip
+					oldestUpdated = peerTip.LastUpdated
+					oldestBlockNumber = peerTip.Tip.BlockNumber
 				}
 			}
 		}
@@ -284,7 +289,7 @@ func (cs *ChainSelector) evictLeastRecentPeerLocked() *ouroboros.ConnectionId {
 		cs.config.Logger.Debug(
 			"evicting least-recent peer due to tracking limit",
 			"connection_id", oldestConn.String(),
-			"last_updated", oldestTip.LastUpdated,
+			"last_updated", oldestUpdated,
 			"peer_count", len(cs.peerTips),
 			"max_tracked_peers", cs.maxTrackedPeers,
 		)

--- a/database/block_lru_cache_test.go
+++ b/database/block_lru_cache_test.go
@@ -160,6 +160,7 @@ func TestCachedBlockExtractReturnsCopy(t *testing.T) {
 
 	// Extract a range from the middle
 	extracted := block.Extract(4, 4)
+	require.NotNil(t, extracted)
 	require.Equal(t, []byte("EFGH"), extracted)
 
 	// Mutate the returned slice
@@ -170,6 +171,7 @@ func TestCachedBlockExtractReturnsCopy(t *testing.T) {
 
 	// Extract the same range again and verify the cached data is unchanged
 	extractedAgain := block.Extract(4, 4)
+	require.NotNil(t, extractedAgain)
 	assert.Equal(
 		t,
 		[]byte("EFGH"),

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -74,7 +74,7 @@ func (ls *LedgerState) emitTransactionRollbackEvents(
 		}
 
 		txs := blk.Transactions()
-		if txs == nil {
+		if len(txs) == 0 {
 			continue
 		}
 		for i := len(txs) - 1; i >= 0; i-- {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2622,6 +2622,9 @@ func (ls *LedgerState) computePParams(
 	// that belonged to a different (earlier) era, then load
 	// its pparams.
 	var prevEraPParams lcommon.ProtocolParameters
+	if len(epochCache) == 0 {
+		return pparams, prevEraPParams, nil
+	}
 	for i := len(epochCache) - 1; i >= 0; i-- {
 		ep := epochCache[i]
 		if ep.EraId != era.Id {

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -385,6 +385,9 @@ func extractCostModelsFromPParams(
 func extractRawCostModels(
 	pp lcommon.ProtocolParameters,
 ) map[uint][]int64 {
+	if pp == nil {
+		return nil
+	}
 	// Prefer the interface if the type implements it.
 	if provider, ok := pp.(costModelsProvider); ok {
 		return provider.GetCostModels()

--- a/mesh/construction.go
+++ b/mesh/construction.go
@@ -137,6 +137,13 @@ func (s *Server) handleConstructionHash(
 		writeError(w, meshErr)
 		return
 	}
+	if tx == nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			errors.New("decoded transaction is nil"),
+		))
+		return
+	}
 
 	writeJSON(
 		w,
@@ -179,6 +186,13 @@ func (s *Server) parseSignedTransaction(
 	tx, meshErr := decodeTxCbor(txHex)
 	if meshErr != nil {
 		writeError(w, meshErr)
+		return
+	}
+	if tx == nil {
+		writeError(w, wrapErr(
+			ErrInvalidTransaction,
+			errors.New("decoded transaction is nil"),
+		))
 		return
 	}
 

--- a/mesh/convert.go
+++ b/mesh/convert.go
@@ -16,6 +16,7 @@ package mesh
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"slices"
@@ -370,6 +371,12 @@ func decodeTxCbor(
 		return nil, wrapErr(
 			ErrInvalidTransaction,
 			fmt.Errorf("decode tx: %w", err),
+		)
+	}
+	if tx == nil {
+		return nil, wrapErr(
+			ErrInvalidTransaction,
+			errors.New("decoded transaction is nil"),
 		)
 	}
 	return tx, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nil-pointer guards across chain selection, ledger, and mesh to prevent panics and return clear errors. Improves peer eviction stability, transaction handling, and protocol parameter extraction.

- **Bug Fixes**
  - Chain selection: skip nil peer tips, compare using LastUpdated and BlockNumber values, and keep tie-break/logging deterministic without nil derefs.
  - Ledger: skip rollback when no transactions, short-circuit pparams lookup when epoch cache is empty, and return nil cost models when pparams is nil.
  - Mesh: treat decoded nil transactions as invalid in construction/hash and parseSignedTransaction; return ErrInvalidTransaction if CBOR decode yields nil.
  - Tests: assert Extract returns non-nil slices before comparisons.

<sup>Written for commit 02d07fedcebb84634b9138f4e522bd0d1831370a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced transaction validation with improved edge-case handling to increase system reliability
* Strengthened protocol parameter and blockchain state processing with additional robustness checks
* Optimized peer selection logic for more consistent operation
* Added protective validations to prevent processing errors from nil values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->