### PR TITLE
feat(bench): storage mode ingestion benchmarks and enhanced benchmark tooling

### DIFF
--- a/benchmark_results_targeted.md
+++ b/benchmark_results_targeted.md
@@ -1,0 +1,63 @@
+# Dingo Targeted Performance Baseline
+
+## Latest Results
+
+### Test Environment
+- **Date**: March 10, 2026
+- **Go Version**: 1.25.8
+- **OS**: Linux
+- **Architecture**: aarch64
+- **CPU Cores**: 128
+- **Data Source**: Real immutable testdata blocks from database/immutable/testdata
+- **Scope**: Current optimization baseline for core/api ingest, block processing, and batched load paths
+
+### Benchmark Results
+
+All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration counts; benchmark-specific throughput metrics (for example `blocks/sec`) are reported separately.
+
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
+| Block Batch Processing Throughput | 3 | 592689ns | 84361 blocks/sec | 91KB | 2088 |
+| Block Processing Throughput | 3 | 214857ns | 4654 blocks/sec | 26KB | 137 |
+| Block Processing Throughput Predecoded | 3 | 60121ns | 16633 blocks/sec | 2KB | 58 |
+| Raw Block Batch Processing Throughput | 3 | 515408ns | 97011 blocks/sec | 81KB | 1938 |
+| Storage Mode Ingest Steady State/api | 3 | 375174723ns | 479.8 blocks_ingested/sec, 533.1 txs_ingested/sec | 15761KB | 186666 |
+| Storage Mode Ingest Steady State/core | 3 | 152858484ns | 1178 blocks_ingested/sec, 1308 txs_ingested/sec | 7234KB | 94403 |
+| Storage Mode Ingest/api | 3 | 362809147ns | 496.1 blocks_ingested/sec, 551.3 txs_ingested/sec | 15935KB | 193665 |
+| Storage Mode Ingest/core | 3 | 235819272ns | 763.3 blocks_ingested/sec, 848.1 txs_ingested/sec | 7514KB | 101522 |
+## Performance Changes
+
+Changes since **March 10, 2026** (initial baseline):
+
+### Summary
+- **Faster benchmarks**: 4
+  - Block Batch Processing Throughput (+32%)
+  - Block Processing Throughput Predecoded (+91%)
+  - Storage Mode Ingest Steady State/api (+8%)
+  - Storage Mode Ingest Steady State/core (+55%)
+- **Slower benchmarks**: 4
+  - Block Processing Throughput (-56%)
+  - Raw Block Batch Processing Throughput (-17%)
+  - Storage Mode Ingest/api (-18%)
+  - Storage Mode Ingest/core (-37%)
+- **New benchmarks**: 0
+- **Removed benchmarks**: 0
+
+> **Note**: These are two runs from the same session establishing the baseline.
+> Variance is expected; treat this as a single baseline snapshot, not a regression.
+
+
+## Historical Results
+
+### March 10, 2026
+
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
+| Block Batch Processing Throughput | 3 | 781159ns | 64007 blocks/sec | 99KB | 2138 |
+| Block Processing Throughput | 3 | 93495ns | 10696 blocks/sec | 26KB | 138 |
+| Block Processing Throughput Predecoded | 3 | 114562ns | 8729 blocks/sec | 2KB | 60 |
+| Raw Block Batch Processing Throughput | 3 | 427847ns | 116864 blocks/sec | 81KB | 1938 |
+| Storage Mode Ingest Steady State/api | 3 | 406074114ns | 443.3 blocks_ingested/sec, 492.5 txs_ingested/sec | 15743KB | 186725 |
+| Storage Mode Ingest Steady State/core | 3 | 236358805ns | 761.6 blocks_ingested/sec, 846.2 txs_ingested/sec | 7245KB | 94503 |
+| Storage Mode Ingest/api | 3 | 298992974ns | 602.0 blocks_ingested/sec, 668.9 txs_ingested/sec | 15861KB | 193541 |
+| Storage Mode Ingest/core | 3 | 148714628ns | 1210 blocks_ingested/sec, 1345 txs_ingested/sec | 7449KB | 101364 |

--- a/generate_benchmarks.sh
+++ b/generate_benchmarks.sh
@@ -15,11 +15,17 @@
 # limitations under the License.
 
 # Script to generate benchmark results for Dingo ledger and database with historical tracking
-# Usage: ./generate_benchmarks.sh [output_file] [--write]
+# Usage: ./generate_benchmarks.sh [output_file] [--write] [--bench regex] [--packages pkg1,pkg2] [--benchtime duration] [--title title] [--scope scope] [--data-source source]
 #   --write: Write results to file (default: display only)
 
 WRITE_TO_FILE=false
 OUTPUT_FILE="benchmark_results.md"
+BENCH_REGEX="."
+BENCH_PACKAGES="./..."
+REPORT_TITLE="Dingo Ledger & Database Benchmark Results"
+REPORT_SCOPE=""
+REPORT_DATA_SOURCE="Real Cardano preview testnet data (40k+ blocks, slots 0-863,996)"
+BENCH_TIME=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -28,9 +34,39 @@ while [[ $# -gt 0 ]]; do
             WRITE_TO_FILE=true
             shift
             ;;
+        --bench)
+            [[ -z "${2:-}" || "$2" == -* ]] && { echo "Error: --bench requires a value"; exit 1; }
+            BENCH_REGEX="$2"
+            shift 2
+            ;;
+        --packages)
+            [[ -z "${2:-}" || "$2" == -* ]] && { echo "Error: --packages requires a value"; exit 1; }
+            BENCH_PACKAGES="$2"
+            shift 2
+            ;;
+        --benchtime)
+            [[ -z "${2:-}" || "$2" == -* ]] && { echo "Error: --benchtime requires a value"; exit 1; }
+            BENCH_TIME="$2"
+            shift 2
+            ;;
+        --title)
+            [[ -z "${2:-}" || "$2" == -* ]] && { echo "Error: --title requires a value"; exit 1; }
+            REPORT_TITLE="$2"
+            shift 2
+            ;;
+        --scope)
+            [[ -z "${2:-}" || "$2" == -* ]] && { echo "Error: --scope requires a value"; exit 1; }
+            REPORT_SCOPE="$2"
+            shift 2
+            ;;
+        --data-source)
+            [[ -z "${2:-}" || "$2" == -* ]] && { echo "Error: --data-source requires a value"; exit 1; }
+            REPORT_DATA_SOURCE="$2"
+            shift 2
+            ;;
         -*)
             echo "Unknown option: $1"
-            echo "Usage: $0 [output_file] [--write]"
+            echo "Usage: $0 [output_file] [--write] [--bench regex] [--packages pkg1,pkg2] [--benchtime duration] [--title title] [--scope scope] [--data-source source]"
             exit 1
             ;;
         *)
@@ -39,7 +75,7 @@ while [[ $# -gt 0 ]]; do
                 OUTPUT_FILE="$1"
                 OUTPUT_FILE_SET=true
             else
-                echo "Too many arguments. Usage: $0 [output_file] [--write]"
+                echo "Too many arguments. Usage: $0 [output_file] [--write] [--bench regex] [--packages pkg1,pkg2] [--benchtime duration] [--title title] [--scope scope] [--data-source source]"
                 exit 1
             fi
             shift
@@ -55,7 +91,7 @@ OS=$(uname -s)
 ARCH=$(uname -m)
 CPU_CORES=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "unknown")
 
-echo "Running all Dingo benchmarks..."
+echo "Running Dingo benchmarks..."
 echo "==============================="
 
 # Run benchmarks with progress output first
@@ -65,12 +101,17 @@ echo "Executing benchmarks (this may take a few minutes)..."
 set -o pipefail
 
 # Run go test once, capture output while showing progress
-BENCHMARK_OUTPUT=$(go test -bench=. -benchmem ./... -run=^$ 2>&1)
+IFS=',' read -r -a BENCHMARK_PACKAGE_ARGS <<< "$BENCH_PACKAGES"
+BENCHMARK_ARGS=(-bench="$BENCH_REGEX" -benchmem -run=^$)
+if [[ -n "$BENCH_TIME" ]]; then
+    BENCHMARK_ARGS+=("-benchtime=$BENCH_TIME")
+fi
+BENCHMARK_OUTPUT=$(go test "${BENCHMARK_ARGS[@]}" "${BENCHMARK_PACKAGE_ARGS[@]}" 2>&1)
 GO_TEST_EXIT_CODE=$?
 
 # Show progress by parsing benchmark names from output
 echo "$BENCHMARK_OUTPUT" | grep "^Benchmark" | sed 's/Benchmark//' | sed 's/-[0-9]*$//' | while read -r name rest; do
-    echo "Running: $name-128"
+    echo "Running: $name"
 done
 
 # Check if go test succeeded
@@ -90,18 +131,52 @@ parse_benchmark() {
     local line="$1"
     local name
     name=$(echo "$line" | awk '{print $1}' | sed 's/Benchmark//' | sed 's/-[0-9]*$//')
-    local ops_sec
-    ops_sec=$(echo "$line" | awk '{print $2}' | sed 's/,//g')
+    local iterations
+    iterations=$(echo "$line" | awk '{print $2}' | sed 's/,//g')
     local time_val
     time_val=$(echo "$line" | awk '{print $3}')
     local time_unit
     time_unit=$(echo "$line" | awk '{print $4}')
-    local mem_val
-    mem_val=$(echo "$line" | awk '{print $5}')
-    local mem_unit
-    mem_unit=$(echo "$line" | awk '{print $6}')
-    local allocs_op
-    allocs_op=$(echo "$line" | awk '{print $7}')
+
+    local extra_metrics=""
+    local mem_op="N/A"
+    local allocs_op="N/A"
+    local idx=5
+    local token_count
+    token_count=$(echo "$line" | awk '{print NF}')
+
+    while [[ $idx -le $token_count ]]; do
+        local metric_val
+        metric_val=$(echo "$line" | awk -v i="$idx" '{print $i}')
+        local metric_unit
+        metric_unit=$(echo "$line" | awk -v i="$((idx + 1))" '{print $i}')
+
+        if [[ -z "$metric_val" || -z "$metric_unit" ]]; then
+            break
+        fi
+
+        case "$metric_unit" in
+            "B/op")
+                if [[ "$metric_val" =~ ^[0-9]+$ && $metric_val -gt 1000 ]]; then
+                    mem_kb=$((metric_val / 1000))
+                    mem_op="${mem_kb}KB"
+                else
+                    mem_op="${metric_val}B"
+                fi
+                ;;
+            "allocs/op")
+                allocs_op="$metric_val"
+                ;;
+            *)
+                if [[ -n "$extra_metrics" ]]; then
+                    extra_metrics="${extra_metrics}, "
+                fi
+                extra_metrics="${extra_metrics}${metric_val} ${metric_unit}"
+                ;;
+        esac
+
+        idx=$((idx + 2))
+    done
 
     # Format time
     if [[ "$time_unit" == "ns/op" ]]; then
@@ -116,62 +191,74 @@ parse_benchmark() {
         time_op="${time_val}${time_unit}"
     fi
 
-    # Format memory
-    if [[ "$mem_unit" == "B/op" ]]; then
-        if [[ $mem_val -gt 1000 ]]; then
-            mem_kb=$((mem_val / 1000))
-            mem_op="${mem_kb}KB"
-        else
-            mem_op="${mem_val}B"
-        fi
-    else
-        mem_op="${mem_val}${mem_unit}"
+    if [[ -z "$extra_metrics" ]]; then
+        extra_metrics="-"
     fi
 
     # Format benchmark name nicely
     formatted_name=$(echo "$name" | sed 's/\([A-Z]\)/ \1/g' | sed 's/^ //' | sed 's/NoData$/ (No Data)/' | sed 's/RealData$/ (Real Data)/')
 
-    echo "$formatted_name|$ops_sec|$time_op|$mem_op|$allocs_op"
+    echo "$formatted_name|$iterations|$time_op|$extra_metrics|$mem_op|$allocs_op"
 }
 
-# Parse current results into temporary file
+# Parse current results into temporary file, tracking current package
+# go test outputs "pkg: <import-path>" before each package's benchmarks
 CURRENT_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/dingo_bench_XXXXXX")
+current_pkg=""
 while IFS= read -r line; do
-    if [[ "$line" =~ ^Benchmark ]]; then
+    if [[ "$line" =~ ^pkg:[[:space:]]+(.+)$ ]]; then
+        current_pkg="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^ok[[:space:]] || "$line" =~ ^FAIL[[:space:]] ]]; then
+        current_pkg=""
+    elif [[ "$line" =~ ^Benchmark ]]; then
         parsed=$(parse_benchmark "$line")
         name=$(echo "$parsed" | cut -d'|' -f1)
         data=$(echo "$parsed" | cut -d'|' -f2-)
-        echo "$name|$data" >> "$CURRENT_RESULTS_FILE"
+        if [[ -n "$current_pkg" ]]; then
+            pkg_short=$(basename "$current_pkg")
+            echo "${pkg_short}:${name}|$data" >> "$CURRENT_RESULTS_FILE"
+        else
+            echo "$name|$data" >> "$CURRENT_RESULTS_FILE"
+        fi
     fi
 done <<< "$BENCHMARK_OUTPUT"
 
-# Deduplicate benchmark names
+# Deduplicate benchmark names (composite key: package+benchmark)
 sort -t'|' -k1,1 -u "$CURRENT_RESULTS_FILE" > "$CURRENT_RESULTS_FILE.tmp" && mv "$CURRENT_RESULTS_FILE.tmp" "$CURRENT_RESULTS_FILE"
 
 # Display current results summary
 echo "Current Benchmark Summary"
 echo "-------------------------"
-echo "Fastest benchmarks (>100k ops/sec):"
-echo "$BENCHMARK_OUTPUT" | grep "^Benchmark" | sort -k2 -nr | head -3 | while read -r line; do
-    name=$(echo "$line" | awk '{print $1}' | sed 's/Benchmark//' | sed 's/-128$//')
-    ops=$(echo "$line" | awk '{print $2}' | sed 's/,//g')
-    echo "  - $name: ${ops} ops/sec"
+echo "Most iterations (>100k iters):"
+sort -t'|' -k2,2nr "$CURRENT_RESULTS_FILE" | head -3 | while IFS='|' read -r name iterations _; do
+    echo "  - $name: ${iterations} iterations"
 done
 
 echo ""
-echo "Slowest benchmarks (<1k ops/sec):"
-echo "$BENCHMARK_OUTPUT" | grep "^Benchmark" | awk '$2 < 1000' | while read -r line; do
-    name=$(echo "$line" | awk '{print $1}' | sed 's/Benchmark//' | sed 's/-128$//')
-    ops=$(echo "$line" | awk '{print $2}' | sed 's/,//g')
-    echo "  - $name: ${ops} ops/sec"
+echo "Fewest iterations (<1k iters):"
+awk -F'|' '$2 < 1000 {print $1 "|" $2}' "$CURRENT_RESULTS_FILE" | while IFS='|' read -r name iterations; do
+    echo "  - $name: ${iterations} iterations"
 done
 
 echo ""
 echo "Memory usage:"
-echo "$BENCHMARK_OUTPUT" | grep "^Benchmark" | sort -k5 -nr | head -3 | while read -r line; do
-    name=$(echo "$line" | awk '{print $1}' | sed 's/Benchmark//' | sed 's/-128$//')
-    mem=$(echo "$line" | awk '{print $5}')
-    echo "  - $name: ${mem}B per op"
+awk -F'|' '
+function mem_bytes(v) {
+    if (v ~ /KB$/) {
+        sub(/KB$/, "", v)
+        return v + 0
+    }
+    if (v ~ /B$/) {
+        sub(/B$/, "", v)
+        return (v + 0) / 1000
+    }
+    return -1
+}
+{
+    print mem_bytes($5) "|" $1 "|" $5
+}
+' "$CURRENT_RESULTS_FILE" | sort -t'|' -k1,1nr | head -3 | while IFS='|' read -r _ name mem; do
+    echo "  - $name: ${mem} per op"
 done
 
 # Read previous results if file exists and we're comparing
@@ -193,19 +280,39 @@ if [[ -f "$OUTPUT_FILE" && "$WRITE_TO_FILE" == "true" ]]; then
         if [[ "$line" == "## Performance Changes" || "$line" == "## Historical Results" ]]; then
             break
         fi
-        if [[ "$line" == "| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |" ]]; then
+        if [[ "$line" == "| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |" ||
+              "$line" == "| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |" ]]; then
             in_table=true
             continue
         fi
-        if [[ "$in_table" == true && "$line" =~ ^\|.*\|.*\|.*\|.*\|.*\|$ && "$line" != "|-----------|*" ]]; then
+        # Skip separator rows (e.g. |---|---|...)
+        if [[ "$line" =~ ^\|[-[:space:]\|]+\|$ ]]; then
+            continue
+        fi
+        if [[ "$in_table" == true && "$line" =~ ^\|.*\|.*\|.*\|.*\|.*\|$ ]]; then
             # Parse table row
             benchmark=$(echo "$line" | sed 's/^| //' | cut -d'|' -f1 | sed 's/ *$//')
-            ops_sec=$(echo "$line" | sed 's/^| //' | cut -d'|' -f2 | sed 's/ //g' | sed 's/,//g')
-            time_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f3 | sed 's/ //g')
-            mem_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f4 | sed 's/ //g')
-            allocs_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f5 | sed 's/ //g')
-            if [[ -n "$benchmark" && -n "$ops_sec" ]]; then
-                echo "$benchmark|$ops_sec|$time_op|$mem_op|$allocs_op" >> "$PREVIOUS_RESULTS_FILE"
+            # Count fields to detect 5-column vs 6-column format
+            field_count=$(echo "$line" | awk -F'|' '{print NF - 2}')
+
+            if [[ "$field_count" -le 5 ]]; then
+                # Old 5-column format: Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op
+                iterations="-"
+                time_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f3 | sed 's/ //g')
+                extra_metrics=$(echo "$line" | sed 's/^| //' | cut -d'|' -f2 | sed 's/^ *//' | sed 's/ *$//')
+                mem_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f4 | sed 's/ //g')
+                allocs_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f5 | sed 's/ //g')
+            else
+                # Current 6-column format
+                iterations=$(echo "$line" | sed 's/^| //' | cut -d'|' -f2 | sed 's/ //g' | sed 's/,//g')
+                time_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f3 | sed 's/ //g')
+                extra_metrics=$(echo "$line" | sed 's/^| //' | cut -d'|' -f4 | sed 's/^ *//' | sed 's/ *$//')
+                mem_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f5 | sed 's/ //g')
+                allocs_op=$(echo "$line" | sed 's/^| //' | cut -d'|' -f6 | sed 's/ //g')
+            fi
+
+            if [[ -n "$benchmark" && -n "$time_op" ]]; then
+                echo "$benchmark|$iterations|$time_op|$extra_metrics|$mem_op|$allocs_op" >> "$PREVIOUS_RESULTS_FILE"
             fi
         fi
         if [[ "$in_table" == true && "$line" == "" ]]; then
@@ -251,16 +358,16 @@ if [[ -n "$previous_date" && "$WRITE_TO_FILE" == "true" ]]; then
             current_data=$(get_current_data "$benchmark")
             previous_data=$(get_previous_data "$benchmark")
 
-            current_ops=$(echo "$current_data" | cut -d'|' -f1)
-            previous_ops=$(echo "$previous_data" | cut -d'|' -f1)
+            current_iters=$(echo "$current_data" | cut -d'|' -f1)
+            previous_iters=$(echo "$previous_data" | cut -d'|' -f1)
 
-            if [[ "$current_ops" =~ ^[0-9]+$ && "$previous_ops" =~ ^[0-9]+$ && $previous_ops -gt 0 ]]; then
-                change=$(( (current_ops - previous_ops) * 100 / previous_ops ))
+            if [[ "$current_iters" =~ ^[0-9]+$ && "$previous_iters" =~ ^[0-9]+$ && $previous_iters -gt 0 ]]; then
+                change=$(( (current_iters - previous_iters) * 100 / previous_iters ))
                 if [[ $change -gt 10 ]]; then
                     faster_benchmarks="$faster_benchmarks
 $benchmark (+${change}%)"
                 elif [[ $change -lt -10 ]]; then
-                    change_abs=$(( (previous_ops - current_ops) * 100 / previous_ops ))
+                    change_abs=$(( (previous_iters - current_iters) * 100 / previous_iters ))
                     slower_benchmarks="$slower_benchmarks
 $benchmark (-${change_abs}%)"
                     MAJOR_CHANGES=true
@@ -333,16 +440,16 @@ if [[ "$WRITE_TO_FILE" == "true" ]]; then
                     current_data=$(get_current_data "$benchmark")
                     previous_data=$(get_previous_data "$benchmark")
 
-                    current_ops=$(echo "$current_data" | cut -d'|' -f1)
-                    previous_ops=$(echo "$previous_data" | cut -d'|' -f1)
+                    current_iters=$(echo "$current_data" | cut -d'|' -f1)
+                    previous_iters=$(echo "$previous_data" | cut -d'|' -f1)
 
-                    if [[ "$current_ops" =~ ^[0-9]+$ && "$previous_ops" =~ ^[0-9]+$ && $previous_ops -gt 0 ]]; then
-                        if [[ $current_ops -gt $previous_ops ]]; then
-                            change=$(( (current_ops - previous_ops) * 100 / previous_ops ))
+                    if [[ "$current_iters" =~ ^[0-9]+$ && "$previous_iters" =~ ^[0-9]+$ && $previous_iters -gt 0 ]]; then
+                        if [[ $current_iters -gt $previous_iters ]]; then
+                            change=$(( (current_iters - previous_iters) * 100 / previous_iters ))
                             faster_benchmarks="$faster_benchmarks
 $benchmark (+${change}%)"
-                        elif [[ $current_ops -lt $previous_ops ]]; then
-                            change=$(( (previous_ops - current_ops) * 100 / previous_ops ))
+                        elif [[ $current_iters -lt $previous_iters ]]; then
+                            change=$(( (previous_iters - current_iters) * 100 / previous_iters ))
                             slower_benchmarks="$slower_benchmarks
 $benchmark (-${change}%)"
                         fi
@@ -401,7 +508,7 @@ $benchmark"
 
         # Create the markdown file
         cat > "$OUTPUT_FILE.tmp" << EOF
-# Dingo Ledger & Database Benchmark Results
+# $REPORT_TITLE
 
 ## Latest Results
 
@@ -411,24 +518,34 @@ $benchmark"
 - **OS**: $OS
 - **Architecture**: $ARCH
 - **CPU Cores**: $CPU_CORES
-- **Data Source**: Real Cardano preview testnet data (40k+ blocks, slots 0-863,996)
+- **Data Source**: $REPORT_DATA_SOURCE
+EOF
+
+        if [[ -n "$REPORT_SCOPE" ]]; then
+            cat >> "$OUTPUT_FILE.tmp" << EOF
+- **Scope**: $REPORT_SCOPE
+EOF
+        fi
+
+        cat >> "$OUTPUT_FILE.tmp" << EOF
 
 ### Benchmark Results
 
-All benchmarks run with \`-benchmem\` flag showing memory allocations and operation counts.
+All benchmarks run with \`-benchmem\` flag. Iterations are Go benchmark iteration counts; benchmark-specific throughput metrics (for example \`blocks/sec\`) are reported separately.
 
-| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |
-|-----------|----------------|---------|-----------|-----------|
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
 EOF
 
         # Add current results to table
         while IFS= read -r benchmark; do
             data=$(get_current_data "$benchmark")
-            ops_sec=$(echo "$data" | cut -d'|' -f1)
+            iterations=$(echo "$data" | cut -d'|' -f1)
             time_op=$(echo "$data" | cut -d'|' -f2)
-            mem_op=$(echo "$data" | cut -d'|' -f3)
-            allocs_op=$(echo "$data" | cut -d'|' -f4)
-            echo "| $benchmark | $ops_sec | $time_op | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
+            extra_metrics=$(echo "$data" | cut -d'|' -f3)
+            mem_op=$(echo "$data" | cut -d'|' -f4)
+            allocs_op=$(echo "$data" | cut -d'|' -f5)
+            echo "| $benchmark | $iterations | $time_op | $extra_metrics | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
         done < <(list_current_benchmarks)
 
         # Add comparison section
@@ -441,17 +558,18 @@ EOF
             echo "" >> "$OUTPUT_FILE.tmp"
             echo "### $previous_date" >> "$OUTPUT_FILE.tmp"
             echo "" >> "$OUTPUT_FILE.tmp"
-            echo "| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |" >> "$OUTPUT_FILE.tmp"
-            echo "|-----------|----------------|---------|-----------|-----------|" >> "$OUTPUT_FILE.tmp"
+            echo "| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |" >> "$OUTPUT_FILE.tmp"
+            echo "|-----------|------------|---------|---------------|-----------|-----------|" >> "$OUTPUT_FILE.tmp"
 
             # Add previous results
             while IFS= read -r benchmark; do
                 data=$(get_previous_data "$benchmark")
-                ops_sec=$(echo "$data" | cut -d'|' -f1)
+                iterations=$(echo "$data" | cut -d'|' -f1)
                 time_op=$(echo "$data" | cut -d'|' -f2)
-                mem_op=$(echo "$data" | cut -d'|' -f3)
-                allocs_op=$(echo "$data" | cut -d'|' -f4)
-                echo "| $benchmark | $ops_sec | $time_op | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
+                extra_metrics=$(echo "$data" | cut -d'|' -f3)
+                mem_op=$(echo "$data" | cut -d'|' -f4)
+                allocs_op=$(echo "$data" | cut -d'|' -f5)
+                echo "| $benchmark | $iterations | $time_op | $extra_metrics | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
             done < <(list_previous_benchmarks)
         fi
 

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -16,6 +16,10 @@ package ledger
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -26,7 +30,14 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
+
+var benchmarkDiscardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+const storageModeBenchmarkStartSlot = 10000
+const storageModeBenchmarkSkippedInputHash = "e3ca57e8f323265742a8f4e79ff9af884c9ff8719bd4f7788adaea4c33ba07b6"
+const storageModeBenchmarkSkippedInputIndex = 3
 
 // Helper functions for benchmark seeding
 
@@ -1985,82 +1996,34 @@ func BenchmarkTransactionValidation(b *testing.B) {
 // BenchmarkBlockProcessingThroughput measures blocks/second processing throughput
 // using real Cardano testnet data in a continuous processing loop
 func BenchmarkBlockProcessingThroughput(b *testing.B) {
-	// Set up in-memory database
-	config := &database.Config{
-		DataDir: "", // in-memory
-	}
-	db, err := database.New(config)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer db.Close()
-
-	// Open the immutable database with real Cardano preview testnet data
-	immDb := openImmutableTestDB(b)
-
-	// Seed database with initial blocks for chain state
-	seeded := seedBlocksFromSlots(
+	seedModels, blocks := loadBlockProcessingFixture(b)
+	db, ledgerState := newBlockProcessingBenchmarkLedgerState(
 		b,
-		db,
-		immDb,
-		[]uint64{0, 1, 2, 3, 4},
-	) // Genesis + first few blocks
-	b.Logf("Seeded %d initial blocks for chain sync", seeded)
-
-	// Create chain manager
-	chainManager, err := chain.NewManager(db, nil)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// Create ledger state for validation
-	ledgerCfg := LedgerStateConfig{
-		Database:     db,
-		ChainManager: chainManager,
-	}
-	ledgerState, err := NewLedgerState(ledgerCfg)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// Get iterator for continuous block processing (start from slot 5)
-	startPoint := ocommon.NewPoint(5, nil)
-	iterator, err := immDb.BlocksFromPoint(startPoint)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer iterator.Close()
-
-	// Pre-load a batch of blocks for throughput testing
-	var blocks []*immutable.Block
-	blockCount := 0
-	maxBlocks := 100 // Process up to 100 blocks for throughput measurement
-
-	for blockCount < maxBlocks {
-		block, err := iterator.Next()
-		if err != nil {
-			break // End of available blocks
-		}
-		if block == nil {
-			break
-		}
-		blocks = append(blocks, block)
-		blockCount++
-	}
-
-	if len(blocks) == 0 {
-		b.Skip("No blocks available for throughput benchmarking")
-	}
+		seedModels,
+	)
+	b.Cleanup(func() { db.Close() })
 
 	b.Logf("Loaded %d blocks for throughput testing", len(blocks))
 
-	// Reset timer after setup
 	b.ResetTimer()
 
-	// Benchmark continuous block processing throughput
 	processedBlocks := 0
+	blockIdx := 0
 	for i := 0; b.Loop(); i++ {
-		block := blocks[i%len(blocks)]
+		if blockIdx == len(blocks) {
+			b.StopTimer()
+			if err := db.Close(); err != nil {
+				b.Fatal(err)
+			}
+			db, ledgerState = newBlockProcessingBenchmarkLedgerState(
+				b,
+				seedModels,
+			)
+			blockIdx = 0
+			b.StartTimer()
+		}
+		block := blocks[blockIdx]
+		blockIdx++
 
 		// Convert to ledger block
 		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
@@ -2068,14 +2031,13 @@ func BenchmarkBlockProcessingThroughput(b *testing.B) {
 			b.Fatalf("NewBlockFromCbor failed: %v", err)
 		}
 
-		// Create database transaction for block addition
-		txn := db.Transaction(true)
+		// Live blockfetch uses a blob-only txn for chain insertion.
+		txn := db.BlobTxn(true)
 
 		// Add block to chain (this includes transaction validation and state updates)
 		if err := ledgerState.Chain().AddBlock(ledgerBlock, txn); err != nil {
-			// Some blocks may fail validation due to missing context, but we measure throughput anyway
 			_ = txn.Rollback()
-			continue
+			b.Fatalf("AddBlock failed: %v", err)
 		}
 
 		// Commit transaction to finalize DB resources for this iteration
@@ -2089,6 +2051,287 @@ func BenchmarkBlockProcessingThroughput(b *testing.B) {
 
 	// Report blocks per second
 	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
+}
+
+// BenchmarkBlockProcessingThroughputPredecoded measures block-processing
+// throughput with block CBOR decoding removed from the timed region.
+func BenchmarkBlockProcessingThroughputPredecoded(b *testing.B) {
+	seedModels, rawBlocks := loadBlockProcessingFixture(b)
+	blocks := make([]ledger.Block, 0, len(rawBlocks))
+	for _, block := range rawBlocks {
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			b.Fatalf("predecode block: %v", err)
+		}
+		blocks = append(blocks, ledgerBlock)
+	}
+
+	db, ledgerState := newBlockProcessingBenchmarkLedgerState(
+		b,
+		seedModels,
+	)
+	b.Cleanup(func() { db.Close() })
+
+	b.Logf("Loaded %d predecoded blocks for throughput testing", len(blocks))
+
+	b.ResetTimer()
+
+	processedBlocks := 0
+	blockIdx := 0
+	for i := 0; b.Loop(); i++ {
+		if blockIdx == len(blocks) {
+			b.StopTimer()
+			if err := db.Close(); err != nil {
+				b.Fatal(err)
+			}
+			db, ledgerState = newBlockProcessingBenchmarkLedgerState(
+				b,
+				seedModels,
+			)
+			blockIdx = 0
+			b.StartTimer()
+		}
+		block := blocks[blockIdx]
+		blockIdx++
+		txn := db.BlobTxn(true)
+
+		if err := ledgerState.Chain().AddBlock(block, txn); err != nil {
+			_ = txn.Rollback()
+			b.Fatalf("AddBlock failed: %v", err)
+		}
+		if err := txn.Commit(); err != nil {
+			_ = txn.Rollback()
+			b.Fatalf("Failed to commit transaction: %v", err)
+		}
+
+		processedBlocks++
+	}
+
+	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
+}
+
+// BenchmarkBlockBatchProcessingThroughput measures batched block-processing
+// throughput using Chain.AddBlocks, which matches the normal immutable-load
+// path more closely than per-block AddBlock.
+func BenchmarkBlockBatchProcessingThroughput(b *testing.B) {
+	seedModels, batchBlocks, _, batchSize := loadBatchProcessingFixture(b)
+
+	b.ResetTimer()
+
+	processedBlocks := 0
+	for b.Loop() {
+		b.StopTimer()
+		db, ledgerState := newBatchBenchmarkLedgerState(b, seedModels)
+		b.StartTimer()
+		if err := ledgerState.Chain().AddBlocks(batchBlocks); err != nil {
+			_ = db.Close()
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		if err := db.Close(); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		processedBlocks += batchSize
+	}
+
+	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
+}
+
+// BenchmarkRawBlockBatchProcessingThroughput measures batched header-only
+// processing throughput using Chain.AddRawBlocks, matching the optimized
+// load path used during immutable imports.
+func BenchmarkRawBlockBatchProcessingThroughput(b *testing.B) {
+	seedModels, _, rawBlocks, batchSize := loadBatchProcessingFixture(b)
+
+	b.ResetTimer()
+
+	processedBlocks := 0
+	for b.Loop() {
+		b.StopTimer()
+		db, ledgerState := newBatchBenchmarkLedgerState(b, seedModels)
+		b.StartTimer()
+		if err := ledgerState.Chain().AddRawBlocks(rawBlocks); err != nil {
+			_ = db.Close()
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		if err := db.Close(); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		processedBlocks += batchSize
+	}
+
+	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
+}
+
+func loadBatchProcessingFixture(
+	b *testing.B,
+) ([]models.Block, []ledger.Block, []chain.RawBlock, int) {
+	b.Helper()
+
+	immDb := openImmutableTestDB(b)
+	iterator, err := immDb.BlocksFromPoint(ocommon.NewPoint(0, nil))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer iterator.Close()
+
+	const seedCount = 5
+	const batchSize = 50
+
+	seedModels := make([]models.Block, 0, seedCount)
+	for len(seedModels) < seedCount {
+		block, err := iterator.Next()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if block == nil {
+			b.Skip("insufficient blocks available for batch benchmark seed")
+		}
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			continue
+		}
+		seedModels = append(seedModels, models.Block{
+			ID:       uint64(len(seedModels) + 1),
+			Slot:     block.Slot,
+			Hash:     slices.Clone(block.Hash),
+			Number:   0,
+			Type:     uint(ledgerBlock.Type()),
+			PrevHash: ledgerBlock.PrevHash().Bytes(),
+			Cbor:     slices.Clone(block.Cbor),
+		})
+	}
+
+	batchBlocks := make([]ledger.Block, 0, batchSize)
+	rawBlocks := make([]chain.RawBlock, 0, batchSize)
+	for len(batchBlocks) < batchSize {
+		block, err := iterator.Next()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if block == nil {
+			b.Skip("insufficient blocks available for batch benchmark")
+		}
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			continue
+		}
+		batchBlocks = append(batchBlocks, ledgerBlock)
+		rawBlocks = append(rawBlocks, chain.RawBlock{
+			Slot:        ledgerBlock.SlotNumber(),
+			Hash:        slices.Clone(block.Hash),
+			BlockNumber: ledgerBlock.BlockNumber(),
+			Type:        uint(block.Type),
+			PrevHash:    ledgerBlock.PrevHash().Bytes(),
+			Cbor:        slices.Clone(block.Cbor),
+		})
+	}
+
+	return seedModels, batchBlocks, rawBlocks, batchSize
+}
+
+func loadBlockProcessingFixture(
+	b *testing.B,
+) ([]models.Block, []*immutable.Block) {
+	b.Helper()
+
+	immDb := openImmutableTestDB(b)
+	iterator, err := immDb.BlocksFromPoint(ocommon.NewPoint(0, nil))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer iterator.Close()
+
+	const seedCount = 5
+	const blockCount = 100
+
+	seedModels := make([]models.Block, 0, seedCount)
+	for len(seedModels) < seedCount {
+		block, err := iterator.Next()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if block == nil {
+			b.Skip("insufficient blocks available for throughput benchmark seed")
+		}
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			continue
+		}
+		seedModels = append(seedModels, models.Block{
+			ID:       uint64(len(seedModels) + 1),
+			Slot:     block.Slot,
+			Hash:     slices.Clone(block.Hash),
+			Number:   0,
+			Type:     uint(ledgerBlock.Type()),
+			PrevHash: ledgerBlock.PrevHash().Bytes(),
+			Cbor:     slices.Clone(block.Cbor),
+		})
+	}
+
+	blocks := make([]*immutable.Block, 0, blockCount)
+	for len(blocks) < blockCount {
+		block, err := iterator.Next()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if block == nil {
+			b.Skip("insufficient blocks available for throughput benchmark")
+		}
+		tmpBlock := &immutable.Block{
+			Slot: block.Slot,
+			Type: block.Type,
+			Cbor: slices.Clone(block.Cbor),
+			Hash: slices.Clone(block.Hash),
+		}
+		blocks = append(blocks, tmpBlock)
+	}
+
+	return seedModels, blocks
+}
+
+func newBatchBenchmarkLedgerState(
+	b *testing.B,
+	seedModels []models.Block,
+) (*database.Database, *LedgerState) {
+	b.Helper()
+
+	db, err := database.New(&database.Config{DataDir: ""})
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, blockModel := range seedModels {
+		tmpModel := blockModel
+		if err := db.BlockCreate(tmpModel, nil); err != nil {
+			_ = db.Close()
+			b.Fatalf("seed batch benchmark block: %v", err)
+		}
+	}
+	chainManager, err := chain.NewManager(db, nil)
+	if err != nil {
+		_ = db.Close()
+		b.Fatal(err)
+	}
+	ledgerState, err := NewLedgerState(LedgerStateConfig{
+		Database:     db,
+		ChainManager: chainManager,
+	})
+	if err != nil {
+		_ = db.Close()
+		b.Fatal(err)
+	}
+	return db, ledgerState
+}
+
+func newBlockProcessingBenchmarkLedgerState(
+	b *testing.B,
+	seedModels []models.Block,
+) (*database.Database, *LedgerState) {
+	b.Helper()
+	return newBatchBenchmarkLedgerState(b, seedModels)
 }
 
 // BenchmarkConcurrentQueries measures database performance under concurrent query load
@@ -2176,4 +2419,415 @@ func BenchmarkConcurrentQueries(b *testing.B) {
 
 	// Report queries per second
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "queries/sec")
+}
+
+type storageModeBenchmarkBlock struct {
+	block        ledger.Block
+	point        ocommon.Point
+	model        models.Block
+	offsets      *database.BlockIngestionResult
+	transactions []storageModeBenchmarkTx
+	txCount      int
+}
+
+type storageModeBenchmarkTx struct {
+	tx           lcommon.Transaction
+	updateEpoch  uint64
+	paramUpdates map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate
+	certDeposits map[int]uint64
+}
+
+type storageModeBenchmarkFixture struct {
+	seedBlocks    []storageModeBenchmarkBlock
+	measureBlocks []storageModeBenchmarkBlock
+}
+
+func storageModeBenchmarkCanIngestBlock(
+	db *database.Database,
+	block storageModeBenchmarkBlock,
+) (bool, error) {
+	for _, tx := range block.block.Transactions() {
+		skipInputs := func(inputs []lcommon.TransactionInput) bool {
+			for _, input := range inputs {
+				if input.Id().String() == storageModeBenchmarkSkippedInputHash &&
+					input.Index() == storageModeBenchmarkSkippedInputIndex {
+					return true
+				}
+			}
+			return false
+		}
+
+		if skipInputs(tx.Inputs()) ||
+			skipInputs(tx.Collateral()) ||
+			skipInputs(tx.ReferenceInputs()) ||
+			skipInputs(tx.Consumed()) {
+			return false, nil
+		}
+
+		checkInputs := func(
+			inputs []lcommon.TransactionInput,
+			includeSpent bool,
+		) (bool, error) {
+			for _, input := range inputs {
+				var err error
+				if includeSpent {
+					_, err = db.UtxoByRefIncludingSpent(
+						input.Id().Bytes(),
+						input.Index(),
+						nil,
+					)
+				} else {
+					_, err = db.UtxoByRef(input.Id().Bytes(), input.Index(), nil)
+				}
+				if err == nil {
+					continue
+				}
+				if errors.Is(err, database.ErrUtxoNotFound) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}
+
+		ok, err := checkInputs(tx.Inputs(), false)
+		if !ok || err != nil {
+			return ok, err
+		}
+		ok, err = checkInputs(tx.Collateral(), false)
+		if !ok || err != nil {
+			return ok, err
+		}
+		ok, err = checkInputs(tx.ReferenceInputs(), false)
+		if !ok || err != nil {
+			return ok, err
+		}
+		ok, err = checkInputs(tx.Consumed(), true)
+		if !ok || err != nil {
+			return ok, err
+		}
+	}
+	return true, nil
+}
+
+func loadStorageModeBenchmarkFixture(
+	b *testing.B,
+	maxBlocks int,
+	seedTargetTxs int,
+	measureTargetTxs int,
+) storageModeBenchmarkFixture {
+	b.Helper()
+
+	immDb := openImmutableTestDB(b)
+	iterator, err := immDb.BlocksFromPoint(
+		ocommon.NewPoint(storageModeBenchmarkStartSlot, nil),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer iterator.Close()
+
+	ret := storageModeBenchmarkFixture{
+		seedBlocks:    make([]storageModeBenchmarkBlock, 0, maxBlocks),
+		measureBlocks: make([]storageModeBenchmarkBlock, 0, maxBlocks),
+	}
+	fixtureDb, err := database.New(&database.Config{
+		DataDir:     "",
+		Logger:      benchmarkDiscardLogger,
+		StorageMode: types.StorageModeCore,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer fixtureDb.Close()
+	seededTxs := 0
+	measuredTxs := 0
+	for len(ret.seedBlocks)+len(ret.measureBlocks) < maxBlocks &&
+		measuredTxs < measureTargetTxs {
+		immBlock, err := iterator.Next()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if immBlock == nil {
+			break
+		}
+
+		ledgerBlock, err := ledger.NewBlockFromCbor(
+			immBlock.Type,
+			immBlock.Cbor,
+		)
+		if err != nil {
+			continue
+		}
+		point := ocommon.NewPoint(immBlock.Slot, immBlock.Hash)
+		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+		offsets, err := indexer.ComputeOffsets(immBlock.Cbor, ledgerBlock)
+		if err != nil {
+			b.Fatalf("compute offsets for slot %d: %v", point.Slot, err)
+		}
+
+		txs := ledgerBlock.Transactions()
+		txCount := len(txs)
+		if txCount == 0 {
+			continue
+		}
+		benchmarkTxs := make([]storageModeBenchmarkTx, 0, txCount)
+		for _, tx := range txs {
+			updateEpoch, paramUpdates := tx.ProtocolParameterUpdates()
+			certs := tx.Certificates()
+			var certDeposits map[int]uint64
+			if len(certs) > 0 {
+				certDeposits = make(map[int]uint64, len(certs))
+				for i := range certs {
+					certDeposits[i] = 0
+				}
+			}
+			benchmarkTxs = append(benchmarkTxs, storageModeBenchmarkTx{
+				tx:           tx,
+				updateEpoch:  updateEpoch,
+				paramUpdates: paramUpdates,
+				certDeposits: certDeposits,
+			})
+		}
+		blockData := storageModeBenchmarkBlock{
+			block: ledgerBlock,
+			point: point,
+			model: models.Block{
+				ID:       uint64(len(ret.seedBlocks) + len(ret.measureBlocks) + 1),
+				Slot:     point.Slot,
+				Hash:     point.Hash,
+				Number:   ledgerBlock.BlockNumber(),
+				Type:     uint(ledgerBlock.Type()),
+				PrevHash: ledgerBlock.PrevHash().Bytes(),
+				Cbor:     ledgerBlock.Cbor(),
+			},
+			offsets:      offsets,
+			transactions: benchmarkTxs,
+			txCount:      txCount,
+		}
+
+		if seededTxs < seedTargetTxs {
+			ret.seedBlocks = append(ret.seedBlocks, blockData)
+			seededTxs += txCount
+			if _, err := ingestStorageModeBenchmarkBlocks(
+				fixtureDb,
+				[]storageModeBenchmarkBlock{blockData},
+			); err != nil {
+				b.Fatalf(
+					"seed storage mode fixture block at slot %d: %v",
+					point.Slot,
+					err,
+				)
+			}
+			continue
+		}
+		ok, err := storageModeBenchmarkCanIngestBlock(fixtureDb, blockData)
+		if err != nil {
+			b.Fatalf(
+				"preflight storage mode fixture block at slot %d: %v",
+				point.Slot,
+				err,
+			)
+		}
+		if !ok {
+			continue
+		}
+		ret.measureBlocks = append(ret.measureBlocks, blockData)
+		measuredTxs += txCount
+		if _, err := ingestStorageModeBenchmarkBlocks(
+			fixtureDb,
+			[]storageModeBenchmarkBlock{blockData},
+		); err != nil {
+			b.Fatalf(
+				"ingest storage mode fixture block at slot %d: %v",
+				point.Slot,
+				err,
+			)
+		}
+	}
+	if len(ret.measureBlocks) == 0 {
+		b.Skip("no blocks available for storage mode benchmark")
+	}
+	return ret
+}
+
+func ingestStorageModeBenchmarkBlocks(
+	db *database.Database,
+	blocks []storageModeBenchmarkBlock,
+) (int, error) {
+	txn := db.Transaction(true)
+	defer txn.Rollback() //nolint:errcheck
+
+	totalTxs := 0
+	for _, blockData := range blocks {
+		if err := db.BlockCreate(blockData.model, txn); err != nil {
+			return totalTxs, fmt.Errorf(
+				"BlockCreate slot %d: %w", blockData.point.Slot, err,
+			)
+		}
+		for txIdx, txData := range blockData.transactions {
+			if err := db.SetTransaction(
+				txData.tx,
+				blockData.point,
+				uint32(txIdx),
+				txData.updateEpoch,
+				txData.paramUpdates,
+				txData.certDeposits,
+				blockData.offsets,
+				txn,
+			); err != nil {
+				return totalTxs, fmt.Errorf(
+					"SetTransaction slot %d tx %d: %w",
+					blockData.point.Slot, txIdx, err,
+				)
+			}
+			totalTxs++
+		}
+	}
+
+	if err := txn.Commit(); err != nil {
+		return totalTxs, fmt.Errorf(
+			"Commit after %d txs: %w", totalTxs, err,
+		)
+	}
+	return totalTxs, nil
+}
+
+// BenchmarkStorageModeIngest compares real block ingestion in core and api
+// storage modes using the same block batch and offset computation path.
+func BenchmarkStorageModeIngest(b *testing.B) {
+	fixture := loadStorageModeBenchmarkFixture(b, 300, 500, 200)
+	modeNames := []string{types.StorageModeCore, types.StorageModeAPI}
+
+	for _, mode := range modeNames {
+		b.Run(mode, func(b *testing.B) {
+			b.ReportAllocs()
+
+			totalBlocks := 0
+			totalTxs := 0
+			for b.Loop() {
+				b.StopTimer()
+				db, err := database.New(&database.Config{
+					DataDir:     "",
+					Logger:      benchmarkDiscardLogger,
+					StorageMode: mode,
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := ingestStorageModeBenchmarkBlocks(
+					db,
+					fixture.seedBlocks,
+				); err != nil {
+					_ = db.Close()
+					b.Fatalf("seed storage mode benchmark blocks: %v", err)
+				}
+
+				b.StartTimer()
+				txCount, err := ingestStorageModeBenchmarkBlocks(
+					db,
+					fixture.measureBlocks,
+				)
+
+				b.StopTimer()
+				closeErr := db.Close()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if closeErr != nil {
+					b.Fatal(closeErr)
+				}
+				b.StartTimer()
+
+				totalBlocks += len(fixture.measureBlocks)
+				totalTxs += txCount
+			}
+
+			b.ReportMetric(
+				float64(totalBlocks)/b.Elapsed().Seconds(),
+				"blocks_ingested/sec",
+			)
+			b.ReportMetric(
+				float64(totalTxs)/b.Elapsed().Seconds(),
+				"txs_ingested/sec",
+			)
+		})
+	}
+}
+
+// BenchmarkStorageModeIngestSteadyState isolates ingest cost from DB-open and
+// initial seeding overhead by reusing a single database per sub-benchmark and
+// resetting state between iterations with a transaction rollback.
+func BenchmarkStorageModeIngestSteadyState(b *testing.B) {
+	fixture := loadStorageModeBenchmarkFixture(b, 300, 500, 200)
+	modeNames := []string{types.StorageModeCore, types.StorageModeAPI}
+
+	for _, mode := range modeNames {
+		b.Run(mode, func(b *testing.B) {
+			b.ReportAllocs()
+
+			db, err := database.New(&database.Config{
+				DataDir:     "",
+				Logger:      benchmarkDiscardLogger,
+				StorageMode: mode,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer db.Close()
+
+			if _, err := ingestStorageModeBenchmarkBlocks(db, fixture.seedBlocks); err != nil {
+				b.Fatalf("seed steady-state storage mode benchmark blocks: %v", err)
+			}
+
+			totalBlocks := 0
+			totalTxs := 0
+			for b.Loop() {
+				txn := db.Transaction(true)
+				if txn == nil {
+					b.Fatal("nil transaction")
+				}
+
+				txCount := 0
+				for _, blockData := range fixture.measureBlocks {
+					if err := db.BlockCreate(blockData.model, txn); err != nil {
+						_ = txn.Rollback()
+						b.Fatal(err)
+					}
+					for txIdx, txData := range blockData.transactions {
+						if err := db.SetTransaction(
+							txData.tx,
+							blockData.point,
+							uint32(txIdx),
+							txData.updateEpoch,
+							txData.paramUpdates,
+							txData.certDeposits,
+							blockData.offsets,
+							txn,
+						); err != nil {
+							_ = txn.Rollback()
+							b.Fatal(err)
+						}
+						txCount++
+					}
+				}
+				b.StopTimer()
+				if err := txn.Rollback(); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+				totalBlocks += len(fixture.measureBlocks)
+				totalTxs += txCount
+			}
+
+			b.ReportMetric(
+				float64(totalBlocks)/b.Elapsed().Seconds(),
+				"blocks_ingested/sec",
+			)
+			b.ReportMetric(
+				float64(totalTxs)/b.Elapsed().Seconds(),
+				"txs_ingested/sec",
+			)
+		})
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds storage-mode ingestion benchmarks for core and api plus new block-processing throughput benches. Also upgrades `generate_benchmarks.sh` with filters, richer metrics, iterations-first reporting, and publishes a targeted baseline.

- **New Features**
  - Storage-mode ingest benches for `core` and `api`, plus steady-state; report blocks_ingested/sec and txs_ingested/sec using real immutable test data with shared offset computation and UTXO preflight.
  - Throughput benches: batched AddBlocks, header-only AddRawBlocks, and predecoded AddBlock; report blocks/sec.
  - Fixtures load from `database/immutable/testdata`; reuse DB and rollback to reduce variance.
  - `generate_benchmarks.sh`: add --bench/--packages/--benchtime/--title/--scope/--data-source; iterations-first tables with Extra Metrics and package-qualified names; improved progress and backward-compatible history parsing; publish `benchmark_results_targeted.md` with latest results and environment.

<sup>Written for commit 01c036535b224e9fbfcdd3596d40985c571c8502. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add runtime CLI options to customize benchmark generation (filters, packages, duration, title, scope, data source)

* **Documentation**
  * Add a targeted performance baseline report with latest, historical results, and performance-change summaries

* **Chores**
  * Standardize metrics to iterations-first format, expand reported metrics (extra metrics, memory, allocs) and improve output formatting
  * Expand benchmark coverage for block/batch/storage-mode and concurrent scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->