### PR TITLE
ci(publish): use node 24 for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -299,7 +299,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 https://github.com/actions/setup-node/releases/tag/v6.3.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          node-version: '23.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Update package.json
         run: sed -e "s/0.999.0/${RELEASE_VERSION}/" .github/package.json > package.json


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use Node `24.x` for the npm publish step in GitHub Actions when tags are pushed. This aligns with our current runtime and prevents potential publish issues with Node `23.x`.

<sup>Written for commit 619578c793b04733259d35bb84804f81a76f3c2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release build process tooling to enhance package compatibility and ensure optimal release quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->