### PR TITLE
refactor: event type renames

### DIFF
--- a/chain/event.go
+++ b/chain/event.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	ChainUpdateEventType = "chain.update"
-	ChainForkEventType   = "chain.fork-detected"
+	ChainForkEventType   = "chain.fork_detected"
 )
 
 type ChainBlockEvent struct {

--- a/connmanager/event.go
+++ b/connmanager/event.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	InboundConnectionEventType          = "connmanager.inbound-conn"
-	ConnectionClosedEventType           = "connmanager.conn-closed"
-	ConnectionRecycleRequestedEventType = "connmanager.connection-recycle-requested"
+	InboundConnectionEventType          = "connmanager.inbound_conn"
+	ConnectionClosedEventType           = "connmanager.conn_closed"
+	ConnectionRecycleRequestedEventType = "connmanager.connection_recycle_requested"
 )
 
 type InboundConnectionEvent struct {

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -24,11 +24,11 @@ import (
 )
 
 const (
-	BlockfetchEventType        event.EventType = "blockfetch.event"
+	BlockfetchEventType        event.EventType = "ledger.blockfetch"
 	BlockEventType             event.EventType = "ledger.block"
-	ChainsyncEventType         event.EventType = "chainsync.event"
+	ChainsyncEventType         event.EventType = "ledger.chainsync"
 	LedgerErrorEventType       event.EventType = "ledger.error"
-	PoolStateRestoredEventType event.EventType = "ledger.pool.restored"
+	PoolStateRestoredEventType event.EventType = "ledger.pool_restored"
 	TransactionEventType       event.EventType = "ledger.tx"
 )
 

--- a/ledger/forging/events.go
+++ b/ledger/forging/events.go
@@ -33,7 +33,7 @@ package forging
 import "github.com/blinklabs-io/dingo/event"
 
 // SlotBattleEventType is the event type for slot battles (competing blocks)
-const SlotBattleEventType = event.EventType("forging.slot-battle")
+const SlotBattleEventType = event.EventType("forging.slot_battle")
 
 // SlotBattleEvent is emitted when the node detects competing blocks for the
 // same slot, either from receiving an external block while preparing to forge

--- a/peergov/event.go
+++ b/peergov/event.go
@@ -19,17 +19,17 @@ import (
 )
 
 const (
-	OutboundConnectionEventType = "peergov.outbound-conn"
-	PeerDemotedEventType        = "peergov.peer-demoted"
-	PeerPromotedEventType       = "peergov.peer-promoted"
-	PeerRemovedEventType        = "peergov.peer-removed"
-	PeerAddedEventType          = "peergov.peer-added"
+	OutboundConnectionEventType = "peergov.outbound_conn"
+	PeerDemotedEventType        = "peergov.peer_demoted"
+	PeerPromotedEventType       = "peergov.peer_promoted"
+	PeerRemovedEventType        = "peergov.peer_removed"
+	PeerAddedEventType          = "peergov.peer_added"
 	// Phase 7: Enhanced Observability event types
-	PeerChurnEventType   = "peergov.peer-churn"
-	QuotaStatusEventType = "peergov.quota-status"
+	PeerChurnEventType   = "peergov.peer_churn"
+	QuotaStatusEventType = "peergov.quota_status"
 	// Phase 5: Bootstrap Peer Lifecycle event types
-	BootstrapExitedEventType   = "peergov.bootstrap-exited"
-	BootstrapRecoveryEventType = "peergov.bootstrap-recovery"
+	BootstrapExitedEventType   = "peergov.bootstrap_exited"
+	BootstrapRecoveryEventType = "peergov.bootstrap_recovery"
 )
 
 type OutboundConnectionEvent struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized event type names to snake_case and consistent namespaces across chain, ledger, forging, connmanager, and peergov for clearer logs and easier event filtering.

- **Refactors**
  - chain: chain.fork-detected → chain.fork_detected
  - connmanager: inbound-conn → inbound_conn, conn-closed → conn_closed, connection-recycle-requested → connection_recycle_requested
  - ledger: blockfetch.event → ledger.blockfetch, chainsync.event → ledger.chainsync, ledger.pool.restored → ledger.pool_restored
  - forging: forging.slot-battle → forging.slot_battle
  - peergov: outbound-conn → outbound_conn; peer-* and quota-status/peer-churn/bootstrap-* now use underscores (e.g., peer-demoted → peer_demoted, bootstrap-exited → bootstrap_exited)

- **Migration**
  - Update any event subscribers, log parsers, or metrics to the new names; search for hyphenated types and replace with the snake_case equivalents.

<sup>Written for commit 5ab2a2ad88a3e536559a6661d51449a8077d3886. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized event identifiers across chain, connection management, ledger, forging, and peer governance modules to follow consistent naming conventions for improved system cohesion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->