### PR TITLE
fix(mithril): increase allowed certificate depth

### DIFF
--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -567,7 +567,10 @@ func VerifyCertificateChain(
 		return errors.New("certificate hash is empty")
 	}
 
-	const maxDepth = 100
+	// Certificate chains on long-lived networks can exceed hundreds
+	// of links; keep a high bound to prevent runaway loops while
+	// allowing normal operation.
+	const maxDepth = 10000
 
 	currentHash := certificateHash
 	seen := make(map[string]bool)

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -386,4 +387,59 @@ func TestFindImmutableDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyCertificateChainAllowsDeepChains(t *testing.T) {
+	const chainDepth = 150
+	const snapshotDigest = "snapshot-digest-123"
+
+	certs := make(map[string]Certificate, chainDepth+1)
+	for i := 0; i <= chainDepth; i++ {
+		hash := fmt.Sprintf("cert-%03d", i)
+		prev := fmt.Sprintf("cert-%03d", i+1)
+		if i == chainDepth {
+			prev = hash
+		}
+		cert := Certificate{
+			Hash:         hash,
+			PreviousHash: prev,
+			ProtocolMessage: ProtocolMessage{
+				MessageParts: map[string]string{},
+			},
+		}
+		if i == 0 {
+			cert.ProtocolMessage.MessageParts["snapshot_digest"] =
+				snapshotDigest
+		}
+		certs[hash] = cert
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		var hash string
+		_, err := fmt.Sscanf(r.URL.Path, "/certificate/%s", &hash)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		cert, ok := certs[hash]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cert)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	err := VerifyCertificateChain(
+		context.Background(),
+		client,
+		"cert-000",
+		snapshotDigest,
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase allowed certificate chain depth in VerifyCertificateChain to prevent false failures on long-lived networks. Adds a test to ensure deep chains verify correctly.

- **Bug Fixes**
  - Raised max depth from 100 to 10000 to avoid premature termination when traversing long certificate chains.
  - Added TestVerifyCertificateChainAllowsDeepChains to validate a 150-link chain with matching snapshot digest.

<sup>Written for commit 4a4457ceae70736d565dac4d4ea15000f2a2389c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

