### PR TITLE
fix: stabilize bidirectional peer reuse

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/blinklabs-io/dingo/event"
@@ -499,13 +500,19 @@ func (c *ConnectionManager) RemoveConnection(connId ouroboros.ConnectionId) {
 	c.updateConnectionMetrics()
 }
 
-// HasInboundFromHost returns true if there is already an inbound connection
-// from the same host (IP) as peerAddr, regardless of port or DiffusionMode.
-// When OutboundSourcePort is set (listen port reuse), an outbound connection
-// to the same host would create an identical TCP 4-tuple and fail with
-// EADDRINUSE. The existing inbound connection serves as the bidirectional
-// link between the two nodes.
-func (c *ConnectionManager) HasInboundFromHost(
+// HasInboundPeerAddress returns true if there is already an inbound connection
+// from the same remote peer address as peerAddr.
+//
+// This intentionally matches on the full remote address, not just the host.
+// TCP collisions require the same 4-tuple, so a connection from the same host
+// but a different source port must not suppress a valid outbound dial.
+//
+// When OutboundSourcePort is set (listen-port reuse), an outbound connection
+// to the same remote peer address may collide with an existing inbound
+// connection if the peer also connected from its listening port. In that case
+// the existing inbound connection should be treated as the reusable duplex
+// connection, matching ouroboros-network's exact-address connection tracking.
+func (c *ConnectionManager) HasInboundPeerAddress(
 	peerAddr string,
 ) bool {
 	// Only relevant when listen port reuse is enabled. With ephemeral
@@ -514,35 +521,32 @@ func (c *ConnectionManager) HasInboundFromHost(
 	if c.config.OutboundSourcePort == 0 {
 		return false
 	}
-	targetHost, _, err := net.SplitHostPort(peerAddr)
-	if err != nil {
-		// If peerAddr has no port, treat the whole string as the host
-		targetHost = peerAddr
+	targetAddr := normalizePeerAddr(peerAddr)
+	if targetAddr == "" {
+		return false
 	}
-	targetIP := net.ParseIP(targetHost)
 	c.connectionsMutex.Lock()
 	defer c.connectionsMutex.Unlock()
 	for _, info := range c.connections {
-		if !info.isInbound || info.conn == nil {
+		if !info.isInbound || info.isNtC || info.conn == nil {
 			continue
 		}
-		connHost, _, err := net.SplitHostPort(info.peerAddr)
-		if err != nil {
-			connHost = info.peerAddr
-		}
-		// Use canonical IP comparison when both are valid IPs to handle
-		// equivalent IPv6 representations (e.g. ::ffff:192.0.2.1 vs
-		// ::ffff:c000:201). Fall back to string comparison for hostnames.
-		connIP := net.ParseIP(connHost)
-		if connIP != nil && targetIP != nil {
-			if connIP.Equal(targetIP) {
-				return true
-			}
-		} else if connHost == targetHost {
+		if normalizePeerAddr(info.peerAddr) == targetAddr {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizePeerAddr(peerAddr string) string {
+	host, port, err := net.SplitHostPort(peerAddr)
+	if err != nil {
+		return strings.ToLower(peerAddr)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return net.JoinHostPort(ip.String(), port)
+	}
+	return net.JoinHostPort(strings.ToLower(host), port)
 }
 
 func (c *ConnectionManager) GetConnectionById(

--- a/connmanager/peeraddr_test.go
+++ b/connmanager/peeraddr_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"net"
+	"testing"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizePeerAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ipv4 preserved",
+			input:    "1.2.3.4:3001",
+			expected: "1.2.3.4:3001",
+		},
+		{
+			name:     "ipv6 canonicalized",
+			input:    "[2001:0db8::1]:3001",
+			expected: "[2001:db8::1]:3001",
+		},
+		{
+			name:     "hostname lowercased",
+			input:    "Relay.Example.Com:3001",
+			expected: "relay.example.com:3001",
+		},
+		{
+			name:     "invalid hostport lowercased",
+			input:    "Relay.Example.Com",
+			expected: "relay.example.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, normalizePeerAddr(test.input))
+		})
+	}
+}
+
+func TestHasInboundPeerAddress(t *testing.T) {
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		OutboundSourcePort: 3001,
+	})
+	cm.connections[ouroboros.ConnectionId{}] = &connectionInfo{
+		conn:      &ouroboros.Connection{},
+		isInbound: true,
+		peerAddr:  "1.2.3.4:3001",
+	}
+	cm.connections[ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3002},
+	}] = &connectionInfo{
+		conn:      &ouroboros.Connection{},
+		isInbound: true,
+		peerAddr:  "1.2.3.4:3002",
+	}
+	cm.connections[ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3999},
+	}] = &connectionInfo{
+		conn:      &ouroboros.Connection{},
+		isInbound: false,
+		peerAddr:  "1.2.3.4:3001",
+	}
+	cm.connections[ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3003},
+	}] = &connectionInfo{
+		conn:      nil,
+		isInbound: true,
+		peerAddr:  "1.2.3.4:3003",
+	}
+
+	assert.True(t, cm.HasInboundPeerAddress("1.2.3.4:3001"))
+	assert.True(t, cm.HasInboundPeerAddress("1.2.3.4:3002"))
+	assert.False(t, cm.HasInboundPeerAddress("1.2.3.4:3999"))
+	assert.False(t, cm.HasInboundPeerAddress("1.2.3.4:3003"))
+}
+
+func TestHasInboundPeerAddressDisabledWithoutPortReuse(t *testing.T) {
+	cm := NewConnectionManager(ConnectionManagerConfig{})
+	cm.connections[ouroboros.ConnectionId{}] = &connectionInfo{
+		conn:      &ouroboros.Connection{},
+		isInbound: true,
+		peerAddr:  "1.2.3.4:3001",
+	}
+
+	assert.False(t, cm.HasInboundPeerAddress("1.2.3.4:3001"))
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -522,10 +522,31 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 			}
 		}
 	}
-	// Do NOT start TxSubmission client on inbound connections.
-	// The relay's connection manager may not have started its
-	// responder-direction TxSubmission server yet when we send
-	// Init(), causing a muxer protocol error and connection reset.
-	// TxSubmission client will be started on our own outbound
-	// connection instead.
+	// Start TxSubmission client on full-duplex inbound connections.
+	// This registers a mempool consumer and sends Init() so we can
+	// offer our transactions to the peer. Without this, peers that
+	// connect TO us (and whose inbound suppresses our outbound dial)
+	// would never receive our mempool transactions.
+	//
+	// The remote peer's TxSubmission server is guaranteed to be ready
+	// because the Ouroboros handshake completed bilaterally before
+	// either side starts mini-protocol messages — the remote's
+	// NewConnection() has finished and all protocol handlers are
+	// registered by the time our InboundConnectionEvent fires.
+	if o.Mempool != nil {
+		if err := o.txsubmissionClientStart(connId); err != nil {
+			o.config.Logger.Warn(
+				"txsubmission client failed on inbound connection",
+				"error", err,
+				"connection_id", connId.String(),
+			)
+			// Non-fatal: the connection is still useful for
+			// chainsync, keep-alive, and peer-sharing.
+		} else {
+			o.config.Logger.Debug(
+				"started txsubmission client on inbound connection",
+				"connection_id", connId.String(),
+			)
+		}
+	}
 }

--- a/peergov/bootstrap.go
+++ b/peergov/bootstrap.go
@@ -58,7 +58,8 @@ func (p *PeerGovernor) shouldExitBootstrap() (bool, string) {
 		ledgerPeerCount := 0
 		for _, peer := range p.peers {
 			if peer != nil && peer.Source == PeerSourceP2PLedger &&
-				(peer.State == PeerStateWarm || peer.State == PeerStateHot) {
+				peer.hasClientConnection() &&
+				(peer.State == PeerStateHot || peer.State == PeerStateWarm) {
 				ledgerPeerCount++
 			}
 		}
@@ -225,7 +226,8 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 	// Count hot peers
 	hotCount := 0
 	for _, peer := range p.peers {
-		if peer != nil && peer.State == PeerStateHot {
+		if peer != nil && peer.State == PeerStateHot &&
+			peer.hasClientConnection() {
 			hotCount++
 		}
 	}
@@ -246,7 +248,7 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 		if peer == nil {
 			continue
 		}
-		if peer.State == PeerStateWarm && peer.Connection != nil {
+		if peer.State == PeerStateWarm && peer.hasClientConnection() {
 			if peer.Source == PeerSourceP2PGossip ||
 				peer.Source == PeerSourceP2PLedger {
 				hasWarmCandidates = true

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -202,30 +202,33 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			)
 			return
 		}
-		// If an inbound connection already upgraded this peer to warm,
-		// the outbound dial is unnecessary — the inbound serves as the
-		// bidirectional link for both client and server protocols.
-		if currentPeer := p.peers[peerIdx]; currentPeer.Connection != nil {
+		// Only a client-capable connection can replace the outbound dial.
+		// This matches ouroboros-network's duplex-connection reuse: an
+		// existing inbound responder-only connection is not enough to
+		// satisfy the local initiator side.
+		if currentPeer := p.peers[peerIdx]; currentPeer.hasClientConnection() {
 			p.mu.Unlock()
 			p.config.Logger.Info(
-				"outbound: peer already connected via inbound, stopping outbound attempts",
+				"outbound: peer already connected via reusable duplex connection, stopping outbound attempts",
 				"address", peer.Address,
 			)
 			return
 		}
+		currentPeerConnKnown := p.peers[peerIdx].Connection != nil
 		p.mu.Unlock()
 
-		// Skip outbound if the peer already has an inbound connection
-		// from the same host. When both nodes reuse their listen port
-		// for outbound (OutboundSourcePort), a separate outbound would
-		// create an identical TCP 4-tuple and fail with EADDRINUSE.
-		// The existing inbound connection serves both directions.
-		// Poll periodically rather than returning so that when the
-		// inbound drops the outbound attempt proceeds naturally.
-		if p.config.ConnManager != nil &&
-			p.config.ConnManager.HasInboundFromHost(peer.Address) {
+		// Skip outbound if there is already an inbound connection from the
+		// same exact remote peer address. Matching on the full remote
+		// address avoids suppressing valid outbound dials to peers that
+		// happen to share a host but use a different source port.
+		//
+		// We only wait here while the peer connection state is not yet known.
+		// Once the inbound side has finished negotiating, only a client-capable
+		// duplex connection should suppress the outbound dial.
+		if !currentPeerConnKnown && p.config.ConnManager != nil &&
+			p.config.ConnManager.HasInboundPeerAddress(peer.NormalizedAddress) {
 			p.config.Logger.Info(
-				"outbound: inbound from same host exists, waiting",
+				"outbound: inbound from same peer address exists before negotiation completes, waiting",
 				"address", peer.Address,
 			)
 			select {
@@ -333,15 +336,24 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		}
 		// When the dial fails because an inbound connection already
 		// occupies the TCP 4-tuple, don't count it as a peer failure.
-		// Loop back to the HasInboundFromHost check instead.
-		if isAddrInUseError(err) &&
-			p.config.ConnManager != nil &&
-			p.config.ConnManager.HasInboundFromHost(peer.Address) {
-			p.config.Logger.Info(
-				"outbound: dial failed due to existing inbound, waiting",
-				"address", peer.Address,
-			)
-			continue
+		// Loop back to the exact inbound peer-address check instead.
+		if isAddrInUseError(err) {
+			p.mu.Lock()
+			peerIdx := p.peerIndexByAddress(peer.NormalizedAddress)
+			currentPeerConnKnown := false
+			if peerIdx != -1 {
+				currentPeerConnKnown = p.peers[peerIdx].Connection != nil
+			}
+			p.mu.Unlock()
+			if !currentPeerConnKnown &&
+				p.config.ConnManager != nil &&
+				p.config.ConnManager.HasInboundPeerAddress(peer.NormalizedAddress) {
+				p.config.Logger.Info(
+					"outbound: dial failed while exact inbound peer address is still negotiating, waiting",
+					"address", peer.Address,
+				)
+				continue
+			}
 		}
 		p.mu.Lock()
 		// Re-lookup peer to avoid stale pointer if slice was rebuilt

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -135,13 +135,17 @@ func (p *Peer) setConnection(conn *ouroboros.Connection, outbound bool) {
 		ProtocolVersion: uint(protoVersion),
 		VersionData:     versionData,
 	}
-	// Determine whether connection can be used as a client
+	// Determine whether connection can be used as a client.
 	// This should be true for any outbound connections and any inbound
-	// connections in full-duplex mode
-	if p.Connection != nil && (outbound ||
+	// connections in full-duplex mode.
+	if outbound || (versionData != nil &&
 		versionData.DiffusionMode() == oprotocol.DiffusionModeInitiatorAndResponder) {
 		p.Connection.IsClient = true
 	}
+}
+
+func (p *Peer) hasClientConnection() bool {
+	return p != nil && p.Connection != nil && p.Connection.IsClient
 }
 
 type PeerConnection struct {

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -226,7 +226,7 @@ func TestPeerGovernor_Reconcile_Promotions(t *testing.T) {
 	// Manually set one peer to warm with connection (should promote to hot)
 	pg.mu.Lock()
 	pg.peers[0].State = PeerStateWarm
-	pg.peers[0].Connection = &PeerConnection{} // Mock connection
+	pg.peers[0].Connection = &PeerConnection{IsClient: true}
 	pg.mu.Unlock()
 
 	pg.reconcile()
@@ -236,6 +236,30 @@ func TestPeerGovernor_Reconcile_Promotions(t *testing.T) {
 	assert.Equal(t, PeerStateCold, peers[1].State)
 
 	// Event publishing is tested indirectly
+}
+
+func TestPeerGovernor_Reconcile_SkipsResponderOnlyWarmPromotion(t *testing.T) {
+	eventBus := newMockEventBus()
+	reg := prometheus.NewRegistry()
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     eventBus,
+		PromRegistry: reg,
+		MinHotPeers:  1,
+	})
+
+	pg.AddPeer("44.0.0.1:3001", PeerSourceP2PGossip)
+
+	pg.mu.Lock()
+	pg.peers[0].State = PeerStateWarm
+	pg.peers[0].Connection = &PeerConnection{IsClient: false}
+	pg.mu.Unlock()
+
+	pg.reconcile()
+
+	peers := pg.GetPeers()
+	assert.Equal(t, PeerStateWarm, peers[0].State)
 }
 
 func TestPeerGovernor_Reconcile_Demotions(t *testing.T) {
@@ -339,7 +363,7 @@ func TestPeerGovernor_Reconcile_MinimumHotPeers(t *testing.T) {
 	pg.mu.Lock()
 	for i := range pg.peers {
 		pg.peers[i].State = PeerStateWarm
-		pg.peers[i].Connection = &PeerConnection{} // Mock connection
+		pg.peers[i].Connection = &PeerConnection{IsClient: true}
 	}
 	pg.mu.Unlock()
 
@@ -375,9 +399,9 @@ func TestPeerGovernor_Metrics(t *testing.T) {
 
 	pg.mu.Lock()
 	pg.peers[0].State = PeerStateWarm
-	pg.peers[0].Connection = &PeerConnection{}
+	pg.peers[0].Connection = &PeerConnection{IsClient: true}
 	pg.peers[1].State = PeerStateHot
-	pg.peers[1].Connection = &PeerConnection{}
+	pg.peers[1].Connection = &PeerConnection{IsClient: true}
 	pg.mu.Unlock()
 
 	// Force metrics update
@@ -419,7 +443,7 @@ func TestPeerGovernor_PeerSharing(t *testing.T) {
 	pg.mu.Lock()
 	for i := range pg.peers {
 		pg.peers[i].State = PeerStateHot
-		pg.peers[i].Connection = &PeerConnection{}
+		pg.peers[i].Connection = &PeerConnection{IsClient: true}
 	}
 	pg.mu.Unlock()
 
@@ -3336,7 +3360,7 @@ func TestPeerGovernor_ReconcilePromotion_ValencyAware(t *testing.T) {
 			GroupID:          "public-root-0",
 			Valency:          2,
 			PerformanceScore: 0.6,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 		},
 		{
 			Address:          "public2:3001",
@@ -3345,7 +3369,7 @@ func TestPeerGovernor_ReconcilePromotion_ValencyAware(t *testing.T) {
 			GroupID:          "public-root-0",
 			Valency:          2,
 			PerformanceScore: 0.7,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 		},
 		// Warm peer for group2 (at valency) - lower priority
 		{
@@ -3355,7 +3379,7 @@ func TestPeerGovernor_ReconcilePromotion_ValencyAware(t *testing.T) {
 			GroupID:          "public-root-1",
 			Valency:          1,
 			PerformanceScore: 0.9,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 		},
 	}
 
@@ -3475,7 +3499,7 @@ func TestPeerGovernor_InboundPeer_TenureRequirement(t *testing.T) {
 			Address:          "192.168.1.1:3001",
 			Source:           PeerSourceInboundConn,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.8,        // Above threshold
 			FirstSeen:        time.Now(), // Just seen, not enough tenure
 		},
@@ -3515,7 +3539,7 @@ func TestPeerGovernor_InboundPeer_HigherScoreThreshold(t *testing.T) {
 			Address:          "192.168.1.1:3001",
 			Source:           PeerSourceInboundConn,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.4, // Above normal 0.3, below inbound 0.6
 			FirstSeen: time.Now().
 				Add(-5 * time.Minute),
@@ -3558,7 +3582,7 @@ func TestPeerGovernor_InboundPeer_BothRequirementsMet(t *testing.T) {
 			Address:    "192.168.1.1:3001",
 			Source:     PeerSourceInboundConn,
 			State:      PeerStateWarm,
-			Connection: &PeerConnection{},
+			Connection: &PeerConnection{IsClient: true},
 			FirstSeen: time.Now().
 				Add(-10 * time.Minute),
 			// Sufficient tenure (>= 5min)
@@ -3611,7 +3635,7 @@ func TestPeerGovernor_NonInboundPeer_UsesNormalThreshold(t *testing.T) {
 			Address:          "192.168.1.1:3001",
 			Source:           PeerSourceP2PGossip,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.4,        // Above normal 0.3, below inbound 0.6
 			FirstSeen:        time.Now(), // Just seen (would fail inbound tenure)
 		},
@@ -3780,7 +3804,7 @@ func TestPeerGovernor_InboundPeer_MixedPeerPromotion(t *testing.T) {
 			Address:          "192.168.1.1:3001",
 			Source:           PeerSourceInboundConn,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.9,        // High score but...
 			FirstSeen:        time.Now(), // Insufficient tenure
 		},
@@ -3788,7 +3812,7 @@ func TestPeerGovernor_InboundPeer_MixedPeerPromotion(t *testing.T) {
 			Address:          "192.168.1.2:3001",
 			Source:           PeerSourceP2PGossip,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.5, // Lower score
 			FirstSeen:        time.Now(),
 		},
@@ -3796,7 +3820,7 @@ func TestPeerGovernor_InboundPeer_MixedPeerPromotion(t *testing.T) {
 			Address:          "192.168.1.3:3001",
 			Source:           PeerSourceP2PGossip,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.4, // Even lower score
 			FirstSeen:        time.Now(),
 		},
@@ -3847,7 +3871,7 @@ func TestPeerGovernor_PerSourceMetrics(t *testing.T) {
 			Address:    "192.168.1.1:3001",
 			Source:     PeerSourceP2PGossip,
 			State:      PeerStateHot,
-			Connection: &PeerConnection{},
+			Connection: &PeerConnection{IsClient: true},
 		},
 		{
 			Address: "192.168.1.2:3001",
@@ -3863,7 +3887,7 @@ func TestPeerGovernor_PerSourceMetrics(t *testing.T) {
 			Address:    "192.168.1.4:3001",
 			Source:     PeerSourceTopologyPublicRoot,
 			State:      PeerStateHot,
-			Connection: &PeerConnection{},
+			Connection: &PeerConnection{IsClient: true},
 		},
 		{
 			Address: "192.168.1.5:3001",
@@ -3959,14 +3983,14 @@ func TestPeerGovernor_ChurnMetricsBySource(t *testing.T) {
 			Address:          "192.168.1.1:3001",
 			Source:           PeerSourceP2PGossip,
 			State:            PeerStateHot,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.5,
 		},
 		{
 			Address:          "192.168.1.2:3001",
 			Source:           PeerSourceP2PLedger,
 			State:            PeerStateHot,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.4,
 		},
 		// Warm peers to be promoted
@@ -3974,7 +3998,7 @@ func TestPeerGovernor_ChurnMetricsBySource(t *testing.T) {
 			Address:          "192.168.1.3:3001",
 			Source:           PeerSourceP2PGossip,
 			State:            PeerStateWarm,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.8,
 		},
 	}
@@ -4071,7 +4095,7 @@ func TestPeerGovernor_EventsPublished(t *testing.T) {
 			Address:          "192.168.1.1:3001",
 			Source:           PeerSourceP2PGossip,
 			State:            PeerStateHot,
-			Connection:       &PeerConnection{},
+			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.5,
 		},
 	}
@@ -4111,19 +4135,19 @@ func TestPeerGovernor_EventsPublished(t *testing.T) {
 			Address:    "192.168.1.1:3001",
 			Source:     PeerSourceP2PGossip,
 			State:      PeerStateHot,
-			Connection: &PeerConnection{},
+			Connection: &PeerConnection{IsClient: true},
 		},
 		{
 			Address:    "192.168.1.2:3001",
 			Source:     PeerSourceTopologyPublicRoot,
 			State:      PeerStateHot,
-			Connection: &PeerConnection{},
+			Connection: &PeerConnection{IsClient: true},
 		},
 		{
 			Address:    "192.168.1.3:3001",
 			Source:     PeerSourceP2PLedger,
 			State:      PeerStateHot,
-			Connection: &PeerConnection{},
+			Connection: &PeerConnection{IsClient: true},
 		},
 	}
 	pg.mu.Unlock()
@@ -4281,9 +4305,10 @@ func TestPeerGovernor_ShouldExitBootstrap_LedgerPeerCount(t *testing.T) {
 	// Add ledger peers (warm/hot count towards exit)
 	for i := range 3 {
 		pg.peers = append(pg.peers, &Peer{
-			Address: fmt.Sprintf("192.168.1.%d:3001", i+1),
-			Source:  PeerSourceP2PLedger,
-			State:   PeerStateWarm,
+			Address:    fmt.Sprintf("192.168.1.%d:3001", i+1),
+			Source:     PeerSourceP2PLedger,
+			State:      PeerStateWarm,
+			Connection: &PeerConnection{IsClient: true},
 		})
 	}
 
@@ -4330,6 +4355,74 @@ func TestPeerGovernor_ShouldExitBootstrap_LedgerPeerCount_ColdNotCounted(
 		t,
 		shouldExit,
 		"should not exit bootstrap when ledger peers are cold",
+	)
+}
+
+func TestPeerGovernor_ShouldExitBootstrap_LedgerPeerCount_ResponderOnlyWarmNotCounted(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinLedgerPeersForExit: 3,
+	})
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3001",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateWarm,
+	})
+
+	for i := range 3 {
+		pg.peers = append(pg.peers, &Peer{
+			Address:    fmt.Sprintf("192.168.1.%d:3001", i+1),
+			Source:     PeerSourceP2PLedger,
+			State:      PeerStateWarm,
+			Connection: &PeerConnection{IsClient: false},
+		})
+	}
+
+	shouldExit, _ := pg.shouldExitBootstrap()
+	pg.mu.Unlock()
+
+	assert.False(
+		t,
+		shouldExit,
+		"should not exit bootstrap when warm ledger peers are responder-only",
+	)
+}
+
+func TestPeerGovernor_ShouldExitBootstrap_LedgerPeerCount_ResponderOnlyHotNotCounted(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinLedgerPeersForExit: 3,
+	})
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3001",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateWarm,
+	})
+
+	for i := range 3 {
+		pg.peers = append(pg.peers, &Peer{
+			Address:    fmt.Sprintf("192.168.1.%d:3001", i+1),
+			Source:     PeerSourceP2PLedger,
+			State:      PeerStateHot,
+			Connection: &PeerConnection{IsClient: false},
+		})
+	}
+
+	shouldExit, _ := pg.shouldExitBootstrap()
+	pg.mu.Unlock()
+
+	assert.False(
+		t,
+		shouldExit,
+		"should not exit bootstrap when hot ledger peers are responder-only",
 	)
 }
 
@@ -4603,7 +4696,7 @@ func TestPeerGovernor_BootstrapRecovery_NotNeededWithWarmCandidates(
 		Address:    "192.168.1.1:3001",
 		Source:     PeerSourceP2PGossip,
 		State:      PeerStateWarm,
-		Connection: &PeerConnection{}, // Has connection
+		Connection: &PeerConnection{IsClient: true},
 	})
 
 	_ = pg.checkBootstrapRecoveryLocked()
@@ -4613,6 +4706,39 @@ func TestPeerGovernor_BootstrapRecovery_NotNeededWithWarmCandidates(
 		t,
 		pg.bootstrapExited,
 		"bootstrapExited should remain true with warm candidates",
+	)
+	pg.mu.Unlock()
+}
+
+func TestPeerGovernor_BootstrapRecovery_IgnoresResponderOnlyWarmCandidates(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:           3,
+		AutoBootstrapRecovery: boolPtr(true),
+	})
+
+	pg.mu.Lock()
+	pg.bootstrapExited = true
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3001",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateCold,
+	})
+	pg.peers = append(pg.peers, &Peer{
+		Address:    "192.168.1.1:3001",
+		Source:     PeerSourceP2PGossip,
+		State:      PeerStateWarm,
+		Connection: &PeerConnection{IsClient: false},
+	})
+
+	_ = pg.checkBootstrapRecoveryLocked()
+
+	assert.False(
+		t,
+		pg.bootstrapExited,
+		"bootstrap should recover when only responder-only warm peers exist",
 	)
 	pg.mu.Unlock()
 }
@@ -4639,14 +4765,16 @@ func TestPeerGovernor_BootstrapRecovery_NotNeededWithEnoughHotPeers(
 
 	// Add enough hot peers (>= MinHotPeers)
 	pg.peers = append(pg.peers, &Peer{
-		Address: "192.168.1.1:3001",
-		Source:  PeerSourceP2PGossip,
-		State:   PeerStateHot,
+		Address:    "192.168.1.1:3001",
+		Source:     PeerSourceP2PGossip,
+		State:      PeerStateHot,
+		Connection: &PeerConnection{IsClient: true},
 	})
 	pg.peers = append(pg.peers, &Peer{
-		Address: "192.168.1.2:3001",
-		Source:  PeerSourceP2PGossip,
-		State:   PeerStateHot,
+		Address:    "192.168.1.2:3001",
+		Source:     PeerSourceP2PGossip,
+		State:      PeerStateHot,
+		Connection: &PeerConnection{IsClient: true},
 	})
 
 	_ = pg.checkBootstrapRecoveryLocked()
@@ -4685,7 +4813,7 @@ func TestPeerGovernor_Reconcile_ExitsBootstrap(t *testing.T) {
 		Address:    "192.168.1.1:3001",
 		Source:     PeerSourceP2PGossip,
 		State:      PeerStateHot,
-		Connection: &PeerConnection{},
+		Connection: &PeerConnection{IsClient: true},
 	})
 	pg.mu.Unlock()
 
@@ -4728,7 +4856,7 @@ func TestPeerGovernor_Reconcile_SkipsBootstrapPromotionAfterExit(t *testing.T) {
 		Address:    "44.0.0.1:3001",
 		Source:     PeerSourceTopologyBootstrapPeer,
 		State:      PeerStateWarm,
-		Connection: &PeerConnection{},
+		Connection: &PeerConnection{IsClient: true},
 	})
 
 	// Add warm gossip peer with connection (should be promoted)
@@ -4736,7 +4864,7 @@ func TestPeerGovernor_Reconcile_SkipsBootstrapPromotionAfterExit(t *testing.T) {
 		Address:    "192.168.1.1:3001",
 		Source:     PeerSourceP2PGossip,
 		State:      PeerStateWarm,
-		Connection: &PeerConnection{},
+		Connection: &PeerConnection{IsClient: true},
 	})
 	pg.mu.Unlock()
 

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -154,7 +154,7 @@ func (p *PeerGovernor) reconcile() {
 		candidates := []*Peer{}
 		for _, peer := range p.peers {
 			if peer != nil && peer.State == PeerStateWarm &&
-				peer.Connection != nil {
+				peer.hasClientConnection() {
 				// Skip bootstrap peers if bootstrap has been exited
 				if p.isBootstrapPeer(peer) && !p.canPromoteBootstrapPeer() {
 					continue


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes bidirectional connection reuse when listen-port reuse is enabled by matching the exact peer address (host+port) and only suppressing outbound once a client-capable duplex connection exists. Also starts `TxSubmission` on duplex inbound so peers still receive our mempool transactions.

- **Bug Fixes**
  - Replaced host-only check with `HasInboundPeerAddress` (full address match) and added normalization (IPv6 canonical form, lowercase hostnames).
  - Outbound dials wait only while an exact inbound is still negotiating; after negotiation, only a client-capable connection (`IsClient`) suppresses outbound, including EADDRINUSE handling.
  - Count only client-capable connections via `hasClientConnection()` for warm/hot promotions, bootstrap exit, and recovery.
  - Start `TxSubmission` client on inbound full-duplex connections to maintain mempool propagation when outbound is suppressed.

<sup>Written for commit 3edc588e35196c5f5cdc58559b3fcda6dab126dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Precise peer-address matching for inbound/outbound collision handling.
  * Distinguishes client-capable vs responder-only peer connections.
  * Inbound connections can now start transaction-submission clients when available.

* **Bug Fixes**
  * Bootstrap exit and recovery now count only peers with active client connections.
  * Outbound connection reuse now requires exact inbound peer-address and client-capable connections.

* **Tests**
  * Expanded tests for address normalization, inbound-address detection, and bootstrap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->