### PR TITLE
refactor(chain): typed block cache keys

### DIFF
--- a/chain/blockcache.go
+++ b/chain/blockcache.go
@@ -16,6 +16,9 @@ package chain
 
 import (
 	"container/list"
+	"fmt"
+	"io"
+	"log/slog"
 	"sync"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -35,14 +38,25 @@ const DefaultBlockCacheCapacity = 10000
 type blockCache struct {
 	mu           sync.Mutex
 	capacity     int
-	items        map[string]*list.Element
+	items        map[[32]byte]*list.Element
 	order        *list.List // front = most recent, back = least recent
+	logger       *slog.Logger
 	cachedBlocks prometheus.Gauge
 }
 
 type blockCacheEntry struct {
-	hash  string
+	hash  [32]byte
 	block models.Block
+}
+
+func blockCacheKey(hash []byte) ([32]byte, error) {
+	if len(hash) != 32 {
+		return [32]byte{}, fmt.Errorf(
+			"blockCacheKey: expected 32-byte hash, got %d bytes",
+			len(hash),
+		)
+	}
+	return [32]byte(hash), nil
 }
 
 // newBlockCache creates a new block cache with the given
@@ -57,8 +71,9 @@ func newBlockCache(
 	}
 	c := &blockCache{
 		capacity: capacity,
-		items:    make(map[string]*list.Element),
+		items:    make(map[[32]byte]*list.Element),
 		order:    list.New(),
+		logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
 	}
 	if promRegistry != nil {
 		c.initMetrics(promRegistry)
@@ -89,11 +104,15 @@ func (c *blockCache) updateMetrics() {
 // and false if not found. Accessing a block moves it to the
 // front of the LRU list.
 func (c *blockCache) Get(
-	hash string,
+	hash []byte,
 ) (models.Block, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if elem, ok := c.items[hash]; ok {
+	key, err := blockCacheKey(hash)
+	if err != nil {
+		return models.Block{}, false
+	}
+	if elem, ok := c.items[key]; ok {
 		c.order.MoveToFront(elem)
 		return elem.Value.(*blockCacheEntry).block, true
 	}
@@ -106,7 +125,16 @@ func (c *blockCache) Get(
 func (c *blockCache) Put(block models.Block) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	hash := string(block.Hash)
+	hash, err := blockCacheKey(block.Hash)
+	if err != nil {
+		c.logger.Warn(
+			"block cache: skipping block with invalid hash length",
+			"hash_len", len(block.Hash),
+			"block_id", block.ID,
+			"error", err,
+		)
+		return
+	}
 
 	// If already in cache, update and move to front
 	if elem, ok := c.items[hash]; ok {
@@ -131,12 +159,16 @@ func (c *blockCache) Put(block models.Block) {
 }
 
 // Delete removes a block from the cache by its hash.
-func (c *blockCache) Delete(hash string) {
+func (c *blockCache) Delete(hash []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if elem, ok := c.items[hash]; ok {
+	key, err := blockCacheKey(hash)
+	if err != nil {
+		return
+	}
+	if elem, ok := c.items[key]; ok {
 		c.order.Remove(elem)
-		delete(c.items, hash)
+		delete(c.items, key)
 		c.updateMetrics()
 	}
 }

--- a/chain/blockcache_test.go
+++ b/chain/blockcache_test.go
@@ -15,6 +15,7 @@
 package chain
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"sync"
 	"testing"
@@ -26,24 +27,30 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 )
 
+// testHash returns a deterministic 32-byte hash derived from a label.
+func testHash(label string) []byte {
+	h := sha256.Sum256([]byte(label))
+	return h[:]
+}
+
 func TestBlockCache_BasicOperations(t *testing.T) {
 	cache := newBlockCache(3, nil)
 
 	// Test empty cache
-	_, ok := cache.Get("nonexistent")
+	_, ok := cache.Get(testHash("nonexistent"))
 	assert.False(t, ok)
 	assert.Equal(t, 0, cache.Len())
 
 	// Add a block
 	block1 := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 100,
 	}
 	cache.Put(block1)
 	assert.Equal(t, 1, cache.Len())
 
 	// Retrieve it
-	got, ok := cache.Get("hash1")
+	got, ok := cache.Get(testHash("hash1"))
 	assert.True(t, ok)
 	assert.Equal(t, uint64(100), got.Slot)
 }
@@ -53,15 +60,15 @@ func TestBlockCache_LRUEviction(t *testing.T) {
 
 	// Add 3 blocks
 	block1 := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 1,
 	}
 	block2 := models.Block{
-		Hash: []byte("hash2"),
+		Hash: testHash("hash2"),
 		Slot: 2,
 	}
 	block3 := models.Block{
-		Hash: []byte("hash3"),
+		Hash: testHash("hash3"),
 		Slot: 3,
 	}
 
@@ -71,9 +78,9 @@ func TestBlockCache_LRUEviction(t *testing.T) {
 	assert.Equal(t, 3, cache.Len())
 
 	// All should be present
-	_, ok1 := cache.Get("hash1")
-	_, ok2 := cache.Get("hash2")
-	_, ok3 := cache.Get("hash3")
+	_, ok1 := cache.Get(testHash("hash1"))
+	_, ok2 := cache.Get(testHash("hash2"))
+	_, ok3 := cache.Get(testHash("hash3"))
 	assert.True(t, ok1)
 	assert.True(t, ok2)
 	assert.True(t, ok3)
@@ -82,20 +89,20 @@ func TestBlockCache_LRUEviction(t *testing.T) {
 	// used). After the Gets above, order is hash3, hash2,
 	// hash1 (most to least recent), so hash1 is evicted.
 	block4 := models.Block{
-		Hash: []byte("hash4"),
+		Hash: testHash("hash4"),
 		Slot: 4,
 	}
 	cache.Put(block4)
 	assert.Equal(t, 3, cache.Len())
 
 	// hash1 should be evicted
-	_, ok1 = cache.Get("hash1")
+	_, ok1 = cache.Get(testHash("hash1"))
 	assert.False(t, ok1)
 
 	// Others should still be present
-	_, ok2 = cache.Get("hash2")
-	_, ok3 = cache.Get("hash3")
-	_, ok4 := cache.Get("hash4")
+	_, ok2 = cache.Get(testHash("hash2"))
+	_, ok3 = cache.Get(testHash("hash3"))
+	_, ok4 := cache.Get(testHash("hash4"))
 	assert.True(t, ok2)
 	assert.True(t, ok3)
 	assert.True(t, ok4)
@@ -106,14 +113,14 @@ func TestBlockCache_UpdateExisting(t *testing.T) {
 
 	// Add a block
 	block1 := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 100,
 	}
 	cache.Put(block1)
 
 	// Update it
 	block1Updated := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 200,
 	}
 	cache.Put(block1Updated)
@@ -122,7 +129,7 @@ func TestBlockCache_UpdateExisting(t *testing.T) {
 	assert.Equal(t, 1, cache.Len())
 
 	// Should have updated slot
-	got, ok := cache.Get("hash1")
+	got, ok := cache.Get(testHash("hash1"))
 	assert.True(t, ok)
 	assert.Equal(t, uint64(200), got.Slot)
 }
@@ -132,15 +139,15 @@ func TestBlockCache_AccessMovesToFront(t *testing.T) {
 
 	// Add 3 blocks in order
 	block1 := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 1,
 	}
 	block2 := models.Block{
-		Hash: []byte("hash2"),
+		Hash: testHash("hash2"),
 		Slot: 2,
 	}
 	block3 := models.Block{
-		Hash: []byte("hash3"),
+		Hash: testHash("hash3"),
 		Slot: 3,
 	}
 
@@ -149,27 +156,27 @@ func TestBlockCache_AccessMovesToFront(t *testing.T) {
 	cache.Put(block3)
 
 	// Access hash1, moving it to front
-	cache.Get("hash1")
+	cache.Get(testHash("hash1"))
 
 	// Add block4 - should evict hash2 (now least recently
 	// used)
 	block4 := models.Block{
-		Hash: []byte("hash4"),
+		Hash: testHash("hash4"),
 		Slot: 4,
 	}
 	cache.Put(block4)
 
 	// hash1 should still be present (was accessed)
-	_, ok1 := cache.Get("hash1")
+	_, ok1 := cache.Get(testHash("hash1"))
 	assert.True(t, ok1)
 
 	// hash2 should be evicted
-	_, ok2 := cache.Get("hash2")
+	_, ok2 := cache.Get(testHash("hash2"))
 	assert.False(t, ok2)
 
 	// hash3 and hash4 should be present
-	_, ok3 := cache.Get("hash3")
-	_, ok4 := cache.Get("hash4")
+	_, ok3 := cache.Get(testHash("hash3"))
+	_, ok4 := cache.Get(testHash("hash4"))
 	assert.True(t, ok3)
 	assert.True(t, ok4)
 }
@@ -197,15 +204,15 @@ func TestBlockCache_Delete(t *testing.T) {
 
 	// Add blocks
 	block1 := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 1,
 	}
 	block2 := models.Block{
-		Hash: []byte("hash2"),
+		Hash: testHash("hash2"),
 		Slot: 2,
 	}
 	block3 := models.Block{
-		Hash: []byte("hash3"),
+		Hash: testHash("hash3"),
 		Slot: 3,
 	}
 	cache.Put(block1)
@@ -214,21 +221,21 @@ func TestBlockCache_Delete(t *testing.T) {
 	assert.Equal(t, 3, cache.Len())
 
 	// Delete middle block
-	cache.Delete("hash2")
+	cache.Delete(testHash("hash2"))
 	assert.Equal(t, 2, cache.Len())
 
 	// Deleted block should not be found
-	_, ok := cache.Get("hash2")
+	_, ok := cache.Get(testHash("hash2"))
 	assert.False(t, ok)
 
 	// Other blocks should still be present
-	_, ok1 := cache.Get("hash1")
-	_, ok3 := cache.Get("hash3")
+	_, ok1 := cache.Get(testHash("hash1"))
+	_, ok3 := cache.Get(testHash("hash3"))
 	assert.True(t, ok1)
 	assert.True(t, ok3)
 
 	// Deleting a non-existent key should be a no-op
-	cache.Delete("nonexistent")
+	cache.Delete(testHash("nonexistent"))
 	assert.Equal(t, 2, cache.Len())
 }
 
@@ -245,13 +252,13 @@ func TestBlockCache_ConcurrentAccess(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for i := range opsPerGoroutine {
-				hash := fmt.Sprintf(
+				hash := testHash(fmt.Sprintf(
 					"hash-%d-%d",
 					id,
 					i,
-				)
+				))
 				block := models.Block{
-					Hash: []byte(hash),
+					Hash: hash,
 					Slot: uint64(
 						id*opsPerGoroutine + i,
 					),
@@ -266,11 +273,11 @@ func TestBlockCache_ConcurrentAccess(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for i := range opsPerGoroutine {
-				hash := fmt.Sprintf(
+				hash := testHash(fmt.Sprintf(
 					"hash-%d-%d",
 					id,
 					i,
-				)
+				))
 				cache.Get(hash)
 			}
 		}(g)
@@ -281,11 +288,11 @@ func TestBlockCache_ConcurrentAccess(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for i := range opsPerGoroutine {
-				hash := fmt.Sprintf(
+				hash := testHash(fmt.Sprintf(
 					"hash-%d-%d",
 					id,
 					i,
-				)
+				))
 				cache.Delete(hash)
 			}
 		}(g)
@@ -305,11 +312,11 @@ func TestBlockCache_PrometheusMetric(t *testing.T) {
 
 	// Add blocks and verify metric is registered
 	block1 := models.Block{
-		Hash: []byte("hash1"),
+		Hash: testHash("hash1"),
 		Slot: 1,
 	}
 	block2 := models.Block{
-		Hash: []byte("hash2"),
+		Hash: testHash("hash2"),
 		Slot: 2,
 	}
 	cache.Put(block1)
@@ -339,7 +346,7 @@ func TestBlockCache_PrometheusMetric(t *testing.T) {
 	)
 
 	// Delete a block and verify metric updates
-	cache.Delete("hash1")
+	cache.Delete(testHash("hash1"))
 	metrics, err = registry.Gather()
 	require.NoError(t, err)
 	for _, mf := range metrics {

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -15,6 +15,7 @@
 package chain
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -32,6 +33,10 @@ import (
 
 const (
 	initialBlockIndex uint64 = 1
+	// Mainnet full blocks can make larger batches exceed practical Badger
+	// transaction limits during import, so keep the runtime batch size
+	// conservative even if smaller benchmark fixtures tolerate more.
+	blockImportBatchSize = 50
 )
 
 type Chain struct {
@@ -103,6 +108,9 @@ func (c *Chain) AddBlockHeader(header ledger.BlockHeader) error {
 	if c == nil {
 		return errors.New("chain is nil")
 	}
+	headerHash := header.Hash()
+	headerPrevHash := header.PrevHash()
+	headerPrevHashBytes := headerPrevHash.Bytes()
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	// Reject headers when the queue is at capacity to prevent
@@ -114,10 +122,10 @@ func (c *Chain) AddBlockHeader(header ledger.BlockHeader) error {
 	if c.tipBlockIndex >= initialBlockIndex ||
 		len(c.headers) > 0 {
 		headerTip := c.headerTip()
-		if string(header.PrevHash().Bytes()) != string(headerTip.Point.Hash) {
+		if !bytes.Equal(headerPrevHashBytes, headerTip.Point.Hash) {
 			return NewBlockNotFitChainTipError(
-				header.Hash().String(),
-				header.PrevHash().String(),
+				headerHash.String(),
+				headerPrevHash.String(),
 				hex.EncodeToString(headerTip.Point.Hash),
 			)
 		}
@@ -131,12 +139,12 @@ func (c *Chain) AddBlock(
 	block ledger.Block,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, txn)
+	evt, err := c.addBlockInternal(block, txn, true)
 	if err != nil {
 		return err
 	}
 	// Publish event immediately for standalone (non-batched) calls
-	if c.eventBus != nil {
+	if c.eventBus != nil && evt.Type != "" {
 		c.eventBus.Publish(ChainUpdateEventType, evt)
 	}
 	return nil
@@ -149,6 +157,7 @@ func (c *Chain) AddBlock(
 func (c *Chain) addBlockInternal(
 	block ledger.Block,
 	txn *database.Txn,
+	notifyWaiters bool,
 ) (event.Event, error) {
 	if c == nil {
 		return event.Event{}, errors.New("chain is nil")
@@ -162,22 +171,34 @@ func (c *Chain) addBlockInternal(
 	if err := c.reconcile(); err != nil {
 		return event.Event{}, fmt.Errorf("reconcile chain: %w", err)
 	}
+	return c.addBlockLocked(block, txn, notifyWaiters)
+}
+
+func (c *Chain) addBlockLocked(
+	block ledger.Block,
+	txn *database.Txn,
+	notifyWaiters bool,
+) (event.Event, error) {
+	blockHash := block.Hash()
+	blockHashBytes := blockHash.Bytes()
+	blockPrevHash := block.PrevHash()
+	blockPrevHashBytes := blockPrevHash.Bytes()
 	// Check that the new block matches our first header, if any
 	if len(c.headers) > 0 {
 		firstHeader := c.headers[0]
-		if block.Hash().String() != firstHeader.Hash().String() {
+		if !bytes.Equal(blockHashBytes, firstHeader.Hash().Bytes()) {
 			return event.Event{}, NewBlockNotMatchHeaderError(
-				block.Hash().String(),
+				blockHash.String(),
 				firstHeader.Hash().String(),
 			)
 		}
 	}
 	// Check that this block fits on the current chain tip
 	if c.tipBlockIndex >= initialBlockIndex {
-		if string(block.PrevHash().Bytes()) != string(c.currentTip.Point.Hash) {
+		if !bytes.Equal(blockPrevHashBytes, c.currentTip.Point.Hash) {
 			return event.Event{}, NewBlockNotFitChainTipError(
-				block.Hash().String(),
-				block.PrevHash().String(),
+				blockHash.String(),
+				blockPrevHash.String(),
 				hex.EncodeToString(c.currentTip.Point.Hash),
 			)
 		}
@@ -185,7 +206,7 @@ func (c *Chain) addBlockInternal(
 	// Build new block record
 	tmpPoint := ocommon.NewPoint(
 		block.SlotNumber(),
-		block.Hash().Bytes(),
+		blockHashBytes,
 	)
 	newBlockIndex := c.tipBlockIndex + 1
 	tmpBlock := models.Block{
@@ -194,7 +215,7 @@ func (c *Chain) addBlockInternal(
 		Hash:     tmpPoint.Hash,
 		Number:   block.BlockNumber(),
 		Type:     uint(block.Type()), //nolint:gosec
-		PrevHash: block.PrevHash().Bytes(),
+		PrevHash: blockPrevHashBytes,
 		Cbor:     block.Cbor(),
 	}
 	if err := c.manager.addBlock(tmpBlock, txn, c.persistent); err != nil {
@@ -213,13 +234,12 @@ func (c *Chain) addBlockInternal(
 		BlockNumber: block.BlockNumber(),
 	}
 	c.tipBlockIndex = newBlockIndex
-	// Notify waiting iterators
-	c.waitingChanMutex.Lock()
-	if c.waitingChan != nil {
-		close(c.waitingChan)
-		c.waitingChan = nil
+	if notifyWaiters {
+		c.notifyWaitingIterators()
 	}
-	c.waitingChanMutex.Unlock()
+	if c.eventBus == nil {
+		return event.Event{}, nil
+	}
 	// Build event for caller to publish after transaction commit
 	evt := event.NewEvent(
 		ChainUpdateEventType,
@@ -239,7 +259,7 @@ func (c *Chain) AddBlocks(blocks []ledger.Block) error {
 	batchSize := 0
 	for {
 		batchSize = min(
-			50,
+			blockImportBatchSize,
 			len(blocks)-batchOffset,
 		)
 		if batchSize == 0 {
@@ -249,22 +269,31 @@ func (c *Chain) AddBlocks(blocks []ledger.Block) error {
 		// published only after the transaction commits successfully.
 		// This prevents subscribers from observing rolled-back data
 		// when a later block in the batch fails.
-		var pendingEvents []event.Event
+		pendingEvents := make([]event.Event, 0, batchSize)
 		txn := c.manager.db.BlobTxn(true)
 		err := txn.Do(func(txn *database.Txn) error {
-			pendingEvents = pendingEvents[:0]
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			c.manager.mutex.Lock()
+			defer c.manager.mutex.Unlock()
+			if err := c.reconcile(); err != nil {
+				return fmt.Errorf("reconcile chain: %w", err)
+			}
 			for _, tmpBlock := range blocks[batchOffset : batchOffset+batchSize] {
-				evt, err := c.addBlockInternal(tmpBlock, txn)
+				evt, err := c.addBlockLocked(tmpBlock, txn, false)
 				if err != nil {
 					return err
 				}
-				pendingEvents = append(pendingEvents, evt)
+				if evt.Type != "" {
+					pendingEvents = append(pendingEvents, evt)
+				}
 			}
 			return nil
 		})
 		if err != nil {
 			return err
 		}
+		c.notifyWaitingIterators()
 		// Transaction committed successfully; publish all events
 		if c.eventBus != nil {
 			for _, evt := range pendingEvents {
@@ -287,28 +316,13 @@ type RawBlock struct {
 	Cbor        []byte
 }
 
-// addRawBlock adds a pre-extracted block to the chain without requiring
-// a full ledger.Block interface. This is used for bulk loading where only
-// the block header has been decoded.
-//
-// The caller must notify waitingChan after the enclosing transaction
-// commits. See AddRawBlocks for the complete flow.
-func (c *Chain) addRawBlock(
-	rb RawBlock, txn *database.Txn,
-) (*event.Event, error) {
-	if c == nil {
-		return nil, errors.New("chain is nil")
-	}
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	c.manager.mutex.Lock()
-	defer c.manager.mutex.Unlock()
-	if err := c.reconcile(); err != nil {
-		return nil, fmt.Errorf("reconcile: %w", err)
-	}
+func (c *Chain) addRawBlockLocked(
+	rb RawBlock,
+	txn *database.Txn,
+) (event.Event, error) {
 	// Validate hash fields before any comparisons
 	if len(rb.Hash) == 0 {
-		return nil, errors.New(
+		return event.Event{}, errors.New(
 			"invalid raw block: empty Hash",
 		)
 	}
@@ -317,15 +331,15 @@ func (c *Chain) addRawBlock(
 	// The narrower check ensures we only enforce PrevHash presence once the chain is beyond the initial block.
 	if c.tipBlockIndex >= initialBlockIndex &&
 		len(rb.PrevHash) == 0 {
-		return nil, errors.New(
+		return event.Event{}, errors.New(
 			"invalid raw block: empty PrevHash",
 		)
 	}
 	// Check that the new block matches our first header, if any
 	if len(c.headers) > 0 {
 		firstHeader := c.headers[0]
-		if string(rb.Hash) != string(firstHeader.Hash().Bytes()) {
-			return nil, NewBlockNotMatchHeaderError(
+		if !bytes.Equal(rb.Hash, firstHeader.Hash().Bytes()) {
+			return event.Event{}, NewBlockNotMatchHeaderError(
 				hex.EncodeToString(rb.Hash),
 				firstHeader.Hash().String(),
 			)
@@ -333,8 +347,8 @@ func (c *Chain) addRawBlock(
 	}
 	// Check that this block fits on the current chain tip
 	if c.tipBlockIndex >= initialBlockIndex {
-		if string(rb.PrevHash) != string(c.currentTip.Point.Hash) {
-			return nil, NewBlockNotFitChainTipError(
+		if !bytes.Equal(rb.PrevHash, c.currentTip.Point.Hash) {
+			return event.Event{}, NewBlockNotFitChainTipError(
 				hex.EncodeToString(rb.Hash),
 				hex.EncodeToString(rb.PrevHash),
 				hex.EncodeToString(c.currentTip.Point.Hash),
@@ -353,7 +367,7 @@ func (c *Chain) addRawBlock(
 		Cbor:     rb.Cbor,
 	}
 	if err := c.manager.addBlock(tmpBlock, txn, c.persistent); err != nil {
-		return nil, fmt.Errorf("persisting block: %w", err)
+		return event.Event{}, fmt.Errorf("persisting block: %w", err)
 	}
 	if !c.persistent {
 		c.blocks = append(c.blocks, tmpPoint)
@@ -366,23 +380,18 @@ func (c *Chain) addRawBlock(
 		BlockNumber: rb.BlockNumber,
 	}
 	c.tipBlockIndex = newBlockIndex
-	// NOTE: Do NOT close waitingChan here. AddRawBlocks notifies
-	// waiters once per batch after the transaction commits,
-	// reducing lock contention for large bulk loads.
-	//
 	// Build event for deferred publication (same pattern as
 	// addBlockLocked — publish after the transaction commits).
 	if c.eventBus != nil {
-		evt := event.NewEvent(
+		return event.NewEvent(
 			ChainUpdateEventType,
 			ChainBlockEvent{
 				Point: tmpPoint,
 				Block: tmpBlock,
 			},
-		)
-		return &evt, nil
+		), nil
 	}
-	return nil, nil
+	return event.Event{}, nil
 }
 
 // AddRawBlocks adds a batch of pre-extracted blocks to the chain.
@@ -392,25 +401,31 @@ func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
 	}
 	batchOffset := 0
 	for {
-		batchSize := min(50, len(blocks)-batchOffset)
+		batchSize := min(blockImportBatchSize, len(blocks)-batchOffset)
 		if batchSize == 0 {
 			break
 		}
 		// Collect events inside the transaction callback and
 		// publish them only after the transaction commits
 		// successfully.
-		var pendingEvents []event.Event
+		pendingEvents := make([]event.Event, 0, batchSize)
 		txn := c.manager.db.BlobTxn(true)
 		err := txn.Do(func(txn *database.Txn) error {
-			pendingEvents = pendingEvents[:0]
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			c.manager.mutex.Lock()
+			defer c.manager.mutex.Unlock()
+			if err := c.reconcile(); err != nil {
+				return fmt.Errorf("reconcile: %w", err)
+			}
 			for _, rb := range blocks[batchOffset : batchOffset+batchSize] {
-				evt, err := c.addRawBlock(rb, txn)
+				evt, err := c.addRawBlockLocked(rb, txn)
 				if err != nil {
 					return err
 				}
-				if evt != nil {
+				if evt.Type != "" {
 					pendingEvents = append(
-						pendingEvents, *evt,
+						pendingEvents, evt,
 					)
 				}
 			}
@@ -419,14 +434,7 @@ func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
 		if err != nil {
 			return fmt.Errorf("add raw block batch: %w", err)
 		}
-		// Notify waiting iterators after the transaction has
-		// committed successfully.
-		c.waitingChanMutex.Lock()
-		if c.waitingChan != nil {
-			close(c.waitingChan)
-			c.waitingChan = nil
-		}
-		c.waitingChanMutex.Unlock()
+		c.notifyWaitingIterators()
 		// Publish events (only when eventBus is set).
 		if c.eventBus != nil {
 			for _, evt := range pendingEvents {
@@ -438,6 +446,15 @@ func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
 		batchOffset += batchSize
 	}
 	return nil
+}
+
+func (c *Chain) notifyWaitingIterators() {
+	c.waitingChanMutex.Lock()
+	defer c.waitingChanMutex.Unlock()
+	if c.waitingChan != nil {
+		close(c.waitingChan)
+		c.waitingChan = nil
+	}
 }
 
 func (c *Chain) Rollback(point ocommon.Point) error {
@@ -484,7 +501,7 @@ func (c *Chain) rollbackLocked(
 				continue
 			}
 			if header.SlotNumber() == point.Slot &&
-				string(header.Hash().Bytes()) == string(point.Hash) {
+				bytes.Equal(header.Hash().Bytes(), point.Hash) {
 				return nil, nil
 			}
 			if header.SlotNumber() < point.Slot {
@@ -866,12 +883,7 @@ func (c *Chain) iterNext(
 // Call this after a DB transaction that adds blocks has been committed
 // to ensure iterators see the newly visible data.
 func (c *Chain) NotifyIterators() {
-	c.waitingChanMutex.Lock()
-	if c.waitingChan != nil {
-		close(c.waitingChan)
-		c.waitingChan = nil
-	}
-	c.waitingChanMutex.Unlock()
+	c.notifyWaitingIterators()
 }
 
 func (c *Chain) reconcile() error {
@@ -903,7 +915,7 @@ func (c *Chain) reconcile() error {
 		if c.blocks[i].Slot != tmpBlock.Slot {
 			continue
 		}
-		if string(c.blocks[i].Hash) != string(tmpBlock.Hash) {
+		if !bytes.Equal(c.blocks[i].Hash, tmpBlock.Hash) {
 			continue
 		}
 		// Adjust our chain-local blocks and offset point from primary chain
@@ -945,7 +957,7 @@ func (c *Chain) reconcile() error {
 		}
 		// Update last common block index and return when we find a matching block on the primary chain
 		if tmpBlock.Slot == primaryBlock.Slot &&
-			string(tmpBlock.Hash) == string(primaryBlock.Hash) {
+			bytes.Equal(tmpBlock.Hash, primaryBlock.Hash) {
 			c.lastCommonBlockIndex = tmpBlock.ID
 			break
 		}

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -214,7 +214,7 @@ func (cm *ChainManager) blockByPoint(
 	txn *database.Txn,
 ) (models.Block, error) {
 	// Check in-memory cache
-	if blk, ok := cm.blockCache.Get(string(point.Hash)); ok {
+	if blk, ok := cm.blockCache.Get(point.Hash); ok {
 		if blk.Slot == point.Slot {
 			return blk, nil
 		}
@@ -245,7 +245,7 @@ func (cm *ChainManager) blockByHash(
 	cm.mutex.RLock()
 	defer cm.mutex.RUnlock()
 	// Check in-memory cache
-	if blk, ok := cm.blockCache.Get(string(blockHash)); ok {
+	if blk, ok := cm.blockCache.Get(blockHash); ok {
 		return blk, nil
 	}
 	return models.Block{}, models.ErrBlockNotFound


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch block cache keys to typed `[32]byte` and replace string hash comparisons with `bytes.Equal`. This tightens hash handling, reduces allocations, and makes batched imports and event delivery safer.

- **Refactors**
  - Cache keyed by `[32]byte` via `blockCacheKey`; `Get`/`Delete` now accept `[]byte` and enforce 32‑byte keys; warn and skip invalid hashes.
  - Use `bytes.Equal` for hash checks in header validation, block adds, rollback, and reconcile.
  - Extracted `addBlockLocked`/`addRawBlockLocked` and `notifyWaitingIterators`; notify once per committed batch; publish events only after commit and skip empty events.
  - Added `blockImportBatchSize` (50); moved chain/manager locking and `reconcile` inside the transaction in `AddBlocks`/`AddRawBlocks`; updated tests and manager cache lookups for `[]byte` keys.

<sup>Written for commit 2001157798866a799eab358b6564ec9f5716d9cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved block caching to use a more efficient key format, reducing lookup overhead and improving cache consistency.
  * Restructured block-import/add flow with batching and clearer internal handling for more reliable and efficient block processing.

* **Tests**
  * Stabilized tests with deterministic, consistent block hashing to improve test reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->