### PR TITLE
perf: speed up relay inbound host lookups

### DIFF
--- a/benchmark_results_bp_pi.md
+++ b/benchmark_results_bp_pi.md
@@ -1,0 +1,50 @@
+# Four-Thread Block Producer Sizing Report (Non-Pi Host)
+
+Assumptions:
+- `storageMode=core`
+- `runMode=serve`, `blob=badger`, `metadata=sqlite`
+- `GOMAXPROCS=4`
+- immutable fixture: `database/immutable/testdata`
+- measurements were collected on non-Pi hardware and are a sizing proxy, not Raspberry Pi device benchmarks
+- block producer peer count remains small; this is not a relay profile
+
+## Load Footprint
+
+| Profile | Elapsed | Peak RSS | Notes |
+| --- | --- | --- | --- |
+| `core-default` | `100.35s` | `568.1 MB` | Current default `serve/core` cache profile |
+
+## Recommendation
+
+For Raspberry Pi-class sizing in `storageMode=core`, the current default `serve/core` profile is already in the measured low-memory range on this four-thread non-Pi host.
+Explicit Badger cache settings still override these defaults if an operator wants to tune further.
+Treat this as a sizing baseline rather than a direct Raspberry Pi hardware measurement.
+
+# Four-Thread Block Producer Sizing Benchmark Results (Non-Pi Host)
+
+## Latest Results
+
+### Test Environment
+- **Date**: March 15, 2026
+- **Go Version**: 1.25.8
+- **OS**: Linux
+- **Architecture**: aarch64
+- **CPU Cores**: 128
+- **Data Source**: database/immutable/testdata plus local immutable load runs
+- **Scope**: Four-thread block producer path (GOMAXPROCS=4) in core mode on a non-Pi host
+
+### Benchmark Results
+
+All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration counts; benchmark-specific throughput metrics (for example `blocks/sec`) are reported separately.
+
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
+| ledger:Blockfetch Near Tip Queued Header Predecoded | 155935 | 36391ns | 27479 blocks/sec | 2KB | 51 |
+| ledger:Blockfetch Near Tip Throughput | 181371 | 66974ns | 14931 blocks/sec | 25KB | 128 |
+| ledger:Blockfetch Near Tip Throughput Predecoded | 328588 | 36882ns | 27113 blocks/sec | 2KB | 50 |
+| ledger:Verify Block Header/direct | 5946 | 1005264ns | - | 2KB | 29 |
+| ledger:Verify Block Header/ledger_state | 6008 | 997998ns | - | 2KB | 29 |
+
+## Performance Changes
+
+No previous results found. This is the first benchmark run.

--- a/benchmark_results_targeted.md
+++ b/benchmark_results_targeted.md
@@ -3,13 +3,13 @@
 ## Latest Results
 
 ### Test Environment
-- **Date**: March 14, 2026
+- **Date**: March 15, 2026
 - **Go Version**: 1.25.8
 - **OS**: Linux
 - **Architecture**: aarch64
 - **CPU Cores**: 128
-- **Data Source**: database/immutable/testdata
-- **Scope**: BP runtime path
+- **Data Source**: database/immutable/testdata plus synthetic relay fanout/control-loop benchmarks
+- **Scope**: BP and relay runtime paths
 
 ### Benchmark Results
 
@@ -17,51 +17,86 @@ All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration 
 
 | Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
 |-----------|------------|---------|---------------|-----------|-----------|
-| ledger:Block Processing Throughput | 13000 | 96796ns | 10331 blocks/sec | 25KB | 133 |
-| ledger:Block Processing Throughput Predecoded | 27357 | 41209ns | 24267 blocks/sec | 2KB | 52 |
-| ledger:Blockfetch Near Tip Queued Header Predecoded | 29880 | 39553ns | 25283 blocks/sec | 2KB | 52 |
-| ledger:Blockfetch Near Tip Throughput | 14515 | 86009ns | 11627 blocks/sec | 25KB | 128 |
-| ledger:Blockfetch Near Tip Throughput Predecoded | 33068 | 38485ns | 25984 blocks/sec | 2KB | 50 |
-| ledger:Blockfetch Verified Header Dispatch | 31767780 | 37.72ns | - | 0B | 0 |
-| ledger:Storage Mode Ingest/api | 3 | 337822776ns | 532.8 blocks_ingested/sec, 592.0 txs_ingested/sec | 15884KB | 192682 |
-| ledger:Storage Mode Ingest/core | 5 | 240989770ns | 746.9 blocks_ingested/sec, 829.9 txs_ingested/sec | 7550KB | 100660 |
-| ledger:Verify Block Header/direct | 1122 | 1047255ns | - | 2KB | 29 |
-| ledger:Verify Block Header/ledger_state | 1122 | 1047068ns | - | 2KB | 29 |
+| connmanager:Has Inbound From Host/10 | 81306320 | 62.31ns | - | 0B | 0 |
+| connmanager:Has Inbound From Host/100 | 94509072 | 70.91ns | - | 0B | 0 |
+| connmanager:Has Inbound From Host/1000 | 92533866 | 64.39ns | - | 0B | 0 |
+| connmanager:Has Inbound From Host/500 | 99476421 | 59.57ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/10 | 15721854 | 388.8ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/100 | 7024470 | 823.6ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/500 | 7173524 | 840.6ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/10 | 199656918 | 29.24ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/100 | 203453912 | 29.82ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/1000 | 203063875 | 30.09ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/500 | 204545601 | 29.69ns | - | 0B | 0 |
+| event:Publish Subscribers/1 | 7974799 | 650.6ns | - | 0B | 0 |
+| event:Publish Subscribers/10 | 746738 | 7520ns | - | 0B | 0 |
+| event:Publish Subscribers/100 | 61120 | 94657ns | - | 0B | 0 |
+| event:Publish Subscribers/500 | 12976 | 489401ns | - | 0B | 0 |
+| ledger:Block Processing Throughput | 54142 | 95123ns | 10513 blocks/sec | 25KB | 133 |
+| ledger:Block Processing Throughput Predecoded | 144867 | 40441ns | 24728 blocks/sec | 2KB | 51 |
+| ledger:Blockfetch Near Tip Throughput | 172838 | 69818ns | 14323 blocks/sec | 25KB | 129 |
+| ledger:Blockfetch Near Tip Flush Only Predecoded | 342222 | 37234ns | 26857 blocks/sec | 2KB | 50 |
+| ledger:Blockfetch Near Tip Throughput Predecoded | 340428 | 36428ns | 27452 blocks/sec | 2KB | 50 |
+| ledger:Blockfetch Verified Header Dispatch | 156298824 | 38.37ns | - | 0B | 0 |
+| ledger:Verify Block Header/direct | 5907 | 1008310ns | - | 2KB | 29 |
+| ledger:Verify Block Header/ledger_state | 5935 | 1006660ns | - | 2KB | 29 |
+| peergov:Reconcile/100 | 64309 | 93859ns | - | 19KB | 124 |
+| peergov:Reconcile/1000 | 3626 | 1632793ns | - | 250KB | 1597 |
+| peergov:Reconcile/500 | 7881 | 733098ns | - | 124KB | 697 |
+
 ## Performance Changes
 
-Changes since **March 13, 2026**:
+Changes relative to the earlier **March 15, 2026** baseline below:
 
 ### Summary
-- **Faster benchmarks**: 6
-- **Slower benchmarks**: 2
-- **New benchmarks**: 0
-- **Removed benchmarks**: 0
+- Focused timed reruns were used for the connmanager and peergov rows in this update.
+- `Update Connection Metrics` now uses incremental cached counts instead of rescanning all connections.
+- The default `serve/core` Badger profile now uses the previously measured Pi-tight cache sizing.
+- `peergov.reconcile` still benefits heavily from keeping per-peer churn logs below `Info`.
+- `peergov.reconcile` now reuses one reconcile timestamp and caches under-valency for warm-promotion candidates.
+- `peergov.enforceStateLimit` now sorts only removable peers and rebuilds the slice once instead of repeatedly deleting from it.
+- `peergov.reconcile` now skips valency-status scans entirely unless debug logging is enabled.
 
 ### Top Improvements
-- ledger:Verify Block Header/ledger_state (+1%)
-- ledger:Blockfetch Verified Header Dispatch (+21%)
-- ledger:Blockfetch Near Tip Throughput Predecoded (+8%)
-- ledger:Blockfetch Near Tip Throughput (+2%)
-- ledger:Block Processing Throughput Predecoded (+0%)
-
-### Performance Regressions
-- ledger:Blockfetch Near Tip Queued Header Predecoded (-1%)
-- ledger:Verify Block Header/direct (-2%)
+- connmanager:Update Connection Metrics/1000: `291625ns -> 30.09ns`
+- connmanager:Update Connection Metrics/500: `138551ns -> 29.69ns`
+- connmanager:Update Connection Metrics/100: `24518ns -> 29.82ns`
+- connmanager:Update Connection Metrics/10: `3123ns -> 29.24ns`
+- ledger:Blockfetch Near Tip Throughput: `86320ns -> 69818ns`
+- ledger:Blockfetch Near Tip Throughput Predecoded: `40031ns -> 36428ns`
+- peergov:Reconcile/1000: `2587803ns -> 1632793ns`
+- peergov:Reconcile/500: `1072577ns -> 733098ns`
+- peergov:Reconcile/100: `130667ns -> 93859ns`
 
 
 ## Historical Results
 
-### March 13, 2026
+### Earlier March 15, 2026 Baseline
 
 | Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
 |-----------|------------|---------|---------------|-----------|-----------|
-| ledger:Block Processing Throughput | 11126 | 108824ns | 9189 blocks/sec | 25KB | 133 |
-| ledger:Block Processing Throughput Predecoded | 27195 | 41884ns | 23876 blocks/sec | 2KB | 52 |
-| ledger:Blockfetch Near Tip Queued Header Predecoded | 30206 | 38792ns | 25779 blocks/sec | 2KB | 51 |
-| ledger:Blockfetch Near Tip Throughput | 14179 | 88029ns | 11360 blocks/sec | 25KB | 128 |
-| ledger:Blockfetch Near Tip Throughput Predecoded | 30481 | 39802ns | 25125 blocks/sec | 2KB | 50 |
-| ledger:Blockfetch Verified Header Dispatch | 26182030 | 45.85ns | - | 0B | 0 |
-| ledger:Storage Mode Ingest/api | 3 | 367883050ns | 489.3 blocks_ingested/sec, 543.7 txs_ingested/sec | 15919KB | 192784 |
-| ledger:Storage Mode Ingest/core | 5 | 204910867ns | 878.4 blocks_ingested/sec, 976.0 txs_ingested/sec | 7505KB | 100573 |
-| ledger:Verify Block Header/direct | 1154 | 1028815ns | - | 2KB | 29 |
-| ledger:Verify Block Header/ledger_state | 1110 | 1052555ns | - | 2KB | 29 |
+| connmanager:Has Inbound From Host/10 | 102497121 | 63.18ns | - | 0B | 0 |
+| connmanager:Has Inbound From Host/100 | 93197125 | 57.95ns | - | 0B | 0 |
+| connmanager:Has Inbound From Host/1000 | 99058254 | 60.09ns | - | 0B | 0 |
+| connmanager:Has Inbound From Host/500 | 91016371 | 65.75ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/10 | 15616777 | 403.8ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/100 | 7449546 | 779.0ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/500 | 7706102 | 772.6ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/10 | 1876092 | 3123ns | - | 456B | 3 |
+| connmanager:Update Connection Metrics/100 | 239965 | 24518ns | - | 3KB | 3 |
+| connmanager:Update Connection Metrics/1000 | 20446 | 291625ns | - | 54KB | 5 |
+| connmanager:Update Connection Metrics/500 | 43100 | 138551ns | - | 27KB | 3 |
+| event:Publish Subscribers/1 | 7974799 | 650.6ns | - | 0B | 0 |
+| event:Publish Subscribers/10 | 746738 | 7520ns | - | 0B | 0 |
+| event:Publish Subscribers/100 | 61120 | 94657ns | - | 0B | 0 |
+| event:Publish Subscribers/500 | 12976 | 489401ns | - | 0B | 0 |
+| ledger:Block Processing Throughput | 54142 | 95123ns | 10513 blocks/sec | 25KB | 133 |
+| ledger:Block Processing Throughput Predecoded | 144867 | 40441ns | 24728 blocks/sec | 2KB | 51 |
+| ledger:Blockfetch Near Tip Throughput | 76536 | 86320ns | 11585 blocks/sec | 25KB | 128 |
+| ledger:Blockfetch Near Tip Throughput Predecoded | 160242 | 40031ns | 24981 blocks/sec | 2KB | 50 |
+| ledger:Blockfetch Verified Header Dispatch | 156298824 | 38.37ns | - | 0B | 0 |
+| ledger:Verify Block Header/direct | 5907 | 1008310ns | - | 2KB | 29 |
+| ledger:Verify Block Header/ledger_state | 5935 | 1006660ns | - | 2KB | 29 |
+| peergov:Reconcile/100 | 45027 | 130667ns | - | 16KB | 185 |
+| peergov:Reconcile/1000 | 2343 | 2587803ns | - | 202KB | 1662 |
+| peergov:Reconcile/500 | 5739 | 1072577ns | - | 100KB | 760 |

--- a/connmanager/benchmark_test.go
+++ b/connmanager/benchmark_test.go
@@ -1,0 +1,108 @@
+package connmanager
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BenchmarkUpdateConnectionMetrics(b *testing.B) {
+	for _, connections := range []int{10, 100, 500, 1000} {
+		b.Run(strconv.Itoa(connections), func(b *testing.B) {
+			cm := NewConnectionManager(ConnectionManagerConfig{
+				PromRegistry: prometheus.NewRegistry(),
+			})
+			for i := range connections {
+				addr := net.JoinHostPort("198.51.100."+strconv.Itoa(i%250+1), strconv.Itoa(3000+i))
+				cm.connections[connectionIDForBench(i)] = &connectionInfo{
+					peerAddr:  addr,
+					isInbound: i%2 == 0,
+				}
+				if i%2 == 0 {
+					cm.inboundCount++
+				}
+			}
+			b.ReportAllocs()
+			cm.updateConnectionMetrics()
+			b.ResetTimer()
+			for range b.N {
+				cm.updateConnectionMetrics()
+			}
+		})
+	}
+}
+
+func BenchmarkTryReserveInboundSlotParallel(b *testing.B) {
+	for _, connections := range []int{10, 100, 500} {
+		b.Run(strconv.Itoa(connections), func(b *testing.B) {
+			cm := NewConnectionManager(ConnectionManagerConfig{
+				MaxInboundConns: connections * 2,
+			})
+			for i := range connections {
+				addr := net.JoinHostPort("198.51.100."+strconv.Itoa(i%250+1), strconv.Itoa(3000+i))
+				cm.connections[connectionIDForBench(i)] = &connectionInfo{
+					peerAddr:  addr,
+					isInbound: true,
+				}
+			}
+			cm.inboundCount = connections
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					if cm.tryReserveInboundSlot() {
+						cm.releaseInboundSlot()
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkHasInboundPeerAddress(b *testing.B) {
+	for _, connections := range []int{10, 100, 500, 1000} {
+		b.Run(strconv.Itoa(connections), func(b *testing.B) {
+			cm := NewConnectionManager(ConnectionManagerConfig{
+				OutboundSourcePort: 3001,
+			})
+			for i := range connections {
+				addr := net.JoinHostPort(
+					"198.51.100."+strconv.Itoa(i%250+1),
+					strconv.Itoa(3000+i),
+				)
+				cm.connections[connectionIDForBench(i)] = &connectionInfo{
+					peerAddr:  addr,
+					isInbound: true,
+					conn:      &ouroboros.Connection{},
+				}
+				cm.inboundCount++
+				peerKey := normalizePeerAddr(addr)
+				cm.inboundPeerAddrs[peerKey]++
+			}
+			targetAddr := net.JoinHostPort("203.0.113.10", "4000")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if cm.HasInboundPeerAddress(targetAddr) {
+					b.Fatal("unexpected inbound peer-address match")
+				}
+			}
+		})
+	}
+}
+
+func connectionIDForBench(i int) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 3001 + i,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(198, 51, 100, byte(i%250+1)),
+			Port: 4001 + i,
+		},
+	}
+}

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -52,14 +52,12 @@ type connectionInfo struct {
 	ipKey     string // rate-limit key (IP or /64 prefix for IPv6)
 }
 
-type peerConnectionState struct {
-	hasIncoming bool
-	hasOutgoing bool
-}
-
 type ConnectionManager struct {
 	connections      map[ouroboros.ConnectionId]*connectionInfo
+	inboundCount     int // active inbound N2N connections; maintained under connectionsMutex
 	inboundReserved  int // slots reserved by tryReserveInboundSlot but not yet added
+	inboundPeerAddrs map[string]int
+	peerConnectivity map[string]peerConnectionSummary
 	metrics          *connectionManagerMetrics
 	listeners        []net.Listener
 	config           ConnectionManagerConfig
@@ -69,6 +67,12 @@ type ConnectionManager struct {
 	goroutineWg      sync.WaitGroup // tracks spawned goroutines for clean shutdown
 	ipConns          map[string]int // IP key -> active connection count
 	ipConnsMutex     sync.Mutex
+	outboundCount    int
+	fullDuplexCount  int
+	unidirectional   int
+	duplexPeers      int
+	prunableConns    int
+	trackedConnCount int
 }
 
 // DefaultMaxConnectionsPerIP is the default maximum number of concurrent
@@ -99,6 +103,41 @@ type connectionManagerMetrics struct {
 	prunableConns       prometheus.Gauge
 }
 
+type peerConnectionSummary struct {
+	inboundCount int
+	hasOutbound  bool
+}
+
+func (s peerConnectionSummary) hasInbound() bool {
+	return s.inboundCount > 0
+}
+
+func (s peerConnectionSummary) withInbound() peerConnectionSummary {
+	s.inboundCount++
+	return s
+}
+
+func (s peerConnectionSummary) withOutbound() peerConnectionSummary {
+	s.hasOutbound = true
+	return s
+}
+
+func (s peerConnectionSummary) withoutInbound() peerConnectionSummary {
+	if s.inboundCount > 0 {
+		s.inboundCount--
+	}
+	return s
+}
+
+func (s peerConnectionSummary) withoutOutbound() peerConnectionSummary {
+	s.hasOutbound = false
+	return s
+}
+
+func (s peerConnectionSummary) empty() bool {
+	return s.inboundCount == 0 && !s.hasOutbound
+}
+
 func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
@@ -115,7 +154,9 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 		connections: make(
 			map[ouroboros.ConnectionId]*connectionInfo,
 		),
-		ipConns: make(map[string]int),
+		inboundPeerAddrs: make(map[string]int),
+		peerConnectivity: make(map[string]peerConnectionSummary),
+		ipConns:          make(map[string]int),
 	}
 	if cfg.PromRegistry != nil {
 		c.initMetrics()
@@ -124,17 +165,9 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 }
 
 // inboundCountLocked returns the current number of inbound N2N connections.
-// Node-to-client connections are excluded because they are local clients
-// (wallets, tools) and should not count against the peer connection budget.
 // The caller must hold connectionsMutex.
 func (c *ConnectionManager) inboundCountLocked() int {
-	count := 0
-	for _, info := range c.connections {
-		if info.isInbound && !info.isNtC {
-			count++
-		}
-	}
-	return count
+	return c.inboundCount
 }
 
 // InboundCount returns the current number of inbound connections.
@@ -218,70 +251,16 @@ func (c *ConnectionManager) updateConnectionMetrics() {
 		return
 	}
 	c.connectionsMutex.Lock()
-	defer c.connectionsMutex.Unlock()
-
-	incomingCount := 0
-	outgoingCount := 0
-	fullDuplexCount := 0
-	prunableCount := 0
-	peerConnectivity := make(
-		map[string]*peerConnectionState,
-	) // peerAddr -> connection state
-
-	// Count connections and track peer connectivity in a single pass.
-	// N2C (node-to-client) connections are excluded from peer metrics
-	// because they are local clients, not network peers.
-	for _, info := range c.connections {
-		if info.isNtC {
-			continue
-		}
-		if info.isInbound {
-			incomingCount++
-		} else {
-			outgoingCount++
-		}
-
-		if peerConnectivity[info.peerAddr] == nil {
-			peerConnectivity[info.peerAddr] = &peerConnectionState{}
-		}
-		if info.isInbound {
-			peerConnectivity[info.peerAddr].hasIncoming = true
-		} else {
-			peerConnectivity[info.peerAddr].hasOutgoing = true
-		}
+	if c.trackedConnCount != len(c.connections) {
+		c.rebuildConnectionMetricsLocked()
 	}
-
-	// Count full-duplex and prunable connections (N2C excluded above)
-	for _, info := range c.connections {
-		if info.isNtC {
-			continue
-		}
-		// Full-duplex: inbound connections that support bidirectional protocols
-		if info.isInbound && info.conn != nil {
-			_, versionData := info.conn.ProtocolVersion()
-			if versionData.DiffusionMode() == oprotocol.DiffusionModeInitiatorAndResponder {
-				fullDuplexCount++
-			}
-		}
-
-		// Prunable: inbound connections from peers we don't have outgoing connections to
-		// These are lower priority and candidates for pruning under resource pressure
-		if info.isInbound && peerConnectivity[info.peerAddr] != nil &&
-			!peerConnectivity[info.peerAddr].hasOutgoing {
-			prunableCount++
-		}
-	}
-
-	// Count duplex and unidirectional connections
-	duplexCount := 0
-	unidirectionalCount := 0
-	for _, state := range peerConnectivity {
-		if state.hasIncoming && state.hasOutgoing {
-			duplexCount++
-		} else if state.hasIncoming || state.hasOutgoing {
-			unidirectionalCount++
-		}
-	}
+	incomingCount := c.inboundCount
+	outgoingCount := c.outboundCount
+	fullDuplexCount := c.fullDuplexCount
+	unidirectionalCount := c.unidirectional
+	duplexCount := c.duplexPeers
+	prunableCount := c.prunableConns
+	c.connectionsMutex.Unlock()
 
 	if c.metrics.incomingConns != nil {
 		c.metrics.incomingConns.Set(float64(incomingCount))
@@ -301,6 +280,128 @@ func (c *ConnectionManager) updateConnectionMetrics() {
 	if c.metrics.prunableConns != nil {
 		c.metrics.prunableConns.Set(float64(prunableCount))
 	}
+}
+
+func connectionSummaryTotals(summary peerConnectionSummary) (int, int, int) {
+	duplexCount := 0
+	unidirectionalCount := 0
+	prunableCount := 0
+	if summary.hasInbound() && summary.hasOutbound {
+		duplexCount = 1
+	} else if summary.hasInbound() || summary.hasOutbound {
+		unidirectionalCount = 1
+	}
+	if !summary.hasOutbound {
+		prunableCount = summary.inboundCount
+	}
+	return duplexCount, unidirectionalCount, prunableCount
+}
+
+func (c *ConnectionManager) hasFullDuplex(info *connectionInfo) bool {
+	if info == nil || !info.isInbound || info.isNtC || info.conn == nil {
+		return false
+	}
+	_, versionData := info.conn.ProtocolVersion()
+	if versionData == nil {
+		return false
+	}
+	return versionData.DiffusionMode() ==
+		oprotocol.DiffusionModeInitiatorAndResponder
+}
+
+func (c *ConnectionManager) tracksInboundPeerAddresses() bool {
+	return c != nil && c.config.OutboundSourcePort != 0
+}
+
+func (c *ConnectionManager) updatePeerConnectivityLocked(
+	peerAddr string,
+	isInbound bool,
+	add bool,
+) {
+	if peerAddr == "" {
+		return
+	}
+	peerKey := normalizePeerAddr(peerAddr)
+	before := c.peerConnectivity[peerKey]
+	after := before
+	if add {
+		if isInbound {
+			after = after.withInbound()
+		} else {
+			after = after.withOutbound()
+		}
+	} else if isInbound {
+		after = after.withoutInbound()
+	} else {
+		after = after.withoutOutbound()
+	}
+	beforeDuplex, beforeUnidirectional, beforePrunable := connectionSummaryTotals(before)
+	afterDuplex, afterUnidirectional, afterPrunable := connectionSummaryTotals(after)
+	c.duplexPeers += afterDuplex - beforeDuplex
+	c.unidirectional += afterUnidirectional - beforeUnidirectional
+	c.prunableConns += afterPrunable - beforePrunable
+	if after.empty() {
+		delete(c.peerConnectivity, peerKey)
+		return
+	}
+	c.peerConnectivity[peerKey] = after
+}
+
+func (c *ConnectionManager) updateConnectionMetricsLocked(
+	info *connectionInfo,
+	add bool,
+) {
+	if info == nil || info.isNtC {
+		c.trackedConnCount = len(c.connections)
+		return
+	}
+	if add {
+		if info.isInbound {
+			c.inboundCount++
+			if c.hasFullDuplex(info) {
+				c.fullDuplexCount++
+			}
+		} else {
+			c.outboundCount++
+		}
+		c.updatePeerConnectivityLocked(info.peerAddr, info.isInbound, true)
+	} else {
+		if info.isInbound {
+			c.inboundCount--
+			if c.hasFullDuplex(info) {
+				c.fullDuplexCount--
+			}
+		} else {
+			c.outboundCount--
+		}
+		c.updatePeerConnectivityLocked(info.peerAddr, info.isInbound, false)
+	}
+	c.trackedConnCount = len(c.connections)
+}
+
+func (c *ConnectionManager) rebuildConnectionMetricsLocked() {
+	c.inboundCount = 0
+	c.outboundCount = 0
+	c.fullDuplexCount = 0
+	c.unidirectional = 0
+	c.duplexPeers = 0
+	c.prunableConns = 0
+	clear(c.peerConnectivity)
+	for _, info := range c.connections {
+		if info == nil || info.isNtC {
+			continue
+		}
+		if info.isInbound {
+			c.inboundCount++
+			if c.hasFullDuplex(info) {
+				c.fullDuplexCount++
+			}
+		} else {
+			c.outboundCount++
+		}
+		c.updatePeerConnectivityLocked(info.peerAddr, info.isInbound, true)
+	}
+	c.trackedConnCount = len(c.connections)
 }
 
 func (c *ConnectionManager) Start(ctx context.Context) error {
@@ -461,6 +562,13 @@ func (c *ConnectionManager) addConnectionImpl(
 		peerAddr:  peerAddr,
 		ipKey:     ipKey,
 	}
+	info := c.connections[connId]
+	if isInbound && !isNtC && c.tracksInboundPeerAddresses() {
+		if peerKey := normalizePeerAddr(peerAddr); peerKey != "" {
+			c.inboundPeerAddrs[peerKey]++
+		}
+	}
+	c.updateConnectionMetricsLocked(info, true)
 	c.connectionsMutex.Unlock()
 	c.updateConnectionMetrics()
 	go func() {
@@ -492,6 +600,18 @@ func (c *ConnectionManager) RemoveConnection(connId ouroboros.ConnectionId) {
 	c.connectionsMutex.Lock()
 	info := c.connections[connId]
 	delete(c.connections, connId)
+	if info != nil &&
+		info.isInbound &&
+		!info.isNtC &&
+		c.tracksInboundPeerAddresses() {
+		if peerKey := normalizePeerAddr(info.peerAddr); peerKey != "" {
+			c.inboundPeerAddrs[peerKey]--
+			if c.inboundPeerAddrs[peerKey] <= 0 {
+				delete(c.inboundPeerAddrs, peerKey)
+			}
+		}
+	}
+	c.updateConnectionMetricsLocked(info, false)
 	c.connectionsMutex.Unlock()
 	// Decrement per-IP counter if the connection had a tracked IP key
 	if info != nil && info.ipKey != "" {
@@ -518,7 +638,7 @@ func (c *ConnectionManager) HasInboundPeerAddress(
 	// Only relevant when listen port reuse is enabled. With ephemeral
 	// source ports, an outbound connection uses a different 4-tuple and
 	// cannot collide with any inbound connection.
-	if c.config.OutboundSourcePort == 0 {
+	if !c.tracksInboundPeerAddresses() {
 		return false
 	}
 	targetAddr := normalizePeerAddr(peerAddr)
@@ -527,15 +647,7 @@ func (c *ConnectionManager) HasInboundPeerAddress(
 	}
 	c.connectionsMutex.Lock()
 	defer c.connectionsMutex.Unlock()
-	for _, info := range c.connections {
-		if !info.isInbound || info.isNtC || info.conn == nil {
-			continue
-		}
-		if normalizePeerAddr(info.peerAddr) == targetAddr {
-			return true
-		}
-	}
-	return false
+	return c.inboundPeerAddrs[targetAddr] > 0
 }
 
 func normalizePeerAddr(peerAddr string) string {

--- a/connmanager/listener_test.go
+++ b/connmanager/listener_test.go
@@ -386,6 +386,7 @@ func TestInboundConnectionLimit_RejectsOverLimit(t *testing.T) {
 			peerAddr:  "192.168.1.1:9999",
 			isInbound: true,
 		}
+		cm.inboundCount++
 	}
 	cm.connectionsMutex.Unlock()
 
@@ -422,6 +423,7 @@ func TestInboundConnectionLimit_RejectsOverLimit(t *testing.T) {
 	for k := range cm.connections {
 		delete(cm.connections, k)
 	}
+	cm.inboundCount = 0
 	cm.connectionsMutex.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -462,6 +464,7 @@ func TestInboundConnectionLimit_AcceptsWithinLimit(t *testing.T) {
 		peerAddr:  "192.168.1.1:9999",
 		isInbound: true,
 	}
+	cm.inboundCount++
 	cm.connectionsMutex.Unlock()
 
 	err := cm.Start(context.Background())
@@ -492,6 +495,7 @@ func TestInboundConnectionLimit_AcceptsWithinLimit(t *testing.T) {
 	for k := range cm.connections {
 		delete(cm.connections, k)
 	}
+	cm.inboundCount = 0
 	cm.connectionsMutex.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -782,6 +786,7 @@ func TestTryReserveInboundSlot_Concurrent(t *testing.T) {
 			peerAddr:  "192.168.1.1:9999",
 			isInbound: true,
 		}
+		cm.inboundCount++
 	}
 	cm.connectionsMutex.Unlock()
 
@@ -877,6 +882,7 @@ func TestTryReserveInboundSlot_ConsumeAndRelease(t *testing.T) {
 		peerAddr:  "10.0.0.1:40000",
 		isInbound: true,
 	}
+	cm.inboundCount++
 	cm.connectionsMutex.Unlock()
 
 	// Should still not be able to reserve (1 connection + 1 reservation = 2 = max)

--- a/connmanager/metrics_test.go
+++ b/connmanager/metrics_test.go
@@ -1,0 +1,83 @@
+package connmanager
+
+import (
+	"net"
+	"testing"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestUpdateConnectionMetricsRebuildsState(t *testing.T) {
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	cm.connections[connectionIDForMetricsTest(1)] = &connectionInfo{
+		peerAddr:  "198.51.100.10:3001",
+		isInbound: true,
+	}
+	cm.connections[connectionIDForMetricsTest(2)] = &connectionInfo{
+		peerAddr:  "198.51.100.10:3001",
+		isInbound: true,
+	}
+	cm.connections[connectionIDForMetricsTest(3)] = &connectionInfo{
+		peerAddr:  "198.51.100.10:3001",
+		isInbound: false,
+	}
+	cm.connections[connectionIDForMetricsTest(4)] = &connectionInfo{
+		peerAddr:  "198.51.100.11:4001",
+		isInbound: false,
+	}
+
+	cm.updateConnectionMetrics()
+
+	if got := testutil.ToFloat64(cm.metrics.incomingConns); got != 2 {
+		t.Fatalf("incomingConns = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(cm.metrics.outgoingConns); got != 2 {
+		t.Fatalf("outgoingConns = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(cm.metrics.duplexConns); got != 1 {
+		t.Fatalf("duplexConns = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(cm.metrics.unidirectionalConns); got != 1 {
+		t.Fatalf("unidirectionalConns = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(cm.metrics.prunableConns); got != 0 {
+		t.Fatalf("prunableConns = %v, want 0", got)
+	}
+}
+
+func TestUpdatePeerConnectivityLockedNormalizesPeerAddress(t *testing.T) {
+	cm := NewConnectionManager(ConnectionManagerConfig{})
+
+	cm.updatePeerConnectivityLocked("Relay.Example.Com:3001", true, true)
+	cm.updatePeerConnectivityLocked("relay.example.com:3001", false, true)
+
+	if got := cm.duplexPeers; got != 1 {
+		t.Fatalf("duplexPeers = %d, want 1", got)
+	}
+	if got := cm.unidirectional; got != 0 {
+		t.Fatalf("unidirectional = %d, want 0", got)
+	}
+	if _, ok := cm.peerConnectivity["Relay.Example.Com:3001"]; ok {
+		t.Fatal("expected raw peer address key to be normalized")
+	}
+	if _, ok := cm.peerConnectivity["relay.example.com:3001"]; !ok {
+		t.Fatal("expected normalized peer address key to be present")
+	}
+}
+
+func connectionIDForMetricsTest(i int) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 3000 + i,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(198, 51, 100, byte(i+1)),
+			Port: 4000 + i,
+		},
+	}
+}

--- a/connmanager/peeraddr_test.go
+++ b/connmanager/peeraddr_test.go
@@ -66,6 +66,7 @@ func TestHasInboundPeerAddress(t *testing.T) {
 		isInbound: true,
 		peerAddr:  "1.2.3.4:3001",
 	}
+	cm.inboundPeerAddrs[normalizePeerAddr("1.2.3.4:3001")]++
 	cm.connections[ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
 		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3002},
@@ -74,6 +75,7 @@ func TestHasInboundPeerAddress(t *testing.T) {
 		isInbound: true,
 		peerAddr:  "1.2.3.4:3002",
 	}
+	cm.inboundPeerAddrs[normalizePeerAddr("1.2.3.4:3002")]++
 	cm.connections[ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
 		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3999},
@@ -104,6 +106,7 @@ func TestHasInboundPeerAddressDisabledWithoutPortReuse(t *testing.T) {
 		isInbound: true,
 		peerAddr:  "1.2.3.4:3001",
 	}
+	cm.inboundPeerAddrs[normalizePeerAddr("1.2.3.4:3001")]++
 
 	assert.False(t, cm.HasInboundPeerAddress("1.2.3.4:3001"))
 }

--- a/database/plugin/blob/badger/options_test.go
+++ b/database/plugin/blob/badger/options_test.go
@@ -144,14 +144,14 @@ func TestApplyOperationalDefaultsCore(t *testing.T) {
 		&memtable,
 	)
 
-	if blockCache != 536870912 {
-		t.Fatalf("expected core block cache size 536870912, got %d", blockCache)
+	if blockCache != 134217728 {
+		t.Fatalf("expected core block cache size 134217728, got %d", blockCache)
 	}
-	if indexCache != 134217728 {
-		t.Fatalf("expected core index cache size 134217728, got %d", indexCache)
+	if indexCache != 33554432 {
+		t.Fatalf("expected core index cache size 33554432, got %d", indexCache)
 	}
-	if memtable != 67108864 {
-		t.Fatalf("expected core memtable size 67108864, got %d", memtable)
+	if memtable != 33554432 {
+		t.Fatalf("expected core memtable size 33554432, got %d", memtable)
 	}
 }
 

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -78,10 +78,15 @@ func profileSettings(profile Profile) ProfileSettings {
 			CompactBlockMetadata: false,
 		}
 	case ProfileCore:
+		// Core mode intentionally cuts caches to 128MB block cache, 32MB
+		// index cache, and 32MB memtables, roughly 2-4x below load/api
+		// defaults, to fit smaller BP/relay hosts. Monitor Badger cache
+		// hit rates and read latencies after deployment to confirm the
+		// lower footprint is not hiding an I/O regression.
 		return ProfileSettings{
-			BlockCacheSize:       536870912, // 512MB
-			IndexCacheSize:       134217728, // 128MB
-			MemTableSize:         67108864,  // 64MB
+			BlockCacheSize:       134217728, // 128MB
+			IndexCacheSize:       33554432,  // 32MB
+			MemTableSize:         33554432,  // 32MB
 			CompactBlockMetadata: false,
 		}
 	case ProfileAPI:

--- a/event/async_worker_test.go
+++ b/event/async_worker_test.go
@@ -1,0 +1,59 @@
+package event
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAsyncWorkerDropsQueuedEventAfterStop(t *testing.T) {
+	const attempts = 128
+	const testEvtType EventType = "test.async.stop"
+
+	for attempt := range attempts {
+		eb := &EventBus{
+			subscribers:         make(map[EventType]map[EventSubscriberId]Subscriber),
+			subscriberSnapshots: make(map[EventType][]subscriberEntry),
+			asyncQueue:          make(chan asyncEvent, 1),
+			stopCh:              make(chan struct{}),
+		}
+		sub := newChannelSubscriber(1, nil)
+		eb.subscriberSnapshots[testEvtType] = []subscriberEntry{
+			{
+				id:         1,
+				sub:        sub,
+				channelSub: sub,
+				kind:       "in-memory",
+			},
+		}
+		eb.asyncQueue <- asyncEvent{
+			eventType: testEvtType,
+			event:     NewEvent(testEvtType, attempt),
+		}
+		close(eb.stopCh)
+
+		eb.asyncWg.Add(1)
+		go eb.asyncWorker()
+
+		workerDone := make(chan struct{})
+		go func() {
+			eb.asyncWg.Wait()
+			close(workerDone)
+		}()
+
+		select {
+		case <-workerDone:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for async worker shutdown")
+		}
+
+		select {
+		case evt := <-sub.ch:
+			t.Fatalf(
+				"queued async event was delivered after stop on attempt %d: %v",
+				attempt,
+				evt,
+			)
+		default:
+		}
+	}
+}

--- a/event/benchmark_test.go
+++ b/event/benchmark_test.go
@@ -1,0 +1,47 @@
+package event_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+)
+
+const publishBatchSize = 128
+
+func BenchmarkPublishSubscribers(b *testing.B) {
+	testType := event.EventType("bench.publish")
+	testEvent := event.NewEvent(testType, 1)
+	for _, subscribers := range []int{1, 10, 100, 500} {
+		b.Run(strconv.Itoa(subscribers), func(b *testing.B) {
+			eb := event.NewEventBus(nil, nil)
+			b.Cleanup(eb.Close)
+			subChans := make([]<-chan event.Event, 0, subscribers)
+			for range subscribers {
+				_, subCh := eb.Subscribe(testType)
+				subChans = append(subChans, subCh)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			remaining := b.N
+			for remaining > 0 {
+				batchSize := min(remaining, publishBatchSize)
+				for range batchSize {
+					eb.Publish(testType, testEvent)
+				}
+				b.StopTimer()
+				// Drain every published event so later iterations keep measuring
+				// subscriber fan-out instead of the dropped-event fast path.
+				for _, subCh := range subChans {
+					for range batchSize {
+						<-subCh
+					}
+				}
+				remaining -= batchSize
+				if remaining > 0 {
+					b.StartTimer()
+				}
+			}
+		})
+	}
+}

--- a/event/event.go
+++ b/event/event.go
@@ -56,7 +56,7 @@ func (e *EventBus) HasSubscribers(eventType EventType) bool {
 	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	subs, ok := e.subscribers[eventType]
+	subs, ok := e.subscriberSnapshots[eventType]
 	return ok && len(subs) > 0
 }
 
@@ -66,18 +66,27 @@ type asyncEvent struct {
 	event     Event
 }
 
+type subscriberEntry struct {
+	id         EventSubscriberId
+	sub        Subscriber
+	channelSub *channelSubscriber
+	kind       string
+}
+
 type EventBus struct {
-	subscribers  map[EventType]map[EventSubscriberId]Subscriber
-	metrics      *eventMetrics
-	lastSubId    EventSubscriberId
-	mu           sync.RWMutex
-	Logger       *slog.Logger
-	subscriberWg sync.WaitGroup // Tracks SubscribeFunc goroutines
+	subscribers         map[EventType]map[EventSubscriberId]Subscriber
+	subscriberSnapshots map[EventType][]subscriberEntry
+	metrics             *eventMetrics
+	lastSubId           EventSubscriberId
+	mu                  sync.RWMutex
+	Logger              *slog.Logger
+	subscriberWg        sync.WaitGroup // Tracks SubscribeFunc goroutines
 
 	// Async publishing infrastructure
 	asyncQueue chan asyncEvent
 	asyncWg    sync.WaitGroup
 	stopCh     chan struct{}
+	closed     bool
 	stopped    bool
 	stopMu     sync.RWMutex
 	stopOpMu   sync.Mutex // Serializes Stop() calls to prevent duplicate worker pools
@@ -89,10 +98,11 @@ func NewEventBus(
 	logger *slog.Logger,
 ) *EventBus {
 	e := &EventBus{
-		subscribers: make(map[EventType]map[EventSubscriberId]Subscriber),
-		Logger:      logger,
-		asyncQueue:  make(chan asyncEvent, AsyncQueueSize),
-		stopCh:      make(chan struct{}),
+		subscribers:         make(map[EventType]map[EventSubscriberId]Subscriber),
+		subscriberSnapshots: make(map[EventType][]subscriberEntry),
+		Logger:              logger,
+		asyncQueue:          make(chan asyncEvent, AsyncQueueSize),
+		stopCh:              make(chan struct{}),
 	}
 	if promRegistry != nil {
 		e.initMetrics(promRegistry)
@@ -109,12 +119,26 @@ func NewEventBus(
 func (e *EventBus) asyncWorker() {
 	defer e.asyncWg.Done()
 	for {
+		// Prioritize shutdown before attempting to receive queued async work.
+		select {
+		case <-e.stopCh:
+			return
+		default:
+		}
+
 		select {
 		case <-e.stopCh:
 			return
 		case ae, ok := <-e.asyncQueue:
 			if !ok {
 				return
+			}
+			// Drop queued work if shutdown began after the dequeue but before
+			// Publish ran so Stop/Close do not deliver buffered async events.
+			select {
+			case <-e.stopCh:
+				return
+			default:
 			}
 			// Publish directly — channelSubscriber.Deliver uses non-blocking
 			// sends so this cannot block forever on in-memory subscribers.
@@ -220,6 +244,7 @@ func (e *EventBus) subscribeInternal(
 	}
 	evtTypeSubs := e.subscribers[eventType]
 	evtTypeSubs[subId] = chSub
+	e.refreshSubscriberSnapshotLocked(eventType)
 	if e.metrics != nil {
 		e.metrics.subscribers.WithLabelValues(string(eventType), "in-memory").
 			Inc()
@@ -228,12 +253,12 @@ func (e *EventBus) subscribeInternal(
 }
 
 // Subscribe allows a consumer to receive events of a particular type via a channel.
-// Returns (0, nil) if the EventBus is stopped.
+// Returns (0, nil) if the EventBus is stopped or closed.
 func (e *EventBus) Subscribe(
 	eventType EventType,
 ) (EventSubscriberId, <-chan Event) {
 	e.stopMu.RLock()
-	if e.stopped {
+	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return 0, nil
 	}
@@ -243,7 +268,7 @@ func (e *EventBus) Subscribe(
 }
 
 // SubscribeFunc allows a consumer to receive events of a particular type via a callback function.
-// Returns 0 if the EventBus is stopped.
+// Returns 0 if the EventBus is stopped or closed.
 func (e *EventBus) SubscribeFunc(
 	eventType EventType,
 	handlerFunc EventHandlerFunc,
@@ -254,7 +279,7 @@ func (e *EventBus) SubscribeFunc(
 	// 2. SubscribeFunc() calls Add(1) after Wait() started with counter=0
 	// Which would cause a panic or leave the goroutine blocked forever.
 	e.stopMu.RLock()
-	if e.stopped {
+	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return 0
 	}
@@ -307,6 +332,9 @@ func (e *EventBus) Unsubscribe(eventType EventType, subId EventSubscriberId) {
 			delete(evtTypeSubs, subId)
 			if len(evtTypeSubs) == 0 {
 				delete(e.subscribers, eventType)
+				delete(e.subscriberSnapshots, eventType)
+			} else {
+				e.refreshSubscriberSnapshotLocked(eventType)
 			}
 			if e.metrics != nil {
 				kind := "remote"
@@ -379,47 +407,29 @@ func (e *EventBus) deliverWithTimeout(
 
 // Publish allows a producer to send an event of a particular type to all subscribers
 func (e *EventBus) Publish(eventType EventType, evt Event) {
-	// Build list of channels inside read lock to avoid map race condition
 	e.mu.RLock()
-	subs, ok := e.subscribers[eventType]
-	type subItem struct {
-		id  EventSubscriberId
-		sub Subscriber
-	}
-	subList := make([]subItem, 0, len(subs))
-	if ok {
-		for id, sub := range subs {
-			subList = append(subList, subItem{id: id, sub: sub})
-		}
-	}
+	subList := e.subscriberSnapshots[eventType]
 	e.mu.RUnlock()
-	// Send event on gathered subscribers (non-blocking for channel
-	// subscribers, time-bounded for remote subscribers via deliverWithTimeout)
+	if len(subList) == 0 {
+		if e.metrics != nil {
+			e.metrics.eventsTotal.WithLabelValues(string(eventType)).Inc()
+		}
+		return
+	}
 	for _, item := range subList {
-		// Protect against panics inside subscriber Deliver implementations.
 		var deliverErr error
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					deliverErr = fmt.Errorf("subscriber deliver panic: %v", r)
-				}
-			}()
+		if item.channelSub != nil {
+			deliverErr = item.channelSub.Deliver(evt)
+		} else {
 			deliverErr = e.deliverWithTimeout(item.sub, evt)
-		}()
+		}
 
 		if deliverErr != nil {
-			// Unregister the failing subscriber
 			e.Unsubscribe(eventType, item.id)
-			// Record metric if available
 			if e.metrics != nil {
-				kind := "remote"
-				if _, ok := item.sub.(*channelSubscriber); ok {
-					kind = "in-memory"
-				}
-				e.metrics.deliveryErrors.WithLabelValues(string(eventType), kind).
+				e.metrics.deliveryErrors.WithLabelValues(string(eventType), item.kind).
 					Inc()
 			}
-			// Log the delivery error/panic for observability using provided logger if present
 			if e.Logger != nil {
 				e.Logger.Debug(
 					"event delivery error",
@@ -429,7 +439,13 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 					deliverErr,
 				)
 			} else {
-				slog.Default().Debug("event delivery error", "type", eventType, "err", deliverErr)
+				slog.Default().Debug(
+					"event delivery error",
+					"type",
+					eventType,
+					"err",
+					deliverErr,
+				)
 			}
 		}
 	}
@@ -441,11 +457,11 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 // PublishAsync enqueues an event for asynchronous delivery to all subscribers.
 // This method returns immediately without blocking on subscriber delivery.
 // Use this for non-critical events where immediate delivery is not required.
-// Returns false if the EventBus is stopped or the async queue is full.
+// Returns false if the EventBus is stopped, closed, or the async queue is full.
 func (e *EventBus) PublishAsync(eventType EventType, evt Event) bool {
 	// Capture asyncQueue under lock to protect against concurrent reassignment in Stop()
 	e.stopMu.RLock()
-	if e.stopped {
+	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return false
 	}
@@ -474,13 +490,13 @@ func (e *EventBus) PublishAsync(eventType EventType, evt Event) bool {
 
 // RegisterSubscriber allows external adapters (e.g., network-backed subscribers)
 // to register with the EventBus. It returns the assigned subscriber id.
-// Returns 0 if the EventBus is stopped.
+// Returns 0 if the EventBus is stopped or closed.
 func (e *EventBus) RegisterSubscriber(
 	eventType EventType,
 	sub Subscriber,
 ) EventSubscriberId {
 	e.stopMu.RLock()
-	if e.stopped {
+	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return 0
 	}
@@ -494,6 +510,7 @@ func (e *EventBus) RegisterSubscriber(
 		e.subscribers[eventType] = make(map[EventSubscriberId]Subscriber)
 	}
 	e.subscribers[eventType][subId] = sub
+	e.refreshSubscriberSnapshotLocked(eventType)
 	if e.metrics != nil {
 		e.metrics.subscribers.WithLabelValues(string(eventType), "remote").Inc()
 	}
@@ -504,14 +521,33 @@ func (e *EventBus) RegisterSubscriber(
 // This ensures that SubscribeFunc goroutines exit cleanly during shutdown.
 // The EventBus can still be reused after Stop() is called.
 func (e *EventBus) Stop() {
+	e.shutdown(true)
+}
+
+// Close permanently shuts down the EventBus and its worker pool.
+// Unlike Stop, Close does not restart async workers, so the EventBus
+// cannot be reused.
+func (e *EventBus) Close() {
+	e.shutdown(false)
+}
+
+func (e *EventBus) shutdown(restart bool) {
+	if e == nil {
+		return
+	}
 	// Serialize Stop() calls to prevent race conditions that could spawn
 	// duplicate worker pools when called concurrently
 	e.stopOpMu.Lock()
 	defer e.stopOpMu.Unlock()
 
-	// Mark as stopped to prevent new async publishes during shutdown
+	// Mark as stopped to prevent new async publishes during shutdown.
+	// Close permanently marks the bus as closed so future Stop() calls
+	// cannot restart the worker pool.
 	e.stopMu.Lock()
 	wasAlreadyStopped := e.stopped
+	if !restart {
+		e.closed = true
+	}
 	e.stopped = true
 	e.stopMu.Unlock()
 
@@ -525,6 +561,7 @@ func (e *EventBus) Stop() {
 	// Copy and clear subscribers
 	subsCopy := e.subscribers
 	e.subscribers = make(map[EventType]map[EventSubscriberId]Subscriber)
+	e.subscriberSnapshots = make(map[EventType][]subscriberEntry)
 	e.mu.Unlock()
 
 	// Close subscribers outside of lock
@@ -542,8 +579,16 @@ func (e *EventBus) Stop() {
 		e.metrics.subscribers.Reset()
 	}
 
+	if !restart {
+		return
+	}
+
 	// Reinitialize async infrastructure to allow continued use
 	e.stopMu.Lock()
+	if e.closed {
+		e.stopMu.Unlock()
+		return
+	}
 	e.asyncQueue = make(chan asyncEvent, AsyncQueueSize)
 	e.stopCh = make(chan struct{})
 	e.stopped = false
@@ -554,4 +599,26 @@ func (e *EventBus) Stop() {
 		e.asyncWg.Add(1)
 		go e.asyncWorker()
 	}
+}
+
+func (e *EventBus) refreshSubscriberSnapshotLocked(eventType EventType) {
+	subs, ok := e.subscribers[eventType]
+	if !ok || len(subs) == 0 {
+		delete(e.subscriberSnapshots, eventType)
+		return
+	}
+	snapshot := make([]subscriberEntry, 0, len(subs))
+	for id, sub := range subs {
+		entry := subscriberEntry{
+			id:   id,
+			sub:  sub,
+			kind: "remote",
+		}
+		if channelSub, ok := sub.(*channelSubscriber); ok {
+			entry.channelSub = channelSub
+			entry.kind = "in-memory"
+		}
+		snapshot = append(snapshot, entry)
+	}
+	e.subscriberSnapshots[eventType] = snapshot
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -192,6 +192,56 @@ func TestEventBusStop(t *testing.T) {
 	}
 }
 
+func TestEventBusClose(t *testing.T) {
+	var testEvtType event.EventType = "test.close"
+	eb := event.NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	_, subCh := eb.Subscribe(testEvtType)
+	doneCh := make(chan bool, 1)
+	eb.SubscribeFunc(testEvtType, func(evt event.Event) {
+		doneCh <- true
+	})
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "before"))
+	select {
+	case <-doneCh:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("SubscribeFunc did not receive event before Close")
+	}
+
+	eb.Close()
+
+	channelClosed := false
+	timeout := time.After(100 * time.Millisecond)
+	for !channelClosed {
+		select {
+		case _, ok := <-subCh:
+			if !ok {
+				channelClosed = true
+			}
+		case <-timeout:
+			t.Fatal("subscriber channel was not closed after Close")
+		}
+	}
+
+	if subId, ch := eb.Subscribe(testEvtType); subId != 0 || ch != nil {
+		t.Fatal("Subscribe should fail after Close")
+	}
+	if subId := eb.SubscribeFunc(testEvtType, func(event.Event) {}); subId != 0 {
+		t.Fatal("SubscribeFunc should fail after Close")
+	}
+	if ok := eb.PublishAsync(
+		testEvtType,
+		event.NewEvent(testEvtType, "after-close"),
+	); ok {
+		t.Fatal("PublishAsync should fail after Close")
+	}
+
+	// Close should be idempotent and must not restart the worker pool.
+	eb.Close()
+}
+
 func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	var testEvtType event.EventType = "test.panic"
 	eb := event.NewEventBus(nil, nil)

--- a/generate_benchmarks.sh
+++ b/generate_benchmarks.sh
@@ -549,6 +549,7 @@ EOF
         done < <(list_current_benchmarks)
 
         # Add comparison section
+        echo "" >> "$OUTPUT_FILE.tmp"
         generate_comparison >> "$OUTPUT_FILE.tmp"
 
         # Add historical section if previous results exist

--- a/generate_bp_pi_report.sh
+++ b/generate_bp_pi_report.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_FILE="${1:-benchmark_results_bp_pi.md}"
+CACHE_DIR="${CACHE_DIR:-/tmp/dingo-bp-pi-go-cache}"
+GOMAXPROCS_VALUE="${GOMAXPROCS_VALUE:-4}"
+BENCH_TIME="${BENCH_TIME:-5s}"
+IMMUTABLE_PATH="${IMMUTABLE_PATH:-database/immutable/testdata}"
+DEFAULT_DB_DIR="${DEFAULT_DB_DIR:-}"
+DEFAULT_LOG_FILE="${DEFAULT_LOG_FILE:-}"
+DB_DIR_BASE="${DB_DIR_BASE:-/tmp}"
+TMP_BENCH_FILE="$(mktemp)"
+TIME_FORMAT_STYLE=""
+TIME_CMD=()
+AUTO_DEFAULT_DB_DIR=0
+AUTO_DEFAULT_LOG_FILE=0
+
+cleanup() {
+  local exit_status=$?
+
+  rm -f "$TMP_BENCH_FILE"
+  if [[ "$exit_status" -ne 0 ]]; then
+    if [[ "$AUTO_DEFAULT_LOG_FILE" -eq 1 ]]; then
+      printf 'preserving profile log for debugging: %s\n' \
+        "$DEFAULT_LOG_FILE" >&2
+    fi
+    if [[ "$AUTO_DEFAULT_DB_DIR" -eq 1 ]]; then
+      printf 'preserving profile database for debugging: %s\n' \
+        "$DEFAULT_DB_DIR" >&2
+    fi
+    return "$exit_status"
+  fi
+
+  if [[ "$AUTO_DEFAULT_LOG_FILE" -eq 1 ]]; then
+    rm -f "$DEFAULT_LOG_FILE"
+  fi
+  if [[ "$AUTO_DEFAULT_DB_DIR" -eq 1 ]]; then
+    rm -rf "$DEFAULT_DB_DIR"
+  fi
+  return "$exit_status"
+}
+trap cleanup EXIT
+
+create_temp_dir() {
+  mktemp -d "${DB_DIR_BASE%/}/dingo-bp-pi-db-default.XXXXXX"
+}
+
+create_temp_file() {
+  mktemp "${DB_DIR_BASE%/}/dingo-bp-pi-default.XXXXXX.log"
+}
+
+resolve_path() {
+  local path="$1"
+  local current
+  local candidate
+  local part
+  local -a parts=()
+
+  if [[ -z "$path" ]]; then
+    return 1
+  fi
+
+  if [[ "$path" == /* ]]; then
+    current="/"
+  else
+    current="$(pwd -P)"
+  fi
+
+  local IFS='/'
+  read -r -a parts <<< "$path"
+  for part in "${parts[@]}"; do
+    case "$part" in
+      ""|".")
+        continue
+        ;;
+      "..")
+        if [[ "$current" != "/" ]]; then
+          current="${current%/*}"
+          if [[ -z "$current" ]]; then
+            current="/"
+          fi
+        fi
+        ;;
+      *)
+        if [[ "$current" == "/" ]]; then
+          candidate="/$part"
+        else
+          candidate="$current/$part"
+        fi
+        if [[ -d "$candidate" ]]; then
+          current="$(cd "$candidate" && pwd -P)"
+        else
+          current="$candidate"
+        fi
+        ;;
+    esac
+  done
+
+  printf '%s\n' "$current"
+}
+
+configure_time_cmd() {
+  if command -v gtime >/dev/null 2>&1 &&
+    gtime -f "elapsed=%e rss_kb=%M" true >/dev/null 2>&1; then
+    TIME_FORMAT_STYLE="gnu"
+    TIME_CMD=(gtime -f "elapsed=%e rss_kb=%M")
+    return 0
+  fi
+
+  if /usr/bin/time -f "elapsed=%e rss_kb=%M" true >/dev/null 2>&1; then
+    TIME_FORMAT_STYLE="gnu"
+    TIME_CMD=(/usr/bin/time -f "elapsed=%e rss_kb=%M")
+    return 0
+  fi
+
+  if /usr/bin/time -l true >/dev/null 2>&1; then
+    TIME_FORMAT_STYLE="bsd"
+    TIME_CMD=(/usr/bin/time -l)
+    return 0
+  fi
+
+  echo "error: failed to find a supported time command" >&2
+  return 1
+}
+
+validate_db_dir() {
+  local db_dir="$1"
+  local log_file="$2"
+  local resolved_db_dir
+  local resolved_base_dir
+
+  if [[ -z "$db_dir" || "$db_dir" == "/" || "$db_dir" == "." || "$db_dir" == "~" ]]; then
+    printf 'error: refusing to remove unsafe db_dir value %q\n' "$db_dir" >"$log_file"
+    return 1
+  fi
+
+  if ! resolved_db_dir="$(resolve_path "$db_dir")"; then
+    printf 'error: failed to resolve db_dir %q\n' "$db_dir" >"$log_file"
+    return 1
+  fi
+  if ! resolved_base_dir="$(resolve_path "$DB_DIR_BASE")"; then
+    printf 'error: failed to resolve DB_DIR_BASE %q\n' "$DB_DIR_BASE" >"$log_file"
+    return 1
+  fi
+
+  if [[ "$resolved_db_dir" == "$resolved_base_dir" ]]; then
+    printf 'error: refusing to remove db_dir %q because it resolves to the base directory %q\n' \
+      "$resolved_db_dir" "$resolved_base_dir" >"$log_file"
+    return 1
+  fi
+
+  case "$resolved_db_dir" in
+    "$resolved_base_dir"/*) ;;
+    *)
+      printf 'error: refusing to remove db_dir %q outside allowed base %q\n' \
+        "$resolved_db_dir" "$resolved_base_dir" >"$log_file"
+      return 1
+      ;;
+  esac
+}
+
+extract_profile_line() {
+  local log_file="$1"
+
+  case "$TIME_FORMAT_STYLE" in
+    gnu)
+      awk '/elapsed=/{ line = $0 } END { print line }' "$log_file"
+      ;;
+    bsd)
+      awk '
+        /^[[:space:]]*[0-9]+([.][0-9]+)?[[:space:]]+real([[:space:]]|$)/ {
+          elapsed = $1
+        }
+        /^[[:space:]]*[0-9]+[[:space:]]+maximum resident set size([[:space:]]|$)/ {
+          rss_kb = $1
+        }
+        END {
+          if (elapsed != "" || rss_kb != "") {
+            printf "elapsed=%s rss_kb=%s\n", elapsed, rss_kb
+          }
+        }
+      ' "$log_file"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+run_load_profile() {
+  local db_dir="$1"
+  local log_file="$2"
+  shift 2
+
+  validate_db_dir "$db_dir" "$log_file"
+  rm -rf "$db_dir"
+  : > "$log_file"
+  env -i \
+    PATH="$PATH" \
+    HOME="${HOME:-/tmp}" \
+    GOMAXPROCS="$GOMAXPROCS_VALUE" \
+    DINGO_RUN_MODE=serve \
+    DINGO_STORAGE_MODE=core \
+    "${TIME_CMD[@]}" \
+    ./dingo \
+    --config /dev/null \
+    --blob badger \
+    --metadata sqlite \
+    --data-dir "$db_dir" \
+    load "$IMMUTABLE_PATH" "$@" \
+    > "$log_file" 2>&1
+
+  extract_profile_line "$log_file"
+}
+
+parse_metric() {
+  local line="$1"
+  local key="$2"
+  echo "$line" | awk -v needle="$key" '{
+    for (i = 1; i <= NF; i++) {
+      split($i, kv, "=")
+      if (kv[1] == needle) {
+        print kv[2]
+        exit
+      }
+    }
+  }'
+}
+
+configure_time_cmd
+
+DB_DIR_BASE="$(resolve_path "$DB_DIR_BASE")"
+
+if [[ -z "$DEFAULT_DB_DIR" ]]; then
+  DEFAULT_DB_DIR="$(create_temp_dir)"
+  AUTO_DEFAULT_DB_DIR=1
+fi
+
+if [[ -z "$DEFAULT_LOG_FILE" ]]; then
+  DEFAULT_LOG_FILE="$(create_temp_file)"
+  AUTO_DEFAULT_LOG_FILE=1
+fi
+
+pushd "$ROOT_DIR" >/dev/null
+
+env \
+  GOCACHE="$CACHE_DIR" \
+  GOMAXPROCS="$GOMAXPROCS_VALUE" \
+  ./generate_benchmarks.sh \
+  "$TMP_BENCH_FILE" \
+  --write \
+  --packages ./ledger \
+  --bench 'Benchmark(BlockfetchNearTipThroughput|BlockfetchNearTipThroughputPredecoded|BlockfetchNearTipQueuedHeaderPredecoded|BlockfetchNearTipFlushOnlyPredecoded|VerifyBlockHeader)$' \
+  --benchtime "$BENCH_TIME" \
+  --title "Four-Thread Block Producer Sizing Benchmark Results (Non-Pi Host)" \
+  --scope "Four-thread block producer path (GOMAXPROCS=${GOMAXPROCS_VALUE}) in core mode on a non-Pi host" \
+  --data-source "database/immutable/testdata plus local immutable load runs"
+
+env \
+  GOCACHE="$CACHE_DIR" \
+  GOFLAGS=-buildvcs=false \
+  CGO_ENABLED=0 \
+  go build -o ./dingo ./cmd/dingo
+
+default_line="$(run_load_profile "$DEFAULT_DB_DIR" "$DEFAULT_LOG_FILE")"
+
+default_elapsed="$(parse_metric "$default_line" "elapsed")"
+default_rss_kb="$(parse_metric "$default_line" "rss_kb")"
+
+if [[ ! "$default_elapsed" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "error: failed to parse numeric elapsed value from $DEFAULT_LOG_FILE: ${default_elapsed:-<empty>}" >&2
+  exit 1
+fi
+if [[ ! "$default_rss_kb" =~ ^[0-9]+$ ]]; then
+  echo "error: failed to parse numeric rss_kb value from $DEFAULT_LOG_FILE: ${default_rss_kb:-<empty>}" >&2
+  exit 1
+fi
+
+default_rss_mb="$(awk "BEGIN { printf \"%.1f\", ${default_rss_kb} / 1024 }")"
+
+{
+  echo "# Four-Thread Block Producer Sizing Report (Non-Pi Host)"
+  echo
+  echo "Assumptions:"
+  printf -- "- \`storageMode=core\`\n"
+  printf -- "- \`runMode=serve\`, \`blob=badger\`, \`metadata=sqlite\`\n"
+  printf -- "- \`GOMAXPROCS=%s\`\n" "$GOMAXPROCS_VALUE"
+  printf -- "- immutable fixture: \`%s\`\n" "$IMMUTABLE_PATH"
+  echo "- measurements were collected on non-Pi hardware and are a sizing proxy, not Raspberry Pi device benchmarks"
+  echo "- block producer peer count remains small; this is not a relay profile"
+  echo
+  echo "## Load Footprint"
+  echo
+  echo "| Profile | Elapsed | Peak RSS | Notes |"
+  echo "| --- | --- | --- | --- |"
+  printf -- "| \`core-default\` | \`%ss\` | \`%s MB\` | Current default \`serve/core\` cache profile |\n" "$default_elapsed" "$default_rss_mb"
+  echo
+  echo "## Recommendation"
+  echo
+  printf -- "For Raspberry Pi-class sizing in \`storageMode=core\`, the current default \`serve/core\` profile is already in the measured low-memory range on this four-thread non-Pi host.\n"
+  echo "Explicit Badger cache settings still override these defaults if an operator wants to tune further."
+  echo "Treat this as a sizing baseline rather than a direct Raspberry Pi hardware measurement."
+  echo
+  cat "$TMP_BENCH_FILE"
+} > "$OUTPUT_FILE"
+
+popd >/dev/null

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2176,6 +2176,69 @@ func BenchmarkBlockfetchNearTipThroughputPredecoded(b *testing.B) {
 	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
 }
 
+// BenchmarkBlockfetchNearTipFlushOnlyPredecoded isolates the one-block near-tip
+// flush path after blockfetch has already validated and queued the block.
+func BenchmarkBlockfetchNearTipFlushOnlyPredecoded(b *testing.B) {
+	seedModels, rawBlocks := loadBlockProcessingFixture(b)
+	blocks := make([]ledger.Block, 0, len(rawBlocks))
+	points := make([]ocommon.Point, 0, len(rawBlocks))
+	for _, block := range rawBlocks {
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			b.Fatalf("predecode block: %v", err)
+		}
+		blocks = append(blocks, ledgerBlock)
+		points = append(points, ocommon.NewPoint(block.Slot, block.Hash))
+	}
+
+	db, ledgerState := newBlockProcessingBenchmarkLedgerState(
+		b,
+		seedModels,
+	)
+	b.Cleanup(func() { db.Close() })
+
+	b.Logf(
+		"Loaded %d predecoded blocks for near-tip flush-only testing",
+		len(blocks),
+	)
+
+	b.ResetTimer()
+
+	processedBlocks := 0
+	blockIdx := 0
+	for i := 0; b.Loop(); i++ {
+		if blockIdx == len(blocks) {
+			b.StopTimer()
+			if err := db.Close(); err != nil {
+				b.Fatal(err)
+			}
+			db, ledgerState = newBlockProcessingBenchmarkLedgerState(
+				b,
+				seedModels,
+			)
+			blockIdx = 0
+			b.StartTimer()
+		}
+		ledgerState.pendingBlockfetchEvents = append(
+			ledgerState.pendingBlockfetchEvents[:0],
+			BlockfetchEvent{
+				Block: blocks[blockIdx],
+				Point: points[blockIdx],
+				Type:  uint(blocks[blockIdx].Type()),
+			},
+		)
+		blockIdx++
+
+		if err := ledgerState.flushPendingBlockfetchBlocks(); err != nil {
+			b.Fatalf("flushPendingBlockfetchBlocks failed: %v", err)
+		}
+
+		processedBlocks++
+	}
+
+	b.ReportMetric(float64(processedBlocks)/b.Elapsed().Seconds(), "blocks/sec")
+}
+
 // BenchmarkBlockfetchNearTipQueuedHeaderPredecoded measures the near-tip
 // blockfetch path when the matching header has already been queued, which is
 // the common live-sync case before full block arrival.

--- a/peergov/benchmark_test.go
+++ b/peergov/benchmark_test.go
@@ -1,0 +1,136 @@
+package peergov
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+)
+
+func BenchmarkReconcile(b *testing.B) {
+	for _, peerCount := range []int{100, 500, 1000} {
+		b.Run(strconv.Itoa(peerCount), func(b *testing.B) {
+			pg := NewPeerGovernor(PeerGovernorConfig{
+				Logger:                         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+				MinHotPeers:                    20,
+				TargetNumberOfActivePeers:      20,
+				TargetNumberOfEstablishedPeers: 50,
+				TargetNumberOfKnownPeers:       150,
+			})
+			basePeers := benchmarkPeers(peerCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				b.StopTimer()
+				pg.peers = cloneBenchmarkPeers(basePeers)
+				pg.denyList = make(map[string]time.Time)
+				pg.bootstrapExited = false
+				pg.lastBootstrapExit = time.Time{}
+				b.StartTimer()
+				pg.reconcile(b.Context())
+			}
+		})
+	}
+}
+
+func benchmarkPeers(count int) []*Peer {
+	now := time.Now()
+	peers := make([]*Peer, 0, count)
+	for i := range count {
+		peer := &Peer{
+			Address:           net.JoinHostPort("198.51.100."+strconv.Itoa(i%250+1), strconv.Itoa(3000+i)),
+			NormalizedAddress: net.JoinHostPort("198.51.100."+strconv.Itoa(i%250+1), strconv.Itoa(3000+i)),
+			FirstSeen:         now.Add(-2 * time.Hour),
+			LastActivity:      now.Add(-1 * time.Minute),
+			GroupID:           "group-" + strconv.Itoa(i%16),
+			Valency:           2,
+			WarmValency:       4,
+		}
+		switch i % 6 {
+		case 0:
+			peer.Source = PeerSourceTopologyLocalRoot
+		case 1:
+			peer.Source = PeerSourceTopologyPublicRoot
+		case 2:
+			peer.Source = PeerSourceP2PGossip
+		case 3:
+			peer.Source = PeerSourceP2PLedger
+		case 4:
+			peer.Source = PeerSourceInboundConn
+		default:
+			peer.Source = PeerSourceUnknown
+		}
+		switch {
+		case i < 20:
+			peer.State = PeerStateHot
+			peer.Connection = benchmarkPeerConnection(i)
+			if i%3 == 0 {
+				peer.LastActivity = now.Add(-30 * time.Minute)
+			}
+		case i < count/2:
+			peer.State = PeerStateWarm
+			peer.Connection = benchmarkPeerConnection(i)
+			peer.BlockFetchLatencyMs = 120 + float64(i%40)
+			peer.BlockFetchLatencyInit = true
+			peer.BlockFetchSuccessRate = 0.95
+			peer.BlockFetchSuccessInit = true
+			peer.ConnectionStability = 0.90
+			peer.ConnectionStabilityInit = true
+			peer.HeaderArrivalRate = 4 + float64(i%5)
+			peer.HeaderArrivalRateInit = true
+			peer.TipSlotDelta = int64(-(i % 10))
+			peer.TipSlotDeltaInit = true
+			if peer.Source == PeerSourceInboundConn {
+				peer.FirstSeen = now.Add(-30 * time.Minute)
+			}
+			peer.UpdatePeerScore()
+		default:
+			peer.State = PeerStateCold
+			if i%5 == 0 {
+				peer.Connection = benchmarkPeerConnection(i)
+			}
+			if i%9 == 0 {
+				peer.ReconnectCount = 5
+			}
+		}
+		peers = append(peers, peer)
+	}
+	return peers
+}
+
+func cloneBenchmarkPeers(peers []*Peer) []*Peer {
+	cloned := make([]*Peer, 0, len(peers))
+	for _, peer := range peers {
+		if peer == nil {
+			cloned = append(cloned, nil)
+			continue
+		}
+		peerCopy := *peer
+		if peer.Connection != nil {
+			connCopy := *peer.Connection
+			peerCopy.Connection = &connCopy
+		}
+		cloned = append(cloned, &peerCopy)
+	}
+	return cloned
+}
+
+func benchmarkPeerConnection(i int) *PeerConnection {
+	return &PeerConnection{
+		Id: ouroboros.ConnectionId{
+			LocalAddr: &net.TCPAddr{
+				IP:   net.IPv4(127, 0, 0, 1),
+				Port: 3001 + i,
+			},
+			RemoteAddr: &net.TCPAddr{
+				IP:   net.IPv4(198, 51, 100, byte(i%250+1)),
+				Port: 4001 + i,
+			},
+		},
+		IsClient: true,
+	}
+}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -314,7 +314,7 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 		for {
 			select {
 			case <-t.C:
-				p.reconcile()
+				p.reconcile(ctx)
 			case <-stop:
 				return
 			case <-ctx.Done():

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -229,7 +229,7 @@ func TestPeerGovernor_Reconcile_Promotions(t *testing.T) {
 	pg.peers[0].Connection = &PeerConnection{IsClient: true}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	assert.Equal(t, PeerStateHot, peers[0].State)
@@ -256,7 +256,7 @@ func TestPeerGovernor_Reconcile_SkipsResponderOnlyWarmPromotion(t *testing.T) {
 	pg.peers[0].Connection = &PeerConnection{IsClient: false}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	assert.Equal(t, PeerStateWarm, peers[0].State)
@@ -283,7 +283,7 @@ func TestPeerGovernor_Reconcile_Demotions(t *testing.T) {
 		// Make it inactive
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	assert.Equal(t, PeerStateWarm, peers[0].State)
@@ -309,7 +309,7 @@ func TestPeerGovernor_Reconcile_Removal(t *testing.T) {
 	pg.peers[0].ReconnectCount = 5 // Exceeds MaxReconnectFailureThreshold
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	assert.Len(t, peers, 0)
@@ -334,7 +334,7 @@ func TestPeerGovernor_Reconcile_RemovalThresholdBoundary(t *testing.T) {
 	pg.peers[0].ReconnectCount = pg.config.MaxReconnectFailureThreshold
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	assert.Len(t, peers, 1)
@@ -367,7 +367,7 @@ func TestPeerGovernor_Reconcile_MinimumHotPeers(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	hotCount := 0
@@ -447,7 +447,7 @@ func TestPeerGovernor_PeerSharing(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// Should have requested peers from both hot peers
 	assert.Equal(t, 2, peerRequestCount)
@@ -955,7 +955,7 @@ func TestPeerGovernor_Reconcile_CleanupDenyList(t *testing.T) {
 	pg.mu.Unlock()
 
 	// Run reconcile to trigger cleanup
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// Check deny list - only non-expired entry should remain
 	pg.mu.Lock()
@@ -1476,7 +1476,7 @@ func TestPeerGovernor_EnforcePeerTargets_ColdPeers(t *testing.T) {
 	assert.Len(t, pg.peers, 5)
 
 	// Run reconcile to enforce limits
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// Should have removed 2 peers (down to 3)
 	assert.Len(t, pg.peers, 3)
@@ -1522,7 +1522,7 @@ func TestPeerGovernor_EnforcePeerTargets_TopologyPeersNeverRemoved(
 	assert.Len(t, pg.peers, 5)
 
 	// Run reconcile to enforce limits
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// All topology peers should be kept (3) even though limit is 2
 	// Only ledger peers should be removed
@@ -1560,7 +1560,7 @@ func TestPeerGovernor_EnforcePeerTargets_Unlimited(t *testing.T) {
 	assert.Len(t, pg.peers, 10)
 
 	// Run reconcile - should not remove any peers when unlimited
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	assert.Len(t, pg.peers, 10)
 }
@@ -3383,7 +3383,7 @@ func TestPeerGovernor_ReconcilePromotion_ValencyAware(t *testing.T) {
 		},
 	}
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// With MinHotPeers=3, we need 2 more hot peers
 	// Group1 is under valency, so public1 and public2 should be promoted first
@@ -3506,7 +3506,7 @@ func TestPeerGovernor_InboundPeer_TenureRequirement(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	// Should still be warm because tenure requirement is not met
@@ -3548,7 +3548,7 @@ func TestPeerGovernor_InboundPeer_HigherScoreThreshold(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	// Should still be warm because score is below inbound threshold
@@ -3600,7 +3600,7 @@ func TestPeerGovernor_InboundPeer_BothRequirementsMet(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	// Should be hot because both requirements are met
@@ -3642,7 +3642,7 @@ func TestPeerGovernor_NonInboundPeer_UsesNormalThreshold(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	// Should be hot because gossip peers use normal threshold, not inbound threshold
@@ -3827,7 +3827,7 @@ func TestPeerGovernor_InboundPeer_MixedPeerPromotion(t *testing.T) {
 	}
 	pg.mu.Unlock()
 
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	peers := pg.GetPeers()
 	var inboundState, gossip1State, gossip2State PeerState
@@ -4158,7 +4158,7 @@ func TestPeerGovernor_EventsPublished(t *testing.T) {
 	quotaMu.Unlock()
 
 	// Run reconcile which should publish QuotaStatusEvent
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// Wait for async event delivery
 	require.Eventually(t, func() bool {
@@ -4818,7 +4818,7 @@ func TestPeerGovernor_Reconcile_ExitsBootstrap(t *testing.T) {
 	pg.mu.Unlock()
 
 	// Run reconcile
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// Verify bootstrap was exited
 	pg.mu.Lock()
@@ -4869,7 +4869,7 @@ func TestPeerGovernor_Reconcile_SkipsBootstrapPromotionAfterExit(t *testing.T) {
 	pg.mu.Unlock()
 
 	// Run reconcile
-	pg.reconcile()
+	pg.reconcile(t.Context())
 
 	// Check results
 	pg.mu.Lock()

--- a/peergov/quotas.go
+++ b/peergov/quotas.go
@@ -199,7 +199,7 @@ func (p *PeerGovernor) enforceTopologyQuota(currentCount int) []pendingEvent {
 		peer := candidates[i]
 		peer.State = PeerStateWarm // Demote to warm, not cold
 		demoted++
-		p.config.Logger.Info(
+		p.config.Logger.Debug(
 			"demoted public root to warm due to topology quota",
 			"address", peer.Address,
 			"score", peer.PerformanceScore,
@@ -291,7 +291,7 @@ func (p *PeerGovernor) enforceGroupValency() []pendingEvent {
 			peer := candidates[i]
 			peer.State = PeerStateWarm
 			demoted++
-			p.config.Logger.Info(
+			p.config.Logger.Debug(
 				"demoted peer to warm due to group valency",
 				"address", peer.Address,
 				"group", groupID,
@@ -348,7 +348,7 @@ func (p *PeerGovernor) enforceSourceQuota(
 		peer := candidates[i]
 		peer.State = PeerStateWarm
 		demoted++
-		p.config.Logger.Info(
+		p.config.Logger.Debug(
 			"demoted peer to warm due to source quota",
 			"address", peer.Address,
 			"category", category,

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -16,12 +16,19 @@ package peergov
 
 import (
 	"cmp"
+	"context"
+	"log/slog"
 	"slices"
 	"time"
 )
 
-func (p *PeerGovernor) reconcile() {
+func (p *PeerGovernor) reconcile(ctx context.Context) {
 	p.mu.Lock()
+	now := time.Now()
+	debugEnabled := p.config.Logger.Enabled(
+		ctx,
+		slog.LevelDebug,
+	)
 
 	p.config.Logger.Debug("starting peer reconcile")
 
@@ -52,11 +59,11 @@ func (p *PeerGovernor) reconcile() {
 		case PeerStateHot:
 			// Demote if inactive (no connection or last activity > timeout)
 			if peer.Connection == nil ||
-				time.Since(peer.LastActivity) > p.config.InactivityTimeout {
+				now.Sub(peer.LastActivity) > p.config.InactivityTimeout {
 				p.peers[i].State = PeerStateWarm
 				warmDemotions++
 				activeDecreased++
-				p.config.Logger.Info(
+				p.config.Logger.Debug(
 					"demoted peer to warm due to inactivity",
 					"address",
 					peer.Address,
@@ -98,7 +105,7 @@ func (p *PeerGovernor) reconcile() {
 				} else {
 					p.peers[i].State = PeerStateWarm
 					coldPromotions++
-					p.config.Logger.Info(
+					p.config.Logger.Debug(
 						"promoted peer to warm",
 						"address",
 						peer.Address,
@@ -113,10 +120,10 @@ func (p *PeerGovernor) reconcile() {
 				if p.isTopologyPeer(peer.Source) {
 					continue
 				}
-				p.denyList[peer.NormalizedAddress] = time.Now().
+				p.denyList[peer.NormalizedAddress] = now.
 					Add(p.config.DenyDuration)
 				knownRemoved++
-				p.config.Logger.Info(
+				p.config.Logger.Debug(
 					"removing failed peer",
 					"address",
 					peer.Address,
@@ -151,7 +158,11 @@ func (p *PeerGovernor) reconcile() {
 		}
 		// Score-based selection: collect warm peers with connections, compute scores,
 		// sort by valency priority then score, and promote top N to reach the refill target.
-		candidates := []*Peer{}
+		type promotionCandidate struct {
+			peer         *Peer
+			underValency bool
+		}
+		candidates := make([]promotionCandidate, 0, len(p.peers))
 		for _, peer := range p.peers {
 			if peer != nil && peer.State == PeerStateWarm &&
 				peer.hasClientConnection() {
@@ -160,24 +171,31 @@ func (p *PeerGovernor) reconcile() {
 					continue
 				}
 				peer.UpdatePeerScore()
-				candidates = append(candidates, peer)
+				candidates = append(candidates, promotionCandidate{peer: peer})
 			}
 		}
 
 		// Get group counts for valency-aware sorting
 		groups := p.countPeersByGroup()
+		for i := range candidates {
+			candidates[i].underValency = p.isGroupUnderHotValency(
+				candidates[i].peer,
+				groups,
+			)
+		}
 
 		// Comparator: under-valency groups first, then by score descending
-		rankCandidates := func(a, b *Peer) int {
-			aUnder := p.isGroupUnderHotValency(a, groups)
-			bUnder := p.isGroupUnderHotValency(b, groups)
-			if aUnder && !bUnder {
+		rankCandidates := func(a, b promotionCandidate) int {
+			if a.underValency && !b.underValency {
 				return -1
 			}
-			if !aUnder && bUnder {
+			if !a.underValency && b.underValency {
 				return 1
 			}
-			return cmp.Compare(b.PerformanceScore, a.PerformanceScore)
+			return cmp.Compare(
+				b.peer.PerformanceScore,
+				a.peer.PerformanceScore,
+			)
 		}
 
 		// Initial sort
@@ -186,7 +204,7 @@ func (p *PeerGovernor) reconcile() {
 		needed := refillTarget - hotCount
 		promoted := 0
 		for i := 0; i < len(candidates) && promoted < needed; i++ {
-			peer := candidates[i]
+			peer := candidates[i].peer
 			// Check inbound peer eligibility (score threshold and tenure)
 			if !p.isInboundEligibleForHot(peer) {
 				p.config.Logger.Debug(
@@ -205,7 +223,7 @@ func (p *PeerGovernor) reconcile() {
 				continue
 			}
 			peer.State = PeerStateHot
-			peer.LastActivity = time.Now()
+			peer.LastActivity = now
 			warmPromotions++
 			activeIncreased++
 			promoted++
@@ -214,12 +232,20 @@ func (p *PeerGovernor) reconcile() {
 				gc.Hot++
 				gc.Warm--
 			}
-			// Re-sort remaining candidates so valency changes
-			// from this promotion are reflected in the next pick.
+			// Recompute valency priority only for the affected group, then
+			// resort the remaining candidates for the next pick.
 			if i+1 < len(candidates) {
+				for j := i + 1; j < len(candidates); j++ {
+					if candidates[j].peer.GroupID == peer.GroupID {
+						candidates[j].underValency = p.isGroupUnderHotValency(
+							candidates[j].peer,
+							groups,
+						)
+					}
+				}
 				slices.SortFunc(candidates[i+1:], rankCandidates)
 			}
-			p.config.Logger.Info(
+			p.config.Logger.Debug(
 				"promoted peer to hot (score-based)",
 				"address", peer.Address,
 				"score", peer.PerformanceScore,
@@ -268,7 +294,9 @@ func (p *PeerGovernor) reconcile() {
 	)
 
 	// Log valency status for topology groups
-	p.logValencyStatus()
+	if debugEnabled {
+		p.logValencyStatus()
+	}
 
 	// Enforce overall peer targets by removing excess peers
 	// Priority order (highest to lowest): Topology > Gossip > Ledger > Inbound > Unknown
@@ -369,80 +397,102 @@ func (p *PeerGovernor) enforceStateLimit(
 ) []pendingEvent {
 	var events []pendingEvent
 
-	// Collect peers in this state
-	var peersInState []*Peer
-	for _, peer := range p.peers {
-		if peer != nil && peer.State == state {
-			peersInState = append(peersInState, peer)
+	type removalCandidate struct {
+		idx      int
+		peer     *Peer
+		priority int
+	}
+
+	stateCount := 0
+	candidates := make([]removalCandidate, 0, len(p.peers))
+	for idx, peer := range p.peers {
+		if peer == nil || peer.State != state {
+			continue
 		}
+		stateCount++
+		if p.isTopologyPeer(peer.Source) {
+			continue
+		}
+		candidates = append(candidates, removalCandidate{
+			idx:      idx,
+			peer:     peer,
+			priority: p.peerSourcePriority(peer.Source),
+		})
 	}
 
 	// Check if we're over the limit
-	excess := len(peersInState) - limit
+	excess := stateCount - limit
 	if excess <= 0 {
 		return events
 	}
 
-	// Sort peers by removal priority (lowest priority first)
+	removeCount := min(excess, len(candidates))
+	if removeCount <= 0 {
+		return events
+	}
+
+	// Sort removable peers by removal priority (lowest priority first)
 	// Priority order (highest to lowest):
 	// - Topology peers (LocalRoot, PublicRoot, Bootstrap) - never remove
 	// - Gossip peers
 	// - Ledger peers
 	// - Inbound peers
 	// - Unknown peers
-	slices.SortFunc(peersInState, func(a, b *Peer) int {
+	slices.SortFunc(candidates, func(a, b removalCandidate) int {
 		// First compare by source priority (lower priority = remove first)
-		aPriority := p.peerSourcePriority(a.Source)
-		bPriority := p.peerSourcePriority(b.Source)
-		if aPriority != bPriority {
-			return cmp.Compare(aPriority, bPriority)
+		if a.priority != b.priority {
+			return cmp.Compare(a.priority, b.priority)
 		}
 		// Same priority: lower score = remove first
-		return cmp.Compare(a.PerformanceScore, b.PerformanceScore)
+		return cmp.Compare(
+			a.peer.PerformanceScore,
+			b.peer.PerformanceScore,
+		)
 	})
 
-	// Remove excess peers (they're sorted lowest priority first)
+	removeIdx := make([]bool, len(p.peers))
 	removed := 0
-	for i := 0; i < len(peersInState) && removed < excess; i++ {
-		peer := peersInState[i]
-
-		// Never remove topology peers
-		if p.isTopologyPeer(peer.Source) {
-			continue
-		}
-
-		// Find and remove from main peer list
-		for j := len(p.peers) - 1; j >= 0; j-- {
-			if p.peers[j] == peer {
-				p.config.Logger.Info(
-					"removing peer due to limit exceeded",
-					"address", peer.Address,
-					"state", state,
-					"source", peer.Source,
-					"limit", limit,
-				)
-				// Close connection if peer has one (for warm/hot peers)
-				if peer.Connection != nil && p.config.ConnManager != nil {
-					conn := p.config.ConnManager.GetConnectionById(
-						peer.Connection.Id,
-					)
-					if conn != nil {
-						conn.Close()
-					}
-				}
-				events = append(events, pendingEvent{
-					PeerRemovedEventType,
-					PeerStateChangeEvent{
-						Address: peer.Address,
-						Reason:  "limit exceeded",
-					},
-				})
-				p.peers = slices.Delete(p.peers, j, j+1)
-				removed++
-				*removedCount++
-				break
+	for i := 0; i < removeCount; i++ {
+		candidate := candidates[i]
+		peer := candidate.peer
+		p.config.Logger.Debug(
+			"removing peer due to limit exceeded",
+			"address", peer.Address,
+			"state", state,
+			"source", peer.Source,
+			"limit", limit,
+		)
+		if peer.Connection != nil && p.config.ConnManager != nil {
+			conn := p.config.ConnManager.GetConnectionById(peer.Connection.Id)
+			if conn != nil {
+				conn.Close()
 			}
 		}
+		events = append(events, pendingEvent{
+			PeerRemovedEventType,
+			PeerStateChangeEvent{
+				Address: peer.Address,
+				Reason:  "limit exceeded",
+			},
+		})
+		removeIdx[candidate.idx] = true
+		removed++
+		*removedCount++
+	}
+
+	if removed > 0 {
+		originalPeers := p.peers
+		kept := originalPeers[:0]
+		for idx, peer := range originalPeers {
+			if removeIdx[idx] {
+				continue
+			}
+			kept = append(kept, peer)
+		}
+		for idx := len(kept); idx < len(originalPeers); idx++ {
+			originalPeers[idx] = nil
+		}
+		p.peers = kept
 	}
 
 	if removed > 0 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up relay inbound host checks and connection metrics using O(1) lookups and incremental counters. Also cuts event publish overhead, adds a closeable event bus, streamlines `peergov` reconcile, tightens `badger` core caches, and ships focused benchmarks plus a 4‑thread BP sizing report.

- **Refactors**
  - `connmanager`: O(1) `HasInboundPeerAddress` via normalized `inboundPeerAddrs` (only with `OutboundSourcePort`); metrics use cached running totals with lazy rebuild; tracks inbound/outbound, full‑duplex, unidirectional, duplex‑peers, and prunable counts incrementally; parallel‑safe inbound slot reservation; added microbenchmarks/tests.
  - `event`: Per‑type subscriber snapshots for `Publish`/`HasSubscribers`; added `Close()` to permanently shut down and close subscribers; Stop/Close block async publishes and drop queued events; delivery errors capture subscriber kind; added publish benchmarks/tests.
  - `peergov`: `reconcile(ctx)` reuses one timestamp, caches under‑valency flags for candidate sorting, and logs demotions at debug; `enforceStateLimit` sorts removable peers and removes in one pass; valency status only at debug; added reconcile benchmarks.
  - `ledger`: Added near‑tip flush‑only benchmark to isolate blockfetch flush cost.
  - `database/plugin/blob/badger`: Default `serve/core` cache profile set to 128MB block, 32MB index, 32MB memtable; tests updated.
  - Benchmarks/docs: Refreshed targeted BP/relay results; added `generate_bp_pi_report.sh` and a non‑Pi four‑thread BP sizing report.

<sup>Written for commit 59f2a4d2f4c8e8e49527d5c7f35117d14d6c521a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Optimizations**
  * Reduced default cache sizes to lower memory usage.
  * Faster event publishing via subscriber snapshotting.
  * Peer reconciliation now respects cancellation for more responsive operations.

* **Improvements**
  * Centralized inbound connection tracking and per-peer address handling.
  * Lowered log verbosity for peer management.
  * Exposed inbound connection count for observability.

* **New Features**
  * New benchmarking script and non-Pi sizing report.

* **Testing**
  * Added many benchmarks and tests for connections, events, ledger, and peer governor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->