### PR TITLE
fix(ledger): use safe type assertions in chainsync event handlers

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -82,7 +82,11 @@ const (
 func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 	ls.chainsyncMutex.Lock()
 	defer ls.chainsyncMutex.Unlock()
-	e := evt.Data.(ChainsyncEvent)
+	e, ok := evt.Data.(ChainsyncEvent)
+	if !ok {
+		ls.logUnexpectedChainsyncEventData("ChainsyncEvent", evt)
+		return
+	}
 	if e.Rollback {
 		if err := ls.handleEventChainsyncRollback(e); err != nil {
 			ls.config.Logger.Error(
@@ -140,7 +144,11 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
-	e := evt.Data.(BlockfetchEvent)
+	e, ok := evt.Data.(BlockfetchEvent)
+	if !ok {
+		ls.logUnexpectedChainsyncEventData("BlockfetchEvent", evt)
+		return
+	}
 	if e.BatchDone {
 		if err := ls.handleEventBlockfetchBatchDone(e); err != nil {
 			ls.config.Logger.Error(
@@ -207,6 +215,21 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 			}
 		}
 	}
+}
+
+func (ls *LedgerState) logUnexpectedChainsyncEventData(
+	expectedType string,
+	evt event.Event,
+) {
+	ls.config.Logger.Warn(
+		"received unexpected event data type",
+		"component", "ledger",
+		"expected", expectedType,
+		"data_type", fmt.Sprintf("%T", evt.Data),
+		"event_type", evt.Type,
+		"event_timestamp", evt.Timestamp,
+		"event", evt,
+	)
 }
 
 // detectConnectionSwitch checks for an active connection change and logs a

--- a/ledger/chainsync_event_logging_test.go
+++ b/ledger/chainsync_event_logging_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+)
+
+func newTestLedgerStateWithBuffer() (*LedgerState, *bytes.Buffer) {
+	var logBuf bytes.Buffer
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(
+				slog.NewJSONHandler(
+					&logBuf,
+					&slog.HandlerOptions{Level: slog.LevelWarn},
+				),
+			),
+		},
+	}
+	return ls, &logBuf
+}
+
+func assertLogContains(t *testing.T, buf *bytes.Buffer, wants []string) {
+	t.Helper()
+	logOutput := buf.String()
+	for _, want := range wants {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("expected log output to contain %q, got %s", want, logOutput)
+		}
+	}
+}
+
+func TestHandleEventChainsync_WarnsOnUnexpectedEventDataType(t *testing.T) {
+	ls, logBuf := newTestLedgerStateWithBuffer()
+	evt := event.Event{
+		Type:      event.EventType("chainsync.test"),
+		Timestamp: time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC),
+		Data:      "unexpected",
+	}
+
+	ls.handleEventChainsync(evt)
+
+	assertLogContains(t, logBuf, []string{
+		`"msg":"received unexpected event data type"`,
+		`"expected":"ChainsyncEvent"`,
+		`"data_type":"string"`,
+		`"event_type":"chainsync.test"`,
+		`"event_timestamp":"2026-03-16T12:00:00Z"`,
+		`"event":{"Timestamp":"2026-03-16T12:00:00Z","Data":"unexpected","Type":"chainsync.test"}`,
+	})
+}
+
+func TestHandleEventBlockfetch_WarnsOnUnexpectedEventDataType(t *testing.T) {
+	ls, logBuf := newTestLedgerStateWithBuffer()
+	evt := event.Event{
+		Type:      event.EventType("blockfetch.test"),
+		Timestamp: time.Date(2026, 3, 16, 12, 5, 0, 0, time.UTC),
+		Data:      123,
+	}
+
+	ls.handleEventBlockfetch(evt)
+
+	assertLogContains(t, logBuf, []string{
+		`"msg":"received unexpected event data type"`,
+		`"expected":"BlockfetchEvent"`,
+		`"data_type":"int"`,
+		`"event_type":"blockfetch.test"`,
+		`"event_timestamp":"2026-03-16T12:05:00Z"`,
+		`"event":{"Timestamp":"2026-03-16T12:05:00Z","Data":123,"Type":"blockfetch.test"}`,
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use safe type assertions in chainsync and blockfetch event handlers to prevent panics on malformed payloads, logging a structured warning and returning early when types don’t match. Added a shared logging helper and tests confirming the warning includes expected type, actual data type, event type, timestamp, and the full event payload.

<sup>Written for commit bb71196c41087e7c470bccee86083a07f0e3c1c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness during chain and block event processing by adding defensive checks that skip unexpected event payloads and log warnings instead of failing.
  * Ensures uninterrupted operation when malformed or mismatched event data is encountered.

* **Tests**
  * Added tests verifying warning logs include structured fields (message, expected type, actual type, event type, timestamp, payload) when event data is unexpected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->