### PR TITLE
fix(ledger): evolving nonce fix for genesis

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1365,8 +1365,12 @@ func (ls *LedgerState) calculateEpochNonce(
 		}
 	} else if len(currentEpoch.EvolvingNonce) == 32 {
 		// Resume fallback: if epoch nonce state was checkpointed at an
-		// earlier slot, locate that anchor by matching stored block nonces
-		// and continue from the following slot.
+		// earlier slot (snapshot import), locate that anchor by matching
+		// stored block nonces and continue from the following slot.
+		// If no anchor is found, fall through to the defaults which
+		// compute from epoch start — this is always correct (just
+		// slower) and handles genesis sync where the epoch's
+		// EvolvingNonce was set at creation and never updated.
 		nonceRows, nonceErr := ls.db.GetBlockNoncesInSlotRange(
 			currentEpoch.StartSlot,
 			epochEndSlot,
@@ -1378,28 +1382,18 @@ func (ls *LedgerState) calculateEpochNonce(
 				nonceErr,
 			)
 		}
-		var anchorSlot uint64
-		var foundAnchor bool
 		for _, row := range nonceRows {
 			if len(row.Nonce) == 32 &&
 				bytes.Equal(currentEpoch.EvolvingNonce, row.Nonce) {
-				anchorSlot = row.Slot
-				foundAnchor = true
+				if row.Slot+1 < epochEndSlot {
+					computeStartSlot = row.Slot + 1
+					computeEpochLength = epochEndSlot -
+						computeStartSlot
+				} else {
+					computeEpochLength = 0
+				}
 				break
 			}
-		}
-		if !foundAnchor {
-			return nil, nil, nil, nil, fmt.Errorf(
-				"cannot resume epoch nonce: stored evolving nonce has no matching anchor block in epoch range [%d, %d)",
-				currentEpoch.StartSlot,
-				epochEndSlot,
-			)
-		}
-		if anchorSlot+1 < epochEndSlot {
-			computeStartSlot = anchorSlot + 1
-			computeEpochLength = epochEndSlot - computeStartSlot
-		} else {
-			computeEpochLength = 0
 		}
 	}
 

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -439,9 +439,11 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		}
 	} else if len(prevEpoch.EvolvingNonce) == 32 {
 		// Resume fallback: when epoch nonce state was checkpointed at an
-		// earlier slot, detect that anchor by matching block nonces in this
-		// epoch range. If found, continue from the following slot instead of
-		// replaying from epoch start.
+		// earlier slot (snapshot import), detect that anchor by matching
+		// block nonces in this epoch range. If found, continue from the
+		// following slot instead of replaying from epoch start.
+		// If no anchor is found, fall through to defaults (compute from
+		// epoch start) — handles genesis sync gracefully.
 		nonceRows, nonceErr := ls.db.GetBlockNoncesInSlotRange(
 			prevEpoch.StartSlot,
 			prevEpochEndSlot,
@@ -453,28 +455,18 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 				nonceErr,
 			)
 		}
-		var anchorSlot uint64
-		var foundAnchor bool
 		for _, row := range nonceRows {
 			if len(row.Nonce) == 32 &&
 				bytes.Equal(prevEpoch.EvolvingNonce, row.Nonce) {
-				anchorSlot = row.Slot
-				foundAnchor = true
+				if row.Slot+1 < prevEpochEndSlot {
+					computeStartSlot = row.Slot + 1
+					computeEpochLength = prevEpochEndSlot -
+						computeStartSlot
+				} else {
+					computeEpochLength = 0
+				}
 				break
 			}
-		}
-		if !foundAnchor {
-			return nil, nil, nil, nil, fmt.Errorf(
-				"cannot resume epoch nonce: stored evolving nonce has no matching anchor block in epoch range [%d, %d)",
-				prevEpoch.StartSlot,
-				prevEpochEndSlot,
-			)
-		}
-		if anchorSlot+1 < prevEpochEndSlot {
-			computeStartSlot = anchorSlot + 1
-			computeEpochLength = prevEpochEndSlot - computeStartSlot
-		} else {
-			computeEpochLength = 0
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes epoch evolving nonce computation for genesis and snapshot imports. If no anchor block is found in the epoch, we now fall back to recomputing from epoch start instead of erroring.

- **Bug Fixes**
  - In `calculateEpochNonce` and `computeEpochNonceForSlot`, remove hard error when no matching anchor is found; compute from epoch start (correct but slower).
  - Keep fast path when an anchor exists by resuming from `anchorSlot + 1`, and handle end-of-epoch cases safely.

<sup>Written for commit 8c57373290b5e2e60280d8d9cd793f8fa5e1387f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

