### PR TITLE
fix(badger): return error instead of panic on invalid block metadata

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -177,10 +177,13 @@ func buildBlockBlobMetadataKey(dst []byte, baseKey []byte) {
 func marshalBlockMetadataInto(
 	dst []byte,
 	metadata types.BlockMetadata,
-) {
+) error {
 	prevHashLen := len(metadata.PrevHash)
 	if prevHashLen > blockMetadataPrevHashMaxLen {
-		panic("invalid block metadata prev hash length")
+		return fmt.Errorf(
+			"invalid block metadata prev hash length: %d",
+			prevHashLen,
+		)
 	}
 	copy(dst[:4], blockMetadataBinaryMagic[:])
 	binary.BigEndian.PutUint64(dst[4:12], metadata.ID)
@@ -191,6 +194,7 @@ func marshalBlockMetadataInto(
 		uint32(prevHashLen),
 	)
 	copy(dst[32:], metadata.PrevHash)
+	return nil
 }
 
 func unmarshalBlockMetadata(data []byte) (types.BlockMetadata, error) {
@@ -537,7 +541,9 @@ func (d *BlobStoreBadger) SetBlock(
 	var tmpMetadataBytes []byte
 	if d.compactBlockMetadata {
 		tmpMetadataBytes = packed[metadataKeyEnd:]
-		marshalBlockMetadataInto(tmpMetadataBytes, tmpMetadata)
+		if err := marshalBlockMetadataInto(tmpMetadataBytes, tmpMetadata); err != nil {
+			return err
+		}
 	} else {
 		tmpMetadataBytes, err = cbor.Encode(tmpMetadata)
 		if err != nil {

--- a/database/plugin/blob/badger/database_test.go
+++ b/database/plugin/blob/badger/database_test.go
@@ -31,7 +31,9 @@ func TestMarshalBlockMetadataRoundTrip(t *testing.T) {
 	}
 
 	encoded := make([]byte, 32+len(expected.PrevHash))
-	marshalBlockMetadataInto(encoded, expected)
+	if err := marshalBlockMetadataInto(encoded, expected); err != nil {
+		t.Fatalf("marshalBlockMetadataInto failed: %v", err)
+	}
 	if len(encoded) != 64 {
 		t.Fatalf("expected encoded length 64, got %d", len(encoded))
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return an error instead of panicking when block metadata has an invalid `PrevHash` length in the Badger blob store, preventing process crashes. `SetBlock` now propagates this error for safer writes.

- **Bug Fixes**
  - `marshalBlockMetadataInto` now returns `error` on oversized `PrevHash` (includes length in message).
  - `SetBlock` checks and returns the error in the compact metadata path.
  - Updated `TestMarshalBlockMetadataRoundTrip` to handle the new error return.

<sup>Written for commit b02697ff74fa76876b73360bfb6e51e40c4e89df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

