### PR TITLE
fix(event): increase queue size to 10000

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	EventQueueSize       = 1000
+	EventQueueSize       = 10000
 	AsyncQueueSize       = 1000
 	AsyncWorkerPoolSize  = 4
 	RemoteDeliverTimeout = 5 * time.Second


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increases the event queue capacity from 1,000 to 10,000 to better absorb traffic spikes and reduce dropped events under load.

<sup>Written for commit b26a0af9fe6f4f7e669d8a1be25f629482c3fd22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

