### PR TITLE
fix: allow specifying network magic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.161.1
+	github.com/blinklabs-io/gouroboros v0.163.0
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.27
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.161.1 h1:1r4DAwSebt8/XlK31zJty9QMKuf7rB58bPl59OF1mg0=
-github.com/blinklabs-io/gouroboros v0.161.1/go.mod h1:J8m943TBvY+ZfYmIsI94ipvE8XHNhV1V5PNtywr9YAo=
+github.com/blinklabs-io/gouroboros v0.163.0 h1:P5I6nA0riUDxk/qMjD49fdTFlE81O9x2SgN4++ZEuCk=
+github.com/blinklabs-io/gouroboros v0.163.0/go.mod h1:J8m943TBvY+ZfYmIsI94ipvE8XHNhV1V5PNtywr9YAo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.27 h1:/leKVzb2XrgXo2yGsgpynpw/fh2sB8RNom+k3mXUwhA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,7 @@ type Config struct {
 	ShutdownTimeout      string  `yaml:"shutdownTimeout"                                                  split_words:"true"`
 	LedgerCatchupTimeout string  `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
 	Network              string  `yaml:"network"`
+	NetworkMagic         uint32  `yaml:"networkMagic"                                                     split_words:"true"`
 	MempoolCapacity      int64   `yaml:"mempoolCapacity"                                                  split_words:"true"`
 	EvictionWatermark    float64 `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
 	RejectionWatermark   float64 `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
@@ -365,6 +366,7 @@ var globalConfig = &Config{
 	IntersectTip:         false,
 	ValidateHistorical:   false,
 	Network:              "preview",
+	NetworkMagic:         0,
 	MetricsPort:          12798,
 	PrivateBindAddr:      "127.0.0.1",
 	PrivatePort:          3002,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -275,6 +275,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithEvictionWatermark(cfg.EvictionWatermark),
 			dingo.WithRejectionWatermark(cfg.RejectionWatermark),
 			dingo.WithNetwork(cfg.Network),
+			dingo.WithNetworkMagic(cfg.NetworkMagic),
 			dingo.WithCardanoNodeConfig(nodeCfg),
 			dingo.WithListeners(listeners...),
 			dingo.WithOutboundSourcePort(cfg.RelayPort),


### PR DESCRIPTION
Fixes #1724

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for specifying Cardano network magic via the config and forwards it to the node so connections use the correct network. Fixes #1724.

- **New Features**
  - Added `networkMagic` (uint32) config option with default 0.
  - Value is passed to the node to select the intended network.

- **Dependencies**
  - Bumped `github.com/blinklabs-io/gouroboros` to v0.163.0.

<sup>Written for commit 634e33483af121d926a760a450a11f274d927b01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network magic configuration option for enhanced network settings support.

* **Chores**
  * Updated gouroboros library dependency to v0.163.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->