### PR TITLE
test: lock in peer governor config normalization

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -16,6 +16,7 @@ package dingo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -53,4 +54,36 @@ func TestWithStorageMode(t *testing.T) {
 	// Apply core mode
 	WithStorageMode(StorageModeCore)(cfg)
 	assert.Equal(t, StorageModeCore, cfg.storageMode)
+}
+
+func TestPeerGovernorOptionsIgnoreNonPositiveValues(t *testing.T) {
+	cfg := &Config{}
+
+	WithMinHotPeers(-1)(cfg)
+	WithReconcileInterval(-1 * time.Minute)(cfg)
+	WithInactivityTimeout(-5 * time.Minute)(cfg)
+	WithMaxConnectionsPerIP(-2)(cfg)
+	WithMaxInboundConns(0)(cfg)
+
+	assert.Zero(t, cfg.minHotPeers)
+	assert.Zero(t, cfg.reconcileInterval)
+	assert.Zero(t, cfg.inactivityTimeout)
+	assert.Zero(t, cfg.maxConnectionsPerIP)
+	assert.Zero(t, cfg.maxInboundConns)
+}
+
+func TestPeerGovernorOptionsApplyPositiveValues(t *testing.T) {
+	cfg := &Config{}
+
+	WithMinHotPeers(3)(cfg)
+	WithReconcileInterval(30 * time.Second)(cfg)
+	WithInactivityTimeout(2 * time.Minute)(cfg)
+	WithMaxConnectionsPerIP(4)(cfg)
+	WithMaxInboundConns(25)(cfg)
+
+	assert.Equal(t, 3, cfg.minHotPeers)
+	assert.Equal(t, 30*time.Second, cfg.reconcileInterval)
+	assert.Equal(t, 2*time.Minute, cfg.inactivityTimeout)
+	assert.Equal(t, 4, cfg.maxConnectionsPerIP)
+	assert.Equal(t, 25, cfg.maxInboundConns)
 }

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -104,6 +104,26 @@ func TestNewPeerGovernor(t *testing.T) {
 				ReconcileInterval:            10 * time.Minute,
 				MaxReconnectFailureThreshold: 10,
 				MinHotPeers:                  5,
+				InactivityTimeout:            defaultInactivityTimeout,
+				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
+			},
+		},
+		{
+			name: "non-positive values fall back to defaults",
+			config: PeerGovernorConfig{
+				Logger: slog.New(
+					slog.NewJSONHandler(io.Discard, nil),
+				),
+				ReconcileInterval:            -10 * time.Minute,
+				MaxReconnectFailureThreshold: -10,
+				MinHotPeers:                  -5,
+				InactivityTimeout:            -3 * time.Minute,
+			},
+			expected: PeerGovernorConfig{
+				ReconcileInterval:            defaultReconcileInterval,
+				MaxReconnectFailureThreshold: defaultMaxReconnectFailureThreshold,
+				MinHotPeers:                  defaultMinHotPeers,
+				InactivityTimeout:            defaultInactivityTimeout,
 				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
 			},
 		},
@@ -125,6 +145,11 @@ func TestNewPeerGovernor(t *testing.T) {
 				pg.config.MaxReconnectFailureThreshold,
 			)
 			assert.Equal(t, tt.expected.MinHotPeers, pg.config.MinHotPeers)
+			assert.Equal(
+				t,
+				tt.expected.InactivityTimeout,
+				pg.config.InactivityTimeout,
+			)
 			assert.Equal(
 				t,
 				tt.expected.BootstrapRecoveryCooldown,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests to lock in `PeerGovernor` config normalization. Ensure non‑positive values are ignored in options and constructor, defaults are applied (`ReconcileInterval`, `InactivityTimeout`, `MinHotPeers`, `BootstrapRecoveryCooldown`), and positive values are respected for `MinHotPeers`, `ReconcileInterval`, `InactivityTimeout`, `MaxConnectionsPerIP`, and `MaxInboundConns`.

<sup>Written for commit ff4697004324b9db7c9cf97a72ae7acb266e70fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

