### PR TITLE
feat(config): use peer config targets from cardano config as fallback

### DIFF
--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -66,6 +66,15 @@ type CardanoNodeConfig struct {
 	TestAlonzoHardForkAtEpoch    *uint64 `yaml:"TestAlonzoHardForkAtEpoch"`
 	TestBabbageHardForkAtEpoch   *uint64 `yaml:"TestBabbageHardForkAtEpoch"`
 	TestConwayHardForkAtEpoch    *uint64 `yaml:"TestConwayHardForkAtEpoch"`
+
+	// P2P peer target configuration from cardano-node config.json.
+	// These are read but only used as fallback defaults when the
+	// Dingo-native config (dingo.yaml / env) does not specify them.
+	TargetNumberOfRootPeers        int  `yaml:"TargetNumberOfRootPeers"`
+	TargetNumberOfKnownPeers       int  `yaml:"TargetNumberOfKnownPeers"`
+	TargetNumberOfEstablishedPeers int  `yaml:"TargetNumberOfEstablishedPeers"`
+	TargetNumberOfActivePeers      int  `yaml:"TargetNumberOfActivePeers"`
+	EnableP2P                      bool `yaml:"EnableP2P"`
 }
 
 const (
@@ -595,6 +604,17 @@ func (c *CardanoNodeConfig) LoadConwayGenesisFromReader(r io.Reader) error {
 	}
 	c.conwayGenesis = &conwayGenesis
 	return nil
+}
+
+// P2PTargets returns the peer target values from the cardano-node
+// config.json. Values of 0 mean the field was not present.
+func (c *CardanoNodeConfig) P2PTargets() (
+	rootPeers, knownPeers, establishedPeers, activePeers int,
+) {
+	return c.TargetNumberOfRootPeers,
+		c.TargetNumberOfKnownPeers,
+		c.TargetNumberOfEstablishedPeers,
+		c.TargetNumberOfActivePeers
 }
 
 // HardForkEpoch returns the epoch at which the named era's hard fork

--- a/config/cardano/node_test.go
+++ b/config/cardano/node_test.go
@@ -52,6 +52,11 @@ var expectedCardanoNodeConfig = &CardanoNodeConfig{
 	TestAllegraHardForkAtEpoch:                  ptrUint64(0),
 	TestMaryHardForkAtEpoch:                     ptrUint64(0),
 	TestAlonzoHardForkAtEpoch:                   ptrUint64(0),
+	TargetNumberOfRootPeers:                     60,
+	TargetNumberOfKnownPeers:                    150,
+	TargetNumberOfEstablishedPeers:               50,
+	TargetNumberOfActivePeers:                    20,
+	EnableP2P:                                   true,
 }
 
 func TestCardanoNodeConfig(t *testing.T) {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -140,6 +140,23 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		),
 		"component", "node",
 	)
+	// Apply cardano-node config.json P2P targets as fallback when the
+	// Dingo-native config (dingo.yaml / env) does not specify them.
+	// Priority: dingo.yaml/env > cardano config.json > peergov defaults.
+	if nodeCfg != nil {
+		rp, kp, ep, ap := nodeCfg.P2PTargets()
+		if cfg.TargetNumberOfKnownPeers == 0 && kp > 0 {
+			cfg.TargetNumberOfKnownPeers = kp
+		}
+		if cfg.TargetNumberOfEstablishedPeers == 0 && ep > 0 {
+			cfg.TargetNumberOfEstablishedPeers = ep
+		}
+		if cfg.TargetNumberOfActivePeers == 0 && ap > 0 {
+			cfg.TargetNumberOfActivePeers = ap
+		}
+		_ = rp // TargetNumberOfRootPeers not yet wired to peergov
+	}
+
 	listeners := []dingo.ListenerConfig{}
 	if cfg.RelayPort > 0 {
 		// Public "relay" port (node-to-node)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use peer target values from cardano-node config.json as fallback when Dingo config doesn’t set them. This keeps explicit `dingo.yaml`/env values unchanged but improves defaults.

- **New Features**
  - Parse P2P targets from cardano config into `config/cardano.CardanoNodeConfig` (`TargetNumberOf{Root,Known,Established,Active}Peers`, `EnableP2P`).
  - Fallback in `internal/node.Run`: use `Known`, `Established`, and `Active` from cardano config only when Dingo config is zero. Priority: `dingo.yaml`/env > cardano config.json > defaults.
  - Root peers are parsed but not yet used.

<sup>Written for commit c36f5fa6339b3028b9d759c486c07112ab54c002. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added P2P peer target configuration options for managing root, known, established, and active peer connections.
  * Introduced layered configuration priority system: environment and config files take precedence over node configuration defaults.

* **Tests**
  * Updated test cases to validate P2P configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->