### PR TITLE
fix: peer filtering

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -439,6 +439,20 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 	var bestPeerTip *PeerChainTip
 
 	for connId, peerTip := range cs.peerTips {
+		// Don't consider peers that are implausibly far behind local tip.
+		// This prevents switching to stale or cross-network peers when
+		// local tip and k are known.
+		if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 &&
+			peerTip.Tip.BlockNumber+cs.securityParam < cs.localTip.BlockNumber {
+			cs.config.Logger.Debug(
+				"skipping implausibly-behind peer",
+				"connection_id", connId.String(),
+				"peer_block_number", peerTip.Tip.BlockNumber,
+				"local_block_number", cs.localTip.BlockNumber,
+				"security_param", cs.securityParam,
+			)
+			continue
+		}
 		if peerTip.IsStale(cs.config.StaleTipThreshold) {
 			cs.config.Logger.Debug(
 				"skipping stale peer",

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -1139,3 +1139,46 @@ func TestChainSelectorNormalOperationWithinLimit(t *testing.T) {
 		)
 	}
 }
+
+func TestSelectBestChainSkipsImplausiblyBehindPeer(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: 2160,
+	})
+
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
+		BlockNumber: 50000,
+	})
+
+	behindConn := newTestConnectionId(1)
+	behindTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 70000, Hash: []byte("behind")},
+		BlockNumber: 47000, // 3000 behind (>k)
+	}
+	cs.UpdatePeerTip(behindConn, behindTip, nil)
+
+	bestPeer := cs.SelectBestChain()
+	assert.Nil(t, bestPeer, "implausibly-behind peer should not be selected")
+}
+
+func TestSelectBestChainAllowsPlausiblyBehindPeer(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: 2160,
+	})
+
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
+		BlockNumber: 50000,
+	})
+
+	behindConn := newTestConnectionId(1)
+	behindTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 98000, Hash: []byte("behind-ok")},
+		BlockNumber: 49000, // 1000 behind (<=k)
+	}
+	cs.UpdatePeerTip(behindConn, behindTip, nil)
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, behindConn, *bestPeer)
+}

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -38,7 +38,7 @@ const DefaultMaxClients = 3
 // client with no activity is considered stalled. This value
 // must stay in sync with config.DefaultChainsyncConfig() and
 // the fallback in internal/node/node.go.
-const DefaultStallTimeout = 30 * time.Second
+const DefaultStallTimeout = 2 * time.Minute
 
 // ClientStatus represents the sync status of a chainsync client.
 type ClientStatus int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,7 +132,7 @@ type ChainsyncConfig struct {
 	// connections. Default: 3.
 	MaxClients int `yaml:"maxClients"   envconfig:"DINGO_CHAINSYNC_MAX_CLIENTS"`
 	// StallTimeout is the duration after which a client with no
-	// activity is considered stalled. Default: "30s".
+	// activity is considered stalled. Default: "2m".
 	StallTimeout string `yaml:"stallTimeout" envconfig:"DINGO_CHAINSYNC_STALL_TIMEOUT"`
 }
 
@@ -142,7 +142,7 @@ type ChainsyncConfig struct {
 func DefaultChainsyncConfig() ChainsyncConfig {
 	return ChainsyncConfig{
 		MaxClients:   3,
-		StallTimeout: "30s",
+		StallTimeout: "2m",
 	}
 }
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
-	"github.com/blinklabs-io/dingo/connmanager"
 	cardano "github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
@@ -244,9 +244,21 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 	// Filter events from non-active connections when chain selection is enabled
 	if activeConnId, configured := ls.detectConnectionSwitch(); configured {
 		if activeConnId == nil {
-			// No active connection set yet, process this event
+			// If we already have local chain progress, avoid applying
+			// rollback/header events until an active connection is
+			// selected. This prevents transient "active=nil" races from
+			// accepting deep rollback signals from non-authoritative peers.
+			if ls.chain.Tip().Point.Slot > 0 {
+				ls.config.Logger.Debug(
+					"no active connection, dropping rollback event",
+					"connection_id", e.ConnectionId.String(),
+					"slot", e.Point.Slot,
+					"local_tip_slot", ls.chain.Tip().Point.Slot,
+				)
+				return nil
+			}
 			ls.config.Logger.Debug(
-				"no active connection, processing rollback event",
+				"no active connection at origin, processing rollback event",
 				"connection_id", e.ConnectionId.String(),
 				"slot", e.Point.Slot,
 			)
@@ -432,9 +444,19 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	// Filter events from non-active connections when chain selection is enabled
 	if activeConnId, configured := ls.detectConnectionSwitch(); configured {
 		if activeConnId == nil {
-			// No active connection set yet, process this event
+			// If we already have local chain progress, avoid applying
+			// events until an active connection is selected.
+			if ls.chain.Tip().Point.Slot > 0 {
+				ls.config.Logger.Debug(
+					"no active connection, dropping event",
+					"connection_id", e.ConnectionId.String(),
+					"slot", e.Point.Slot,
+					"local_tip_slot", ls.chain.Tip().Point.Slot,
+				)
+				return nil
+			}
 			ls.config.Logger.Debug(
-				"no active connection, processing event",
+				"no active connection at origin, processing event",
 				"connection_id", e.ConnectionId.String(),
 				"slot", e.Point.Slot,
 			)

--- a/node.go
+++ b/node.go
@@ -438,12 +438,29 @@ func (n *Node) Run(ctx context.Context) error {
 		defer ticker.Stop()
 		recycleAt := make(map[string]time.Time)
 		lastRecycled := make(map[string]time.Time)
+		lastProgressSlot := n.chainManager.PrimaryChain().Tip().Point.Slot
+		lastProgressAt := time.Now()
+		// Trigger plateau recovery before the hard 10m SLO so
+		// recycle + reconnect time does not breach the budget.
+		const plateauThreshold = 8 * time.Minute
 		for {
 			select {
 			case <-recyclerCtx.Done():
 				return
 			case <-ticker.C:
 				now := time.Now()
+				localTip := n.chainManager.PrimaryChain().Tip()
+				localTipSlot := localTip.Point.Slot
+				if n.chainSelector != nil {
+					n.chainSelector.SetLocalTip(localTip)
+					if k := n.ledgerState.SecurityParam(); k > 0 {
+						n.chainSelector.SetSecurityParam(uint64(k)) //nolint:gosec
+					}
+				}
+				if localTipSlot > lastProgressSlot {
+					lastProgressSlot = localTipSlot
+					lastProgressAt = now
+				}
 				n.chainsyncState.CheckStalledClients()
 				trackedClients := n.chainsyncState.GetTrackedClients()
 				trackedByID := make(
@@ -464,13 +481,53 @@ func (n *Node) Run(ctx context.Context) error {
 						delete(lastRecycled, connKey)
 					}
 				}
+				// Safety net: if local tip has not moved for a long time
+				// while peers are ahead, recycle the selected chainsync
+				// connection even if it is not marked stalled.
+				if now.Sub(lastProgressAt) > plateauThreshold &&
+					n.chainSelector != nil {
+					if bestPeer := n.chainSelector.GetBestPeer(); bestPeer != nil {
+						if bestPeerTip := n.chainSelector.GetPeerTip(*bestPeer); bestPeerTip != nil &&
+							bestPeerTip.Tip.Point.Slot > localTipSlot {
+							targetConn := n.chainsyncState.GetClientConnId()
+							if targetConn == nil {
+								targetCopy := *bestPeer
+								targetConn = &targetCopy
+							}
+							connKey := targetConn.String()
+							if last, ok := lastRecycled[connKey]; !ok ||
+								now.Sub(last) >= cooldown {
+								n.config.logger.Warn(
+									"local tip plateau detected, recycling chainsync connection",
+									"connection_id", connKey,
+									"local_tip_slot", localTipSlot,
+									"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+									"plateau_duration", now.Sub(lastProgressAt),
+								)
+								n.eventBus.PublishAsync(
+									connmanager.ConnectionRecycleRequestedEventType,
+									event.NewEvent(
+										connmanager.ConnectionRecycleRequestedEventType,
+										connmanager.ConnectionRecycleRequestedEvent{
+											ConnectionId: *targetConn,
+											ConnKey:      connKey,
+											Reason:       "local_tip_plateau",
+										},
+									),
+								)
+								delete(recycleAt, connKey)
+								lastRecycled[connKey] = now
+								lastProgressAt = now
+							}
+						}
+					}
+				}
 				for _, conn := range trackedClients {
 					if conn.Status != chainsync.ClientStatusStalled {
 						continue
 					}
 					connKey := conn.ConnId.String()
-					dueAt, exists := recycleAt[connKey]
-					if !exists || dueAt.Before(now) {
+					if _, exists := recycleAt[connKey]; !exists {
 						recycleAt[connKey] = now.Add(grace)
 						n.config.logger.Info(
 							"chainsync client stalled, scheduling guarded recycle",
@@ -497,8 +554,29 @@ func (n *Node) Run(ctx context.Context) error {
 					}
 					active := n.chainsyncState.GetClientConnId()
 					if active == nil {
-						// No active chainsync connection is selected yet.
-						// Skip recycle and re-check on the next tick.
+						// If no active client is selected and this client
+						// is overdue + stalled, recycle to force a fresh
+						// connection attempt and avoid indefinite stalls.
+						n.config.logger.Warn(
+							"chainsync client stalled with no active selection, recycling connection",
+							"connection_id", connKey,
+							"stall_timeout", chainsyncCfg.StallTimeout,
+							"grace_period", grace,
+							"recycle_cooldown", cooldown,
+						)
+						n.eventBus.PublishAsync(
+							connmanager.ConnectionRecycleRequestedEventType,
+							event.NewEvent(
+								connmanager.ConnectionRecycleRequestedEventType,
+								connmanager.ConnectionRecycleRequestedEvent{
+									ConnectionId: connId,
+									ConnKey:      connKey,
+									Reason:       "stalled_connection_no_active_selection",
+								},
+							),
+						)
+						delete(recycleAt, connKey)
+						lastRecycled[connKey] = now
 						continue
 					}
 					if active.String() != connKey {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -367,6 +367,13 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	point ocommon.Point,
 	tip ochainsync.Tip,
 ) error {
+	// Only feed ledger from the currently selected chainsync connection.
+	if o.ChainsyncState != nil {
+		if active := o.ChainsyncState.GetClientConnId(); active != nil &&
+			*active != ctx.ConnectionId {
+			return nil
+		}
+	}
 	// Generate event
 	o.EventBus.Publish(
 		ledger.ChainsyncEventType,
@@ -441,20 +448,39 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				},
 			),
 		)
-		// Publish chainsync event for ledger processing
-		o.EventBus.Publish(
-			ledger.ChainsyncEventType,
-			event.NewEvent(
+		// Only feed ledger from the currently selected chainsync
+		// connection to avoid overloading the ledger subscriber
+		// queue with non-active peer traffic.
+		if o.ChainsyncState == nil {
+			o.EventBus.Publish(
 				ledger.ChainsyncEventType,
-				ledger.ChainsyncEvent{
-					ConnectionId: ctx.ConnectionId,
-					Point:        point,
-					Type:         blockType,
-					BlockHeader:  v,
-					Tip:          tip,
-				},
-			),
-		)
+				event.NewEvent(
+					ledger.ChainsyncEventType,
+					ledger.ChainsyncEvent{
+						ConnectionId: ctx.ConnectionId,
+						Point:        point,
+						Type:         blockType,
+						BlockHeader:  v,
+						Tip:          tip,
+					},
+				),
+			)
+		} else if active := o.ChainsyncState.GetClientConnId(); active == nil ||
+			*active == ctx.ConnectionId {
+			o.EventBus.Publish(
+				ledger.ChainsyncEventType,
+				event.NewEvent(
+					ledger.ChainsyncEventType,
+					ledger.ChainsyncEvent{
+						ConnectionId: ctx.ConnectionId,
+						Point:        point,
+						Type:         blockType,
+						BlockHeader:  v,
+						Tip:          tip,
+					},
+				),
+			)
+		}
 		// Update ChainSync performance metrics for peer scoring
 		o.updateChainsyncMetrics(ctx.ConnectionId, tip)
 	default:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip implausibly-behind peers in chain selection and send ledger events only from the active chainsync to prevent stale rollbacks and stuck syncs. Adds plateau recovery and raises the stall timeout to reduce false stalls.

- **Bug Fixes**
  - Chain selection: ignore peers >k behind the local tip; allow peers within k; added tests.
  - Ledger/events: gate roll forward/back by the active chainsync connection; drop events when no active is selected and the local chain has progressed.
  - Node: detect local-tip plateaus (8m) and recycle chainsync; recycle stalled clients with no active selection; keep the selector updated with the local tip and k.
  - Config: increase chainsync stall timeout default from 30s to 2m.

<sup>Written for commit e5f23d189a54dcd755320720a7f1ef7ca2cbf85f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced peer selection logic to better identify and filter peers that are implausibly behind the local chain.
  * Increased chain synchronization stall timeout to improve stability during network delays.
  * Added plateau detection mechanism to automatically recycle connections when local chain progress stalls while peers advance.
  * Improved event filtering to prevent non-active peer traffic from affecting synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->