### PR TITLE
perf: blockfetch metrics

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -50,6 +50,16 @@ func NewEvent(eventType EventType, eventData any) Event {
 	}
 }
 
+func (e *EventBus) HasSubscribers(eventType EventType) bool {
+	if e == nil {
+		return false
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	subs, ok := e.subscribers[eventType]
+	return ok && len(subs) > 0
+}
+
 // asyncEvent wraps an event with its type for the async queue
 type asyncEvent struct {
 	eventType EventType

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2053,6 +2053,64 @@ func BenchmarkBlockProcessingThroughput(b *testing.B) {
 	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
 }
 
+// BenchmarkBlockfetchNearTipThroughput measures the live blockfetch handler
+// when we are effectively at tip, so each received block is flushed
+// immediately instead of waiting for a multi-block commit batch.
+func BenchmarkBlockfetchNearTipThroughput(b *testing.B) {
+	seedModels, blocks := loadBlockProcessingFixture(b)
+	db, ledgerState := newBlockProcessingBenchmarkLedgerState(
+		b,
+		seedModels,
+	)
+	b.Cleanup(func() { db.Close() })
+
+	b.Logf("Loaded %d blocks for near-tip blockfetch testing", len(blocks))
+
+	b.ResetTimer()
+
+	processedBlocks := 0
+	blockIdx := 0
+	for i := 0; b.Loop(); i++ {
+		if blockIdx == len(blocks) {
+			b.StopTimer()
+			if err := db.Close(); err != nil {
+				b.Fatal(err)
+			}
+			db, ledgerState = newBlockProcessingBenchmarkLedgerState(
+				b,
+				seedModels,
+			)
+			blockIdx = 0
+			b.StartTimer()
+		}
+		block := blocks[blockIdx]
+		blockIdx++
+
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			b.Fatalf("NewBlockFromCbor failed: %v", err)
+		}
+		evt := BlockfetchEvent{
+			Block: ledgerBlock,
+			Point: ocommon.NewPoint(block.Slot, block.Hash),
+			Type:  block.Type,
+		}
+
+		if err := ledgerState.handleEventBlockfetchBlock(evt); err != nil {
+			b.Fatalf("handleEventBlockfetchBlock failed: %v", err)
+		}
+		// Flush after each block to simulate near-tip behavior where
+		// blocks are committed individually rather than batched.
+		if err := ledgerState.flushPendingBlockfetchBlocks(); err != nil {
+			b.Fatalf("flushPendingBlockfetchBlocks failed: %v", err)
+		}
+
+		processedBlocks++
+	}
+
+	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
+}
+
 // BenchmarkBlockProcessingThroughputPredecoded measures block-processing
 // throughput with block CBOR decoding removed from the timed region.
 func BenchmarkBlockProcessingThroughputPredecoded(b *testing.B) {

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -28,6 +28,11 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
+// blockfetchMetricsCdfUpdateInterval controls how often CDF metrics are
+// recomputed. Updating on every block is wasteful; every 32 blocks (or
+// on late blocks) is sufficient for dashboard accuracy.
+const blockfetchMetricsCdfUpdateInterval = 32
+
 // MaxBlockFetchRange is the maximum slot range allowed for a single block
 // fetch request. This prevents peers from requesting unbounded ranges that
 // would cause the server to iterate the entire chain. The value of 129600
@@ -236,18 +241,23 @@ func (o *Ouroboros) blockfetchClientBlock(
 
 		if o.metrics != nil {
 			o.metrics.blockDelay.Set(delaySeconds)
-			atomic.AddInt64(&o.metrics.totalBlocksFetched, 1)
+			total := atomic.AddInt64(&o.metrics.totalBlocksFetched, 1)
+			// Cumulative CDF buckets: each counter includes all
+			// blocks at or below its threshold.
 			if delaySeconds < 1.0 {
 				atomic.AddInt64(&o.metrics.blocksUnder1s, 1)
-			} else if delaySeconds < 3.0 {
+			}
+			if delaySeconds < 3.0 {
 				atomic.AddInt64(&o.metrics.blocksUnder3s, 1)
-			} else if delaySeconds < 5.0 {
+			}
+			if delaySeconds < 5.0 {
 				atomic.AddInt64(&o.metrics.blocksUnder5s, 1)
 			} else {
 				o.metrics.lateBlocks.Inc()
 			}
-			total := atomic.LoadInt64(&o.metrics.totalBlocksFetched)
-			if total > 0 {
+			if total == 1 ||
+				total%blockfetchMetricsCdfUpdateInterval == 0 ||
+				delaySeconds >= 5.0 {
 				under1 := atomic.LoadInt64(&o.metrics.blocksUnder1s)
 				under3 := atomic.LoadInt64(&o.metrics.blocksUnder3s)
 				under5 := atomic.LoadInt64(&o.metrics.blocksUnder5s)
@@ -272,22 +282,23 @@ func (o *Ouroboros) blockfetchClientBlock(
 			)
 		}
 	}
-	// Generate event
-	o.EventBus.Publish(
-		ledger.BlockfetchEventType,
-		event.NewEvent(
+	if o.EventBus != nil && o.EventBus.HasSubscribers(ledger.BlockfetchEventType) {
+		o.EventBus.Publish(
 			ledger.BlockfetchEventType,
-			ledger.BlockfetchEvent{
-				ConnectionId: ctx.ConnectionId,
-				Point: ocommon.NewPoint(
-					block.SlotNumber(),
-					block.Hash().Bytes(),
-				),
-				Type:  blockType,
-				Block: block,
-			},
-		),
-	)
+			event.NewEvent(
+				ledger.BlockfetchEventType,
+				ledger.BlockfetchEvent{
+					ConnectionId: ctx.ConnectionId,
+					Point: ocommon.NewPoint(
+						block.SlotNumber(),
+						block.Hash().Bytes(),
+					),
+					Type:  blockType,
+					Block: block,
+				},
+			),
+		)
+	}
 	return nil
 }
 
@@ -298,16 +309,17 @@ func (o *Ouroboros) blockfetchClientBatchDone(
 	o.blockFetchMutex.Lock()
 	delete(o.blockFetchStarts, ctx.ConnectionId)
 	o.blockFetchMutex.Unlock()
-	// Generate event
-	o.EventBus.Publish(
-		ledger.BlockfetchEventType,
-		event.NewEvent(
+	if o.EventBus != nil && o.EventBus.HasSubscribers(ledger.BlockfetchEventType) {
+		o.EventBus.Publish(
 			ledger.BlockfetchEventType,
-			ledger.BlockfetchEvent{
-				ConnectionId: ctx.ConnectionId,
-				BatchDone:    true,
-			},
-		),
-	)
+			event.NewEvent(
+				ledger.BlockfetchEventType,
+				ledger.BlockfetchEvent{
+					ConnectionId: ctx.ConnectionId,
+					BatchDone:    true,
+				},
+			),
+		)
+	}
 	return nil
 }

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -20,12 +20,16 @@ import (
 	"log/slog"
 	"net"
 	"testing"
+	"time"
 
 	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/event"
 )
 
@@ -183,4 +187,64 @@ func TestBlockfetchServerRequestRange_ExactlyAtLimit(t *testing.T) {
 			end,
 		)
 	}, "range exactly at limit should pass validation and reach LedgerState call")
+}
+
+func BenchmarkBlockfetchClientBlockMetrics(b *testing.B) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	eventBus := event.NewEventBus(nil, logger)
+	o := NewOuroboros(OuroborosConfig{
+		Logger:       logger,
+		EventBus:     eventBus,
+		PromRegistry: prometheus.NewRegistry(),
+	})
+
+	immDb, err := immutable.New("../database/immutable/testdata")
+	if err != nil {
+		b.Fatal(err)
+	}
+	iterator, err := immDb.BlocksFromPoint(ocommon.NewPoint(0, nil))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer iterator.Close()
+
+	const blockCount = 100
+	blocks := make([]gledger.Block, 0, blockCount)
+	for len(blocks) < blockCount {
+		block, err := iterator.Next()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if block == nil {
+			break
+		}
+		decoded, err := gledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			continue
+		}
+		blocks = append(blocks, decoded)
+	}
+	if len(blocks) == 0 {
+		b.Skip("no decoded blocks available")
+	}
+
+	connId := testConnId()
+	ctx := blockfetch.CallbackContext{ConnectionId: connId}
+	o.blockFetchMutex.Lock()
+	o.blockFetchStarts[connId] = time.Now().Add(-50 * time.Millisecond)
+	o.blockFetchMutex.Unlock()
+
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		// Reset fetch start each iteration so delaySeconds is
+		// consistent across all iterations.
+		o.blockFetchMutex.Lock()
+		o.blockFetchStarts[connId] = time.Now().Add(-50 * time.Millisecond)
+		o.blockFetchMutex.Unlock()
+
+		block := blocks[i%len(blocks)]
+		if err := o.blockfetchClientBlock(ctx, uint(block.Type()), block); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize blockfetch metrics to cut hot‑path overhead and skip event publishing when no one is listening. Adds `EventBus.HasSubscribers`, cumulative CDF buckets with batched recompute, and benchmarks for metrics and near‑tip throughput.

- **Refactors**
  - Recompute CDF every 32 blocks, on late blocks (≥5s), and on the first block via `blockfetchMetricsCdfUpdateInterval`.
  - Make CDF buckets cumulative (each threshold includes all below it).
  - Publish `BlockfetchEvent` and batch‑done events only if `EventBus` has subscribers.

- **New Features**
  - Added `EventBus.HasSubscribers(eventType)`.
  - Added `BenchmarkBlockfetchNearTipThroughput` and `BenchmarkBlockfetchClientBlockMetrics`.

<sup>Written for commit 2a2b5eb2bced7fb3ca25a501f271d8ad6c87888f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmarks for block fetch throughput in near-tip scenarios.
  * Added metrics benchmarking test for block fetch operations.

* **Performance**
  * Optimized event publishing by reducing unnecessary emissions when no subscribers are present.
  * Improved CDF metrics computation efficiency with selective update intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->