### PR TITLE
feat: micro-batch blockfetch commits and trusted replay for immutable…

### DIFF
--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -649,7 +649,9 @@ func (b *Backfill) Run(ctx context.Context) error {
 		var blockTxCount int
 
 		parsedBlock, parseErr := gledger.NewBlockFromCbor(
-			blk.BlockType, blk.Cbor,
+			blk.BlockType,
+			blk.Cbor,
+			lcommon.VerifyConfig{SkipBodyHashValidation: true},
 		)
 		if parseErr != nil {
 			b.logger.Warn(

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -26,11 +26,11 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/ledger"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	fxcbor "github.com/fxamacker/cbor/v2"
 )
 
@@ -143,12 +143,11 @@ func LoadWithDB(
 	defer closeDB()
 	// Enable bulk-load optimizations if the metadata store supports them
 	defer WithBulkLoadPragmas(db, logger)()
-	// Load chain
-	eventBus := event.NewEventBus(nil, logger)
-	defer eventBus.Stop()
+	// Immutable load replays trusted block batches directly into the ledger, so
+	// it does not need the event-driven reread path here.
 	cm, err := chain.NewManager(
 		db,
-		eventBus,
+		nil,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to load chain manager: %w", err)
@@ -160,12 +159,13 @@ func LoadWithDB(
 	// Load state
 	ls, err := ledger.NewLedgerState(
 		ledger.LedgerStateConfig{
-			Database:           db,
-			ChainManager:       cm,
-			Logger:             logger,
-			CardanoNodeConfig:  nodeCfg,
-			EventBus:           eventBus,
-			ValidateHistorical: cfg.ValidateHistorical,
+			Database:              db,
+			ChainManager:          cm,
+			Logger:                logger,
+			CardanoNodeConfig:     nodeCfg,
+			ValidateHistorical:    cfg.ValidateHistorical,
+			TrustedReplay:         true,
+			ManualBlockProcessing: true,
 			DatabaseWorkerPoolConfig: ledger.DatabaseWorkerPoolConfig{
 				WorkerPoolSize: cfg.DatabaseWorkers,
 				TaskQueueSize:  cfg.DatabaseQueueSize,
@@ -181,59 +181,42 @@ func LoadWithDB(
 	}
 	defer ls.Close()
 
-	blocksCopied, immutableTipSlot, err := copyBlocks(
-		ctx, logger, immutableDir, c,
+	replayCtx, cancelReplay := context.WithCancel(ctx)
+	defer cancelReplay()
+	replayBatches := make(chan []gledger.Block, 1)
+	replayErrCh := make(chan error, 1)
+	go func() {
+		err := ls.ProcessTrustedBlockBatches(
+			replayCtx,
+			replayBatches,
+		)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			// Cancel immediately so copyBlocksDirect and the
+			// forwarding goroutine inside ProcessTrustedBlockBatches
+			// unblock via ctx.Done() instead of deadlocking.
+			cancelReplay()
+		}
+		replayErrCh <- err
+	}()
+
+	blocksCopied, immutableTipSlot, err := copyBlocksDirect(
+		replayCtx, logger, immutableDir, c, replayBatches,
 	)
+	close(replayBatches)
 	if err != nil {
+		cancelReplay()
+		<-replayErrCh
 		return fmt.Errorf("loading blocks: %w", err)
 	}
-
-	// Wait for ledger to catch up with tight polling
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-	catchupTimeout := 30 * time.Minute
-	if cfg.LedgerCatchupTimeout != "" {
-		if parsed, pErr := time.ParseDuration(
-			cfg.LedgerCatchupTimeout,
-		); pErr == nil {
-			catchupTimeout = parsed
-		} else {
-			logger.Warn(
-				"invalid ledgerCatchupTimeout, using default",
-				"value", cfg.LedgerCatchupTimeout,
-				"error", pErr,
-			)
-		}
+	if err := <-replayErrCh; err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("processing trusted block batches: %w", err)
 	}
-	timeout := time.After(catchupTimeout)
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf(
-				"cancelled waiting for ledger to catch up"+
-					" (tip slot %d, target slot %d): %w",
-				ls.Tip().Point.Slot,
-				immutableTipSlot,
-				ctx.Err(),
-			)
-		case <-ticker.C:
-			tip := ls.Tip()
-			if tip.Point.Slot >= immutableTipSlot {
-				logger.Info(
-					"finished processing blocks from immutable DB",
-					"blocks_copied", blocksCopied,
-				)
-				return nil
-			}
-		case <-timeout:
-			return fmt.Errorf(
-				"timed out waiting for ledger to catch up"+
-					" (tip slot %d, target slot %d)",
-				ls.Tip().Point.Slot,
-				immutableTipSlot,
-			)
-		}
-	}
+	logger.Info(
+		"finished processing blocks from immutable DB",
+		"blocks_copied", blocksCopied,
+		"tip_slot", immutableTipSlot,
+	)
+	return nil
 }
 
 // LoadBlobsResult contains the result of a blob-only ImmutableDB load.
@@ -291,21 +274,19 @@ func LoadBlobsWithDB(
 	}, nil
 }
 
-// copyBlocks reads blocks from an ImmutableDB directory and writes them to
-// the chain's blob store. Returns the number of blocks copied and the
-// immutable tip slot.
-func copyBlocks(
+// copyBlocksDirect reads immutable blocks once, persists them to the chain,
+// and streams the decoded batches to the trusted ledger replay path.
+func copyBlocksDirect(
 	ctx context.Context,
 	logger *slog.Logger,
 	immutableDir string,
 	c *chain.Chain,
+	replayBatches chan<- []gledger.Block,
 ) (int, uint64, error) {
-	// Open immutable DB
 	immutable, err := immutable.New(immutableDir)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to read immutable DB: %w", err)
 	}
-	// Record immutable DB tip
 	immutableTip, err := immutable.GetTip()
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to read immutable DB tip: %w", err)
@@ -313,7 +294,6 @@ func copyBlocks(
 	if immutableTip == nil {
 		return 0, 0, errors.New("immutable DB tip is nil")
 	}
-	// Copy all blocks
 	logger.Info("copying blocks from immutable DB")
 	chainTip := c.Tip()
 	iter, err := immutable.BlocksFromPoint(chainTip.Point)
@@ -327,8 +307,11 @@ func copyBlocks(
 	var blocksCopied int
 	startTime := time.Now()
 	lastProgressLog := time.Time{}
-	lastProgressSlot := chainTip.Point.Slot
+	var lastProgressSlot uint64
 	blockBatch := make([]gledger.Block, 0, loadBlockBatchSize)
+	verifyCfg := lcommon.VerifyConfig{
+		SkipBodyHashValidation: true,
+	}
 	for {
 		for {
 			next, err := iter.Next()
@@ -337,17 +320,19 @@ func copyBlocks(
 					"reading next block: %w", err,
 				)
 			}
-			// No more blocks
 			if next == nil {
 				break
 			}
-			tmpBlock, err := gledger.NewBlockFromCbor(next.Type, next.Cbor)
+			tmpBlock, err := gledger.NewBlockFromCbor(
+				next.Type,
+				next.Cbor,
+				verifyCfg,
+			)
 			if err != nil {
 				return blocksCopied, immutableTip.Slot, fmt.Errorf(
 					"decoding block CBOR: %w", err,
 				)
 			}
-			// Skip first block when continuing a load operation
 			if blocksCopied == 0 &&
 				tmpBlock.SlotNumber() == chainTip.Point.Slot {
 				continue
@@ -360,17 +345,26 @@ func copyBlocks(
 		if len(blockBatch) == 0 {
 			break
 		}
-		// Add block batch to chain
 		if err := c.AddBlocks(blockBatch); err != nil {
 			return blocksCopied, immutableTip.Slot, fmt.Errorf(
 				"failed to import block: %w",
 				err,
 			)
 		}
-		blocksCopied += len(blockBatch)
-		if tmpLen := len(blockBatch); tmpLen > 0 {
-			lastProgressSlot = blockBatch[tmpLen-1].SlotNumber()
+		replayBatch := append(
+			make([]gledger.Block, 0, len(blockBatch)),
+			blockBatch...,
+		)
+		select {
+		case replayBatches <- replayBatch:
+		case <-ctx.Done():
+			return blocksCopied, immutableTip.Slot, fmt.Errorf(
+				"loading blocks: %w",
+				ctx.Err(),
+			)
 		}
+		blocksCopied += len(blockBatch)
+		lastProgressSlot = replayBatch[len(replayBatch)-1].SlotNumber()
 		blockBatch = blockBatch[:0]
 		maybeLogBlockCopyProgress(
 			logger,
@@ -381,16 +375,11 @@ func copyBlocks(
 			startTime,
 			&lastProgressLog,
 		)
-		// Check for cancellation after each batch
 		if err := ctx.Err(); err != nil {
 			return blocksCopied, immutableTip.Slot,
 				fmt.Errorf("loading blocks: %w", err)
 		}
 	}
-	logger.Info(
-		"finished copying blocks from immutable DB",
-		"blocks_copied", blocksCopied,
-	)
 	return blocksCopied, immutableTip.Slot, nil
 }
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -34,6 +34,7 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -44,6 +45,10 @@ const (
 	// Max number of blocks to fetch in a single blockfetch call
 	// This prevents us exceeding the configured recv queue size in the block-fetch protocol
 	blockfetchBatchSize = 500
+
+	// Number of received blockfetch blocks to buffer before committing them.
+	// Keep this small so downstream iterators still see fresh blocks promptly.
+	blockfetchCommitBatchSize = 8
 
 	// Default/fallback slot threshold for blockfetch batches
 	blockfetchBatchSlotThresholdDefault = 2500 * 20
@@ -828,13 +833,10 @@ func (ls *LedgerState) tryResolveFork(
 
 //nolint:unparam
 func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
-	// Process each block immediately as it arrives rather than
-	// buffering until BatchDone. This ensures blocks appear on the
-	// chain promptly, allowing server-side chain iterators (serving
-	// downstream peers via ChainSync) to deliver blocks without
-	// waiting for the entire blockfetch batch to complete. Without
-	// this, a 500-block batch can take 10+ seconds to receive,
-	// exceeding the downstream peer's ChainSync idle timeout.
+	// Process blocks in small commit batches so they appear on the
+	// chain promptly without paying a full blob transaction cost for
+	// every single block. We still flush well before BatchDone to
+	// avoid downstream ChainSync idle timeouts.
 
 	// Verify block header cryptographic proofs (VRF, KES).
 	// Skip during historical sync (validationEnabled=false) because
@@ -847,24 +849,59 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 			)
 		}
 	}
-	// Add block to chain with its own transaction so it becomes
-	// visible to iterators immediately after commit.
-	var addBlockErr error
+	ls.pendingBlockfetchEvents = append(ls.pendingBlockfetchEvents, e)
+	if len(ls.pendingBlockfetchEvents) >= blockfetchCommitBatchSize {
+		if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+			return err
+		}
+	}
+	// Reset timeout timer since we received a block
+	if ls.chainsyncBlockfetchTimeoutTimer != nil {
+		ls.chainsyncBlockfetchTimeoutTimer.Reset(blockfetchBusyTimeout)
+	}
+	return nil
+}
+
+func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
+	if len(ls.pendingBlockfetchEvents) == 0 {
+		return nil
+	}
+	pending := slices.Clone(ls.pendingBlockfetchEvents)
+	ls.pendingBlockfetchEvents = ls.pendingBlockfetchEvents[:0]
+	blocks := make([]gledger.Block, 0, len(pending))
+	for _, pendingEvent := range pending {
+		blocks = append(blocks, pendingEvent.Block)
+	}
+	if err := ls.chain.AddBlocks(blocks); err == nil {
+		ls.Lock()
+		for _, pendingEvent := range pending {
+			ls.checkSlotBattle(pendingEvent, nil)
+		}
+		ls.Unlock()
+		return nil
+	}
+	addBlockErrs := make([]error, len(pending))
 	txn := ls.db.BlobTxn(true)
 	if err := txn.Do(func(txn *database.Txn) error {
-		addBlockErr = ls.chain.AddBlock(e.Block, txn)
-		if addBlockErr != nil {
-			if !errors.As(addBlockErr, &chain.BlockNotFitChainTipError{}) &&
-				!errors.As(addBlockErr, &chain.BlockNotMatchHeaderError{}) {
-				return fmt.Errorf("add chain block: %w", addBlockErr)
+		for idx, pendingEvent := range pending {
+			addBlockErrs[idx] = ls.chain.AddBlock(pendingEvent.Block, txn)
+			if addBlockErrs[idx] == nil {
+				continue
+			}
+			if !errors.As(addBlockErrs[idx], &chain.BlockNotFitChainTipError{}) &&
+				!errors.As(addBlockErrs[idx], &chain.BlockNotMatchHeaderError{}) {
+				return fmt.Errorf(
+					"add chain block: %w",
+					addBlockErrs[idx],
+				)
 			}
 			ls.config.Logger.Warn(
 				fmt.Sprintf(
 					"ignoring blockfetch block: %s",
-					addBlockErr,
+					addBlockErrs[idx],
 				),
 			)
-			if errors.As(addBlockErr, &chain.BlockNotMatchHeaderError{}) {
+			if errors.As(addBlockErrs[idx], &chain.BlockNotMatchHeaderError{}) {
 				ls.chain.ClearHeaders()
 			}
 		}
@@ -872,20 +909,12 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	}); err != nil {
 		return fmt.Errorf("failed processing block event: %w", err)
 	}
-	// Slot-battle check after commit — keeps ls.Lock() outside
-	// any open transaction, preserving consistent lock ordering.
 	ls.Lock()
-	ls.checkSlotBattle(e, addBlockErr)
-	ls.Unlock()
-	// Notify chain iterators now that the transaction has committed
-	// and the block is visible to readers. The notification inside
-	// AddBlock fires before commit, so iterators that wake up from
-	// that signal may not yet see the block.
-	ls.chain.NotifyIterators()
-	// Reset timeout timer since we received a block
-	if ls.chainsyncBlockfetchTimeoutTimer != nil {
-		ls.chainsyncBlockfetchTimeoutTimer.Reset(blockfetchBusyTimeout)
+	for idx, pendingEvent := range pending {
+		ls.checkSlotBattle(pendingEvent, addBlockErrs[idx])
 	}
+	ls.Unlock()
+	ls.chain.NotifyIterators()
 	return nil
 }
 
@@ -1881,6 +1910,7 @@ func (ls *LedgerState) blockfetchRequestRangeCleanup() {
 		close(ls.chainsyncBlockfetchReadyChan)
 		ls.chainsyncBlockfetchReadyChan = nil
 	}
+	ls.pendingBlockfetchEvents = ls.pendingBlockfetchEvents[:0]
 }
 
 func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
@@ -1890,8 +1920,9 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		ls.chainsyncBlockfetchTimeoutTimer = nil
 	}
 	ls.chainsyncBlockfetchTimerGeneration++
-	// Blocks are already processed incrementally in handleEventBlockfetchBlock,
-	// so no batch processing is needed here.
+	if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+		return err
+	}
 	// Continue fetching as long as there are queued headers
 	remainingHeaders := ls.chain.HeaderCount()
 	ls.config.Logger.Debug(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -404,6 +404,8 @@ type LedgerStateConfig struct {
 	ForgedBlockChecker         ForgedBlockChecker
 	SlotBattleRecorder         SlotBattleRecorder
 	ValidateHistorical         bool
+	TrustedReplay              bool
+	ManualBlockProcessing      bool
 	ForgeBlocks                bool
 	DatabaseWorkerPoolConfig   DatabaseWorkerPoolConfig
 }
@@ -448,6 +450,7 @@ type LedgerState struct {
 	chainsyncBlockfetchMutex      sync.Mutex
 	chainsyncBlockfetchReadyMutex sync.Mutex
 	chainsyncBlockfetchReadyChan  chan struct{}
+	pendingBlockfetchEvents       []BlockfetchEvent
 	checkpointWrittenForEpoch     bool
 	closed                        atomic.Bool
 	inRecovery                    bool // guards against recursive recovery in SubmitAsyncDBTxn
@@ -612,8 +615,11 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		ls.slotClock.Start(ctx)
 		go ls.handleSlotTicks()
 	}
-	// Start goroutine to process new blocks
-	go ls.ledgerProcessBlocks()
+	// Start goroutine to process new blocks unless the caller will feed trusted
+	// batches directly into the replay loop.
+	if !ls.config.ManualBlockProcessing {
+		go ls.ledgerProcessBlocks()
+	}
 	return nil
 }
 
@@ -1751,6 +1757,49 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 	// Start chain reader goroutine
 	readChainResultCh := make(chan readChainResult)
 	go ls.ledgerReadChain(ls.ctx, readChainResultCh)
+	if err := ls.ledgerProcessBlocksFromSource(ls.ctx, readChainResultCh); err != nil {
+		ls.config.Logger.Error(
+			"failed to process blocks",
+			"error", err,
+		)
+	}
+}
+
+// ProcessTrustedBlockBatches processes already-decoded trusted block batches
+// synchronously. This is used by immutable load so blocks can be replayed
+// directly without first being reread from the chain store.
+func (ls *LedgerState) ProcessTrustedBlockBatches(
+	ctx context.Context,
+	batches <-chan []ledger.Block,
+) error {
+	// Buffer of 1 so the forwarding goroutine can deposit one result
+	// and exit even if ledgerProcessBlocksFromSource has already returned.
+	readChainResultCh := make(chan readChainResult, 1)
+	go func() {
+		defer close(readChainResultCh)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case batch, ok := <-batches:
+				if !ok {
+					return
+				}
+				select {
+				case readChainResultCh <- readChainResult{blocks: batch}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return ls.ledgerProcessBlocksFromSource(ctx, readChainResultCh)
+}
+
+func (ls *LedgerState) ledgerProcessBlocksFromSource(
+	ctx context.Context,
+	readChainResultCh <-chan readChainResult,
+) error {
 	// Enable bulk-load optimizations when syncing from behind
 	var bulkOptimizer metadata.BulkLoadOptimizer
 	bulkLoadActive := false
@@ -1843,10 +1892,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				return nil
 			}, true)
 			if err != nil {
-				ls.config.Logger.Error(
-					"failed to process epoch rollover: " + err.Error(),
-				)
-				return
+				return fmt.Errorf("process epoch rollover: %w", err)
 			}
 
 			// Apply in-memory state updates with brief lock after successful commit
@@ -1962,16 +2008,18 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				emittedHF = true
 				emittedHFFromEra = hf.FromEra
 				emittedHFToEra = hf.ToEra
-				ls.config.Logger.Info(
-					"emitted hard fork event",
-					"from_era", hf.FromEra,
-					"to_era", hf.ToEra,
-					"epoch",
-					rolloverResult.NewCurrentEpoch.EpochId,
-					"slot",
-					rolloverResult.NewCurrentEpoch.StartSlot,
-					"component", "ledger",
-				)
+				if !ls.config.TrustedReplay {
+					ls.config.Logger.Info(
+						"emitted hard fork event",
+						"from_era", hf.FromEra,
+						"to_era", hf.ToEra,
+						"epoch",
+						rolloverResult.NewCurrentEpoch.EpochId,
+						"slot",
+						rolloverResult.NewCurrentEpoch.StartSlot,
+						"component", "ledger",
+					)
+				}
 			}
 
 			// Emit hard fork events for era transitions
@@ -2059,14 +2107,16 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 								hfEvent,
 							),
 						)
-						ls.config.Logger.Info(
-							"emitted hard fork event"+
-								" (era transition)",
-							"from_era", prevEraId,
-							"to_era",
-							eraResult.NewEra.Id,
-							"component", "ledger",
-						)
+						if !ls.config.TrustedReplay {
+							ls.config.Logger.Info(
+								"emitted hard fork event"+
+									" (era transition)",
+								"from_era", prevEraId,
+								"to_era",
+								eraResult.NewEra.Id,
+								"component", "ledger",
+							)
+						}
 					}
 					prevEraId = eraResult.NewEra.Id
 					prevPParams = eraResult.NewPParams
@@ -2103,7 +2153,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			select {
 			case result, ok := <-readChainResultCh:
 				if !ok {
-					return
+					return nil
 				}
 				nextBatch = result.blocks
 				// Process rollback
@@ -2113,15 +2163,12 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				// method handles its own locking for in-memory state updates.
 				if result.rollback {
 					if err = ls.rollback(result.rollbackPoint); err != nil {
-						ls.config.Logger.Error(
-							"failed to process rollback: " + err.Error(),
-						)
-						return
+						return fmt.Errorf("process rollback: %w", err)
 					}
 					continue
 				}
-			case <-ls.ctx.Done():
-				return
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 		// Process batch in groups of batchSize to stay under DB txn limits
@@ -2200,7 +2247,9 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 					var shouldValidateBlock bool
 					if snapshotValidationEnabled {
 						shouldValidateBlock = true
-					} else if snapshotChainsyncState == SyncingChainsyncState && next.SlotNumber() >= cutoffSlot {
+					} else if !ls.config.TrustedReplay &&
+						snapshotChainsyncState == SyncingChainsyncState &&
+						next.SlotNumber() >= cutoffSlot {
 						wantEnableValidation = true
 						shouldValidateBlock = true
 					}
@@ -2295,18 +2344,12 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 							runningNonce = tmpNonce
 						}
 					}
-					// TODO: batch this
-					// Determine epoch for this slot
-					tmpEpoch, err := ls.SlotToEpoch(tmpPoint.Slot)
-					if err != nil {
-						deltaBatch.Release()
-						return fmt.Errorf("slot->epoch: %w", err)
-					}
-
-					// First block we persist in the current epoch becomes the checkpoint
+					// The loop exits before processing blocks from the next
+					// epoch, so every block that reaches this point belongs
+					// to snapshotEpoch.
+					// First block we persist in the current epoch becomes the checkpoint.
 					isCheckpoint := false
-					if tmpEpoch.EpochId == snapshotEpoch.EpochId &&
-						!localCheckpointWritten {
+					if !localCheckpointWritten {
 						isCheckpoint = true
 						localCheckpointWritten = true
 					}
@@ -2342,10 +2385,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 				return nil
 			}, true)
 			if err != nil {
-				ls.config.Logger.Error(
-					"failed to process block: " + err.Error(),
-				)
-				return
+				return fmt.Errorf("process block batch: %w", err)
 			}
 			// Transaction committed successfully - now update in-memory state.
 			// Only update if blocks were actually processed to avoid resetting tip to zero.
@@ -2382,26 +2422,28 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			}
 		}
 		if len(nextBatch) > 0 {
-			// Determine block source for observability
-			source := "chainsync"
-			if checker != nil {
-				if _, forged := checker.WasForgedByUs(
-					tipForLog.Point.Slot,
-				); forged {
-					source = "forged"
+			if !ls.config.TrustedReplay {
+				// Determine block source for observability
+				source := "chainsync"
+				if checker != nil {
+					if _, forged := checker.WasForgedByUs(
+						tipForLog.Point.Slot,
+					); forged {
+						source = "forged"
+					}
 				}
+				ls.config.Logger.Info(
+					fmt.Sprintf(
+						"chain extended, new tip: %x at slot %d",
+						tipForLog.Point.Hash,
+						tipForLog.Point.Slot,
+					),
+					"component",
+					"ledger",
+					"source",
+					source,
+				)
 			}
-			ls.config.Logger.Info(
-				fmt.Sprintf(
-					"chain extended, new tip: %x at slot %d",
-					tipForLog.Point.Hash,
-					tipForLog.Point.Slot,
-				),
-				"component",
-				"ledger",
-				"source",
-				source,
-			)
 			// Periodic sync progress reporting
 			ls.logSyncProgress(tipForLog.Point.Slot)
 		}
@@ -2436,8 +2478,12 @@ func (ls *LedgerState) ledgerProcessBlock(
 	}
 	// Process transactions
 	var delta *LedgerDelta
-	// Track outputs from earlier transactions in this block for intra-block dependencies
-	intraBlockUtxos := make(map[string]lcommon.Utxo)
+	// Track outputs from earlier transactions in this block for intra-block
+	// dependencies only when TX validation is enabled.
+	var intraBlockUtxos map[string]lcommon.Utxo
+	if shouldValidate {
+		intraBlockUtxos = make(map[string]lcommon.Utxo)
+	}
 	for i, tx := range block.Transactions() {
 		if delta == nil {
 			delta = NewLedgerDelta(


### PR DESCRIPTION
… load

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up immutable DB loads by streaming trusted block batches directly into the ledger, and reduces DB overhead during live sync by micro-batching blockfetch commits. Also skips body-hash validation in immutable/backfill paths to speed up parsing.

- New Features
  - Trusted immutable replay: `copyBlocksDirect` reads immutable blocks once, persists them via `AddBlocks`, and streams batches to `ProcessTrustedBlockBatches` with `TrustedReplay` and `ManualBlockProcessing` enabled. Removes event bus usage and catch-up polling, and suppresses hard-fork/source logs during replay.
  - Micro-batched blockfetch: buffers up to 8 blocks and commits them together, flushing at batch end. Tries bulk `AddBlocks`, falls back to per-block tx when needed, keeping iterators responsive and avoiding idle timeouts.
  - Faster decode paths: use `lcommon.VerifyConfig{SkipBodyHashValidation: true}` for immutable load and backfill.

<sup>Written for commit ac80256480ac5e8bb638f6560834b23eecac1dfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a trusted-replay chain loading mode and options for manual block processing control.

* **Performance Improvements**
  * Batched block commits and concurrent trusted-block processing for faster imports and sync.

* **Refactor**
  * Replaced event-driven chain loading with an immutable-DB-backed trusted-replay path and streamlined blob/block copy flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->