### PR TITLE
fix: support configuring peer sharing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,6 +251,12 @@ type Config struct {
 	// Mesh (Coinbase Rosetta) API port (0 = disabled)
 	MeshPort uint `yaml:"meshPort" envconfig:"DINGO_MESH_PORT"`
 
+	// PeerSharing enables the peer sharing protocol, allowing this node
+	// to advertise known peers to other nodes on request. Defaults to
+	// false; should remain disabled on block producers to avoid leaking
+	// topology information.
+	PeerSharing bool `yaml:"peerSharing" envconfig:"DINGO_PEER_SHARING"`
+
 	// Storage mode: "core" (default) or "api".
 	// "core" stores only consensus data
 	// (UTxOs, certs, pools, pparams).

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -194,6 +194,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithCardanoNodeConfig(nodeCfg),
 			dingo.WithListeners(listeners...),
 			dingo.WithOutboundSourcePort(cfg.RelayPort),
+			dingo.WithPeerSharing(cfg.PeerSharing),
 			dingo.WithUtxorpcPort(cfg.UtxorpcPort),
 			dingo.WithUtxorpcTlsCertFilePath(cfg.TlsCertFilePath),
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an opt-in setting to enable the peer sharing protocol and wire it into node startup. Defaults to off to avoid topology leaks; keep disabled on block producers.

- **New Features**
  - Added `peerSharing` (YAML) and `DINGO_PEER_SHARING` (env) to toggle peer sharing.
  - Passes through to the node via `dingo.WithPeerSharing(cfg.PeerSharing)`.

<sup>Written for commit c358125dc93c5c03f3992dc287a328f1a075335c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

