### PR TITLE
fix: add HTTP timeouts to UTxO RPC, Blockfrost, and Bark servers

### DIFF
--- a/bark/bark.go
+++ b/bark/bark.go
@@ -114,6 +114,8 @@ func (b *Bark) Start(ctx context.Context) error {
 			),
 			Handler:           mux,
 			ReadHeaderTimeout: 60 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       120 * time.Second,
 		}
 	} else {
 		b.config.Logger.Info(
@@ -130,6 +132,8 @@ func (b *Bark) Start(ctx context.Context) error {
 			),
 			Handler:           h2c.NewHandler(mux, &http2.Server{}),
 			ReadHeaderTimeout: 60 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       120 * time.Second,
 		}
 	}
 	b.server = server

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -100,6 +100,8 @@ func (b *Blockfrost) Start(
 		Addr:              b.config.ListenAddress,
 		Handler:           handler,
 		ReadHeaderTimeout: 60 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 	b.httpServer = server
 	b.mu.Unlock()

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -176,6 +176,10 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 			),
 			Handler:           mux,
 			ReadHeaderTimeout: 60 * time.Second,
+			ReadTimeout:       60 * time.Second,
+			IdleTimeout:       120 * time.Second,
+			// WriteTimeout deliberately 0 for gRPC streaming
+			// endpoints (FollowTip, WatchTx, WaitForTx).
 		}
 	} else {
 		u.config.Logger.Info(
@@ -194,6 +198,10 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 			// Use h2c so we can serve HTTP/2 without TLS
 			Handler:           h2c.NewHandler(mux, &http2.Server{}),
 			ReadHeaderTimeout: 60 * time.Second,
+			ReadTimeout:       60 * time.Second,
+			IdleTimeout:       120 * time.Second,
+			// WriteTimeout deliberately 0 for gRPC streaming
+			// endpoints (FollowTip, WatchTx, WaitForTx).
 		}
 	}
 	u.server = server


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add HTTP server timeouts to `utxorpc`, `blockfrost`, and `bark` to prevent hung connections and reduce resource usage. Improves reliability with slow or idle clients while keeping gRPC streaming intact.

- **Bug Fixes**
  - `bark`: Add WriteTimeout 30s and IdleTimeout 120s.
  - `blockfrost`: Add WriteTimeout 30s and IdleTimeout 120s.
  - `utxorpc`: Add ReadTimeout 60s and IdleTimeout 120s; keep WriteTimeout 0 for streaming endpoints (FollowTip, WatchTx, WaitForTx).

<sup>Written for commit a370c194ecadffc05bd9bea657767a8d6f2faf78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

