### PR TITLE
fix(utxorpc): populate native bytes for fetch block and dump history function

### DIFF
--- a/utxorpc/sync.go
+++ b/utxorpc/sync.go
@@ -94,6 +94,7 @@ func (s *syncServiceServer) FetchBlock(
 			Cardano: tmpBlock,
 		}
 		acb.Chain = &acbc
+		acb.NativeBytes = block.Cbor
 		resp.Block = append(resp.Block, &acb)
 	}
 
@@ -172,6 +173,7 @@ func (s *syncServiceServer) DumpHistory(
 			Cardano: tmpBlock,
 		}
 		acb.Chain = &acbc
+		acb.NativeBytes = block.Cbor
 		resp.Block = append(resp.Block, &acb)
 	}
 
@@ -285,6 +287,7 @@ func (s *syncServiceServer) FollowTip(
 				Cardano: tmpBlock,
 			}
 			acb.Chain = &acbc
+			acb.NativeBytes = next.Block.Cbor
 			resp := &sync.FollowTipResponse{
 				Action: &sync.FollowTipResponse_Apply{
 					Apply: &acb,

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
+	sync "github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync"
 )
 
 func TestNewUtxorpc_DefaultLimits(t *testing.T) {
@@ -129,4 +130,18 @@ func TestUtxorpc_StartStop(t *testing.T) {
 	defer cancel()
 	err = u.Stop(ctx)
 	require.NoError(t, err, "failed to stop utxorpc")
+}
+
+// TestAnyChainBlockNativeBytes_NonNil ensures that AnyChainBlock.NativeBytes
+// is a real field in the generated type and can be set to non-nil, which is
+// what the SyncService handlers rely on for raw CBOR propagation.
+func TestAnyChainBlockNativeBytes_NonNil(t *testing.T) {
+	raw := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	acb := &sync.AnyChainBlock{
+		NativeBytes: raw,
+	}
+
+	require.NotNil(t, acb.NativeBytes)
+	require.Equal(t, raw, acb.NativeBytes)
 }


### PR DESCRIPTION
Closes #1474 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate `NativeBytes` for `AnyChainBlock` in `FetchBlock`, `DumpHistory`, and `FollowTip` to include raw CBOR in responses. This fixes missing raw bytes and unblocks clients that rely on them.

- **Bug Fixes**
  - Set `acb.NativeBytes = block.Cbor` (and `next.Block.Cbor` in `FollowTip`) in the three sync handlers.
  - Added a unit test to ensure `sync.AnyChainBlock.NativeBytes` accepts non-nil bytes.

<sup>Written for commit 5f64f8b3614eaec24fcf2852cb7d9380dfbf000f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Raw CBOR block bytes are now accessible in block operations, enabling direct access to encoded block data.

* **Tests**
  * Added test coverage to validate native bytes field accessibility and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->