### PR TITLE
fix(mithril): snapshot import remap

### DIFF
--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"math/big"
 	"net"
+	"slices"
 	"sort"
 	"time"
 
@@ -1078,20 +1079,19 @@ func importSnapShots(
 		)
 	}
 
-	store := cfg.Database.Metadata()
 	epoch := cfg.State.Epoch
 
-	// Import each snapshot type, saving the "go" result for the
-	// epoch summary to avoid recomputing it.
-	var goSnapshots []*models.PoolStakeSnapshot
-	for _, st := range []struct {
-		name string
-		snap *ParsedSnapShot
-	}{
-		{"mark", &snapshots.Mark},
-		{"set", &snapshots.Set},
-		{"go", &snapshots.Go},
-	} {
+	// Mithril exports the current epoch's Mark/Set/Go bundle, but
+	// Dingo persists only Mark snapshots and resolves Set/Go via
+	// epoch offsets:
+	//   - Mark for epoch N     = current mark snapshot
+	//   - Mark for epoch N-1   = imported set snapshot
+	//   - Mark for epoch N-2   = imported go snapshot
+	//
+	// Import the bundle into those historical epochs so leader
+	// schedule queries (which request epoch-2, "mark") work
+	// immediately after a Mithril restore.
+	for _, st := range snapshotImportTargets(epoch, snapshots) {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf(
@@ -1101,50 +1101,18 @@ func importSnapShots(
 		}
 
 		poolSnapshots := AggregatePoolStake(
-			st.snap, epoch, st.name, slot,
+			st.snap,
+			st.targetEpoch,
+			"mark",
+			slot,
 		)
 
-		if st.name == "go" {
-			goSnapshots = poolSnapshots
-		}
-
-		if len(poolSnapshots) == 0 {
-			continue
-		}
-
-		if err := func() error {
-			txn := cfg.Database.MetadataTxn(true)
-			defer txn.Release()
-			metaTxn := txn.Metadata()
-
-			if err := store.DeletePoolStakeSnapshotsForEpoch(
-				epoch, st.name, metaTxn,
-			); err != nil {
-				return fmt.Errorf(
-					"deleting existing %s snapshots: %w",
-					st.name,
-					err,
-				)
-			}
-
-			if err := store.SavePoolStakeSnapshots(
-				poolSnapshots, metaTxn,
-			); err != nil {
-				return fmt.Errorf(
-					"saving %s snapshots: %w",
-					st.name,
-					err,
-				)
-			}
-
-			if err := txn.Commit(); err != nil {
-				return fmt.Errorf(
-					"commit transaction: %w",
-					err,
-				)
-			}
-			return nil
-		}(); err != nil {
+		if err := persistImportedSnapshot(
+			cfg,
+			slot,
+			st,
+			poolSnapshots,
+		); err != nil {
 			return fmt.Errorf(
 				"importing %s snapshots: %w",
 				st.name,
@@ -1160,6 +1128,8 @@ func importSnapShots(
 		cfg.Logger.Info(
 			"imported stake snapshot",
 			"snapshot", st.name,
+			"stored_as", "mark",
+			"target_epoch", st.targetEpoch,
 			"pools", len(poolSnapshots),
 			"total_stake", totalStake,
 			"component", "ledgerstate",
@@ -1203,56 +1173,168 @@ func importSnapShots(
 		}
 	}
 
-	// Save epoch summary using the "go" snapshot computed above
-	var totalStake uint64
-	var totalDelegators uint64
-	for _, ps := range goSnapshots {
-		totalStake += uint64(ps.TotalStake)
-		totalDelegators += ps.DelegatorCount
-	}
+	return nil
+}
 
-	summary := &models.EpochSummary{
-		Epoch:            epoch,
-		TotalActiveStake: types.Uint64(totalStake),
-		TotalPoolCount:   uint64(len(goSnapshots)),
-		TotalDelegators:  totalDelegators,
-		BoundarySlot:     slot,
-		SnapshotReady:    true,
-	}
-
+func persistImportedSnapshot(
+	cfg ImportConfig,
+	slot uint64,
+	st snapshotImportTarget,
+	poolSnapshots []*models.PoolStakeSnapshot,
+) error {
+	store := cfg.Database.Metadata()
 	txn := cfg.Database.MetadataTxn(true)
 	defer txn.Release()
+	metaTxn := txn.Metadata()
 
-	// Check if epoch summary already exists (idempotent import)
-	existing, err := store.GetEpochSummary(
-		epoch, txn.Metadata(),
-	)
-	if err != nil {
+	if err := store.DeletePoolStakeSnapshotsForEpoch(
+		st.targetEpoch,
+		"mark",
+		metaTxn,
+	); err != nil {
 		return fmt.Errorf(
-			"checking existing epoch summary: %w",
+			"deleting existing %s snapshot import for epoch %d: %w",
+			st.name,
+			st.targetEpoch,
 			err,
 		)
 	}
-	if existing != nil {
-		return nil
+
+	if len(poolSnapshots) > 0 {
+		if err := store.SavePoolStakeSnapshots(
+			poolSnapshots, metaTxn,
+		); err != nil {
+			return fmt.Errorf(
+				"saving %s snapshot import for epoch %d: %w",
+				st.name,
+				st.targetEpoch,
+				err,
+			)
+		}
 	}
 
-	if err := store.SaveEpochSummary(
-		summary, txn.Metadata(),
-	); err != nil {
+	totalStake, totalDelegators := summarizePoolSnapshots(
+		poolSnapshots,
+	)
+	existingSummary, err := store.GetEpochSummary(
+		st.targetEpoch, metaTxn,
+	)
+	if err != nil {
 		return fmt.Errorf(
-			"saving epoch summary: %w",
+			"getting existing epoch summary for %s snapshot epoch %d: %w",
+			st.name,
+			st.targetEpoch,
+			err,
+		)
+	}
+	summary := importedEpochSummary(
+		existingSummary,
+		cfg.State.Epoch,
+		st.targetEpoch,
+		slot,
+		cfg.State.EpochNonce,
+		totalStake,
+		uint64(len(poolSnapshots)),
+		totalDelegators,
+	)
+
+	if err := store.SaveEpochSummary(summary, metaTxn); err != nil {
+		return fmt.Errorf(
+			"saving epoch summary for %s snapshot epoch %d: %w",
+			st.name,
+			st.targetEpoch,
 			err,
 		)
 	}
 
 	if err := txn.Commit(); err != nil {
-		return fmt.Errorf(
-			"commit transaction in importSnapShots: %w",
-			err,
-		)
+		return fmt.Errorf("commit transaction: %w", err)
 	}
 	return nil
+}
+
+type snapshotImportTarget struct {
+	name        string
+	targetEpoch uint64
+	snap        *ParsedSnapShot
+}
+
+func summarizePoolSnapshots(
+	poolSnapshots []*models.PoolStakeSnapshot,
+) (uint64, uint64) {
+	var totalStake uint64
+	var totalDelegators uint64
+	for _, ps := range poolSnapshots {
+		totalStake += uint64(ps.TotalStake)
+		totalDelegators += ps.DelegatorCount
+	}
+	return totalStake, totalDelegators
+}
+
+func importedEpochSummary(
+	existing *models.EpochSummary,
+	currentEpoch uint64,
+	targetEpoch uint64,
+	importSlot uint64,
+	currentEpochNonce []byte,
+	totalStake uint64,
+	totalPoolCount uint64,
+	totalDelegators uint64,
+) *models.EpochSummary {
+	summary := &models.EpochSummary{
+		Epoch:            targetEpoch,
+		TotalActiveStake: types.Uint64(totalStake),
+		TotalPoolCount:   totalPoolCount,
+		TotalDelegators:  totalDelegators,
+		SnapshotReady:    true,
+	}
+	if targetEpoch == currentEpoch {
+		summary.BoundarySlot = importSlot
+		if len(currentEpochNonce) > 0 {
+			summary.EpochNonce = slices.Clone(currentEpochNonce)
+		}
+	}
+	if existing == nil {
+		return summary
+	}
+	if targetEpoch != currentEpoch && existing.BoundarySlot != 0 {
+		summary.BoundarySlot = existing.BoundarySlot
+	}
+	if targetEpoch != currentEpoch && len(existing.EpochNonce) > 0 {
+		summary.EpochNonce = slices.Clone(existing.EpochNonce)
+	}
+	return summary
+}
+
+func snapshotImportTargets(
+	currentEpoch uint64,
+	snapshots *ParsedSnapShots,
+) []snapshotImportTarget {
+	if snapshots == nil {
+		return nil
+	}
+	targets := []snapshotImportTarget{
+		{
+			name:        "mark",
+			targetEpoch: currentEpoch,
+			snap:        &snapshots.Mark,
+		},
+	}
+	if currentEpoch > 0 {
+		targets = append(targets, snapshotImportTarget{
+			name:        "set",
+			targetEpoch: currentEpoch - 1,
+			snap:        &snapshots.Set,
+		})
+	}
+	if currentEpoch > 1 {
+		targets = append(targets, snapshotImportTarget{
+			name:        "go",
+			targetEpoch: currentEpoch - 2,
+			snap:        &snapshots.Go,
+		})
+	}
+	return targets
 }
 
 func collectPoolsFromSnapshots(

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotImportTargetsAlignWithRotation(t *testing.T) {
+	snapshots := &ParsedSnapShots{}
+
+	targets := snapshotImportTargets(1237, snapshots)
+	if len(targets) != 3 {
+		t.Fatalf("expected 3 targets, got %d", len(targets))
+	}
+
+	expected := []struct {
+		name  string
+		epoch uint64
+	}{
+		{name: "mark", epoch: 1237},
+		{name: "set", epoch: 1236},
+		{name: "go", epoch: 1235},
+	}
+
+	for i, target := range targets {
+		if target.name != expected[i].name {
+			t.Fatalf(
+				"target %d: expected name %q, got %q",
+				i,
+				expected[i].name,
+				target.name,
+			)
+		}
+		if target.targetEpoch != expected[i].epoch {
+			t.Fatalf(
+				"target %d: expected epoch %d, got %d",
+				i,
+				expected[i].epoch,
+				target.targetEpoch,
+			)
+		}
+	}
+}
+
+func TestSnapshotImportTargetsSkipNegativeEpochs(t *testing.T) {
+	snapshots := &ParsedSnapShots{}
+
+	targets0 := snapshotImportTargets(0, snapshots)
+	if len(targets0) != 1 {
+		t.Fatalf("epoch 0: expected 1 target, got %d", len(targets0))
+	}
+	if targets0[0].name != "mark" || targets0[0].targetEpoch != 0 {
+		t.Fatalf("epoch 0: unexpected target %+v", targets0[0])
+	}
+
+	targets1 := snapshotImportTargets(1, snapshots)
+	if len(targets1) != 2 {
+		t.Fatalf("epoch 1: expected 2 targets, got %d", len(targets1))
+	}
+	if targets1[0].name != "mark" || targets1[0].targetEpoch != 1 {
+		t.Fatalf("epoch 1 mark: unexpected target %+v", targets1[0])
+	}
+	if targets1[1].name != "set" || targets1[1].targetEpoch != 0 {
+		t.Fatalf("epoch 1 set: unexpected target %+v", targets1[1])
+	}
+}
+
+func TestSnapshotImportTargetsNilSnapshots(t *testing.T) {
+	targets := snapshotImportTargets(7, nil)
+	if targets != nil {
+		t.Fatalf("expected nil targets, got %+v", targets)
+	}
+}
+
+func TestImportedEpochSummaryUsesCurrentEpochMetadata(t *testing.T) {
+	nonce := []byte{0x01, 0x02, 0x03}
+
+	summary := importedEpochSummary(
+		nil,
+		1237,
+		1237,
+		456789,
+		nonce,
+		100,
+		2,
+		3,
+	)
+
+	if summary.Epoch != 1237 {
+		t.Fatalf("expected epoch 1237, got %d", summary.Epoch)
+	}
+	if summary.BoundarySlot != 456789 {
+		t.Fatalf(
+			"expected boundary slot 456789, got %d",
+			summary.BoundarySlot,
+		)
+	}
+	if !bytes.Equal(summary.EpochNonce, nonce) {
+		t.Fatalf(
+			"expected epoch nonce %x, got %x",
+			nonce,
+			summary.EpochNonce,
+		)
+	}
+	if !summary.SnapshotReady {
+		t.Fatal("expected snapshot summary to be marked ready")
+	}
+}
+
+func TestImportedEpochSummaryLeavesHistoricalMetadataUnknown(t *testing.T) {
+	summary := importedEpochSummary(
+		nil,
+		1237,
+		1235,
+		456789,
+		[]byte{0x01, 0x02, 0x03},
+		100,
+		2,
+		3,
+	)
+
+	if summary.BoundarySlot != 0 {
+		t.Fatalf(
+			"expected historical boundary slot to remain unknown, got %d",
+			summary.BoundarySlot,
+		)
+	}
+	if len(summary.EpochNonce) != 0 {
+		t.Fatalf(
+			"expected historical epoch nonce to remain unknown, got %x",
+			summary.EpochNonce,
+		)
+	}
+}
+
+func TestImportedEpochSummaryPreservesExistingMetadata(t *testing.T) {
+	existing := &models.EpochSummary{
+		Epoch:        1235,
+		EpochNonce:   []byte{0xaa, 0xbb, 0xcc},
+		BoundarySlot: 777,
+	}
+
+	summary := importedEpochSummary(
+		existing,
+		1237,
+		1235,
+		456789,
+		[]byte{0x01, 0x02, 0x03},
+		100,
+		2,
+		3,
+	)
+
+	if summary.BoundarySlot != existing.BoundarySlot {
+		t.Fatalf(
+			"expected boundary slot %d, got %d",
+			existing.BoundarySlot,
+			summary.BoundarySlot,
+		)
+	}
+	if !bytes.Equal(summary.EpochNonce, existing.EpochNonce) {
+		t.Fatalf(
+			"expected preserved epoch nonce %x, got %x",
+			existing.EpochNonce,
+			summary.EpochNonce,
+		)
+	}
+	if summary.TotalPoolCount != 2 {
+		t.Fatalf(
+			"expected updated total pool count 2, got %d",
+			summary.TotalPoolCount,
+		)
+	}
+}
+
+func TestImportedEpochSummaryKeepsCurrentEpochMetadataWhenExisting(
+	t *testing.T,
+) {
+	existing := &models.EpochSummary{
+		Epoch:        1237,
+		EpochNonce:   []byte{0xaa, 0xbb, 0xcc},
+		BoundarySlot: 777,
+	}
+	currentNonce := []byte{0x01, 0x02, 0x03}
+
+	summary := importedEpochSummary(
+		existing,
+		1237,
+		1237,
+		456789,
+		currentNonce,
+		100,
+		2,
+		3,
+	)
+
+	if summary.BoundarySlot != 456789 {
+		t.Fatalf(
+			"expected current boundary slot 456789, got %d",
+			summary.BoundarySlot,
+		)
+	}
+	if !bytes.Equal(summary.EpochNonce, currentNonce) {
+		t.Fatalf(
+			"expected current epoch nonce %x, got %x",
+			currentNonce,
+			summary.EpochNonce,
+		)
+	}
+}
+
+func TestPersistImportedSnapshotClearsEpochWhenEmpty(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	store := db.Metadata()
+	targetEpoch := uint64(100)
+	poolKeyHash := make([]byte, 28)
+	poolKeyHash[0] = 0x01
+
+	require.NoError(t, store.SavePoolStakeSnapshots(
+		[]*models.PoolStakeSnapshot{
+			{
+				Epoch:          targetEpoch,
+				SnapshotType:   "mark",
+				PoolKeyHash:    poolKeyHash,
+				TotalStake:     10,
+				DelegatorCount: 2,
+				CapturedSlot:   55,
+			},
+		},
+		nil,
+	))
+
+	existingSummary := &models.EpochSummary{
+		Epoch:            targetEpoch,
+		TotalActiveStake: 10,
+		TotalPoolCount:   1,
+		TotalDelegators:  2,
+		BoundarySlot:     777,
+		EpochNonce:       []byte{0xaa, 0xbb, 0xcc},
+	}
+	require.NoError(t, store.SaveEpochSummary(existingSummary, nil))
+
+	err = persistImportedSnapshot(
+		ImportConfig{
+			Database: db,
+			State: &RawLedgerState{
+				Epoch:      102,
+				EpochNonce: []byte{0x01, 0x02, 0x03},
+			},
+		},
+		999,
+		snapshotImportTarget{
+			name:        "set",
+			targetEpoch: targetEpoch,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	snapshots, err := store.GetPoolStakeSnapshotsByEpoch(
+		targetEpoch,
+		"mark",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, snapshots)
+
+	summary, err := store.GetEpochSummary(targetEpoch, nil)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, targetEpoch, summary.Epoch)
+	require.Equal(t, uint64(0), uint64(summary.TotalActiveStake))
+	require.Zero(t, summary.TotalPoolCount)
+	require.Zero(t, summary.TotalDelegators)
+	require.True(t, summary.SnapshotReady)
+	require.Equal(t, existingSummary.BoundarySlot, summary.BoundarySlot)
+	require.True(t, bytes.Equal(existingSummary.EpochNonce, summary.EpochNonce))
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mithril snapshot import by remapping Mark/Set/Go into historical epochs so leader schedule works right after restore. Persists per-epoch summaries with safe, idempotent metadata handling and clears stale data when imports are empty.

- **Bug Fixes**
  - Remap bundle to Dingo epochs: Mark -> epoch N, Set -> N-1, Go -> N-2; store all as "mark".
  - On import, delete existing "mark" snapshots for the target epoch; empty imports clear snapshots and write zeroed summaries.
  - Create/update epoch summaries per target epoch:
    - Preserve `BoundarySlot` and `EpochNonce` for historical epochs; for current epoch set `BoundarySlot` and clone `EpochNonce`; always set `SnapshotReady = true`.
  - Add focused helpers for import targets and persistence (`snapshotImportTargets`, `persistImportedSnapshot`, `importedEpochSummary`, `summarizePoolSnapshots`); logs include `stored_as` and `target_epoch`. Tests cover rotation mapping, low-epoch edges, nil snapshots, empty-import clearing, and metadata preservation.

<sup>Written for commit 500e7765a477c5af4339048f137fd56f36fc6846. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked snapshot import flow to target specific epochs (current and recent history), centralize persistence, and ensure idempotent imports while preserving historical metadata.

* **Logging**
  * Added import-specific details (stored_as, target_epoch) to snapshot import logs.

* **Tests**
  * Added unit tests covering import targets, historical handling, summary merging, and persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->