### PR TITLE
fix(chainsync): filter inbound peers from chain selection and fix dedup gap

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -672,6 +672,18 @@ func (c *ConnectionManager) GetConnectionById(
 	return nil // nil indicates connection not found
 }
 
+// IsInboundConnection returns true if the given connection ID is an inbound
+// connection (a remote peer connected to us). Inbound peers are clients
+// pulling data from us and should not be treated as chain truth sources.
+func (c *ConnectionManager) IsInboundConnection(connId ouroboros.ConnectionId) bool {
+	c.connectionsMutex.Lock()
+	defer c.connectionsMutex.Unlock()
+	if info, exists := c.connections[connId]; exists {
+		return info.isInbound
+	}
+	return false
+}
+
 // HandleConnectionRecycleRequestedEvent closes a connection when
 // a recycle request event is received.
 func (c *ConnectionManager) HandleConnectionRecycleRequestedEvent(

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -408,6 +408,11 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// Update tracked client state and deduplicate headers.
 		// If this header has already been reported by another
 		// client, skip publishing events for it.
+		// Inbound connections are clients pulling data from us.
+		// They are not sources of chain truth and should not
+		// influence chain selection or the blockfetch pipeline.
+		isInbound := o.ConnManager != nil &&
+			o.ConnManager.IsInboundConnection(ctx.ConnectionId)
 		if o.ChainsyncState != nil {
 			isNew := o.ChainsyncState.UpdateClientTip(
 				ctx.ConnectionId,
@@ -416,38 +421,67 @@ func (o *Ouroboros) chainsyncClientRollForward(
 			)
 			if !isNew {
 				// Duplicate header already seen from another
-				// client; skip downstream processing but still
-				// refresh peer liveness and update metrics.
-				o.EventBus.Publish(
-					chainselection.PeerTipUpdateEventType,
-					event.NewEvent(
+				// client; still refresh peer liveness and metrics
+				// for outbound peers used in chain selection.
+				if !isInbound {
+					o.EventBus.Publish(
 						chainselection.PeerTipUpdateEventType,
-						chainselection.PeerTipUpdateEvent{
-							ConnectionId: ctx.ConnectionId,
-							Tip:          tip,
-							VRFOutput:    vrfOutput,
-						},
-					),
-				)
+						event.NewEvent(
+							chainselection.PeerTipUpdateEventType,
+							chainselection.PeerTipUpdateEvent{
+								ConnectionId: ctx.ConnectionId,
+								Tip:          tip,
+								VRFOutput:    vrfOutput,
+							},
+						),
+					)
+				}
 				o.updateChainsyncMetrics(
 					ctx.ConnectionId,
 					tip,
 				)
+				// If this is the active connection, an inactive
+				// peer may have consumed the isNew=true slot
+				// before this connection's callback ran, so the
+				// header never reached the ledger. Publish the
+				// ChainsyncEvent anyway so blockfetch proceeds.
+				if active := o.ChainsyncState.GetClientConnId(); active != nil &&
+					*active == ctx.ConnectionId {
+					o.EventBus.Publish(
+						ledger.ChainsyncEventType,
+						event.NewEvent(
+							ledger.ChainsyncEventType,
+							ledger.ChainsyncEvent{
+								ConnectionId: ctx.ConnectionId,
+								Point:        point,
+								Type:         blockType,
+								BlockHeader:  v,
+								Tip:          tip,
+							},
+						),
+					)
+				}
 				return nil
 			}
 		}
-		// Publish peer tip update for chain selection
-		o.EventBus.Publish(
-			chainselection.PeerTipUpdateEventType,
-			event.NewEvent(
+		// Publish peer tip update for chain selection (outbound only).
+		// Inbound peers are clients pulling data from us, not sources
+		// of chain truth. Letting them into chain selection causes
+		// spurious switches when ephemeral inbound connections report
+		// tips and then disconnect.
+		if !isInbound {
+			o.EventBus.Publish(
 				chainselection.PeerTipUpdateEventType,
-				chainselection.PeerTipUpdateEvent{
-					ConnectionId: ctx.ConnectionId,
-					Tip:          tip,
-					VRFOutput:    vrfOutput,
-				},
-			),
-		)
+				event.NewEvent(
+					chainselection.PeerTipUpdateEventType,
+					chainselection.PeerTipUpdateEvent{
+						ConnectionId: ctx.ConnectionId,
+						Tip:          tip,
+						VRFOutput:    vrfOutput,
+					},
+				),
+			)
+		}
 		// Only feed ledger from the currently selected chainsync
 		// connection to avoid overloading the ledger subscriber
 		// queue with non-active peer traffic.


### PR DESCRIPTION
## Problem

Two related bugs in the chainsync pipeline that cause blockfetch to stall, most visible at tip.

### 1. Inbound peers polluting chain selection

`chainsyncClientRollForward` publishes `PeerTipUpdateEvent` for every connection including inbound ones. Inbound connections are clients pulling data from us — they are not sources of chain truth. When they report a tip and then disconnect, the chain selector reacts with a spurious switch that disrupts the active blockfetch pipeline.

### 2. Dedup gap on the active connection

The global `seenHeaders` dedup marks a header as seen the first time any peer reports it (`isNew=true`). If an inactive outbound peer's callback runs first, `isNew=true` is consumed but the `ChainsyncEvent` is suppressed (non-active connection). When the active connection's callback then runs, `isNew=false` → early return → no `ChainsyncEvent` → blockfetch never fires for that block.

## Fix

**`connmanager`**: Add `IsInboundConnection(connId)` method — reads `connectionInfo.isInbound` which is already tracked.

**`ouroboros/chainsync`**:
- Gate `PeerTipUpdateEvent` publication on `!isInbound` in both the `isNew=true` and `isNew=false` paths
- In the `isNew=false` path, check if the connection is the currently active chainsync connection. If so, publish `ChainsyncEvent` anyway — the inactive peer already consumed `isNew=true` but this connection is the one the ledger is listening to

## Testing

Observed on a preview network block producer: inbound filter eliminates spurious chain switches from connecting downstream clients; the dedup fix ensures blocks are queued for blockfetch when peer callbacks race.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop inbound peers from influencing chain selection and fix a dedup race that could stall blockfetch at tip. Only outbound peers publish tip updates, and the active connection always feeds the ledger when needed.

- **Bug Fixes**
  - Added `IsInboundConnection` in `connmanager` and gated `PeerTipUpdateEvent` in `ouroboros/chainsync` to ignore inbound peers, preventing spurious chain switches.
  - When a header is deduped (`isNew=false`) on the active chainsync connection, still publish `ChainsyncEvent` to the ledger to keep blockfetch moving.

<sup>Written for commit 49e13ddb493df8763bbf964152fd478c80e7f40b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced chain synchronization reliability by improving how the system handles different peer connection types
  * Refined peer tip update logic to ensure only reliable peer information is used for block fetching operations
  * Improved stability in multi-peer scenarios by processing peer information more selectively

<!-- end of auto-generated comment: release notes by coderabbit.ai -->