### PR TITLE
fix: reduce sync flapping on marginal peer leads

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -39,6 +39,7 @@ func safeAddUint64(a, b uint64) uint64 {
 const (
 	defaultEvaluationInterval = 10 * time.Second
 	defaultStaleTipThreshold  = 60 * time.Second
+	defaultMinSwitchBlockDiff = 2
 
 	// DefaultMaxTrackedPeers is the maximum number of peers tracked by
 	// the ChainSelector. When a new peer is added and the limit is reached,
@@ -79,6 +80,7 @@ type ChainSelectorConfig struct {
 	EventBus           *event.EventBus
 	EvaluationInterval time.Duration
 	StaleTipThreshold  time.Duration
+	MinSwitchBlockDiff uint64
 	SecurityParam      uint64
 	ConnectionEligible func(ouroboros.ConnectionId) bool
 	ConnectionPriority func(ouroboros.ConnectionId) int
@@ -113,6 +115,9 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 	}
 	if cfg.StaleTipThreshold == 0 {
 		cfg.StaleTipThreshold = defaultStaleTipThreshold
+	}
+	if cfg.MinSwitchBlockDiff == 0 {
+		cfg.MinSwitchBlockDiff = defaultMinSwitchBlockDiff
 	}
 	maxPeers := cfg.MaxTrackedPeers
 	if maxPeers <= 0 {
@@ -496,6 +501,50 @@ func (cs *ChainSelector) SelectBestChain() *ouroboros.ConnectionId {
 	return cs.selectBestChainLocked()
 }
 
+func (cs *ChainSelector) isPeerSelectableLocked(
+	connId ouroboros.ConnectionId,
+	peerTip *PeerChainTip,
+	logSkip bool,
+) bool {
+	if peerTip == nil {
+		return false
+	}
+	if !cs.isConnectionEligible(connId) {
+		if logSkip {
+			cs.config.Logger.Debug(
+				"skipping ineligible peer",
+				"connection_id", connId.String(),
+			)
+		}
+		return false
+	}
+	if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 &&
+		safeAddUint64(peerTip.Tip.BlockNumber, cs.securityParam) <
+			cs.localTip.BlockNumber {
+		if logSkip {
+			cs.config.Logger.Debug(
+				"skipping implausibly-behind peer",
+				"connection_id", connId.String(),
+				"peer_block_number", peerTip.Tip.BlockNumber,
+				"local_block_number", cs.localTip.BlockNumber,
+				"security_param", cs.securityParam,
+			)
+		}
+		return false
+	}
+	if cs.isPeerTipStale(peerTip) {
+		if logSkip {
+			cs.config.Logger.Debug(
+				"skipping stale peer",
+				"connection_id", connId.String(),
+				"last_updated", peerTip.LastUpdated,
+			)
+		}
+		return false
+	}
+	return true
+}
+
 func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 	if len(cs.peerTips) == 0 {
 		return nil
@@ -505,33 +554,7 @@ func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
 	var bestPeerTip *PeerChainTip
 
 	for connId, peerTip := range cs.peerTips {
-		if !cs.isConnectionEligible(connId) {
-			cs.config.Logger.Debug(
-				"skipping ineligible peer",
-				"connection_id", connId.String(),
-			)
-			continue
-		}
-		// Don't consider peers that are implausibly far behind local tip.
-		// This prevents switching to stale or cross-network peers when
-		// local tip and k are known.
-		if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 &&
-			safeAddUint64(peerTip.Tip.BlockNumber, cs.securityParam) < cs.localTip.BlockNumber {
-			cs.config.Logger.Debug(
-				"skipping implausibly-behind peer",
-				"connection_id", connId.String(),
-				"peer_block_number", peerTip.Tip.BlockNumber,
-				"local_block_number", cs.localTip.BlockNumber,
-				"security_param", cs.securityParam,
-			)
-			continue
-		}
-		if cs.isPeerTipStale(peerTip) {
-			cs.config.Logger.Debug(
-				"skipping stale peer",
-				"connection_id", connId.String(),
-				"last_updated", peerTip.LastUpdated,
-			)
+		if !cs.isPeerSelectableLocked(connId, peerTip, true) {
 			continue
 		}
 
@@ -677,22 +700,27 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 		previousBest := cs.bestPeerConn
 		if previousBest != nil && *previousBest != *newBest {
 			previousPeerTip, ok := cs.peerTips[*previousBest]
-			if ok {
+			if ok && cs.isPeerSelectableLocked(*previousBest, previousPeerTip, false) {
 				newPeerTip, ok := cs.peerTips[*newBest]
 				if !ok {
 					return
 				}
-				previousEligible := cs.isConnectionEligible(*previousBest)
-				previousFresh := !cs.isPeerTipStale(previousPeerTip)
 				// Preserve the incumbent only when it still wins the same
 				// full comparison used during normal best-peer selection.
-				if previousEligible && previousFresh &&
-					cs.comparePeerTips(
-						*previousBest,
-						previousPeerTip,
-						*newBest,
-						newPeerTip,
-					) == ChainABetter {
+				if cs.comparePeerTips(
+					*previousBest,
+					previousPeerTip,
+					*newBest,
+					newPeerTip,
+				) == ChainABetter {
+					newBest = previousBest
+				} else if newPeerTip.Tip.BlockNumber >
+					previousPeerTip.Tip.BlockNumber &&
+					!IsSignificantlyBetter(
+						newPeerTip.Tip,
+						previousPeerTip.Tip,
+						cs.config.MinSwitchBlockDiff,
+					) {
 					newBest = previousBest
 				}
 			}

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -301,10 +301,31 @@ func TestIncumbentAdvantageSwitchesWhenBehind(t *testing.T) {
 
 	cs.UpdatePeerTip(connId2, ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 101, Hash: []byte("tip2")},
-		BlockNumber: 51,
+		BlockNumber: 52,
 	}, nil)
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, connId2, *cs.GetBestPeer())
+}
+
+func TestIncumbentAdvantageKeepsPeerOnMarginalLead(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	cs.UpdatePeerTip(connId1, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(connId2, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("tip2")},
+		BlockNumber: 51,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
 }
 
 func TestNoOscillationWithMultiplePeersAtSameTip(t *testing.T) {
@@ -581,6 +602,33 @@ func TestChainSelectorSwitchesImmediatelyOnPriorityEvent(t *testing.T) {
 		bestPeer := cs.GetBestPeer()
 		return bestPeer != nil && *bestPeer == challengerConn
 	}, time.Second, 5*time.Millisecond)
+}
+
+func TestChainSelectorDoesNotPreserveImplausiblyBehindIncumbent(t *testing.T) {
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: 2,
+	})
+
+	cs.UpdatePeerTip(connId1, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 98, Hash: []byte("tip1")},
+		BlockNumber: 98,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("local")},
+		BlockNumber: 101,
+	})
+
+	cs.UpdatePeerTip(connId2, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 99, Hash: []byte("tip2")},
+		BlockNumber: 99,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
 func TestChainSelectorKeepsChallengerWhenItWinsFullTieBreak(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -73,6 +73,215 @@ type Node struct {
 	shutdownOnce   sync.Once
 }
 
+func plateauThreshold(stallTimeout time.Duration) time.Duration {
+	return max(2*stallTimeout, 4*time.Minute)
+}
+
+func shouldRecycleLocalTipPlateau(
+	now time.Time,
+	lastProgressAt time.Time,
+	localTipSlot uint64,
+	bestPeerTipSlot uint64,
+	lastRecycledAt *time.Time,
+	cooldown time.Duration,
+	threshold time.Duration,
+) bool {
+	if bestPeerTipSlot <= localTipSlot {
+		return false
+	}
+	if now.Sub(lastProgressAt) <= threshold {
+		return false
+	}
+	if lastRecycledAt != nil && now.Sub(*lastRecycledAt) < cooldown {
+		return false
+	}
+	return true
+}
+
+func (n *Node) processChainsyncRecyclerTick(
+	now time.Time,
+	localTipSlot uint64,
+	chainsyncCfg chainsync.Config,
+	recycleAt map[string]time.Time,
+	lastRecycled map[string]time.Time,
+	lastProgressSlot *uint64,
+	lastProgressAt *time.Time,
+	plateauRecoveryThreshold time.Duration,
+	grace time.Duration,
+	cooldown time.Duration,
+) {
+	if localTipSlot > *lastProgressSlot {
+		*lastProgressSlot = localTipSlot
+		*lastProgressAt = now
+	}
+	n.chainsyncState.CheckStalledClients()
+	trackedClients := n.chainsyncState.GetTrackedClients()
+	trackedByID := make(
+		map[string]chainsync.TrackedClient,
+		len(trackedClients),
+	)
+	for _, conn := range trackedClients {
+		connKey := conn.ConnId.String()
+		trackedByID[connKey] = conn
+		if conn.Status != chainsync.ClientStatusStalled {
+			delete(recycleAt, connKey)
+		}
+	}
+	// Prune expired cooldown entries so this map does
+	// not grow without bound over long runtimes.
+	for connKey, last := range lastRecycled {
+		if now.Sub(last) >= cooldown {
+			delete(lastRecycled, connKey)
+		}
+	}
+	// Safety net: if local tip has not moved for a long time
+	// while peers are ahead, recycle the selected chainsync
+	// connection even if it is not marked stalled.
+	if n.chainSelector != nil {
+		if bestPeer := n.chainSelector.GetBestPeer(); bestPeer != nil {
+			if bestPeerTip := n.chainSelector.GetPeerTip(*bestPeer); bestPeerTip != nil &&
+				bestPeerTip.Tip.Point.Slot > localTipSlot {
+				targetConn := n.chainsyncState.GetClientConnId()
+				if targetConn == nil {
+					targetCopy := *bestPeer
+					targetConn = &targetCopy
+				}
+				connKey := targetConn.String()
+				var lastRecycledAt *time.Time
+				if last, ok := lastRecycled[connKey]; ok {
+					lastCopy := last
+					lastRecycledAt = &lastCopy
+				}
+				if shouldRecycleLocalTipPlateau(
+					now,
+					*lastProgressAt,
+					localTipSlot,
+					bestPeerTip.Tip.Point.Slot,
+					lastRecycledAt,
+					cooldown,
+					plateauRecoveryThreshold,
+				) {
+					n.config.logger.Warn(
+						"local tip plateau detected, recycling chainsync connection",
+						"connection_id", connKey,
+						"local_tip_slot", localTipSlot,
+						"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+						"plateau_duration", now.Sub(*lastProgressAt),
+					)
+					n.eventBus.PublishAsync(
+						connmanager.ConnectionRecycleRequestedEventType,
+						event.NewEvent(
+							connmanager.ConnectionRecycleRequestedEventType,
+							connmanager.ConnectionRecycleRequestedEvent{
+								ConnectionId: *targetConn,
+								ConnKey:      connKey,
+								Reason:       "local_tip_plateau",
+							},
+						),
+					)
+					delete(recycleAt, connKey)
+					lastRecycled[connKey] = now
+					*lastProgressAt = now
+				}
+			}
+		}
+	}
+	for _, conn := range trackedClients {
+		if conn.Status != chainsync.ClientStatusStalled {
+			continue
+		}
+		connKey := conn.ConnId.String()
+		if _, exists := recycleAt[connKey]; !exists {
+			recycleAt[connKey] = now.Add(grace)
+			n.config.logger.Info(
+				"chainsync client stalled, scheduling guarded recycle",
+				"connection_id", connKey,
+				"stall_timeout", chainsyncCfg.StallTimeout,
+				"grace_period", grace,
+			)
+		}
+	}
+	for connKey, dueAt := range recycleAt {
+		if now.Before(dueAt) {
+			continue
+		}
+		tracked, ok := trackedByID[connKey]
+		if !ok || tracked.Status != chainsync.ClientStatusStalled {
+			delete(recycleAt, connKey)
+			continue
+		}
+		connId := tracked.ConnId
+		if last, ok := lastRecycled[connKey]; ok &&
+			now.Sub(last) < cooldown {
+			recycleAt[connKey] = now.Add(cooldown - now.Sub(last))
+			continue
+		}
+		active := n.chainsyncState.GetClientConnId()
+		if active == nil {
+			// If no active client is selected and this client
+			// is overdue + stalled, recycle to force a fresh
+			// connection attempt and avoid indefinite stalls.
+			n.config.logger.Warn(
+				"chainsync client stalled with no active selection, recycling connection",
+				"connection_id", connKey,
+				"stall_timeout", chainsyncCfg.StallTimeout,
+				"grace_period", grace,
+				"recycle_cooldown", cooldown,
+			)
+			n.eventBus.PublishAsync(
+				connmanager.ConnectionRecycleRequestedEventType,
+				event.NewEvent(
+					connmanager.ConnectionRecycleRequestedEventType,
+					connmanager.ConnectionRecycleRequestedEvent{
+						ConnectionId: connId,
+						ConnKey:      connKey,
+						Reason:       "stalled_connection_no_active_selection",
+					},
+				),
+			)
+			delete(recycleAt, connKey)
+			lastRecycled[connKey] = now
+			continue
+		}
+		if active.String() != connKey {
+			// Don't recycle non-primary stalled clients. Keep state clean.
+			n.eventBus.PublishAsync(
+				chainsync.ClientRemoveRequestedEventType,
+				event.NewEvent(
+					chainsync.ClientRemoveRequestedEventType,
+					chainsync.ClientRemoveRequestedEvent{
+						ConnId:  connId,
+						ConnKey: connKey,
+						Reason:  "stalled_non_primary_connection",
+					},
+				),
+			)
+			delete(recycleAt, connKey)
+			continue
+		}
+		n.config.logger.Warn(
+			"chainsync client stalled, recycling active connection",
+			"connection_id", connKey,
+			"stall_timeout", chainsyncCfg.StallTimeout,
+			"grace_period", grace,
+			"recycle_cooldown", cooldown,
+		)
+		n.eventBus.PublishAsync(
+			connmanager.ConnectionRecycleRequestedEventType,
+			event.NewEvent(
+				connmanager.ConnectionRecycleRequestedEventType,
+				connmanager.ConnectionRecycleRequestedEvent{
+					ConnectionId: connId,
+					ConnKey:      connKey,
+					Reason:       "stalled_active_connection",
+				},
+			),
+		)
+		delete(recycleAt, connKey)
+		lastRecycled[connKey] = now
+	}
+}
+
 func (n *Node) handleChainSwitchEvent(evt event.Event) {
 	e, ok := evt.Data.(chainselection.ChainSwitchEvent)
 	if !ok {
@@ -506,11 +715,11 @@ func (n *Node) Run(ctx context.Context) error {
 				defer ticker.Stop()
 				recycleAt := make(map[string]time.Time)
 				lastRecycled := make(map[string]time.Time)
-				lastProgressSlot := n.chainManager.PrimaryChain().Tip().Point.Slot
+				lastProgressSlot := n.ledgerState.Tip().Point.Slot
 				lastProgressAt := time.Now()
-				// Trigger plateau recovery before the hard 10m SLO so
-				// recycle + reconnect time does not breach the budget.
-				const plateauThreshold = 8 * time.Minute
+				plateauRecoveryThreshold := plateauThreshold(
+					chainsyncCfg.StallTimeout,
+				)
 				for {
 					select {
 					case <-recyclerCtx.Done():
@@ -518,7 +727,7 @@ func (n *Node) Run(ctx context.Context) error {
 					case <-ticker.C:
 						n.runStallCheckerTick(func() {
 							now := time.Now()
-							localTip := n.chainManager.PrimaryChain().Tip()
+							localTip := n.ledgerState.Tip()
 							localTipSlot := localTip.Point.Slot
 							if n.chainSelector != nil {
 								n.chainSelector.SetLocalTip(localTip)
@@ -526,165 +735,18 @@ func (n *Node) Run(ctx context.Context) error {
 									n.chainSelector.SetSecurityParam(uint64(k)) //nolint:gosec
 								}
 							}
-							if localTipSlot > lastProgressSlot {
-								lastProgressSlot = localTipSlot
-								lastProgressAt = now
-							}
-							n.chainsyncState.CheckStalledClients()
-							trackedClients := n.chainsyncState.GetTrackedClients()
-							trackedByID := make(
-								map[string]chainsync.TrackedClient,
-								len(trackedClients),
+							n.processChainsyncRecyclerTick(
+								now,
+								localTipSlot,
+								chainsyncCfg,
+								recycleAt,
+								lastRecycled,
+								&lastProgressSlot,
+								&lastProgressAt,
+								plateauRecoveryThreshold,
+								grace,
+								cooldown,
 							)
-							for _, conn := range trackedClients {
-								connKey := conn.ConnId.String()
-								trackedByID[connKey] = conn
-								if conn.Status != chainsync.ClientStatusStalled {
-									delete(recycleAt, connKey)
-								}
-							}
-							// Prune expired cooldown entries so this map does
-							// not grow without bound over long runtimes.
-							for connKey, last := range lastRecycled {
-								if now.Sub(last) >= cooldown {
-									delete(lastRecycled, connKey)
-								}
-							}
-							// Safety net: if local tip has not moved for a long time
-							// while peers are ahead, recycle the selected chainsync
-							// connection even if it is not marked stalled.
-							if now.Sub(lastProgressAt) > plateauThreshold &&
-								n.chainSelector != nil {
-								if bestPeer := n.chainSelector.GetBestPeer(); bestPeer != nil {
-									if bestPeerTip := n.chainSelector.GetPeerTip(*bestPeer); bestPeerTip != nil &&
-										bestPeerTip.Tip.Point.Slot > localTipSlot {
-										targetConn := n.chainsyncState.GetClientConnId()
-										if targetConn == nil {
-											targetCopy := *bestPeer
-											targetConn = &targetCopy
-										}
-										connKey := targetConn.String()
-										if last, ok := lastRecycled[connKey]; !ok ||
-											now.Sub(last) >= cooldown {
-											n.config.logger.Warn(
-												"local tip plateau detected, recycling chainsync connection",
-												"connection_id", connKey,
-												"local_tip_slot", localTipSlot,
-												"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
-												"plateau_duration", now.Sub(lastProgressAt),
-											)
-											n.eventBus.PublishAsync(
-												connmanager.ConnectionRecycleRequestedEventType,
-												event.NewEvent(
-													connmanager.ConnectionRecycleRequestedEventType,
-													connmanager.ConnectionRecycleRequestedEvent{
-														ConnectionId: *targetConn,
-														ConnKey:      connKey,
-														Reason:       "local_tip_plateau",
-													},
-												),
-											)
-											delete(recycleAt, connKey)
-											lastRecycled[connKey] = now
-											lastProgressAt = now
-										}
-									}
-								}
-							}
-							for _, conn := range trackedClients {
-								if conn.Status != chainsync.ClientStatusStalled {
-									continue
-								}
-								connKey := conn.ConnId.String()
-								if _, exists := recycleAt[connKey]; !exists {
-									recycleAt[connKey] = now.Add(grace)
-									n.config.logger.Info(
-										"chainsync client stalled, scheduling guarded recycle",
-										"connection_id", connKey,
-										"stall_timeout", chainsyncCfg.StallTimeout,
-										"grace_period", grace,
-									)
-								}
-							}
-							for connKey, dueAt := range recycleAt {
-								if now.Before(dueAt) {
-									continue
-								}
-								tracked, ok := trackedByID[connKey]
-								if !ok || tracked.Status != chainsync.ClientStatusStalled {
-									delete(recycleAt, connKey)
-									continue
-								}
-								connId := tracked.ConnId
-								if last, ok := lastRecycled[connKey]; ok &&
-									now.Sub(last) < cooldown {
-									recycleAt[connKey] = now.Add(cooldown - now.Sub(last))
-									continue
-								}
-								active := n.chainsyncState.GetClientConnId()
-								if active == nil {
-									// If no active client is selected and this client
-									// is overdue + stalled, recycle to force a fresh
-									// connection attempt and avoid indefinite stalls.
-									n.config.logger.Warn(
-										"chainsync client stalled with no active selection, recycling connection",
-										"connection_id", connKey,
-										"stall_timeout", chainsyncCfg.StallTimeout,
-										"grace_period", grace,
-										"recycle_cooldown", cooldown,
-									)
-									n.eventBus.PublishAsync(
-										connmanager.ConnectionRecycleRequestedEventType,
-										event.NewEvent(
-											connmanager.ConnectionRecycleRequestedEventType,
-											connmanager.ConnectionRecycleRequestedEvent{
-												ConnectionId: connId,
-												ConnKey:      connKey,
-												Reason:       "stalled_connection_no_active_selection",
-											},
-										),
-									)
-									delete(recycleAt, connKey)
-									lastRecycled[connKey] = now
-									continue
-								}
-								if active.String() != connKey {
-									// Don't recycle non-primary stalled clients. Keep state clean.
-									n.eventBus.PublishAsync(
-										chainsync.ClientRemoveRequestedEventType,
-										event.NewEvent(
-											chainsync.ClientRemoveRequestedEventType,
-											chainsync.ClientRemoveRequestedEvent{
-												ConnId:  connId,
-												ConnKey: connKey,
-												Reason:  "stalled_non_primary_connection",
-											},
-										),
-									)
-									delete(recycleAt, connKey)
-									continue
-								}
-								n.config.logger.Warn(
-									"chainsync client stalled, recycling active connection",
-									"connection_id", connKey,
-									"stall_timeout", chainsyncCfg.StallTimeout,
-									"grace_period", grace,
-									"recycle_cooldown", cooldown,
-								)
-								n.eventBus.PublishAsync(
-									connmanager.ConnectionRecycleRequestedEventType,
-									event.NewEvent(
-										connmanager.ConnectionRecycleRequestedEventType,
-										connmanager.ConnectionRecycleRequestedEvent{
-											ConnectionId: connId,
-											ConnKey:      connKey,
-											Reason:       "stalled_active_connection",
-										},
-									),
-								)
-								delete(recycleAt, connKey)
-								lastRecycled[connKey] = now
-							}
 						})
 					}
 				}

--- a/node_test.go
+++ b/node_test.go
@@ -20,9 +20,11 @@ import (
 	"net"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -88,6 +90,206 @@ func TestHandleChainSwitchEventUpdatesActiveConnection(t *testing.T) {
 	assert.Equal(t, pointB, state.GetTrackedClient(connB).Cursor)
 	assert.Equal(t, uint64(1), state.GetTrackedClient(connA).HeadersRecv)
 	assert.Equal(t, uint64(1), state.GetTrackedClient(connB).HeadersRecv)
+}
+
+func TestPlateauThreshold(t *testing.T) {
+	assert.Equal(t, 4*time.Minute, plateauThreshold(2*time.Minute))
+	assert.Equal(t, 6*time.Minute, plateauThreshold(3*time.Minute))
+}
+
+func TestShouldRecycleLocalTipPlateau(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	lastProgressAt := now.Add(-5 * time.Minute)
+	threshold := 4 * time.Minute
+	cooldown := 2 * time.Minute
+
+	assert.True(t, shouldRecycleLocalTipPlateau(
+		now,
+		lastProgressAt,
+		100,
+		120,
+		nil,
+		cooldown,
+		threshold,
+	))
+
+	assert.False(t, shouldRecycleLocalTipPlateau(
+		now,
+		now.Add(-3*time.Minute),
+		100,
+		120,
+		nil,
+		cooldown,
+		threshold,
+	))
+
+	lastRecycledAt := now.Add(-1 * time.Minute)
+	assert.False(t, shouldRecycleLocalTipPlateau(
+		now,
+		lastProgressAt,
+		100,
+		120,
+		&lastRecycledAt,
+		cooldown,
+		threshold,
+	))
+
+	assert.False(t, shouldRecycleLocalTipPlateau(
+		now,
+		lastProgressAt,
+		120,
+		120,
+		nil,
+		cooldown,
+		threshold,
+	))
+}
+
+func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, recycleCh := bus.Subscribe(
+		connmanager.ConnectionRecycleRequestedEventType,
+	)
+
+	connId := newNodeTestConnId(1)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Millisecond,
+		},
+	)
+	require.True(t, state.AddClientConnId(connId))
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("best")},
+		BlockNumber: 60,
+	}, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	now := time.Now()
+	lastProgressSlot := uint64(100)
+	lastProgressAt := now
+	recycleAt := map[string]time.Time{
+		connId.String(): now.Add(-time.Second),
+	}
+	lastRecycled := make(map[string]time.Time)
+
+	n.processChainsyncRecyclerTick(
+		now,
+		100,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Millisecond,
+		},
+		recycleAt,
+		lastRecycled,
+		&lastProgressSlot,
+		&lastProgressAt,
+		plateauThreshold(2*time.Minute),
+		time.Second,
+		2*time.Minute,
+	)
+
+	select {
+	case evt := <-recycleCh:
+		recycleEvt, ok := evt.Data.(connmanager.ConnectionRecycleRequestedEvent)
+		require.True(t, ok)
+		assert.Equal(t, connId, recycleEvt.ConnectionId)
+		assert.Equal(
+			t,
+			"stalled_connection_no_active_selection",
+			recycleEvt.Reason,
+		)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected stalled recycler event")
+	}
+}
+
+func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, recycleCh := bus.Subscribe(
+		connmanager.ConnectionRecycleRequestedEventType,
+	)
+
+	connId := newNodeTestConnId(2)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Hour,
+		},
+	)
+	require.True(t, state.AddClientConnId(connId))
+	state.SetClientConnId(connId)
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("best")},
+		BlockNumber: 60,
+	}, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+	}
+
+	now := time.Now()
+	lastProgressSlot := uint64(100)
+	lastProgressAt := now.Add(-5 * time.Minute)
+	recycleAt := make(map[string]time.Time)
+	lastRecycled := make(map[string]time.Time)
+
+	n.processChainsyncRecyclerTick(
+		now,
+		100,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Hour,
+		},
+		recycleAt,
+		lastRecycled,
+		&lastProgressSlot,
+		&lastProgressAt,
+		4*time.Minute,
+		time.Second,
+		2*time.Minute,
+	)
+
+	select {
+	case evt := <-recycleCh:
+		recycleEvt, ok := evt.Data.(connmanager.ConnectionRecycleRequestedEvent)
+		require.True(t, ok)
+		assert.Equal(t, connId, recycleEvt.ConnectionId)
+		assert.Equal(t, "local_tip_plateau", recycleEvt.Reason)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected plateau recycler event")
+	}
 }
 
 func TestRunStallCheckerTickRecoversAndAllowsFutureTicks(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hysteresis to peer switching and tighten stall recovery to cut chainsync flapping on marginal leads and recycle safely based on progress and stall timeout.

- **Bug Fixes**
  - Added `MinSwitchBlockDiff` to `chainselection.ChainSelectorConfig` (default `2`); do not switch on equal tip or +1 block, and only switch when the challenger is significantly ahead or wins the full tie‑break.
  - Selector preserves the incumbent only if it remains eligible and fresh; skips stale or implausibly‑behind peers based on `SecurityParam` and local tip.
  - Tests cover marginal‑lead (+1 vs +2), implausibly‑behind incumbents, and multi‑peer same‑tip cases.

- **Refactors**
  - Extracted `isPeerSelectableLocked`, `plateauThreshold`, `shouldRecycleLocalTipPlateau`, and centralized recycler logic in `processChainsyncRecyclerTick`.
  - Recycler uses `ledgerState.Tip()` for progress, calls `CheckStalledClients()` each tick, prunes cooldowns, recycles only the active stalled client, and removes stalled non‑primary clients.
  - Plateau recovery threshold is `max(2*StallTimeout, 4m)` and recycling is gated by last progress and cooldown; tests added for threshold, plateau detection, and stalled paths.

<sup>Written for commit c6d82012bce00549cc0ec886d3234aeff639300f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain switching now favors incumbents unless challengers are significantly better and emits richer switch events.
  * Centralized recycling logic with plateau-based detection and recovery to better manage stalled progress.

* **Bug Fixes**
  * Improved handling of stale or implausibly-behind peers and reduced oscillation between peers.

* **Tests**
  * Added comprehensive tests for incumbent advantage, switching edge cases, plateau threshold logic, and recycler tick behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->