### PR TITLE
fix(docker): use native mithril sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache m
 
 FROM ghcr.io/blinklabs-io/cardano-cli:10.14.0.0-1 AS cardano-cli
 FROM ghcr.io/blinklabs-io/cardano-configs:20251128-1 AS cardano-configs
-FROM ghcr.io/blinklabs-io/mithril-client:0.12.38-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/nview:0.13.0 AS nview
 FROM ghcr.io/blinklabs-io/txtop:0.14.0 AS txtop
 
@@ -45,7 +44,6 @@ COPY --from=cardano-cli /usr/local/bin/cardano-cli /usr/local/bin/
 COPY --from=cardano-cli /usr/local/include/ /usr/local/include/
 COPY --from=cardano-cli /usr/local/lib/ /usr/local/lib/
 COPY --from=cardano-configs /config/ /opt/cardano/config/
-COPY --from=mithril-client /bin/mithril-client /usr/local/bin/
 COPY --from=nview /bin/nview /usr/local/bin/
 COPY --from=txtop /bin/txtop /usr/local/bin/
 COPY --chmod=0755 bin/entrypoint.sh /bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ docker run -p 3001:3001 \
   ghcr.io/blinklabs-io/dingo
 ```
 
-The image is based on Debian bookworm-slim and includes `cardano-cli`, `mithril-client`, `nview`, and `txtop`. The Dockerfile sets `CARDANO_DATABASE_PATH=/data/db` and `CARDANO_SOCKET_PATH=/ipc/dingo.socket`, overriding the local defaults of `.dingo` and `dingo.socket` — the volume mounts above map to these container paths.
+The image is based on Debian bookworm-slim and includes `cardano-cli`, `nview`, and `txtop`. Mithril snapshot support is built into dingo natively (`dingo mithril sync`). The Dockerfile sets `CARDANO_DATABASE_PATH=/data/db` and `CARDANO_SOCKET_PATH=/ipc/dingo.socket`, overriding the local defaults of `.dingo` and `dingo.socket` — the volume mounts above map to these container paths.
 
 | Port | Service |
 |------|---------|
@@ -213,16 +213,7 @@ See `dingo.yaml.example` for the full set of configuration options.
 
 ## Fast Bootstrapping with Mithril
 
-Instead of syncing from genesis (which can take days on mainnet), you can bootstrap Dingo using a [Mithril](https://mithril.network/) snapshot. There are two approaches depending on your use case:
-
-| Approach | Command | Use Case | Data Available |
-|----------|---------|----------|---------------|
-| `dingo sync --mithril` | `dingo sync --mithril` | Consensus nodes, relays | Current ledger state + all blocks |
-| `mithril-client` + `dingo load` | Manual download + load | Indexers, API nodes | Full historical transaction/certificate data |
-
-### Option 1: `dingo sync --mithril` (Recommended for Consensus)
-
-Dingo has a built-in Mithril client that handles download, extraction, and import automatically. This is the fastest way to get a node running.
+Instead of syncing from genesis (which can take days on mainnet), you can bootstrap Dingo using a [Mithril](https://mithril.network/) snapshot. Dingo has a built-in Mithril client that handles download, extraction, and import automatically. This is the fastest way to get a node running.
 
 ```bash
 # Bootstrap from Mithril and start syncing
@@ -264,71 +255,7 @@ Performance (preview network, ~4M blocks):
 | Load blocks into blob store | ~36 min |
 | Total | ~50 min |
 
-### Option 2: `mithril-client` + `dingo load` (For Indexers/API Nodes)
-
-If you need full historical data (transaction lookups, certificate queries, datum/script resolution), use the external `mithril-client` to download the snapshot and then load it with `dingo load`, which processes every block through the full indexing pipeline.
-
-#### Prerequisites
-
-Install the `mithril-client` CLI from [Mithril releases](https://github.com/input-output-hk/mithril/releases):
-
-```bash
-# Detect OS and architecture
-OS=$(uname -s)
-ARCH=$(uname -m)
-
-case "$OS" in
-  Linux)
-    case "$ARCH" in
-      x86_64)  MITHRIL_PLATFORM="x64-linux-musl" ;;
-      aarch64|arm64) MITHRIL_PLATFORM="arm64-linux-musl" ;;
-      *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
-    esac
-    ;;
-  Darwin)
-    case "$ARCH" in
-      x86_64)  MITHRIL_PLATFORM="x64-macos" ;;
-      arm64)   MITHRIL_PLATFORM="arm64-macos" ;;
-      *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
-    esac
-    ;;
-  *) echo "Unsupported OS: $OS (see Mithril releases for Windows)"; exit 1 ;;
-esac
-
-MITHRIL_VERSION="2506.0"
-curl -L "https://github.com/input-output-hk/mithril/releases/download/${MITHRIL_VERSION}/mithril-${MITHRIL_VERSION}-${MITHRIL_PLATFORM}.tar.gz" -o mithril.tar.gz
-tar -xzf mithril.tar.gz
-sudo mv mithril-client /usr/local/bin/
-rm mithril.tar.gz
-```
-
-For Windows, download the appropriate binary from the [Mithril releases page](https://github.com/input-output-hk/mithril/releases).
-
-#### Bootstrap Workflow
-
-```bash
-# Set network (CARDANO_NETWORK is used by dingo, not mithril-client)
-export CARDANO_NETWORK=preview
-# AGGREGATOR_ENDPOINT is used by mithril-client
-export AGGREGATOR_ENDPOINT=https://aggregator.pre-release-preview.api.mithril.network/aggregator
-
-# For mainnet:
-# export AGGREGATOR_ENDPOINT=https://aggregator.release-mainnet.api.mithril.network/aggregator
-
-# Download snapshot (uses AGGREGATOR_ENDPOINT)
-mithril-client cardano-db download --download-dir /tmp/mithril-snapshot
-
-# Load into Dingo (uses CARDANO_NETWORK for chain config)
-./dingo load /tmp/mithril-snapshot/db/immutable
-
-# Clean up snapshot
-rm -rf /tmp/mithril-snapshot
-
-# Start Dingo
-./dingo -n preview serve
-```
-
-This creates full historical data including transaction records, certificate history, witness data, scripts, datums, and governance votes -- everything needed for rich query APIs.
+For indexers and API nodes that need full historical data (transaction lookups, certificate queries, datum/script resolution), configure the storage mode to `api` and `dingo mithril sync` will automatically backfill historical metadata after loading the snapshot.
 
 ### Disk Space Requirements
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -17,20 +17,18 @@
 #
 # This script handles:
 #   - Environment variable configuration and validation
-#   - First-run detection and Mithril snapshot bootstrapping
-#   - Resumable dingo load operations
+#   - First-run detection and Mithril snapshot bootstrapping via dingo's
+#     built-in mithril sync (no external mithril-client needed)
 #   - Signal forwarding for graceful shutdown
 #   - Debug mode with verbose logging
 #
 # Environment variables:
-#   CARDANO_NETWORK               - Named network: mainnet, preprod, preview, devnet (default: preview)
-#   CARDANO_CONFIG                - Path to cardano node config.json (auto-set from network)
-#   CARDANO_DATABASE_PATH         - Database storage location (default: /data/db)
-#   DINGO_SOCKET_PATH             - Unix socket path for NtC (default: /ipc/dingo.socket)
-#   DINGO_DEBUG                   - Set to any value to enable debug logging and set -x
-#   RESTORE_SNAPSHOT              - Set to any value to bootstrap from Mithril snapshot on first run
-#   GENESIS_VERIFICATION_KEY      - Mithril genesis verification key (auto-loaded from bundled config)
-#   GENESIS_VERIFICATION_KEY_PATH - Path to genesis verification key file (default: auto from network)
+#   CARDANO_NETWORK       - Named network: mainnet, preprod, preview, devnet (default: preview)
+#   CARDANO_CONFIG        - Path to cardano node config.json (auto-set from network)
+#   CARDANO_DATABASE_PATH - Database storage location (default: /data/db)
+#   DINGO_SOCKET_PATH     - Unix socket path for NtC (default: /ipc/dingo.socket)
+#   DINGO_DEBUG           - Set to any value to enable debug logging and set -x
+#   RESTORE_SNAPSHOT      - Set to any value to bootstrap from Mithril snapshot on first run
 
 set -euo pipefail
 
@@ -128,40 +126,8 @@ validate_config_network_match() {
 validate_config_network_match
 
 # --------------------------------------------------------------------------- #
-# Mithril aggregator endpoints for known networks
-# --------------------------------------------------------------------------- #
-
-aggregator_endpoint_for_network() {
-  case "$1" in
-    mainnet) echo "https://aggregator.release-mainnet.api.mithril.network/aggregator" ;;
-    preprod) echo "https://aggregator.release-preprod.api.mithril.network/aggregator" ;;
-    preview) echo "https://aggregator.pre-release-preview.api.mithril.network/aggregator" ;;
-    *)       echo "" ;;
-  esac
-}
-
-# --------------------------------------------------------------------------- #
-# Auto-load Mithril verification keys from bundled config files
-# --------------------------------------------------------------------------- #
-
-CARDANO_CONFIG_BASE="${CARDANO_CONFIG_BASE:-/opt/cardano/config}"
-GENESIS_VERIFICATION_KEY_PATH="${GENESIS_VERIFICATION_KEY_PATH:-${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/genesis.vkey}"
-
-if [[ -z "${GENESIS_VERIFICATION_KEY:-}" ]] && [[ -f "${GENESIS_VERIFICATION_KEY_PATH}" ]]; then
-  GENESIS_VERIFICATION_KEY="$(<"${GENESIS_VERIFICATION_KEY_PATH}")"
-  log "Loaded GENESIS_VERIFICATION_KEY from ${GENESIS_VERIFICATION_KEY_PATH}"
-fi
-export GENESIS_VERIFICATION_KEY="${GENESIS_VERIFICATION_KEY:-}"
-
-# --------------------------------------------------------------------------- #
 # First-run detection and Mithril snapshot bootstrap
 # --------------------------------------------------------------------------- #
-
-# Marker file to track load completion. If this file does not exist but the
-# snapshot download directory does, we know a previous load was interrupted
-# and should be resumed.
-LOAD_COMPLETE_MARKER="${CARDANO_DATABASE_PATH}/.load_complete"
-SNAPSHOT_DIR="${CARDANO_DATABASE_PATH}/.mithril_snapshot"
 
 is_first_run() {
   # Database is considered empty if the data directory does not exist or
@@ -179,83 +145,21 @@ is_first_run() {
   return 1
 }
 
-needs_load_resume() {
-  # A load needs resuming if the snapshot directory exists but the completion
-  # marker is absent (i.e., a previous dingo load was interrupted).
-  [[ -d "${SNAPSHOT_DIR}" ]] && [[ ! -f "${LOAD_COMPLETE_MARKER}" ]]
-}
-
-download_mithril_snapshot() {
-  local network="${CARDANO_NETWORK}"
-  local endpoint
-
-  endpoint="$(aggregator_endpoint_for_network "${network}")"
-  if [[ -z "${endpoint}" ]]; then
-    die "Mithril snapshot bootstrap is not supported for network '${network}'"
-  fi
-
-  # Check that mithril-client is available
-  if ! command -v mithril-client &>/dev/null; then
-    die "mithril-client is not installed but RESTORE_SNAPSHOT is set"
-  fi
-
-  if [[ -z "${GENESIS_VERIFICATION_KEY:-}" ]]; then
-    die "GENESIS_VERIFICATION_KEY must be set when RESTORE_SNAPSHOT is enabled"
-  fi
-
-  log "Downloading Mithril snapshot for '${network}'..."
-  mkdir -p "${SNAPSHOT_DIR}"
-
-  AGGREGATOR_ENDPOINT="${endpoint}" \
-    mithril-client cardano-db download \
-      --genesis-verification-key "${GENESIS_VERIFICATION_KEY}" \
-      --download-dir "${SNAPSHOT_DIR}" \
-      latest
-
-  log "Mithril snapshot download complete"
-}
-
-load_snapshot() {
-  local immutable_path="${SNAPSHOT_DIR}/db/immutable"
-
-  if [[ ! -d "${immutable_path}" ]]; then
-    die "Snapshot immutable directory not found: ${immutable_path}"
-  fi
-
-  log "Loading snapshot into Dingo database..."
-
-  # Build dingo load arguments
-  local load_args=("load")
-  if [[ -n "${DINGO_DEBUG:-}" ]]; then
-    load_args=("--debug" "load")
-  fi
-  load_args+=("${immutable_path}")
-
-  dingo "${load_args[@]}"
-
-  # Mark load as complete
-  touch "${LOAD_COMPLETE_MARKER}"
-  log "Snapshot load complete"
-
-  # Clean up snapshot data to reclaim disk space
-  log "Cleaning up snapshot download..."
-  rm -rf "${SNAPSHOT_DIR}"
-  log "Snapshot cleanup complete"
-}
-
 bootstrap_if_needed() {
-  # Resume an interrupted load if detected
-  if needs_load_resume; then
-    warn "Detected incomplete snapshot load, resuming..."
-    load_snapshot
-    return 0
-  fi
-
   # Only bootstrap on first run when RESTORE_SNAPSHOT is set
   if [[ -n "${RESTORE_SNAPSHOT:-}" ]] && is_first_run; then
     log "First run detected with RESTORE_SNAPSHOT set, bootstrapping from Mithril..."
-    download_mithril_snapshot
-    load_snapshot
+
+    # Build dingo mithril sync arguments
+    local sync_args=()
+    if [[ -n "${DINGO_DEBUG:-}" ]]; then
+      sync_args+=("--debug")
+    fi
+    sync_args+=("mithril" "sync")
+
+    dingo "${sync_args[@]}"
+
+    log "Mithril bootstrap complete"
     return 0
   fi
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch Docker image to use dingo’s native Mithril snapshot sync (`dingo mithril sync`) and remove the external `mithril-client`. This simplifies first-run bootstrap and reduces image complexity.

- **Refactors**
  - Replace snapshot bootstrap logic in `entrypoint.sh` with `dingo mithril sync` when `RESTORE_SNAPSHOT` is set.
  - Remove aggregator endpoint and `GENESIS_VERIFICATION_KEY*` handling and all snapshot download/resume code.
  - Update README to reflect native Mithril support and simplify instructions; note that `api` storage mode will backfill historical metadata.

- **Dependencies**
  - Remove `ghcr.io/blinklabs-io/mithril-client` from the Docker build and image.
  - Image still ships `cardano-cli`, `nview`, and `txtop`.

<sup>Written for commit 356a5f5ae2f3eae1959b5c13fde1d42e88734c78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

