### PR TITLE
feat(database): mithril backfill transactions from gap blocks

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -949,17 +949,14 @@ func processGapBlocks(
 			txn := db.Transaction(true)
 			defer txn.Release()
 			// Gap blocks are already reflected in the Mithril
-			// snapshot's ledger state, so cert deposits are not
-			// needed. Pass an empty (non-nil) map to avoid the
-			// nil-certDeposits hard error in SetTransaction —
-			// deposit-bearing certs will store deposit=0 which
-			// is acceptable since the snapshot state is
-			// authoritative.
-			emptyDeposits := map[int]uint64{}
+			// snapshot's UTxO set, so input UTxOs are already
+			// consumed. Use SetGapBlockTransaction which stores
+			// only blob offsets and the TX record without
+			// attempting to look up or consume inputs.
 			for i, tx := range txs {
-				if err := db.SetTransaction(
+				if err := db.SetGapBlockTransaction(
 					tx, point, uint32(i), // #nosec G115 -- tx index within a block
-					0, nil, emptyDeposits, offsets, txn,
+					offsets, txn,
 				); err != nil {
 					return fmt.Errorf(
 						"storing TX: %w", err,

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -359,6 +359,80 @@ func saveCertRecord(record any, db *gorm.DB) error {
 	return result.Error
 }
 
+// SetGapBlockTransaction stores a transaction record and its produced
+// outputs without looking up or consuming input UTxOs. Gap blocks
+// from mithril sync have their UTxO state already reflected in the
+// snapshot, so input processing must be skipped entirely.
+func (d *MetadataStoreMysql) SetGapBlockTransaction(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	var feeUint uint64
+	if txFee := tx.Fee(); txFee != nil {
+		if txFee.BitLen() > 64 {
+			feeUint = math.MaxUint64
+		} else {
+			feeUint = txFee.Uint64()
+		}
+	}
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Slot:       point.Slot,
+		Fee:        types.Uint64(feeUint),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	collateralReturn := tx.CollateralReturn()
+	for _, utxo := range tx.Produced() {
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			m := models.UtxoLedgerToModel(utxo, point.Slot)
+			tmpTx.CollateralReturn = &m
+			continue
+		}
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		tmpTx.Outputs = append(tmpTx.Outputs, m)
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index", "slot"},
+		),
+	}).Create(tmpTx)
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create gap block transaction at slot %d: %w",
+			point.Slot,
+			result.Error,
+		)
+	}
+	if tmpTx.ID == 0 {
+		existingTx, err := d.GetTransactionByHash(txHash, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"fetch transaction ID after upsert: %w", err,
+			)
+		}
+		if existingTx == nil {
+			return fmt.Errorf(
+				"transaction not found after upsert: %x",
+				txHash,
+			)
+		}
+		tmpTx.ID = existingTx.ID
+	}
+	return nil
+}
+
 // SetTransaction adds a new transaction to the database and processes all certificates
 func (d *MetadataStoreMysql) SetTransaction(
 	tx lcommon.Transaction,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -361,6 +361,80 @@ func saveCertRecord(record any, db *gorm.DB) error {
 	return result.Error
 }
 
+// SetGapBlockTransaction stores a transaction record and its produced
+// outputs without looking up or consuming input UTxOs. Gap blocks
+// from mithril sync have their UTxO state already reflected in the
+// snapshot, so input processing must be skipped entirely.
+func (d *MetadataStorePostgres) SetGapBlockTransaction(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	var feeUint uint64
+	if txFee := tx.Fee(); txFee != nil {
+		if txFee.BitLen() > 64 {
+			feeUint = math.MaxUint64
+		} else {
+			feeUint = txFee.Uint64()
+		}
+	}
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Slot:       point.Slot,
+		Fee:        types.Uint64(feeUint),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	collateralReturn := tx.CollateralReturn()
+	for _, utxo := range tx.Produced() {
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			m := models.UtxoLedgerToModel(utxo, point.Slot)
+			tmpTx.CollateralReturn = &m
+			continue
+		}
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		tmpTx.Outputs = append(tmpTx.Outputs, m)
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index", "slot"},
+		),
+	}).Create(tmpTx)
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create gap block transaction at slot %d: %w",
+			point.Slot,
+			result.Error,
+		)
+	}
+	if tmpTx.ID == 0 {
+		existingTx, err := d.GetTransactionByHash(txHash, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"fetch transaction ID after upsert: %w", err,
+			)
+		}
+		if existingTx == nil {
+			return fmt.Errorf(
+				"transaction not found after upsert: %x",
+				txHash,
+			)
+		}
+		tmpTx.ID = existingTx.ID
+	}
+	return nil
+}
+
 // SetTransaction adds a new transaction to the database and processes all certificates
 func (d *MetadataStorePostgres) SetTransaction(
 	tx lcommon.Transaction,

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -417,6 +417,99 @@ func saveCertRecord(record any, db *gorm.DB) error {
 	return result.Error
 }
 
+// SetGapBlockTransaction stores a transaction record and its produced
+// outputs without looking up or consuming input UTxOs. Gap blocks
+// from mithril sync have their UTxO state already reflected in the
+// snapshot, so input processing must be skipped entirely.
+func (d *MetadataStoreSqlite) SetGapBlockTransaction(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Slot:       point.Slot,
+		Fee:        types.Uint64(tx.Fee().Uint64()),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	// Store produced outputs only (no input lookup or consumption)
+	collateralReturn := tx.CollateralReturn()
+	for _, utxo := range tx.Produced() {
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			m := models.UtxoLedgerToModel(utxo, point.Slot)
+			tmpTx.CollateralReturn = &m
+			continue
+		}
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		tmpTx.Outputs = append(tmpTx.Outputs, m)
+	}
+	outputsToCreate := tmpTx.Outputs
+	tmpTx.Outputs = nil
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index", "slot"},
+		),
+	}).Create(tmpTx)
+	tmpTx.Outputs = outputsToCreate
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create gap block transaction at slot %d: %w",
+			point.Slot,
+			result.Error,
+		)
+	}
+	if tmpTx.ID == 0 {
+		var existing struct{ ID uint }
+		if err := db.Model(&models.Transaction{}).
+			Select("id").
+			Where("hash = ?", txHash).
+			Take(&existing).Error; err != nil {
+			return fmt.Errorf(
+				"fetch transaction ID after upsert: %w", err,
+			)
+		}
+		tmpTx.ID = existing.ID
+	}
+	for i := range tmpTx.Outputs {
+		tmpTx.Outputs[i].ID = 0
+		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
+		result := db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
+			DoNothing: true,
+		}).Create(&tmpTx.Outputs[i])
+		if result.Error != nil {
+			return fmt.Errorf(
+				"create gap block utxo output %d for tx %x: %w",
+				i, txHash, result.Error,
+			)
+		}
+	}
+	if tmpTx.CollateralReturn != nil {
+		tmpTx.CollateralReturn.CollateralReturnForTxID = &tmpTx.ID
+		if result := db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
+			DoNothing: true,
+		}).Create(tmpTx.CollateralReturn); result.Error != nil {
+			return fmt.Errorf(
+				"create gap block collateral return: %w",
+				result.Error,
+			)
+		}
+	}
+	return nil
+}
+
 // SetTransaction adds a new transaction to the database and processes all certificates
 func (d *MetadataStoreSqlite) SetTransaction(
 	tx lcommon.Transaction,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -326,6 +326,17 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// SetGapBlockTransaction stores a transaction record and its
+	// produced outputs without looking up or consuming input UTxOs.
+	// This is used for mithril gap blocks where the snapshot's UTxO
+	// set already reflects the correct spent/unspent state.
+	SetGapBlockTransaction(
+		lcommon.Transaction,
+		ocommon.Point,
+		uint32, // idx
+		types.Txn,
+	) error
+
 	// SetGenesisTransaction stores a genesis transaction record.
 	// Genesis transactions have no inputs, witnesses, or fees - just outputs.
 	SetGenesisTransaction(

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -138,6 +138,101 @@ func (d *Database) SetTransaction(
 	return nil
 }
 
+// SetGapBlockTransaction stores a transaction from a mithril gap block.
+// It records blob offsets (TX and UTxO) for CBOR resolution and creates
+// a minimal metadata record, but does NOT look up or consume input
+// UTxOs because the mithril snapshot already reflects the correct
+// spent/unspent state.
+func (d *Database) SetGapBlockTransaction(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	offsets *BlockIngestionResult,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.Transaction(true)
+		owned = true
+		defer txn.Rollback() //nolint:errcheck
+	}
+
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return types.ErrBlobStoreUnavailable
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return types.ErrNilTxn
+	}
+
+	txHash := tx.Hash()
+	var txHashArray [32]byte
+	copy(txHashArray[:], txHash.Bytes())
+
+	if offsets == nil {
+		return fmt.Errorf(
+			"missing offsets for gap block transaction %s at slot %d",
+			hex.EncodeToString(txHash.Bytes()[:8]),
+			point.Slot,
+		)
+	}
+	txOffset, ok := offsets.TxOffsets[txHashArray]
+	if !ok {
+		return fmt.Errorf(
+			"missing TX offset for gap block %s at slot %d",
+			hex.EncodeToString(txHash.Bytes()[:8]),
+			point.Slot,
+		)
+	}
+	offsetData := EncodeTxOffset(&txOffset)
+	if err := blob.SetTx(blobTxn, txHash.Bytes(), offsetData); err != nil {
+		return fmt.Errorf("set gap block tx offset: %w", err)
+	}
+
+	// Store UTxO offsets for produced outputs
+	for _, utxo := range tx.Produced() {
+		txId := utxo.Id.Id().Bytes()
+		outputIdx := utxo.Id.Index()
+		ref := UtxoRef{
+			TxId:      txHashArray,
+			OutputIdx: outputIdx,
+		}
+		offset, ok := offsets.UtxoOffsets[ref]
+		if !ok {
+			return fmt.Errorf(
+				"missing UTxO offset for gap block %s#%d at slot %d",
+				hex.EncodeToString(txId[:8]),
+				outputIdx,
+				point.Slot,
+			)
+		}
+		offsetData := EncodeUtxoOffset(&offset)
+		if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
+			return fmt.Errorf(
+				"set gap block utxo offset %x#%d: %w",
+				txId[:8], outputIdx, err,
+			)
+		}
+	}
+
+	if err := d.metadata.SetGapBlockTransaction(
+		tx, point, idx, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"set gap block transaction metadata: %w", err,
+		)
+	}
+
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // SetGenesisTransaction stores a genesis transaction with its UTxO outputs.
 // Genesis transactions have no inputs, witnesses, or fees - just outputs.
 // The offsets map contains pre-computed byte offsets into the synthetic genesis block.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a dedicated path to backfill transactions from Mithril gap blocks. We store TX/UTxO blob offsets and a minimal TX record without resolving inputs, matching the snapshot’s UTxO state.

- **New Features**
  - Added Database.SetGapBlockTransaction to persist TX and produced UTxO blob offsets and write minimal metadata; validates required offsets and skips input consumption.
  - Introduced MetadataStore.SetGapBlockTransaction and implementations for MySQL, Postgres, and SQLite:
    - Upsert TX by hash with block hash/index, slot, fee, TTL, validity.
    - Store produced outputs and collateral return only; no input lookup.
    - SQLite inserts outputs explicitly; MySQL/Postgres handle fee ≥64-bit via capping.
  - Updated gap block processing to call SetGapBlockTransaction instead of SetTransaction.

<sup>Written for commit 0de077a7338d5619366e581ee266945cb48d0de2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

