### PR TITLE
fix: peer limits and metrics

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -47,6 +47,7 @@ type connectionInfo struct {
 	conn      *ouroboros.Connection
 	peerAddr  string
 	isInbound bool
+	isNtC     bool   // true for node-to-client (local) connections
 	ipKey     string // rate-limit key (IP or /64 prefix for IPv6)
 }
 
@@ -121,12 +122,14 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 	return c
 }
 
-// inboundCount returns the current number of inbound connections.
+// inboundCountLocked returns the current number of inbound N2N connections.
+// Node-to-client connections are excluded because they are local clients
+// (wallets, tools) and should not count against the peer connection budget.
 // The caller must hold connectionsMutex.
 func (c *ConnectionManager) inboundCountLocked() int {
 	count := 0
 	for _, info := range c.connections {
-		if info.isInbound {
+		if info.isInbound && !info.isNtC {
 			count++
 		}
 	}
@@ -224,8 +227,13 @@ func (c *ConnectionManager) updateConnectionMetrics() {
 		map[string]*peerConnectionState,
 	) // peerAddr -> connection state
 
-	// Count connections and track peer connectivity in a single pass
+	// Count connections and track peer connectivity in a single pass.
+	// N2C (node-to-client) connections are excluded from peer metrics
+	// because they are local clients, not network peers.
 	for _, info := range c.connections {
+		if info.isNtC {
+			continue
+		}
 		if info.isInbound {
 			incomingCount++
 		} else {
@@ -242,8 +250,11 @@ func (c *ConnectionManager) updateConnectionMetrics() {
 		}
 	}
 
-	// Count full-duplex and prunable connections
+	// Count full-duplex and prunable connections (N2C excluded above)
 	for _, info := range c.connections {
+		if info.isNtC {
+			continue
+		}
 		// Full-duplex: inbound connections that support bidirectional protocols
 		if info.isInbound && info.conn != nil {
 			_, versionData := info.conn.ProtocolVersion()
@@ -397,12 +408,31 @@ func (c *ConnectionManager) AddConnection(
 	isInbound bool,
 	peerAddr string,
 ) {
-	c.addConnectionWithIPKey(conn, isInbound, peerAddr, "")
+	c.addConnectionImpl(conn, isInbound, false, peerAddr, "")
 }
 
 func (c *ConnectionManager) addConnectionWithIPKey(
 	conn *ouroboros.Connection,
 	isInbound bool,
+	peerAddr string,
+	ipKey string,
+) {
+	c.addConnectionImpl(conn, isInbound, false, peerAddr, ipKey)
+}
+
+func (c *ConnectionManager) addNtCConnectionWithIPKey(
+	conn *ouroboros.Connection,
+	isInbound bool,
+	peerAddr string,
+	ipKey string,
+) {
+	c.addConnectionImpl(conn, isInbound, true, peerAddr, ipKey)
+}
+
+func (c *ConnectionManager) addConnectionImpl(
+	conn *ouroboros.Connection,
+	isInbound bool,
+	isNtC bool,
 	peerAddr string,
 	ipKey string,
 ) {
@@ -426,6 +456,7 @@ func (c *ConnectionManager) addConnectionWithIPKey(
 	c.connections[connId] = &connectionInfo{
 		conn:      conn,
 		isInbound: isInbound,
+		isNtC:     isNtC,
 		peerAddr:  peerAddr,
 		ipKey:     ipKey,
 	}

--- a/connmanager/event.go
+++ b/connmanager/event.go
@@ -30,6 +30,7 @@ type InboundConnectionEvent struct {
 	ConnectionId ouroboros.ConnectionId
 	LocalAddr    net.Addr
 	RemoteAddr   net.Addr
+	IsNtC        bool // true for node-to-client (local) connections
 }
 
 type ConnectionClosedEvent struct {

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -173,7 +173,70 @@ func (c *ConnectionManager) startListener(
 			}
 			// Successful accept - reset consecutive error count
 			consecutiveErrors = 0
-			// Atomically check and reserve an inbound slot before any further processing
+
+			// NtC (node-to-client) connections bypass the inbound
+			// slot budget and per-IP rate limiting — they are local
+			// clients (wallets, tools), not network peers.
+			if l.UseNtC {
+				// Wrap UNIX connections
+				if uConn, ok := conn.(*net.UnixConn); ok {
+					tmpConn, err := NewUnixConn(uConn)
+					if err != nil {
+						c.config.Logger.Error(
+							fmt.Sprintf("listener: accept failed: %s", err),
+						)
+						_ = conn.Close()
+						continue
+					}
+					conn = tmpConn
+				}
+				c.config.Logger.Info(
+					fmt.Sprintf(
+						"listener: accepted NtC connection from %s",
+						conn.RemoteAddr(),
+					),
+				)
+				connOpts := append(
+					defaultConnOpts,
+					ouroboros.WithConnection(conn),
+				)
+				oConn, err := ouroboros.NewConnection(connOpts...)
+				if err != nil {
+					c.config.Logger.Error(
+						fmt.Sprintf(
+							"listener: failed to setup NtC connection: %s",
+							err,
+						),
+					)
+					conn.Close()
+					continue
+				}
+				peerAddr := "unknown"
+				if conn.RemoteAddr() != nil {
+					peerAddr = conn.RemoteAddr().String()
+				}
+				c.addNtCConnectionWithIPKey(
+					oConn, true, peerAddr, "",
+				)
+				// Generate event
+				if c.config.EventBus != nil {
+					c.config.EventBus.Publish(
+						InboundConnectionEventType,
+						event.NewEvent(
+							InboundConnectionEventType,
+							InboundConnectionEvent{
+								ConnectionId: oConn.Id(),
+								LocalAddr:    conn.LocalAddr(),
+								RemoteAddr:   conn.RemoteAddr(),
+								IsNtC:        true,
+							},
+						),
+					)
+				}
+				continue
+			}
+
+			// N2N path: reserve an inbound slot before further processing
 			if !c.tryReserveInboundSlot() {
 				c.config.Logger.Warn(
 					fmt.Sprintf(
@@ -260,6 +323,7 @@ func (c *ConnectionManager) startListener(
 							ConnectionId: oConn.Id(),
 							LocalAddr:    conn.LocalAddr(),
 							RemoteAddr:   conn.RemoteAddr(),
+							IsNtC:        l.UseNtC,
 						},
 					),
 				)

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -459,6 +459,11 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 		)
 		return
 	}
+	// Skip node-to-client connections — N2N mini-protocols don't
+	// apply to local client connections.
+	if e.IsNtC {
+		return
+	}
 	connId := e.ConnectionId
 
 	// Look up the connection to check its negotiated diffusion mode

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -436,6 +436,11 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 		)
 		return
 	}
+	// Skip node-to-client connections — they are local clients
+	// (wallets, tools), not network peers.
+	if e.IsNtC {
+		return
+	}
 	address := e.RemoteAddr.String()
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -42,10 +42,12 @@ const (
 	defaultTargetNumberOfActivePeers      = 20
 	defaultTargetNumberOfRootPeers        = 60
 
-	// Default per-source quotas for active peers
-	defaultActivePeersTopologyQuota = 3
-	defaultActivePeersGossipQuota   = 12
-	defaultActivePeersLedgerQuota   = 5
+	// Default per-source quotas for active peers.
+	// Each quota is a ceiling, not a reservation. The global
+	// TargetNumberOfActivePeers (default 20) still applies.
+	defaultActivePeersTopologyQuota = 10
+	defaultActivePeersGossipQuota   = 10
+	defaultActivePeersLedgerQuota   = 10
 
 	// Default churn configuration
 	defaultGossipChurnInterval     = 5 * time.Minute

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -1341,10 +1341,53 @@ func TestPeerGovernor_PeerTargets_DefaultValues(t *testing.T) {
 	assert.Equal(t, 50, pg.config.TargetNumberOfEstablishedPeers)
 	assert.Equal(t, 20, pg.config.TargetNumberOfActivePeers)
 	assert.Equal(t, 60, pg.config.TargetNumberOfRootPeers)
-	// Per-source quotas
-	assert.Equal(t, 3, pg.config.ActivePeersTopologyQuota)
-	assert.Equal(t, 12, pg.config.ActivePeersGossipQuota)
-	assert.Equal(t, 5, pg.config.ActivePeersLedgerQuota)
+	// Per-source quotas (ceilings, not reservations)
+	assert.Equal(t, 10, pg.config.ActivePeersTopologyQuota)
+	assert.Equal(t, 10, pg.config.ActivePeersGossipQuota)
+	assert.Equal(t, 10, pg.config.ActivePeersLedgerQuota)
+}
+
+// TestPeerGovernor_QuotaSumExceedsTarget verifies that the global
+// TargetNumberOfActivePeers caps total hot peers even when per-source
+// quotas sum to more than the target (10+10+10=30 > 20).
+func TestPeerGovernor_QuotaSumExceedsTarget(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+
+	// Simulate 30 hot peers across 3 sources (10 each)
+	for i := 0; i < 10; i++ {
+		pg.peers = append(pg.peers, &Peer{
+			Address: fmt.Sprintf("gossip-%d:3001", i),
+			Source:  PeerSourceP2PGossip,
+			State:   PeerStateHot,
+		})
+		pg.peers = append(pg.peers, &Peer{
+			Address: fmt.Sprintf("ledger-%d:3001", i),
+			Source:  PeerSourceP2PLedger,
+			State:   PeerStateHot,
+		})
+		pg.peers = append(pg.peers, &Peer{
+			Address: fmt.Sprintf("topo-%d:3001", i),
+			Source:  PeerSourceTopologyPublicRoot,
+			State:   PeerStateHot,
+		})
+	}
+
+	// enforcePeerLimits should demote excess beyond target
+	var removedCount int
+	pg.enforcePeerLimits(&removedCount)
+
+	hotCount := 0
+	for _, p := range pg.peers {
+		if p != nil && p.State == PeerStateHot {
+			hotCount++
+		}
+	}
+	assert.LessOrEqual(
+		t, hotCount, pg.config.TargetNumberOfActivePeers,
+		"total hot peers must not exceed TargetNumberOfActivePeers",
+	)
 }
 
 func TestPeerGovernor_PeerTargets_CustomValues(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude node-to-client (NtC) connections from peer limits, metrics, and inbound/rate-limit budgets so local wallets/tools don’t consume peer slots or inflate stats. Also set default active peer quotas to 10/10/10 as ceilings enforced by the global active-peer target.

- **Bug Fixes**
  - Tag NtC connections/events (`IsNtC`); listener accepts NtC (incl. UNIX), publishes events, and `ConnectionManager` excludes NtC from inbound counts and all peer metrics.
  - NtC bypass inbound slot reservation and per-IP rate limiting; added `addNtCConnectionWithIPKey` and unified add logic via `addConnectionImpl`.
  - `ouroboros` and `peergov` ignore NtC in inbound handlers.
  - Update default per-source active-peer quotas to 10/10/10 (ceilings); tests confirm global `TargetNumberOfActivePeers` caps totals when quotas exceed the target.

<sup>Written for commit 04b484a1c8e9aa72f18bb21276b376613ea3013d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinction between peer connections and local client connections for improved connection management.

* **Bug Fixes**
  * Peer metrics now correctly exclude local connections from calculations.

* **Improvements**
  * Updated default active peer quota limits (topology, gossip, and ledger) to 10 each for enhanced peer distribution strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->