### PR TITLE
fix: epoch nonce resume

### DIFF
--- a/database/block_nonce.go
+++ b/database/block_nonce.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"github.com/blinklabs-io/dingo/database/models"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
@@ -27,6 +28,26 @@ func (d *Database) GetBlockNonce(
 		return d.metadata.GetBlockNonce(point, nil)
 	}
 	return d.metadata.GetBlockNonce(point, txn.Metadata())
+}
+
+// GetBlockNoncesInSlotRange fetches all block nonces in [startSlot, endSlot).
+func (d *Database) GetBlockNoncesInSlotRange(
+	startSlot uint64,
+	endSlot uint64,
+	txn *Txn,
+) ([]models.BlockNonce, error) {
+	if txn == nil {
+		return d.metadata.GetBlockNoncesInSlotRange(
+			startSlot,
+			endSlot,
+			nil,
+		)
+	}
+	return d.metadata.GetBlockNoncesInSlotRange(
+		startSlot,
+		endSlot,
+		txn.Metadata(),
+	)
 }
 
 // DeleteBlockNoncesBeforeSlot removes all block_nonces older than the given slot number

--- a/database/plugin/metadata/mysql/block_nonce.go
+++ b/database/plugin/metadata/mysql/block_nonce.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -70,6 +71,27 @@ func (d *MetadataStoreMysql) GetBlockNonce(
 		return nil, nil // Record not found
 	}
 	return ret.Nonce, nil
+}
+
+// GetBlockNoncesInSlotRange retrieves all block nonces where slot >= startSlot and slot < endSlot.
+func (d *MetadataStoreMysql) GetBlockNoncesInSlotRange(
+	startSlot uint64,
+	endSlot uint64,
+	txn types.Txn,
+) ([]models.BlockNonce, error) {
+	var results []models.BlockNonce
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("resolveDB failed for slot range [%d,%d): %w", startSlot, endSlot, err)
+	}
+	result := db.
+		Where("slot >= ? AND slot < ?", startSlot, endSlot).
+		Order("slot ASC").
+		Find(&results)
+	if result.Error != nil {
+		return nil, fmt.Errorf("query failed for slot range [%d,%d): %w", startSlot, endSlot, result.Error)
+	}
+	return results, nil
 }
 
 // DeleteBlockNoncesBeforeSlot deletes block_nonce records with slot less than the specified value

--- a/database/plugin/metadata/postgres/block_nonce.go
+++ b/database/plugin/metadata/postgres/block_nonce.go
@@ -16,6 +16,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -70,6 +71,27 @@ func (d *MetadataStorePostgres) GetBlockNonce(
 		return nil, nil // Record not found
 	}
 	return ret.Nonce, nil
+}
+
+// GetBlockNoncesInSlotRange retrieves all block nonces where slot >= startSlot and slot < endSlot.
+func (d *MetadataStorePostgres) GetBlockNoncesInSlotRange(
+	startSlot uint64,
+	endSlot uint64,
+	txn types.Txn,
+) ([]models.BlockNonce, error) {
+	var results []models.BlockNonce
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("resolveDB failed for slot range [%d,%d): %w", startSlot, endSlot, err)
+	}
+	result := db.
+		Where("slot >= ? AND slot < ?", startSlot, endSlot).
+		Order("slot ASC").
+		Find(&results)
+	if result.Error != nil {
+		return nil, fmt.Errorf("query failed for slot range [%d,%d): %w", startSlot, endSlot, result.Error)
+	}
+	return results, nil
 }
 
 // DeleteBlockNoncesBeforeSlot deletes block_nonce records with slot less than the specified value

--- a/database/plugin/metadata/sqlite/block_nonce.go
+++ b/database/plugin/metadata/sqlite/block_nonce.go
@@ -72,6 +72,27 @@ func (d *MetadataStoreSqlite) GetBlockNonce(
 	return ret.Nonce, nil
 }
 
+// GetBlockNoncesInSlotRange retrieves all block nonces where slot >= startSlot and slot < endSlot.
+func (d *MetadataStoreSqlite) GetBlockNoncesInSlotRange(
+	startSlot uint64,
+	endSlot uint64,
+	txn types.Txn,
+) ([]models.BlockNonce, error) {
+	var results []models.BlockNonce
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where("slot >= ? AND slot < ?", startSlot, endSlot).
+		Order("slot ASC").
+		Find(&results)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return results, nil
+}
+
 // DeleteBlockNoncesBeforeSlot deletes block_nonce records with slot less than the specified value
 func (d *MetadataStoreSqlite) DeleteBlockNoncesBeforeSlot(
 	slotNumber uint64,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -184,6 +184,13 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]byte, error)
 
+	// GetBlockNoncesInSlotRange retrieves all block nonces in [startSlot, endSlot).
+	GetBlockNoncesInSlotRange(
+		startSlot uint64,
+		endSlot uint64,
+		txn types.Txn,
+	) ([]models.BlockNonce, error)
+
 	// GetDatum retrieves a datum by its hash, returning nil if not found.
 	GetDatum(
 		lcommon.Blake2b256,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
-	"github.com/blinklabs-io/dingo/connmanager"
 	cardano "github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
@@ -1316,16 +1316,81 @@ func (ls *LedgerState) calculateEpochNonce(
 		prevCandidateNonce = genesisHashBytes
 	}
 
+	// When importing from a snapshot, currentEpoch may carry tip-time
+	// nonce state (evolving/candidate already advanced through the
+	// imported tip slot). In that case, continue accumulation from the
+	// next slot rather than replaying from epoch start.
+	computeStartSlot := currentEpoch.StartSlot
+	computeEpochLength := uint64(currentEpoch.LengthInSlots)
+	epochEndSlot := currentEpoch.StartSlot +
+		uint64(currentEpoch.LengthInSlots)
+	ls.RLock()
+	tipSlot := ls.currentTip.Point.Slot
+	tipBlockNonceCopy := append([]byte(nil), ls.currentTipBlockNonce...)
+	ls.RUnlock()
+	if tipSlot >= currentEpoch.StartSlot &&
+		tipSlot < epochEndSlot &&
+		len(currentEpoch.CandidateNonce) == 32 &&
+		len(currentEpoch.EvolvingNonce) == 32 &&
+		len(tipBlockNonceCopy) == 32 &&
+		bytes.Equal(currentEpoch.EvolvingNonce, tipBlockNonceCopy) {
+		if nextSlot := tipSlot + 1; nextSlot < epochEndSlot {
+			computeStartSlot = nextSlot
+			computeEpochLength = epochEndSlot - nextSlot
+		} else {
+			// Tip already at/after epoch end: no additional blocks to fold.
+			computeEpochLength = 0
+		}
+	} else if len(currentEpoch.EvolvingNonce) == 32 {
+		// Resume fallback: if epoch nonce state was checkpointed at an
+		// earlier slot, locate that anchor by matching stored block nonces
+		// and continue from the following slot.
+		nonceRows, nonceErr := ls.db.GetBlockNoncesInSlotRange(
+			currentEpoch.StartSlot,
+			epochEndSlot,
+			txn,
+		)
+		if nonceErr != nil {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"fetch block nonces in epoch range: %w",
+				nonceErr,
+			)
+		}
+		var anchorSlot uint64
+		var foundAnchor bool
+		for _, row := range nonceRows {
+			if len(row.Nonce) == 32 &&
+				bytes.Equal(currentEpoch.EvolvingNonce, row.Nonce) {
+				anchorSlot = row.Slot
+				foundAnchor = true
+				break
+			}
+		}
+		if !foundAnchor {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"cannot resume epoch nonce: stored evolving nonce has no matching anchor block in epoch range [%d, %d)",
+				currentEpoch.StartSlot,
+				epochEndSlot,
+			)
+		}
+		if anchorSlot+1 < epochEndSlot {
+			computeStartSlot = anchorSlot + 1
+			computeEpochLength = epochEndSlot - computeStartSlot
+		} else {
+			computeEpochLength = 0
+		}
+	}
+
 	// Compute candidateNonce (frozen at stability window cutoff)
-	// and evolvingNonce (after all blocks) from blocks in the
-	// current epoch. Each block's VRF output is accumulated via
-	// the Nonce semigroup (⭒) starting from prevEvolvingNonce.
+	// and evolvingNonce (after all blocks) from the remaining
+	// current-epoch blocks. Each block's VRF output is accumulated
+	// via the Nonce semigroup (⭒) starting from prevEvolvingNonce.
 	candidateNonce, evolvingNonce, err := ls.computeCandidateNonce(
 		txn,
 		prevEvolvingNonce,
 		prevCandidateNonce,
-		currentEpoch.StartSlot,
-		uint64(currentEpoch.LengthInSlots),
+		computeStartSlot,
+		computeEpochLength,
 	)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf(
@@ -1337,8 +1402,6 @@ func (ls *LedgerState) calculateEpochNonce(
 	// This is prevHashToNonce(prevHash of last block of current
 	// epoch N). It will be stored as LastEpochBlockNonce on the
 	// new epoch record.
-	epochEndSlot := currentEpoch.StartSlot +
-		uint64(currentEpoch.LengthInSlots)
 	var labNonceToSave []byte
 	blockLastCurrentEpoch, err := database.BlockBeforeSlotTxn(
 		txn,

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -213,7 +214,10 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 		return models.Epoch{}, errors.New("epoch cache is empty")
 	}
 
-	for _, ep := range cacheCopy {
+	// Search newest-to-oldest so that if cache entries overlap
+	// (e.g., after rollback/rebuild), we use the most recent epoch data.
+	for i := len(cacheCopy) - 1; i >= 0; i-- {
+		ep := cacheCopy[i]
 		if ep.LengthInSlots == 0 {
 			continue
 		}
@@ -393,12 +397,80 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		prevCandidateNonce = genesisHash
 	}
 
+	computeStartSlot := prevEpoch.StartSlot
+	computeEpochLength := uint64(prevEpoch.LengthInSlots)
+	prevEpochEndSlot := prevEpoch.StartSlot +
+		uint64(prevEpoch.LengthInSlots)
+	// When resuming from a snapshot, prevEpoch can carry nonce state
+	// already advanced to the imported tip slot. Continue from the next
+	// slot in that case instead of replaying from epoch start.
+	ls.RLock()
+	currentTipSlot := ls.currentTip.Point.Slot
+	currentTipBlockNonce := append(
+		[]byte(nil),
+		ls.currentTipBlockNonce...,
+	)
+	ls.RUnlock()
+	if currentTipSlot >= prevEpoch.StartSlot &&
+		currentTipSlot < prevEpochEndSlot &&
+		len(prevEpoch.CandidateNonce) == 32 &&
+		len(prevEpoch.EvolvingNonce) == 32 &&
+		len(currentTipBlockNonce) == 32 &&
+		bytes.Equal(prevEpoch.EvolvingNonce, currentTipBlockNonce) {
+		if nextSlot := currentTipSlot + 1; nextSlot < prevEpochEndSlot {
+			computeStartSlot = nextSlot
+			computeEpochLength = prevEpochEndSlot - nextSlot
+		} else {
+			// Tip already at/after epoch end: no additional blocks to fold.
+			computeEpochLength = 0
+		}
+	} else if len(prevEpoch.EvolvingNonce) == 32 {
+		// Resume fallback: when epoch nonce state was checkpointed at an
+		// earlier slot, detect that anchor by matching block nonces in this
+		// epoch range. If found, continue from the following slot instead of
+		// replaying from epoch start.
+		nonceRows, nonceErr := ls.db.GetBlockNoncesInSlotRange(
+			prevEpoch.StartSlot,
+			prevEpochEndSlot,
+			nil,
+		)
+		if nonceErr != nil {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"fetch block nonces in epoch range: %w",
+				nonceErr,
+			)
+		}
+		var anchorSlot uint64
+		var foundAnchor bool
+		for _, row := range nonceRows {
+			if len(row.Nonce) == 32 &&
+				bytes.Equal(prevEpoch.EvolvingNonce, row.Nonce) {
+				anchorSlot = row.Slot
+				foundAnchor = true
+				break
+			}
+		}
+		if !foundAnchor {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"cannot resume epoch nonce: stored evolving nonce has no matching anchor block in epoch range [%d, %d)",
+				prevEpoch.StartSlot,
+				prevEpochEndSlot,
+			)
+		}
+		if anchorSlot+1 < prevEpochEndSlot {
+			computeStartSlot = anchorSlot + 1
+			computeEpochLength = prevEpochEndSlot - computeStartSlot
+		} else {
+			computeEpochLength = 0
+		}
+	}
+
 	candidateNonce, evolvingNonce, err := ls.computeCandidateNonce(
 		nil, // non-transactional
 		prevEvolvingNonce,
 		prevCandidateNonce,
-		prevEpoch.StartSlot,
-		uint64(prevEpoch.LengthInSlots),
+		computeStartSlot,
+		computeEpochLength,
 	)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf(
@@ -407,8 +479,6 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 	}
 
 	// Compute the labNonce to SAVE for the next epoch's formula.
-	prevEpochEndSlot := prevEpoch.StartSlot +
-		uint64(prevEpoch.LengthInSlots)
 	var labNonceToSave []byte
 	boundaryBlock, err := database.BlockBeforeSlot(
 		ls.db,

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -83,6 +83,13 @@ type RawLedgerState struct {
 	// tip block nonce so that subsequent block processing computes
 	// correct rolling nonces after a mithril snapshot restore.
 	EvolvingNonce []byte
+	// CandidateNonce is the Praos candidate nonce as of the imported
+	// tip. This is required to correctly continue nonce accumulation
+	// from snapshot tip to epoch boundary.
+	CandidateNonce []byte
+	// LastEpochBlockNonce is the lagged lab nonce from consensus
+	// state (used in epoch nonce calculation).
+	LastEpochBlockNonce []byte
 	// EraBoundsWarning holds a non-fatal error from era bounds
 	// extraction. When set, epoch generation falls back to
 	// the single-epoch path.
@@ -1417,8 +1424,8 @@ func generateAndSaveEpochs(
 			cfg.State.Epoch,
 			cfg.State.EpochNonce,
 			cfg.State.EvolvingNonce,
-			nil, // candidateNonce not available from import
-			nil, // lastEpochBlockNonce not available from import
+			cfg.State.CandidateNonce,
+			cfg.State.LastEpochBlockNonce,
 			uint(cfg.State.EraIndex),
 			slotLength,
 			lengthInSlots,
@@ -1529,11 +1536,15 @@ func generateAndSaveEpochs(
 
 		var nonce []byte
 		var evolvingNonce []byte
+		var candidateNonce []byte
+		var lastEpochBlockNonce []byte
 		if e == cfg.State.Epoch {
 			nonce = cfg.State.EpochNonce
 			// NOTE: tip-time EvolvingNonce (may be mid-epoch).
 			// Corrected by the first full epoch rollover.
 			evolvingNonce = cfg.State.EvolvingNonce
+			candidateNonce = cfg.State.CandidateNonce
+			lastEpochBlockNonce = cfg.State.LastEpochBlockNonce
 		}
 
 		if err := store.SetEpoch(
@@ -1541,8 +1552,8 @@ func generateAndSaveEpochs(
 			e,
 			nonce,
 			evolvingNonce,
-			nil, // candidateNonce not available from import
-			nil, // lastEpochBlockNonce not available from import
+			candidateNonce,
+			lastEpochBlockNonce,
 			currentEraId,
 			slotLength,
 			epochLength,

--- a/ledgerstate/snapshot.go
+++ b/ledgerstate/snapshot.go
@@ -349,6 +349,8 @@ func parseSnapshotData(data []byte) (*RawLedgerState, error) {
 	} else if nonces != nil {
 		result.EpochNonce = nonces.EpochNonce
 		result.EvolvingNonce = nonces.EvolvingNonce
+		result.CandidateNonce = nonces.CandidateNonce
+		result.LastEpochBlockNonce = nonces.LastEpochBlockNonce
 	}
 
 	return result, nil
@@ -705,6 +707,12 @@ type praosNonces struct {
 	// EpochNonce is the epoch nonce (eta_0) used for VRF leader
 	// election in the current epoch.
 	EpochNonce []byte
+	// CandidateNonce is the current Praos candidate nonce (eta_c)
+	// at the imported tip.
+	CandidateNonce []byte
+	// LastEpochBlockNonce is the lagged lab nonce used in epoch
+	// nonce calculation.
+	LastEpochBlockNonce []byte
 }
 
 // parsePraosNonces extracts the evolving nonce and epoch nonce from
@@ -836,6 +844,39 @@ func parsePraosNonces(headerStateData []byte) (*praosNonces, error) {
 		)
 	}
 	result.EpochNonce = epochNonce
+
+	// Extract candidate nonce (index 3)
+	candidateNonce, err := decodeNonce(praosState[3])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding candidate nonce: %w", err,
+		)
+	}
+	if candidateNonce != nil && len(candidateNonce) != 32 {
+		return nil, fmt.Errorf(
+			"invalid candidate nonce length %d, expected 32",
+			len(candidateNonce),
+		)
+	}
+	result.CandidateNonce = candidateNonce
+
+	// Extract lastEpochBlockNonce (index 6) when present.
+	// Older eras/encodings may not include this field.
+	if len(praosState) > 6 {
+		lastEpochBlockNonce, err := decodeNonce(praosState[6])
+		if err != nil {
+			return nil, fmt.Errorf(
+				"decoding last epoch block nonce: %w", err,
+			)
+		}
+		if lastEpochBlockNonce != nil && len(lastEpochBlockNonce) != 32 {
+			return nil, fmt.Errorf(
+				"invalid last epoch block nonce length %d, expected 32",
+				len(lastEpochBlockNonce),
+			)
+		}
+		result.LastEpochBlockNonce = lastEpochBlockNonce
+	}
 
 	return result, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix resuming epoch nonce computation after snapshot restore and rollbacks. Accumulation now continues from the correct slot (tip or anchor) to avoid replay and keep candidate/evolving nonces correct.

- **Bug Fixes**
  - Continue from tip when evolving nonce equals tip block nonce; otherwise, scan the epoch with GetBlockNoncesInSlotRange, anchor on a match, and resume from the next slot (error if none).
  - Apply the resume logic in both chain sync and header verification paths.
  - Skip accumulation if the tip is at/after the epoch end.
  - Parse CandidateNonce and LastEpochBlockNonce from snapshots; persist and use them during import and epoch generation.
  - Search epoch cache newest-to-oldest to avoid stale entries after rollbacks or rebuilds.

<sup>Written for commit 05cfe0b4343e3e438013c71be29d243fd68b6319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshots and imports now include consensus nonces so resumed or imported ledger state carries epoch-aware nonce data.
  * Added ability to fetch block nonces by slot range to support efficient anchor lookup during resume.

* **Bug Fixes**
  * Improved epoch boundary and resumption logic to avoid unnecessary recomputation.
  * Enhanced fallback behavior and diagnostic messages when resuming from tip or locating resume anchors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->