### PR TITLE
fix(ledger): vrf domain separation

### DIFF
--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -153,9 +153,12 @@ func CalculateEtaVBabbage(
 	if !ok {
 		return nil, errors.New("unexpected block type")
 	}
+	// Praos (Babbage+) uses domain separation + double hash,
+	// unlike TPraos which uses the raw VRF output directly.
+	vrfNonce := praosVRFNonceValue(h.Body.VrfResult.Output)
 	tmpNonce, err := lcommon.CalculateRollingNonce(
 		prevBlockNonce,
-		h.Body.VrfResult.Output,
+		vrfNonce,
 	)
 	if err != nil {
 		return nil, err

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -120,9 +120,12 @@ func CalculateEtaVConway(
 	if !ok {
 		return nil, errors.New("unexpected block type")
 	}
+	// Praos (Babbage+) uses domain separation + double hash,
+	// unlike TPraos which uses the raw VRF output directly.
+	vrfNonce := praosVRFNonceValue(h.Body.VrfResult.Output)
 	tmpNonce, err := lcommon.CalculateRollingNonce(
 		prevBlockNonce,
-		h.Body.VrfResult.Output,
+		vrfNonce,
 	)
 	if err != nil {
 		return nil, err

--- a/ledger/eras/eras.go
+++ b/ledger/eras/eras.go
@@ -22,6 +22,29 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// praosVRFNonceValue computes the nonce contribution from a Praos
+// (Babbage/Conway) block's VRF output. In Praos, the VRF output
+// is NOT used raw — it goes through domain separation and double
+// hashing matching the Haskell vrfNonceValue function:
+//
+//	hashVRF SVRFNonce cert = blake2b_256("N" || rawVrfOutput)
+//	vrfNonceValue = blake2b_256(hashVRF result)
+//
+// This differs from TPraos (Shelley–Alonzo) which uses the raw
+// 64-byte NonceVrf output directly via coerce.
+//
+// Ref: Ouroboros.Consensus.Protocol.Praos.VRF (vrfNonceValue, hashVRF)
+func praosVRFNonceValue(vrfOutput []byte) []byte {
+	// Step 1: range extension with domain separator "N"
+	tagged := make([]byte, 1+len(vrfOutput))
+	tagged[0] = 'N'
+	copy(tagged[1:], vrfOutput)
+	rangeExtended := lcommon.Blake2b256Hash(tagged)
+	// Step 2: nonce generation
+	nonceValue := lcommon.Blake2b256Hash(rangeExtended.Bytes())
+	return nonceValue.Bytes()
+}
+
 var ErrIncompatibleProtocolParams = errors.New("pparams are not expected type")
 
 type EraDesc struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes VRF nonce derivation for Praos (Babbage/Conway) by applying domain separation with "N" and a double Blake2b-256 hash. This aligns EtaV/rolling nonce computation with consensus and stops using the raw VRF output.

- **Bug Fixes**
  - Added praosVRFNonceValue to compute the separated, double-hashed VRF nonce.
  - Updated CalculateEtaV for Babbage and Conway to use the derived nonce (TPraos paths unchanged).

<sup>Written for commit 5c7b8b7dce06cfea5c7da780ccea154733b55ea0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cryptographic nonce derivation for Babbage and Conway ledger eras to enhance consensus reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->