### PR TITLE
fix: add read locks to GetCurrentPParams and PrimaryChain

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1014,7 +1014,7 @@ func (c *Chain) reconcile() error {
 		return nil
 	}
 	// Check our blocks against primary chain until we find a match
-	primaryChain := c.manager.PrimaryChain()
+	primaryChain := c.manager.primaryChainLocked()
 	if primaryChain == nil {
 		return models.ErrBlockNotFound
 	}

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -79,6 +79,14 @@ func (cm *ChainManager) SetLedger(
 }
 
 func (cm *ChainManager) PrimaryChain() *Chain {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+	return cm.primaryChainLocked()
+}
+
+// primaryChainLocked returns the primary chain without acquiring the mutex.
+// The caller must already hold cm.mutex (read or write).
+func (cm *ChainManager) primaryChainLocked() *Chain {
 	if cm.chains == nil {
 		return nil
 	}
@@ -86,6 +94,8 @@ func (cm *ChainManager) PrimaryChain() *Chain {
 }
 
 func (cm *ChainManager) Chain(id ChainId) *Chain {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
 	return cm.chains[id]
 }
 
@@ -93,7 +103,7 @@ func (cm *ChainManager) Chain(id ChainId) *Chain {
 func (cm *ChainManager) NewChain(point ocommon.Point) (*Chain, error) {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
-	primaryChain := cm.PrimaryChain()
+	primaryChain := cm.primaryChainLocked()
 	if primaryChain == nil {
 		return nil, errors.New("primary chain not available")
 	}
@@ -131,7 +141,7 @@ func (cm *ChainManager) NewChainFromIntersect(
 ) (*Chain, error) {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
-	primaryChain := cm.PrimaryChain()
+	primaryChain := cm.primaryChainLocked()
 	if primaryChain == nil {
 		return nil, errors.New("primary chain not available")
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3124,6 +3124,8 @@ func (ls *LedgerState) UpstreamTipSlot() uint64 {
 
 // GetCurrentPParams returns the currentPParams value
 func (ls *LedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
+	ls.RLock()
+	defer ls.RUnlock()
 	return ls.currentPParams
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add read locks to protect concurrent reads of the primary chain and current protocol parameters. This prevents data races and avoids double-locking in chain operations.

- **Bug Fixes**
  - Guard `PrimaryChain()` and `Chain(id)` with read locks.
  - Guard `GetCurrentPParams()` with a read lock.
  - Add internal `primaryChainLocked()` and use it in `NewChain`, `NewChainFromIntersect`, and `reconcile()` to avoid acquiring the mutex twice.

<sup>Written for commit 536e4cbacaddc414d602f15eda9e869c2ac0ccce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

