### PR TITLE
fix(docker): run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,14 @@ ENV CARDANO_SOCKET_PATH=/ipc/dingo.socket
 EXPOSE 3001 3002 9090 12798
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD wget -qO/dev/null http://127.0.0.1:12798/metrics || exit 1
+RUN addgroup --system dingo && adduser --system --no-create-home --ingroup dingo dingo
+RUN mkdir -p /data/db /ipc && chown -R dingo:dingo /data/db /ipc
+USER dingo
 ENTRYPOINT ["/bin/entrypoint.sh"]
 CMD ["serve"]
 
 FROM dingo AS antithesis
+USER root
 RUN apt-get update -y && \
   apt-get install -y \
     curl \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run the container as a non-root `dingo` user to harden security and follow container best practices. Adds a system user/group, fixes ownership of `/data/db` and `/ipc`, sets `USER dingo`, and uses `USER root` only in the `antithesis` stage for package installs.

- **Migration**
  - If you mount host volumes to `/data/db` or `/ipc`, ensure they are writable by the `dingo` user (update host permissions as needed).
  - No action needed if you don’t mount these paths.

<sup>Written for commit baa09869667204b053cfb3a632a4cef66f7e7d9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

