### PR TITLE
fix(ledger): data race in epoch cache handling

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -329,10 +329,19 @@ func (ls *LedgerState) advanceEpochCache() error {
 	}
 
 	// Update cache under write lock, checking for concurrent advance
+	// or rollback that may have changed the cache since we read it.
 	ls.Lock()
 	lastCached := ls.epochCache[len(ls.epochCache)-1]
 	if lastCached.EpochId >= newEpoch.EpochId {
 		// Another goroutine or ledger processing already advanced
+		ls.Unlock()
+		return nil
+	}
+	// Verify the base epoch we used for computation is still the cache
+	// tail. A concurrent rollback could have pruned the cache, making
+	// our computed newEpoch stale.
+	if lastCached.EpochId != lastEpoch.EpochId ||
+		lastCached.StartSlot != lastEpoch.StartSlot {
 		ls.Unlock()
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race in epoch cache advancement that could append a stale epoch after a concurrent advance or rollback. The cache tail is now re-validated under lock before appending, preventing inconsistent state under concurrency.

- **Bug Fixes**
  - Validate that the cache tail still matches the base epoch (ID and start slot) before appending; if it changed, do nothing.
  - Keep early exit when another goroutine already advanced the cache.

<sup>Written for commit 33a094776e2173fb6173a4ddcf6d55e93cbc17da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Strengthened concurrent operation handling to prevent cache conflicts and maintain consistent system state during simultaneous updates and rollbacks.
- Enhanced cache validation with state verification checks performed before modifications to ensure data accuracy and prevent conflicts in concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->