### PR TITLE
feat: candidate nonce, epoch nonce formula, verify header eager advance

### DIFF
--- a/database/block_range.go
+++ b/database/block_range.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// ForEachBlockInRange iterates blocks in the slot range [startSlot, endSlot)
+// from the blob store and calls fn for each block. Blocks are visited in
+// ascending slot order. Iteration stops early if fn returns a non-nil error.
+func ForEachBlockInRange(
+	txn *Txn,
+	startSlot, endSlot uint64,
+	fn func(block models.Block) error,
+) error {
+	if fn == nil {
+		return errors.New("ForEachBlockInRange: callback fn must not be nil")
+	}
+	if txn == nil {
+		return types.ErrNilTxn
+	}
+	if startSlot >= endSlot {
+		return nil
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return types.ErrBlobStoreUnavailable
+	}
+	iterOpts := types.BlobIteratorOptions{
+		Prefix: []byte(types.BlockBlobKeyPrefix),
+	}
+	it := blob.NewIterator(blobTxn, iterOpts)
+	if it == nil {
+		return errors.New("blob iterator is nil")
+	}
+	defer it.Close()
+	startKey := slices.Concat(
+		[]byte(types.BlockBlobKeyPrefix),
+		types.BlockBlobKeyUint64ToBytes(startSlot),
+	)
+	for it.Seek(startKey); it.ValidForPrefix(
+		[]byte(types.BlockBlobKeyPrefix),
+	); it.Next() {
+		item := it.Item()
+		if item == nil {
+			continue
+		}
+		k := item.Key()
+		if k == nil {
+			continue
+		}
+		// Skip the metadata key
+		if strings.HasSuffix(
+			string(k),
+			types.BlockBlobMetadataKeySuffix,
+		) {
+			continue
+		}
+		// Check if we've passed the end slot
+		point, err := BlockBlobKeyToPoint(k)
+		if err != nil {
+			return fmt.Errorf(
+				"BlockBlobKeyToPoint failed for key=%q: %w",
+				k, err,
+			)
+		}
+		if point.Slot >= endSlot {
+			break
+		}
+		block, err := blockByKey(txn, k)
+		if err != nil {
+			return fmt.Errorf(
+				"blockByKey failed for key=%q: %w", k, err,
+			)
+		}
+		if err := fn(block); err != nil {
+			return fmt.Errorf(
+				"processing block slot=%d key=%q: %w",
+				point.Slot, k, err,
+			)
+		}
+	}
+	return it.Err()
+}
+
+// ForEachBlockInRangeDB is a convenience wrapper that creates a read-only
+// transaction and calls ForEachBlockInRange.
+func ForEachBlockInRangeDB(
+	db *Database,
+	startSlot, endSlot uint64,
+	fn func(block models.Block) error,
+) error {
+	txn := db.Transaction(false)
+	return txn.Do(func(txn *Txn) error {
+		return ForEachBlockInRange(txn, startSlot, endSlot, fn)
+	})
+}

--- a/database/epoch.go
+++ b/database/epoch.go
@@ -60,7 +60,7 @@ func (d *Database) DeleteEpochsAfterSlot(
 
 func (d *Database) SetEpoch(
 	slot, epoch uint64,
-	nonce []byte,
+	nonce, evolvingNonce, candidateNonce, lastEpochBlockNonce []byte,
 	era, slotLength, lengthInSlots uint,
 	txn *Txn,
 ) error {
@@ -69,6 +69,9 @@ func (d *Database) SetEpoch(
 			slot,
 			epoch,
 			nonce,
+			evolvingNonce,
+			candidateNonce,
+			lastEpochBlockNonce,
 			era,
 			slotLength,
 			lengthInSlots,
@@ -79,6 +82,9 @@ func (d *Database) SetEpoch(
 		slot,
 		epoch,
 		nonce,
+		evolvingNonce,
+		candidateNonce,
+		lastEpochBlockNonce,
 		era,
 		slotLength,
 		lengthInSlots,

--- a/database/models/epoch.go
+++ b/database/models/epoch.go
@@ -15,8 +15,27 @@
 package models
 
 type Epoch struct {
-	Nonce []byte
-	ID    uint `gorm:"primarykey"`
+	Nonce         []byte
+	EvolvingNonce []byte
+	// CandidateNonce holds the frozen candidate nonce from the end
+	// of the previous epoch (psCandidateNonce in Haskell). In
+	// Ouroboros Praos, the candidate nonce tracks the evolving
+	// nonce until the randomness stabilisation window cutoff
+	// (4k/f slots before the end of the epoch), then freezes.
+	// When 4k/f >= epochLength (e.g., devnets with short epochs),
+	// the candidate nonce is never updated and stays at its
+	// initial value (genesis hash). This field carries the
+	// candidate nonce across epochs so it can seed the next
+	// epoch's computation correctly.
+	CandidateNonce []byte
+	// LastEpochBlockNonce holds the prevHash of the last applied
+	// block from the PREVIOUS epoch transition (praosStateLabNonce
+	// in Haskell). In Ouroboros Praos, the epoch nonce formula uses
+	// a lagged lab nonce: at the N→N+1 transition, the nonce saved
+	// at N-1→N is used. This field is nil for epoch 0 (equivalent
+	// to NeutralNonce / identity).
+	LastEpochBlockNonce []byte
+	ID                  uint `gorm:"primarykey"`
 	// NOTE: we would normally use this as the primary key, but GORM doesn't
 	// like a primary key value of 0
 	EpochId       uint64 `gorm:"uniqueIndex"`

--- a/database/plugin/metadata/mysql/epoch.go
+++ b/database/plugin/metadata/mysql/epoch.go
@@ -93,17 +93,20 @@ func (d *MetadataStoreMysql) DeleteEpochsAfterSlot(
 // SetEpoch saves an epoch
 func (d *MetadataStoreMysql) SetEpoch(
 	slot, epoch uint64,
-	nonce []byte,
+	nonce, evolvingNonce, candidateNonce, lastEpochBlockNonce []byte,
 	era, slotLength, lengthInSlots uint,
 	txn types.Txn,
 ) error {
 	tmpItem := models.Epoch{
-		EpochId:       epoch,
-		StartSlot:     slot,
-		Nonce:         nonce,
-		EraId:         era,
-		SlotLength:    slotLength,
-		LengthInSlots: lengthInSlots,
+		EpochId:             epoch,
+		StartSlot:           slot,
+		Nonce:               nonce,
+		EvolvingNonce:       evolvingNonce,
+		CandidateNonce:      candidateNonce,
+		LastEpochBlockNonce: lastEpochBlockNonce,
+		EraId:               era,
+		SlotLength:          slotLength,
+		LengthInSlots:       lengthInSlots,
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -114,6 +117,9 @@ func (d *MetadataStoreMysql) SetEpoch(
 		DoUpdates: clause.AssignmentColumns([]string{
 			"start_slot",
 			"nonce",
+			"evolving_nonce",
+			"candidate_nonce",
+			"last_epoch_block_nonce",
 			"era_id",
 			"slot_length",
 			"length_in_slots",

--- a/database/plugin/metadata/postgres/epoch.go
+++ b/database/plugin/metadata/postgres/epoch.go
@@ -93,17 +93,20 @@ func (d *MetadataStorePostgres) DeleteEpochsAfterSlot(
 // SetEpoch saves an epoch
 func (d *MetadataStorePostgres) SetEpoch(
 	slot, epoch uint64,
-	nonce []byte,
+	nonce, evolvingNonce, candidateNonce, lastEpochBlockNonce []byte,
 	era, slotLength, lengthInSlots uint,
 	txn types.Txn,
 ) error {
 	tmpItem := models.Epoch{
-		EpochId:       epoch,
-		StartSlot:     slot,
-		Nonce:         nonce,
-		EraId:         era,
-		SlotLength:    slotLength,
-		LengthInSlots: lengthInSlots,
+		EpochId:             epoch,
+		StartSlot:           slot,
+		Nonce:               nonce,
+		EvolvingNonce:       evolvingNonce,
+		CandidateNonce:      candidateNonce,
+		LastEpochBlockNonce: lastEpochBlockNonce,
+		EraId:               era,
+		SlotLength:          slotLength,
+		LengthInSlots:       lengthInSlots,
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -114,6 +117,9 @@ func (d *MetadataStorePostgres) SetEpoch(
 		DoUpdates: clause.AssignmentColumns([]string{
 			"start_slot",
 			"nonce",
+			"evolving_nonce",
+			"candidate_nonce",
+			"last_epoch_block_nonce",
 			"era_id",
 			"slot_length",
 			"length_in_slots",

--- a/database/plugin/metadata/sqlite/epoch.go
+++ b/database/plugin/metadata/sqlite/epoch.go
@@ -115,17 +115,20 @@ func (d *MetadataStoreSqlite) DeleteEpochsAfterSlot(
 // SetEpoch saves an epoch
 func (d *MetadataStoreSqlite) SetEpoch(
 	slot, epoch uint64,
-	nonce []byte,
+	nonce, evolvingNonce, candidateNonce, lastEpochBlockNonce []byte,
 	era, slotLength, lengthInSlots uint,
 	txn types.Txn,
 ) error {
 	tmpItem := models.Epoch{
-		EpochId:       epoch,
-		StartSlot:     slot,
-		Nonce:         nonce,
-		EraId:         era,
-		SlotLength:    slotLength,
-		LengthInSlots: lengthInSlots,
+		EpochId:             epoch,
+		StartSlot:           slot,
+		Nonce:               nonce,
+		EvolvingNonce:       evolvingNonce,
+		CandidateNonce:      candidateNonce,
+		LastEpochBlockNonce: lastEpochBlockNonce,
+		EraId:               era,
+		SlotLength:          slotLength,
+		LengthInSlots:       lengthInSlots,
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -136,6 +139,9 @@ func (d *MetadataStoreSqlite) SetEpoch(
 		DoUpdates: clause.AssignmentColumns([]string{
 			"start_slot",
 			"nonce",
+			"evolving_nonce",
+			"candidate_nonce",
+			"last_epoch_block_nonce",
 			"era_id",
 			"slot_length",
 			"length_in_slots",

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -287,6 +287,9 @@ type MetadataStore interface {
 		uint64, // slot
 		uint64, // epoch
 		[]byte, // nonce
+		[]byte, // evolvingNonce
+		[]byte, // candidateNonce
+		[]byte, // lastEpochBlockNonce
 		uint, // era
 		uint, // slotLength
 		uint, // lengthInSlots

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.15.0
-	github.com/blinklabs-io/gouroboros v0.159.2
+	github.com/blinklabs-io/gouroboros v0.160.0
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
-	github.com/blinklabs-io/plutigo v0.0.25
+	github.com/blinklabs-io/plutigo v0.0.26
 	github.com/blockfrost/blockfrost-go v0.3.0
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.1

--- a/go.sum
+++ b/go.sum
@@ -136,12 +136,12 @@ github.com/blinklabs-io/bursa v0.15.0 h1:kRgoX+i9duRVXDHEDJXbrEHiLeLRA4TyqatAOfo
 github.com/blinklabs-io/bursa v0.15.0/go.mod h1:84ZHhG8pjOjjN6mGveeDrQHhRhDkbixdvR3mZ2BOr/k=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.159.2 h1:igIFQSMEDAXa0vSGKoz+65ytWOBFMN1ucEvrfxww0+4=
-github.com/blinklabs-io/gouroboros v0.159.2/go.mod h1:OuKGQEmPF7O/uf0OX8jrdTZBl8qIkuI9ti4t++JV65Y=
+github.com/blinklabs-io/gouroboros v0.160.0 h1:E+8y59xcBqEZHLfjxpgCEwOBWOJcQ2ijmJyi8D39sus=
+github.com/blinklabs-io/gouroboros v0.160.0/go.mod h1:ZhQREyLgf8zv63oz2qNj9rEhForAJj/ySTMiXdeH3l8=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
-github.com/blinklabs-io/plutigo v0.0.25 h1:0FIsUPnuL9O/YLYC7ZhwHW3wpubLjPNwX/FZgj5b0Nw=
-github.com/blinklabs-io/plutigo v0.0.25/go.mod h1:a7U+TDtoyHrbNuGGQCWxkVqsfiuoc9CO889hlsur7mY=
+github.com/blinklabs-io/plutigo v0.0.26 h1:LrEMTtgpiUMjTXwHgBt/PAZeW6l/6UQUbeYK/tbiBkM=
+github.com/blinklabs-io/plutigo v0.0.26/go.mod h1:a7U+TDtoyHrbNuGGQCWxkVqsfiuoc9CO889hlsur7mY=
 github.com/blockfrost/blockfrost-go v0.3.0 h1:7DhMWaGSY4a4E6JnomovzwhSBsHUAbX3Em+TVBkgjB4=
 github.com/blockfrost/blockfrost-go v0.3.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/ledger/candidate_nonce.go
+++ b/ledger/candidate_nonce.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+)
+
+// computeCandidateNonce computes the candidate nonce and end-of-epoch
+// evolving nonce for the given epoch.
+//
+// In Ouroboros Praos, the PrtclState nonces (evolving and candidate)
+// carry across epoch boundaries without resetting. Each block updates
+// them via the Nonce semigroup (⭒) operator:
+//
+//	NeutralNonce ⭒ Nonce(x) = Nonce(x)                   (identity)
+//	Nonce(a) ⭒ Nonce(b) = Nonce(blake2b_256(a || b))     (combine)
+//
+// The VRF contribution is blake2b_256(vrfOutput), so:
+//
+//	η_v' = η_v ⭒ Nonce(blake2b_256(vrfOutput))
+//
+// The candidate nonce tracks the evolving nonce until the stability
+// window cutoff (slot + stabilityWindow >= firstSlotNextEpoch), then
+// freezes. The frozen value is used in the epoch nonce formula:
+//
+//	epochNonce(N+1) = blake2b_256(candidateNonce(N) || labNonce(N))
+//
+// The evolving nonce continues to be updated past the cutoff with
+// all remaining blocks. Its end-of-epoch value becomes the starting
+// point for the next epoch.
+//
+// Parameters:
+//   - txn: optional database transaction (nil to create a new one)
+//   - prevEvolvingNonce: evolving nonce at the end of the previous
+//     epoch (genesis hash for the first Shelley epoch)
+//   - prevCandidateNonce: candidate nonce at the end of the previous
+//     epoch (genesis hash for the first Shelley epoch). In Haskell,
+//     psCandidateNonce carries across epochs independently of the
+//     evolving nonce. When 4k/f >= epochLength, the candidate is
+//     never updated and this value is returned as-is.
+//   - epochStartSlot: first slot of the epoch
+//   - epochLengthInSlots: total slots in the epoch
+//
+// Returns:
+//   - candidateNonce: the evolving nonce frozen at the stability
+//     window cutoff
+//   - evolvingNonce: the evolving nonce after all blocks in the epoch
+func (ls *LedgerState) computeCandidateNonce(
+	txn *database.Txn,
+	prevEvolvingNonce []byte,
+	prevCandidateNonce []byte,
+	epochStartSlot uint64,
+	epochLengthInSlots uint64,
+) ([]byte, []byte, error) {
+	stabilityWindow := ls.nonceStabilityWindow()
+	epochEndSlot := epochStartSlot + epochLengthInSlots
+
+	// Start from the previous epoch's evolving nonce
+	evolvingNonce := make([]byte, len(prevEvolvingNonce))
+	copy(evolvingNonce, prevEvolvingNonce)
+
+	// candidateNonce starts at prevCandidateNonce (carried across
+	// epochs, matching Haskell's psCandidateNonce). It tracks the
+	// evolving nonce until the stability window cutoff. When
+	// stabilityWindow >= epochLength, no blocks update it, so it
+	// stays at prevCandidateNonce.
+	candidateNonce := make([]byte, len(prevCandidateNonce))
+	copy(candidateNonce, prevCandidateNonce)
+
+	// Determine the cutoff slot. Blocks at or past this slot do NOT
+	// update candidateNonce (it freezes), but still update evolvingNonce.
+	var cutoffSlot uint64
+	if stabilityWindow >= epochLengthInSlots {
+		// All blocks are past the cutoff — candidateNonce stays at
+		// prevCandidateNonce, but evolvingNonce is still updated.
+		cutoffSlot = epochStartSlot
+	} else {
+		cutoffSlot = epochStartSlot + epochLengthInSlots -
+			stabilityWindow
+	}
+
+	var blockCount, preCutoffCount int
+
+	iterFn := func(block models.Block) error {
+		// Byron blocks have no VRF contribution. Skip them
+		// before decoding to avoid failures on devnet EBBs
+		// whose CBOR layout may differ from mainnet.
+		if block.Type == byron.BlockTypeByronEbb ||
+			block.Type == byron.BlockTypeByronMain {
+			return nil
+		}
+		parsedBlock, err := block.Decode()
+		if err != nil {
+			return fmt.Errorf(
+				"decode block at slot %d: %w",
+				block.Slot,
+				err,
+			)
+		}
+		eraId := uint(parsedBlock.Era().Id)
+		era := eras.GetEraById(eraId)
+		if era == nil || era.CalculateEtaVFunc == nil {
+			// Unknown era - no VRF contribution
+			return nil
+		}
+		newNonce, err := era.CalculateEtaVFunc(
+			ls.config.CardanoNodeConfig,
+			evolvingNonce,
+			parsedBlock,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"calculate etaV at slot %d: %w",
+				block.Slot,
+				err,
+			)
+		}
+		evolvingNonce = newNonce
+		blockCount++
+
+		// Before the cutoff, candidateNonce tracks evolvingNonce
+		if block.Slot < cutoffSlot {
+			candidateNonce = make([]byte, len(evolvingNonce))
+			copy(candidateNonce, evolvingNonce)
+			preCutoffCount++
+		}
+		return nil
+	}
+
+	if txn != nil {
+		err := database.ForEachBlockInRange(
+			txn,
+			epochStartSlot,
+			epochEndSlot,
+			iterFn,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"iterate blocks [%d, %d): %w",
+				epochStartSlot,
+				epochEndSlot,
+				err,
+			)
+		}
+	} else {
+		err := database.ForEachBlockInRangeDB(
+			ls.db,
+			epochStartSlot,
+			epochEndSlot,
+			iterFn,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"iterate blocks [%d, %d): %w",
+				epochStartSlot,
+				epochEndSlot,
+				err,
+			)
+		}
+	}
+
+	ls.config.Logger.Debug(
+		"computed candidate nonce from block VRF outputs",
+		"epoch_start_slot", epochStartSlot,
+		"cutoff_slot", cutoffSlot,
+		"stability_window", stabilityWindow,
+		"block_count", blockCount,
+		"pre_cutoff_count", preCutoffCount,
+		"candidate_nonce", hex.EncodeToString(candidateNonce),
+		"evolving_nonce", hex.EncodeToString(evolvingNonce),
+		"component", "ledger",
+	)
+
+	return candidateNonce, evolvingNonce, nil
+}
+
+// nonceStabilityWindow returns the randomness stabilisation window
+// (in slots) for nonce computation. In Ouroboros Praos (Conway+),
+// this determines when the evolving nonce is frozen: blocks with
+// slot + window >= firstSlotNextEpoch do NOT contribute.
+//
+// The value is 4k/f where k is securityParam and f is
+// activeSlotsCoeff from Shelley genesis. Note: pre-Conway eras used
+// 3k/f (computeStabilityWindow), but Conway uses 4k/f
+// (computeRandomnessStabilisationWindow) as per the Praos protocol.
+// See cardano-ledger StabilityWindow.hs.
+func (ls *LedgerState) nonceStabilityWindow() uint64 {
+	if ls.config.CardanoNodeConfig == nil {
+		return 0
+	}
+	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if shelleyGenesis == nil {
+		return 0
+	}
+	k := shelleyGenesis.SecurityParam
+	if k <= 0 {
+		return 0
+	}
+	activeSlotsCoeff := shelleyGenesis.ActiveSlotsCoeff.Rat
+	if activeSlotsCoeff == nil ||
+		activeSlotsCoeff.Num().Sign() <= 0 {
+		return 0
+	}
+	// 4k/f = 4 * k * denom / num
+	numerator := new(big.Int).SetInt64(int64(k))
+	numerator.Mul(numerator, big.NewInt(4))
+	numerator.Mul(numerator, activeSlotsCoeff.Denom())
+	denominator := new(big.Int).Set(activeSlotsCoeff.Num())
+	result := new(big.Int).Div(numerator, denominator)
+	// Ceiling division: if there's a remainder, add 1
+	remainder := new(big.Int).Mod(numerator, denominator)
+	if remainder.Sign() != 0 {
+		result.Add(result, big.NewInt(1))
+	}
+	if !result.IsUint64() {
+		return 0
+	}
+	return result.Uint64()
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -685,46 +685,17 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	// exceeding the downstream peer's ChainSync idle timeout.
 
 	// Verify block header cryptographic proofs (VRF, KES).
-	// Only verify when the epoch cache has data for this block's slot.
-	// The epoch cache is populated asynchronously by ledgerProcessBlocks
-	// epoch rollovers, which may lag behind blockfetch delivery. Blocks
-	// whose slots fall outside the current epoch cache are skipped here
-	// and will be validated during ledger processing when the epoch data
-	// becomes available.
-	//
-	// When the node is close to the upstream tip (within the stability
-	// window), verification failures are fatal — we reject the block.
-	// During initial sync (far behind the tip), failures are logged as
-	// warnings to mirror the Haskell node's behavior of skipping
-	// VRF/KES checks during fast sync.
-	if _, err := ls.epochForSlot(e.Point.Slot); err == nil {
-		if err := ls.verifyBlockHeaderCrypto(e.Block); err != nil {
-			upstreamTip := ls.syncUpstreamTipSlot.Load()
-			syncThreshold := ls.calculateStabilityWindow()
-			// Use subtraction to avoid uint64 overflow when
-			// e.Point.Slot + syncThreshold would wrap.
-			nearTip := upstreamTip > 0 &&
-				(e.Point.Slot >= upstreamTip ||
-					upstreamTip-e.Point.Slot <= syncThreshold)
-			if nearTip {
-				return fmt.Errorf(
-					"block header crypto verification failed: %w",
-					err,
-				)
-			}
-			// During bulk sync, VRF verification may fail when the
-			// local stake distribution snapshot doesn't match (e.g.
-			// multi-pool DevNet where the other pool's VRF key hash
-			// isn't in our ledger state yet). Log as warning only.
-			ls.config.Logger.Warn(
-				fmt.Sprintf(
-					"block header crypto verification failed (non-fatal): %s",
-					err,
-				),
-				"component", "ledger",
-				"slot", e.Point.Slot,
-			)
-		}
+	// Verification is always fatal — invalid blocks are rejected
+	// regardless of sync position. The epoch cache is populated at
+	// startup by loadEpochs, so epoch data is available for all
+	// blocks in the current epoch. Epoch transitions are processed
+	// synchronously during ledger block processing, which runs
+	// ahead of blockfetch delivery.
+	if err := ls.verifyBlockHeaderCrypto(e.Block); err != nil {
+		return fmt.Errorf(
+			"block header crypto verification failed: %w",
+			err,
+		)
 	}
 	// Add block to chain with its own transaction so it becomes
 	// visible to iterators immediately after commit.
@@ -1139,97 +1110,182 @@ func writeCborMajorType(buf *bytes.Buffer, majorType, n int) {
 	}
 }
 
+// calculateEpochNonce computes the epoch nonce for epoch N+1, the
+// end-of-epoch evolving nonce, and the labNonce to save for epoch
+// N+2's computation.
+//
+// The Ouroboros Praos formula is:
+//
+//	epochNonce(N+1) = candidateNonce(N) ⭒ lastEpochBlockNonce(N)
+//
+// where lastEpochBlockNonce(N) was saved at the N-1→N transition
+// (it's the prevHash of the last block of epoch N-1). This value
+// is stored in currentEpoch.LastEpochBlockNonce.
+//
+// The ⭒ operator has NeutralNonce as identity:
+//
+//	x ⭒ NeutralNonce = x
+//
+// For the very first epoch transition (0→1), lastEpochBlockNonce
+// is nil (NeutralNonce), so epochNonce = candidateNonce.
+//
+// Returns (epochNonce, evolvingNonce, candidateNonce, labNonce, error).
+// The caller must store candidateNonce as the new epoch's CandidateNonce
+// and labNonce as the new epoch's LastEpochBlockNonce so the next
+// transition can use them.
 func (ls *LedgerState) calculateEpochNonce(
 	txn *database.Txn,
 	epochStartSlot uint64,
 	currentEra eras.EraDesc,
 	currentEpoch models.Epoch,
-) ([]byte, error) {
+) ([]byte, []byte, []byte, []byte, error) {
 	// No epoch nonce in Byron
 	if currentEra.Id == 0 {
-		return nil, nil
+		return nil, nil, nil, nil, nil
 	}
 	if ls.config.CardanoNodeConfig == nil {
-		return nil, errors.New("CardanoNodeConfig is nil")
+		return nil, nil, nil, nil, errors.New("CardanoNodeConfig is nil")
 	}
 	if ls.config.CardanoNodeConfig.ShelleyGenesisHash == "" {
-		return nil, errors.New("could not get Shelley genesis hash")
+		return nil, nil, nil, nil, errors.New(
+			"could not get Shelley genesis hash",
+		)
 	}
 	genesisHashBytes, err := hex.DecodeString(
 		ls.config.CardanoNodeConfig.ShelleyGenesisHash,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("decode genesis hash: %w", err)
-	}
-	// For the first Shelley epoch (or when no previous nonce exists),
-	// the epoch nonce is the Shelley genesis hash. This matches
-	// cardano-node where the initial epochNonce and candidateNonce
-	// are both set to the genesis hash, and with NeutralNonce as
-	// lastEpochBlockNonce the identity operation yields genesis hash.
-	if len(currentEpoch.Nonce) == 0 || currentEpoch.EpochId == 0 {
-		return genesisHashBytes, nil
+		return nil, nil, nil, nil, fmt.Errorf(
+			"decode genesis hash: %w", err,
+		)
 	}
 
-	// In Ouroboros Praos, the candidate nonce is the Shelley genesis
-	// hash. Empirically confirmed: cardano-node reports the genesis
-	// hash as candidateNonce at every epoch. The UPDN state resets
-	// at epoch boundaries so the candidate nonce never diverges from
-	// its initial value.
-	candidateNonce := genesisHashBytes
+	// For the initial epoch creation (no blocks yet), the epoch
+	// nonce and initial evolving nonce are both the genesis hash.
+	// This matches cardano-node where the initial state sets
+	// epochNonce, candidateNonce, and evolvingNonce all to the
+	// genesis hash. lastEpochBlockNonce is nil (NeutralNonce).
+	if len(currentEpoch.Nonce) == 0 {
+		return genesisHashBytes, genesisHashBytes, genesisHashBytes, nil, nil
+	}
 
-	// The lastEpochBlockNonce used here is the labNonce captured at
-	// the PREVIOUS epoch boundary (not the current one). In Haskell:
-	//   newState.epochNonce = oldState.candidateNonce <> oldState.lastEpochBlockNonce
-	//   newState.lastEpochBlockNonce = oldState.labNonce
-	// So epoch N's nonce uses lastEpochBlockNonce from before the
-	// N-1→N transition. We look up the last block before the CURRENT
-	// epoch's start slot (last block of the epoch BEFORE the current
-	// one), and use its PrevHash (matching Haskell's labNonce =
-	// hashToNonce(prevHash)).
-	blockLastPrevEpoch, err := database.BlockBeforeSlotTxn(
+	// In Ouroboros Praos, the evolving nonce carries across epoch
+	// boundaries without resetting (PrtclState is never reset).
+	// For migration compatibility (epochs stored before this
+	// field existed), fall back to genesis hash.
+	prevEvolvingNonce := currentEpoch.EvolvingNonce
+	if len(prevEvolvingNonce) == 0 {
+		prevEvolvingNonce = genesisHashBytes
+	}
+
+	// The candidate nonce also carries across epochs independently
+	// of the evolving nonce. When 4k/f >= epochLength (e.g., short
+	// devnet epochs), the candidate is never updated by any block
+	// and stays at its carried value. Fall back to genesis hash
+	// for epochs stored before this field existed.
+	prevCandidateNonce := currentEpoch.CandidateNonce
+	if len(prevCandidateNonce) == 0 {
+		prevCandidateNonce = genesisHashBytes
+	}
+
+	// Compute candidateNonce (frozen at stability window cutoff)
+	// and evolvingNonce (after all blocks) from blocks in the
+	// current epoch. Each block's VRF output is accumulated via
+	// the Nonce semigroup (⭒) starting from prevEvolvingNonce.
+	candidateNonce, evolvingNonce, err := ls.computeCandidateNonce(
 		txn,
+		prevEvolvingNonce,
+		prevCandidateNonce,
 		currentEpoch.StartSlot,
+		uint64(currentEpoch.LengthInSlots),
 	)
 	if err != nil {
-		if errors.Is(err, models.ErrBlockNotFound) {
-			// No block before this epoch - equivalent to NeutralNonce,
-			// which acts as identity, so return candidateNonce.
-			return candidateNonce, nil
-		}
-		return nil, fmt.Errorf("lookup block before slot: %w", err)
-	}
-	if len(blockLastPrevEpoch.PrevHash) == 0 {
-		return candidateNonce, nil
+		return nil, nil, nil, nil, fmt.Errorf(
+			"compute candidate nonce: %w", err,
+		)
 	}
 
-	// Combine candidateNonce and lastEpochBlockNonce using
-	// blake2b_256(candidateNonce || lastEpochBlockNonce).
-	// The lastEpochBlockNonce is the PrevHash of the boundary block,
-	// matching Haskell's labNonce = hashToNonce(prevHash(block)).
-	if len(candidateNonce) < 32 || len(blockLastPrevEpoch.PrevHash) < 32 {
-		return nil, fmt.Errorf(
-			"epoch nonce requires 32-byte inputs: candidateNonce=%d, prevHash=%d",
-			len(candidateNonce), len(blockLastPrevEpoch.PrevHash),
+	// Compute the labNonce to SAVE for epoch N+2's computation.
+	// This is prevHashToNonce(prevHash of last block of current
+	// epoch N). It will be stored as LastEpochBlockNonce on the
+	// new epoch record.
+	epochEndSlot := currentEpoch.StartSlot +
+		uint64(currentEpoch.LengthInSlots)
+	var labNonceToSave []byte
+	blockLastCurrentEpoch, err := database.BlockBeforeSlotTxn(
+		txn,
+		epochEndSlot,
+	)
+	if err != nil {
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"lookup block before slot: %w", err,
+			)
+		}
+		// No block — labNonceToSave stays nil (NeutralNonce)
+	} else if len(blockLastCurrentEpoch.PrevHash) > 0 {
+		labNonceToSave = blockLastCurrentEpoch.PrevHash
+	}
+
+	// Use the LAGGED lastEpochBlockNonce from the current epoch
+	// record (set at the PREVIOUS transition) in the formula.
+	// If nil/empty, it's NeutralNonce (identity): result is
+	// just candidateNonce.
+	lastEpochBlockNonce := currentEpoch.LastEpochBlockNonce
+	if len(lastEpochBlockNonce) == 0 {
+		// NeutralNonce is the identity element of ⭒:
+		//   candidateNonce ⭒ NeutralNonce = candidateNonce
+		// So the epoch nonce is just the candidate nonce.
+		ls.config.Logger.Debug(
+			"epoch nonce computed (NeutralNonce, using candidateNonce)",
+			"component", "ledger",
+			"epoch_start_slot", epochStartSlot,
+			"candidate_nonce",
+			hex.EncodeToString(candidateNonce),
+			"lab_nonce_to_save",
+			hex.EncodeToString(labNonceToSave),
+			"epoch_nonce",
+			hex.EncodeToString(candidateNonce),
+			"evolving_nonce",
+			hex.EncodeToString(evolvingNonce),
+		)
+		return candidateNonce, evolvingNonce, candidateNonce, labNonceToSave, nil
+	}
+
+	// candidateNonce ⭒ lastEpochBlockNonce
+	// = blake2b_256(candidateNonce || lastEpochBlockNonce)
+	if len(candidateNonce) < 32 ||
+		len(lastEpochBlockNonce) < 32 {
+		return nil, nil, nil, nil, fmt.Errorf(
+			"epoch nonce requires 32-byte inputs: "+
+				"candidateNonce=%d, lastEpochBlockNonce=%d",
+			len(candidateNonce),
+			len(lastEpochBlockNonce),
 		)
 	}
 	result, err := lcommon.CalculateEpochNonce(
 		candidateNonce,
-		blockLastPrevEpoch.PrevHash,
+		lastEpochBlockNonce,
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("calculate epoch nonce: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf(
+			"calculate epoch nonce: %w", err,
+		)
 	}
 	ls.config.Logger.Debug(
 		"epoch nonce computed",
 		"component", "ledger",
 		"epoch_start_slot", epochStartSlot,
 		"candidate_nonce", hex.EncodeToString(candidateNonce),
-		"lab_nonce", hex.EncodeToString(blockLastPrevEpoch.PrevHash),
-		"boundary_block_slot", blockLastPrevEpoch.Slot,
+		"last_epoch_block_nonce",
+		hex.EncodeToString(lastEpochBlockNonce),
+		"lab_nonce_to_save",
+		hex.EncodeToString(labNonceToSave),
 		"epoch_nonce", hex.EncodeToString(result.Bytes()),
+		"evolving_nonce", hex.EncodeToString(evolvingNonce),
 	)
-	return result.Bytes(), nil
+	return result.Bytes(), evolvingNonce, candidateNonce, labNonceToSave, nil
 }
 
 // processEpochRollover processes an epoch rollover and returns the result without
@@ -1270,7 +1326,7 @@ func (ls *LedgerState) processEpochRollover(
 		if err != nil {
 			return nil, fmt.Errorf("calculate epoch length: %w", err)
 		}
-		tmpNonce, err := ls.calculateEpochNonce(
+		tmpNonce, tmpEvolvingNonce, tmpCandidateNonce, tmpLabNonce, err := ls.calculateEpochNonce(
 			txn,
 			0,
 			currentEra,
@@ -1283,6 +1339,9 @@ func (ls *LedgerState) processEpochRollover(
 			epochStartSlot,
 			0, // epoch
 			tmpNonce,
+			tmpEvolvingNonce,
+			tmpCandidateNonce,
+			tmpLabNonce,
 			currentEra.Id,
 			epochSlotLength,
 			epochLength,
@@ -1405,7 +1464,7 @@ func (ls *LedgerState) processEpochRollover(
 	if err != nil {
 		return nil, fmt.Errorf("calculate epoch length: %w", err)
 	}
-	tmpNonce, err := ls.calculateEpochNonce(
+	tmpNonce, tmpEvolvingNonce, tmpCandidateNonce, tmpLabNonce, err := ls.calculateEpochNonce(
 		txn,
 		epochStartSlot,
 		currentEra,
@@ -1418,6 +1477,9 @@ func (ls *LedgerState) processEpochRollover(
 		epochStartSlot,
 		currentEpoch.EpochId+1,
 		tmpNonce,
+		tmpEvolvingNonce,
+		tmpCandidateNonce,
+		tmpLabNonce,
 		currentEra.Id,
 		epochSlotLength,
 		epochLength,

--- a/ledger/chainsync_test.go
+++ b/ledger/chainsync_test.go
@@ -66,7 +66,7 @@ func TestCalculateEpochNonce_ByronEra(t *testing.T) {
 	}
 
 	// Byron era should return nil nonce
-	nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
+	nonce, _, _, _, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestCalculateEpochNonce_InitialEpochWithoutNonce(t *testing.T) {
 	}
 
 	// Initial epoch should return genesis hash
-	nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
+	nonce, _, _, _, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestCalculateEpochNonce_InvalidGenesisHash(t *testing.T) {
 		},
 	}
 
-	_, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
+	_, _, _, _, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err == nil {
 		t.Fatal("expected error for invalid genesis hash, got nil")
 	}
@@ -204,7 +204,7 @@ func TestCalculateEpochNonce_MissingShelleyGenesis(t *testing.T) {
 		},
 	}
 
-	_, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
+	_, _, _, _, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
 	if err == nil {
 		t.Fatal("expected error for missing Shelley genesis, got nil")
 	}
@@ -248,7 +248,7 @@ func TestCalculateEpochNonce_NegativeSecurityParam(t *testing.T) {
 
 	// Test will depend on whether the genesis loads successfully
 	// If it loads, we expect an error about negative k
-	_, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
+	_, _, _, _, err := ls.calculateEpochNonce(nil, 86400, ls.currentEra, ls.currentEpoch)
 	// Either genesis loading fails or calculateEpochNonce catches negative k
 	if err == nil {
 		t.Log("Note: negative k may be caught during genesis loading")
@@ -323,7 +323,7 @@ func TestCalculateEpochNonce_ShelleyEraDifferentParams(t *testing.T) {
 			}
 
 			// Initial epoch should return genesis hash
-			nonce, err := ls.calculateEpochNonce(
+			nonce, _, _, _, err := ls.calculateEpochNonce(
 				nil,
 				0,
 				ls.currentEra,
@@ -454,7 +454,7 @@ func TestCalculateEpochNonce_StabilityWindowCalculation(t *testing.T) {
 
 			// Test for Byron era - should return nil
 			if tc.era.Id == 0 {
-				nonce, err := ls.calculateEpochNonce(
+				nonce, _, _, _, err := ls.calculateEpochNonce(
 					nil,
 					0,
 					ls.currentEra,
@@ -473,7 +473,7 @@ func TestCalculateEpochNonce_StabilityWindowCalculation(t *testing.T) {
 			}
 
 			// For non-Byron eras, test initial epoch returns genesis hash
-			nonce, err := ls.calculateEpochNonce(
+			nonce, _, _, _, err := ls.calculateEpochNonce(
 				nil,
 				0,
 				ls.currentEra,
@@ -529,7 +529,7 @@ func TestCalculateEpochNonce_IntegerArithmeticPrecision(t *testing.T) {
 	}
 
 	// Should handle fractional coefficients correctly using integer arithmetic
-	nonce, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
+	nonce, _, _, _, err := ls.calculateEpochNonce(nil, 0, ls.currentEra, ls.currentEpoch)
 	if err != nil {
 		t.Fatalf("unexpected error with fractional coefficient: %v", err)
 	}
@@ -677,7 +677,7 @@ func TestCalculateEpochNonce_AllEras(t *testing.T) {
 				},
 			}
 
-			nonce, err := ls.calculateEpochNonce(
+			nonce, _, _, _, err := ls.calculateEpochNonce(
 				nil,
 				0,
 				ls.currentEra,
@@ -733,7 +733,7 @@ func TestCalculateEpochNonce_MissingByronGenesisInByronEra(t *testing.T) {
 	}
 
 	// Byron era returns nil nonce immediately without genesis validation
-	nonce, err := ls.calculateEpochNonce(
+	nonce, _, _, _, err := ls.calculateEpochNonce(
 		nil,
 		86400,
 		ls.currentEra,

--- a/ledger/epoch_nonce_test.go
+++ b/ledger/epoch_nonce_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEpochNonceFormula validates the epoch nonce formula:
+//
+//	epochNonce(N+1) = blake2b_256(candidateNonce(N) || lastEpochBlockNonce(N))
+//
+// This uses deterministic synthetic inputs to verify the CalculateEpochNonce
+// function produces the correct blake2b_256 hash of the concatenated nonces.
+func TestEpochNonceFormula(t *testing.T) {
+	// Synthetic 32-byte candidateNonce
+	candidateNonce := mustDecodeHex(
+		t,
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	)
+	// Synthetic 32-byte lastEpochBlockNonce (prevHash of last block)
+	lastEpochBlockNonce := mustDecodeHex(
+		t,
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	)
+
+	// Compute epoch nonce using the production function
+	result, err := lcommon.CalculateEpochNonce(
+		candidateNonce,
+		lastEpochBlockNonce,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Verify the result matches blake2b_256(candidateNonce || lastEpochBlockNonce)
+	concat := append(candidateNonce, lastEpochBlockNonce...)
+	expected := lcommon.Blake2b256Hash(concat)
+	assert.Equal(
+		t,
+		hex.EncodeToString(expected.Bytes()),
+		hex.EncodeToString(result.Bytes()),
+		"epoch nonce should equal blake2b_256(candidateNonce || lastEpochBlockNonce)",
+	)
+}
+
+// TestEpochNonceNeutralIdentity verifies the neutral nonce semantics:
+// when lastEpochBlockNonce is nil (epoch 0→1 transition), the caller
+// uses candidateNonce directly as the epoch nonce (bypassing
+// CalculateEpochNonce). This mirrors the production code in
+// calculateEpochNonce and computeEpochNonceForSlot.
+func TestEpochNonceNeutralIdentity(t *testing.T) {
+	candidateNonce := mustDecodeHex(
+		t,
+		"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	)
+
+	// Simulate the NeutralNonce path: when lastEpochBlockNonce is nil,
+	// the epoch nonce IS the candidateNonce (identity element of ⭒).
+	var lastEpochBlockNonce []byte // nil = NeutralNonce
+	var epochNonce []byte
+	if len(lastEpochBlockNonce) == 0 {
+		epochNonce = candidateNonce
+	} else {
+		result, err := lcommon.CalculateEpochNonce(
+			candidateNonce,
+			lastEpochBlockNonce,
+			nil,
+		)
+		require.NoError(t, err)
+		epochNonce = result.Bytes()
+	}
+
+	assert.Equal(
+		t,
+		hex.EncodeToString(candidateNonce),
+		hex.EncodeToString(epochNonce),
+		"with NeutralNonce, epoch nonce should equal candidateNonce",
+	)
+}
+
+// TestEpochNonceNonCommutative verifies that the nonce semigroup
+// operator is NOT commutative: blake2b_256(a || b) != blake2b_256(b || a).
+func TestEpochNonceNonCommutative(t *testing.T) {
+	a := mustDecodeHex(
+		t,
+		"1111111111111111111111111111111111111111111111111111111111111111",
+	)
+	b := mustDecodeHex(
+		t,
+		"2222222222222222222222222222222222222222222222222222222222222222",
+	)
+
+	resultAB, err := lcommon.CalculateEpochNonce(a, b, nil)
+	require.NoError(t, err)
+
+	resultBA, err := lcommon.CalculateEpochNonce(b, a, nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(
+		t,
+		hex.EncodeToString(resultAB.Bytes()),
+		hex.EncodeToString(resultBA.Bytes()),
+		"nonce combination should not be commutative",
+	)
+}
+
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2260,8 +2260,8 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 					// Calculate block rolling nonce (evolving nonce η_v).
 					// The evolving nonce is ALWAYS computed for every block.
 					// The candidate nonce (used in epoch nonce calc) is
-					// determined by looking up the stored nonce at the
-					// stability window point in calculateEpochNonce().
+					// computed by iterating blocks from the blob store
+					// up to the stability window cutoff.
 					var blockNonce []byte
 					if snapshotEra.CalculateEtaVFunc != nil {
 						tmpEra := eras.Eras[next.Era().Id]
@@ -3026,8 +3026,7 @@ func (ls *LedgerState) EpochNonce(epoch uint64) []byte {
 
 // computeNextEpochNonce speculatively computes the epoch nonce for the
 // next epoch (currentEpoch.EpochId + 1) using data from the current epoch.
-// This mirrors the logic in calculateEpochNonce but uses non-transactional
-// DB reads so it can be called from EpochNonce without a DB transaction.
+// Uses the lagged lastEpochBlockNonce from the current epoch record.
 //
 // Returns nil if the nonce cannot be computed (e.g., missing block data,
 // Byron era, or missing genesis config).
@@ -3039,11 +3038,11 @@ func (ls *LedgerState) computeNextEpochNonce(
 	if currentEra.Id == 0 {
 		return nil
 	}
-	// Need the Shelley genesis hash for nonce computation
 	if ls.config.CardanoNodeConfig == nil ||
 		ls.config.CardanoNodeConfig.ShelleyGenesisHash == "" {
 		return nil
 	}
+
 	genesisHashBytes, err := hex.DecodeString(
 		ls.config.CardanoNodeConfig.ShelleyGenesisHash,
 	)
@@ -3051,50 +3050,49 @@ func (ls *LedgerState) computeNextEpochNonce(
 		return nil
 	}
 
-	// For the first Shelley epoch (or when no previous nonce exists),
-	// the next epoch's nonce is the Shelley genesis hash.
-	if len(currentEpoch.Nonce) == 0 || currentEpoch.EpochId == 0 {
+	if len(currentEpoch.Nonce) == 0 {
 		return genesisHashBytes
 	}
 
-	epochStartSlot := currentEpoch.StartSlot + uint64(
-		currentEpoch.LengthInSlots,
-	)
+	prevEvolvingNonce := currentEpoch.EvolvingNonce
+	if len(prevEvolvingNonce) == 0 {
+		prevEvolvingNonce = genesisHashBytes
+	}
 
-	// In Ouroboros Praos, the candidate nonce is the Shelley genesis
-	// hash (confirmed empirically against cardano-node).
-	candidateNonce := genesisHashBytes
+	prevCandidateNonce := currentEpoch.CandidateNonce
+	if len(prevCandidateNonce) == 0 {
+		prevCandidateNonce = genesisHashBytes
+	}
 
-	// The lastEpochBlockNonce is the labNonce captured at the PREVIOUS
-	// epoch boundary. We look up the last block before the CURRENT
-	// epoch's start slot (last block of the epoch before the current
-	// one) and use its PrevHash, matching Haskell's labNonce semantics.
-	blockLastPrevEpoch, err := database.BlockBeforeSlot(
-		ls.db, currentEpoch.StartSlot,
+	candidateNonce, _, err := ls.computeCandidateNonce(
+		nil,
+		prevEvolvingNonce,
+		prevCandidateNonce,
+		currentEpoch.StartSlot,
+		uint64(currentEpoch.LengthInSlots),
 	)
 	if err != nil {
 		ls.config.Logger.Warn(
-			"failed to query block before epoch start",
+			"failed to compute candidate nonce",
 			"component", "ledger",
-			"queried_slot", currentEpoch.StartSlot,
 			"error", err,
 		)
-		return candidateNonce
-	}
-	if len(blockLastPrevEpoch.PrevHash) == 0 {
-		// No block before this epoch - equivalent to NeutralNonce.
-		return candidateNonce
+		return nil
 	}
 
-	// Combine using blake2b_256(candidateNonce || lastEpochBlockNonce).
-	// The lastEpochBlockNonce is the PrevHash of the boundary block,
-	// matching Haskell's labNonce = hashToNonce(prevHash(block)).
-	if len(candidateNonce) < 32 || len(blockLastPrevEpoch.PrevHash) < 32 {
+	// Use the LAGGED lastEpochBlockNonce. When NeutralNonce
+	// (epoch 0→1), candidateNonce ⭒ NeutralNonce = candidateNonce.
+	lastEpochBlockNonce := currentEpoch.LastEpochBlockNonce
+	if len(lastEpochBlockNonce) == 0 {
+		return candidateNonce
+	}
+	if len(candidateNonce) < 32 ||
+		len(lastEpochBlockNonce) < 32 {
 		return nil
 	}
 	result, calcErr := lcommon.CalculateEpochNonce(
 		candidateNonce,
-		blockLastPrevEpoch.PrevHash,
+		lastEpochBlockNonce,
 		nil,
 	)
 	if calcErr != nil {
@@ -3109,9 +3107,9 @@ func (ls *LedgerState) computeNextEpochNonce(
 		"speculative epoch nonce computed for next epoch",
 		"component", "ledger",
 		"next_epoch", currentEpoch.EpochId+1,
-		"epoch_start_slot", epochStartSlot,
 		"candidate_nonce", hex.EncodeToString(candidateNonce),
-		"lab_nonce", hex.EncodeToString(blockLastPrevEpoch.PrevHash),
+		"last_epoch_block_nonce",
+		hex.EncodeToString(lastEpochBlockNonce),
 		"epoch_nonce", hex.EncodeToString(result.Bytes()),
 	)
 	return result.Bytes()

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -128,11 +129,18 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 	// at epoch boundaries are verified against the correct nonce.
 	epoch, err := ls.epochForSlot(blockSlot)
 	if err != nil {
-		return fmt.Errorf(
-			"block header verification rejected: no epoch data for slot %d: %w",
-			blockSlot,
-			err,
-		)
+		// Epoch cache doesn't cover this slot yet. Blockfetch can
+		// deliver blocks past the epoch boundary before the ledger
+		// processing goroutine runs the full epoch rollover. Eagerly
+		// compute the next epoch(s) so verification can proceed.
+		epoch, err = ls.ensureEpochForSlot(blockSlot)
+		if err != nil {
+			return fmt.Errorf(
+				"block header verification rejected: no epoch data for slot %d: %w",
+				blockSlot,
+				err,
+			)
+		}
 	}
 
 	// Reject blocks for which we have epoch data but no nonce.
@@ -211,4 +219,223 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 		len(cacheCopy),
 		lastValidEnd,
 	)
+}
+
+// ensureEpochForSlot advances the epoch cache until it covers the target
+// slot, then returns the epoch. This handles the case where blockfetch
+// delivers blocks past an epoch boundary before the ledger processing
+// goroutine has run the full epoch rollover. The epoch nonce is computed
+// from chain data (the last block before the boundary), which is available
+// because blockfetch delivers blocks in order.
+func (ls *LedgerState) ensureEpochForSlot(
+	targetSlot uint64,
+) (models.Epoch, error) {
+	const maxAdvance = 5 // Safety limit against runaway loops
+	for range maxAdvance {
+		if err := ls.advanceEpochCache(); err != nil {
+			return models.Epoch{}, fmt.Errorf(
+				"advance epoch cache: %w",
+				err,
+			)
+		}
+		epoch, err := ls.epochForSlot(targetSlot)
+		if err == nil {
+			return epoch, nil
+		}
+	}
+	return models.Epoch{}, fmt.Errorf(
+		"could not advance epoch cache to cover slot %d after %d advances",
+		targetSlot,
+		maxAdvance,
+	)
+}
+
+// advanceEpochCache computes the next epoch's parameters and nonce from
+// chain data and appends it to the in-memory epoch cache. This is a
+// lightweight alternative to the full processEpochRollover — it only
+// populates the nonce and epoch boundaries needed for header verification,
+// without running pparam updates, snapshot rotation, or DB writes.
+// The full rollover will run later in ledgerProcessBlocks and replace
+// the cache with the authoritative DB-backed version.
+func (ls *LedgerState) advanceEpochCache() error {
+	// Read last epoch under read lock
+	ls.RLock()
+	if len(ls.epochCache) == 0 {
+		ls.RUnlock()
+		return errors.New("epoch cache is empty")
+	}
+	lastEpoch := ls.epochCache[len(ls.epochCache)-1]
+	ls.RUnlock()
+
+	if lastEpoch.LengthInSlots == 0 {
+		return errors.New("last epoch has zero length")
+	}
+
+	newStartSlot := lastEpoch.StartSlot + uint64(lastEpoch.LengthInSlots)
+
+	// Compute epoch nonce (requires DB access, done outside lock)
+	nonce, evolvingNonce, candidateNonce, labNonce, err := ls.computeEpochNonceForSlot(newStartSlot, lastEpoch)
+	if err != nil {
+		return fmt.Errorf(
+			"compute epoch nonce for epoch %d: %w",
+			lastEpoch.EpochId+1,
+			err,
+		)
+	}
+
+	newEpoch := models.Epoch{
+		EpochId:             lastEpoch.EpochId + 1,
+		StartSlot:           newStartSlot,
+		LengthInSlots:       lastEpoch.LengthInSlots,
+		SlotLength:          lastEpoch.SlotLength,
+		EraId:               lastEpoch.EraId,
+		Nonce:               nonce,
+		EvolvingNonce:       evolvingNonce,
+		CandidateNonce:      candidateNonce,
+		LastEpochBlockNonce: labNonce,
+	}
+
+	// Update cache under write lock, checking for concurrent advance
+	ls.Lock()
+	lastCached := ls.epochCache[len(ls.epochCache)-1]
+	if lastCached.EpochId >= newEpoch.EpochId {
+		// Another goroutine or ledger processing already advanced
+		ls.Unlock()
+		return nil
+	}
+	ls.epochCache = append(ls.epochCache, newEpoch)
+	ls.Unlock()
+
+	ls.config.Logger.Debug(
+		"eagerly advanced epoch cache for header verification",
+		"new_epoch", newEpoch.EpochId,
+		"start_slot", newEpoch.StartSlot,
+		"nonce", hex.EncodeToString(newEpoch.Nonce),
+		"prev_epoch_id", lastEpoch.EpochId,
+		"prev_epoch_nonce", hex.EncodeToString(lastEpoch.Nonce),
+		"component", "ledger",
+	)
+
+	return nil
+}
+
+// computeEpochNonceForSlot computes the epoch nonce, evolving nonce,
+// and labNonce for a new epoch starting at epochStartSlot. This
+// mirrors calculateEpochNonce but uses non-transactional DB lookups
+// since we're not inside the ledger processing pipeline.
+//
+// Returns (epochNonce, evolvingNonce, candidateNonce, labNonce, error).
+func (ls *LedgerState) computeEpochNonceForSlot(
+	epochStartSlot uint64,
+	prevEpoch models.Epoch,
+) ([]byte, []byte, []byte, []byte, error) {
+	if ls.config.CardanoNodeConfig == nil {
+		return nil, nil, nil, nil, errors.New("CardanoNodeConfig is nil")
+	}
+	genesisHashHex := ls.config.CardanoNodeConfig.ShelleyGenesisHash
+	if genesisHashHex == "" {
+		return nil, nil, nil, nil, errors.New(
+			"shelley genesis hash not available",
+		)
+	}
+	genesisHash, err := hex.DecodeString(genesisHashHex)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf(
+			"decode genesis hash: %w", err,
+		)
+	}
+
+	// For the initial epoch (no nonce yet), return genesis hash
+	// for both epoch nonce and initial evolving nonce.
+	if len(prevEpoch.Nonce) == 0 {
+		return genesisHash, genesisHash, genesisHash, nil, nil
+	}
+
+	prevEvolvingNonce := prevEpoch.EvolvingNonce
+	if len(prevEvolvingNonce) == 0 {
+		prevEvolvingNonce = genesisHash
+	}
+
+	// The candidate nonce carries across epochs independently of the
+	// evolving nonce. Fall back to genesis hash when not stored (e.g.,
+	// epochs created before this field existed).
+	prevCandidateNonce := prevEpoch.CandidateNonce
+	if len(prevCandidateNonce) == 0 {
+		prevCandidateNonce = genesisHash
+	}
+
+	candidateNonce, evolvingNonce, err := ls.computeCandidateNonce(
+		nil, // non-transactional
+		prevEvolvingNonce,
+		prevCandidateNonce,
+		prevEpoch.StartSlot,
+		uint64(prevEpoch.LengthInSlots),
+	)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf(
+			"compute candidate nonce: %w", err,
+		)
+	}
+
+	// Compute the labNonce to SAVE for the next epoch's formula.
+	prevEpochEndSlot := prevEpoch.StartSlot +
+		uint64(prevEpoch.LengthInSlots)
+	var labNonceToSave []byte
+	boundaryBlock, err := database.BlockBeforeSlot(
+		ls.db,
+		prevEpochEndSlot,
+	)
+	if err != nil {
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"lookup boundary block: %w", err,
+			)
+		}
+	} else if len(boundaryBlock.PrevHash) > 0 {
+		labNonceToSave = boundaryBlock.PrevHash
+	}
+
+	// Use the LAGGED lastEpochBlockNonce in the formula.
+	lastEpochBlockNonce := prevEpoch.LastEpochBlockNonce
+	if len(lastEpochBlockNonce) == 0 {
+		// NeutralNonce is the identity element of ⭒:
+		//   candidateNonce ⭒ NeutralNonce = candidateNonce
+		ls.config.Logger.Debug(
+			"computed epoch nonce for cache advance "+
+				"(NeutralNonce, using candidateNonce)",
+			"new_epoch_start_slot", epochStartSlot,
+			"prev_epoch_id", prevEpoch.EpochId,
+			"candidate_nonce",
+			hex.EncodeToString(candidateNonce),
+			"epoch_nonce",
+			hex.EncodeToString(candidateNonce),
+			"component", "ledger",
+		)
+		return candidateNonce, evolvingNonce, candidateNonce, labNonceToSave, nil
+	}
+
+	result, err := lcommon.CalculateEpochNonce(
+		candidateNonce,
+		lastEpochBlockNonce,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf(
+			"calculate epoch nonce: %w", err,
+		)
+	}
+
+	ls.config.Logger.Debug(
+		"computed epoch nonce for cache advance",
+		"new_epoch_start_slot", epochStartSlot,
+		"prev_epoch_id", prevEpoch.EpochId,
+		"last_epoch_block_nonce",
+		hex.EncodeToString(lastEpochBlockNonce),
+		"candidate_nonce", hex.EncodeToString(candidateNonce),
+		"evolving_nonce", hex.EncodeToString(evolvingNonce),
+		"epoch_nonce", hex.EncodeToString(result.Bytes()),
+		"component", "ledger",
+	)
+
+	return result.Bytes(), evolvingNonce, candidateNonce, labNonceToSave, nil
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -167,6 +167,10 @@ func createTestBlock(
 		if encErr != nil {
 			continue
 		}
+		// Store the CBOR on the header body so that
+		// VerifyBlock's extractOriginalBodyCbor can retrieve it
+		// for KES signature verification.
+		headerBody.SetCbor(headerBodyCbor)
 
 		kesSig, signErr := kes.Sign(kesSk, 0, headerBodyCbor)
 		if signErr != nil {

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1318,11 +1318,18 @@ func generateAndSaveEpochs(
 			epochStartSlot = cfg.State.EraBoundSlot +
 				epochsSinceBound*uint64(lengthInSlots)
 		}
+		// NOTE: cfg.State.EvolvingNonce is the tip-time value, which
+		// may be mid-epoch. This is the best available seed at import
+		// time. The first full epoch rollover (processEpochRollover)
+		// will recompute and store the correct end-of-epoch value.
 		// #nosec G115
 		if err := store.SetEpoch(
 			epochStartSlot,
 			cfg.State.Epoch,
 			cfg.State.EpochNonce,
+			cfg.State.EvolvingNonce,
+			nil, // candidateNonce not available from import
+			nil, // lastEpochBlockNonce not available from import
 			uint(cfg.State.EraIndex),
 			slotLength,
 			lengthInSlots,
@@ -1376,6 +1383,9 @@ func generateAndSaveEpochs(
 				startSlot,
 				e,
 				nil, // historical epochs don't need nonce
+				nil, // evolvingNonce not available from import
+				nil, // candidateNonce not available from import
+				nil, // lastEpochBlockNonce not available from import
 				eraId,
 				slotLength,
 				epochLength,
@@ -1429,14 +1439,21 @@ func generateAndSaveEpochs(
 			(e-lastBound.Epoch)*uint64(epochLength)
 
 		var nonce []byte
+		var evolvingNonce []byte
 		if e == cfg.State.Epoch {
 			nonce = cfg.State.EpochNonce
+			// NOTE: tip-time EvolvingNonce (may be mid-epoch).
+			// Corrected by the first full epoch rollover.
+			evolvingNonce = cfg.State.EvolvingNonce
 		}
 
 		if err := store.SetEpoch(
 			startSlot,
 			e,
 			nonce,
+			evolvingNonce,
+			nil, // candidateNonce not available from import
+			nil, // lastEpochBlockNonce not available from import
 			currentEraId,
 			slotLength,
 			epochLength,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements correct Praos nonce handling (candidate, evolving, and lagged lab nonce) and eagerly advances the epoch cache during header verification so VRF/KES checks never wait on rollovers. Adds slot-range block iteration and persists new nonce fields in epoch metadata.

- **New Features**
  - Track EvolvingNonce, CandidateNonce, and LastEpochBlockNonce in epoch records (MySQL/Postgres/SQLite).
  - Compute candidate nonce by folding block VRF outputs up to the 4k/f stabilisation window; return end-of-epoch evolving nonce.
  - Calculate epoch nonce as candidateNonce ⭒ lastEpochBlockNonce (NeutralNonce handled), used at rollovers and during speculative cache advance.
  - Eagerly advance the epoch cache (ensureEpochForSlot/advanceEpochCache) to cover future slots for header verification.
  - Add ForEachBlockInRange(+DB) to iterate blocks by slot from the blob store.

- **Refactors**
  - Always verify VRF/KES and reject invalid headers; removed “near-tip” relaxations.
  - Updated computeNextEpochNonce and rollover/import paths to use candidate/evolving/lab nonces; added epoch nonce formula tests.
  - Extend SetEpoch and metadata stores for new fields; bump gouroboros to v0.160.0 and plutigo to v0.0.26.

<sup>Written for commit 6a4f63af754fbf5339ff2e2f0a58a1b70cace736. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block range iteration for efficient slot-based block processing.
  * Epoch nonce handling expanded to track evolving, candidate, and last-epoch-block nonces.
  * Header verification now advances epoch cache automatically for missing epoch data.

* **Bug Fixes**
  * Improved robustness around epoch verification and nonce propagation.

* **Tests**
  * Added unit tests for epoch nonce behavior.

* **Chores**
  * Bumped Ouroboros and Plutigo dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->