### PR TITLE
fix(forging): convert absolute KES period to relative before evolving…

### DIFF
--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -134,8 +134,9 @@ func (pc *PoolCredentials) LoadFromFiles(
 	return nil
 }
 
-// UpdateKESPeriod updates the KES key to the specified period.
-// This should be called when the KES period advances.
+// UpdateKESPeriod updates the KES key to the specified absolute period.
+// The absolute period is converted to a relative period using the opcert
+// start KES period before evolving.
 func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -144,10 +145,24 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 		return errors.New("KES key not loaded")
 	}
 
-	if period < pc.kesSKey.Period {
+	// Convert absolute KES period to relative (0-based from opcert start)
+	relativePeriod := period
+	if pc.opCert != nil {
+		if period < pc.opCert.KESPeriod {
+			return fmt.Errorf(
+				"absolute KES period %d is before opcert start period %d",
+				period,
+				pc.opCert.KESPeriod,
+			)
+		}
+		relativePeriod = period - pc.opCert.KESPeriod
+	}
+
+	if relativePeriod < pc.kesSKey.Period {
 		return fmt.Errorf(
-			"cannot evolve KES key backward: current period %d, requested %d",
+			"cannot evolve KES key backward: current period %d, requested %d (absolute %d)",
 			pc.kesSKey.Period,
+			relativePeriod,
 			period,
 		)
 	}
@@ -155,11 +170,12 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 	// Evolve KES key to the target period. kes.Update returns a new SecretKey
 	// with a deep copy of the data, so pc.kesSKey is only replaced on success.
 	evolvedKey := pc.kesSKey
-	for evolvedKey.Period < period {
+	for evolvedKey.Period < relativePeriod {
 		newKey, err := kes.Update(evolvedKey)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to update KES key to period %d: %w",
+				"failed to update KES key to period %d (absolute %d): %w",
+				relativePeriod,
 				period,
 				err,
 			)
@@ -188,11 +204,9 @@ func (pc *PoolCredentials) VRFProve(alpha []byte) ([]byte, []byte, error) {
 	return proof, output, nil
 }
 
-// KESSign signs a message with the KES key at the specified period.
-//
-// IMPORTANT: Callers must ensure UpdateKESPeriod(period) was called before KESSign
-// to evolve the key to the correct period. The kes.Sign function expects the key
-// to already be at the requested period.
+// KESSign signs a message with the KES key at the specified absolute period.
+// The absolute period is converted to a relative period using the opcert
+// start KES period before signing.
 func (pc *PoolCredentials) KESSign(period uint64, message []byte) ([]byte, error) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
@@ -201,9 +215,22 @@ func (pc *PoolCredentials) KESSign(period uint64, message []byte) ([]byte, error
 		return nil, errors.New("KES key not loaded")
 	}
 
-	sig, err := kes.Sign(pc.kesSKey, period, message)
+	// Convert absolute KES period to relative (0-based from opcert start)
+	relativePeriod := period
+	if pc.opCert != nil {
+		if period < pc.opCert.KESPeriod {
+			return nil, fmt.Errorf(
+				"absolute KES period %d is before opcert start period %d",
+				period,
+				pc.opCert.KESPeriod,
+			)
+		}
+		relativePeriod = period - pc.opCert.KESPeriod
+	}
+
+	sig, err := kes.Sign(pc.kesSKey, relativePeriod, message)
 	if err != nil {
-		return nil, fmt.Errorf("KESSign period %d: %w", period, err)
+		return nil, fmt.Errorf("KESSign period %d (relative %d): %w", period, relativePeriod, err)
 	}
 	return sig, nil
 }

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -427,3 +427,97 @@ func TestOpCertValidationMismatchedKESKey(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "KES verification key mismatch")
 }
+
+func TestKESSignWithOpCertOffset(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	// The test opCert has KESPeriod=0. Override it to 795 to simulate
+	// a real-world opcert with a non-zero start KES period.
+	pc.opCert.KESPeriod = 795
+
+	// Evolve to absolute period 825 (relative period = 825 - 795 = 30)
+	require.NoError(t, pc.UpdateKESPeriod(825))
+
+	// Sign at absolute period 825. KESSign should convert to relative
+	// period 30 internally, which is within the valid range (0-63).
+	message := []byte("test block header at absolute period 825")
+	signature, err := pc.KESSign(825, message)
+	require.NoError(t, err)
+	assert.Equal(t, kes.CardanoKesSignatureSize, len(signature))
+
+	// Verify signature at relative period 30
+	ok := kes.VerifySignedKES(pc.kesVKey, 30, message, signature)
+	assert.True(t, ok, "KES signature should verify at relative period 30")
+}
+
+func TestKESSignWithoutOpCert(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	// Remove the opCert to test backwards compatibility — when opCert
+	// is nil, KESSign should use the period as-is (no offset).
+	pc.opCert = nil
+
+	// Evolve to period 5, then sign at period 5 — without opCert,
+	// the period should be used directly (no offset subtraction).
+	require.NoError(t, pc.UpdateKESPeriod(5))
+	message := []byte("test block header without opcert")
+	signature, err := pc.KESSign(5, message)
+	require.NoError(t, err)
+	assert.Equal(t, kes.CardanoKesSignatureSize, len(signature))
+
+	// Verify at period 5
+	ok := kes.VerifySignedKES(pc.kesVKey, 5, message, signature)
+	assert.True(t, ok, "KES signature should verify at period 5 without opcert")
+}
+
+func TestUpdateKESPeriodWithOpCertOffset(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	// Override opcert start KES period to 795
+	pc.opCert.KESPeriod = 795
+
+	// UpdateKESPeriod(825) should evolve to relative period 30
+	// (825 - 795 = 30)
+	err := pc.UpdateKESPeriod(825)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(30), pc.kesSKey.Period,
+		"KES key should be at relative period 30")
+}
+
+func TestUpdateKESPeriodExhaustedWithOffset(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	// Set opcert start to 100. For depth 6, max relative period is 63.
+	// Absolute period 164 maps to relative 64 (164 - 100 = 64), which
+	// exceeds the maximum.
+	pc.opCert.KESPeriod = 100
+	err := pc.UpdateKESPeriod(164)
+	assert.Error(t, err, "should fail when relative period exceeds max for depth 6")
+	assert.Contains(t, err.Error(), "failed to update KES key to period 64 (absolute 164)")
+}
+
+func TestUpdateKESPeriodBeforeOpCertStart(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	// Opcert start = 795. Absolute period 700 is before start — should
+	// error, not underflow.
+	pc.opCert.KESPeriod = 795
+	err := pc.UpdateKESPeriod(700)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "before opcert start period")
+}


### PR DESCRIPTION
… and signing

UpdateKESPeriod and KESSign receive the absolute KES period from the slot clock, but the KES key only supports periods 0 through maxEvolutions. The opcert's start KES period must be subtracted to get the relative period before evolving or signing.

Without this, any pool whose opcert start period exceeds maxEvolutions (63 for depth 6) fails to sign blocks with "key is exhausted" even though the key has valid evolutions remaining.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert absolute KES periods from the slot clock to relative periods (offset by the opcert start) before evolving and signing. Prevents false "key is exhausted" errors and adds a clear error when the absolute period is before the opcert start.

- **Bug Fixes**
  - Convert absolute to relative in `UpdateKESPeriod` and `KESSign` using the opcert’s start KES period; error if the absolute period is before the opcert start; use the raw period when no opcert is loaded.
  - Improve errors to include both absolute and relative periods and context (e.g., evolve backward, update failures); add tests for opcert offset, no-opcert behavior, before-start errors, and exhaustion when the relative period exceeds `maxEvolutions`.

<sup>Written for commit 912ad2acccfb96da2994e926654a952f7d3a4ff8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved KES period handling: signing and period-evolution now convert absolute periods to relative periods against the operational certificate start, with clearer error messages for boundary and evolution failures.

* **Tests**
  * Added tests covering signing with and without operational certificate context, offset handling, and edge cases (exhaustion and pre-start period errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->