### PR TITLE
fix: offer wider intersect list

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -753,28 +753,44 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 		return nil
 	}
 	points := make([]ocommon.Point, 0, count)
-	seen := make(map[uint64]struct{}, count)
-	appendPoint := func(blockIndex uint64) bool {
+	seen := make(map[string]struct{}, count)
+	appendPoint := func(point ocommon.Point) bool {
 		if len(points) >= count {
 			return false
 		}
-		if _, ok := seen[blockIndex]; ok {
+		key := fmt.Sprintf("%d:%x", point.Slot, point.Hash)
+		if _, ok := seen[key]; ok {
 			return true
+		}
+		points = append(points, point)
+		seen[key] = struct{}{}
+		return true
+	}
+	appendBlockPoint := func(blockIndex uint64) bool {
+		if len(points) >= count {
+			return false
 		}
 		blk, err := c.blockByIndex(blockIndex)
 		if err != nil {
 			return false
 		}
-		points = append(
-			points,
+		return appendPoint(
 			ocommon.NewPoint(blk.Slot, blk.Hash),
 		)
-		seen[blockIndex] = struct{}{}
-		return true
+	}
+	denseStartIndex := c.tipBlockIndex
+	tip := c.currentTip.Point
+	if tip.Slot > 0 || len(tip.Hash) > 0 {
+		appendPoint(tip)
+		if denseStartIndex > initialBlockIndex {
+			denseStartIndex--
+		} else {
+			denseStartIndex = 0
+		}
 	}
 	denseCount := min(count, intersectDensePointCount)
-	for idx := c.tipBlockIndex; idx >= initialBlockIndex && len(points) < denseCount; idx-- {
-		if !appendPoint(idx) {
+	for idx := denseStartIndex; idx >= initialBlockIndex && len(points) < denseCount; idx-- {
+		if !appendBlockPoint(idx) {
 			break
 		}
 	}
@@ -788,12 +804,12 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 		if offset == 0 || offset >= c.tipBlockIndex {
 			break
 		}
-		if !appendPoint(c.tipBlockIndex - offset) {
+		if !appendBlockPoint(c.tipBlockIndex - offset) {
 			break
 		}
 	}
 	if len(points) < count {
-		_ = appendPoint(initialBlockIndex)
+		_ = appendBlockPoint(initialBlockIndex)
 	}
 	return points
 }

--- a/chain/intersect_internal_test.go
+++ b/chain/intersect_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+func TestIntersectPointsKeepsCurrentTipFallback(t *testing.T) {
+	db, err := database.New(&database.Config{
+		DataDir:        t.TempDir(),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	persistedBlock := models.Block{
+		ID:     initialBlockIndex,
+		Slot:   1,
+		Hash:   bytes.Repeat([]byte{0x01}, 32),
+		Number: 1,
+		Cbor:   []byte{0x80},
+	}
+	require.NoError(t, db.BlockCreate(persistedBlock, nil))
+
+	cm, err := NewManager(db, nil)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+
+	pendingTip := ocommon.NewPoint(2, bytes.Repeat([]byte{0xde}, 32))
+	c.currentTip = ochainsync.Tip{
+		Point:       pendingTip,
+		BlockNumber: 2,
+	}
+	c.tipBlockIndex = initialBlockIndex + 1
+
+	points := c.IntersectPoints(4)
+	require.Len(t, points, 2)
+	require.Equal(t, pendingTip.Slot, points[0].Slot)
+	require.Equal(t, pendingTip.Hash, points[0].Hash)
+	require.Equal(t, persistedBlock.Slot, points[1].Slot)
+	require.Equal(t, persistedBlock.Hash, points[1].Hash)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3092,7 +3092,10 @@ func (ls *LedgerState) IntersectPoints(
 		return nil, nil
 	}
 	if ls.chain != nil {
-		return ls.chain.IntersectPoints(count), nil
+		points := ls.chain.IntersectPoints(count)
+		if len(points) > 0 {
+			return points, nil
+		}
 	}
 	return ls.RecentChainPoints(count)
 }

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -32,9 +32,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
@@ -2132,4 +2134,28 @@ func TestCleanupOrphanedBlobs_SlotZero(t *testing.T) {
 	// Verify block at slot 1 was deleted
 	_, err = database.BlockByPoint(db, makeTestPoint(block))
 	assert.Error(t, err, "block at slot 1 should be deleted")
+}
+
+func TestIntersectPointsReturnsStorageErrorWhenSampledListIsEmpty(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	txn := db.BlobTxn(true)
+	err = txn.Do(func(txn *database.Txn) error {
+		return db.Blob().Set(
+			txn.Blob(),
+			dbtypes.BlockBlobIndexKey(1),
+			[]byte("bad"),
+		)
+	})
+	require.NoError(t, err)
+
+	ls := &LedgerState{
+		db:    db,
+		chain: cm.PrimaryChain(),
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.Error(t, err)
+	assert.Nil(t, points)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Broadened the ChainSync intersection list by including the in-memory tip and improving de-duplication to reduce missed intersections. Updated `ledger` to fall back only when the chain sample is empty and to surface storage errors.

- **Bug Fixes**
  - Include `currentTip` as the first intersect point when available; adjust dense scan to avoid re-adding it.
  - Deduplicate points by slot:hash instead of block index.
  - Always include the initial block index as a last-resort point when needed.
  - In `ledger`, return `chain`-sampled points when non-empty; otherwise use `RecentChainPoints` and propagate storage errors.
  - Added tests for pending tip inclusion and empty-sample storage error.

<sup>Written for commit 247cde26bef955fd91edd16e15ed92d96ef633b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain point sampling to better preserve the current tip in intersection results.
  * Added fallback mechanism when point list is empty, ensuring proper error handling.

* **Tests**
  * Added test coverage for tip preservation in chain operations.
  * Added test coverage for error scenarios in point sampling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->