### PR TITLE
feat: leader schedule store

### DIFF
--- a/event/epoch_nonce_ready.go
+++ b/event/epoch_nonce_ready.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+// EpochNonceReadyEventType is emitted once the current epoch has advanced
+// past the randomness stabilisation cutoff, which means the next epoch's
+// nonce is now stable and its leader schedule can be precomputed.
+const EpochNonceReadyEventType = EventType("epoch.nonce_ready")
+
+// EpochNonceReadyEvent signals that the next epoch's nonce is stable.
+type EpochNonceReadyEvent struct {
+	CurrentEpoch uint64
+	ReadyEpoch   uint64
+	CutoffSlot   uint64
+}

--- a/event/epoch_nonce_ready_test.go
+++ b/event/epoch_nonce_ready_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
+)
+
+func TestEpochNonceReadyEventType(t *testing.T) {
+	assert.Equal(
+		t,
+		event.EventType("epoch.nonce_ready"),
+		event.EpochNonceReadyEventType,
+	)
+}
+
+func TestEpochNonceReadyEventPublishSubscribe(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	testEvent := event.EpochNonceReadyEvent{
+		CurrentEpoch: 1238,
+		ReadyEpoch:   1239,
+		CutoffSlot:   107015040,
+	}
+
+	_, subCh := eb.Subscribe(event.EpochNonceReadyEventType)
+
+	eb.Publish(
+		event.EpochNonceReadyEventType,
+		event.NewEvent(event.EpochNonceReadyEventType, testEvent),
+	)
+
+	select {
+	case evt, ok := <-subCh:
+		require.True(t, ok, "event channel closed unexpectedly")
+		require.Equal(t, event.EpochNonceReadyEventType, evt.Type)
+
+		readyEvent, ok := evt.Data.(event.EpochNonceReadyEvent)
+		require.True(t, ok, "event data was not EpochNonceReadyEvent")
+
+		assert.Equal(t, testEvent.CurrentEpoch, readyEvent.CurrentEpoch)
+		assert.Equal(t, testEvent.ReadyEpoch, readyEvent.ReadyEpoch)
+		assert.Equal(t, testEvent.CutoffSlot, readyEvent.CutoffSlot)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for epoch nonce ready event")
+	}
+}

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -15,6 +15,7 @@
 package leader
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/blinklabs-io/dingo/event"
+	ledgerpkg "github.com/blinklabs-io/dingo/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -44,11 +46,23 @@ type EpochInfoProvider interface {
 	// EpochNonce returns the nonce for the given epoch.
 	EpochNonce(epoch uint64) []byte
 
+	// NextEpochNonceReadyEpoch reports the next epoch number when the
+	// upcoming epoch's nonce is already stable and its leader schedule can
+	// be precomputed immediately. Returns false when startup should wait
+	// for the normal nonce-ready event path instead.
+	NextEpochNonceReadyEpoch() (uint64, bool)
+
 	// SlotsPerEpoch returns the number of slots in an epoch.
 	SlotsPerEpoch() uint64
 
 	// ActiveSlotCoeff returns the active slot coefficient (f parameter).
 	ActiveSlotCoeff() float64
+}
+
+// ScheduleStore persists computed schedules for later reuse.
+type ScheduleStore interface {
+	LoadSchedule(epoch uint64, poolId lcommon.PoolKeyHash) (*Schedule, error)
+	SaveSchedule(schedule *Schedule) error
 }
 
 // maxCachedSchedules is the number of epoch schedules to keep in memory.
@@ -71,6 +85,7 @@ type Election struct {
 	epochProvider EpochInfoProvider
 	eventBus      *event.EventBus
 	logger        *slog.Logger
+	scheduleStore ScheduleStore
 
 	mu             sync.RWMutex
 	schedules      map[uint64]*Schedule // epoch -> schedule
@@ -79,6 +94,8 @@ type Election struct {
 	stopCh         chan struct{} // signals the monitoring goroutine to exit
 	computeCh      chan uint64   // requests background schedule computation
 	subscriptionId event.EventSubscriberId
+	nonceReadySub  event.EventSubscriberId
+	rollbackSub    event.EventSubscriberId
 }
 
 // NewElection creates a new leader election manager for a stake pool.
@@ -103,13 +120,21 @@ func NewElection(
 	}
 }
 
-// Start begins listening for epoch transitions and maintaining the schedule.
+// SetScheduleStore configures an optional persistent schedule store.
+func (e *Election) SetScheduleStore(store ScheduleStore) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.scheduleStore = store
+}
+
+// Start begins listening for epoch transitions and maintaining schedules.
 // The provided context controls the election's lifecycle. When the context is
 // canceled, the election will automatically stop and clean up resources.
 //
 // The initial schedule for the current epoch is computed asynchronously in
 // the background so Start returns immediately and the forger can begin its
-// slot-aligned loop without delay.
+// slot-aligned loop without delay. The next epoch is queued later, once the
+// ledger reports that its nonce has reached the stability cutoff.
 func (e *Election) Start(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -140,15 +165,51 @@ func (e *Election) Start(ctx context.Context) error {
 	} else {
 		go e.epochTransitionLoop(ctx, evtCh)
 	}
+
+	var nonceReadyCh <-chan event.Event
+	e.nonceReadySub, nonceReadyCh = e.eventBus.Subscribe(
+		event.EpochNonceReadyEventType,
+	)
+	if nonceReadyCh == nil {
+		e.logger.Warn(
+			"event bus not available, next-epoch precompute will not be tracked",
+			"component", "leader",
+		)
+	} else {
+		go e.epochNonceReadyLoop(ctx, nonceReadyCh)
+	}
+
+	var rollbackCh <-chan event.Event
+	e.rollbackSub, rollbackCh = e.eventBus.Subscribe(
+		ledgerpkg.PoolStateRestoredEventType,
+	)
+	if rollbackCh == nil {
+		e.logger.Warn(
+			"event bus not available, rollback invalidation will not be tracked",
+			"component", "leader",
+		)
+	} else {
+		go e.rollbackLoop(ctx, rollbackCh)
+	}
 	go e.scheduleComputeLoop(ctx, e.computeCh)
 
 	// Kick off initial schedule computation for the current epoch.
-	// The next epoch's schedule cannot be pre-computed because
-	// its nonce depends on the stability window passing first.
 	currentEpoch := e.epochProvider.CurrentEpoch()
 	select {
 	case e.computeCh <- currentEpoch:
 	default:
+	}
+	if nextEpoch, ok := e.epochProvider.NextEpochNonceReadyEpoch(); ok {
+		select {
+		case e.computeCh <- nextEpoch:
+		default:
+		}
+		e.logger.Info(
+			"next epoch nonce already stable at startup, precomputing leader schedule",
+			"component", "leader",
+			"current_epoch", currentEpoch,
+			"ready_epoch", nextEpoch,
+		)
 	}
 
 	// Monitor context cancellation to automatically stop.
@@ -227,6 +288,83 @@ func (e *Election) epochTransitionLoop(
 	}
 }
 
+func (e *Election) epochNonceReadyLoop(
+	ctx context.Context,
+	evtCh <-chan event.Event,
+) {
+	for evt := range evtCh {
+		latest := evt
+	drain:
+		for {
+			select {
+			case newer, ok := <-evtCh:
+				if !ok {
+					return
+				}
+				latest = newer
+			default:
+				break drain
+			}
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		readyEvent, ok := latest.Data.(event.EpochNonceReadyEvent)
+		if !ok {
+			e.logger.Error(
+				"invalid event data for epoch nonce readiness",
+				"component", "leader",
+			)
+			continue
+		}
+
+		e.logger.Info(
+			"next epoch nonce is stable, precomputing leader schedule",
+			"component", "leader",
+			"current_epoch", readyEvent.CurrentEpoch,
+			"ready_epoch", readyEvent.ReadyEpoch,
+			"cutoff_slot", readyEvent.CutoffSlot,
+		)
+		e.queueScheduleCompute(readyEvent.ReadyEpoch)
+	}
+}
+
+func (e *Election) rollbackLoop(
+	ctx context.Context,
+	evtCh <-chan event.Event,
+) {
+	for evt := range evtCh {
+		if ctx.Err() != nil {
+			return
+		}
+
+		restoreEvent, ok := evt.Data.(ledgerpkg.PoolStateRestoredEvent)
+		if !ok {
+			e.logger.Error(
+				"invalid event data for rollback restoration",
+				"component", "leader",
+			)
+			continue
+		}
+
+		cleared := e.clearSchedules()
+		currentEpoch := e.epochProvider.CurrentEpoch()
+		e.logger.Info(
+			"ledger rollback restored state, invalidating leader schedules",
+			"component", "leader",
+			"rollback_slot", restoreEvent.Slot,
+			"cleared_schedules", cleared,
+			"current_epoch", currentEpoch,
+		)
+		e.queueScheduleCompute(currentEpoch)
+		if nextEpoch, ok := e.epochProvider.NextEpochNonceReadyEpoch(); ok {
+			e.queueScheduleCompute(nextEpoch)
+		}
+	}
+}
+
 // scheduleComputeLoop processes background schedule computation requests.
 // When ShouldProduceBlock detects a missing schedule for a slot's epoch,
 // it sends the epoch number to computeCh. This goroutine picks it up and
@@ -295,6 +433,20 @@ func (e *Election) Stop() error {
 		)
 		e.subscriptionId = 0
 	}
+	if e.nonceReadySub != 0 {
+		e.eventBus.Unsubscribe(
+			event.EpochNonceReadyEventType,
+			e.nonceReadySub,
+		)
+		e.nonceReadySub = 0
+	}
+	if e.rollbackSub != 0 {
+		e.eventBus.Unsubscribe(
+			ledgerpkg.PoolStateRestoredEventType,
+			e.rollbackSub,
+		)
+		e.rollbackSub = 0
+	}
 	e.running = false
 	e.schedules = nil
 
@@ -322,6 +474,35 @@ func (e *Election) RefreshScheduleForEpoch(
 		return nil
 	}
 
+	if schedule, err := e.loadPersistedSchedule(epoch); err != nil {
+		e.logger.Warn(
+			"failed to load persisted leader schedule",
+			"component", "leader",
+			"epoch", epoch,
+			"error", err,
+		)
+	} else if schedule != nil {
+		valid, reason, err := e.validatePersistedSchedule(epoch, schedule)
+		if err != nil {
+			e.logger.Warn(
+				"failed to validate persisted leader schedule",
+				"component", "leader",
+				"epoch", epoch,
+				"error", err,
+			)
+		} else if valid {
+			e.storeSchedule(epoch, schedule)
+			return nil
+		} else {
+			e.logger.Info(
+				"ignoring stale persisted leader schedule",
+				"component", "leader",
+				"epoch", epoch,
+				"reason", reason,
+			)
+		}
+	}
+
 	schedule, err := e.computeSchedule(ctx, epoch)
 	if err != nil {
 		return err
@@ -330,7 +511,103 @@ func (e *Election) RefreshScheduleForEpoch(
 		return nil // no stake or nonce not available
 	}
 	e.storeSchedule(epoch, schedule)
+	e.persistSchedule(schedule)
 	return nil
+}
+
+func (e *Election) loadPersistedSchedule(
+	epoch uint64,
+) (*Schedule, error) {
+	e.mu.RLock()
+	store := e.scheduleStore
+	e.mu.RUnlock()
+	if store == nil {
+		return nil, nil
+	}
+	schedule, err := store.LoadSchedule(epoch, e.poolId)
+	if err != nil {
+		return nil, err
+	}
+	if schedule == nil {
+		return nil, nil
+	}
+	e.logger.Info(
+		"loaded persisted leader schedule",
+		"component", "leader",
+		"epoch", epoch,
+		"leader_slots", schedule.SlotCount(),
+		"leader_slot_list", schedule.LeaderSlotsSnapshot(),
+	)
+	return schedule, nil
+}
+
+func (e *Election) validatePersistedSchedule(
+	epoch uint64,
+	schedule *Schedule,
+) (bool, string, error) {
+	if schedule == nil {
+		return false, "schedule missing", nil
+	}
+
+	expectedNonce := e.epochProvider.EpochNonce(epoch)
+	if len(expectedNonce) == 0 {
+		return false, "epoch nonce unavailable", nil
+	}
+	if !bytes.Equal(expectedNonce, schedule.EpochNonce) {
+		return false, "epoch nonce changed", nil
+	}
+
+	snapshotEpoch := scheduleSnapshotEpoch(epoch)
+	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
+	if err != nil {
+		return false, "", fmt.Errorf(
+			"get pool stake for epoch %d: %w",
+			snapshotEpoch,
+			err,
+		)
+	}
+	if poolStake != schedule.PoolStake {
+		return false, "pool stake changed", nil
+	}
+
+	totalStake, err := e.stakeProvider.GetTotalActiveStake(snapshotEpoch)
+	if err != nil {
+		return false, "", fmt.Errorf(
+			"get total stake for epoch %d: %w",
+			snapshotEpoch,
+			err,
+		)
+	}
+	if totalStake != schedule.TotalStake {
+		return false, "total stake changed", nil
+	}
+
+	return true, "", nil
+}
+
+func (e *Election) persistSchedule(schedule *Schedule) {
+	e.mu.RLock()
+	store := e.scheduleStore
+	e.mu.RUnlock()
+	if store == nil || schedule == nil {
+		return
+	}
+	if err := store.SaveSchedule(schedule); err != nil {
+		e.logger.Warn(
+			"failed to persist leader schedule",
+			"component", "leader",
+			"epoch", schedule.Epoch,
+			"error", err,
+		)
+		return
+	}
+	e.logger.Info(
+		"persisted leader schedule",
+		"component", "leader",
+		"epoch", schedule.Epoch,
+		"leader_slots", schedule.SlotCount(),
+		"leader_slot_list", schedule.LeaderSlotsSnapshot(),
+	)
 }
 
 // computeSchedule gathers stake data, epoch nonce, and runs VRF for every
@@ -348,10 +625,7 @@ func (e *Election) computeSchedule(
 	// For genesis epochs (0 and 1), use the genesis snapshot directly.
 	// The Cardano spec uses genesis staking for leader election until
 	// the first Mark→Set→Go rotation completes at epoch 2.
-	var snapshotEpoch uint64
-	if currentEpoch >= 2 {
-		snapshotEpoch = currentEpoch - 2
-	}
+	snapshotEpoch := scheduleSnapshotEpoch(currentEpoch)
 
 	// Get pool stake from Go snapshot
 	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
@@ -433,9 +707,17 @@ func (e *Election) computeSchedule(
 		"total_stake", totalStake,
 		"stake_ratio", schedule.StakeRatio(),
 		"leader_slots", schedule.SlotCount(),
+		"leader_slot_list", schedule.LeaderSlotsSnapshot(),
 	)
 
 	return schedule, nil
+}
+
+func scheduleSnapshotEpoch(epoch uint64) uint64 {
+	if epoch < 2 {
+		return 0
+	}
+	return epoch - 2
 }
 
 // storeSchedule saves a computed schedule under a brief write lock and
@@ -455,6 +737,31 @@ func (e *Election) storeSchedule(epoch uint64, schedule *Schedule) {
 			ep < epoch-maxCachedSchedules+1 {
 			delete(e.schedules, ep)
 		}
+	}
+}
+
+func (e *Election) clearSchedules() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.running || e.schedules == nil {
+		return 0
+	}
+	count := len(e.schedules)
+	clear(e.schedules)
+	return count
+}
+
+func (e *Election) queueScheduleCompute(epoch uint64) {
+	e.mu.RLock()
+	computeCh := e.computeCh
+	e.mu.RUnlock()
+	if computeCh == nil {
+		return
+	}
+	select {
+	case computeCh <- epoch:
+	default:
 	}
 }
 
@@ -487,11 +794,7 @@ func (e *Election) ShouldProduceBlock(slot uint64) bool {
 			"epoch", slotEpoch,
 		)
 		if computeCh != nil {
-			select {
-			case computeCh <- slotEpoch:
-			default:
-				// Request already pending
-			}
+			e.queueScheduleCompute(slotEpoch)
 		}
 		return false
 	}

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -15,8 +15,11 @@
 package leader
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
+	ledgerpkg "github.com/blinklabs-io/dingo/ledger"
 )
 
 // electionTestNonce is a 32-byte epoch nonce for election tests.
@@ -78,18 +82,19 @@ func (m *mockStakeProvider) GetTotalActiveStake(epoch uint64) (uint64, error) {
 // mockEpochProvider implements EpochInfoProvider for testing
 type mockEpochProvider struct {
 	currentEpoch    atomic.Uint64
-	epochNonce      []byte
+	epochNonce      atomic.Value
 	slotsPerEpoch   uint64
 	activeSlotCoeff float64
+	nextEpochReady  atomic.Uint64
 }
 
 func newMockEpochProvider() *mockEpochProvider {
 	m := &mockEpochProvider{
-		epochNonce:      electionTestNonce,
 		slotsPerEpoch:   electionSlotsPerEpoch,
 		activeSlotCoeff: 0.05,
 	}
 	m.currentEpoch.Store(10)
+	m.SetEpochNonce(electionTestNonce)
 	return m
 }
 
@@ -98,7 +103,19 @@ func (m *mockEpochProvider) CurrentEpoch() uint64 {
 }
 
 func (m *mockEpochProvider) EpochNonce(epoch uint64) []byte {
-	return m.epochNonce
+	nonce, ok := m.epochNonce.Load().([]byte)
+	if !ok || len(nonce) == 0 {
+		return nil
+	}
+	return append([]byte(nil), nonce...)
+}
+
+func (m *mockEpochProvider) NextEpochNonceReadyEpoch() (uint64, bool) {
+	nextEpoch := m.nextEpochReady.Load()
+	if nextEpoch == 0 {
+		return 0, false
+	}
+	return nextEpoch, true
 }
 
 func (m *mockEpochProvider) SlotsPerEpoch() uint64 {
@@ -107,6 +124,60 @@ func (m *mockEpochProvider) SlotsPerEpoch() uint64 {
 
 func (m *mockEpochProvider) ActiveSlotCoeff() float64 {
 	return m.activeSlotCoeff
+}
+
+func (m *mockEpochProvider) SetEpochNonce(nonce []byte) {
+	if len(nonce) == 0 {
+		m.epochNonce.Store([]byte(nil))
+		return
+	}
+	m.epochNonce.Store(append([]byte(nil), nonce...))
+}
+
+type mockScheduleStore struct {
+	mu        sync.RWMutex
+	schedules map[string]*Schedule
+	loadErr   error
+	saveErr   error
+}
+
+func newMockScheduleStore() *mockScheduleStore {
+	return &mockScheduleStore{
+		schedules: make(map[string]*Schedule),
+	}
+}
+
+func (m *mockScheduleStore) LoadSchedule(
+	epoch uint64,
+	poolId lcommon.PoolKeyHash,
+) (*Schedule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+	return m.schedules[m.key(epoch, poolId)], nil
+}
+
+func (m *mockScheduleStore) SaveSchedule(schedule *Schedule) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.schedules[m.key(schedule.Epoch, schedule.PoolId)] = schedule
+	return nil
+}
+
+func (m *mockScheduleStore) key(
+	epoch uint64,
+	poolId lcommon.PoolKeyHash,
+) string {
+	return fmt.Sprintf("%d:%x", epoch, poolId[:])
+}
+
+func makeElectionNonce(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
 }
 
 // waitForSchedule polls until CurrentSchedule returns non-nil, or fails
@@ -217,6 +288,179 @@ func TestElectionScheduleEarlyEpochs(t *testing.T) {
 	// Schedule is computed asynchronously; wait for it.
 	schedule := waitForSchedule(t, election, 30*time.Second)
 	assert.Equal(t, uint64(1), schedule.Epoch)
+}
+
+func TestElectionLoadsPersistedSchedule(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	store := newMockScheduleStore()
+	persisted := NewSchedule(10, poolId, 1000, 10000, electionTestNonce)
+	persisted.AddLeaderSlot(101)
+	persisted.AddLeaderSlot(104)
+	require.NoError(t, store.SaveSchedule(persisted))
+
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+	epochProvider := newMockEpochProvider()
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+	election.SetScheduleStore(store)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	schedule := waitForSchedule(t, election, 5*time.Second)
+	assert.Equal(
+		t,
+		persisted.LeaderSlotsSnapshot(),
+		schedule.LeaderSlotsSnapshot(),
+	)
+}
+
+func TestElectionIgnoresStalePersistedSchedule(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	store := newMockScheduleStore()
+	persisted := NewSchedule(10, poolId, 1_000_000, 1_000_000, makeElectionNonce(0x44))
+	persisted.AddLeaderSlot(999)
+	require.NoError(t, store.SaveSchedule(persisted))
+
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.activeSlotCoeff = 1.0
+	epochProvider.SetEpochNonce(makeElectionNonce(0x55))
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+	election.SetScheduleStore(store)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	schedule := waitForSchedule(t, election, 30*time.Second)
+	require.NotNil(t, schedule)
+	assert.NotEqual(t, []uint64{999}, schedule.LeaderSlotsSnapshot())
+	assert.True(t, bytes.Equal(makeElectionNonce(0x55), schedule.EpochNonce))
+
+	var persistedAfterLoad *Schedule
+	require.Eventually(t, func() bool {
+		var err error
+		persistedAfterLoad, err = store.LoadSchedule(10, poolId)
+		require.NoError(t, err)
+		return persistedAfterLoad != nil &&
+			bytes.Equal(makeElectionNonce(0x55), persistedAfterLoad.EpochNonce)
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func TestElectionPersistsComputedSchedule(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 10000
+	stakeProvider.poolStakes[string(poolId[:])] = 1000
+
+	store := newMockScheduleStore()
+	epochProvider := newMockEpochProvider()
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+	election.SetScheduleStore(store)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	schedule := waitForSchedule(t, election, 30*time.Second)
+	require.NotNil(t, schedule)
+
+	var persisted *Schedule
+	require.Eventually(t, func() bool {
+		var err error
+		persisted, err = store.LoadSchedule(schedule.Epoch, poolId)
+		require.NoError(t, err)
+		return persisted != nil
+	}, 2*time.Second, 50*time.Millisecond)
+	assert.Equal(
+		t,
+		schedule.LeaderSlotsSnapshot(),
+		persisted.LeaderSlotsSnapshot(),
+	)
+}
+
+func TestElectionPrecomputesNextEpochAtStartupWhenNonceReady(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	store := newMockScheduleStore()
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch.Store(10)
+	epochProvider.nextEpochReady.Store(11)
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+	election.SetScheduleStore(store)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	waitForSchedule(t, election, 30*time.Second)
+
+	require.Eventually(t, func() bool {
+		return election.ScheduleForEpoch(11) != nil
+	}, 30*time.Second, 100*time.Millisecond,
+		"next epoch schedule should be precomputed at startup")
+
+	require.Eventually(t, func() bool {
+		schedule, err := store.LoadSchedule(11, poolId)
+		require.NoError(t, err)
+		return schedule != nil
+	}, 2*time.Second, 50*time.Millisecond,
+		"next epoch schedule should be persisted at startup")
 }
 
 func TestElectionZeroPoolStake(t *testing.T) {
@@ -403,6 +647,177 @@ func TestElectionEpochTransition(t *testing.T) {
 	schedule = election.CurrentSchedule()
 	require.NotNil(t, schedule)
 	assert.Equal(t, uint64(11), schedule.Epoch)
+}
+
+func TestElectionPrecomputesNextEpochOnNonceReady(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch.Store(10)
+
+	store := newMockScheduleStore()
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+	election.SetScheduleStore(store)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	waitForSchedule(t, election, 30*time.Second)
+	assert.Nil(t, election.ScheduleForEpoch(11))
+
+	eventBus.Publish(
+		event.EpochNonceReadyEventType,
+		event.NewEvent(
+			event.EpochNonceReadyEventType,
+			event.EpochNonceReadyEvent{
+				CurrentEpoch: 10,
+				ReadyEpoch:   11,
+				CutoffSlot:   95,
+			},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		return election.ScheduleForEpoch(11) != nil
+	}, 30*time.Second, 100*time.Millisecond,
+		"next epoch schedule should be precomputed after nonce-ready event")
+
+	require.Eventually(t, func() bool {
+		schedule, err := store.LoadSchedule(11, poolId)
+		require.NoError(t, err)
+		return schedule != nil
+	}, 2*time.Second, 50*time.Millisecond,
+		"next epoch schedule should be persisted")
+}
+
+func TestElectionInvalidatesSchedulesAfterRollback(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.activeSlotCoeff = 1.0
+	epochProvider.SetEpochNonce(makeElectionNonce(0x11))
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	schedule := waitForSchedule(t, election, 30*time.Second)
+	require.True(t, bytes.Equal(makeElectionNonce(0x11), schedule.EpochNonce))
+
+	epochProvider.SetEpochNonce(makeElectionNonce(0x22))
+
+	eventBus.Publish(
+		ledgerpkg.PoolStateRestoredEventType,
+		event.NewEvent(
+			ledgerpkg.PoolStateRestoredEventType,
+			ledgerpkg.PoolStateRestoredEvent{Slot: 95},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		recomputed := election.ScheduleForEpoch(10)
+		return recomputed != nil &&
+			bytes.Equal(makeElectionNonce(0x22), recomputed.EpochNonce)
+	}, 30*time.Second, 100*time.Millisecond,
+		"rollback should invalidate and recompute the current epoch schedule")
+}
+
+func TestElectionRollbackKeepsNextEpochRecomputable(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.activeSlotCoeff = 1.0
+	epochProvider.SetEpochNonce(makeElectionNonce(0x31))
+	epochProvider.nextEpochReady.Store(11)
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	waitForSchedule(t, election, 30*time.Second)
+	require.Eventually(t, func() bool {
+		return election.ScheduleForEpoch(11) != nil
+	}, 30*time.Second, 100*time.Millisecond)
+
+	epochProvider.nextEpochReady.Store(0)
+	epochProvider.SetEpochNonce(makeElectionNonce(0x32))
+
+	eventBus.Publish(
+		ledgerpkg.PoolStateRestoredEventType,
+		event.NewEvent(
+			ledgerpkg.PoolStateRestoredEventType,
+			ledgerpkg.PoolStateRestoredEvent{Slot: 90},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		return election.ScheduleForEpoch(11) == nil
+	}, 5*time.Second, 50*time.Millisecond,
+		"rollback before cutoff should clear the precomputed next-epoch schedule")
+
+	epochProvider.nextEpochReady.Store(11)
+	eventBus.Publish(
+		event.EpochNonceReadyEventType,
+		event.NewEvent(
+			event.EpochNonceReadyEventType,
+			event.EpochNonceReadyEvent{
+				CurrentEpoch: 10,
+				ReadyEpoch:   11,
+				CutoffSlot:   95,
+			},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		schedule := election.ScheduleForEpoch(11)
+		return schedule != nil &&
+			bytes.Equal(makeElectionNonce(0x32), schedule.EpochNonce)
+	}, 30*time.Second, 100*time.Millisecond,
+		"nonce-ready replay should rebuild the next epoch schedule after rollback")
 }
 
 func TestElectionConcurrentAccess(t *testing.T) {

--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -82,6 +82,13 @@ func (s *Schedule) SlotCount() int {
 	return len(s.LeaderSlots)
 }
 
+// LeaderSlotsSnapshot returns a copy of the leader slot list.
+func (s *Schedule) LeaderSlotsSnapshot() []uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]uint64(nil), s.LeaderSlots...)
+}
+
 // StakeRatio returns the pool's stake as a fraction of total stake.
 func (s *Schedule) StakeRatio() float64 {
 	if s.TotalStake == 0 {

--- a/ledger/leader/store.go
+++ b/ledger/leader/store.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leader
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+const syncStateSchedulePrefix = "leader_schedule"
+
+type syncStateStore interface {
+	GetSyncState(key string, txn types.Txn) (string, error)
+	SetSyncState(key, value string, txn types.Txn) error
+}
+
+type syncStateScheduleRecord struct {
+	Epoch       uint64   `json:"epoch"`
+	PoolID      string   `json:"pool_id"`
+	PoolStake   uint64   `json:"pool_stake"`
+	TotalStake  uint64   `json:"total_stake"`
+	EpochNonce  string   `json:"epoch_nonce"`
+	LeaderSlots []uint64 `json:"leader_slots"`
+}
+
+// syncStateScheduleStore persists schedules in metadata sync state.
+type syncStateScheduleStore struct {
+	store syncStateStore
+}
+
+// NewSyncStateScheduleStore creates a ScheduleStore backed by sync state.
+func NewSyncStateScheduleStore(store syncStateStore) ScheduleStore {
+	if store == nil {
+		return nil
+	}
+	return &syncStateScheduleStore{store: store}
+}
+
+// LoadSchedule returns a previously persisted leader schedule, if present.
+func (s *syncStateScheduleStore) LoadSchedule(
+	epoch uint64,
+	poolId lcommon.PoolKeyHash,
+) (*Schedule, error) {
+	if s == nil || s.store == nil {
+		return nil, nil
+	}
+	key := syncStateScheduleKey(epoch, poolId)
+	raw, err := s.store.GetSyncState(key, nil)
+	if err != nil {
+		return nil, fmt.Errorf("load schedule %q: %w", key, err)
+	}
+	if raw == "" {
+		return nil, nil
+	}
+
+	var record syncStateScheduleRecord
+	if err := json.Unmarshal([]byte(raw), &record); err != nil {
+		return nil, fmt.Errorf("decode schedule %q: %w", key, err)
+	}
+	if record.Epoch != epoch {
+		return nil, fmt.Errorf(
+			"schedule %q epoch mismatch: got %d want %d",
+			key,
+			record.Epoch,
+			epoch,
+		)
+	}
+	expectedPoolID := hex.EncodeToString(poolId[:])
+	if record.PoolID != expectedPoolID {
+		return nil, fmt.Errorf(
+			"schedule %q pool mismatch: got %s want %s",
+			key,
+			record.PoolID,
+			expectedPoolID,
+		)
+	}
+	epochNonce, err := hex.DecodeString(record.EpochNonce)
+	if err != nil {
+		return nil, fmt.Errorf("decode epoch nonce for %q: %w", key, err)
+	}
+	schedule := NewSchedule(
+		record.Epoch,
+		poolId,
+		record.PoolStake,
+		record.TotalStake,
+		epochNonce,
+	)
+	for _, slot := range record.LeaderSlots {
+		schedule.AddLeaderSlot(slot)
+	}
+	return schedule, nil
+}
+
+// SaveSchedule persists a computed leader schedule.
+func (s *syncStateScheduleStore) SaveSchedule(schedule *Schedule) error {
+	if s == nil || s.store == nil || schedule == nil {
+		return nil
+	}
+	record := syncStateScheduleRecord{
+		Epoch:       schedule.Epoch,
+		PoolID:      hex.EncodeToString(schedule.PoolId[:]),
+		PoolStake:   schedule.PoolStake,
+		TotalStake:  schedule.TotalStake,
+		EpochNonce:  hex.EncodeToString(schedule.EpochNonce),
+		LeaderSlots: schedule.LeaderSlotsSnapshot(),
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf(
+			"encode leader schedule for epoch %d: %w",
+			schedule.Epoch,
+			err,
+		)
+	}
+	key := syncStateScheduleKey(schedule.Epoch, schedule.PoolId)
+	if err := s.store.SetSyncState(key, string(payload), nil); err != nil {
+		return fmt.Errorf("save schedule %q: %w", key, err)
+	}
+	return nil
+}
+
+func syncStateScheduleKey(
+	epoch uint64,
+	poolId lcommon.PoolKeyHash,
+) string {
+	return fmt.Sprintf(
+		"%s:%s:%d",
+		syncStateSchedulePrefix,
+		hex.EncodeToString(poolId[:]),
+		epoch,
+	)
+}

--- a/ledger/leader/store_test.go
+++ b/ledger/leader/store_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leader
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+type mockSyncStateStore struct {
+	values map[string]string
+	getErr error
+	setErr error
+}
+
+func newMockSyncStateStore() *mockSyncStateStore {
+	return &mockSyncStateStore{
+		values: make(map[string]string),
+	}
+}
+
+func (m *mockSyncStateStore) GetSyncState(
+	key string,
+	txn types.Txn,
+) (string, error) {
+	if m.getErr != nil {
+		return "", m.getErr
+	}
+	return m.values[key], nil
+}
+
+func (m *mockSyncStateStore) SetSyncState(
+	key string,
+	value string,
+	txn types.Txn,
+) error {
+	if m.setErr != nil {
+		return m.setErr
+	}
+	m.values[key] = value
+	return nil
+}
+
+func TestSyncStateScheduleStoreRoundTrip(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	backingStore := newMockSyncStateStore()
+	store := NewSyncStateScheduleStore(backingStore)
+
+	schedule := NewSchedule(42, poolId, 1000, 10000, electionTestNonce)
+	schedule.AddLeaderSlot(420)
+	schedule.AddLeaderSlot(424)
+
+	err := store.SaveSchedule(schedule)
+	require.NoError(t, err)
+
+	loaded, err := store.LoadSchedule(42, poolId)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, schedule.Epoch, loaded.Epoch)
+	assert.Equal(t, schedule.PoolId, loaded.PoolId)
+	assert.Equal(t, schedule.PoolStake, loaded.PoolStake)
+	assert.Equal(t, schedule.TotalStake, loaded.TotalStake)
+	assert.Equal(t, schedule.EpochNonce, loaded.EpochNonce)
+	assert.Equal(
+		t,
+		schedule.LeaderSlotsSnapshot(),
+		loaded.LeaderSlotsSnapshot(),
+	)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -485,6 +485,7 @@ type LedgerState struct {
 	syncProgressLastLog  time.Time     // last time we logged sync progress
 	syncProgressLastSlot uint64        // slot at last progress log (for rate calc)
 	syncUpstreamTipSlot  atomic.Uint64 // upstream peer's tip slot
+	nextNonceReadyEpoch  atomic.Uint64 // last ready epoch emitted for next-epoch nonce stability
 
 	// Rate-limiting for non-active connection drop messages (Fix 3)
 	dropEventLastLog    time.Time // last time we logged a drop event
@@ -1005,8 +1006,9 @@ func (ls *LedgerState) initForge() {
 }
 
 // handleSlotTicks processes slot tick notifications from the slot clock.
-// When an epoch boundary is detected via slot timing, it can emit an
-// EpochTransitionEvent for subscribers like snapshot managers and leader election.
+// When the current epoch crosses the nonce stability cutoff or reaches an
+// epoch boundary, it emits events for subscribers like snapshot managers and
+// leader election.
 //
 // The slot clock provides proactive epoch detection that doesn't depend on block
 // arrival. This is critical for block production where the node must wake up at
@@ -1021,10 +1023,6 @@ func (ls *LedgerState) handleSlotTicks() {
 	logger := ls.config.Logger.With("component", "ledger")
 
 	for tick := range ls.slotTickChan {
-		if !tick.IsEpochStart {
-			continue
-		}
-
 		// Get current state snapshot
 		ls.RLock()
 		currentEpoch := ls.currentEpoch
@@ -1037,15 +1035,29 @@ func (ls *LedgerState) handleSlotTicks() {
 		// consider the node "near tip" when the ledger tip is within 95%
 		// of the upstream peer's tip slot.
 		if !ls.isNearTip(tipSlot) {
-			logger.Debug(
-				"slot clock epoch boundary during catch up (suppressed)",
-				"slot_clock_epoch",
-				tick.Epoch,
-				"ledger_epoch",
-				currentEpoch.EpochId,
-				"slot",
-				tick.Slot,
-			)
+			if tick.IsEpochStart {
+				logger.Debug(
+					"slot clock epoch boundary during catch up (suppressed)",
+					"slot_clock_epoch",
+					tick.Epoch,
+					"ledger_epoch",
+					currentEpoch.EpochId,
+					"slot",
+					tick.Slot,
+				)
+			}
+			continue
+		}
+
+		ls.emitNextEpochNonceReady(
+			logger,
+			tick,
+			currentEpoch,
+			currentEra,
+			tipSlot,
+		)
+
+		if !tick.IsEpochStart {
 			continue
 		}
 
@@ -1114,6 +1126,57 @@ func (ls *LedgerState) handleSlotTicks() {
 			)
 		}
 	}
+}
+
+func (ls *LedgerState) emitNextEpochNonceReady(
+	logger *slog.Logger,
+	tick SlotTick,
+	currentEpoch models.Epoch,
+	currentEra eras.EraDesc,
+	tipSlot uint64,
+) {
+	if ls.config.EventBus == nil || currentEra.Id == 0 {
+		return
+	}
+	// Only publish when wall-clock and ledger agree on the current epoch.
+	if tick.Epoch != currentEpoch.EpochId {
+		return
+	}
+
+	cutoffSlot, ready := ls.nextEpochNonceReadyCutoffSlot(currentEpoch)
+	if !ready || tick.Slot < cutoffSlot || tipSlot < cutoffSlot {
+		return
+	}
+
+	readyEpoch := currentEpoch.EpochId + 1
+	if len(ls.EpochNonce(readyEpoch)) == 0 {
+		return
+	}
+	if ls.nextNonceReadyEpoch.Load() == readyEpoch {
+		return
+	}
+	ls.nextNonceReadyEpoch.Store(readyEpoch)
+
+	readyEvent := event.EpochNonceReadyEvent{
+		CurrentEpoch: currentEpoch.EpochId,
+		ReadyEpoch:   readyEpoch,
+		CutoffSlot:   cutoffSlot,
+	}
+	ls.config.EventBus.Publish(
+		event.EpochNonceReadyEventType,
+		event.NewEvent(event.EpochNonceReadyEventType, readyEvent),
+	)
+	logger.Info(
+		"next epoch nonce is stable, leader schedule can be precomputed",
+		"current_epoch", currentEpoch.EpochId,
+		"ready_epoch", readyEpoch,
+		"cutoff_slot", cutoffSlot,
+		"slot", tick.Slot,
+	)
+}
+
+func (ls *LedgerState) resetNextEpochNonceReady() {
+	ls.nextNonceReadyEpoch.Store(0)
 }
 
 // isNearTip returns true when the given slot is within 95% of the
@@ -1483,6 +1546,9 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	// Always update nonce - clear it on genesis rollback, set
 	// it otherwise
 	ls.currentTipBlockNonce = newNonce
+	// Allow the nonce-ready event to be emitted again if replay crosses
+	// the cutoff on a different fork after rollback.
+	ls.resetNextEpochNonceReady()
 	ls.updateTipMetrics()
 	ls.Unlock()
 	var hash string
@@ -3136,6 +3202,47 @@ func (ls *LedgerState) CurrentEpoch() uint64 {
 	return ls.currentEpoch.EpochId
 }
 
+// NextEpochNonceReadyEpoch reports the upcoming epoch when the current
+// epoch has already crossed the nonce stability cutoff and the next leader
+// schedule can be precomputed immediately.
+func (ls *LedgerState) NextEpochNonceReadyEpoch() (uint64, bool) {
+	ls.RLock()
+	currentEpoch := ls.currentEpoch
+	currentEra := ls.currentEra
+	tipSlot := ls.currentTip.Point.Slot
+	ls.RUnlock()
+
+	if currentEra.Id == 0 {
+		return 0, false
+	}
+
+	currentSlot, err := ls.CurrentSlot()
+	if err != nil {
+		return 0, false
+	}
+
+	epochLength := uint64(currentEpoch.LengthInSlots)
+	if epochLength == 0 {
+		return 0, false
+	}
+	epochEndSlot := currentEpoch.StartSlot + epochLength
+	if currentSlot < currentEpoch.StartSlot || currentSlot >= epochEndSlot {
+		return 0, false
+	}
+
+	cutoffSlot, ready := ls.nextEpochNonceReadyCutoffSlot(currentEpoch)
+	if !ready || currentSlot < cutoffSlot || tipSlot < cutoffSlot {
+		return 0, false
+	}
+
+	readyEpoch := currentEpoch.EpochId + 1
+	if len(ls.EpochNonce(readyEpoch)) == 0 {
+		return 0, false
+	}
+
+	return readyEpoch, true
+}
+
 // EpochNonce returns the nonce for the given epoch.
 // The epoch nonce is used for VRF-based leader election.
 // Returns nil if the epoch nonce is not available (e.g., for Byron era).
@@ -3192,6 +3299,23 @@ func (ls *LedgerState) EpochNonce(epoch uint64) []byte {
 	nonce := make([]byte, len(ep.Nonce))
 	copy(nonce, ep.Nonce)
 	return nonce
+}
+
+// nextEpochNonceReadyCutoffSlot returns the slot at which the current epoch's
+// candidate nonce stops changing, which is when the next epoch's nonce is
+// stable and the next leader schedule can be precomputed.
+func (ls *LedgerState) nextEpochNonceReadyCutoffSlot(
+	currentEpoch models.Epoch,
+) (uint64, bool) {
+	epochLength := uint64(currentEpoch.LengthInSlots)
+	if epochLength == 0 {
+		return 0, false
+	}
+	stabilityWindow := ls.nonceStabilityWindow()
+	if stabilityWindow >= epochLength {
+		return currentEpoch.StartSlot, true
+	}
+	return currentEpoch.StartSlot + epochLength - stabilityWindow, true
 }
 
 // computeNextEpochNonce speculatively computes the epoch nonce for the

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +35,7 @@ import (
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
 
@@ -704,6 +707,328 @@ func TestCalculateStabilityWindow_LargeValues(t *testing.T) {
 	if result != expectedWindow {
 		t.Errorf("expected stability window %d, got %d", expectedWindow, result)
 	}
+}
+
+func newNonceReadyTestConfig(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+
+	byronGenesisJSON := `{
+		"protocolConsts": {
+			"k": 432,
+			"protocolMagic": 2
+		}
+	}`
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.5,
+		"securityParam": 1,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: strings.Repeat("11", 32),
+	}
+	require.NoError(
+		t,
+		cfg.LoadByronGenesisFromReader(strings.NewReader(byronGenesisJSON)),
+	)
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+	return cfg
+}
+
+func newNonceReadyTestLedgerState(
+	t *testing.T,
+	eventBus *event.EventBus,
+	tipSlot uint64,
+) *LedgerState {
+	t.Helper()
+
+	return &LedgerState{
+		currentEra: eras.ShelleyEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId:             10,
+			StartSlot:           1000,
+			LengthInSlots:       100,
+			Nonce:               nil,
+			EvolvingNonce:       []byte{0x02},
+			CandidateNonce:      []byte{0x03},
+			LastEpochBlockNonce: []byte{0x04},
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: tipSlot,
+			},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newNonceReadyTestConfig(t),
+			EventBus:          eventBus,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+func TestNextEpochNonceReadyCutoffSlot(t *testing.T) {
+	byronGenesisJSON := `{
+		"protocolConsts": {
+			"k": 432,
+			"protocolMagic": 2
+		}
+	}`
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(
+		t,
+		cfg.LoadByronGenesisFromReader(strings.NewReader(byronGenesisJSON)),
+	)
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+
+	ls := &LedgerState{
+		currentEra: eras.ShelleyEraDesc,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	cutoffSlot, ok := ls.nextEpochNonceReadyCutoffSlot(models.Epoch{
+		EpochId:       1238,
+		StartSlot:     106963200,
+		LengthInSlots: 86400,
+	})
+	require.True(t, ok)
+	assert.Equal(t, uint64(107015040), cutoffSlot)
+}
+
+func TestNextEpochNonceReadyEpoch(t *testing.T) {
+	byronGenesisJSON := `{
+		"protocolConsts": {
+			"k": 432,
+			"protocolMagic": 2
+		}
+	}`
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.5,
+		"securityParam": 1,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: strings.Repeat("11", 32),
+	}
+	require.NoError(
+		t,
+		cfg.LoadByronGenesisFromReader(strings.NewReader(byronGenesisJSON)),
+	)
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+
+	currentSlot := uint64(1095)
+	provider := newMockSlotTimeProvider(
+		time.Now().Add(-time.Duration(currentSlot)*time.Second),
+		time.Second,
+		100,
+	)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+	clock.nowFunc = func() time.Time {
+		return provider.systemStart.Add(time.Duration(currentSlot) * time.Second)
+	}
+
+	ls := &LedgerState{
+		currentEra: eras.ShelleyEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId:             10,
+			StartSlot:           1000,
+			LengthInSlots:       100,
+			Nonce:               nil,
+			EvolvingNonce:       []byte{0x02},
+			CandidateNonce:      []byte{0x03},
+			LastEpochBlockNonce: []byte{0x04},
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 1095,
+			},
+		},
+		slotClock: clock,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.syncUpstreamTipSlot.Store(1100)
+
+	readyEpoch, ok := ls.NextEpochNonceReadyEpoch()
+	require.True(t, ok)
+	assert.Equal(t, uint64(11), readyEpoch)
+}
+
+func TestNextEpochNonceReadyEpochNotReadyBeforeCutoff(t *testing.T) {
+	byronGenesisJSON := `{
+		"protocolConsts": {
+			"k": 432,
+			"protocolMagic": 2
+		}
+	}`
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.5,
+		"securityParam": 1,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: strings.Repeat("11", 32),
+	}
+	require.NoError(
+		t,
+		cfg.LoadByronGenesisFromReader(strings.NewReader(byronGenesisJSON)),
+	)
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+
+	currentSlot := uint64(1085)
+	provider := newMockSlotTimeProvider(
+		time.Now().Add(-time.Duration(currentSlot)*time.Second),
+		time.Second,
+		100,
+	)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+	clock.nowFunc = func() time.Time {
+		return provider.systemStart.Add(time.Duration(currentSlot) * time.Second)
+	}
+
+	ls := &LedgerState{
+		currentEra: eras.ShelleyEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId:             10,
+			StartSlot:           1000,
+			LengthInSlots:       100,
+			Nonce:               nil,
+			EvolvingNonce:       []byte{0x02},
+			CandidateNonce:      []byte{0x03},
+			LastEpochBlockNonce: []byte{0x04},
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 1085,
+			},
+		},
+		slotClock: clock,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.syncUpstreamTipSlot.Store(1100)
+
+	readyEpoch, ok := ls.NextEpochNonceReadyEpoch()
+	require.False(t, ok)
+	assert.Equal(t, uint64(0), readyEpoch)
+}
+
+func TestEmitNextEpochNonceReadyRequiresLedgerTipAtCutoff(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	_, evtCh := eventBus.Subscribe(event.EpochNonceReadyEventType)
+	ls := newNonceReadyTestLedgerState(t, eventBus, 1085)
+
+	ls.emitNextEpochNonceReady(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		SlotTick{Slot: 1095, Epoch: 10},
+		ls.currentEpoch,
+		ls.currentEra,
+		1085,
+	)
+
+	select {
+	case evt := <-evtCh:
+		t.Fatalf("unexpected nonce-ready event published: %#v", evt)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.Equal(t, uint64(0), ls.nextNonceReadyEpoch.Load())
+}
+
+func TestResetNextEpochNonceReadyAllowsReEmit(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	_, evtCh := eventBus.Subscribe(event.EpochNonceReadyEventType)
+	ls := newNonceReadyTestLedgerState(t, eventBus, 1095)
+	ls.nextNonceReadyEpoch.Store(11)
+	ls.resetNextEpochNonceReady()
+
+	ls.emitNextEpochNonceReady(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		SlotTick{Slot: 1095, Epoch: 10},
+		ls.currentEpoch,
+		ls.currentEra,
+		1095,
+	)
+
+	select {
+	case evt := <-evtCh:
+		readyEvent, ok := evt.Data.(event.EpochNonceReadyEvent)
+		require.True(t, ok)
+		assert.Equal(t, uint64(10), readyEvent.CurrentEpoch)
+		assert.Equal(t, uint64(11), readyEvent.ReadyEpoch)
+	case <-time.After(time.Second):
+		t.Fatal("expected nonce-ready event after rollback reset")
+	}
+}
+
+func TestNextEpochNonceReadyCutoffSlotShortEpoch(t *testing.T) {
+	byronGenesisJSON := `{
+		"protocolConsts": {
+			"k": 432,
+			"protocolMagic": 2
+		}
+	}`
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(
+		t,
+		cfg.LoadByronGenesisFromReader(strings.NewReader(byronGenesisJSON)),
+	)
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+
+	ls := &LedgerState{
+		currentEra: eras.ShelleyEraDesc,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	cutoffSlot, ok := ls.nextEpochNonceReadyCutoffSlot(models.Epoch{
+		EpochId:       42,
+		StartSlot:     1000,
+		LengthInSlots: 100,
+	})
+	require.True(t, ok)
+	assert.Equal(t, uint64(1000), cutoffSlot)
 }
 
 // TestDatabaseWorkerPoolBasic tests basic worker pool functionality

--- a/node.go
+++ b/node.go
@@ -1106,6 +1106,13 @@ func (n *Node) initBlockForger(
 		n.eventBus,
 		n.config.logger,
 	)
+	if n.db != nil {
+		if scheduleStore := leader.NewSyncStateScheduleStore(
+			n.db.Metadata(),
+		); scheduleStore != nil {
+			election.SetScheduleStore(scheduleStore)
+		}
+	}
 
 	// Start leader election (subscribes to epoch transitions)
 	if err := election.Start(ctx); err != nil {
@@ -1240,6 +1247,10 @@ func (a *epochInfoAdapter) CurrentEpoch() uint64 {
 
 func (a *epochInfoAdapter) EpochNonce(epoch uint64) []byte {
 	return a.ledgerState.EpochNonce(epoch)
+}
+
+func (a *epochInfoAdapter) NextEpochNonceReadyEpoch() (uint64, bool) {
+	return a.ledgerState.NextEpochNonceReadyEpoch()
 }
 
 func (a *epochInfoAdapter) SlotsPerEpoch() uint64 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add persistent leader schedule storage, precompute next-epoch schedules when the nonce becomes stable, and handle rollbacks by invalidating and recomputing schedules. This reduces cold-start latency and avoids recomputing schedules across restarts and rollbacks.

- **New Features**
  - Added `ScheduleStore` with a sync-state-backed implementation `leader.NewSyncStateScheduleStore`; wired in `node.go` when a DB is available.
  - `Election` loads persisted schedules before computing and persists new ones; `SetScheduleStore` added. Subscribes to `epoch.nonce_ready` to precompute the next epoch and to `PoolStateRestoredEvent` to clear and recompute after rollbacks.
  - Ledger emits `epoch.nonce_ready` once the current epoch crosses the nonce stability cutoff, exposes `NextEpochNonceReadyEpoch()` for startup precompute, and resets readiness after rollbacks.
  - Added `Schedule.LeaderSlotsSnapshot()` for safe slot logging/storage; improved logs with slot lists. Introduced `queueScheduleCompute` to debounce compute requests.

<sup>Written for commit 5383c46c21fa534ba68c89d512a395eab5ec3400. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

