### PR TITLE
fix(ledger): validate epoch nonce cache entries against current nonce

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -200,20 +200,17 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 }
 
 func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {
+	nonceHex := hex.EncodeToString(nonce)
 	ls.RLock()
 	cachedNonce, ok := ls.epochNonceHexCache[epochId]
 	ls.RUnlock()
-	if ok {
+	if ok && cachedNonce == nonceHex {
 		return cachedNonce
 	}
-	nonceHex := hex.EncodeToString(nonce)
 	ls.Lock()
 	defer ls.Unlock()
 	if ls.epochNonceHexCache == nil {
 		ls.epochNonceHexCache = make(map[uint64]string)
-	}
-	if cachedNonce, ok := ls.epochNonceHexCache[epochId]; ok {
-		return cachedNonce
 	}
 	ls.epochNonceHexCache[epochId] = nonceHex
 	return nonceHex


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate epoch nonce cache entries against the provided nonce in `ledger` to prevent stale returns during block header verification. If the cached value doesn’t match the current nonce, we now recompute and update the cache.

- **Bug Fixes**
  - Compare the cached hex to the current nonce’s hex before returning; otherwise update the cache.
  - Remove the redundant write-lock shortcut that could return a mismatched cached value.

<sup>Written for commit 0fef32e54c9d28b4ec376f6c6351b307c5f3790d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

