### PR TITLE
test(devnet): use epoch length 1500

### DIFF
--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -46,7 +46,6 @@ services:
   dingo-producer:
     build:
       context: ../../..
-      dockerfile: Dockerfile
     container_name: dingo-producer
     depends_on:
       configurator:

--- a/internal/test/devnet/testnet.yaml
+++ b/internal/test/devnet/testnet.yaml
@@ -27,11 +27,13 @@ protocolConsts:
   k: 100
 
 --- # Shelley Genesis Override
-# 1s slots, ~13.3 min epochs, block every ~5s per pool (~2.5s total)
-# stabilityWindow = 3k/f = 3*100/0.4 = 750 < 800 = epochLength ✓
+# 1s slots, 25 min epochs, block every ~5s per pool (~2.5s total)
+# nonceStabilityWindow = 4k/f = 4*100/0.4 = 1000 < 1500 = epochLength ✓
+# blockfetchStabilityWindow = 3k/f = 3*100/0.4 = 750
+# Candidate nonce freezes 1000 slots before epoch end (at slot 500).
 # Partition tolerance: K / per-pool-rate where per-pool-rate = 1-(1-f)^(1/n)
 # With f=0.4, n=2: per-pool-rate ≈ 0.225, so K / per-pool-rate ≈ 100/0.225 ≈ 444s (~7.4 min)
-epochLength: 800
+epochLength: 1500
 slotLength: 1
 activeSlotsCoeff: 0.4
 securityParam: 100


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase devnet epochLength from 800 to 1500 (1s slots) so the 1000-slot nonce stability window fits within an epoch and epochs are ~25 minutes. Also remove the redundant dockerfile override for dingo-producer in docker-compose.

<sup>Written for commit 1ac86f475914ed0b22b8087718fdd05f77ddbf32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

