### PR TITLE
test: explain conway tx size fixture

### DIFF
--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -217,6 +217,10 @@ func TestTxSizeForFee_RebuiltConwayTxPreservesCanonicalSize(t *testing.T) {
 		TxMetadata: tx.TxMetadata,
 	}
 
+	// 699 is the canonical Conway transaction byte length produced by
+	// NewConwayTransactionFromCbor for this fixture; TxSizeForFee must preserve
+	// that exact serialized size when reconstructing the transaction for min-fee
+	// accounting.
 	assert.Equal(t, uint64(699), TxSizeForFee(rebuilt))
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the Conway transaction size fixture by noting that 699 bytes is the canonical size from `NewConwayTransactionFromCbor`, and that `TxSizeForFee` must preserve this exact size when reconstructing for min-fee accounting. Makes the test’s assertion rationale explicit to avoid confusion during maintenance.

<sup>Written for commit c586a3f6f4c49124f343f82116b8374f52d99e6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

