### PR TITLE
fix(ledger): retry block processing on transient errors

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1907,12 +1907,15 @@ func (ls *LedgerState) ledgerReadChain(
 }
 
 func (ls *LedgerState) ledgerProcessBlocks() {
-	// Start chain reader goroutine
-	readChainResultCh := make(chan readChainResult)
-	go ls.ledgerReadChain(ls.ctx, readChainResultCh)
-	if err := ls.ledgerProcessBlocksFromSource(ls.ctx, readChainResultCh); err != nil {
-		ls.config.Logger.Error(
-			"failed to process blocks",
+	for {
+		readChainResultCh := make(chan readChainResult)
+		go ls.ledgerReadChain(ls.ctx, readChainResultCh)
+		err := ls.ledgerProcessBlocksFromSource(ls.ctx, readChainResultCh)
+		if err == nil || ls.ctx.Err() != nil {
+			return
+		}
+		ls.config.Logger.Warn(
+			"block processing failed, restarting pipeline",
 			"error", err,
 		)
 	}


### PR DESCRIPTION
## Summary
- `ledgerProcessBlocks` exited permanently on the first error from `ledgerProcessBlocksFromSource`, including transient failures like badger `Transaction Conflict. Please retry`
- This left the node in a zombie state: connections active, metrics updating, but no blocks processed — ever again until restart
- Observed in production when a badger transaction conflict occurred during a fork rollback, killing the block processing goroutine permanently
- Fix wraps the processing in a retry loop that restarts on non-fatal errors, only exiting on context cancellation (graceful shutdown)

## Test plan
- [ ] Existing ledger tests pass
- [ ] Verify node recovers from simulated badger transaction conflict without restart
- [ ] Verify graceful shutdown still works (context cancellation exits the loop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a retry loop to block processing to recover from transient errors (e.g., `badger` transaction conflicts), preventing the node from getting stuck. Processing restarts automatically and only stops on graceful shutdown or successful completion.

- **Bug Fixes**
  - Wrap `ledgerProcessBlocks` in a loop that re-spawns the chain reader and restarts processing on errors.
  - Exit only if the context is canceled or processing returns nil; downgrade failure log to warn to indicate retry.

<sup>Written for commit bec6557f6d0273c04adf13532048b108f1cfb706. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced block processing pipeline to automatically recover from failures, improving system resilience and preventing interruptions during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->