### PR TITLE
fix(node): replace os.Exit in metrics server with error propagation

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -33,6 +34,72 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+func waitForSignalOrError(
+	signalCtx context.Context,
+	errChan <-chan error,
+) (error, bool) {
+	select {
+	case err := <-errChan:
+		return err, false
+	case <-signalCtx.Done():
+		// Prefer a queued component error over treating shutdown as a clean
+		// signal-driven exit when both happen at roughly the same time.
+		select {
+		case err := <-errChan:
+			return err, false
+		default:
+		}
+		return nil, true
+	}
+}
+
+func gracefulShutdown(
+	logger *slog.Logger,
+	metricsServer *http.Server,
+	d *dingo.Node,
+	timeout time.Duration,
+) error {
+	shutdownErr := shutdownNodeResources(
+		metricsServer.Shutdown,
+		d.Stop,
+		timeout,
+	)
+	if shutdownErr != nil {
+		logger.Error(
+			"graceful shutdown failed",
+			"error",
+			shutdownErr,
+		)
+	}
+	return shutdownErr
+}
+
+func shutdownNodeResources(
+	metricsServerShutdown func(context.Context) error,
+	nodeStop func() error,
+	timeout time.Duration,
+) error {
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(),
+		timeout,
+	)
+	defer cancel()
+	var err error
+	if shutdownErr := metricsServerShutdown(shutdownCtx); shutdownErr != nil {
+		err = errors.Join(
+			err,
+			fmt.Errorf("metrics server shutdown: %w", shutdownErr),
+		)
+	}
+	if stopErr := nodeStop(); stopErr != nil {
+		err = errors.Join(
+			err,
+			fmt.Errorf("node stop: %w", stopErr),
+		)
+	}
+	return err
+}
 
 func Run(cfg *config.Config, logger *slog.Logger) error {
 	logger.Debug(fmt.Sprintf("config: %+v", cfg), "component", "node")
@@ -278,16 +345,6 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	go func() {
-		if err := metricsServer.ListenAndServe(); err != nil &&
-			err != http.ErrServerClosed {
-			logger.Error(
-				fmt.Sprintf("failed to start metrics listener: %s", err),
-				"component", "node",
-			)
-			os.Exit(1)
-		}
-	}()
 	// Wait for interrupt/termination signal
 	signalCtx, signalCtxStop := signal.NotifyContext(
 		context.Background(),
@@ -296,11 +353,24 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	)
 	defer signalCtxStop()
 
-	// Run node in goroutine
-	errChan := make(chan error, 1)
+	// Error channel for both node and metrics goroutines
+	errChan := make(chan error, 2)
+	go func() {
+		if err := metricsServer.ListenAndServe(); err != nil &&
+			err != http.ErrServerClosed {
+			logger.Error(
+				fmt.Sprintf("failed to start metrics listener: %s", err),
+				"component", "node",
+			)
+			errChan <- fmt.Errorf("metrics server: %w", err)
+		}
+	}()
 	go func() {
 		//nolint:contextcheck
 		err := d.Run(signalCtx)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		select {
 		case errChan <- err:
 		case <-signalCtx.Done():
@@ -308,68 +378,53 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	}()
 
 	// Wait for signal or error
-	select {
-	case <-signalCtx.Done():
+	err, signaled := waitForSignalOrError(signalCtx, errChan)
+	if signaled {
 		logger.Info("signal received, initiating graceful shutdown")
 
-		// Shutdown metrics server
-		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(),
+		if err := gracefulShutdown(
+			logger,
+			metricsServer,
+			d,
 			shutdownTimeout,
-		)
-		defer cancel()
-		if err := metricsServer.Shutdown(shutdownCtx); err != nil {
-			logger.Error("metrics server shutdown error", "error", err)
-		}
-
-		// Shutdown node
-		if err := d.Stop(); err != nil {
-			logger.Error("shutdown errors occurred", "error", err)
+		); err != nil {
 			return err
 		}
 		logger.Info("shutdown complete")
 		return nil
-
-	case err := <-errChan:
-		if err == nil {
-			logger.Info("node stopped")
-			// Graceful cleanup
-			shutdownCtx, cancel := context.WithTimeout(
-				context.Background(),
-				shutdownTimeout,
-			)
-			defer cancel()
-			if err := metricsServer.Shutdown(shutdownCtx); err != nil {
-				logger.Error("metrics server shutdown error", "error", err)
-			}
-			if err := d.Stop(); err != nil {
-				logger.Error("shutdown errors occurred", "error", err)
-				return err
-			}
-			return nil
-		}
-		logger.Error("node error", "error", err)
-		signalCtxStop()
-
-		// Shutdown node resources
-		if stopErr := d.Stop(); stopErr != nil {
-			logger.Error(
-				"shutdown errors occurred during error cleanup",
-				"error",
-				stopErr,
-			)
-		}
-
-		// Cleanup on error
-		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(),
-			shutdownTimeout,
-		)
-		defer cancel()
-		if shutdownErr := metricsServer.Shutdown(shutdownCtx); shutdownErr != nil {
-			logger.Error("metrics server shutdown error", "error", shutdownErr)
-		}
-
-		return err
 	}
+
+	if err == nil {
+		logger.Info("node stopped")
+		if err := gracefulShutdown(
+			logger,
+			metricsServer,
+			d,
+			shutdownTimeout,
+		); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	logger.Error("node error", "error", err)
+	signalCtxStop()
+
+	cleanupErr := shutdownNodeResources(
+		metricsServer.Shutdown,
+		d.Stop,
+		shutdownTimeout,
+	)
+	if cleanupErr != nil {
+		logger.Error(
+			"error cleanup failed",
+			"error",
+			cleanupErr,
+			"node_error",
+			err,
+		)
+		return errors.Join(err, cleanupErr)
+	}
+
+	return err
 }

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitForSignalOrErrorPrefersQueuedError(t *testing.T) {
+	t.Parallel()
+
+	signalCtx, signalCtxStop := context.WithCancel(context.Background())
+	errChan := make(chan error, 1)
+	expectedErr := errors.New("metrics server: bind failed")
+
+	errChan <- expectedErr
+	signalCtxStop()
+
+	err, signaled := waitForSignalOrError(signalCtx, errChan)
+	if signaled {
+		t.Fatal("expected queued error to win over signal shutdown")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+}
+
+func TestWaitForSignalOrErrorReturnsSignalWithoutQueuedError(t *testing.T) {
+	t.Parallel()
+
+	signalCtx, signalCtxStop := context.WithCancel(context.Background())
+	errChan := make(chan error, 1)
+
+	signalCtxStop()
+
+	err, signaled := waitForSignalOrError(signalCtx, errChan)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !signaled {
+		t.Fatal("expected signal shutdown when no error is queued")
+	}
+}
+
+func TestShutdownNodeResourcesAggregatesErrors(t *testing.T) {
+	t.Parallel()
+
+	metricsErr := errors.New("metrics failed")
+	nodeErr := errors.New("node failed")
+
+	err := shutdownNodeResources(
+		func(context.Context) error {
+			return metricsErr
+		},
+		func() error {
+			return nodeErr
+		},
+		5*time.Second,
+	)
+	if err == nil {
+		t.Fatal("expected shutdown error")
+	}
+	if !errors.Is(err, metricsErr) {
+		t.Fatalf("expected metrics shutdown error to be joined: %v", err)
+	}
+	if !errors.Is(err, nodeErr) {
+		t.Fatalf("expected node stop error to be joined: %v", err)
+	}
+	if !strings.Contains(err.Error(), "metrics server shutdown: metrics failed") {
+		t.Fatalf("expected metrics shutdown context in error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "node stop: node failed") {
+		t.Fatalf("expected node stop context in error: %v", err)
+	}
+}
+
+func TestShutdownNodeResourcesReturnsNilWithoutErrors(t *testing.T) {
+	t.Parallel()
+
+	err := shutdownNodeResources(
+		func(context.Context) error {
+			return nil
+		},
+		func() error {
+			return nil
+		},
+		5*time.Second,
+	)
+	if err != nil {
+		t.Fatalf("expected nil shutdown error, got %v", err)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `os.Exit` in the metrics server with error propagation and a helper-driven shutdown path that aggregates cleanup errors. This enables graceful shutdown and ensures queued component errors win over signals.

- **Bug Fixes**
  - Route metrics server failures to a shared buffered `errChan` (wrapped as "metrics server: ..."); remove `os.Exit(1)`.
  - Add `waitForSignalOrError` and treat `context.Canceled` from the node as a clean stop; create the signal context and `errChan` before starting goroutines.
  - Add `gracefulShutdown` and `shutdownNodeResources` to centralize cleanup and join multiple shutdown errors; on error paths, join the node error with cleanup errors; add tests for error-vs-signal preference and shutdown error aggregation.

<sup>Written for commit 307152892673124a60f670a4a3fac205b684172a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified, more reliable shutdown flow that coordinates stopping services and preserves error reporting.
  * Startup failures are reported centrally rather than causing immediate process exit, enabling graceful teardown.
* **Tests**
  * Added tests validating shutdown behavior and that queued startup errors take precedence over interrupt signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->