### PR TITLE
fix(load): preserve byron ebb linkage in raw import

### DIFF
--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -334,7 +335,8 @@ func copyBlocksDirect(
 				)
 			}
 			if blocksCopied == 0 &&
-				tmpBlock.SlotNumber() == chainTip.Point.Slot {
+				next.Slot == chainTip.Point.Slot &&
+				bytes.Equal(next.Hash, chainTip.Point.Hash) {
 				continue
 			}
 			blockBatch = append(blockBatch, tmpBlock)
@@ -436,7 +438,8 @@ func copyBlocksRaw(
 			// references the EBB, not the block before it.
 			// Skip first block when continuing a load operation
 			if blocksCopied == 0 &&
-				next.Slot == chainTip.Point.Slot {
+				next.Slot == chainTip.Point.Slot &&
+				bytes.Equal(next.Hash, chainTip.Point.Hash) {
 				continue
 			}
 			// Extract header CBOR from the block's outer array

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -2,10 +2,20 @@ package node
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database/immutable"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	fxcbor "github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractHeaderCbor(t *testing.T) {
@@ -116,4 +126,80 @@ func TestCborArrayHeaderLen(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCopyBlocksRaw_PreservesByronEbbLinkageAtOrigin(t *testing.T) {
+	t.Parallel()
+
+	immutableDir := filepath.Join(
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+	imm, err := immutable.New(immutableDir)
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: []byte{}})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	ebbBlock, err := iter.Next()
+	require.NoError(t, err)
+	require.NotNil(t, ebbBlock)
+	require.True(t, ebbBlock.IsEbb)
+
+	nextBlock, err := iter.Next()
+	require.NoError(t, err)
+	require.NotNil(t, nextBlock)
+
+	ebbHeader, err := decodeImmutableBlockHeader(ebbBlock)
+	require.NoError(t, err)
+	nextHeader, err := decodeImmutableBlockHeader(nextBlock)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		ebbHeader.Hash().Bytes(),
+		nextHeader.PrevHash().Bytes(),
+	)
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	blocksCopied, _, err := copyBlocksRaw(
+		context.Background(),
+		logger,
+		immutableDir,
+		cm.PrimaryChain(),
+	)
+	require.NoError(t, err)
+	require.Greater(t, blocksCopied, 1)
+
+	ebbPoint := ocommon.NewPoint(
+		ebbHeader.SlotNumber(),
+		ebbHeader.Hash().Bytes(),
+	)
+	importedEbb, err := cm.BlockByPoint(ebbPoint, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ebbPoint.Hash, importedEbb.Hash)
+
+	nextPoint := ocommon.NewPoint(
+		nextHeader.SlotNumber(),
+		nextHeader.Hash().Bytes(),
+	)
+	importedNext, err := cm.BlockByPoint(nextPoint, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ebbPoint.Hash, importedNext.PrevHash)
+}
+
+func decodeImmutableBlockHeader(
+	block *immutable.Block,
+) (gledger.BlockHeader, error) {
+	headerCbor, err := extractHeaderCbor(block.Cbor)
+	if err != nil {
+		return nil, err
+	}
+	return gledger.NewBlockHeaderFromCbor(block.Type, headerCbor)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes raw and direct block import to preserve Byron EBB linkage when resuming from the chain tip by matching both slot and hash, preventing the EBB at origin from being skipped.

- **Bug Fixes**
  - Updated resume-skip logic to compare slot and hash in `copyBlocksRaw` and `copyBlocksDirect`.
  - Added a regression test to ensure the next block’s `PrevHash` matches the Byron EBB hash when importing from origin.

<sup>Written for commit bdd2e5cba362dad034835f08d8af185afcf59ac3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved block identification during chain loading by requiring both slot and hash confirmation before skipping initial blocks, ensuring more accurate chain synchronization.

* **Tests**
  * Added test coverage for block linkage preservation during copy operations to verify data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->