### PR TITLE
fix: KES period handling

### DIFF
--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -442,7 +442,33 @@ func (ks *KeyStore) CurrentKESPeriod() uint64 {
 	return ks.kesSKey.Period
 }
 
-// EvolveKESTo evolves the KES key to the specified period.
+func (ks *KeyStore) currentAbsoluteKESPeriodUnsafe() uint64 {
+	if ks.kesSKey == nil {
+		return 0
+	}
+	if ks.opCert == nil {
+		return ks.kesSKey.Period
+	}
+	return ks.opCert.KESPeriod + ks.kesSKey.Period
+}
+
+func (ks *KeyStore) relativeKESPeriodUnsafe(
+	absolutePeriod uint64,
+) (uint64, error) {
+	if ks.opCert == nil {
+		return 0, ErrOpCertNotLoaded
+	}
+	if absolutePeriod < ks.opCert.KESPeriod {
+		return 0, fmt.Errorf(
+			"current KES period %d is before opcert start %d",
+			absolutePeriod,
+			ks.opCert.KESPeriod,
+		)
+	}
+	return absolutePeriod - ks.opCert.KESPeriod, nil
+}
+
+// EvolveKESTo evolves the KES key to the specified ABSOLUTE period.
 func (ks *KeyStore) EvolveKESTo(targetPeriod uint64) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
@@ -454,12 +480,22 @@ func (ks *KeyStore) evolveKESToUnsafe(targetPeriod uint64) error {
 		return ErrKESKeyNotLoaded
 	}
 
-	for ks.kesSKey.Period < targetPeriod {
+	relativeTarget, err := ks.relativeKESPeriodUnsafe(targetPeriod)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to compute relative KES period for target period %d: %w",
+			targetPeriod,
+			err,
+		)
+	}
+
+	for ks.kesSKey.Period < relativeTarget {
 		oldKey := ks.kesSKey
 		newKey, err := kes.Update(oldKey)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to evolve KES key to period %d: %w",
+				"failed to evolve KES key to period %d (absolute %d): %w",
+				relativeTarget,
 				targetPeriod,
 				err,
 			)
@@ -536,7 +572,7 @@ func (ks *KeyStore) monitorSlots(ctx context.Context, slotClock SlotClock) {
 	var lastPeriod uint64
 	ks.mu.RLock()
 	if ks.kesSKey != nil {
-		lastPeriod = ks.kesSKey.Period
+		lastPeriod = ks.currentAbsoluteKESPeriodUnsafe()
 	}
 	ks.mu.RUnlock()
 
@@ -605,7 +641,16 @@ func (k *kesSignerImpl) Sign(period uint64, message []byte) ([]byte, error) {
 		return nil, ErrKESKeyNotLoaded
 	}
 
-	return kes.Sign(k.ks.kesSKey, period, message)
+	relativePeriod, err := k.ks.relativeKESPeriodUnsafe(period)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to compute relative KES period for signing period %d: %w",
+			period,
+			err,
+		)
+	}
+
+	return kes.Sign(k.ks.kesSKey, relativePeriod, message)
 }
 
 func (k *kesSignerImpl) VKey() []byte {

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -15,10 +15,13 @@
 package keystore
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -68,6 +71,23 @@ func setupTestKeys(t *testing.T) (string, string, string) {
 	require.NoError(t, os.WriteFile(opCertPath, []byte(testOpCertJSON), 0o600))
 
 	return vrfPath, kesPath, opCertPath
+}
+
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func TestKeyStoreLoadFromFiles(t *testing.T) {
@@ -204,6 +224,53 @@ func TestKESEvolution(t *testing.T) {
 	err = ks.EvolveKESTo(3)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(3), ks.CurrentKESPeriod())
+}
+
+func TestKESEvolutionUsesOpCertStartPeriod(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath: vrfPath,
+		KESSKeyPath: kesPath,
+		OpCertPath:  opCertPath,
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	ks.opCert.KESPeriod = 100
+
+	require.NoError(t, ks.EvolveKESTo(105))
+	assert.Equal(t, uint64(5), ks.CurrentKESPeriod())
+
+	kesSigner := ks.KESSigner()
+	require.NotNil(t, kesSigner)
+	message := []byte("shifted opcert KES sign")
+	signature, err := kesSigner.Sign(105, message)
+	require.NoError(t, err)
+
+	ok := kes.VerifySignedKES(kesSigner.VKey(), 5, message, signature)
+	assert.True(t, ok, "KES signature verification failed at relative period 5")
+}
+
+func TestKESEvolutionRejectsBeforeOpCertStart(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath: vrfPath,
+		KESSKeyPath: kesPath,
+		OpCertPath:  opCertPath,
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	ks.opCert.KESPeriod = 100
+
+	err := ks.EvolveKESTo(99)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before opcert start")
+	assert.Equal(t, uint64(0), ks.CurrentKESPeriod())
 }
 
 func TestOpCertValidation(t *testing.T) {
@@ -385,6 +452,67 @@ func TestKeyStoreKESEvolutionOnPeriodChange(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return ks.CurrentKESPeriod() == 3
 	}, time.Second, 10*time.Millisecond, "KES period should evolve to 3")
+}
+
+func TestKeyStoreKESEvolutionTracksAbsolutePeriodsInMonitor(t *testing.T) {
+	vrfPath, kesPath, opCertPath := setupTestKeys(t)
+
+	var logBuf safeBuffer
+	logger := slog.New(
+		slog.NewTextHandler(
+			&logBuf,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+
+	config := KeyStoreConfig{
+		VRFSKeyPath:       vrfPath,
+		KESSKeyPath:       kesPath,
+		OpCertPath:        opCertPath,
+		SlotsPerKESPeriod: 100,
+		Logger:            logger,
+	}
+
+	ks := NewKeyStore(config)
+	require.NoError(t, ks.LoadFromFiles())
+
+	ks.opCert.KESPeriod = 5
+
+	// Start at slot 550 so the absolute chain KES period is 5 while the
+	// stored KES key period remains relative to the opcert window (0).
+	slotClock := newMockSlotClock(550)
+
+	err := ks.Start(context.Background(), slotClock)
+	require.NoError(t, err)
+	defer func() { _ = ks.Stop() }()
+
+	require.Eventually(t, func() bool {
+		return slotClock.HasSubscribers()
+	}, time.Second, 10*time.Millisecond, "monitor should subscribe to slot clock")
+
+	assert.Equal(t, uint64(0), ks.CurrentKESPeriod())
+
+	slotClock.AdvanceSlot(599)
+
+	require.Never(t, func() bool {
+		return strings.Contains(
+			logBuf.String(),
+			"KES period changed, evolving key",
+		)
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	slotClock.AdvanceSlot(650)
+
+	require.Eventually(t, func() bool {
+		return ks.CurrentKESPeriod() == 1
+	}, time.Second, 10*time.Millisecond, "KES period should evolve to relative period 1")
+
+	require.Eventually(t, func() bool {
+		return strings.Count(
+			logBuf.String(),
+			"KES period changed, evolving key",
+		) == 1
+	}, time.Second, 10*time.Millisecond, "monitor should only log a single real period change")
 }
 
 func TestKeyStoreNotLoadedError(t *testing.T) {

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -134,9 +134,26 @@ func (pc *PoolCredentials) LoadFromFiles(
 	return nil
 }
 
-// UpdateKESPeriod updates the KES key to the specified absolute period.
-// The absolute period is converted to a relative period using the opcert
-// start KES period before evolving.
+func (pc *PoolCredentials) relativeKESPeriodUnsafe(
+	absolutePeriod uint64,
+) (uint64, error) {
+	if pc.opCert == nil {
+		return absolutePeriod, nil
+	}
+	if absolutePeriod < pc.opCert.KESPeriod {
+		return 0, fmt.Errorf(
+			"current KES period %d is before opcert start period %d",
+			absolutePeriod,
+			pc.opCert.KESPeriod,
+		)
+	}
+	return absolutePeriod - pc.opCert.KESPeriod, nil
+}
+
+// UpdateKESPeriod evolves the KES key to the specified ABSOLUTE period.
+// The secret key itself tracks the relative period within the opcert window,
+// so we translate chain KES periods by subtracting the opcert start period
+// when an opcert is loaded.
 func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -145,24 +162,20 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 		return errors.New("KES key not loaded")
 	}
 
-	// Convert absolute KES period to relative (0-based from opcert start)
-	relativePeriod := period
-	if pc.opCert != nil {
-		if period < pc.opCert.KESPeriod {
-			return fmt.Errorf(
-				"absolute KES period %d is before opcert start period %d",
-				period,
-				pc.opCert.KESPeriod,
-			)
-		}
-		relativePeriod = period - pc.opCert.KESPeriod
+	targetPeriod, err := pc.relativeKESPeriodUnsafe(period)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to compute target KES period for absolute period %d: %w",
+			period,
+			err,
+		)
 	}
 
-	if relativePeriod < pc.kesSKey.Period {
+	if targetPeriod < pc.kesSKey.Period {
 		return fmt.Errorf(
 			"cannot evolve KES key backward: current period %d, requested %d (absolute %d)",
 			pc.kesSKey.Period,
-			relativePeriod,
+			targetPeriod,
 			period,
 		)
 	}
@@ -170,12 +183,12 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 	// Evolve KES key to the target period. kes.Update returns a new SecretKey
 	// with a deep copy of the data, so pc.kesSKey is only replaced on success.
 	evolvedKey := pc.kesSKey
-	for evolvedKey.Period < relativePeriod {
+	for evolvedKey.Period < targetPeriod {
 		newKey, err := kes.Update(evolvedKey)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to update KES key to period %d (absolute %d): %w",
-				relativePeriod,
+				targetPeriod,
 				period,
 				err,
 			)
@@ -204,9 +217,12 @@ func (pc *PoolCredentials) VRFProve(alpha []byte) ([]byte, []byte, error) {
 	return proof, output, nil
 }
 
-// KESSign signs a message with the KES key at the specified absolute period.
-// The absolute period is converted to a relative period using the opcert
-// start KES period before signing.
+// KESSign signs a message with the KES key at the specified ABSOLUTE period.
+//
+// IMPORTANT: Callers must ensure UpdateKESPeriod(period) was called before KESSign
+// to evolve the key to the correct period. The kes.Sign function expects the key
+// to already be at the relative period within the opcert window when an opcert
+// is loaded.
 func (pc *PoolCredentials) KESSign(period uint64, message []byte) ([]byte, error) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
@@ -215,22 +231,23 @@ func (pc *PoolCredentials) KESSign(period uint64, message []byte) ([]byte, error
 		return nil, errors.New("KES key not loaded")
 	}
 
-	// Convert absolute KES period to relative (0-based from opcert start)
-	relativePeriod := period
-	if pc.opCert != nil {
-		if period < pc.opCert.KESPeriod {
-			return nil, fmt.Errorf(
-				"absolute KES period %d is before opcert start period %d",
-				period,
-				pc.opCert.KESPeriod,
-			)
-		}
-		relativePeriod = period - pc.opCert.KESPeriod
+	relativePeriod, err := pc.relativeKESPeriodUnsafe(period)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to compute signing KES period for absolute period %d: %w",
+			period,
+			err,
+		)
 	}
 
 	sig, err := kes.Sign(pc.kesSKey, relativePeriod, message)
 	if err != nil {
-		return nil, fmt.Errorf("KESSign period %d (relative %d): %w", period, relativePeriod, err)
+		return nil, fmt.Errorf(
+			"KESSign relative period %d (absolute %d): %w",
+			relativePeriod,
+			period,
+			err,
+		)
 	}
 	return sig, nil
 }

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -224,6 +224,49 @@ func TestKESPeriodUpdateBackward(t *testing.T) {
 	assert.Equal(t, uint64(5), pc.kesSKey.Period)
 }
 
+func TestKESPeriodUpdateUsesOpCertStartPeriod(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	pc.opCert.KESPeriod = 100
+
+	require.NoError(t, pc.UpdateKESPeriod(105))
+	assert.Equal(t, uint64(5), pc.kesSKey.Period)
+}
+
+func TestKESPeriodUpdateRejectsBeforeOpCertStart(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	pc.opCert.KESPeriod = 100
+
+	err := pc.UpdateKESPeriod(99)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before opcert start")
+	assert.Equal(t, uint64(0), pc.kesSKey.Period)
+}
+
+func TestKESSignUsesRelativePeriodWithNonZeroOpCertStart(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	pc.opCert.KESPeriod = 100
+	require.NoError(t, pc.UpdateKESPeriod(105))
+
+	message := []byte("test message with shifted opcert period")
+	signature, err := pc.KESSign(105, message)
+	require.NoError(t, err)
+
+	ok := kes.VerifySignedKES(pc.kesVKey, 5, message, signature)
+	assert.True(t, ok, "KES signature verification failed at relative period 5")
+}
+
 func TestOpCertValidation(t *testing.T) {
 	// Create a properly-signed OpCert programmatically so we can verify
 	// the full validation path including cold key signature verification


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix KES period handling by converting chain absolute periods to opcert‑relative periods and updating monitoring to compare absolute periods. Prevents early/backward evolution, removes spurious evolution logs, and ensures signing uses the correct period.

- **Bug Fixes**
  - `keystore`: `EvolveKESTo`/`Sign` now take absolute periods and compute relative via `opCert.KESPeriod`. Reject pre-start periods or missing opcert. Slot monitor tracks absolute periods to avoid false evolutions/logs. Errors include both relative and absolute periods.
  - `ledger/forging`: `UpdateKESPeriod` and `KESSign` translate absolute periods, block backward evolution, and improve errors (include relative/absolute). Tests cover shifted opcert starts, pre-start rejection, correct signing with non-zero opcert start, and monitor log behavior.

<sup>Written for commit 65dded64a8d4b39664aa547953a8472e63d2514c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent KES key evolution to periods before the operational certificate start.
  * Ensure signing uses the correct relative KES period derived from the opcert start.
  * Improve error messages to include both relative and absolute periods for clarity.
  * Monitoring now tracks and logs absolute KES periods correctly.

* **Refactor**
  * Added internal helpers for safer period conversions; old key material is zeroed after evolution and logs reflect new periods.

* **Tests**
  * Added comprehensive tests covering opcert-period validation, KES evolution, signing behavior, and monitoring/log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->