### PR TITLE
fix(peergov): run initial reconcile after start

### DIFF
--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -355,6 +355,21 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 
 	// Start outbound connections
 	p.startOutboundConnections()
+
+	// Run initial reconcile shortly after startup so gossip and
+	// ledger peer discovery happen promptly rather than waiting
+	// for the first full reconcile interval.
+	go func(stop <-chan struct{}) {
+		select {
+		case <-time.After(initialReconnectDelay):
+			p.reconcile(ctx)
+		case <-stop:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}(stopCh)
+
 	return nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run an initial reconcile shortly after startup so gossip and ledger peer discovery happen promptly instead of waiting for the first full reconcile interval.

<sup>Written for commit bcec867423d0e98dc693f7b387f43296bb3caafa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

