### PR TITLE
fix: appease new golangci-lint

### DIFF
--- a/bark/bark.go
+++ b/bark/bark.go
@@ -142,7 +142,7 @@ func (b *Bark) Start(ctx context.Context) error {
 		return err
 	}
 
-	go func() {
+	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
 		b.mu.Lock()
 		if b.server == server {

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -118,7 +118,7 @@ func (b *Blockfrost) Start(
 	)
 
 	// Monitor context for cancellation
-	go func() {
+	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
 		b.mu.Lock()
 		srv := b.httpServer

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -124,7 +124,7 @@ func (d *BlobStoreS3) opContext() (context.Context, context.CancelFunc) {
 	if timeout == 0 {
 		timeout = 60 * time.Second
 	}
-	return context.WithTimeout(context.Background(), timeout)
+	return context.WithTimeout(context.Background(), timeout) //nolint:gosec // G118: cancel func is returned to caller
 }
 
 // Close implements the BlobStore interface.

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -123,7 +123,7 @@ func (d *BlobStoreGCS) opContext() (context.Context, context.CancelFunc) {
 	if timeout == 0 {
 		timeout = 60 * time.Second
 	}
-	return context.WithTimeout(context.Background(), timeout)
+	return context.WithTimeout(context.Background(), timeout) //nolint:gosec // G118: cancel func is returned to caller
 }
 
 // Close closes the GCS client.

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -189,7 +189,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Launch context monitor before unlocking so there
 	// is no window where Stop() could race with the
 	// goroutine not yet existing.
-	go func() {
+	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
 		s.mu.Lock()
 		srv := s.httpServer

--- a/node.go
+++ b/node.go
@@ -431,7 +431,7 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	stallRecoveryGrace := max(chainsyncCfg.StallTimeout, 30*time.Second)
 	stallRecycleCooldown := max(2*chainsyncCfg.StallTimeout, 2*time.Minute)
-	recyclerCtx, recyclerCancel := context.WithCancel(n.ctx)
+	recyclerCtx, recyclerCancel := context.WithCancel(n.ctx) //nolint:gosec // G118: cancel func stored in started slice
 	started = append(started, recyclerCancel)
 	go func(interval, grace, cooldown time.Duration) {
 		ticker := time.NewTicker(interval)

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -208,7 +208,7 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 	}
 
 	// Monitor context for cancellation and shutdown server
-	go func() {
+	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
 		u.mu.Lock()
 		if u.server != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes new golangci-lint gosec G118 warnings by adding scoped //nolint tags to intentional long-lived goroutines and returned cancel functions. No behavior change; this only clears CI lint failures.

<sup>Written for commit 0912ada359dc1ca1f25026179fb2345e8ad7491a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

