### PR TITLE
chore(deps): gouroboros 0.160.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.160.0
+	github.com/blinklabs-io/gouroboros v0.160.1
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.26
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.160.0 h1:E+8y59xcBqEZHLfjxpgCEwOBWOJcQ2ijmJyi8D39sus=
-github.com/blinklabs-io/gouroboros v0.160.0/go.mod h1:ZhQREyLgf8zv63oz2qNj9rEhForAJj/ySTMiXdeH3l8=
+github.com/blinklabs-io/gouroboros v0.160.1 h1:h/gfs4iKkk3Irfrk1g6ndsPdra9uc9kE5hVPrEz1nXo=
+github.com/blinklabs-io/gouroboros v0.160.1/go.mod h1:ZhQREyLgf8zv63oz2qNj9rEhForAJj/ySTMiXdeH3l8=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.26 h1:LrEMTtgpiUMjTXwHgBt/PAZeW6l/6UQUbeYK/tbiBkM=

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -126,7 +126,8 @@ func TestVRFSigner(t *testing.T) {
 
 	// Generate VRF proof for a sample slot
 	epochNonce := make([]byte, 32) // All zeros for test
-	alpha := vrf.MkInputVrf(1000, epochNonce)
+	alpha, err := vrf.MkInputVrf(1000, epochNonce)
+	require.NoError(t, err)
 
 	proof, output, err := vrfSigner.Prove(alpha)
 	require.NoError(t, err)

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -435,7 +435,10 @@ func (b *DefaultBlockBuilder) BuildBlock(
 	}
 
 	// Generate VRF proof using MkInputVrf(slot, epochNonce)
-	alpha := vrf.MkInputVrf(int64(slot), epochNonce) // #nosec G115 -- validated above
+	alpha, err := vrf.MkInputVrf(int64(slot), epochNonce) // #nosec G115 -- validated above
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create VRF input: %w", err)
+	}
 	vrfProof, vrfOutput, err := b.creds.VRFProve(alpha)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate VRF proof: %w", err)

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -573,7 +573,10 @@ func (f *BlockForger) VRFProofForSlot(
 	}
 
 	// Create VRF input: MkInputVrf(slot, epochNonce)
-	alpha := vrf.MkInputVrf(int64(slot), epochNonce) // #nosec G115 -- validated above
+	alpha, err := vrf.MkInputVrf(int64(slot), epochNonce) // #nosec G115 -- validated above
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create VRF input: %w", err)
+	}
 
 	return f.creds.VRFProve(alpha)
 }

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -117,7 +117,8 @@ func TestVRFProve(t *testing.T) {
 
 	// Generate VRF proof for a sample slot
 	epochNonce := make([]byte, 32) // All zeros for test
-	alpha := vrf.MkInputVrf(1000, epochNonce)
+	alpha, err := vrf.MkInputVrf(1000, epochNonce)
+	require.NoError(t, err)
 
 	proof, output, err := pc.VRFProve(alpha)
 	require.NoError(t, err)

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -106,7 +106,10 @@ func createTestBlock(
 
 	var result *realBabbageBlock
 	for slot := uint64(1); slot <= 200; slot++ {
-		vrfInput := vrf.MkInputVrf(int64(slot), epochNonce) //nolint:gosec
+		vrfInput, vrfInputErr := vrf.MkInputVrf(int64(slot), epochNonce) //nolint:gosec
+		if vrfInputErr != nil {
+			continue
+		}
 		vrfProof, vrfOutput, proveErr := vrf.Prove(vrfSk, vrfInput)
 		if proveErr != nil {
 			continue


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `github.com/blinklabs-io/gouroboros` to v0.160.1 and update VRF input creation to the new error-returning API. Propagates and handles VRF input errors in forging code and tests.

- **Dependencies**
  - Bump `github.com/blinklabs-io/gouroboros` from v0.160.0 to v0.160.1.

- **Refactors**
  - Switch to `alpha, err := vrf.MkInputVrf(...)` in forging paths and return wrapped errors.
  - Update tests to check the error (`require.NoError`) and handle failures (skip slot in `verify_header_test.go`).

<sup>Written for commit 0d8525ab15f98988a9cc4f403e61e6477d07e57b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation and error handling around VRF inputs, improving block forging reliability and preventing use of invalid VRF data.
* **Chores**
  * Minor dependency version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->