### PR TITLE
fix(ledger): validation cut-off

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2150,13 +2150,18 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			ls.RUnlock()
 
 			// Compute stability window and cutoff slot outside the callback
-			// to avoid reading ls fields without the lock. Use chain tip slot
-			// (not ledger tip) to prevent enabling validation too early during
-			// historical block sync.
+			// to avoid reading ls fields without the lock. Use the wall-clock
+			// slot as a reference when it exceeds the local chain tip. When
+			// syncing from genesis the local chain tip starts at 0, which
+			// would make cutoffSlot 0 and validate ALL historical blocks.
 			stabilityWindow := ls.calculateStabilityWindowForEra(snapshotEra.Id)
+			referenceSlot := chainTipSlot
+			if wallSlot, err := ls.CurrentSlot(); err == nil && wallSlot > referenceSlot {
+				referenceSlot = wallSlot
+			}
 			var cutoffSlot uint64
-			if chainTipSlot >= stabilityWindow {
-				cutoffSlot = chainTipSlot - stabilityWindow
+			if referenceSlot >= stabilityWindow {
+				cutoffSlot = referenceSlot - stabilityWindow
 			}
 
 			// Track pending state changes during transaction
@@ -2198,6 +2203,17 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 					} else if snapshotChainsyncState == SyncingChainsyncState && next.SlotNumber() >= cutoffSlot {
 						wantEnableValidation = true
 						shouldValidateBlock = true
+					}
+					// Flush accumulated deltas before the first validated
+					// block so that UTxOs created by earlier non-validated
+					// blocks are visible during validation lookups.
+					if shouldValidateBlock && len(deltaBatch.deltas) > 0 {
+						if err := deltaBatch.apply(ls, txn); err != nil {
+							deltaBatch.Release()
+							return err
+						}
+						deltaBatch.Release()
+						deltaBatch = NewLedgerDeltaBatch()
 					}
 					// Compute CBOR offsets for this block (required for transaction storage)
 					var blockOffsets *database.BlockIngestionResult


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix validation cutoff logic to prevent validating historical blocks during initial sync and ensure correct UTxO visibility before validation. Adjusts reference slot selection and delta handling in ledger processing.

- **Bug Fixes**
  - Use the larger of chain tip slot and wall-clock slot for the cutoff; avoids cutoff=0 at genesis and mass validation of history.
  - Flush accumulated deltas before the first validated block so prior UTxOs are visible during validation lookups.

<sup>Written for commit f37b058da47df202ee912896b24f28bd5f5aaf0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

