### PR TITLE
fix(chain): header queue size

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -83,15 +83,18 @@ func (c *Chain) headerTip() ochainsync.Tip {
 }
 
 // MaxQueuedHeaders returns the maximum number of headers that may be
-// queued. When the security parameter is available (securityParam > 0),
-// the limit is securityParam * 2. Otherwise, DefaultMaxQueuedHeaders is
-// used as a safe fallback.
+// queued. The limit is the larger of securityParam * 2 and
+// DefaultMaxQueuedHeaders. Using the default as a floor ensures the
+// queue is large enough for the chainsync/blockfetch pipeline: headers
+// arrive much faster than blocks, so the queue must accommodate several
+// blockfetch batches worth of headers beyond the accumulation threshold
+// to avoid drops that break the header chain.
 func (c *Chain) MaxQueuedHeaders() int {
 	if c == nil || c.manager == nil {
 		return DefaultMaxQueuedHeaders
 	}
 	if sp := c.manager.securityParam; sp > 0 {
-		return sp * 2
+		return max(sp*2, DefaultMaxQueuedHeaders)
 	}
 	return DefaultMaxQueuedHeaders
 }

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -551,7 +551,9 @@ func TestHeaderQueueLimitDefault(t *testing.T) {
 }
 
 func TestHeaderQueueLimitFromSecurityParam(t *testing.T) {
-	securityParam := 5
+	// securityParam must be large enough that sp*2 exceeds
+	// DefaultMaxQueuedHeaders, otherwise the default floor applies.
+	securityParam := chain.DefaultMaxQueuedHeaders/2 + 1
 	expectedLimit := securityParam * 2
 
 	cm, err := chain.NewManager(nil, nil)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes header queue sizing in `chain` by using the larger of securityParam*2 and `DefaultMaxQueuedHeaders`. This prevents header drops in the chainsync/blockfetch pipeline.

- **Bug Fixes**
  - Updated `MaxQueuedHeaders` to use max(securityParam*2, `DefaultMaxQueuedHeaders`).
  - Adjusted `TestHeaderQueueLimitFromSecurityParam` to ensure sp*2 exceeds the default.

<sup>Written for commit 2452b9c9bf4ef12429bc101d8798569ceffd34fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header queue limit calculation to enforce a minimum floor value, ensuring the system maintains adequate capacity to handle multiple blockfetch batch operations.

* **Tests**
  * Updated test configuration to dynamically validate header queue behavior with improved threshold calculations, enhancing test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->