### PR TITLE
fix(ouroboros): check iterator error in blockfetch server

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -38,6 +39,22 @@ const blockfetchMetricsCdfUpdateInterval = 32
 // would cause the server to iterate the entire chain. The value of 129600
 // corresponds to the stability window (3k/f) on mainnet (k=2160, f=0.05).
 const MaxBlockFetchRange = 129600
+
+type blockfetchRangeIterator interface {
+	Next(bool) (*chain.ChainIteratorResult, error)
+	Cancel()
+}
+
+type blockfetchBatchServer interface {
+	StartBatch() error
+	Block(uint, []byte) error
+	BatchDone() error
+}
+
+type blockfetchConnection interface {
+	ErrorChan() chan error
+	Close() error
+}
 
 func (o *Ouroboros) blockfetchServerConnOpts() []blockfetch.BlockFetchOptionFunc {
 	return []blockfetch.BlockFetchOptionFunc{
@@ -115,67 +132,131 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 	go func() {
 		conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
 		if conn == nil {
+			chainIter.Cancel()
 			return
 		}
-		if err := ctx.Server.StartBatch(); err != nil {
-			o.config.Logger.Error(
-				"blockfetch: failed to start batch",
-				"connection_id", ctx.ConnectionId.String(),
-				"error", err,
-			)
-			return
-		}
-	Loop:
-		for {
-			select {
-			case <-conn.ErrorChan():
-				return
-			default:
-				next, _ := chainIter.Next(false)
-				if next == nil {
-					break Loop
-				}
-				if next.Block.Slot > end.Slot {
-					break Loop
-				}
-				blockBytes := next.Block.Cbor
-				err := ctx.Server.Block(
-					next.Block.Type,
-					blockBytes,
-				)
-				if err != nil {
-					// Log the error with context (#398)
-					o.config.Logger.Error(
-						"blockfetch: failed to send block to peer",
-						"connection_id", ctx.ConnectionId.String(),
-						"block_slot", next.Block.Slot,
-						"start_slot", start.Slot,
-						"end_slot", end.Slot,
-						"error", err,
-					)
-					return
-				}
-				if o.metrics != nil {
-					o.metrics.servedBlockCount.Inc()
-				}
-				// Make sure we don't hang waiting for the next block if we've already hit the end
-				if next.Block.Slot == end.Slot {
-					break Loop
-				}
-			}
-		}
-		// Signal batch completion
-		if err := ctx.Server.BatchDone(); err != nil {
-			o.config.Logger.Error(
-				"blockfetch: failed to signal batch completion",
-				"connection_id", ctx.ConnectionId.String(),
-				"start_slot", start.Slot,
-				"end_slot", end.Slot,
-				"error", err,
-			)
-		}
+		o.blockfetchServerSendBatch(
+			ctx.ConnectionId.String(),
+			start,
+			end,
+			chainIter,
+			ctx.Server,
+			conn,
+		)
 	}()
 	return nil
+}
+
+func (o *Ouroboros) blockfetchServerSendBatch(
+	connectionID string,
+	start ocommon.Point,
+	end ocommon.Point,
+	chainIter blockfetchRangeIterator,
+	server blockfetchBatchServer,
+	conn blockfetchConnection,
+) {
+	defer chainIter.Cancel()
+	if err := server.StartBatch(); err != nil {
+		o.config.Logger.Error(
+			"blockfetch: failed to start batch",
+			"connection_id", connectionID,
+			"error", err,
+		)
+		return
+	}
+Loop:
+	for {
+		select {
+		case <-conn.ErrorChan():
+			return
+		default:
+			next, iterErr := chainIter.Next(false)
+			if iterErr != nil {
+				if errors.Is(iterErr, chain.ErrIteratorChainTip) {
+					break Loop
+				}
+				o.config.Logger.Error(
+					"blockfetch: iterator error, aborting batch",
+					"connection_id", connectionID,
+					"start_slot", start.Slot,
+					"end_slot", end.Slot,
+					"error", iterErr,
+				)
+				o.closeBlockfetchConnection(
+					conn,
+					connectionID,
+					"iterator error after StartBatch",
+				)
+				return
+			}
+			if next == nil {
+				break Loop
+			}
+			if next.Block.Slot > end.Slot {
+				break Loop
+			}
+			blockBytes := next.Block.Cbor
+			err := server.Block(
+				next.Block.Type,
+				blockBytes,
+			)
+			if err != nil {
+				// After StartBatch(), the only safe recovery for a
+				// failed stream is to drop the transport.
+				o.config.Logger.Error(
+					"blockfetch: failed to send block to peer",
+					"connection_id", connectionID,
+					"block_slot", next.Block.Slot,
+					"start_slot", start.Slot,
+					"end_slot", end.Slot,
+					"error", err,
+				)
+				o.closeBlockfetchConnection(
+					conn,
+					connectionID,
+					"failed to stream block after StartBatch",
+				)
+				return
+			}
+			if o.metrics != nil {
+				o.metrics.servedBlockCount.Inc()
+			}
+			// Make sure we don't hang waiting for the next block if we've already hit the end
+			if next.Block.Slot == end.Slot {
+				break Loop
+			}
+		}
+	}
+	// Signal batch completion
+	if err := server.BatchDone(); err != nil {
+		o.config.Logger.Error(
+			"blockfetch: failed to signal batch completion",
+			"connection_id", connectionID,
+			"start_slot", start.Slot,
+			"end_slot", end.Slot,
+			"error", err,
+		)
+		o.closeBlockfetchConnection(
+			conn,
+			connectionID,
+			"failed to send BatchDone after StartBatch",
+		)
+	}
+}
+
+func (o *Ouroboros) closeBlockfetchConnection(
+	conn blockfetchConnection,
+	connectionID string,
+	reason string,
+) {
+	if err := conn.Close(); err != nil {
+		o.config.Logger.Debug(
+			"blockfetch: failed to close connection after aborted batch",
+			"connection_id", connectionID,
+			"reason", reason,
+			"error", err,
+		)
+	}
 }
 
 // BlockfetchClientRequestRange is called by the ledger when it needs to request a range of block bodies

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -16,6 +16,7 @@ package ouroboros
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -29,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/event"
 )
@@ -39,6 +41,69 @@ func testConnId() ouroboros_conn.ConnectionId {
 		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
 		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
 	}
+}
+
+type stubBlockfetchBatchServer struct {
+	startBatchCalls int
+	blockCalls      int
+	batchDoneCalls  int
+	startBatchErr   error
+	blockErr        error
+	batchDoneErr    error
+}
+
+func (s *stubBlockfetchBatchServer) StartBatch() error {
+	s.startBatchCalls++
+	return s.startBatchErr
+}
+
+func (s *stubBlockfetchBatchServer) Block(_ uint, _ []byte) error {
+	s.blockCalls++
+	return s.blockErr
+}
+
+func (s *stubBlockfetchBatchServer) BatchDone() error {
+	s.batchDoneCalls++
+	return s.batchDoneErr
+}
+
+type blockfetchIteratorStep struct {
+	result *chain.ChainIteratorResult
+	err    error
+}
+
+type stubBlockfetchIterator struct {
+	steps       []blockfetchIteratorStep
+	nextCalls   int
+	cancelCalls int
+}
+
+func (i *stubBlockfetchIterator) Next(bool) (*chain.ChainIteratorResult, error) {
+	if i.nextCalls >= len(i.steps) {
+		return nil, chain.ErrIteratorChainTip
+	}
+	step := i.steps[i.nextCalls]
+	i.nextCalls++
+	return step.result, step.err
+}
+
+func (i *stubBlockfetchIterator) Cancel() {
+	i.cancelCalls++
+}
+
+type stubBlockfetchConnection struct {
+	errChan    chan error
+	closeCalls int
+	closeErr   error
+}
+
+func (c *stubBlockfetchConnection) ErrorChan() chan error {
+	return c.errChan
+}
+
+func (c *stubBlockfetchConnection) Close() error {
+	c.closeCalls++
+	return c.closeErr
 }
 
 func TestBlockfetchServerRequestRange_StartAfterEnd(t *testing.T) {
@@ -187,6 +252,70 @@ func TestBlockfetchServerRequestRange_ExactlyAtLimit(t *testing.T) {
 			end,
 		)
 	}, "range exactly at limit should pass validation and reach LedgerState call")
+}
+
+func TestBlockfetchServerSendBatch_ClosesConnectionOnIteratorError(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	iter := &stubBlockfetchIterator{
+		steps: []blockfetchIteratorStep{
+			{err: errors.New("iterator exploded")},
+		},
+	}
+	server := &stubBlockfetchBatchServer{}
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error),
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(200, []byte{0x02})
+
+	o.blockfetchServerSendBatch(
+		testConnId().String(),
+		start,
+		end,
+		iter,
+		server,
+		conn,
+	)
+
+	assert.Equal(t, 1, server.startBatchCalls)
+	assert.Equal(t, 0, server.batchDoneCalls)
+	assert.Equal(t, 1, conn.closeCalls)
+	assert.Equal(t, 1, iter.cancelCalls)
+}
+
+func TestBlockfetchServerSendBatch_BatchDoneAtChainTip(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	iter := &stubBlockfetchIterator{}
+	server := &stubBlockfetchBatchServer{}
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error),
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(200, []byte{0x02})
+
+	o.blockfetchServerSendBatch(
+		testConnId().String(),
+		start,
+		end,
+		iter,
+		server,
+		conn,
+	)
+
+	assert.Equal(t, 1, server.startBatchCalls)
+	assert.Equal(t, 1, server.batchDoneCalls)
+	assert.Equal(t, 0, conn.closeCalls)
+	assert.Equal(t, 1, iter.cancelCalls)
 }
 
 func BenchmarkBlockfetchClientBlockMetrics(b *testing.B) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handled iterator errors in the BlockFetch server to stop at chain tip and abort batches on unexpected errors; now closes the connection to avoid half-open streams. Refactored send path to always cancel the iterator and call BatchDone when safe, using `github.com/blinklabs-io/dingo/chain` to detect `chain.ErrIteratorChainTip`, with tests for iterator error and tip cases.

<sup>Written for commit 4c7cf8d1a5ee3da34e861259811017f7d409d2a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

