### PR TITLE
fix(ouroboros): keep inbound connections alive when chainsync client fails

### DIFF
--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -499,22 +499,15 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 		if o.ChainsyncState.TryAddClientConnId(connId, maxClients) {
 			if err := o.chainsyncClientStart(connId); err != nil {
 				o.ChainsyncState.RemoveClientConnId(connId)
-				o.config.Logger.Error(
-					"failed to start inbound chainsync client, closing",
+				o.config.Logger.Warn(
+					"chainsync client failed on inbound connection, keeping alive for other protocols",
 					"error", err,
 					"connection_id", connId.String(),
 				)
-				// Close the connection so peergov stops tracking it and
-				// outbound retries are not blocked by a stale inbound.
-				if closeErr := conn.Close(); closeErr != nil {
-					o.config.Logger.Warn(
-						"failed to close connection",
-						"error", closeErr,
-						"connection_id", connId.String(),
-					)
-				}
-				o.ConnManager.RemoveConnection(connId)
-				return
+				// Don't close the connection — the peer may still be
+				// useful for keep-alive, peer-sharing, or other
+				// mini-protocols (e.g. cardano-cli ping or partial
+				// full-duplex peers).
 			} else {
 				o.config.Logger.Debug(
 					"started chainsync client on inbound connection",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep inbound connections open when the chainsync client fails to start, so peers can still serve keep-alive and other mini-protocols. This reduces peer churn and improves stability.

- **Bug Fixes**
  - Stop closing and deregistering the inbound connection on chainsync start errors; keep it alive for other protocols.
  - Downgrade log from error to warn to mark the condition as non-fatal.

<sup>Written for commit 5d717d5096f41ca859485ae509dc1b62d8a813cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

