### PR TITLE
fix: dev mode always enables API storage

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -153,6 +153,14 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.StorageModeAPI,
 		)
 	}
+	// Dev mode always uses API storage for full transaction metadata
+	if cfg.RunMode.IsDevMode() && !storageMode.IsAPI() {
+		logger.Info(
+			"dev mode: overriding storage mode to api",
+			"previous", string(storageMode),
+		)
+		storageMode = dingo.StorageModeAPI
+	}
 	// APIs require "api" storage mode
 	anyAPIEnabled := cfg.BlockfrostPort > 0 ||
 		cfg.MeshPort > 0 ||


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Dev mode now always uses API storage by overriding any non-API storageMode, ensuring full transaction metadata and consistent local behavior. The previous mode is logged for visibility.

<sup>Written for commit cde8440b4fd3e22828fb0680ceda72ef417296c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

