### PR TITLE
fix: preserve stable leader schedules across rollbacks

### DIFF
--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -185,7 +185,7 @@ func (e *Election) Start(ctx context.Context) error {
 	)
 	if rollbackCh == nil {
 		e.logger.Warn(
-			"event bus not available, rollback invalidation will not be tracked",
+			"event bus not available, rollback schedule invalidation will not be tracked",
 			"component", "leader",
 		)
 	} else {
@@ -336,11 +336,25 @@ func (e *Election) rollbackLoop(
 	evtCh <-chan event.Event,
 ) {
 	for evt := range evtCh {
+		latest := evt
+	drain:
+		for {
+			select {
+			case newer, ok := <-evtCh:
+				if !ok {
+					return
+				}
+				latest = newer
+			default:
+				break drain
+			}
+		}
+
 		if ctx.Err() != nil {
 			return
 		}
 
-		restoreEvent, ok := evt.Data.(ledgerpkg.PoolStateRestoredEvent)
+		restoreEvent, ok := latest.Data.(ledgerpkg.PoolStateRestoredEvent)
 		if !ok {
 			e.logger.Error(
 				"invalid event data for rollback restoration",
@@ -349,18 +363,25 @@ func (e *Election) rollbackLoop(
 			continue
 		}
 
-		cleared := e.clearSchedules()
 		currentEpoch := e.epochProvider.CurrentEpoch()
+		readyEpoch, nextReady := e.epochProvider.NextEpochNonceReadyEpoch()
+		cleared := e.clearUnstableSchedules(
+			currentEpoch,
+			readyEpoch,
+			nextReady,
+		)
 		e.logger.Info(
-			"ledger rollback restored state, invalidating leader schedules",
+			"ledger rollback restored state, pruning unstable leader schedules",
 			"component", "leader",
 			"rollback_slot", restoreEvent.Slot,
-			"cleared_schedules", cleared,
 			"current_epoch", currentEpoch,
+			"next_epoch_ready", nextReady,
+			"ready_epoch", readyEpoch,
+			"cleared_schedules", cleared,
 		)
 		e.queueScheduleCompute(currentEpoch)
-		if nextEpoch, ok := e.epochProvider.NextEpochNonceReadyEpoch(); ok {
-			e.queueScheduleCompute(nextEpoch)
+		if nextReady {
+			e.queueScheduleCompute(readyEpoch)
 		}
 	}
 }
@@ -740,16 +761,30 @@ func (e *Election) storeSchedule(epoch uint64, schedule *Schedule) {
 	}
 }
 
-func (e *Election) clearSchedules() int {
+func (e *Election) clearUnstableSchedules(
+	currentEpoch uint64,
+	readyEpoch uint64,
+	nextReady bool,
+) int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if !e.running || e.schedules == nil {
 		return 0
 	}
-	count := len(e.schedules)
-	clear(e.schedules)
-	return count
+
+	cleared := 0
+	for epoch := range e.schedules {
+		if epoch <= currentEpoch {
+			continue
+		}
+		if nextReady && epoch == readyEpoch {
+			continue
+		}
+		delete(e.schedules, epoch)
+		cleared++
+	}
+	return cleared
 }
 
 func (e *Election) queueScheduleCompute(epoch uint64) {

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -83,6 +83,8 @@ func (m *mockStakeProvider) GetTotalActiveStake(epoch uint64) (uint64, error) {
 type mockEpochProvider struct {
 	currentEpoch    atomic.Uint64
 	epochNonce      atomic.Value
+	nonceMu         sync.RWMutex
+	epochNonces     map[uint64][]byte
 	slotsPerEpoch   uint64
 	activeSlotCoeff float64
 	nextEpochReady  atomic.Uint64
@@ -92,6 +94,7 @@ func newMockEpochProvider() *mockEpochProvider {
 	m := &mockEpochProvider{
 		slotsPerEpoch:   electionSlotsPerEpoch,
 		activeSlotCoeff: 0.05,
+		epochNonces:     make(map[uint64][]byte),
 	}
 	m.currentEpoch.Store(10)
 	m.SetEpochNonce(electionTestNonce)
@@ -103,11 +106,18 @@ func (m *mockEpochProvider) CurrentEpoch() uint64 {
 }
 
 func (m *mockEpochProvider) EpochNonce(epoch uint64) []byte {
+	m.nonceMu.RLock()
+	if nonce, ok := m.epochNonces[epoch]; ok {
+		m.nonceMu.RUnlock()
+		return cloneElectionNonce(nonce)
+	}
+	m.nonceMu.RUnlock()
+
 	nonce, ok := m.epochNonce.Load().([]byte)
 	if !ok || len(nonce) == 0 {
 		return nil
 	}
-	return append([]byte(nil), nonce...)
+	return cloneElectionNonce(nonce)
 }
 
 func (m *mockEpochProvider) NextEpochNonceReadyEpoch() (uint64, bool) {
@@ -127,11 +137,20 @@ func (m *mockEpochProvider) ActiveSlotCoeff() float64 {
 }
 
 func (m *mockEpochProvider) SetEpochNonce(nonce []byte) {
+	m.epochNonce.Store(cloneElectionNonce(nonce))
+}
+
+func (m *mockEpochProvider) SetEpochNonceForEpoch(
+	epoch uint64,
+	nonce []byte,
+) {
+	m.nonceMu.Lock()
+	defer m.nonceMu.Unlock()
 	if len(nonce) == 0 {
-		m.epochNonce.Store([]byte(nil))
+		delete(m.epochNonces, epoch)
 		return
 	}
-	m.epochNonce.Store(append([]byte(nil), nonce...))
+	m.epochNonces[epoch] = cloneElectionNonce(nonce)
 }
 
 type mockScheduleStore struct {
@@ -178,6 +197,13 @@ func (m *mockScheduleStore) key(
 
 func makeElectionNonce(fill byte) []byte {
 	return bytes.Repeat([]byte{fill}, 32)
+}
+
+func cloneElectionNonce(nonce []byte) []byte {
+	if len(nonce) == 0 {
+		return nil
+	}
+	return append([]byte(nil), nonce...)
 }
 
 // waitForSchedule polls until CurrentSchedule returns non-nil, or fails
@@ -704,7 +730,7 @@ func TestElectionPrecomputesNextEpochOnNonceReady(t *testing.T) {
 		"next epoch schedule should be persisted")
 }
 
-func TestElectionInvalidatesSchedulesAfterRollback(t *testing.T) {
+func TestElectionRollbackKeepsCurrentSchedule(t *testing.T) {
 	poolId := lcommon.PoolKeyHash{}
 	stakeProvider := newMockStakeProvider()
 	stakeProvider.totalStake = 1_000_000
@@ -712,7 +738,6 @@ func TestElectionInvalidatesSchedulesAfterRollback(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.activeSlotCoeff = 1.0
-	epochProvider.SetEpochNonce(makeElectionNonce(0x11))
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -731,9 +756,11 @@ func TestElectionInvalidatesSchedulesAfterRollback(t *testing.T) {
 	defer func() { _ = election.Stop() }()
 
 	schedule := waitForSchedule(t, election, 30*time.Second)
-	require.True(t, bytes.Equal(makeElectionNonce(0x11), schedule.EpochNonce))
-
-	epochProvider.SetEpochNonce(makeElectionNonce(0x22))
+	leaderSlots := schedule.LeaderSlotsSnapshot()
+	if len(leaderSlots) == 0 {
+		t.Fatalf("current schedule should contain at least one leader slot")
+	}
+	leaderSlot := leaderSlots[0]
 
 	eventBus.Publish(
 		ledgerpkg.PoolStateRestoredEventType,
@@ -744,14 +771,21 @@ func TestElectionInvalidatesSchedulesAfterRollback(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		recomputed := election.ScheduleForEpoch(10)
-		return recomputed != nil &&
-			bytes.Equal(makeElectionNonce(0x22), recomputed.EpochNonce)
-	}, 30*time.Second, 100*time.Millisecond,
-		"rollback should invalidate and recompute the current epoch schedule")
+		current := election.ScheduleForEpoch(10)
+		if current == nil {
+			return false
+		}
+		currentSlots := current.LeaderSlotsSnapshot()
+		return currentSlots != nil &&
+			len(currentSlots) > 0 &&
+			bytes.Equal(schedule.EpochNonce, current.EpochNonce) &&
+			currentSlots[0] == leaderSlot &&
+			election.ShouldProduceBlock(leaderSlot)
+	}, time.Second, 20*time.Millisecond,
+		"rollback should not invalidate a stable current-epoch schedule")
 }
 
-func TestElectionRollbackKeepsNextEpochRecomputable(t *testing.T) {
+func TestElectionRollbackKeepsStableNextSchedule(t *testing.T) {
 	poolId := lcommon.PoolKeyHash{}
 	stakeProvider := newMockStakeProvider()
 	stakeProvider.totalStake = 1_000_000
@@ -759,8 +793,8 @@ func TestElectionRollbackKeepsNextEpochRecomputable(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.activeSlotCoeff = 1.0
-	epochProvider.SetEpochNonce(makeElectionNonce(0x31))
 	epochProvider.nextEpochReady.Store(11)
+	epochProvider.SetEpochNonceForEpoch(11, makeElectionNonce(0x31))
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -779,13 +813,71 @@ func TestElectionRollbackKeepsNextEpochRecomputable(t *testing.T) {
 	defer func() { _ = election.Stop() }()
 
 	waitForSchedule(t, election, 30*time.Second)
+	var nextBefore *Schedule
 	require.Eventually(t, func() bool {
-		return election.ScheduleForEpoch(11) != nil
+		nextBefore = election.ScheduleForEpoch(11)
+		return nextBefore != nil
 	}, 30*time.Second, 100*time.Millisecond)
+	expectedSlots := nextBefore.LeaderSlotsSnapshot()
+	expectedNonce := append([]byte(nil), nextBefore.EpochNonce...)
+
+	eventBus.Publish(
+		ledgerpkg.PoolStateRestoredEventType,
+		event.NewEvent(
+			ledgerpkg.PoolStateRestoredEventType,
+			ledgerpkg.PoolStateRestoredEvent{Slot: 95},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		schedule := election.ScheduleForEpoch(11)
+		return schedule == nextBefore &&
+			bytes.Equal(expectedNonce, schedule.EpochNonce) &&
+			assert.ObjectsAreEqual(expectedSlots, schedule.LeaderSlotsSnapshot())
+	}, time.Second, 20*time.Millisecond,
+		"rollback after cutoff should not invalidate a stable next-epoch schedule")
+}
+
+func TestElectionRollbackClearsUnstableNextSchedule(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.activeSlotCoeff = 1.0
+	epochProvider.nextEpochReady.Store(11)
+	epochProvider.SetEpochNonceForEpoch(11, makeElectionNonce(0x31))
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	waitForSchedule(t, election, 30*time.Second)
+	var nextBefore *Schedule
+	require.Eventually(t, func() bool {
+		nextBefore = election.ScheduleForEpoch(11)
+		return nextBefore != nil
+	}, 30*time.Second, 100*time.Millisecond)
+	require.True(
+		t,
+		bytes.Equal(makeElectionNonce(0x31), nextBefore.EpochNonce),
+	)
 
 	epochProvider.nextEpochReady.Store(0)
-	epochProvider.SetEpochNonce(makeElectionNonce(0x32))
-
+	epochProvider.SetEpochNonceForEpoch(11, makeElectionNonce(0x32))
 	eventBus.Publish(
 		ledgerpkg.PoolStateRestoredEventType,
 		event.NewEvent(
@@ -815,6 +907,7 @@ func TestElectionRollbackKeepsNextEpochRecomputable(t *testing.T) {
 	require.Eventually(t, func() bool {
 		schedule := election.ScheduleForEpoch(11)
 		return schedule != nil &&
+			schedule != nextBefore &&
 			bytes.Equal(makeElectionNonce(0x32), schedule.EpochNonce)
 	}, 30*time.Second, 100*time.Millisecond,
 		"nonce-ready replay should rebuild the next epoch schedule after rollback")

--- a/node.go
+++ b/node.go
@@ -349,11 +349,10 @@ func (n *Node) handleChainSwitchEvent(evt event.Event) {
 		"new_tip_block", e.NewTip.BlockNumber,
 		"new_tip_slot", e.NewTip.Point.Slot,
 	)
+	// Peer switches only change which already-running chainsync stream feeds
+	// the ledger. Restarting chainsync here re-enters FindIntersect and can
+	// race the protocol state machine under load.
 	n.chainsyncState.SetClientConnId(e.NewConnectionId)
-	n.ouroboros.ResumeChainsyncOnPeerSwitch(
-		n.ctx,
-		e.NewConnectionId,
-	)
 }
 
 func New(cfg Config) (*Node, error) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -15,7 +15,6 @@
 package ouroboros
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -25,7 +24,6 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
-	dchainsync "github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -98,20 +96,6 @@ func normalizeIntersectPoints(points []ocommon.Point) []ocommon.Point {
 
 func isOriginPoint(point ocommon.Point) bool {
 	return point.Slot == 0 && len(point.Hash) == 0
-}
-
-func shouldRestartChainsyncOnSwitch(
-	localTip ocommon.Point,
-	trackedClient *dchainsync.TrackedClient,
-) bool {
-	if trackedClient == nil || isOriginPoint(localTip) {
-		return false
-	}
-	if trackedClient.Cursor.Slot > localTip.Slot {
-		return true
-	}
-	return trackedClient.Cursor.Slot == localTip.Slot &&
-		!bytes.Equal(trackedClient.Cursor.Hash, localTip.Hash)
 }
 
 func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
@@ -797,77 +781,6 @@ func (o *Ouroboros) restartChainsyncClientAsync(
 		}
 		mu.Unlock()
 	}()
-}
-
-func (o *Ouroboros) ResumeChainsyncOnPeerSwitch(
-	ctx context.Context,
-	connId ouroboros.ConnectionId,
-) {
-	if o == nil ||
-		o.ConnManager == nil ||
-		o.ChainsyncState == nil ||
-		o.LedgerState == nil {
-		return
-	}
-	localTip := o.LedgerState.Tip()
-	trackedClient := o.ChainsyncState.GetTrackedClient(connId)
-	if !shouldRestartChainsyncOnSwitch(localTip.Point, trackedClient) {
-		return
-	}
-	localPoint := localTip.Point
-	reason := "active peer switch exact intersect"
-	o.restartChainsyncClientAsync(
-		ctx,
-		connId,
-		reason,
-		func() error {
-			conn := o.ConnManager.GetConnectionById(connId)
-			if conn == nil {
-				return fmt.Errorf("connection not found: %s", connId.String())
-			}
-			cs := conn.ChainSync()
-			if cs == nil || cs.Client == nil {
-				return fmt.Errorf(
-					"chainsync client not available: %s",
-					connId.String(),
-				)
-			}
-			if err := cs.Client.Stop(); err != nil {
-				return fmt.Errorf("stop chainsync client: %w", err)
-			}
-			o.ChainsyncState.ClearSeenHeadersFrom(localPoint.Slot)
-			err := o.RestartChainsyncClientWithPoints(
-				connId,
-				[]ocommon.Point{localPoint},
-			)
-			if err == nil {
-				o.config.Logger.Info(
-					"restarted switched peer chainsync from local tip",
-					"connection_id", connId.String(),
-					"local_tip_slot", localPoint.Slot,
-					"tracked_cursor_slot", trackedClient.Cursor.Slot,
-				)
-				return nil
-			}
-			if !errors.Is(err, ochainsync.ErrIntersectNotFound) {
-				return err
-			}
-			o.config.Logger.Info(
-				"exact local-tip intersect unavailable on switched peer, falling back",
-				"connection_id", connId.String(),
-				"local_tip_slot", localPoint.Slot,
-				"tracked_cursor_slot", trackedClient.Cursor.Slot,
-			)
-			if err := cs.Client.Stop(); err != nil {
-				return fmt.Errorf(
-					"stop chainsync client after intersect fallback: %w",
-					err,
-				)
-			}
-			o.ChainsyncState.ClearSeenHeaders()
-			return o.RestartChainsyncClient(connId)
-		},
-	)
 }
 
 // SubscribeChainsyncResync registers an EventBus subscriber that

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -122,64 +122,6 @@ func TestNormalizeIntersectPoints(t *testing.T) {
 	)
 }
 
-func TestShouldRestartChainsyncOnSwitch(t *testing.T) {
-	tests := []struct {
-		name          string
-		localTip      ocommon.Point
-		trackedClient *dchainsync.TrackedClient
-		want          bool
-	}{
-		{
-			name:     "nil tracked client",
-			localTip: ocommon.NewPoint(100, []byte("tip")),
-			want:     false,
-		},
-		{
-			name:          "origin local tip",
-			localTip:      ocommon.NewPointOrigin(),
-			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(5, []byte("a"))},
-			want:          false,
-		},
-		{
-			name:          "tracked cursor behind local tip",
-			localTip:      ocommon.NewPoint(100, []byte("tip")),
-			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(90, []byte("a"))},
-			want:          false,
-		},
-		{
-			name:          "tracked cursor equal to local tip",
-			localTip:      ocommon.NewPoint(100, []byte("tip")),
-			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(100, []byte("tip"))},
-			want:          false,
-		},
-		{
-			name:          "tracked cursor same slot different hash",
-			localTip:      ocommon.NewPoint(100, []byte("tip")),
-			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(100, []byte("fork"))},
-			want:          true,
-		},
-		{
-			name:          "tracked cursor ahead of local tip",
-			localTip:      ocommon.NewPoint(100, []byte("tip")),
-			trackedClient: &dchainsync.TrackedClient{Cursor: ocommon.NewPoint(110, []byte("ahead"))},
-			want:          true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			require.Equal(
-				t,
-				test.want,
-				shouldRestartChainsyncOnSwitch(
-					test.localTip,
-					test.trackedClient,
-				),
-			)
-		})
-	}
-}
-
 func TestChainsyncClientRollForward_IneligiblePeerDoesNotPoisonDedup(
 	t *testing.T,
 ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves stable leader schedules across rollbacks and stops restarting `chainsync` on peer switches to avoid protocol races. On rollback, only unstable future schedules are pruned; current and nonce-ready next schedules remain, and recomputation runs as needed.

- **Bug Fixes**
  - `leader.Election`: coalesces rollback events by draining the channel and prunes only schedules past the current epoch, keeping the current and nonce-ready next epoch; queues recompute for the current epoch and for the next-ready epoch when available.
  - Tests cover preserving the current schedule (including leader slots), keeping a stable next schedule intact, and clearing/rebuilding the next schedule when nonce-ready changes.

- **Refactors**
  - Removed `ouroboros.ResumeChainsyncOnPeerSwitch` and related tests; `node.handleChainSwitchEvent` now only updates the active `chainsync` connection ID to prevent FindIntersect races.

<sup>Written for commit 65677a4bd7cf269ba0dc08e6e26440394084b927. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback handling to preserve stable leader schedules instead of clearing all schedules, ensuring current and upcoming epoch schedules remain intact across rollbacks.
  * Simplified peer connection switching by removing automatic chainsync restart logic, reducing potential race conditions under load.

* **Improvements**
  * Enhanced rollback event processing and added detailed logging fields for better debugging and monitoring of rollback operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->