### PR TITLE
fix(database): reset badger caches to defaults

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -248,6 +248,15 @@ func (db *BlobStoreBadger) open() error {
 	if err := db.init(); err != nil {
 		return err
 	}
+	if db.dataDir != "" {
+		db.logger.Info(
+			"badger blob store opened",
+			"component", "database",
+			"block_cache_size_mb", db.blockCacheSize/(1024*1024),
+			"index_cache_size_mb", db.indexCacheSize/(1024*1024),
+			"data_dir", db.dataDir,
+		)
+	}
 	return nil
 }
 

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -21,13 +21,21 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin"
 )
 
-// Default cache sizes for BadgerDB (in bytes)
+// Default cache sizes for BadgerDB (in bytes).
+//
+// Block cache is needed because we use Snappy compression. Badger's
+// own default is 256 MB block cache and 0 (unlimited) index cache.
+// Setting IndexCacheSize to 0 lets Badger memory-map the full index
+// without eviction, which is preferable to capping it.
+//
+// Operators can override via block-cache-size / index-cache-size CLI
+// flags or YAML config.
 const (
-	DefaultBlockCacheSize   = 1610612736 // 1.5GB (increased from 768MB)
-	DefaultIndexCacheSize   = 536870912  // 512MB (increased from 256MB)
-	DefaultValueLogFileSize = 1073741824 // 1GB (keep large values on disk, write amplification reduction)
-	DefaultMemTableSize     = 134217728  // 128MB (increased from 64MB for better write buffering)
-	DefaultValueThreshold   = 1048576    // 1MB (keep small values in LSM, large blobs in value log)
+	DefaultBlockCacheSize   = 268435456  // 256 MB — Badger's own default; sufficient for core nodes
+	DefaultIndexCacheSize   = 0          // 0 = unlimited; Badger memory-maps the full index
+	DefaultValueLogFileSize = 1073741824 // 1 GB
+	DefaultMemTableSize     = 134217728  // 128 MB
+	DefaultValueThreshold   = 1048576    // 1 MB
 )
 
 type Profile string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reset BadgerDB cache sizes to defaults and log configured sizes on startup. This reduces memory use and aligns with Badger’s recommended settings.

- **Bug Fixes**
  - Set `DefaultBlockCacheSize` to 256 MB and `DefaultIndexCacheSize` to 0 (unlimited, memory-mapped).
  - Kept `DefaultValueLogFileSize` at 1 GB, `DefaultMemTableSize` at 128 MB, and `DefaultValueThreshold` at 1 MB.
  - Added startup log showing `block_cache_size_mb`, `index_cache_size_mb`, and `data_dir` when the blob store opens.

<sup>Written for commit 2e7f49a91b29e2652b2f226516b32e1eb722b33e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

