### PR TITLE
fix(ouroboros): check AddConsumer error in txsubmission handler

### DIFF
--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -49,8 +49,7 @@ func (o *Ouroboros) txsubmissionClientStart(
 	connId ouroboros.ConnectionId,
 ) error {
 	// Register mempool consumer
-	// We don't bother capturing the consumer because we can easily look it up later by connection ID
-	_ = o.Mempool.AddConsumer(connId)
+	o.Mempool.AddConsumer(connId)
 	// Start TxSubmission loop
 	conn := o.ConnManager.GetConnectionById(connId)
 	if conn == nil {
@@ -227,6 +226,12 @@ func (o *Ouroboros) txsubmissionClientRequestTxIds(
 	connId := ctx.ConnectionId
 	ret := []txsubmission.TxIdAndSize{}
 	consumer := o.Mempool.Consumer(connId)
+	if consumer == nil {
+		return nil, fmt.Errorf(
+			"no mempool consumer for connection: %s",
+			connId.String(),
+		)
+	}
 	// Clear TX cache
 	if ack > 0 {
 		consumer.ClearCache()
@@ -295,6 +300,12 @@ func (o *Ouroboros) txsubmissionClientRequestTxs(
 	connId := ctx.ConnectionId
 	ret := []txsubmission.TxBody{}
 	consumer := o.Mempool.Consumer(connId)
+	if consumer == nil {
+		return nil, fmt.Errorf(
+			"no mempool consumer for connection: %s",
+			connId.String(),
+		)
+	}
 	for _, txId := range txIds {
 		txHash := hex.EncodeToString(txId.TxId[:])
 		tx := consumer.GetTxFromCache(txHash)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Register the mempool consumer on `ouroboros` `txsubmission` client start. Return clear errors in `requestTxIds` and `requestTxs` when no consumer is found to prevent nil dereferences and make failures per connection explicit.

<sup>Written for commit fbeb288401485aa851aed2042933c9d169e5a0e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

