### PR TITLE
fix(peergov): classify protocol timeout as expected connection close …

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -70,6 +70,7 @@ func isExpectedConnectionCloseError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "connection reset by peer") ||
 		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "timeout waiting on transition") ||
 		msg == "eof"
 }
 


### PR DESCRIPTION
…error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat protocol timeouts as expected connection closes in `peergov` to reduce noisy error logs and avoid unnecessary retries. Updates `isExpectedConnectionCloseError` to recognize "timeout waiting on transition".

<sup>Written for commit f64f7493940992b6f6dda85190afaa0bc7eac5a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for connection timeout scenarios to improve reliability during connection state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->