### PR TITLE
build(deps): gouroboros 0.160.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,12 +16,13 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.160.1
+	github.com/blinklabs-io/gouroboros v0.160.2
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.26
 	github.com/blockfrost/blockfrost-go v0.3.0
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/dgraph-io/badger/v4 v4.9.1
+	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/getsops/sops/v3 v3.12.1
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-sql-driver/mysql v1.9.3
@@ -128,7 +129,6 @@ require (
 	github.com/ethereum/go-ethereum v1.17.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/getsops/gopgagent v0.0.0-20241224165529-7044f28e491e // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/go-faster/city v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.160.1 h1:h/gfs4iKkk3Irfrk1g6ndsPdra9uc9kE5hVPrEz1nXo=
-github.com/blinklabs-io/gouroboros v0.160.1/go.mod h1:ZhQREyLgf8zv63oz2qNj9rEhForAJj/ySTMiXdeH3l8=
+github.com/blinklabs-io/gouroboros v0.160.2 h1:BS5dAhqrVNQyJG+d169Hz+JdT/Ce99ezafOJcIxB7Kk=
+github.com/blinklabs-io/gouroboros v0.160.2/go.mod h1:ZhQREyLgf8zv63oz2qNj9rEhForAJj/ySTMiXdeH3l8=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.26 h1:LrEMTtgpiUMjTXwHgBt/PAZeW6l/6UQUbeYK/tbiBkM=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `github.com/blinklabs-io/gouroboros` to v0.160.2 and make `github.com/fxamacker/cbor/v2` v2.9.0 a direct dependency for consistency. Syncs `go.mod` and `go.sum`.

<sup>Written for commit bfea94d226902ac768d5e099a1eacdfa3f83722b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

