### PR TITLE
fix(ledger): move conway tx validity checks later

### DIFF
--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -170,13 +170,9 @@ func ValidateTxConway(
 	if _, ok := pp.(*conway.ConwayProtocolParameters); !ok {
 		return ErrIncompatibleProtocolParams
 	}
-	// Conway invalid transactions are expected to fail script validation on-chain.
-	// Skip local UTxO validation for these txs so block replay follows consensus
-	// handling of collateral/produced outputs rather than rejecting the block.
-	if !tx.IsValid() {
-		return nil
-	}
-	// Validate TX through ledger validation rules
+	// Validate TX through ledger validation rules (Phase-1).
+	// These must run even for isValid=false transactions, which still
+	// require valid structure, fees, and UTxO references for collateral.
 	errs := []error{}
 	var err error
 	for idx, validationFunc := range conway.UtxoValidationRules {
@@ -191,9 +187,12 @@ func ValidateTxConway(
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
-	// Core Conway transaction validity checks (fees/size/scripts/etc.) are
-	// covered by conway.UtxoValidationRules. Avoid duplicate local checks
-	// that can drift from upstream consensus behavior.
+	// Skip script evaluation (Phase-2) if TX is marked as not valid.
+	// These transactions failed script validation on-chain; collateral
+	// is consumed instead of regular inputs.
+	if !tx.IsValid() {
+		return nil
+	}
 	return nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved Conway transaction validity checks so Phase‑1 UTxO validations run before the `isValid` gate, aligning local behavior with on-chain consensus and preventing replay rejections.

- **Bug Fixes**
  - Run `conway.UtxoValidationRules` (Phase‑1) for all Conway transactions to validate structure, fees, and UTxO references.
  - Skip script evaluation (Phase‑2) when `tx.IsValid()` is false to match on-chain collateral handling.

<sup>Written for commit 38823e21421e6a2c2d3a7f6efe266aa845be1ea6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated transaction validation process to ensure comprehensive validation phases execute consistently across all transaction types, with improved handling of invalid transactions and optimized validation robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->