### PR TITLE
fix(ouroboros): leios notify timeout

### DIFF
--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -16,6 +16,7 @@ package ouroboros
 
 import (
 	"fmt"
+	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/protocol"
@@ -32,6 +33,11 @@ func (o *Ouroboros) leiosnotifyServerConnOpts() []oleiosnotify.LeiosNotifyOption
 func (o *Ouroboros) leiosnotifyClientConnOpts() []oleiosnotify.LeiosNotifyOptionFunc {
 	return []oleiosnotify.LeiosNotifyOptionFunc{
 		oleiosnotify.WithNotificationFunc(o.leiosnotifyClientNotification),
+		// Disable the Busy-state timeout. LeiosNotify is a push-based
+		// notification protocol where the server only sends when it has
+		// something to announce. Idle waits of arbitrary length are
+		// normal and should not kill the connection.
+		oleiosnotify.WithTimeout(time.Duration(0)),
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable the LeiosNotify client busy-state timeout to prevent idle disconnects. This fits the push-based protocol where long idle periods are expected.

- **Bug Fixes**
  - Set `oleiosnotify.WithTimeout(0)` in client options so connections stay open until the server has notifications.

<sup>Written for commit 0b1126e56e4a04df8e19ada05b2b3021d83ae8cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed idle connection timeout behavior in LeiosNotify client, allowing long-lived connections to persist without automatic termination during periods of inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->