### PR TITLE
fix(utxorpc): add Reset action and Tip field to FollowTip

### DIFF
--- a/utxorpc/sync.go
+++ b/utxorpc/sync.go
@@ -270,30 +270,35 @@ func (s *syncServiceServer) FollowTip(
 
 			if next.Rollback {
 				// Chain rolled back - emit Reset action
-				// Lookup block metadata for height and timestamp
-				rollbackBlock, err := s.utxorpc.config.LedgerState.GetBlock(
-					next.Point,
-				)
-				if err != nil {
-					s.utxorpc.config.Logger.Error(
-						"failed to get rollback block",
-						"error", err,
-					)
-					return err
-				}
-				// Convert slot to timestamp (milliseconds)
+				var height uint64
 				var timestamp uint64
-				if slotTime, err := s.utxorpc.config.LedgerState.SlotToTime(
-					next.Point.Slot,
-				); err == nil {
-					timestamp = uint64(slotTime.UnixMilli())
+				// Handle rollback-to-origin (genesis) separately
+				// Origin point has slot=0 and empty hash, no block to fetch
+				if next.Point.Slot > 0 || len(next.Point.Hash) > 0 {
+					rollbackBlock, err := s.utxorpc.config.LedgerState.GetBlock(
+						next.Point,
+					)
+					if err != nil {
+						s.utxorpc.config.Logger.Error(
+							"failed to get rollback block",
+							"error", err,
+						)
+						return err
+					}
+					height = rollbackBlock.Number
+					// Convert slot to timestamp (milliseconds)
+					if slotTime, err := s.utxorpc.config.LedgerState.SlotToTime(
+						next.Point.Slot,
+					); err == nil {
+						timestamp = uint64(slotTime.UnixMilli())
+					}
 				}
 				resp = &sync.FollowTipResponse{
 					Action: &sync.FollowTipResponse_Reset_{
 						Reset_: &sync.BlockRef{
 							Slot:      next.Point.Slot,
 							Hash:      next.Point.Hash,
-							Height:    rollbackBlock.Number,
+							Height:    height,
 							Timestamp: timestamp,
 						},
 					},

--- a/utxorpc/sync_test.go
+++ b/utxorpc/sync_test.go
@@ -117,8 +117,11 @@ func TestChainIteratorResult_RollbackField(t *testing.T) {
 	require.NotEmpty(t, forwardResult.Block.Cbor, "Block CBOR should not be empty")
 }
 
-// TestFollowTip_LogicFlow documents the expected logic flow for FollowTip
-// This is a documentation test that shows how the code should behave
+// TestFollowTip_LogicFlow documents the expected logic flow for FollowTip.
+// Note: These are structure tests that verify data types and logic patterns,
+// not integration tests. They don't call the actual FollowTip handler, so
+// they won't catch issues in the full request/response flow. For full
+// integration testing, see internal/integration/ tests.
 func TestFollowTip_LogicFlow(t *testing.T) {
 	// Simulate the logic flow in FollowTip
 	
@@ -221,4 +224,51 @@ func TestFollowTip_LogicFlow(t *testing.T) {
 		require.Equal(t, uint64(200), resp.Tip.Height, "Tip height should be 200")
 		require.NotZero(t, resp.Tip.Timestamp, "Tip timestamp should be set")
 	})
+}
+
+// TestFollowTip_RollbackToOrigin verifies that rollback to genesis (origin)
+// is handled correctly without attempting to fetch a non-existent block
+func TestFollowTip_RollbackToOrigin(t *testing.T) {
+	// Origin point has slot=0 and empty hash
+	originPoint := ocommon.NewPoint(0, []byte{})
+	
+	next := &chain.ChainIteratorResult{
+		Point:    originPoint,
+		Rollback: true,
+	}
+	
+	var resp *sync.FollowTipResponse
+	
+	// Simulate the rollback-to-origin logic
+	if next.Rollback {
+		var height uint64
+		var timestamp uint64
+		
+		// Origin check: don't call GetBlock for genesis
+		if next.Point.Slot > 0 || len(next.Point.Hash) > 0 {
+			// Would call GetBlock here for non-origin rollbacks
+			t.Fatal("should not attempt to fetch block for origin point")
+		}
+		// For origin, height and timestamp remain zero
+		
+		resp = &sync.FollowTipResponse{
+			Action: &sync.FollowTipResponse_Reset_{
+				Reset_: &sync.BlockRef{
+					Slot:      next.Point.Slot,
+					Hash:      next.Point.Hash,
+					Height:    height,
+					Timestamp: timestamp,
+				},
+			},
+		}
+	}
+	
+	// Verify Reset action for origin
+	reset, ok := resp.Action.(*sync.FollowTipResponse_Reset_)
+	require.True(t, ok, "should be Reset action")
+	require.NotNil(t, reset.Reset_, "Reset_ should not be nil")
+	require.Equal(t, uint64(0), reset.Reset_.Slot, "origin slot should be 0")
+	require.Empty(t, reset.Reset_.Hash, "origin hash should be empty")
+	require.Equal(t, uint64(0), reset.Reset_.Height, "origin height should be 0")
+	require.Equal(t, uint64(0), reset.Reset_.Timestamp, "origin timestamp should be 0")
 }


### PR DESCRIPTION
Closes #1470 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`utxorpc` FollowTip now emits a Reset action on rollbacks (including rollback to origin) and includes the current chain tip in every response. This lets clients handle rollbacks and display accurate tip info.

- **Bug Fixes**
  - On rollback, send `Reset` with `BlockRef {slot, hash, height, timestamp(ms)}`; for non-origin, set via `LedgerState.GetBlock` and `SlotToTime`, and for origin (slot=0, empty hash) skip lookups and leave height/timestamp as 0.
  - On forward blocks, continue sending `Apply`.
  - Always populate `Tip` with a `BlockRef` from `LedgerState.Tip()` including height and timestamp(ms).
  - Added tests for Reset/Apply structures, Tip field, rollback-to-origin, and logic flow.

<sup>Written for commit 72f91da1cc98735462b41d4bb37336f017086444. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced block synchronization protocol with improved rollback recovery mechanisms.
  * Added comprehensive tip information tracking in synchronization responses.

* **Bug Fixes**
  * Improved error handling for rollback scenarios and chain state recovery.

* **Tests**
  * Added extensive test coverage for synchronization protocol structures and control flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->