### PR TITLE
fix(ledgerstate): store mithril snapshots at correct epochs for leader election

### DIFF
--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1083,14 +1083,25 @@ func importSnapShots(
 
 	// Import each snapshot type, saving the "go" result for the
 	// epoch summary to avoid recomputing it.
+	//
+	// Dingo's leader election always queries (epoch, "mark") using an
+	// epoch offset of currentEpoch-2. So we store each snapshot under
+	// the epoch it logically represents as a "mark" snapshot:
+	//   mark  → (epoch,   "mark") — stake at end of this epoch
+	//   set   → (epoch-1, "mark") — stake at end of the previous epoch
+	//   go    → (epoch-2, "mark") — stake two epochs back
+	// This ensures GetPoolStake(currentEpoch-2, "mark") finds the
+	// correct data after a mithril bootstrap.
 	var goSnapshots []*models.PoolStakeSnapshot
 	for _, st := range []struct {
-		name string
-		snap *ParsedSnapShot
+		name     string
+		snap     *ParsedSnapShot
+		dbEpoch  uint64
+		dbType   string
 	}{
-		{"mark", &snapshots.Mark},
-		{"set", &snapshots.Set},
-		{"go", &snapshots.Go},
+		{"mark", &snapshots.Mark, epoch, "mark"},
+		{"set", &snapshots.Set, epoch - 1, "mark"},
+		{"go", &snapshots.Go, epoch - 2, "mark"},
 	} {
 		select {
 		case <-ctx.Done():
@@ -1101,7 +1112,7 @@ func importSnapShots(
 		}
 
 		poolSnapshots := AggregatePoolStake(
-			st.snap, epoch, st.name, slot,
+			st.snap, st.dbEpoch, st.dbType, slot,
 		)
 
 		if st.name == "go" {
@@ -1118,7 +1129,7 @@ func importSnapShots(
 			metaTxn := txn.Metadata()
 
 			if err := store.DeletePoolStakeSnapshotsForEpoch(
-				epoch, st.name, metaTxn,
+				st.dbEpoch, st.dbType, metaTxn,
 			); err != nil {
 				return fmt.Errorf(
 					"deleting existing %s snapshots: %w",


### PR DESCRIPTION
## Problem

`importSnapShots` stored mark/set/go snapshots all under `cfg.State.Epoch` (the import epoch N) with their original type names. But `GetPoolStake` always queries `(epoch, "mark")` using a `currentEpoch-2` offset to implement the Go snapshot semantics.

Result: after mithril bootstrap at epoch N, leader election for the first epoch after bootstrap queries `(N-1, "mark")` which doesn't exist, so pool stake returns 0 and no leader schedule is computed. The node can never forge in the epoch immediately following a mithril bootstrap.

## Fix

Store each snapshot at the epoch it logically represents:
- `mark` → `(epoch, "mark")` — already correct
- `set` → `(epoch-1, "mark")` — this was epoch N-1's mark snapshot; store it there  
- `go` → `(epoch-2, "mark")` — this was epoch N-2's mark snapshot; store it there

This ensures `GetPoolStake(currentEpoch-2, "mark")` always finds data regardless of which epoch the mithril snapshot was taken from.

## Testing

Verified on preview network: after patching the live SQLite database to apply the same remapping, `GetPoolStake` now returns the correct pool stake (~1,094 billion lovelace) and leader schedule computation succeeds.

Signed-off-by: wcatz <waynecataldo@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leader election after Mithril bootstrap by storing mark/set/go snapshots under the epochs they actually represent as "mark". Ensures `GetPoolStake(currentEpoch-2, "mark")` always finds the correct stake so the first post-bootstrap epoch can forge.

- **Bug Fixes**
  - Remap storage: mark → (epoch, "mark"), set → (epoch-1, "mark"), go → (epoch-2, "mark").
  - Import now writes/deletes using the remapped epoch/type to keep snapshot lookups consistent.

<sup>Written for commit 4b24f5b3d828816b8c43e326e145a23efbd84c17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized and refined internal stake snapshot processing mechanisms, including enhanced creation, aggregation, and persistence operations, to improve overall data consistency and accuracy. Changes ensure reliable snapshot data management across various system operational phases while maintaining full backward compatibility with all existing public APIs and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->