### PR TITLE
fix(load): import Byron EBBs instead of skipping

### DIFF
--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -431,16 +431,9 @@ func copyBlocksRaw(
 			if next == nil {
 				break
 			}
-			// Skip EBBs — Byron Epoch Boundary Blocks have a
-			// different header layout that
-			// NewBlockHeaderFromCbor cannot decode. This is
-			// safe for chain continuity because EBBs are not
-			// part of the PrevHash chain: the next regular
-			// block's PrevHash points to the block before
-			// the EBB, not the EBB itself.
-			if next.IsEbb {
-				continue
-			}
+			// EBBs (Byron Epoch Boundary Blocks) must be
+			// imported: the next regular block's PrevHash
+			// references the EBB, not the block before it.
 			// Skip first block when continuing a load operation
 			if blocksCopied == 0 &&
 				next.Slot == chainTip.Point.Slot {


### PR DESCRIPTION
Closes #1700 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Import Byron Epoch Boundary Blocks (EBBs) during load instead of skipping them to keep the PrevHash chain intact and avoid gaps when resuming. Closes #1700.

<sup>Written for commit 36a9744030c59dafaf3d8434b6bdf28782b07b27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block import process to correctly handle Byron Epoch Boundary blocks during import operations, ensuring complete block sequences and maintaining proper block chain continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->