### PR TITLE
fix: reconcile primary chain tip with ledger tip on start

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -15,6 +15,7 @@
 package chain
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -304,6 +305,122 @@ func (cm *ChainManager) loadPrimaryChain() error {
 		}
 	}
 	cm.chains[primaryChainId] = chain
+	return nil
+}
+
+// RewindPrimaryChainToPoint silently prunes the persistent primary chain back
+// to the specified point without emitting rollback/fork events. This runs
+// during startup reconciliation to discard speculative blob-only blocks that
+// were never applied to the authoritative ledger metadata tip, so emitting the
+// normal ChainRollbackEvent/ChainForkEvent flow would be incorrect and could
+// trigger external undo/transaction rollback handlers for work that never
+// actually happened. Callers should treat this as persistent chain pruning
+// only, not a normal rollback/fork transition.
+func (cm *ChainManager) RewindPrimaryChainToPoint(
+	point ocommon.Point,
+) error {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+	primaryChain := cm.primaryChainLocked()
+	if primaryChain == nil {
+		return errors.New("primary chain not available")
+	}
+	if !primaryChain.persistent {
+		return errors.New("primary chain is not persistent")
+	}
+	primaryChain.mutex.Lock()
+	defer primaryChain.mutex.Unlock()
+
+	rollbackIndex := uint64(0)
+	rollbackBlockNumber := uint64(0)
+	targetTip := ochainsync.Tip{}
+	targetTipSet := false
+	err := func() error {
+		txn := cm.db.BlobTxn(true)
+		return txn.Do(func(txn *database.Txn) error {
+			currentTip := primaryChain.currentTip
+			if point.Slot > 0 || len(point.Hash) > 0 {
+				tmpBlock, err := cm.blockByPoint(point, txn)
+				if err != nil {
+					return fmt.Errorf("lookup rewind point: %w", err)
+				}
+				rollbackIndex = tmpBlock.ID
+				rollbackBlockNumber = tmpBlock.Number
+				if primaryChain.tipBlockIndex < rollbackIndex {
+					return fmt.Errorf(
+						"primary chain tip index %d is behind rewind point index %d",
+						primaryChain.tipBlockIndex,
+						rollbackIndex,
+					)
+				}
+				if primaryChain.tipBlockIndex == rollbackIndex &&
+					primaryChain.currentTip.Point.Slot == point.Slot &&
+					bytes.Equal(primaryChain.currentTip.Point.Hash, point.Hash) {
+					// Already at the requested tip, so there is nothing to prune.
+					targetTip = primaryChain.currentTip
+					targetTipSet = true
+					return nil
+				}
+				targetTip = ochainsync.Tip{
+					Point:       point,
+					BlockNumber: rollbackBlockNumber,
+				}
+				targetTipSet = true
+			} else {
+				rollbackIndex = 0
+				targetTip = ochainsync.Tip{
+					Point:       point,
+					BlockNumber: 0,
+				}
+				targetTipSet = true
+			}
+			for currentTip.Point.Slot != point.Slot ||
+				!bytes.Equal(currentTip.Point.Hash, point.Hash) {
+				currentBlock, err := cm.blockByPoint(currentTip.Point, txn)
+				if err != nil {
+					return fmt.Errorf(
+						"lookup current primary block: %w",
+						err,
+					)
+				}
+				if err := database.BlockDeleteTxn(txn, currentBlock); err != nil {
+					return fmt.Errorf(
+						"delete primary block %d: %w",
+						currentBlock.ID,
+						err,
+					)
+				}
+				if len(currentBlock.PrevHash) == 0 {
+					currentTip = ochainsync.Tip{}
+					break
+				}
+				prevBlock, err := database.BlockByHashTxn(txn, currentBlock.PrevHash)
+				if err != nil {
+					return fmt.Errorf(
+						"lookup previous primary block: %w",
+						err,
+					)
+				}
+				currentTip = ochainsync.Tip{
+					Point: ocommon.NewPoint(
+						prevBlock.Slot,
+						prevBlock.Hash,
+					),
+					BlockNumber: prevBlock.Number,
+				}
+			}
+			if !targetTipSet {
+				targetTip = currentTip
+			}
+			return nil
+		})
+	}()
+	if err != nil {
+		return err
+	}
+	primaryChain.headers = primaryChain.headers[:0]
+	primaryChain.tipBlockIndex = rollbackIndex
+	primaryChain.currentTip = targetTip
 	return nil
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
@@ -630,6 +631,9 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// Load current tip
 	if err := ls.loadTip(); err != nil {
 		return fmt.Errorf("failed to load tip: %w", err)
+	}
+	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
+		return fmt.Errorf("failed to reconcile primary chain tip: %w", err)
 	}
 	// Create genesis block
 	if err := ls.createGenesisBlock(); err != nil {
@@ -3088,6 +3092,39 @@ func (ls *LedgerState) loadTip() error {
 	}
 	ls.updateTipMetrics()
 	ls.Unlock()
+	return nil
+}
+
+func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
+	if ls.chain == nil || ls.config.ChainManager == nil {
+		return nil
+	}
+	ledgerTip := ls.currentTip
+	chainTip := ls.chain.Tip()
+	if chainTip.Point.Slot == ledgerTip.Point.Slot &&
+		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash) {
+		return nil
+	}
+	if chainTip.Point.Slot < ledgerTip.Point.Slot {
+		return fmt.Errorf(
+			"primary chain tip %d is behind ledger tip %d",
+			chainTip.Point.Slot,
+			ledgerTip.Point.Slot,
+		)
+	}
+	ls.config.Logger.Warn(
+		"primary chain tip ahead of ledger tip at startup, pruning speculative blocks",
+		"component", "ledger",
+		"chain_tip_slot", chainTip.Point.Slot,
+		"ledger_tip_slot", ledgerTip.Point.Slot,
+		"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+		"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+	)
+	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
+		ledgerTip.Point,
+	); err != nil {
+		return fmt.Errorf("rewind primary chain: %w", err)
+	}
 	return nil
 }
 

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -33,7 +34,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -2226,4 +2226,61 @@ func TestDensityWindow(t *testing.T) {
 	// Window should have trimmed entries past rollback slot
 	lastEntry := ls.densityWindow[len(ls.densityWindow)-1]
 	assert.LessOrEqual(t, lastEntry.slot, rollbackSlot)
+}
+
+func TestReconcilePrimaryChainTipWithLedgerTipPrunesSpeculativeBlocks(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := make([]models.Block, 0, 5)
+	for slot := uint64(1); slot <= 5; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ledgerTipBlock := blocks[2]
+	ledgerTip := ochainsync.Tip{
+		Point:       makeTestPoint(ledgerTipBlock),
+		BlockNumber: ledgerTipBlock.Number,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+
+	ls := &LedgerState{
+		db:    db,
+		chain: cm.PrimaryChain(),
+		config: LedgerStateConfig{
+			ChainManager: cm,
+			Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.currentTip = ledgerTip
+	require.NoError(t, ls.reconcilePrimaryChainTipWithLedgerTip())
+
+	chainTip := cm.PrimaryChain().Tip()
+	assert.Equal(t, ledgerTip.Point.Slot, chainTip.Point.Slot)
+	assert.Equal(t, ledgerTip.BlockNumber, chainTip.BlockNumber)
+	assert.Equal(t, ledgerTip.Point.Hash, chainTip.Point.Hash)
+
+	for _, block := range blocks[:3] {
+		_, err := database.BlockByPoint(db, makeTestPoint(block))
+		assert.NoError(t, err, "block at slot %d should still exist", block.Slot)
+	}
+	for _, block := range blocks[3:] {
+		_, err := database.BlockByPoint(db, makeTestPoint(block))
+		assert.Error(t, err, "block at slot %d should be pruned", block.Slot)
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On startup, reconcile the primary chain tip with the ledger tip by pruning speculative blocks so both tips match. Prevents mismatched states and spurious rollbacks after restarts.

- **Bug Fixes**
  - Added `chain.ChainManager.RewindPrimaryChainToPoint(point)` to silently prune the persistent primary chain back to a target point without emitting rollback/fork events.
  - `ledger.Start()` now calls `reconcilePrimaryChainTipWithLedgerTip()`; prunes when the chain is ahead, errors if it’s behind, no-op if equal.
  - Emits a warning with slot/hash details when pruning speculative blocks.
  - Added a unit test to verify blocks beyond the ledger tip are pruned and the chain tip matches the ledger.

<sup>Written for commit 80b22687d824c70451da61a611e061512d928dbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced chain state management: the system now automatically reconciles the primary chain tip with the ledger tip during startup, ensuring consistency and pruning any speculative blocks that diverge from the ledger state.
  * Added the ability to rewind and reset the primary chain to a specified point while maintaining transaction integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->