### PR TITLE
fix: chain state reconciliation

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -521,6 +521,71 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	return nil
 }
 
+// ValidateRollback verifies that Rollback(point) would be accepted without
+// mutating chain state. Callers can use this to avoid applying external
+// side effects before the chain's rollback pre-checks have run.
+func (c *Chain) ValidateRollback(point ocommon.Point) error {
+	if c == nil {
+		return errors.New("chain is nil")
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.manager.mutex.Lock()
+	defer c.manager.mutex.Unlock()
+	// Verify chain integrity
+	if err := c.reconcile(); err != nil {
+		return fmt.Errorf("reconcile chain: %w", err)
+	}
+	// Check headers for rollback point without mutating them
+	if len(c.headers) > 0 {
+		var header queuedHeader
+		for i := len(c.headers) - 1; i >= 0; i-- {
+			header = c.headers[i]
+			if header.point.Slot > point.Slot {
+				continue
+			}
+			if header.point.Slot == point.Slot &&
+				bytes.Equal(header.point.Hash, point.Hash) {
+				return nil
+			}
+			if header.point.Slot < point.Slot {
+				return models.ErrBlockNotFound
+			}
+		}
+	}
+	// Lookup block for rollback point
+	var rollbackBlockIndex uint64
+	if point.Slot > 0 {
+		tmpBlock, err := c.manager.blockByPoint(point, nil)
+		if err != nil {
+			return fmt.Errorf("lookup rollback point: %w", err)
+		}
+		rollbackBlockIndex = tmpBlock.ID
+	}
+	// Calculate fork depth before deleting blocks
+	forkDepth := c.tipBlockIndex - rollbackBlockIndex
+	// Reject rollbacks that exceed the security parameter K on
+	// the persistent chain. Ephemeral (fork-tracking) chains are
+	// not subject to this limit. The check is skipped when
+	// securityParam is 0 (ledger not yet initialized) or when
+	// the chain is shorter than K blocks (initial sync), since
+	// the entire chain can be safely replaced during sync.
+	securityParam := c.manager.securityParam
+	if c.persistent && securityParam > 0 &&
+		c.tipBlockIndex >= uint64(securityParam) && //nolint:gosec
+		forkDepth > uint64(securityParam) { //nolint:gosec
+		slog.Default().Warn(
+			"rejecting rollback that exceeds "+
+				"security parameter K",
+			"fork_depth", forkDepth,
+			"security_param", securityParam,
+			"rollback_slot", point.Slot,
+		)
+		return ErrRollbackExceedsSecurityParam
+	}
+	return nil
+}
+
 // rollbackLocked performs all rollback logic under locks and returns
 // events to be published by the caller after locks are released.
 func (c *Chain) rollbackLocked(

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -309,13 +309,9 @@ func (cm *ChainManager) loadPrimaryChain() error {
 }
 
 // RewindPrimaryChainToPoint silently prunes the persistent primary chain back
-// to the specified point without emitting rollback/fork events. This runs
-// during startup reconciliation to discard speculative blob-only blocks that
-// were never applied to the authoritative ledger metadata tip, so emitting the
-// normal ChainRollbackEvent/ChainForkEvent flow would be incorrect and could
-// trigger external undo/transaction rollback handlers for work that never
-// actually happened. Callers should treat this as persistent chain pruning
-// only, not a normal rollback/fork transition.
+// to the specified point without emitting rollback/fork events. This is used
+// during startup to discard speculative blob-only blocks that were never
+// committed into the authoritative ledger metadata tip.
 func (cm *ChainManager) RewindPrimaryChainToPoint(
 	point ocommon.Point,
 ) error {
@@ -334,7 +330,6 @@ func (cm *ChainManager) RewindPrimaryChainToPoint(
 	rollbackIndex := uint64(0)
 	rollbackBlockNumber := uint64(0)
 	targetTip := ochainsync.Tip{}
-	targetTipSet := false
 	err := func() error {
 		txn := cm.db.BlobTxn(true)
 		return txn.Do(func(txn *database.Txn) error {
@@ -356,23 +351,13 @@ func (cm *ChainManager) RewindPrimaryChainToPoint(
 				if primaryChain.tipBlockIndex == rollbackIndex &&
 					primaryChain.currentTip.Point.Slot == point.Slot &&
 					bytes.Equal(primaryChain.currentTip.Point.Hash, point.Hash) {
-					// Already at the requested tip, so there is nothing to prune.
 					targetTip = primaryChain.currentTip
-					targetTipSet = true
 					return nil
 				}
 				targetTip = ochainsync.Tip{
 					Point:       point,
 					BlockNumber: rollbackBlockNumber,
 				}
-				targetTipSet = true
-			} else {
-				rollbackIndex = 0
-				targetTip = ochainsync.Tip{
-					Point:       point,
-					BlockNumber: 0,
-				}
-				targetTipSet = true
 			}
 			for currentTip.Point.Slot != point.Slot ||
 				!bytes.Equal(currentTip.Point.Hash, point.Hash) {
@@ -409,7 +394,7 @@ func (cm *ChainManager) RewindPrimaryChainToPoint(
 					BlockNumber: prevBlock.Number,
 				}
 			}
-			if !targetTipSet {
+			if targetTip.Point.Slot == 0 && len(targetTip.Point.Hash) == 0 {
 				targetTip = currentTip
 			}
 			return nil

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -15,6 +15,7 @@
 package chainselection
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -705,9 +706,23 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 				if !ok {
 					return
 				}
+				if CompareChains(
+					newPeerTip.Tip,
+					previousPeerTip.Tip,
+				) == ChainEqual &&
+					cs.connectionPriority(*newBest) ==
+						cs.connectionPriority(*previousBest) &&
+					len(newPeerTip.VRFOutput) == VRFOutputSize &&
+					len(previousPeerTip.VRFOutput) == VRFOutputSize &&
+					bytes.Equal(
+						newPeerTip.VRFOutput,
+						previousPeerTip.VRFOutput,
+					) {
+					newBest = previousBest
+				} else if
 				// Preserve the incumbent only when it still wins the same
 				// full comparison used during normal best-peer selection.
-				if cs.comparePeerTips(
+				cs.comparePeerTips(
 					*previousBest,
 					previousPeerTip,
 					*newBest,

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -477,6 +477,93 @@ func TestChainSelectorPrefersHigherPriorityPeerAtEqualTip(t *testing.T) {
 	assert.Equal(t, localRootConn, *cs.GetBestPeer())
 }
 
+func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+	sharedVRF := make64ByteVRF(0x01)
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+
+	// Seed the incumbent using a temporary priority advantage, then
+	// remove that advantage. Equal-priority peers at the same tip
+	// should not steal incumbency just because the selector re-evaluates.
+	setSelectorConnectionPriority(cs, connId1, 10)
+	setSelectorConnectionPriority(cs, connId2, 20)
+	cs.UpdatePeerTip(connId1, equalTip, sharedVRF)
+	cs.UpdatePeerTip(connId2, equalTip, sharedVRF)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+
+	setSelectorConnectionPriority(cs, connId1, 50)
+	setSelectorConnectionPriority(cs, connId2, 50)
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, connId1, *bestPeer)
+
+	switched := cs.EvaluateAndSwitch()
+	assert.False(t, switched)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+}
+
+func TestChainSelectorDoesNotPreserveIncumbentWithInvalidEqualVRF(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name string
+		vrfA []byte
+		vrfB []byte
+	}{
+		{
+			name: "nil vrf",
+			vrfA: nil,
+			vrfB: nil,
+		},
+		{
+			name: "short vrf",
+			vrfA: []byte{0x01},
+			vrfB: []byte{0x01},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			connId1 := newTestConnectionId(1)
+			connId2 := newTestConnectionId(2)
+			cs := NewChainSelector(ChainSelectorConfig{})
+
+			equalTip := ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+				BlockNumber: 60,
+			}
+
+			setSelectorConnectionPriority(cs, connId1, 10)
+			setSelectorConnectionPriority(cs, connId2, 20)
+			cs.UpdatePeerTip(connId1, equalTip, tc.vrfA)
+			cs.UpdatePeerTip(connId2, equalTip, tc.vrfB)
+			require.NotNil(t, cs.GetBestPeer())
+			assert.Equal(t, connId2, *cs.GetBestPeer())
+
+			setSelectorConnectionPriority(cs, connId1, 50)
+			setSelectorConnectionPriority(cs, connId2, 50)
+
+			bestPeer := cs.SelectBestChain()
+			require.NotNil(t, bestPeer)
+			assert.Equal(t, connId1, *bestPeer)
+
+			switched := cs.EvaluateAndSwitch()
+			assert.True(t, switched)
+			require.NotNil(t, cs.GetBestPeer())
+			assert.Equal(t, connId1, *cs.GetBestPeer())
+		})
+	}
+}
+
 func TestChainSelectorUpdatesConnectionStateFromPeerGovEvents(t *testing.T) {
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -35,7 +35,6 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
-	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -80,6 +79,8 @@ const (
 	resyncReasonRollbackNotFound = "rollback point not found"
 )
 
+var errChainsyncResyncRequested = errors.New("chainsync resync requested")
+
 func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 	ls.chainsyncMutex.Lock()
 	defer ls.chainsyncMutex.Unlock()
@@ -104,6 +105,9 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 		}
 	} else if e.BlockHeader != nil {
 		if err := ls.handleEventChainsyncBlockHeader(e); err != nil {
+			if errors.Is(err, errChainsyncResyncRequested) {
+				return
+			}
 			// Header queue full is expected during bulk sync when
 			// pipelined headers arrive faster than blockfetch can
 			// drain them. Log at DEBUG to avoid log spam.
@@ -143,6 +147,11 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 }
 
 func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
+	// Header pipeline ownership and buffered header queues are shared with the
+	// chainsync handler, so blockfetch processing must take the same outer lock
+	// before touching state that may clear or replay queued headers.
+	ls.chainsyncMutex.Lock()
+	defer ls.chainsyncMutex.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
 	e, ok := evt.Data.(BlockfetchEvent)
@@ -248,10 +257,27 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 	if !ok {
 		return
 	}
+	ls.chainsyncMutex.Lock()
+	defer ls.chainsyncMutex.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
 	if ls.selectedBlockfetchConnId == e.ConnectionId {
 		ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
+	}
+	clearedActiveBlockfetch := false
+	if ls.activeBlockfetchConnId == e.ConnectionId {
+		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		clearedActiveBlockfetch = true
+	}
+	delete(ls.bufferedHeaderEvents, e.ConnectionId)
+	clearedHeaderPipeline := false
+	if ls.headerPipelineConnId == e.ConnectionId {
+		ls.clearQueuedHeaders()
+		clearedHeaderPipeline = true
+	}
+	if clearedActiveBlockfetch || clearedHeaderPipeline {
+		ls.scheduleBufferedHeaderReplayLocked()
 	}
 }
 
@@ -309,6 +335,222 @@ func (ls *LedgerState) detectConnectionSwitch() (
 		ls.rollbackHistory = nil
 	}
 	return activeConnId, true, switched
+}
+
+// bufferHeaderEvent mutates bufferedHeaderEvents in place. Callers must hold
+// ls.chainsyncMutex before invoking it.
+func (ls *LedgerState) bufferHeaderEvent(e ChainsyncEvent) {
+	if ls.bufferedHeaderEvents == nil {
+		ls.bufferedHeaderEvents = make(
+			map[ouroboros.ConnectionId][]ChainsyncEvent,
+		)
+	}
+	events := ls.bufferedHeaderEvents[e.ConnectionId]
+	if len(events) > 0 {
+		last := events[len(events)-1]
+		if last.Point.Slot == e.Point.Slot &&
+			bytes.Equal(last.Point.Hash, e.Point.Hash) {
+			return
+		}
+	}
+	const maxBufferedHeadersPerConn = 128
+	if len(events) >= maxBufferedHeadersPerConn {
+		events = append(events[1:], e)
+	} else {
+		events = append(events, e)
+	}
+	ls.bufferedHeaderEvents[e.ConnectionId] = events
+}
+
+// clearQueuedHeaders resets the queued header pipeline state.
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) clearQueuedHeaders() {
+	ls.chain.ClearHeaders()
+	ls.headerPipelineConnId = ouroboros.ConnectionId{}
+}
+
+func (ls *LedgerState) requestChainsyncResync(
+	connId ouroboros.ConnectionId,
+	reason string,
+) {
+	ls.headerMismatchCount = 0
+	ls.rollbackHistory = nil
+	delete(ls.bufferedHeaderEvents, connId)
+	if ls.config.EventBus == nil {
+		return
+	}
+	ls.config.EventBus.Publish(
+		event.ChainsyncResyncEventType,
+		event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{
+				ConnectionId: connId,
+				Reason:       reason,
+			},
+		),
+	)
+}
+
+func (ls *LedgerState) shouldBufferHeaderEvent(e ChainsyncEvent) bool {
+	if ls.headerPipelineConnId == (ouroboros.ConnectionId{}) {
+		ls.headerPipelineConnId = e.ConnectionId
+		return false
+	}
+	if ls.headerPipelineConnId == e.ConnectionId {
+		return false
+	}
+	ls.bufferHeaderEvent(e)
+	ls.config.Logger.Debug(
+		"buffering header from non-owner connection",
+		"component", "ledger",
+		"event_connection_id", e.ConnectionId.String(),
+		"owner_connection_id", ls.headerPipelineConnId.String(),
+		"slot", e.Point.Slot,
+	)
+	return true
+}
+
+// nextBufferedHeaderConnId selects the buffered connection to replay next.
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) nextBufferedHeaderConnId() (
+	ouroboros.ConnectionId,
+	bool,
+) {
+	if ls.selectedBlockfetchConnId != (ouroboros.ConnectionId{}) &&
+		len(ls.bufferedHeaderEvents[ls.selectedBlockfetchConnId]) > 0 {
+		return ls.selectedBlockfetchConnId, true
+	}
+	var (
+		bestConn ouroboros.ConnectionId
+		bestTip  uint64
+		found    bool
+	)
+	for connId, events := range ls.bufferedHeaderEvents {
+		if len(events) == 0 {
+			continue
+		}
+		tipSlot := events[len(events)-1].Tip.Point.Slot
+		if !found || tipSlot > bestTip {
+			bestConn = connId
+			bestTip = tipSlot
+			found = true
+		}
+	}
+	return bestConn, found
+}
+
+// scheduleBufferedHeaderReplayLocked replays buffered headers when the active
+// header/blockfetch pipeline is idle. Callers must hold chainsyncMutex and
+// chainsyncBlockfetchMutex.
+func (ls *LedgerState) scheduleBufferedHeaderReplayLocked() {
+	if ls.chain == nil ||
+		ls.chainsyncBlockfetchReadyChan != nil ||
+		ls.headerPipelineConnId != (ouroboros.ConnectionId{}) ||
+		ls.chain.HeaderCount() > 0 {
+		return
+	}
+	if nextConnId, ok := ls.nextBufferedHeaderConnId(); ok {
+		ls.replayBufferedHeadersAsync(nextConnId)
+	}
+}
+
+func (ls *LedgerState) replayBufferedHeadersAsync(
+	connId ouroboros.ConnectionId,
+) {
+	go func() {
+		ls.chainsyncMutex.Lock()
+		defer ls.chainsyncMutex.Unlock()
+		ls.chainsyncBlockfetchMutex.Lock()
+		blockfetchActive := ls.chainsyncBlockfetchReadyChan != nil
+		ls.chainsyncBlockfetchMutex.Unlock()
+		if blockfetchActive {
+			return
+		}
+		if ls.headerPipelineConnId != (ouroboros.ConnectionId{}) ||
+			ls.chain.HeaderCount() > 0 {
+			return
+		}
+		if err := ls.replayBufferedHeaderEvents(connId); err != nil {
+			ls.config.Logger.Warn(
+				"failed to replay buffered header events",
+				"component", "ledger",
+				"connection_id", connId.String(),
+				"error", err,
+			)
+		}
+	}()
+}
+
+func (ls *LedgerState) replayBufferedHeaderEvents(
+	connId ouroboros.ConnectionId,
+) error {
+	if len(ls.bufferedHeaderEvents[connId]) == 0 {
+		return nil
+	}
+	events := append(
+		[]ChainsyncEvent(nil),
+		ls.bufferedHeaderEvents[connId]...,
+	)
+	delete(ls.bufferedHeaderEvents, connId)
+	for _, evt := range events {
+		if err := ls.handleEventChainsyncBlockHeader(evt); err != nil {
+			if errors.Is(err, errChainsyncResyncRequested) {
+				break
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (ls *LedgerState) maybeStartBlockfetchForHeader(
+	e ChainsyncEvent,
+	allowedHeaderCount int,
+) error {
+	currentHeaderCount := ls.chain.HeaderCount()
+	// Wait for additional block headers before fetching block bodies if we're
+	// far enough out from upstream tip.
+	slotThreshold := ls.calculateStabilityWindow()
+	if e.Point.Slot < e.Tip.Point.Slot &&
+		(e.Tip.Point.Slot-e.Point.Slot > slotThreshold) &&
+		currentHeaderCount < allowedHeaderCount {
+		ls.config.Logger.Debug(
+			"accumulating headers (far from tip)",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"tip_slot", e.Tip.Point.Slot,
+			"threshold", slotThreshold,
+			"header_count", currentHeaderCount,
+		)
+		return nil
+	}
+	// We use the blockfetch lock to ensure we aren't starting a batch at the same
+	// time as blockfetch starts a new one to avoid deadlocks.
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	// Don't start fetch if there's already one in progress.
+	if ls.chainsyncBlockfetchReadyChan != nil {
+		ls.config.Logger.Debug(
+			"blockfetch in progress, queuing header",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"header_count", ls.chain.HeaderCount(),
+		)
+		return nil
+	}
+	// Mark blockfetch as in progress.
+	ls.selectedBlockfetchConnId = e.ConnectionId
+	initialConnId := ls.selectInitialBlockfetchConn(e.ConnectionId)
+	ls.config.Logger.Debug(
+		"starting blockfetch",
+		"component", "ledger",
+		"connection_id", initialConnId.String(),
+		"header_count", ls.chain.HeaderCount(),
+	)
+	if err := ls.startQueuedBlockfetchLocked(initialConnId); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
@@ -429,7 +671,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		)
 		ls.chainsyncState = RollbackChainsyncState
 	}
-	if err := ls.chain.Rollback(e.Point); err != nil {
+	if err := ls.rollbackChainAndState(e.Point); err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			// Missing rollback point can happen when local state and peer
 			// chainsync cursor drift. Recover by forcing re-intersect.
@@ -505,7 +747,8 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 func (ls *LedgerState) resetChainsyncResyncState() {
 	ls.rollbackHistory = nil
 	ls.headerMismatchCount = 0
-	ls.chain.ClearHeaders()
+	ls.bufferedHeaderEvents = nil
+	ls.clearQueuedHeaders()
 	ls.chainsyncBlockfetchMutex.Lock()
 	ls.blockfetchRequestRangeCleanup()
 	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
@@ -561,6 +804,9 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		ls.metrics.forks.Add(1)
 	}
 	ls.chainsyncState = SyncingChainsyncState
+	if ls.shouldBufferHeaderEvent(e) {
+		return nil
+	}
 	// Allow us to build up a few blockfetch batches worth of headers,
 	// but never exceed the chain's actual header queue capacity.
 	allowedHeaderCount := min(
@@ -584,7 +830,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 			// Header doesn't fit current chain tip. Clear stale queued
 			// headers so subsequent headers are evaluated against the
 			// block tip rather than perpetuating the mismatch.
-			ls.chain.ClearHeaders()
+			ls.clearQueuedHeaders()
 			ls.headerMismatchCount++
 			ls.config.Logger.Debug(
 				"block header does not fit chain tip",
@@ -598,9 +844,13 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 			// from — the common ancestor. If that block exists on our
 			// chain and the peer's chain is ahead, we roll back to
 			// the common ancestor so chainsync can continue.
-			if resolved := ls.tryResolveFork(
+			resolved, err := ls.tryResolveFork(
 				e, notFitErr,
-			); resolved {
+			)
+			if err != nil {
+				return err
+			}
+			if resolved {
 				return nil
 			}
 			// Fallback: after several consecutive mismatches where
@@ -616,18 +866,11 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 					"connection_id", e.ConnectionId.String(),
 					"consecutive_mismatches", ls.headerMismatchCount,
 				)
-				ls.headerMismatchCount = 0
-				ls.rollbackHistory = nil
-				ls.config.EventBus.Publish(
-					event.ChainsyncResyncEventType,
-					event.NewEvent(
-						event.ChainsyncResyncEventType,
-						event.ChainsyncResyncEvent{
-							ConnectionId: e.ConnectionId,
-							Reason:       "persistent chain fork",
-						},
-					),
+				ls.requestChainsyncResync(
+					e.ConnectionId,
+					"persistent chain fork",
 				)
+				return errChainsyncResyncRequested
 			}
 			return nil
 		}
@@ -635,69 +878,27 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	}
 	// Reset mismatch counter on successful header addition
 	ls.headerMismatchCount = 0
-	// Wait for additional block headers before fetching block bodies if we're
-	// far enough out from upstream tip
-	// Use security window as slot threshold if available
-	slotThreshold := ls.calculateStabilityWindow()
-	if e.Point.Slot < e.Tip.Point.Slot &&
-		(e.Tip.Point.Slot-e.Point.Slot > slotThreshold) &&
-		(headerCount+1) < allowedHeaderCount {
-		ls.config.Logger.Debug(
-			"accumulating headers (far from tip)",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"tip_slot", e.Tip.Point.Slot,
-			"threshold", slotThreshold,
-			"header_count", headerCount+1,
-		)
-		return nil
-	}
-	// We use the blockfetch lock to ensure we aren't starting a batch at the same
-	// time as blockfetch starts a new one to avoid deadlocks
-	ls.chainsyncBlockfetchMutex.Lock()
-	defer ls.chainsyncBlockfetchMutex.Unlock()
-	// Don't start fetch if there's already one in progress
-	if ls.chainsyncBlockfetchReadyChan != nil {
-		ls.config.Logger.Debug(
-			"blockfetch in progress, queuing header",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"header_count", ls.chain.HeaderCount(),
-		)
-		return nil
-	}
-	// Mark blockfetch as in progress
-	ls.selectedBlockfetchConnId = e.ConnectionId
-	initialConnId := ls.selectInitialBlockfetchConn(e.ConnectionId)
-	ls.config.Logger.Debug(
-		"starting blockfetch",
-		"component", "ledger",
-		"connection_id", initialConnId.String(),
-		"header_count", ls.chain.HeaderCount(),
-	)
-	err := ls.startQueuedBlockfetchLocked(initialConnId)
-	if err != nil {
-		return err
-	}
-	return nil
+	return ls.maybeStartBlockfetchForHeader(e, allowedHeaderCount)
 }
 
 // tryResolveFork attempts to resolve a chain fork when an incoming header
 // doesn't fit the local chain tip. The incoming header's prevHash identifies
-// the common ancestor. If that block exists on our chain and the peer's
-// chain is ahead, we roll back to the common ancestor so chainsync can
-// continue on the network's canonical chain.
+// a block that exists on our local chain. If the peer's immediate prevHash
+// is already unknown to us, the connection's chainsync cursor has drifted
+// out of continuity with the local header queue and the correct recovery is
+// a fresh FindIntersect on that connection rather than repeated mismatch
+// counting.
 //
 // Returns true if the fork was resolved (chain rolled back), false if the
 // common ancestor was not found or the rollback could not be performed.
 func (ls *LedgerState) tryResolveFork(
 	e ChainsyncEvent,
 	notFitErr chain.BlockNotFitChainTipError,
-) bool {
+) (bool, error) {
 	// Only resolve forks when the peer is ahead of us.
 	localTip := ls.chain.Tip()
 	if e.Tip.Point.Slot <= localTip.Point.Slot {
-		return false
+		return false, nil
 	}
 
 	// The incoming header's prevHash is the common ancestor hash.
@@ -711,19 +912,26 @@ func (ls *LedgerState) tryResolveFork(
 			"error", err,
 			"block_prev_hash", notFitErr.BlockPrevHash(),
 		)
-		return false
+		return false, nil
 	}
 	ancestorBlock, err := database.BlockByHash(ls.db, prevHashBytes)
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
-			// Common ancestor not found in our database — can't resolve.
+			// The peer's header stream is not continuous with our local
+			// chain view. This usually means we buffered or resumed a
+			// stale stream and need a fresh intersection on that
+			// connection instead of waiting for more mismatches.
 			ls.config.Logger.Debug(
-				"common ancestor not found in database, "+
-					"falling back to mismatch counting",
+				"common ancestor not found locally, triggering chainsync re-sync",
 				"component", "ledger",
+				"connection_id", e.ConnectionId.String(),
 				"block_prev_hash", notFitErr.BlockPrevHash(),
 			)
-			return false
+			ls.requestChainsyncResync(
+				e.ConnectionId,
+				resyncReasonRollbackNotFound,
+			)
+			return false, errChainsyncResyncRequested
 		}
 		ls.config.Logger.Error(
 			"unexpected error looking up common ancestor",
@@ -731,7 +939,7 @@ func (ls *LedgerState) tryResolveFork(
 			"error", err,
 			"block_prev_hash", notFitErr.BlockPrevHash(),
 		)
-		return false
+		return false, nil
 	}
 
 	rollbackPoint := ocommon.NewPoint(
@@ -747,7 +955,7 @@ func (ls *LedgerState) tryResolveFork(
 		"connection_id", e.ConnectionId.String(),
 	)
 
-	if err := ls.chain.Rollback(rollbackPoint); err != nil {
+	if err := ls.rollbackChainAndState(rollbackPoint); err != nil {
 		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
 			// Fork exceeds security parameter K. We must not
 			// follow a chain that requires rolling back more
@@ -764,22 +972,11 @@ func (ls *LedgerState) tryResolveFork(
 				ls.chain.Tip().Point.Slot,
 				"peer_tip_slot", e.Tip.Point.Slot,
 			)
-			// Reset mismatch state so the fallback path in the
-			// caller does not fire a duplicate resync event.
-			ls.headerMismatchCount = 0
-			ls.rollbackHistory = nil
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
-					event.ChainsyncResyncEventType,
-					event.NewEvent(
-						event.ChainsyncResyncEventType,
-						event.ChainsyncResyncEvent{
-							ConnectionId: e.ConnectionId,
-							Reason:       "fork resolution exceeds security parameter K",
-						},
-					),
-				)
-			}
+			ls.requestChainsyncResync(
+				e.ConnectionId,
+				"fork resolution exceeds security parameter K",
+			)
+			return false, errChainsyncResyncRequested
 		} else {
 			ls.config.Logger.Error(
 				"failed to roll back to common ancestor",
@@ -788,44 +985,12 @@ func (ls *LedgerState) tryResolveFork(
 				"ancestor_slot", ancestorBlock.Slot,
 			)
 		}
-		return false
+		return false, nil
 	}
 
 	// Mark state as rollback so the next block header event logs
 	// "switched to fork" and increments the fork metric.
 	ls.chainsyncState = RollbackChainsyncState
-
-	// Invalidate epoch cache entries for epochs that started after
-	// the rollback point. These epochs have nonces computed from the
-	// old fork's blocks and would cause VRF verification failures on
-	// blocks from the new fork. The ledger-level rollback (which
-	// recomputes nonces) is asynchronous, so we must prune the cache
-	// here to prevent stale nonce lookups in handleEventBlockfetchBlock.
-	ls.Lock()
-	newCache := make([]models.Epoch, 0, len(ls.epochCache))
-	for _, ep := range ls.epochCache {
-		if ep.StartSlot <= rollbackPoint.Slot {
-			newCache = append(newCache, ep)
-		}
-	}
-	ls.epochCache = newCache
-	if len(newCache) > 0 {
-		ls.currentEpoch = newCache[len(newCache)-1]
-		eraDesc := eras.GetEraById(ls.currentEpoch.EraId)
-		if eraDesc != nil {
-			ls.currentEra = *eraDesc
-		} else {
-			ls.config.Logger.Warn(
-				"unknown era ID after fork rollback epoch prune, currentEra may be stale",
-				"era_id", ls.currentEpoch.EraId,
-				"component", "ledger",
-			)
-		}
-	} else {
-		ls.currentEpoch = models.Epoch{}
-		ls.currentEra = eras.EraDesc{}
-	}
-	ls.Unlock()
 
 	// Rollback succeeded — re-add the header that triggered fork
 	// detection. Only reset mismatch tracking on successful header
@@ -842,11 +1007,24 @@ func (ls *LedgerState) tryResolveFork(
 		)
 		// Do not reset mismatch state — let the caller know the
 		// resolution failed so subsequent mismatch tracking proceeds.
-		return false
+		return false, nil
+	}
+	allowedHeaderCount := min(
+		blockfetchBatchSize*4,
+		ls.chain.MaxQueuedHeaders(),
+	)
+	if err := ls.maybeStartBlockfetchForHeader(
+		e,
+		allowedHeaderCount,
+	); err != nil {
+		return false, fmt.Errorf(
+			"start blockfetch after fork resolution: %w",
+			err,
+		)
 	}
 	ls.headerMismatchCount = 0
 	ls.rollbackHistory = nil
-	return true
+	return true, nil
 }
 
 //nolint:unparam
@@ -942,101 +1120,40 @@ func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
 	}
 	pending := ls.pendingBlockfetchEvents
 	ls.pendingBlockfetchEvents = ls.pendingBlockfetchEvents[:0]
-	if len(pending) == 1 {
-		pendingEvent := pending[0]
-		txn := ls.db.BlobTxn(true)
-		// Avoid Txn.Do in the normal one-block hot path. Near tip we hit this
-		// path for almost every block, and blob-only transactions can commit or
-		// roll back directly without the callback/defer overhead.
+	// Commit each block before exposing it on the primary chain. The chain tip
+	// is used immediately by fork detection, so batching blob writes behind an
+	// already-advanced in-memory tip can strand the node on a fork when ancestor
+	// lookups hit uncommitted state.
+	for _, pendingEvent := range pending {
 		addBlockErr := ls.chain.AddBlockWithPoint(
 			pendingEvent.Block,
 			pendingEvent.Point,
-			txn,
+			nil,
 		)
-		if addBlockErr != nil {
-			var notFitErr chain.BlockNotFitChainTipError
-			var notMatchErr chain.BlockNotMatchHeaderError
-			ignored := errors.As(addBlockErr, &notFitErr) ||
-				errors.As(addBlockErr, &notMatchErr)
-			if rollbackErr := txn.Rollback(); rollbackErr != nil {
-				return fmt.Errorf(
-					"failed rolling back block transaction: %w",
-					rollbackErr,
-				)
-			}
-			if !ignored {
-				return fmt.Errorf(
-					"failed processing block event: add chain block: %w",
-					addBlockErr,
-				)
-			}
-			ls.config.Logger.Warn(
-				fmt.Sprintf(
-					"ignoring blockfetch block: %s",
-					addBlockErr,
-				),
-			)
-			if errors.As(addBlockErr, &notMatchErr) {
-				ls.chain.ClearHeaders()
-			}
-		} else if err := txn.Commit(); err != nil {
-			_ = txn.Rollback()
+		if addBlockErr == nil {
+			ls.checkSlotBattle(pendingEvent, nil)
+			continue
+		}
+		var notFitErr chain.BlockNotFitChainTipError
+		var notMatchErr chain.BlockNotMatchHeaderError
+		ignored := errors.As(addBlockErr, &notFitErr) ||
+			errors.As(addBlockErr, &notMatchErr)
+		if !ignored {
 			return fmt.Errorf(
-				"failed processing block event: commit block transaction: %w",
-				err,
+				"failed processing block event: add chain block: %w",
+				addBlockErr,
 			)
+		}
+		ls.config.Logger.Warn(
+			fmt.Sprintf(
+				"ignoring blockfetch block: %s",
+				addBlockErr,
+			),
+		)
+		if errors.As(addBlockErr, &notMatchErr) {
+			ls.clearQueuedHeaders()
 		}
 		ls.checkSlotBattle(pendingEvent, addBlockErr)
-		ls.chain.NotifyIterators()
-		return nil
-	}
-	blocks := make([]gledger.Block, 0, len(pending))
-	for _, pendingEvent := range pending {
-		blocks = append(blocks, pendingEvent.Block)
-	}
-	if err := ls.chain.AddBlocks(blocks); err == nil {
-		ls.Lock()
-		for _, pendingEvent := range pending {
-			ls.checkSlotBattle(pendingEvent, nil)
-		}
-		ls.Unlock()
-		return nil
-	}
-	addBlockErrs := make([]error, len(pending))
-	txn := ls.db.BlobTxn(true)
-	if err := txn.Do(func(txn *database.Txn) error {
-		for idx, pendingEvent := range pending {
-			addBlockErrs[idx] = ls.chain.AddBlockWithPoint(
-				pendingEvent.Block,
-				pendingEvent.Point,
-				txn,
-			)
-			if addBlockErrs[idx] == nil {
-				continue
-			}
-			if !errors.As(addBlockErrs[idx], &chain.BlockNotFitChainTipError{}) &&
-				!errors.As(addBlockErrs[idx], &chain.BlockNotMatchHeaderError{}) {
-				return fmt.Errorf(
-					"add chain block: %w",
-					addBlockErrs[idx],
-				)
-			}
-			ls.config.Logger.Warn(
-				fmt.Sprintf(
-					"ignoring blockfetch block: %s",
-					addBlockErrs[idx],
-				),
-			)
-			if errors.As(addBlockErrs[idx], &chain.BlockNotMatchHeaderError{}) {
-				ls.chain.ClearHeaders()
-			}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed processing block event: %w", err)
-	}
-	for idx, pendingEvent := range pending {
-		ls.checkSlotBattle(pendingEvent, addBlockErrs[idx])
 	}
 	ls.chain.NotifyIterators()
 	return nil
@@ -2019,6 +2136,8 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 	ls.chainsyncBlockfetchTimeoutTimer = time.AfterFunc(
 		blockfetchBusyTimeout,
 		func() {
+			ls.chainsyncMutex.Lock()
+			defer ls.chainsyncMutex.Unlock()
 			ls.chainsyncBlockfetchMutex.Lock()
 			defer ls.chainsyncBlockfetchMutex.Unlock()
 			// Check if this timer callback is stale (a newer timer was started)
@@ -2056,6 +2175,8 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 	if headerCount == 0 {
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		ls.clearQueuedHeaders()
+		ls.scheduleBufferedHeaderReplayLocked()
 		ls.config.Logger.Info(
 			fmt.Sprintf(
 				"blockfetch operation timed out after %s",
@@ -2150,6 +2271,8 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		// No more headers to fetch, allow chainsync to collect more
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		ls.clearQueuedHeaders()
+		ls.scheduleBufferedHeaderReplayLocked()
 		return nil
 	}
 	// Clean up from blockfetch batch

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1,0 +1,644 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type chainsyncRollbackFixture struct {
+	ls            *LedgerState
+	connId        ouroboros.ConnectionId
+	ancestorTip   ochainsync.Tip
+	currentTip    ochainsync.Tip
+	ancestorNonce []byte
+	forkPoint     ocommon.Point
+}
+
+type testSecurityParamLedger struct {
+	securityParam int
+}
+
+func (m testSecurityParamLedger) SecurityParam() int {
+	return m.securityParam
+}
+
+func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestRollbackChainAndStateRejectedRollbackDoesNotMutateLedgerState(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	blocks := []chain.RawBlock{
+		{
+			Slot:        10,
+			Hash:        testHashBytes("rollback-precheck-1"),
+			BlockNumber: 1,
+			Type:        1,
+			Cbor:        []byte{0x80},
+		},
+		{
+			Slot:        20,
+			Hash:        testHashBytes("rollback-precheck-2"),
+			BlockNumber: 2,
+			Type:        1,
+			PrevHash:    testHashBytes("rollback-precheck-1"),
+			Cbor:        []byte{0x80},
+		},
+		{
+			Slot:        30,
+			Hash:        testHashBytes("rollback-precheck-3"),
+			BlockNumber: 3,
+			Type:        1,
+			PrevHash:    testHashBytes("rollback-precheck-2"),
+			Cbor:        []byte{0x80},
+		},
+		{
+			Slot:        40,
+			Hash:        testHashBytes("rollback-precheck-4"),
+			BlockNumber: 4,
+			Type:        1,
+			PrevHash:    testHashBytes("rollback-precheck-3"),
+			Cbor:        []byte{0x80},
+		},
+	}
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(blocks))
+
+	ls, err := NewLedgerState(
+		LedgerStateConfig{
+			Database:          db,
+			ChainManager:      cm,
+			CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+			Logger: slog.New(
+				slog.NewJSONHandler(io.Discard, nil),
+			),
+		},
+	)
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	cm.SetLedger(testSecurityParamLedger{securityParam: 1})
+
+	rollbackPoint := ocommon.NewPoint(blocks[1].Slot, blocks[1].Hash)
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(blocks[3].Slot, blocks[3].Hash),
+		BlockNumber: blocks[3].BlockNumber,
+	}
+	rollbackNonce := []byte("rollback-point-nonce")
+	currentNonce := []byte("current-point-nonce")
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			rollbackPoint.Hash,
+			rollbackPoint.Slot,
+			rollbackNonce,
+			true,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			currentNonce,
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = append([]byte(nil), currentNonce...)
+
+	err = ls.rollbackChainAndState(rollbackPoint)
+	require.ErrorIs(t, err, chain.ErrRollbackExceedsSecurityParam)
+
+	assert.Equal(t, currentTip, ls.chain.Tip())
+	assert.Equal(t, currentTip, ls.currentTip)
+	assert.True(t, bytes.Equal(currentNonce, ls.currentTipBlockNonce))
+
+	dbTip, err := db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, currentTip, dbTip)
+}
+
+func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	var requestedConnId ouroboros.ConnectionId
+	fixture.ls.config.BlockfetchRequestRangeFunc = func(
+		connId ouroboros.ConnectionId,
+		start ocommon.Point,
+		end ocommon.Point,
+	) error {
+		_ = start
+		_ = end
+		requestedConnId = connId
+		return nil
+	}
+	t.Cleanup(func() {
+		fixture.ls.blockfetchRequestRangeCleanup()
+	})
+
+	forkHash := testHashBytes("fork-block")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 10,
+	}
+	err := fixture.ls.chain.AddBlockHeader(header)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved, err := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		},
+		notFitErr,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
+	assert.Equal(t, fixture.connId, requestedConnId)
+	assert.Equal(t, fixture.connId, fixture.ls.activeBlockfetchConnId)
+	require.NotNil(t, fixture.ls.chainsyncBlockfetchReadyChan)
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	staleHash := testHashBytes("stale-fork-block")
+	stalePrevHash := testHashBytes("missing-ancestor")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(staleHash),
+		prevHash:    lcommon.NewBlake2b256(stalePrevHash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 10,
+	}
+	fixture.ls.bufferedHeaderEvents = map[ouroboros.ConnectionId][]ChainsyncEvent{
+		fixture.connId: {{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		}},
+	}
+
+	err := fixture.ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			header.SlotNumber(),
+			header.Hash().Bytes(),
+		),
+		BlockHeader: header,
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockNumber: header.BlockNumber(),
+		},
+	})
+	require.ErrorIs(t, err, errChainsyncResyncRequested)
+
+	select {
+	case resync := <-resyncCh:
+		assert.Equal(t, fixture.connId, resync.ConnectionId)
+		assert.Equal(t, resyncReasonRollbackNotFound, resync.Reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected chainsync resync event")
+	}
+
+	assert.Zero(t, fixture.ls.headerMismatchCount)
+	_, ok := fixture.ls.bufferedHeaderEvents[fixture.connId]
+	assert.False(t, ok)
+}
+
+func TestReplayBufferedHeaderEventsStopsAfterResyncRequest(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+	fixture.ls.config.BlockfetchRequestRangeFunc = func(
+		ouroboros.ConnectionId,
+		ocommon.Point,
+		ocommon.Point,
+	) error {
+		t.Fatal("unexpected blockfetch request after resync")
+		return nil
+	}
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	staleHash := testHashBytes("stale-fork-block")
+	stalePrevHash := testHashBytes("missing-ancestor")
+	validHash := testHashBytes("valid-buffered-header")
+	staleHeader := mockHeader{
+		hash:        lcommon.NewBlake2b256(staleHash),
+		prevHash:    lcommon.NewBlake2b256(stalePrevHash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 10,
+	}
+	validHeader := mockHeader{
+		hash:        lcommon.NewBlake2b256(validHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 2,
+		slot:        fixture.currentTip.Point.Slot + 20,
+	}
+	fixture.ls.bufferedHeaderEvents = map[ouroboros.ConnectionId][]ChainsyncEvent{
+		fixture.connId: {
+			{
+				ConnectionId: fixture.connId,
+				Point: ocommon.NewPoint(
+					staleHeader.SlotNumber(),
+					staleHeader.Hash().Bytes(),
+				),
+				BlockHeader: staleHeader,
+				Tip: ochainsync.Tip{
+					Point: ocommon.NewPoint(
+						staleHeader.SlotNumber(),
+						staleHeader.Hash().Bytes(),
+					),
+					BlockNumber: staleHeader.BlockNumber(),
+				},
+			},
+			{
+				ConnectionId: fixture.connId,
+				Point: ocommon.NewPoint(
+					validHeader.SlotNumber(),
+					validHeader.Hash().Bytes(),
+				),
+				BlockHeader: validHeader,
+				Tip: ochainsync.Tip{
+					Point: ocommon.NewPoint(
+						validHeader.SlotNumber(),
+						validHeader.Hash().Bytes(),
+					),
+					BlockNumber: validHeader.BlockNumber(),
+				},
+			},
+		},
+	}
+
+	err := fixture.ls.replayBufferedHeaderEvents(fixture.connId)
+	require.NoError(t, err)
+
+	select {
+	case resync := <-resyncCh:
+		assert.Equal(t, fixture.connId, resync.ConnectionId)
+		assert.Equal(t, resyncReasonRollbackNotFound, resync.Reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected chainsync resync event")
+	}
+
+	assert.Zero(t, fixture.ls.headerMismatchCount)
+	assert.Equal(t, 0, fixture.ls.chain.HeaderCount())
+	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.headerPipelineConnId)
+	_, ok := fixture.ls.bufferedHeaderEvents[fixture.connId]
+	assert.False(t, ok)
+}
+
+func TestReplayBufferedHeadersAsyncSkipsActiveBlockfetch(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	requestedCh := make(chan struct{}, 1)
+	fixture.ls.config.BlockfetchRequestRangeFunc = func(
+		ouroboros.ConnectionId,
+		ocommon.Point,
+		ocommon.Point,
+	) error {
+		select {
+		case requestedCh <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	headerHash := testHashBytes("async-buffered-header")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(headerHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 1,
+	}
+	fixture.ls.bufferedHeaderEvents = map[ouroboros.ConnectionId][]ChainsyncEvent{
+		fixture.connId: {{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		}},
+	}
+
+	fixture.ls.chainsyncMutex.Lock()
+	fixture.ls.replayBufferedHeadersAsync(fixture.connId)
+	fixture.ls.chainsyncBlockfetchMutex.Lock()
+	fixture.ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	fixture.ls.chainsyncBlockfetchMutex.Unlock()
+	fixture.ls.chainsyncMutex.Unlock()
+
+	select {
+	case <-requestedCh:
+		t.Fatal("unexpected blockfetch request while active batch is present")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	fixture.ls.chainsyncMutex.Lock()
+	defer fixture.ls.chainsyncMutex.Unlock()
+	assert.Equal(t, 0, fixture.ls.chain.HeaderCount())
+	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.headerPipelineConnId)
+	_, ok := fixture.ls.bufferedHeaderEvents[fixture.connId]
+	assert.True(t, ok)
+}
+
+func TestReconcilePrimaryChainTipWithLedgerTipRollsBackMetadata(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.reconcilePrimaryChainTipWithLedgerTip())
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestProcessChainIteratorRollbackAppliesMatchingRollback(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	err := fixture.ls.processChainIteratorRollback(
+		fixture.ancestorTip.Point,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestProcessChainIteratorRollbackSkipsStaleRollback(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	currentNonce := append([]byte(nil), fixture.ls.currentTipBlockNonce...)
+	err := fixture.ls.processChainIteratorRollback(
+		fixture.ancestorTip.Point,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(currentNonce, fixture.ls.currentTipBlockNonce),
+	)
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.currentTip, dbTip)
+}
+
+func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {
+	t.Helper()
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ancestorHash := testHashBytes("ancestor-block")
+	currentHash := testHashBytes("current-block")
+	ancestorBlock := chain.RawBlock{
+		Slot:        10,
+		Hash:        ancestorHash,
+		BlockNumber: 1,
+		Type:        1,
+		Cbor:        []byte{0x80},
+	}
+	currentBlock := chain.RawBlock{
+		Slot:        20,
+		Hash:        currentHash,
+		BlockNumber: 2,
+		Type:        1,
+		PrevHash:    ancestorHash,
+		Cbor:        []byte{0x80},
+	}
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
+			ancestorBlock,
+			currentBlock,
+		}),
+	)
+
+	ls, err := NewLedgerState(
+		LedgerStateConfig{
+			Database:          db,
+			ChainManager:      cm,
+			CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+			Logger: slog.New(
+				slog.NewJSONHandler(io.Discard, nil),
+			),
+		},
+	)
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	ancestorTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(ancestorBlock.Slot, ancestorBlock.Hash),
+		BlockNumber: ancestorBlock.BlockNumber,
+	}
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(currentBlock.Slot, currentBlock.Hash),
+		BlockNumber: currentBlock.BlockNumber,
+	}
+	ancestorNonce := []byte("nonce-ancestor")
+	currentNonce := []byte("nonce-current")
+
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			ancestorTip.Point.Hash,
+			ancestorTip.Point.Slot,
+			ancestorNonce,
+			true,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			currentNonce,
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = append([]byte(nil), currentNonce...)
+	ls.chainsyncState = SyncingChainsyncState
+
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+
+	return &chainsyncRollbackFixture{
+		ls:            ls,
+		connId:        connId,
+		ancestorTip:   ancestorTip,
+		currentTip:    currentTip,
+		ancestorNonce: ancestorNonce,
+		forkPoint:     ocommon.NewPoint(currentBlock.Slot+10, testHashBytes("fork-point")),
+	}
+}
+
+func testHashBytes(seed string) []byte {
+	sum := sha256.Sum256([]byte(seed))
+	return append([]byte(nil), sum[:]...)
+}

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -20,9 +20,11 @@ import (
 	"log/slog"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -285,6 +287,103 @@ func TestHandleChainSwitchEventUpdatesSelectedBlockfetchConnId(t *testing.T) {
 	assert.Equal(t, connId, nextConnId)
 }
 
+func TestHandleConnectionClosedEventClearsActiveBlockfetchState(t *testing.T) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	ls := &LedgerState{
+		chain:                        &chain.Chain{},
+		activeBlockfetchConnId:       connId1,
+		selectedBlockfetchConnId:     connId1,
+		headerPipelineConnId:         connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		pendingBlockfetchEvents: []BlockfetchEvent{
+			{ConnectionId: connId1},
+		},
+		bufferedHeaderEvents: map[ouroboros.ConnectionId][]ChainsyncEvent{
+			connId1: {{ConnectionId: connId1}},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.handleConnectionClosedEvent(event.NewEvent(
+		connmanager.ConnectionClosedEventType,
+		connmanager.ConnectionClosedEvent{ConnectionId: connId1},
+	))
+
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.activeBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.selectedBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.headerPipelineConnId)
+	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
+	assert.Empty(t, ls.pendingBlockfetchEvents)
+	_, ok := ls.bufferedHeaderEvents[connId1]
+	assert.False(t, ok)
+}
+
+func TestHandleEventChainsyncBlockHeaderBuffersNonOwnerConnection(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	header1Hash := lcommon.NewBlake2b256([]byte("hdr-1"))
+	header2Hash := lcommon.NewBlake2b256([]byte("hdr-2"))
+	header1 := mockHeader{
+		hash:        header1Hash,
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}
+	header2 := mockHeader{
+		hash:        header2Hash,
+		prevHash:    header1Hash,
+		blockNumber: 2,
+		slot:        2,
+	}
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId1,
+		BlockHeader:  header1,
+		Point:        ocommon.NewPoint(header1.slot, header1.hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60001, []byte("tip-1")),
+			BlockNumber: 60001,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, connId1, ls.headerPipelineConnId)
+	assert.Equal(t, 1, ls.chain.HeaderCount())
+
+	err = ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId2,
+		BlockHeader:  header2,
+		Point:        ocommon.NewPoint(header2.slot, header2.hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60002, []byte("tip-2")),
+			BlockNumber: 60002,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, connId1, ls.headerPipelineConnId)
+	assert.Equal(t, 1, ls.chain.HeaderCount())
+	require.Len(t, ls.bufferedHeaderEvents[connId2], 1)
+	assert.Equal(t, header2.slot, ls.bufferedHeaderEvents[connId2][0].Point.Slot)
+}
+
 func TestHandleEventChainsyncBlockHeader_ProcessesEligibleNonActivePeer(
 	t *testing.T,
 ) {
@@ -335,6 +434,61 @@ func TestHandleEventChainsyncBlockHeader_ProcessesEligibleNonActivePeer(
 	assert.Equal(t, 1, testChain.HeaderCount())
 	assert.Equal(t, connId2, requestedConn)
 	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
+}
+
+func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	headerHash := lcommon.NewBlake2b256([]byte("hdr-2"))
+	ls := &LedgerState{
+		chain:                        &chain.Chain{},
+		activeBlockfetchConnId:       connId1,
+		selectedBlockfetchConnId:     connId2,
+		headerPipelineConnId:         connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		bufferedHeaderEvents: map[ouroboros.ConnectionId][]ChainsyncEvent{
+			connId2: {{
+				ConnectionId: connId2,
+				BlockHeader: mockHeader{
+					hash:        headerHash,
+					prevHash:    lcommon.NewBlake2b256(nil),
+					blockNumber: 1,
+					slot:        1,
+				},
+				Point: ocommon.NewPoint(1, headerHash.Bytes()),
+				Tip: ochainsync.Tip{
+					Point:       ocommon.NewPoint(60001, []byte("tip-2")),
+					BlockNumber: 60001,
+				},
+			}},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+		ConnectionId: connId1,
+		BatchDone:    true,
+	})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		ls.chainsyncMutex.Lock()
+		defer ls.chainsyncMutex.Unlock()
+		return ls.headerPipelineConnId == connId2 &&
+			len(ls.bufferedHeaderEvents[connId2]) == 0 &&
+			ls.chain.HeaderCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, connId2, ls.headerPipelineConnId)
+	assert.Equal(t, 1, ls.chain.HeaderCount())
 }
 
 func TestHandleBlockfetchTimeoutLocked_RetriesQueuedRangeUsingActivePeer(
@@ -410,6 +564,58 @@ func TestHandleBlockfetchTimeoutLocked_ClearsActiveConnectionWithoutHeaders(
 	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
 	_, ok := ls.nextBlockfetchConnId()
 	assert.False(t, ok)
+}
+
+func TestHandleBlockfetchTimeoutLocked_ReplaysBufferedHeadersWithoutHeaders(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	headerHash := lcommon.NewBlake2b256([]byte("hdr-timeout"))
+	ls := &LedgerState{
+		chain:                        &chain.Chain{},
+		activeBlockfetchConnId:       connId1,
+		selectedBlockfetchConnId:     connId2,
+		headerPipelineConnId:         connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		bufferedHeaderEvents: map[ouroboros.ConnectionId][]ChainsyncEvent{
+			connId2: {{
+				ConnectionId: connId2,
+				BlockHeader: mockHeader{
+					hash:        headerHash,
+					prevHash:    lcommon.NewBlake2b256(nil),
+					blockNumber: 1,
+					slot:        1,
+				},
+				Point: ocommon.NewPoint(1, headerHash.Bytes()),
+				Tip: ochainsync.Tip{
+					Point:       ocommon.NewPoint(60001, []byte("tip-2")),
+					BlockNumber: 60001,
+				},
+			}},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.handleBlockfetchTimeoutLocked(connId1)
+
+	require.Eventually(t, func() bool {
+		ls.chainsyncMutex.Lock()
+		defer ls.chainsyncMutex.Unlock()
+		return ls.headerPipelineConnId == connId2 &&
+			len(ls.bufferedHeaderEvents[connId2]) == 0 &&
+			ls.chain.HeaderCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, connId2, ls.headerPipelineConnId)
+	assert.Equal(t, 1, ls.chain.HeaderCount())
 }
 
 func TestHandleBlockfetchTimeoutLocked_RetryFailureUsesAlternateSelectedPeer(

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/blinklabs-io/dingo/event"
-	ledgerpkg "github.com/blinklabs-io/dingo/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -95,7 +94,6 @@ type Election struct {
 	computeCh      chan uint64   // requests background schedule computation
 	subscriptionId event.EventSubscriberId
 	nonceReadySub  event.EventSubscriberId
-	rollbackSub    event.EventSubscriberId
 }
 
 // NewElection creates a new leader election manager for a stake pool.
@@ -177,19 +175,6 @@ func (e *Election) Start(ctx context.Context) error {
 		)
 	} else {
 		go e.epochNonceReadyLoop(ctx, nonceReadyCh)
-	}
-
-	var rollbackCh <-chan event.Event
-	e.rollbackSub, rollbackCh = e.eventBus.Subscribe(
-		ledgerpkg.PoolStateRestoredEventType,
-	)
-	if rollbackCh == nil {
-		e.logger.Warn(
-			"event bus not available, rollback schedule invalidation will not be tracked",
-			"component", "leader",
-		)
-	} else {
-		go e.rollbackLoop(ctx, rollbackCh)
 	}
 	go e.scheduleComputeLoop(ctx, e.computeCh)
 
@@ -331,61 +316,6 @@ func (e *Election) epochNonceReadyLoop(
 	}
 }
 
-func (e *Election) rollbackLoop(
-	ctx context.Context,
-	evtCh <-chan event.Event,
-) {
-	for evt := range evtCh {
-		latest := evt
-	drain:
-		for {
-			select {
-			case newer, ok := <-evtCh:
-				if !ok {
-					return
-				}
-				latest = newer
-			default:
-				break drain
-			}
-		}
-
-		if ctx.Err() != nil {
-			return
-		}
-
-		restoreEvent, ok := latest.Data.(ledgerpkg.PoolStateRestoredEvent)
-		if !ok {
-			e.logger.Error(
-				"invalid event data for rollback restoration",
-				"component", "leader",
-			)
-			continue
-		}
-
-		currentEpoch := e.epochProvider.CurrentEpoch()
-		readyEpoch, nextReady := e.epochProvider.NextEpochNonceReadyEpoch()
-		cleared := e.clearUnstableSchedules(
-			currentEpoch,
-			readyEpoch,
-			nextReady,
-		)
-		e.logger.Info(
-			"ledger rollback restored state, pruning unstable leader schedules",
-			"component", "leader",
-			"rollback_slot", restoreEvent.Slot,
-			"current_epoch", currentEpoch,
-			"next_epoch_ready", nextReady,
-			"ready_epoch", readyEpoch,
-			"cleared_schedules", cleared,
-		)
-		e.queueScheduleCompute(currentEpoch)
-		if nextReady {
-			e.queueScheduleCompute(readyEpoch)
-		}
-	}
-}
-
 // scheduleComputeLoop processes background schedule computation requests.
 // When ShouldProduceBlock detects a missing schedule for a slot's epoch,
 // it sends the epoch number to computeCh. This goroutine picks it up and
@@ -460,13 +390,6 @@ func (e *Election) Stop() error {
 			e.nonceReadySub,
 		)
 		e.nonceReadySub = 0
-	}
-	if e.rollbackSub != 0 {
-		e.eventBus.Unsubscribe(
-			ledgerpkg.PoolStateRestoredEventType,
-			e.rollbackSub,
-		)
-		e.rollbackSub = 0
 	}
 	e.running = false
 	e.schedules = nil
@@ -759,32 +682,6 @@ func (e *Election) storeSchedule(epoch uint64, schedule *Schedule) {
 			delete(e.schedules, ep)
 		}
 	}
-}
-
-func (e *Election) clearUnstableSchedules(
-	currentEpoch uint64,
-	readyEpoch uint64,
-	nextReady bool,
-) int {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if !e.running || e.schedules == nil {
-		return 0
-	}
-
-	cleared := 0
-	for epoch := range e.schedules {
-		if epoch <= currentEpoch {
-			continue
-		}
-		if nextReady && epoch == readyEpoch {
-			continue
-		}
-		delete(e.schedules, epoch)
-		cleared++
-	}
-	return cleared
 }
 
 func (e *Election) queueScheduleCompute(epoch uint64) {

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -82,8 +82,7 @@ func (m *mockStakeProvider) GetTotalActiveStake(epoch uint64) (uint64, error) {
 // mockEpochProvider implements EpochInfoProvider for testing
 type mockEpochProvider struct {
 	currentEpoch    atomic.Uint64
-	epochNonce      atomic.Value
-	nonceMu         sync.RWMutex
+	epochNonceMu    sync.RWMutex
 	epochNonces     map[uint64][]byte
 	slotsPerEpoch   uint64
 	activeSlotCoeff float64
@@ -106,18 +105,13 @@ func (m *mockEpochProvider) CurrentEpoch() uint64 {
 }
 
 func (m *mockEpochProvider) EpochNonce(epoch uint64) []byte {
-	m.nonceMu.RLock()
-	if nonce, ok := m.epochNonces[epoch]; ok {
-		m.nonceMu.RUnlock()
-		return cloneElectionNonce(nonce)
-	}
-	m.nonceMu.RUnlock()
-
-	nonce, ok := m.epochNonce.Load().([]byte)
+	m.epochNonceMu.RLock()
+	nonce, ok := m.epochNonces[epoch]
+	m.epochNonceMu.RUnlock()
 	if !ok || len(nonce) == 0 {
 		return nil
 	}
-	return cloneElectionNonce(nonce)
+	return append([]byte(nil), nonce...)
 }
 
 func (m *mockEpochProvider) NextEpochNonceReadyEpoch() (uint64, bool) {
@@ -137,20 +131,17 @@ func (m *mockEpochProvider) ActiveSlotCoeff() float64 {
 }
 
 func (m *mockEpochProvider) SetEpochNonce(nonce []byte) {
-	m.epochNonce.Store(cloneElectionNonce(nonce))
+	m.SetEpochNonceForEpoch(m.CurrentEpoch(), nonce)
 }
 
-func (m *mockEpochProvider) SetEpochNonceForEpoch(
-	epoch uint64,
-	nonce []byte,
-) {
-	m.nonceMu.Lock()
-	defer m.nonceMu.Unlock()
+func (m *mockEpochProvider) SetEpochNonceForEpoch(epoch uint64, nonce []byte) {
+	m.epochNonceMu.Lock()
+	defer m.epochNonceMu.Unlock()
 	if len(nonce) == 0 {
 		delete(m.epochNonces, epoch)
 		return
 	}
-	m.epochNonces[epoch] = cloneElectionNonce(nonce)
+	m.epochNonces[epoch] = append([]byte(nil), nonce...)
 }
 
 type mockScheduleStore struct {
@@ -197,13 +188,6 @@ func (m *mockScheduleStore) key(
 
 func makeElectionNonce(fill byte) []byte {
 	return bytes.Repeat([]byte{fill}, 32)
-}
-
-func cloneElectionNonce(nonce []byte) []byte {
-	if len(nonce) == 0 {
-		return nil
-	}
-	return append([]byte(nil), nonce...)
 }
 
 // waitForSchedule polls until CurrentSchedule returns non-nil, or fails
@@ -294,6 +278,7 @@ func TestElectionScheduleEarlyEpochs(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(1)
+	epochProvider.SetEpochNonceForEpoch(1, electionTestNonce)
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -456,6 +441,9 @@ func TestElectionPrecomputesNextEpochAtStartupWhenNonceReady(t *testing.T) {
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
 	epochProvider.nextEpochReady.Store(11)
+	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
+	electionTestNonce11[0] ^= 0xff
+	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -477,14 +465,17 @@ func TestElectionPrecomputesNextEpochAtStartupWhenNonceReady(t *testing.T) {
 	waitForSchedule(t, election, 30*time.Second)
 
 	require.Eventually(t, func() bool {
-		return election.ScheduleForEpoch(11) != nil
+		schedule := election.ScheduleForEpoch(11)
+		return schedule != nil &&
+			bytes.Equal(electionTestNonce11, schedule.EpochNonce)
 	}, 30*time.Second, 100*time.Millisecond,
 		"next epoch schedule should be precomputed at startup")
 
 	require.Eventually(t, func() bool {
 		schedule, err := store.LoadSchedule(11, poolId)
 		require.NoError(t, err)
-		return schedule != nil
+		return schedule != nil &&
+			bytes.Equal(electionTestNonce11, schedule.EpochNonce)
 	}, 2*time.Second, 50*time.Millisecond,
 		"next epoch schedule should be persisted at startup")
 }
@@ -497,6 +488,9 @@ func TestElectionZeroPoolStake(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
+	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
+	electionTestNonce11[0] ^= 0xff
+	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -533,6 +527,9 @@ func TestElectionShouldProduceBlock(t *testing.T) {
 	// we reliably get leader slots despite the small sample size.
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
+	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
+	electionTestNonce11[0] ^= 0xff
+	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 	epochProvider.activeSlotCoeff = 0.9
 
 	eventBus := event.NewEventBus(nil, nil)
@@ -615,6 +612,9 @@ func TestElectionEpochTransition(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
+	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
+	electionTestNonce11[0] ^= 0xff
+	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -683,6 +683,9 @@ func TestElectionPrecomputesNextEpochOnNonceReady(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
+	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
+	electionTestNonce11[0] ^= 0xff
+	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	store := newMockScheduleStore()
 	eventBus := event.NewEventBus(nil, nil)
@@ -718,14 +721,17 @@ func TestElectionPrecomputesNextEpochOnNonceReady(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		return election.ScheduleForEpoch(11) != nil
+		schedule := election.ScheduleForEpoch(11)
+		return schedule != nil &&
+			bytes.Equal(electionTestNonce11, schedule.EpochNonce)
 	}, 30*time.Second, 100*time.Millisecond,
 		"next epoch schedule should be precomputed after nonce-ready event")
 
 	require.Eventually(t, func() bool {
 		schedule, err := store.LoadSchedule(11, poolId)
 		require.NoError(t, err)
-		return schedule != nil
+		return schedule != nil &&
+			bytes.Equal(electionTestNonce11, schedule.EpochNonce)
 	}, 2*time.Second, 50*time.Millisecond,
 		"next epoch schedule should be persisted")
 }
@@ -756,10 +762,8 @@ func TestElectionRollbackKeepsCurrentSchedule(t *testing.T) {
 	defer func() { _ = election.Stop() }()
 
 	schedule := waitForSchedule(t, election, 30*time.Second)
-	leaderSlots := schedule.LeaderSlotsSnapshot()
-	if len(leaderSlots) == 0 {
-		t.Fatalf("current schedule should contain at least one leader slot")
-	}
+	leaderSlots := append([]uint64(nil), schedule.LeaderSlotsSnapshot()...)
+	require.NotEmpty(t, leaderSlots)
 	leaderSlot := leaderSlots[0]
 
 	eventBus.Publish(
@@ -775,17 +779,15 @@ func TestElectionRollbackKeepsCurrentSchedule(t *testing.T) {
 		if current == nil {
 			return false
 		}
-		currentSlots := current.LeaderSlotsSnapshot()
-		return currentSlots != nil &&
-			len(currentSlots) > 0 &&
-			bytes.Equal(schedule.EpochNonce, current.EpochNonce) &&
-			currentSlots[0] == leaderSlot &&
+		currentLeaderSlots := current.LeaderSlotsSnapshot()
+		return bytes.Equal(schedule.EpochNonce, current.EpochNonce) &&
+			assert.ObjectsAreEqual(leaderSlots, currentLeaderSlots) &&
 			election.ShouldProduceBlock(leaderSlot)
 	}, time.Second, 20*time.Millisecond,
 		"rollback should not invalidate a stable current-epoch schedule")
 }
 
-func TestElectionRollbackKeepsStableNextSchedule(t *testing.T) {
+func TestElectionRollbackKeepsPrecomputedNextSchedule(t *testing.T) {
 	poolId := lcommon.PoolKeyHash{}
 	stakeProvider := newMockStakeProvider()
 	stakeProvider.totalStake = 1_000_000
@@ -794,7 +796,9 @@ func TestElectionRollbackKeepsStableNextSchedule(t *testing.T) {
 	epochProvider := newMockEpochProvider()
 	epochProvider.activeSlotCoeff = 1.0
 	epochProvider.nextEpochReady.Store(11)
-	epochProvider.SetEpochNonceForEpoch(11, makeElectionNonce(0x31))
+	nextEpochNonce := append([]byte(nil), electionTestNonce...)
+	nextEpochNonce[0] ^= 0xff
+	epochProvider.SetEpochNonceForEpoch(11, nextEpochNonce)
 
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
@@ -825,92 +829,17 @@ func TestElectionRollbackKeepsStableNextSchedule(t *testing.T) {
 		ledgerpkg.PoolStateRestoredEventType,
 		event.NewEvent(
 			ledgerpkg.PoolStateRestoredEventType,
-			ledgerpkg.PoolStateRestoredEvent{Slot: 95},
-		),
-	)
-
-	require.Eventually(t, func() bool {
-		schedule := election.ScheduleForEpoch(11)
-		return schedule == nextBefore &&
-			bytes.Equal(expectedNonce, schedule.EpochNonce) &&
-			assert.ObjectsAreEqual(expectedSlots, schedule.LeaderSlotsSnapshot())
-	}, time.Second, 20*time.Millisecond,
-		"rollback after cutoff should not invalidate a stable next-epoch schedule")
-}
-
-func TestElectionRollbackClearsUnstableNextSchedule(t *testing.T) {
-	poolId := lcommon.PoolKeyHash{}
-	stakeProvider := newMockStakeProvider()
-	stakeProvider.totalStake = 1_000_000
-	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
-
-	epochProvider := newMockEpochProvider()
-	epochProvider.activeSlotCoeff = 1.0
-	epochProvider.nextEpochReady.Store(11)
-	epochProvider.SetEpochNonceForEpoch(11, makeElectionNonce(0x31))
-
-	eventBus := event.NewEventBus(nil, nil)
-	defer eventBus.Stop()
-
-	election := NewElection(
-		poolId,
-		electionTestVRFSeed,
-		stakeProvider,
-		epochProvider,
-		eventBus,
-		slog.Default(),
-	)
-
-	err := election.Start(context.Background())
-	require.NoError(t, err)
-	defer func() { _ = election.Stop() }()
-
-	waitForSchedule(t, election, 30*time.Second)
-	var nextBefore *Schedule
-	require.Eventually(t, func() bool {
-		nextBefore = election.ScheduleForEpoch(11)
-		return nextBefore != nil
-	}, 30*time.Second, 100*time.Millisecond)
-	require.True(
-		t,
-		bytes.Equal(makeElectionNonce(0x31), nextBefore.EpochNonce),
-	)
-
-	epochProvider.nextEpochReady.Store(0)
-	epochProvider.SetEpochNonceForEpoch(11, makeElectionNonce(0x32))
-	eventBus.Publish(
-		ledgerpkg.PoolStateRestoredEventType,
-		event.NewEvent(
-			ledgerpkg.PoolStateRestoredEventType,
 			ledgerpkg.PoolStateRestoredEvent{Slot: 90},
-		),
-	)
-
-	require.Eventually(t, func() bool {
-		return election.ScheduleForEpoch(11) == nil
-	}, 5*time.Second, 50*time.Millisecond,
-		"rollback before cutoff should clear the precomputed next-epoch schedule")
-
-	epochProvider.nextEpochReady.Store(11)
-	eventBus.Publish(
-		event.EpochNonceReadyEventType,
-		event.NewEvent(
-			event.EpochNonceReadyEventType,
-			event.EpochNonceReadyEvent{
-				CurrentEpoch: 10,
-				ReadyEpoch:   11,
-				CutoffSlot:   95,
-			},
 		),
 	)
 
 	require.Eventually(t, func() bool {
 		schedule := election.ScheduleForEpoch(11)
 		return schedule != nil &&
-			schedule != nextBefore &&
-			bytes.Equal(makeElectionNonce(0x32), schedule.EpochNonce)
-	}, 30*time.Second, 100*time.Millisecond,
-		"nonce-ready replay should rebuild the next epoch schedule after rollback")
+			bytes.Equal(expectedNonce, schedule.EpochNonce) &&
+			assert.ObjectsAreEqual(expectedSlots, schedule.LeaderSlotsSnapshot())
+	}, time.Second, 20*time.Millisecond,
+		"rollback should not invalidate a precomputed next-epoch schedule")
 }
 
 func TestElectionConcurrentAccess(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -468,6 +468,7 @@ type LedgerState struct {
 	chainsyncBlockfetchReadyChan  chan struct{}
 	activeBlockfetchConnId        ouroboros.ConnectionId // connection used for current blockfetch pipeline
 	selectedBlockfetchConnId      ouroboros.ConnectionId // latest selected chainsync connection for the next batch
+	headerPipelineConnId          ouroboros.ConnectionId // connection that currently owns the queued header/blockfetch pipeline
 	pendingBlockfetchEvents       []BlockfetchEvent
 	checkpointWrittenForEpoch     bool
 	closed                        atomic.Bool
@@ -503,7 +504,8 @@ type LedgerState struct {
 	lastActiveConnId *ouroboros.ConnectionId // tracks active connection for switch detection
 
 	// Header mismatch tracking for fork detection and re-sync
-	headerMismatchCount int // consecutive header mismatch count
+	headerMismatchCount  int // consecutive header mismatch count
+	bufferedHeaderEvents map[ouroboros.ConnectionId][]ChainsyncEvent
 }
 
 // EraTransitionResult holds computed state from an era transition
@@ -653,7 +655,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// Start goroutine to process new blocks unless the caller will feed trusted
 	// batches directly into the replay loop.
 	if !ls.config.ManualBlockProcessing {
-		go ls.ledgerProcessBlocks()
+		go ls.ledgerProcessBlocks(ctx)
 	}
 	return nil
 }
@@ -1593,6 +1595,46 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	return nil
 }
 
+// rollbackChainAndState first validates that the primary chain will accept the
+// rollback, then synchronizes the metadata-backed ledger state and rewinds the
+// primary chain to the same point.
+func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
+	if err := ls.chain.ValidateRollback(point); err != nil {
+		return fmt.Errorf("validate primary chain rollback: %w", err)
+	}
+	if err := ls.rollback(point); err != nil {
+		return fmt.Errorf("rollback ledger state: %w", err)
+	}
+	if err := ls.chain.Rollback(point); err != nil {
+		return fmt.Errorf("rollback primary chain: %w", err)
+	}
+	return nil
+}
+
+// processChainIteratorRollback applies a rollback emitted by the primary chain
+// iterator only when the chain still sits at that rollback point. Iterator
+// rollbacks can lag behind live blockfetch/chainsync activity; if the primary
+// chain has already re-extended past the rollback point, applying the rollback
+// again would desynchronize metadata from the blob-backed chain.
+func (ls *LedgerState) processChainIteratorRollback(
+	point ocommon.Point,
+) error {
+	chainTip := ls.chain.Tip()
+	if chainTip.Point.Slot != point.Slot ||
+		!bytes.Equal(chainTip.Point.Hash, point.Hash) {
+		ls.config.Logger.Debug(
+			"skipping stale chain iterator rollback",
+			"component", "ledger",
+			"rollback_slot", point.Slot,
+			"rollback_hash", hex.EncodeToString(point.Hash),
+			"chain_tip_slot", chainTip.Point.Slot,
+			"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+		)
+		return nil
+	}
+	return ls.rollback(point)
+}
+
 // transitionToEra performs an era transition and returns the result without
 // mutating LedgerState. This allows callers to capture the computed state in a
 // transaction and apply it to in-memory state after the transaction commits.
@@ -1811,6 +1853,7 @@ type readChainResult struct {
 	rollbackPoint ocommon.Point
 	blocks        []ledger.Block
 	rollback      bool
+	err           error
 }
 
 func (ls *LedgerState) ledgerReadChain(
@@ -1823,6 +1866,12 @@ func (ls *LedgerState) ledgerReadChain(
 		ls.config.Logger.Error(
 			"failed to create chain iterator: " + err.Error(),
 		)
+		select {
+		case resultCh <- readChainResult{
+			err: fmt.Errorf("create chain iterator: %w", err),
+		}:
+		case <-ctx.Done():
+		}
 		return
 	}
 	// Read blocks from chain iterator and decode
@@ -1852,6 +1901,15 @@ func (ls *LedgerState) ledgerReadChain(
 						ls.config.Logger.Error(
 							"failed to get next block from chain iterator: " + err.Error(),
 						)
+						select {
+						case resultCh <- readChainResult{
+							err: fmt.Errorf(
+								"get next block from chain iterator: %w",
+								err,
+							),
+						}:
+						case <-ctx.Done():
+						}
 						return
 					}
 					shouldBlock = true
@@ -1861,6 +1919,12 @@ func (ls *LedgerState) ledgerReadChain(
 			}
 			if next == nil {
 				ls.config.Logger.Error("next block from chain iterator is nil")
+				select {
+				case resultCh <- readChainResult{
+					err: errors.New("next block from chain iterator is nil"),
+				}:
+				case <-ctx.Done():
+				}
 				return
 			}
 			if next.Rollback {
@@ -1880,6 +1944,12 @@ func (ls *LedgerState) ledgerReadChain(
 				ls.config.Logger.Error(
 					"failed to decode block: " + err.Error(),
 				)
+				select {
+				case resultCh <- readChainResult{
+					err: fmt.Errorf("decode block: %w", err),
+				}:
+				case <-ctx.Done():
+				}
 				return
 			}
 			// Add to batch
@@ -1911,12 +1981,20 @@ func (ls *LedgerState) ledgerReadChain(
 	}
 }
 
-func (ls *LedgerState) ledgerProcessBlocks() {
+func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 	for {
+		attemptCtx, cancel := context.WithCancel(ctx)
 		readChainResultCh := make(chan readChainResult)
-		go ls.ledgerReadChain(ls.ctx, readChainResultCh)
-		err := ls.ledgerProcessBlocksFromSource(ls.ctx, readChainResultCh)
-		if err == nil || ls.ctx.Err() != nil {
+		go func() {
+			defer close(readChainResultCh)
+			ls.ledgerReadChain(attemptCtx, readChainResultCh)
+		}()
+		err := ls.ledgerProcessBlocksFromSource(
+			attemptCtx,
+			readChainResultCh,
+		)
+		cancel()
+		if err == nil || ctx.Err() != nil {
 			return
 		}
 		ls.config.Logger.Warn(
@@ -2317,6 +2395,9 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				if !ok {
 					return nil
 				}
+				if result.err != nil {
+					return result.err
+				}
 				nextBatch = result.blocks
 				// Process rollback
 				// Note: We do NOT hold ls.Lock() here because rollback() calls
@@ -2324,7 +2405,9 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// that re-acquires ls.Lock(), causing a deadlock. The rollback
 				// method handles its own locking for in-memory state updates.
 				if result.rollback {
-					if err = ls.rollback(result.rollbackPoint); err != nil {
+					if err = ls.processChainIteratorRollback(
+						result.rollbackPoint,
+					); err != nil {
 						return fmt.Errorf("process rollback: %w", err)
 					}
 					continue
@@ -3106,11 +3189,21 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 		return nil
 	}
 	if chainTip.Point.Slot < ledgerTip.Point.Slot {
-		return fmt.Errorf(
-			"primary chain tip %d is behind ledger tip %d",
-			chainTip.Point.Slot,
-			ledgerTip.Point.Slot,
+		ls.config.Logger.Warn(
+			"ledger tip ahead of primary chain tip at startup, rolling back metadata to chain tip",
+			"component", "ledger",
+			"chain_tip_slot", chainTip.Point.Slot,
+			"ledger_tip_slot", ledgerTip.Point.Slot,
+			"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+			"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
 		)
+		if err := ls.rollback(chainTip.Point); err != nil {
+			return fmt.Errorf(
+				"rollback ledger tip to primary chain tip: %w",
+				err,
+			)
+		}
+		return nil
 	}
 	ls.config.Logger.Warn(
 		"primary chain tip ahead of ledger tip at startup, pruning speculative blocks",

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -15,8 +15,10 @@
 package ledger
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -41,6 +43,26 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
+
+func TestLedgerProcessBlocksFromSourceReturnsReaderError(t *testing.T) {
+	ls := &LedgerState{
+		validationEnabled: true,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	readErr := errors.New("reader failed")
+	readChainResultCh := make(chan readChainResult, 1)
+	readChainResultCh <- readChainResult{err: readErr}
+	close(readChainResultCh)
+
+	err := ls.ledgerProcessBlocksFromSource(
+		context.Background(),
+		readChainResultCh,
+	)
+	require.ErrorIs(t, err, readErr)
+}
 
 // TestCalculateStabilityWindow_ByronEra tests the stability window calculation for Byron era
 func TestCalculateStabilityWindow_ByronEra(t *testing.T) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -540,11 +540,21 @@ func (o *Ouroboros) chainsyncClientRollForward(
 			return nil
 		}
 		if !isNew {
-			// Duplicate header already delivered by another
-			// eligible peer. Keep the peer tip fresh, but do not
-			// re-publish the same header into the ledger queue.
-			o.updateChainsyncMetrics(ctx.ConnectionId, tip)
-			return nil
+			activeConnId := o.ChainsyncState.GetClientConnId()
+			if activeConnId != nil && *activeConnId == ctx.ConnectionId {
+				o.config.Logger.Debug(
+					"publishing duplicate header from selected connection",
+					"component", "ouroboros",
+					"connection_id", ctx.ConnectionId.String(),
+					"slot", point.Slot,
+				)
+			} else {
+				// Duplicate header already delivered by another
+				// eligible peer. Keep the peer tip fresh, but do not
+				// re-publish the same header into the ledger queue.
+				o.updateChainsyncMetrics(ctx.ConnectionId, tip)
+				return nil
+			}
 		}
 		o.EventBus.Publish(
 			ledger.ChainsyncEventType,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -122,6 +122,68 @@ func TestNormalizeIntersectPoints(t *testing.T) {
 	)
 }
 
+func TestChainsyncClientRollForwardPublishesDuplicateFromSelectedPeer(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ch := bus.Subscribe(ledger.ChainsyncEventType)
+	state := dchainsync.NewState(bus, nil)
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connB))
+	state.SetClientConnId(connA)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connB},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	select {
+	case evt1 := <-ch:
+		data1, ok := evt1.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connB, data1.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal("expected initial header to be published")
+	}
+
+	err = o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connA},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	select {
+	case evt2 := <-ch:
+		data2, ok := evt2.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connA, data2.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal("expected duplicate header from selected peer to publish")
+	}
+}
+
 func TestChainsyncClientRollForward_IneligiblePeerDoesNotPoisonDedup(
 	t *testing.T,
 ) {

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -308,7 +308,6 @@ func (p *PeerGovernor) IsChainSelectionEligible(
 ) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
 	peerIdx := p.peerIndexByConnId(connId)
 	if peerIdx == -1 || p.peers[peerIdx] == nil {
 		return false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chain state reconciliation so the primary chain and ledger metadata stay in sync through rollbacks, forks, and peer switches. Stabilizes chainsync by buffering headers across connections, preferring the selected peer, and triggering resyncs to avoid getting stuck on a fork.

- **Bug Fixes**
  - Rewind both the primary chain and ledger metadata together (`rollbackChainAndState`), pre‑validate against K (`ValidateRollback`) to avoid mutating state when rejected; skip stale iterator rollbacks.
  - On startup, if the ledger tip is ahead of the primary chain, roll back metadata to the chain tip instead of failing reconciliation.
  - Buffer headers from non-owner connections and replay them when the pipeline is idle, preferring the selected peer; clear queued headers and schedule replay on batch completion, timeouts, connection close, or header/block mismatches.
  - Resync chainsync when a header’s prevHash isn’t found locally (stale cursor) or fork resolution exceeds K; stop header replay on resync.
  - Commit each fetched block before advancing the in-memory tip to keep fork detection and ancestor lookups reliable.
  - Deduplicate roll‑forward headers across peers, but still publish duplicates from the selected connection to keep the pipeline moving.
  - Preserve the incumbent best peer when tips, priorities, and VRFs are equal in `chainselection`.
  - Added tests for rollback synchronization, buffered header replay (incl. drain/timeout/close), duplicate header publishing, selector incumbency, reader error propagation, and startup reconciliation.

- **Refactors**
  - Removed rollback-driven schedule invalidation from `ledger/leader/election`; tests updated.
  - Simplified startup rewind in `chain/manager`; coordinated `chainsync`/`blockfetch` locking and made `ledgerProcessBlocks` exit cleanly when its reader returns.

<sup>Written for commit 3e914496dcb42e1af277d823e2ae27b38df6febc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fork recovery, resync and rollback robustness with buffered header replay, safer rollback application, and duplicate-header handling from the active peer.
* **Refactor**
  * Simplified rewind/rollback and leader-schedule refresh behavior for more predictable background processing and startup reconciliation.
* **Behavior**
  * Chain-selection preserves incumbents when tips, priority and VRF match; invalid/short VRF no longer prevents switches.
* **Tests**
  * Added extensive tests for chainsync, rollback/resync, replay, connection-closure, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->