### PR TITLE
fix(ledger): epoch cache panic with concurrent rollbacks

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -331,6 +331,10 @@ func (ls *LedgerState) advanceEpochCache() error {
 	// Update cache under write lock, checking for concurrent advance
 	// or rollback that may have changed the cache since we read it.
 	ls.Lock()
+	if len(ls.epochCache) == 0 {
+		ls.Unlock()
+		return nil
+	}
 	lastCached := ls.epochCache[len(ls.epochCache)-1]
 	if lastCached.EpochId >= newEpoch.EpochId {
 		// Another goroutine or ledger processing already advanced


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent panic in `advanceEpochCache` when a concurrent rollback empties `epochCache`. Adds an early-return guard under the write lock to skip indexing when the cache is empty.

<sup>Written for commit 9757a28871c8346ce8595fbfd6e6bab148379d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved epoch verification stability by adding defensive checks to prevent potential errors when processing operations with empty cache states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->