### PR TITLE
fix(peergov): hot peer management

### DIFF
--- a/config.go
+++ b/config.go
@@ -107,6 +107,12 @@ type Config struct {
 	activePeersTopologyQuota int
 	activePeersGossipQuota   int
 	activePeersLedgerQuota   int
+	// Peer governor tuning (0 = use default)
+	minHotPeers         int
+	reconcileInterval   time.Duration
+	inactivityTimeout   time.Duration
+	maxConnectionsPerIP int
+	maxInboundConns     int
 	// Block production configuration (SPO mode)
 	// Field names match cardano-node environment variable naming convention
 	blockProducer                 bool
@@ -449,7 +455,7 @@ func WithPeerTargets(
 
 // WithActivePeersQuotas specifies the per-source quotas for active peers.
 // Use 0 to use the default quota, or a negative value to disable enforcement.
-// Default quotas: topology=3, gossip=12, ledger=5
+// Default quotas: topology=20, gossip=20, ledger=20
 func WithActivePeersQuotas(
 	topologyQuota, gossipQuota, ledgerQuota int,
 ) ConfigOptionFunc {
@@ -457,6 +463,56 @@ func WithActivePeersQuotas(
 		c.activePeersTopologyQuota = topologyQuota
 		c.activePeersGossipQuota = gossipQuota
 		c.activePeersLedgerQuota = ledgerQuota
+	}
+}
+
+// WithMinHotPeers specifies the minimum number of hot peers before aggressive
+// promotion is triggered. Non-positive values are ignored. Default: 10.
+func WithMinHotPeers(n int) ConfigOptionFunc {
+	return func(c *Config) {
+		if n > 0 {
+			c.minHotPeers = n
+		}
+	}
+}
+
+// WithReconcileInterval specifies how often the peer governor runs its
+// reconciliation loop. Non-positive values are ignored. Default: 5m.
+func WithReconcileInterval(d time.Duration) ConfigOptionFunc {
+	return func(c *Config) {
+		if d > 0 {
+			c.reconcileInterval = d
+		}
+	}
+}
+
+// WithInactivityTimeout specifies how long a hot peer can be inactive
+// before being demoted to warm. Non-positive values are ignored. Default: 10m.
+func WithInactivityTimeout(d time.Duration) ConfigOptionFunc {
+	return func(c *Config) {
+		if d > 0 {
+			c.inactivityTimeout = d
+		}
+	}
+}
+
+// WithMaxConnectionsPerIP specifies the maximum number of concurrent
+// inbound connections from a single IP. Non-positive values are ignored. Default: 5.
+func WithMaxConnectionsPerIP(n int) ConfigOptionFunc {
+	return func(c *Config) {
+		if n > 0 {
+			c.maxConnectionsPerIP = n
+		}
+	}
+}
+
+// WithMaxInboundConns specifies the maximum number of inbound connections.
+// Non-positive values are ignored. Default: 100.
+func WithMaxInboundConns(n int) ConfigOptionFunc {
+	return func(c *Config) {
+		if n > 0 {
+			c.maxInboundConns = n
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/blinklabs-io/dingo/topology"
@@ -218,6 +219,13 @@ type Config struct {
 	ActivePeersTopologyQuota int `yaml:"activePeersTopologyQuota" envconfig:"DINGO_ACTIVE_PEERS_TOPOLOGY_QUOTA"`
 	ActivePeersGossipQuota   int `yaml:"activePeersGossipQuota"   envconfig:"DINGO_ACTIVE_PEERS_GOSSIP_QUOTA"`
 	ActivePeersLedgerQuota   int `yaml:"activePeersLedgerQuota"   envconfig:"DINGO_ACTIVE_PEERS_LEDGER_QUOTA"`
+
+	// Peer governor tuning (0 = use default)
+	MinHotPeers         int           `yaml:"minHotPeers"         envconfig:"DINGO_MIN_HOT_PEERS"`
+	ReconcileInterval   time.Duration `yaml:"reconcileInterval"   envconfig:"DINGO_RECONCILE_INTERVAL"`
+	InactivityTimeout   time.Duration `yaml:"inactivityTimeout"   envconfig:"DINGO_INACTIVITY_TIMEOUT"`
+	MaxConnectionsPerIP int           `yaml:"maxConnectionsPerIP" envconfig:"DINGO_MAX_CONNECTIONS_PER_IP"`
+	MaxInboundConns     int           `yaml:"maxInboundConns"     envconfig:"DINGO_MAX_INBOUND_CONNS"`
 
 	// Cache configuration for the tiered CBOR cache system
 	Cache CacheConfig `yaml:"cache"`

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -224,6 +224,11 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				cfg.ActivePeersGossipQuota,
 				cfg.ActivePeersLedgerQuota,
 			),
+			dingo.WithMinHotPeers(cfg.MinHotPeers),
+			dingo.WithReconcileInterval(cfg.ReconcileInterval),
+			dingo.WithInactivityTimeout(cfg.InactivityTimeout),
+			dingo.WithMaxConnectionsPerIP(cfg.MaxConnectionsPerIP),
+			dingo.WithMaxInboundConns(cfg.MaxInboundConns),
 			dingo.WithChainsyncMaxClients(
 				cfg.Chainsync.MaxClients,
 			),

--- a/node.go
+++ b/node.go
@@ -382,12 +382,14 @@ func (n *Node) Run(ctx context.Context) error {
 	tmpListeners := n.ouroboros.ConfigureListeners(n.config.listeners)
 	n.connManager = connmanager.NewConnectionManager(
 		connmanager.ConnectionManagerConfig{
-			Logger:             n.config.logger,
-			EventBus:           n.eventBus,
-			Listeners:          tmpListeners,
-			OutboundSourcePort: n.config.outboundSourcePort,
-			OutboundConnOpts:   n.ouroboros.OutboundConnOpts(),
-			PromRegistry:       n.config.promRegistry,
+			Logger:              n.config.logger,
+			EventBus:            n.eventBus,
+			Listeners:           tmpListeners,
+			OutboundSourcePort:  n.config.outboundSourcePort,
+			OutboundConnOpts:    n.ouroboros.OutboundConnOpts(),
+			PromRegistry:        n.config.promRegistry,
+			MaxConnectionsPerIP: n.config.maxConnectionsPerIP,
+			MaxInboundConns:     n.config.maxInboundConns,
 		},
 	)
 	n.eventBus.SubscribeFunc(
@@ -653,6 +655,9 @@ func (n *Node) Run(ctx context.Context) error {
 			ActivePeersTopologyQuota:       n.config.activePeersTopologyQuota,
 			ActivePeersGossipQuota:         n.config.activePeersGossipQuota,
 			ActivePeersLedgerQuota:         n.config.activePeersLedgerQuota,
+			MinHotPeers:                    n.config.minHotPeers,
+			ReconcileInterval:              n.config.reconcileInterval,
+			InactivityTimeout:              n.config.inactivityTimeout,
 			SyncProgressProvider:           n.ledgerState,
 		},
 	)

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -28,23 +28,24 @@ import (
 )
 
 const (
-	defaultReconcileInterval            = 30 * time.Minute
+	defaultReconcileInterval            = 5 * time.Minute
 	defaultMaxReconnectFailureThreshold = 3
-	defaultMinHotPeers                  = 3
+	defaultMinHotPeers                  = 10
 	defaultInactivityTimeout            = 10 * time.Minute
 	defaultTestCooldown                 = 5 * time.Minute
 	defaultDenyDuration                 = 30 * time.Minute
 	defaultLedgerPeerRefreshInterval    = 1 * time.Hour
 
-	// Default peer targets (applied when config value is 0)
+	// Default peer targets match cardano-node config.json defaults.
 	defaultTargetNumberOfKnownPeers       = 150
 	defaultTargetNumberOfEstablishedPeers = 50
 	defaultTargetNumberOfActivePeers      = 20
 	defaultTargetNumberOfRootPeers        = 60
 
 	// Default per-source quotas for active peers.
-	// Each quota is a ceiling, not a reservation. The global
-	// TargetNumberOfActivePeers (default 20) still applies.
+	// Each quota is a ceiling, not a reservation. Set equal to
+	// TargetNumberOfActivePeers so no single source is artificially
+	// constrained — the global target still caps the total.
 	defaultActivePeersTopologyQuota = 20
 	defaultActivePeersGossipQuota   = 20
 	defaultActivePeersLedgerQuota   = 20
@@ -174,16 +175,16 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
-	if cfg.ReconcileInterval == 0 {
+	if cfg.ReconcileInterval <= 0 {
 		cfg.ReconcileInterval = defaultReconcileInterval
 	}
 	if cfg.MaxReconnectFailureThreshold <= 0 {
 		cfg.MaxReconnectFailureThreshold = defaultMaxReconnectFailureThreshold
 	}
-	if cfg.MinHotPeers == 0 {
+	if cfg.MinHotPeers <= 0 {
 		cfg.MinHotPeers = defaultMinHotPeers
 	}
-	if cfg.InactivityTimeout == 0 {
+	if cfg.InactivityTimeout <= 0 {
 		cfg.InactivityTimeout = defaultInactivityTimeout
 	}
 	if cfg.TestCooldown == 0 {
@@ -215,6 +216,13 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 		cfg.TargetNumberOfRootPeers = defaultTargetNumberOfRootPeers
 	} else if cfg.TargetNumberOfRootPeers < 0 {
 		cfg.TargetNumberOfRootPeers = 0
+	}
+	// Clamp MinHotPeers so it never exceeds the active target.
+	// Otherwise bootstrap recovery would keep re-triggering on nodes
+	// configured with a small active-peer target.
+	if cfg.TargetNumberOfActivePeers > 0 &&
+		cfg.MinHotPeers > cfg.TargetNumberOfActivePeers {
+		cfg.MinHotPeers = cfg.TargetNumberOfActivePeers
 	}
 	// Per-source quotas: 0 means use default
 	if cfg.ActivePeersTopologyQuota == 0 {

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -320,11 +320,15 @@ func TestPeerGovernor_Reconcile_MinimumHotPeers(t *testing.T) {
 	eventBus := newMockEventBus()
 	reg := prometheus.NewRegistry()
 
+	// MinHotPeers=2 with unlimited active target (-1 → 0 internally).
+	// The promotion target should fall back to MinHotPeers so only 2
+	// of the 3 warm peers are promoted to hot.
 	pg := NewPeerGovernor(PeerGovernorConfig{
-		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:     eventBus,
-		PromRegistry: reg,
-		MinHotPeers:  2,
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                  eventBus,
+		PromRegistry:              reg,
+		MinHotPeers:               2,
+		TargetNumberOfActivePeers: -1, // unlimited
 	})
 
 	// Add 3 warm peers with connections
@@ -352,7 +356,7 @@ func TestPeerGovernor_Reconcile_MinimumHotPeers(t *testing.T) {
 		t,
 		2,
 		hotCount,
-	) // Only MinHotPeers warm peers should be promoted to hot (score-based selection)
+	) // Only MinHotPeers warm peers should be promoted when target is unlimited
 
 	// Event publishing is tested indirectly
 }
@@ -1336,7 +1340,7 @@ func TestPeerGovernor_PeerTargets_DefaultValues(t *testing.T) {
 		// TargetNumberOf* not set (0)
 	})
 
-	// Should use default values
+	// Should use default values (match cardano-node config.json)
 	assert.Equal(t, 150, pg.config.TargetNumberOfKnownPeers)
 	assert.Equal(t, 50, pg.config.TargetNumberOfEstablishedPeers)
 	assert.Equal(t, 20, pg.config.TargetNumberOfActivePeers)

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -73,7 +73,7 @@ func (p *PeerGovernor) reconcile() {
 			// Do not promote warm peers here; collect them and perform
 			// score-based promotion later. This avoids unconditional
 			// promotion and lets the scoring policy decide which warm
-			// peers to promote when ensuring MinHotPeers.
+			// peers to promote when ensuring the promotion target.
 			// Note: warm peers remain warm unless promoted in scoring block below.
 		case PeerStateCold:
 			// Promote to warm if connection exists
@@ -140,9 +140,17 @@ func (p *PeerGovernor) reconcile() {
 			hotCount++
 		}
 	}
+	// Trigger promotion when hot peers drop below the low-water mark
+	// (MinHotPeers), then refill up to TargetNumberOfActivePeers.
+	// When TargetNumberOfActivePeers is 0 (unlimited), fall back to
+	// MinHotPeers as the refill goal.
 	if hotCount < p.config.MinHotPeers {
+		refillTarget := p.config.TargetNumberOfActivePeers
+		if refillTarget <= 0 {
+			refillTarget = p.config.MinHotPeers
+		}
 		// Score-based selection: collect warm peers with connections, compute scores,
-		// sort by valency priority then score, and promote top N required to reach MinHotPeers.
+		// sort by valency priority then score, and promote top N to reach the refill target.
 		candidates := []*Peer{}
 		for _, peer := range p.peers {
 			if peer != nil && peer.State == PeerStateWarm &&
@@ -159,22 +167,23 @@ func (p *PeerGovernor) reconcile() {
 		// Get group counts for valency-aware sorting
 		groups := p.countPeersByGroup()
 
-		// Sort candidates: 1) under-valency groups first, 2) by score descending
-		slices.SortFunc(candidates, func(a, b *Peer) int {
+		// Comparator: under-valency groups first, then by score descending
+		rankCandidates := func(a, b *Peer) int {
 			aUnder := p.isGroupUnderHotValency(a, groups)
 			bUnder := p.isGroupUnderHotValency(b, groups)
-			// Under-valency peers come first
 			if aUnder && !bUnder {
 				return -1
 			}
 			if !aUnder && bUnder {
 				return 1
 			}
-			// Same valency status: sort by score descending
 			return cmp.Compare(b.PerformanceScore, a.PerformanceScore)
-		})
+		}
 
-		needed := p.config.MinHotPeers - hotCount
+		// Initial sort
+		slices.SortFunc(candidates, rankCandidates)
+
+		needed := refillTarget - hotCount
 		promoted := 0
 		for i := 0; i < len(candidates) && promoted < needed; i++ {
 			peer := candidates[i]
@@ -205,8 +214,13 @@ func (p *PeerGovernor) reconcile() {
 				gc.Hot++
 				gc.Warm--
 			}
+			// Re-sort remaining candidates so valency changes
+			// from this promotion are reflected in the next pick.
+			if i+1 < len(candidates) {
+				slices.SortFunc(candidates[i+1:], rankCandidates)
+			}
 			p.config.Logger.Info(
-				"promoted peer to hot to meet minimum (score-based)",
+				"promoted peer to hot (score-based)",
 				"address", peer.Address,
 				"score", peer.PerformanceScore,
 				"group", peer.GroupID,
@@ -215,7 +229,7 @@ func (p *PeerGovernor) reconcile() {
 				PeerPromotedEventType,
 				PeerStateChangeEvent{
 					Address: peer.Address,
-					Reason:  "minimum hot peers (score)",
+					Reason:  "target active peers (score)",
 				},
 			})
 			hotCount++
@@ -266,7 +280,7 @@ func (p *PeerGovernor) reconcile() {
 	if p.config.PeerRequestFunc != nil {
 		for _, peer := range p.peers {
 			if peer != nil && peer.State == PeerStateHot &&
-				peer.Connection != nil && peer.Source != PeerSourceTopologyLocalRoot {
+				peer.Connection != nil {
 				eligiblePeersCopy = append(eligiblePeersCopy, *peer)
 			}
 		}


### PR DESCRIPTION
Closes #1635 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hot peer promotion in `peergov` so when hot peers fall below the low-water mark it refills to the active target (or `MinHotPeers` if unlimited), with safer tuning knobs and inbound connection limits. Defaults now match `cardano-node` and reconciliation runs more often.

- **Bug Fixes**
  - When hot peers dip below `MinHotPeers`, promote warm peers (valency-aware, score-based with dynamic re-sorting) to reach `TargetNumberOfActivePeers` or fallback to `MinHotPeers`; clamp `MinHotPeers` to not exceed the active target.
  - Include all hot peers (including topology roots) as candidates for peer requests.

- **New Features**
  - Added config/env and builder options: `MinHotPeers`/`WithMinHotPeers`, `ReconcileInterval`/`WithReconcileInterval`, `InactivityTimeout`/`WithInactivityTimeout`, `MaxConnectionsPerIP`/`WithMaxConnectionsPerIP`, `MaxInboundConns`/`WithMaxInboundConns` (wired through `internal/node` and `connmanager`).
  - Updated defaults: reconcile interval 5m, `MinHotPeers` 10, per-source active peer quotas 20, and peer targets match `cardano-node` (known 150, established 50, active 20, root 60).

<sup>Written for commit f089e0b37d409505bfb3590b2548e8d814150abf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configurable options for peer governance and connection limits: min hot peers, reconcile interval, inactivity timeout, max connections per IP, and max inbound connections.

* **Configuration Updates**
  * Increased default active-peer quotas to 20 across categories; reconcile cadence shortened (30 → 5 minutes) and minimum hot peers raised (3 → 10).

* **Behavior Changes**
  * Promotion logic now targets a configurable active-peers goal with fallback to a minimum; per-source quotas aligned to avoid artificial constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->