### PR TITLE
fix: compare LengthInSlots and Nonce in epoch cache check

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -343,9 +343,11 @@ func (ls *LedgerState) advanceEpochCache() error {
 	}
 	// Verify the base epoch we used for computation is still the cache
 	// tail. A concurrent rollback could have pruned the cache, making
-	// our computed newEpoch stale.
+	// our computed newEpoch stale (e.g. after a hard fork or rollback).
 	if lastCached.EpochId != lastEpoch.EpochId ||
-		lastCached.StartSlot != lastEpoch.StartSlot {
+		lastCached.StartSlot != lastEpoch.StartSlot ||
+		lastCached.LengthInSlots != lastEpoch.LengthInSlots ||
+		!bytes.Equal(lastCached.Nonce, lastEpoch.Nonce) {
 		ls.Unlock()
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extend the epoch cache guard to also compare LengthInSlots and Nonce, not just EpochId and StartSlot. This prevents using a stale computed epoch after rollbacks or hard forks.

<sup>Written for commit b6bee47d6c7b8850e234588271717e520375b14a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

