### PR TITLE
fix(database): wrap sqlite stake snapshot write errors

### DIFF
--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -35,7 +35,13 @@ func (d *MetadataStoreSqlite) SavePoolStakeSnapshot(
 	if err != nil {
 		return err
 	}
-	return db.Create(snapshot).Error
+	if err := db.Create(snapshot).Error; err != nil {
+		return fmt.Errorf(
+			"failed to create pool stake snapshot: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // SavePoolStakeSnapshots saves multiple pool stake snapshots in batch
@@ -253,10 +259,16 @@ func (d *MetadataStoreSqlite) DeletePoolStakeSnapshotsForEpoch(
 	if err != nil {
 		return err
 	}
-	return db.Where(
+	if err := db.Where(
 		"epoch = ? AND snapshot_type = ?",
 		epoch, snapshotType,
-	).Delete(&models.PoolStakeSnapshot{}).Error
+	).Delete(&models.PoolStakeSnapshot{}).Error; err != nil {
+		return fmt.Errorf(
+			"failed to delete pool stake snapshots for epoch: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // DeletePoolStakeSnapshotsAfterEpoch deletes all pool stake snapshots after a given epoch.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add contextual error wrapping for stake snapshot writes in the sqlite metadata store to make failures easier to debug. `SavePoolStakeSnapshot` and `DeletePoolStakeSnapshotsForEpoch` now return wrapped errors instead of raw GORM errors.

<sup>Written for commit 52bcca7838460be07d43dfeeb85600b3857f8dcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

