### PR TITLE
fix(ledger): conway invalid tx processing

### DIFF
--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -170,6 +170,12 @@ func ValidateTxConway(
 	if _, ok := pp.(*conway.ConwayProtocolParameters); !ok {
 		return ErrIncompatibleProtocolParams
 	}
+	// Conway invalid transactions are expected to fail script validation on-chain.
+	// Skip local UTxO validation for these txs so block replay follows consensus
+	// handling of collateral/produced outputs rather than rejecting the block.
+	if !tx.IsValid() {
+		return nil
+	}
 	// Validate TX through ledger validation rules
 	errs := []error{}
 	var err error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip local UTxO validation for Conway transactions flagged invalid (tx.IsValid() == false) to match on-chain handling of script failures. This prevents block replay rejections by allowing collateral/produced outputs to be processed per consensus.

<sup>Written for commit dfa07cf5c7878a1f1a971d366feb05432cee68e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

