### PR TITLE
fix: chain/network resilience

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
@@ -79,21 +80,26 @@ type ChainSelectorConfig struct {
 	EvaluationInterval time.Duration
 	StaleTipThreshold  time.Duration
 	SecurityParam      uint64
+	ConnectionEligible func(ouroboros.ConnectionId) bool
+	ConnectionPriority func(ouroboros.ConnectionId) int
 	MaxTrackedPeers    int // 0 means use DefaultMaxTrackedPeers
 }
 
 // ChainSelector tracks chain tips from multiple peers and selects the best
 // chain according to Ouroboros Praos rules.
 type ChainSelector struct {
-	config          ChainSelectorConfig
-	securityParam   uint64
-	maxTrackedPeers int
-	peerTips        map[ouroboros.ConnectionId]*PeerChainTip
-	bestPeerConn    *ouroboros.ConnectionId
-	localTip        ochainsync.Tip
-	mutex           sync.RWMutex
-	ctx             context.Context
-	cancel          context.CancelFunc
+	config            ChainSelectorConfig
+	securityParam     uint64
+	maxTrackedPeers   int
+	peerTips          map[ouroboros.ConnectionId]*PeerChainTip
+	eligible          map[ouroboros.ConnectionId]bool
+	priority          map[ouroboros.ConnectionId]int
+	evaluationTrigger chan struct{}
+	bestPeerConn      *ouroboros.ConnectionId
+	localTip          ochainsync.Tip
+	mutex             sync.RWMutex
+	ctx               context.Context
+	cancel            context.CancelFunc
 }
 
 // NewChainSelector creates a new ChainSelector with the given configuration.
@@ -112,12 +118,26 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 	if maxPeers <= 0 {
 		maxPeers = DefaultMaxTrackedPeers
 	}
-	return &ChainSelector{
-		config:          cfg,
-		securityParam:   cfg.SecurityParam,
-		maxTrackedPeers: maxPeers,
-		peerTips:        make(map[ouroboros.ConnectionId]*PeerChainTip),
+	cs := &ChainSelector{
+		config:            cfg,
+		securityParam:     cfg.SecurityParam,
+		maxTrackedPeers:   maxPeers,
+		peerTips:          make(map[ouroboros.ConnectionId]*PeerChainTip),
+		eligible:          make(map[ouroboros.ConnectionId]bool),
+		priority:          make(map[ouroboros.ConnectionId]int),
+		evaluationTrigger: make(chan struct{}, 1),
 	}
+	if cfg.EventBus != nil {
+		cfg.EventBus.SubscribeFunc(
+			peergov.PeerEligibilityChangedEventType,
+			cs.handlePeerEligibilityChangedEvent,
+		)
+		cfg.EventBus.SubscribeFunc(
+			peergov.PeerPriorityChangedEventType,
+			cs.handlePeerPriorityChangedEvent,
+		)
+	}
+	return cs
 }
 
 // Start begins the chain selector's background evaluation loop and subscribes
@@ -233,7 +253,16 @@ func (cs *ChainSelector) UpdatePeerTip(
 		// Check if this peer's tip is better than the current best peer's tip
 		if cs.bestPeerConn != nil {
 			if bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]; ok {
-				if IsBetterChain(tip, bestPeerTip.Tip) {
+				comparison := CompareChains(tip, bestPeerTip.Tip)
+				if comparison == ChainABetter {
+					shouldEvaluate = true
+				} else if comparison == ChainEqual &&
+					cs.comparePeerTips(
+						connId,
+						cs.peerTips[connId],
+						*cs.bestPeerConn,
+						bestPeerTip,
+					) == ChainABetter {
 					shouldEvaluate = true
 				}
 			}
@@ -324,10 +353,16 @@ func (cs *ChainSelector) evictLeastRecentPeerLocked() *ouroboros.ConnectionId {
 			"peer_count", len(cs.peerTips),
 			"max_tracked_peers", cs.maxTrackedPeers,
 		)
-		delete(cs.peerTips, oldestConn)
+		cs.deletePeerLocked(oldestConn)
 		return &oldestConn
 	}
 	return nil
+}
+
+func (cs *ChainSelector) deletePeerLocked(connId ouroboros.ConnectionId) {
+	delete(cs.peerTips, connId)
+	delete(cs.eligible, connId)
+	delete(cs.priority, connId)
 }
 
 // RemovePeer removes a peer from tracking.
@@ -338,7 +373,7 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
 
-		delete(cs.peerTips, connId)
+		cs.deletePeerLocked(connId)
 
 		if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
 			previousBest := *cs.bestPeerConn
@@ -470,6 +505,13 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 	var bestPeerTip *PeerChainTip
 
 	for connId, peerTip := range cs.peerTips {
+		if !cs.isConnectionEligible(connId) {
+			cs.config.Logger.Debug(
+				"skipping ineligible peer",
+				"connection_id", connId.String(),
+			)
+			continue
+		}
 		// Don't consider peers that are implausibly far behind local tip.
 		// This prevents switching to stale or cross-network peers when
 		// local tip and k are known.
@@ -484,7 +526,7 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 			)
 			continue
 		}
-		if peerTip.IsStale(cs.config.StaleTipThreshold) {
+		if cs.isPeerTipStale(peerTip) {
 			cs.config.Logger.Debug(
 				"skipping stale peer",
 				"connection_id", connId.String(),
@@ -499,33 +541,17 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 			continue
 		}
 
-		comparison := CompareChains(peerTip.Tip, bestPeerTip.Tip)
+		comparison := cs.comparePeerTips(
+			connId,
+			peerTip,
+			bestConnId,
+			bestPeerTip,
+		)
 		switch comparison {
 		case ChainABetter:
 			bestConnId = connId
 			bestPeerTip = peerTip
-		case ChainEqual:
-			// VRF tiebreaker: lower VRF output wins (per Ouroboros Praos)
-			vrfComparison := CompareVRFOutputs(
-				peerTip.VRFOutput,
-				bestPeerTip.VRFOutput,
-			)
-			switch vrfComparison {
-			case ChainABetter:
-				// peerTip has lower VRF, it wins
-				bestConnId = connId
-				bestPeerTip = peerTip
-			case ChainEqual:
-				// VRF outputs are equal (or one/both nil), use connection ID
-				// as final deterministic tiebreaker
-				if connId.String() < bestConnId.String() {
-					bestConnId = connId
-					bestPeerTip = peerTip
-				}
-			case ChainBBetter, ChainComparisonUnknown:
-				// bestPeerTip has lower VRF (or unknown); no change
-			}
-		case ChainBBetter, ChainComparisonUnknown:
+		case ChainBBetter, ChainComparisonUnknown, ChainEqual:
 			// Current best is better (or unknown); no change needed
 		}
 	}
@@ -534,6 +560,99 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 		return nil
 	}
 	return &bestConnId
+}
+
+func (cs *ChainSelector) isConnectionEligible(
+	connId ouroboros.ConnectionId,
+) bool {
+	eligible, ok := cs.eligible[connId]
+	if !ok {
+		return true
+	}
+	return eligible
+}
+
+func (cs *ChainSelector) connectionPriority(
+	connId ouroboros.ConnectionId,
+) int {
+	return cs.priority[connId]
+}
+
+func (cs *ChainSelector) isPeerTipStale(peerTip *PeerChainTip) bool {
+	return peerTip != nil &&
+		peerTip.IsStale(cs.config.StaleTipThreshold)
+}
+
+func (cs *ChainSelector) comparePeerTips(
+	connIdA ouroboros.ConnectionId,
+	peerTipA *PeerChainTip,
+	connIdB ouroboros.ConnectionId,
+	peerTipB *PeerChainTip,
+) ChainComparisonResult {
+	if peerTipA == nil || peerTipB == nil {
+		return ChainComparisonUnknown
+	}
+	comparison := CompareChains(peerTipA.Tip, peerTipB.Tip)
+	switch comparison {
+	case ChainABetter, ChainBBetter, ChainComparisonUnknown:
+		return comparison
+	case ChainEqual:
+		priorityA := cs.connectionPriority(connIdA)
+		priorityB := cs.connectionPriority(connIdB)
+		if priorityA > priorityB {
+			return ChainABetter
+		}
+		if priorityB > priorityA {
+			return ChainBBetter
+		}
+		vrfComparison := CompareVRFOutputs(
+			peerTipA.VRFOutput,
+			peerTipB.VRFOutput,
+		)
+		switch vrfComparison {
+		case ChainABetter, ChainBBetter:
+			return vrfComparison
+		case ChainEqual, ChainComparisonUnknown:
+		}
+		if connIdA.String() < connIdB.String() {
+			return ChainABetter
+		}
+		if connIdB.String() < connIdA.String() {
+			return ChainBBetter
+		}
+		return ChainEqual
+	default:
+		return ChainComparisonUnknown
+	}
+}
+
+func (cs *ChainSelector) handlePeerEligibilityChangedEvent(evt event.Event) {
+	e, ok := evt.Data.(peergov.PeerEligibilityChangedEvent)
+	if !ok {
+		return
+	}
+	cs.mutex.Lock()
+	cs.eligible[e.ConnectionId] = e.Eligible
+	cs.mutex.Unlock()
+	cs.triggerEvaluation()
+}
+
+func (cs *ChainSelector) handlePeerPriorityChangedEvent(evt event.Event) {
+	e, ok := evt.Data.(peergov.PeerPriorityChangedEvent)
+	if !ok {
+		return
+	}
+	cs.mutex.Lock()
+	cs.priority[e.ConnectionId] = e.Priority
+	cs.mutex.Unlock()
+	cs.triggerEvaluation()
+}
+
+func (cs *ChainSelector) triggerEvaluation() {
+	select {
+	case cs.evaluationTrigger <- struct{}{}:
+	default:
+	}
 }
 
 // EvaluateAndSwitch evaluates all peer tips and switches to the best chain if
@@ -556,6 +675,28 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 		}
 
 		previousBest := cs.bestPeerConn
+		if previousBest != nil && *previousBest != *newBest {
+			previousPeerTip, ok := cs.peerTips[*previousBest]
+			if ok {
+				newPeerTip, ok := cs.peerTips[*newBest]
+				if !ok {
+					return
+				}
+				previousEligible := cs.isConnectionEligible(*previousBest)
+				previousFresh := !cs.isPeerTipStale(previousPeerTip)
+				// Preserve the incumbent only when it still wins the same
+				// full comparison used during normal best-peer selection.
+				if previousEligible && previousFresh &&
+					cs.comparePeerTips(
+						*previousBest,
+						previousPeerTip,
+						*newBest,
+						newPeerTip,
+					) == ChainABetter {
+					newBest = previousBest
+				}
+			}
+		}
 
 		if previousBest == nil || *previousBest != *newBest {
 			newPeerTip, ok := cs.peerTips[*newBest]
@@ -657,6 +798,8 @@ func (cs *ChainSelector) evaluationLoop() {
 		select {
 		case <-cs.ctx.Done():
 			return
+		case <-cs.evaluationTrigger:
+			cs.runTriggeredEvaluation()
 		case <-ticker.C:
 			cs.runEvaluationTick()
 		}
@@ -675,6 +818,18 @@ func (cs *ChainSelector) runEvaluationTick() {
 		}
 	}()
 	cs.cleanupStalePeers()
+	cs.EvaluateAndSwitch()
+}
+
+func (cs *ChainSelector) runTriggeredEvaluation() {
+	defer func() {
+		if r := recover(); r != nil {
+			cs.config.Logger.Error(
+				"panic in triggered evaluation, continuing",
+				"panic", r,
+			)
+		}
+	}()
 	cs.EvaluateAndSwitch()
 }
 
@@ -698,7 +853,7 @@ func (cs *ChainSelector) cleanupStalePeers() {
 					"connection_id", connId.String(),
 					"last_updated", peerTip.LastUpdated,
 				)
-				delete(cs.peerTips, connId)
+				cs.deletePeerLocked(connId)
 				// Track if this was the best peer
 				if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
 					connIdCopy := connId

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -15,12 +15,14 @@
 package chainselection
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -40,6 +42,26 @@ func newTestConnectionId(n int) ouroboros.ConnectionId {
 		LocalAddr:  localAddr,
 		RemoteAddr: remoteAddr,
 	}
+}
+
+func setSelectorConnectionEligible(
+	cs *ChainSelector,
+	connId ouroboros.ConnectionId,
+	eligible bool,
+) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	cs.eligible[connId] = eligible
+}
+
+func setSelectorConnectionPriority(
+	cs *ChainSelector,
+	connId ouroboros.ConnectionId,
+	priority int,
+) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	cs.priority[connId] = priority
 }
 
 func TestChainSelectorUpdatePeerTip(t *testing.T) {
@@ -93,11 +115,19 @@ func TestChainSelectorRemovePeer(t *testing.T) {
 	}
 
 	cs.UpdatePeerTip(connId, tip, nil)
+	setSelectorConnectionEligible(cs, connId, false)
+	setSelectorConnectionPriority(cs, connId, 20)
 	assert.Equal(t, 1, cs.PeerCount())
 
 	cs.RemovePeer(connId)
 	assert.Equal(t, 0, cs.PeerCount())
 	assert.Nil(t, cs.GetPeerTip(connId))
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	_, eligibleFound := cs.eligible[connId]
+	_, priorityFound := cs.priority[connId]
+	assert.False(t, eligibleFound)
+	assert.False(t, priorityFound)
 }
 
 func TestChainSelectorRemoveBestPeer(t *testing.T) {
@@ -235,6 +265,347 @@ func TestChainSelectorEvaluateAndSwitch(t *testing.T) {
 	assert.False(t, switched)
 }
 
+func TestIncumbentAdvantageNoSwitchAtEqualBlockNumber(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	cs.UpdatePeerTip(connId1, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(connId2, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+}
+
+func TestIncumbentAdvantageSwitchesWhenBehind(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	cs.UpdatePeerTip(connId1, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(connId2, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("tip2")},
+		BlockNumber: 51,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+}
+
+func TestNoOscillationWithMultiplePeersAtSameTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+	connId3 := newTestConnectionId(3)
+
+	for _, peer := range []struct {
+		conn ouroboros.ConnectionId
+		slot uint64
+		hash []byte
+	}{
+		{conn: connId1, slot: 100, hash: []byte("tip1")},
+		{conn: connId2, slot: 101, hash: []byte("tip2")},
+		{conn: connId3, slot: 102, hash: []byte("tip3")},
+	} {
+		cs.UpdatePeerTip(peer.conn, ochainsync.Tip{
+			Point:       ocommon.Point{Slot: peer.slot, Hash: peer.hash},
+			BlockNumber: 50,
+		}, nil)
+	}
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(connId2, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 103, Hash: []byte("tip2b")},
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+}
+
+func TestChainSelectorSkipsIneligiblePeers(t *testing.T) {
+	ineligibleConn := newTestConnectionId(1)
+	eligibleConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+	setSelectorConnectionEligible(cs, ineligibleConn, false)
+
+	cs.UpdatePeerTip(ineligibleConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("tip1")},
+		BlockNumber: 60,
+	}, nil)
+	assert.Nil(t, cs.GetBestPeer())
+
+	cs.UpdatePeerTip(eligibleConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 110, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, eligibleConn, *cs.GetBestPeer())
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, eligibleConn, *bestPeer)
+}
+
+func TestChainSelectorDoesNotSwitchToIneligiblePeerAfterDisconnect(t *testing.T) {
+	eligibleConn := newTestConnectionId(1)
+	ineligibleConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+	setSelectorConnectionEligible(cs, ineligibleConn, false)
+
+	cs.UpdatePeerTip(eligibleConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 50,
+	}, nil)
+	cs.UpdatePeerTip(ineligibleConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 110, Hash: []byte("tip2")},
+		BlockNumber: 60,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, eligibleConn, *cs.GetBestPeer())
+
+	cs.RemovePeer(eligibleConn)
+	assert.Nil(t, cs.GetBestPeer())
+}
+
+func TestChainSelectorSwitchesAwayWhenIncumbentBecomesIneligible(t *testing.T) {
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+	cs.UpdatePeerTip(incumbentConn, equalTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(challengerConn, equalTip, nil)
+	setSelectorConnectionEligible(cs, incumbentConn, false)
+	switched := cs.EvaluateAndSwitch()
+	assert.True(t, switched)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challengerConn, *cs.GetBestPeer())
+}
+
+func TestChainSelectorDoesNotRestoreStaleIncumbent(t *testing.T) {
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{
+		StaleTipThreshold: 20 * time.Millisecond,
+	})
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+	cs.UpdatePeerTip(incumbentConn, equalTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	require.Eventually(t, func() bool {
+		cs.mutex.RLock()
+		defer cs.mutex.RUnlock()
+		peerTip := cs.peerTips[incumbentConn]
+		return peerTip != nil && peerTip.IsStale(20*time.Millisecond)
+	}, time.Second, 5*time.Millisecond)
+
+	cs.UpdatePeerTip(challengerConn, equalTip, nil)
+	switched := cs.EvaluateAndSwitch()
+	assert.True(t, switched)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challengerConn, *cs.GetBestPeer())
+}
+
+func TestChainSelectorPrefersHigherPriorityPeerAtEqualTip(t *testing.T) {
+	publicRootConn := newTestConnectionId(1)
+	localRootConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+	setSelectorConnectionPriority(cs, localRootConn, 20)
+	setSelectorConnectionPriority(cs, publicRootConn, 10)
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+
+	cs.UpdatePeerTip(publicRootConn, equalTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, publicRootConn, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(localRootConn, equalTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, localRootConn, *cs.GetBestPeer())
+}
+
+func TestChainSelectorUpdatesConnectionStateFromPeerGovEvents(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus: eventBus,
+	})
+	connId := newTestConnectionId(1)
+
+	require.Eventually(t, func() bool {
+		cs.mutex.RLock()
+		defer cs.mutex.RUnlock()
+		return cs.isConnectionEligible(connId) &&
+			cs.connectionPriority(connId) == 0
+	}, time.Second, 5*time.Millisecond)
+
+	eventBus.Publish(
+		peergov.PeerEligibilityChangedEventType,
+		event.NewEvent(
+			peergov.PeerEligibilityChangedEventType,
+			peergov.PeerEligibilityChangedEvent{
+				ConnectionId: connId,
+				Eligible:     false,
+			},
+		),
+	)
+	eventBus.Publish(
+		peergov.PeerPriorityChangedEventType,
+		event.NewEvent(
+			peergov.PeerPriorityChangedEventType,
+			peergov.PeerPriorityChangedEvent{
+				ConnectionId: connId,
+				Priority:     40,
+			},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		cs.mutex.RLock()
+		defer cs.mutex.RUnlock()
+		return !cs.isConnectionEligible(connId) &&
+			cs.connectionPriority(connId) == 40
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestChainSelectorSwitchesImmediatelyOnEligibilityEvent(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:           eventBus,
+		EvaluationInterval: time.Hour,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, cs.Start(ctx))
+
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+
+	cs.UpdatePeerTip(incumbentConn, equalTip, nil)
+	cs.UpdatePeerTip(challengerConn, equalTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	eventBus.Publish(
+		peergov.PeerEligibilityChangedEventType,
+		event.NewEvent(
+			peergov.PeerEligibilityChangedEventType,
+			peergov.PeerEligibilityChangedEvent{
+				ConnectionId: incumbentConn,
+				Eligible:     false,
+			},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		bestPeer := cs.GetBestPeer()
+		return bestPeer != nil && *bestPeer == challengerConn
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestChainSelectorSwitchesImmediatelyOnPriorityEvent(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:           eventBus,
+		EvaluationInterval: time.Hour,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, cs.Start(ctx))
+
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+
+	cs.UpdatePeerTip(incumbentConn, equalTip, nil)
+	cs.UpdatePeerTip(challengerConn, equalTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	eventBus.Publish(
+		peergov.PeerPriorityChangedEventType,
+		event.NewEvent(
+			peergov.PeerPriorityChangedEventType,
+			peergov.PeerPriorityChangedEvent{
+				ConnectionId: challengerConn,
+				Priority:     40,
+			},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		bestPeer := cs.GetBestPeer()
+		return bestPeer != nil && *bestPeer == challengerConn
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestChainSelectorKeepsChallengerWhenItWinsFullTieBreak(t *testing.T) {
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbentTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 130, Hash: []byte("incumbent")},
+		BlockNumber: 60,
+	}
+	challengerTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("challenger")},
+		BlockNumber: 60,
+	}
+
+	cs.UpdatePeerTip(incumbentConn, incumbentTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(challengerConn, challengerTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challengerConn, *cs.GetBestPeer())
+}
+
 func TestChainSelectorStalePeerFiltering(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
 		StaleTipThreshold: 100 * time.Millisecond,
@@ -318,6 +689,8 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 
 	// Trigger cleanup - this should emit ChainSwitchEvent when best peer is
 	// removed
+	setSelectorConnectionEligible(cs, connId1, false)
+	setSelectorConnectionPriority(cs, connId1, 10)
 	cs.cleanupStalePeers()
 
 	// Verify the new best peer is selected
@@ -335,6 +708,12 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("expected ChainSwitchEvent was not emitted")
 	}
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	_, eligibleFound := cs.eligible[connId1]
+	_, priorityFound := cs.priority[connId1]
+	assert.False(t, eligibleFound)
+	assert.False(t, priorityFound)
 }
 
 func TestChainSelectorGetAllPeerTips(t *testing.T) {
@@ -427,6 +806,32 @@ func TestChainSelectorVRFTiebreaker(t *testing.T) {
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
 	assert.Equal(t, connId2, *bestPeer, "peer with lower VRF should win")
+}
+
+func TestChainSelectorUpdatePeerTipTriggersVRFTieBreakEvaluation(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("same")},
+		BlockNumber: 50,
+	}
+	vrfLower := make64ByteVRF(0x00)
+	vrfHigher := make64ByteVRF(0x01)
+
+	cs.UpdatePeerTip(connId1, tip, vrfHigher)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(connId2, tip, vrfLower)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(
+		t,
+		connId2,
+		*cs.GetBestPeer(),
+		"peer with lower VRF should trigger immediate evaluation",
+	)
 }
 
 func TestChainSelectorVRFTiebreakerWithNilVRF(t *testing.T) {
@@ -904,6 +1309,8 @@ func TestChainSelectorPeerEvictionAtCapacity(t *testing.T) {
 	// It may or may not be the best peer (peer maxPeers-1 has highest
 	// block number and becomes best via auto-evaluation). Verify peer 0
 	// exists before we trigger eviction.
+	setSelectorConnectionEligible(cs, connIds[0], false)
+	setSelectorConnectionPriority(cs, connIds[0], 10)
 	require.NotNil(
 		t,
 		cs.GetPeerTip(connIds[0]),
@@ -942,6 +1349,12 @@ func TestChainSelectorPeerEvictionAtCapacity(t *testing.T) {
 		cs.GetPeerTip(connIds[0]),
 		"oldest peer should have been evicted",
 	)
+	cs.mutex.RLock()
+	_, eligibleFound := cs.eligible[connIds[0]]
+	_, priorityFound := cs.priority[connIds[0]]
+	cs.mutex.RUnlock()
+	assert.False(t, eligibleFound)
+	assert.False(t, priorityFound)
 
 	// Peers 1 through maxPeers-1 should still be present
 	for i := 1; i < maxPeers; i++ {

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -607,6 +607,20 @@ func (s *State) ClearSeenHeaders() {
 	s.seenHeaders = make(map[uint64][]headerRecord)
 }
 
+// ClearSeenHeadersFrom removes entries from the header deduplication cache
+// above the specified slot. This allows a restarted chainsync client
+// to replay headers beyond a known-good intersect point after an active-peer
+// switch without discarding older fork-detection history.
+func (s *State) ClearSeenHeadersFrom(fromSlot uint64) {
+	s.seenHeadersMutex.Lock()
+	defer s.seenHeadersMutex.Unlock()
+	for slot := range s.seenHeaders {
+		if slot > fromSlot {
+			delete(s.seenHeaders, slot)
+		}
+	}
+}
+
 // cloneBytes returns a copy of the byte slice, or nil if the
 // input is nil.
 func cloneBytes(b []byte) []byte {

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -815,6 +815,43 @@ func TestPruneSeenHeaders(t *testing.T) {
 	require.False(t, isNew)
 }
 
+func TestClearSeenHeadersFrom(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(50, []byte("old")),
+		ochainsync.Tip{Point: ocommon.NewPoint(50, []byte("old"))})
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("keep")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("keep"))})
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(150, []byte("replay")),
+		ochainsync.Tip{Point: ocommon.NewPoint(150, []byte("replay"))})
+
+	s.ClearSeenHeadersFrom(100)
+
+	isNew := s.UpdateClientTip(connB,
+		ocommon.NewPoint(50, []byte("old")),
+		ochainsync.Tip{Point: ocommon.NewPoint(50, []byte("old"))})
+	require.False(t, isNew)
+
+	isNew = s.UpdateClientTip(connB,
+		ocommon.NewPoint(100, []byte("keep")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("keep"))})
+	require.False(t, isNew)
+
+	isNew = s.UpdateClientTip(connB,
+		ocommon.NewPoint(150, []byte("replay")),
+		ochainsync.Tip{Point: ocommon.NewPoint(150, []byte("replay"))})
+	require.True(t, isNew)
+}
+
 // --- Config tests ---
 
 func TestDefaultConfig(t *testing.T) {

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/chainselection"
 	cardano "github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
@@ -232,6 +233,28 @@ func (ls *LedgerState) logUnexpectedChainsyncEventData(
 	)
 }
 
+func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
+	e, ok := evt.Data.(chainselection.ChainSwitchEvent)
+	if !ok {
+		return
+	}
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	ls.selectedBlockfetchConnId = e.NewConnectionId
+}
+
+func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
+	e, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+	if !ok {
+		return
+	}
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	if ls.selectedBlockfetchConnId == e.ConnectionId {
+		ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
+	}
+}
+
 // detectConnectionSwitch checks for an active connection change and logs a
 // summary of dropped events when a switch is detected. It returns the current
 // active connection ID and whether connection filtering is configured. When
@@ -255,13 +278,22 @@ func (ls *LedgerState) detectConnectionSwitch() (activeConnId *ouroboros.Connect
 			ls.dropEventCount = 0
 			ls.dropRollbackCount = 0
 			ls.headerMismatchCount = 0
-			// Clear header queue and blockfetch state from old
-			// connection so stale headers don't block the new
-			// connection's blockfetch pipeline.
-			ls.chain.ClearHeaders()
+			// Reset blockfetch state, but preserve queued headers. Valid
+			// headers remain valid across peer switches, and clearing them
+			// forces the sync pipeline to restart from scratch on every
+			// selector churn event.
 			ls.chainsyncBlockfetchMutex.Lock()
-			ls.blockfetchRequestRangeCleanup()
-			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+			if ls.chainsyncBlockfetchReadyChan == nil {
+				ls.blockfetchRequestRangeCleanup()
+				ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+			} else {
+				ls.config.Logger.Debug(
+					"preserving in-flight blockfetch batch across connection switch",
+					"component", "ledger",
+					"blockfetch_connection_id",
+					ls.activeBlockfetchConnId.String(),
+				)
+			}
 			ls.chainsyncBlockfetchMutex.Unlock()
 			// Clear per-connection state (e.g., header dedup cache)
 			// so the new connection can re-deliver blocks from the
@@ -473,6 +505,7 @@ func (ls *LedgerState) resetChainsyncResyncState() {
 	ls.chain.ClearHeaders()
 	ls.chainsyncBlockfetchMutex.Lock()
 	ls.blockfetchRequestRangeCleanup()
+	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 	ls.chainsyncBlockfetchMutex.Unlock()
 }
 
@@ -675,6 +708,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	// Mark blockfetch as in progress
 	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
 	ls.activeBlockfetchConnId = e.ConnectionId
+	ls.selectedBlockfetchConnId = e.ConnectionId
 	// Request next bulk range
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
 	ls.config.Logger.Debug(
@@ -691,6 +725,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	)
 	if err != nil {
 		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return err
 	}
 	return nil
@@ -865,14 +900,14 @@ func (ls *LedgerState) tryResolveFork(
 
 //nolint:unparam
 func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
-	// Drop blocks from a stale connection (e.g., after connection switch)
-	if e.ConnectionId != ls.activeBlockfetchConnId {
-		return nil
-	}
 	// Process blocks in small commit batches so they appear on the
 	// chain promptly without paying a full blob transaction cost for
 	// every single block. We still flush well before BatchDone to
 	// avoid downstream ChainSync idle timeouts.
+	if ls.chainsyncBlockfetchReadyChan == nil ||
+		e.ConnectionId != ls.activeBlockfetchConnId {
+		return nil
+	}
 
 	// Verify block header cryptographic proofs (VRF, KES).
 	// Skip during historical sync (validationEnabled=false) because
@@ -902,6 +937,16 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 		ls.chainsyncBlockfetchTimeoutTimer.Reset(blockfetchBusyTimeout)
 	}
 	return nil
+}
+
+func (ls *LedgerState) nextBlockfetchConnId() (ouroboros.ConnectionId, bool) {
+	if ls.selectedBlockfetchConnId != (ouroboros.ConnectionId{}) {
+		return ls.selectedBlockfetchConnId, true
+	}
+	if ls.activeBlockfetchConnId == (ouroboros.ConnectionId{}) {
+		return ouroboros.ConnectionId{}, false
+	}
+	return ls.activeBlockfetchConnId, true
 }
 
 func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
@@ -1974,6 +2019,7 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 				return
 			}
 			ls.blockfetchRequestRangeCleanup()
+			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 			ls.config.Logger.Info(
 				fmt.Sprintf(
 					"blockfetch operation timed out after %s",
@@ -2007,7 +2053,8 @@ func (ls *LedgerState) blockfetchRequestRangeCleanup() {
 
 func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	// Drop batch-done from a stale connection (e.g., after connection switch)
-	if e.ConnectionId != ls.activeBlockfetchConnId {
+	if ls.chainsyncBlockfetchReadyChan == nil ||
+		e.ConnectionId != ls.activeBlockfetchConnId {
 		return nil
 	}
 	// Stop the blockfetch timeout timer and invalidate any pending callbacks
@@ -2031,21 +2078,36 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	if remainingHeaders == 0 {
 		// No more headers to fetch, allow chainsync to collect more
 		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return nil
 	}
 	// Clean up from blockfetch batch
 	ls.blockfetchRequestRangeCleanup()
+	nextConnId, ok := ls.nextBlockfetchConnId()
+	if !ok {
+		ls.config.Logger.Debug(
+			"headers pending but no next blockfetch connection is available",
+			"component", "ledger",
+			"remaining_headers", remainingHeaders,
+			"active_blockfetch_connection_id",
+			ls.activeBlockfetchConnId.String(),
+		)
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		return nil
+	}
 	// Mark blockfetch as in progress for next batch
 	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	ls.activeBlockfetchConnId = nextConnId
 	// Request next waiting bulk range using the active connection
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
 	err := ls.blockfetchRequestRangeStart(
-		ls.activeBlockfetchConnId,
+		nextConnId,
 		headerStart,
 		headerEnd,
 	)
 	if err != nil {
 		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return err
 	}
 	return nil

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockHeader struct {
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	blockNumber uint64
+	slot        uint64
+}
+
+func (m mockHeader) Hash() lcommon.Blake2b256          { return m.hash }
+func (m mockHeader) PrevHash() lcommon.Blake2b256      { return m.prevHash }
+func (m mockHeader) BlockNumber() uint64               { return m.blockNumber }
+func (m mockHeader) SlotNumber() uint64                { return m.slot }
+func (m mockHeader) IssuerVkey() lcommon.IssuerVkey    { return lcommon.IssuerVkey{} }
+func (m mockHeader) BlockBodySize() uint64             { return 0 }
+func (m mockHeader) Era() lcommon.Era                  { return babbage.EraBabbage }
+func (m mockHeader) Cbor() []byte                      { return nil }
+func (m mockHeader) BlockBodyHash() lcommon.Blake2b256 { return lcommon.Blake2b256{} }
+
+func TestDetectConnectionSwitchPreservesQueuedHeaders(t *testing.T) {
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("hdr-1")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, testChain.HeaderCount())
+
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	currentConn := connId2
+	switchCalls := 0
+
+	ls := &LedgerState{
+		chain:                        testChain,
+		lastActiveConnId:             &connId1,
+		activeBlockfetchConnId:       connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		pendingBlockfetchEvents: []BlockfetchEvent{
+			{
+				ConnectionId: connId1,
+				Block:        &mockBabbageBlock{slot: 2},
+				Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
+			},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &currentConn
+			},
+			ConnectionSwitchFunc: func() {
+				switchCalls++
+			},
+		},
+	}
+
+	activeConnId, configured := ls.detectConnectionSwitch()
+	require.True(t, configured)
+	require.NotNil(t, activeConnId)
+	assert.Equal(t, connId2, *activeConnId)
+	assert.Equal(t, 1, testChain.HeaderCount())
+	assert.Equal(t, connId1, ls.activeBlockfetchConnId)
+	require.NotNil(t, ls.chainsyncBlockfetchReadyChan)
+	require.Len(t, ls.pendingBlockfetchEvents, 1)
+	assert.Equal(t, 1, switchCalls)
+}
+
+func TestHandleEventBlockfetchBlockAllowsBlocksFromActiveBatch(t *testing.T) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	ls := &LedgerState{
+		activeBlockfetchConnId:       connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+		ConnectionId: connId1,
+		Block:        &mockBabbageBlock{slot: 2},
+		Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
+	})
+	require.NoError(t, err)
+	require.Len(t, ls.pendingBlockfetchEvents, 1)
+	assert.Equal(t, connId1, ls.pendingBlockfetchEvents[0].ConnectionId)
+}
+
+func TestHandleEventBlockfetchBlockDropsBlocksFromStaleConnection(t *testing.T) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	ls := &LedgerState{
+		activeBlockfetchConnId:       connId2,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+		ConnectionId: connId1,
+		Block:        &mockBabbageBlock{slot: 2},
+		Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
+	})
+	require.NoError(t, err)
+	require.Empty(t, ls.pendingBlockfetchEvents)
+}
+
+func TestHandleEventBlockfetchBatchDoneUsesSelectedConnectionAfterSwitch(
+	t *testing.T,
+) {
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("hdr-1")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	requestedConnId := ouroboros.ConnectionId{}
+	requestCount := 0
+
+	ls := &LedgerState{
+		chain:                        testChain,
+		activeBlockfetchConnId:       connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				requestCount++
+				requestedConnId = connId
+				return nil
+			},
+		},
+	}
+	ls.handleChainSwitchEvent(event.NewEvent(
+		chainselection.ChainSwitchEventType,
+		chainselection.ChainSwitchEvent{
+			PreviousConnectionId: connId1,
+			NewConnectionId:      connId2,
+		},
+	))
+
+	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+		ConnectionId: connId1,
+		BatchDone:    true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, requestCount)
+	assert.Equal(t, connId2, requestedConnId)
+	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
+
+	ls.blockfetchRequestRangeCleanup()
+}
+
+func TestHandleEventBlockfetchBatchDoneFallsBackToCurrentConnection(
+	t *testing.T,
+) {
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("hdr-1")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	requestedConnId := ouroboros.ConnectionId{}
+	requestCount := 0
+
+	ls := &LedgerState{
+		chain:                        testChain,
+		activeBlockfetchConnId:       connId,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				requestCount++
+				requestedConnId = connId
+				return nil
+			},
+		},
+	}
+
+	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+		ConnectionId: connId,
+		BatchDone:    true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, requestCount)
+	assert.Equal(t, connId, requestedConnId)
+	assert.Equal(t, connId, ls.activeBlockfetchConnId)
+
+	ls.blockfetchRequestRangeCleanup()
+	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+}
+
+func TestHandleChainSwitchEventUpdatesSelectedBlockfetchConnId(t *testing.T) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	ls := &LedgerState{}
+
+	ls.handleChainSwitchEvent(event.NewEvent(
+		chainselection.ChainSwitchEventType,
+		chainselection.ChainSwitchEvent{
+			NewConnectionId: connId,
+		},
+	))
+
+	nextConnId, ok := ls.nextBlockfetchConnId()
+	require.True(t, ok)
+	assert.Equal(t, connId, nextConnId)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -29,7 +29,9 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
@@ -464,6 +466,7 @@ type LedgerState struct {
 	chainsyncBlockfetchReadyMutex sync.Mutex
 	chainsyncBlockfetchReadyChan  chan struct{}
 	activeBlockfetchConnId        ouroboros.ConnectionId // connection used for current blockfetch pipeline
+	selectedBlockfetchConnId      ouroboros.ConnectionId // latest selected chainsync connection for the next batch
 	pendingBlockfetchEvents       []BlockfetchEvent
 	checkpointWrittenForEpoch     bool
 	closed                        atomic.Bool
@@ -473,6 +476,8 @@ type LedgerState struct {
 	chainsyncSubID   event.EventSubscriberId
 	blockfetchSubID  event.EventSubscriberId
 	chainUpdateSubID event.EventSubscriberId
+	chainSwitchSubID event.EventSubscriberId
+	connClosedSubID  event.EventSubscriberId
 
 	// rollbackMu serializes rollbackWG.Add with Close's rollbackWG.Wait
 	// to prevent Add-after-Wait panics from the TOCTOU race between
@@ -599,6 +604,14 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFunc(
 			chain.ChainUpdateEventType,
 			ls.handleEventChainUpdate,
+		)
+		ls.chainSwitchSubID = ls.config.EventBus.SubscribeFunc(
+			chainselection.ChainSwitchEventType,
+			ls.handleChainSwitchEvent,
+		)
+		ls.connClosedSubID = ls.config.EventBus.SubscribeFunc(
+			connmanager.ConnectionClosedEventType,
+			ls.handleConnectionClosedEvent,
 		)
 	}
 	// Schedule periodic process to purge consumed UTxOs outside of the rollback window
@@ -858,6 +871,14 @@ func (ls *LedgerState) Close() error {
 		ls.config.EventBus.Unsubscribe(
 			chain.ChainUpdateEventType,
 			ls.chainUpdateSubID,
+		)
+		ls.config.EventBus.Unsubscribe(
+			chainselection.ChainSwitchEventType,
+			ls.chainSwitchSubID,
+		)
+		ls.config.EventBus.Unsubscribe(
+			connmanager.ConnectionClosedEventType,
+			ls.connClosedSubID,
 		)
 	}
 

--- a/node.go
+++ b/node.go
@@ -90,10 +90,11 @@ func (n *Node) handleChainSwitchEvent(evt event.Event) {
 		"new_tip_block", e.NewTip.BlockNumber,
 		"new_tip_slot", e.NewTip.Point.Slot,
 	)
-	// Do not restart chainsync on peer switch. Every connected peer
-	// already maintains its own chainsync client state and pipeline; a
-	// switch only changes which peer's stream feeds the ledger.
 	n.chainsyncState.SetClientConnId(e.NewConnectionId)
+	n.ouroboros.ResumeChainsyncOnPeerSwitch(
+		n.ctx,
+		e.NewConnectionId,
+	)
 }
 
 func New(cfg Config) (*Node, error) {
@@ -229,12 +230,13 @@ func (n *Node) Run(ctx context.Context) error {
 				return nil
 			},
 			ConnectionSwitchFunc: func() {
-				// Clear the header dedup cache so the new connection
-				// can re-deliver blocks from the intersection without
-				// them being filtered as duplicates from the old
-				// connection.
-				if n.chainsyncState != nil {
-					n.chainsyncState.ClearSeenHeaders()
+				// Retain older seen-header history so a switched peer
+				// can replay only the post-tip segment from the local
+				// intersect point without re-delivering older headers.
+				if n.chainsyncState != nil && n.ledgerState != nil {
+					n.chainsyncState.ClearSeenHeadersFrom(
+						n.ledgerState.Tip().Point.Slot,
+					)
 				}
 			},
 			FatalErrorFunc: func(err error) {
@@ -419,6 +421,58 @@ func (n *Node) Run(ctx context.Context) error {
 		connmanager.InboundConnectionEventType,
 		n.ouroboros.HandleInboundConnEvent,
 	)
+	// Configure peer governor before opening listeners so topology-driven
+	// outbound connections start first and do not lose the race to inbounds.
+	// Create ledger peer provider for discovering peers from stake pool relays.
+	ledgerPeerProvider, err := ledger.NewLedgerPeerProvider(
+		n.ledgerState,
+		n.db,
+		n.eventBus,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create ledger peer provider: %w", err)
+	}
+
+	// Get UseLedgerAfterSlot from topology config (defaults to -1 = disabled).
+	var useLedgerAfterSlot int64 = -1
+	if n.config.topologyConfig != nil {
+		useLedgerAfterSlot = n.config.topologyConfig.UseLedgerAfterSlot
+	}
+
+	n.peerGov = peergov.NewPeerGovernor(
+		peergov.PeerGovernorConfig{
+			Logger:                         n.config.logger,
+			EventBus:                       n.eventBus,
+			ConnManager:                    n.connManager,
+			DisableOutbound:                n.config.isDevMode(),
+			PromRegistry:                   n.config.promRegistry,
+			PeerRequestFunc:                n.ouroboros.RequestPeersFromPeer,
+			LedgerPeerProvider:             ledgerPeerProvider,
+			UseLedgerAfterSlot:             useLedgerAfterSlot,
+			TargetNumberOfKnownPeers:       n.config.targetNumberOfKnownPeers,
+			TargetNumberOfEstablishedPeers: n.config.targetNumberOfEstablishedPeers,
+			TargetNumberOfActivePeers:      n.config.targetNumberOfActivePeers,
+			ActivePeersTopologyQuota:       n.config.activePeersTopologyQuota,
+			ActivePeersGossipQuota:         n.config.activePeersGossipQuota,
+			ActivePeersLedgerQuota:         n.config.activePeersLedgerQuota,
+			MinHotPeers:                    n.config.minHotPeers,
+			ReconcileInterval:              n.config.reconcileInterval,
+			InactivityTimeout:              n.config.inactivityTimeout,
+			SyncProgressProvider:           n.ledgerState,
+		},
+	)
+	n.ouroboros.PeerGov = n.peerGov
+	n.eventBus.SubscribeFunc(
+		peergov.OutboundConnectionEventType,
+		n.ouroboros.HandleOutboundConnEvent,
+	)
+	if n.config.topologyConfig != nil {
+		n.peerGov.LoadTopologyConfig(n.config.topologyConfig)
+	}
+	if err := n.peerGov.Start(n.ctx); err != nil { //nolint:contextcheck
+		return fmt.Errorf("peer governor start failed: %w", err)
+	}
+	started = append(started, func() { n.peerGov.Stop() })
 	// Start listeners
 	if err := n.connManager.Start(n.ctx); err != nil { //nolint:contextcheck
 		return err
@@ -644,57 +698,6 @@ func (n *Node) Run(ctx context.Context) error {
 			}
 		}
 	}(stallCheckInterval, stallRecoveryGrace, stallRecycleCooldown)
-	// Configure peer governor
-	// Create ledger peer provider for discovering peers from stake pool relays
-	ledgerPeerProvider, err := ledger.NewLedgerPeerProvider(
-		n.ledgerState,
-		n.db,
-		n.eventBus,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create ledger peer provider: %w", err)
-	}
-
-	// Get UseLedgerAfterSlot from topology config (defaults to -1 = disabled)
-	var useLedgerAfterSlot int64 = -1
-	if n.config.topologyConfig != nil {
-		useLedgerAfterSlot = n.config.topologyConfig.UseLedgerAfterSlot
-	}
-
-	n.peerGov = peergov.NewPeerGovernor(
-		peergov.PeerGovernorConfig{
-			Logger:                         n.config.logger,
-			EventBus:                       n.eventBus,
-			ConnManager:                    n.connManager,
-			DisableOutbound:                n.config.isDevMode(),
-			PromRegistry:                   n.config.promRegistry,
-			PeerRequestFunc:                n.ouroboros.RequestPeersFromPeer,
-			LedgerPeerProvider:             ledgerPeerProvider,
-			UseLedgerAfterSlot:             useLedgerAfterSlot,
-			TargetNumberOfKnownPeers:       n.config.targetNumberOfKnownPeers,
-			TargetNumberOfEstablishedPeers: n.config.targetNumberOfEstablishedPeers,
-			TargetNumberOfActivePeers:      n.config.targetNumberOfActivePeers,
-			ActivePeersTopologyQuota:       n.config.activePeersTopologyQuota,
-			ActivePeersGossipQuota:         n.config.activePeersGossipQuota,
-			ActivePeersLedgerQuota:         n.config.activePeersLedgerQuota,
-			MinHotPeers:                    n.config.minHotPeers,
-			ReconcileInterval:              n.config.reconcileInterval,
-			InactivityTimeout:              n.config.inactivityTimeout,
-			SyncProgressProvider:           n.ledgerState,
-		},
-	)
-	n.ouroboros.PeerGov = n.peerGov
-	n.eventBus.SubscribeFunc(
-		peergov.OutboundConnectionEventType,
-		n.ouroboros.HandleOutboundConnEvent,
-	)
-	if n.config.topologyConfig != nil {
-		n.peerGov.LoadTopologyConfig(n.config.topologyConfig)
-	}
-	if err := n.peerGov.Start(n.ctx); err != nil { //nolint:contextcheck
-		return err
-	}
-	started = append(started, func() { n.peerGov.Stop() })
 	// Configure UTxO RPC (only when port is configured)
 	if n.config.utxorpcPort > 0 {
 		n.utxorpc = utxorpc.NewUtxorpc(

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
+	dchainsync "github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -77,6 +79,122 @@ func (o *Ouroboros) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 	}
 }
 
+func normalizeIntersectPoints(points []ocommon.Point) []ocommon.Point {
+	if len(points) == 0 {
+		return nil
+	}
+	result := make([]ocommon.Point, 0, len(points))
+	seen := make(map[string]struct{}, len(points))
+	for _, point := range points {
+		key := fmt.Sprintf("%d:%x", point.Slot, point.Hash)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, point)
+	}
+	return result
+}
+
+func isOriginPoint(point ocommon.Point) bool {
+	return point.Slot == 0 && len(point.Hash) == 0
+}
+
+func shouldRestartChainsyncOnSwitch(
+	localTip ocommon.Point,
+	trackedClient *dchainsync.TrackedClient,
+) bool {
+	if trackedClient == nil || isOriginPoint(localTip) {
+		return false
+	}
+	if trackedClient.Cursor.Slot > localTip.Slot {
+		return true
+	}
+	return trackedClient.Cursor.Slot == localTip.Slot &&
+		!bytes.Equal(trackedClient.Cursor.Hash, localTip.Hash)
+}
+
+func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
+	connId ouroboros.ConnectionId,
+) ([]ocommon.Point, error) {
+	if o.LedgerState == nil {
+		return nil, errors.New("ledger state not available")
+	}
+	conn := o.ConnManager.GetConnectionById(connId)
+	if conn == nil {
+		return nil, fmt.Errorf("failed to lookup connection ID: %s", connId.String())
+	}
+	if conn.ChainSync() == nil || conn.ChainSync().Client == nil {
+		return nil, fmt.Errorf(
+			"ChainSync client not available on connection: %s",
+			connId.String(),
+		)
+	}
+	intersectPoints, err := o.LedgerState.IntersectPoints(
+		chainsyncIntersectPointCount,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"LedgerState.IntersectPoints failed: %w",
+			err,
+		)
+	}
+	// Determine start point if we have no stored chain points
+	if len(intersectPoints) == 0 {
+		if o.config.IntersectTip {
+			// Start initial chainsync from current chain tip
+			tip, err := conn.ChainSync().Client.GetCurrentTip()
+			if err != nil {
+				return nil, fmt.Errorf(
+					"ChainSync.Client.GetCurrentTip failed: %w",
+					err,
+				)
+			}
+			intersectPoints = append(intersectPoints, tip.Point)
+		} else if len(o.config.IntersectPoints) > 0 {
+			// Start initial chainsync at specific point(s)
+			intersectPoints = append(
+				intersectPoints,
+				o.config.IntersectPoints...,
+			)
+		}
+	}
+	intersectPoints = normalizeIntersectPoints(intersectPoints)
+	// Always include origin as the last intersect point. This
+	// ensures FindIntersect succeeds even when the peer follows
+	// a different fork (e.g. multi-producer DevNet). Without
+	// origin, peers on divergent chains have no common point.
+	if len(intersectPoints) == 0 ||
+		!isOriginPoint(intersectPoints[len(intersectPoints)-1]) {
+		intersectPoints = append(intersectPoints, ocommon.NewPointOrigin())
+	}
+	return intersectPoints, nil
+}
+
+func (o *Ouroboros) syncChainsyncClient(
+	connId ouroboros.ConnectionId,
+	intersectPoints []ocommon.Point,
+) error {
+	conn := o.ConnManager.GetConnectionById(connId)
+	if conn == nil {
+		return fmt.Errorf("failed to lookup connection ID: %s", connId.String())
+	}
+	if conn.ChainSync() == nil || conn.ChainSync().Client == nil {
+		return fmt.Errorf(
+			"ChainSync client not available on connection: %s",
+			connId.String(),
+		)
+	}
+	intersectPoints = normalizeIntersectPoints(intersectPoints)
+	if len(intersectPoints) == 0 {
+		intersectPoints = []ocommon.Point{ocommon.NewPointOrigin()}
+	}
+	if o.PeerGov != nil {
+		o.PeerGov.SetPeerHotByConnId(connId)
+	}
+	return conn.ChainSync().Client.Sync(intersectPoints)
+}
+
 // RestartChainsyncClient restarts the chainsync client on an existing
 // connection without closing the TCP connection. This avoids disrupting
 // other mini-protocols (blockfetch, txsubmission, keepalive) and
@@ -88,6 +206,22 @@ func (o *Ouroboros) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 // the intersection point is behind the client's current position, which
 // triggers the normal rollback handler.
 func (o *Ouroboros) RestartChainsyncClient(connId ouroboros.ConnectionId) error {
+	intersectPoints, err := o.buildDefaultChainsyncIntersectPoints(connId)
+	if err != nil {
+		return fmt.Errorf(
+			"build default chainsync intersect points: %w",
+			err,
+		)
+	}
+	return o.RestartChainsyncClientWithPoints(connId, intersectPoints)
+}
+
+// RestartChainsyncClientWithPoints restarts the chainsync client on an
+// existing connection and begins syncing from the specified intersect point(s).
+func (o *Ouroboros) RestartChainsyncClientWithPoints(
+	connId ouroboros.ConnectionId,
+	intersectPoints []ocommon.Point,
+) error {
 	conn := o.ConnManager.GetConnectionById(connId)
 	if conn == nil {
 		return fmt.Errorf("connection not found: %s", connId.String())
@@ -102,8 +236,7 @@ func (o *Ouroboros) RestartChainsyncClient(connId ouroboros.ConnectionId) error 
 	// Start re-registers the protocol with the muxer (handles
 	// stopped→starting→running transition internally).
 	cs.Client.Start()
-	// Re-negotiate intersection using the same logic as initial start.
-	if err := o.chainsyncClientStart(connId); err != nil {
+	if err := o.syncChainsyncClient(connId, intersectPoints); err != nil {
 		return fmt.Errorf(
 			"chainsync restart failed for conn %v: %w",
 			connId, err,
@@ -113,56 +246,17 @@ func (o *Ouroboros) RestartChainsyncClient(connId ouroboros.ConnectionId) error 
 }
 
 func (o *Ouroboros) chainsyncClientStart(connId ouroboros.ConnectionId) error {
-	conn := o.ConnManager.GetConnectionById(connId)
-	if conn == nil {
-		return fmt.Errorf("failed to lookup connection ID: %s", connId.String())
-	}
-	if conn.ChainSync() == nil {
+	intersectPoints, err := o.buildDefaultChainsyncIntersectPoints(connId)
+	if err != nil {
 		return fmt.Errorf(
-			"ChainSync protocol not available on connection: %s",
-			connId.String(),
+			"build default chainsync intersect points for start: %w",
+			err,
 		)
 	}
-	intersectPoints, err := o.LedgerState.IntersectPoints(
-		chainsyncIntersectPointCount,
-	)
-	if err != nil {
-		return err
+	if err := o.syncChainsyncClient(connId, intersectPoints); err != nil {
+		return fmt.Errorf("sync chainsync client: %w", err)
 	}
-	// Determine start point if we have no stored chain points
-	if len(intersectPoints) == 0 {
-		if o.config.IntersectTip {
-			// Start initial chainsync from current chain tip
-			tip, err := conn.ChainSync().Client.GetCurrentTip()
-			if err != nil {
-				return err
-			}
-			intersectPoints = append(
-				intersectPoints,
-				tip.Point,
-				ocommon.NewPointOrigin(),
-			)
-			if o.PeerGov != nil {
-				o.PeerGov.SetPeerHotByConnId(connId)
-			}
-			return conn.ChainSync().Client.Sync(intersectPoints)
-		} else if len(o.config.IntersectPoints) > 0 {
-			// Start initial chainsync at specific point(s)
-			intersectPoints = append(
-				intersectPoints,
-				o.config.IntersectPoints...,
-			)
-		}
-	}
-	// Always include origin as the last intersect point. This
-	// ensures FindIntersect succeeds even when the peer follows
-	// a different fork (e.g. multi-producer DevNet). Without
-	// origin, peers on divergent chains have no common point.
-	intersectPoints = append(intersectPoints, ocommon.NewPointOrigin())
-	if o.PeerGov != nil {
-		o.PeerGov.SetPeerHotByConnId(connId)
-	}
-	return conn.ChainSync().Client.Sync(intersectPoints)
+	return nil
 }
 
 func (o *Ouroboros) chainsyncServerFindIntersect(
@@ -559,6 +653,141 @@ func (o *Ouroboros) updateChainsyncMetrics(
 	o.PeerGov.UpdatePeerChainSyncObservation(connId, headerRate, tipDelta)
 }
 
+func (o *Ouroboros) restartChainsyncClientAsync(
+	ctx context.Context,
+	connId ouroboros.ConnectionId,
+	reason string,
+	restartFn func() error,
+) {
+	conn := o.ConnManager.GetConnectionById(connId)
+	if conn == nil {
+		return
+	}
+	go func() {
+		// Serialize restarts for the same connection to prevent
+		// overlapping stop/restart goroutines.
+		muVal, _ := o.restartMu.LoadOrStore(
+			connId, &sync.Mutex{},
+		)
+		mu := muVal.(*sync.Mutex)
+		mu.Lock()
+
+		o.config.Logger.Info(
+			"restarting chainsync client",
+			"connection_id", connId.String(),
+			"reason", reason,
+		)
+		var closeOnce sync.Once
+		closeConn := func() {
+			closeOnce.Do(func() { conn.Close() })
+		}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			if err := restartFn(); err != nil {
+				o.config.Logger.Warn(
+					"chainsync restart failed, closing connection",
+					"error", err,
+					"connection_id", connId.String(),
+					"reason", reason,
+				)
+				closeConn()
+			}
+		}()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			o.config.Logger.Info(
+				"node shutting down, aborting chainsync restart",
+				"connection_id", connId.String(),
+				"reason", reason,
+			)
+			closeConn()
+			<-done
+		case <-time.After(chainsyncRestartTimeout):
+			o.config.Logger.Warn(
+				"chainsync restart timed out, closing connection",
+				"connection_id", connId.String(),
+				"reason", reason,
+			)
+			closeConn()
+			<-done
+		}
+		mu.Unlock()
+	}()
+}
+
+func (o *Ouroboros) ResumeChainsyncOnPeerSwitch(
+	ctx context.Context,
+	connId ouroboros.ConnectionId,
+) {
+	if o == nil ||
+		o.ConnManager == nil ||
+		o.ChainsyncState == nil ||
+		o.LedgerState == nil {
+		return
+	}
+	localTip := o.LedgerState.Tip()
+	trackedClient := o.ChainsyncState.GetTrackedClient(connId)
+	if !shouldRestartChainsyncOnSwitch(localTip.Point, trackedClient) {
+		return
+	}
+	localPoint := localTip.Point
+	reason := "active peer switch exact intersect"
+	o.restartChainsyncClientAsync(
+		ctx,
+		connId,
+		reason,
+		func() error {
+			conn := o.ConnManager.GetConnectionById(connId)
+			if conn == nil {
+				return fmt.Errorf("connection not found: %s", connId.String())
+			}
+			cs := conn.ChainSync()
+			if cs == nil || cs.Client == nil {
+				return fmt.Errorf(
+					"chainsync client not available: %s",
+					connId.String(),
+				)
+			}
+			if err := cs.Client.Stop(); err != nil {
+				return fmt.Errorf("stop chainsync client: %w", err)
+			}
+			o.ChainsyncState.ClearSeenHeadersFrom(localPoint.Slot)
+			err := o.RestartChainsyncClientWithPoints(
+				connId,
+				[]ocommon.Point{localPoint},
+			)
+			if err == nil {
+				o.config.Logger.Info(
+					"restarted switched peer chainsync from local tip",
+					"connection_id", connId.String(),
+					"local_tip_slot", localPoint.Slot,
+					"tracked_cursor_slot", trackedClient.Cursor.Slot,
+				)
+				return nil
+			}
+			if !errors.Is(err, ochainsync.ErrIntersectNotFound) {
+				return err
+			}
+			o.config.Logger.Info(
+				"exact local-tip intersect unavailable on switched peer, falling back",
+				"connection_id", connId.String(),
+				"local_tip_slot", localPoint.Slot,
+				"tracked_cursor_slot", trackedClient.Cursor.Slot,
+			)
+			if err := cs.Client.Stop(); err != nil {
+				return fmt.Errorf(
+					"stop chainsync client after intersect fallback: %w",
+					err,
+				)
+			}
+			o.ChainsyncState.ClearSeenHeaders()
+			return o.RestartChainsyncClient(connId)
+		},
+	)
+}
+
 // SubscribeChainsyncResync registers an EventBus subscriber that
 // handles chainsync re-sync events. When a resync is requested
 // (e.g. because the ledger detected a persistent fork), this
@@ -579,52 +808,27 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 				return
 			}
 			connId := e.ConnectionId
-			conn := o.ConnManager.GetConnectionById(connId)
-			if conn == nil {
-				return
-			}
-
-			// Run stop + clear + restart asynchronously.
-			// cs.Client.Stop() can block waiting for the
-			// protocol to drain, and Sync() waits for a
-			// FindIntersect response delivered via the
-			// chainsync callback which needs the chainsync
-			// mutex held by our caller. Doing either
-			// synchronously would block the EventBus or
-			// deadlock.
-			go func() {
-				// Serialize restarts for the same connection
-				// to prevent overlapping stop/restart goroutines.
-				muVal, _ := o.restartMu.LoadOrStore(
-					connId, &sync.Mutex{},
-				)
-				mu := muVal.(*sync.Mutex)
-				mu.Lock()
-
-				o.config.Logger.Info(
-					"restarting chainsync for re-sync",
-					"connection_id", connId.String(),
-					"reason", e.Reason,
-				)
-				var closeOnce sync.Once
-				closeConn := func() {
-					closeOnce.Do(func() { conn.Close() })
-				}
-				done := make(chan struct{})
-				go func() {
-					defer close(done)
+			o.restartChainsyncClientAsync(
+				ctx,
+				connId,
+				e.Reason,
+				func() error {
+					conn := o.ConnManager.GetConnectionById(connId)
+					if conn == nil {
+						return fmt.Errorf(
+							"connection not found: %s",
+							connId.String(),
+						)
+					}
 					// Stop the chainsync client to halt
 					// mismatching headers.
 					cs := conn.ChainSync()
 					if cs != nil && cs.Client != nil {
 						if err := cs.Client.Stop(); err != nil {
-							o.config.Logger.Warn(
-								"chainsync stop failed, closing connection",
-								"error", err,
-								"connection_id", connId.String(),
+							return fmt.Errorf(
+								"stop chainsync client: %w",
+								err,
 							)
-							closeConn()
-							return
 						}
 					}
 					// Clear the header dedup cache so the
@@ -633,40 +837,9 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 					if o.ChainsyncState != nil {
 						o.ChainsyncState.ClearSeenHeaders()
 					}
-					if err := o.RestartChainsyncClient(
-						connId,
-					); err != nil {
-						o.config.Logger.Warn(
-							"chainsync restart failed, closing connection",
-							"error", err,
-							"connection_id", connId.String(),
-						)
-						closeConn()
-					}
-				}()
-				// Hold the mutex until the restart worker
-				// completes to prevent overlapping restarts.
-				// On timeout or shutdown, close the connection
-				// but still wait for done before releasing.
-				select {
-				case <-done:
-				case <-ctx.Done():
-					o.config.Logger.Info(
-						"node shutting down, aborting chainsync restart",
-						"connection_id", connId.String(),
-					)
-					closeConn()
-					<-done
-				case <-time.After(chainsyncRestartTimeout):
-					o.config.Logger.Warn(
-						"chainsync restart timed out, closing connection",
-						"connection_id", connId.String(),
-					)
-					closeConn()
-					<-done
-				}
-				mu.Unlock()
-			}()
+					return o.RestartChainsyncClient(connId)
+				},
+			)
 		},
 	)
 }

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+
+	dchainsync "github.com/blinklabs-io/dingo/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeIntersectPoints(t *testing.T) {
+	points := []ocommon.Point{
+		ocommon.NewPoint(20, []byte("b")),
+		ocommon.NewPoint(30, []byte("c")),
+		ocommon.NewPoint(20, []byte("b")),
+		ocommon.NewPointOrigin(),
+		ocommon.NewPointOrigin(),
+	}
+
+	normalized := normalizeIntersectPoints(points)
+
+	require.Equal(
+		t,
+		[]ocommon.Point{
+			ocommon.NewPoint(20, []byte("b")),
+			ocommon.NewPoint(30, []byte("c")),
+			ocommon.NewPointOrigin(),
+		},
+		normalized,
+	)
+}
+
+func TestShouldRestartChainsyncOnSwitch(t *testing.T) {
+	tests := []struct {
+		name          string
+		localTip      ocommon.Point
+		trackedClient *dchainsync.TrackedClient
+		want          bool
+	}{
+		{
+			name:     "nil tracked client",
+			localTip: ocommon.NewPoint(100, []byte("tip")),
+			want:     false,
+		},
+		{
+			name:          "origin local tip",
+			localTip:      ocommon.NewPointOrigin(),
+			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(5, []byte("a"))},
+			want:          false,
+		},
+		{
+			name:          "tracked cursor behind local tip",
+			localTip:      ocommon.NewPoint(100, []byte("tip")),
+			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(90, []byte("a"))},
+			want:          false,
+		},
+		{
+			name:          "tracked cursor equal to local tip",
+			localTip:      ocommon.NewPoint(100, []byte("tip")),
+			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(100, []byte("tip"))},
+			want:          false,
+		},
+		{
+			name:          "tracked cursor same slot different hash",
+			localTip:      ocommon.NewPoint(100, []byte("tip")),
+			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(100, []byte("fork"))},
+			want:          true,
+		},
+		{
+			name:          "tracked cursor ahead of local tip",
+			localTip:      ocommon.NewPoint(100, []byte("tip")),
+			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(110, []byte("ahead"))},
+			want:          true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				test.want,
+				shouldRestartChainsyncOnSwitch(
+					test.localTip,
+					test.trackedClient,
+				),
+			)
+		})
+	}
+}

--- a/peergov/bootstrap.go
+++ b/peergov/bootstrap.go
@@ -88,8 +88,8 @@ func (p *PeerGovernor) shouldExitBootstrap() (bool, string) {
 	return false, ""
 }
 
-// exitBootstrap demotes all bootstrap peers to cold and marks bootstrap as exited.
-// This closes connections to bootstrap peers and prevents them from being promoted.
+// exitBootstrap marks bootstrap as exited while preserving bootstrap-source
+// classification so recovery remains reachable.
 // Acquires p.mu internally and publishes events after releasing it to avoid deadlock.
 //
 //nolint:unused // Used by tests
@@ -104,60 +104,46 @@ func (p *PeerGovernor) exitBootstrap(reason string) {
 // exitBootstrapLocked exits bootstrap mode and returns pending events.
 // Must be called with p.mu held.
 func (p *PeerGovernor) exitBootstrapLocked(reason string) []pendingEvent {
-	var events []pendingEvent
+	events := make([]pendingEvent, 0, 1)
 	if p.bootstrapExited {
 		return events
 	}
+	oldBootstrapExited := p.bootstrapExited
 
+	preservedCount := 0
 	demotedCount := 0
 	for _, peer := range p.peers {
 		if peer == nil || peer.Source != PeerSourceTopologyBootstrapPeer {
 			continue
 		}
-		if peer.State == PeerStateHot || peer.State == PeerStateWarm {
-			prevState := peer.State
-			peer.State = PeerStateCold
-			demotedCount++
-
-			// Close the connection if it exists
-			if peer.Connection != nil {
-				if p.config.ConnManager != nil {
-					conn := p.config.ConnManager.GetConnectionById(
-						peer.Connection.Id,
-					)
-					if conn != nil {
-						conn.Close()
-					}
-				}
-				peer.Connection = nil
-			}
-
-			p.config.Logger.Info(
-				"bootstrap exit: demoted peer to cold",
-				"address", peer.Address,
-				"previous_state", prevState,
-			)
-			if p.metrics != nil {
-				p.metrics.churnDemotionsBySource.WithLabelValues(
-					peer.Source.String(),
-				).Inc()
-			}
-			events = append(events, pendingEvent{
-				PeerDemotedEventType,
-				PeerStateChangeEvent{
-					Address: peer.Address,
-					Reason:  "bootstrap exit",
-				},
-			})
-		}
+		preservedCount++
+		p.config.Logger.Info(
+			"bootstrap exit: preserving bootstrap peer source for recovery",
+			"address", peer.Address,
+			"state", peer.State,
+		)
 	}
 
 	p.bootstrapExited = true
+	for _, peer := range p.peers {
+		if peer == nil ||
+			peer.Source != PeerSourceTopologyBootstrapPeer ||
+			peer.Connection == nil {
+			continue
+		}
+		events = p.appendChainSelectionEventsLocked(
+			events,
+			oldBootstrapExited,
+			peer.Source,
+			clonePeerConnection(peer.Connection),
+			peer,
+		)
+	}
 	p.lastBootstrapExit = time.Now()
 	p.config.Logger.Info(
 		"exited bootstrap mode",
 		"reason", reason,
-		"demoted_peers", demotedCount,
+		"preserved_peers", preservedCount,
 	)
 
 	events = append(events, pendingEvent{
@@ -195,6 +181,16 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 
 	// Only check if bootstrap was previously exited
 	if !p.bootstrapExited {
+		return events
+	}
+	hasBootstrapPeers := false
+	for _, peer := range p.peers {
+		if peer != nil && peer.Source == PeerSourceTopologyBootstrapPeer {
+			hasBootstrapPeers = true
+			break
+		}
+	}
+	if !hasBootstrapPeers {
 		return events
 	}
 
@@ -266,7 +262,22 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 	}
 
 	// Re-enable bootstrap peers
+	oldBootstrapExited := p.bootstrapExited
 	p.bootstrapExited = false
+	for _, peer := range p.peers {
+		if peer == nil ||
+			peer.Source != PeerSourceTopologyBootstrapPeer ||
+			peer.Connection == nil {
+			continue
+		}
+		events = p.appendChainSelectionEventsLocked(
+			events,
+			oldBootstrapExited,
+			peer.Source,
+			clonePeerConnection(peer.Connection),
+			peer,
+		)
+	}
 	p.config.Logger.Info(
 		"re-enabling bootstrap peers due to low hot peer count",
 		"hot_count", hotCount,

--- a/peergov/churn.go
+++ b/peergov/churn.go
@@ -69,6 +69,8 @@ func (p *PeerGovernor) gossipChurn() {
 		if !canDemote {
 			continue // Never demote this peer (e.g., local roots)
 		}
+		oldSource := peer.Source
+		oldConn := clonePeerConnection(peer.Connection)
 		peer.State = targetState
 
 		// Close connection when demoting to cold
@@ -87,6 +89,13 @@ func (p *PeerGovernor) gossipChurn() {
 				"address", peer.Address,
 			)
 		}
+		events = p.appendChainSelectionEventsLocked(
+			events,
+			p.bootstrapExited,
+			oldSource,
+			oldConn,
+			peer,
+		)
 
 		demoted++
 		p.config.Logger.Debug(

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -261,11 +261,21 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			}
 			// Use the peer from the slice in case the pointer changed
 			currentPeer := p.peers[peerIdx]
+			oldSource := currentPeer.Source
+			oldConn := clonePeerConnection(currentPeer.Connection)
 			currentPeer.ConnectedAt = time.Now()
 			currentPeer.setConnection(conn, true)
 			currentPeer.State = PeerStateWarm
+			selectionEvents := p.appendChainSelectionEventsLocked(
+				nil,
+				p.bootstrapExited,
+				oldSource,
+				oldConn,
+				currentPeer,
+			)
 			p.updatePeerMetrics()
 			p.mu.Unlock()
+			p.publishPendingEvents(selectionEvents)
 			// Generate event
 			p.publishEvent(
 				OutboundConnectionEventType,
@@ -457,8 +467,8 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)
 
+	var selectionEvents []pendingEvent
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	peerIdx := -1
 	// Check if peer already exists (possibly as inbound)
 	for i, peer := range p.peers {
@@ -481,6 +491,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 				"cap", p.maxPeerListSize(),
 				"current", len(p.peers),
 			)
+			p.mu.Unlock()
 			return
 		}
 		tmpPeer = &Peer{
@@ -500,8 +511,11 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 		tmpPeer = p.peers[peerIdx]
 	}
 	if tmpPeer == nil {
+		p.mu.Unlock()
 		return
 	}
+	oldSource := tmpPeer.Source
+	oldConn := clonePeerConnection(tmpPeer.Connection)
 	if p.config.ConnManager != nil {
 		conn := p.config.ConnManager.GetConnectionById(e.ConnectionId)
 		if conn != nil {
@@ -520,7 +534,17 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 		tmpPeer.ReconnectDelay = 0
 		tmpPeer.ReconnectCount = 0
 	}
+	selectionEvents = p.appendChainSelectionEventsLocked(
+		selectionEvents,
+		p.bootstrapExited,
+		oldSource,
+		oldConn,
+		tmpPeer,
+	)
 	p.updatePeerMetrics()
+	p.mu.Unlock()
+
+	p.publishPendingEvents(selectionEvents)
 }
 
 func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
@@ -532,8 +556,8 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 		)
 		return
 	}
+	var selectionEvents []pendingEvent
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if e.Error != nil {
 		closeMsg := fmt.Sprintf(
 			"unexpected connection failure: %s",
@@ -558,8 +582,17 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 	peerIdx := p.peerIndexByConnId(e.ConnectionId)
 	if peerIdx != -1 && p.peers[peerIdx] != nil {
 		peer := p.peers[peerIdx]
+		oldSource := peer.Source
+		oldConn := clonePeerConnection(peer.Connection)
 		peer.Connection = nil
 		peer.State = PeerStateCold
+		selectionEvents = p.appendChainSelectionEventsLocked(
+			selectionEvents,
+			p.bootstrapExited,
+			oldSource,
+			oldConn,
+			peer,
+		)
 		p.updatePeerMetrics()
 		// Only reconnect for outbound peers that are not on the deny list
 		if peer.Source != PeerSourceInboundConn &&
@@ -604,6 +637,9 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 			}
 		}
 	}
+	p.mu.Unlock()
+
+	p.publishPendingEvents(selectionEvents)
 }
 
 // DenyPeer adds a peer to the deny list for the specified duration.

--- a/peergov/event.go
+++ b/peergov/event.go
@@ -19,11 +19,13 @@ import (
 )
 
 const (
-	OutboundConnectionEventType = "peergov.outbound_conn"
-	PeerDemotedEventType        = "peergov.peer_demoted"
-	PeerPromotedEventType       = "peergov.peer_promoted"
-	PeerRemovedEventType        = "peergov.peer_removed"
-	PeerAddedEventType          = "peergov.peer_added"
+	OutboundConnectionEventType     = "peergov.outbound_conn"
+	PeerDemotedEventType            = "peergov.peer_demoted"
+	PeerPromotedEventType           = "peergov.peer_promoted"
+	PeerRemovedEventType            = "peergov.peer_removed"
+	PeerAddedEventType              = "peergov.peer_added"
+	PeerEligibilityChangedEventType = "peergov.peer_eligibility_changed"
+	PeerPriorityChangedEventType    = "peergov.peer_priority_changed"
 	// Phase 7: Enhanced Observability event types
 	PeerChurnEventType   = "peergov.peer_churn"
 	QuotaStatusEventType = "peergov.quota_status"
@@ -39,6 +41,16 @@ type OutboundConnectionEvent struct {
 type PeerStateChangeEvent struct {
 	Address string
 	Reason  string
+}
+
+type PeerEligibilityChangedEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	Eligible     bool
+}
+
+type PeerPriorityChangedEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	Priority     int
 }
 
 // PeerChurnEvent provides detailed information about a peer state change

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -46,6 +46,31 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
+func requirePendingEventData[T any](
+	t *testing.T,
+	events []pendingEvent,
+	eventType event.EventType,
+) T {
+	t.Helper()
+	for _, pending := range events {
+		if pending.eventType != eventType {
+			continue
+		}
+		data, ok := pending.data.(T)
+		require.Truef(
+			t,
+			ok,
+			"unexpected event payload type for %s: %T",
+			eventType,
+			pending.data,
+		)
+		return data
+	}
+	t.Fatalf("missing pending event %s", eventType)
+	var zero T
+	return zero
+}
+
 func TestNewPeerGovernor(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -483,6 +508,218 @@ func TestPeerGovernor_SetPeerHotByConnId(t *testing.T) {
 	peers := pg.GetPeers()
 	assert.Equal(t, PeerStateHot, peers[0].State)
 	assert.True(t, peers[0].LastActivity.After(time.Now().Add(-1*time.Second)))
+}
+
+func TestPeerGovernorAppendChainSelectionEventsLocked(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:3004")
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+
+	t.Run("new outbound connection publishes eligible and priority", func(t *testing.T) {
+		events := pg.appendChainSelectionEventsLocked(
+			nil,
+			pg.bootstrapExited,
+			PeerSourceP2PGossip,
+			nil,
+			&Peer{
+				Source:     PeerSourceP2PGossip,
+				Connection: &PeerConnection{Id: connId, IsClient: true},
+			},
+		)
+		require.Len(t, events, 2)
+		assert.Equal(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			events[0].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerEligibilityChangedEvent{
+				ConnectionId: connId,
+				Eligible:     true,
+			},
+			events[0].data,
+		)
+		assert.Equal(
+			t,
+			event.EventType(PeerPriorityChangedEventType),
+			events[1].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerPriorityChangedEvent{
+				ConnectionId: connId,
+				Priority:     20,
+			},
+			events[1].data,
+		)
+	})
+
+	t.Run("same connection source change only updates priority", func(t *testing.T) {
+		events := pg.appendChainSelectionEventsLocked(
+			nil,
+			pg.bootstrapExited,
+			PeerSourceP2PGossip,
+			&PeerConnection{Id: connId, IsClient: true},
+			&Peer{
+				Source:     PeerSourceTopologyLocalRoot,
+				Connection: &PeerConnection{Id: connId, IsClient: true},
+			},
+		)
+		require.Len(t, events, 1)
+		assert.Equal(
+			t,
+			event.EventType(PeerPriorityChangedEventType),
+			events[0].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerPriorityChangedEvent{
+				ConnectionId: connId,
+				Priority:     50,
+			},
+			events[0].data,
+		)
+	})
+
+	t.Run("same connection eligibility flip publishes change", func(t *testing.T) {
+		events := pg.appendChainSelectionEventsLocked(
+			nil,
+			pg.bootstrapExited,
+			PeerSourceInboundConn,
+			&PeerConnection{Id: connId, IsClient: true},
+			&Peer{
+				Source:     PeerSourceInboundConn,
+				Connection: &PeerConnection{Id: connId, IsClient: false},
+			},
+		)
+		require.Len(t, events, 1)
+		assert.Equal(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			events[0].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerEligibilityChangedEvent{
+				ConnectionId: connId,
+				Eligible:     false,
+			},
+			events[0].data,
+		)
+	})
+
+	t.Run("connection removal clears eligibility and priority", func(t *testing.T) {
+		events := pg.appendChainSelectionEventsLocked(
+			nil,
+			pg.bootstrapExited,
+			PeerSourceP2PGossip,
+			&PeerConnection{Id: connId, IsClient: true},
+			&Peer{
+				Source: PeerSourceP2PGossip,
+			},
+		)
+		require.Len(t, events, 2)
+		assert.Equal(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			events[0].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerEligibilityChangedEvent{
+				ConnectionId: connId,
+				Eligible:     false,
+			},
+			events[0].data,
+		)
+		assert.Equal(
+			t,
+			event.EventType(PeerPriorityChangedEventType),
+			events[1].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerPriorityChangedEvent{
+				ConnectionId: connId,
+				Priority:     0,
+			},
+			events[1].data,
+		)
+	})
+
+	t.Run("responder-only inbound connection publishes ineligible state", func(t *testing.T) {
+		events := pg.appendChainSelectionEventsLocked(
+			nil,
+			pg.bootstrapExited,
+			PeerSourceInboundConn,
+			nil,
+			&Peer{
+				Source:     PeerSourceInboundConn,
+				Connection: &PeerConnection{Id: connId, IsClient: false},
+			},
+		)
+		require.Len(t, events, 1)
+		assert.Equal(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			events[0].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerEligibilityChangedEvent{
+				ConnectionId: connId,
+				Eligible:     false,
+			},
+			events[0].data,
+		)
+	})
+
+	t.Run("responder-only outbound connection publishes ineligible state", func(t *testing.T) {
+		events := pg.appendChainSelectionEventsLocked(
+			nil,
+			pg.bootstrapExited,
+			PeerSourceP2PGossip,
+			nil,
+			&Peer{
+				Source:     PeerSourceP2PGossip,
+				Connection: &PeerConnection{Id: connId, IsClient: false},
+			},
+		)
+		require.Len(t, events, 2)
+		assert.Equal(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			events[0].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerEligibilityChangedEvent{
+				ConnectionId: connId,
+				Eligible:     false,
+			},
+			events[0].data,
+		)
+		assert.Equal(
+			t,
+			event.EventType(PeerPriorityChangedEventType),
+			events[1].eventType,
+		)
+		assert.Equal(
+			t,
+			PeerPriorityChangedEvent{
+				ConnectionId: connId,
+				Priority:     20,
+			},
+			events[1].data,
+		)
+	})
 }
 
 func TestPeerGovernor_HandleInboundConnection(t *testing.T) {
@@ -2021,6 +2258,119 @@ func TestPeerGovernor_LoadTopologyConfig_ValencyStored(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, publicRootCount, "should have 1 public root peer")
+}
+
+func TestPeerGovernor_LoadTopologyConfig_ExitedBootstrapKeepsBootstrapSource(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	pg.bootstrapExited = true
+
+	topologyConfig := &topology.TopologyConfig{
+		BootstrapPeers: []topology.TopologyConfigP2PBootstrapPeer{
+			{Address: "44.0.0.10", Port: 3001},
+		},
+	}
+
+	pg.LoadTopologyConfig(topologyConfig)
+
+	require.Len(t, pg.peers, 1)
+	assert.EqualValues(t, PeerSourceTopologyBootstrapPeer, pg.peers[0].Source)
+	assert.Equal(t, "44.0.0.10:3001", pg.peers[0].Address)
+}
+
+func TestPeerGovernor_LoadTopologyConfig_ReusesExistingTopologyPeerState(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("44.0.0.2"), Port: 3002},
+	}
+	firstSeen := time.Now().Add(-time.Hour)
+	conn := &PeerConnection{Id: connId, IsClient: true}
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "44.0.0.2:3002",
+		NormalizedAddress: "44.0.0.2:3002",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateWarm,
+		Connection:        conn,
+		ReconnectCount:    3,
+		ReconnectDelay:    2 * time.Second,
+		FirstSeen:         firstSeen,
+	})
+
+	pg.LoadTopologyConfig(&topology.TopologyConfig{
+		LocalRoots: []topology.TopologyConfigP2PLocalRoot{
+			{
+				AccessPoints: []topology.TopologyConfigP2PAccessPoint{
+					{Address: "44.0.0.2", Port: 3002},
+				},
+				Advertise: true,
+				Valency:   2,
+			},
+		},
+	})
+
+	require.Len(t, pg.peers, 1)
+	peer := pg.peers[0]
+	assert.EqualValues(t, PeerSourceTopologyLocalRoot, peer.Source)
+	assert.Equal(t, PeerStateWarm, peer.State)
+	assert.Same(t, conn, peer.Connection)
+	assert.Equal(t, 3, peer.ReconnectCount)
+	assert.Equal(t, 2*time.Second, peer.ReconnectDelay)
+	assert.Equal(t, firstSeen, peer.FirstSeen)
+	assert.Equal(t, uint(2), peer.Valency)
+}
+
+func TestPeerGovernor_LoadTopologyConfig_RemovesOrphanedTopologyPeers(
+	t *testing.T,
+) {
+	eventBus := newMockEventBus()
+	t.Cleanup(func() { eventBus.Stop() })
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: eventBus,
+	})
+	_, evtCh := eventBus.Subscribe(PeerRemovedEventType)
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "44.0.0.2:3002",
+		NormalizedAddress: "44.0.0.2:3002",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateCold,
+	})
+
+	pg.LoadTopologyConfig(&topology.TopologyConfig{
+		LocalRoots: []topology.TopologyConfigP2PLocalRoot{
+			{
+				AccessPoints: []topology.TopologyConfigP2PAccessPoint{
+					{Address: "44.0.0.3", Port: 3003},
+				},
+			},
+		},
+	})
+
+	require.Len(t, pg.peers, 1)
+	assert.Equal(t, "44.0.0.3:3003", pg.peers[0].Address)
+	select {
+	case evt := <-evtCh:
+		removedEvent, ok := evt.Data.(PeerStateChangeEvent)
+		require.True(t, ok)
+		assert.Equal(
+			t,
+			PeerStateChangeEvent{
+				Address: "44.0.0.2:3002",
+				Reason:  "topology removed",
+			},
+			removedEvent,
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected topology removal event")
+	}
 }
 
 // Tests for churn system (Phase 3)
@@ -4542,7 +4892,7 @@ func TestPeerGovernor_ShouldExitBootstrap_AlreadyExited(t *testing.T) {
 	assert.False(t, shouldExit, "should not exit bootstrap when already exited")
 }
 
-func TestPeerGovernor_ExitBootstrap_DemotesPeers(t *testing.T) {
+func TestPeerGovernor_ExitBootstrap_PreservesBootstrapPeers(t *testing.T) {
 	eventBus := newMockEventBus()
 
 	pg := NewPeerGovernor(PeerGovernorConfig{
@@ -4576,13 +4926,25 @@ func TestPeerGovernor_ExitBootstrap_DemotesPeers(t *testing.T) {
 
 	_ = pg.exitBootstrapLocked("test reason")
 
-	// Verify all bootstrap peers are cold
+	// Verify bootstrap peers keep source classification and state
+	bootstrapStates := make(map[string]PeerState)
+	bootstrapCount := 0
+	publicRootCount := 0
 	for _, peer := range pg.peers {
 		if peer.Source == PeerSourceTopologyBootstrapPeer {
-			assert.Equal(t, PeerStateCold, peer.State,
-				"bootstrap peer %s should be cold after exit", peer.Address)
+			bootstrapStates[peer.Address] = peer.State
+			bootstrapCount++
+		}
+		if peer.Source == PeerSourceTopologyPublicRoot {
+			publicRootCount++
 		}
 	}
+	assert.Equal(t, 3, bootstrapCount, "all bootstrap peers should remain bootstrap sourced")
+	assert.Equal(t, 0, publicRootCount, "bootstrap exit should not reclassify bootstrap peers")
+	assert.Equal(t, 3, len(bootstrapStates), "all bootstrap peers should remain present")
+	assert.Equal(t, PeerStateHot, bootstrapStates["44.0.0.1:3001"])
+	assert.Equal(t, PeerStateWarm, bootstrapStates["44.0.0.1:3002"])
+	assert.Equal(t, PeerStateCold, bootstrapStates["44.0.0.1:3003"])
 
 	// Verify non-bootstrap peer is unaffected
 	var gossipPeer *Peer
@@ -4599,6 +4961,91 @@ func TestPeerGovernor_ExitBootstrap_DemotesPeers(t *testing.T) {
 	// Verify bootstrapExited flag is set
 	assert.True(t, pg.bootstrapExited, "bootstrapExited should be true")
 	pg.mu.Unlock()
+}
+
+func TestPeerGovernor_ExitBootstrapDoesNotReportDemotions(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3001",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateHot,
+	})
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3002",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateWarm,
+	})
+	events := pg.exitBootstrapLocked("test reason")
+	pg.mu.Unlock()
+
+	require.Len(t, events, 1)
+	assert.Equal(
+		t,
+		event.EventType(BootstrapExitedEventType),
+		events[0].eventType,
+	)
+	assert.Equal(
+		t,
+		BootstrapExitedEvent{
+			Reason:       "test reason",
+			DemotedPeers: 0,
+		},
+		events[0].data,
+	)
+}
+
+func TestPeerGovernor_ExitBootstrapPublishesChainSelectionDowngrade(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("44.0.0.1"), Port: 3001},
+	}
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3001",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateHot,
+		Connection: &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		},
+	})
+	events := pg.exitBootstrapLocked("test reason")
+	pg.mu.Unlock()
+
+	assert.Equal(
+		t,
+		PeerEligibilityChangedEvent{
+			ConnectionId: connId,
+			Eligible:     false,
+		},
+		requirePendingEventData[PeerEligibilityChangedEvent](
+			t,
+			events,
+			PeerEligibilityChangedEventType,
+		),
+	)
+	assert.Equal(
+		t,
+		PeerPriorityChangedEvent{
+			ConnectionId: connId,
+			Priority:     0,
+		},
+		requirePendingEventData[PeerPriorityChangedEvent](
+			t,
+			events,
+			PeerPriorityChangedEventType,
+		),
+	)
 }
 
 func TestPeerGovernor_ExitBootstrap_PreventsPromotion(t *testing.T) {
@@ -4669,6 +5116,59 @@ func TestPeerGovernor_BootstrapRecovery(t *testing.T) {
 		"bootstrapExited should be false after recovery",
 	)
 	pg.mu.Unlock()
+}
+
+func TestPeerGovernor_BootstrapRecoveryPublishesChainSelectionUpgrade(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:           3,
+		AutoBootstrapRecovery: boolPtr(true),
+	})
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("44.0.0.1"), Port: 3001},
+	}
+
+	pg.mu.Lock()
+	pg.bootstrapExited = true
+	pg.peers = append(pg.peers, &Peer{
+		Address: "44.0.0.1:3001",
+		Source:  PeerSourceTopologyBootstrapPeer,
+		State:   PeerStateWarm,
+		Connection: &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		},
+	})
+	events := pg.checkBootstrapRecoveryLocked()
+	pg.mu.Unlock()
+
+	assert.Equal(
+		t,
+		PeerEligibilityChangedEvent{
+			ConnectionId: connId,
+			Eligible:     true,
+		},
+		requirePendingEventData[PeerEligibilityChangedEvent](
+			t,
+			events,
+			PeerEligibilityChangedEventType,
+		),
+	)
+	assert.Equal(
+		t,
+		PeerPriorityChangedEvent{
+			ConnectionId: connId,
+			Priority:     40,
+		},
+		requirePendingEventData[PeerPriorityChangedEvent](
+			t,
+			events,
+			PeerPriorityChangedEventType,
+		),
+	)
 }
 
 func TestPeerGovernor_BootstrapRecovery_NotNeededWithWarmCandidates(
@@ -4830,14 +5330,16 @@ func TestPeerGovernor_Reconcile_ExitsBootstrap(t *testing.T) {
 	// Find the bootstrap peer
 	var bootstrapPeer *Peer
 	for _, peer := range pg.peers {
-		if peer.Source == PeerSourceTopologyBootstrapPeer {
+		if peer.Address == "44.0.0.1:3001" {
 			bootstrapPeer = peer
 			break
 		}
 	}
 	assert.NotNil(t, bootstrapPeer)
-	assert.Equal(t, PeerStateCold, bootstrapPeer.State,
-		"bootstrap peer should be cold after reconcile")
+	assert.EqualValues(t, PeerSourceTopologyBootstrapPeer, bootstrapPeer.Source,
+		"bootstrap peer should keep bootstrap source after reconcile")
+	assert.Equal(t, PeerStateWarm, bootstrapPeer.State,
+		"bootstrap peer should keep its state after reconcile")
 	pg.mu.Unlock()
 }
 

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -303,6 +303,148 @@ func (p *PeerGovernor) SetPeerHotByConnId(connId ouroboros.ConnectionId) {
 	}
 }
 
+func clonePeerConnection(conn *PeerConnection) *PeerConnection {
+	if conn == nil {
+		return nil
+	}
+	connCopy := *conn
+	return &connCopy
+}
+
+func chainSelectionEligible(source PeerSource, conn *PeerConnection) bool {
+	_ = source
+	return conn != nil && conn.IsClient
+}
+
+func chainSelectionPriority(source PeerSource) int {
+	switch source {
+	case PeerSourceTopologyLocalRoot:
+		return 50
+	case PeerSourceTopologyBootstrapPeer:
+		return 40
+	case PeerSourceTopologyPublicRoot:
+		return 30
+	case PeerSourceP2PGossip:
+		return 20
+	case PeerSourceP2PLedger:
+		return 10
+	default:
+		return 0
+	}
+}
+
+type chainSelectionPeerState struct {
+	connId   ouroboros.ConnectionId
+	eligible bool
+	priority int
+	ok       bool
+}
+
+func chainSelectionState(
+	bootstrapExited bool,
+	source PeerSource,
+	conn *PeerConnection,
+) chainSelectionPeerState {
+	if conn == nil {
+		return chainSelectionPeerState{}
+	}
+	eligible := chainSelectionEligible(source, conn)
+	priority := chainSelectionPriority(source)
+	if source == PeerSourceTopologyBootstrapPeer && bootstrapExited {
+		eligible = false
+		priority = 0
+	}
+	return chainSelectionPeerState{
+		connId:   conn.Id,
+		eligible: eligible,
+		priority: priority,
+		ok:       true,
+	}
+}
+
+func (p *PeerGovernor) appendChainSelectionEventsLocked(
+	events []pendingEvent,
+	oldBootstrapExited bool,
+	oldSource PeerSource,
+	oldConn *PeerConnection,
+	peer *Peer,
+) []pendingEvent {
+	oldState := chainSelectionState(oldBootstrapExited, oldSource, oldConn)
+	newState := chainSelectionPeerState{}
+	if peer != nil {
+		newState = chainSelectionState(
+			p.bootstrapExited,
+			peer.Source,
+			peer.Connection,
+		)
+	}
+	if oldState.ok && newState.ok && oldState.connId == newState.connId {
+		if oldState.eligible != newState.eligible {
+			events = append(events, pendingEvent{
+				PeerEligibilityChangedEventType,
+				PeerEligibilityChangedEvent{
+					ConnectionId: newState.connId,
+					Eligible:     newState.eligible,
+				},
+			})
+		}
+		if oldState.priority != newState.priority {
+			events = append(events, pendingEvent{
+				PeerPriorityChangedEventType,
+				PeerPriorityChangedEvent{
+					ConnectionId: newState.connId,
+					Priority:     newState.priority,
+				},
+			})
+		}
+		return events
+	}
+	if oldState.ok {
+		if oldState.eligible {
+			events = append(events, pendingEvent{
+				PeerEligibilityChangedEventType,
+				PeerEligibilityChangedEvent{
+					ConnectionId: oldState.connId,
+					Eligible:     false,
+				},
+			})
+		}
+		if oldState.priority != 0 {
+			events = append(events, pendingEvent{
+				PeerPriorityChangedEventType,
+				PeerPriorityChangedEvent{
+					ConnectionId: oldState.connId,
+					Priority:     0,
+				},
+			})
+		}
+	}
+	if newState.ok {
+		if oldState.connId != newState.connId ||
+			oldState.eligible != newState.eligible {
+			events = append(events, pendingEvent{
+				PeerEligibilityChangedEventType,
+				PeerEligibilityChangedEvent{
+					ConnectionId: newState.connId,
+					Eligible:     newState.eligible,
+				},
+			})
+		}
+		if newState.priority != 0 &&
+			(oldState.connId != newState.connId ||
+				oldState.priority != newState.priority) {
+			events = append(events, pendingEvent{
+				PeerPriorityChangedEventType,
+				PeerPriorityChangedEvent{
+					ConnectionId: newState.connId,
+					Priority:     newState.priority,
+				},
+			})
+		}
+	}
+	return events
+}
+
 func (p *PeerGovernor) UpdatePeerBlockFetchObservation(
 	connId ouroboros.ConnectionId,
 	latencyMs float64,

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -86,6 +86,8 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 			// Promote to warm if connection exists
 			// Skip bootstrap peers if bootstrap has been exited
 			if peer.Connection != nil {
+				oldSource := peer.Source
+				oldConn := clonePeerConnection(peer.Connection)
 				if p.isBootstrapPeer(peer) && !p.canPromoteBootstrapPeer() {
 					// Bootstrap peer with connection but bootstrap exited
 					// Close the connection and keep peer cold
@@ -101,6 +103,13 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 					p.config.Logger.Debug(
 						"prevented bootstrap peer promotion after exit",
 						"address", peer.Address,
+					)
+					events = p.appendChainSelectionEventsLocked(
+						events,
+						p.bootstrapExited,
+						oldSource,
+						oldConn,
+						peer,
 					)
 				} else {
 					p.peers[i].State = PeerStateWarm

--- a/peergov/topology.go
+++ b/peergov/topology.go
@@ -107,122 +107,179 @@ func (p *PeerGovernor) LoadTopologyConfig(
 		})
 	}
 
+	var events []pendingEvent
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	// Remove peers originally sourced from the topology
-	tmpPeers := []*Peer{}
+	isTopologySource := func(source PeerSource) bool {
+		return source == PeerSourceTopologyBootstrapPeer ||
+			source == PeerSourceTopologyLocalRoot ||
+			source == PeerSourceTopologyPublicRoot
+	}
+	topologySnapshot := make(map[string]*Peer)
+	// Remove peers originally sourced from the topology, but keep a snapshot
+	// so we can reuse any still-present entries and preserve connection state.
+	tmpPeers := make([]*Peer, 0, len(p.peers))
 	for _, tmpPeer := range p.peers {
 		if tmpPeer == nil {
 			continue
 		}
-		if tmpPeer.Source == PeerSourceTopologyBootstrapPeer ||
-			tmpPeer.Source == PeerSourceTopologyLocalRoot ||
-			tmpPeer.Source == PeerSourceTopologyPublicRoot {
+		if isTopologySource(tmpPeer.Source) {
+			topologySnapshot[tmpPeer.NormalizedAddress] = tmpPeer
 			continue
 		}
 		tmpPeers = append(tmpPeers, tmpPeer)
 	}
 	p.peers = tmpPeers
-	// Add topology bootstrap peers
 	now := time.Now()
-	for _, resolved := range bootstrapResolved {
-		p.peers = append(
-			p.peers,
-			&Peer{
-				Address:           resolved.address,
-				NormalizedAddress: resolved.normalized,
-				Source:            PeerSourceTopologyBootstrapPeer,
+	upsertTopologyPeer := func(
+		address string,
+		normalized string,
+		source PeerSource,
+		sharable bool,
+		valency uint,
+		warmValency uint,
+		groupID string,
+	) {
+		newPeer := func() *Peer {
+			return &Peer{
+				Address:           address,
+				NormalizedAddress: normalized,
+				Source:            source,
 				State:             PeerStateCold,
+				Sharable:          sharable,
 				EMAAlpha:          p.config.EMAAlpha,
+				Valency:           valency,
+				WarmValency:       warmValency,
+				GroupID:           groupID,
 				FirstSeen:         now,
-			},
+			}
+		}
+		updatePeer := func(peer *Peer) *Peer {
+			if peer.FirstSeen.IsZero() {
+				peer.FirstSeen = now
+			}
+			peer.Address = address
+			peer.NormalizedAddress = normalized
+			peer.Source = source
+			peer.Sharable = sharable
+			peer.EMAAlpha = p.config.EMAAlpha
+			peer.Valency = valency
+			peer.WarmValency = warmValency
+			peer.GroupID = groupID
+			return peer
+		}
+		existingPeerIdx := -1
+		for i, existingPeer := range p.peers {
+			if existingPeer != nil &&
+				existingPeer.NormalizedAddress == normalized {
+				existingPeerIdx = i
+				break
+			}
+		}
+		if existingPeerIdx >= 0 {
+			existingPeer := p.peers[existingPeerIdx]
+			oldSource := existingPeer.Source
+			oldConn := clonePeerConnection(existingPeer.Connection)
+			p.peers = slices.Delete(
+				p.peers,
+				existingPeerIdx,
+				existingPeerIdx+1,
+			)
+			p.peers = append(p.peers, updatePeer(existingPeer))
+			events = p.appendChainSelectionEventsLocked(
+				events,
+				p.bootstrapExited,
+				oldSource,
+				oldConn,
+				existingPeer,
+			)
+			return
+		}
+		if existingPeer, ok := topologySnapshot[normalized]; ok {
+			delete(topologySnapshot, normalized)
+			oldSource := existingPeer.Source
+			oldConn := clonePeerConnection(existingPeer.Connection)
+			p.peers = append(p.peers, updatePeer(existingPeer))
+			events = p.appendChainSelectionEventsLocked(
+				events,
+				p.bootstrapExited,
+				oldSource,
+				oldConn,
+				existingPeer,
+			)
+			return
+		}
+		p.peers = append(p.peers, newPeer())
+	}
+	// Add topology bootstrap peers
+	for _, resolved := range bootstrapResolved {
+		upsertTopologyPeer(
+			resolved.address,
+			resolved.normalized,
+			PeerSourceTopologyBootstrapPeer,
+			false,
+			0,
+			0,
+			"",
 		)
 	}
 	// Add topology local roots
 	for groupIdx, localRoot := range localRootsResolved {
 		groupID := fmt.Sprintf("local-root-%d", groupIdx)
 		for _, resolved := range localRoot.peers {
-			tmpPeer := &Peer{
-				Address:           resolved.address,
-				NormalizedAddress: resolved.normalized,
-				Source:            PeerSourceTopologyLocalRoot,
-				State:             PeerStateCold,
-				Sharable:          localRoot.advertise,
-				EMAAlpha:          p.config.EMAAlpha,
-				Valency:           localRoot.valency,
-				WarmValency:       localRoot.warmValency,
-				GroupID:           groupID,
-				FirstSeen:         now,
-			}
-			// Check for existing peer with this address
-			existingPeerIdx := -1
-			for i, existingPeer := range p.peers {
-				if existingPeer != nil &&
-					existingPeer.NormalizedAddress == resolved.normalized {
-					existingPeerIdx = i
-					break
-				}
-			}
-			if existingPeerIdx >= 0 {
-				existingPeer := p.peers[existingPeerIdx]
-				// Preserve active connection state for any peer with a connection
-				if existingPeer.Connection != nil {
-					tmpPeer.Connection = existingPeer.Connection
-					tmpPeer.State = existingPeer.State
-					tmpPeer.ReconnectCount = existingPeer.ReconnectCount
-					tmpPeer.ReconnectDelay = existingPeer.ReconnectDelay
-					tmpPeer.Sharable = existingPeer.Sharable
-				}
-				// Remove the existing peer
-				p.peers = slices.Delete(
-					p.peers, existingPeerIdx,
-					existingPeerIdx+1)
-			}
-			p.peers = append(p.peers, tmpPeer)
+			upsertTopologyPeer(
+				resolved.address,
+				resolved.normalized,
+				PeerSourceTopologyLocalRoot,
+				localRoot.advertise,
+				localRoot.valency,
+				localRoot.warmValency,
+				groupID,
+			)
 		}
 	}
 	// Add topology public roots
 	for groupIdx, publicRoot := range publicRootsResolved {
 		groupID := fmt.Sprintf("public-root-%d", groupIdx)
 		for _, resolved := range publicRoot.peers {
-			tmpPeer := &Peer{
-				Address:           resolved.address,
-				NormalizedAddress: resolved.normalized,
-				Source:            PeerSourceTopologyPublicRoot,
-				State:             PeerStateCold,
-				Sharable:          publicRoot.advertise,
-				EMAAlpha:          p.config.EMAAlpha,
-				Valency:           publicRoot.valency,
-				WarmValency:       publicRoot.warmValency,
-				GroupID:           groupID,
-				FirstSeen:         now,
+			upsertTopologyPeer(
+				resolved.address,
+				resolved.normalized,
+				PeerSourceTopologyPublicRoot,
+				publicRoot.advertise,
+				publicRoot.valency,
+				publicRoot.warmValency,
+				groupID,
+			)
+		}
+	}
+	for _, orphanPeer := range topologySnapshot {
+		if orphanPeer == nil {
+			continue
+		}
+		events = p.appendChainSelectionEventsLocked(
+			events,
+			p.bootstrapExited,
+			orphanPeer.Source,
+			clonePeerConnection(orphanPeer.Connection),
+			nil,
+		)
+		events = append(events, pendingEvent{
+			PeerRemovedEventType,
+			PeerStateChangeEvent{
+				Address: orphanPeer.Address,
+				Reason:  "topology removed",
+			},
+		})
+		if orphanPeer.Connection != nil && p.config.ConnManager != nil {
+			if conn := p.config.ConnManager.GetConnectionById(
+				orphanPeer.Connection.Id,
+			); conn != nil {
+				conn.Close()
 			}
-			// Check for existing peer with this address
-			existingPeerIdx := -1
-			for i, existingPeer := range p.peers {
-				if existingPeer != nil &&
-					existingPeer.NormalizedAddress == resolved.normalized {
-					existingPeerIdx = i
-					break
-				}
-			}
-			if existingPeerIdx >= 0 {
-				existingPeer := p.peers[existingPeerIdx]
-				// Preserve active connection state for any peer with a connection
-				if existingPeer.Connection != nil {
-					tmpPeer.Connection = existingPeer.Connection
-					tmpPeer.State = existingPeer.State
-					tmpPeer.ReconnectCount = existingPeer.ReconnectCount
-					tmpPeer.ReconnectDelay = existingPeer.ReconnectDelay
-					tmpPeer.Sharable = existingPeer.Sharable
-				}
-				// Remove the existing peer
-				p.peers = slices.Delete(
-					p.peers, existingPeerIdx,
-					existingPeerIdx+1)
-			}
-			p.peers = append(p.peers, tmpPeer)
 		}
 	}
 	p.updatePeerMetrics()
+	p.mu.Unlock()
+
+	p.publishPendingEvents(events)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves chain selection and sync resilience by preferring eligible, higher‑priority peers and resuming `chainsync` from the exact local tip on peer switches. This reduces churn, keeps blockfetch warm across switches, and prevents equal‑tip oscillation.

- **New Features**
  - `peergov`/`chainselection`: publish and consume eligibility/priority; skip ineligible peers; prefer higher‑priority at equal tips; preserve the incumbent unless a challenger wins the full tie‑break; emit updates on connect, churn, reconcile, and topology load. Inbound responder‑only connections are ineligible; priority order: LocalRoot > Bootstrap > PublicRoot > Gossip > Ledger. Added events `peergov.peer_eligibility_changed` and `peergov.peer_priority_changed`.
  - `ouroboros`/`chainsync`/`node`: add async, timeout‑guarded resume from the exact local tip on active‑peer switches; normalize and de‑dupe intersect points (always includes origin); add `chainsync.State.ClearSeenHeadersFrom` and use it on connection switches to prune only headers above the local tip.
  - `ledger`: keep headers and in‑flight blockfetch across connection switches; track the selected chainsync connection on chain‑switch events and clear on connection close; route the next batch via the selected connection; process only the active batch; reset on timeouts/errors.

- **Refactors**
  - `peergov/bootstrap`: exit bootstrap without demoting or reclassifying bootstrap peers; only attempt recovery if bootstrap peers remain.

<sup>Written for commit b8214504d3dfd7a3f47d7bcb7898fb1a44439c06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable peer eligibility and priority for chain selection
  * New observability events for peer eligibility and priority changes
  * Chainsync resume/restart on peer switches and header-pruning helpers

* **Bug Fixes**
  * Preserve queued headers and in-flight blockfetch across connection switches
  * Avoid demoting bootstrap peers when exiting bootstrap

* **Improvements**
  * More deterministic, priority- and VRF-aware peer selection with improved logging and timeouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->