### PR TITLE
fix(chainsync): accept headers from all eligible peers

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -85,12 +85,16 @@ type ChainsyncClientState struct {
 // TrackedClient holds per-connection state for a tracked
 // chainsync client (outbound node-to-node connections).
 type TrackedClient struct {
-	ConnId       ouroboros.ConnectionId
-	Cursor       ocommon.Point
-	Tip          ochainsync.Tip
-	Status       ClientStatus
-	LastActivity time.Time
-	HeadersRecv  uint64
+	ConnId ouroboros.ConnectionId
+	Cursor ocommon.Point
+	Tip    ochainsync.Tip
+	Status ClientStatus
+	// ObservabilityOnly marks connections that should keep
+	// tip/activity metrics but must not consume the eligible
+	// client pool or become active for ledger ingress.
+	ObservabilityOnly bool
+	LastActivity      time.Time
+	HeadersRecv       uint64
 	// TODO: BytesRecv needs to be wired to the underlying
 	// connection's byte counter. Currently unused.
 	BytesRecv uint64
@@ -243,22 +247,24 @@ func (s *State) RemoveClientConnId(
 ) {
 	s.clientConnIdMutex.Lock()
 	defer s.clientConnIdMutex.Unlock()
+	tc, exists := s.trackedClients[connId]
 	wasPrimary := s.activeClientConnId != nil &&
 		*s.activeClientConnId == connId
+	wasEligible := exists && !tc.ObservabilityOnly
 	delete(s.trackedClients, connId)
 	if wasPrimary {
 		s.activeClientConnId = nil
 		s.promoteBestClientLocked()
 	}
 	// Emit client removed event
-	if s.eventBus != nil {
+	if wasEligible && s.eventBus != nil {
 		s.eventBus.PublishAsync(
 			ClientRemovedEventType,
 			event.NewEvent(
 				ClientRemovedEventType,
 				ClientRemovedEvent{
 					ConnId:       connId,
-					TotalClients: len(s.trackedClients),
+					TotalClients: s.eligibleClientCountLocked(),
 					WasPrimary:   wasPrimary,
 				},
 			),
@@ -286,7 +292,8 @@ func (s *State) promoteBestClientLocked() {
 	var bestId *ouroboros.ConnectionId
 	var bestSlot uint64
 	for id, tc := range s.trackedClients {
-		if tc.Status == ClientStatusFailed ||
+		if tc.ObservabilityOnly ||
+			tc.Status == ClientStatusFailed ||
 			tc.Status == ClientStatusStalled {
 			continue
 		}
@@ -305,25 +312,27 @@ func (s *State) promoteBestClientLocked() {
 // Caller must hold clientConnIdMutex.
 func (s *State) addTrackedClientLocked(
 	connId ouroboros.ConnectionId,
+	observabilityOnly bool,
 ) {
 	s.trackedClients[connId] = &TrackedClient{
-		ConnId:       connId,
-		Status:       ClientStatusSyncing,
-		LastActivity: time.Now(),
+		ConnId:            connId,
+		Status:            ClientStatusSyncing,
+		ObservabilityOnly: observabilityOnly,
+		LastActivity:      time.Now(),
 	}
 	// Set as active if there's no active client
-	if s.activeClientConnId == nil {
+	if !observabilityOnly && s.activeClientConnId == nil {
 		s.activeClientConnId = &connId
 	}
 	// Emit client added event
-	if s.eventBus != nil {
+	if !observabilityOnly && s.eventBus != nil {
 		s.eventBus.PublishAsync(
 			ClientAddedEventType,
 			event.NewEvent(
 				ClientAddedEventType,
 				ClientAddedEvent{
 					ConnId:       connId,
-					TotalClients: len(s.trackedClients),
+					TotalClients: s.eligibleClientCountLocked(),
 				},
 			),
 		)
@@ -339,6 +348,21 @@ func (s *State) AddClientConnId(
 	connId ouroboros.ConnectionId,
 ) bool {
 	return s.TryAddClientConnId(connId, s.config.MaxClients)
+}
+
+// TryAddObservedClientConnId adds a connection to observability-only tracking.
+// Observability-only clients do not consume the eligible client limit and are
+// never promoted as the active chainsync source.
+func (s *State) TryAddObservedClientConnId(
+	connId ouroboros.ConnectionId,
+) bool {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+	if _, exists := s.trackedClients[connId]; exists {
+		return false
+	}
+	s.addTrackedClientLocked(connId, true)
+	return true
 }
 
 // HasClientConnId returns true if the connection ID is being
@@ -373,7 +397,7 @@ func (s *State) GetClientConnIds() []ouroboros.ConnectionId {
 func (s *State) ClientConnCount() int {
 	s.clientConnIdMutex.RLock()
 	defer s.clientConnIdMutex.RUnlock()
-	return len(s.trackedClients)
+	return s.eligibleClientCountLocked()
 }
 
 // TryAddClientConnId atomically checks if a connection can be
@@ -391,20 +415,128 @@ func (s *State) TryAddClientConnId(
 		return false
 	}
 	// Check client limit
-	if len(s.trackedClients) >= maxClients {
+	if s.eligibleClientCountLocked() >= maxClients {
 		return false
 	}
-	s.addTrackedClientLocked(connId)
+	s.addTrackedClientLocked(connId, false)
+	return true
+}
+
+// ClientObservabilityOnly reports whether a tracked client is currently
+// observability-only. The second return value reports whether the client exists.
+func (s *State) ClientObservabilityOnly(
+	connId ouroboros.ConnectionId,
+) (bool, bool) {
+	s.clientConnIdMutex.RLock()
+	defer s.clientConnIdMutex.RUnlock()
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		return false, false
+	}
+	return tc.ObservabilityOnly, true
+}
+
+// SetClientObservabilityOnly toggles whether a tracked client participates in
+// the eligible chainsync pool. Promoting an observability-only client back into
+// the eligible pool respects MaxClients; when the pool is full, the client
+// remains observability-only and this method returns false.
+func (s *State) SetClientObservabilityOnly(
+	connId ouroboros.ConnectionId,
+	observabilityOnly bool,
+) bool {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		return false
+	}
+	if tc.ObservabilityOnly == observabilityOnly {
+		return true
+	}
+	if !observabilityOnly &&
+		s.config.MaxClients > 0 &&
+		s.eligibleClientCountLocked() >= s.config.MaxClients {
+		return false
+	}
+
+	wasPrimary := s.activeClientConnId != nil &&
+		*s.activeClientConnId == connId
+	wasEligible := !tc.ObservabilityOnly
+	tc.ObservabilityOnly = observabilityOnly
+	needPromote := false
+	if wasPrimary && observabilityOnly {
+		s.activeClientConnId = nil
+		needPromote = true
+	}
+	if !observabilityOnly && s.activeClientConnId == nil {
+		needPromote = true
+	}
+	if needPromote {
+		s.promoteBestClientLocked()
+	}
+
+	if s.eventBus == nil {
+		return true
+	}
+	if wasEligible && observabilityOnly {
+		s.eventBus.PublishAsync(
+			ClientRemovedEventType,
+			event.NewEvent(
+				ClientRemovedEventType,
+				ClientRemovedEvent{
+					ConnId:       connId,
+					TotalClients: s.eligibleClientCountLocked(),
+					WasPrimary:   wasPrimary,
+				},
+			),
+		)
+	}
+	if !wasEligible && !observabilityOnly {
+		s.eventBus.PublishAsync(
+			ClientAddedEventType,
+			event.NewEvent(
+				ClientAddedEventType,
+				ClientAddedEvent{
+					ConnId:       connId,
+					TotalClients: s.eligibleClientCountLocked(),
+				},
+			),
+		)
+	}
 	return true
 }
 
 // UpdateClientTip updates the cursor, tip, and activity
-// tracking for a tracked client. Returns true if the header at
-// this point is new (not a duplicate).
+// tracking for a tracked client, and performs header
+// deduplication. Returns true if the header at this point is
+// new (not a duplicate).
 func (s *State) UpdateClientTip(
 	connId ouroboros.ConnectionId,
 	point ocommon.Point,
 	tip ochainsync.Tip,
+) bool {
+	return s.updateClientTip(connId, point, tip, true)
+}
+
+// UpdateClientTipWithoutDedup updates the cursor, tip, and
+// activity tracking for a tracked client without recording the
+// header in the shared dedup cache. This is used for peers that
+// should not drive ledger ingress, so they do not suppress
+// later delivery of the same header from an eligible peer.
+func (s *State) UpdateClientTipWithoutDedup(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+	tip ochainsync.Tip,
+) {
+	s.updateClientTip(connId, point, tip, false)
+}
+
+func (s *State) updateClientTip(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+	tip ochainsync.Tip,
+	dedup bool,
 ) bool {
 	s.clientConnIdMutex.Lock()
 	tc, exists := s.trackedClients[connId]
@@ -421,6 +553,9 @@ func (s *State) UpdateClientTip(
 	}
 	s.clientConnIdMutex.Unlock()
 
+	if !dedup {
+		return true
+	}
 	// Header deduplication and fork detection
 	return s.processHeader(connId, point)
 }
@@ -524,7 +659,8 @@ func (s *State) CheckStalledClients() []ouroboros.ConnectionId {
 	now := time.Now()
 	var stalled []ouroboros.ConnectionId
 	for id, tc := range s.trackedClients {
-		if tc.Status == ClientStatusStalled ||
+		if tc.ObservabilityOnly ||
+			tc.Status == ClientStatusStalled ||
 			tc.Status == ClientStatusFailed {
 			continue
 		}
@@ -642,4 +778,14 @@ func (s *State) PruneSeenHeaders(beforeSlot uint64) {
 			delete(s.seenHeaders, slot)
 		}
 	}
+}
+
+func (s *State) eligibleClientCountLocked() int {
+	count := 0
+	for _, tc := range s.trackedClients {
+		if !tc.ObservabilityOnly {
+			count++
+		}
+	}
+	return count
 }

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -120,6 +120,112 @@ func TestTryAddClientConnId_DuplicateRejected(t *testing.T) {
 	require.Equal(t, 1, s.ClientConnCount())
 }
 
+func TestTryAddObservedClientConnId_DoesNotConsumeEligibleLimit(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.Config{
+		MaxClients:   1,
+		StallTimeout: 30 * time.Second,
+	})
+
+	connObserved := newTestConnId(1)
+	connEligible := newTestConnId(2)
+
+	require.True(t, s.TryAddObservedClientConnId(connObserved))
+	require.True(t, s.TryAddClientConnId(connEligible, 1))
+	require.True(t, s.HasClientConnId(connObserved))
+	require.True(t, s.HasClientConnId(connEligible))
+	require.Equal(t, 1, s.ClientConnCount())
+
+	observabilityOnly, exists := s.ClientObservabilityOnly(connObserved)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connEligible, *active)
+}
+
+func TestSetClientObservabilityOnly_DemotesPrimary(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	s.AddClientConnId(connB)
+	s.SetClientConnId(connA)
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(500, []byte("ha")),
+		ochainsync.Tip{Point: ocommon.NewPoint(500, []byte("ha"))},
+	)
+	s.UpdateClientTip(connB,
+		ocommon.NewPoint(400, []byte("hb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(400, []byte("hb"))},
+	)
+
+	require.True(t, s.SetClientObservabilityOnly(connA, true))
+	require.Equal(t, 1, s.ClientConnCount())
+
+	observabilityOnly, exists := s.ClientObservabilityOnly(connA)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connB, *active)
+}
+
+func TestSetClientObservabilityOnly_EligiblePromotionRespectsMaxClients(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.Config{
+		MaxClients:   1,
+		StallTimeout: 30 * time.Second,
+	})
+
+	connObserved := newTestConnId(1)
+	connEligible := newTestConnId(2)
+	require.True(t, s.TryAddObservedClientConnId(connObserved))
+	require.True(t, s.TryAddClientConnId(connEligible, 1))
+
+	require.False(t, s.SetClientObservabilityOnly(connObserved, false))
+
+	observabilityOnly, exists := s.ClientObservabilityOnly(connObserved)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+	require.Equal(t, 1, s.ClientConnCount())
+}
+
+func TestSetClientObservabilityOnly_PreservesCurrentActiveClient(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	s.AddClientConnId(connA)
+	require.True(t, s.TryAddObservedClientConnId(connB))
+	s.SetClientConnId(connA)
+	s.UpdateClientTip(connA,
+		ocommon.NewPoint(100, []byte("ha")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("ha"))},
+	)
+	s.UpdateClientTipWithoutDedup(connB,
+		ocommon.NewPoint(500, []byte("hb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(500, []byte("hb"))},
+	)
+
+	require.True(t, s.SetClientObservabilityOnly(connB, false))
+
+	active := s.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connA, *active)
+}
+
 func TestAddClientConnId_DuplicatePreservesState(
 	t *testing.T,
 ) {
@@ -604,6 +710,31 @@ func TestStallDetection_PrimaryFailover(t *testing.T) {
 	active := s.GetClientConnId()
 	require.NotNil(t, active)
 	require.Equal(t, connB, *active)
+}
+
+func TestStallDetection_SkipsObservabilityOnlyClient(t *testing.T) {
+	bus := newTestEventBus(t)
+	cfg := chainsync.Config{
+		MaxClients:   1,
+		StallTimeout: 50 * time.Millisecond,
+	}
+	s := newTestState(t, bus, cfg)
+
+	conn := newTestConnId(1)
+	require.True(t, s.TryAddObservedClientConnId(conn))
+	s.UpdateClientTipWithoutDedup(conn,
+		ocommon.NewPoint(100, []byte("ha")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("ha"))},
+	)
+
+	require.Eventually(t, func() bool {
+		return len(s.CheckStalledClients()) == 0
+	}, 250*time.Millisecond, 10*time.Millisecond)
+
+	tc := s.GetTrackedClient(conn)
+	require.NotNil(t, tc)
+	require.Equal(t, chainsync.ClientStatusSyncing, tc.Status)
+	require.True(t, tc.ObservabilityOnly)
 }
 
 // --- Client synced tests ---

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -256,26 +256,29 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 }
 
 // detectConnectionSwitch checks for an active connection change and logs a
-// summary of dropped events when a switch is detected. It returns the current
-// active connection ID and whether connection filtering is configured. When
-// configured is false, callers should skip all connection-based filtering.
-func (ls *LedgerState) detectConnectionSwitch() (activeConnId *ouroboros.ConnectionId, configured bool) {
+// summary of dropped rollback events when a switch is detected. It returns the
+// current active connection ID and whether connection filtering is configured.
+// When configured is false, callers should skip all connection-based filtering.
+func (ls *LedgerState) detectConnectionSwitch() (
+	activeConnId *ouroboros.ConnectionId,
+	configured bool,
+	switched bool,
+) {
 	if ls.config.GetActiveConnectionFunc == nil {
-		return nil, false
+		return nil, false, false
 	}
 	activeConnId = ls.config.GetActiveConnectionFunc()
 	if activeConnId != nil &&
 		(ls.lastActiveConnId == nil || *ls.lastActiveConnId != *activeConnId) {
+		switched = true
 		if ls.lastActiveConnId != nil {
 			ls.config.Logger.Info(
 				"active connection changed",
 				"component", "ledger",
 				"previous_connection_id", ls.lastActiveConnId.String(),
 				"new_connection_id", activeConnId.String(),
-				"dropped_headers", ls.dropEventCount,
 				"dropped_rollbacks", ls.dropRollbackCount,
 			)
-			ls.dropEventCount = 0
 			ls.dropRollbackCount = 0
 			ls.headerMismatchCount = 0
 			// Reset blockfetch state, but preserve queued headers. Valid
@@ -305,12 +308,12 @@ func (ls *LedgerState) detectConnectionSwitch() (activeConnId *ouroboros.Connect
 		ls.lastActiveConnId = activeConnId
 		ls.rollbackHistory = nil
 	}
-	return activeConnId, true
+	return activeConnId, true, switched
 }
 
 func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 	// Filter events from non-active connections when chain selection is enabled
-	if activeConnId, configured := ls.detectConnectionSwitch(); configured {
+	if activeConnId, configured, _ := ls.detectConnectionSwitch(); configured {
 		if activeConnId == nil {
 			// If we already have local chain progress, avoid applying
 			// rollback/header events until an active connection is
@@ -510,48 +513,6 @@ func (ls *LedgerState) resetChainsyncResyncState() {
 }
 
 func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
-	// Filter events from non-active connections when chain selection is enabled
-	if activeConnId, configured := ls.detectConnectionSwitch(); configured {
-		if activeConnId == nil {
-			// If we already have local chain progress, avoid applying
-			// events until an active connection is selected.
-			if ls.chain.Tip().Point.Slot > 0 {
-				ls.config.Logger.Debug(
-					"no active connection, dropping event",
-					"connection_id", e.ConnectionId.String(),
-					"slot", e.Point.Slot,
-					"local_tip_slot", ls.chain.Tip().Point.Slot,
-				)
-				return nil
-			}
-			ls.config.Logger.Debug(
-				"no active connection at origin, processing event",
-				"connection_id", e.ConnectionId.String(),
-				"slot", e.Point.Slot,
-			)
-		} else if *activeConnId != e.ConnectionId {
-			// Event is from non-active connection, skip
-			// Rate-limit this message to once per dropEventLogInterval
-			now := time.Now()
-			if now.Sub(ls.dropEventLastLog) >= dropEventLogInterval {
-				suppressed := ls.dropEventCount
-				ls.dropEventCount = 0
-				ls.dropEventLastLog = now
-				ls.config.Logger.Debug(
-					"dropping event from non-active connection",
-					"component", "ledger",
-					"event_connection_id", e.ConnectionId.String(),
-					"active_connection_id", activeConnId.String(),
-					"slot", e.Point.Slot,
-					"suppressed_since_last_log", suppressed,
-				)
-			} else {
-				ls.dropEventCount++
-			}
-			return nil
-		}
-	}
-
 	// Track upstream tip for sync progress reporting
 	if e.Tip.Point.Slot > ls.syncUpstreamTipSlot.Load() {
 		ls.syncUpstreamTipSlot.Store(e.Tip.Point.Slot)
@@ -706,26 +667,16 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		return nil
 	}
 	// Mark blockfetch as in progress
-	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
-	ls.activeBlockfetchConnId = e.ConnectionId
 	ls.selectedBlockfetchConnId = e.ConnectionId
-	// Request next bulk range
-	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
+	initialConnId := ls.selectInitialBlockfetchConn(e.ConnectionId)
 	ls.config.Logger.Debug(
 		"starting blockfetch",
 		"component", "ledger",
-		"header_start_slot", headerStart.Slot,
-		"header_end_slot", headerEnd.Slot,
+		"connection_id", initialConnId.String(),
 		"header_count", ls.chain.HeaderCount(),
 	)
-	err := ls.blockfetchRequestRangeStart(
-		e.ConnectionId,
-		headerStart,
-		headerEnd,
-	)
+	err := ls.startQueuedBlockfetchLocked(initialConnId)
 	if err != nil {
-		ls.blockfetchRequestRangeCleanup()
-		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return err
 	}
 	return nil
@@ -947,6 +898,42 @@ func (ls *LedgerState) nextBlockfetchConnId() (ouroboros.ConnectionId, bool) {
 		return ouroboros.ConnectionId{}, false
 	}
 	return ls.activeBlockfetchConnId, true
+}
+
+func (ls *LedgerState) nextBlockfetchConnIdExcept(
+	excludedConnId ouroboros.ConnectionId,
+) (ouroboros.ConnectionId, bool) {
+	if ls.selectedBlockfetchConnId != (ouroboros.ConnectionId{}) &&
+		ls.selectedBlockfetchConnId != excludedConnId {
+		return ls.selectedBlockfetchConnId, true
+	}
+	if ls.activeBlockfetchConnId == (ouroboros.ConnectionId{}) ||
+		ls.activeBlockfetchConnId == excludedConnId {
+		return ouroboros.ConnectionId{}, false
+	}
+	return ls.activeBlockfetchConnId, true
+}
+
+func (ls *LedgerState) startQueuedBlockfetchLocked(
+	connId ouroboros.ConnectionId,
+) error {
+	if ls.chain.HeaderCount() == 0 {
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		return nil
+	}
+	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	ls.activeBlockfetchConnId = connId
+	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
+	if err := ls.blockfetchRequestRangeStart(
+		connId,
+		headerStart,
+		headerEnd,
+	); err != nil {
+		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		return err
+	}
+	return nil
 }
 
 func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
@@ -1982,6 +1969,26 @@ func (ls *LedgerState) checkSlotBattle(
 	}
 }
 
+// selectInitialBlockfetchConn starts blockfetch on the same connection that
+// delivered the header. This keeps header and block ingress aligned and leaves
+// room for future selection logic if a different connection becomes preferable.
+func (ls *LedgerState) selectInitialBlockfetchConn(
+	headerConnId ouroboros.ConnectionId,
+) ouroboros.ConnectionId {
+	return headerConnId
+}
+
+func (ls *LedgerState) selectRetryBlockfetchConn(
+	currentConnId ouroboros.ConnectionId,
+) ouroboros.ConnectionId {
+	if ls.config.GetActiveConnectionFunc != nil {
+		if activeConnId := ls.config.GetActiveConnectionFunc(); activeConnId != nil {
+			return *activeConnId
+		}
+	}
+	return currentConnId
+}
+
 func (ls *LedgerState) blockfetchRequestRangeStart(
 	connId ouroboros.ConnectionId,
 	start ocommon.Point,
@@ -2018,16 +2025,7 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 			if ls.chainsyncBlockfetchTimerGeneration != currentGeneration {
 				return
 			}
-			ls.blockfetchRequestRangeCleanup()
-			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
-			ls.config.Logger.Info(
-				fmt.Sprintf(
-					"blockfetch operation timed out after %s",
-					blockfetchBusyTimeout,
-				),
-				"component",
-				"ledger",
-			)
+			ls.handleBlockfetchTimeoutLocked(connId)
 		},
 	)
 	return nil
@@ -2049,6 +2047,77 @@ func (ls *LedgerState) blockfetchRequestRangeCleanup() {
 		ls.chainsyncBlockfetchReadyChan = nil
 	}
 	ls.pendingBlockfetchEvents = ls.pendingBlockfetchEvents[:0]
+}
+
+func (ls *LedgerState) handleBlockfetchTimeoutLocked(
+	currentConnId ouroboros.ConnectionId,
+) {
+	headerCount := ls.chain.HeaderCount()
+	if headerCount == 0 {
+		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		ls.config.Logger.Info(
+			fmt.Sprintf(
+				"blockfetch operation timed out after %s",
+				blockfetchBusyTimeout,
+			),
+			"component",
+			"ledger",
+			"connection_id",
+			currentConnId.String(),
+		)
+		return
+	}
+
+	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
+	retryConnId := ls.selectRetryBlockfetchConn(currentConnId)
+	ls.blockfetchRequestRangeCleanup()
+	ls.config.Logger.Warn(
+		"blockfetch operation timed out, retrying queued range",
+		"component", "ledger",
+		"previous_connection_id", currentConnId.String(),
+		"retry_connection_id", retryConnId.String(),
+		"header_start_slot", headerStart.Slot,
+		"header_end_slot", headerEnd.Slot,
+		"header_count", headerCount,
+	)
+	if err := ls.startQueuedBlockfetchLocked(retryConnId); err != nil {
+		ls.config.Logger.Error(
+			"failed to retry blockfetch range after timeout",
+			"component", "ledger",
+			"connection_id", retryConnId.String(),
+			"error", err,
+		)
+		if nextConnId, ok := ls.nextBlockfetchConnIdExcept(retryConnId); ok {
+			ls.config.Logger.Warn(
+				"retrying queued range on alternate blockfetch connection",
+				"component", "ledger",
+				"failed_connection_id", retryConnId.String(),
+				"retry_connection_id", nextConnId.String(),
+				"header_count", ls.chain.HeaderCount(),
+			)
+			if retryErr := ls.startQueuedBlockfetchLocked(nextConnId); retryErr != nil {
+				ls.config.Logger.Error(
+					"failed to restart queued blockfetch after timeout retry failure",
+					"component", "ledger",
+					"connection_id", nextConnId.String(),
+					"error", retryErr,
+				)
+				if ls.chain.HeaderCount() > 0 && ls.config.EventBus != nil {
+					ls.config.EventBus.Publish(
+						event.ChainsyncResyncEventType,
+						event.NewEvent(
+							event.ChainsyncResyncEventType,
+							event.ChainsyncResyncEvent{
+								ConnectionId: retryConnId,
+								Reason:       "blockfetch timeout retry failed on all available connections",
+							},
+						),
+					)
+				}
+			}
+		}
+	}
 }
 
 func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
@@ -2096,18 +2165,8 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		return nil
 	}
 	// Mark blockfetch as in progress for next batch
-	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
-	ls.activeBlockfetchConnId = nextConnId
-	// Request next waiting bulk range using the active connection
-	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
-	err := ls.blockfetchRequestRangeStart(
-		nextConnId,
-		headerStart,
-		headerEnd,
-	)
+	err := ls.startQueuedBlockfetchLocked(nextConnId)
 	if err != nil {
-		ls.blockfetchRequestRangeCleanup()
-		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return err
 	}
 	return nil

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -26,6 +27,7 @@ import (
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,8 +95,9 @@ func TestDetectConnectionSwitchPreservesQueuedHeaders(t *testing.T) {
 		},
 	}
 
-	activeConnId, configured := ls.detectConnectionSwitch()
+	activeConnId, configured, switched := ls.detectConnectionSwitch()
 	require.True(t, configured)
+	require.True(t, switched)
 	require.NotNil(t, activeConnId)
 	assert.Equal(t, connId2, *activeConnId)
 	assert.Equal(t, 1, testChain.HeaderCount())
@@ -280,4 +283,190 @@ func TestHandleChainSwitchEventUpdatesSelectedBlockfetchConnId(t *testing.T) {
 	nextConnId, ok := ls.nextBlockfetchConnId()
 	require.True(t, ok)
 	assert.Equal(t, connId, nextConnId)
+}
+
+func TestHandleEventChainsyncBlockHeader_ProcessesEligibleNonActivePeer(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	hash1 := lcommon.NewBlake2b256([]byte("hdr-1"))
+	testChain := &chain.Chain{}
+	var requestedConn ouroboros.ConnectionId
+	ls := &LedgerState{
+		chain:            testChain,
+		lastActiveConnId: &connId1,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = start
+				_ = end
+				requestedConn = connId
+				return nil
+			},
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId2,
+		Point:        ocommon.NewPoint(1, hash1.Bytes()),
+		BlockHeader: mockHeader{
+			hash:        hash1,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 1,
+			slot:        1,
+		},
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(1, hash1.Bytes()),
+			BlockNumber: 1,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, testChain.HeaderCount())
+	assert.Equal(t, connId2, requestedConn)
+	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
+}
+
+func TestHandleBlockfetchTimeoutLocked_RetriesQueuedRangeUsingActivePeer(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	hash1 := lcommon.NewBlake2b256([]byte("hdr-1"))
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        hash1,
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+
+	var requestedConn ouroboros.ConnectionId
+	ls := &LedgerState{
+		chain:                  testChain,
+		activeBlockfetchConnId: connId1,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &connId2
+			},
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = start
+				_ = end
+				requestedConn = connId
+				return nil
+			},
+		},
+	}
+
+	ls.handleBlockfetchTimeoutLocked(connId1)
+
+	assert.Equal(t, connId2, requestedConn)
+	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
+	assert.Equal(t, 1, testChain.HeaderCount())
+}
+
+func TestHandleBlockfetchTimeoutLocked_ClearsActiveConnectionWithoutHeaders(
+	t *testing.T,
+) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+
+	ls := &LedgerState{
+		chain:                        &chain.Chain{},
+		activeBlockfetchConnId:       connId,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.handleBlockfetchTimeoutLocked(connId)
+
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.activeBlockfetchConnId)
+	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
+	_, ok := ls.nextBlockfetchConnId()
+	assert.False(t, ok)
+}
+
+func TestHandleBlockfetchTimeoutLocked_RetryFailureUsesAlternateSelectedPeer(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	connId3 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3003},
+	}
+	hash1 := lcommon.NewBlake2b256([]byte("hdr-1"))
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        hash1,
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+
+	requestedConnIds := make([]ouroboros.ConnectionId, 0, 2)
+	ls := &LedgerState{
+		chain:                    testChain,
+		activeBlockfetchConnId:   connId1,
+		selectedBlockfetchConnId: connId3,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &connId2
+			},
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = start
+				_ = end
+				requestedConnIds = append(requestedConnIds, connId)
+				if connId == connId2 {
+					return errors.New("retry failed")
+				}
+				return nil
+			},
+		},
+	}
+
+	ls.handleBlockfetchTimeoutLocked(connId1)
+
+	require.Equal(t, []ouroboros.ConnectionId{connId2, connId3}, requestedConnIds)
+	assert.Equal(t, connId3, ls.activeBlockfetchConnId)
+	require.NotNil(t, ls.chainsyncBlockfetchReadyChan)
+	assert.Equal(t, 1, testChain.HeaderCount())
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -492,9 +492,7 @@ type LedgerState struct {
 	syncUpstreamTipSlot  atomic.Uint64 // upstream peer's tip slot
 	nextNonceReadyEpoch  atomic.Uint64 // last ready epoch emitted for next-epoch nonce stability
 
-	// Rate-limiting for non-active connection drop messages (Fix 3)
-	dropEventLastLog    time.Time // last time we logged a drop event
-	dropEventCount      int64     // count of suppressed drop events since last log
+	// Rate-limiting for non-active rollback drop messages
 	dropRollbackLastLog time.Time // last time we logged a drop rollback
 	dropRollbackCount   int64     // count of suppressed drop rollbacks since last log
 

--- a/node.go
+++ b/node.go
@@ -49,32 +49,82 @@ import (
 )
 
 type Node struct {
-	connManager    *connmanager.ConnectionManager
-	peerGov        *peergov.PeerGovernor
-	chainsyncState *chainsync.State
-	chainSelector  *chainselection.ChainSelector
-	eventBus       *event.EventBus
-	mempool        *mempool.Mempool
-	chainManager   *chain.ChainManager
-	db             *database.Database
-	ledgerState    *ledger.LedgerState
-	snapshotMgr    *snapshot.Manager
-	utxorpc        *utxorpc.Utxorpc
-	bark           *bark.Bark
-	blockfrostAPI  *blockfrost.Blockfrost
-	meshAPI        *mesh.Server
-	ouroboros      *ouroborosPkg.Ouroboros
-	blockForger    *forging.BlockForger
-	leaderElection *leader.Election
-	shutdownFuncs  []func(context.Context) error
-	config         Config
-	ctx            context.Context
-	cancel         context.CancelFunc
-	shutdownOnce   sync.Once
+	connManager                      *connmanager.ConnectionManager
+	peerGov                          *peergov.PeerGovernor
+	chainsyncState                   *chainsync.State
+	chainSelector                    *chainselection.ChainSelector
+	eventBus                         *event.EventBus
+	mempool                          *mempool.Mempool
+	chainManager                     *chain.ChainManager
+	db                               *database.Database
+	ledgerState                      *ledger.LedgerState
+	snapshotMgr                      *snapshot.Manager
+	utxorpc                          *utxorpc.Utxorpc
+	bark                             *bark.Bark
+	blockfrostAPI                    *blockfrost.Blockfrost
+	meshAPI                          *mesh.Server
+	ouroboros                        *ouroborosPkg.Ouroboros
+	blockForger                      *forging.BlockForger
+	leaderElection                   *leader.Election
+	shutdownFuncs                    []func(context.Context) error
+	config                           Config
+	ctx                              context.Context
+	cancel                           context.CancelFunc
+	shutdownOnce                     sync.Once
+	chainsyncIngressEligibilityMu    sync.RWMutex
+	chainsyncIngressEligibilityCache map[ouroboros.ConnectionId]bool
 }
 
 func plateauThreshold(stallTimeout time.Duration) time.Duration {
 	return max(2*stallTimeout, 4*time.Minute)
+}
+
+func (n *Node) isChainsyncIngressEligible(
+	connId ouroboros.ConnectionId,
+) bool {
+	n.chainsyncIngressEligibilityMu.RLock()
+	defer n.chainsyncIngressEligibilityMu.RUnlock()
+	if n.chainsyncIngressEligibilityCache == nil {
+		return false
+	}
+	eligible, ok := n.chainsyncIngressEligibilityCache[connId]
+	if !ok {
+		return false
+	}
+	return eligible
+}
+
+func (n *Node) setChainsyncIngressEligibility(
+	connId ouroboros.ConnectionId,
+	eligible bool,
+) {
+	n.chainsyncIngressEligibilityMu.Lock()
+	defer n.chainsyncIngressEligibilityMu.Unlock()
+	if n.chainsyncIngressEligibilityCache == nil {
+		n.chainsyncIngressEligibilityCache = make(
+			map[ouroboros.ConnectionId]bool,
+		)
+	}
+	n.chainsyncIngressEligibilityCache[connId] = eligible
+}
+
+func (n *Node) deleteChainsyncIngressEligibility(
+	connId ouroboros.ConnectionId,
+) {
+	n.chainsyncIngressEligibilityMu.Lock()
+	defer n.chainsyncIngressEligibilityMu.Unlock()
+	if n.chainsyncIngressEligibilityCache == nil {
+		return
+	}
+	delete(n.chainsyncIngressEligibilityCache, connId)
+}
+
+func (n *Node) handlePeerEligibilityChangedEvent(evt event.Event) {
+	e, ok := evt.Data.(peergov.PeerEligibilityChangedEvent)
+	if !ok {
+		return
+	}
+	n.setChainsyncIngressEligibility(e.ConnectionId, e.Eligible)
 }
 
 func shouldRecycleLocalTipPlateau(
@@ -406,17 +456,21 @@ func (n *Node) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to load chain manager: %w", err)
 	}
 	n.chainManager = cm
+	n.chainsyncIngressEligibilityCache = make(
+		map[ouroboros.ConnectionId]bool,
+	)
 	// Initialize Ouroboros
 	n.ouroboros = ouroborosPkg.NewOuroboros(ouroborosPkg.OuroborosConfig{
-		Logger:          n.config.logger,
-		EventBus:        n.eventBus,
-		ConnManager:     n.connManager,
-		NetworkMagic:    n.config.networkMagic,
-		PeerSharing:     n.config.peerSharing,
-		IntersectTip:    n.config.intersectTip,
-		IntersectPoints: n.config.intersectPoints,
-		PromRegistry:    n.config.promRegistry,
-		EnableLeios:     n.config.runMode == runModeLeios,
+		Logger:                   n.config.logger,
+		EventBus:                 n.eventBus,
+		ConnManager:              n.connManager,
+		NetworkMagic:             n.config.networkMagic,
+		PeerSharing:              n.config.peerSharing,
+		IntersectTip:             n.config.intersectTip,
+		IntersectPoints:          n.config.intersectPoints,
+		PromRegistry:             n.config.promRegistry,
+		EnableLeios:              n.config.runMode == runModeLeios,
+		ChainsyncIngressEligible: n.isChainsyncIngressEligible,
 	})
 	// Load state
 	state, err := ledger.NewLedgerState(
@@ -432,7 +486,10 @@ func (n *Node) Run(ctx context.Context) error {
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
 			DatabaseWorkerPoolConfig:   n.config.DatabaseWorkerPoolConfig,
 			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
-				// Return the active chainsync client connection from chainsync state
+				// Return the current best peer for rollback filtering and
+				// blockfetch fallback. Headers can arrive from any eligible
+				// peer, but rollbacks and retry selection still need a
+				// current best connection.
 				if n.chainsyncState != nil {
 					return n.chainsyncState.GetClientConnId()
 				}
@@ -542,6 +599,14 @@ func (n *Node) Run(ctx context.Context) error {
 	)
 	n.ouroboros.ChainsyncState = n.chainsyncState
 	n.eventBus.SubscribeFunc(
+		peergov.PeerEligibilityChangedEventType,
+		n.handlePeerEligibilityChangedEvent,
+	)
+	n.eventBus.SubscribeFunc(
+		peergov.PeerEligibilityChangedEventType,
+		n.ouroboros.HandlePeerEligibilityChangedEvent,
+	)
+	n.eventBus.SubscribeFunc(
 		chainsync.ClientRemoveRequestedEventType,
 		n.chainsyncState.HandleClientRemoveRequestedEvent,
 	)
@@ -588,6 +653,7 @@ func (n *Node) Run(ctx context.Context) error {
 				return
 			}
 			n.chainSelector.RemovePeer(e.ConnectionId)
+			n.deleteChainsyncIngressEligibility(e.ConnectionId)
 		},
 	)
 	// Start the chain selector

--- a/node_test.go
+++ b/node_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -90,6 +91,34 @@ func TestHandleChainSwitchEventUpdatesActiveConnection(t *testing.T) {
 	assert.Equal(t, pointB, state.GetTrackedClient(connB).Cursor)
 	assert.Equal(t, uint64(1), state.GetTrackedClient(connA).HeadersRecv)
 	assert.Equal(t, uint64(1), state.GetTrackedClient(connB).HeadersRecv)
+}
+
+func TestChainsyncIngressEligibilityCacheDefaultsAndUpdates(t *testing.T) {
+	connId := newNodeTestConnId(3003)
+	n := &Node{}
+
+	assert.False(t, n.isChainsyncIngressEligible(connId))
+
+	n.handlePeerEligibilityChangedEvent(event.NewEvent(
+		peergov.PeerEligibilityChangedEventType,
+		peergov.PeerEligibilityChangedEvent{
+			ConnectionId: connId,
+			Eligible:     false,
+		},
+	))
+	assert.False(t, n.isChainsyncIngressEligible(connId))
+
+	n.handlePeerEligibilityChangedEvent(event.NewEvent(
+		peergov.PeerEligibilityChangedEventType,
+		peergov.PeerEligibilityChangedEvent{
+			ConnectionId: connId,
+			Eligible:     true,
+		},
+	))
+	assert.True(t, n.isChainsyncIngressEligible(connId))
+
+	n.deleteChainsyncIngressEligibility(connId)
+	assert.False(t, n.isChainsyncIngressEligible(connId))
 }
 
 func TestPlateauThreshold(t *testing.T) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -461,12 +461,15 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	point ocommon.Point,
 	tip ochainsync.Tip,
 ) error {
-	// Only feed ledger from the currently selected chainsync connection.
-	if o.ChainsyncState != nil {
-		if active := o.ChainsyncState.GetClientConnId(); active != nil &&
-			*active != ctx.ConnectionId {
-			return nil
-		}
+	if o.ConnManager != nil &&
+		o.ConnManager.IsInboundConnection(ctx.ConnectionId) {
+		return nil
+	}
+	if !o.reconcileChainsyncIngressAdmission(
+		ctx.ConnectionId,
+		o.shouldPublishChainsyncToLedger(ctx.ConnectionId),
+	) {
+		return nil
 	}
 	// Generate event
 	o.EventBus.Publish(
@@ -499,63 +502,35 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// selection tie-breaking (used in both dedup and normal
 		// paths below).
 		vrfOutput := chainselection.GetVRFOutput(v)
-		// Update tracked client state and deduplicate headers.
-		// If this header has already been reported by another
-		// client, skip publishing events for it.
 		// Inbound connections are clients pulling data from us.
 		// They are not sources of chain truth and should not
 		// influence chain selection or the blockfetch pipeline.
 		isInbound := o.ConnManager != nil &&
 			o.ConnManager.IsInboundConnection(ctx.ConnectionId)
-		if o.ChainsyncState != nil {
-			isNew := o.ChainsyncState.UpdateClientTip(
+		ingressEligible := false
+		if !isInbound {
+			ingressEligible = o.reconcileChainsyncIngressAdmission(
 				ctx.ConnectionId,
-				point,
-				tip,
+				o.shouldPublishChainsyncToLedger(ctx.ConnectionId),
 			)
-			if !isNew {
-				// Duplicate header already seen from another
-				// client; still refresh peer liveness and metrics
-				// for outbound peers used in chain selection.
-				if !isInbound {
-					o.EventBus.Publish(
-						chainselection.PeerTipUpdateEventType,
-						event.NewEvent(
-							chainselection.PeerTipUpdateEventType,
-							chainselection.PeerTipUpdateEvent{
-								ConnectionId: ctx.ConnectionId,
-								Tip:          tip,
-								VRFOutput:    vrfOutput,
-							},
-						),
-					)
-				}
-				o.updateChainsyncMetrics(
+		}
+		// Update tracked client state and deduplicate headers.
+		// If this header has already been reported by another
+		// eligible client, skip publishing it into the ledger.
+		isNew := true
+		if o.ChainsyncState != nil {
+			if ingressEligible {
+				isNew = o.ChainsyncState.UpdateClientTip(
 					ctx.ConnectionId,
+					point,
 					tip,
 				)
-				// If this is the active connection, an inactive
-				// peer may have consumed the isNew=true slot
-				// before this connection's callback ran, so the
-				// header never reached the ledger. Publish the
-				// ChainsyncEvent anyway so blockfetch proceeds.
-				if active := o.ChainsyncState.GetClientConnId(); active != nil &&
-					*active == ctx.ConnectionId {
-					o.EventBus.Publish(
-						ledger.ChainsyncEventType,
-						event.NewEvent(
-							ledger.ChainsyncEventType,
-							ledger.ChainsyncEvent{
-								ConnectionId: ctx.ConnectionId,
-								Point:        point,
-								Type:         blockType,
-								BlockHeader:  v,
-								Tip:          tip,
-							},
-						),
-					)
-				}
-				return nil
+			} else {
+				o.ChainsyncState.UpdateClientTipWithoutDedup(
+					ctx.ConnectionId,
+					point,
+					tip,
+				)
 			}
 		}
 		// Publish peer tip update for chain selection (outbound only).
@@ -576,45 +551,118 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				),
 			)
 		}
-		// Only feed ledger from the currently selected chainsync
-		// connection to avoid overloading the ledger subscriber
-		// queue with non-active peer traffic.
-		if o.ChainsyncState == nil {
-			o.EventBus.Publish(
-				ledger.ChainsyncEventType,
-				event.NewEvent(
-					ledger.ChainsyncEventType,
-					ledger.ChainsyncEvent{
-						ConnectionId: ctx.ConnectionId,
-						Point:        point,
-						Type:         blockType,
-						BlockHeader:  v,
-						Tip:          tip,
-					},
-				),
-			)
-		} else if active := o.ChainsyncState.GetClientConnId(); active == nil ||
-			*active == ctx.ConnectionId {
-			o.EventBus.Publish(
-				ledger.ChainsyncEventType,
-				event.NewEvent(
-					ledger.ChainsyncEventType,
-					ledger.ChainsyncEvent{
-						ConnectionId: ctx.ConnectionId,
-						Point:        point,
-						Type:         blockType,
-						BlockHeader:  v,
-						Tip:          tip,
-					},
-				),
-			)
+		if !ingressEligible {
+			o.updateChainsyncMetrics(ctx.ConnectionId, tip)
+			return nil
 		}
+		if !isNew {
+			// Duplicate header already delivered by another
+			// eligible peer. Keep the peer tip fresh, but do not
+			// re-publish the same header into the ledger queue.
+			o.updateChainsyncMetrics(ctx.ConnectionId, tip)
+			return nil
+		}
+		o.EventBus.Publish(
+			ledger.ChainsyncEventType,
+			event.NewEvent(
+				ledger.ChainsyncEventType,
+				ledger.ChainsyncEvent{
+					ConnectionId: ctx.ConnectionId,
+					Point:        point,
+					Type:         blockType,
+					BlockHeader:  v,
+					Tip:          tip,
+				},
+			),
+		)
 		// Update ChainSync performance metrics for peer scoring
 		o.updateChainsyncMetrics(ctx.ConnectionId, tip)
 	default:
 		return fmt.Errorf("unexpected block data type: %T", v)
 	}
 	return nil
+}
+
+func (o *Ouroboros) shouldPublishChainsyncToLedger(
+	connId ouroboros.ConnectionId,
+) bool {
+	if o.config.ChainsyncIngressEligible == nil {
+		return true
+	}
+	return o.config.ChainsyncIngressEligible(connId)
+}
+
+func (o *Ouroboros) maxTrackedChainsyncClients() int {
+	maxClients := defaultMaxChainsyncClients
+	if o.ChainsyncState != nil && o.ChainsyncState.MaxClients() > 0 {
+		maxClients = o.ChainsyncState.MaxClients()
+	}
+	return maxClients
+}
+
+func (o *Ouroboros) registerTrackedChainsyncClient(
+	connId ouroboros.ConnectionId,
+	ingressEligible bool,
+) bool {
+	if o.ChainsyncState == nil {
+		return false
+	}
+	if ingressEligible {
+		if o.ChainsyncState.TryAddClientConnId(
+			connId,
+			o.maxTrackedChainsyncClients(),
+		) {
+			return true
+		}
+		if o.ChainsyncState.HasClientConnId(connId) {
+			observabilityOnly, exists := o.ChainsyncState.ClientObservabilityOnly(
+				connId,
+			)
+			if !exists {
+				return false
+			}
+			if observabilityOnly {
+				return o.reconcileChainsyncIngressAdmission(connId, true)
+			}
+			return true
+		}
+		return false
+	}
+	if o.ChainsyncState.TryAddObservedClientConnId(connId) {
+		return true
+	}
+	return o.reconcileChainsyncIngressAdmission(connId, false)
+}
+
+func (o *Ouroboros) reconcileChainsyncIngressAdmission(
+	connId ouroboros.ConnectionId,
+	desiredEligible bool,
+) bool {
+	if o.ChainsyncState == nil {
+		return desiredEligible
+	}
+	observabilityOnly, exists := o.ChainsyncState.ClientObservabilityOnly(
+		connId,
+	)
+	if !exists {
+		return false
+	}
+	if desiredEligible {
+		if !observabilityOnly {
+			return true
+		}
+		if !o.ChainsyncState.SetClientObservabilityOnly(connId, false) {
+			return false
+		}
+		observabilityOnly, exists = o.ChainsyncState.ClientObservabilityOnly(
+			connId,
+		)
+		return exists && !observabilityOnly
+	}
+	if !observabilityOnly {
+		_ = o.ChainsyncState.SetClientObservabilityOnly(connId, true)
+	}
+	return false
 }
 
 // updateChainsyncMetrics calculates and updates ChainSync performance metrics

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -15,12 +15,90 @@
 package ouroboros
 
 import (
+	"net"
 	"testing"
+	"time"
 
 	dchainsync "github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/peergov"
+	"github.com/blinklabs-io/gouroboros"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
+
+type testBlockHeader struct {
+	hash        gledger.Blake2b256
+	prevHash    gledger.Blake2b256
+	blockNumber uint64
+	slotNumber  uint64
+	bodySize    uint64
+	bodyHash    gledger.Blake2b256
+}
+
+func (h *testBlockHeader) Hash() gledger.Blake2b256 {
+	return h.hash
+}
+
+func (h *testBlockHeader) PrevHash() gledger.Blake2b256 {
+	return h.prevHash
+}
+
+func (h *testBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+func (h *testBlockHeader) SlotNumber() uint64 {
+	return h.slotNumber
+}
+
+func (h *testBlockHeader) IssuerVkey() gledger.IssuerVkey {
+	return gledger.IssuerVkey{}
+}
+
+func (h *testBlockHeader) BlockBodySize() uint64 {
+	return h.bodySize
+}
+
+func (h *testBlockHeader) Era() gledger.Era {
+	return gledger.Era{}
+}
+
+func (h *testBlockHeader) Cbor() []byte {
+	return nil
+}
+
+func (h *testBlockHeader) BlockBodyHash() gledger.Blake2b256 {
+	return h.bodyHash
+}
+
+func newTestBlockHeader(slot, block uint64, hashByte byte) gledger.BlockHeader {
+	var hash gledger.Blake2b256
+	hash[0] = hashByte
+	return &testBlockHeader{
+		hash:        hash,
+		blockNumber: block,
+		slotNumber:  slot,
+	}
+}
+
+func newTestConnId(local, remote string) ouroboros.ConnectionId {
+	localAddr, err := net.ResolveTCPAddr("tcp", local)
+	if err != nil {
+		panic(err)
+	}
+	remoteAddr, err := net.ResolveTCPAddr("tcp", remote)
+	if err != nil {
+		panic(err)
+	}
+	return ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+}
 
 func TestNormalizeIntersectPoints(t *testing.T) {
 	points := []ocommon.Point{
@@ -99,5 +177,174 @@ func TestShouldRestartChainsyncOnSwitch(t *testing.T) {
 				),
 			)
 		})
+	}
+}
+
+func TestChainsyncClientRollForward_IneligiblePeerDoesNotPoisonDedup(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connEligible := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connIneligible := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	state := dchainsync.NewState(bus, nil)
+	require.True(t, state.AddClientConnId(connEligible))
+	require.True(t, state.AddClientConnId(connIneligible))
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(connId ouroboros.ConnectionId) bool {
+			return connId == connEligible
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+
+	header := newTestBlockHeader(42, 7, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(42, header.Hash().Bytes()),
+		BlockNumber: 7,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connIneligible},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	select {
+	case evt := <-ledgerCh:
+		t.Fatalf("unexpected ledger event from ineligible peer: %#v", evt)
+	default:
+	}
+
+	err = o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connEligible},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+
+	select {
+	case evt := <-ledgerCh:
+		data, ok := evt.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connEligible, data.ConnectionId)
+		require.Equal(t, tip.Point.Slot, data.Point.Slot)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected eligible peer header to feed the ledger")
+	}
+}
+
+func TestRegisterTrackedChainsyncClient_ObservabilityOnlyDoesNotConsumePool(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connObserved := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	connEligible := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	state := dchainsync.NewStateWithConfig(bus, nil, dchainsync.Config{
+		MaxClients:   1,
+		StallTimeout: time.Minute,
+	})
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	o.ChainsyncState = state
+
+	require.True(t, o.registerTrackedChainsyncClient(connObserved, false))
+	observabilityOnly, exists := state.ClientObservabilityOnly(connObserved)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+	require.Equal(t, 0, state.ClientConnCount())
+
+	require.True(t, o.registerTrackedChainsyncClient(connEligible, true))
+	require.Equal(t, 1, state.ClientConnCount())
+
+	active := state.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connEligible, *active)
+}
+
+func TestHandlePeerEligibilityChangedEvent_DemotesObservedIngress(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	state := dchainsync.NewState(bus, nil)
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connB))
+	state.SetClientConnId(connA)
+	state.UpdateClientTip(
+		connA,
+		ocommon.NewPoint(200, []byte("ha")),
+		ochainsync.Tip{Point: ocommon.NewPoint(200, []byte("ha"))},
+	)
+	state.UpdateClientTip(
+		connB,
+		ocommon.NewPoint(100, []byte("hb")),
+		ochainsync.Tip{Point: ocommon.NewPoint(100, []byte("hb"))},
+	)
+
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	o.ChainsyncState = state
+	o.HandlePeerEligibilityChangedEvent(event.NewEvent(
+		peergov.PeerEligibilityChangedEventType,
+		peergov.PeerEligibilityChangedEvent{
+			ConnectionId: connA,
+			Eligible:     false,
+		},
+	))
+
+	observabilityOnly, exists := state.ClientObservabilityOnly(connA)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+
+	active := state.GetClientConnId()
+	require.NotNil(t, active)
+	require.Equal(t, connB, *active)
+}
+
+func TestChainsyncClientRollForward_UntrackedPeerDoesNotPublishToLedger(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connId := newTestConnId("127.0.0.1:6000", "3.3.3.3:3001")
+	state := dchainsync.NewState(bus, nil)
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	header := newTestBlockHeader(42, 7, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(42, header.Hash().Bytes()),
+		BlockNumber: 7,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+
+	select {
+	case evt := <-ledgerCh:
+		t.Fatalf("unexpected ledger event from untracked peer: %#v", evt)
+	default:
 	}
 }

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -90,6 +90,11 @@ type OuroborosConfig struct {
 	// mini-protocol. A value of 0 uses DefaultMaxTxSubmissionsPerSecond.
 	// A negative value disables rate limiting.
 	MaxTxSubmissionsPerSecond int
+	// ChainsyncIngressEligible reports whether a peer is allowed to
+	// feed chainsync events into the ledger pipeline. This lets us
+	// keep inbound/public noise out of ledger ingress while still
+	// tracking peer tips separately for selection and observability.
+	ChainsyncIngressEligible func(ouroboros.ConnectionId) bool
 	// Enable experimental Leios protocol support
 	EnableLeios bool
 }
@@ -370,6 +375,22 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	}
 }
 
+func (o *Ouroboros) HandlePeerEligibilityChangedEvent(evt event.Event) {
+	e, ok := evt.Data.(peergov.PeerEligibilityChangedEvent)
+	if !ok {
+		o.config.Logger.Warn(
+			"received unexpected event data type for peer eligibility change event",
+			"expected", "peergov.PeerEligibilityChangedEvent",
+			"got", fmt.Sprintf("%T", evt.Data),
+		)
+		return
+	}
+	_ = o.reconcileChainsyncIngressAdmission(
+		e.ConnectionId,
+		e.Eligible,
+	)
+}
+
 func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	e, ok := evt.Data.(peergov.OutboundConnectionEvent)
 	if !ok {
@@ -395,12 +416,11 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	// the Ouroboros handshake/protocol negotiation has already failed and the
 	// peer will reject further mini-protocol starts on this connection.
 	if o.ChainsyncState != nil {
-		maxClients := defaultMaxChainsyncClients
-		if o.ChainsyncState.MaxClients() > 0 {
-			maxClients = o.ChainsyncState.MaxClients()
-		}
-		// Atomically check and add the client to avoid race conditions
-		if o.ChainsyncState.TryAddClientConnId(connId, maxClients) {
+		shouldStartChainsync := o.registerTrackedChainsyncClient(
+			connId,
+			o.shouldPublishChainsyncToLedger(connId),
+		)
+		if shouldStartChainsync {
 			if err := o.chainsyncClientStart(connId); err != nil {
 				// Roll back the registration on failure
 				o.ChainsyncState.RemoveClientConnId(connId)
@@ -419,7 +439,8 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 		} else if !o.ChainsyncState.HasClientConnId(connId) {
 			// Not already tracked and TryAdd failed means limit reached
 			o.config.Logger.Debug(
-				"chainsync client limit reached, skipping",
+				"chainsync client limit reached, skipping eligible admission",
+				"connection_id", connId.String(),
 			)
 		}
 	}
@@ -497,11 +518,7 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	// peergov stops tracking it and outbound retries are not blocked
 	// by a stale inbound.
 	if o.ChainsyncState != nil {
-		maxClients := defaultMaxChainsyncClients
-		if o.ChainsyncState.MaxClients() > 0 {
-			maxClients = o.ChainsyncState.MaxClients()
-		}
-		if o.ChainsyncState.TryAddClientConnId(connId, maxClients) {
+		if o.registerTrackedChainsyncClient(connId, false) {
 			if err := o.chainsyncClientStart(connId); err != nil {
 				o.ChainsyncState.RemoveClientConnId(connId)
 				o.config.Logger.Warn(

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -303,6 +303,23 @@ func (p *PeerGovernor) SetPeerHotByConnId(connId ouroboros.ConnectionId) {
 	}
 }
 
+func (p *PeerGovernor) IsChainSelectionEligible(
+	connId ouroboros.ConnectionId,
+) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	peerIdx := p.peerIndexByConnId(connId)
+	if peerIdx == -1 || p.peers[peerIdx] == nil {
+		return false
+	}
+	return chainSelectionState(
+		p.bootstrapExited,
+		p.peers[peerIdx].Source,
+		p.peers[peerIdx].Connection,
+	).eligible
+}
+
 func clonePeerConnection(conn *PeerConnection) *PeerConnection {
 	if conn == nil {
 		return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept ChainSync headers from any eligible peer and track ineligible peers as observability‑only so they don’t affect dedup or consume client slots. Rollbacks stay filtered to the active peer, and blockfetch starts on the header’s connection and retries queued ranges on the active peer after timeouts with fallback.

- **Bug Fixes**
  - `ouroboros`: Gate ledger ingress/dedup by `ChainsyncIngressEligible`; publish headers from any eligible peer; auto‑register outbound/inbound clients as eligible or observability‑only and reconcile on `PeerEligibilityChanged`; ignore inbound and untracked peers for ingress while still updating tips/metrics.
  - `chainsync`: Add observability‑only clients (`TryAddObservedClientConnId`, `SetClientObservabilityOnly`, `ClientObservabilityOnly`) that don’t count toward `MaxClients`, aren’t promoted or stalled, and use `UpdateClientTipWithoutDedup`; `ClientConnCount` and client add/remove events now reflect eligible count only.
  - `ledger`: Accept headers regardless of active connection; keep rollback filtering; start blockfetch on the header’s connection; on timeout, retry the queued range using the current active peer with fallback to the selected peer.
  - `node`/`peergov`: Provide `OuroborosConfig.ChainsyncIngressEligible` via a cached check; subscribe to `PeerEligibilityChanged` to update cache and reconcile clients; clear cache on disconnect; add `peergov.IsChainSelectionEligible`.
  - Tests cover: eligible non‑active header ingress, ineligible peer not poisoning dedup, observability‑only behavior and limits, stall detection skip, blockfetch timeout retry on active peer and fallback, and untracked peer ignored for ledger ingress.

<sup>Written for commit 1ec047c6a31a1c64c8afcfd943c9c4b2290b9faf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-peer chainsync eligibility and an "observability-only" mode so peers can be monitored without consuming active client slots.

* **Improvements**
  * More robust connection-switching, blockfetch timeout/retry and promotion logic to improve header processing and fetch continuity.
  * Stall detection and client-count reporting now ignore observability-only peers to avoid false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->