### PR TITLE
fix(sqlite): execute VACUUM instead of only preparing it

### DIFF
--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -197,7 +197,7 @@ func (d *MetadataStoreSqlite) runVacuum() error {
 	if d.dataDir == "" || closed {
 		return nil
 	}
-	if result := d.DB().Raw("VACUUM"); result.Error != nil {
+	if result := d.DB().Exec("VACUUM"); result.Error != nil {
 		return result.Error
 	}
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Execute SQLite VACUUM by switching from Raw to Exec so the command actually runs, not just prepares. This compacts the database and reclaims disk space.

<sup>Written for commit dcadee128590263e569c6e2f3c1defe0467b805c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

