### PR TITLE
fix(config): use empty CardanoConfig default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -637,14 +637,10 @@ func LoadConfig(configFile string) (*Config, error) {
 		return nil, err
 	}
 
-	// Set default CardanoConfig path based on network if not provided by user
-	if globalConfig.CardanoConfig == "" {
-		if globalConfig.Network == "preview" {
-			globalConfig.CardanoConfig = "preview/config.json"
-		} else {
-			globalConfig.CardanoConfig = "/opt/cardano/" + globalConfig.Network + "/config.json"
-		}
-	}
+	// NOTE: Do not set a default CardanoConfig here. The network flag
+	// can be overridden after LoadConfig returns (see main.go
+	// PersistentPreRunE). Each consumer resolves the cardano config
+	// path using cfg.Network at call time instead.
 
 	_, err = LoadTopologyConfig()
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,7 +170,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 		EvictionWatermark:           0.90,
 		RejectionWatermark:          0.95,
 		BindAddr:                    "0.0.0.0",
-		CardanoConfig:               "preview/config.json", // Set dynamically based on network
+		CardanoConfig:               "", // Resolved by consumers using cfg.Network
 		DatabasePath:                ".dingo",
 		SocketPath:                  "dingo.socket",
 		IntersectTip:                false,
@@ -330,12 +330,10 @@ func TestLoadConfig_EmbeddedDefaults(t *testing.T) {
 		t.Fatalf("expected no error loading default config, got: %v", err)
 	}
 
-	// Should use embedded path for CardanoConfig
-	expected := "preview/config.json"
-	if cfg.CardanoConfig != expected {
+	// CardanoConfig is no longer set by LoadConfig; consumers resolve it
+	if cfg.CardanoConfig != "" {
 		t.Errorf(
-			"expected CardanoConfig to be %q, got %q",
-			expected,
+			"expected CardanoConfig to be empty, got %q",
 			cfg.CardanoConfig,
 		)
 	}
@@ -360,12 +358,10 @@ func TestLoadConfig_MainnetNetwork(t *testing.T) {
 		t.Fatalf("expected no error for non-preview network, got: %v", err)
 	}
 
-	// Should use /opt/cardano path for non-preview networks
-	expected := "/opt/cardano/mainnet/config.json"
-	if cfg.CardanoConfig != expected {
+	// CardanoConfig is no longer set by LoadConfig; consumers resolve it
+	if cfg.CardanoConfig != "" {
 		t.Errorf(
-			"expected CardanoConfig to be %q, got %q",
-			expected,
+			"expected CardanoConfig to be empty, got %q",
 			cfg.CardanoConfig,
 		)
 	}
@@ -386,12 +382,10 @@ func TestLoadConfig_DevnetNetwork(t *testing.T) {
 		t.Fatalf("expected no error for devnet network, got: %v", err)
 	}
 
-	// Should use /opt/cardano path for devnet network
-	expected := "/opt/cardano/devnet/config.json"
-	if cfg.CardanoConfig != expected {
+	// CardanoConfig is no longer set by LoadConfig; consumers resolve it
+	if cfg.CardanoConfig != "" {
 		t.Errorf(
-			"expected CardanoConfig to be %q, got %q",
-			expected,
+			"expected CardanoConfig to be empty, got %q",
 			cfg.CardanoConfig,
 		)
 	}
@@ -593,34 +587,28 @@ database:
 
 func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 	validTests := []struct {
-		name           string
-		network        string
-		wantConfigPath string
+		name    string
+		network string
 	}{
 		{
-			name:           "preview",
-			network:        "preview",
-			wantConfigPath: "preview/config.json",
+			name:    "preview",
+			network: "preview",
 		},
 		{
-			name:           "mainnet",
-			network:        "mainnet",
-			wantConfigPath: "/opt/cardano/mainnet/config.json",
+			name:    "mainnet",
+			network: "mainnet",
 		},
 		{
-			name:           "preprod",
-			network:        "preprod",
-			wantConfigPath: "/opt/cardano/preprod/config.json",
+			name:    "preprod",
+			network: "preprod",
 		},
 		{
-			name:           "hyphenated name",
-			network:        "my-devnet",
-			wantConfigPath: "/opt/cardano/my-devnet/config.json",
+			name:    "hyphenated name",
+			network: "my-devnet",
 		},
 		{
-			name:           "underscore name",
-			network:        "test_net",
-			wantConfigPath: "/opt/cardano/test_net/config.json",
+			name:    "underscore name",
+			network: "test_net",
 		},
 	}
 
@@ -643,11 +631,11 @@ func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 				)
 			}
 
-			if cfg.CardanoConfig != tt.wantConfigPath {
+			// CardanoConfig is resolved by consumers, not LoadConfig
+			if cfg.CardanoConfig != "" {
 				t.Errorf(
-					"CardanoConfig = %q, want %q",
+					"CardanoConfig = %q, want empty",
 					cfg.CardanoConfig,
-					tt.wantConfigPath,
 				)
 			}
 		})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop setting a default Cardano config path in `LoadConfig`. `CardanoConfig` now defaults to empty and is resolved by consumers using `cfg.Network`, preventing mismatches when the network is overridden later.

- **Bug Fixes**
  - Removed implicit Cardano config path logic from `LoadConfig`; consumers resolve it at call time.
  - Updated tests to expect an empty `CardanoConfig`.

<sup>Written for commit 1b418f98296dced476df85d72673ff7651661b85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

