### PR TITLE
fix(ledger): blockfetch flush to prevent stall

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2133,6 +2133,8 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	}
 	ls.chainsyncBlockfetchTimerGeneration++
 	if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return err
 	}
 	// Continue fetching as long as there are queued headers


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents chain sync stalls by cleaning up blockfetch state when a block batch flush fails. On flush error, we clear the active blockfetch connection and request range so the client recovers and continues fetching.

- **Bug Fixes**
  - In handleEventBlockfetchBatchDone, call blockfetchRequestRangeCleanup() and reset activeBlockfetchConnId to empty `ouroboros.ConnectionId` on flush error.

<sup>Written for commit 47443a83894828171e296fb78278d97fc4e36acd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

