### PR TITLE
fix: peer switch doesn't restart chainsync

### DIFF
--- a/node.go
+++ b/node.go
@@ -73,6 +73,29 @@ type Node struct {
 	shutdownOnce   sync.Once
 }
 
+func (n *Node) handleChainSwitchEvent(evt event.Event) {
+	e, ok := evt.Data.(chainselection.ChainSwitchEvent)
+	if !ok {
+		return
+	}
+	prevConn := "(none)"
+	if e.PreviousConnectionId.LocalAddr != nil &&
+		e.PreviousConnectionId.RemoteAddr != nil {
+		prevConn = e.PreviousConnectionId.String()
+	}
+	n.config.logger.Info(
+		"chain switch: updating active connection",
+		"previous_connection", prevConn,
+		"new_connection", e.NewConnectionId.String(),
+		"new_tip_block", e.NewTip.BlockNumber,
+		"new_tip_slot", e.NewTip.Point.Slot,
+	)
+	// Do not restart chainsync on peer switch. Every connected peer
+	// already maintains its own chainsync client state and pipeline; a
+	// switch only changes which peer's stream feeds the ledger.
+	n.chainsyncState.SetClientConnId(e.NewConnectionId)
+}
+
 func New(cfg Config) (*Node, error) {
 	eventBus := event.NewEventBus(cfg.promRegistry, cfg.logger)
 	n := &Node{
@@ -326,25 +349,7 @@ func (n *Node) Run(ctx context.Context) error {
 	// Subscribe to chain switch events to update active connection
 	n.eventBus.SubscribeFunc(
 		chainselection.ChainSwitchEventType,
-		func(evt event.Event) {
-			e, ok := evt.Data.(chainselection.ChainSwitchEvent)
-			if !ok {
-				return
-			}
-			prevConn := "(none)"
-			if e.PreviousConnectionId.LocalAddr != nil &&
-				e.PreviousConnectionId.RemoteAddr != nil {
-				prevConn = e.PreviousConnectionId.String()
-			}
-			n.config.logger.Info(
-				"chain switch: updating active connection",
-				"previous_connection", prevConn,
-				"new_connection", e.NewConnectionId.String(),
-				"new_tip_block", e.NewTip.BlockNumber,
-				"new_tip_slot", e.NewTip.Point.Slot,
-			)
-			n.chainsyncState.SetClientConnId(e.NewConnectionId)
-		},
+		n.handleChainSwitchEvent,
 	)
 	// Subscribe to chain fork events for monitoring
 	n.eventBus.SubscribeFunc(

--- a/node_test.go
+++ b/node_test.go
@@ -17,11 +17,78 @@ package dingo
 import (
 	"io"
 	"log/slog"
+	"net"
 	"sync/atomic"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func newNodeTestConnId(id uint) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 6000,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: int(id),
+		},
+	}
+}
+
+func TestHandleChainSwitchEventUpdatesActiveConnection(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.DefaultConfig(),
+	)
+	connA := newNodeTestConnId(3001)
+	connB := newNodeTestConnId(3002)
+	state.AddClientConnId(connA)
+	state.AddClientConnId(connB)
+	state.SetClientConnId(connA)
+	pointA := ocommon.NewPoint(100, []byte("hash-a"))
+	pointB := ocommon.NewPoint(200, []byte("hash-b"))
+	tipA := ochainsync.Tip{Point: pointA, BlockNumber: 10}
+	tipB := ochainsync.Tip{Point: pointB, BlockNumber: 20}
+	state.UpdateClientTip(connA, pointA, tipA)
+	state.UpdateClientTip(connB, pointB, tipB)
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+	}
+
+	n.handleChainSwitchEvent(
+		event.NewEvent(
+			chainselection.ChainSwitchEventType,
+			chainselection.ChainSwitchEvent{
+				PreviousConnectionId: connA,
+				NewConnectionId:      connB,
+				NewTip:               tipB,
+			},
+		),
+	)
+
+	active := state.GetClientConnId()
+	require.NotNil(t, active)
+	assert.Equal(t, connB, *active)
+	assert.Equal(t, pointA, state.GetTrackedClient(connA).Cursor)
+	assert.Equal(t, pointB, state.GetTrackedClient(connB).Cursor)
+	assert.Equal(t, uint64(1), state.GetTrackedClient(connA).HeadersRecv)
+	assert.Equal(t, uint64(1), state.GetTrackedClient(connB).HeadersRecv)
+}
 
 func TestRunStallCheckerTickRecoversAndAllowsFutureTicks(t *testing.T) {
 	n := &Node{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop restarting `chainsync` when switching peers. We now only switch the active client connection, keeping per‑peer sync state and pipelines intact for smoother failover.

- **Bug Fixes**
  - On `chainselection.ChainSwitchEvent`, update the active `chainsync` connection via `SetClientConnId` instead of restarting the pipeline. Added a test to confirm the active connection changes and per‑peer cursors/metrics are preserved.

- **Refactors**
  - Extracted `handleChainSwitchEvent` and hooked it into the event bus. Improved connection/tip logging for chain switches.

<sup>Written for commit de14ad5a4cb3c4fbbd3e32c712e55cd2e06870c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal organization of chain switch event handling with better separation of concerns.

* **Tests**
  * Added test coverage for chain switch event behavior and connection state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->