### PR TITLE
fix: add shutdown progress logging and timeouts to prevent hang on exit

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -839,18 +839,56 @@ func (ls *LedgerState) Close() error {
 	// Wait for in-flight rollback event emission goroutines.
 	// Hold rollbackMu so no new goroutine can Add(1) between our
 	// closed flag and this Wait.
+	ls.config.Logger.Info("waiting for in-flight rollback goroutines")
+	rollbackStart := time.Now()
 	ls.rollbackMu.Lock()
-	ls.rollbackWG.Wait()
+	rollbackDone := make(chan struct{})
+	go func() {
+		ls.rollbackWG.Wait()
+		close(rollbackDone)
+	}()
+	select {
+	case <-rollbackDone:
+		ls.config.Logger.Info(
+			"rollback goroutines finished",
+			"elapsed", time.Since(rollbackStart).Round(time.Millisecond),
+		)
+	case <-time.After(10 * time.Second):
+		ls.config.Logger.Warn(
+			"timed out waiting for rollback goroutines",
+			"elapsed", time.Since(rollbackStart).Round(time.Millisecond),
+		)
+	}
 	ls.rollbackMu.Unlock()
 
 	// Stop slot clock
 	if ls.slotClock != nil {
+		ls.config.Logger.Info("stopping slot clock")
 		ls.slotClock.Stop()
+		ls.config.Logger.Info("slot clock stopped")
 	}
 
 	// Shutdown database worker pool
 	if ls.dbWorkerPool != nil {
-		ls.dbWorkerPool.Shutdown()
+		ls.config.Logger.Info("shutting down database worker pool")
+		poolStart := time.Now()
+		poolDone := make(chan struct{})
+		go func() {
+			ls.dbWorkerPool.Shutdown()
+			close(poolDone)
+		}()
+		select {
+		case <-poolDone:
+			ls.config.Logger.Info(
+				"database worker pool shut down",
+				"elapsed", time.Since(poolStart).Round(time.Millisecond),
+			)
+		case <-time.After(15 * time.Second):
+			ls.config.Logger.Warn(
+				"timed out waiting for database worker pool shutdown",
+				"elapsed", time.Since(poolStart).Round(time.Millisecond),
+			)
+		}
 	}
 
 	// Note: We don't close the database here because LedgerState doesn't own it.

--- a/node.go
+++ b/node.go
@@ -849,6 +849,7 @@ func (n *Node) Stop() error {
 }
 
 func (n *Node) shutdown() error {
+	shutdownStart := time.Now()
 	// Create shutdown context with timeout (default 30s if not configured)
 	shutdownTimeout := 30 * time.Second
 	if n.config.shutdownTimeout > 0 {
@@ -862,10 +863,13 @@ func (n *Node) shutdown() error {
 
 	var err error
 
-	n.config.logger.Debug("starting graceful shutdown")
+	n.config.logger.Info(
+		"starting graceful shutdown",
+		"timeout", shutdownTimeout,
+	)
 
 	// Phase 1: Stop accepting new work
-	n.config.logger.Debug("shutdown phase 1: stopping new work")
+	n.config.logger.Info("shutdown phase 1: stopping new work")
 
 	// Stop block forger first to prevent new blocks
 	if n.blockForger != nil {
@@ -929,8 +933,14 @@ func (n *Node) shutdown() error {
 		}
 	}
 
+	n.config.logger.Info(
+		"shutdown phase 1 complete",
+		"elapsed", time.Since(shutdownStart).Round(time.Millisecond),
+	)
+
 	// Phase 2: Drain and close connections
-	n.config.logger.Debug("shutdown phase 2: draining connections")
+	n.config.logger.Info("shutdown phase 2: draining connections")
+	phase2Start := time.Now()
 
 	if n.mempool != nil {
 		if stopErr := n.mempool.Stop(ctx); stopErr != nil {
@@ -947,29 +957,52 @@ func (n *Node) shutdown() error {
 		}
 	}
 
+	n.config.logger.Info(
+		"shutdown phase 2 complete",
+		"elapsed", time.Since(phase2Start).Round(time.Millisecond),
+	)
+
 	// Phase 3: Flush state and close database
-	n.config.logger.Debug("shutdown phase 3: flushing state")
+	n.config.logger.Info("shutdown phase 3: flushing state")
+	phase3Start := time.Now()
 
 	if n.ledgerState != nil {
+		n.config.logger.Info("closing ledger state")
+		t := time.Now()
 		if closeErr := n.ledgerState.Close(); closeErr != nil {
 			err = errors.Join(
 				err,
 				fmt.Errorf("ledger state close: %w", closeErr),
 			)
 		}
+		n.config.logger.Info(
+			"ledger state closed",
+			"elapsed", time.Since(t).Round(time.Millisecond),
+		)
 	}
 
 	if n.db != nil {
+		n.config.logger.Info("closing database")
+		t := time.Now()
 		if closeErr := n.db.Close(); closeErr != nil {
 			err = errors.Join(
 				err,
 				fmt.Errorf("database close: %w", closeErr),
 			)
 		}
+		n.config.logger.Info(
+			"database closed",
+			"elapsed", time.Since(t).Round(time.Millisecond),
+		)
 	}
 
+	n.config.logger.Info(
+		"shutdown phase 3 complete",
+		"elapsed", time.Since(phase3Start).Round(time.Millisecond),
+	)
+
 	// Phase 4: Cleanup resources
-	n.config.logger.Debug("shutdown phase 4: cleanup resources")
+	n.config.logger.Info("shutdown phase 4: cleanup resources")
 
 	// Call registered shutdown functions
 	for _, fn := range n.shutdownFuncs {
@@ -983,7 +1016,10 @@ func (n *Node) shutdown() error {
 		n.eventBus.Stop()
 	}
 
-	n.config.logger.Debug("graceful shutdown complete")
+	n.config.logger.Info(
+		"graceful shutdown complete",
+		"total_elapsed", time.Since(shutdownStart).Round(time.Millisecond),
+	)
 	return err
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add progress logs and timeouts to the shutdown path to prevent hangs on exit and make shutdown status visible. Each phase now reports elapsed time, with long waits bounded.

- **Bug Fixes**
  - Bounded waits to avoid blocking: rollback goroutines (10s) and DB worker pool shutdown (15s).
  - Switched to Info-level logs with elapsed timing for each shutdown phase, plus ledger state and database close.
  - Log the configured shutdown timeout (default 30s) and phase completions for easier diagnosis.

<sup>Written for commit 887738ad95c9a17c0bfe623095873e60a44f6a3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

