### PR TITLE
fix(chain): allow rollback beyond k if we're beyond k

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -527,10 +527,12 @@ func (c *Chain) rollbackLocked(
 	// Reject rollbacks that exceed the security parameter K on
 	// the persistent chain. Ephemeral (fork-tracking) chains are
 	// not subject to this limit. The check is skipped when
-	// securityParam is 0, which means the ledger has not been
-	// initialized yet.
+	// securityParam is 0 (ledger not yet initialized) or when
+	// the chain is shorter than K blocks (initial sync), since
+	// the entire chain can be safely replaced during sync.
 	securityParam := c.manager.securityParam
 	if c.persistent && securityParam > 0 &&
+		c.tipBlockIndex >= uint64(securityParam) && //nolint:gosec
 		forkDepth > uint64(securityParam) { //nolint:gosec
 		slog.Default().Warn(
 			"rejecting rollback that exceeds "+

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -30,9 +30,9 @@ import (
 
 // MaxBlockFetchRange is the maximum slot range allowed for a single block
 // fetch request. This prevents peers from requesting unbounded ranges that
-// would cause the server to iterate the entire chain. The value of 2160
-// corresponds to one mainnet epoch and aligns with the security parameter K.
-const MaxBlockFetchRange = 2160
+// would cause the server to iterate the entire chain. The value of 129600
+// corresponds to the stability window (3k/f) on mainnet (k=2160, f=0.05).
+const MaxBlockFetchRange = 129600
 
 func (o *Ouroboros) blockfetchServerConnOpts() []blockfetch.BlockFetchOptionFunc {
 	return []blockfetch.BlockFetchOptionFunc{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow deeper rollbacks during initial sync by skipping the K-limit until the chain is at least K blocks long; enforce the K limit once the tip >= K on persistent chains. Also increase `ouroboros` `MaxBlockFetchRange` to 129600 slots (stability window, 3k/f) to align with protocol and reduce request splits.

<sup>Written for commit 18755200dcaa915c2cdcdb94e3cd9e17e746842a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved chain synchronization handling to allow for more flexible rollback behavior during initial sync phases.
  * Increased maximum block fetch range to support larger data requests during blockchain synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->