### PR TITLE
fix: multiple fixes from preview testing

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -266,6 +266,16 @@ func (s *State) RemoveClientConnId(
 	}
 }
 
+// HandleClientRemoveRequestedEvent removes a tracked client when
+// a component publishes a client removal request event.
+func (s *State) HandleClientRemoveRequestedEvent(evt event.Event) {
+	e, ok := evt.Data.(ClientRemoveRequestedEvent)
+	if !ok {
+		return
+	}
+	s.RemoveClientConnId(e.ConnId)
+}
+
 // promoteBestClientLocked selects the tracked client with the
 // highest tip slot as the new active client. Only healthy
 // (syncing or synced) clients are considered. If no healthy

--- a/chainsync/event.go
+++ b/chainsync/event.go
@@ -40,6 +40,10 @@ const (
 	// ForkDetectedEventType is emitted when two clients report
 	// different block hashes for the same slot.
 	ForkDetectedEventType event.EventType = "chainsync.fork_detected"
+
+	// ClientRemoveRequestedEventType is emitted when another
+	// component requests chainsync to remove a tracked client.
+	ClientRemoveRequestedEventType event.EventType = "chainsync.client_remove_requested"
 )
 
 // ClientAddedEvent contains details about a newly registered
@@ -80,4 +84,12 @@ type ForkDetectedEvent struct {
 	ConnIdA ouroboros.ConnectionId
 	ConnIdB ouroboros.ConnectionId
 	Point   ocommon.Point
+}
+
+// ClientRemoveRequestedEvent contains the connection details for
+// a requested tracked-client removal.
+type ClientRemoveRequestedEvent struct {
+	ConnId  ouroboros.ConnectionId
+	ConnKey string
+	Reason  string
 }

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -524,3 +524,29 @@ func (c *ConnectionManager) GetConnectionById(
 	}
 	return nil // nil indicates connection not found
 }
+
+// HandleConnectionRecycleRequestedEvent closes a connection when
+// a recycle request event is received.
+func (c *ConnectionManager) HandleConnectionRecycleRequestedEvent(
+	evt event.Event,
+) {
+	e, ok := evt.Data.(ConnectionRecycleRequestedEvent)
+	if !ok {
+		return
+	}
+	conn := c.GetConnectionById(e.ConnectionId)
+	if conn != nil {
+		c.config.Logger.Info(
+			"recycling connection on request",
+			"connection_id", e.ConnectionId.String(),
+			"reason", e.Reason,
+		)
+		if err := conn.Close(); err != nil {
+			c.config.Logger.Debug(
+				"failed to close recycled connection",
+				"connection_id", e.ConnectionId.String(),
+				"error", err,
+			)
+		}
+	}
+}

--- a/connmanager/event.go
+++ b/connmanager/event.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	InboundConnectionEventType = "connmanager.inbound-conn"
-	ConnectionClosedEventType  = "connmanager.conn-closed"
+	InboundConnectionEventType          = "connmanager.inbound-conn"
+	ConnectionClosedEventType           = "connmanager.conn-closed"
+	ConnectionRecycleRequestedEventType = "connmanager.connection-recycle-requested"
 )
 
 type InboundConnectionEvent struct {
@@ -34,4 +35,12 @@ type InboundConnectionEvent struct {
 type ConnectionClosedEvent struct {
 	ConnectionId ouroboros.ConnectionId
 	Error        error
+}
+
+// ConnectionRecycleRequestedEvent requests that a specific
+// connection be recycled.
+type ConnectionRecycleRequestedEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	ConnKey      string
+	Reason       string
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -66,6 +66,10 @@ const (
 	// find the common ancestor and reduces disruptive resyncs
 	// in multi-producer networks where short forks are expected.
 	headerMismatchResyncThreshold = 20
+
+	// Chainsync re-sync reasons
+	resyncReasonRollbackAhead    = "rollback point ahead of local tip"
+	resyncReasonRollbackNotFound = "rollback point not found"
 )
 
 func (ls *LedgerState) handleEventChainsync(evt event.Event) {
@@ -279,6 +283,35 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		return nil
 	}
 
+	// A rollback point ahead of our local tip is invalid for the
+	// current chain view and typically indicates intersect drift.
+	// Trigger a chainsync re-sync instead of failing hard.
+	localTip := ls.chain.HeaderTip()
+	if e.Point.Slot > localTip.Point.Slot {
+		ls.config.Logger.Warn(
+			"received rollback point ahead of local tip, triggering chainsync re-sync",
+			"component", "ledger",
+			"rollback_slot", e.Point.Slot,
+			"local_tip_slot", localTip.Point.Slot,
+			"connection_id", e.ConnectionId.String(),
+		)
+		ls.resetChainsyncResyncState()
+		ls.chainsyncState = SyncingChainsyncState
+		if ls.config.EventBus != nil {
+			ls.config.EventBus.Publish(
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
+					event.ChainsyncResyncEventType,
+					event.ChainsyncResyncEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       resyncReasonRollbackAhead,
+					},
+				),
+			)
+		}
+		return nil
+	}
+
 	if ls.chainsyncState == SyncingChainsyncState {
 		ls.config.Logger.Info(
 			fmt.Sprintf(
@@ -290,6 +323,32 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		ls.chainsyncState = RollbackChainsyncState
 	}
 	if err := ls.chain.Rollback(e.Point); err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			// Missing rollback point can happen when local state and peer
+			// chainsync cursor drift. Recover by forcing re-intersect.
+			ls.config.Logger.Warn(
+				"rollback point not found locally, triggering chainsync re-sync",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"hash", hex.EncodeToString(e.Point.Hash),
+				"connection_id", e.ConnectionId.String(),
+			)
+			ls.resetChainsyncResyncState()
+			ls.chainsyncState = SyncingChainsyncState
+			if ls.config.EventBus != nil {
+				ls.config.EventBus.Publish(
+					event.ChainsyncResyncEventType,
+					event.NewEvent(
+						event.ChainsyncResyncEventType,
+						event.ChainsyncResyncEvent{
+							ConnectionId: e.ConnectionId,
+							Reason:       resyncReasonRollbackNotFound,
+						},
+					),
+				)
+			}
+			return nil
+		}
 		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
 			// The peer's chain has diverged beyond K blocks from
 			// ours. This is a security violation — we must not
@@ -328,6 +387,21 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		return fmt.Errorf("chain rollback failed: %w", err)
 	}
 	return nil
+}
+
+// resetChainsyncResyncState clears chainsync-local recovery state before a
+// re-sync. It mutates rollbackHistory, headerMismatchCount, and queued
+// chain/blockfetch state by calling chain.ClearHeaders and
+// blockfetchRequestRangeCleanup (while holding chainsyncBlockfetchMutex).
+// Callers must hold chainsyncMutex before invoking this method to avoid races
+// with other chainsync operations.
+func (ls *LedgerState) resetChainsyncResyncState() {
+	ls.rollbackHistory = nil
+	ls.headerMismatchCount = 0
+	ls.chain.ClearHeaders()
+	ls.chainsyncBlockfetchMutex.Lock()
+	ls.blockfetchRequestRangeCleanup()
+	ls.chainsyncBlockfetchMutex.Unlock()
 }
 
 func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -208,27 +208,9 @@ func ValidateTxBabbage(
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
-	// Validate transaction size against protocol limit
-	if err = ValidateTxSize(tx, tmpPparams.MaxTxSize); err != nil {
-		return err
-	}
-	// Validate fee covers base cost + execution unit prices
-	var pricesMem, pricesSteps *big.Rat
-	if tmpPparams.ExecutionCosts.MemPrice != nil {
-		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()
-	}
-	if tmpPparams.ExecutionCosts.StepPrice != nil {
-		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
-	}
-	if err = ValidateTxFee(
-		tx,
-		tmpPparams.MinFeeA,
-		tmpPparams.MinFeeB,
-		pricesMem,
-		pricesSteps,
-	); err != nil {
-		return err
-	}
+	// Core Babbage transaction validity checks (fees/size/etc.) are covered
+	// by babbage.UtxoValidationRules. Keep additional local validation scoped
+	// to script execution compatibility.
 	// Skip script evaluation if TX is marked as not valid
 	if !tx.IsValid() {
 		return nil

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -167,247 +167,27 @@ func ValidateTxConway(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	tmpPparams, ok := pp.(*conway.ConwayProtocolParameters)
-	if !ok {
+	if _, ok := pp.(*conway.ConwayProtocolParameters); !ok {
 		return ErrIncompatibleProtocolParams
 	}
 	// Validate TX through ledger validation rules
 	errs := []error{}
 	var err error
-	for _, validationFunc := range conway.UtxoValidationRules {
+	for idx, validationFunc := range conway.UtxoValidationRules {
 		err = validationFunc(tx, slot, ls, pp)
 		if err != nil {
 			errs = append(
 				errs,
-				err,
+				fmt.Errorf("conway utxo validation rule %d: %w", idx, err),
 			)
 		}
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
-	// Validate transaction size against protocol limit
-	if err = ValidateTxSize(tx, tmpPparams.MaxTxSize); err != nil {
-		return err
-	}
-	// Validate fee covers base cost + execution unit prices
-	var pricesMem, pricesSteps *big.Rat
-	if tmpPparams.ExecutionCosts.MemPrice != nil {
-		pricesMem = tmpPparams.ExecutionCosts.MemPrice.ToBigRat()
-	}
-	if tmpPparams.ExecutionCosts.StepPrice != nil {
-		pricesSteps = tmpPparams.ExecutionCosts.StepPrice.ToBigRat()
-	}
-	if err = ValidateTxFee(
-		tx,
-		tmpPparams.MinFeeA,
-		tmpPparams.MinFeeB,
-		pricesMem,
-		pricesSteps,
-	); err != nil {
-		return err
-	}
-	// Skip script evaluation if TX is marked as not valid
-	if !tx.IsValid() {
-		return nil
-	}
-	// Resolve inputs
-	resolvedInputs := []lcommon.Utxo{}
-	for _, tmpInput := range tx.Inputs() {
-		tmpUtxo, err := ls.UtxoById(tmpInput)
-		if err != nil {
-			return err
-		}
-		resolvedInputs = append(
-			resolvedInputs,
-			tmpUtxo,
-		)
-	}
-	// Resolve reference inputs
-	resolvedRefInputs := []lcommon.Utxo{}
-	for _, tmpRefInput := range tx.ReferenceInputs() {
-		tmpUtxo, err := ls.UtxoById(tmpRefInput)
-		if err != nil {
-			return err
-		}
-		resolvedRefInputs = append(
-			resolvedRefInputs,
-			tmpUtxo,
-		)
-	}
-	// Build TX script map
-	scripts := make(map[lcommon.ScriptHash]lcommon.Script)
-	// Add script refs from all resolved UTxOs (both inputs and reference inputs)
-	for _, utxo := range slices.Concat(resolvedInputs, resolvedRefInputs) {
-		tmpScript := utxo.Output.ScriptRef()
-		if tmpScript == nil {
-			continue
-		}
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV2Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV3Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().NativeScripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	// Evaluate scripts
-	var txInfoV3 script.TxInfo
-	txInfoV3, err = script.NewTxInfoV3FromTransaction(
-		ls,
-		tx,
-		slices.Concat(resolvedInputs, resolvedRefInputs),
-	)
-	if err != nil {
-		return err
-	}
-	for _, redeemerPair := range txInfoV3.(script.TxInfoV3).Redeemers {
-		purpose := redeemerPair.Key
-		if purpose == nil {
-			return errors.New("script purpose is nil")
-		}
-		redeemer := redeemerPair.Value
-		// Lookup script from redeemer purpose
-		tmpScript := scripts[purpose.ScriptHash()]
-		if tmpScript == nil {
-			return fmt.Errorf(
-				"could not find script with hash %s",
-				purpose.ScriptHash().String(),
-			)
-		}
-		switch s := tmpScript.(type) {
-		case lcommon.PlutusV1Script:
-			txInfoV1, err := script.NewTxInfoV1FromTransaction(
-				ls,
-				tx,
-				slices.Concat(resolvedInputs, resolvedRefInputs),
-			)
-			if err != nil {
-				return err
-			}
-			// Get spent UTxO datum
-			var datum data.PlutusData
-			if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
-				datum = tmp.Datum
-			}
-			sc := script.NewScriptContextV1V2(txInfoV1, purpose)
-			evalContext, err := cek.NewEvalContext(
-				lang.LanguageVersionV1,
-				cek.ProtoVersion{
-					Major: tmpPparams.ProtocolVersion.Major,
-					Minor: tmpPparams.ProtocolVersion.Minor,
-				},
-				tmpPparams.CostModels[0],
-			)
-			if err != nil {
-				return fmt.Errorf("build evaluation context: %w", err)
-			}
-			_, err = s.Evaluate(
-				datum,
-				redeemer.Data,
-				sc.ToPlutusData(),
-				redeemer.ExUnits,
-				evalContext,
-			)
-			if err != nil {
-				return err
-			}
-		case lcommon.PlutusV2Script:
-			txInfoV2, err := script.NewTxInfoV2FromTransaction(
-				ls,
-				tx,
-				slices.Concat(resolvedInputs, resolvedRefInputs),
-			)
-			if err != nil {
-				return err
-			}
-			// Get spent UTxO datum
-			var datum data.PlutusData
-			if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
-				datum = tmp.Datum
-			}
-			sc := script.NewScriptContextV1V2(txInfoV2, purpose)
-			evalContext, err := cek.NewEvalContext(
-				lang.LanguageVersionV2,
-				cek.ProtoVersion{
-					Major: tmpPparams.ProtocolVersion.Major,
-					Minor: tmpPparams.ProtocolVersion.Minor,
-				},
-				tmpPparams.CostModels[1],
-			)
-			if err != nil {
-				return fmt.Errorf("build evaluation context: %w", err)
-			}
-			_, err = s.Evaluate(
-				datum,
-				redeemer.Data,
-				sc.ToPlutusData(),
-				redeemer.ExUnits,
-				evalContext,
-			)
-			if err != nil {
-				return err
-			}
-		case lcommon.PlutusV3Script:
-			sc := script.NewScriptContextV3(txInfoV3, redeemer, purpose)
-			evalContext, err := cek.NewEvalContext(
-				lang.LanguageVersionV3,
-				cek.ProtoVersion{
-					Major: tmpPparams.ProtocolVersion.Major,
-					Minor: tmpPparams.ProtocolVersion.Minor,
-				},
-				tmpPparams.CostModels[2],
-			)
-			if err != nil {
-				return fmt.Errorf("build evaluation context: %w", err)
-			}
-			_, err = s.Evaluate(
-				sc.ToPlutusData(),
-				redeemer.ExUnits,
-				evalContext,
-			)
-			if err != nil {
-				/*
-					fmt.Printf("TX ID: %s\n", tx.Hash().String())
-					fmt.Printf("purpose = %#v, redeemer = %#v\n", purpose, redeemer)
-					scriptHash := s.Hash()
-					fmt.Printf("scriptHash = %s\n", scriptHash.String())
-					fmt.Printf("tx = %x\n", tx.Cbor())
-					// Build inputs/outputs strings that can be plugged into Aiken script_context tests for comparison
-					var tmpInputs []lcommon.TransactionInput
-					var tmpOutputs []lcommon.TransactionOutput
-					for _, input := range slices.Concat(resolvedInputs, resolvedRefInputs) {
-						tmpInputs = append(tmpInputs, input.Id)
-						tmpOutputs = append(tmpOutputs, input.Output)
-					}
-					tmpInputsCbor, err2 := cbor.Encode(tmpInputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpInputs = %x\n", tmpInputsCbor)
-					tmpOutputsCbor, err2 := cbor.Encode(tmpOutputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpOutputs = %x\n", tmpOutputsCbor)
-					scCbor, err2 := data.Encode(sc.ToPlutusData())
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("scCbor = %x\n", scCbor)
-				*/
-				return err
-			}
-		default:
-			return fmt.Errorf("unimplemented script type: %T", tmpScript)
-		}
-	}
+	// Core Conway transaction validity checks (fees/size/scripts/etc.) are
+	// covered by conway.UtxoValidationRules. Avoid duplicate local checks
+	// that can drift from upstream consensus behavior.
 	return nil
 }
 

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -353,7 +353,7 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	}
 
 	if distribution.TotalPools == 0 {
-		m.logger.Warn(
+		m.logger.Info(
 			"no genesis pools; leader election disabled"+
 				" until pool stake is registered",
 			"component", "snapshot",

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -473,17 +473,13 @@ func parseCredentialMap(
 
 		// StakePool delegation (index 1): pool key hash
 		if len(elem) > 1 {
-			var poolHash []byte
-			if _, err := cbor.Decode(
-				elem[1], &poolHash,
-			); err != nil {
-				partial = true
-			} else if len(poolHash) == 28 {
+			poolHash, ok := parsePoolDelegation(elem[1])
+			if ok && len(poolHash) == 28 {
 				acct.PoolKeyHash = poolHash
-			} else if len(poolHash) > 0 {
+			} else if !ok || len(poolHash) > 0 {
 				partial = true
 			}
-			// len(poolHash) == 0 means CBOR null — valid "no delegation"
+			// len(poolHash) == 0 means no delegation.
 		}
 
 		// DRep delegation (index 2): key/script credential or
@@ -534,6 +530,40 @@ func parseCredentialMap(
 		)
 	}
 	return accounts, warning
+}
+
+// parsePoolDelegation decodes stake pool delegation values from UMElem.
+// This supports both plain hash encoding and credential-like wrappers.
+func parsePoolDelegation(data []byte) ([]byte, bool) {
+	if len(data) == 0 || data[0] == 0xf6 {
+		return nil, true
+	}
+
+	// Common case: raw 28-byte pool key hash.
+	var poolHash []byte
+	if _, err := cbor.Decode(data, &poolHash); err == nil {
+		if len(poolHash) == 0 || len(poolHash) == 28 {
+			return poolHash, true
+		}
+	}
+
+	// Fallback: credential-like [type, hash] encoding.
+	if cred, err := parseCredential(data); err == nil && len(cred.Hash) == 28 {
+		return cred.Hash, true
+	}
+
+	// Fallback: generic 2-element array with hash at index 1.
+	var parts []cbor.RawMessage
+	if _, err := cbor.Decode(data, &parts); err == nil && len(parts) > 1 {
+		var wrapped []byte
+		if _, err := cbor.Decode(parts[1], &wrapped); err == nil {
+			if len(wrapped) == 0 || len(wrapped) == 28 {
+				return wrapped, true
+			}
+		}
+	}
+
+	return nil, false
 }
 
 // parsePState decodes the pool state.

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"math/big"
 	"net"
+	"sort"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -331,19 +332,24 @@ func ImportLedgerState(
 	}
 
 	// Import cert state (accounts, pools, DReps)
+	certStatePoolsImported := false
+	certStatePhaseRan := false
 	if !models.IsPhaseCompleted(
 		completedPhase,
 		models.ImportPhaseCertState,
 	) {
+		certStatePhaseRan = true
 		if cfg.State.CertStateData != nil {
-			if err := importCertState(
+			poolsImported, err := importCertState(
 				ctx, cfg, slot, progress,
-			); err != nil {
+			)
+			if err != nil {
 				return fmt.Errorf(
 					"importing cert state: %w",
 					err,
 				)
 			}
+			certStatePoolsImported = poolsImported > 0
 		}
 		if err := setCheckpoint(
 			cfg, models.ImportPhaseCertState,
@@ -363,8 +369,24 @@ func ImportLedgerState(
 		models.ImportPhaseSnapshots,
 	) {
 		if cfg.State.SnapShotsData != nil {
+			allowSnapshotPoolFallback := certStatePhaseRan &&
+				!certStatePoolsImported
+			if !allowSnapshotPoolFallback && !certStatePhaseRan &&
+				!certStatePoolsImported {
+				// On resume, cert-state may have completed in a prior run.
+				// Allow snapshot fallback only when no active pools exist
+				// in the database.
+				hasActivePools, err := hasActivePoolsInDatabase(cfg)
+				if err != nil {
+					return fmt.Errorf(
+						"checking existing pools before snapshot fallback: %w",
+						err,
+					)
+				}
+				allowSnapshotPoolFallback = !hasActivePools
+			}
 			if err := importSnapShots(
-				ctx, cfg, slot, progress,
+				ctx, cfg, slot, progress, allowSnapshotPoolFallback,
 			); err != nil {
 				return fmt.Errorf(
 					"importing stake snapshots: %w",
@@ -459,6 +481,17 @@ func ImportLedgerState(
 	)
 
 	return nil
+}
+
+func hasActivePoolsInDatabase(cfg ImportConfig) (bool, error) {
+	txn := cfg.Database.MetadataTxn(false)
+	defer txn.Release()
+	store := cfg.Database.Metadata()
+	pools, err := store.GetActivePoolKeyHashes(txn.Metadata())
+	if err != nil {
+		return false, err
+	}
+	return len(pools) > 0, nil
 }
 
 // setCheckpoint persists the completed phase if resume tracking
@@ -623,7 +656,7 @@ func importCertState(
 	cfg ImportConfig,
 	slot uint64,
 	progress func(ImportProgress),
-) error {
+) (int, error) {
 	cfg.Logger.Info(
 		"parsing cert state",
 		"component", "ledgerstate",
@@ -632,7 +665,7 @@ func importCertState(
 	certState, err := ParseCertState(cfg.State.CertStateData)
 	if err != nil {
 		if certState == nil {
-			return fmt.Errorf(
+			return 0, fmt.Errorf(
 				"parsing cert state: %w", err,
 			)
 		}
@@ -648,7 +681,7 @@ func importCertState(
 		if err := importAccounts(
 			ctx, cfg, certState.Accounts, slot,
 		); err != nil {
-			return fmt.Errorf(
+			return 0, fmt.Errorf(
 				"importing accounts: %w",
 				err,
 			)
@@ -665,12 +698,14 @@ func importCertState(
 	}
 
 	// Import pools
+	importedPools := 0
 	if len(certState.Pools) > 0 {
 		if err := importPools(
 			ctx, cfg, certState.Pools, slot,
 		); err != nil {
-			return fmt.Errorf("importing pools: %w", err)
+			return 0, fmt.Errorf("importing pools: %w", err)
 		}
+		importedPools = len(certState.Pools)
 		progress(ImportProgress{
 			Stage:   "pools",
 			Current: len(certState.Pools),
@@ -687,7 +722,7 @@ func importCertState(
 		if err := importDReps(
 			ctx, cfg, certState.DReps, slot,
 		); err != nil {
-			return fmt.Errorf("importing DReps: %w", err)
+			return 0, fmt.Errorf("importing DReps: %w", err)
 		}
 		progress(ImportProgress{
 			Stage:   "dreps",
@@ -700,7 +735,7 @@ func importCertState(
 		})
 	}
 
-	return nil
+	return importedPools, nil
 }
 
 // importAccounts imports parsed accounts into the metadata store.
@@ -1003,6 +1038,7 @@ func importSnapShots(
 	cfg ImportConfig,
 	slot uint64,
 	progress func(ImportProgress),
+	allowPoolFallback bool,
 ) error {
 	cfg.Logger.Info(
 		"parsing stake snapshots",
@@ -1123,6 +1159,29 @@ func importSnapShots(
 		})
 	}
 
+	if allowPoolFallback {
+		// Fallback pool import path:
+		// Snapshot data includes pool parameters and remains reliable when
+		// cert-state pool data is unavailable.
+		snapshotPools := collectPoolsFromSnapshots(snapshots)
+		if len(snapshotPools) > 0 {
+			if err := importPools(ctx, cfg, snapshotPools, slot); err != nil {
+				return fmt.Errorf(
+					"importing pools from snapshots: %w",
+					err,
+				)
+			}
+			progress(ImportProgress{
+				Stage:   "pools",
+				Current: len(snapshotPools),
+				Description: fmt.Sprintf(
+					"%d pools imported from snapshots",
+					len(snapshotPools),
+				),
+			})
+		}
+	}
+
 	// Save epoch summary using the "go" snapshot computed above
 	var totalStake uint64
 	var totalDelegators uint64
@@ -1173,6 +1232,36 @@ func importSnapShots(
 		)
 	}
 	return nil
+}
+
+func collectPoolsFromSnapshots(
+	snapshots *ParsedSnapShots,
+) []ParsedPool {
+	type poolMap map[string]*ParsedPool
+	seen := make(map[string]ParsedPool)
+	for _, pm := range []poolMap{
+		snapshots.Mark.PoolParams,
+		snapshots.Set.PoolParams,
+		snapshots.Go.PoolParams,
+	} {
+		for _, pool := range pm {
+			if pool == nil || len(pool.PoolKeyHash) != 28 {
+				continue
+			}
+			hexKey := hex.EncodeToString(pool.PoolKeyHash)
+			seen[hexKey] = *pool
+		}
+	}
+	ret := make([]ParsedPool, 0, len(seen))
+	keys := make([]string, 0, len(seen))
+	for hexKey := range seen {
+		keys = append(keys, hexKey)
+	}
+	sort.Strings(keys)
+	for _, hexKey := range keys {
+		ret = append(ret, seen[hexKey])
+	}
+	return ret
 }
 
 // importTip sets the chain tip to the snapshot's tip and generates

--- a/node.go
+++ b/node.go
@@ -87,6 +87,7 @@ func New(cfg Config) (*Node, error) {
 	return n, nil
 }
 
+//nolint:contextcheck // Run is the lifecycle boundary and derives n.ctx from the caller context.
 func (n *Node) Run(ctx context.Context) error {
 	// Configure tracing
 	if n.config.tracing {
@@ -304,6 +305,10 @@ func (n *Node) Run(ctx context.Context) error {
 		chainsyncCfg,
 	)
 	n.ouroboros.ChainsyncState = n.chainsyncState
+	n.eventBus.SubscribeFunc(
+		chainsync.ClientRemoveRequestedEventType,
+		n.chainsyncState.HandleClientRemoveRequestedEvent,
+	)
 	// Initialize chain selector for multi-peer chain selection
 	n.chainSelector = chainselection.NewChainSelector(
 		chainselection.ChainSelectorConfig{
@@ -384,6 +389,10 @@ func (n *Node) Run(ctx context.Context) error {
 			PromRegistry:       n.config.promRegistry,
 		},
 	)
+	n.eventBus.SubscribeFunc(
+		connmanager.ConnectionRecycleRequestedEventType,
+		n.connManager.HandleConnectionRecycleRequestedEvent,
+	)
 	n.ouroboros.ConnManager = n.connManager
 	// Subscribe ouroboros to chainsync resync events from the
 	// ledger. This replaces the previous ChainsyncResyncFunc
@@ -414,6 +423,124 @@ func (n *Node) Run(ctx context.Context) error {
 			)
 		}
 	})
+	// Detect stalled chainsync clients and recycle truly stuck connections.
+	// Use a grace period + cooldown to avoid flapping healthy but quiet peers.
+	stallCheckInterval := max(chainsyncCfg.StallTimeout/2, 10*time.Second)
+	if stallCheckInterval > 30*time.Second {
+		stallCheckInterval = 30 * time.Second
+	}
+	stallRecoveryGrace := max(chainsyncCfg.StallTimeout, 30*time.Second)
+	stallRecycleCooldown := max(2*chainsyncCfg.StallTimeout, 2*time.Minute)
+	recyclerCtx, recyclerCancel := context.WithCancel(n.ctx)
+	started = append(started, recyclerCancel)
+	go func(interval, grace, cooldown time.Duration) {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		recycleAt := make(map[string]time.Time)
+		lastRecycled := make(map[string]time.Time)
+		for {
+			select {
+			case <-recyclerCtx.Done():
+				return
+			case <-ticker.C:
+				now := time.Now()
+				n.chainsyncState.CheckStalledClients()
+				trackedClients := n.chainsyncState.GetTrackedClients()
+				trackedByID := make(
+					map[string]chainsync.TrackedClient,
+					len(trackedClients),
+				)
+				for _, conn := range trackedClients {
+					connKey := conn.ConnId.String()
+					trackedByID[connKey] = conn
+					if conn.Status != chainsync.ClientStatusStalled {
+						delete(recycleAt, connKey)
+					}
+				}
+				// Prune expired cooldown entries so this map does
+				// not grow without bound over long runtimes.
+				for connKey, last := range lastRecycled {
+					if now.Sub(last) >= cooldown {
+						delete(lastRecycled, connKey)
+					}
+				}
+				for _, conn := range trackedClients {
+					if conn.Status != chainsync.ClientStatusStalled {
+						continue
+					}
+					connKey := conn.ConnId.String()
+					dueAt, exists := recycleAt[connKey]
+					if !exists || dueAt.Before(now) {
+						recycleAt[connKey] = now.Add(grace)
+						n.config.logger.Info(
+							"chainsync client stalled, scheduling guarded recycle",
+							"connection_id", connKey,
+							"stall_timeout", chainsyncCfg.StallTimeout,
+							"grace_period", grace,
+						)
+					}
+				}
+				for connKey, dueAt := range recycleAt {
+					if now.Before(dueAt) {
+						continue
+					}
+					tracked, ok := trackedByID[connKey]
+					if !ok || tracked.Status != chainsync.ClientStatusStalled {
+						delete(recycleAt, connKey)
+						continue
+					}
+					connId := tracked.ConnId
+					if last, ok := lastRecycled[connKey]; ok &&
+						now.Sub(last) < cooldown {
+						recycleAt[connKey] = now.Add(cooldown - now.Sub(last))
+						continue
+					}
+					active := n.chainsyncState.GetClientConnId()
+					if active == nil {
+						// No active chainsync connection is selected yet.
+						// Skip recycle and re-check on the next tick.
+						continue
+					}
+					if active.String() != connKey {
+						// Don't recycle non-primary stalled clients. Keep state clean.
+						n.eventBus.PublishAsync(
+							chainsync.ClientRemoveRequestedEventType,
+							event.NewEvent(
+								chainsync.ClientRemoveRequestedEventType,
+								chainsync.ClientRemoveRequestedEvent{
+									ConnId:  connId,
+									ConnKey: connKey,
+									Reason:  "stalled_non_primary_connection",
+								},
+							),
+						)
+						delete(recycleAt, connKey)
+						continue
+					}
+					n.config.logger.Warn(
+						"chainsync client stalled, recycling active connection",
+						"connection_id", connKey,
+						"stall_timeout", chainsyncCfg.StallTimeout,
+						"grace_period", grace,
+						"recycle_cooldown", cooldown,
+					)
+					n.eventBus.PublishAsync(
+						connmanager.ConnectionRecycleRequestedEventType,
+						event.NewEvent(
+							connmanager.ConnectionRecycleRequestedEventType,
+							connmanager.ConnectionRecycleRequestedEvent{
+								ConnectionId: connId,
+								ConnKey:      connKey,
+								Reason:       "stalled_active_connection",
+							},
+						),
+					)
+					delete(recycleAt, connKey)
+					lastRecycled[connKey] = now
+				}
+			}
+		}
+	}(stallCheckInterval, stallRecoveryGrace, stallRecycleCooldown)
 	// Configure peer governor
 	// Create ledger peer provider for discovering peers from stake pool relays
 	ledgerPeerProvider, err := ledger.NewLedgerPeerProvider(

--- a/peergov/bootstrap.go
+++ b/peergov/bootstrap.go
@@ -14,7 +14,10 @@
 
 package peergov
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // shouldExitBootstrap checks if conditions are met to exit bootstrap mode.
 // Returns true if ANY of these conditions are met:
@@ -149,6 +152,7 @@ func (p *PeerGovernor) exitBootstrapLocked(reason string) []pendingEvent {
 	}
 
 	p.bootstrapExited = true
+	p.lastBootstrapExit = time.Now()
 	p.config.Logger.Info(
 		"exited bootstrap mode",
 		"reason", reason,
@@ -193,10 +197,28 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 		return events
 	}
 
+	// Avoid immediate exit/recovery flapping right after bootstrap exit.
+	if !p.lastBootstrapExit.IsZero() &&
+		time.Since(p.lastBootstrapExit) < p.config.BootstrapRecoveryCooldown {
+		remaining := p.config.BootstrapRecoveryCooldown -
+			time.Since(p.lastBootstrapExit)
+		if remaining < 0 {
+			remaining = 0
+		}
+		p.config.Logger.Debug(
+			"bootstrap recovery skipped: cooldown active",
+			"remaining", remaining,
+		)
+		return events
+	}
+
 	// Check if auto-recovery is enabled
 	// nil = use default (true), explicit false disables
 	if p.config.AutoBootstrapRecovery != nil &&
 		!*p.config.AutoBootstrapRecovery {
+		p.config.Logger.Debug(
+			"bootstrap recovery skipped: auto recovery disabled",
+		)
 		return events
 	}
 
@@ -210,6 +232,11 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 
 	// Only recover if we're below minimum hot peers
 	if hotCount >= p.config.MinHotPeers {
+		p.config.Logger.Debug(
+			"bootstrap recovery skipped: enough hot peers",
+			"hot_count", hotCount,
+			"min_hot_peers", p.config.MinHotPeers,
+		)
 		return events
 	}
 
@@ -230,6 +257,9 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 
 	// If we have warm candidates from gossip/ledger, don't recover bootstrap
 	if hasWarmCandidates {
+		p.config.Logger.Debug(
+			"bootstrap recovery skipped: warm gossip/ledger candidates available",
+		)
 		return events
 	}
 

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -15,13 +15,63 @@
 package peergov
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 )
+
+func isConnectionCancellationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "operation was canceled") ||
+		strings.Contains(msg, "context canceled") ||
+		strings.Contains(msg, "use of closed network connection")
+}
+
+func isExpectedNetworkDialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "server misbehaving") ||
+		strings.Contains(msg, "connect: connection refused") ||
+		strings.Contains(msg, "no route to host") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "cannot assign requested address") ||
+		strings.Contains(msg, "version data mismatch") ||
+		strings.Contains(msg, "timeout waiting on transition")
+}
+
+func isExpectedConnectionCloseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "broken pipe") ||
+		msg == "eof"
+}
 
 func (p *PeerGovernor) startOutboundConnections() {
 	// Skip outbound connections if disabled
@@ -74,6 +124,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		return
 	}
 	currentPeer.Reconnecting = true
+	reconnectPeer := currentPeer
 	// Read any pre-existing reconnect delay set by
 	// handleConnectionClosedEvent for short-lived connections.
 	preDelay := currentPeer.ReconnectDelay
@@ -85,8 +136,8 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 	// Ensure Reconnecting is cleared when this goroutine exits
 	defer func() {
 		p.mu.Lock()
-		idx := p.peerIndexByAddress(peer.NormalizedAddress)
-		if idx != -1 {
+		idx := p.peerIndexByAddress(reconnectPeer.NormalizedAddress)
+		if idx != -1 && p.peers[idx] == reconnectPeer {
 			p.peers[idx].Reconnecting = false
 		}
 		p.mu.Unlock()
@@ -193,13 +244,67 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			)
 			return
 		}
-		p.config.Logger.Error(
-			fmt.Sprintf(
-				"outbound: failed to establish connection to %s: %s",
-				peer.Address,
-				err,
-			),
+		if isConnectionCancellationError(err) {
+			select {
+			case <-p.stopCh:
+				p.config.Logger.Debug(
+					"outbound: connection attempt canceled during shutdown",
+					"address", peer.Address,
+				)
+				return
+			default:
+			}
+			if p.ctx.Err() != nil {
+				p.config.Logger.Debug(
+					"outbound: connection attempt canceled, governor context done",
+					"address", peer.Address,
+				)
+				return
+			}
+			p.mu.Lock()
+			peerIdx = p.peerIndexByAddress(peer.NormalizedAddress)
+			if peerIdx == -1 {
+				p.mu.Unlock()
+				p.config.Logger.Debug(
+					"outbound: peer removed during canceled connection attempt",
+					"address", peer.Address,
+				)
+				return
+			}
+			currentPeer := p.peers[peerIdx]
+			if currentPeer.ReconnectDelay == 0 {
+				currentPeer.ReconnectDelay = initialReconnectDelay
+			} else if currentPeer.ReconnectDelay < maxReconnectDelay {
+				currentPeer.ReconnectDelay *= reconnectBackoffFactor
+				if currentPeer.ReconnectDelay > maxReconnectDelay {
+					currentPeer.ReconnectDelay = maxReconnectDelay
+				}
+			}
+			reconnectDelay := currentPeer.ReconnectDelay
+			p.mu.Unlock()
+			p.config.Logger.Debug(
+				"outbound: connection attempt canceled, retrying with backoff",
+				"address", peer.Address,
+				"error", err,
+				"delay", reconnectDelay,
+			)
+			select {
+			case <-p.stopCh:
+				return
+			case <-time.After(reconnectDelay):
+			}
+			continue
+		}
+		failMsg := fmt.Sprintf(
+			"outbound: failed to establish connection to %s: %s",
+			peer.Address,
+			err,
 		)
+		if isExpectedNetworkDialError(err) {
+			p.config.Logger.Info(failMsg)
+		} else {
+			p.config.Logger.Error(failMsg)
+		}
 		p.mu.Lock()
 		// Re-lookup peer to avoid stale pointer if slice was rebuilt
 		peerIdx = p.peerIndexByAddress(peer.NormalizedAddress)
@@ -224,7 +329,45 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		// Copy values while holding lock for use after unlock
 		reconnectDelay := currentPeer.ReconnectDelay
 		reconnectCount := currentPeer.ReconnectCount
+		peerSource := currentPeer.Source
+		peerAddress := currentPeer.Address
+		peerNormalizedAddress := currentPeer.NormalizedAddress
+		if !p.isTopologyPeer(peerSource) &&
+			reconnectCount > p.config.MaxReconnectFailureThreshold {
+			// Fail fast for non-topology peers. Waiting for the long
+			// reconcile interval causes large reconnect storms.
+			p.denyList[peerNormalizedAddress] = time.Now().Add(
+				p.config.DenyDuration,
+			)
+			p.peers = append(p.peers[:peerIdx], p.peers[peerIdx+1:]...)
+			p.updatePeerMetrics()
+			p.mu.Unlock()
+			p.config.Logger.Info(
+				"outbound: removing peer after repeated connection failures",
+				"address", peerAddress,
+				"source", peerSource.String(),
+				"retry_count", reconnectCount,
+				"deny_duration", p.config.DenyDuration,
+			)
+			p.publishEvent(
+				PeerRemovedEventType,
+				PeerStateChangeEvent{
+					Address: peerAddress,
+					Reason:  "excessive outbound connection failures",
+				},
+			)
+			return
+		}
 		p.mu.Unlock()
+		select {
+		case <-p.stopCh:
+			p.config.Logger.Debug(
+				"outbound: stopping connection attempts due to shutdown",
+				"address", peer.Address,
+			)
+			return
+		default:
+		}
 		p.config.Logger.Info(
 			fmt.Sprintf(
 				"outbound: delaying %s (retry %d) before reconnecting to %s",
@@ -337,13 +480,21 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if e.Error != nil {
-		p.config.Logger.Error(
-			fmt.Sprintf(
-				"unexpected connection failure: %s",
-				e.Error,
-			),
-			"connection_id", e.ConnectionId.String(),
+		closeMsg := fmt.Sprintf(
+			"unexpected connection failure: %s",
+			e.Error,
 		)
+		if isExpectedConnectionCloseError(e.Error) {
+			p.config.Logger.Info(
+				closeMsg,
+				"connection_id", e.ConnectionId.String(),
+			)
+		} else {
+			p.config.Logger.Error(
+				closeMsg,
+				"connection_id", e.ConnectionId.String(),
+			)
+		}
 	} else {
 		p.config.Logger.Info("connection closed",
 			"connection_id", e.ConnectionId.String(),

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+)
+
+func TestIsExpectedConnectionCloseError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "eof",
+			err:  io.EOF,
+			want: true,
+		},
+		{
+			name: "broken pipe",
+			err:  errors.New("write tcp 1.2.3.4:1234: broken pipe"),
+			want: true,
+		},
+		{
+			name: "wrapped epipe",
+			err:  fmt.Errorf("write failed: %w", syscall.EPIPE),
+			want: true,
+		},
+		{
+			name: "wrapped econnreset",
+			err:  fmt.Errorf("read failed: %w", syscall.ECONNRESET),
+			want: true,
+		},
+		{
+			name: "wrapped econnaborted",
+			err:  fmt.Errorf("accept failed: %w", syscall.ECONNABORTED),
+			want: true,
+		},
+		{
+			name: "net op error wrapped syscall",
+			err: &net.OpError{
+				Op:  "write",
+				Net: "tcp",
+				Err: fmt.Errorf("wrapped: %w", syscall.EPIPE),
+			},
+			want: true,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unexpected",
+			err:  errors.New("tls: bad certificate"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isExpectedConnectionCloseError(tc.err)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsConnectionCancellationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "context canceled",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "wrapped context canceled",
+			err:  fmt.Errorf("wrapped: %w", context.Canceled),
+			want: true,
+		},
+		{
+			name: "net err closed",
+			err:  net.ErrClosed,
+			want: true,
+		},
+		{
+			name: "wrapped net err closed",
+			err:  fmt.Errorf("wrapped: %w", net.ErrClosed),
+			want: true,
+		},
+		{
+			name: "operation was canceled string",
+			err:  errors.New("dial tcp: operation was canceled"),
+			want: true,
+		},
+		{
+			name: "syscall econnaborted",
+			err:  syscall.ECONNABORTED,
+			want: false,
+		},
+		{
+			name: "io eof",
+			err:  io.EOF,
+			want: false,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unexpected",
+			err:  errors.New("tls: bad certificate"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isConnectionCancellationError(tc.err)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsExpectedNetworkDialError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "no such host",
+			err:  errors.New("lookup relay.example: no such host"),
+			want: true,
+		},
+		{
+			name: "wrapped no route to host",
+			err: fmt.Errorf(
+				"dial failed: %w",
+				errors.New("connect: no route to host"),
+			),
+			want: true,
+		},
+		{
+			name: "io timeout",
+			err:  errors.New("dial tcp: i/o timeout"),
+			want: true,
+		},
+		{
+			name: "version mismatch",
+			err:  errors.New("version data mismatch"),
+			want: true,
+		},
+		{
+			name: "net op error wrapping no route",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: errors.New("connect: no route to host"),
+			},
+			want: true,
+		},
+		{
+			name: "syscall econnaborted",
+			err:  syscall.ECONNABORTED,
+			want: false,
+		},
+		{
+			name: "io eof",
+			err:  io.EOF,
+			want: false,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unexpected",
+			err:  errors.New("tls: bad certificate"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isExpectedNetworkDialError(tc.err)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -28,13 +28,13 @@ import (
 )
 
 const (
-	defaultReconcileInterval         = 30 * time.Minute
-	defaultMaxReconnectFailures      = 3
-	defaultMinHotPeers               = 3
-	defaultInactivityTimeout         = 10 * time.Minute
-	defaultTestCooldown              = 5 * time.Minute
-	defaultDenyDuration              = 30 * time.Minute
-	defaultLedgerPeerRefreshInterval = 1 * time.Hour
+	defaultReconcileInterval            = 30 * time.Minute
+	defaultMaxReconnectFailureThreshold = 3
+	defaultMinHotPeers                  = 3
+	defaultInactivityTimeout            = 10 * time.Minute
+	defaultTestCooldown                 = 5 * time.Minute
+	defaultDenyDuration                 = 30 * time.Minute
+	defaultLedgerPeerRefreshInterval    = 1 * time.Hour
 
 	// Default peer targets (applied when config value is 0)
 	defaultTargetNumberOfKnownPeers       = 150
@@ -59,8 +59,9 @@ const (
 	defaultInboundMinTenure         = 10 * time.Minute
 
 	// Default bootstrap exit configuration
-	defaultMinLedgerPeersForExit = 5
-	defaultSyncProgressForExit   = 0.95 // 95%
+	defaultMinLedgerPeersForExit     = 5
+	defaultSyncProgressForExit       = 0.95 // 95%
+	defaultBootstrapRecoveryCooldown = 2 * time.Minute
 )
 
 const (
@@ -93,23 +94,24 @@ type PeerGovernor struct {
 	config                PeerGovernorConfig
 	lastLedgerPeerRefresh atomic.Int64 // UnixNano timestamp of last ledger peer discovery
 	bootstrapExited       bool         // Whether bootstrap peers have been exited
+	lastBootstrapExit     time.Time    // Timestamp of most recent bootstrap exit
 	mu                    sync.Mutex
 }
 
 type PeerGovernorConfig struct {
-	PromRegistry         prometheus.Registerer
-	Logger               *slog.Logger
-	EventBus             *event.EventBus
-	ConnManager          *connmanager.ConnectionManager
-	PeerRequestFunc      func(peer *Peer) []string
-	PeerTestFunc         func(address string) error // Custom peer test function
-	ReconcileInterval    time.Duration
-	MaxReconnectFailures int
-	MinHotPeers          int
-	InactivityTimeout    time.Duration
-	TestCooldown         time.Duration // Min time between suitability tests
-	DenyDuration         time.Duration // How long to deny failed peers
-	DisableOutbound      bool
+	PromRegistry                 prometheus.Registerer
+	Logger                       *slog.Logger
+	EventBus                     *event.EventBus
+	ConnManager                  *connmanager.ConnectionManager
+	PeerRequestFunc              func(peer *Peer) []string
+	PeerTestFunc                 func(address string) error // Custom peer test function
+	ReconcileInterval            time.Duration
+	MaxReconnectFailureThreshold int
+	MinHotPeers                  int
+	InactivityTimeout            time.Duration
+	TestCooldown                 time.Duration // Min time between suitability tests
+	DenyDuration                 time.Duration // How long to deny failed peers
+	DisableOutbound              bool
 
 	// Ledger peer discovery configuration
 	LedgerPeerProvider        LedgerPeerProvider // Provider for ledger peer information
@@ -153,10 +155,11 @@ type PeerGovernorConfig struct {
 	// Bootstrap peer exit configuration
 	// Bootstrap peers are used during initial sync but should be exited once
 	// the node has established sufficient ledger peers or reached sync progress.
-	MinLedgerPeersForExit int                  // Min ledger peers to exit bootstrap (0 = default 5)
-	SyncProgressForExit   float64              // Sync progress threshold to exit (0 = default 0.95)
-	AutoBootstrapRecovery *bool                // Re-enable bootstrap if hot peers drop too low (nil = default true)
-	SyncProgressProvider  SyncProgressProvider // Provider for current sync progress
+	MinLedgerPeersForExit     int                  // Min ledger peers to exit bootstrap (0 = default 5)
+	SyncProgressForExit       float64              // Sync progress threshold to exit (0 = default 0.95)
+	AutoBootstrapRecovery     *bool                // Re-enable bootstrap if hot peers drop too low (nil = default true)
+	BootstrapRecoveryCooldown time.Duration        // Minimum time to wait after bootstrap exit before recovery
+	SyncProgressProvider      SyncProgressProvider // Provider for current sync progress
 }
 
 // pendingEvent holds an event to publish after releasing locks.
@@ -172,8 +175,8 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	if cfg.ReconcileInterval == 0 {
 		cfg.ReconcileInterval = defaultReconcileInterval
 	}
-	if cfg.MaxReconnectFailures == 0 {
-		cfg.MaxReconnectFailures = defaultMaxReconnectFailures
+	if cfg.MaxReconnectFailureThreshold <= 0 {
+		cfg.MaxReconnectFailureThreshold = defaultMaxReconnectFailureThreshold
 	}
 	if cfg.MinHotPeers == 0 {
 		cfg.MinHotPeers = defaultMinHotPeers
@@ -252,6 +255,9 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 		cfg.SyncProgressForExit = defaultSyncProgressForExit
 	}
 	// AutoBootstrapRecovery: nil means use default (true), explicit false disables
+	if cfg.BootstrapRecoveryCooldown <= 0 {
+		cfg.BootstrapRecoveryCooldown = defaultBootstrapRecoveryCooldown
+	}
 	cfg.Logger = cfg.Logger.With("component", "peergov")
 	p := &PeerGovernor{
 		config:   cfg,

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -58,10 +58,11 @@ func TestNewPeerGovernor(t *testing.T) {
 				Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 			},
 			expected: PeerGovernorConfig{
-				ReconcileInterval:    defaultReconcileInterval,
-				MaxReconnectFailures: defaultMaxReconnectFailures,
-				MinHotPeers:          defaultMinHotPeers,
-				InactivityTimeout:    defaultInactivityTimeout,
+				ReconcileInterval:            defaultReconcileInterval,
+				MaxReconnectFailureThreshold: defaultMaxReconnectFailureThreshold,
+				MinHotPeers:                  defaultMinHotPeers,
+				InactivityTimeout:            defaultInactivityTimeout,
+				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
 			},
 		},
 		{
@@ -70,14 +71,15 @@ func TestNewPeerGovernor(t *testing.T) {
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
 				),
-				ReconcileInterval:    10 * time.Minute,
-				MaxReconnectFailures: 10,
-				MinHotPeers:          5,
+				ReconcileInterval:            10 * time.Minute,
+				MaxReconnectFailureThreshold: 10,
+				MinHotPeers:                  5,
 			},
 			expected: PeerGovernorConfig{
-				ReconcileInterval:    10 * time.Minute,
-				MaxReconnectFailures: 10,
-				MinHotPeers:          5,
+				ReconcileInterval:            10 * time.Minute,
+				MaxReconnectFailureThreshold: 10,
+				MinHotPeers:                  5,
+				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
 			},
 		},
 	}
@@ -94,10 +96,15 @@ func TestNewPeerGovernor(t *testing.T) {
 			)
 			assert.Equal(
 				t,
-				tt.expected.MaxReconnectFailures,
-				pg.config.MaxReconnectFailures,
+				tt.expected.MaxReconnectFailureThreshold,
+				pg.config.MaxReconnectFailureThreshold,
 			)
 			assert.Equal(t, tt.expected.MinHotPeers, pg.config.MinHotPeers)
+			assert.Equal(
+				t,
+				tt.expected.BootstrapRecoveryCooldown,
+				pg.config.BootstrapRecoveryCooldown,
+			)
 			assert.NotNil(t, pg.config.Logger)
 		})
 	}
@@ -265,17 +272,17 @@ func TestPeerGovernor_Reconcile_Removal(t *testing.T) {
 	reg := prometheus.NewRegistry()
 
 	pg := NewPeerGovernor(PeerGovernorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:             eventBus,
-		PromRegistry:         reg,
-		MaxReconnectFailures: 3,
+		Logger:                       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                     eventBus,
+		PromRegistry:                 reg,
+		MaxReconnectFailureThreshold: 3,
 	})
 
 	// Add peer and set excessive failures
 	pg.AddPeer("44.0.0.1:3001", PeerSourceP2PGossip)
 
 	pg.mu.Lock()
-	pg.peers[0].ReconnectCount = 5 // Exceeds MaxReconnectFailures
+	pg.peers[0].ReconnectCount = 5 // Exceeds MaxReconnectFailureThreshold
 	pg.mu.Unlock()
 
 	pg.reconcile()
@@ -284,6 +291,29 @@ func TestPeerGovernor_Reconcile_Removal(t *testing.T) {
 	assert.Len(t, peers, 0)
 
 	// Event publishing is tested indirectly
+}
+
+func TestPeerGovernor_Reconcile_RemovalThresholdBoundary(t *testing.T) {
+	eventBus := newMockEventBus()
+	reg := prometheus.NewRegistry()
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                     eventBus,
+		PromRegistry:                 reg,
+		MaxReconnectFailureThreshold: 3,
+	})
+
+	pg.AddPeer("44.0.0.1:3001", PeerSourceP2PGossip)
+
+	pg.mu.Lock()
+	pg.peers[0].ReconnectCount = pg.config.MaxReconnectFailureThreshold
+	pg.mu.Unlock()
+
+	pg.reconcile()
+
+	peers := pg.GetPeers()
+	assert.Len(t, peers, 1)
 }
 
 func TestPeerGovernor_Reconcile_MinimumHotPeers(t *testing.T) {

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -108,7 +108,13 @@ func (p *PeerGovernor) reconcile() {
 						PeerStateChangeEvent{Address: peer.Address, Reason: "connection established"},
 					})
 				}
-			} else if peer.ReconnectCount > p.config.MaxReconnectFailures {
+			} else if peer.ReconnectCount >
+				p.config.MaxReconnectFailureThreshold {
+				if p.isTopologyPeer(peer.Source) {
+					continue
+				}
+				p.denyList[peer.NormalizedAddress] = time.Now().
+					Add(p.config.DenyDuration)
 				knownRemoved++
 				p.config.Logger.Info(
 					"removing failed peer",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves chainsync recovery and peer governance to prevent stalls and bootstrap flapping, with event‑driven connection recycle/removal and safer rollback-triggered re-syncs. Also hardens pool imports and aligns TX validation with upstream rules.

- **Bug Fixes**
  - Chainsync re-syncs when rollback points are ahead of or missing from the local tip; resets rollback/header/blockfetch state and publishes resync events with reasons.
  - Stalled clients use a grace period and cooldown; only the active stalled connection is recycled, non-primary stalled clients are removed via events; node subscribes to client-remove and connection-recycle requests.
  - Outbound connections classify expected dial/close/cancel errors, stop retries on shutdown/context cancel, and deny-list/remove non-topology peers after repeated failures.
  - Bootstrap recovery adds a cooldown after exit and is skipped when auto-recovery is disabled, enough hot peers exist, or warm candidates are available; “no genesis pools” now logs at info.
  - Config updates: MaxReconnectFailures → MaxReconnectFailureThreshold; added BootstrapRecoveryCooldown.

- **New Features**
  - More robust stake-pool delegation parsing via parsePoolDelegation, plus snapshot-based pool import fallback when cert-state has no pools (or none exist on resume).
  - Babbage/Conway validators now use upstream UtxoValidationRules; Conway errors include the rule index.

<sup>Written for commit 62ecae694e94dae7870c5b35063f9899dc925a3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stalled chain-sync detection with automatic guarded recovery and events to recycle or remove connections
  * Configurable bootstrap recovery cooldown and new reconnect failure threshold setting

* **Bug Fixes**
  * Improved rollback/resync handling with distinct recovery paths and published resync events
  * Safer outbound connection handling and deny-listing of repeatedly failing peers
  * Snapshot import fallback for missing pool data and multi-encoding stake-pool delegation decoding

* **Refactor**
  * Era-specific delegation of transaction validity checks to consensus validation rules

* **Tests**
  * Added unit tests for connection error classification helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->