### PR TITLE
feat(cmd): add RunMode field and comprehensive help text to root command

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -195,7 +195,45 @@ func main() {
 	}
 
 	rootCmd := &cobra.Command{
-		Use: programName,
+		Use:   programName,
+		Short: "Dingo - a Go Cardano node",
+		Long: `Dingo - a Go Cardano node by Blink Labs.
+
+Configuration Precedence (highest to lowest):
+  1. CLI flags          (e.g. --network preview)
+  2. Environment vars   (e.g. CARDANO_NETWORK=preview)
+  3. Config file        (dingo.yaml or --config path)
+  4. Built-in defaults
+
+Data Directory:
+  The CARDANO_DATABASE_PATH env var (or databasePath in config) sets the
+  data directory for both blob and metadata storage plugins. Plugin-specific
+  flags override this global setting:
+
+    --blob-badger-data-dir      overrides the blob plugin data directory
+    --metadata-sqlite-data-dir  overrides the metadata plugin data directory
+
+  For example, to store metadata separately from block data:
+    dingo --blob-badger-data-dir /fast-ssd/blocks \
+          --metadata-sqlite-data-dir /nvme/indexes
+
+Storage Mode:
+  --blob-badger-storage-mode and --metadata-*-storage-mode override the
+  global storageMode config. Use "core" for minimal validation data or
+  "api" for full indexing (witnesses, scripts, datums, redeemers).
+
+Network:
+  --network sets the Cardano network name and automatically derives the
+  path to the corresponding Cardano node config files (genesis, topology).
+  This overrides the CARDANO_NETWORK env var and the network config field.
+
+Database Workers:
+  --db-workers controls the worker pool size. When using SQLite, set
+  --metadata-sqlite-max-connections to match (both default to 5).
+
+DSN Override:
+  --metadata-mysql-dsn and --metadata-postgres-dsn override all individual
+  connection flags (host, port, user, password, database) when set.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.FromContext(cmd.Context())
 			if cfg == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds RunMode to the CLI and expands the root command help with clear, actionable guidance on configuration, storage, network, and DB settings. Improves discoverability of flags, env vars, and their precedence.

- **New Features**
  - Pass RunMode from config into blob and metadata plugin options in serve and node flows.
  - Add Short/Long help to the root command with configuration precedence: flags > env vars > config file > defaults.
  - Document data directories using `CARDANO_DATABASE_PATH`/`databasePath` and per-plugin overrides `--blob-badger-data-dir` and `--metadata-sqlite-data-dir`.
  - Clarify storage modes (core vs api) and override flags: `--blob-badger-storage-mode`, `--metadata-*-storage-mode`; note `--network` overrides env/config for network selection.
  - Explain DB workers (`--db-workers`) and SQLite connections (`--metadata-sqlite-max-connections`, default 5), and note DSN overrides (`--metadata-mysql-dsn`, `--metadata-postgres-dsn`) take precedence over individual flags.

<sup>Written for commit 01e9d1fd1a5a8ac4d558a43e8f6107dfb4b0866d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

