### PR TITLE
fix(utxorpc): populate ReadGenesis caip2 from network magic

### DIFF
--- a/utxorpc/query.go
+++ b/utxorpc/query.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -656,23 +657,13 @@ func (s *queryServiceServer) ReadGenesis(
 	return connect.NewResponse(resp), nil
 }
 
-const (
-	cardanoMainnetNetworkMagic uint32 = 764824073
-	cardanoPreprodNetworkMagic uint32 = 1
-	cardanoPreviewNetworkMagic uint32 = 2
-)
-
 func caip2FromNetworkMagic(networkMagic uint32) string {
-	switch networkMagic {
-	case cardanoMainnetNetworkMagic:
-		return "cardano:mainnet"
-	case cardanoPreprodNetworkMagic:
-		return "cardano:preprod"
-	case cardanoPreviewNetworkMagic:
-		return "cardano:preview"
-	default:
+	network, ok := ouroboros.NetworkByNetworkMagic(networkMagic)
+	if !ok {
 		return fmt.Sprintf("cardano:%d", networkMagic)
 	}
+
+	return "cardano:" + network.String()
 }
 
 func buildCardanoGenesis(

--- a/utxorpc/query_test.go
+++ b/utxorpc/query_test.go
@@ -17,10 +17,20 @@ package utxorpc
 import (
 	"testing"
 
+	"math"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCaip2FromNetworkMagic_KnownNetworks(t *testing.T) {
+	mainnet, ok := ouroboros.NetworkByName("mainnet")
+	require.True(t, ok, "expected mainnet network to exist")
+	preprod, ok := ouroboros.NetworkByName("preprod")
+	require.True(t, ok, "expected preprod network to exist")
+	preview, ok := ouroboros.NetworkByName("preview")
+	require.True(t, ok, "expected preview network to exist")
+
 	tests := []struct {
 		name   string
 		magic  uint32
@@ -28,17 +38,17 @@ func TestCaip2FromNetworkMagic_KnownNetworks(t *testing.T) {
 	}{
 		{
 			name:  "mainnet",
-			magic: cardanoMainnetNetworkMagic,
+			magic: mainnet.NetworkMagic,
 			caip2: "cardano:mainnet",
 		},
 		{
 			name:  "preprod",
-			magic: cardanoPreprodNetworkMagic,
+			magic: preprod.NetworkMagic,
 			caip2: "cardano:preprod",
 		},
 		{
 			name:  "preview",
-			magic: cardanoPreviewNetworkMagic,
+			magic: preview.NetworkMagic,
 			caip2: "cardano:preview",
 		},
 	}
@@ -54,8 +64,14 @@ func TestCaip2FromNetworkMagic_KnownNetworks(t *testing.T) {
 }
 
 func TestCaip2FromNetworkMagic_UnknownNetwork(t *testing.T) {
-	const unknownMagic uint32 = 42
-	got := caip2FromNetworkMagic(unknownMagic)
-	require.Equal(t, "cardano:42", got)
+	const devnetMagic uint32 = 42
+	got := caip2FromNetworkMagic(devnetMagic)
+	require.Equal(t, "cardano:devnet", got)
+}
+
+func TestCaip2FromNetworkMagic_CustomNetwork(t *testing.T) {
+	const customMagic uint32 = math.MaxUint32
+	got := caip2FromNetworkMagic(customMagic)
+	require.Equal(t, "cardano:4294967295", got)
 }
 


### PR DESCRIPTION
Closes #1477 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate the `caip2` field in `ReadGenesis` responses using Cardano network magic via `gouroboros` to return proper CAIP-2 chain IDs. Closes #1477.

- **Bug Fixes**
  - Use `gouroboros.NetworkByNetworkMagic` to derive CAIP-2 (mainnet, preprod, preview, devnet); fallback to "cardano:{magic}" for custom networks.
  - Set `Caip2` in `ReadGenesis` responses in `utxorpc`.
  - Add unit tests for known networks, devnet, and numeric fallback.

<sup>Written for commit 1c9bb97afc3fab5e3145a58fbb711ecb82473bcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Genesis responses now include CAIP2 identifiers derived from network magic for mainnet, preprod, preview, and other networks.

* **Tests**
  * Added unit tests validating CAIP2 identifier mappings, including known networks and fallback formatting for unknown network magic.

* **Style**
  * Minor logging formatting cleaned up for clearer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->