### PR TITLE
feat(aws): add minio to github actions to support integration testing…

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  # Linux job with Postgres and MySQL services for integration tests
+  # Linux job with Postgres, MySQL and MinIO (fake s3) services for integration tests
   go-test-linux:
     name: go-test (Linux)
     strategy:
@@ -47,6 +47,15 @@ jobs:
           --health-retries 5
         ports:
           - 3306:3306
+      minio:
+        image: minio/minio
+        options: >-
+          --health-cmd "curl localhost:9000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 9001:9001
     env:
       POSTGRES_HOST: localhost
       POSTGRES_PORT: '5432'
@@ -58,6 +67,9 @@ jobs:
       MYSQL_USER: mysql
       MYSQL_PASSWORD: mysql
       MYSQL_DATABASE: dingo_test
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_ENDPOINT: "http://localhost:9000/"
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -632,6 +632,19 @@ func isS3NotFound(err error) bool {
 	return errors.As(err, &noSuchKey)
 }
 
+func isS3BucketAlreadyExists(err error) bool {
+	var bucketAlreadyOwned = &s3types.BucketAlreadyOwnedByYou{}
+	if errors.As(err, &bucketAlreadyOwned) {
+		return true
+	}
+
+	var bucketAlreadyExists = &s3types.BucketAlreadyExists{}
+	if errors.As(err, &bucketAlreadyExists) {
+		return true
+	}
+	return false
+}
+
 func (d *BlobStoreS3) listKeys(
 	opts types.BlobIteratorOptions,
 ) ([]string, error) {
@@ -778,6 +791,18 @@ func (d *BlobStoreS3) Start() error {
 	}
 
 	client := s3.NewFromConfig(awsCfg)
+
+	// attempt to create bucket if it doesn't already exist
+	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(d.bucket),
+		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(d.region),
+		},
+	})
+	if err != nil && !isS3BucketAlreadyExists(err) {
+		cancel()
+		return fmt.Errorf("failed creating s3 bucket: %w", err)
+	}
 
 	d.client = client
 	d.startupCtx = ctx

--- a/database/plugin/blob/aws/database_test.go
+++ b/database/plugin/blob/aws/database_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package aws
+
+import (
+	"os"
+	"testing"
+)
+
+func isAwsConfigured() bool {
+	return os.Getenv("AWS_ACCESS_KEY_ID") != "" &&
+		os.Getenv("AWS_SECRET_ACCESS_KEY") != "" &&
+		os.Getenv("AWS_ENDPOINT") != ""
+}
+
+func TestNewWithOptions(t *testing.T) {
+	if !isAwsConfigured() {
+		t.Skip("AWS is not configured.  To run tests, set " +
+			"AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_ENDPOINT " +
+			"environment variables")
+	}
+
+	db, err := NewWithOptions(
+		WithEndpoint(os.Getenv("AWS_ENDPOINT")),
+		WithBucket("dingo"),
+		WithPrefix(""),
+		WithRegion("us-east-1"),
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := db.Start(); err != nil {
+		t.Error(err)
+		return
+	}
+}


### PR DESCRIPTION
… aws plugin

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MinIO to GitHub Actions to run S3 integration tests for the AWS blob plugin and updates the plugin to auto-create the bucket on startup.

- **New Features**
  - CI: Add `minio/minio` service to `go-test` workflow with health checks and set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ENDPOINT`.
  - S3 plugin: `BlobStoreS3.Start()` now attempts `CreateBucket` and ignores `BucketAlreadyOwnedByYou` and `BucketAlreadyExists` errors.
  - Tests: Add `database_test.go` to verify `NewWithOptions` and `Start()` when AWS env vars are set; skips if not configured.

<sup>Written for commit 39273c28ac9b7eed1e2f1dfc7b3376cb6e88bf27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MinIO service to testing infrastructure for S3-compatible blob storage testing.

* **Bug Fixes**
  * Made S3 bucket creation idempotent to prevent failures when buckets already exist.

* **Tests**
  * Added test coverage for AWS blob storage initialization with configurable endpoint, bucket, and region options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->