### PR TITLE
build(go): minimum Go 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: go-test (Linux)
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -81,7 +81,7 @@ jobs:
     name: go-test (${{ matrix.platform }})
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [macos-latest, windows-latest]
         include:
           - platform: macos-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-1.24.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.25.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.24.x-
+            ${{ runner.os }}-go-1.25.x-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ especially as there is functionality which has not yet been developed.
 
 ## Development / Building
 
-This requires Go 1.24 or later. You also need `make`.
+This requires Go 1.25 or later. You also need `make`.
 
 ```bash
 # Format, test, and build (default target)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/dingo
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.10
+toolchain go1.25.8
 
 require (
 	cloud.google.com/go/storage v1.60.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raise the minimum Go version to 1.25 (toolchain 1.25.8) and update CI to test 1.25.x and 1.26.x. README and go.mod now reflect the new baseline.

- **Migration**
  - Upgrade to Go 1.25+ locally (recommended 1.25.8) before building or running tests.

<sup>Written for commit 60a7e8084e83ab4627370a81b71f1df42b707abf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement to 1.25
  * Updated CI/CD testing matrix to validate against Go 1.25.x and 1.26.x versions
  * Updated Go toolchain to version 1.25.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->