### PR TITLE
feat: mempool utxo overlay

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3316,15 +3316,14 @@ func resolveValidationEra(
 	return *txEra, nil
 }
 
-// ValidateTx runs ledger validation on the provided transaction.
-// It accepts transactions from the current era and the immediately
-// previous era (era-1), as Cardano allows during the overlap
-// period after a hard fork.
-func (ls *LedgerState) ValidateTx(
+// validateTxCore is the shared validation flow for ValidateTx and
+// ValidateTxWithOverlay. It snapshots ledger state, resolves the
+// validation era, opens a DB transaction, and invokes the era's
+// ValidateTxFunc with a LedgerView built by the provided callback.
+func (ls *LedgerState) validateTxCore(
 	tx lcommon.Transaction,
+	buildLV func(txn *database.Txn) *LedgerView,
 ) error {
-	// Snapshot mutable state under read lock to avoid data races
-	// with concurrent writers (e.g., ledgerProcessBlocks)
 	ls.RLock()
 	snapshotEra := ls.currentEra
 	snapshotSlot := ls.currentTip.Point.Slot
@@ -3337,22 +3336,16 @@ func (ls *LedgerState) ValidateTx(
 		return err
 	}
 	if validationEra.ValidateTxFunc != nil {
-		// Use the previous era's protocol parameters when validating
-		// a transaction from the immediately previous era (era-1).
 		pp := snapshotPParams
 		if validationEra.Id != snapshotEra.Id && snapshotPrevEraPParams != nil {
 			pp = snapshotPrevEraPParams
 		}
 		txn := ls.db.Transaction(false)
 		err := txn.Do(func(txn *database.Txn) error {
-			lv := &LedgerView{
-				txn: txn,
-				ls:  ls,
-			}
 			return validationEra.ValidateTxFunc(
 				tx,
 				snapshotSlot,
-				lv,
+				buildLV(txn),
 				pp,
 			)
 		})
@@ -3361,6 +3354,37 @@ func (ls *LedgerState) ValidateTx(
 		}
 	}
 	return nil
+}
+
+// ValidateTx runs ledger validation on the provided transaction.
+// It accepts transactions from the current era and the immediately
+// previous era (era-1), as Cardano allows during the overlap
+// period after a hard fork.
+func (ls *LedgerState) ValidateTx(
+	tx lcommon.Transaction,
+) error {
+	return ls.validateTxCore(tx, func(txn *database.Txn) *LedgerView {
+		return &LedgerView{txn: txn, ls: ls}
+	})
+}
+
+// ValidateTxWithOverlay runs ledger validation with a UTxO overlay from pending
+// mempool transactions. consumedUtxos contains inputs already spent by pending TXs
+// (double-spend check), createdUtxos contains outputs created by pending TXs
+// (dependent TX chaining). Both may be nil for no overlay.
+func (ls *LedgerState) ValidateTxWithOverlay(
+	tx lcommon.Transaction,
+	consumedUtxos map[string]struct{},
+	createdUtxos map[string]lcommon.Utxo,
+) error {
+	return ls.validateTxCore(tx, func(txn *database.Txn) *LedgerView {
+		return &LedgerView{
+			txn:             txn,
+			ls:              ls,
+			intraBlockUtxos: createdUtxos,
+			consumedUtxos:   consumedUtxos,
+		}
+	})
 }
 
 // EvaluateTx evaluates the scripts in the provided transaction and returns the calculated

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -33,12 +33,18 @@ import (
 // ErrNilDecodedOutput is returned when a decoded UTxO output is nil.
 var ErrNilDecodedOutput = errors.New("nil decoded output")
 
+// ErrUtxoAlreadyConsumed is returned when a UTxO has been consumed by a pending transaction.
+var ErrUtxoAlreadyConsumed = errors.New("UTxO already consumed")
+
 type LedgerView struct {
 	ls  *LedgerState
 	txn *database.Txn
 	// intraBlockUtxos tracks outputs created by earlier transactions in the same block.
 	// Key format: hex(txId) + ":" + outputIdx
 	intraBlockUtxos map[string]lcommon.Utxo
+	// consumedUtxos tracks inputs consumed by pending mempool transactions.
+	// Key format: hex(txId) + ":" + outputIdx
+	consumedUtxos map[string]struct{}
 }
 
 func (lv *LedgerView) NetworkId() uint {
@@ -57,9 +63,19 @@ func (lv *LedgerView) NetworkId() uint {
 func (lv *LedgerView) UtxoById(
 	utxoId lcommon.TransactionInput,
 ) (lcommon.Utxo, error) {
-	// Check intra-block UTxOs first (outputs from earlier txs in same block)
+	key := fmt.Sprintf("%s:%d", utxoId.Id().String(), utxoId.Index())
+	// Check consumed UTxOs first (spent by pending mempool TX)
+	if lv.consumedUtxos != nil {
+		if _, ok := lv.consumedUtxos[key]; ok {
+			return lcommon.Utxo{}, fmt.Errorf(
+				"utxo %s: %w",
+				key,
+				ErrUtxoAlreadyConsumed,
+			)
+		}
+	}
+	// Check intra-block/overlay UTxOs (outputs from earlier txs)
 	if lv.intraBlockUtxos != nil {
-		key := fmt.Sprintf("%s:%d", utxoId.Id().String(), utxoId.Index())
 		if utxo, ok := lv.intraBlockUtxos[key]; ok {
 			return utxo, nil
 		}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -16,6 +16,7 @@ package mempool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -61,6 +63,11 @@ type MempoolTransaction struct {
 // TxValidator defines the interface for transaction validation needed by mempool.
 type TxValidator interface {
 	ValidateTx(tx gledger.Transaction) error
+	ValidateTxWithOverlay(
+		tx gledger.Transaction,
+		consumedUtxos map[string]struct{},
+		createdUtxos map[string]lcommon.Utxo,
+	) error
 }
 type MempoolConfig struct {
 	PromRegistry       prometheus.Registerer
@@ -98,6 +105,193 @@ type Mempool struct {
 	sync.RWMutex
 	doneOnce       sync.Once
 	consumersMutex sync.Mutex
+	overlay        *utxoOverlay
+}
+
+// appliedTx records a pending transaction and its UTxO effects for overlay rebuild.
+type appliedTx struct {
+	hash     string
+	txType   uint
+	cbor     []byte
+	consumed []string                // UTxO keys consumed by this TX
+	created  map[string]lcommon.Utxo // UTxO keys created by this TX
+}
+
+// utxoOverlay tracks cumulative UTxO state changes from all pending mempool TXs.
+type utxoOverlay struct {
+	consumed map[string]struct{}     // all inputs consumed by pending TXs
+	created  map[string]lcommon.Utxo // all outputs created by pending TXs
+	applied  []appliedTx             // ordered list for rebuild
+}
+
+func newUtxoOverlay() *utxoOverlay {
+	return &utxoOverlay{
+		consumed: make(map[string]struct{}),
+		created:  make(map[string]lcommon.Utxo),
+	}
+}
+
+// applyTx adds a validated transaction's UTxO effects to the overlay.
+func (o *utxoOverlay) applyTx(
+	hash string,
+	txType uint,
+	cbor []byte,
+	tx lcommon.Transaction,
+) {
+	at := appliedTx{
+		hash:    hash,
+		txType:  txType,
+		cbor:    cbor,
+		created: make(map[string]lcommon.Utxo),
+	}
+	for _, input := range tx.Inputs() {
+		key := fmt.Sprintf("%s:%d", input.Id().String(), input.Index())
+		o.consumed[key] = struct{}{}
+		at.consumed = append(at.consumed, key)
+	}
+	for _, utxo := range tx.Produced() {
+		key := fmt.Sprintf(
+			"%s:%d",
+			utxo.Id.Id().String(),
+			utxo.Id.Index(),
+		)
+		o.created[key] = utxo
+		at.created[key] = utxo
+	}
+	o.applied = append(o.applied, at)
+}
+
+// reset clears the overlay to empty state.
+func (o *utxoOverlay) reset() {
+	o.consumed = make(map[string]struct{})
+	o.created = make(map[string]lcommon.Utxo)
+	o.applied = nil
+}
+
+// rebuildAggregates rebuilds consumed/created maps from the applied list.
+func (o *utxoOverlay) rebuildAggregates() {
+	o.consumed = make(map[string]struct{})
+	o.created = make(map[string]lcommon.Utxo)
+	for _, at := range o.applied {
+		for _, key := range at.consumed {
+			o.consumed[key] = struct{}{}
+		}
+		for key, utxo := range at.created {
+			o.created[key] = utxo
+		}
+	}
+}
+
+// removeBatchWithDescendants removes the specified TXs from the applied list,
+// then iteratively prunes any descendant TXs that consume UTxOs created by
+// removed TXs. Calls rebuildAggregates before returning.
+// Returns the hashes of pruned descendants (not including the primary hashes).
+func (o *utxoOverlay) removeBatchWithDescendants(
+	hashes map[string]struct{},
+) []string {
+	// Remove specified TXs and collect their created UTxOs
+	orphanedUtxos := make(map[string]struct{})
+	var remaining []appliedTx
+	for _, at := range o.applied {
+		if _, remove := hashes[at.hash]; remove {
+			for key := range at.created {
+				orphanedUtxos[key] = struct{}{}
+			}
+		} else {
+			remaining = append(remaining, at)
+		}
+	}
+	o.applied = remaining
+
+	// Iteratively prune TXs that consume orphaned UTxOs (transitive)
+	var pruned []string
+	if len(orphanedUtxos) > 0 {
+		changed := true
+		for changed {
+			changed = false
+			var newRemaining []appliedTx
+			for _, at := range o.applied {
+				isOrphan := false
+				for _, key := range at.consumed {
+					if _, ok := orphanedUtxos[key]; ok {
+						isOrphan = true
+						break
+					}
+				}
+				if isOrphan {
+					for key := range at.created {
+						orphanedUtxos[key] = struct{}{}
+					}
+					pruned = append(pruned, at.hash)
+					changed = true
+				} else {
+					newRemaining = append(newRemaining, at)
+				}
+			}
+			o.applied = newRemaining
+		}
+	}
+
+	o.rebuildAggregates()
+	return pruned
+}
+
+// simulateRemoveBatch computes what consumed/created maps would look like
+// after removing the specified TXs and their descendants, without mutating
+// the overlay. Used to validate incoming TXs before committing eviction.
+func (o *utxoOverlay) simulateRemoveBatch(
+	hashes map[string]struct{},
+) (map[string]struct{}, map[string]lcommon.Utxo) {
+	// Remove specified TXs and collect their created UTxOs
+	orphanedUtxos := make(map[string]struct{})
+	remaining := make([]appliedTx, 0, len(o.applied))
+	for _, at := range o.applied {
+		if _, remove := hashes[at.hash]; remove {
+			for key := range at.created {
+				orphanedUtxos[key] = struct{}{}
+			}
+		} else {
+			remaining = append(remaining, at)
+		}
+	}
+	// Iteratively prune TXs that consume orphaned UTxOs (transitive)
+	if len(orphanedUtxos) > 0 {
+		changed := true
+		for changed {
+			changed = false
+			var newRemaining []appliedTx
+			for _, at := range remaining {
+				isOrphan := false
+				for _, key := range at.consumed {
+					if _, ok := orphanedUtxos[key]; ok {
+						isOrphan = true
+						break
+					}
+				}
+				if isOrphan {
+					for key := range at.created {
+						orphanedUtxos[key] = struct{}{}
+					}
+					changed = true
+				} else {
+					newRemaining = append(newRemaining, at)
+				}
+			}
+			remaining = newRemaining
+		}
+	}
+	// Rebuild maps from surviving TXs
+	consumed := make(map[string]struct{})
+	created := make(map[string]lcommon.Utxo)
+	for _, at := range remaining {
+		for _, key := range at.consumed {
+			consumed[key] = struct{}{}
+		}
+		for key, utxo := range at.created {
+			created[key] = utxo
+		}
+	}
+	return consumed, created
 }
 
 type MempoolFullError struct {
@@ -116,6 +310,9 @@ func (e *MempoolFullError) Error() string {
 }
 
 func NewMempool(config MempoolConfig) *Mempool {
+	if config.Validator == nil {
+		panic("mempool: validator must not be nil")
+	}
 	evictionWatermark := config.EvictionWatermark
 	if evictionWatermark == 0 {
 		evictionWatermark = DefaultEvictionWatermark
@@ -136,6 +333,7 @@ func NewMempool(config MempoolConfig) *Mempool {
 		eventBus:           config.EventBus,
 		consumers:          make(map[ouroboros.ConnectionId]*MempoolConsumer),
 		txByHash:           make(map[string]*MempoolTransaction),
+		overlay:            newUtxoOverlay(),
 		validator:          config.Validator,
 		config:             config,
 		done:               make(chan struct{}),
@@ -237,6 +435,7 @@ func (m *Mempool) Stop(ctx context.Context) error {
 	m.transactions = []*MempoolTransaction{}
 	m.txByHash = make(map[string]*MempoolTransaction)
 	m.currentSizeBytes = 0
+	m.overlay.reset()
 	// Reset metrics
 	m.metrics.txsInMempool.Set(0)
 	m.metrics.mempoolBytes.Set(0)
@@ -254,7 +453,6 @@ func (m *Mempool) Consumer(connId ouroboros.ConnectionId) *MempoolConsumer {
 
 func (m *Mempool) processChainEvents() {
 	if m.eventBus == nil {
-		// No event bus configured; nothing to process
 		return
 	}
 	chainUpdateSubId, chainUpdateChan := m.eventBus.Subscribe(
@@ -279,56 +477,99 @@ func (m *Mempool) processChainEvents() {
 			len(chainUpdateChan) > 0 {
 			continue
 		}
-		// MEM-04 fix: snapshot transactions under lock, validate outside lock,
-		// then re-acquire lock to remove invalids. This avoids holding the write
-		// lock during potentially expensive Plutus script re-validation.
-		type txSnapshot struct {
-			Hash string
-			Type uint
-			Cbor []byte
-		}
-		m.RLock()
-		snapshot := make([]txSnapshot, len(m.transactions))
-		for i, tx := range m.transactions {
-			snapshot[i] = txSnapshot{
-				Hash: tx.Hash,
-				Type: tx.Type,
-				Cbor: tx.Cbor,
-			}
-		}
-		m.RUnlock()
-		// Validate outside any lock
-		var invalidHashes []string
-		for _, snap := range snapshot {
-			tmpTx, err := gledger.NewTransactionFromCbor(
-				snap.Type,
-				snap.Cbor,
-			)
-			if err != nil {
-				invalidHashes = append(invalidHashes, snap.Hash)
-				m.logger.Error(
-					"transaction failed decode during re-validation",
-					"component", "mempool",
-					"tx_hash", snap.Hash,
-					"error", err,
-				)
-				continue
-			}
-			if err := m.validator.ValidateTx(tmpTx); err != nil {
-				invalidHashes = append(invalidHashes, snap.Hash)
-				m.logger.Debug(
-					"transaction failed re-validation",
-					"component", "mempool",
-					"tx_hash", snap.Hash,
-					"error", err,
-				)
-			}
-		}
-		// Remove invalid transactions under lock
-		if len(invalidHashes) > 0 {
-			m.removeTransactions(invalidHashes)
-		}
+		// Rebuild overlay: re-validate each pending TX in order against
+		// a fresh overlay, removing TXs that no longer validate.
+		m.rebuildOverlay()
 		lastValidationTime = time.Now()
+	}
+}
+
+// rebuildOverlay re-validates all pending TXs sequentially, rebuilding the
+// UTxO overlay from scratch. TXs that fail re-validation are removed.
+// Runs under the write lock for the entire duration to prevent races with
+// AddTransaction (which also holds the write lock when updating the overlay).
+// This is safe because mempool TX submission rate is low at tip and
+// cardano-node also serializes mempool additions.
+func (m *Mempool) rebuildOverlay() {
+	if m.validator == nil {
+		panic("mempool: validator is nil in rebuildOverlay")
+	}
+	m.Lock()
+	prevApplied := make([]appliedTx, len(m.overlay.applied))
+	copy(prevApplied, m.overlay.applied)
+
+	if len(prevApplied) == 0 {
+		m.Unlock()
+		return
+	}
+
+	// Re-validate each TX in order against a fresh overlay.
+	// Build new overlay incrementally — each valid TX extends it.
+	newOverlay := newUtxoOverlay()
+	var invalidHashes []string
+
+	for _, at := range prevApplied {
+		tmpTx, err := gledger.NewTransactionFromCbor(at.txType, at.cbor)
+		if err != nil {
+			invalidHashes = append(invalidHashes, at.hash)
+			m.logger.Error(
+				"transaction failed decode during re-validation",
+				"component", "mempool",
+				"tx_hash", at.hash,
+				"error", err,
+			)
+			continue
+		}
+		if err := m.validator.ValidateTxWithOverlay(
+			tmpTx,
+			newOverlay.consumed,
+			newOverlay.created,
+		); err != nil {
+			invalidHashes = append(invalidHashes, at.hash)
+			m.logger.Debug(
+				"transaction failed re-validation",
+				"component", "mempool",
+				"tx_hash", at.hash,
+				"error", err,
+			)
+			continue
+		}
+		// TX still valid — add its effects to the new overlay
+		newOverlay.applyTx(at.hash, at.txType, at.cbor, tmpTx)
+	}
+
+	// Swap overlay AND remove invalid TXs atomically so readers
+	// never see TXs in m.transactions that aren't in the overlay.
+	m.overlay = newOverlay
+	var events []event.Event
+	if len(invalidHashes) > 0 {
+		hashSet := make(map[string]struct{}, len(invalidHashes))
+		for _, h := range invalidHashes {
+			hashSet[h] = struct{}{}
+		}
+		m.consumersMutex.Lock()
+		for i := len(m.transactions) - 1; i >= 0; i-- {
+			h := m.transactions[i].Hash
+			if _, found := hashSet[h]; found {
+				evt := m.removeTransactionByIndexLocked(i)
+				if evt != nil {
+					events = append(events, *evt)
+				}
+				delete(hashSet, h)
+				if len(hashSet) == 0 {
+					break
+				}
+			}
+		}
+		m.consumersMutex.Unlock()
+	}
+	m.Unlock()
+
+	// MEM-03: Publish events outside locks
+	if m.eventBus != nil {
+		for _, evt := range events {
+			m.eventBus.Publish(RemoveTransactionEventType, evt)
+		}
 	}
 }
 
@@ -359,12 +600,12 @@ func (m *Mempool) expireTransactions() {
 func (m *Mempool) removeExpiredTransactions() {
 	now := time.Now()
 	var events []event.Event
-	var expiredCount int
+	var removedCount int
 	m.Lock()
 	m.consumersMutex.Lock()
-	// Iterate backward to safely remove by index
-	for i := len(m.transactions) - 1; i >= 0; i-- {
-		tx := m.transactions[i]
+	// Collect expired transaction hashes
+	expiredHashes := make(map[string]struct{})
+	for _, tx := range m.transactions {
 		if now.Sub(tx.LastSeen) > m.transactionTTL {
 			m.logger.Debug(
 				"removing expired transaction",
@@ -372,11 +613,33 @@ func (m *Mempool) removeExpiredTransactions() {
 				"tx_hash", tx.Hash,
 				"age", now.Sub(tx.LastSeen).String(),
 			)
-			_, evt := m.removeTransactionByIndexLocked(i)
-			expiredCount++
-			if evt != nil {
-				events = append(events, *evt)
+			expiredHashes[tx.Hash] = struct{}{}
+		}
+	}
+	directExpiredCount := len(expiredHashes)
+	if directExpiredCount > 0 {
+		// Remove from overlay with descendant pruning
+		pruned := m.overlay.removeBatchWithDescendants(expiredHashes)
+		// Add pruned descendants to the removal set
+		for _, h := range pruned {
+			expiredHashes[h] = struct{}{}
+		}
+		// Remove all from transactions list (backward for safe index handling)
+		for i := len(m.transactions) - 1; i >= 0; i-- {
+			if _, ok := expiredHashes[m.transactions[i].Hash]; ok {
+				evt := m.removeTransactionByIndexLocked(i)
+				removedCount++
+				if evt != nil {
+					events = append(events, *evt)
+				}
 			}
+		}
+		if len(pruned) > 0 {
+			m.logger.Debug(
+				"pruned orphaned descendant transactions during expiry",
+				"component", "mempool",
+				"pruned_count", len(pruned),
+			)
 		}
 	}
 	m.consumersMutex.Unlock()
@@ -387,36 +650,28 @@ func (m *Mempool) removeExpiredTransactions() {
 			m.eventBus.Publish(RemoveTransactionEventType, evt)
 		}
 	}
-	if expiredCount > 0 {
-		m.metrics.txsExpired.Add(float64(expiredCount))
+	if removedCount > 0 {
+		m.metrics.txsExpired.Add(float64(removedCount))
 		m.logger.Debug(
 			"expired transactions removed from mempool",
 			"component", "mempool",
-			"expired_count", expiredCount,
+			"expired_count", directExpiredCount,
+			"total_removed", removedCount,
 		)
 	}
 }
 
 func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
-	// Decode transaction
+	if m.validator == nil {
+		return errors.New("mempool: validator is nil in AddTransaction")
+	}
+	// Decode transaction outside the lock (CPU-bound, no shared state)
 	tmpTx, err := gledger.NewTransactionFromCbor(txType, txBytes)
 	if err != nil {
 		return fmt.Errorf("decode transaction: %w", err)
 	}
-	// Validate transaction
-	if err := m.validator.ValidateTx(tmpTx); err != nil {
-		return fmt.Errorf("validate transaction: %w", err)
-	}
-	// Build mempool entry
 	txHash := tmpTx.Hash().String()
-	tx := MempoolTransaction{
-		Hash:     txHash,
-		Type:     txType,
-		Cbor:     txBytes,
-		LastSeen: time.Now(),
-	}
-	// Collect events to publish and eviction events inside the lock,
-	// then publish them all after releasing locks (MEM-03 fix).
+	// Collect events to publish outside locks (MEM-03 fix)
 	var addEvent *event.Event
 	var evictedEvents []event.Event
 	func() {
@@ -427,18 +682,19 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 			m.Unlock()
 		}()
 		// Update last seen for existing TX
-		existingTx := m.getTransaction(tx.Hash)
+		existingTx := m.getTransaction(txHash)
 		if existingTx != nil {
 			existingTx.LastSeen = time.Now()
 			m.logger.Debug(
 				"updated last seen for transaction",
 				"component", "mempool",
-				"tx_hash", tx.Hash,
+				"tx_hash", txHash,
 			)
 			return
 		}
-		// Enforce mempool capacity using watermarks
-		txSize := int64(len(tx.Cbor))
+		// Enforce mempool capacity using watermarks before validation
+		// so we don't waste time validating TXs that will be rejected.
+		txSize := int64(len(txBytes))
 		newSize := m.currentSizeBytes + txSize
 		rejectionThreshold := int64(
 			float64(m.config.MempoolCapacity) * m.rejectionWatermark,
@@ -451,33 +707,75 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 			}
 			return
 		}
+		// Determine if eviction is needed and simulate the
+		// post-eviction overlay to validate against. This avoids
+		// mutating state before we know the TX is valid.
+		validConsumed := m.overlay.consumed
+		validCreated := m.overlay.created
+		var needsEviction bool
+		var targetBytes int64
 		evictionThreshold := int64(
 			float64(m.config.MempoolCapacity) * m.evictionWatermark,
 		)
 		if newSize > evictionThreshold {
-			targetBytes := max(int64(0), evictionThreshold-txSize)
+			needsEviction = true
+			targetBytes = max(int64(0), evictionThreshold-txSize)
+			// Compute which TXs would be evicted from the front
+			evictedHashes := make(map[string]struct{})
+			var evictedBytes int64
+			for i := 0; i < len(m.transactions) &&
+				m.currentSizeBytes-evictedBytes > targetBytes; i++ {
+				evictedBytes += int64(len(m.transactions[i].Cbor))
+				evictedHashes[m.transactions[i].Hash] = struct{}{}
+			}
+			validConsumed, validCreated = m.overlay.simulateRemoveBatch(evictedHashes)
+		}
+		// Validate against the (possibly simulated) post-eviction
+		// overlay so we don't accept a TX whose inputs were created
+		// by an evicted parent, and don't evict live TXs if
+		// validation fails.
+		if err = m.validator.ValidateTxWithOverlay(
+			tmpTx,
+			validConsumed,
+			validCreated,
+		); err != nil {
+			err = fmt.Errorf("validate transaction: %w", err)
+			return
+		}
+		// Validation passed: commit the eviction
+		if needsEviction {
 			evictedEvents = m.evictOldestLocked(targetBytes)
 		}
+		overlayCbor := slices.Clone(txBytes)
+		txCbor := slices.Clone(txBytes)
+		// Update UTxO overlay with this TX's effects
+		m.overlay.applyTx(txHash, txType, overlayCbor, tmpTx)
 		// Add transaction record
-		m.transactions = append(m.transactions, &tx)
-		m.txByHash[tx.Hash] = &tx
+		tx := &MempoolTransaction{
+			Hash:     txHash,
+			Type:     txType,
+			Cbor:     txCbor,
+			LastSeen: time.Now(),
+		}
+		m.transactions = append(m.transactions, tx)
+		m.txByHash[txHash] = tx
 		m.currentSizeBytes += txSize
 		m.logger.Debug(
 			"added transaction",
 			"component", "mempool",
-			"tx_hash", tx.Hash,
+			"tx_hash", txHash,
 		)
 		m.metrics.txsProcessedNum.Inc()
 		m.metrics.txsInMempool.Inc()
-		m.metrics.mempoolBytes.Add(float64(len(tx.Cbor)))
+		m.metrics.mempoolBytes.Add(float64(txSize))
 		// Prepare event for publishing outside the lock
 		if m.eventBus != nil {
 			evt := event.NewEvent(
 				AddTransactionEventType,
 				AddTransactionEvent{
-					Hash: tx.Hash,
-					Type: tx.Type,
-					Body: tx.Cbor,
+					Hash: txHash,
+					Type: txType,
+					Body: slices.Clone(txBytes),
 				},
 			)
 			addEvent = &evt
@@ -523,64 +821,40 @@ func (m *Mempool) getTransaction(txHash string) *MempoolTransaction {
 }
 
 func (m *Mempool) RemoveTransaction(txHash string) {
-	var evt *event.Event
+	var events []event.Event
 	m.Lock()
-	if m.removeTransaction(txHash, &evt) {
+	m.consumersMutex.Lock()
+	// Remove from overlay with descendant pruning
+	toRemove := map[string]struct{}{txHash: {}}
+	pruned := m.overlay.removeBatchWithDescendants(toRemove)
+	for _, h := range pruned {
+		toRemove[h] = struct{}{}
+	}
+	// Remove all from transactions list (backward for safe index handling)
+	var removed bool
+	for i := len(m.transactions) - 1; i >= 0; i-- {
+		if _, ok := toRemove[m.transactions[i].Hash]; ok {
+			evt := m.removeTransactionByIndexLocked(i)
+			removed = true
+			if evt != nil {
+				events = append(events, *evt)
+			}
+		}
+	}
+	if removed {
+		if len(pruned) > 0 {
+			m.logger.Debug(
+				"pruned orphaned descendant transactions",
+				"component", "mempool",
+				"primary_tx_hash", txHash,
+				"pruned_count", len(pruned),
+			)
+		}
 		m.logger.Debug(
 			"removed transaction",
 			"component", "mempool",
 			"tx_hash", txHash,
 		)
-	}
-	m.Unlock()
-	// MEM-03: Publish event outside the lock
-	if evt != nil && m.eventBus != nil {
-		m.eventBus.Publish(RemoveTransactionEventType, *evt)
-	}
-}
-
-func (m *Mempool) removeTransaction(
-	txHash string,
-	evtOut **event.Event,
-) bool {
-	for txIdx, tx := range m.transactions {
-		if tx.Hash == txHash {
-			ok, evt := m.removeTransactionByIndex(txIdx)
-			if evtOut != nil {
-				*evtOut = evt
-			}
-			return ok
-		}
-	}
-	return false
-}
-
-// removeTransactions removes multiple transactions by hash. Events
-// are published outside the lock. Returns the number of transactions
-// actually removed.
-func (m *Mempool) removeTransactions(hashes []string) int {
-	hashSet := make(map[string]struct{}, len(hashes))
-	for _, h := range hashes {
-		hashSet[h] = struct{}{}
-	}
-	var events []event.Event
-	var removedCount int
-	m.Lock()
-	m.consumersMutex.Lock()
-	// Iterate backward to safely remove by index
-	for i := len(m.transactions) - 1; i >= 0; i-- {
-		tx := m.transactions[i]
-		if _, found := hashSet[tx.Hash]; found {
-			_, evt := m.removeTransactionByIndexLocked(i)
-			removedCount++
-			if evt != nil {
-				events = append(events, *evt)
-			}
-			delete(hashSet, tx.Hash)
-			if len(hashSet) == 0 {
-				break
-			}
-		}
 	}
 	m.consumersMutex.Unlock()
 	m.Unlock()
@@ -590,14 +864,6 @@ func (m *Mempool) removeTransactions(hashes []string) int {
 			m.eventBus.Publish(RemoveTransactionEventType, evt)
 		}
 	}
-	return removedCount
-}
-
-func (m *Mempool) removeTransactionByIndex(txIdx int) (bool, *event.Event) {
-	m.consumersMutex.Lock()
-	result, evt := m.removeTransactionByIndexLocked(txIdx)
-	m.consumersMutex.Unlock()
-	return result, evt
 }
 
 // removeTransactionByIndexLocked removes a transaction by its
@@ -606,9 +872,9 @@ func (m *Mempool) removeTransactionByIndex(txIdx int) (bool, *event.Event) {
 // the caller must publish it after releasing locks (MEM-03).
 func (m *Mempool) removeTransactionByIndexLocked(
 	txIdx int,
-) (bool, *event.Event) {
+) *event.Event {
 	if txIdx >= len(m.transactions) {
-		return false, nil
+		return nil
 	}
 	tx := m.transactions[txIdx]
 	txSize := int64(len(tx.Cbor))
@@ -640,7 +906,7 @@ func (m *Mempool) removeTransactionByIndexLocked(
 		)
 		evt = &e
 	}
-	return true, evt
+	return evt
 }
 
 // evictOldestLocked removes transactions from the front of the
@@ -660,6 +926,14 @@ func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
 	if evicted == 0 {
 		return nil
 	}
+
+	// Collect hashes of evicted TXs for overlay removal
+	evictedHashes := make(map[string]struct{}, evicted)
+	for i := range evicted {
+		evictedHashes[m.transactions[i].Hash] = struct{}{}
+	}
+	// Remove from overlay with descendant pruning
+	pruned := m.overlay.removeBatchWithDescendants(evictedHashes)
 
 	// Clean up hash map, update metrics, and collect events
 	// for each evicted transaction
@@ -688,7 +962,7 @@ func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
 	)
 	m.currentSizeBytes -= evictedBytes
 
-	// Adjust all consumer indexes in one pass
+	// Adjust all consumer indexes in one pass for front removal
 	for _, consumer := range m.consumers {
 		consumer.nextTxIdxMu.Lock()
 		if consumer.nextTxIdx > evicted {
@@ -699,11 +973,33 @@ func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
 		consumer.nextTxIdxMu.Unlock()
 	}
 
-	m.metrics.txsEvicted.Add(float64(evicted))
+	// Remove pruned orphaned descendants from transactions list
+	if len(pruned) > 0 {
+		prunedSet := make(map[string]struct{}, len(pruned))
+		for _, h := range pruned {
+			prunedSet[h] = struct{}{}
+		}
+		for i := len(m.transactions) - 1; i >= 0; i-- {
+			if _, ok := prunedSet[m.transactions[i].Hash]; ok {
+				evt := m.removeTransactionByIndexLocked(i)
+				if evt != nil {
+					events = append(events, *evt)
+				}
+			}
+		}
+		m.logger.Debug(
+			"pruned orphaned descendant transactions during eviction",
+			"component", "mempool",
+			"pruned_count", len(pruned),
+		)
+	}
+
+	totalEvicted := evicted + len(pruned)
+	m.metrics.txsEvicted.Add(float64(totalEvicted))
 	m.logger.Debug(
 		"evicted transactions from mempool",
 		"component", "mempool",
-		"evicted_count", evicted,
+		"evicted_count", totalEvicted,
 		"current_size_bytes", m.currentSizeBytes,
 	)
 	return events

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -28,7 +28,9 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +67,14 @@ func (v *mockValidator) ValidateTx(tx gledger.Transaction) error {
 		return fmt.Errorf("validation failed for %s", tx.Hash())
 	}
 	return nil
+}
+
+func (v *mockValidator) ValidateTxWithOverlay(
+	tx gledger.Transaction,
+	_ map[string]struct{},
+	_ map[string]lcommon.Utxo,
+) error {
+	return v.ValidateTx(tx)
 }
 
 func (v *mockValidator) setFailHash(hash string, fail bool) {
@@ -167,6 +177,7 @@ func TestMempool_Stop(t *testing.T) {
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:     event.NewEventBus(nil, nil),
 		PromRegistry: prometheus.NewRegistry(),
+		Validator:    newMockValidator(),
 	})
 
 	// Add a consumer to test cleanup
@@ -2838,4 +2849,290 @@ func TestMempool_MEM03_NoDeadlockOnConcurrentPublish(
 			"deadlock detected during concurrent publish operations",
 		)
 	}
+}
+
+// =============================================================================
+// UTxO Overlay Tests
+// =============================================================================
+
+// overlayValidator validates transactions using the UTxO overlay.
+// It checks that all inputs exist (in overlay created or base UTxOs)
+// and none are in the consumed set.
+type overlayValidator struct {
+	baseUtxos map[string]lcommon.Utxo // simulated database UTxOs
+	mu        sync.Mutex
+}
+
+func newOverlayValidator(
+	utxos map[string]lcommon.Utxo,
+) *overlayValidator {
+	return &overlayValidator{baseUtxos: utxos}
+}
+
+func (v *overlayValidator) ValidateTx(
+	tx gledger.Transaction,
+) error {
+	return v.ValidateTxWithOverlay(tx, nil, nil)
+}
+
+func (v *overlayValidator) ValidateTxWithOverlay(
+	tx gledger.Transaction,
+	consumedUtxos map[string]struct{},
+	createdUtxos map[string]lcommon.Utxo,
+) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	for _, input := range tx.Inputs() {
+		key := fmt.Sprintf(
+			"%s:%d",
+			input.Id().String(),
+			input.Index(),
+		)
+		// Check consumed first (double-spend)
+		if consumedUtxos != nil {
+			if _, spent := consumedUtxos[key]; spent {
+				return fmt.Errorf("UTxO %s already consumed", key)
+			}
+		}
+		// Check overlay created
+		if createdUtxos != nil {
+			if _, ok := createdUtxos[key]; ok {
+				continue
+			}
+		}
+		// Check base UTxOs
+		if _, ok := v.baseUtxos[key]; ok {
+			continue
+		}
+		return fmt.Errorf("UTxO %s not found", key)
+	}
+	return nil
+}
+
+// removeBaseUtxo simulates a UTxO being consumed by a confirmed block.
+func (v *overlayValidator) removeBaseUtxo(key string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	delete(v.baseUtxos, key)
+}
+
+// hexToBlake2b256 converts a hex string to a Blake2b256 hash.
+func hexToBlake2b256(t *testing.T, h string) lcommon.Blake2b256 {
+	t.Helper()
+	var hash lcommon.Blake2b256
+	b, err := hex.DecodeString(h)
+	require.NoError(t, err)
+	copy(hash[:], b)
+	return hash
+}
+
+// buildMockTx builds a mock transaction with the given inputs and outputs.
+// It uses ouroboros-mock internally.
+func buildMockTx(
+	t *testing.T,
+	txHashHex string,
+	inputs []lcommon.TransactionInput,
+	outputs []lcommon.TransactionOutput,
+) lcommon.Transaction {
+	t.Helper()
+	txIdBytes, err := hex.DecodeString(txHashHex)
+	require.NoError(t, err)
+	builder := mockledger.NewTransactionBuilder().
+		WithId(txIdBytes).
+		WithFee(100000).
+		WithValid(true)
+	for _, inp := range inputs {
+		builder = builder.WithInputs(inp)
+	}
+	for _, out := range outputs {
+		builder = builder.WithOutputs(out)
+	}
+	tx, err := builder.Build()
+	require.NoError(t, err)
+	return tx
+}
+
+// buildMockInput builds a mock transaction input.
+func buildMockInput(
+	t *testing.T,
+	txHashHex string,
+	index uint32,
+) lcommon.TransactionInput {
+	t.Helper()
+	b, err := hex.DecodeString(txHashHex)
+	require.NoError(t, err)
+	inp, err := mockledger.NewSimpleTransactionInput(b, index)
+	require.NoError(t, err)
+	return inp
+}
+
+// buildMockOutput builds a mock transaction output with a valid testnet address.
+func buildMockOutput(
+	t *testing.T,
+	lovelace uint64,
+) lcommon.TransactionOutput {
+	t.Helper()
+	// Use the real testnet address from the test transaction
+	out, err := mockledger.NewSimpleTransactionOutput(
+		"addr_test1qpe6s9amgfwtu9u6lqj998vke6uncswr4dg88qqft5d7f67kfjf77qy57hqhnefcqyy7hmhsygj9j38rj984hn9r57fswc4wg0",
+		lovelace,
+	)
+	require.NoError(t, err)
+	return out
+}
+
+func TestOverlayDoubleSpendRejection(t *testing.T) {
+	// Setup: one UTxO in the "database"
+	inputHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	utxoKey := inputHash + ":0"
+
+	sharedInput := buildMockInput(t, inputHash, 0)
+	baseOutput := buildMockOutput(t, 1000000)
+
+	baseUtxos := map[string]lcommon.Utxo{
+		utxoKey: {Id: sharedInput, Output: baseOutput},
+	}
+	v := newOverlayValidator(baseUtxos)
+
+	// Create a fresh overlay
+	overlay := newUtxoOverlay()
+
+	// TX-A consumes the UTxO — should succeed
+	txA := buildMockTx(
+		t,
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		[]lcommon.TransactionInput{sharedInput},
+		[]lcommon.TransactionOutput{buildMockOutput(t, 900000)},
+	)
+	err := v.ValidateTxWithOverlay(txA, overlay.consumed, overlay.created)
+	require.NoError(t, err, "TX-A should pass overlay validation")
+
+	// Apply TX-A to the overlay
+	overlay.applyTx(txA.Hash().String(), 0, nil, txA)
+
+	// Verify input is now consumed
+	_, consumed := overlay.consumed[utxoKey]
+	assert.True(t, consumed, "input should be in consumed set")
+
+	// TX-B consumes the same UTxO — should be rejected (double-spend)
+	txB := buildMockTx(
+		t,
+		"2222222222222222222222222222222222222222222222222222222222222222",
+		[]lcommon.TransactionInput{sharedInput},
+		[]lcommon.TransactionOutput{buildMockOutput(t, 900000)},
+	)
+	err = v.ValidateTxWithOverlay(txB, overlay.consumed, overlay.created)
+	require.Error(t, err, "TX-B should be rejected (double-spend)")
+	assert.Contains(t, err.Error(), "already consumed")
+}
+
+func TestOverlayDependentTxChaining(t *testing.T) {
+	// Setup: one UTxO in the "database"
+	inputHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	utxoKey := inputHash + ":0"
+
+	baseInput := buildMockInput(t, inputHash, 0)
+	baseOutput := buildMockOutput(t, 2000000)
+
+	baseUtxos := map[string]lcommon.Utxo{
+		utxoKey: {Id: baseInput, Output: baseOutput},
+	}
+	v := newOverlayValidator(baseUtxos)
+
+	overlay := newUtxoOverlay()
+
+	// TX-A consumes base UTxO, creates new output
+	txHashA := "1111111111111111111111111111111111111111111111111111111111111111"
+	txA := buildMockTx(
+		t,
+		txHashA,
+		[]lcommon.TransactionInput{baseInput},
+		[]lcommon.TransactionOutput{buildMockOutput(t, 1800000)},
+	)
+	err := v.ValidateTxWithOverlay(txA, overlay.consumed, overlay.created)
+	require.NoError(t, err, "TX-A should pass")
+	overlay.applyTx(txA.Hash().String(), 0, nil, txA)
+
+	// Verify TX-A's output is in the overlay created set
+	txAOutputKey := txHashA + ":0"
+	_, created := overlay.created[txAOutputKey]
+	assert.True(t, created, "TX-A output should be in created set")
+
+	// TX-B consumes TX-A's output (which only exists in overlay, not DB)
+	inputFromA := buildMockInput(t, txHashA, 0)
+	txB := buildMockTx(
+		t,
+		"2222222222222222222222222222222222222222222222222222222222222222",
+		[]lcommon.TransactionInput{inputFromA},
+		[]lcommon.TransactionOutput{buildMockOutput(t, 1600000)},
+	)
+	err = v.ValidateTxWithOverlay(txB, overlay.consumed, overlay.created)
+	require.NoError(t, err, "TX-B should pass (spends TX-A output from overlay)")
+	overlay.applyTx(txB.Hash().String(), 0, nil, txB)
+
+	// Verify both TXs are tracked
+	assert.Len(t, overlay.applied, 2)
+
+	// TX-C with input not in DB or overlay should fail
+	unknownInput := buildMockInput(
+		t,
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		0,
+	)
+	txC := buildMockTx(
+		t,
+		"3333333333333333333333333333333333333333333333333333333333333333",
+		[]lcommon.TransactionInput{unknownInput},
+		[]lcommon.TransactionOutput{buildMockOutput(t, 500000)},
+	)
+	err = v.ValidateTxWithOverlay(txC, overlay.consumed, overlay.created)
+	require.Error(t, err, "TX-C should fail (input not found)")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestOverlayRebuildOnChainUpdate(t *testing.T) {
+	// This test uses the real test transaction CBOR because rebuildOverlay
+	// re-decodes transactions from their stored CBOR bytes.
+	//
+	// The real TX has input: 0c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8:1
+
+	realInputHash := "0c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8"
+	realInputKey := realInputHash + ":1"
+
+	// Create a base UTxO set containing the real TX's input
+	realInput := buildMockInput(t, realInputHash, 1)
+	realOutput := buildMockOutput(t, 50000000)
+	baseUtxos := map[string]lcommon.Utxo{
+		realInputKey: {Id: realInput, Output: realOutput},
+	}
+	v := newOverlayValidator(baseUtxos)
+	m := newTestMempoolWithValidator(t, v)
+	defer func() {
+		require.NoError(t, m.Stop(context.Background()))
+	}()
+
+	// Add the real TX via AddTransaction
+	txBytes := getTestTxBytes(t)
+	err := m.AddTransaction(uint(conway.EraIdConway), txBytes)
+	require.NoError(t, err, "real TX should be accepted")
+
+	// Verify TX is in mempool
+	m.RLock()
+	assert.Len(t, m.transactions, 1, "mempool should have 1 TX")
+	m.RUnlock()
+
+	// Simulate chain update: a confirmed block consumed the same UTxO
+	v.removeBaseUtxo(realInputKey)
+
+	// Rebuild overlay (simulates what processChainEvents does)
+	m.rebuildOverlay()
+
+	// TX should be evicted because its input is no longer in base UTxOs
+	m.RLock()
+	assert.Empty(
+		t,
+		m.transactions,
+		"TX should be removed after its input was consumed by a confirmed block",
+	)
+	m.RUnlock()
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UTxO overlay to `mempool` and threads it through `ledger` validation so pending spends/outputs are honored during admission, eviction, expiry, removals, and chain updates. Enables safe dependent TX chaining, blocks cross‑mempool double‑spends, and prunes descendants when parents are removed or invalidated.

- **New Features**
  - `ledger`: refactored validation into `validateTxCore`; added `ValidateTxWithOverlay`; `LedgerView.UtxoById` checks `consumedUtxos` and returns `ErrUtxoAlreadyConsumed`.
  - `mempool`: maintains an ordered UTxO overlay; `AddTransaction` validates against a simulated post‑eviction overlay before committing eviction and applying effects; chain updates rebuild the overlay by re‑decoding CBOR and re‑validating sequentially under a write lock; `Stop` resets the overlay; `RemoveTransaction`/eviction/expiry update the overlay and prune descendants; metrics: eviction count includes pruned descendants and expiry logs direct‑expired vs total removed; constructor requires a `Validator` (and `AddTransaction` errors if missing).

<sup>Written for commit 2252a014a5212c5cece96e96693e077d18f363d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mempool now maintains an overlay of pending UTxO changes to prevent double-spends, support dependent transaction chains, and revalidate/remove affected transactions after evictions or chain updates.
  * Exposes a validation API that supports both standard and overlay-aware validation and returns clearer errors when an input is already consumed by a pending transaction.

* **Tests**
  * Added comprehensive overlay-focused tests for double-spend rejection, dependent-tx chaining, and rebuild-on-chain-update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->