### PR TITLE
feat(config): hard fork testing options from Cardano config

### DIFF
--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -49,6 +49,19 @@ type CardanoNodeConfig struct {
 	ConwayGenesisHash  string `yaml:"ConwayGenesisHash"`
 	ShelleyGenesisFile string `yaml:"ShelleyGenesisFile"`
 	ShelleyGenesisHash string `yaml:"ShelleyGenesisHash"`
+
+	// Hard fork epoch configuration. Pointer types distinguish
+	// "not set" (nil) from "set to 0" (*0), which is critical
+	// because setting these to 0 instructs the node to perform
+	// the hard fork at genesis (epoch 0), starting directly in
+	// that era. This is used by devnets and testnets.
+	ExperimentalHardForksEnabled *bool   `yaml:"ExperimentalHardForksEnabled"`
+	TestShelleyHardForkAtEpoch   *uint64 `yaml:"TestShelleyHardForkAtEpoch"`
+	TestAllegraHardForkAtEpoch   *uint64 `yaml:"TestAllegraHardForkAtEpoch"`
+	TestMaryHardForkAtEpoch      *uint64 `yaml:"TestMaryHardForkAtEpoch"`
+	TestAlonzoHardForkAtEpoch    *uint64 `yaml:"TestAlonzoHardForkAtEpoch"`
+	TestBabbageHardForkAtEpoch   *uint64 `yaml:"TestBabbageHardForkAtEpoch"`
+	TestConwayHardForkAtEpoch    *uint64 `yaml:"TestConwayHardForkAtEpoch"`
 }
 
 func NewCardanoNodeConfigFromReader(r io.Reader) (*CardanoNodeConfig, error) {
@@ -433,6 +446,38 @@ func (c *CardanoNodeConfig) LoadConwayGenesisFromReader(r io.Reader) error {
 	}
 	c.conwayGenesis = &conwayGenesis
 	return nil
+}
+
+// HardForkEpoch returns the epoch at which the named era's hard fork
+// is configured to occur, and whether the setting was present. When
+// ExperimentalHardForksEnabled is not explicitly set to true, all
+// hard fork epochs are treated as unconfigured.
+func (c *CardanoNodeConfig) HardForkEpoch(era string) (uint64, bool) {
+	if c.ExperimentalHardForksEnabled == nil ||
+		!*c.ExperimentalHardForksEnabled {
+		return 0, false
+	}
+	var p *uint64
+	switch era {
+	case "shelley":
+		p = c.TestShelleyHardForkAtEpoch
+	case "allegra":
+		p = c.TestAllegraHardForkAtEpoch
+	case "mary":
+		p = c.TestMaryHardForkAtEpoch
+	case "alonzo":
+		p = c.TestAlonzoHardForkAtEpoch
+	case "babbage":
+		p = c.TestBabbageHardForkAtEpoch
+	case "conway":
+		p = c.TestConwayHardForkAtEpoch
+	default:
+		return 0, false
+	}
+	if p == nil {
+		return 0, false
+	}
+	return *p, true
 }
 
 func validateGenesisHash(

--- a/config/cardano/node_test.go
+++ b/config/cardano/node_test.go
@@ -30,16 +30,24 @@ const (
 	testDataDir = "testdata"
 )
 
+func ptrBool(v bool) *bool       { return &v }
+func ptrUint64(v uint64) *uint64 { return &v }
+
 var expectedCardanoNodeConfig = &CardanoNodeConfig{
-	path:               testDataDir,
-	AlonzoGenesisFile:  "alonzo-genesis.json",
-	AlonzoGenesisHash:  "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-	ByronGenesisFile:   "byron-genesis.json",
-	ByronGenesisHash:   "83de1d7302569ad56cf9139a41e2e11346d4cb4a31c00142557b6ab3fa550761",
-	ConwayGenesisFile:  "conway-genesis.json",
-	ConwayGenesisHash:  "9cc5084f02e27210eacba47af0872e3dba8946ad9460b6072d793e1d2f3987ef",
-	ShelleyGenesisFile: "shelley-genesis.json",
-	ShelleyGenesisHash: "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d",
+	path:                         testDataDir,
+	AlonzoGenesisFile:            "alonzo-genesis.json",
+	AlonzoGenesisHash:            "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
+	ByronGenesisFile:             "byron-genesis.json",
+	ByronGenesisHash:             "83de1d7302569ad56cf9139a41e2e11346d4cb4a31c00142557b6ab3fa550761",
+	ConwayGenesisFile:            "conway-genesis.json",
+	ConwayGenesisHash:            "9cc5084f02e27210eacba47af0872e3dba8946ad9460b6072d793e1d2f3987ef",
+	ShelleyGenesisFile:           "shelley-genesis.json",
+	ShelleyGenesisHash:           "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d",
+	ExperimentalHardForksEnabled: ptrBool(false),
+	TestShelleyHardForkAtEpoch:   ptrUint64(0),
+	TestAllegraHardForkAtEpoch:   ptrUint64(0),
+	TestMaryHardForkAtEpoch:      ptrUint64(0),
+	TestAlonzoHardForkAtEpoch:    ptrUint64(0),
 }
 
 func TestCardanoNodeConfig(t *testing.T) {
@@ -220,6 +228,82 @@ func TestGenesisHashMismatchConway(t *testing.T) {
 	err = cfg.loadGenesisConfigs()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Conway genesis hash mismatch")
+}
+
+func TestHardForkEpoch(t *testing.T) {
+	t.Run("enabled with all eras at epoch 0", func(t *testing.T) {
+		cfg := &CardanoNodeConfig{
+			ExperimentalHardForksEnabled: ptrBool(true),
+			TestShelleyHardForkAtEpoch:   ptrUint64(0),
+			TestAllegraHardForkAtEpoch:   ptrUint64(0),
+			TestMaryHardForkAtEpoch:      ptrUint64(0),
+			TestAlonzoHardForkAtEpoch:    ptrUint64(0),
+			TestBabbageHardForkAtEpoch:   ptrUint64(0),
+			TestConwayHardForkAtEpoch:    ptrUint64(0),
+		}
+		for _, era := range []string{
+			"shelley", "allegra", "mary",
+			"alonzo", "babbage", "conway",
+		} {
+			epoch, ok := cfg.HardForkEpoch(era)
+			assert.True(t, ok, "era %s should be configured", era)
+			assert.Equal(
+				t, uint64(0), epoch,
+				"era %s should fork at epoch 0", era,
+			)
+		}
+	})
+
+	t.Run("disabled ignores all epochs", func(t *testing.T) {
+		cfg := &CardanoNodeConfig{
+			ExperimentalHardForksEnabled: ptrBool(false),
+			TestShelleyHardForkAtEpoch:   ptrUint64(0),
+			TestConwayHardForkAtEpoch:    ptrUint64(0),
+		}
+		_, ok := cfg.HardForkEpoch("shelley")
+		assert.False(t, ok,
+			"should not report configured when disabled")
+	})
+
+	t.Run("nil flag ignores all epochs", func(t *testing.T) {
+		cfg := &CardanoNodeConfig{
+			TestShelleyHardForkAtEpoch: ptrUint64(0),
+		}
+		_, ok := cfg.HardForkEpoch("shelley")
+		assert.False(t, ok,
+			"should not report configured when flag is nil")
+	})
+
+	t.Run("partial configuration", func(t *testing.T) {
+		cfg := &CardanoNodeConfig{
+			ExperimentalHardForksEnabled: ptrBool(true),
+			TestShelleyHardForkAtEpoch:   ptrUint64(0),
+			// Conway not set
+		}
+		_, shelleyOk := cfg.HardForkEpoch("shelley")
+		assert.True(t, shelleyOk, "shelley should be configured")
+
+		_, conwayOk := cfg.HardForkEpoch("conway")
+		assert.False(t, conwayOk, "conway should not be configured")
+	})
+
+	t.Run("unknown era", func(t *testing.T) {
+		cfg := &CardanoNodeConfig{
+			ExperimentalHardForksEnabled: ptrBool(true),
+		}
+		_, ok := cfg.HardForkEpoch("unknown")
+		assert.False(t, ok, "unknown era should not be configured")
+	})
+
+	t.Run("non-zero epoch", func(t *testing.T) {
+		cfg := &CardanoNodeConfig{
+			ExperimentalHardForksEnabled: ptrBool(true),
+			TestConwayHardForkAtEpoch:    ptrUint64(5),
+		}
+		epoch, ok := cfg.HardForkEpoch("conway")
+		assert.True(t, ok)
+		assert.Equal(t, uint64(5), epoch)
+	})
 }
 
 func TestCanonicalizeByronGenesisJSON(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds optional hard fork epoch settings to the Cardano node config, gated by ExperimentalHardForksEnabled. This enables dev/test networks to start in a specific era (epoch 0) or fork at a chosen epoch, with defaults unchanged when disabled.

- **New Features**
  - Per-era hard fork epoch fields (Shelley → Conway) use pointers to distinguish “unset” from 0.
  - ExperimentalHardForksEnabled flag gates all hard fork settings.
  - HardForkEpoch(era) helper returns the epoch and whether it’s configured.
  - Tests cover enabled/disabled, nil, partial config, unknown era, and non-zero epochs.

<sup>Written for commit 8456049c2fa5ffa19670c0832e98c63757213d8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

