### PR TITLE
fix(ledger): epoch transition loop draining

### DIFF
--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -185,12 +185,11 @@ func (m *Manager) Stop() error {
 	return nil
 }
 
-// epochTransitionLoop reads epoch transition events from the channel,
-// draining any queued stale events so only the latest is processed.
-// During rapid sync (e.g., devnet with fast epochs), many epoch
-// transitions can queue up while a snapshot is being captured. This
-// loop skips intermediate epochs to avoid wasting work on snapshots
-// that will be immediately superseded.
+// epochTransitionLoop reads epoch transition events from the channel
+// and processes each one. Every epoch transition must be handled so
+// that stake snapshots exist for the full Mark/Set/Go rotation window.
+// Skipping intermediate events would leave gaps that break leader
+// election (pool_stake=0 for the missing "Go" epoch).
 func (m *Manager) epochTransitionLoop(
 	ctx context.Context,
 	evtCh <-chan event.Event,
@@ -206,45 +205,14 @@ func (m *Manager) epochTransitionLoop(
 				return
 			}
 		}
-		// Drain any queued events, keeping only the latest.
-		latest := evt
-		skipped := false
-	drain:
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case newer, chOk := <-evtCh:
-				if !chOk {
-					return
-				}
-				latest = newer
-				skipped = true
-			default:
-				break drain
-			}
-		}
 
-		epochEvent, ok := latest.Data.(event.EpochTransitionEvent)
+		epochEvent, ok := evt.Data.(event.EpochTransitionEvent)
 		if !ok {
 			m.logger.Error(
 				"invalid event data for epoch transition",
 				"component", "snapshot",
 			)
 			continue
-		}
-
-		if skipped {
-			// We skipped intermediate events
-			skippedEvt, ok := evt.Data.(event.EpochTransitionEvent)
-			if ok {
-				m.logger.Info(
-					"fast-forwarded past intermediate epoch transitions",
-					"component", "snapshot",
-					"from_epoch", skippedEvt.NewEpoch,
-					"to_epoch", epochEvent.NewEpoch,
-				)
-			}
 		}
 
 		if err := m.handleEpochTransition(ctx, epochEvent); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Process every epoch transition instead of draining queued events to ensure snapshots cover the full Mark/Set/Go window and prevent leader election gaps.

- **Bug Fixes**
  - Removed draining logic that skipped intermediate transitions during fast epochs.
  - Use the received event directly when calling `handleEpochTransition`, avoiding `pool_stake=0` in a missing “Go” epoch.

<sup>Written for commit f38f9da0ef3dd09cf45544e31a674f6e0dfd2517. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced epoch transition event processing to handle all transitions without skipping intermediate events, ensuring complete and reliable snapshots throughout the Mark/Set/Go rotation cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->