### PR TITLE
fix: offer wider intersect list

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -37,6 +37,10 @@ const (
 	// transaction limits during import, so keep the runtime batch size
 	// conservative even if smaller benchmark fixtures tolerate more.
 	blockImportBatchSize = 50
+	// Keep a dense window near the tip so short peer gaps intersect on a
+	// recent block, then fall back to exponentially older points to avoid
+	// origin intersects when the peer lags by more than a few dozen blocks.
+	intersectDensePointCount = 32
 )
 
 type Chain struct {
@@ -731,6 +735,65 @@ func (c *Chain) RecentPoints(count int) []ocommon.Point {
 			points,
 			ocommon.NewPoint(blk.Slot, blk.Hash),
 		)
+	}
+	return points
+}
+
+// IntersectPoints returns up to count points in descending order for
+// chainsync FindIntersect. It keeps a dense window near the tip and
+// then samples exponentially older blocks so lagging peers can still
+// find a recent common point without falling all the way back to origin.
+func (c *Chain) IntersectPoints(count int) []ocommon.Point {
+	if c == nil || count <= 0 {
+		return nil
+	}
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	if c.tipBlockIndex < initialBlockIndex {
+		return nil
+	}
+	points := make([]ocommon.Point, 0, count)
+	seen := make(map[uint64]struct{}, count)
+	appendPoint := func(blockIndex uint64) bool {
+		if len(points) >= count {
+			return false
+		}
+		if _, ok := seen[blockIndex]; ok {
+			return true
+		}
+		blk, err := c.blockByIndex(blockIndex)
+		if err != nil {
+			return false
+		}
+		points = append(
+			points,
+			ocommon.NewPoint(blk.Slot, blk.Hash),
+		)
+		seen[blockIndex] = struct{}{}
+		return true
+	}
+	denseCount := min(count, intersectDensePointCount)
+	for idx := c.tipBlockIndex; idx >= initialBlockIndex && len(points) < denseCount; idx-- {
+		if !appendPoint(idx) {
+			break
+		}
+	}
+	if len(points) >= count {
+		return points
+	}
+	if c.tipBlockIndex <= initialBlockIndex {
+		return points
+	}
+	for offset := uint64(denseCount); len(points) < count; offset *= 2 {
+		if offset == 0 || offset >= c.tipBlockIndex {
+			break
+		}
+		if !appendPoint(c.tipBlockIndex - offset) {
+			break
+		}
+	}
+	if len(points) < count {
+		_ = appendPoint(initialBlockIndex)
 	}
 	return points
 }

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -807,6 +807,73 @@ func TestRecentPointsWithDatabase(t *testing.T) {
 	}
 }
 
+func TestIntersectPointsIncludesOlderSamples(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf(
+			"unexpected error creating chain manager: %s",
+			err,
+		)
+	}
+	c := cm.PrimaryChain()
+	headers := makeLinkedHeaders(80, 0, 1, "")
+	for _, header := range headers {
+		if err := c.AddBlock(header, nil); err != nil {
+			t.Fatalf(
+				"unexpected error adding block to chain: %s",
+				err,
+			)
+		}
+	}
+
+	points := c.IntersectPoints(40)
+	if len(points) != 35 {
+		t.Fatalf("expected 35 points, got %d", len(points))
+	}
+
+	for i := range 32 {
+		expected := headers[len(headers)-1-i]
+		if points[i].Slot != expected.MockSlot {
+			t.Fatalf(
+				"dense point %d: expected slot %d, got %d",
+				i,
+				expected.MockSlot,
+				points[i].Slot,
+			)
+		}
+	}
+
+	expectedOlder := []struct {
+		pointIdx  int
+		headerIdx int
+	}{
+		{pointIdx: 32, headerIdx: 47},
+		{pointIdx: 33, headerIdx: 15},
+		{pointIdx: 34, headerIdx: 0},
+	}
+	for _, expected := range expectedOlder {
+		header := headers[expected.headerIdx]
+		point := points[expected.pointIdx]
+		if point.Slot != header.MockSlot {
+			t.Fatalf(
+				"older point %d: expected slot %d, got %d",
+				expected.pointIdx,
+				header.MockSlot,
+				point.Slot,
+			)
+		}
+		if string(point.Hash) != string(decodeHex(header.MockHash)) {
+			t.Fatalf(
+				"older point %d: expected hash %x, got %x",
+				expected.pointIdx,
+				decodeHex(header.MockHash),
+				point.Hash,
+			)
+		}
+	}
+}
+
 // mockLedger implements the interface{ SecurityParam() int }
 // interface used by ChainManager.SetLedger.
 type mockLedger struct {

--- a/database/plugin/metadata/mysql/stake_snapshot.go
+++ b/database/plugin/metadata/mysql/stake_snapshot.go
@@ -35,7 +35,13 @@ func (d *MetadataStoreMysql) SavePoolStakeSnapshot(
 	if err != nil {
 		return err
 	}
-	return db.Create(snapshot).Error
+	if err := db.Create(snapshot).Error; err != nil {
+		return fmt.Errorf(
+			"failed to create pool stake snapshot: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // SavePoolStakeSnapshots saves multiple pool stake snapshots in batch
@@ -50,7 +56,26 @@ func (d *MetadataStoreMysql) SavePoolStakeSnapshots(
 	if err != nil {
 		return err
 	}
-	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(snapshots).Error
+	if err := db.Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "epoch"},
+				{Name: "snapshot_type"},
+				{Name: "pool_key_hash"},
+			},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"total_stake",
+				"delegator_count",
+				"captured_slot",
+			}),
+		},
+	).Create(snapshots).Error; err != nil {
+		return fmt.Errorf(
+			"failed to create pool stake snapshots: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // GetPoolStakeSnapshot retrieves a specific pool's stake snapshot
@@ -156,7 +181,30 @@ func (d *MetadataStoreMysql) SaveEpochSummary(
 	if err != nil {
 		return err
 	}
-	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(summary).Error
+	if err := db.Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{{Name: "epoch"}},
+			DoUpdates: append(
+				clause.AssignmentColumns([]string{
+					"total_active_stake",
+					"total_pool_count",
+					"total_delegators",
+					"epoch_nonce",
+					"boundary_slot",
+				}),
+				clause.Assignment{
+					Column: clause.Column{Name: "snapshot_ready"},
+					Value:  clause.Expr{SQL: "snapshot_ready OR VALUES(snapshot_ready)"},
+				},
+			),
+		},
+	).Create(summary).Error; err != nil {
+		return fmt.Errorf(
+			"failed to upsert epoch summary for stake snapshot: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // GetEpochSummary retrieves an epoch summary by epoch number
@@ -210,10 +258,16 @@ func (d *MetadataStoreMysql) DeletePoolStakeSnapshotsForEpoch(
 	if err != nil {
 		return err
 	}
-	return db.Where(
+	if err := db.Where(
 		"epoch = ? AND snapshot_type = ?",
 		epoch, snapshotType,
-	).Delete(&models.PoolStakeSnapshot{}).Error
+	).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"failed to delete pool stake snapshots for stake snapshot: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // DeletePoolStakeSnapshotsAfterEpoch deletes all pool stake snapshots after a given epoch.

--- a/database/plugin/metadata/postgres/stake_snapshot.go
+++ b/database/plugin/metadata/postgres/stake_snapshot.go
@@ -35,7 +35,13 @@ func (d *MetadataStorePostgres) SavePoolStakeSnapshot(
 	if err != nil {
 		return err
 	}
-	return db.Create(snapshot).Error
+	if err := db.Create(snapshot).Error; err != nil {
+		return fmt.Errorf(
+			"stake_snapshot.SavePoolStakeSnapshot: failed to create snapshot: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // SavePoolStakeSnapshots saves multiple pool stake snapshots in batch
@@ -50,7 +56,26 @@ func (d *MetadataStorePostgres) SavePoolStakeSnapshots(
 	if err != nil {
 		return err
 	}
-	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(snapshots).Error
+	if err := db.Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "epoch"},
+				{Name: "snapshot_type"},
+				{Name: "pool_key_hash"},
+			},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"total_stake",
+				"delegator_count",
+				"captured_slot",
+			}),
+		},
+	).Create(snapshots).Error; err != nil {
+		return fmt.Errorf(
+			"stake_snapshot.SavePoolStakeSnapshots: failed to create snapshots: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // GetPoolStakeSnapshot retrieves a specific pool's stake snapshot
@@ -156,7 +181,30 @@ func (d *MetadataStorePostgres) SaveEpochSummary(
 	if err != nil {
 		return err
 	}
-	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(summary).Error
+	if err := db.Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{{Name: "epoch"}},
+			DoUpdates: append(
+				clause.AssignmentColumns([]string{
+					"total_active_stake",
+					"total_pool_count",
+					"total_delegators",
+					"epoch_nonce",
+					"boundary_slot",
+				}),
+				clause.Assignment{
+					Column: clause.Column{Name: "snapshot_ready"},
+					Value:  clause.Expr{SQL: "snapshot_ready OR excluded.snapshot_ready"},
+				},
+			),
+		},
+	).Create(summary).Error; err != nil {
+		return fmt.Errorf(
+			"stake_snapshot.SaveEpochSummary: failed to upsert epoch summary: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // GetEpochSummary retrieves an epoch summary by epoch number
@@ -210,10 +258,16 @@ func (d *MetadataStorePostgres) DeletePoolStakeSnapshotsForEpoch(
 	if err != nil {
 		return err
 	}
-	return db.Where(
+	if err := db.Where(
 		"epoch = ? AND snapshot_type = ?",
 		epoch, snapshotType,
-	).Delete(&models.PoolStakeSnapshot{}).Error
+	).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"stake_snapshot.DeletePoolStakeSnapshotsForEpoch: failed to delete snapshots: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // DeletePoolStakeSnapshotsAfterEpoch deletes all pool stake snapshots after a given epoch.

--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -50,7 +50,26 @@ func (d *MetadataStoreSqlite) SavePoolStakeSnapshots(
 	if err != nil {
 		return err
 	}
-	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(snapshots).Error
+	if err := db.Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "epoch"},
+				{Name: "snapshot_type"},
+				{Name: "pool_key_hash"},
+			},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"total_stake",
+				"delegator_count",
+				"captured_slot",
+			}),
+		},
+	).Create(snapshots).Error; err != nil {
+		return fmt.Errorf(
+			"failed to save pool stake snapshots: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // GetPoolStakeSnapshot retrieves a specific pool's stake snapshot
@@ -156,10 +175,31 @@ func (d *MetadataStoreSqlite) SaveEpochSummary(
 	if err != nil {
 		return err
 	}
-	// Use ON CONFLICT DO NOTHING so duplicate epoch events (from both
-	// slot-clock and block-based transitions) are idempotent.
-	return db.Clauses(clause.OnConflict{DoNothing: true}).
-		Create(summary).Error
+	// Duplicate epoch events can arrive first from the slot clock and later
+	// from block processing with more complete snapshot data. Upsert so the
+	// later event repairs any partial/empty summary instead of being ignored.
+	if err := db.Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{{Name: "epoch"}},
+			DoUpdates: append(
+				clause.AssignmentColumns([]string{
+					"total_active_stake",
+					"total_pool_count",
+					"total_delegators",
+					"epoch_nonce",
+					"boundary_slot",
+				}),
+				clause.Assignment{
+					Column: clause.Column{Name: "snapshot_ready"},
+					Value:  clause.Expr{SQL: "snapshot_ready OR excluded.snapshot_ready"},
+				},
+			),
+		},
+	).
+		Create(summary).Error; err != nil {
+		return fmt.Errorf("failed to save epoch summary: %w", err)
+	}
+	return nil
 }
 
 // GetEpochSummary retrieves an epoch summary by epoch number

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -331,6 +331,80 @@ func TestEpochSummaryGetLatestEmpty(t *testing.T) {
 	assert.Nil(t, latest, "expected nil for empty table")
 }
 
+func TestSavePoolStakeSnapshotsUpsertsExistingRows(t *testing.T) {
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	poolKeyHash := []byte("pool_key_hash_12345678901234")
+	initial := []*models.PoolStakeSnapshot{
+		{
+			Epoch:          100,
+			SnapshotType:   "mark",
+			PoolKeyHash:    poolKeyHash,
+			TotalStake:     1,
+			DelegatorCount: 1,
+			CapturedSlot:   100,
+		},
+	}
+	require.NoError(t, store.SavePoolStakeSnapshots(initial, nil))
+
+	updated := []*models.PoolStakeSnapshot{
+		{
+			Epoch:          100,
+			SnapshotType:   "mark",
+			PoolKeyHash:    poolKeyHash,
+			TotalStake:     999,
+			DelegatorCount: 9,
+			CapturedSlot:   200,
+		},
+	}
+	require.NoError(t, store.SavePoolStakeSnapshots(updated, nil))
+
+	retrieved, err := store.GetPoolStakeSnapshot(100, "mark", poolKeyHash, nil)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, uint64(999), uint64(retrieved.TotalStake))
+	assert.Equal(t, uint64(9), retrieved.DelegatorCount)
+	assert.Equal(t, uint64(200), retrieved.CapturedSlot)
+}
+
+func TestSaveEpochSummaryUpsertsExistingRow(t *testing.T) {
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	initial := &models.EpochSummary{
+		Epoch:            100,
+		TotalActiveStake: 1,
+		TotalPoolCount:   1,
+		TotalDelegators:  1,
+		EpochNonce:       []byte("old_nonce_1234567890123456789012"),
+		BoundarySlot:     100,
+		SnapshotReady:    false,
+	}
+	require.NoError(t, store.SaveEpochSummary(initial, nil))
+
+	updated := &models.EpochSummary{
+		Epoch:            100,
+		TotalActiveStake: 999,
+		TotalPoolCount:   9,
+		TotalDelegators:  99,
+		EpochNonce:       []byte("new_nonce_1234567890123456789012"),
+		BoundarySlot:     200,
+		SnapshotReady:    true,
+	}
+	require.NoError(t, store.SaveEpochSummary(updated, nil))
+
+	retrieved, err := store.GetEpochSummary(100, nil)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, uint64(999), uint64(retrieved.TotalActiveStake))
+	assert.Equal(t, uint64(9), retrieved.TotalPoolCount)
+	assert.Equal(t, uint64(99), retrieved.TotalDelegators)
+	assert.Equal(t, uint64(200), retrieved.BoundarySlot)
+	assert.True(t, retrieved.SnapshotReady)
+	assert.Equal(t, updated.EpochNonce, retrieved.EpochNonce)
+}
+
 // TestDeletePoolStakeSnapshotsForEpoch tests deleting snapshots for a specific epoch
 func TestDeletePoolStakeSnapshotsForEpoch(t *testing.T) {
 	store := setupStakeSnapshotTestStore(t)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3015,6 +3015,22 @@ func (ls *LedgerState) RecentChainPoints(
 	return points, nil
 }
 
+// IntersectPoints returns chainsync FindIntersect candidates ordered from
+// newest to oldest. The point list stays dense near the tip and spreads out
+// deeper in history so lagging peers intersect recent chain state instead of
+// falling back to origin after only a small tip gap.
+func (ls *LedgerState) IntersectPoints(
+	count int,
+) ([]ocommon.Point, error) {
+	if count <= 0 {
+		return nil, nil
+	}
+	if ls.chain != nil {
+		return ls.chain.IntersectPoints(count), nil
+	}
+	return ls.RecentChainPoints(count)
+}
+
 // pointKey returns a string key for deduplication of chain points.
 func pointKey(p ocommon.Point) string {
 	return fmt.Sprintf("%d:%x", p.Slot, p.Hash)

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -363,22 +363,23 @@ func parseCertPoolParamsMap(data []byte) ([]ParsedPool, error) {
 }
 
 // parseDState decodes the delegation state.
-// DState contains:
-//   - rewards: map[Credential]Coin
-//   - delegations: map[Credential]PoolKeyHash
-//   - ptrs: map[Ptr]Credential (legacy, skipped)
-//   - various other fields
+// Modern ledger snapshots encode DState as:
+//
+//	[Accounts, FutureGenDelegs, GenDelegs, InstantaneousRewards]
+//
+// where Accounts is era-specific:
+//   - Shelley-family eras: [credentialMap, ptrMap]
+//   - Conway-era: direct credentialMap
+//
+// Historical snapshots may still surface the older unified-map
+// layout, so the downstream credential parser accepts all of the
+// known account encodings.
 func parseDState(data []byte) ([]ParsedAccount, error) {
 	ds, err := decodeRawElements(data)
 	if err != nil {
 		return nil, fmt.Errorf("decoding DState: %w", err)
 	}
 
-	// The DState structure has evolved across eras. In Conway:
-	// DState = [dsUnified, dsFutureGenDelegs, dsGenDelegs, dsIRewards]
-	// dsUnified = UMap = [credentials, ptrs]
-	// credentials encodes as map of:
-	//   credential -> UMElem = [rdPair, stakePool, drepDelegation, ...]
 	if len(ds) < 1 {
 		return nil, fmt.Errorf(
 			"DState has %d elements, expected at least 1",
@@ -386,16 +387,14 @@ func parseDState(data []byte) ([]ParsedAccount, error) {
 		)
 	}
 
-	// Parse the unified map (UMap)
+	// Parse the accounts/unified map payload.
 	return parseUMap(ds[0])
 }
 
-// parseUMap decodes the unified map containing rewards and
-// delegations.
-// UMap = [<credential-map>, <ptr-map>]
-// credential-map: map[Credential]UMElem
-// UMElem = [<RDPair>, <StakePool>, <DRep>, ...]
-// RDPair = [<reward>, <deposit>]
+// parseUMap decodes the era-specific account payload:
+//   - Shelley-family eras: [credentialMap, ptrMap]
+//   - Conway-era: direct credentialMap
+//   - Historical snapshots: unified-map-like account payloads
 func parseUMap(data []byte) ([]ParsedAccount, error) {
 	umapArr, err := decodeRawArray(data)
 	if err != nil {
@@ -410,9 +409,13 @@ func parseUMap(data []byte) ([]ParsedAccount, error) {
 	return parseCredentialMap(umapArr[0])
 }
 
-// parseCredentialMap decodes the credential -> UMElem map using
-// decodeMapEntries to handle indefinite-length maps (0xbf) and
-// non-comparable array keys.
+// parseCredentialMap decodes the credential -> account-state map
+// using decodeMapEntries to handle indefinite-length maps (0xbf)
+// and non-comparable array keys. Snapshot imports have surfaced
+// multiple account-state encodings over time:
+//   - ConwayAccountState = [balance, deposit, pool?, drep?]
+//   - ShelleyAccountState = [ptr, balance, deposit, pool?]
+//   - Legacy UMElem = [rdPair, pool?, drep?, ...]
 func parseCredentialMap(
 	data []byte,
 ) ([]ParsedAccount, error) {
@@ -439,10 +442,9 @@ func parseCredentialMap(
 			Active:     true,
 		}
 
-		// Decode UMElem = [RDPair, StakePool, DRep, ...].
-		// If the entire UMElem fails to decode, the account
-		// cannot be reconstructed (no reward, no delegation,
-		// no DRep), so skip the entry entirely.
+		// Decode the account-state payload. If the shape is
+		// unknown, the account cannot be reconstructed, so skip
+		// the entry entirely.
 		var elem []cbor.RawMessage
 		if _, err := cbor.Decode(
 			entry.ValueRaw, &elem,
@@ -451,50 +453,10 @@ func parseCredentialMap(
 			continue
 		}
 
-		// Track whether any sub-fields failed to decode.
-		// The account is still added but operators should
-		// know some fields defaulted to zero values.
-		partial := false
-
-		// RDPair (index 0): [reward, deposit]
-		if len(elem) > 0 {
-			var rdPair []uint64
-			if _, err := cbor.Decode(
-				elem[0], &rdPair,
-			); err == nil && len(rdPair) > 0 {
-				acct.Reward = rdPair[0]
-				if len(rdPair) > 1 {
-					acct.Deposit = rdPair[1]
-				}
-			} else {
-				partial = true
-			}
-		}
-
-		// StakePool delegation (index 1): pool key hash
-		if len(elem) > 1 {
-			poolHash, ok := parsePoolDelegation(elem[1])
-			if ok && len(poolHash) == 28 {
-				acct.PoolKeyHash = poolHash
-			} else if !ok || len(poolHash) > 0 {
-				partial = true
-			}
-			// len(poolHash) == 0 means no delegation.
-		}
-
-		// DRep delegation (index 2): key/script credential or
-		// AlwaysAbstain/AlwaysNoConfidence pseudo-DRep.
-		// DRep is supplementary: a decode failure is non-fatal
-		// because the account's reward, deposit, and pool
-		// delegation are still valid without it.
-		// CBOR null (0xf6) means "no DRep delegation" — valid.
-		if len(elem) > 2 && len(elem[2]) > 0 && elem[2][0] != 0xf6 {
-			drepCred, err := parseDRepDelegation(elem[2])
-			if err == nil {
-				acct.DRepCred = drepCred
-			} else {
-				partial = true
-			}
+		partial, ok := parseAccountState(elem, &acct)
+		if !ok {
+			decodeErrors++
+			continue
 		}
 
 		if partial {
@@ -530,6 +492,137 @@ func parseCredentialMap(
 		)
 	}
 	return accounts, warning
+}
+
+func parseAccountState(
+	elem []cbor.RawMessage,
+	acct *ParsedAccount,
+) (bool, bool) {
+	if partial, ok := parseConwayAccountState(elem, acct); ok {
+		return partial, true
+	}
+	if partial, ok := parseShelleyAccountState(elem, acct); ok {
+		return partial, true
+	}
+	if partial, ok := parseLegacyUMElem(elem, acct); ok {
+		return partial, true
+	}
+	return false, false
+}
+
+func parseConwayAccountState(
+	elem []cbor.RawMessage,
+	acct *ParsedAccount,
+) (bool, bool) {
+	if len(elem) < 2 {
+		return false, false
+	}
+
+	reward, ok := parseUint64(elem[0])
+	if !ok {
+		return false, false
+	}
+	deposit, ok := parseUint64(elem[1])
+	if !ok {
+		return false, false
+	}
+
+	acct.Reward = reward
+	acct.Deposit = deposit
+
+	partial := false
+	if len(elem) > 2 {
+		poolHash, ok := parsePoolDelegation(elem[2])
+		if ok {
+			acct.PoolKeyHash = poolHash
+		} else {
+			partial = true
+		}
+	}
+	if len(elem) > 3 && len(elem[3]) > 0 && elem[3][0] != 0xf6 {
+		drepCred, err := parseDRepDelegation(elem[3])
+		if err == nil {
+			acct.DRepCred = drepCred
+		} else {
+			partial = true
+		}
+	}
+	return partial, true
+}
+
+func parseShelleyAccountState(
+	elem []cbor.RawMessage,
+	acct *ParsedAccount,
+) (bool, bool) {
+	if len(elem) < 4 {
+		return false, false
+	}
+
+	reward, ok := parseUint64(elem[1])
+	if !ok {
+		return false, false
+	}
+	deposit, ok := parseUint64(elem[2])
+	if !ok {
+		return false, false
+	}
+
+	acct.Reward = reward
+	acct.Deposit = deposit
+
+	poolHash, ok := parsePoolDelegation(elem[3])
+	if ok {
+		acct.PoolKeyHash = poolHash
+		return false, true
+	}
+	return true, true
+}
+
+func parseLegacyUMElem(
+	elem []cbor.RawMessage,
+	acct *ParsedAccount,
+) (bool, bool) {
+	if len(elem) < 1 {
+		return false, false
+	}
+
+	var rdPair []uint64
+	if _, err := cbor.Decode(elem[0], &rdPair); err != nil ||
+		len(rdPair) == 0 {
+		return false, false
+	}
+
+	acct.Reward = rdPair[0]
+	if len(rdPair) > 1 {
+		acct.Deposit = rdPair[1]
+	}
+
+	partial := false
+	if len(elem) > 1 {
+		poolHash, ok := parsePoolDelegation(elem[1])
+		if ok {
+			acct.PoolKeyHash = poolHash
+		} else {
+			partial = true
+		}
+	}
+	if len(elem) > 2 && len(elem[2]) > 0 && elem[2][0] != 0xf6 {
+		drepCred, err := parseDRepDelegation(elem[2])
+		if err == nil {
+			acct.DRepCred = drepCred
+		} else {
+			partial = true
+		}
+	}
+	return partial, true
+}
+
+func parseUint64(data []byte) (uint64, bool) {
+	var value uint64
+	if _, err := cbor.Decode(data, &value); err != nil {
+		return 0, false
+	}
+	return value, true
 }
 
 // parsePoolDelegation decodes stake pool delegation values from UMElem.

--- a/ledgerstate/certstate_test.go
+++ b/ledgerstate/certstate_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+type testCredentialKey struct {
+	cbor.StructAsArray
+	Type uint64
+	Hash [28]byte
+}
+
+type testPtr struct {
+	cbor.StructAsArray
+	Slot    uint64
+	TxIndex uint64
+	Cert    uint64
+}
+
+func TestParseCredentialMapConwayAccountState(t *testing.T) {
+	stakingKey := bytes.Repeat([]byte{0x11}, 28)
+	poolHash := bytes.Repeat([]byte{0x22}, 28)
+	drepHash := bytes.Repeat([]byte{0x33}, 28)
+
+	data := encodeCredentialMapEntry(
+		t,
+		testCredentialKey{
+			Type: 0,
+			Hash: toFixed28(stakingKey),
+		},
+		[]any{
+			uint64(101),
+			uint64(202),
+			poolHash,
+			[]any{uint64(0), drepHash},
+		},
+	)
+
+	accounts, err := parseCredentialMap(data)
+	if err != nil {
+		t.Fatalf("parseCredentialMap failed: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+
+	acct := accounts[0]
+	if !bytes.Equal(acct.StakingKey.Hash, stakingKey) {
+		t.Fatalf("staking key mismatch: %x", acct.StakingKey.Hash)
+	}
+	if acct.Reward != 101 {
+		t.Fatalf("expected reward 101, got %d", acct.Reward)
+	}
+	if acct.Deposit != 202 {
+		t.Fatalf("expected deposit 202, got %d", acct.Deposit)
+	}
+	if !bytes.Equal(acct.PoolKeyHash, poolHash) {
+		t.Fatalf("pool hash mismatch: %x", acct.PoolKeyHash)
+	}
+	if acct.DRepCred.Type != CredentialTypeKey {
+		t.Fatalf("expected key drep, got type %d", acct.DRepCred.Type)
+	}
+	if !bytes.Equal(acct.DRepCred.Hash, drepHash) {
+		t.Fatalf("drep hash mismatch: %x", acct.DRepCred.Hash)
+	}
+}
+
+func TestParseCredentialMapShelleyAccountState(t *testing.T) {
+	stakingKey := bytes.Repeat([]byte{0x44}, 28)
+	poolHash := bytes.Repeat([]byte{0x55}, 28)
+
+	data := encodeCredentialMapEntry(
+		t,
+		testCredentialKey{
+			Type: 0,
+			Hash: toFixed28(stakingKey),
+		},
+		[]any{
+			testPtr{Slot: 1, TxIndex: 2, Cert: 3},
+			uint64(303),
+			uint64(404),
+			poolHash,
+		},
+	)
+
+	accounts, err := parseCredentialMap(data)
+	if err != nil {
+		t.Fatalf("parseCredentialMap failed: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+
+	acct := accounts[0]
+	if acct.Reward != 303 {
+		t.Fatalf("expected reward 303, got %d", acct.Reward)
+	}
+	if acct.Deposit != 404 {
+		t.Fatalf("expected deposit 404, got %d", acct.Deposit)
+	}
+	if !bytes.Equal(acct.PoolKeyHash, poolHash) {
+		t.Fatalf("pool hash mismatch: %x", acct.PoolKeyHash)
+	}
+}
+
+func TestParseCredentialMapLegacyUMElem(t *testing.T) {
+	stakingKey := bytes.Repeat([]byte{0x66}, 28)
+	poolHash := bytes.Repeat([]byte{0x77}, 28)
+
+	data := encodeCredentialMapEntry(
+		t,
+		testCredentialKey{
+			Type: 0,
+			Hash: toFixed28(stakingKey),
+		},
+		[]any{
+			[]uint64{505, 606},
+			poolHash,
+			[]any{uint64(2)},
+		},
+	)
+
+	accounts, err := parseCredentialMap(data)
+	if err != nil {
+		t.Fatalf("parseCredentialMap failed: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+
+	acct := accounts[0]
+	if acct.Reward != 505 {
+		t.Fatalf("expected reward 505, got %d", acct.Reward)
+	}
+	if acct.Deposit != 606 {
+		t.Fatalf("expected deposit 606, got %d", acct.Deposit)
+	}
+	if !bytes.Equal(acct.PoolKeyHash, poolHash) {
+		t.Fatalf("pool hash mismatch: %x", acct.PoolKeyHash)
+	}
+	if acct.DRepCred.Type != CredentialTypeAbstain {
+		t.Fatalf("expected abstain drep, got type %d", acct.DRepCred.Type)
+	}
+}
+
+func encodeCredentialMapEntry(t *testing.T, key any, value any) []byte {
+	t.Helper()
+
+	keyRaw, err := cbor.Encode(key)
+	if err != nil {
+		t.Fatalf("encoding key: %v", err)
+	}
+	valueRaw, err := cbor.Encode(value)
+	if err != nil {
+		t.Fatalf("encoding value: %v", err)
+	}
+
+	data := append([]byte{0xa1}, keyRaw...)
+	data = append(data, valueRaw...)
+	return data
+}
+
+func toFixed28(src []byte) [28]byte {
+	var dst [28]byte
+	copy(dst[:], src)
+	return dst
+}

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -123,7 +123,7 @@ func (o *Ouroboros) chainsyncClientStart(connId ouroboros.ConnectionId) error {
 			connId.String(),
 		)
 	}
-	intersectPoints, err := o.LedgerState.RecentChainPoints(
+	intersectPoints, err := o.LedgerState.IntersectPoints(
 		chainsyncIntersectPointCount,
 	)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand chainsync intersect candidates with a dense tip window and exponentially older points so lagging peers intersect recent blocks. Harden `ledgerstate` DState/account parsing to support Conway, Shelley, and legacy layouts; also upsert stake snapshot and epoch summary rows so later events repair partial data.

- **Bug Fixes**
  - Chainsync: use `LedgerState.IntersectPoints` → `chain.IntersectPoints` in `ouroboros` for FindIntersect; dense tip window (32) plus exponentially older samples; adds tests.
  - Ledger parsing: update `ledgerstate` credential/DState parsing to accept Conway account state, Shelley account state, and legacy UMElem; factor helpers; adds unit tests.
  - Metadata DB: upsert in `SavePoolStakeSnapshots` and `SaveEpochSummary` across MySQL/Postgres/SQLite with clearer errors; adds SQLite upsert tests.

<sup>Written for commit e65566751b7c3d28cd2946f32e9d41e8c9c8385a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chain intersection point selection exposed via LedgerState, providing richer recent + older points for more robust synchronization.

* **Bug Fixes / Data Integrity**
  * Metadata storage now upserts stake snapshots and epoch summaries, replacing prior records instead of ignoring conflicts; DB operations return clearer error context.

* **Tests**
  * Added tests validating intersection sampling and upsert behavior for stake snapshots and epoch summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->