### PR TITLE
fix(chainselection): implausible tip check

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -27,6 +27,14 @@ import (
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
 
+// safeAddUint64 returns a + b, clamped to math.MaxUint64 on overflow.
+func safeAddUint64(a, b uint64) uint64 {
+	if a > math.MaxUint64-b {
+		return math.MaxUint64
+	}
+	return a + b
+}
+
 const (
 	defaultEvaluationInterval = 10 * time.Second
 	defaultStaleTipThreshold  = 60 * time.Second
@@ -134,9 +142,10 @@ func (cs *ChainSelector) Stop() {
 //
 // Returns true if the tip was accepted, false if it was rejected as
 // implausible. A tip is considered implausible if it claims a block number
-// more than securityParam (k) blocks ahead of the local tip. This check is
-// skipped during initial sync (when securityParam is 0 or localTip is at
-// block 0).
+// more than securityParam (k) blocks ahead of a reference point. For known
+// peers, the reference is the peer's own previous tip; for new peers, the
+// reference is the best known peer tip. This avoids rejecting legitimate
+// peers during sync (where the local tip is far behind).
 func (cs *ChainSelector) UpdatePeerTip(
 	connId ouroboros.ConnectionId,
 	tip ochainsync.Tip,
@@ -150,22 +159,44 @@ func (cs *ChainSelector) UpdatePeerTip(
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
 
-		// Reject implausible tips that claim to be too far ahead of our
-		// local chain. This prevents a malicious peer from spoofing an
-		// extremely high block number to hijack chain selection.
-		// Skip the check during initial sync when we have no local tip
-		// or securityParam is not yet set.
-		if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 {
-			maxPlausibleBlock := cs.localTip.BlockNumber +
-				cs.securityParam
-			if tip.BlockNumber > maxPlausibleBlock {
+		// Reject implausible tips that claim to be too far ahead of
+		// a reference point. Three cases:
+		//  1. Known peer: compare against the peer's own previous
+		//     tip — chainsync advances incrementally so the delta
+		//     is always small. Always checked (even if prev == 0).
+		//  2. New peer with existing peers: compare against the
+		//     best known peer tip to prevent a malicious newcomer
+		//     from spoofing an extremely high block number.
+		//  3. First peer ever: no reference exists, accept to
+		//     allow bootstrap.
+		if cs.securityParam > 0 {
+			rejectTip := false
+			var referenceBlock uint64
+			if prevTip, exists := cs.peerTips[connId]; exists {
+				// Case 1: known peer — always check
+				referenceBlock = prevTip.Tip.BlockNumber
+				rejectTip = tip.BlockNumber >
+					safeAddUint64(referenceBlock, cs.securityParam)
+			} else if len(cs.peerTips) > 0 {
+				// Case 2: new peer — check against best known
+				for _, pt := range cs.peerTips {
+					if pt.Tip.BlockNumber > referenceBlock {
+						referenceBlock = pt.Tip.BlockNumber
+					}
+				}
+				rejectTip = tip.BlockNumber >
+					safeAddUint64(referenceBlock, cs.securityParam)
+			}
+			// Case 3: len(peerTips)==0 && peer not known → bootstrap
+			if rejectTip {
 				cs.config.Logger.Warn(
 					"rejecting implausible peer tip",
 					"connection_id", connId.String(),
 					"claimed_block", tip.BlockNumber,
-					"local_block", cs.localTip.BlockNumber,
+					"reference_block", referenceBlock,
 					"security_param", cs.securityParam,
-					"max_plausible_block", maxPlausibleBlock,
+					"max_plausible_block",
+					safeAddUint64(referenceBlock, cs.securityParam),
 				)
 				accepted = false
 				return
@@ -443,7 +474,7 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 		// This prevents switching to stale or cross-network peers when
 		// local tip and k are known.
 		if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 &&
-			peerTip.Tip.BlockNumber+cs.securityParam < cs.localTip.BlockNumber {
+			safeAddUint64(peerTip.Tip.BlockNumber, cs.securityParam) < cs.localTip.BlockNumber {
 			cs.config.Logger.Debug(
 				"skipping implausibly-behind peer",
 				"connection_id", connId.String(),

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -553,6 +553,16 @@ func TestUpdatePeerTipRejectsImplausibleTip(t *testing.T) {
 		BlockNumber: 50000,
 	})
 
+	// Add a plausible peer first so the implausible check activates
+	// (the check requires len(peerTips) > 0 to avoid blocking
+	// initial sync where all peers are legitimately far ahead).
+	existingConn := newTestConnectionId(2)
+	plausibleTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
+		BlockNumber: 50500,
+	}
+	cs.UpdatePeerTip(existingConn, plausibleTip, nil)
+
 	connId := newTestConnectionId(1)
 
 	// A spoofed tip claiming to be far beyond local tip + k
@@ -572,7 +582,7 @@ func TestUpdatePeerTipRejectsImplausibleTip(t *testing.T) {
 		cs.GetPeerTip(connId),
 		"rejected tip should not be tracked",
 	)
-	assert.Equal(t, 0, cs.PeerCount(), "peer count should remain 0")
+	assert.Equal(t, 1, cs.PeerCount(), "peer count should remain 1 (existing peer only)")
 }
 
 func TestUpdatePeerTipAcceptsPlausibleTip(t *testing.T) {
@@ -647,15 +657,24 @@ func TestUpdatePeerTipRejectsTipOneOverBoundary(t *testing.T) {
 		BlockNumber: 50000,
 	})
 
+	// Add a plausible peer first so the implausible check has a
+	// reference point. The reference is the best known peer tip
+	// (block 50500), not the local tip.
+	existingConn := newTestConnectionId(2)
+	cs.UpdatePeerTip(existingConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
+		BlockNumber: 50500,
+	}, nil)
+
 	connId := newTestConnectionId(1)
 
-	// Tip one block past the boundary
+	// Tip one block past the boundary (reference peer block + k + 1)
 	overBoundaryTip := ochainsync.Tip{
 		Point: ocommon.Point{
-			Slot: 104001,
+			Slot: 106000,
 			Hash: []byte("over"),
 		},
-		BlockNumber: 50000 + 2160 + 1,
+		BlockNumber: 50500 + 2160 + 1,
 	}
 
 	accepted := cs.UpdatePeerTip(connId, overBoundaryTip, nil)
@@ -720,6 +739,73 @@ func TestUpdatePeerTipAcceptsTipWhenLocalTipZero(t *testing.T) {
 		"all tips should be accepted when local tip is at block 0",
 	)
 	assert.NotNil(t, cs.GetPeerTip(connId))
+}
+
+func TestUpdatePeerTipAcceptsDuringInitialSyncNoPeers(t *testing.T) {
+	// During genesis sync, local tip advances past 0 but the node
+	// has no accepted peers yet. The implausible check must be
+	// skipped so the first real peer can be accepted even though
+	// its tip is millions of blocks ahead of our local chain.
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: 432, // preview k
+	})
+
+	// Local tip at block 100 (just started syncing from genesis)
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 2000, Hash: []byte("local")},
+		BlockNumber: 100,
+	})
+
+	connId := newTestConnectionId(1)
+
+	// Real peer claiming tip at block 4M (far beyond 100 + 432)
+	realTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 106000000, Hash: []byte("real")},
+		BlockNumber: 4000000,
+	}
+
+	accepted := cs.UpdatePeerTip(connId, realTip, nil)
+	assert.True(
+		t,
+		accepted,
+		"first peer should be accepted during initial sync even if far ahead",
+	)
+	assert.NotNil(t, cs.GetPeerTip(connId))
+}
+
+func TestUpdatePeerTipRejectsKnownPeerJumpFromZero(t *testing.T) {
+	// A known peer whose previous tip was at block 0 must still be
+	// checked. Without this, a malicious peer could send tip=0 first,
+	// then tip=MaxUint64 to bypass the implausible check.
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: 2160,
+	})
+
+	connId := newTestConnectionId(1)
+
+	// First tip at block 0 — accepted (first peer, no reference)
+	zeroTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 0, Hash: []byte("zero")},
+		BlockNumber: 0,
+	}
+	accepted := cs.UpdatePeerTip(connId, zeroTip, nil)
+	assert.True(t, accepted, "first tip at block 0 should be accepted")
+
+	// Second tip jumps to far beyond 0 + k
+	spoofedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: math.MaxUint64, Hash: []byte("spoof")},
+		BlockNumber: math.MaxUint64,
+	}
+	accepted = cs.UpdatePeerTip(connId, spoofedTip, nil)
+	assert.False(
+		t,
+		accepted,
+		"known peer jumping from block 0 to MaxUint64 should be rejected",
+	)
+	// Peer tip should still be the original block 0 tip
+	pt := cs.GetPeerTip(connId)
+	require.NotNil(t, pt)
+	assert.Equal(t, uint64(0), pt.Tip.BlockNumber)
 }
 
 func TestUpdatePeerTipSpoofedPeerDoesNotBecomesBest(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix implausible tip validation in `chainselection` to compare new tips against a peer-based reference and use overflow-safe boundary math. This blocks spoofed high tips without rejecting legitimate peers during bootstrap and sync.

- **Bug Fixes**
  - `UpdatePeerTip` now checks known peers against their previous tip (even if 0), new peers against the best known peer tip, and accepts the first peer when no reference exists.
  - Added `safeAddUint64` and used it for k math in tip validation and in the "implausibly-behind" peer filter to avoid overflow near `MaxUint64`.
  - Tests expanded for initial sync with no peers, rejecting a known peer jumping from 0 to `MaxUint64`, and the k+1 boundary; logs include `reference_block` and `max_plausible_block`.

<sup>Written for commit c9bf818dfd5146785ef252b7b89be833e6e3753f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-tip validation using reference-based plausibility checks, reducing false rejections and better handling bootstrap/initial-sync cases; logs now include reference and max-plausible block info.

* **Tests**
  * Expanded tests for peer validation edge cases: initial sync, known-peer jumps, boundary conditions, and security-parameter edge values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->