### PR TITLE
ci: enable race detector in test workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -95,7 +95,7 @@ jobs:
       - name: go-build
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test ./...
+        run: go test -race ./...
 
   # macOS and Windows jobs without Postgres service
   go-test-other:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable the Go race detector in CI tests to catch data races and fail builds early. Updates the Linux test step to run `go test -race ./...`.

<sup>Written for commit fc156675acb22b88b83e4f688e967c120d157961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing infrastructure by enabling race condition detection in the continuous integration pipeline for improved code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->