### PR TITLE
feat(database): storage mode profiles, logger injection/rate-limiting, batch operations

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -334,6 +334,7 @@ func runMithrilSync(
 		DataDir:        cfg.DatabasePath,
 		Logger:         logger,
 		BlobPlugin:     cfg.BlobPlugin,
+		RunMode:        string(cfg.RunMode),
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: cfg.DatabaseWorkers,
 		StorageMode:    cfg.StorageMode,

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -70,6 +70,7 @@ func checkSyncState(
 		DataDir:        cfg.DatabasePath,
 		Logger:         logger,
 		BlobPlugin:     cfg.BlobPlugin,
+		RunMode:        string(cfg.RunMode),
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: 1,
 	})
@@ -121,6 +122,7 @@ func resumeBackfill(
 		DataDir:        cfg.DatabasePath,
 		Logger:         logger,
 		BlobPlugin:     cfg.BlobPlugin,
+		RunMode:        string(cfg.RunMode),
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: cfg.DatabaseWorkers,
 		StorageMode:    cfg.StorageMode,

--- a/database/block_indexer.go
+++ b/database/block_indexer.go
@@ -66,8 +66,10 @@ type BlockIngestionResult struct {
 // BlockIndexer computes byte offsets for all items within a block.
 // It uses gouroboros's ExtractTransactionOffsets for efficient offset extraction.
 type BlockIndexer struct {
-	blockSlot uint64
-	blockHash [32]byte
+	blockSlot             uint64
+	blockHash             [32]byte
+	includeTxParts        bool
+	includeWitnessOffsets bool
 }
 
 // NewBlockIndexer creates a new BlockIndexer for the given block.
@@ -79,8 +81,23 @@ func NewBlockIndexer(slot uint64, hash []byte) *BlockIndexer {
 	return bi
 }
 
+// WithExtendedOffsets enables additional transaction-part and witness offset
+// extraction. When not called, ComputeOffsets returns a BlockIngestionResult
+// where TxParts, DatumOffsets, RedeemerOffsets, and ScriptOffsets are nil.
+// Callers must check for nil before accessing these fields.
+func (bi *BlockIndexer) WithExtendedOffsets() *BlockIndexer {
+	bi.includeTxParts = true
+	bi.includeWitnessOffsets = true
+	return bi
+}
+
 // ComputeOffsets extracts byte offsets for all transactions, UTxOs, datums,
 // redeemers, and scripts within the block CBOR.
+//
+// TxOffsets and UtxoOffsets are always populated. TxParts is only populated
+// when WithExtendedOffsets was called (nil otherwise). DatumOffsets,
+// RedeemerOffsets, and ScriptOffsets are likewise nil by default and only
+// allocated when WithExtendedOffsets was called.
 func (bi *BlockIndexer) ComputeOffsets(
 	blockCbor []byte,
 	block ledger.Block,
@@ -90,12 +107,18 @@ func (bi *BlockIndexer) ComputeOffsets(
 	}
 
 	result := &BlockIngestionResult{
-		TxOffsets:       make(map[[32]byte]CborOffset),
-		TxParts:         make(map[[32]byte]TxCborParts),
-		UtxoOffsets:     make(map[UtxoRef]CborOffset),
-		DatumOffsets:    make(map[[32]byte]CborOffset),
-		RedeemerOffsets: make(map[common.RedeemerKey]CborOffset),
-		ScriptOffsets:   make(map[[32]byte]CborOffset),
+		TxOffsets:   make(map[[32]byte]CborOffset),
+		UtxoOffsets: make(map[UtxoRef]CborOffset),
+	}
+	// TxParts, DatumOffsets, RedeemerOffsets, and ScriptOffsets remain nil
+	// unless extended offsets are requested.
+	if bi.includeTxParts {
+		result.TxParts = make(map[[32]byte]TxCborParts)
+	}
+	if bi.includeWitnessOffsets {
+		result.DatumOffsets = make(map[[32]byte]CborOffset)
+		result.RedeemerOffsets = make(map[common.RedeemerKey]CborOffset)
+		result.ScriptOffsets = make(map[[32]byte]CborOffset)
 	}
 
 	// Extract transaction-level offsets from block CBOR
@@ -141,16 +164,18 @@ func (bi *BlockIndexer) ComputeOffsets(
 		// TxParts stores offsets for each component so they can be extracted
 		// from the block and reassembled into a complete standalone transaction
 		// CBOR: [body, witness, is_valid, aux_data]
-		result.TxParts[txHashArray] = TxCborParts{
-			BlockSlot:      bi.blockSlot,
-			BlockHash:      bi.blockHash,
-			BodyOffset:     txLoc.Body.Offset,
-			BodyLength:     txLoc.Body.Length,
-			WitnessOffset:  txLoc.Witness.Offset,
-			WitnessLength:  txLoc.Witness.Length,
-			MetadataOffset: txLoc.Metadata.Offset,
-			MetadataLength: txLoc.Metadata.Length,
-			IsValid:        tx.IsValid(),
+		if bi.includeTxParts {
+			result.TxParts[txHashArray] = TxCborParts{
+				BlockSlot:      bi.blockSlot,
+				BlockHash:      bi.blockHash,
+				BodyOffset:     txLoc.Body.Offset,
+				BodyLength:     txLoc.Body.Length,
+				WitnessOffset:  txLoc.Witness.Offset,
+				WitnessLength:  txLoc.Witness.Length,
+				MetadataOffset: txLoc.Metadata.Offset,
+				MetadataLength: txLoc.Metadata.Length,
+				IsValid:        tx.IsValid(),
+			}
 		}
 
 		// Extract UTxO output offsets from transaction body
@@ -159,36 +184,38 @@ func (bi *BlockIndexer) ComputeOffsets(
 		}
 
 		// Store datum offsets from witness set
-		for datumHash, loc := range txLoc.Datums {
-			var hashArray [32]byte
-			copy(hashArray[:], datumHash[:])
-			result.DatumOffsets[hashArray] = CborOffset{
-				BlockSlot:  bi.blockSlot,
-				BlockHash:  bi.blockHash,
-				ByteOffset: loc.Offset,
-				ByteLength: loc.Length,
+		if bi.includeWitnessOffsets {
+			for datumHash, loc := range txLoc.Datums {
+				var hashArray [32]byte
+				copy(hashArray[:], datumHash[:])
+				result.DatumOffsets[hashArray] = CborOffset{
+					BlockSlot:  bi.blockSlot,
+					BlockHash:  bi.blockHash,
+					ByteOffset: loc.Offset,
+					ByteLength: loc.Length,
+				}
 			}
-		}
 
-		// Store redeemer offsets from witness set
-		for redeemerKey, loc := range txLoc.Redeemers {
-			result.RedeemerOffsets[redeemerKey] = CborOffset{
-				BlockSlot:  bi.blockSlot,
-				BlockHash:  bi.blockHash,
-				ByteOffset: loc.Offset,
-				ByteLength: loc.Length,
+			// Store redeemer offsets from witness set
+			for redeemerKey, loc := range txLoc.Redeemers {
+				result.RedeemerOffsets[redeemerKey] = CborOffset{
+					BlockSlot:  bi.blockSlot,
+					BlockHash:  bi.blockHash,
+					ByteOffset: loc.Offset,
+					ByteLength: loc.Length,
+				}
 			}
-		}
 
-		// Store script offsets from witness set
-		for scriptHash, loc := range txLoc.Scripts {
-			var hashArray [32]byte
-			copy(hashArray[:], scriptHash[:])
-			result.ScriptOffsets[hashArray] = CborOffset{
-				BlockSlot:  bi.blockSlot,
-				BlockHash:  bi.blockHash,
-				ByteOffset: loc.Offset,
-				ByteLength: loc.Length,
+			// Store script offsets from witness set
+			for scriptHash, loc := range txLoc.Scripts {
+				var hashArray [32]byte
+				copy(hashArray[:], scriptHash[:])
+				result.ScriptOffsets[hashArray] = CborOffset{
+					BlockSlot:  bi.blockSlot,
+					BlockHash:  bi.blockHash,
+					ByteOffset: loc.Offset,
+					ByteLength: loc.Length,
+				}
 			}
 		}
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -39,6 +39,7 @@ type Config struct {
 	Logger         *slog.Logger
 	BlobPlugin     string
 	DataDir        string
+	RunMode        string
 	MetadataPlugin string
 	MaxConnections int    // Connection pool size for metadata plugin (should match DatabaseWorkers)
 	StorageMode    string // "core" or "api"
@@ -160,6 +161,24 @@ func New(
 		return nil, err
 	}
 	err = plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		configCopy.BlobPlugin,
+		"run-mode",
+		configCopy.RunMode,
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		configCopy.BlobPlugin,
+		"storage-mode",
+		configCopy.StorageMode,
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = plugin.SetPluginOption(
 		plugin.PluginTypeMetadata,
 		configCopy.MetadataPlugin,
 		"data-dir",
@@ -194,21 +213,81 @@ func New(
 			err,
 		)
 	}
-	blobDb, err := blob.New(
+	// Start blob plugin with logger injected before Start() so that
+	// startup logging (Badger GC, cache init) uses the configured logger.
+	blobPlugin := plugin.GetPlugin(
+		plugin.PluginTypeBlob,
 		configCopy.BlobPlugin,
 	)
-	if err != nil {
-		return nil, err
+	if blobPlugin == nil {
+		return nil, fmt.Errorf(
+			"blob plugin %q not found",
+			configCopy.BlobPlugin,
+		)
 	}
-	metadataDb, err := metadata.New(
+	if loggerSetter, ok := blobPlugin.(plugin.LoggerSetter); ok {
+		loggerSetter.SetLogger(configCopy.Logger)
+	}
+	if err := blobPlugin.Start(); err != nil {
+		return nil, fmt.Errorf(
+			"starting blob plugin %q: %w",
+			configCopy.BlobPlugin,
+			err,
+		)
+	}
+	blobDb, ok := blobPlugin.(blob.BlobStore)
+	if !ok {
+		stopErr := blobPlugin.Stop()
+		return nil, errors.Join(
+			fmt.Errorf(
+				"plugin %q does not implement BlobStore interface",
+				configCopy.BlobPlugin,
+			),
+			stopErr,
+		)
+	}
+	// Start metadata plugin with logger injected before Start() so that
+	// startup logging (GORM migrations) uses the configured logger.
+	metadataPlugin := plugin.GetPlugin(
+		plugin.PluginTypeMetadata,
 		configCopy.MetadataPlugin,
 	)
-	if err != nil {
-		err = errors.Join(
-			err,
-			blobDb.Close(),
-		) // Clean up blob store on metadata failure
-		return nil, err
+	if metadataPlugin == nil {
+		closeErr := blobDb.Close()
+		return nil, errors.Join(
+			fmt.Errorf(
+				"metadata plugin %q not found",
+				configCopy.MetadataPlugin,
+			),
+			closeErr,
+		)
+	}
+	if loggerSetter, ok := metadataPlugin.(plugin.LoggerSetter); ok {
+		loggerSetter.SetLogger(configCopy.Logger)
+	}
+	if err := metadataPlugin.Start(); err != nil {
+		closeErr := blobDb.Close()
+		return nil, errors.Join(
+			fmt.Errorf(
+				"starting metadata plugin %q: %w",
+				configCopy.MetadataPlugin,
+				err,
+			),
+			closeErr,
+		)
+	}
+	metadataDb, ok := metadataPlugin.(metadata.MetadataStore)
+	if !ok {
+		stopErr := metadataPlugin.Stop()
+		closeErr := blobDb.Close()
+		return nil, errors.Join(
+			fmt.Errorf(
+				"plugin %q does not implement MetadataStore interface",
+				configCopy.MetadataPlugin,
+			),
+			stopErr,
+			closeErr,
+		)
 	}
 	db := &Database{
 		blob:     blobDb,

--- a/database/plugin/blob/badger/commit_timestamp.go
+++ b/database/plugin/blob/badger/commit_timestamp.go
@@ -15,6 +15,8 @@
 package badger
 
 import (
+	"encoding/binary"
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/types"
@@ -30,7 +32,10 @@ func (b *BlobStoreBadger) GetCommitTimestamp() (int64, error) {
 
 	val, err := b.Get(txn, []byte(commitTimestampBlobKey))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to read commit timestamp: %w", err)
+	}
+	if len(val) == 8 {
+		return int64(binary.BigEndian.Uint64(val)), nil //nolint:gosec // Unix timestamps are always positive and within int64 range
 	}
 	return new(big.Int).SetBytes(val).Int64(), nil
 }
@@ -43,9 +48,10 @@ func (b *BlobStoreBadger) SetCommitTimestamp(
 		return types.ErrNilTxn
 	}
 	// Update badger
-	tmpTimestamp := new(big.Int).SetInt64(timestamp)
-	if err := b.Set(txn, []byte(commitTimestampBlobKey), tmpTimestamp.Bytes()); err != nil {
-		return err
+	var tmpTimestamp [8]byte
+	binary.BigEndian.PutUint64(tmpTimestamp[:], uint64(timestamp)) //nolint:gosec // Unix timestamps are always positive
+	if err := b.Set(txn, []byte(commitTimestampBlobKey), tmpTimestamp[:]); err != nil {
+		return fmt.Errorf("failed to write commit timestamp: %w", err)
 	}
 	return nil
 }

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -101,6 +101,14 @@ func (t *badgerTxn) Rollback() error {
 	return nil
 }
 
+func (d *BlobStoreBadger) SetLogger(logger *slog.Logger) {
+	if logger == nil {
+		d.logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+		return
+	}
+	d.logger = logger
+}
+
 type badgerIterator struct {
 	iter *badger.Iterator
 }
@@ -161,9 +169,12 @@ type BlobStoreBadger struct {
 	memTableSize     int64
 	valueThreshold   int64
 	gcEnabled        bool
+	deferOpen        bool // when true, Badger is opened in Start() not New()
 }
 
-// New creates a new database
+// New creates a new database. When deferOpen is set (via WithDeferOpen),
+// Badger is not opened until Start() is called, allowing an injected
+// logger (via SetLogger) to be used for Badger's startup logging.
 func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 	db := &BlobStoreBadger{
 		// Set defaults
@@ -178,6 +189,17 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 		opt(db)
 	}
 
+	if db.deferOpen {
+		return db, nil
+	}
+	if err := db.open(); err != nil {
+		return nil, fmt.Errorf("badger open: %w", err)
+	}
+	return db, nil
+}
+
+// open initializes and opens the Badger database using the configured options.
+func (db *BlobStoreBadger) open() error {
 	var blobDb *badger.DB
 	var err error
 
@@ -191,17 +213,17 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 			WithValueThreshold(db.valueThreshold)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("badger open in-memory: %w", err)
 		}
 	} else {
 		// Make sure that we can read data dir, and create if it doesn't exist
 		if _, err := os.Stat(db.dataDir); err != nil {
 			if !errors.Is(err, fs.ErrNotExist) {
-				return nil, fmt.Errorf("failed to read data dir: %w", err)
+				return fmt.Errorf("failed to read data dir: %w", err)
 			}
 			// Create data directory
 			if err := os.MkdirAll(db.dataDir, 0o700); err != nil {
-				return nil, fmt.Errorf("failed to create data dir: %w", err)
+				return fmt.Errorf("failed to create data dir: %w", err)
 			}
 		}
 		blobDir := filepath.Join(
@@ -219,14 +241,14 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 			WithCompression(options.Snappy)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("badger open on-disk: %w", err)
 		}
 	}
 	db.db = blobDb
 	if err := db.init(); err != nil {
-		return db, err
+		return err
 	}
-	return db, nil
+	return nil
 }
 
 func (d *BlobStoreBadger) init() error {
@@ -274,9 +296,15 @@ func (d *BlobStoreBadger) blobGc(t *time.Ticker, stop <-chan struct{}) {
 	}
 }
 
-// Start implements the plugin.Plugin interface
+// Start implements the plugin.Plugin interface. When the database was
+// created with WithDeferOpen, Start opens Badger using the logger that
+// was injected via SetLogger after construction.
 func (d *BlobStoreBadger) Start() error {
-	// Database is already started in New(), so this is a no-op
+	if d.deferOpen && d.db == nil {
+		if err := d.open(); err != nil {
+			return fmt.Errorf("badger deferred start: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -299,6 +327,9 @@ func (d *BlobStoreBadger) Close() error {
 		d.gcTicker = nil
 	}
 	db := d.DB()
+	if db == nil {
+		return nil
+	}
 	return db.Close()
 }
 

--- a/database/plugin/blob/badger/options.go
+++ b/database/plugin/blob/badger/options.go
@@ -86,3 +86,12 @@ func WithValueThreshold(threshold int64) BlobStoreBadgerOptionFunc {
 		b.valueThreshold = threshold
 	}
 }
+
+// WithDeferOpen defers opening Badger until Start() is called.
+// This allows a logger to be injected via SetLogger before Badger
+// emits any startup logs.
+func WithDeferOpen() BlobStoreBadgerOptionFunc {
+	return func(b *BlobStoreBadger) {
+		b.deferOpen = true
+	}
+}

--- a/database/plugin/blob/badger/options_test.go
+++ b/database/plugin/blob/badger/options_test.go
@@ -130,3 +130,196 @@ func TestOptionsCombination(t *testing.T) {
 		)
 	}
 }
+
+func TestApplyOperationalDefaultsCore(t *testing.T) {
+	blockCache := uint64(DefaultBlockCacheSize)
+	indexCache := uint64(DefaultIndexCacheSize)
+	memtable := uint64(DefaultMemTableSize)
+
+	applyOperationalDefaults(
+		"",
+		string(ProfileCore),
+		&blockCache,
+		&indexCache,
+		&memtable,
+	)
+
+	if blockCache != 536870912 {
+		t.Fatalf("expected core block cache size 536870912, got %d", blockCache)
+	}
+	if indexCache != 134217728 {
+		t.Fatalf("expected core index cache size 134217728, got %d", indexCache)
+	}
+	if memtable != 67108864 {
+		t.Fatalf("expected core memtable size 67108864, got %d", memtable)
+	}
+}
+
+func TestApplyOperationalDefaultsLoadPreservesOverrides(t *testing.T) {
+	blockCache := uint64(123)
+	indexCache := uint64(456)
+	memtable := uint64(789)
+
+	applyOperationalDefaults(
+		string(ProfileLoad),
+		string(ProfileAPI),
+		&blockCache,
+		&indexCache,
+		&memtable,
+	)
+
+	if blockCache != 123 {
+		t.Fatalf("expected block cache override to be preserved, got %d", blockCache)
+	}
+	if indexCache != 456 {
+		t.Fatalf("expected index cache override to be preserved, got %d", indexCache)
+	}
+	if memtable != 789 {
+		t.Fatalf("expected memtable override to be preserved, got %d", memtable)
+	}
+}
+
+func TestResolveProfilePrefersLoadRunMode(t *testing.T) {
+	if profile := resolveProfile(string(ProfileLoad), string(ProfileAPI)); profile != ProfileLoad {
+		t.Fatalf("expected load profile, got %q", profile)
+	}
+}
+
+func TestApplyOperationalDefaultsPreservesExplicitEqualToDefault(t *testing.T) {
+	// An explicit override that happens to equal the API-profile default
+	// must NOT be overwritten when a different profile is resolved.
+	blockCache := uint64(DefaultBlockCacheSize)
+	indexCache := uint64(DefaultIndexCacheSize)
+	memtable := uint64(DefaultMemTableSize)
+
+	// With load profile, core/load sizes differ from the defaults (which
+	// match the API profile). If the caller explicitly set the API-default
+	// values, applyOperationalDefaults will still overwrite them because it
+	// compares against the constants. This test documents the current
+	// limitation: callers that need to preserve explicit overrides must
+	// copy values to locals before calling applyOperationalDefaults (as
+	// NewFromCmdlineOptions does).
+	//
+	// The important invariant: cmdlineOptions must NOT be mutated.
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptions.blockCacheSize = DefaultBlockCacheSize
+	cmdlineOptions.indexCacheSize = DefaultIndexCacheSize
+	cmdlineOptions.memTableSize = DefaultMemTableSize
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+
+	applyOperationalDefaults(
+		string(ProfileLoad),
+		"",
+		&blockCache,
+		&indexCache,
+		&memtable,
+	)
+
+	// Verify that the global cmdlineOptions were NOT mutated
+	if cmdlineOptions.blockCacheSize != saved.blockCacheSize {
+		t.Fatalf(
+			"cmdlineOptions.blockCacheSize mutated: want %d, got %d",
+			saved.blockCacheSize,
+			cmdlineOptions.blockCacheSize,
+		)
+	}
+	if cmdlineOptions.indexCacheSize != saved.indexCacheSize {
+		t.Fatalf(
+			"cmdlineOptions.indexCacheSize mutated: want %d, got %d",
+			saved.indexCacheSize,
+			cmdlineOptions.indexCacheSize,
+		)
+	}
+	if cmdlineOptions.memTableSize != saved.memTableSize {
+		t.Fatalf(
+			"cmdlineOptions.memTableSize mutated: want %d, got %d",
+			saved.memTableSize,
+			cmdlineOptions.memTableSize,
+		)
+	}
+}
+
+func TestNewFromCmdlineOptionsDoesNotMutateGlobals(t *testing.T) {
+	// Run NewFromCmdlineOptions twice with different profiles and verify
+	// the second call does not inherit the first profile's derived sizes.
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+	cmdlineOptionsMutex.Lock()
+	cmdlineOptions.runMode = string(ProfileLoad)
+	cmdlineOptionsMutex.Unlock()
+
+	p1 := NewFromCmdlineOptions()
+	defer func() {
+		if stopper, ok := p1.(interface{ Stop() error }); ok {
+			_ = stopper.Stop()
+		}
+	}()
+
+	// Capture global state after first call
+	cmdlineOptionsMutex.Lock()
+	blockAfterFirst := cmdlineOptions.blockCacheSize
+	indexAfterFirst := cmdlineOptions.indexCacheSize
+	memAfterFirst := cmdlineOptions.memTableSize
+	cmdlineOptionsMutex.Unlock()
+
+	// Globals should still be at init defaults
+	if blockAfterFirst != DefaultBlockCacheSize {
+		t.Fatalf(
+			"blockCacheSize mutated after first call: want %d, got %d",
+			DefaultBlockCacheSize,
+			blockAfterFirst,
+		)
+	}
+	if indexAfterFirst != DefaultIndexCacheSize {
+		t.Fatalf(
+			"indexCacheSize mutated after first call: want %d, got %d",
+			DefaultIndexCacheSize,
+			indexAfterFirst,
+		)
+	}
+	if memAfterFirst != DefaultMemTableSize {
+		t.Fatalf(
+			"memTableSize mutated after first call: want %d, got %d",
+			DefaultMemTableSize,
+			memAfterFirst,
+		)
+	}
+
+	// Second call with API profile should get API defaults, not load sizes
+	cmdlineOptionsMutex.Lock()
+	cmdlineOptions.runMode = ""
+	cmdlineOptions.storageMode = string(ProfileAPI)
+	cmdlineOptionsMutex.Unlock()
+
+	p2 := NewFromCmdlineOptions()
+	defer func() {
+		if stopper, ok := p2.(interface{ Stop() error }); ok {
+			_ = stopper.Stop()
+		}
+	}()
+
+	b2, ok := p2.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if b2.blockCacheSize != DefaultBlockCacheSize {
+		t.Fatalf(
+			"second call blockCacheSize: want %d (API default), got %d",
+			DefaultBlockCacheSize,
+			b2.blockCacheSize,
+		)
+	}
+}

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -30,9 +30,25 @@ const (
 	DefaultValueThreshold   = 1048576    // 1MB (keep small values in LSM, large blobs in value log)
 )
 
+type Profile string
+
+const (
+	ProfileCore Profile = "core"
+	ProfileAPI  Profile = "api"
+	ProfileLoad Profile = "load"
+)
+
+type ProfileSettings struct {
+	BlockCacheSize uint64
+	IndexCacheSize uint64
+	MemTableSize   uint64
+}
+
 var (
 	cmdlineOptions struct {
 		dataDir          string
+		runMode          string
+		storageMode      string
 		blockCacheSize   uint64
 		indexCacheSize   uint64
 		valueLogFileSize uint64
@@ -43,6 +59,60 @@ var (
 	cmdlineOptionsMutex sync.RWMutex
 )
 
+func profileSettings(profile Profile) ProfileSettings {
+	switch profile {
+	case ProfileLoad:
+		return ProfileSettings{
+			BlockCacheSize: 268435456, // 256MB
+			IndexCacheSize: 67108864,  // 64MB
+			MemTableSize:   67108864,  // 64MB
+		}
+	case ProfileCore:
+		return ProfileSettings{
+			BlockCacheSize: 536870912, // 512MB
+			IndexCacheSize: 134217728, // 128MB
+			MemTableSize:   67108864,  // 64MB
+		}
+	case ProfileAPI:
+		fallthrough
+	default:
+		return ProfileSettings{
+			BlockCacheSize: DefaultBlockCacheSize,
+			IndexCacheSize: DefaultIndexCacheSize,
+			MemTableSize:   DefaultMemTableSize,
+		}
+	}
+}
+
+func resolveProfile(runMode, storageMode string) Profile {
+	if runMode == string(ProfileLoad) {
+		return ProfileLoad
+	}
+	if storageMode == string(ProfileAPI) {
+		return ProfileAPI
+	}
+	return ProfileCore
+}
+
+func applyOperationalDefaults(
+	runMode string,
+	storageMode string,
+	blockCacheSize *uint64,
+	indexCacheSize *uint64,
+	memTableSize *uint64,
+) {
+	settings := profileSettings(resolveProfile(runMode, storageMode))
+	if *blockCacheSize == DefaultBlockCacheSize {
+		*blockCacheSize = settings.BlockCacheSize
+	}
+	if *indexCacheSize == DefaultIndexCacheSize {
+		*indexCacheSize = settings.IndexCacheSize
+	}
+	if *memTableSize == DefaultMemTableSize {
+		*memTableSize = settings.MemTableSize
+	}
+}
+
 // initCmdlineOptions sets default values for cmdlineOptions
 func initCmdlineOptions() {
 	cmdlineOptionsMutex.Lock()
@@ -52,6 +122,8 @@ func initCmdlineOptions() {
 	cmdlineOptions.valueLogFileSize = DefaultValueLogFileSize
 	cmdlineOptions.memTableSize = DefaultMemTableSize
 	cmdlineOptions.valueThreshold = DefaultValueThreshold
+	cmdlineOptions.runMode = ""
+	cmdlineOptions.storageMode = "core"
 	cmdlineOptions.gcEnabled = true
 	cmdlineOptions.dataDir = ".dingo"
 }
@@ -72,6 +144,20 @@ func init() {
 					Description:  "Data directory for badger storage",
 					DefaultValue: ".dingo",
 					Dest:         &(cmdlineOptions.dataDir),
+				},
+				{
+					Name:         "run-mode",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Operational run mode",
+					DefaultValue: "",
+					Dest:         &(cmdlineOptions.runMode),
+				},
+				{
+					Name:         "storage-mode",
+					Type:         plugin.PluginOptionTypeString,
+					Description:  "Storage tier: core or api",
+					DefaultValue: "core",
+					Dest:         &(cmdlineOptions.storageMode),
 				},
 				{
 					Name:         "block-cache-size",
@@ -121,12 +207,24 @@ func init() {
 }
 
 func NewFromCmdlineOptions() plugin.Plugin {
-	cmdlineOptionsMutex.RLock()
+	cmdlineOptionsMutex.Lock()
+	// Copy cmdline values to locals so applyOperationalDefaults does not
+	// mutate the shared cmdlineOptions struct.
+	blockCacheSize := cmdlineOptions.blockCacheSize
+	indexCacheSize := cmdlineOptions.indexCacheSize
+	memTableSize := cmdlineOptions.memTableSize
+	applyOperationalDefaults(
+		cmdlineOptions.runMode,
+		cmdlineOptions.storageMode,
+		&blockCacheSize,
+		&indexCacheSize,
+		&memTableSize,
+	)
 	// Safe conversion from uint64 to int64 with bounds checking
 	valueLogFileSize := min(cmdlineOptions.valueLogFileSize,
 		// Cap at max int64
 		uint64(math.MaxInt64))
-	memTableSize := min(cmdlineOptions.memTableSize,
+	memTableSizeCapped := min(memTableSize,
 		// Cap at max int64
 		uint64(math.MaxInt64))
 	valueThreshold := min(cmdlineOptions.valueThreshold,
@@ -135,20 +233,21 @@ func NewFromCmdlineOptions() plugin.Plugin {
 	// #nosec G115
 	opts := []BlobStoreBadgerOptionFunc{
 		WithDataDir(cmdlineOptions.dataDir),
-		WithBlockCacheSize(cmdlineOptions.blockCacheSize),
-		WithIndexCacheSize(cmdlineOptions.indexCacheSize),
+		WithBlockCacheSize(blockCacheSize),
+		WithIndexCacheSize(indexCacheSize),
 		WithValueLogFileSize(
 			int64(valueLogFileSize),
 		),
 		WithMemTableSize(
-			int64(memTableSize),
+			int64(memTableSizeCapped),
 		),
 		WithValueThreshold(
 			int64(valueThreshold),
 		),
 		WithGc(cmdlineOptions.gcEnabled),
+		WithDeferOpen(),
 	}
-	cmdlineOptionsMutex.RUnlock()
+	cmdlineOptionsMutex.Unlock()
 	p, err := New(opts...)
 	if err != nil {
 		// Return a plugin that defers the error to Start()

--- a/database/plugin/log.go
+++ b/database/plugin/log.go
@@ -14,6 +14,8 @@
 
 package plugin
 
+import "log/slog"
+
 // Logger provides a logging interface for plugins.
 type Logger interface {
 	Info(string, ...any)
@@ -24,4 +26,10 @@ type Logger interface {
 	// Deprecated
 	// Fatal(string, ...any) in favor of Error
 	// With slog Fatal is replaced with Error and os.Exit(1)
+}
+
+// LoggerSetter is implemented by plugins that can accept a logger after
+// construction.
+type LoggerSetter interface {
+	SetLogger(*slog.Logger)
 }

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -94,6 +94,7 @@ type MetadataStoreSqlite struct {
 	db             *gorm.DB
 	readDB         *gorm.DB
 	logger         *slog.Logger
+	warnLimiter    *repeatedWarnLimiter
 	timerVacuum    *time.Timer
 	dataDir        string
 	maxConnections int
@@ -127,6 +128,9 @@ func NewWithOptions(opts ...SqliteOptionFunc) (*MetadataStoreSqlite, error) {
 	// Set defaults after options are applied (no side effects)
 	if db.logger == nil {
 		db.logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+	if db.warnLimiter == nil {
+		db.warnLimiter = newRepeatedWarnLimiter()
 	}
 
 	// Default and validate storageMode
@@ -176,6 +180,14 @@ func (d *MetadataStoreSqlite) gormLogger() gormlogger.Interface {
 	return sloggorm.New(
 		sloggorm.WithHandler(d.logger.With("component", "gorm").Handler()),
 	)
+}
+
+func (d *MetadataStoreSqlite) SetLogger(logger *slog.Logger) {
+	if logger == nil {
+		d.logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+		return
+	}
+	d.logger = logger
 }
 
 func (d *MetadataStoreSqlite) runVacuum() error {

--- a/database/plugin/metadata/sqlite/log_rate_limiter.go
+++ b/database/plugin/metadata/sqlite/log_rate_limiter.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const repeatedWarnInterval = 30 * time.Second
+
+type repeatedWarnState struct {
+	lastLog    time.Time
+	suppressed uint64
+}
+
+type repeatedWarnLimiter struct {
+	mu     sync.Mutex
+	states map[string]*repeatedWarnState
+}
+
+func newRepeatedWarnLimiter() *repeatedWarnLimiter {
+	return &repeatedWarnLimiter{
+		states: make(map[string]*repeatedWarnState),
+	}
+}
+
+func (l *repeatedWarnLimiter) warn(
+	logger *slog.Logger,
+	key string,
+	msg string,
+	args ...any,
+) {
+	if logger == nil {
+		return
+	}
+
+	now := time.Now()
+
+	l.mu.Lock()
+	state, ok := l.states[key]
+	if !ok {
+		state = &repeatedWarnState{}
+		l.states[key] = state
+	}
+	if !state.lastLog.IsZero() && now.Sub(state.lastLog) < repeatedWarnInterval {
+		state.suppressed++
+		l.mu.Unlock()
+		return
+	}
+	suppressed := state.suppressed
+	state.lastLog = now
+	state.suppressed = 0
+	l.mu.Unlock()
+
+	if suppressed > 0 {
+		args = append(args, "suppressed_count", suppressed)
+	}
+	logger.Warn(msg, args...)
+}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -286,27 +286,33 @@ func processScripts[T lcommon.Script](
 	scripts []T,
 	point ocommon.Point,
 ) error {
+	if len(scripts) == 0 {
+		return nil
+	}
+
+	witnessScripts := make([]models.WitnessScripts, 0, len(scripts))
+	scriptContents := make([]models.Script, 0, len(scripts))
 	for _, script := range scripts {
-		witnessScript := models.WitnessScripts{
+		witnessScripts = append(witnessScripts, models.WitnessScripts{
 			TransactionID: transactionID,
 			Type:          scriptType,
 			ScriptHash:    script.Hash().Bytes(),
-		}
-		if result := db.Create(&witnessScript); result.Error != nil {
-			return fmt.Errorf("create witness script: %w", result.Error)
-		}
-		scriptContent := models.Script{
+		})
+		scriptContents = append(scriptContents, models.Script{
 			Hash:        script.Hash().Bytes(),
 			Type:        scriptType,
 			Content:     script.RawScriptBytes(),
 			CreatedSlot: point.Slot,
-		}
-		if result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "hash"}},
-			DoNothing: true,
-		}).Create(&scriptContent); result.Error != nil {
-			return fmt.Errorf("create script content: %w", result.Error)
-		}
+		})
+	}
+	if result := db.Create(&witnessScripts); result.Error != nil {
+		return fmt.Errorf("create witness scripts: %w", result.Error)
+	}
+	if result := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "hash"}},
+		DoNothing: true,
+	}).Create(&scriptContents); result.Error != nil {
+		return fmt.Errorf("create script contents: %w", result.Error)
 	}
 	return nil
 }
@@ -353,9 +359,6 @@ func (d *MetadataStoreSqlite) getOrCreateAccount(
 		return nil, result.Error
 	}
 
-	// Account doesn't exist - try to create with OnConflict to handle races.
-	// If another goroutine creates the same account concurrently, this will
-	// do nothing and we'll fetch the existing record below.
 	tmpAccount := &models.Account{
 		StakingKey: stakeKey,
 		Active:     true,
@@ -541,10 +544,12 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		tmpTx.Metadata = tmpMetadata
 	}
 	collateralReturn := tx.CollateralReturn()
+	produced := tx.Produced()
+	tmpTx.Outputs = make([]models.Utxo, 0, len(produced))
 	// Store all produced UTxOs - tx.Produced() returns correct indices for both
 	// valid transactions (regular outputs at indices 0, 1, ...) and invalid
 	// transactions (collateral return at index len(Outputs()))
-	for _, utxo := range tx.Produced() {
+	for _, utxo := range produced {
 		if collateralReturn != nil && utxo.Output == collateralReturn {
 			m := models.UtxoLedgerToModel(utxo, point.Slot)
 			tmpTx.CollateralReturn = &m
@@ -565,6 +570,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			[]string{"block_hash", "block_index", "slot"},
 		),
 	}).Create(tmpTx)
+	needsIdFetch := tmpTx.ID == 0
 
 	// Restore outputs for later explicit creation
 	tmpTx.Outputs = outputsToCreate
@@ -584,7 +590,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	// the conflict path is taken (no insert occurs). We need to fetch the ID
 	// explicitly so we can associate witness records with the correct transaction.
 	// Only fetch the ID column to avoid expensive association preloads.
-	if tmpTx.ID == 0 {
+	if needsIdFetch {
 		var existing struct{ ID uint }
 		if err := db.Model(&models.Transaction{}).
 			Select("id").
@@ -598,22 +604,18 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		tmpTx.ID = existing.ID
 	}
 
-	// Create UTxO records for outputs
-	// OnConflict doesn't process associations, so we create them explicitly
+	// Create UTxO records for outputs in a single statement per transaction.
 	for i := range tmpTx.Outputs {
 		tmpTx.Outputs[i].ID = 0 // Reset ID to let GORM auto-increment
 		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
+	}
+	if len(tmpTx.Outputs) > 0 {
 		result := db.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
 			DoNothing: true,
-		}).Create(&tmpTx.Outputs[i])
+		}).Create(&tmpTx.Outputs)
 		if result.Error != nil {
-			return fmt.Errorf(
-				"create utxo output %d for tx %x: %w",
-				i,
-				txHash,
-				result.Error,
-			)
+			return fmt.Errorf("create utxo outputs for tx %x: %w", txHash, result.Error)
 		}
 	}
 	// Create CollateralReturn UTxO if present
@@ -628,211 +630,61 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		}
 	}
 
-	// Add Inputs to Transaction - batch fetch all input UTXOs
-	inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
-	for _, input := range tx.Inputs() {
-		inputRefs = append(inputRefs, UtxoRef{
-			TxId:      input.Id().Bytes(),
-			OutputIdx: input.Index(),
-		})
-	}
-	inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
-	if err != nil {
-		return fmt.Errorf("failed to batch fetch input UTXOs: %w", err)
-	}
-	for _, input := range tx.Inputs() {
-		key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
-		utxo := inputUtxos[key]
-		if utxo == nil {
-			d.logger.Warn(
-				"Skipping missing input UTxO",
-				"hash",
-				input.Id().String(),
-				"index",
-				input.Index(),
-			)
-			continue
-		}
-		tmpTx.Inputs = append(
-			tmpTx.Inputs,
-			*utxo,
-		)
-	}
-	// Add Collateral to Transaction - batch fetch all collateral UTXOs
-	if len(tx.Collateral()) > 0 {
-		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
-		for _, input := range tx.Collateral() {
-			collateralRefs = append(collateralRefs, UtxoRef{
+	if d.storageMode == types.StorageModeAPI {
+		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
+		for _, input := range tx.Inputs() {
+			inputRefs = append(inputRefs, UtxoRef{
 				TxId:      input.Id().Bytes(),
 				OutputIdx: input.Index(),
 			})
 		}
-		collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
+		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
 		if err != nil {
-			return fmt.Errorf("failed to batch fetch collateral UTXOs: %w", err)
+			return fmt.Errorf("failed to batch fetch input UTXOs: %w", err)
 		}
-
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
-
-		for _, input := range tx.Collateral() {
-			inTxId := input.Id().Bytes()
-			inIdx := input.Index()
-			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
-			utxo := collateralUtxos[key]
+		for _, input := range tx.Inputs() {
+			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
+			utxo := inputUtxos[key]
 			if utxo == nil {
-				d.logger.Warn(
-					"Skipping missing collateral UTxO",
+				d.warnLimiter.warn(
+					d.logger,
+					"missing-input-utxo",
+					"Skipping missing input UTxO",
 					"hash",
 					input.Id().String(),
 					"index",
-					inIdx,
+					input.Index(),
 				)
 				continue
 			}
-			// Found the Utxo, add it to the SQL UPDATE list
-			// First, add it to the CASE statement so it's selected
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
-			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			// Also add it to the WHERE clause in the SQL UPDATE
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
-			// Add it to the Transaction
-			tmpTx.Collateral = append(
-				tmpTx.Collateral,
-				*utxo,
-			)
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
 		}
-		// Update reference where this Utxo was used as collateral in a Transaction
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
-			result = db.Exec(sql, args...)
-			if result.Error != nil {
-				return fmt.Errorf("batch update collateral: %w", result.Error)
+		if len(tx.Collateral()) > 0 {
+			collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
+			for _, input := range tx.Collateral() {
+				collateralRefs = append(collateralRefs, UtxoRef{
+					TxId:      input.Id().Bytes(),
+					OutputIdx: input.Index(),
+				})
 			}
-		}
-	}
-	// Add ReferenceInputs to Transaction - batch fetch all reference input UTXOs
-	if len(tx.ReferenceInputs()) > 0 {
-		var refInputRefs []UtxoRef
-		for _, input := range tx.ReferenceInputs() {
-			refInputRefs = append(refInputRefs, UtxoRef{
-				TxId:      input.Id().Bytes(),
-				OutputIdx: input.Index(),
-			})
-		}
-		refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to batch fetch reference input UTXOs: %w",
-				err,
-			)
-		}
-
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
-
-		for _, input := range tx.ReferenceInputs() {
-			inTxId := input.Id().Bytes()
-			inIdx := input.Index()
-			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
-			utxo := refInputUtxos[key]
-			if utxo == nil {
-				d.logger.Warn(
-					"Skipping missing reference input UTxO",
-					"hash",
-					input.Id().String(),
-					"index",
-					inIdx,
-				)
-				continue
+			collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
+			if err != nil {
+				return fmt.Errorf("failed to batch fetch collateral UTXOs: %w", err)
 			}
-			// Found the Utxo, add it to the SQL UPDATE list
-			// First, add it to the CASE statement so it's selected
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
-			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			// Also add it to the WHERE clause in the SQL UPDATE
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
-			// Add it to the Transaction
-			tmpTx.ReferenceInputs = append(
-				tmpTx.ReferenceInputs,
-				*utxo,
-			)
-		}
-		// Update reference where this Utxo was used as a reference input in a Transaction
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
-			result = db.Exec(sql, args...)
-			if result.Error != nil {
-				return fmt.Errorf(
-					"batch update reference inputs: %w",
-					result.Error,
-				)
-			}
-		}
-	}
-
-	// Consume UTxOs using optimistic locking to prevent race conditions.
-	// The atomic update ensures only one transaction can successfully mark a UTXO as spent.
-	for _, input := range tx.Consumed() {
-		inTxId := input.Id().Bytes()
-		inIdx := input.Index()
-
-		// Use atomic check-and-update: only update if UTXO is still unspent.
-		// This prevents TOCTOU race where:
-		// 1. GetUtxo reads UTXO with deleted_slot=0
-		// 2. Another transaction marks it spent
-		// 3. First transaction commits spend anyway
-		result = db.Model(&models.Utxo{}).
-			Where("tx_id = ? AND output_idx = ?", inTxId, inIdx).
-			Where("deleted_slot = 0").       // Only update if still unspent
-			Where("spent_at_tx_id IS NULL"). // Require NULL for first spend
-			Updates(map[string]any{
-				"deleted_slot":   point.Slot,
-				"spent_at_tx_id": txHash,
-			})
-		if result.Error != nil {
-			return result.Error
-		}
-
-		// Check if update succeeded - if no rows affected, the UTXO was already spent
-		// or doesn't exist
-		if result.RowsAffected == 0 {
-			// Check if UTXO exists at all (may be missing or already spent)
-			var existingUtxo models.Utxo
-			checkResult := db.Where("tx_id = ? AND output_idx = ?", inTxId, inIdx).
-				First(&existingUtxo)
-			if checkResult.Error != nil {
-				if errors.Is(checkResult.Error, gorm.ErrRecordNotFound) {
-					d.logger.Warn(
-						"input UTxO not found",
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.Collateral() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+				utxo := collateralUtxos[key]
+				if utxo == nil {
+					d.warnLimiter.warn(
+						d.logger,
+						"missing-collateral-utxo",
+						"Skipping missing collateral UTxO",
 						"hash",
 						input.Id().String(),
 						"index",
@@ -840,26 +692,191 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					)
 					continue
 				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				result = db.Exec(sql, args...)
+				if result.Error != nil {
+					return fmt.Errorf("batch update collateral: %w", result.Error)
+				}
+			}
+		}
+		if len(tx.ReferenceInputs()) > 0 {
+			var refInputRefs []UtxoRef
+			for _, input := range tx.ReferenceInputs() {
+				refInputRefs = append(refInputRefs, UtxoRef{
+					TxId:      input.Id().Bytes(),
+					OutputIdx: input.Index(),
+				})
+			}
+			refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
+			if err != nil {
 				return fmt.Errorf(
-					"failed to check UTXO %x#%d: %w",
-					inTxId,
-					inIdx,
-					checkResult.Error,
+					"failed to batch fetch reference input UTXOs: %w",
+					err,
 				)
 			}
-			// UTXO exists but was already spent - check if by the same transaction (idempotent retry)
-			if existingUtxo.SpentAtTxId != nil &&
-				bytes.Equal(existingUtxo.SpentAtTxId, txHash) {
-				// Same transaction, this is an idempotent retry - OK to continue
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.ReferenceInputs() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+				utxo := refInputUtxos[key]
+				if utxo == nil {
+					d.warnLimiter.warn(
+						d.logger,
+						"missing-reference-input-utxo",
+						"Skipping missing reference input UTxO",
+						"hash",
+						input.Id().String(),
+						"index",
+						inIdx,
+					)
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.ReferenceInputs = append(tmpTx.ReferenceInputs, *utxo)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				result = db.Exec(sql, args...)
+				if result.Error != nil {
+					return fmt.Errorf("batch update reference inputs: %w", result.Error)
+				}
+			}
+		}
+	}
+
+	// Consume UTxOs using optimistic locking to prevent race conditions.
+	// The atomic update ensures only one transaction can successfully mark a UTXO as spent.
+	if len(tx.Consumed()) > 0 {
+		type consumedUtxoRef struct {
+			txID []byte
+			idx  uint32
+			hash string
+		}
+		consumedRefs := make([]consumedUtxoRef, 0, len(tx.Consumed()))
+		for _, input := range tx.Consumed() {
+			inTxID := input.Id().Bytes()
+			inIdx := input.Index()
+			duplicate := false
+			for i := range consumedRefs {
+				if consumedRefs[i].idx == inIdx &&
+					bytes.Equal(consumedRefs[i].txID, inTxID) {
+					duplicate = true
+					break
+				}
+			}
+			if duplicate {
 				continue
 			}
-			// UTXO was spent by a different transaction - this is a conflict
-			return fmt.Errorf(
-				"%w: %x:%d",
-				types.ErrUtxoConflict,
-				inTxId,
-				inIdx,
+			consumedRefs = append(consumedRefs, consumedUtxoRef{
+				txID: inTxID,
+				idx:  inIdx,
+				hash: input.Id().String(),
+			})
+		}
+		if len(consumedRefs) > 0 {
+			whereConditions := make([]string, 0, len(consumedRefs))
+			updateArgs := make([]any, 0, 2+(len(consumedRefs)*2))
+			updateArgs = append(updateArgs, point.Slot, txHash)
+			for _, ref := range consumedRefs {
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				updateArgs = append(updateArgs, ref.txID, ref.idx)
+			}
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
+				strings.Join(whereConditions, " OR "),
 			)
+			result = db.Exec(sql, updateArgs...)
+			if result.Error != nil {
+				return fmt.Errorf("batch consume utxos: %w", result.Error)
+			}
+			if result.RowsAffected != int64(len(consumedRefs)) {
+				for _, ref := range consumedRefs {
+					var existingUtxo models.Utxo
+					checkResult := db.Where(
+						"tx_id = ? AND output_idx = ?",
+						ref.txID,
+						ref.idx,
+					).First(&existingUtxo)
+					if checkResult.Error != nil {
+						if errors.Is(checkResult.Error, gorm.ErrRecordNotFound) {
+							d.warnLimiter.warn(
+								d.logger,
+								"input-utxo-not-found",
+								"input UTxO not found",
+								"hash",
+								ref.hash,
+								"index",
+								ref.idx,
+							)
+							continue
+						}
+						return fmt.Errorf(
+							"failed to check UTXO %x#%d: %w",
+							ref.txID,
+							ref.idx,
+							checkResult.Error,
+						)
+					}
+					if existingUtxo.SpentAtTxId != nil &&
+						bytes.Equal(existingUtxo.SpentAtTxId, txHash) {
+						continue
+					}
+					if existingUtxo.DeletedSlot == 0 &&
+						existingUtxo.SpentAtTxId == nil {
+						return fmt.Errorf(
+							"batch consume did not update UTXO %x#%d",
+							ref.txID,
+							ref.idx,
+						)
+					}
+					return fmt.Errorf(
+						"%w: %x:%d",
+						types.ErrUtxoConflict,
+						ref.txID,
+						ref.idx,
+					)
+				}
+			}
 		}
 	}
 	// Address indexing, witnesses, scripts, redeemers, and plutus data only stored in API mode
@@ -883,9 +900,11 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			idx,
 			addressUtxos,
 		)
-		if result := db.Where("transaction_id = ?", tmpTx.ID).
-			Delete(&models.AddressTransaction{}); result.Error != nil {
-			return fmt.Errorf("delete existing address transactions: %w", result.Error)
+		if needsIdFetch {
+			if result := db.Where("transaction_id = ?", tmpTx.ID).
+				Delete(&models.AddressTransaction{}); result.Error != nil {
+				return fmt.Errorf("delete existing address transactions: %w", result.Error)
+			}
 		}
 		if len(addressTxs) > 0 {
 			if result := db.Create(&addressTxs); result.Error != nil {
@@ -896,69 +915,72 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		// Delete existing witness records to ensure idempotency on retry.
 		// Note: Caller's transaction (via txn parameter) already provides atomicity,
 		// so we don't need a nested db.Transaction() which would create an unnecessary savepoint.
-		result := db.Where(
-			"transaction_id = ?", tmpTx.ID,
-		).Delete(&models.KeyWitness{})
-		if result.Error != nil {
-			return fmt.Errorf(
-				"failed to delete key witnesses: %w",
-				result.Error,
-			)
-		}
-		result = db.Where(
-			"transaction_id = ?", tmpTx.ID,
-		).Delete(&models.WitnessScripts{})
-		if result.Error != nil {
-			return fmt.Errorf(
-				"failed to delete witness scripts: %w",
-				result.Error,
-			)
-		}
-		result = db.Where(
-			"transaction_id = ?", tmpTx.ID,
-		).Delete(&models.Redeemer{})
-		if result.Error != nil {
-			return fmt.Errorf(
-				"failed to delete redeemers: %w",
-				result.Error,
-			)
-		}
-		result = db.Where(
-			"transaction_id = ?", tmpTx.ID,
-		).Delete(&models.PlutusData{})
-		if result.Error != nil {
-			return fmt.Errorf(
-				"failed to delete plutus data: %w",
-				result.Error,
-			)
+		if needsIdFetch {
+			result := db.Where(
+				"transaction_id = ?", tmpTx.ID,
+			).Delete(&models.KeyWitness{})
+			if result.Error != nil {
+				return fmt.Errorf(
+					"failed to delete key witnesses: %w",
+					result.Error,
+				)
+			}
+			result = db.Where(
+				"transaction_id = ?", tmpTx.ID,
+			).Delete(&models.WitnessScripts{})
+			if result.Error != nil {
+				return fmt.Errorf(
+					"failed to delete witness scripts: %w",
+					result.Error,
+				)
+			}
+			result = db.Where(
+				"transaction_id = ?", tmpTx.ID,
+			).Delete(&models.Redeemer{})
+			if result.Error != nil {
+				return fmt.Errorf(
+					"failed to delete redeemers: %w",
+					result.Error,
+				)
+			}
+			result = db.Where(
+				"transaction_id = ?", tmpTx.ID,
+			).Delete(&models.PlutusData{})
+			if result.Error != nil {
+				return fmt.Errorf(
+					"failed to delete plutus data: %w",
+					result.Error,
+				)
+			}
 		}
 		ws := tx.Witnesses()
 		if ws != nil {
+			keyWitnesses := make([]models.KeyWitness, 0, len(ws.Vkey())+len(ws.Bootstrap()))
+
 			// Add Vkey Witnesses
 			for _, vkey := range ws.Vkey() {
-				keyWitness := models.KeyWitness{
+				keyWitnesses = append(keyWitnesses, models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeVkey,
 					Vkey:          vkey.Vkey,
 					Signature:     vkey.Signature,
-				}
-				if result := db.Create(&keyWitness); result.Error != nil {
-					return fmt.Errorf("create vkey witness: %w", result.Error)
-				}
+				})
 			}
 
 			// Add Bootstrap Witnesses
 			for _, bootstrap := range ws.Bootstrap() {
-				keyWitness := models.KeyWitness{
+				keyWitnesses = append(keyWitnesses, models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeBootstrap,
 					PublicKey:     bootstrap.PublicKey,
 					Signature:     bootstrap.Signature,
 					ChainCode:     bootstrap.ChainCode,
 					Attributes:    bootstrap.Attributes,
-				}
-				if result := db.Create(&keyWitness); result.Error != nil {
-					return fmt.Errorf("create bootstrap witness: %w", result.Error)
+				})
+			}
+			if len(keyWitnesses) > 0 {
+				if result := db.Create(&keyWitnesses); result.Error != nil {
+					return fmt.Errorf("create key witnesses: %w", result.Error)
 				}
 			}
 
@@ -1007,25 +1029,26 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			// Add PlutusData (Datums) — only for valid transactions,
 			// matching storeTransactionDatums which hash-indexes them.
 			if tx.IsValid() {
+				plutusDataRows := make([]models.PlutusData, 0, len(ws.PlutusData()))
 				for _, datum := range ws.PlutusData() {
-					plutusData := models.PlutusData{
+					plutusDataRows = append(plutusDataRows, models.PlutusData{
 						TransactionID: tmpTx.ID,
 						Data:          datum.Cbor(),
-					}
-					if result := db.Create(&plutusData); result.Error != nil {
-						return fmt.Errorf(
-							"create plutus data: %w",
-							result.Error,
-						)
+					})
+				}
+				if len(plutusDataRows) > 0 {
+					if result := db.Create(&plutusDataRows); result.Error != nil {
+						return fmt.Errorf("create plutus data: %w", result.Error)
 					}
 				}
 			}
 
 			// Add Redeemers
 			if ws.Redeemers() != nil {
+				redeemers := make([]models.Redeemer, 0)
 				for key, value := range ws.Redeemers().Iter() {
 					//nolint:gosec
-					redeemer := models.Redeemer{
+					redeemers = append(redeemers, models.Redeemer{
 						TransactionID: tmpTx.ID,
 						Tag:           uint8(key.Tag),
 						Index:         key.Index,
@@ -1036,20 +1059,16 @@ func (d *MetadataStoreSqlite) SetTransaction(
 						ExUnitsCPU: uint64(
 							max(0, value.ExUnits.Steps),
 						),
-					}
-					if result := db.Create(&redeemer); result.Error != nil {
-						return fmt.Errorf("create redeemer: %w", result.Error)
+					})
+				}
+				if len(redeemers) > 0 {
+					if result := db.Create(&redeemers); result.Error != nil {
+						return fmt.Errorf("create redeemers: %w", result.Error)
 					}
 				}
 			}
 		}
 	} // end storageMode == types.StorageModeAPI
-
-	// Avoid updating associations
-	result = db.Omit(clause.Associations).Save(tmpTx)
-	if result.Error != nil {
-		return result.Error
-	}
 
 	// Process certificates - all certificate types are handled here in a consolidated manner
 	// This centralizes certificate processing logic within the metadata layer following DRY principles

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -62,6 +62,7 @@ func ensureDB(
 		Logger:         logger,
 		PromRegistry:   nil,
 		BlobPlugin:     cfg.BlobPlugin,
+		RunMode:        string(cfg.RunMode),
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: cfg.DatabaseWorkers,
 	}

--- a/node.go
+++ b/node.go
@@ -126,6 +126,7 @@ func (n *Node) Run(ctx context.Context) error {
 		Logger:         n.config.logger,
 		PromRegistry:   n.config.promRegistry,
 		BlobPlugin:     n.config.blobPlugin,
+		RunMode:        n.config.runMode,
 		MetadataPlugin: n.config.metadataPlugin,
 		MaxConnections: n.config.DatabaseWorkerPoolConfig.WorkerPoolSize,
 		StorageMode:    string(n.config.storageMode),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds run/storage-mode profiles with pre-Start logger injection across plugins and deferred `badger` open, plus rate-limited warnings and batched `sqlite` writes to speed ingest. Also makes extended offsets opt-in in the block indexer and standardizes `badger` commit timestamps to 8‑byte big‑endian.

- **New Features**
  - `badger`: run/storage-mode profiles (`core`, `api`, `load`) auto-tune cache/memtable; `WithDeferOpen()` and `SetLogger()` ensure startup logs use the injected `slog`; commit timestamp now fixed-width 8-byte big-endian (reader remains backward compatible).
  - Database wiring: added `RunMode` to config; pass `run-mode`/`storage-mode` to the blob plugin via `SetPluginOption`; inject `slog` via `LoggerSetter` and start plugins before use; `sqlite` implements `SetLogger`.
  - Block indexer: `WithExtendedOffsets()` opt-in; TxParts/Datum/Redeemer/Script offsets are nil by default.
  - `sqlite`: per-key warning rate limiter with `suppressed_count`.

- **Refactors**
  - `sqlite` ingest: batch-create outputs and witnesses/scripts/datums/redeemers; batch-update collateral/reference links (API mode); batch-consume inputs via a single guarded UPDATE with conflict checks; only clear associations when updating an existing tx.

<sup>Written for commit 163e2102f492d24c85cc1665d6c34dde620cd4c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime profiles (Core/API/Load) and run-mode/storage-mode options to tune defaults.
  * Added logger injection support and ability to defer plugin open/start.
  * Opt-in extended offset extraction to reduce memory allocations.

* **Improvements**
  * Reworked database initialization/startup with stronger validation and cleanup.
  * Large-scale batching of database writes and reads for performance and idempotency.
  * Added per-key log rate limiting.

* **Tests**
  * Expanded tests for operational defaults and profile resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->