### PR TITLE
feat(ledgerstate): robust era-aware pparams extraction and UTxO import progress tracking

### DIFF
--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1247,7 +1247,7 @@ func ParseGovState(
 		return nil, nil
 	}
 
-	fields, err := decodeRawArray(data)
+	fields, err := decodeRawElements(data)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"decoding GovState: %w", err,

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"net"
 	"sort"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -226,6 +227,7 @@ type ImportProgress struct {
 	Stage       string
 	Current     int
 	Total       int
+	Percent     float64
 	Description string
 }
 
@@ -561,6 +563,8 @@ func importUTxOs(
 
 	store := cfg.Database.Metadata()
 	totalImported := 0
+	lastProgressLog := time.Time{}
+	lastLoggedPercent := -5.0
 
 	batchCallback := func(batch []ParsedUTxO) error {
 		select {
@@ -598,35 +602,37 @@ func importUTxOs(
 			)
 		}
 
-		prevTotal := totalImported
 		totalImported += len(batch)
 
-		if totalImported/100000 > prevTotal/100000 {
-			cfg.Logger.Info(
-				"UTxO import progress",
-				"component", "ledgerstate",
-				"count", totalImported,
-			)
-		}
-
-		progress(ImportProgress{
-			Stage:   "utxo",
-			Current: totalImported,
-			Description: fmt.Sprintf(
-				"%d UTxOs imported",
-				totalImported,
-			),
-		})
-
 		return nil
+	}
+
+	reportProgress := func(p UTxOParseProgress) {
+		now := time.Now()
+		if !lastProgressLog.IsZero() &&
+			now.Sub(lastProgressLog) < 10*time.Second &&
+			p.Percent < 100 &&
+			p.Percent-lastLoggedPercent < 5.0 {
+			return
+		}
+		lastProgressLog = now
+		lastLoggedPercent = p.Percent
+		progress(ImportProgress{
+			Stage:       "utxo",
+			Current:     p.EntriesProcessed,
+			Total:       p.TotalEntries,
+			Percent:     p.Percent,
+			Description: "UTxO import progress",
+		})
 	}
 
 	var err error
 	if cfg.State.UTxOTablePath != "" {
 		// UTxO-HD format: stream from tvar file
-		_, err = ParseUTxOsFromFile(
+		_, err = parseUTxOsFromFileWithProgress(
 			cfg.State.UTxOTablePath,
 			batchCallback,
+			reportProgress,
 		)
 		if err != nil {
 			return fmt.Errorf(
@@ -636,9 +642,10 @@ func importUTxOs(
 		}
 	} else {
 		// Legacy format: decode from inline CBOR
-		_, err = ParseUTxOsStreaming(
+		_, err = parseUTxOsStreamingWithProgress(
 			cfg.State.UTxOData,
 			batchCallback,
+			reportProgress,
 		)
 		if err != nil {
 			return fmt.Errorf(
@@ -697,6 +704,7 @@ func importCertState(
 			Stage:   "accounts",
 			Current: len(certState.Accounts),
 			Total:   len(certState.Accounts),
+			Percent: 100,
 			Description: fmt.Sprintf(
 				"%d accounts imported",
 				len(certState.Accounts),
@@ -717,6 +725,7 @@ func importCertState(
 			Stage:   "pools",
 			Current: len(certState.Pools),
 			Total:   len(certState.Pools),
+			Percent: 100,
 			Description: fmt.Sprintf(
 				"%d pools imported",
 				len(certState.Pools),
@@ -735,6 +744,7 @@ func importCertState(
 			Stage:   "dreps",
 			Current: len(certState.DReps),
 			Total:   len(certState.DReps),
+			Percent: 100,
 			Description: fmt.Sprintf(
 				"%d DReps imported",
 				len(certState.DReps),
@@ -1158,6 +1168,8 @@ func importSnapShots(
 		progress(ImportProgress{
 			Stage:   "snapshots",
 			Current: len(poolSnapshots),
+			Total:   len(poolSnapshots),
+			Percent: 100,
 			Description: fmt.Sprintf(
 				"%s: %d pools",
 				st.name,
@@ -1181,6 +1193,8 @@ func importSnapShots(
 			progress(ImportProgress{
 				Stage:   "pools",
 				Current: len(snapshotPools),
+				Total:   len(snapshotPools),
+				Percent: 100,
 				Description: fmt.Sprintf(
 					"%d pools imported from snapshots",
 					len(snapshotPools),
@@ -1653,6 +1667,15 @@ func importPParams(
 	)
 
 	pparamsCbor := []byte(cfg.State.PParamsData)
+	if err := validatePParamsData(
+		cfg.State.EraIndex,
+		pparamsCbor,
+	); err != nil {
+		return fmt.Errorf(
+			"validating protocol parameters: %w",
+			err,
+		)
+	}
 
 	store := cfg.Database.Metadata()
 	txn := cfg.Database.MetadataTxn(true)
@@ -1856,6 +1879,7 @@ func importGovState(
 
 	progress(ImportProgress{
 		Stage:       "governance",
+		Percent:     100,
 		Description: "governance state imported",
 	})
 

--- a/ledgerstate/pparams.go
+++ b/ledgerstate/pparams.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+func extractPParamsData(
+	eraIndex int,
+	govStateData cbor.RawMessage,
+) (cbor.RawMessage, error) {
+	if len(govStateData) == 0 {
+		return nil, nil
+	}
+	govFields, err := decodeRawElements(govStateData)
+	if err != nil {
+		return nil, fmt.Errorf("decoding GovState: %w", err)
+	}
+
+	tried := make(map[int]struct{}, len(govFields))
+	var errs []string
+	for _, idx := range pparamsCandidateIndexes(eraIndex, len(govFields)) {
+		if idx < 0 || idx >= len(govFields) || len(govFields[idx]) == 0 {
+			continue
+		}
+		tried[idx] = struct{}{}
+		if err := validatePParamsData(eraIndex, govFields[idx]); err == nil {
+			return govFields[idx], nil
+		} else {
+			errs = append(errs, fmt.Sprintf("field %d: %v", idx, err))
+		}
+	}
+	for idx, field := range govFields {
+		if len(field) == 0 {
+			continue
+		}
+		if _, ok := tried[idx]; ok {
+			continue
+		}
+		if err := validatePParamsData(eraIndex, field); err == nil {
+			return field, nil
+		} else {
+			errs = append(errs, fmt.Sprintf("field %d: %v", idx, err))
+		}
+	}
+	if len(errs) == 0 {
+		return nil, nil
+	}
+	return nil, fmt.Errorf(
+		"detecting %s protocol parameters: %s",
+		EraName(eraIndex),
+		strings.Join(errs, "; "),
+	)
+}
+
+func pparamsCandidateIndexes(eraIndex, fieldCount int) []int {
+	candidates := make([]int, 0, min(fieldCount, 4))
+	if eraIndex >= EraConway {
+		candidates = append(candidates, 3, 4, 5, 2)
+	} else {
+		candidates = append(candidates, 2, 3, 4, 5)
+	}
+	return candidates
+}
+
+func validatePParamsData(eraIndex int, data []byte) error {
+	if eraIndex < 0 {
+		return fmt.Errorf("negative era index %d", eraIndex)
+	}
+	era := eras.GetEraById(uint(eraIndex)) //nolint:gosec // bounds checked above
+	if era == nil {
+		return fmt.Errorf("unknown era %d", eraIndex)
+	}
+	if era.DecodePParamsFunc == nil {
+		return fmt.Errorf("%s era does not define protocol parameters", era.Name)
+	}
+	if _, err := era.DecodePParamsFunc(data); err != nil {
+		return fmt.Errorf("decoding %s protocol parameters: %w", era.Name, err)
+	}
+	return nil
+}

--- a/ledgerstate/snapshot.go
+++ b/ledgerstate/snapshot.go
@@ -556,22 +556,17 @@ func parseCurrentEra(
 	// GovState (index 3 in UTxOState)
 	if len(utxoState) > 3 {
 		result.GovStateData = utxoState[3]
-
-		// Extract current protocol parameters from GovState.
-		// Conway: [proposals, committee, constitution,
-		//          cur_pparams, prev_pparams, ...]
-		// Shelley-Babbage: [cur_proposals, future_proposals,
-		//                   cur_pparams, prev_pparams, ...]
-		govFields, govErr := decodeRawArray(utxoState[3])
-		if govErr == nil {
-			pparamsIdx := 2 // Shelley through Babbage
-			if eraIndex >= EraConway {
-				pparamsIdx = 3
-			}
-			if len(govFields) > pparamsIdx {
-				result.PParamsData = govFields[pparamsIdx]
-			}
+		pparamsData, pparamsErr := extractPParamsData(
+			eraIndex,
+			utxoState[3],
+		)
+		if pparamsErr != nil {
+			return nil, fmt.Errorf(
+				"extracting protocol parameters: %w",
+				pparamsErr,
+			)
 		}
+		result.PParamsData = pparamsData
 	}
 
 	return result, nil

--- a/ledgerstate/snapshot_test.go
+++ b/ledgerstate/snapshot_test.go
@@ -19,10 +19,15 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash/crc32"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lbabbage "github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	lconway "github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/require"
 )
 
@@ -257,6 +262,166 @@ func TestVerifyChecksumFileMismatch(t *testing.T) {
 
 	err = VerifyChecksumFile(lstatePath)
 	require.ErrorContains(t, err, "mismatch")
+}
+
+func TestExtractPParamsDataBabbageGovState(t *testing.T) {
+	pparams := testBabbagePParams()
+	pparamsData, err := cbor.Encode(pparams)
+	require.NoError(t, err)
+
+	govStateData, err := cbor.Encode([]any{
+		uint64(1),
+		uint64(2),
+		cbor.RawMessage(pparamsData),
+		uint64(4),
+	})
+	require.NoError(t, err)
+
+	got, err := extractPParamsData(EraBabbage, govStateData)
+	require.NoError(t, err)
+	require.Equal(t, pparamsData, []byte(got))
+}
+
+func TestExtractPParamsDataConwayGovStateMap(t *testing.T) {
+	pparams := testConwayPParams()
+	pparamsData, err := cbor.Encode(pparams)
+	require.NoError(t, err)
+
+	govStateData, err := cbor.Encode(map[uint64]any{
+		0: uint64(1),
+		1: uint64(2),
+		2: uint64(3),
+		3: cbor.RawMessage(pparamsData),
+		4: uint64(5),
+	})
+	require.NoError(t, err)
+
+	got, err := extractPParamsData(EraConway, govStateData)
+	require.NoError(t, err)
+	require.Equal(t, pparamsData, []byte(got))
+}
+
+func TestExtractPParamsDataDetectsEraSpecificType(t *testing.T) {
+	alonzoData, err := cbor.Encode(testBabbagePParams())
+	require.NoError(t, err)
+	conwayData, err := cbor.Encode(testConwayPParams())
+	require.NoError(t, err)
+
+	govStateData, err := cbor.Encode([]any{
+		uint64(1),
+		uint64(2),
+		cbor.RawMessage(alonzoData),
+		cbor.RawMessage(conwayData),
+	})
+	require.NoError(t, err)
+
+	got, err := extractPParamsData(EraConway, govStateData)
+	require.NoError(t, err)
+	require.Equal(t, conwayData, []byte(got))
+}
+
+func testBabbagePParams() *lbabbage.BabbageProtocolParameters {
+	return &lbabbage.BabbageProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 &cbor.Rat{Rat: big.NewRat(3, 10)},
+		Rho:                &cbor.Rat{Rat: big.NewRat(3, 1000)},
+		Tau:                &cbor.Rat{Rat: big.NewRat(1, 5)},
+		ProtocolMajor:      8,
+		ProtocolMinor:      0,
+		MinPoolCost:        340000000,
+		AdaPerUtxoByte:     4310,
+		CostModels:         map[uint][]int64{1: []int64{0}},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(577, 10000)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(721, 10000000)},
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 10000000,
+			Steps:  10000000000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 50000000,
+			Steps:  40000000000,
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+	}
+}
+
+func testConwayPParams() *lconway.ConwayProtocolParameters {
+	return &lconway.ConwayProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 &cbor.Rat{Rat: big.NewRat(3, 10)},
+		Rho:                &cbor.Rat{Rat: big.NewRat(3, 1000)},
+		Tau:                &cbor.Rat{Rat: big.NewRat(1, 5)},
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 10,
+			Minor: 0,
+		},
+		MinPoolCost:    340000000,
+		AdaPerUtxoByte: 4310,
+		CostModels:     map[uint][]int64{1: []int64{0}},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(577, 10000)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(721, 10000000)},
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 10000000,
+			Steps:  10000000000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 50000000,
+			Steps:  40000000000,
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+		PoolVotingThresholds: lconway.PoolVotingThresholds{
+			MotionNoConfidence:    cbor.Rat{Rat: big.NewRat(1, 2)},
+			CommitteeNormal:       cbor.Rat{Rat: big.NewRat(1, 2)},
+			CommitteeNoConfidence: cbor.Rat{Rat: big.NewRat(1, 2)},
+			HardForkInitiation:    cbor.Rat{Rat: big.NewRat(1, 2)},
+			PpSecurityGroup:       cbor.Rat{Rat: big.NewRat(1, 2)},
+		},
+		DRepVotingThresholds: lconway.DRepVotingThresholds{
+			MotionNoConfidence:    cbor.Rat{Rat: big.NewRat(1, 2)},
+			CommitteeNormal:       cbor.Rat{Rat: big.NewRat(1, 2)},
+			CommitteeNoConfidence: cbor.Rat{Rat: big.NewRat(1, 2)},
+			UpdateToConstitution:  cbor.Rat{Rat: big.NewRat(1, 2)},
+			HardForkInitiation:    cbor.Rat{Rat: big.NewRat(1, 2)},
+			PpNetworkGroup:        cbor.Rat{Rat: big.NewRat(1, 2)},
+			PpEconomicGroup:       cbor.Rat{Rat: big.NewRat(1, 2)},
+			PpTechnicalGroup:      cbor.Rat{Rat: big.NewRat(1, 2)},
+			PpGovGroup:            cbor.Rat{Rat: big.NewRat(1, 2)},
+			TreasuryWithdrawal:    cbor.Rat{Rat: big.NewRat(1, 2)},
+		},
+		MinCommitteeSize:        5,
+		CommitteeTermLimit:      146,
+		GovActionValidityPeriod: 20,
+		GovActionDeposit:        100000000000,
+		DRepDeposit:             500000000,
+		DRepInactivityPeriod:    20,
+		MinFeeRefScriptCostPerByte: &cbor.Rat{
+			Rat: big.NewRat(1, 1),
+		},
+	}
 }
 
 func TestVerifyChecksumFileWrongLength(t *testing.T) {

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -165,6 +165,14 @@ const utxoBatchSize = 10000
 // streaming decode.
 type UTxOCallback func(batch []ParsedUTxO) error
 
+type UTxOParseProgress struct {
+	EntriesProcessed int
+	TotalEntries     int
+	BytesProcessed   int
+	TotalBytes       int
+	Percent          float64
+}
+
 // utxoIterFunc returns the next key/value CBOR pair from a UTxO
 // map. It returns done=true when no more entries remain. Callers
 // must not call the function again after done=true is returned.
@@ -175,13 +183,14 @@ type utxoIterFunc func() (
 	err error,
 )
 
-// processBatchedUTxOs reads key/value pairs from next, parses each
-// entry, and delivers them to the callback in batches of
-// utxoBatchSize. This is the shared core for both definite-length
-// and indefinite-length UTxO map parsing.
-func processBatchedUTxOs(
+// processBatchedUTxOsWithProgress reads key/value pairs from next,
+// parses each entry, and delivers them to the callback in batches
+// of utxoBatchSize. An optional progress function is called after
+// each batch with the running total of processed entries.
+func processBatchedUTxOsWithProgress(
 	next utxoIterFunc,
 	callback UTxOCallback,
+	progress func(int),
 ) (int, error) {
 	if callback == nil {
 		return 0, errors.New("nil UTxO callback")
@@ -218,6 +227,9 @@ func processBatchedUTxOs(
 					err,
 				)
 			}
+			if progress != nil {
+				progress(totalCount)
+			}
 			batch = make([]ParsedUTxO, 0, utxoBatchSize)
 		}
 	}
@@ -229,6 +241,9 @@ func processBatchedUTxOs(
 				"UTxO callback error at final batch: %w",
 				err,
 			)
+		}
+		if progress != nil {
+			progress(totalCount)
 		}
 	}
 
@@ -243,11 +258,21 @@ func ParseUTxOsStreaming(
 	data cbor.RawMessage,
 	callback UTxOCallback,
 ) (int, error) {
+	return parseUTxOsStreamingWithProgress(data, callback, nil)
+}
+
+func parseUTxOsStreamingWithProgress(
+	data cbor.RawMessage,
+	callback UTxOCallback,
+	progress func(UTxOParseProgress),
+) (int, error) {
 	// Handle indefinite-length map (0xbf header) by delegating to
 	// the dedicated parser. DecodeMapHeader does not support
 	// indefinite-length maps and would return a confusing error.
 	if len(data) > 0 && data[0] == 0xbf {
-		return parseIndefiniteUTxOMap(data, callback)
+		return parseIndefiniteUTxOMapWithProgress(
+			data, callback, progress,
+		)
 	}
 
 	// The UTxO data is a CBOR map: map[TxIn]TxOut
@@ -296,7 +321,26 @@ func ParseUTxOsStreaming(
 		return keyRaw, valRaw, false, nil
 	}
 
-	return processBatchedUTxOs(next, callback)
+	return processBatchedUTxOsWithProgress(
+		next,
+		callback,
+		func(processed int) {
+			if progress == nil {
+				return
+			}
+			percent := 0.0
+			if count > 0 {
+				percent = float64(processed) / float64(count) * 100
+			}
+			progress(UTxOParseProgress{
+				EntriesProcessed: processed,
+				TotalEntries:     count,
+				BytesProcessed:   decoder.Position(),
+				TotalBytes:       len(data),
+				Percent:          percent,
+			})
+		},
+	)
 }
 
 // parseUTxOEntry decodes a single TxIn -> TxOut entry from the
@@ -505,6 +549,14 @@ func ParseUTxOsFromFile(
 	path string,
 	callback UTxOCallback,
 ) (int, error) {
+	return parseUTxOsFromFileWithProgress(path, callback, nil)
+}
+
+func parseUTxOsFromFileWithProgress(
+	path string,
+	callback UTxOCallback,
+	progress func(UTxOParseProgress),
+) (int, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, fmt.Errorf("reading tvar file: %w", err)
@@ -539,21 +591,27 @@ func ParseUTxOsFromFile(
 
 	// Check for indefinite-length map (0xbf)
 	if len(mapData) > 0 && mapData[0] == 0xbf {
-		return parseIndefiniteUTxOMap(mapData, callback)
+		return parseIndefiniteUTxOMapWithProgress(
+			mapData, callback, progress,
+		)
 	}
 
 	// Definite-length map - use existing streaming parser
-	return ParseUTxOsStreaming(
-		cbor.RawMessage(mapData), callback,
+	return parseUTxOsStreamingWithProgress(
+		cbor.RawMessage(mapData),
+		callback,
+		progress,
 	)
 }
 
-// parseIndefiniteUTxOMap streams UTxO entries from an
+// parseIndefiniteUTxOMapWithProgress streams UTxO entries from an
 // indefinite-length CBOR map (0xbf ... 0xff). Each entry is a
 // TxIn key and TxOut value decoded using the existing parsers.
-func parseIndefiniteUTxOMap(
+// An optional progress callback receives byte-level progress.
+func parseIndefiniteUTxOMapWithProgress(
 	data []byte,
 	callback UTxOCallback,
+	progress func(UTxOParseProgress),
 ) (int, error) {
 	if len(data) < 2 || data[0] != 0xbf {
 		return 0, errors.New("expected indefinite map (0xbf)")
@@ -569,6 +627,7 @@ func parseIndefiniteUTxOMap(
 	}
 
 	entryIndex := 0
+	mapComplete := false
 	next := func() (cbor.RawMessage, cbor.RawMessage, bool, error) {
 		// Check for break byte (0xff) at current position.
 		// The decoder operates on data[1:] (after the 0xbf
@@ -582,6 +641,7 @@ func parseIndefiniteUTxOMap(
 			)
 		}
 		if data[absPos] == 0xff {
+			mapComplete = true
 			return nil, nil, true, nil
 		}
 
@@ -607,7 +667,32 @@ func parseIndefiniteUTxOMap(
 		return keyRaw, valRaw, false, nil
 	}
 
-	return processBatchedUTxOs(next, callback)
+	return processBatchedUTxOsWithProgress(
+		next,
+		callback,
+		func(processed int) {
+			if progress == nil {
+				return
+			}
+			// Account for the 0xbf header (1 byte) + decoder
+			// position. When the 0xff break byte has been reached,
+			// report len(data) so percent reaches exactly 100%.
+			bytesProcessed := min(1+decoder.Position(), len(data))
+			if mapComplete {
+				bytesProcessed = len(data)
+			}
+			percent := 0.0
+			if len(data) > 0 {
+				percent = float64(bytesProcessed) / float64(len(data)) * 100
+			}
+			progress(UTxOParseProgress{
+				EntriesProcessed: processed,
+				BytesProcessed:   bytesProcessed,
+				TotalBytes:       len(data),
+				Percent:          percent,
+			})
+		},
+	)
 }
 
 // UTxOToModel converts a ParsedUTxO to a Dingo database Utxo model.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust, era-aware protocol parameter extraction with strict validation and percent-based UTxO import progress (entries/bytes) across all import paths. Improves snapshot ingest reliability and ensures all stages report 100% on completion.

- **New Features**
  - Era-specific pparams detection via extractPParamsData with validation; snapshot parsing aborts if extraction/validation fails.
  - UTxO import progress reports entries, bytes, totals, and percent via UTxOParseProgress; updates throttled (>=10s or >=5%); supports streaming, file-based, and indefinite-length CBOR maps.
  - ImportProgress now includes Percent and reports 100% for accounts, pools, DReps, snapshots, and governance on completion.

- **Refactors**
  - Switched to decodeRawElements so GovState can be decoded from arrays or maps.
  - Added progress-aware parsers (parseUTxOsStreamingWithProgress, parseUTxOsFromFileWithProgress, parseIndefiniteUTxOMapWithProgress) while keeping existing APIs.
  - Validate protocol parameters in importPParams before storing using era-aware decoding.

<sup>Written for commit b32cc4782279c64c06e6f16f13613be5bd6b07fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced progress reporting for UTxO imports with entries/bytes processed and completion Percent shown.
  * Progress throttling to limit update frequency during large imports.
  * Protocol parameter validation during import to catch invalid CBOR parameters.

* **Tests**
  * Added comprehensive tests for protocol parameter extraction across eras, plus checksum and edge-case validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->