### PR TITLE
fix: SPO-reported metrics, blockfetch pipeline stall, and peer quotas

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -276,6 +276,8 @@ DSN Override:
 		Int("db-workers", 5, "database worker pool worker count")
 	rootCmd.PersistentFlags().
 		Int("db-queue-size", 50, "database worker pool task queue size")
+	rootCmd.PersistentFlags().
+		String("data-dir", "", "data directory for all storage plugins (overrides CARDANO_DATABASE_PATH)")
 
 	// Add plugin-specific flags
 	if err := plugin.PopulateCmdlineOptions(rootCmd.PersistentFlags()); err != nil {
@@ -322,6 +324,17 @@ DSN Override:
 				)
 			}
 			cfg.Network = network
+		}
+
+		// Override data directory if flag is provided
+		if cmd.Root().PersistentFlags().Changed("data-dir") {
+			dataDir, err := cmd.Root().PersistentFlags().GetString("data-dir")
+			if err != nil {
+				return fmt.Errorf(
+					"reading data-dir flag: %w", err,
+				)
+			}
+			cfg.DatabasePath = dataDir
 		}
 
 		// Override database worker pool config if flags are provided

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -312,7 +312,9 @@ func (c *ConnectionManager) startListener(
 			if conn.RemoteAddr() != nil {
 				peerAddr = conn.RemoteAddr().String()
 			}
-			c.addConnectionWithIPKey(oConn, true, peerAddr, ipKey)
+			c.addConnectionWithIPKey(
+				oConn, true, peerAddr, ipKey,
+			)
 			// Generate event
 			if c.config.EventBus != nil {
 				c.config.EventBus.Publish(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -232,6 +232,14 @@ func (ls *LedgerState) detectConnectionSwitch() (activeConnId *ouroboros.Connect
 			ls.dropEventCount = 0
 			ls.dropRollbackCount = 0
 			ls.headerMismatchCount = 0
+			// Clear header queue and blockfetch state from old
+			// connection so stale headers don't block the new
+			// connection's blockfetch pipeline.
+			ls.chain.ClearHeaders()
+			ls.chainsyncBlockfetchMutex.Lock()
+			ls.blockfetchRequestRangeCleanup()
+			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+			ls.chainsyncBlockfetchMutex.Unlock()
 			// Clear per-connection state (e.g., header dedup cache)
 			// so the new connection can re-deliver blocks from the
 			// intersection without them being filtered as duplicates.
@@ -643,6 +651,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	}
 	// Mark blockfetch as in progress
 	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	ls.activeBlockfetchConnId = e.ConnectionId
 	// Request next bulk range
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
 	ls.config.Logger.Debug(
@@ -833,6 +842,10 @@ func (ls *LedgerState) tryResolveFork(
 
 //nolint:unparam
 func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
+	// Drop blocks from a stale connection (e.g., after connection switch)
+	if e.ConnectionId != ls.activeBlockfetchConnId {
+		return nil
+	}
 	// Process blocks in small commit batches so they appear on the
 	// chain promptly without paying a full blob transaction cost for
 	// every single block. We still flush well before BatchDone to
@@ -866,8 +879,42 @@ func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
 	if len(ls.pendingBlockfetchEvents) == 0 {
 		return nil
 	}
-	pending := slices.Clone(ls.pendingBlockfetchEvents)
+	pending := ls.pendingBlockfetchEvents
 	ls.pendingBlockfetchEvents = ls.pendingBlockfetchEvents[:0]
+	if len(pending) == 1 {
+		pendingEvent := pending[0]
+		var addBlockErr error
+		txn := ls.db.BlobTxn(true)
+		if err := txn.Do(func(txn *database.Txn) error {
+			addBlockErr = ls.chain.AddBlock(pendingEvent.Block, txn)
+			if addBlockErr == nil {
+				return nil
+			}
+			var notFitErr chain.BlockNotFitChainTipError
+			var notMatchErr chain.BlockNotMatchHeaderError
+			if errors.As(addBlockErr, &notFitErr) ||
+				errors.As(addBlockErr, &notMatchErr) {
+				ls.config.Logger.Warn(
+					fmt.Sprintf(
+						"ignoring blockfetch block: %s",
+						addBlockErr,
+					),
+				)
+				if errors.As(addBlockErr, &notMatchErr) {
+					ls.chain.ClearHeaders()
+				}
+				return nil
+			}
+			return fmt.Errorf("add chain block: %w", addBlockErr)
+		}); err != nil {
+			return fmt.Errorf("failed processing block event: %w", err)
+		}
+		ls.Lock()
+		ls.checkSlotBattle(pendingEvent, addBlockErr)
+		ls.Unlock()
+		ls.chain.NotifyIterators()
+		return nil
+	}
 	blocks := make([]gledger.Block, 0, len(pending))
 	for _, pendingEvent := range pending {
 		blocks = append(blocks, pendingEvent.Block)
@@ -1914,6 +1961,10 @@ func (ls *LedgerState) blockfetchRequestRangeCleanup() {
 }
 
 func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
+	// Drop batch-done from a stale connection (e.g., after connection switch)
+	if e.ConnectionId != ls.activeBlockfetchConnId {
+		return nil
+	}
 	// Stop the blockfetch timeout timer and invalidate any pending callbacks
 	if ls.chainsyncBlockfetchTimeoutTimer != nil {
 		ls.chainsyncBlockfetchTimeoutTimer.Stop()
@@ -1925,11 +1976,13 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	}
 	// Continue fetching as long as there are queued headers
 	remainingHeaders := ls.chain.HeaderCount()
-	ls.config.Logger.Debug(
-		"batch done, checking for more headers",
-		"component", "ledger",
-		"remaining_headers", remainingHeaders,
-	)
+	if remainingHeaders > 0 {
+		ls.config.Logger.Debug(
+			"batch done, checking for more headers",
+			"component", "ledger",
+			"remaining_headers", remainingHeaders,
+		)
+	}
 	if remainingHeaders == 0 {
 		// No more headers to fetch, allow chainsync to collect more
 		ls.blockfetchRequestRangeCleanup()
@@ -1939,10 +1992,10 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	ls.blockfetchRequestRangeCleanup()
 	// Mark blockfetch as in progress for next batch
 	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
-	// Request next waiting bulk range
+	// Request next waiting bulk range using the active connection
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
 	err := ls.blockfetchRequestRangeStart(
-		e.ConnectionId,
+		ls.activeBlockfetchConnId,
 		headerStart,
 		headerEnd,
 	)

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -232,6 +232,16 @@ func (f *BlockForger) Start(ctx context.Context) error {
 
 	f.logger.Info("block forger started", "mode", f.modeString())
 
+	// Set initial KES period metrics so dashboards show correct values
+	// immediately rather than waiting for the first block production.
+	if f.metrics != nil && f.slotClock != nil && f.creds != nil {
+		if slotsPerKES := f.slotClock.SlotsPerKESPeriod(); slotsPerKES > 0 {
+			if currentSlot, err := f.slotClock.CurrentSlot(); err == nil {
+				f.updateKESMetrics(currentSlot / slotsPerKES)
+			}
+		}
+	}
+
 	go f.runLoop(ctx)
 	return nil
 }

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -38,7 +38,6 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		Name: "cardano_node_metrics_blockNum_int",
 		Help: "current block number",
 	})
-	// TODO: figure out how to calculate this (#390)
 	m.density = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_density_real",
 		Help: "chain density",

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -439,6 +439,8 @@ type LedgerState struct {
 	chainsyncState                     ChainsyncState
 	currentTipBlockNonce               []byte
 	epochCache                         []models.Epoch
+	epochNonceHexCache                 map[uint64]string
+	reachedTip                         bool
 	currentTip                         ochainsync.Tip
 	currentEpoch                       models.Epoch
 	dbWorkerPool                       *DatabaseWorkerPool
@@ -450,6 +452,7 @@ type LedgerState struct {
 	chainsyncBlockfetchMutex      sync.Mutex
 	chainsyncBlockfetchReadyMutex sync.Mutex
 	chainsyncBlockfetchReadyChan  chan struct{}
+	activeBlockfetchConnId        ouroboros.ConnectionId // connection used for current blockfetch pipeline
 	pendingBlockfetchEvents       []BlockfetchEvent
 	checkpointWrittenForEpoch     bool
 	closed                        atomic.Bool
@@ -535,11 +538,12 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 		cfg.DatabaseWorkerPoolConfig = DefaultDatabaseWorkerPoolConfig()
 	}
 	ls := &LedgerState{
-		config:            cfg,
-		chainsyncState:    InitChainsyncState,
-		db:                cfg.Database,
-		chain:             cfg.ChainManager.PrimaryChain(),
-		validationEnabled: cfg.ValidateHistorical,
+		config:             cfg,
+		chainsyncState:     InitChainsyncState,
+		db:                 cfg.Database,
+		chain:              cfg.ChainManager.PrimaryChain(),
+		epochNonceHexCache: make(map[uint64]string),
+		validationEnabled:  cfg.ValidateHistorical,
 	}
 	return ls, nil
 }
@@ -1435,6 +1439,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.Lock()
 	if newEpochs != nil {
 		ls.epochCache = newEpochs
+
 		if len(newEpochs) > 0 {
 			ls.currentEpoch = newCurrentEpoch
 			// Only update currentEra when we successfully
@@ -1540,6 +1545,17 @@ func (ls *LedgerState) transitionToEra(
 		}
 	}
 	return result, nil
+}
+
+// IsAtTip reports whether the node has caught up to the chain tip at least
+// once since boot. This is used to gate metrics that are only meaningful
+// when processing live blocks (e.g., block delay CDF). Unlike
+// validationEnabled (which starts true when ValidateHistorical is set),
+// reachedTip only flips when the node actually reaches the stability window.
+func (ls *LedgerState) IsAtTip() bool {
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.reachedTip
 }
 
 // calculateStabilityWindow returns the stability window based on the current era.
@@ -1943,6 +1959,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			}
 			if rolloverResult != nil {
 				ls.epochCache = rolloverResult.NewEpochCache
+
 				ls.currentEpoch = rolloverResult.NewCurrentEpoch
 				ls.currentEra = rolloverResult.NewCurrentEra
 				ls.currentPParams = rolloverResult.NewCurrentPParams
@@ -2285,6 +2302,15 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					var shouldValidateBlock bool
 					if snapshotValidationEnabled {
 						shouldValidateBlock = true
+						// When validation was already enabled from
+						// config (ValidateHistorical), we still need
+						// to detect reaching the chain tip for
+						// metrics gating (IsAtTip).
+						if !wantEnableValidation &&
+							snapshotChainsyncState == SyncingChainsyncState &&
+							next.SlotNumber() >= cutoffSlot {
+							wantEnableValidation = true
+						}
 					} else if !ls.config.TrustedReplay &&
 						snapshotChainsyncState == SyncingChainsyncState &&
 						next.SlotNumber() >= cutoffSlot {
@@ -2437,6 +2463,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				if wantEnableValidation {
 					ls.validationEnabled = true
+					ls.reachedTip = true
 				}
 				ls.updateTipMetrics()
 				// Capture tip for logging while holding the lock
@@ -2655,6 +2682,15 @@ func (ls *LedgerState) updateTipMetrics() {
 	ls.metrics.slotInEpoch.Set(
 		float64(ls.currentTip.Point.Slot - ls.currentEpoch.StartSlot),
 	)
+	// Chain density = blocks / slots (0.0 to 1.0)
+	if ls.currentTip.Point.Slot > 0 {
+		ls.metrics.density.Set(
+			float64(ls.currentTip.BlockNumber) /
+				float64(ls.currentTip.Point.Slot),
+		)
+	} else {
+		ls.metrics.density.Set(0)
+	}
 }
 
 // loadPParams reads currentEpoch, currentEra, and epochCache and writes
@@ -2813,6 +2849,7 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 		return err
 	}
 	ls.epochCache = epochs
+	clear(ls.epochNonceHexCache)
 	if len(epochs) > 0 {
 		// Set current epoch and era
 		ls.currentEpoch = epochs[len(epochs)-1]
@@ -2866,6 +2903,7 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 	}
 	// Apply result immediately during startup
 	ls.epochCache = rolloverResult.NewEpochCache
+	clear(ls.epochNonceHexCache)
 	ls.currentEpoch = rolloverResult.NewCurrentEpoch
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -68,9 +68,9 @@ func (ls *LedgerState) verifyBlockHeaderOnlyCrypto(header ledger.BlockHeader) er
 //
 // Returns an error if verification fails, nil if the block passes
 // verification or is a Byron-era block.
-func verifyBlockHeader(
+func verifyBlockHeaderHex(
 	block ledger.Block,
-	epochNonce []byte,
+	epochNonceHex string,
 	slotsPerKesPeriod uint64,
 ) error {
 	// Skip Byron-era blocks - they use PBFT consensus, not Praos,
@@ -80,14 +80,12 @@ func verifyBlockHeader(
 	}
 
 	// Epoch nonce is required for post-Byron blocks
-	if len(epochNonce) == 0 {
+	if epochNonceHex == "" {
 		return fmt.Errorf(
 			"epoch nonce not available for block at slot %d",
 			block.SlotNumber(),
 		)
 	}
-
-	eta0Hex := hex.EncodeToString(epochNonce)
 
 	// Use gouroboros VerifyBlock for VRF + KES verification.
 	// We skip body hash validation, transaction validation, and stake
@@ -106,7 +104,7 @@ func verifyBlockHeader(
 
 	isValid, _, _, _, err := ledger.VerifyBlock(
 		block,
-		eta0Hex,
+		epochNonceHex,
 		slotsPerKesPeriod,
 		config,
 	)
@@ -196,7 +194,28 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 	}
 	slotsPerKesPeriod := uint64(shelleyGenesis.SlotsPerKESPeriod) //nolint:gosec
 
-	return verifyBlockHeader(block, epoch.Nonce, slotsPerKesPeriod)
+	return verifyBlockHeaderHex(
+		block,
+		ls.epochNonceHex(epoch.EpochId, epoch.Nonce),
+		slotsPerKesPeriod,
+	)
+}
+
+func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {
+	nonceHex := hex.EncodeToString(nonce)
+	ls.RLock()
+	cachedNonce, ok := ls.epochNonceHexCache[epochId]
+	ls.RUnlock()
+	if ok && cachedNonce == nonceHex {
+		return cachedNonce
+	}
+	ls.Lock()
+	defer ls.Unlock()
+	if ls.epochNonceHexCache == nil {
+		ls.epochNonceHexCache = make(map[uint64]string)
+	}
+	ls.epochNonceHexCache[epochId] = nonceHex
+	return nonceHex
 }
 
 // epochForSlot searches the epoch cache for the epoch containing the
@@ -206,18 +225,16 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 // Returns the matching epoch or an error if no epoch covers the slot.
 func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 	ls.RLock()
-	cacheCopy := make([]models.Epoch, len(ls.epochCache))
-	copy(cacheCopy, ls.epochCache)
-	ls.RUnlock()
+	defer ls.RUnlock()
 
-	if len(cacheCopy) == 0 {
+	if len(ls.epochCache) == 0 {
 		return models.Epoch{}, errors.New("epoch cache is empty")
 	}
 
 	// Search newest-to-oldest so that if cache entries overlap
 	// (e.g., after rollback/rebuild), we use the most recent epoch data.
-	for i := len(cacheCopy) - 1; i >= 0; i-- {
-		ep := cacheCopy[i]
+	for i := len(ls.epochCache) - 1; i >= 0; i-- {
+		ep := ls.epochCache[i]
 		if ep.LengthInSlots == 0 {
 			continue
 		}
@@ -231,10 +248,10 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 	// meaningful error message.
 	var lastValidEnd uint64
 	var hasValidEpoch bool
-	for i := len(cacheCopy) - 1; i >= 0; i-- {
-		if cacheCopy[i].LengthInSlots > 0 {
-			lastValidEnd = cacheCopy[i].StartSlot +
-				uint64(cacheCopy[i].LengthInSlots)
+	for i := len(ls.epochCache) - 1; i >= 0; i-- {
+		if ls.epochCache[i].LengthInSlots > 0 {
+			lastValidEnd = ls.epochCache[i].StartSlot +
+				uint64(ls.epochCache[i].LengthInSlots)
 			hasValidEpoch = true
 			break
 		}
@@ -243,13 +260,13 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 		return models.Epoch{}, fmt.Errorf(
 			"slot %d not covered by any known epoch (cache has %d epochs, all with zero length)",
 			slot,
-			len(cacheCopy),
+			len(ls.epochCache),
 		)
 	}
 	return models.Epoch{}, fmt.Errorf(
 		"slot %d not covered by any known epoch (cache has %d epochs, last ends at slot %d)",
 		slot,
-		len(cacheCopy),
+		len(ls.epochCache),
 		lastValidEnd,
 	)
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"crypto/ed25519"
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"math/big"
@@ -27,6 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/kes"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -35,6 +37,20 @@ import (
 	"github.com/stretchr/testify/require"
 	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
+
+// verifyBlockHeader is a test helper that wraps verifyBlockHeaderHex,
+// accepting raw epoch nonce bytes for convenience.
+func verifyBlockHeader(
+	block gledger.Block,
+	epochNonce []byte,
+	slotsPerKesPeriod uint64,
+) error {
+	return verifyBlockHeaderHex(
+		block,
+		hex.EncodeToString(epochNonce),
+		slotsPerKesPeriod,
+	)
+}
 
 // tamperOption controls which part of a test block to corrupt.
 type tamperOption int

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -225,21 +225,20 @@ func (o *Ouroboros) blockfetchClientBlock(
 	o.blockFetchMutex.Unlock()
 	if exists {
 		fetchDuration := time.Since(startTime)
-		fetchSeconds := fetchDuration.Seconds()
 
-		// Calculate block delay as wallclock time minus block slot time (cardano-node compatible)
-		var delaySeconds float64
-		if o.LedgerState != nil {
+		// Only publish block delay metrics after reaching tip once.
+		// During catch-up all blocks are naturally "late" relative to
+		// wall-clock time, which permanently poisons the CDF.
+		atTip := o.LedgerState != nil && o.LedgerState.IsAtTip()
+		if atTip && o.metrics != nil {
+			// Calculate block delay as wallclock time minus block slot time (cardano-node compatible)
+			var delaySeconds float64
 			if blockSlotTime, err := o.LedgerState.SlotToTime(block.SlotNumber()); err == nil {
 				delaySeconds = time.Since(blockSlotTime).Seconds()
 			} else {
-				delaySeconds = fetchSeconds
+				delaySeconds = fetchDuration.Seconds()
 			}
-		} else {
-			delaySeconds = fetchSeconds
-		}
 
-		if o.metrics != nil {
 			o.metrics.blockDelay.Set(delaySeconds)
 			total := atomic.AddInt64(&o.metrics.totalBlocksFetched, 1)
 			// Cumulative CDF buckets: each counter includes all

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -45,9 +45,9 @@ const (
 	// Default per-source quotas for active peers.
 	// Each quota is a ceiling, not a reservation. The global
 	// TargetNumberOfActivePeers (default 20) still applies.
-	defaultActivePeersTopologyQuota = 10
-	defaultActivePeersGossipQuota   = 10
-	defaultActivePeersLedgerQuota   = 10
+	defaultActivePeersTopologyQuota = 20
+	defaultActivePeersGossipQuota   = 20
+	defaultActivePeersLedgerQuota   = 20
 
 	// Default churn configuration
 	defaultGossipChurnInterval     = 5 * time.Minute

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -1342,9 +1342,9 @@ func TestPeerGovernor_PeerTargets_DefaultValues(t *testing.T) {
 	assert.Equal(t, 20, pg.config.TargetNumberOfActivePeers)
 	assert.Equal(t, 60, pg.config.TargetNumberOfRootPeers)
 	// Per-source quotas (ceilings, not reservations)
-	assert.Equal(t, 10, pg.config.ActivePeersTopologyQuota)
-	assert.Equal(t, 10, pg.config.ActivePeersGossipQuota)
-	assert.Equal(t, 10, pg.config.ActivePeersLedgerQuota)
+	assert.Equal(t, 20, pg.config.ActivePeersTopologyQuota)
+	assert.Equal(t, 20, pg.config.ActivePeersGossipQuota)
+	assert.Equal(t, 20, pg.config.ActivePeersLedgerQuota)
 }
 
 // TestPeerGovernor_QuotaSumExceedsTarget verifies that the global


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inaccurate SPO metrics and unblocks the `blockfetch` pipeline after connection switches. Also raises per-source peer quotas and adds a `--data-dir` flag.

- **Bug Fixes**
  - On connection switch, clear header queue and blockfetch state, track the active blockfetch connection, and drop stale block/batch events to prevent stalls (`ledger/chainsync`).
  - Handle single-block batches; ignore “not fit/match” blocks and reset headers to keep fetching (`ledger/chainsync`).
  - Publish block delay metrics only after the node has reached tip once to avoid a poisoned CDF during catch-up (`ouroboros`).
  - Compute chain density from the current tip (`ledger`).
  - Increase per-source active peer quotas to 20 for topology/gossip/ledger; tests updated (`peergov`).

- **New Features**
  - Add `--data-dir` to `cmd/dingo` to override `CARDANO_DATABASE_PATH`.
  - Initialize KES period metrics when the forger starts (`ledger`).
  - Cache epoch nonce hex for header verification to reduce overhead (`ledger`).

<sup>Written for commit e63c69bcb875fe7f99a862e70587d9a1edf666a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a global CLI flag to specify the data storage directory.

* **Improvements**
  - Increased per-source active peer quotas from 10 to 20.
  - Clear and isolate per-connection sync state during peer switches; ignore stale blocks from inactive connections.
  - Only report block delay metrics when node is at tip; improved KES-period metrics initialization timing.
  - Use cached epoch nonces to streamline header verification and reduce contention.

* **Tests**
  - Updated tests to reflect quota and header-verification changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->