### PR TITLE
feat(load): progress reporting, CBOR extraction optimization, and download improvements

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -277,8 +277,24 @@ func runMithrilSync(
 			CleanupAfterLoad:       cfg.Mithril.CleanupAfterLoad,
 			VerifyCertificateChain: cfg.Mithril.VerifyCertificates,
 			Logger:                 logger,
-			OnProgress: func(p mithril.DownloadProgress) {
-				if p.TotalBytes > 0 {
+			OnProgress: func() func(mithril.DownloadProgress) {
+				const progressLogInterval = 10 * time.Second
+				const progressLogPercentStep = 5.0
+
+				lastLogTime := time.Time{}
+				lastLoggedPercent := -progressLogPercentStep
+
+				return func(p mithril.DownloadProgress) {
+					if p.TotalBytes <= 0 {
+						return
+					}
+					now := time.Now()
+					if !lastLogTime.IsZero() &&
+						now.Sub(lastLogTime) < progressLogInterval &&
+						p.Percent < 100 &&
+						(p.Percent-lastLoggedPercent) < progressLogPercentStep {
+						return
+					}
 					logger.Info(
 						fmt.Sprintf(
 							"download progress: %.1f%% (%s / %s) at %s/s",
@@ -289,8 +305,10 @@ func runMithrilSync(
 						),
 						"component", "mithril",
 					)
+					lastLogTime = now
+					lastLoggedPercent = p.Percent
 				}
-			},
+			}(),
 		},
 	)
 	if err != nil {
@@ -688,11 +706,26 @@ func importLedgerState(
 				nodeCfg,
 			),
 			OnProgress: func(p ledgerstate.ImportProgress) {
-				logger.Info(
-					p.Description,
+				attrs := []any{
 					"component", "mithril",
 					"stage", p.Stage,
-				)
+				}
+				msg := p.Description
+				if p.Total > 0 {
+					pct := float64(p.Current) / float64(p.Total) * 100
+					attrs = append(
+						attrs,
+						"progress",
+						fmt.Sprintf("%.1f%%", pct),
+						"current",
+						p.Current,
+						"total",
+						p.Total,
+					)
+				} else if p.Current > 0 {
+					attrs = append(attrs, "current", p.Current)
+				}
+				logger.Info(msg, attrs...)
 			},
 		},
 	); err != nil {
@@ -1013,6 +1046,15 @@ func postProcessUtxoOffsets(
 			"opening immutable DB: %w", err,
 		)
 	}
+	immutableTip, err := imm.GetTip()
+	if err != nil {
+		return fmt.Errorf(
+			"getting immutable DB tip: %w", err,
+		)
+	}
+	if immutableTip == nil {
+		return errors.New("immutable DB tip is nil")
+	}
 
 	iter, err := imm.BlocksFromPoint(ocommon.Point{})
 	if err != nil {
@@ -1022,14 +1064,35 @@ func postProcessUtxoOffsets(
 	}
 	defer iter.Close()
 
-	const batchBlocks = 100
+	const batchBlocks = 50
+	const batchUtxoOffsets = 10000
 	var processedBlocks, totalUtxos int
+	startTime := time.Now()
+	lastProgressLog := time.Time{}
+	lastProgressSlot := uint64(0)
 	txn := db.BlobTxn(true)
 	blocksInBatch := 0
+	utxosInBatch := 0
 	// Deferred rollback ensures the active transaction is cleaned
 	// up if the loop body panics. Rollback after Commit is a no-op
 	// in Badger, so this is safe on the normal path.
 	defer func() { txn.Rollback() }() //nolint:errcheck
+
+	flushTxn := func() error {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"committing UTxO offsets: %w",
+				err,
+			)
+		}
+		blocksInBatch = 0
+		utxosInBatch = 0
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("cancelled: %w", err)
+		}
+		txn = db.BlobTxn(true)
+		return nil
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -1107,6 +1170,13 @@ func postProcessUtxoOffsets(
 						)
 					}
 					totalUtxos++
+					utxosInBatch++
+					if utxosInBatch >= batchUtxoOffsets {
+						if err := flushTxn(); err != nil {
+							return err
+						}
+						blobTxn = txn.Blob()
+					}
 				}
 			}
 		} else {
@@ -1195,42 +1265,41 @@ func postProcessUtxoOffsets(
 						)
 					}
 					totalUtxos++
+					utxosInBatch++
+					if utxosInBatch >= batchUtxoOffsets {
+						if err := flushTxn(); err != nil {
+							return err
+						}
+						blobTxn = txn.Blob()
+					}
 				}
 			}
 		}
 
 		processedBlocks++
+		lastProgressSlot = next.Slot
 		blocksInBatch++
 
 		if blocksInBatch >= batchBlocks {
-			if err := txn.Commit(); err != nil {
-				return fmt.Errorf(
-					"committing UTxO offsets: %w",
-					err,
-				)
+			if err := flushTxn(); err != nil {
+				return err
 			}
-			blocksInBatch = 0
-			// Check for cancellation between batches, before
-			// opening a new transaction that would leak.
-			if err := ctx.Err(); err != nil {
-				return fmt.Errorf("cancelled: %w", err)
-			}
-			txn = db.BlobTxn(true)
 		}
 
-		if processedBlocks > 0 && processedBlocks%50000 == 0 {
-			logger.Info(
-				"UTxO offset progress",
-				"component", "mithril",
-				"blocks", processedBlocks,
-				"utxos", totalUtxos,
-			)
-		}
+		maybeLogUtxoOffsetProgress(
+			logger,
+			processedBlocks,
+			totalUtxos,
+			lastProgressSlot,
+			immutableTip.Slot,
+			startTime,
+			&lastProgressLog,
+		)
 	}
 
 	// Commit remaining batch; the deferred rollback handles
 	// cleanup when there is nothing to commit.
-	if blocksInBatch > 0 {
+	if blocksInBatch > 0 || utxosInBatch > 0 {
 		if err := txn.Commit(); err != nil {
 			return fmt.Errorf(
 				"committing final UTxO offsets: %w",
@@ -1247,6 +1316,45 @@ func postProcessUtxoOffsets(
 	)
 
 	return nil
+}
+
+func maybeLogUtxoOffsetProgress(
+	logger *slog.Logger,
+	processedBlocks int,
+	totalUtxos int,
+	currentSlot uint64,
+	tipSlot uint64,
+	startTime time.Time,
+	lastLogTime *time.Time,
+) {
+	now := time.Now()
+	if !lastLogTime.IsZero() && now.Sub(*lastLogTime) < 10*time.Second {
+		return
+	}
+	*lastLogTime = now
+
+	elapsed := now.Sub(startTime)
+	attrs := []any{
+		"component", "mithril",
+		"blocks", processedBlocks,
+		"utxos", totalUtxos,
+		"slot", currentSlot,
+	}
+	if elapsed > 0 {
+		attrs = append(
+			attrs,
+			"blocks_per_sec",
+			fmt.Sprintf("%.0f", float64(processedBlocks)/elapsed.Seconds()),
+		)
+	}
+	if tipSlot > 0 {
+		attrs = append(
+			attrs,
+			"progress",
+			fmt.Sprintf("%.1f%%", float64(currentSlot)/float64(tipSlot)*100),
+		)
+	}
+	logger.Info("UTxO offset progress", attrs...)
 }
 
 // findNthOccurrence returns the byte offset of the nth (0-indexed)

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -32,6 +31,15 @@ import (
 	"github.com/blinklabs-io/dingo/ledger"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	fxcbor "github.com/fxamacker/cbor/v2"
+)
+
+// Mainnet full blocks can overflow practical Badger transaction limits with
+// larger import batches, so keep the runtime load batch size aligned with the
+// chain import batch cap.
+const (
+	loadBlockBatchSize  = 50
+	progressLogInterval = 10 * time.Second
 )
 
 func Load(ctx context.Context, cfg *config.Config, logger *slog.Logger, immutableDir string) error {
@@ -316,7 +324,10 @@ func copyBlocks(
 	}
 	defer iter.Close()
 	var blocksCopied int
-	blockBatch := make([]gledger.Block, 0, 50)
+	startTime := time.Now()
+	lastProgressLog := time.Time{}
+	lastProgressSlot := chainTip.Point.Slot
+	blockBatch := make([]gledger.Block, 0, loadBlockBatchSize)
 	for {
 		for {
 			next, err := iter.Next()
@@ -356,13 +367,19 @@ func copyBlocks(
 			)
 		}
 		blocksCopied += len(blockBatch)
-		blockBatch = slices.Delete(blockBatch, 0, len(blockBatch))
-		if blocksCopied > 0 && blocksCopied%10000 == 0 {
-			logger.Info(
-				"copying blocks from immutable DB",
-				"blocks_copied", blocksCopied,
-			)
+		if tmpLen := len(blockBatch); tmpLen > 0 {
+			lastProgressSlot = blockBatch[tmpLen-1].SlotNumber()
 		}
+		blockBatch = blockBatch[:0]
+		maybeLogBlockCopyProgress(
+			logger,
+			"copying blocks from immutable DB",
+			blocksCopied,
+			lastProgressSlot,
+			immutableTip.Slot,
+			startTime,
+			&lastProgressLog,
+		)
 		// Check for cancellation after each batch
 		if err := ctx.Err(); err != nil {
 			return blocksCopied, immutableTip.Slot,
@@ -409,7 +426,10 @@ func copyBlocksRaw(
 	}
 	defer iter.Close()
 	var blocksCopied int
-	blockBatch := make([]chain.RawBlock, 0, 50)
+	startTime := time.Now()
+	lastProgressLog := time.Time{}
+	lastProgressSlot := chainTip.Point.Slot
+	blockBatch := make([]chain.RawBlock, 0, loadBlockBatchSize)
 	for {
 		for {
 			next, err := iter.Next()
@@ -476,13 +496,19 @@ func copyBlocksRaw(
 			)
 		}
 		blocksCopied += len(blockBatch)
-		blockBatch = slices.Delete(blockBatch, 0, len(blockBatch))
-		if blocksCopied > 0 && blocksCopied%10000 == 0 {
-			logger.Info(
-				"copying blocks from immutable DB",
-				"blocks_copied", blocksCopied,
-			)
+		if tmpLen := len(blockBatch); tmpLen > 0 {
+			lastProgressSlot = blockBatch[tmpLen-1].Slot
 		}
+		blockBatch = blockBatch[:0]
+		maybeLogBlockCopyProgress(
+			logger,
+			"copying blocks from immutable DB",
+			blocksCopied,
+			lastProgressSlot,
+			immutableTip.Slot,
+			startTime,
+			&lastProgressLog,
+		)
 		// Check for cancellation after each batch
 		if err := ctx.Err(); err != nil {
 			return blocksCopied, immutableTip.Slot,
@@ -496,16 +522,96 @@ func copyBlocksRaw(
 	return blocksCopied, immutableTip.Slot, nil
 }
 
+func maybeLogBlockCopyProgress(
+	logger *slog.Logger,
+	msg string,
+	blocksCopied int,
+	currentSlot uint64,
+	tipSlot uint64,
+	startTime time.Time,
+	lastLogTime *time.Time,
+) {
+	now := time.Now()
+	if !lastLogTime.IsZero() && now.Sub(*lastLogTime) < progressLogInterval {
+		return
+	}
+	*lastLogTime = now
+
+	elapsed := now.Sub(startTime)
+	attrs := []any{
+		"blocks_copied", blocksCopied,
+		"slot", currentSlot,
+	}
+	if elapsed > 0 {
+		attrs = append(
+			attrs,
+			"blocks_per_sec",
+			fmt.Sprintf("%.0f", float64(blocksCopied)/elapsed.Seconds()),
+		)
+	}
+	if tipSlot > 0 {
+		attrs = append(
+			attrs,
+			"progress",
+			fmt.Sprintf("%.1f%%", float64(currentSlot)/float64(tipSlot)*100),
+		)
+	}
+	logger.Info(msg, attrs...)
+}
+
 // extractHeaderCbor extracts the header CBOR from a full block's CBOR.
 // All Cardano block eras encode as a CBOR array where the first element
 // is the block header.
 func extractHeaderCbor(blockCbor []byte) ([]byte, error) {
-	var parts []gcbor.RawMessage
-	if _, err := gcbor.Decode(blockCbor, &parts); err != nil {
-		return nil, fmt.Errorf("decoding block outer array: %w", err)
+	headerLen, err := cborArrayHeaderLen(blockCbor)
+	if err != nil {
+		return nil, err
 	}
-	if len(parts) == 0 {
-		return nil, errors.New("empty block array")
+	var headerCbor gcbor.RawMessage
+	if _, err := fxcbor.UnmarshalFirst(blockCbor[headerLen:], &headerCbor); err != nil {
+		return nil, fmt.Errorf("decoding block header CBOR: %w", err)
 	}
-	return []byte(parts[0]), nil
+	if len(headerCbor) == 0 {
+		return nil, errors.New("empty block header")
+	}
+	return []byte(headerCbor), nil
+}
+
+func cborArrayHeaderLen(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, errors.New("empty CBOR data")
+	}
+	majorType := data[0] & gcbor.CborTypeMask
+	if majorType != gcbor.CborTypeArray {
+		return 0, errors.New("block CBOR is not an array")
+	}
+	additional := data[0] &^ gcbor.CborTypeMask
+	switch {
+	case additional <= gcbor.CborMaxUintSimple:
+		return 1, nil
+	case additional == 24:
+		if len(data) < 2 {
+			return 0, errors.New("truncated CBOR array header")
+		}
+		return 2, nil
+	case additional == 25:
+		if len(data) < 3 {
+			return 0, errors.New("truncated CBOR array header")
+		}
+		return 3, nil
+	case additional == 26:
+		if len(data) < 5 {
+			return 0, errors.New("truncated CBOR array header")
+		}
+		return 5, nil
+	case additional == 27:
+		if len(data) < 9 {
+			return 0, errors.New("truncated CBOR array header")
+		}
+		return 9, nil
+	case additional == 31:
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unsupported CBOR array additional info: %d", additional)
+	}
 }

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -1,0 +1,119 @@
+package node
+
+import (
+	"bytes"
+	"testing"
+
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
+	fxcbor "github.com/fxamacker/cbor/v2"
+)
+
+func TestExtractHeaderCbor(t *testing.T) {
+	t.Parallel()
+
+	header := gcbor.RawMessage{0x01}
+	body := gcbor.RawMessage{0x02}
+	blockCbor, err := fxcbor.Marshal([]gcbor.RawMessage{header, body})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	got, err := extractHeaderCbor(blockCbor)
+	if err != nil {
+		t.Fatalf("extractHeaderCbor returned error: %v", err)
+	}
+	if !bytes.Equal(got, header) {
+		t.Fatalf("unexpected header bytes: got %x want %x", got, header)
+	}
+}
+
+func TestCborArrayHeaderLen(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		data    []byte
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "small definite",
+			data: []byte{gcbor.CborTypeArray + 2, 0x01, 0x02},
+			want: 1,
+		},
+		{
+			name: "uint8 length",
+			data: []byte{gcbor.CborTypeArray + 24, 0x20},
+			want: 2,
+		},
+		{
+			name: "uint16 length",
+			data: []byte{gcbor.CborTypeArray + 25, 0x01, 0x00},
+			want: 3,
+		},
+		{
+			name: "uint32 length",
+			data: []byte{gcbor.CborTypeArray + 26, 0x00, 0x01, 0x00, 0x00},
+			want: 5,
+		},
+		{
+			name: "uint64 length",
+			data: []byte{gcbor.CborTypeArray + 27, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00},
+			want: 9,
+		},
+		{
+			name: "indefinite",
+			data: []byte{gcbor.CborTypeArray + 31, 0x01, 0xff},
+			want: 1,
+		},
+		{
+			name:    "empty input",
+			data:    []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "non-array major type",
+			data:    []byte{gcbor.CborTypeMap + 2},
+			wantErr: true,
+		},
+		{
+			name:    "truncated uint8 header",
+			data:    []byte{gcbor.CborTypeArray + 24},
+			wantErr: true,
+		},
+		{
+			name:    "truncated uint16 header",
+			data:    []byte{gcbor.CborTypeArray + 25, 0x01},
+			wantErr: true,
+		},
+		{
+			name:    "truncated uint32 header",
+			data:    []byte{gcbor.CborTypeArray + 26, 0x00, 0x01},
+			wantErr: true,
+		},
+		{
+			name:    "truncated uint64 header",
+			data:    []byte{gcbor.CborTypeArray + 27, 0x00, 0x00, 0x00},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := cborArrayHeaderLen(test.data)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cborArrayHeaderLen returned error: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("unexpected header len: got %d want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -45,6 +45,17 @@ type DownloadProgress struct {
 // to report progress.
 type ProgressFunc func(DownloadProgress)
 
+type countingReader struct {
+	reader io.Reader
+	read   int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.reader.Read(p)
+	cr.read += int64(n)
+	return n, err
+}
+
 // DownloadConfig holds configuration for downloading a snapshot
 // archive.
 type DownloadConfig struct {
@@ -534,8 +545,17 @@ func ExtractArchive(
 	}
 	defer file.Close()
 
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf(
+			"stating archive: %w",
+			err,
+		)
+	}
+	countingFile := &countingReader{reader: file}
+
 	// Create zstd reader
-	zr, err := zstd.NewReader(file)
+	zr, err := zstd.NewReader(countingFile)
 	if err != nil {
 		return "", fmt.Errorf(
 			"creating zstd reader: %w",
@@ -549,6 +569,8 @@ func ExtractArchive(
 
 	var filesExtracted int
 	var totalExtracted int64
+	lastProgressLog := time.Time{}
+	lastLoggedPercent := -5.0
 	for {
 		if err := ctx.Err(); err != nil {
 			return "", fmt.Errorf(
@@ -683,13 +705,27 @@ func ExtractArchive(
 				)
 			}
 			filesExtracted++
-
-			if filesExtracted%1000 == 0 {
-				logger.Info(
-					"extracting archive",
-					"component", "mithril",
-					"files_extracted", filesExtracted,
-				)
+			if fileInfo.Size() > 0 {
+				percent := float64(countingFile.read) / float64(fileInfo.Size()) * 100
+				now := time.Now()
+				if lastProgressLog.IsZero() ||
+					now.Sub(lastProgressLog) >= 10*time.Second ||
+					percent-lastLoggedPercent >= 5.0 {
+					logger.Info(
+						"extracting archive",
+						"component", "mithril",
+						"progress",
+						fmt.Sprintf("%.1f%%", percent),
+						"archive_bytes_read",
+						humanBytes(countingFile.read),
+						"archive_size",
+						humanBytes(fileInfo.Size()),
+						"files_extracted",
+						filesExtracted,
+					)
+					lastProgressLog = now
+					lastLoggedPercent = percent
+				}
 			}
 		default:
 			// Skip symlinks and other types for security
@@ -701,10 +737,30 @@ func ExtractArchive(
 		"extraction complete",
 		"component", "mithril",
 		"files_extracted", filesExtracted,
+		"progress", "100.0%",
+		"archive_size", humanBytes(fileInfo.Size()),
 		"destination", destDir,
 	)
 
 	return destDir, nil
+}
+
+func humanBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
 }
 
 // validRelPath checks that a path is a valid relative path and does


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds granular, rate-limited progress reporting across Mithril download, extraction, block copy, and UTxO offset indexing, and speeds up header CBOR extraction to improve load performance and visibility.

- **New Features**
  - Progress logs for snapshot download (time/percent gated), archive extraction (% complete, bytes read), block copy (blocks/sec and slot-based %), and UTxO offsets (blocks/sec and slot-based %).
  - More informative ledger import logs with stage, percent, and current/total.

- **Refactors**
  - Faster header CBOR extraction using `github.com/fxamacker/cbor/v2` and a lightweight array header parser; added unit tests.
  - Safer, smaller batches: set load/import batch size to 50; flush Badger transactions every 10k UTxOs or 50 blocks; improved cancellation checks.
  - Helper progress loggers and human-readable byte formatting; validate immutable DB tip before iterating.

<sup>Written for commit bf54d882b63cb2392eab8889c204aef03994478b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Mithril download progress reporting with configurable, time-based throttling and detailed logging
  * Improved block loading progress tracking with batch-based updates and performance metrics
  * Better archive extraction progress display with percentages and human-readable file sizes

* **Tests**
  * Added comprehensive test coverage for block header extraction and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->