### PR TITLE
ci(update-workflow): Switch to actions/attest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Attest Docker Hub image
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
-          subject-name: index.docker.io/blinklabs/dingo
+          subject-name: docker.io/blinklabs/dingo
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
       - name: Attest GHCR image
@@ -234,7 +234,7 @@ jobs:
         if: matrix.arch == 'amd64'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
-          subject-name: index.docker.io/blinklabs/dingo
+          subject-name: docker.io/blinklabs/dingo
           subject-digest: ${{ steps.antithesis-push.outputs.digest }}
           push-to-registry: true
       - name: Attest antithesis GHCR image


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI attestation to `actions/attest` v4.1.0 (pinned), replacing `actions/attest-build-provenance`.
Update publish workflow to attest the binary and Docker images (Docker Hub, GHCR, including antithesis), and normalize Docker Hub subject to `docker.io/blinklabs/dingo`.

<sup>Written for commit 893574907fab276c9177c1617520b86b216b4847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use the newer attest action across multiple build and image attestations, and corrected Docker image naming; improves build provenance handling for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->