### PR TITLE
fix(ledger): header verification sync

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/connmanager"
 	cardano "github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -156,6 +158,28 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 		}
 	} else if e.Block != nil {
 		if err := ls.handleEventBlockfetchBlock(e); err != nil {
+			if strings.Contains(
+				err.Error(),
+				"block header crypto verification failed",
+			) && ls.config.EventBus != nil {
+				ls.config.Logger.Warn(
+					"recycling connection after header verification failure",
+					"component", "ledger",
+					"connection_id", e.ConnectionId.String(),
+					"slot", e.Point.Slot,
+					"hash", hex.EncodeToString(e.Point.Hash),
+				)
+				ls.config.EventBus.Publish(
+					connmanager.ConnectionRecycleRequestedEventType,
+					event.NewEvent(
+						connmanager.ConnectionRecycleRequestedEventType,
+						connmanager.ConnectionRecycleRequestedEvent{
+							ConnectionId: e.ConnectionId,
+							Reason:       "block_header_verification_failure",
+						},
+					),
+				)
+			}
 			ls.config.Logger.Error(
 				"failed to handle block",
 				"component", "ledger",
@@ -440,6 +464,38 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	// Track upstream tip for sync progress reporting
 	if e.Tip.Point.Slot > ls.syncUpstreamTipSlot.Load() {
 		ls.syncUpstreamTipSlot.Store(e.Tip.Point.Slot)
+	}
+
+	// Verify header crypto before accepting it into the header queue.
+	// Skip during historical sync (validationEnabled=false) because
+	// historical blocks were already validated by the network and the
+	// epoch nonce may not be fully computed yet (e.g. Byron→Shelley).
+	if ls.validationEnabled {
+		if err := ls.verifyBlockHeaderOnlyCrypto(e.BlockHeader); err != nil {
+			if ls.config.EventBus != nil {
+				ls.config.Logger.Warn(
+					"recycling connection after header verification failure",
+					"component", "ledger",
+					"connection_id", e.ConnectionId.String(),
+					"slot", e.Point.Slot,
+					"hash", hex.EncodeToString(e.Point.Hash),
+				)
+				ls.config.EventBus.Publish(
+					connmanager.ConnectionRecycleRequestedEventType,
+					event.NewEvent(
+						connmanager.ConnectionRecycleRequestedEventType,
+						connmanager.ConnectionRecycleRequestedEvent{
+							ConnectionId: e.ConnectionId,
+							Reason:       "header_verification_failure",
+						},
+					),
+				)
+			}
+			return fmt.Errorf(
+				"block header crypto verification failed: %w",
+				err,
+			)
+		}
 	}
 
 	if ls.chainsyncState == RollbackChainsyncState {
@@ -759,17 +815,15 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	// exceeding the downstream peer's ChainSync idle timeout.
 
 	// Verify block header cryptographic proofs (VRF, KES).
-	// Verification is always fatal — invalid blocks are rejected
-	// regardless of sync position. The epoch cache is populated at
-	// startup by loadEpochs, so epoch data is available for all
-	// blocks in the current epoch. Epoch transitions are processed
-	// synchronously during ledger block processing, which runs
-	// ahead of blockfetch delivery.
-	if err := ls.verifyBlockHeaderCrypto(e.Block); err != nil {
-		return fmt.Errorf(
-			"block header crypto verification failed: %w",
-			err,
-		)
+	// Skip during historical sync (validationEnabled=false) because
+	// historical blocks were already validated by the network.
+	if ls.validationEnabled {
+		if err := ls.verifyBlockHeaderCrypto(e.Block); err != nil {
+			return fmt.Errorf(
+				"block header crypto verification failed: %w",
+				err,
+			)
+		}
 	}
 	// Add block to chain with its own transaction so it becomes
 	// visible to iterators immediately after commit.

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -24,7 +24,36 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
+
+// headerOnlyBlock adapts a block header to the Block interface so we can
+// run strict VRF/KES verification at chainsync-header time.
+type headerOnlyBlock struct {
+	header ledger.BlockHeader
+}
+
+func (b headerOnlyBlock) Header() ledger.BlockHeader { return b.header }
+func (b headerOnlyBlock) Type() int                  { return 0 }
+func (b headerOnlyBlock) Transactions() []lcommon.Transaction {
+	return nil
+}
+func (b headerOnlyBlock) Utxorpc() (*utxorpc.Block, error) { return nil, nil }
+func (b headerOnlyBlock) Hash() lcommon.Blake2b256         { return b.header.Hash() }
+func (b headerOnlyBlock) PrevHash() lcommon.Blake2b256     { return b.header.PrevHash() }
+func (b headerOnlyBlock) BlockNumber() uint64              { return b.header.BlockNumber() }
+func (b headerOnlyBlock) SlotNumber() uint64               { return b.header.SlotNumber() }
+func (b headerOnlyBlock) IssuerVkey() lcommon.IssuerVkey   { return b.header.IssuerVkey() }
+func (b headerOnlyBlock) BlockBodySize() uint64            { return b.header.BlockBodySize() }
+func (b headerOnlyBlock) Era() lcommon.Era                 { return b.header.Era() }
+func (b headerOnlyBlock) Cbor() []byte                     { return b.header.Cbor() }
+func (b headerOnlyBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return b.header.BlockBodyHash()
+}
+
+func (ls *LedgerState) verifyBlockHeaderOnlyCrypto(header ledger.BlockHeader) error {
+	return ls.verifyBlockHeaderCrypto(headerOnlyBlock{header: header})
+}
 
 // verifyBlockHeader performs cryptographic verification of a block header.
 // This includes VRF proof verification and KES signature verification.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add cryptographic header verification at ChainSync header time and recycle connections on failure. Skip verification during historical sync to avoid false negatives.

- **Bug Fixes**
  - Verify VRF/KES on headers before queuing (verifyBlockHeaderOnlyCrypto).
  - Add headerOnlyBlock adapter to reuse existing verification logic.
  - Gate header/block verification behind validationEnabled; skip during historical sync.
  - On verification failure, log and publish ConnectionRecycleRequestedEvent (reasons: header_verification_failure, block_header_verification_failure).

<sup>Written for commit 1098f31f1f4213229430ef942e1de12f81b2f7fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

