### PR TITLE
fix: default bind address is sufficient

### DIFF
--- a/config.go
+++ b/config.go
@@ -159,10 +159,6 @@ func (n *Node) configValidate() error {
 			StorageModeAPI,
 		)
 	}
-	// Default bindAddr used for API listeners.
-	if n.config.bindAddr == "" {
-		n.config.bindAddr = "0.0.0.0"
-	}
 	// APIs require "api" storage mode.
 	anyAPIEnabled := n.config.utxorpcPort > 0 ||
 		n.config.blockfrostPort > 0 ||


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the hardcoded default for `bindAddr` in `configValidate`. We now defer to listener/OS defaults when unset, avoiding unintended binds to `0.0.0.0` and relying on existing defaults.

<sup>Written for commit 7192ada1fff3765d07d17302096be891f37112e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

