### PR TITLE
fix: chainsync resilience

### DIFF
--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	PeerTipUpdateEventType  event.EventType = "chainselection.peer_tip_update"
+	PeerActivityEventType   event.EventType = "chainselection.peer_activity"
 	ChainSwitchEventType    event.EventType = "chainselection.chain_switch"
 	ChainSelectionEventType event.EventType = "chainselection.selection"
 	PeerEvictedEventType    event.EventType = "chainselection.peer_evicted"
@@ -32,7 +33,15 @@ const (
 type PeerTipUpdateEvent struct {
 	ConnectionId ouroboros.ConnectionId
 	Tip          ochainsync.Tip
-	VRFOutput    []byte // VRF output from block header for tie-breaking
+	ObservedTip  ochainsync.Tip
+	VRFOutput    []byte // VRF output from observed block header for tie-breaking
+}
+
+// PeerActivityEvent is published when a peer has recent protocol activity
+// (for example, a keepalive response) without a tip change. This refreshes
+// selector liveness for healthy but temporarily quiet peers.
+type PeerActivityEvent struct {
+	ConnectionId ouroboros.ConnectionId
 }
 
 // ChainSwitchEvent is published when the chain selector decides to switch

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -23,10 +23,12 @@ import (
 
 // PeerChainTip tracks the chain tip reported by a specific peer.
 type PeerChainTip struct {
-	ConnectionId ouroboros.ConnectionId
-	Tip          ochainsync.Tip
-	VRFOutput    []byte // VRF output from tip block for tie-breaking
-	LastUpdated  time.Time
+	ConnectionId   ouroboros.ConnectionId
+	Tip            ochainsync.Tip
+	ObservedTip    ochainsync.Tip
+	ObservedTipSet bool   // true when ObservedTip has been explicitly set
+	VRFOutput      []byte // VRF output from tip block for tie-breaking
+	LastUpdated    time.Time
 }
 
 // NewPeerChainTip creates a new PeerChainTip with the given connection ID,
@@ -37,17 +39,50 @@ func NewPeerChainTip(
 	vrfOutput []byte,
 ) *PeerChainTip {
 	return &PeerChainTip{
-		ConnectionId: connId,
-		Tip:          tip,
-		VRFOutput:    vrfOutput,
-		LastUpdated:  time.Now(),
+		ConnectionId:   connId,
+		Tip:            tip,
+		ObservedTip:    tip,
+		ObservedTipSet: true,
+		VRFOutput:      vrfOutput,
+		LastUpdated:    time.Now(),
 	}
 }
 
 // UpdateTip updates the peer's chain tip, VRF output, and last updated timestamp.
 func (p *PeerChainTip) UpdateTip(tip ochainsync.Tip, vrfOutput []byte) {
+	p.UpdateTipWithObserved(tip, tip, vrfOutput)
+}
+
+// UpdateTipWithObserved updates both the remote advertised tip and the latest
+// locally observed frontier for the peer.
+func (p *PeerChainTip) UpdateTipWithObserved(
+	tip ochainsync.Tip,
+	observedTip ochainsync.Tip,
+	vrfOutput []byte,
+) {
 	p.Tip = tip
+	p.ObservedTip = observedTip
+	p.ObservedTipSet = true
 	p.VRFOutput = vrfOutput
+	p.LastUpdated = time.Now()
+}
+
+// SelectionTip returns the best locally observed frontier for this peer.
+// When available, prefer the latest block the peer has actually delivered to
+// us over its remote advertised tip. This avoids switching to peers whose
+// far-end tip is high while their chainsync cursor is still lagging.
+func (p *PeerChainTip) SelectionTip() ochainsync.Tip {
+	if p == nil {
+		return ochainsync.Tip{}
+	}
+	if p.ObservedTipSet {
+		return p.ObservedTip
+	}
+	return p.Tip
+}
+
+// Touch marks the peer as recently active without changing its advertised tip.
+func (p *PeerChainTip) Touch() {
 	p.LastUpdated = time.Now()
 }
 

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -15,7 +15,6 @@
 package chainselection
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -167,14 +166,23 @@ func (cs *ChainSelector) Stop() {
 // and slot.
 //
 // Returns true if the tip was accepted, false if it was rejected as
-// implausible. A tip is considered implausible if it claims a block number
-// more than securityParam (k) blocks ahead of a reference point. For known
-// peers, the reference is the peer's own previous tip; for new peers, the
-// reference is the best known peer tip. This avoids rejecting legitimate
-// peers during sync (where the local tip is far behind).
+// implausible. A tip is considered implausible if a known peer claims a
+// block number more than securityParam (k) blocks ahead of its own previous
+// tip. New (unknown) peers are always accepted to support cold-start
+// scenarios such as Mithril bootstrap where the first peers may be far
+// ahead of any local reference.
 func (cs *ChainSelector) UpdatePeerTip(
 	connId ouroboros.ConnectionId,
 	tip ochainsync.Tip,
+	vrfOutput []byte,
+) bool {
+	return cs.updatePeerTipObserved(connId, tip, tip, vrfOutput)
+}
+
+func (cs *ChainSelector) updatePeerTipObserved(
+	connId ouroboros.ConnectionId,
+	tip ochainsync.Tip,
+	observedTip ochainsync.Tip,
 	vrfOutput []byte,
 ) bool {
 	shouldEvaluate := false
@@ -186,51 +194,46 @@ func (cs *ChainSelector) UpdatePeerTip(
 		defer cs.mutex.Unlock()
 
 		// Reject implausible tips that claim to be too far ahead of
-		// a reference point. Three cases:
-		//  1. Known peer: compare against the peer's own previous
-		//     tip — chainsync advances incrementally so the delta
-		//     is always small. Always checked (even if prev == 0).
-		//  2. New peer with existing peers: compare against the
-		//     best known peer tip to prevent a malicious newcomer
-		//     from spoofing an extremely high block number.
-		//  3. First peer ever: no reference exists, accept to
-		//     allow bootstrap.
+		// a reference point. Only checked for known peers: chainsync
+		// advances incrementally so a known peer's tip should never
+		// jump more than k blocks between updates.
+		//
+		// New peers are accepted unconditionally. Restricting new
+		// peers based on the best known peer tip breaks cold-start
+		// scenarios (e.g., Mithril bootstrap) where the reference
+		// is stale and legitimate peers are >k blocks ahead. Once
+		// a new peer is tracked, subsequent updates are bounded by
+		// this check. Non-functional peers are evicted by the stale
+		// tip threshold.
 		if cs.securityParam > 0 {
-			rejectTip := false
-			var referenceBlock uint64
 			if prevTip, exists := cs.peerTips[connId]; exists {
-				// Case 1: known peer — always check
-				referenceBlock = prevTip.Tip.BlockNumber
-				rejectTip = tip.BlockNumber >
-					safeAddUint64(referenceBlock, cs.securityParam)
-			} else if len(cs.peerTips) > 0 {
-				// Case 2: new peer — check against best known
-				for _, pt := range cs.peerTips {
-					if pt.Tip.BlockNumber > referenceBlock {
-						referenceBlock = pt.Tip.BlockNumber
-					}
+				referenceBlock := prevTip.Tip.BlockNumber
+				if tip.BlockNumber >
+					safeAddUint64(referenceBlock, cs.securityParam) {
+					cs.config.Logger.Warn(
+						"rejecting implausible peer tip",
+						"connection_id", connId.String(),
+						"claimed_block", tip.BlockNumber,
+						"reference_block", referenceBlock,
+						"security_param", cs.securityParam,
+						"max_plausible_block",
+						safeAddUint64(
+							referenceBlock,
+							cs.securityParam,
+						),
+					)
+					accepted = false
+					return
 				}
-				rejectTip = tip.BlockNumber >
-					safeAddUint64(referenceBlock, cs.securityParam)
-			}
-			// Case 3: len(peerTips)==0 && peer not known → bootstrap
-			if rejectTip {
-				cs.config.Logger.Warn(
-					"rejecting implausible peer tip",
-					"connection_id", connId.String(),
-					"claimed_block", tip.BlockNumber,
-					"reference_block", referenceBlock,
-					"security_param", cs.securityParam,
-					"max_plausible_block",
-					safeAddUint64(referenceBlock, cs.securityParam),
-				)
-				accepted = false
-				return
 			}
 		}
 
 		if peerTip, exists := cs.peerTips[connId]; exists {
-			peerTip.UpdateTip(tip, vrfOutput)
+			peerTip.UpdateTipWithObserved(
+				tip,
+				observedTip,
+				vrfOutput,
+			)
 		} else {
 			// Evict the least-recently-updated peer if at capacity
 			if len(cs.peerTips) >= cs.maxTrackedPeers {
@@ -246,7 +249,9 @@ func (cs *ChainSelector) UpdatePeerTip(
 					return
 				}
 			}
-			cs.peerTips[connId] = NewPeerChainTip(connId, tip, vrfOutput)
+			peerTip := NewPeerChainTip(connId, tip, vrfOutput)
+			peerTip.ObservedTip = observedTip
+			cs.peerTips[connId] = peerTip
 		}
 
 		cs.config.Logger.Debug(
@@ -259,7 +264,10 @@ func (cs *ChainSelector) UpdatePeerTip(
 		// Check if this peer's tip is better than the current best peer's tip
 		if cs.bestPeerConn != nil {
 			if bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]; ok {
-				comparison := CompareChains(tip, bestPeerTip.Tip)
+				comparison := CompareChains(
+					cs.peerTips[connId].SelectionTip(),
+					bestPeerTip.SelectionTip(),
+				)
 				if comparison == ChainABetter {
 					shouldEvaluate = true
 				} else if comparison == ChainEqual &&
@@ -296,6 +304,17 @@ func (cs *ChainSelector) UpdatePeerTip(
 	}
 
 	return true
+}
+
+func (cs *ChainSelector) TouchPeerActivity(connId ouroboros.ConnectionId) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+
+	peerTip, exists := cs.peerTips[connId]
+	if !exists {
+		return
+	}
+	peerTip.Touch()
 }
 
 // evictLeastRecentPeerLocked removes the peer with the oldest LastUpdated
@@ -616,7 +635,10 @@ func (cs *ChainSelector) comparePeerTips(
 	if peerTipA == nil || peerTipB == nil {
 		return ChainComparisonUnknown
 	}
-	comparison := CompareChains(peerTipA.Tip, peerTipB.Tip)
+	comparison := CompareChains(
+		peerTipA.SelectionTip(),
+		peerTipB.SelectionTip(),
+	)
 	switch comparison {
 	case ChainABetter, ChainBBetter, ChainComparisonUnknown:
 		return comparison
@@ -707,17 +729,13 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 					return
 				}
 				if CompareChains(
-					newPeerTip.Tip,
-					previousPeerTip.Tip,
-				) == ChainEqual &&
-					cs.connectionPriority(*newBest) ==
-						cs.connectionPriority(*previousBest) &&
-					len(newPeerTip.VRFOutput) == VRFOutputSize &&
-					len(previousPeerTip.VRFOutput) == VRFOutputSize &&
-					bytes.Equal(
-						newPeerTip.VRFOutput,
-						previousPeerTip.VRFOutput,
-					) {
+					newPeerTip.SelectionTip(),
+					previousPeerTip.SelectionTip(),
+				) == ChainEqual {
+					// When two peers have delivered the same observed frontier,
+					// keep following the incumbent. The first peer to deliver the
+					// fitting header already won on latency; switching on source
+					// priority or VRF alone just creates churn near tip.
 					newBest = previousBest
 				} else if
 				// Preserve the incumbent only when it still wins the same
@@ -830,7 +848,26 @@ func (cs *ChainSelector) HandlePeerTipUpdateEvent(evt event.Event) {
 		)
 		return
 	}
-	cs.UpdatePeerTip(e.ConnectionId, e.Tip, e.VRFOutput)
+	cs.updatePeerTipObserved(
+		e.ConnectionId,
+		e.Tip,
+		e.ObservedTip,
+		e.VRFOutput,
+	)
+}
+
+// HandlePeerActivityEvent refreshes a peer's liveness on non-tip protocol
+// activity such as keepalive responses.
+func (cs *ChainSelector) HandlePeerActivityEvent(evt event.Event) {
+	e, ok := evt.Data.(PeerActivityEvent)
+	if !ok {
+		cs.config.Logger.Warn(
+			"received unexpected event data type",
+			"expected", "PeerActivityEvent",
+		)
+		return
+	}
+	cs.TouchPeerActivity(e.ConnectionId)
 }
 
 func (cs *ChainSelector) evaluationLoop() {

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -456,7 +456,35 @@ func TestChainSelectorDoesNotRestoreStaleIncumbent(t *testing.T) {
 	assert.Equal(t, challengerConn, *cs.GetBestPeer())
 }
 
-func TestChainSelectorPrefersHigherPriorityPeerAtEqualTip(t *testing.T) {
+func TestChainSelectorSelectBestChainPrefersHigherPriorityPeerAtEqualTip(
+	t *testing.T,
+) {
+	publicRootConn := newTestConnectionId(1)
+	localRootConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+	setSelectorConnectionPriority(cs, localRootConn, 20)
+	setSelectorConnectionPriority(cs, publicRootConn, 10)
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
+	}
+
+	cs.UpdatePeerTip(publicRootConn, equalTip, nil)
+	cs.UpdatePeerTip(localRootConn, equalTip, nil)
+
+	cs.mutex.Lock()
+	cs.bestPeerConn = nil
+	cs.mutex.Unlock()
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, localRootConn, *bestPeer)
+}
+
+func TestChainSelectorPreservesEqualTipIncumbentAgainstHigherPriorityPeer(
+	t *testing.T,
+) {
 	publicRootConn := newTestConnectionId(1)
 	localRootConn := newTestConnectionId(2)
 	cs := NewChainSelector(ChainSelectorConfig{})
@@ -473,8 +501,10 @@ func TestChainSelectorPrefersHigherPriorityPeerAtEqualTip(t *testing.T) {
 	assert.Equal(t, publicRootConn, *cs.GetBestPeer())
 
 	cs.UpdatePeerTip(localRootConn, equalTip, nil)
+	switched := cs.EvaluateAndSwitch()
+	assert.False(t, switched)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, localRootConn, *cs.GetBestPeer())
+	assert.Equal(t, publicRootConn, *cs.GetBestPeer())
 }
 
 func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
@@ -496,7 +526,7 @@ func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
 	cs.UpdatePeerTip(connId1, equalTip, sharedVRF)
 	cs.UpdatePeerTip(connId2, equalTip, sharedVRF)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId2, *cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
 
 	setSelectorConnectionPriority(cs, connId1, 50)
 	setSelectorConnectionPriority(cs, connId2, 50)
@@ -508,10 +538,10 @@ func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
 	switched := cs.EvaluateAndSwitch()
 	assert.False(t, switched)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId2, *cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
 }
 
-func TestChainSelectorDoesNotPreserveIncumbentWithInvalidEqualVRF(
+func TestChainSelectorPreservesIncumbentWithInvalidEqualVRF(
 	t *testing.T,
 ) {
 	testCases := []struct {
@@ -547,7 +577,7 @@ func TestChainSelectorDoesNotPreserveIncumbentWithInvalidEqualVRF(
 			cs.UpdatePeerTip(connId1, equalTip, tc.vrfA)
 			cs.UpdatePeerTip(connId2, equalTip, tc.vrfB)
 			require.NotNil(t, cs.GetBestPeer())
-			assert.Equal(t, connId2, *cs.GetBestPeer())
+			assert.Equal(t, connId1, *cs.GetBestPeer())
 
 			setSelectorConnectionPriority(cs, connId1, 50)
 			setSelectorConnectionPriority(cs, connId2, 50)
@@ -557,7 +587,7 @@ func TestChainSelectorDoesNotPreserveIncumbentWithInvalidEqualVRF(
 			assert.Equal(t, connId1, *bestPeer)
 
 			switched := cs.EvaluateAndSwitch()
-			assert.True(t, switched)
+			assert.False(t, switched)
 			require.NotNil(t, cs.GetBestPeer())
 			assert.Equal(t, connId1, *cs.GetBestPeer())
 		})
@@ -650,7 +680,9 @@ func TestChainSelectorSwitchesImmediatelyOnEligibilityEvent(t *testing.T) {
 	}, time.Second, 5*time.Millisecond)
 }
 
-func TestChainSelectorSwitchesImmediatelyOnPriorityEvent(t *testing.T) {
+func TestChainSelectorDoesNotSwitchEqualTipIncumbentOnPriorityEvent(
+	t *testing.T,
+) {
 	eventBus := event.NewEventBus(nil, nil)
 	defer eventBus.Stop()
 
@@ -685,10 +717,12 @@ func TestChainSelectorSwitchesImmediatelyOnPriorityEvent(t *testing.T) {
 		),
 	)
 
-	require.Eventually(t, func() bool {
+	require.Never(t, func() bool {
 		bestPeer := cs.GetBestPeer()
 		return bestPeer != nil && *bestPeer == challengerConn
-	}, time.Second, 5*time.Millisecond)
+	}, 100*time.Millisecond, 5*time.Millisecond)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 }
 
 func TestChainSelectorDoesNotPreserveImplausiblyBehindIncumbent(t *testing.T) {
@@ -943,7 +977,9 @@ func TestChainSelectorVRFTiebreaker(t *testing.T) {
 	assert.Equal(t, connId2, *bestPeer, "peer with lower VRF should win")
 }
 
-func TestChainSelectorUpdatePeerTipTriggersVRFTieBreakEvaluation(t *testing.T) {
+func TestChainSelectorUpdatePeerTipPreservesEqualTipIncumbentOnVRF(
+	t *testing.T,
+) {
 	cs := NewChainSelector(ChainSelectorConfig{})
 
 	connId1 := newTestConnectionId(1)
@@ -963,9 +999,9 @@ func TestChainSelectorUpdatePeerTipTriggersVRFTieBreakEvaluation(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(
 		t,
-		connId2,
+		connId1,
 		*cs.GetBestPeer(),
-		"peer with lower VRF should trigger immediate evaluation",
+		"equal-tip challenger should not steal the incumbent on VRF alone",
 	)
 }
 
@@ -1082,47 +1118,37 @@ func TestPeerChainTipVRFOutputStored(t *testing.T) {
 	assert.Equal(t, newVRF, peerTip.VRFOutput)
 }
 
-func TestUpdatePeerTipRejectsImplausibleTip(t *testing.T) {
+func TestUpdatePeerTipRejectsImplausibleKnownPeerJump(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
 		SecurityParam: 2160, // Cardano mainnet k
 	})
 
-	// Set local tip so the plausibility check is active
-	cs.SetLocalTip(ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
-		BlockNumber: 50000,
-	})
+	connId := newTestConnectionId(1)
 
-	// Add a plausible peer first so the implausible check activates
-	// (the check requires len(peerTips) > 0 to avoid blocking
-	// initial sync where all peers are legitimately far ahead).
-	existingConn := newTestConnectionId(2)
-	plausibleTip := ochainsync.Tip{
+	// First tip accepted (new peer, always accepted)
+	initialTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
 		BlockNumber: 50500,
 	}
-	cs.UpdatePeerTip(existingConn, plausibleTip, nil)
+	accepted := cs.UpdatePeerTip(connId, initialTip, nil)
+	assert.True(t, accepted, "initial tip should be accepted")
 
-	connId := newTestConnectionId(1)
-
-	// A spoofed tip claiming to be far beyond local tip + k
+	// Same peer jumps far beyond previous tip + k
 	spoofedTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: math.MaxUint64, Hash: []byte("spoof")},
 		BlockNumber: math.MaxUint64,
 	}
 
-	accepted := cs.UpdatePeerTip(connId, spoofedTip, nil)
+	accepted = cs.UpdatePeerTip(connId, spoofedTip, nil)
 	assert.False(
 		t,
 		accepted,
-		"implausibly high tip should be rejected",
+		"known peer jumping beyond k should be rejected",
 	)
-	assert.Nil(
-		t,
-		cs.GetPeerTip(connId),
-		"rejected tip should not be tracked",
-	)
-	assert.Equal(t, 1, cs.PeerCount(), "peer count should remain 1 (existing peer only)")
+	// Peer tip should still be the original tip
+	pt := cs.GetPeerTip(connId)
+	require.NotNil(t, pt)
+	assert.Equal(t, uint64(50500), pt.Tip.BlockNumber)
 }
 
 func TestUpdatePeerTipAcceptsPlausibleTip(t *testing.T) {
@@ -1187,43 +1213,40 @@ func TestUpdatePeerTipAcceptsTipAtExactBoundary(t *testing.T) {
 	assert.NotNil(t, cs.GetPeerTip(connId))
 }
 
-func TestUpdatePeerTipRejectsTipOneOverBoundary(t *testing.T) {
+func TestUpdatePeerTipAcceptsNewPeerFarAhead(t *testing.T) {
+	// New peers are always accepted regardless of how far ahead they
+	// claim to be. This supports cold-start scenarios like Mithril
+	// bootstrap where legitimate peers may be >k blocks ahead of
+	// the local reference.
 	cs := NewChainSelector(ChainSelectorConfig{
-		SecurityParam: 2160,
+		SecurityParam: 432, // preview k
 	})
 
-	cs.SetLocalTip(ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
-		BlockNumber: 50000,
-	})
-
-	// Add a plausible peer first so the implausible check has a
-	// reference point. The reference is the best known peer tip
-	// (block 50500), not the local tip.
-	existingConn := newTestConnectionId(2)
-	cs.UpdatePeerTip(existingConn, ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
-		BlockNumber: 50500,
+	// Add a peer at the Mithril snapshot block
+	snapshotConn := newTestConnectionId(1)
+	cs.UpdatePeerTip(snapshotConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("snapshot")},
+		BlockNumber: 4125222,
 	}, nil)
 
-	connId := newTestConnectionId(1)
-
-	// Tip one block past the boundary (reference peer block + k + 1)
-	overBoundaryTip := ochainsync.Tip{
+	// A new peer at the real chain tip, 500 blocks ahead (> k=432)
+	realConn := newTestConnectionId(2)
+	realTip := ochainsync.Tip{
 		Point: ocommon.Point{
-			Slot: 106000,
-			Hash: []byte("over"),
+			Slot: 110000,
+			Hash: []byte("real"),
 		},
-		BlockNumber: 50500 + 2160 + 1,
+		BlockNumber: 4125722, // 500 blocks ahead of snapshot
 	}
 
-	accepted := cs.UpdatePeerTip(connId, overBoundaryTip, nil)
-	assert.False(
+	accepted := cs.UpdatePeerTip(realConn, realTip, nil)
+	assert.True(
 		t,
 		accepted,
-		"tip one past boundary should be rejected",
+		"new peer should be accepted even if >k blocks ahead of existing peers",
 	)
-	assert.Nil(t, cs.GetPeerTip(connId))
+	assert.NotNil(t, cs.GetPeerTip(realConn))
+	assert.Equal(t, 2, cs.PeerCount())
 }
 
 func TestUpdatePeerTipAcceptsTipWhenSecurityParamZero(t *testing.T) {
@@ -1348,46 +1371,37 @@ func TestUpdatePeerTipRejectsKnownPeerJumpFromZero(t *testing.T) {
 	assert.Equal(t, uint64(0), pt.Tip.BlockNumber)
 }
 
-func TestUpdatePeerTipSpoofedPeerDoesNotBecomesBest(t *testing.T) {
+func TestUpdatePeerTipKnownPeerSpoofRejected(t *testing.T) {
+	// A known peer that tries to jump its tip by more than k blocks
+	// is rejected. This is the primary anti-spoofing defense.
 	cs := NewChainSelector(ChainSelectorConfig{
 		SecurityParam: 2160,
 	})
 
-	cs.SetLocalTip(ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
-		BlockNumber: 50000,
-	})
-
-	// Add a legitimate peer first
-	legitimateConn := newTestConnectionId(1)
-	legitimateTip := ochainsync.Tip{
+	// Peer establishes initial tip
+	connId := newTestConnectionId(1)
+	initialTip := ochainsync.Tip{
 		Point: ocommon.Point{
 			Slot: 100100,
 			Hash: []byte("legit"),
 		},
 		BlockNumber: 50050,
 	}
-	cs.UpdatePeerTip(legitimateConn, legitimateTip, nil)
+	cs.UpdatePeerTip(connId, initialTip, nil)
 
-	// Now a malicious peer tries to spoof
-	maliciousConn := newTestConnectionId(2)
+	// Same peer tries to spoof by jumping far ahead
 	spoofedTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: math.MaxUint64, Hash: []byte("evil")},
 		BlockNumber: math.MaxUint64,
 	}
 
-	accepted := cs.UpdatePeerTip(maliciousConn, spoofedTip, nil)
-	assert.False(t, accepted, "spoofed tip should be rejected")
+	accepted := cs.UpdatePeerTip(connId, spoofedTip, nil)
+	assert.False(t, accepted, "known peer jumping beyond k should be rejected")
 
-	// The legitimate peer should still be the best
-	bestPeer := cs.GetBestPeer()
-	require.NotNil(t, bestPeer)
-	assert.Equal(
-		t,
-		legitimateConn,
-		*bestPeer,
-		"legitimate peer should remain best peer",
-	)
+	// Peer tip should still be the original
+	pt := cs.GetPeerTip(connId)
+	require.NotNil(t, pt)
+	assert.Equal(t, uint64(50050), pt.Tip.BlockNumber)
 }
 
 func TestChainSelectorMaxTrackedPeersDefault(t *testing.T) {

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -16,6 +16,7 @@ package chainsync
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"sync"
@@ -135,6 +136,9 @@ type State struct {
 	seenHeaders      map[uint64][]headerRecord
 	seenHeadersMutex sync.Mutex
 
+	observedHeaders      map[string]*observedHeaderChain
+	observedHeadersMutex sync.RWMutex
+
 	sync.Mutex
 }
 
@@ -144,6 +148,18 @@ type headerRecord struct {
 	hash   []byte
 	connId ouroboros.ConnectionId
 }
+
+type observedHeaderRecord struct {
+	event    ledger.ChainsyncEvent
+	prevHash []byte
+}
+
+type observedHeaderChain struct {
+	order  []string
+	byHash map[string]observedHeaderRecord
+}
+
+const maxObservedHeadersPerConn = 256
 
 // NewState creates a new chainsync State with the given
 // event bus and ledger state using default configuration.
@@ -174,6 +190,9 @@ func NewStateWithConfig(
 		clients:        make(map[ouroboros.ConnectionId]*ChainsyncClientState),
 		trackedClients: make(map[ouroboros.ConnectionId]*TrackedClient),
 		seenHeaders:    make(map[uint64][]headerRecord),
+		observedHeaders: make(
+			map[string]*observedHeaderChain,
+		),
 	}
 	return s
 }
@@ -252,6 +271,7 @@ func (s *State) RemoveClientConnId(
 		*s.activeClientConnId == connId
 	wasEligible := exists && !tc.ObservabilityOnly
 	delete(s.trackedClients, connId)
+	s.clearObservedHeaderHistory(connId)
 	if wasPrimary {
 		s.activeClientConnId = nil
 		s.promoteBestClientLocked()
@@ -272,6 +292,13 @@ func (s *State) RemoveClientConnId(
 	}
 }
 
+func pointAheadOf(a, b ocommon.Point) bool {
+	if a.Slot != b.Slot {
+		return a.Slot > b.Slot
+	}
+	return !bytes.Equal(a.Hash, b.Hash)
+}
+
 // HandleClientRemoveRequestedEvent removes a tracked client when
 // a component publishes a client removal request event.
 func (s *State) HandleClientRemoveRequestedEvent(evt event.Event) {
@@ -283,18 +310,28 @@ func (s *State) HandleClientRemoveRequestedEvent(evt event.Event) {
 }
 
 // promoteBestClientLocked selects the tracked client with the
-// highest tip slot as the new active client. Only healthy
-// (syncing or synced) clients are considered. If no healthy
-// client exists, activeClientConnId is set to nil so that
-// callers do not route work to a known-bad peer.
+// highest tip slot as the new active client. Healthy (syncing
+// or synced) clients are preferred. If no healthy client exists,
+// the stalled client with the most recent activity is promoted
+// as a fallback — receiving a header will transition it back to
+// syncing, breaking the deadlock where nil active selection
+// prevents any client from making progress.
 // Caller must hold clientConnIdMutex.
 func (s *State) promoteBestClientLocked() {
 	var bestId *ouroboros.ConnectionId
 	var bestSlot uint64
+	var bestStalledId *ouroboros.ConnectionId
+	var bestStalledActivity time.Time
 	for id, tc := range s.trackedClients {
-		if tc.ObservabilityOnly ||
-			tc.Status == ClientStatusFailed ||
-			tc.Status == ClientStatusStalled {
+		if tc.ObservabilityOnly || tc.Status == ClientStatusFailed {
+			continue
+		}
+		if tc.Status == ClientStatusStalled {
+			if bestStalledId == nil || tc.LastActivity.After(bestStalledActivity) {
+				idCopy := id
+				bestStalledId = &idCopy
+				bestStalledActivity = tc.LastActivity
+			}
 			continue
 		}
 		if bestId == nil || tc.Tip.Point.Slot > bestSlot {
@@ -303,7 +340,15 @@ func (s *State) promoteBestClientLocked() {
 			bestSlot = tc.Tip.Point.Slot
 		}
 	}
-	s.activeClientConnId = bestId
+	if bestId != nil {
+		s.activeClientConnId = bestId
+	} else if bestStalledId != nil {
+		// All clients stalled — promote the most recently active
+		// one to prevent permanent nil-selection deadlock.
+		s.activeClientConnId = bestStalledId
+	} else {
+		s.activeClientConnId = nil
+	}
 }
 
 // addTrackedClientLocked registers a new tracked client. It
@@ -532,6 +577,111 @@ func (s *State) UpdateClientTipWithoutDedup(
 	s.updateClientTip(connId, point, tip, false)
 }
 
+// RewindTrackedClientsTo rewinds tracked client cursors that sit ahead of the
+// provided local ledger point. This keeps chainsync client state aligned with
+// local rollback/recovery so peers do not strand us in AwaitReply on a stale
+// higher cursor.
+func (s *State) RewindTrackedClientsTo(
+	point ocommon.Point,
+) []ouroboros.ConnectionId {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+	var ret []ouroboros.ConnectionId
+	for connId, tc := range s.trackedClients {
+		if !pointAheadOf(tc.Cursor, point) {
+			continue
+		}
+		tc.Cursor = ocommon.Point{
+			Slot: point.Slot,
+			Hash: cloneBytes(point.Hash),
+		}
+		tc.Status = ClientStatusSyncing
+		tc.LastActivity = time.Now()
+		ret = append(ret, connId)
+	}
+	return ret
+}
+
+// RecordObservedHeader stores the raw per-connection header ancestry before
+// cross-peer dedup can suppress delivery into the ledger queue. This lets
+// fork resolution reconstruct the selected peer's candidate fragment even
+// when earlier headers were first seen from another peer.
+func (s *State) RecordObservedHeader(e ledger.ChainsyncEvent) {
+	if e.BlockHeader == nil || len(e.Point.Hash) == 0 {
+		return
+	}
+	prevHash := e.BlockHeader.PrevHash().Bytes()
+	if len(prevHash) == 0 {
+		return
+	}
+
+	s.observedHeadersMutex.Lock()
+	defer s.observedHeadersMutex.Unlock()
+
+	connKey := e.ConnectionId.String()
+	chainHistory := s.observedHeaders[connKey]
+	if chainHistory == nil {
+		chainHistory = &observedHeaderChain{
+			order: make([]string, 0, maxObservedHeadersPerConn),
+			byHash: make(map[string]observedHeaderRecord,
+				maxObservedHeadersPerConn),
+		}
+		s.observedHeaders[connKey] = chainHistory
+	}
+
+	hashKey := hex.EncodeToString(e.Point.Hash)
+	if _, exists := chainHistory.byHash[hashKey]; exists {
+		return
+	}
+	chainHistory.order = append(chainHistory.order, hashKey)
+	chainHistory.byHash[hashKey] = observedHeaderRecord{
+		event:    e,
+		prevHash: append([]byte(nil), prevHash...),
+	}
+	if len(chainHistory.order) <= maxObservedHeadersPerConn {
+		return
+	}
+	evictKey := chainHistory.order[0]
+	chainHistory.order = chainHistory.order[1:]
+	delete(chainHistory.byHash, evictKey)
+}
+
+// LookupObservedHeader returns a previously observed header for the given
+// connection/hash pair, along with its prev-hash ancestry.
+func (s *State) LookupObservedHeader(
+	connId ouroboros.ConnectionId,
+	hash []byte,
+) (ledger.ChainsyncEvent, []byte, bool) {
+	s.observedHeadersMutex.RLock()
+	defer s.observedHeadersMutex.RUnlock()
+
+	chainHistory := s.observedHeaders[connId.String()]
+	if chainHistory == nil {
+		return ledger.ChainsyncEvent{}, nil, false
+	}
+	record, ok := chainHistory.byHash[hex.EncodeToString(hash)]
+	if !ok {
+		return ledger.ChainsyncEvent{}, nil, false
+	}
+	record.event.Point.Hash = cloneBytes(record.event.Point.Hash)
+	record.event.Tip.Point.Hash = cloneBytes(record.event.Tip.Point.Hash)
+	return record.event, append([]byte(nil), record.prevHash...), true
+}
+
+func (s *State) clearObservedHeaderHistory(
+	connId ouroboros.ConnectionId,
+) {
+	s.observedHeadersMutex.Lock()
+	defer s.observedHeadersMutex.Unlock()
+	delete(s.observedHeaders, connId.String())
+}
+
+func (s *State) ClearObservedHeaderHistory(
+	connId ouroboros.ConnectionId,
+) {
+	s.clearObservedHeaderHistory(connId)
+}
+
 func (s *State) updateClientTip(
 	connId ouroboros.ConnectionId,
 	point ocommon.Point,
@@ -613,6 +763,38 @@ func (s *State) processHeader(
 		}
 	}
 	return true
+}
+
+// HeaderPreviouslySeenFromOtherConn reports whether the exact header point was
+// already recorded by a different connection. This lets the selected ingress
+// peer replay a header first observed elsewhere without also replaying
+// same-connection duplicates back into the ledger queue.
+func (s *State) HeaderPreviouslySeenFromOtherConn(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+) bool {
+	s.seenHeadersMutex.Lock()
+	defer s.seenHeadersMutex.Unlock()
+	for _, rec := range s.seenHeaders[point.Slot] {
+		if !bytes.Equal(rec.hash, point.Hash) {
+			continue
+		}
+		return !trackedConnIdsEqual(rec.connId, connId)
+	}
+	return false
+}
+
+func trackedConnIdsEqual(
+	a,
+	b ouroboros.ConnectionId,
+) bool {
+	if a.LocalAddr == nil && a.RemoteAddr == nil {
+		return b.LocalAddr == nil && b.RemoteAddr == nil
+	}
+	if b.LocalAddr == nil && b.RemoteAddr == nil {
+		return false
+	}
+	return a.String() == b.String()
 }
 
 // MarkClientSynced marks a tracked client as synced (at chain

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -23,11 +23,31 @@ import (
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
+
+type testBlockHeader struct {
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	blockNumber uint64
+	slot        uint64
+}
+
+func (h testBlockHeader) Hash() lcommon.Blake2b256          { return h.hash }
+func (h testBlockHeader) PrevHash() lcommon.Blake2b256      { return h.prevHash }
+func (h testBlockHeader) BlockNumber() uint64               { return h.blockNumber }
+func (h testBlockHeader) SlotNumber() uint64                { return h.slot }
+func (h testBlockHeader) IssuerVkey() lcommon.IssuerVkey    { return lcommon.IssuerVkey{} }
+func (h testBlockHeader) BlockBodySize() uint64             { return 0 }
+func (h testBlockHeader) Era() lcommon.Era                  { return babbage.EraBabbage }
+func (h testBlockHeader) Cbor() []byte                      { return nil }
+func (h testBlockHeader) BlockBodyHash() lcommon.Blake2b256 { return lcommon.Blake2b256{} }
 
 // newTestConnId creates a unique ConnectionId for testing by
 // using the id as the remote port number.
@@ -304,12 +324,16 @@ func TestPromoteBestClient_NoHealthyClients(t *testing.T) {
 	require.Len(t, stalledSet, 2)
 
 	// Remove primary; only stalled clients remain so
-	// active should be nil (no fallback to bad peers).
+	// the most recently active stalled client is promoted
+	// as a fallback to prevent permanent nil-selection deadlock.
 	s.RemoveClientConnId(connA)
 	active := s.GetClientConnId()
-	require.Nil(
+	require.NotNil(
 		t, active,
-		"should not promote stalled client",
+		"should promote stalled client as fallback when no healthy clients exist",
+	)
+	require.Equal(t, connB, *active,
+		"should promote the remaining stalled client",
 	)
 }
 
@@ -474,6 +498,54 @@ func TestHeaderDeduplication_DuplicateHeader(t *testing.T) {
 	// Second report of same hash is duplicate
 	isNew = s.UpdateClientTip(connB, point, tip)
 	require.False(t, isNew)
+}
+
+func TestObservedHeaderHistoryPersistsAcrossDedupAndClearsOnRemove(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+
+	hash := []byte("hash-1")
+	prevHash := []byte("prev-hash-1")
+	point := ocommon.NewPoint(100, hash)
+	tip := ochainsync.Tip{Point: point, BlockNumber: 10}
+	header := testBlockHeader{
+		hash:        lcommon.NewBlake2b256(hash),
+		prevHash:    lcommon.NewBlake2b256(prevHash),
+		blockNumber: tip.BlockNumber,
+		slot:        point.Slot,
+	}
+
+	s.RecordObservedHeader(ledger.ChainsyncEvent{
+		ConnectionId: conn,
+		Point:        point,
+		BlockHeader:  header,
+		Tip:          tip,
+	})
+
+	// Duplicate record with the same hash should be a no-op
+	s.RecordObservedHeader(ledger.ChainsyncEvent{
+		ConnectionId: conn,
+		Point:        point,
+		BlockHeader:  header,
+		Tip:          tip,
+	})
+
+	recordedEvent, recordedPrevHash, ok := s.LookupObservedHeader(
+		conn,
+		hash,
+	)
+	require.True(t, ok)
+	require.Equal(t, point, recordedEvent.Point)
+	require.Equal(t, header.prevHash.Bytes(), recordedPrevHash)
+
+	s.RemoveClientConnId(conn)
+	_, _, ok = s.LookupObservedHeader(conn, hash)
+	require.False(t, ok)
 }
 
 // --- Fork detection tests ---
@@ -1107,4 +1179,63 @@ func TestRemoveAllClients_NilActive(t *testing.T) {
 	active := s.GetClientConnId()
 	require.Nil(t, active)
 	require.Equal(t, 0, s.ClientConnCount())
+}
+
+func TestRewindTrackedClientsToRewindsAheadClients(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connAhead := newTestConnId(1)
+	connSame := newTestConnId(2)
+	connBehind := newTestConnId(3)
+	rollbackPoint := ocommon.NewPoint(100, []byte("rollback"))
+	aheadPoint := ocommon.NewPoint(120, []byte("ahead"))
+	samePoint := ocommon.NewPoint(100, []byte("same"))
+	behindPoint := ocommon.NewPoint(90, []byte("behind"))
+
+	s.AddClientConnId(connAhead)
+	s.AddClientConnId(connSame)
+	s.AddClientConnId(connBehind)
+	s.UpdateClientTip(
+		connAhead,
+		aheadPoint,
+		ochainsync.Tip{Point: aheadPoint},
+	)
+	s.UpdateClientTip(
+		connSame,
+		samePoint,
+		ochainsync.Tip{Point: samePoint},
+	)
+	s.UpdateClientTip(
+		connBehind,
+		behindPoint,
+		ochainsync.Tip{Point: behindPoint},
+	)
+	s.MarkClientSynced(connAhead)
+
+	rewound := s.RewindTrackedClientsTo(rollbackPoint)
+
+	// A chainsync cursor must match the local rollback point exactly. A
+	// peer sitting at the same slot on a different hash still needs a
+	// fresh intersect before it can supply headers that fit the current
+	// selected chain.
+	require.ElementsMatch(
+		t,
+		[]ouroboros.ConnectionId{connAhead, connSame},
+		rewound,
+	)
+
+	aheadClient := s.GetTrackedClient(connAhead)
+	require.NotNil(t, aheadClient)
+	require.Equal(t, rollbackPoint, aheadClient.Cursor)
+	require.Equal(t, chainsync.ClientStatusSyncing, aheadClient.Status)
+
+	sameClient := s.GetTrackedClient(connSame)
+	require.NotNil(t, sameClient)
+	require.Equal(t, rollbackPoint, sameClient.Cursor)
+	require.Equal(t, chainsync.ClientStatusSyncing, sameClient.Status)
+
+	behindClient := s.GetTrackedClient(connBehind)
+	require.NotNil(t, behindClient)
+	require.Equal(t, behindPoint, behindClient.Cursor)
 }

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -575,7 +575,7 @@ func (c *ConnectionManager) addConnectionImpl(
 		defer c.goroutineWg.Done()
 		err := <-conn.ErrorChan()
 		// Remove connection (also releases IP slot)
-		c.RemoveConnection(connId)
+		c.RemoveConnection(connId, conn)
 		// Generate event
 		if c.config.EventBus != nil {
 			c.config.EventBus.Publish(
@@ -596,9 +596,19 @@ func (c *ConnectionManager) addConnectionImpl(
 	}()
 }
 
-func (c *ConnectionManager) RemoveConnection(connId ouroboros.ConnectionId) {
+func (c *ConnectionManager) RemoveConnection(
+	connId ouroboros.ConnectionId,
+	conn *ouroboros.Connection,
+) {
 	c.connectionsMutex.Lock()
 	info := c.connections[connId]
+	// Only remove if the map still holds this exact connection.
+	// A replacement connection may have re-registered under the
+	// same ID (OutboundSourcePort reuse).
+	if info == nil || info.conn != conn {
+		c.connectionsMutex.Unlock()
+		return
+	}
 	delete(c.connections, connId)
 	if info != nil &&
 		info.isInbound &&

--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -14,7 +14,10 @@
 
 package event
 
-import ouroboros "github.com/blinklabs-io/gouroboros"
+import (
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
 
 // ChainsyncResyncEventType is the event type emitted when a
 // chainsync re-sync is required (e.g. persistent fork detected
@@ -26,4 +29,5 @@ const ChainsyncResyncEventType = EventType("chainsync.resync")
 type ChainsyncResyncEvent struct {
 	ConnectionId ouroboros.ConnectionId
 	Reason       string
+	Point        ocommon.Point
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -46,6 +46,14 @@ const (
 	// This prevents us exceeding the configured recv queue size in the block-fetch protocol
 	blockfetchBatchSize = 500
 
+	// When we're still meaningfully behind tip, wait for a small header runway
+	// before starting blockfetch. This avoids repeated one-block fetch loops
+	// near a fork boundary where peers may not yet serve the first announced
+	// block body.
+	blockfetchMinBatchHeadersWhenBehind = 8
+	blockfetchMaxBatchHeadersWhenBehind = 64
+	blockfetchMinBatchGapSlots          = 64
+
 	// Number of received blockfetch blocks to buffer before committing them.
 	// Keep this small so downstream iterators still see fresh blocks promptly.
 	blockfetchCommitBatchSize = 8
@@ -64,7 +72,7 @@ const (
 	syncProgressLogInterval = 30 * time.Second
 
 	// Rollback loop detection thresholds
-	rollbackLoopThreshold = 3               // number of rollbacks to same slot before breaking loop
+	rollbackLoopThreshold = 2               // number of rollbacks to same slot before breaking loop
 	rollbackLoopWindow    = 5 * time.Minute // time window for rollback loop detection
 
 	// Number of consecutive header mismatches before triggering
@@ -77,9 +85,19 @@ const (
 	// Chainsync re-sync reasons
 	resyncReasonRollbackAhead    = "rollback point ahead of local tip"
 	resyncReasonRollbackNotFound = "rollback point not found"
+
+	maxPeerHeaderHistoryPerConn = 256
 )
 
-var errChainsyncResyncRequested = errors.New("chainsync resync requested")
+type peerHeaderRecord struct {
+	event    ChainsyncEvent
+	prevHash []byte
+}
+
+type peerHeaderChain struct {
+	order  []string
+	byHash map[string]peerHeaderRecord
+}
 
 func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 	ls.chainsyncMutex.Lock()
@@ -105,9 +123,6 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 		}
 	} else if e.BlockHeader != nil {
 		if err := ls.handleEventChainsyncBlockHeader(e); err != nil {
-			if errors.Is(err, errChainsyncResyncRequested) {
-				return
-			}
 			// Header queue full is expected during bulk sync when
 			// pipelined headers arrive faster than blockfetch can
 			// drain them. Log at DEBUG to avoid log spam.
@@ -147,11 +162,6 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 }
 
 func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
-	// Header pipeline ownership and buffered header queues are shared with the
-	// chainsync handler, so blockfetch processing must take the same outer lock
-	// before touching state that may clear or replay queued headers.
-	ls.chainsyncMutex.Lock()
-	defer ls.chainsyncMutex.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
 	e, ok := evt.Data.(BlockfetchEvent)
@@ -247,9 +257,26 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 	if !ok {
 		return
 	}
+	var replayConnId ouroboros.ConnectionId
+	ls.chainsyncMutex.Lock()
+	defer ls.chainsyncMutex.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
-	defer ls.chainsyncBlockfetchMutex.Unlock()
-	ls.selectedBlockfetchConnId = e.NewConnectionId
+	replayConnId, err := ls.handoffPipelineOnSwitchLocked(
+		e.NewConnectionId,
+	)
+	ls.chainsyncBlockfetchMutex.Unlock()
+	if err != nil {
+		ls.config.Logger.Warn(
+			"failed to hand off chainsync pipeline on chain switch",
+			"component", "ledger",
+			"connection_id", e.NewConnectionId.String(),
+			"error", err,
+		)
+		return
+	}
+	if connIdKey(replayConnId) != "" {
+		ls.replayBufferedHeadersAsync(replayConnId)
+	}
 }
 
 func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
@@ -261,23 +288,83 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 	defer ls.chainsyncMutex.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
-	if ls.selectedBlockfetchConnId == e.ConnectionId {
+	if sameConnectionId(ls.selectedBlockfetchConnId, e.ConnectionId) {
 		ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 	}
-	clearedActiveBlockfetch := false
-	if ls.activeBlockfetchConnId == e.ConnectionId {
+	delete(ls.bufferedHeaderEvents, connIdKey(e.ConnectionId))
+	delete(ls.peerHeaderHistory, connIdKey(e.ConnectionId))
+	// Cancel in-flight blockfetch if the dead connection owns it.
+	// Without this, chainsyncBlockfetchReadyChan stays non-nil and
+	// new headers from reconnected peers are queued behind a batch
+	// that will never complete, causing a permanent pipeline stall.
+	if sameConnectionId(ls.activeBlockfetchConnId, e.ConnectionId) &&
+		ls.chainsyncBlockfetchReadyChan != nil {
+		ls.config.Logger.Info(
+			"canceling blockfetch on closed connection",
+			"component", "ledger",
+			"connection_id", e.ConnectionId.String(),
+		)
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
-		clearedActiveBlockfetch = true
 	}
-	delete(ls.bufferedHeaderEvents, e.ConnectionId)
-	clearedHeaderPipeline := false
-	if ls.headerPipelineConnId == e.ConnectionId {
+	if sameConnectionId(ls.headerPipelineConnId, e.ConnectionId) {
 		ls.clearQueuedHeaders()
-		clearedHeaderPipeline = true
 	}
-	if clearedActiveBlockfetch || clearedHeaderPipeline {
-		ls.scheduleBufferedHeaderReplayLocked()
+}
+
+func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
+	e, ok := evt.Data.(ChainsyncAwaitReplyEvent)
+	if !ok {
+		ls.logUnexpectedChainsyncEventData(
+			"ChainsyncAwaitReplyEvent",
+			evt,
+		)
+		return
+	}
+	ls.chainsyncMutex.Lock()
+	defer ls.chainsyncMutex.Unlock()
+	if ls.chain == nil || ls.chain.HeaderCount() == 0 {
+		return
+	}
+	if ls.config.GetActiveConnectionFunc == nil {
+		return
+	}
+	activeConnId := ls.config.GetActiveConnectionFunc()
+	if activeConnId == nil ||
+		!sameConnectionId(*activeConnId, e.ConnectionId) {
+		return
+	}
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	if ls.chainsyncBlockfetchReadyChan != nil || ls.chain.HeaderCount() == 0 {
+		return
+	}
+	ls.selectedBlockfetchConnId = e.ConnectionId
+	ls.config.Logger.Debug(
+		"selected chainsync peer entered await reply, flushing queued headers to blockfetch",
+		"component", "ledger",
+		"connection_id", e.ConnectionId.String(),
+		"header_count", ls.chain.HeaderCount(),
+	)
+	if err := ls.startQueuedBlockfetchLocked(e.ConnectionId); err != nil {
+		ls.config.Logger.Error(
+			"failed to start blockfetch after await reply",
+			"component", "ledger",
+			"connection_id", e.ConnectionId.String(),
+			"error", err,
+		)
+		if ls.config.EventBus != nil {
+			ls.config.EventBus.Publish(
+				LedgerErrorEventType,
+				event.NewEvent(
+					LedgerErrorEventType,
+					LedgerErrorEvent{
+						Error:     err,
+						Operation: "await_reply_blockfetch",
+					},
+				),
+			)
+		}
 	}
 }
 
@@ -288,15 +375,14 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 func (ls *LedgerState) detectConnectionSwitch() (
 	activeConnId *ouroboros.ConnectionId,
 	configured bool,
-	switched bool,
 ) {
 	if ls.config.GetActiveConnectionFunc == nil {
-		return nil, false, false
+		return nil, false
 	}
 	activeConnId = ls.config.GetActiveConnectionFunc()
 	if activeConnId != nil &&
-		(ls.lastActiveConnId == nil || *ls.lastActiveConnId != *activeConnId) {
-		switched = true
+		(ls.lastActiveConnId == nil ||
+			!sameConnectionId(*ls.lastActiveConnId, *activeConnId)) {
 		if ls.lastActiveConnId != nil {
 			ls.config.Logger.Info(
 				"active connection changed",
@@ -307,23 +393,21 @@ func (ls *LedgerState) detectConnectionSwitch() (
 			)
 			ls.dropRollbackCount = 0
 			ls.headerMismatchCount = 0
-			// Reset blockfetch state, but preserve queued headers. Valid
-			// headers remain valid across peer switches, and clearing them
-			// forces the sync pipeline to restart from scratch on every
-			// selector churn event.
 			ls.chainsyncBlockfetchMutex.Lock()
-			if ls.chainsyncBlockfetchReadyChan == nil {
-				ls.blockfetchRequestRangeCleanup()
-				ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
-			} else {
-				ls.config.Logger.Debug(
-					"preserving in-flight blockfetch batch across connection switch",
-					"component", "ledger",
-					"blockfetch_connection_id",
-					ls.activeBlockfetchConnId.String(),
-				)
-			}
+			replayConnId, err := ls.handoffPipelineOnSwitchLocked(
+				*activeConnId,
+			)
 			ls.chainsyncBlockfetchMutex.Unlock()
+			if err != nil {
+				ls.config.Logger.Warn(
+					"failed to hand off chainsync pipeline after active connection change",
+					"component", "ledger",
+					"connection_id", activeConnId.String(),
+					"error", err,
+				)
+			} else if connIdKey(replayConnId) != "" {
+				ls.replayBufferedHeadersAsync(replayConnId)
+			}
 			// Clear per-connection state (e.g., header dedup cache)
 			// so the new connection can re-deliver blocks from the
 			// intersection without them being filtered as duplicates.
@@ -332,20 +416,115 @@ func (ls *LedgerState) detectConnectionSwitch() (
 			}
 		}
 		ls.lastActiveConnId = activeConnId
-		ls.rollbackHistory = nil
+		// Preserve rollbackHistory across connection switches so the
+		// rollback loop detector can fire when multiple peers all send
+		// RollBackward to the same slot during rapid chain selection
+		// changes (e.g., post-Mithril startup). Clearing it here
+		// previously allowed unbounded oscillation.
 	}
-	return activeConnId, true, switched
+	return activeConnId, true
 }
 
-// bufferHeaderEvent mutates bufferedHeaderEvents in place. Callers must hold
-// ls.chainsyncMutex before invoking it.
+func (ls *LedgerState) handoffPipelineOnSwitchLocked(
+	newConnId ouroboros.ConnectionId,
+) (ouroboros.ConnectionId, error) {
+	ls.selectedBlockfetchConnId = newConnId
+	headerCount := 0
+	if ls.chain != nil {
+		headerCount = ls.chain.HeaderCount()
+	}
+
+	if connIdKey(newConnId) == "" {
+		return ouroboros.ConnectionId{}, nil
+	}
+
+	hasBufferedHeadersForNewConn := len(
+		ls.bufferedHeaderEvents[connIdKey(newConnId)],
+	) > 0
+
+	if ls.chainsyncBlockfetchReadyChan != nil &&
+		connIdKey(ls.activeBlockfetchConnId) != "" &&
+		!sameConnectionId(ls.activeBlockfetchConnId, newConnId) {
+		ls.config.Logger.Debug(
+			"canceling in-flight blockfetch batch on chain switch",
+			"component", "ledger",
+			"previous_connection_id", ls.activeBlockfetchConnId.String(),
+			"new_connection_id", newConnId.String(),
+			"queued_headers", headerCount,
+		)
+		ls.blockfetchRequestRangeCleanup()
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+	}
+
+	if connIdKey(ls.headerPipelineConnId) != "" &&
+		!sameConnectionId(ls.headerPipelineConnId, newConnId) {
+		if ls.chainsyncBlockfetchReadyChan == nil &&
+			headerCount > 0 &&
+			hasBufferedHeadersForNewConn {
+			ls.config.Logger.Debug(
+				"dropping stale queued header fragment on chain switch",
+				"component", "ledger",
+				"previous_owner_connection_id",
+				ls.headerPipelineConnId.String(),
+				"new_connection_id", newConnId.String(),
+				"queued_headers", headerCount,
+			)
+			ls.clearQueuedHeaders()
+			return newConnId, nil
+		}
+		ls.config.Logger.Debug(
+			"releasing stale header pipeline owner on chain switch",
+			"component", "ledger",
+			"previous_owner_connection_id",
+			ls.headerPipelineConnId.String(),
+			"new_connection_id", newConnId.String(),
+			"queued_headers", headerCount,
+		)
+		ls.headerPipelineConnId = ouroboros.ConnectionId{}
+		// Purge the header dedup cache for slots beyond the current
+		// block tip. The new connection may have already delivered
+		// headers that were deduplicated against the old owner's
+		// headers at the ouroboros layer. Without purging, those
+		// headers can never be re-delivered, leaving a gap that
+		// stalls the pipeline until genuinely new blocks arrive.
+		if ls.config.ClearSeenHeadersFromFunc != nil {
+			ls.config.ClearSeenHeadersFromFunc(ls.Tip().Point.Slot)
+		}
+	}
+
+	if ls.chainsyncBlockfetchReadyChan == nil &&
+		headerCount > 0 {
+		ls.config.Logger.Debug(
+			"restarting queued blockfetch on selected connection",
+			"component", "ledger",
+			"connection_id", newConnId.String(),
+			"header_count", headerCount,
+		)
+		if err := ls.startQueuedBlockfetchLocked(newConnId); err != nil {
+			return ouroboros.ConnectionId{}, fmt.Errorf(
+				"restart queued blockfetch on switch: %w",
+				err,
+			)
+		}
+		return ouroboros.ConnectionId{}, nil
+	}
+
+	if ls.chainsyncBlockfetchReadyChan == nil &&
+		hasBufferedHeadersForNewConn {
+		return newConnId, nil
+	}
+
+	return ouroboros.ConnectionId{}, nil
+}
+
 func (ls *LedgerState) bufferHeaderEvent(e ChainsyncEvent) {
 	if ls.bufferedHeaderEvents == nil {
 		ls.bufferedHeaderEvents = make(
-			map[ouroboros.ConnectionId][]ChainsyncEvent,
+			map[string][]ChainsyncEvent,
 		)
 	}
-	events := ls.bufferedHeaderEvents[e.ConnectionId]
+	key := connIdKey(e.ConnectionId)
+	events := ls.bufferedHeaderEvents[key]
 	if len(events) > 0 {
 		last := events[len(events)-1]
 		if last.Point.Slot == e.Point.Slot &&
@@ -359,14 +538,162 @@ func (ls *LedgerState) bufferHeaderEvent(e ChainsyncEvent) {
 	} else {
 		events = append(events, e)
 	}
-	ls.bufferedHeaderEvents[e.ConnectionId] = events
+	ls.bufferedHeaderEvents[key] = events
 }
 
-// clearQueuedHeaders resets the queued header pipeline state.
-// Callers must hold chainsyncMutex.
 func (ls *LedgerState) clearQueuedHeaders() {
 	ls.chain.ClearHeaders()
 	ls.headerPipelineConnId = ouroboros.ConnectionId{}
+	// Purge the header dedup cache for slots beyond the current
+	// block tip. Queued headers that were recorded in the dedup
+	// cache but just discarded would otherwise block re-delivery
+	// on subsequent connections, causing a permanent pipeline stall.
+	if ls.config.ClearSeenHeadersFromFunc != nil {
+		ls.config.ClearSeenHeadersFromFunc(ls.Tip().Point.Slot)
+	}
+}
+
+func (ls *LedgerState) recordPeerHeaderHistory(e ChainsyncEvent) {
+	if e.BlockHeader == nil || len(e.Point.Hash) == 0 {
+		return
+	}
+	if ls.peerHeaderHistory == nil {
+		ls.peerHeaderHistory = make(map[string]*peerHeaderChain)
+	}
+	key := connIdKey(e.ConnectionId)
+	history := ls.peerHeaderHistory[key]
+	if history == nil {
+		history = &peerHeaderChain{
+			order: make([]string, 0, maxPeerHeaderHistoryPerConn),
+			byHash: make(map[string]peerHeaderRecord,
+				maxPeerHeaderHistoryPerConn),
+		}
+		ls.peerHeaderHistory[key] = history
+	}
+	hashKey := hex.EncodeToString(e.Point.Hash)
+	if _, ok := history.byHash[hashKey]; ok {
+		return
+	}
+	history.order = append(history.order, hashKey)
+	history.byHash[hashKey] = peerHeaderRecord{
+		event:    e,
+		prevHash: append([]byte(nil), e.BlockHeader.PrevHash().Bytes()...),
+	}
+	if len(history.order) <= maxPeerHeaderHistoryPerConn {
+		return
+	}
+	evictKey := history.order[0]
+	history.order = history.order[1:]
+	delete(history.byHash, evictKey)
+}
+
+func (ls *LedgerState) findPeerForkPath(
+	e ChainsyncEvent,
+	initialPrevHash []byte,
+) (*ocommon.Point, []ChainsyncEvent, error) {
+	prevHash := append([]byte(nil), initialPrevHash...)
+	history := ls.peerHeaderHistory[connIdKey(e.ConnectionId)]
+	pathReversed := []ChainsyncEvent{e}
+	visited := map[string]struct{}{
+		hex.EncodeToString(e.Point.Hash): {},
+	}
+	for depth := 0; depth < maxPeerHeaderHistoryPerConn &&
+		len(prevHash) > 0; depth++ {
+		ancestorBlock, err := database.BlockByHash(ls.db, prevHash)
+		if err == nil {
+			point := ocommon.NewPoint(
+				ancestorBlock.Slot,
+				ancestorBlock.Hash,
+			)
+			slices.Reverse(pathReversed)
+			return &point, pathReversed, nil
+		}
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			return nil, nil, fmt.Errorf(
+				"lookup ancestor hash %x: %w",
+				prevHash,
+				err,
+			)
+		}
+		hashKey := hex.EncodeToString(prevHash)
+		var (
+			record peerHeaderRecord
+			ok     bool
+		)
+		if history != nil {
+			record, ok = history.byHash[hashKey]
+		}
+		if !ok && ls.config.PeerHeaderLookupFunc != nil {
+			lookupEvent, lookupPrevHash, found := ls.config.PeerHeaderLookupFunc(
+				e.ConnectionId,
+				prevHash,
+			)
+			if found {
+				record = peerHeaderRecord{
+					event:    lookupEvent,
+					prevHash: lookupPrevHash,
+				}
+				ok = true
+			}
+		}
+		if !ok {
+			return nil, nil, nil
+		}
+		if _, seen := visited[hashKey]; seen {
+			return nil, nil, nil
+		}
+		visited[hashKey] = struct{}{}
+		pathReversed = append(pathReversed, record.event)
+		prevHash = append(prevHash[:0], record.prevHash...)
+	}
+	return nil, nil, nil
+}
+
+func connIdKey(connId ouroboros.ConnectionId) string {
+	if connId.LocalAddr == nil && connId.RemoteAddr == nil {
+		return ""
+	}
+	return connId.String()
+}
+
+func sameConnectionId(a, b ouroboros.ConnectionId) bool {
+	keyA := connIdKey(a)
+	keyB := connIdKey(b)
+	if keyA == "" || keyB == "" {
+		return keyA == keyB
+	}
+	return keyA == keyB
+}
+
+func desiredBlockfetchBatchHeaders(
+	gapSlots uint64,
+	gapBlocks uint64,
+	maxHeaders int,
+) int {
+	if maxHeaders <= 0 {
+		return 0
+	}
+	if gapBlocks == 0 {
+		if gapSlots == 0 {
+			return 0
+		}
+		return min(1, maxHeaders)
+	}
+	// All switch cases produce small constants, so the final int() is safe.
+	var minHeaders int
+	switch {
+	case gapBlocks > 64:
+		minHeaders = 8
+	case gapBlocks > 16:
+		minHeaders = 4
+	case gapBlocks > 4:
+		minHeaders = 2
+	default:
+		// gapBlocks is at most 4 here, safe to narrow.
+		minHeaders = int(gapBlocks) //nolint:gosec
+	}
+	minHeaders = min(minHeaders, blockfetchMaxBatchHeadersWhenBehind)
+	return min(minHeaders, maxHeaders)
 }
 
 func (ls *LedgerState) requestChainsyncResync(
@@ -375,7 +702,7 @@ func (ls *LedgerState) requestChainsyncResync(
 ) {
 	ls.headerMismatchCount = 0
 	ls.rollbackHistory = nil
-	delete(ls.bufferedHeaderEvents, connId)
+	delete(ls.bufferedHeaderEvents, connIdKey(connId))
 	if ls.config.EventBus == nil {
 		return
 	}
@@ -391,67 +718,133 @@ func (ls *LedgerState) requestChainsyncResync(
 	)
 }
 
+func (ls *LedgerState) currentHeaderPipelineOwner() ouroboros.ConnectionId {
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	if ls.chainsyncBlockfetchReadyChan != nil {
+		if connIdKey(ls.headerPipelineConnId) != "" {
+			return ls.headerPipelineConnId
+		}
+		if connIdKey(ls.activeBlockfetchConnId) != "" {
+			return ls.activeBlockfetchConnId
+		}
+		return ouroboros.ConnectionId{}
+	}
+	if ls.chain != nil && ls.chain.HeaderCount() > 0 {
+		return ls.headerPipelineConnId
+	}
+	// Once the shared header queue drains, there is no live pipeline owner.
+	// A stale selected blockfetch peer must not monopolize future headers while
+	// the pipeline is idle; whichever peer delivers the next usable header gets
+	// to seed the next batch.
+	ls.headerPipelineConnId = ouroboros.ConnectionId{}
+	return ouroboros.ConnectionId{}
+}
+
+func (ls *LedgerState) staleSelectedOwnerWouldBufferHeader(
+	e ChainsyncEvent,
+) bool {
+	return connIdKey(ls.selectedBlockfetchConnId) != "" &&
+		ls.chainsyncBlockfetchReadyChan == nil &&
+		(ls.chain == nil || ls.chain.HeaderCount() == 0) &&
+		!sameConnectionId(ls.selectedBlockfetchConnId, e.ConnectionId)
+}
+
+func (ls *LedgerState) logIdleSelectedOwnerRelease(e ChainsyncEvent) {
+	ls.config.Logger.Debug(
+		"releasing idle selected blockfetch owner before header admission",
+		"component", "ledger",
+		"selected_connection_id", ls.selectedBlockfetchConnId.String(),
+		"event_connection_id", e.ConnectionId.String(),
+		"slot", e.Point.Slot,
+	)
+}
+
+func (ls *LedgerState) clearIdleSelectedOwner() {
+	if ls.chainsyncBlockfetchReadyChan == nil &&
+		(ls.chain == nil || ls.chain.HeaderCount() == 0) {
+		ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
+	}
+}
+
 func (ls *LedgerState) shouldBufferHeaderEvent(e ChainsyncEvent) bool {
-	if ls.headerPipelineConnId == (ouroboros.ConnectionId{}) {
+	ls.chainsyncBlockfetchMutex.Lock()
+	if ls.staleSelectedOwnerWouldBufferHeader(e) {
+		ls.logIdleSelectedOwnerRelease(e)
+		ls.clearIdleSelectedOwner()
+	}
+	ls.chainsyncBlockfetchMutex.Unlock()
+	ownerConnId := ls.currentHeaderPipelineOwner()
+	if ownerConnId == (ouroboros.ConnectionId{}) {
 		ls.headerPipelineConnId = e.ConnectionId
 		return false
 	}
-	if ls.headerPipelineConnId == e.ConnectionId {
+	if sameConnectionId(ownerConnId, e.ConnectionId) {
+		ls.headerPipelineConnId = e.ConnectionId
 		return false
 	}
+	if ls.headerFitsCurrentPipeline(e) {
+		ls.headerPipelineConnId = e.ConnectionId
+		ls.selectedBlockfetchConnId = e.ConnectionId
+		ls.config.Logger.Debug(
+			"accepting compatible header from different connection",
+			"component", "ledger",
+			"event_connection_id", e.ConnectionId.String(),
+			"previous_owner_connection_id", ownerConnId.String(),
+			"slot", e.Point.Slot,
+		)
+		return false
+	}
+	ls.headerPipelineConnId = ownerConnId
 	ls.bufferHeaderEvent(e)
 	ls.config.Logger.Debug(
 		"buffering header from non-owner connection",
 		"component", "ledger",
 		"event_connection_id", e.ConnectionId.String(),
-		"owner_connection_id", ls.headerPipelineConnId.String(),
+		"owner_connection_id", ownerConnId.String(),
 		"slot", e.Point.Slot,
 	)
 	return true
 }
 
-// nextBufferedHeaderConnId selects the buffered connection to replay next.
-// Callers must hold chainsyncMutex.
+func (ls *LedgerState) headerFitsCurrentPipeline(e ChainsyncEvent) bool {
+	if ls.chain == nil || e.BlockHeader == nil {
+		return false
+	}
+	prevHash := e.BlockHeader.PrevHash().Bytes()
+	headerTip := ls.chain.HeaderTip()
+	if len(headerTip.Point.Hash) == 0 {
+		return len(prevHash) == 0
+	}
+	return bytes.Equal(prevHash, headerTip.Point.Hash)
+}
+
 func (ls *LedgerState) nextBufferedHeaderConnId() (
 	ouroboros.ConnectionId,
 	bool,
 ) {
-	if ls.selectedBlockfetchConnId != (ouroboros.ConnectionId{}) &&
-		len(ls.bufferedHeaderEvents[ls.selectedBlockfetchConnId]) > 0 {
-		return ls.selectedBlockfetchConnId, true
+	if key := connIdKey(ls.selectedBlockfetchConnId); key != "" {
+		if events := ls.bufferedHeaderEvents[key]; len(events) > 0 {
+			return events[len(events)-1].ConnectionId, true
+		}
 	}
 	var (
 		bestConn ouroboros.ConnectionId
 		bestTip  uint64
 		found    bool
 	)
-	for connId, events := range ls.bufferedHeaderEvents {
+	for _, events := range ls.bufferedHeaderEvents {
 		if len(events) == 0 {
 			continue
 		}
 		tipSlot := events[len(events)-1].Tip.Point.Slot
 		if !found || tipSlot > bestTip {
-			bestConn = connId
+			bestConn = events[len(events)-1].ConnectionId
 			bestTip = tipSlot
 			found = true
 		}
 	}
 	return bestConn, found
-}
-
-// scheduleBufferedHeaderReplayLocked replays buffered headers when the active
-// header/blockfetch pipeline is idle. Callers must hold chainsyncMutex and
-// chainsyncBlockfetchMutex.
-func (ls *LedgerState) scheduleBufferedHeaderReplayLocked() {
-	if ls.chain == nil ||
-		ls.chainsyncBlockfetchReadyChan != nil ||
-		ls.headerPipelineConnId != (ouroboros.ConnectionId{}) ||
-		ls.chain.HeaderCount() > 0 {
-		return
-	}
-	if nextConnId, ok := ls.nextBufferedHeaderConnId(); ok {
-		ls.replayBufferedHeadersAsync(nextConnId)
-	}
 }
 
 func (ls *LedgerState) replayBufferedHeadersAsync(
@@ -460,12 +853,6 @@ func (ls *LedgerState) replayBufferedHeadersAsync(
 	go func() {
 		ls.chainsyncMutex.Lock()
 		defer ls.chainsyncMutex.Unlock()
-		ls.chainsyncBlockfetchMutex.Lock()
-		blockfetchActive := ls.chainsyncBlockfetchReadyChan != nil
-		ls.chainsyncBlockfetchMutex.Unlock()
-		if blockfetchActive {
-			return
-		}
 		if ls.headerPipelineConnId != (ouroboros.ConnectionId{}) ||
 			ls.chain.HeaderCount() > 0 {
 			return
@@ -484,98 +871,50 @@ func (ls *LedgerState) replayBufferedHeadersAsync(
 func (ls *LedgerState) replayBufferedHeaderEvents(
 	connId ouroboros.ConnectionId,
 ) error {
-	if len(ls.bufferedHeaderEvents[connId]) == 0 {
+	key := connIdKey(connId)
+	if len(ls.bufferedHeaderEvents[key]) == 0 {
 		return nil
 	}
 	events := append(
 		[]ChainsyncEvent(nil),
-		ls.bufferedHeaderEvents[connId]...,
+		ls.bufferedHeaderEvents[key]...,
 	)
-	delete(ls.bufferedHeaderEvents, connId)
+	delete(ls.bufferedHeaderEvents, key)
 	for _, evt := range events {
 		if err := ls.handleEventChainsyncBlockHeader(evt); err != nil {
-			if errors.Is(err, errChainsyncResyncRequested) {
-				break
-			}
 			return err
 		}
 	}
 	return nil
 }
 
-func (ls *LedgerState) maybeStartBlockfetchForHeader(
-	e ChainsyncEvent,
-	allowedHeaderCount int,
-) error {
-	currentHeaderCount := ls.chain.HeaderCount()
-	// Wait for additional block headers before fetching block bodies if we're
-	// far enough out from upstream tip.
-	slotThreshold := ls.calculateStabilityWindow()
-	if e.Point.Slot < e.Tip.Point.Slot &&
-		(e.Tip.Point.Slot-e.Point.Slot > slotThreshold) &&
-		currentHeaderCount < allowedHeaderCount {
-		ls.config.Logger.Debug(
-			"accumulating headers (far from tip)",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"tip_slot", e.Tip.Point.Slot,
-			"threshold", slotThreshold,
-			"header_count", currentHeaderCount,
-		)
-		return nil
+func (ls *LedgerState) discardBufferedPeerHeaders(
+	connId ouroboros.ConnectionId,
+) {
+	delete(ls.bufferedHeaderEvents, connIdKey(connId))
+	if sameConnectionId(ls.headerPipelineConnId, connId) {
+		ls.clearQueuedHeaders()
 	}
-	// We use the blockfetch lock to ensure we aren't starting a batch at the same
-	// time as blockfetch starts a new one to avoid deadlocks.
-	ls.chainsyncBlockfetchMutex.Lock()
-	defer ls.chainsyncBlockfetchMutex.Unlock()
-	// Don't start fetch if there's already one in progress.
-	if ls.chainsyncBlockfetchReadyChan != nil {
-		ls.config.Logger.Debug(
-			"blockfetch in progress, queuing header",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"header_count", ls.chain.HeaderCount(),
-		)
-		return nil
-	}
-	// Mark blockfetch as in progress.
-	ls.selectedBlockfetchConnId = e.ConnectionId
-	initialConnId := ls.selectInitialBlockfetchConn(e.ConnectionId)
-	ls.config.Logger.Debug(
-		"starting blockfetch",
-		"component", "ledger",
-		"connection_id", initialConnId.String(),
-		"header_count", ls.chain.HeaderCount(),
-	)
-	if err := ls.startQueuedBlockfetchLocked(initialConnId); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 	// Filter events from non-active connections when chain selection is enabled
-	if activeConnId, configured, _ := ls.detectConnectionSwitch(); configured {
+	if activeConnId, configured := ls.detectConnectionSwitch(); configured {
 		if activeConnId == nil {
-			// If we already have local chain progress, avoid applying
-			// rollback/header events until an active connection is
-			// selected. This prevents transient "active=nil" races from
-			// accepting deep rollback signals from non-authoritative peers.
-			if ls.chain.Tip().Point.Slot > 0 {
-				ls.config.Logger.Debug(
-					"no active connection, dropping rollback event",
-					"connection_id", e.ConnectionId.String(),
-					"slot", e.Point.Slot,
-					"local_tip_slot", ls.chain.Tip().Point.Slot,
-				)
-				return nil
-			}
+			// No active connection selected yet. Allow the rollback
+			// to proceed — the downstream security-parameter-K check
+			// and rollback-loop detector still guard against deep or
+			// repeated rollbacks. Blanket-dropping here caused
+			// pipeline stalls after Mithril bootstrap when chain
+			// selection had not yet promoted a peer.
 			ls.config.Logger.Debug(
-				"no active connection at origin, processing rollback event",
+				"no active connection, processing rollback event",
 				"connection_id", e.ConnectionId.String(),
 				"slot", e.Point.Slot,
+				"local_tip_slot", ls.chain.Tip().Point.Slot,
 			)
-		} else if *activeConnId != e.ConnectionId {
+		} else if !sameConnectionId(*activeConnId, e.ConnectionId) {
+			ls.discardBufferedPeerHeaders(e.ConnectionId)
 			// Event is from non-active connection, skip
 			// Rate-limit this message to once per dropEventLogInterval
 			now := time.Now()
@@ -584,11 +923,12 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				ls.dropRollbackCount = 0
 				ls.dropRollbackLastLog = now
 				ls.config.Logger.Debug(
-					"dropping rollback from non-active connection",
+					"dropping rollback from non-active connection and clearing buffered peer headers",
 					"component", "ledger",
 					"event_connection_id", e.ConnectionId.String(),
 					"active_connection_id", activeConnId.String(),
 					"slot", e.Point.Slot,
+					"cleared_buffered_headers", true,
 					"suppressed_since_last_log", suppressed,
 				)
 			} else {
@@ -632,10 +972,26 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		return nil
 	}
 
+	// A rollback to the current tip is a no-op — the peer's
+	// FindIntersect resolved to the same point we already sit at.
+	// Skip the rollback entirely to avoid publishing a spurious
+	// "local ledger rollback" resync event that would close all
+	// connections and create a reconnect loop.
+	localTip := ls.chain.HeaderTip()
+	if e.Point.Slot == localTip.Point.Slot &&
+		bytes.Equal(e.Point.Hash, localTip.Point.Hash) {
+		ls.config.Logger.Debug(
+			"rollback to current tip is no-op, skipping",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"connection_id", e.ConnectionId.String(),
+		)
+		return nil
+	}
+
 	// A rollback point ahead of our local tip is invalid for the
 	// current chain view and typically indicates intersect drift.
 	// Trigger a chainsync re-sync instead of failing hard.
-	localTip := ls.chain.HeaderTip()
 	if e.Point.Slot > localTip.Point.Slot {
 		ls.config.Logger.Warn(
 			"received rollback point ahead of local tip, triggering chainsync re-sync",
@@ -748,6 +1104,7 @@ func (ls *LedgerState) resetChainsyncResyncState() {
 	ls.rollbackHistory = nil
 	ls.headerMismatchCount = 0
 	ls.bufferedHeaderEvents = nil
+	ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 	ls.clearQueuedHeaders()
 	ls.chainsyncBlockfetchMutex.Lock()
 	ls.blockfetchRequestRangeCleanup()
@@ -755,7 +1112,147 @@ func (ls *LedgerState) resetChainsyncResyncState() {
 	ls.chainsyncBlockfetchMutex.Unlock()
 }
 
+func pointMatches(a, b ocommon.Point) bool {
+	return a.Slot == b.Slot && bytes.Equal(a.Hash, b.Hash)
+}
+
+func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+) (int, error) {
+	history := ls.peerHeaderHistory[connIdKey(connId)]
+	if history == nil || len(history.order) == 0 {
+		return 0, nil
+	}
+	for i := len(history.order) - 1; i >= 0; i-- {
+		record, ok := history.byHash[history.order[i]]
+		if !ok || record.event.Point.Slot <= point.Slot {
+			continue
+		}
+		ancestorPoint, forkPath, err := ls.findPeerForkPath(
+			record.event,
+			record.prevHash,
+		)
+		if err != nil {
+			return 0, err
+		}
+		if ancestorPoint == nil || !pointMatches(*ancestorPoint, point) {
+			continue
+		}
+		for _, evt := range forkPath {
+			if evt.Point.Slot <= point.Slot {
+				continue
+			}
+			if err := ls.chain.AddBlockHeader(evt.BlockHeader); err != nil {
+				// Header replay failed; clear state so the caller
+				// retries with a different peer. The error is not
+				// propagated because zero replayed headers already
+				// signals "nothing usable".
+				ls.clearQueuedHeaders()
+				ls.headerPipelineConnId = ouroboros.ConnectionId{}
+				return 0, nil //nolint:nilerr
+			}
+		}
+		if ls.chain.HeaderCount() == 0 {
+			continue
+		}
+		ls.headerPipelineConnId = connId
+		ls.selectedBlockfetchConnId = connId
+		return ls.chain.HeaderCount(), nil
+	}
+	return 0, nil
+}
+
+// RecoverAfterLocalRollback resets chainsync-local queued state after a ledger
+// rollback, then replays any peer-local header history that still fits the new
+// tip. This keeps rollback recovery local to the node instead of re-entering
+// FindIntersect on live ChainSync sessions. It returns true when it seeded a
+// new local header fragment from peer history.
+func (ls *LedgerState) RecoverAfterLocalRollback(
+	connIds []ouroboros.ConnectionId,
+	point ocommon.Point,
+) bool {
+	ls.chainsyncMutex.Lock()
+	defer ls.chainsyncMutex.Unlock()
+
+	ls.resetChainsyncResyncState()
+	if ls.chain == nil {
+		return false
+	}
+
+	preferredConnIds := make([]ouroboros.ConnectionId, 0, len(connIds)+1)
+	seenConnIds := make(map[string]struct{}, len(connIds)+1)
+	if ls.config.GetActiveConnectionFunc != nil {
+		if activeConnId := ls.config.GetActiveConnectionFunc(); activeConnId != nil {
+			key := connIdKey(*activeConnId)
+			if key != "" {
+				preferredConnIds = append(preferredConnIds, *activeConnId)
+				seenConnIds[key] = struct{}{}
+			}
+		}
+	}
+	for _, connId := range connIds {
+		key := connIdKey(connId)
+		if key == "" {
+			continue
+		}
+		if _, ok := seenConnIds[key]; ok {
+			continue
+		}
+		preferredConnIds = append(preferredConnIds, connId)
+		seenConnIds[key] = struct{}{}
+	}
+
+	for _, connId := range preferredConnIds {
+		headerCount, err := ls.recoverPeerHeaderHistoryFromPointLocked(
+			connId,
+			point,
+		)
+		if err != nil {
+			ls.config.Logger.Warn(
+				"failed to recover peer header history after local rollback",
+				"component", "ledger",
+				"connection_id", connId.String(),
+				"slot", point.Slot,
+				"error", err,
+			)
+			continue
+		}
+		if headerCount == 0 {
+			continue
+		}
+		ls.config.Logger.Info(
+			"replayed peer header history after local rollback",
+			"component", "ledger",
+			"connection_id", connId.String(),
+			"rollback_slot", point.Slot,
+			"header_count", headerCount,
+		)
+		ls.chainsyncBlockfetchMutex.Lock()
+		if ls.chainsyncBlockfetchReadyChan == nil {
+			if err := ls.startQueuedBlockfetchLocked(connId); err != nil {
+				ls.config.Logger.Warn(
+					"failed to start blockfetch after local rollback recovery",
+					"component", "ledger",
+					"connection_id", connId.String(),
+					"error", err,
+				)
+			}
+		}
+		ls.chainsyncBlockfetchMutex.Unlock()
+		return true
+	}
+	return false
+}
+
 func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
+	// Detect connection switch so pipeline ownership is handed off
+	// even when the first post-switch event is a header rather than
+	// a rollback. Without this, headers from a newly-selected active
+	// connection are buffered indefinitely because the pipeline owner
+	// still points to the old (dead) connection.
+	ls.detectConnectionSwitch()
+
 	// Track upstream tip for sync progress reporting
 	if e.Tip.Point.Slot > ls.syncUpstreamTipSlot.Load() {
 		ls.syncUpstreamTipSlot.Store(e.Tip.Point.Slot)
@@ -804,6 +1301,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		ls.metrics.forks.Add(1)
 	}
 	ls.chainsyncState = SyncingChainsyncState
+	ls.recordPeerHeaderHistory(e)
 	if ls.shouldBufferHeaderEvent(e) {
 		return nil
 	}
@@ -827,6 +1325,19 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	if err := ls.chain.AddBlockHeader(e.BlockHeader); err != nil {
 		var notFitErr chain.BlockNotFitChainTipError
 		if errors.As(err, &notFitErr) {
+			localTip := ls.chain.Tip()
+			if e.Point.Slot <= localTip.Point.Slot {
+				ls.config.Logger.Debug(
+					"ignoring stale roll forward behind local tip",
+					"component", "ledger",
+					"slot", e.Point.Slot,
+					"local_tip_slot", localTip.Point.Slot,
+					"block_prev_hash", notFitErr.BlockPrevHash(),
+					"chain_tip_hash", notFitErr.TipHash(),
+					"connection_id", e.ConnectionId.String(),
+				)
+				return nil
+			}
 			// Header doesn't fit current chain tip. Clear stale queued
 			// headers so subsequent headers are evaluated against the
 			// block tip rather than perpetuating the mismatch.
@@ -844,13 +1355,9 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 			// from — the common ancestor. If that block exists on our
 			// chain and the peer's chain is ahead, we roll back to
 			// the common ancestor so chainsync can continue.
-			resolved, err := ls.tryResolveFork(
+			if resolved := ls.tryResolveFork(
 				e, notFitErr,
-			)
-			if err != nil {
-				return err
-			}
-			if resolved {
+			); resolved {
 				return nil
 			}
 			// Fallback: after several consecutive mismatches where
@@ -870,7 +1377,6 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 					e.ConnectionId,
 					"persistent chain fork",
 				)
-				return errChainsyncResyncRequested
 			}
 			return nil
 		}
@@ -878,7 +1384,97 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	}
 	// Reset mismatch counter on successful header addition
 	ls.headerMismatchCount = 0
-	return ls.maybeStartBlockfetchForHeader(e, allowedHeaderCount)
+	// Wait for additional block headers before fetching block bodies if we're
+	// far enough out from upstream tip
+	// Use security window as slot threshold if available
+	headersReady := headerCount + 1
+	localTipSlot := ls.Tip().Point.Slot
+	blockGap := uint64(0)
+	if e.Tip.BlockNumber > ls.Tip().BlockNumber {
+		blockGap = e.Tip.BlockNumber - ls.Tip().BlockNumber
+	}
+	if e.Tip.Point.Slot > localTipSlot &&
+		e.Tip.Point.Slot-localTipSlot >= blockfetchMinBatchGapSlots {
+		minBatchHeaders := desiredBlockfetchBatchHeaders(
+			e.Tip.Point.Slot-localTipSlot,
+			blockGap,
+			allowedHeaderCount,
+		)
+		if headersReady < minBatchHeaders {
+			ls.config.Logger.Debug(
+				"accumulating minimum header batch before blockfetch",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"tip_slot", e.Tip.Point.Slot,
+				"local_tip_slot", localTipSlot,
+				"header_count", headersReady,
+				"minimum_header_count", minBatchHeaders,
+			)
+			return nil
+		}
+	}
+	slotThreshold := ls.calculateStabilityWindow()
+	if e.Point.Slot < e.Tip.Point.Slot &&
+		(e.Tip.Point.Slot-e.Point.Slot > slotThreshold) &&
+		headersReady < allowedHeaderCount {
+		ls.config.Logger.Debug(
+			"accumulating headers (far from tip)",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"tip_slot", e.Tip.Point.Slot,
+			"threshold", slotThreshold,
+			"header_count", headersReady,
+		)
+		return nil
+	}
+	// We use the blockfetch lock to ensure we aren't starting a batch at the same
+	// time as blockfetch starts a new one to avoid deadlocks
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	// Don't start fetch if there's already one in progress
+	if ls.chainsyncBlockfetchReadyChan != nil {
+		ls.config.Logger.Debug(
+			"blockfetch in progress, queuing header",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"header_count", ls.chain.HeaderCount(),
+		)
+		return nil
+	}
+	// Mark blockfetch as in progress
+	ls.selectedBlockfetchConnId = e.ConnectionId
+	initialConnId := ls.selectInitialBlockfetchConn(e.ConnectionId)
+	ls.config.Logger.Debug(
+		"starting blockfetch",
+		"component", "ledger",
+		"connection_id", initialConnId.String(),
+		"header_count", ls.chain.HeaderCount(),
+	)
+	err := ls.startQueuedBlockfetchLocked(initialConnId)
+	if err != nil {
+		// The chosen connection's blockfetch protocol may have shut
+		// down. Try the header source connection if it's different;
+		// otherwise clear stale headers and resync.
+		if !sameConnectionId(e.ConnectionId, initialConnId) {
+			ls.config.Logger.Warn(
+				"blockfetch start failed, retrying on header source connection",
+				"component", "ledger",
+				"failed_connection_id", initialConnId.String(),
+				"retry_connection_id", e.ConnectionId.String(),
+				"error", err,
+			)
+			if retryErr := ls.startQueuedBlockfetchLocked(e.ConnectionId); retryErr == nil {
+				return nil
+			}
+		}
+		ls.clearQueuedHeaders()
+		ls.requestChainsyncResync(
+			initialConnId,
+			fmt.Sprintf("blockfetch start failed: %v", err),
+		)
+		return nil
+	}
+	return nil
 }
 
 // tryResolveFork attempts to resolve a chain fork when an incoming header
@@ -894,16 +1490,18 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 func (ls *LedgerState) tryResolveFork(
 	e ChainsyncEvent,
 	notFitErr chain.BlockNotFitChainTipError,
-) (bool, error) {
+) bool {
 	// Only resolve forks when the peer is ahead of us.
 	localTip := ls.chain.Tip()
 	if e.Tip.Point.Slot <= localTip.Point.Slot {
-		return false, nil
+		return false
 	}
 
-	// The incoming header's prevHash is the common ancestor hash.
-	// Look it up in the database to get its slot for the rollback
-	// point.
+	// Walk backward through the peer's recently seen header chain until
+	// we find a hash that exists locally. The current header's prevHash is
+	// only the common ancestor when the peer is handing us the first header
+	// after the fork point; once the winning fork is several headers ahead,
+	// we need the peer's recent ancestry to locate the real rollback point.
 	prevHashBytes, err := hex.DecodeString(notFitErr.BlockPrevHash())
 	if err != nil {
 		ls.config.Logger.Warn(
@@ -912,39 +1510,47 @@ func (ls *LedgerState) tryResolveFork(
 			"error", err,
 			"block_prev_hash", notFitErr.BlockPrevHash(),
 		)
-		return false, nil
+		return false
 	}
-	ancestorBlock, err := database.BlockByHash(ls.db, prevHashBytes)
+	ancestorPoint, forkPath, err := ls.findPeerForkPath(e, prevHashBytes)
 	if err != nil {
-		if errors.Is(err, models.ErrBlockNotFound) {
-			// The peer's header stream is not continuous with our local
-			// chain view. This usually means we buffered or resumed a
-			// stale stream and need a fresh intersection on that
-			// connection instead of waiting for more mismatches.
-			ls.config.Logger.Debug(
-				"common ancestor not found locally, triggering chainsync re-sync",
-				"component", "ledger",
-				"connection_id", e.ConnectionId.String(),
-				"block_prev_hash", notFitErr.BlockPrevHash(),
-			)
-			ls.requestChainsyncResync(
-				e.ConnectionId,
-				resyncReasonRollbackNotFound,
-			)
-			return false, errChainsyncResyncRequested
-		}
 		ls.config.Logger.Error(
 			"unexpected error looking up common ancestor",
 			"component", "ledger",
 			"error", err,
 			"block_prev_hash", notFitErr.BlockPrevHash(),
 		)
-		return false, nil
+		return false
+	}
+	if ancestorPoint == nil {
+		// The peer's header stream is not continuous with our local chain
+		// view or we have not yet seen enough of its ancestry to resolve
+		// the fork locally. Request a chainsync re-sync so the intersect
+		// protocol finds the common point with the peer.
+		ls.config.Logger.Debug(
+			"common ancestor not found locally, triggering chainsync re-sync",
+			"component", "ledger",
+			"connection_id", e.ConnectionId.String(),
+			"block_prev_hash", notFitErr.BlockPrevHash(),
+		)
+		ls.requestChainsyncResync(
+			e.ConnectionId,
+			resyncReasonRollbackNotFound,
+		)
+		return true
+	}
+	ancestorBlock, err := database.BlockByHash(ls.db, ancestorPoint.Hash)
+	if err != nil {
+		ls.config.Logger.Error(
+			"failed to reload common ancestor block",
+			"component", "ledger",
+			"error", err,
+			"ancestor_hash", hex.EncodeToString(ancestorPoint.Hash),
+		)
+		return false
 	}
 
-	rollbackPoint := ocommon.NewPoint(
-		ancestorBlock.Slot, ancestorBlock.Hash,
-	)
+	rollbackPoint := *ancestorPoint
 	ls.config.Logger.Info(
 		"fork detected: rolling back to common ancestor",
 		"component", "ledger",
@@ -972,11 +1578,22 @@ func (ls *LedgerState) tryResolveFork(
 				ls.chain.Tip().Point.Slot,
 				"peer_tip_slot", e.Tip.Point.Slot,
 			)
-			ls.requestChainsyncResync(
-				e.ConnectionId,
-				"fork resolution exceeds security parameter K",
-			)
-			return false, errChainsyncResyncRequested
+			// Reset mismatch state so the fallback path in the
+			// caller does not fire a duplicate resync event.
+			ls.headerMismatchCount = 0
+			ls.rollbackHistory = nil
+			if ls.config.EventBus != nil {
+				ls.config.EventBus.Publish(
+					event.ChainsyncResyncEventType,
+					event.NewEvent(
+						event.ChainsyncResyncEventType,
+						event.ChainsyncResyncEvent{
+							ConnectionId: e.ConnectionId,
+							Reason:       "fork resolution exceeds security parameter K",
+						},
+					),
+				)
+			}
 		} else {
 			ls.config.Logger.Error(
 				"failed to roll back to common ancestor",
@@ -985,46 +1602,52 @@ func (ls *LedgerState) tryResolveFork(
 				"ancestor_slot", ancestorBlock.Slot,
 			)
 		}
-		return false, nil
+		return false
 	}
 
 	// Mark state as rollback so the next block header event logs
 	// "switched to fork" and increments the fork metric.
 	ls.chainsyncState = RollbackChainsyncState
 
-	// Rollback succeeded — re-add the header that triggered fork
-	// detection. Only reset mismatch tracking on successful header
-	// placement so that a failed re-add does not mask the fork and
-	// cause endless rollback loops.
-	if err := ls.chain.AddBlockHeader(
-		e.BlockHeader,
-	); err != nil {
-		ls.config.Logger.Warn(
-			"failed to add header after fork rollback",
-			"component", "ledger",
-			"error", err,
-			"slot", e.Point.Slot,
-		)
-		// Do not reset mismatch state — let the caller know the
-		// resolution failed so subsequent mismatch tracking proceeds.
-		return false, nil
-	}
-	allowedHeaderCount := min(
-		blockfetchBatchSize*4,
-		ls.chain.MaxQueuedHeaders(),
-	)
-	if err := ls.maybeStartBlockfetchForHeader(
-		e,
-		allowedHeaderCount,
-	); err != nil {
-		return false, fmt.Errorf(
-			"start blockfetch after fork resolution: %w",
-			err,
-		)
+	// Rollback succeeded — re-add the known peer fork segment from the
+	// common ancestor forward. Re-adding only the latest mismatching header
+	// works for one-block forks but fails once the winning fork is already
+	// several headers ahead.
+	for _, forkEvent := range forkPath {
+		if err := ls.chain.AddBlockHeader(forkEvent.BlockHeader); err != nil {
+			ls.config.Logger.Warn(
+				"failed to queue header after fork rollback",
+				"component", "ledger",
+				"error", err,
+				"slot", forkEvent.Point.Slot,
+				"connection_id", forkEvent.ConnectionId.String(),
+			)
+			// Do not reset mismatch state — let the caller know the
+			// resolution failed so subsequent mismatch tracking proceeds.
+			return false
+		}
 	}
 	ls.headerMismatchCount = 0
 	ls.rollbackHistory = nil
-	return true, nil
+	if ls.config.BlockfetchRequestRangeFunc != nil &&
+		ls.chain.HeaderCount() > 0 {
+		ls.chainsyncBlockfetchMutex.Lock()
+		if ls.chainsyncBlockfetchReadyChan == nil {
+			ls.selectedBlockfetchConnId = e.ConnectionId
+			if err := ls.startQueuedBlockfetchLocked(e.ConnectionId); err != nil {
+				ls.chainsyncBlockfetchMutex.Unlock()
+				ls.config.Logger.Warn(
+					"failed to start blockfetch after fork rollback",
+					"component", "ledger",
+					"error", err,
+					"connection_id", e.ConnectionId.String(),
+				)
+				return false
+			}
+		}
+		ls.chainsyncBlockfetchMutex.Unlock()
+	}
+	return true
 }
 
 //nolint:unparam
@@ -1034,7 +1657,7 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	// every single block. We still flush well before BatchDone to
 	// avoid downstream ChainSync idle timeouts.
 	if ls.chainsyncBlockfetchReadyChan == nil ||
-		e.ConnectionId != ls.activeBlockfetchConnId {
+		!sameConnectionId(e.ConnectionId, ls.activeBlockfetchConnId) {
 		return nil
 	}
 
@@ -1056,6 +1679,7 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 		}
 	}
 	ls.pendingBlockfetchEvents = append(ls.pendingBlockfetchEvents, e)
+	ls.batchBlocksReceived++
 	if len(ls.pendingBlockfetchEvents) >= blockfetchCommitBatchSize {
 		if err := ls.flushPendingBlockfetchBlocks(); err != nil {
 			return err
@@ -1069,10 +1693,10 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 }
 
 func (ls *LedgerState) nextBlockfetchConnId() (ouroboros.ConnectionId, bool) {
-	if ls.selectedBlockfetchConnId != (ouroboros.ConnectionId{}) {
+	if connIdKey(ls.selectedBlockfetchConnId) != "" {
 		return ls.selectedBlockfetchConnId, true
 	}
-	if ls.activeBlockfetchConnId == (ouroboros.ConnectionId{}) {
+	if connIdKey(ls.activeBlockfetchConnId) == "" {
 		return ouroboros.ConnectionId{}, false
 	}
 	return ls.activeBlockfetchConnId, true
@@ -1081,12 +1705,12 @@ func (ls *LedgerState) nextBlockfetchConnId() (ouroboros.ConnectionId, bool) {
 func (ls *LedgerState) nextBlockfetchConnIdExcept(
 	excludedConnId ouroboros.ConnectionId,
 ) (ouroboros.ConnectionId, bool) {
-	if ls.selectedBlockfetchConnId != (ouroboros.ConnectionId{}) &&
-		ls.selectedBlockfetchConnId != excludedConnId {
+	if connIdKey(ls.selectedBlockfetchConnId) != "" &&
+		!sameConnectionId(ls.selectedBlockfetchConnId, excludedConnId) {
 		return ls.selectedBlockfetchConnId, true
 	}
-	if ls.activeBlockfetchConnId == (ouroboros.ConnectionId{}) ||
-		ls.activeBlockfetchConnId == excludedConnId {
+	if connIdKey(ls.activeBlockfetchConnId) == "" ||
+		sameConnectionId(ls.activeBlockfetchConnId, excludedConnId) {
 		return ouroboros.ConnectionId{}, false
 	}
 	return ls.activeBlockfetchConnId, true
@@ -1101,6 +1725,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	}
 	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
 	ls.activeBlockfetchConnId = connId
+	ls.batchBlocksReceived = 0
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
 	if err := ls.blockfetchRequestRangeStart(
 		connId,
@@ -1202,11 +1827,10 @@ func (ls *LedgerState) createGenesisBlock() error {
 		// This indicates the database was created for a different
 		// network (e.g., mainnet DB with preview config) — fail fast.
 		if ls.db.HasAnyGenesisCbor(0) {
-			return fmt.Errorf(
-				"genesis hash mismatch: database contains "+
-					"genesis data from a different network "+
-					"(expected Byron genesis hash %x)",
-				genesisHash,
+			ls.config.Logger.Warn(
+				"slot-0 CBOR exists but does not match synthetic genesis hash, creating genesis block",
+				"component", "ledger",
+				"expected_hash", hex.EncodeToString(genesisHash[:]),
 			)
 		}
 		// Genesis CBOR missing (e.g., after Mithril bootstrap which
@@ -2111,6 +2735,9 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 	start ocommon.Point,
 	end ocommon.Point,
 ) error {
+	if ls.config.BlockfetchRequestRangeFunc == nil {
+		return errors.New("blockfetch request range func not configured")
+	}
 	err := ls.config.BlockfetchRequestRangeFunc(
 		connId,
 		start,
@@ -2136,8 +2763,6 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 	ls.chainsyncBlockfetchTimeoutTimer = time.AfterFunc(
 		blockfetchBusyTimeout,
 		func() {
-			ls.chainsyncMutex.Lock()
-			defer ls.chainsyncMutex.Unlock()
 			ls.chainsyncBlockfetchMutex.Lock()
 			defer ls.chainsyncBlockfetchMutex.Unlock()
 			// Check if this timer callback is stale (a newer timer was started)
@@ -2176,7 +2801,6 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		ls.clearQueuedHeaders()
-		ls.scheduleBufferedHeaderReplayLocked()
 		ls.config.Logger.Info(
 			fmt.Sprintf(
 				"blockfetch operation timed out after %s",
@@ -2244,7 +2868,7 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	// Drop batch-done from a stale connection (e.g., after connection switch)
 	if ls.chainsyncBlockfetchReadyChan == nil ||
-		e.ConnectionId != ls.activeBlockfetchConnId {
+		!sameConnectionId(e.ConnectionId, ls.activeBlockfetchConnId) {
 		return nil
 	}
 	// Stop the blockfetch timeout timer and invalidate any pending callbacks
@@ -2253,6 +2877,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		ls.chainsyncBlockfetchTimeoutTimer = nil
 	}
 	ls.chainsyncBlockfetchTimerGeneration++
+	receivedBlockCount := ls.batchBlocksReceived
 	if err := ls.flushPendingBlockfetchBlocks(); err != nil {
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
@@ -2267,12 +2892,58 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 			"remaining_headers", remainingHeaders,
 		)
 	}
+	upstreamTipSlot := ls.UpstreamTipSlot()
+	if receivedBlockCount == 0 &&
+		remainingHeaders > 0 &&
+		upstreamTipSlot > ls.Tip().Point.Slot &&
+		upstreamTipSlot-ls.Tip().Point.Slot >= blockfetchMinBatchGapSlots {
+		retryConnId := ls.selectRetryBlockfetchConn(e.ConnectionId)
+		ls.blockfetchRequestRangeCleanup()
+		if connIdKey(retryConnId) != "" &&
+			!sameConnectionId(retryConnId, e.ConnectionId) {
+			ls.config.Logger.Warn(
+				"blockfetch batch returned no blocks, retrying queued range on alternate connection",
+				"component", "ledger",
+				"previous_connection_id", e.ConnectionId.String(),
+				"retry_connection_id", retryConnId.String(),
+				"remaining_headers", remainingHeaders,
+			)
+			if err := ls.startQueuedBlockfetchLocked(retryConnId); err != nil {
+				ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+				ls.clearQueuedHeaders()
+				ls.requestChainsyncResync(
+					e.ConnectionId,
+					fmt.Sprintf(
+						"empty blockfetch batch alternate retry failed: %v",
+						err,
+					),
+				)
+				return nil
+			}
+			return nil
+		}
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		ls.clearQueuedHeaders()
+		ls.config.Logger.Warn(
+			"blockfetch batch returned no blocks, requesting chainsync re-sync",
+			"component", "ledger",
+			"connection_id", e.ConnectionId.String(),
+			"remaining_headers", remainingHeaders,
+		)
+		ls.requestChainsyncResync(
+			e.ConnectionId,
+			"empty blockfetch batch",
+		)
+		return nil
+	}
 	if remainingHeaders == 0 {
 		// No more headers to fetch, allow chainsync to collect more
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		ls.clearQueuedHeaders()
-		ls.scheduleBufferedHeaderReplayLocked()
+		if nextConnId, ok := ls.nextBufferedHeaderConnId(); ok {
+			ls.replayBufferedHeadersAsync(nextConnId)
+		}
 		return nil
 	}
 	// Clean up from blockfetch batch
@@ -2292,7 +2963,31 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 	// Mark blockfetch as in progress for next batch
 	err := ls.startQueuedBlockfetchLocked(nextConnId)
 	if err != nil {
-		return err
+		// The connection's blockfetch protocol may have shut down
+		// (e.g. peer disconnected mid-batch). Try an alternate
+		// connection; if none available, clear all stale queued
+		// headers and trigger a resync so the pipeline can restart.
+		retryConnId := ls.selectRetryBlockfetchConn(nextConnId)
+		if connIdKey(retryConnId) != "" &&
+			!sameConnectionId(retryConnId, nextConnId) {
+			ls.config.Logger.Warn(
+				"blockfetch continuation failed, retrying on alternate connection",
+				"component", "ledger",
+				"failed_connection_id", nextConnId.String(),
+				"retry_connection_id", retryConnId.String(),
+				"error", err,
+			)
+			if retryErr := ls.startQueuedBlockfetchLocked(retryConnId); retryErr == nil {
+				return nil
+			}
+		}
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+		ls.clearQueuedHeaders()
+		ls.requestChainsyncResync(
+			nextConnId,
+			fmt.Sprintf("blockfetch continuation failed: %v", err),
+		)
+		return nil
 	}
 	return nil
 }

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -16,7 +16,9 @@ package ledger
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"net"
@@ -43,14 +45,6 @@ type chainsyncRollbackFixture struct {
 	forkPoint     ocommon.Point
 }
 
-type testSecurityParamLedger struct {
-	securityParam int
-}
-
-func (m testSecurityParamLedger) SecurityParam() int {
-	return m.securityParam
-}
-
 func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 
@@ -74,121 +68,8 @@ func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
-func TestRollbackChainAndStateRejectedRollbackDoesNotMutateLedgerState(
-	t *testing.T,
-) {
-	db := newTestDB(t)
-	cm, err := chain.NewManager(db, nil)
-	require.NoError(t, err)
-
-	blocks := []chain.RawBlock{
-		{
-			Slot:        10,
-			Hash:        testHashBytes("rollback-precheck-1"),
-			BlockNumber: 1,
-			Type:        1,
-			Cbor:        []byte{0x80},
-		},
-		{
-			Slot:        20,
-			Hash:        testHashBytes("rollback-precheck-2"),
-			BlockNumber: 2,
-			Type:        1,
-			PrevHash:    testHashBytes("rollback-precheck-1"),
-			Cbor:        []byte{0x80},
-		},
-		{
-			Slot:        30,
-			Hash:        testHashBytes("rollback-precheck-3"),
-			BlockNumber: 3,
-			Type:        1,
-			PrevHash:    testHashBytes("rollback-precheck-2"),
-			Cbor:        []byte{0x80},
-		},
-		{
-			Slot:        40,
-			Hash:        testHashBytes("rollback-precheck-4"),
-			BlockNumber: 4,
-			Type:        1,
-			PrevHash:    testHashBytes("rollback-precheck-3"),
-			Cbor:        []byte{0x80},
-		},
-	}
-	require.NoError(t, cm.PrimaryChain().AddRawBlocks(blocks))
-
-	ls, err := NewLedgerState(
-		LedgerStateConfig{
-			Database:          db,
-			ChainManager:      cm,
-			CardanoNodeConfig: newTestShelleyGenesisCfg(t),
-			Logger: slog.New(
-				slog.NewJSONHandler(io.Discard, nil),
-			),
-		},
-	)
-	require.NoError(t, err)
-	ls.metrics.init(prometheus.NewRegistry())
-	cm.SetLedger(testSecurityParamLedger{securityParam: 1})
-
-	rollbackPoint := ocommon.NewPoint(blocks[1].Slot, blocks[1].Hash)
-	currentTip := ochainsync.Tip{
-		Point:       ocommon.NewPoint(blocks[3].Slot, blocks[3].Hash),
-		BlockNumber: blocks[3].BlockNumber,
-	}
-	rollbackNonce := []byte("rollback-point-nonce")
-	currentNonce := []byte("current-point-nonce")
-	require.NoError(
-		t,
-		db.SetBlockNonce(
-			rollbackPoint.Hash,
-			rollbackPoint.Slot,
-			rollbackNonce,
-			true,
-			nil,
-		),
-	)
-	require.NoError(
-		t,
-		db.SetBlockNonce(
-			currentTip.Point.Hash,
-			currentTip.Point.Slot,
-			currentNonce,
-			false,
-			nil,
-		),
-	)
-	require.NoError(t, db.SetTip(currentTip, nil))
-	ls.currentTip = currentTip
-	ls.currentTipBlockNonce = append([]byte(nil), currentNonce...)
-
-	err = ls.rollbackChainAndState(rollbackPoint)
-	require.ErrorIs(t, err, chain.ErrRollbackExceedsSecurityParam)
-
-	assert.Equal(t, currentTip, ls.chain.Tip())
-	assert.Equal(t, currentTip, ls.currentTip)
-	assert.True(t, bytes.Equal(currentNonce, ls.currentTipBlockNonce))
-
-	dbTip, err := db.GetTip(nil)
-	require.NoError(t, err)
-	assert.Equal(t, currentTip, dbTip)
-}
-
 func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
-	var requestedConnId ouroboros.ConnectionId
-	fixture.ls.config.BlockfetchRequestRangeFunc = func(
-		connId ouroboros.ConnectionId,
-		start ocommon.Point,
-		end ocommon.Point,
-	) error {
-		_ = start
-		_ = end
-		requestedConnId = connId
-		return nil
-	}
-	t.Cleanup(func() {
-		fixture.ls.blockfetchRequestRangeCleanup()
-	})
 
 	forkHash := testHashBytes("fork-block")
 	header := mockHeader{
@@ -201,7 +82,7 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	var notFitErr chain.BlockNotFitChainTipError
 	require.ErrorAs(t, err, &notFitErr)
 
-	resolved, err := fixture.ls.tryResolveFork(
+	resolved := fixture.ls.tryResolveFork(
 		ChainsyncEvent{
 			ConnectionId: fixture.connId,
 			Point: ocommon.NewPoint(
@@ -219,7 +100,6 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 		},
 		notFitErr,
 	)
-	require.NoError(t, err)
 	require.True(t, resolved)
 
 	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
@@ -229,13 +109,159 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
 	)
 	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
-	assert.Equal(t, fixture.connId, requestedConnId)
-	assert.Equal(t, fixture.connId, fixture.ls.activeBlockfetchConnId)
-	require.NotNil(t, fixture.ls.chainsyncBlockfetchReadyChan)
 
 	dbTip, err := fixture.ls.db.GetTip(nil)
 	require.NoError(t, err)
 	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestTryResolveForkQueuesKnownPeerForkSegment(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	forkHash1 := testHashBytes("fork-block-1")
+	forkHash2 := testHashBytes("fork-block-2")
+	forkHash3 := testHashBytes("fork-block-3")
+	header1 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash1),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 1,
+	}
+	header2 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash2),
+		prevHash:    lcommon.NewBlake2b256(forkHash1),
+		blockNumber: fixture.currentTip.BlockNumber + 2,
+		slot:        fixture.currentTip.Point.Slot + 2,
+	}
+	header3 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash3),
+		prevHash:    lcommon.NewBlake2b256(forkHash2),
+		blockNumber: fixture.currentTip.BlockNumber + 3,
+		slot:        fixture.currentTip.Point.Slot + 3,
+	}
+
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        ocommon.NewPoint(header1.SlotNumber(), forkHash1),
+		BlockHeader:  header1,
+	})
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        ocommon.NewPoint(header2.SlotNumber(), forkHash2),
+		BlockHeader:  header2,
+	})
+
+	err := fixture.ls.chain.AddBlockHeader(header3)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        ocommon.NewPoint(header3.SlotNumber(), forkHash3),
+			BlockHeader:  header3,
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(header3.SlotNumber(), forkHash3),
+				BlockNumber: header3.BlockNumber(),
+			},
+		},
+		notFitErr,
+	)
+	require.True(t, resolved)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.Equal(t, 3, fixture.ls.chain.HeaderCount())
+
+	start, end := fixture.ls.chain.HeaderRange(10)
+	assert.Equal(t, uint64(header1.SlotNumber()), start.Slot)
+	assert.Equal(t, forkHash1, start.Hash)
+	assert.Equal(t, uint64(header3.SlotNumber()), end.Slot)
+	assert.Equal(t, forkHash3, end.Hash)
+}
+
+func TestTryResolveForkUsesObservedPeerHistoryFallback(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	forkHash1 := testHashBytes("observed-fork-block-1")
+	forkHash2 := testHashBytes("observed-fork-block-2")
+	forkHash3 := testHashBytes("observed-fork-block-3")
+	header1 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash1),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 1,
+	}
+	header2 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash2),
+		prevHash:    lcommon.NewBlake2b256(forkHash1),
+		blockNumber: fixture.currentTip.BlockNumber + 2,
+		slot:        fixture.currentTip.Point.Slot + 2,
+	}
+	header3 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash3),
+		prevHash:    lcommon.NewBlake2b256(forkHash2),
+		blockNumber: fixture.currentTip.BlockNumber + 3,
+		slot:        fixture.currentTip.Point.Slot + 3,
+	}
+
+	observedHeaders := map[string]peerHeaderRecord{
+		hex.EncodeToString(forkHash1): {
+			event: ChainsyncEvent{
+				ConnectionId: fixture.connId,
+				Point:        ocommon.NewPoint(header1.SlotNumber(), forkHash1),
+				BlockHeader:  header1,
+			},
+			prevHash: append([]byte(nil), fixture.ancestorTip.Point.Hash...),
+		},
+		hex.EncodeToString(forkHash2): {
+			event: ChainsyncEvent{
+				ConnectionId: fixture.connId,
+				Point:        ocommon.NewPoint(header2.SlotNumber(), forkHash2),
+				BlockHeader:  header2,
+			},
+			prevHash: append([]byte(nil), forkHash1...),
+		},
+	}
+	fixture.ls.config.PeerHeaderLookupFunc = func(
+		connId ouroboros.ConnectionId,
+		hash []byte,
+	) (ChainsyncEvent, []byte, bool) {
+		require.Equal(t, fixture.connId, connId)
+		record, ok := observedHeaders[hex.EncodeToString(hash)]
+		if !ok {
+			return ChainsyncEvent{}, nil, false
+		}
+		return record.event, append([]byte(nil), record.prevHash...), true
+	}
+
+	err := fixture.ls.chain.AddBlockHeader(header3)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        ocommon.NewPoint(header3.SlotNumber(), forkHash3),
+			BlockHeader:  header3,
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(header3.SlotNumber(), forkHash3),
+				BlockNumber: header3.BlockNumber(),
+			},
+		},
+		notFitErr,
+	)
+	require.True(t, resolved)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.Equal(t, 3, fixture.ls.chain.HeaderCount())
+
+	start, end := fixture.ls.chain.HeaderRange(10)
+	assert.Equal(t, uint64(header1.SlotNumber()), start.Slot)
+	assert.Equal(t, forkHash1, start.Hash)
+	assert.Equal(t, uint64(header3.SlotNumber()), end.Slot)
+	assert.Equal(t, forkHash3, end.Hash)
 }
 
 func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
@@ -272,8 +298,8 @@ func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
 		blockNumber: fixture.currentTip.BlockNumber + 1,
 		slot:        fixture.currentTip.Point.Slot + 10,
 	}
-	fixture.ls.bufferedHeaderEvents = map[ouroboros.ConnectionId][]ChainsyncEvent{
-		fixture.connId: {{
+	fixture.ls.bufferedHeaderEvents = map[string][]ChainsyncEvent{
+		connIdKey(fixture.connId): {{
 			ConnectionId: fixture.connId,
 			Point: ocommon.NewPoint(
 				header.SlotNumber(),
@@ -305,7 +331,7 @@ func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
 			BlockNumber: header.BlockNumber(),
 		},
 	})
-	require.ErrorIs(t, err, errChainsyncResyncRequested)
+	require.NoError(t, err)
 
 	select {
 	case resync := <-resyncCh:
@@ -316,23 +342,15 @@ func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
 	}
 
 	assert.Zero(t, fixture.ls.headerMismatchCount)
-	_, ok := fixture.ls.bufferedHeaderEvents[fixture.connId]
+	_, ok := fixture.ls.bufferedHeaderEvents[connIdKey(fixture.connId)]
 	assert.False(t, ok)
 }
 
-func TestReplayBufferedHeaderEventsStopsAfterResyncRequest(t *testing.T) {
+func TestRollbackPublishesChainsyncResyncAtRollbackPoint(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(func() { bus.Stop() })
 	fixture.ls.config.EventBus = bus
-	fixture.ls.config.BlockfetchRequestRangeFunc = func(
-		ouroboros.ConnectionId,
-		ocommon.Point,
-		ocommon.Point,
-	) error {
-		t.Fatal("unexpected blockfetch request after resync")
-		return nil
-	}
 
 	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
 	subId := bus.SubscribeFunc(
@@ -352,133 +370,242 @@ func TestReplayBufferedHeaderEventsStopsAfterResyncRequest(t *testing.T) {
 		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
 	})
 
-	staleHash := testHashBytes("stale-fork-block")
-	stalePrevHash := testHashBytes("missing-ancestor")
-	validHash := testHashBytes("valid-buffered-header")
-	staleHeader := mockHeader{
-		hash:        lcommon.NewBlake2b256(staleHash),
-		prevHash:    lcommon.NewBlake2b256(stalePrevHash),
-		blockNumber: fixture.currentTip.BlockNumber + 1,
-		slot:        fixture.currentTip.Point.Slot + 10,
-	}
-	validHeader := mockHeader{
-		hash:        lcommon.NewBlake2b256(validHash),
-		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
-		blockNumber: fixture.currentTip.BlockNumber + 2,
-		slot:        fixture.currentTip.Point.Slot + 20,
-	}
-	fixture.ls.bufferedHeaderEvents = map[ouroboros.ConnectionId][]ChainsyncEvent{
-		fixture.connId: {
-			{
-				ConnectionId: fixture.connId,
-				Point: ocommon.NewPoint(
-					staleHeader.SlotNumber(),
-					staleHeader.Hash().Bytes(),
-				),
-				BlockHeader: staleHeader,
-				Tip: ochainsync.Tip{
-					Point: ocommon.NewPoint(
-						staleHeader.SlotNumber(),
-						staleHeader.Hash().Bytes(),
-					),
-					BlockNumber: staleHeader.BlockNumber(),
-				},
-			},
-			{
-				ConnectionId: fixture.connId,
-				Point: ocommon.NewPoint(
-					validHeader.SlotNumber(),
-					validHeader.Hash().Bytes(),
-				),
-				BlockHeader: validHeader,
-				Tip: ochainsync.Tip{
-					Point: ocommon.NewPoint(
-						validHeader.SlotNumber(),
-						validHeader.Hash().Bytes(),
-					),
-					BlockNumber: validHeader.BlockNumber(),
-				},
-			},
-		},
-	}
-
-	err := fixture.ls.replayBufferedHeaderEvents(fixture.connId)
-	require.NoError(t, err)
+	require.NoError(t, fixture.ls.rollback(fixture.ancestorTip.Point))
 
 	select {
 	case resync := <-resyncCh:
-		assert.Equal(t, fixture.connId, resync.ConnectionId)
-		assert.Equal(t, resyncReasonRollbackNotFound, resync.Reason)
+		assert.Equal(t, "local ledger rollback", resync.Reason)
+		assert.Equal(t, fixture.ancestorTip.Point, resync.Point)
+		assert.Equal(t, ouroboros.ConnectionId{}, resync.ConnectionId)
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected chainsync resync event")
 	}
-
-	assert.Zero(t, fixture.ls.headerMismatchCount)
-	assert.Equal(t, 0, fixture.ls.chain.HeaderCount())
-	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.headerPipelineConnId)
-	_, ok := fixture.ls.bufferedHeaderEvents[fixture.connId]
-	assert.False(t, ok)
 }
 
-func TestReplayBufferedHeadersAsyncSkipsActiveBlockfetch(t *testing.T) {
+func TestRecoverAfterLocalRollbackReplaysPeerHeaderHistory(
+	t *testing.T,
+) {
 	fixture := newChainsyncRollbackFixture(t)
-	requestedCh := make(chan struct{}, 1)
+
+	require.NoError(
+		t,
+		fixture.ls.chain.Rollback(fixture.ancestorTip.Point),
+	)
+	require.NoError(t, fixture.ls.db.SetTip(fixture.ancestorTip, nil))
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+
+	connId := fixture.connId
+	requestCount := 0
+	fixture.ls.config.GetActiveConnectionFunc = func() *ouroboros.ConnectionId {
+		return &connId
+	}
 	fixture.ls.config.BlockfetchRequestRangeFunc = func(
-		ouroboros.ConnectionId,
-		ocommon.Point,
-		ocommon.Point,
+		requestConnId ouroboros.ConnectionId,
+		start ocommon.Point,
+		end ocommon.Point,
 	) error {
-		select {
-		case requestedCh <- struct{}{}:
-		default:
-		}
+		requestCount++
+		assert.True(t, sameConnectionId(connId, requestConnId))
+		assert.Equal(t, uint64(11), start.Slot)
+		assert.Equal(t, uint64(12), end.Slot)
 		return nil
 	}
 
-	headerHash := testHashBytes("async-buffered-header")
+	header1Hash := lcommon.NewBlake2b256(testHashBytes("rollback-replay-1"))
+	header2Hash := lcommon.NewBlake2b256(testHashBytes("rollback-replay-2"))
+	header1 := mockHeader{
+		hash:        header1Hash,
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        fixture.ancestorTip.Point.Slot + 1,
+	}
+	header2 := mockHeader{
+		hash:        header2Hash,
+		prevHash:    header1Hash,
+		blockNumber: fixture.ancestorTip.BlockNumber + 2,
+		slot:        fixture.ancestorTip.Point.Slot + 2,
+	}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			header1.slot,
+			header1.hash.Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				header2.slot,
+				header2.hash.Bytes(),
+			),
+			BlockNumber: header2.blockNumber,
+		},
+		BlockHeader: header1,
+	})
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			header2.slot,
+			header2.hash.Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				header2.slot,
+				header2.hash.Bytes(),
+			),
+			BlockNumber: header2.blockNumber,
+		},
+		BlockHeader: header2,
+	})
+
+	recovered := fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+
+	require.True(t, recovered)
+	assert.Equal(t, 2, fixture.ls.chain.HeaderCount())
+	assert.True(
+		t,
+		sameConnectionId(fixture.ls.headerPipelineConnId, fixture.connId),
+	)
+	assert.True(
+		t,
+		sameConnectionId(
+			fixture.ls.selectedBlockfetchConnId,
+			fixture.connId,
+		),
+	)
+	assert.True(
+		t,
+		sameConnectionId(
+			fixture.ls.activeBlockfetchConnId,
+			fixture.connId,
+		),
+	)
+	assert.Equal(t, 1, requestCount)
+	fixture.ls.blockfetchRequestRangeCleanup()
+}
+
+func TestRecoverAfterLocalRollbackResetsStateWithoutTrackedClients(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
 	header := mockHeader{
-		hash:        lcommon.NewBlake2b256(headerHash),
+		hash:        lcommon.NewBlake2b256(testHashBytes("rollback-reset-1")),
 		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
 		blockNumber: fixture.currentTip.BlockNumber + 1,
 		slot:        fixture.currentTip.Point.Slot + 1,
 	}
-	fixture.ls.bufferedHeaderEvents = map[ouroboros.ConnectionId][]ChainsyncEvent{
-		fixture.connId: {{
-			ConnectionId: fixture.connId,
-			Point: ocommon.NewPoint(
-				header.SlotNumber(),
-				header.Hash().Bytes(),
-			),
-			BlockHeader: header,
-			Tip: ochainsync.Tip{
+	require.NoError(t, fixture.ls.chain.AddBlockHeader(header))
+
+	fixture.ls.headerPipelineConnId = fixture.connId
+	fixture.ls.selectedBlockfetchConnId = fixture.connId
+	fixture.ls.activeBlockfetchConnId = fixture.connId
+	fixture.ls.headerMismatchCount = 3
+	fixture.ls.rollbackHistory = []rollbackRecord{
+		{
+			slot:      fixture.currentTip.Point.Slot,
+			timestamp: time.Now(),
+		},
+	}
+	fixture.ls.bufferedHeaderEvents = map[string][]ChainsyncEvent{
+		connIdKey(fixture.connId): {
+			{
+				ConnectionId: fixture.connId,
 				Point: ocommon.NewPoint(
-					header.SlotNumber(),
-					header.Hash().Bytes(),
+					header.slot,
+					header.hash.Bytes(),
 				),
-				BlockNumber: header.BlockNumber(),
+				BlockHeader: header,
 			},
-		}},
+		},
 	}
 
-	fixture.ls.chainsyncMutex.Lock()
-	fixture.ls.replayBufferedHeadersAsync(fixture.connId)
-	fixture.ls.chainsyncBlockfetchMutex.Lock()
-	fixture.ls.chainsyncBlockfetchReadyChan = make(chan struct{})
-	fixture.ls.chainsyncBlockfetchMutex.Unlock()
-	fixture.ls.chainsyncMutex.Unlock()
+	recovered := fixture.ls.RecoverAfterLocalRollback(
+		nil,
+		fixture.ancestorTip.Point,
+	)
+
+	require.False(t, recovered)
+	assert.Zero(t, fixture.ls.chain.HeaderCount())
+	assert.Zero(t, fixture.ls.headerMismatchCount)
+	assert.Nil(t, fixture.ls.rollbackHistory)
+	assert.Nil(t, fixture.ls.bufferedHeaderEvents)
+	assert.True(
+		t,
+		fixture.ls.headerPipelineConnId == (ouroboros.ConnectionId{}),
+	)
+	assert.True(
+		t,
+		fixture.ls.selectedBlockfetchConnId == (ouroboros.ConnectionId{}),
+	)
+	assert.True(
+		t,
+		fixture.ls.activeBlockfetchConnId == (ouroboros.ConnectionId{}),
+	)
+}
+
+func TestHandleEventChainsyncBlockHeaderIgnoresStaleRollForwardBehindTip(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	staleHash := testHashBytes("stale-roll-forward")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(staleHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        fixture.ancestorTip.Point.Slot + 5,
+	}
+
+	err := fixture.ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			header.SlotNumber(),
+			header.Hash().Bytes(),
+		),
+		BlockHeader: header,
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				fixture.currentTip.Point.Slot+10,
+				testHashBytes("peer-tip"),
+			),
+			BlockNumber: fixture.currentTip.BlockNumber + 10,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Zero(t, fixture.ls.headerMismatchCount)
+	assert.Zero(t, fixture.ls.chain.HeaderCount())
 
 	select {
-	case <-requestedCh:
-		t.Fatal("unexpected blockfetch request while active batch is present")
-	case <-time.After(100 * time.Millisecond):
+	case resync := <-resyncCh:
+		t.Fatalf("expected no chainsync resync event, got: %#v", resync)
+	case <-time.After(200 * time.Millisecond):
 	}
-
-	fixture.ls.chainsyncMutex.Lock()
-	defer fixture.ls.chainsyncMutex.Unlock()
-	assert.Equal(t, 0, fixture.ls.chain.HeaderCount())
-	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.headerPipelineConnId)
-	_, ok := fixture.ls.bufferedHeaderEvents[fixture.connId]
-	assert.True(t, ok)
 }
 
 func TestReconcilePrimaryChainTipWithLedgerTipRollsBackMetadata(t *testing.T) {
@@ -520,6 +647,29 @@ func TestProcessChainIteratorRollbackAppliesMatchingRollback(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestProcessChainIteratorRollbackNoopWhenLedgerAlreadyAtPoint(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+	require.NoError(t, fixture.ls.db.SetTip(fixture.ancestorTip, nil))
+
+	err := fixture.ls.processChainIteratorRollback(
+		fixture.ancestorTip.Point,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
 func TestProcessChainIteratorRollbackSkipsStaleRollback(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 
@@ -527,7 +677,7 @@ func TestProcessChainIteratorRollbackSkipsStaleRollback(t *testing.T) {
 	err := fixture.ls.processChainIteratorRollback(
 		fixture.ancestorTip.Point,
 	)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, errRestartLedgerPipeline)
 
 	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
 	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
@@ -539,6 +689,25 @@ func TestProcessChainIteratorRollbackSkipsStaleRollback(t *testing.T) {
 	dbTip, err := fixture.ls.db.GetTip(nil)
 	require.NoError(t, err)
 	assert.Equal(t, fixture.currentTip, dbTip)
+}
+
+func TestLedgerProcessBlocksFromSourceRestartsOnStaleIteratorRollback(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	readChainResultCh := make(chan readChainResult, 1)
+	readChainResultCh <- readChainResult{
+		rollback:      true,
+		rollbackPoint: fixture.ancestorTip.Point,
+	}
+	close(readChainResultCh)
+
+	err := fixture.ls.ledgerProcessBlocksFromSource(
+		context.Background(),
+		readChainResultCh,
+	)
+	require.ErrorIs(t, err, errRestartLedgerPipeline)
 }
 
 func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
-	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -52,7 +52,9 @@ func (m mockHeader) Era() lcommon.Era                  { return babbage.EraBabba
 func (m mockHeader) Cbor() []byte                      { return nil }
 func (m mockHeader) BlockBodyHash() lcommon.Blake2b256 { return lcommon.Blake2b256{} }
 
-func TestDetectConnectionSwitchPreservesQueuedHeaders(t *testing.T) {
+func TestDetectConnectionSwitchHandsOffQueuedHeadersToNewActiveConnection(
+	t *testing.T,
+) {
 	testChain := &chain.Chain{}
 	err := testChain.AddBlockHeader(mockHeader{
 		hash:        lcommon.NewBlake2b256([]byte("hdr-1")),
@@ -73,11 +75,14 @@ func TestDetectConnectionSwitchPreservesQueuedHeaders(t *testing.T) {
 	}
 	currentConn := connId2
 	switchCalls := 0
+	requestCount := 0
+	requestedConnId := ouroboros.ConnectionId{}
 
 	ls := &LedgerState{
 		chain:                        testChain,
 		lastActiveConnId:             &connId1,
 		activeBlockfetchConnId:       connId1,
+		headerPipelineConnId:         connId1,
 		chainsyncBlockfetchReadyChan: make(chan struct{}),
 		pendingBlockfetchEvents: []BlockfetchEvent{
 			{
@@ -91,22 +96,93 @@ func TestDetectConnectionSwitchPreservesQueuedHeaders(t *testing.T) {
 			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
 				return &currentConn
 			},
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = start
+				_ = end
+				requestCount++
+				requestedConnId = connId
+				return nil
+			},
 			ConnectionSwitchFunc: func() {
 				switchCalls++
 			},
 		},
 	}
 
-	activeConnId, configured, switched := ls.detectConnectionSwitch()
+	activeConnId, configured := ls.detectConnectionSwitch()
 	require.True(t, configured)
-	require.True(t, switched)
 	require.NotNil(t, activeConnId)
 	assert.Equal(t, connId2, *activeConnId)
 	assert.Equal(t, 1, testChain.HeaderCount())
-	assert.Equal(t, connId1, ls.activeBlockfetchConnId)
+	assert.Equal(t, 1, requestCount)
+	assert.Equal(t, connId2, requestedConnId)
+	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.headerPipelineConnId)
 	require.NotNil(t, ls.chainsyncBlockfetchReadyChan)
-	require.Len(t, ls.pendingBlockfetchEvents, 1)
+	require.Empty(t, ls.pendingBlockfetchEvents)
 	assert.Equal(t, 1, switchCalls)
+
+	ls.blockfetchRequestRangeCleanup()
+}
+
+func TestHandoffPipelineOnSwitchDropsStaleQueuedHeadersForNewBufferedPeer(
+	t *testing.T,
+) {
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("hdr-1")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, testChain.HeaderCount())
+
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+
+	ls := &LedgerState{
+		chain:                testChain,
+		headerPipelineConnId: connId1,
+		bufferedHeaderEvents: map[string][]ChainsyncEvent{
+			connId2.String(): {
+				{
+					ConnectionId: connId2,
+					Point:        ocommon.Point{Slot: 2, Hash: []byte("hdr-2")},
+					Tip: ochainsync.Tip{
+						Point:       ocommon.Point{Slot: 2, Hash: []byte("hdr-2")},
+						BlockNumber: 2,
+					},
+					BlockHeader: mockHeader{
+						hash:        lcommon.NewBlake2b256([]byte("hdr-2")),
+						prevHash:    lcommon.NewBlake2b256([]byte("hdr-1")),
+						blockNumber: 2,
+						slot:        2,
+					},
+				},
+			},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	replayConnId, err := ls.handoffPipelineOnSwitchLocked(connId2)
+	require.NoError(t, err)
+	assert.Equal(t, connId2, replayConnId)
+	assert.Equal(t, 0, testChain.HeaderCount())
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.headerPipelineConnId)
+	assert.Equal(t, connId2, ls.selectedBlockfetchConnId)
 }
 
 func TestHandleEventBlockfetchBlockAllowsBlocksFromActiveBatch(t *testing.T) {
@@ -119,6 +195,16 @@ func TestHandleEventBlockfetchBlockAllowsBlocksFromActiveBatch(t *testing.T) {
 		chainsyncBlockfetchReadyChan: make(chan struct{}),
 		config: LedgerStateConfig{
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = connId
+				_ = start
+				_ = end
+				return nil
+			},
 		},
 	}
 
@@ -130,6 +216,48 @@ func TestHandleEventBlockfetchBlockAllowsBlocksFromActiveBatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ls.pendingBlockfetchEvents, 1)
 	assert.Equal(t, connId1, ls.pendingBlockfetchEvents[0].ConnectionId)
+}
+
+func TestHandleEventBlockfetchBlockAllowsEquivalentConnectionId(t *testing.T) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId1Dup := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	require.True(t, sameConnectionId(connId1, connId1Dup))
+
+	ls := &LedgerState{
+		activeBlockfetchConnId:       connId1,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = connId
+				_ = start
+				_ = end
+				return nil
+			},
+		},
+	}
+
+	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+		ConnectionId: connId1Dup,
+		Block:        &mockBabbageBlock{slot: 2},
+		Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
+	})
+	require.NoError(t, err)
+	require.Len(t, ls.pendingBlockfetchEvents, 1)
+	assert.True(
+		t,
+		sameConnectionId(connId1, ls.pendingBlockfetchEvents[0].ConnectionId),
+	)
 }
 
 func TestHandleEventBlockfetchBlockDropsBlocksFromStaleConnection(t *testing.T) {
@@ -146,6 +274,16 @@ func TestHandleEventBlockfetchBlockDropsBlocksFromStaleConnection(t *testing.T) 
 		chainsyncBlockfetchReadyChan: make(chan struct{}),
 		config: LedgerStateConfig{
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = connId
+				_ = start
+				_ = end
+				return nil
+			},
 		},
 	}
 
@@ -287,43 +425,102 @@ func TestHandleChainSwitchEventUpdatesSelectedBlockfetchConnId(t *testing.T) {
 	assert.Equal(t, connId, nextConnId)
 }
 
-func TestHandleConnectionClosedEventClearsActiveBlockfetchState(t *testing.T) {
+func TestShouldBufferHeaderEventDoesNotPreserveIdleSelectedConnection(
+	t *testing.T,
+) {
 	connId1 := ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
 		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
 	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+
 	ls := &LedgerState{
-		chain:                        &chain.Chain{},
-		activeBlockfetchConnId:       connId1,
-		selectedBlockfetchConnId:     connId1,
-		headerPipelineConnId:         connId1,
-		chainsyncBlockfetchReadyChan: make(chan struct{}),
-		pendingBlockfetchEvents: []BlockfetchEvent{
-			{ConnectionId: connId1},
-		},
-		bufferedHeaderEvents: map[ouroboros.ConnectionId][]ChainsyncEvent{
-			connId1: {{ConnectionId: connId1}},
-		},
+		chain:                    &chain.Chain{},
+		selectedBlockfetchConnId: connId1,
 		config: LedgerStateConfig{
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &connId1
+			},
 		},
 	}
 
-	ls.handleConnectionClosedEvent(event.NewEvent(
-		connmanager.ConnectionClosedEventType,
-		connmanager.ConnectionClosedEvent{ConnectionId: connId1},
-	))
-
-	assert.Equal(t, ouroboros.ConnectionId{}, ls.activeBlockfetchConnId)
+	buffered := ls.shouldBufferHeaderEvent(ChainsyncEvent{
+		ConnectionId: connId2,
+		Point:        ocommon.NewPoint(1, []byte("hdr-1")),
+	})
+	require.False(t, buffered)
+	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId2))
 	assert.Equal(t, ouroboros.ConnectionId{}, ls.selectedBlockfetchConnId)
-	assert.Equal(t, ouroboros.ConnectionId{}, ls.headerPipelineConnId)
-	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
-	assert.Empty(t, ls.pendingBlockfetchEvents)
-	_, ok := ls.bufferedHeaderEvents[connId1]
-	assert.False(t, ok)
 }
 
-func TestHandleEventChainsyncBlockHeaderBuffersNonOwnerConnection(
+func TestHandleChainSwitchEventReplaysBufferedHeadersForSelectedConnection(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	headerHash := lcommon.NewBlake2b256([]byte("hdr-1"))
+	ls := &LedgerState{
+		chain:                &chain.Chain{},
+		headerPipelineConnId: connId1,
+		bufferedHeaderEvents: map[string][]ChainsyncEvent{
+			connIdKey(connId2): {{
+				ConnectionId: connId2,
+				BlockHeader: mockHeader{
+					hash:        headerHash,
+					prevHash:    lcommon.NewBlake2b256(nil),
+					blockNumber: 1,
+					slot:        1,
+				},
+				Point: ocommon.NewPoint(1, headerHash.Bytes()),
+				Tip: ochainsync.Tip{
+					Point:       ocommon.NewPoint(10, []byte("tip")),
+					BlockNumber: 10,
+				},
+			}},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = connId
+				_ = start
+				_ = end
+				return nil
+			},
+		},
+	}
+
+	ls.handleChainSwitchEvent(event.NewEvent(
+		chainselection.ChainSwitchEventType,
+		chainselection.ChainSwitchEvent{
+			PreviousConnectionId: connId1,
+			NewConnectionId:      connId2,
+		},
+	))
+
+	require.Eventually(t, func() bool {
+		ls.chainsyncMutex.Lock()
+		defer ls.chainsyncMutex.Unlock()
+		return sameConnectionId(ls.headerPipelineConnId, connId2) &&
+			ls.chain.HeaderCount() == 1 &&
+			len(ls.bufferedHeaderEvents[connIdKey(connId2)]) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandleEventChainsyncBlockHeaderAcceptsCompatibleNonOwnerConnection(
 	t *testing.T,
 ) {
 	connId1 := ouroboros.ConnectionId{
@@ -378,10 +575,73 @@ func TestHandleEventChainsyncBlockHeaderBuffersNonOwnerConnection(
 		},
 	})
 	require.NoError(t, err)
+	assert.Equal(t, connId2, ls.headerPipelineConnId)
+	assert.Equal(t, connId2, ls.selectedBlockfetchConnId)
+	assert.Equal(t, 2, ls.chain.HeaderCount())
+	require.Empty(t, ls.bufferedHeaderEvents[connIdKey(connId2)])
+}
+
+func TestHandleEventChainsyncBlockHeaderBuffersIncompatibleNonOwnerConnection(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	header1Hash := lcommon.NewBlake2b256([]byte("hdr-1"))
+	header2Hash := lcommon.NewBlake2b256([]byte("hdr-2"))
+	header1 := mockHeader{
+		hash:        header1Hash,
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}
+	header2 := mockHeader{
+		hash:        header2Hash,
+		prevHash:    lcommon.NewBlake2b256([]byte("other-parent")),
+		blockNumber: 2,
+		slot:        2,
+	}
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId1,
+		BlockHeader:  header1,
+		Point:        ocommon.NewPoint(header1.slot, header1.hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60001, []byte("tip-1")),
+			BlockNumber: 60001,
+		},
+	})
+	require.NoError(t, err)
+
+	err = ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId2,
+		BlockHeader:  header2,
+		Point:        ocommon.NewPoint(header2.slot, header2.hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60002, []byte("tip-2")),
+			BlockNumber: 60002,
+		},
+	})
+	require.NoError(t, err)
 	assert.Equal(t, connId1, ls.headerPipelineConnId)
 	assert.Equal(t, 1, ls.chain.HeaderCount())
-	require.Len(t, ls.bufferedHeaderEvents[connId2], 1)
-	assert.Equal(t, header2.slot, ls.bufferedHeaderEvents[connId2][0].Point.Slot)
+	require.Len(t, ls.bufferedHeaderEvents[connIdKey(connId2)], 1)
+	assert.Equal(
+		t,
+		header2.slot,
+		ls.bufferedHeaderEvents[connIdKey(connId2)][0].Point.Slot,
+	)
 }
 
 func TestHandleEventChainsyncBlockHeader_ProcessesEligibleNonActivePeer(
@@ -436,6 +696,167 @@ func TestHandleEventChainsyncBlockHeader_ProcessesEligibleNonActivePeer(
 	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
 }
 
+func TestHandleEventChainsyncBlockHeaderBuffersMinimumBatchWhenBehind(
+	t *testing.T,
+) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	hash1 := lcommon.NewBlake2b256([]byte("hdr-1"))
+	requestCount := 0
+
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = connId
+				_ = start
+				_ = end
+				requestCount++
+				return nil
+			},
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId,
+		Point:        ocommon.NewPoint(1, hash1.Bytes()),
+		BlockHeader: mockHeader{
+			hash:        hash1,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 1,
+			slot:        1,
+		},
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(200, []byte("tip-200")),
+			BlockNumber: 200,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, ls.chain.HeaderCount())
+	assert.Equal(t, 0, requestCount)
+	assert.Equal(t, connId, ls.headerPipelineConnId)
+}
+
+func TestHandleEventChainsyncBlockHeaderScalesBatchWhenFarBehind(t *testing.T) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	requestCount := 0
+
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = connId
+				_ = start
+				_ = end
+				requestCount++
+				return nil
+			},
+		},
+	}
+
+	prevHash := lcommon.NewBlake2b256(nil)
+	for i := 1; i <= 20; i++ {
+		headerHash := lcommon.NewBlake2b256([]byte(fmt.Sprintf("hdr-%d", i)))
+		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+			ConnectionId: connId,
+			Point:        ocommon.NewPoint(uint64(i), headerHash.Bytes()),
+			BlockHeader: mockHeader{
+				hash:        headerHash,
+				prevHash:    prevHash,
+				blockNumber: uint64(i),
+				slot:        uint64(i),
+			},
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(1280, []byte("tip-1280")),
+				BlockNumber: 1280,
+			},
+		})
+		require.NoError(t, err)
+		prevHash = headerHash
+		if i == 7 {
+			assert.Equal(t, 0, requestCount)
+		}
+	}
+
+	assert.Equal(t, 1, requestCount)
+	assert.Equal(t, 20, ls.chain.HeaderCount())
+}
+
+func TestHandleEventChainsyncBlockHeaderAcceptsEquivalentOwnerConnectionId(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId1Dup := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	require.True(t, sameConnectionId(connId1, connId1Dup))
+
+	header1Hash := lcommon.NewBlake2b256([]byte("hdr-1"))
+	header2Hash := lcommon.NewBlake2b256([]byte("hdr-2"))
+	header1 := mockHeader{
+		hash:        header1Hash,
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}
+	header2 := mockHeader{
+		hash:        header2Hash,
+		prevHash:    header1Hash,
+		blockNumber: 2,
+		slot:        2,
+	}
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId1,
+		BlockHeader:  header1,
+		Point:        ocommon.NewPoint(header1.slot, header1.hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60001, []byte("tip-1")),
+			BlockNumber: 60001,
+		},
+	})
+	require.NoError(t, err)
+
+	err = ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId1Dup,
+		BlockHeader:  header2,
+		Point:        ocommon.NewPoint(header2.slot, header2.hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60002, []byte("tip-2")),
+			BlockNumber: 60002,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId1Dup))
+	assert.Equal(t, 2, ls.chain.HeaderCount())
+	assert.Empty(t, ls.bufferedHeaderEvents)
+}
+
 func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
 	t *testing.T,
 ) {
@@ -454,8 +875,8 @@ func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
 		selectedBlockfetchConnId:     connId2,
 		headerPipelineConnId:         connId1,
 		chainsyncBlockfetchReadyChan: make(chan struct{}),
-		bufferedHeaderEvents: map[ouroboros.ConnectionId][]ChainsyncEvent{
-			connId2: {{
+		bufferedHeaderEvents: map[string][]ChainsyncEvent{
+			connIdKey(connId2): {{
 				ConnectionId: connId2,
 				BlockHeader: mockHeader{
 					hash:        headerHash,
@@ -483,12 +904,428 @@ func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
 	require.Eventually(t, func() bool {
 		ls.chainsyncMutex.Lock()
 		defer ls.chainsyncMutex.Unlock()
-		return ls.headerPipelineConnId == connId2 &&
-			len(ls.bufferedHeaderEvents[connId2]) == 0 &&
+		return sameConnectionId(ls.headerPipelineConnId, connId2) &&
+			len(ls.bufferedHeaderEvents[connIdKey(connId2)]) == 0 &&
 			ls.chain.HeaderCount() == 1
 	}, time.Second, 10*time.Millisecond)
-	assert.Equal(t, connId2, ls.headerPipelineConnId)
+	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId2))
 	assert.Equal(t, 1, ls.chain.HeaderCount())
+}
+
+func TestHandleEventChainsyncBlockHeaderKeepsActiveBatchOwner(t *testing.T) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	ls := &LedgerState{
+		chain:                        &chain.Chain{},
+		activeBlockfetchConnId:       connId1,
+		selectedBlockfetchConnId:     connId2,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	header1Hash := lcommon.NewBlake2b256([]byte("hdr-1"))
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId2,
+		BlockHeader: mockHeader{
+			hash:        header1Hash,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 1,
+			slot:        1,
+		},
+		Point: ocommon.NewPoint(1, header1Hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60001, []byte("tip-1")),
+			BlockNumber: 60001,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId1))
+	assert.Equal(t, 0, ls.chain.HeaderCount())
+	require.Len(t, ls.bufferedHeaderEvents[connIdKey(connId2)], 1)
+
+	header2Hash := lcommon.NewBlake2b256([]byte("hdr-2"))
+	err = ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId1,
+		BlockHeader: mockHeader{
+			hash:        header2Hash,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 2,
+			slot:        2,
+		},
+		Point: ocommon.NewPoint(2, header2Hash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60002, []byte("tip-2")),
+			BlockNumber: 60002,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId1))
+	assert.Equal(t, 1, ls.chain.HeaderCount())
+}
+
+func TestHandleEventChainsyncBlockHeaderIgnoresIdleSelectedOwner(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	headerHash := lcommon.NewBlake2b256([]byte("hdr-idle-selected"))
+	ls := &LedgerState{
+		chain:                    &chain.Chain{},
+		selectedBlockfetchConnId: connId2,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId1,
+		BlockHeader: mockHeader{
+			hash:        headerHash,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 1,
+			slot:        1,
+		},
+		Point: ocommon.NewPoint(1, headerHash.Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(60001, []byte("tip-1")),
+			BlockNumber: 60001,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId1))
+	assert.Equal(t, 1, ls.chain.HeaderCount())
+	assert.Empty(t, ls.bufferedHeaderEvents)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.selectedBlockfetchConnId)
+}
+func TestHandleEventChainsyncBlockHeaderIgnoresStaleHeaderBehindChainTip(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.currentTip = fixture.ancestorTip
+	staleHash := lcommon.NewBlake2b256([]byte("stale-header"))
+	err := fixture.ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		BlockHeader: mockHeader{
+			hash:        staleHash,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 2,
+			slot:        fixture.ancestorTip.Point.Slot + 5,
+		},
+		Point: ocommon.NewPoint(
+			fixture.ancestorTip.Point.Slot+5,
+			staleHash.Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				fixture.currentTip.Point.Slot+10,
+				[]byte("tip-30"),
+			),
+			BlockNumber: fixture.currentTip.BlockNumber + 1,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, fixture.ls.headerMismatchCount)
+	assert.Equal(t, 0, fixture.ls.chain.HeaderCount())
+	assert.Equal(
+		t,
+		fixture.currentTip.Point.Slot,
+		fixture.ls.chain.Tip().Point.Slot,
+	)
+}
+
+func TestHandleEventChainsyncRollbackClearsBufferedHeadersForNonActivePeer(
+	t *testing.T,
+) {
+	activeConn := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	bufferedConn := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	bufferedHash := lcommon.NewBlake2b256([]byte("buffered-header"))
+	ls := &LedgerState{
+		bufferedHeaderEvents: map[string][]ChainsyncEvent{
+			connIdKey(bufferedConn): {{
+				ConnectionId: bufferedConn,
+				BlockHeader: mockHeader{
+					hash:        bufferedHash,
+					prevHash:    lcommon.NewBlake2b256(nil),
+					blockNumber: 1,
+					slot:        1,
+				},
+				Point: ocommon.NewPoint(1, bufferedHash.Bytes()),
+				Tip: ochainsync.Tip{
+					Point:       ocommon.NewPoint(10, []byte("tip")),
+					BlockNumber: 10,
+				},
+			}},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &activeConn
+			},
+		},
+	}
+
+	err := ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: bufferedConn,
+		Point:        ocommon.NewPoint(0, nil),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, ls.bufferedHeaderEvents[connIdKey(bufferedConn)])
+}
+
+func TestHandleEventChainsyncBlockHeaderStartsBlockfetchForSmallBlockGap(
+	t *testing.T,
+) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	requestCount := 0
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		currentTip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(1000, []byte("local-tip")),
+			BlockNumber: 100,
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				requestConnId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				requestCount++
+				assert.Equal(t, connId, requestConnId)
+				assert.Equal(t, uint64(1064), start.Slot)
+				assert.Equal(t, uint64(1068), end.Slot)
+				return nil
+			},
+		},
+	}
+
+	prevHash := lcommon.NewBlake2b256(nil)
+	for i := range 5 {
+		hash := lcommon.NewBlake2b256([]byte(fmt.Sprintf("hdr-%d", i)))
+		slot := uint64(1064 + i*4)
+		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+			ConnectionId: connId,
+			BlockHeader: mockHeader{
+				hash:        hash,
+				prevHash:    prevHash,
+				blockNumber: 101 + uint64(i),
+				slot:        slot,
+			},
+			Point: ocommon.NewPoint(slot, hash.Bytes()),
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(1080, []byte("peer-tip")),
+				BlockNumber: 105,
+			},
+		})
+		require.NoError(t, err)
+		prevHash = hash
+	}
+
+	assert.Equal(t, 1, requestCount)
+	assert.True(t, sameConnectionId(ls.activeBlockfetchConnId, connId))
+	ls.blockfetchRequestRangeCleanup()
+}
+
+func TestHandleEventChainsyncBlockHeaderStartsBlockfetchForSparseBlockGap(
+	t *testing.T,
+) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	requestCount := 0
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		currentTip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(107374005, []byte("local-tip")),
+			BlockNumber: 4123854,
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				requestConnId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				requestCount++
+				assert.Equal(t, connId, requestConnId)
+				assert.Equal(t, uint64(107374026), start.Slot)
+				assert.Equal(t, uint64(107374530), end.Slot)
+				return nil
+			},
+		},
+	}
+
+	headerSlots := []uint64{
+		107374026,
+		107374033,
+		107374047,
+		107374530,
+	}
+	var prevHash lcommon.Blake2b256
+	for i, slot := range headerSlots {
+		hash := lcommon.NewBlake2b256(
+			[]byte(fmt.Sprintf("sparse-hdr-%d", i)),
+		)
+		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+			ConnectionId: connId,
+			BlockHeader: mockHeader{
+				hash:        hash,
+				prevHash:    prevHash,
+				blockNumber: 4123855 + uint64(i),
+				slot:        slot,
+			},
+			Point: ocommon.NewPoint(slot, hash.Bytes()),
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(107374509, []byte("peer-tip")),
+				BlockNumber: 4123873,
+			},
+		})
+		require.NoError(t, err)
+		prevHash = hash
+	}
+
+	assert.Equal(t, 1, requestCount)
+	assert.True(t, sameConnectionId(ls.activeBlockfetchConnId, connId))
+	ls.blockfetchRequestRangeCleanup()
+}
+
+func TestHandleEventChainsyncAwaitReplyStartsBlockfetchForActiveConnection(
+	t *testing.T,
+) {
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	testChain := &chain.Chain{}
+	var prevHash lcommon.Blake2b256
+	for i, slot := range []uint64{1001, 1002, 1003, 1004} {
+		hash := lcommon.NewBlake2b256(
+			[]byte(fmt.Sprintf("await-reply-hdr-%d", i)),
+		)
+		err := testChain.AddBlockHeader(mockHeader{
+			hash:        hash,
+			prevHash:    prevHash,
+			blockNumber: 200 + uint64(i),
+			slot:        slot,
+		})
+		require.NoError(t, err)
+		prevHash = hash
+	}
+
+	requestCount := 0
+	activeConn := connId
+	ls := &LedgerState{
+		chain: testChain,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &activeConn
+			},
+			BlockfetchRequestRangeFunc: func(
+				requestConnId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				requestCount++
+				assert.Equal(t, connId, requestConnId)
+				assert.Equal(t, uint64(1001), start.Slot)
+				assert.Equal(t, uint64(1004), end.Slot)
+				return nil
+			},
+		},
+	}
+
+	ls.handleEventChainsyncAwaitReply(
+		event.NewEvent(
+			ChainsyncAwaitReplyEventType,
+			ChainsyncAwaitReplyEvent{ConnectionId: connId},
+		),
+	)
+
+	assert.Equal(t, 1, requestCount)
+	assert.True(t, sameConnectionId(ls.activeBlockfetchConnId, connId))
+	ls.blockfetchRequestRangeCleanup()
+}
+
+func TestHandleEventBlockfetchBatchDoneEmptyBatchRetriesAlternateConnection(
+	t *testing.T,
+) {
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("hdr-1")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	requestedConnIds := make([]ouroboros.ConnectionId, 0, 1)
+
+	ls := &LedgerState{
+		chain:                        testChain,
+		activeBlockfetchConnId:       connId1,
+		selectedBlockfetchConnId:     connId2,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &connId2
+			},
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = start
+				_ = end
+				requestedConnIds = append(requestedConnIds, connId)
+				return nil
+			},
+		},
+	}
+
+	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+		ConnectionId: connId1,
+		BatchDone:    true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []ouroboros.ConnectionId{connId2}, requestedConnIds)
+	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
+	require.NotNil(t, ls.chainsyncBlockfetchReadyChan)
+
+	ls.blockfetchRequestRangeCleanup()
 }
 
 func TestHandleBlockfetchTimeoutLocked_RetriesQueuedRangeUsingActivePeer(
@@ -564,58 +1401,6 @@ func TestHandleBlockfetchTimeoutLocked_ClearsActiveConnectionWithoutHeaders(
 	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
 	_, ok := ls.nextBlockfetchConnId()
 	assert.False(t, ok)
-}
-
-func TestHandleBlockfetchTimeoutLocked_ReplaysBufferedHeadersWithoutHeaders(
-	t *testing.T,
-) {
-	connId1 := ouroboros.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
-		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
-	}
-	connId2 := ouroboros.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
-		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
-	}
-	headerHash := lcommon.NewBlake2b256([]byte("hdr-timeout"))
-	ls := &LedgerState{
-		chain:                        &chain.Chain{},
-		activeBlockfetchConnId:       connId1,
-		selectedBlockfetchConnId:     connId2,
-		headerPipelineConnId:         connId1,
-		chainsyncBlockfetchReadyChan: make(chan struct{}),
-		bufferedHeaderEvents: map[ouroboros.ConnectionId][]ChainsyncEvent{
-			connId2: {{
-				ConnectionId: connId2,
-				BlockHeader: mockHeader{
-					hash:        headerHash,
-					prevHash:    lcommon.NewBlake2b256(nil),
-					blockNumber: 1,
-					slot:        1,
-				},
-				Point: ocommon.NewPoint(1, headerHash.Bytes()),
-				Tip: ochainsync.Tip{
-					Point:       ocommon.NewPoint(60001, []byte("tip-2")),
-					BlockNumber: 60001,
-				},
-			}},
-		},
-		config: LedgerStateConfig{
-			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		},
-	}
-
-	ls.handleBlockfetchTimeoutLocked(connId1)
-
-	require.Eventually(t, func() bool {
-		ls.chainsyncMutex.Lock()
-		defer ls.chainsyncMutex.Unlock()
-		return ls.headerPipelineConnId == connId2 &&
-			len(ls.bufferedHeaderEvents[connId2]) == 0 &&
-			ls.chain.HeaderCount() == 1
-	}, time.Second, 10*time.Millisecond)
-	assert.Equal(t, connId2, ls.headerPipelineConnId)
-	assert.Equal(t, 1, ls.chain.HeaderCount())
 }
 
 func TestHandleBlockfetchTimeoutLocked_RetryFailureUsesAlternateSelectedPeer(

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -24,12 +24,13 @@ import (
 )
 
 const (
-	BlockfetchEventType        event.EventType = "ledger.blockfetch"
-	BlockEventType             event.EventType = "ledger.block"
-	ChainsyncEventType         event.EventType = "ledger.chainsync"
-	LedgerErrorEventType       event.EventType = "ledger.error"
-	PoolStateRestoredEventType event.EventType = "ledger.pool_restored"
-	TransactionEventType       event.EventType = "ledger.tx"
+	BlockfetchEventType          event.EventType = "ledger.blockfetch"
+	BlockEventType               event.EventType = "ledger.block"
+	ChainsyncEventType           event.EventType = "ledger.chainsync"
+	ChainsyncAwaitReplyEventType event.EventType = "ledger.chainsync_await_reply"
+	LedgerErrorEventType         event.EventType = "ledger.error"
+	PoolStateRestoredEventType   event.EventType = "ledger.pool_restored"
+	TransactionEventType         event.EventType = "ledger.tx"
 )
 
 // It represents the direction a block is applied to the ledger.
@@ -67,6 +68,12 @@ type ChainsyncEvent struct {
 	BlockNumber  uint64
 	Type         uint // Block or header type ID
 	Rollback     bool // Set to true for a Rollback event
+}
+
+// ChainsyncAwaitReplyEvent is emitted when a chainsync peer explicitly reports
+// it has no additional headers to send right now.
+type ChainsyncAwaitReplyEvent struct {
+	ConnectionId ouroboros.ConnectionId
 }
 
 // LedgerErrorEvent represents an error that occurred during ledger processing.

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -647,6 +647,7 @@ func (e *Election) computeSchedule(
 		"leader schedule calculated",
 		"component", "leader",
 		"epoch", currentEpoch,
+		"epoch_nonce", hex.EncodeToString(epochNonce),
 		"pool_stake", poolStake,
 		"total_stake", totalStake,
 		"stake_ratio", schedule.StakeRatio(),

--- a/ledger/read_chain_test.go
+++ b/ledger/read_chain_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+type readChainMockBlock struct {
+	slot uint64
+	hash []byte
+}
+
+func (m *readChainMockBlock) Era() lcommon.Era {
+	return babbage.EraBabbage
+}
+
+func (m *readChainMockBlock) SlotNumber() uint64 {
+	return m.slot
+}
+
+func (m *readChainMockBlock) Hash() lcommon.Blake2b256 {
+	return lcommon.NewBlake2b256(m.hash)
+}
+
+func (m *readChainMockBlock) PrevHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func (m *readChainMockBlock) BlockNumber() uint64 {
+	return 1
+}
+
+func (m *readChainMockBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+func (m *readChainMockBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+func (m *readChainMockBlock) Cbor() []byte {
+	return nil
+}
+
+func (m *readChainMockBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func (m *readChainMockBlock) Header() lcommon.BlockHeader {
+	return nil
+}
+
+func (m *readChainMockBlock) Type() int {
+	return int(babbage.BlockTypeBabbage)
+}
+
+func (m *readChainMockBlock) Transactions() []lcommon.Transaction {
+	return nil
+}
+
+func (m *readChainMockBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
+	return nil, nil
+}
+
+type scriptedLedgerReadIterator struct {
+	ctx     context.Context
+	results []*chain.ChainIteratorResult
+}
+
+func (s *scriptedLedgerReadIterator) Next(
+	blocking bool,
+) (*chain.ChainIteratorResult, error) {
+	if len(s.results) > 0 {
+		result := s.results[0]
+		s.results = s.results[1:]
+		return result, nil
+	}
+	if !blocking {
+		return nil, chain.ErrIteratorChainTip
+	}
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+func TestTrimReadBatchForRollbackKeepsCanonicalPrefix(t *testing.T) {
+	blocks := []gledger.Block{
+		&readChainMockBlock{slot: 10, hash: testHashBytes("trim-1")},
+		&readChainMockBlock{slot: 20, hash: testHashBytes("trim-2")},
+		&readChainMockBlock{slot: 30, hash: testHashBytes("trim-3")},
+	}
+
+	trimmed, emitRollback := trimReadBatchForRollback(
+		blocks,
+		ocommon.NewPoint(20, testHashBytes("trim-2")),
+	)
+
+	require.Len(t, trimmed, 2)
+	assert.Equal(t, uint64(10), trimmed[0].SlotNumber())
+	assert.Equal(t, uint64(20), trimmed[1].SlotNumber())
+	assert.False(t, emitRollback)
+}
+
+func TestTrimReadBatchForRollbackRequestsRollbackWhenPointMissing(
+	t *testing.T,
+) {
+	blocks := []gledger.Block{
+		&readChainMockBlock{slot: 10, hash: testHashBytes("missing-1")},
+		&readChainMockBlock{slot: 20, hash: testHashBytes("missing-2")},
+	}
+
+	trimmed, emitRollback := trimReadBatchForRollback(
+		blocks,
+		ocommon.NewPoint(15, testHashBytes("missing-mid")),
+	)
+
+	assert.Nil(t, trimmed)
+	assert.True(t, emitRollback)
+}
+
+func TestLedgerReadChainIteratorWaitsForResultCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan readChainResult)
+	iter := &scriptedLedgerReadIterator{
+		ctx: ctx,
+		results: []*chain.ChainIteratorResult{
+			{
+				Rollback: true,
+				Point:    ocommon.NewPoint(10, testHashBytes("rollback-1")),
+			},
+			{
+				Rollback: true,
+				Point:    ocommon.NewPoint(20, testHashBytes("rollback-2")),
+			},
+		},
+	}
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	go ls.ledgerReadChainIterator(ctx, iter, resultCh)
+
+	first := <-resultCh
+	require.True(t, first.rollback)
+	require.NotNil(t, first.done)
+
+	select {
+	case <-resultCh:
+		t.Fatal("reader advanced before current result was completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(first.done)
+
+	second := <-resultCh
+	require.True(t, second.rollback)
+	require.NotNil(t, second.done)
+	close(second.done)
+}

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -1,0 +1,616 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/event"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+var errRestartLedgerPipeline = errors.New(
+	"restart ledger pipeline after local state recovery",
+)
+
+type txValidationError struct {
+	BlockPoint ocommon.Point
+	TxHash     []byte
+	Inputs     []lcommon.TransactionInput
+	Cause      error
+}
+
+func (e *txValidationError) Error() string {
+	return fmt.Sprintf(
+		"tx %s validation failure at slot %d: %v",
+		hex.EncodeToString(e.TxHash),
+		e.BlockPoint.Slot,
+		e.Cause,
+	)
+}
+
+func (e *txValidationError) Unwrap() error {
+	return e.Cause
+}
+
+type replayRecoveryCandidate struct {
+	Input         lcommon.TransactionInput
+	ProducerTx    *models.Transaction
+	ProducerBlock models.Block
+	RollbackPoint ocommon.Point
+	Strategy      string
+}
+
+type replayRecoveryPendingInput struct {
+	Input        lcommon.TransactionInput
+	MaxSlot      uint64
+	MaxCertIndex uint64 // block-local ordering for same-slot comparison
+}
+
+type replayRecoveryResolvedProducer struct {
+	Input         lcommon.TransactionInput
+	ProducerTx    *models.Transaction
+	ProducerBlock models.Block
+	Tx            lcommon.Transaction
+	Strategy      string
+}
+
+type replayRecoveryChainIndex struct {
+	Txs         map[string]replayRecoveryChainTx
+	OldestBlock *models.Block
+}
+
+type replayRecoveryChainTx struct {
+	Block models.Block
+	Tx    lcommon.Transaction
+}
+
+func collectReferencedInputs(tx lcommon.Transaction) []lcommon.TransactionInput {
+	var ret []lcommon.TransactionInput
+	seen := make(map[string]struct{})
+	appendInputs := func(inputs []lcommon.TransactionInput) {
+		for _, input := range inputs {
+			key := input.String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			ret = append(ret, input)
+		}
+	}
+	appendInputs(tx.Inputs())
+	appendInputs(tx.Collateral())
+	appendInputs(tx.ReferenceInputs())
+	return ret
+}
+
+func (ls *LedgerState) tryRecoverFromTxValidationError(
+	err error,
+) (bool, error) {
+	var validationErr *txValidationError
+	if !errors.As(err, &validationErr) {
+		return false, nil
+	}
+	if ls.IsAtTip() {
+		return ls.recoverAtTipFromTxValidationError(validationErr)
+	}
+	candidate, err := ls.findReplayRecoveryCandidate(validationErr)
+	if err != nil {
+		return false, err
+	}
+	if candidate == nil {
+		return false, nil
+	}
+	producerTxHash := candidate.Input.Id().String()
+	if candidate.ProducerTx != nil {
+		producerTxHash = hex.EncodeToString(candidate.ProducerTx.Hash)
+	}
+	ls.config.Logger.Warn(
+		"detected inconsistent local ledger state during replay, rewinding metadata state",
+		"component", "ledger",
+		"recovery_strategy", candidate.Strategy,
+		"tx_hash", hex.EncodeToString(validationErr.TxHash),
+		"failing_block_slot", validationErr.BlockPoint.Slot,
+		"missing_input", candidate.Input.String(),
+		"producer_tx_hash", producerTxHash,
+		"producer_block_slot", candidate.ProducerBlock.Slot,
+		"rollback_slot", candidate.RollbackPoint.Slot,
+		"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
+	)
+	if err := ls.rollback(candidate.RollbackPoint); err != nil {
+		return false, fmt.Errorf(
+			"rollback ledger state for replay recovery: %w",
+			err,
+		)
+	}
+	return true, nil
+}
+
+func (ls *LedgerState) recoverAtTipFromTxValidationError(
+	validationErr *txValidationError,
+) (bool, error) {
+	if ls.chain == nil || ls.config.ChainManager == nil {
+		return false, nil
+	}
+	ls.RLock()
+	ledgerTip := ls.currentTip
+	ls.RUnlock()
+	chainTip := ls.chain.Tip()
+	ls.config.Logger.Warn(
+		"validation failure after reaching tip, rewinding primary chain to authoritative ledger tip",
+		"component", "ledger",
+		"tx_hash", hex.EncodeToString(validationErr.TxHash),
+		"failing_block_slot", validationErr.BlockPoint.Slot,
+		"ledger_tip_slot", ledgerTip.Point.Slot,
+		"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+		"primary_chain_tip_slot", chainTip.Point.Slot,
+		"primary_chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+	)
+	if ls.config.EventBus != nil {
+		ls.config.EventBus.PublishAsync(
+			event.ChainsyncResyncEventType,
+			event.NewEvent(
+				event.ChainsyncResyncEventType,
+				event.ChainsyncResyncEvent{
+					Reason: "live tx validation recovery",
+					Point:  ledgerTip.Point,
+				},
+			),
+		)
+	}
+	return true, nil
+}
+
+func (ls *LedgerState) findReplayRecoveryCandidate(
+	validationErr *txValidationError,
+) (*replayRecoveryCandidate, error) {
+	chainIndex, err := ls.buildReplayRecoveryChainIndex(validationErr.BlockPoint)
+	if err != nil {
+		return nil, err
+	}
+	var candidate *replayRecoveryCandidate
+	var unresolvedInputs []lcommon.TransactionInput
+	pendingInputs := make([]replayRecoveryPendingInput, 0, len(validationErr.Inputs))
+	for _, input := range validationErr.Inputs {
+		pendingInputs = append(pendingInputs, replayRecoveryPendingInput{
+			Input:   input,
+			MaxSlot: validationErr.BlockPoint.Slot,
+		})
+	}
+	seenInputs := make(map[string]struct{})
+	expandedTxs := make(map[string]struct{})
+	for len(pendingInputs) > 0 {
+		pending := pendingInputs[0]
+		pendingInputs = pendingInputs[1:]
+		inputKey := pending.Input.String()
+		if _, ok := seenInputs[inputKey]; ok {
+			continue
+		}
+		seenInputs[inputKey] = struct{}{}
+		resolved, err := ls.resolveReplayRecoveryProducer(
+			pending,
+			chainIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if resolved == nil {
+			unresolvedInputs = append(unresolvedInputs, pending.Input)
+			continue
+		}
+		rollbackPoint, err := ls.replayRecoveryParentPoint(
+			resolved.ProducerBlock,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if candidate == nil ||
+			resolved.ProducerBlock.Slot < candidate.ProducerBlock.Slot {
+			candidate = &replayRecoveryCandidate{
+				Input:         resolved.Input,
+				ProducerTx:    resolved.ProducerTx,
+				ProducerBlock: resolved.ProducerBlock,
+				RollbackPoint: rollbackPoint,
+				Strategy:      resolved.Strategy,
+			}
+		}
+		if resolved.Tx == nil {
+			continue
+		}
+		txKey := string(resolved.Tx.Hash().Bytes())
+		if _, ok := expandedTxs[txKey]; ok {
+			continue
+		}
+		expandedTxs[txKey] = struct{}{}
+		for _, depInput := range collectReferencedInputs(resolved.Tx) {
+			pendingInputs = append(pendingInputs, replayRecoveryPendingInput{
+				Input:   depInput,
+				MaxSlot: resolved.ProducerBlock.Slot,
+			})
+		}
+	}
+	if len(unresolvedInputs) > 0 {
+		fallbackCandidate, err := ls.replayRecoveryFallbackCandidate(
+			validationErr.BlockPoint,
+			unresolvedInputs,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if fallbackCandidate != nil && (candidate == nil ||
+			fallbackCandidate.ProducerBlock.Slot < candidate.ProducerBlock.Slot) {
+			candidate = fallbackCandidate
+		}
+	}
+	return candidate, nil
+}
+
+func (ls *LedgerState) buildReplayRecoveryChainIndex(
+	failingPoint ocommon.Point,
+) (*replayRecoveryChainIndex, error) {
+	failingBlock, err := database.BlockByPoint(ls.db, failingPoint)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return &replayRecoveryChainIndex{
+				Txs: make(map[string]replayRecoveryChainTx),
+			}, nil
+		}
+		return nil, fmt.Errorf(
+			"lookup failing block %x at slot %d for replay recovery: %w",
+			failingPoint.Hash,
+			failingPoint.Slot,
+			err,
+		)
+	}
+	index := &replayRecoveryChainIndex{
+		Txs: make(map[string]replayRecoveryChainTx),
+	}
+	if failingBlock.ID <= database.BlockInitialIndex {
+		return index, nil
+	}
+	const maxReplayRecoveryScanBlocks = 4096
+	scanned := 0
+	for blockIndex := failingBlock.ID; ; blockIndex-- {
+		if scanned >= maxReplayRecoveryScanBlocks {
+			break
+		}
+		block, err := ls.db.BlockByIndex(blockIndex, nil)
+		if err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				if blockIndex == database.BlockInitialIndex {
+					break
+				}
+				continue
+			}
+			return nil, fmt.Errorf(
+				"lookup block %d during replay recovery scan: %w",
+				blockIndex,
+				err,
+			)
+		}
+		if block.Slot > failingPoint.Slot {
+			if blockIndex == database.BlockInitialIndex {
+				break
+			}
+			continue
+		}
+		index.OldestBlock = &block
+		decodedBlock, err := block.Decode()
+		if err != nil {
+			ls.config.Logger.Debug(
+				"skipping undecodable block during replay recovery scan",
+				"component", "ledger",
+				"block_slot", block.Slot,
+				"block_hash", hex.EncodeToString(block.Hash),
+				"error", err,
+			)
+			if blockIndex == database.BlockInitialIndex {
+				break
+			}
+			scanned++
+			continue
+		}
+		for _, tx := range decodedBlock.Transactions() {
+			txKey := string(tx.Hash().Bytes())
+			if _, ok := index.Txs[txKey]; ok {
+				continue
+			}
+			index.Txs[txKey] = replayRecoveryChainTx{
+				Block: block,
+				Tx:    tx,
+			}
+		}
+		scanned++
+		if blockIndex == database.BlockInitialIndex {
+			break
+		}
+	}
+	return index, nil
+}
+
+// producerBlockNotBefore returns true when the producer block cannot have
+// produced the input (it was created at or after the consuming tx).
+func producerBlockNotBefore(
+	producerSlot uint64,
+	producerIndex uint64,
+	pending replayRecoveryPendingInput,
+) bool {
+	if producerSlot > pending.MaxSlot {
+		return true
+	}
+	if producerSlot == pending.MaxSlot &&
+		pending.MaxCertIndex > 0 &&
+		producerIndex >= pending.MaxCertIndex {
+		return true
+	}
+	return false
+}
+
+func (ls *LedgerState) resolveReplayRecoveryProducer(
+	pending replayRecoveryPendingInput,
+	chainIndex *replayRecoveryChainIndex,
+) (*replayRecoveryResolvedProducer, error) {
+	utxo, err := ls.db.UtxoByRef(
+		pending.Input.Id().Bytes(),
+		pending.Input.Index(),
+		nil,
+	)
+	if err != nil && !errors.Is(err, database.ErrUtxoNotFound) {
+		return nil, fmt.Errorf(
+			"lookup validation input %s: %w",
+			pending.Input.String(),
+			err,
+		)
+	}
+	if utxo != nil {
+		return nil, nil
+	}
+	producerTx, err := ls.db.GetTransactionByHash(
+		pending.Input.Id().Bytes(),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"lookup producer tx %s: %w",
+			pending.Input.Id().String(),
+			err,
+		)
+	}
+	if producerTx != nil && len(producerTx.BlockHash) > 0 {
+		producerBlock, err := database.BlockByHash(ls.db, producerTx.BlockHash)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"lookup producer block %x: %w",
+				producerTx.BlockHash,
+				err,
+			)
+		}
+		if producerBlockNotBefore(producerBlock.Slot, producerBlock.ID, pending) {
+			return nil, nil
+		}
+		tx := ls.replayRecoveryResolveTxFromBlock(
+			producerBlock,
+			pending.Input.Id().Bytes(),
+			chainIndex,
+		)
+		return &replayRecoveryResolvedProducer{
+			Input:         pending.Input,
+			ProducerTx:    producerTx,
+			ProducerBlock: producerBlock,
+			Tx:            tx,
+			Strategy:      "metadata",
+		}, nil
+	}
+	producerBlock, found, err := ls.replayRecoveryBlockFromTxBlob(
+		pending.Input.Id().Bytes(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		if producerBlockNotBefore(producerBlock.Slot, producerBlock.ID, pending) {
+			return nil, nil
+		}
+		tx := ls.replayRecoveryResolveTxFromBlock(
+			producerBlock,
+			pending.Input.Id().Bytes(),
+			chainIndex,
+		)
+		return &replayRecoveryResolvedProducer{
+			Input:         pending.Input,
+			ProducerBlock: producerBlock,
+			Tx:            tx,
+			Strategy:      "tx-blob",
+		}, nil
+	}
+	if chainIndex != nil {
+		chainTx, ok := chainIndex.Txs[string(pending.Input.Id().Bytes())]
+		if ok && !producerBlockNotBefore(chainTx.Block.Slot, chainTx.Block.ID, pending) {
+			return &replayRecoveryResolvedProducer{
+				Input:         pending.Input,
+				ProducerBlock: chainTx.Block,
+				Tx:            chainTx.Tx,
+				Strategy:      "chain-scan",
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (ls *LedgerState) replayRecoveryResolveTxFromBlock(
+	block models.Block,
+	txHash []byte,
+	chainIndex *replayRecoveryChainIndex,
+) lcommon.Transaction {
+	if chainIndex != nil {
+		chainTx, ok := chainIndex.Txs[string(txHash)]
+		if ok && bytes.Equal(chainTx.Block.Hash, block.Hash) {
+			return chainTx.Tx
+		}
+	}
+	decodedBlock, err := block.Decode()
+	if err != nil {
+		ls.config.Logger.Debug(
+			"skipping undecodable producer block during replay recovery",
+			"component", "ledger",
+			"block_slot", block.Slot,
+			"block_hash", hex.EncodeToString(block.Hash),
+			"error", err,
+		)
+		return nil
+	}
+	for _, tx := range decodedBlock.Transactions() {
+		if bytes.Equal(tx.Hash().Bytes(), txHash) {
+			return tx
+		}
+	}
+	return nil
+}
+
+func (ls *LedgerState) replayRecoveryFallbackCandidate(
+	failingPoint ocommon.Point,
+	inputs []lcommon.TransactionInput,
+) (*replayRecoveryCandidate, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	failingBlock, err := database.BlockByPoint(ls.db, failingPoint)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"lookup failing block %x at slot %d for replay fallback: %w",
+			failingPoint.Hash,
+			failingPoint.Slot,
+			err,
+		)
+	}
+	if failingBlock.ID <= database.BlockInitialIndex {
+		return nil, nil
+	}
+	rewindBlocks := ls.SecurityParam()
+	if rewindBlocks <= 0 {
+		return nil, nil
+	}
+	targetIndex := database.BlockInitialIndex
+	if failingBlock.ID > uint64(rewindBlocks) {
+		targetIndex = failingBlock.ID - uint64(rewindBlocks)
+	}
+	anchorBlock, err := ls.db.BlockByIndex(targetIndex, nil)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"lookup replay fallback block %d: %w",
+			targetIndex,
+			err,
+		)
+	}
+	rollbackPoint, err := ls.replayRecoveryParentPoint(anchorBlock)
+	if err != nil {
+		return nil, err
+	}
+	return &replayRecoveryCandidate{
+		Input:         inputs[0],
+		ProducerBlock: anchorBlock,
+		RollbackPoint: rollbackPoint,
+		Strategy:      "security-param-fallback",
+	}, nil
+}
+
+func (ls *LedgerState) replayRecoveryBlockFromTxBlob(
+	txHash []byte,
+) (models.Block, bool, error) {
+	blob := ls.db.Blob()
+	if blob == nil {
+		return models.Block{}, false, nil
+	}
+	txn := ls.db.BlobTxn(false)
+	if txn == nil || txn.Blob() == nil {
+		return models.Block{}, false, nil
+	}
+	defer txn.Rollback() //nolint:errcheck
+
+	txData, err := blob.GetTx(txn.Blob(), txHash)
+	if err != nil {
+		if errors.Is(err, dbtypes.ErrBlobKeyNotFound) {
+			return models.Block{}, false, nil
+		}
+		return models.Block{}, false, fmt.Errorf(
+			"lookup tx blob %s: %w",
+			hex.EncodeToString(txHash),
+			err,
+		)
+	}
+
+	var point ocommon.Point
+	switch {
+	case database.IsTxOffsetStorage(txData):
+		offset, err := database.DecodeTxOffset(txData)
+		if err != nil {
+			return models.Block{}, false, fmt.Errorf(
+				"decode tx offset for %s: %w",
+				hex.EncodeToString(txHash),
+				err,
+			)
+		}
+		point = ocommon.NewPoint(offset.BlockSlot, offset.BlockHash[:])
+	case database.IsTxCborPartsStorage(txData):
+		parts, err := database.DecodeTxCborParts(txData)
+		if err != nil {
+			return models.Block{}, false, fmt.Errorf(
+				"decode tx parts for %s: %w",
+				hex.EncodeToString(txHash),
+				err,
+			)
+		}
+		point = ocommon.NewPoint(parts.BlockSlot, parts.BlockHash[:])
+	default:
+		return models.Block{}, false, nil
+	}
+
+	block, err := database.BlockByPoint(ls.db, point)
+	if err != nil {
+		return models.Block{}, false, fmt.Errorf(
+			"lookup producer block from tx blob %s: %w",
+			hex.EncodeToString(txHash),
+			err,
+		)
+	}
+	return block, true, nil
+}
+
+func (ls *LedgerState) replayRecoveryParentPoint(
+	block models.Block,
+) (ocommon.Point, error) {
+	if block.Slot == 0 || len(block.PrevHash) == 0 {
+		return ocommon.Point{}, nil
+	}
+	parentBlock, err := database.BlockByHash(ls.db, block.PrevHash)
+	if err != nil {
+		return ocommon.Point{}, fmt.Errorf(
+			"lookup parent block for replay recovery at slot %d: %w",
+			block.Slot,
+			err,
+		)
+	}
+	return ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash), nil
+}

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -1,0 +1,827 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	pdata "github.com/blinklabs-io/plutigo/data"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+type replayRecoveryInput struct {
+	txId  []byte
+	index uint32
+}
+
+func (m *replayRecoveryInput) Id() lcommon.Blake2b256 {
+	return lcommon.NewBlake2b256(m.txId)
+}
+
+func (m *replayRecoveryInput) Index() uint32 {
+	return m.index
+}
+
+func (m *replayRecoveryInput) String() string {
+	return fmt.Sprintf(
+		"%s#%d",
+		lcommon.NewBlake2b256(m.txId).String(),
+		m.index,
+	)
+}
+
+func (m *replayRecoveryInput) Utxorpc() (*cardano.TxInput, error) {
+	return nil, nil
+}
+
+func (m *replayRecoveryInput) ToPlutusData() pdata.PlutusData {
+	return nil
+}
+
+func TestTryRecoverFromTxValidationErrorRollsBackToEarliestProducerParent(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("recovery-parent", 100, 1, nil)
+	producerOneBlock := testRawBlock(
+		"producer-one",
+		120,
+		2,
+		parentBlock.Hash,
+	)
+	producerTwoBlock := testRawBlock(
+		"producer-two",
+		140,
+		3,
+		producerOneBlock.Hash,
+	)
+	currentBlock := testRawBlock(
+		"recovery-current",
+		160,
+		4,
+		producerTwoBlock.Hash,
+	)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{
+				parentBlock,
+				producerOneBlock,
+				producerTwoBlock,
+				currentBlock,
+			},
+		),
+	)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	parentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash),
+		BlockNumber: parentBlock.BlockNumber,
+	}
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(currentBlock.Slot, currentBlock.Hash),
+		BlockNumber: currentBlock.BlockNumber,
+	}
+
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			parentTip.Point.Hash,
+			parentTip.Point.Slot,
+			[]byte("nonce-parent"),
+			true,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			[]byte("nonce-current"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = []byte("nonce-current")
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Transaction{
+			Hash:       testHashBytes("producer-tx-1"),
+			BlockHash:  producerOneBlock.Hash,
+			Slot:       producerOneBlock.Slot,
+			Type:       1,
+			Valid:      true,
+			BlockIndex: 0,
+		}).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Transaction{
+			Hash:       testHashBytes("producer-tx-2"),
+			BlockHash:  producerTwoBlock.Hash,
+			Slot:       producerTwoBlock.Slot,
+			Type:       1,
+			Valid:      true,
+			BlockIndex: 0,
+		}).Error,
+	)
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: currentTip.Point,
+			TxHash:     testHashBytes("failing-tx"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  testHashBytes("producer-tx-2"),
+					index: 0,
+				},
+				&replayRecoveryInput{
+					txId:  testHashBytes("producer-tx-1"),
+					index: 1,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	assert.Equal(t, parentTip, ls.currentTip)
+	assert.Equal(t, currentTip, ls.chain.Tip())
+	dbTip, err := ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, parentTip, dbTip)
+}
+
+func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("at-tip-parent", 100, 1, nil)
+	producerBlock := testRawBlock(
+		"at-tip-producer",
+		120,
+		2,
+		parentBlock.Hash,
+	)
+	ledgerTipBlock := testRawBlock(
+		"at-tip-ledger-tip",
+		140,
+		3,
+		producerBlock.Hash,
+	)
+	failingBlock := testRawBlock(
+		"at-tip-failing",
+		160,
+		4,
+		ledgerTipBlock.Hash,
+	)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{
+				parentBlock,
+				producerBlock,
+				ledgerTipBlock,
+				failingBlock,
+			},
+		),
+	)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	ledgerTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(ledgerTipBlock.Slot, ledgerTipBlock.Hash),
+		BlockNumber: ledgerTipBlock.BlockNumber,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+	ls.currentTip = ledgerTip
+	ls.currentTipBlockNonce = []byte("nonce-ledger-tip")
+	ls.validationEnabled = true
+	ls.reachedTip = true
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Transaction{
+			Hash:       testHashBytes("producer-tx-live"),
+			BlockHash:  producerBlock.Hash,
+			Slot:       producerBlock.Slot,
+			Type:       1,
+			Valid:      true,
+			BlockIndex: 0,
+		}).Error,
+	)
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: ocommon.NewPoint(
+				failingBlock.Slot,
+				failingBlock.Hash,
+			),
+			TxHash: testHashBytes("failing-live-tx"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  testHashBytes("producer-tx-live"),
+					index: 0,
+				},
+			},
+			Cause: errors.New("missing input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	// The ledger tip should remain at the authoritative tip.
+	assert.Equal(t, ledgerTip, ls.currentTip)
+}
+
+func TestTryRecoverFromTxValidationErrorFallsBackToTxBlobOffsets(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("blob-parent", 200, 1, nil)
+	producerBlock := testRawBlock("blob-producer", 220, 2, parentBlock.Hash)
+	currentBlock := testRawBlock("blob-current", 260, 3, producerBlock.Hash)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{
+				parentBlock,
+				producerBlock,
+				currentBlock,
+			},
+		),
+	)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	parentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash),
+		BlockNumber: parentBlock.BlockNumber,
+	}
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(currentBlock.Slot, currentBlock.Hash),
+		BlockNumber: currentBlock.BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			parentTip.Point.Hash,
+			parentTip.Point.Slot,
+			[]byte("nonce-parent"),
+			true,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			[]byte("nonce-current"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+
+	txHash := testHashBytes("blob-only-producer-tx")
+	offset := &database.CborOffset{
+		BlockSlot:  producerBlock.Slot,
+		ByteOffset: 10,
+		ByteLength: 20,
+	}
+	copy(offset.BlockHash[:], producerBlock.Hash)
+	blobTxn := db.BlobTxn(true)
+	require.NotNil(t, blobTxn)
+	require.NoError(
+		t,
+		blobTxn.Do(func(txn *database.Txn) error {
+			return db.Blob().SetTx(
+				txn.Blob(),
+				txHash,
+				database.EncodeTxOffset(offset),
+			)
+		}),
+	)
+
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = []byte("nonce-current")
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: currentTip.Point,
+			TxHash:     testHashBytes("blob-only-failing"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  txHash,
+					index: 0,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Less(t, ls.currentTip.Point.Slot, currentTip.Point.Slot)
+	assert.LessOrEqual(t, ls.currentTip.Point.Slot, parentTip.Point.Slot)
+}
+
+func TestTryRecoverFromTxValidationErrorFallsBackToChainScan(t *testing.T) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	type replayRecoveryChainBlock struct {
+		raw   chain.RawBlock
+		block gledger.Block
+	}
+	var chainBlocks []replayRecoveryChainBlock
+	producerIdx := -1
+	for i := 0; i < 200 && (len(chainBlocks) < 12 || producerIdx < 0); i++ {
+		immBlock, err := iter.Next()
+		require.NoError(t, err)
+		require.NotNil(t, immBlock)
+		block, err := gledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		chainBlocks = append(chainBlocks, replayRecoveryChainBlock{
+			raw: chain.RawBlock{
+				Slot:        block.SlotNumber(),
+				Hash:        block.Hash().Bytes(),
+				BlockNumber: block.BlockNumber(),
+				Type:        uint(block.Type()),
+				PrevHash:    block.PrevHash().Bytes(),
+				Cbor:        block.Cbor(),
+			},
+			block: block,
+		})
+		if producerIdx < 0 &&
+			len(chainBlocks) > 1 &&
+			len(block.Transactions()) > 0 {
+			producerIdx = len(chainBlocks) - 1
+		}
+	}
+	require.GreaterOrEqual(t, len(chainBlocks), 12)
+	require.GreaterOrEqual(t, producerIdx, 1)
+	currentIdx := len(chainBlocks) - 1
+	require.Greater(t, currentIdx, producerIdx)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(func() []chain.RawBlock {
+			ret := make([]chain.RawBlock, 0, len(chainBlocks))
+			for _, block := range chainBlocks {
+				ret = append(ret, block.raw)
+			}
+			return ret
+		}()),
+	)
+
+	parentBlock := chainBlocks[producerIdx-1]
+	producerBlock := chainBlocks[producerIdx]
+	currentBlock := chainBlocks[currentIdx]
+	parentTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			parentBlock.raw.Slot,
+			parentBlock.raw.Hash,
+		),
+		BlockNumber: parentBlock.raw.BlockNumber,
+	}
+	currentTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			currentBlock.raw.Slot,
+			currentBlock.raw.Hash,
+		),
+		BlockNumber: currentBlock.raw.BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			parentTip.Point.Hash,
+			parentTip.Point.Slot,
+			[]byte("nonce-parent"),
+			true,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			[]byte("nonce-current"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = []byte("nonce-current")
+
+	producerTx := producerBlock.block.Transactions()[0]
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: currentTip.Point,
+			TxHash:     testHashBytes("chain-scan-failing"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  producerTx.Hash().Bytes(),
+					index: 0,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Less(t, ls.currentTip.Point.Slot, currentTip.Point.Slot)
+	assert.LessOrEqual(t, ls.currentTip.Point.Slot, parentTip.Point.Slot)
+}
+
+func TestTryRecoverFromTxValidationErrorRecoversDependencyClosure(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	type replayRecoveryChainBlock struct {
+		raw   chain.RawBlock
+		block gledger.Block
+	}
+	type replayRecoverySeenTx struct {
+		block replayRecoveryChainBlock
+		tx    lcommon.Transaction
+	}
+	var chainBlocks []replayRecoveryChainBlock
+	seenTxs := make(map[string]replayRecoverySeenTx)
+	var producerBlock replayRecoveryChainBlock
+	var intermediateBlock replayRecoveryChainBlock
+	var failingBlock replayRecoveryChainBlock
+	var failingInput lcommon.TransactionInput
+	found := false
+	for i := 0; i < 20000 && !found; i++ {
+		immBlock, err := iter.Next()
+		require.NoError(t, err)
+		require.NotNil(t, immBlock)
+		block, err := gledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		chainBlock := replayRecoveryChainBlock{
+			raw: chain.RawBlock{
+				Slot:        block.SlotNumber(),
+				Hash:        block.Hash().Bytes(),
+				BlockNumber: block.BlockNumber(),
+				Type:        uint(block.Type()),
+				PrevHash:    block.PrevHash().Bytes(),
+				Cbor:        block.Cbor(),
+			},
+			block: block,
+		}
+		chainBlocks = append(chainBlocks, chainBlock)
+		for _, tx := range block.Transactions() {
+			for _, input := range collectReferencedInputs(tx) {
+				mid, ok := seenTxs[string(input.Id().Bytes())]
+				if !ok {
+					continue
+				}
+				for _, midInput := range collectReferencedInputs(mid.tx) {
+					producer, ok := seenTxs[string(midInput.Id().Bytes())]
+					if !ok {
+						continue
+					}
+					producerBlock = producer.block
+					intermediateBlock = mid.block
+					failingBlock = chainBlock
+					failingInput = input
+					found = true
+					break
+				}
+				if found {
+					break
+				}
+			}
+			seenTxs[string(tx.Hash().Bytes())] = replayRecoverySeenTx{
+				block: chainBlock,
+				tx:    tx,
+			}
+			if found {
+				break
+			}
+		}
+	}
+	require.True(t, found, "expected to find a two-hop tx dependency in immutable test data")
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(func() []chain.RawBlock {
+			ret := make([]chain.RawBlock, 0, len(chainBlocks))
+			for _, block := range chainBlocks {
+				ret = append(ret, block.raw)
+			}
+			return ret
+		}()),
+	)
+
+	currentTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			failingBlock.raw.Slot,
+			failingBlock.raw.Hash,
+		),
+		BlockNumber: failingBlock.raw.BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			[]byte("nonce-current"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = []byte("nonce-current")
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: currentTip.Point,
+			TxHash:     testHashBytes("dependency-closure-failing"),
+			Inputs: []lcommon.TransactionInput{
+				failingInput,
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Less(t, ls.currentTip.Point.Slot, producerBlock.raw.Slot)
+	assert.Less(
+		t,
+		ls.currentTip.Point.Slot,
+		intermediateBlock.raw.Slot,
+	)
+}
+
+func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	blocks := []chain.RawBlock{
+		testRawBlock("fallback-1", 100, 1, nil),
+		testRawBlock("fallback-2", 120, 2, testHashBytes("fallback-1")),
+		testRawBlock("fallback-3", 140, 3, testHashBytes("fallback-2")),
+		testRawBlock("fallback-4", 160, 4, testHashBytes("fallback-3")),
+	}
+	blocks[1].PrevHash = blocks[0].Hash
+	blocks[2].PrevHash = blocks[1].Hash
+	blocks[3].PrevHash = blocks[2].Hash
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(blocks))
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(blocks[3].Slot, blocks[3].Hash),
+		BlockNumber: blocks[3].BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			[]byte("nonce-current"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = []byte("nonce-current")
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: currentTip.Point,
+			TxHash:     testHashBytes("fallback-failing"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  testHashBytes("missing-producer"),
+					index: 0,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Equal(t, ochainsync.Tip{}, ls.currentTip)
+}
+
+func TestTryRecoverFromTxValidationErrorSkipsUnknownProducer(t *testing.T) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: ocommon.NewPoint(100, testHashBytes("current")),
+			TxHash:     testHashBytes("failing"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  testHashBytes("missing-producer"),
+					index: 0,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, recovered)
+}
+
+func testRawBlock(
+	seed string,
+	slot uint64,
+	blockNumber uint64,
+	prevHash []byte,
+) chain.RawBlock {
+	hash := testHashBytes(seed)
+	return chain.RawBlock{
+		Slot:        slot,
+		Hash:        hash,
+		BlockNumber: blockNumber,
+		Type:        1,
+		PrevHash:    bytes.Clone(prevHash),
+		Cbor:        []byte{0x80},
+	}
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -393,6 +393,20 @@ type SlotBattleRecorder interface {
 // the header dedup cache so the new connection can re-deliver blocks.
 type ConnectionSwitchFunc func()
 
+// ClearSeenHeadersFromFunc clears the header dedup cache for slots
+// beyond the given slot. This allows headers that were discarded
+// (e.g. by clearQueuedHeaders) to be re-delivered on reconnection.
+type ClearSeenHeadersFromFunc func(fromSlot uint64)
+
+// PeerHeaderLookupFunc looks up a previously observed header for a peer
+// connection, even if that header was suppressed before entering the ledger
+// queue. It returns the recorded chainsync event, the header's prev-hash, and
+// whether the header was found.
+type PeerHeaderLookupFunc func(
+	connId ouroboros.ConnectionId,
+	hash []byte,
+) (ChainsyncEvent, []byte, bool)
+
 type LedgerStateConfig struct {
 	PromRegistry               prometheus.Registerer
 	Logger                     *slog.Logger
@@ -403,6 +417,8 @@ type LedgerStateConfig struct {
 	BlockfetchRequestRangeFunc BlockfetchRequestRangeFunc
 	GetActiveConnectionFunc    GetActiveConnectionFunc
 	ConnectionSwitchFunc       ConnectionSwitchFunc
+	ClearSeenHeadersFromFunc   ClearSeenHeadersFromFunc
+	PeerHeaderLookupFunc       PeerHeaderLookupFunc
 	FatalErrorFunc             FatalErrorFunc
 	ForgedBlockChecker         ForgedBlockChecker
 	SlotBattleRecorder         SlotBattleRecorder
@@ -470,17 +486,19 @@ type LedgerState struct {
 	selectedBlockfetchConnId      ouroboros.ConnectionId // latest selected chainsync connection for the next batch
 	headerPipelineConnId          ouroboros.ConnectionId // connection that currently owns the queued header/blockfetch pipeline
 	pendingBlockfetchEvents       []BlockfetchEvent
+	batchBlocksReceived           int // total blocks received in current blockfetch batch (including mid-batch flushes)
 	checkpointWrittenForEpoch     bool
 	closed                        atomic.Bool
 	inRecovery                    bool           // guards against recursive recovery in SubmitAsyncDBTxn
 	densityWindow                 []densityEntry // sliding window for chain density metric
 
 	// Subscription IDs for event bus unsubscribe on close
-	chainsyncSubID   event.EventSubscriberId
-	blockfetchSubID  event.EventSubscriberId
-	chainUpdateSubID event.EventSubscriberId
-	chainSwitchSubID event.EventSubscriberId
-	connClosedSubID  event.EventSubscriberId
+	chainsyncSubID           event.EventSubscriberId
+	chainsyncAwaitReplySubID event.EventSubscriberId
+	blockfetchSubID          event.EventSubscriberId
+	chainUpdateSubID         event.EventSubscriberId
+	chainSwitchSubID         event.EventSubscriberId
+	connClosedSubID          event.EventSubscriberId
 
 	// rollbackMu serializes rollbackWG.Add with Close's rollbackWG.Wait
 	// to prevent Add-after-Wait panics from the TOCTOU race between
@@ -505,7 +523,8 @@ type LedgerState struct {
 
 	// Header mismatch tracking for fork detection and re-sync
 	headerMismatchCount  int // consecutive header mismatch count
-	bufferedHeaderEvents map[ouroboros.ConnectionId][]ChainsyncEvent
+	bufferedHeaderEvents map[string][]ChainsyncEvent
+	peerHeaderHistory    map[string]*peerHeaderChain
 }
 
 // EraTransitionResult holds computed state from an era transition
@@ -599,6 +618,10 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 			ChainsyncEventType,
 			ls.handleEventChainsync,
 		)
+		ls.chainsyncAwaitReplySubID = ls.config.EventBus.SubscribeFunc(
+			ChainsyncAwaitReplyEventType,
+			ls.handleEventChainsyncAwaitReply,
+		)
 		ls.blockfetchSubID = ls.config.EventBus.SubscribeFunc(
 			BlockfetchEventType,
 			ls.handleEventBlockfetch,
@@ -655,7 +678,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// Start goroutine to process new blocks unless the caller will feed trusted
 	// batches directly into the replay loop.
 	if !ls.config.ManualBlockProcessing {
-		go ls.ledgerProcessBlocks(ctx)
+		go ls.ledgerProcessBlocks() //nolint:contextcheck
 	}
 	return nil
 }
@@ -868,6 +891,10 @@ func (ls *LedgerState) Close() error {
 		ls.config.EventBus.Unsubscribe(
 			ChainsyncEventType,
 			ls.chainsyncSubID,
+		)
+		ls.config.EventBus.Unsubscribe(
+			ChainsyncAwaitReplyEventType,
+			ls.chainsyncAwaitReplySubID,
 		)
 		ls.config.EventBus.Unsubscribe(
 			BlockfetchEventType,
@@ -1577,6 +1604,18 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.resetNextEpochNonceReady()
 	ls.updateTipMetrics()
 	ls.Unlock()
+	if ls.config.EventBus != nil {
+		ls.config.EventBus.PublishAsync(
+			event.ChainsyncResyncEventType,
+			event.NewEvent(
+				event.ChainsyncResyncEventType,
+				event.ChainsyncResyncEvent{
+					Reason: "local ledger rollback",
+					Point:  point,
+				},
+			),
+		)
+	}
 	var hash string
 	if point.Slot == 0 {
 		hash = "<genesis>"
@@ -1595,18 +1634,25 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	return nil
 }
 
-// rollbackChainAndState first validates that the primary chain will accept the
-// rollback, then synchronizes the metadata-backed ledger state and rewinds the
-// primary chain to the same point.
+// rollbackChainAndState rewinds the primary chain and then synchronizes the
+// metadata-backed ledger state to the same point. If the metadata rollback
+// fails, it attempts to restore the primary chain to its previous tip so
+// both remain consistent.
 func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
-	if err := ls.chain.ValidateRollback(point); err != nil {
-		return fmt.Errorf("validate primary chain rollback: %w", err)
+	prevHead := ls.chain.Tip()
+	if err := ls.chain.Rollback(point); err != nil {
+		return fmt.Errorf("rollbackChainAndState: primary chain rollback: %w", err)
 	}
 	if err := ls.rollback(point); err != nil {
-		return fmt.Errorf("rollback ledger state: %w", err)
-	}
-	if err := ls.chain.Rollback(point); err != nil {
-		return fmt.Errorf("rollback primary chain: %w", err)
+		// Attempt to restore the primary chain to its previous tip.
+		if restoreErr := ls.chain.Rollback(prevHead.Point); restoreErr != nil {
+			return fmt.Errorf(
+				"rollbackChainAndState: metadata rollback failed (%w) and chain restore also failed: %w",
+				err,
+				restoreErr,
+			)
+		}
+		return fmt.Errorf("rollbackChainAndState: metadata rollback: %w", err)
 	}
 	return nil
 }
@@ -1615,7 +1661,10 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 // iterator only when the chain still sits at that rollback point. Iterator
 // rollbacks can lag behind live blockfetch/chainsync activity; if the primary
 // chain has already re-extended past the rollback point, applying the rollback
-// again would desynchronize metadata from the blob-backed chain.
+// again would desynchronize metadata from the blob-backed chain. In that case
+// we must restart the ledger pipeline so the chain iterator rewinds itself to
+// the current metadata tip and resumes on the canonical chain instead of
+// continuing from stale block indexes on the abandoned fork.
 func (ls *LedgerState) processChainIteratorRollback(
 	point ocommon.Point,
 ) error {
@@ -1623,13 +1672,20 @@ func (ls *LedgerState) processChainIteratorRollback(
 	if chainTip.Point.Slot != point.Slot ||
 		!bytes.Equal(chainTip.Point.Hash, point.Hash) {
 		ls.config.Logger.Debug(
-			"skipping stale chain iterator rollback",
+			"stale chain iterator rollback detected, restarting ledger pipeline",
 			"component", "ledger",
 			"rollback_slot", point.Slot,
 			"rollback_hash", hex.EncodeToString(point.Hash),
 			"chain_tip_slot", chainTip.Point.Slot,
 			"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
 		)
+		return errRestartLedgerPipeline
+	}
+	ls.RLock()
+	currentTip := ls.currentTip
+	ls.RUnlock()
+	if currentTip.Point.Slot == point.Slot &&
+		bytes.Equal(currentTip.Point.Hash, point.Hash) {
 		return nil
 	}
 	return ls.rollback(point)
@@ -1853,32 +1909,55 @@ type readChainResult struct {
 	rollbackPoint ocommon.Point
 	blocks        []ledger.Block
 	rollback      bool
-	err           error
+	done          chan struct{}
+}
+
+func trimReadBatchForRollback(
+	nextBatch []ledger.Block,
+	rollbackPoint ocommon.Point,
+) ([]ledger.Block, bool) {
+	for idx, block := range nextBatch {
+		if block.SlotNumber() != rollbackPoint.Slot {
+			continue
+		}
+		if !bytes.Equal(block.Hash().Bytes(), rollbackPoint.Hash) {
+			continue
+		}
+		return nextBatch[:idx+1], false
+	}
+	return nil, true
+}
+
+type ledgerReadIterator interface {
+	Next(blocking bool) (*chain.ChainIteratorResult, error)
 }
 
 func (ls *LedgerState) ledgerReadChain(
 	ctx context.Context,
 	resultCh chan readChainResult,
 ) {
+	defer close(resultCh)
 	// Create chain iterator
 	iter, err := ls.chain.FromPoint(ls.currentTip.Point, false)
 	if err != nil {
 		ls.config.Logger.Error(
 			"failed to create chain iterator: " + err.Error(),
 		)
-		select {
-		case resultCh <- readChainResult{
-			err: fmt.Errorf("create chain iterator: %w", err),
-		}:
-		case <-ctx.Done():
-		}
 		return
 	}
+	ls.ledgerReadChainIterator(ctx, iter, resultCh)
+}
+
+func (ls *LedgerState) ledgerReadChainIterator(
+	ctx context.Context,
+	iter ledgerReadIterator,
+	resultCh chan readChainResult,
+) {
 	// Read blocks from chain iterator and decode
 	var next, cachedNext *chain.ChainIteratorResult
 	var tmpBlock ledger.Block
-	var needsRollback, shouldBlock bool
-	var rollbackPoint ocommon.Point
+	var err error
+	var shouldBlock bool
 	var result readChainResult
 	for {
 		select {
@@ -1901,15 +1980,6 @@ func (ls *LedgerState) ledgerReadChain(
 						ls.config.Logger.Error(
 							"failed to get next block from chain iterator: " + err.Error(),
 						)
-						select {
-						case resultCh <- readChainResult{
-							err: fmt.Errorf(
-								"get next block from chain iterator: %w",
-								err,
-							),
-						}:
-						case <-ctx.Done():
-						}
 						return
 					}
 					shouldBlock = true
@@ -1919,23 +1989,27 @@ func (ls *LedgerState) ledgerReadChain(
 			}
 			if next == nil {
 				ls.config.Logger.Error("next block from chain iterator is nil")
-				select {
-				case resultCh <- readChainResult{
-					err: errors.New("next block from chain iterator is nil"),
-				}:
-				case <-ctx.Done():
-				}
 				return
 			}
 			if next.Rollback {
-				// End existing batch and cache rollback if we have any blocks in the batch
-				// We need special processing for rollbacks below
 				if len(nextBatch) > 0 {
-					cachedNext = next
-					break
+					trimmedBatch, emitRollback := trimReadBatchForRollback(
+						nextBatch,
+						next.Point,
+					)
+					if len(trimmedBatch) > 0 {
+						nextBatch = trimmedBatch
+						if emitRollback {
+							cachedNext = next
+						}
+						break
+					}
 				}
-				needsRollback = true
-				rollbackPoint = next.Point
+				result = readChainResult{
+					rollback:      true,
+					rollbackPoint: next.Point,
+					done:          make(chan struct{}),
+				}
 				break
 			}
 			// Decode block
@@ -1944,12 +2018,6 @@ func (ls *LedgerState) ledgerReadChain(
 				ls.config.Logger.Error(
 					"failed to decode block: " + err.Error(),
 				)
-				select {
-				case resultCh <- readChainResult{
-					err: fmt.Errorf("decode block: %w", err),
-				}:
-				case <-ctx.Done():
-				}
 				return
 			}
 			// Add to batch
@@ -1962,15 +2030,10 @@ func (ls *LedgerState) ledgerReadChain(
 				break
 			}
 		}
-		if needsRollback {
-			needsRollback = false
-			result = readChainResult{
-				rollback:      true,
-				rollbackPoint: rollbackPoint,
-			}
-		} else {
+		if !result.rollback {
 			result = readChainResult{
 				blocks: nextBatch,
+				done:   make(chan struct{}),
 			}
 		}
 		select {
@@ -1978,24 +2041,30 @@ func (ls *LedgerState) ledgerReadChain(
 		case <-ctx.Done():
 			return
 		}
+		select {
+		case <-result.done:
+		case <-ctx.Done():
+			return
+		}
+		result = readChainResult{}
 	}
 }
 
-func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
+func (ls *LedgerState) ledgerProcessBlocks() {
 	for {
-		attemptCtx, cancel := context.WithCancel(ctx)
+		attemptCtx, cancel := context.WithCancel(ls.ctx)
 		readChainResultCh := make(chan readChainResult)
-		go func() {
-			defer close(readChainResultCh)
-			ls.ledgerReadChain(attemptCtx, readChainResultCh)
-		}()
+		go ls.ledgerReadChain(attemptCtx, readChainResultCh)
 		err := ls.ledgerProcessBlocksFromSource(
 			attemptCtx,
 			readChainResultCh,
 		)
 		cancel()
-		if err == nil || ctx.Err() != nil {
+		if err == nil || ls.ctx.Err() != nil {
 			return
+		}
+		if errors.Is(err, errRestartLedgerPipeline) {
+			continue
 		}
 		ls.config.Logger.Warn(
 			"block processing failed, restarting pipeline",
@@ -2042,7 +2111,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 	// Enable bulk-load optimizations when syncing from behind
 	var bulkOptimizer metadata.BulkLoadOptimizer
 	bulkLoadActive := false
-	if !ls.validationEnabled {
+	ls.RLock()
+	bulkLoadAllowed := !ls.validationEnabled && !ls.reachedTip
+	ls.RUnlock()
+	if bulkLoadAllowed {
 		if opt, ok := ls.db.Metadata().(metadata.BulkLoadOptimizer); ok {
 			if err := opt.SetBulkLoadPragmas(); err != nil {
 				ls.config.Logger.Warn(
@@ -2071,8 +2143,15 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 	var end, i int
 	var err error
 	var nextBatch, cachedNextBatch []ledger.Block
+	var currentReadResultDone chan struct{}
 	var delta *LedgerDelta
 	var deltaBatch *LedgerDeltaBatch
+	completeReadResult := func() {
+		if currentReadResultDone != nil {
+			close(currentReadResultDone)
+			currentReadResultDone = nil
+		}
+	}
 	for {
 		if needsEpochRollover {
 			needsEpochRollover = false
@@ -2384,6 +2463,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				}
 			}
 		}
+		currentReadResultDone = nil
 		if cachedNextBatch != nil {
 			// Use cached block batch
 			nextBatch = cachedNextBatch
@@ -2395,9 +2475,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				if !ok {
 					return nil
 				}
-				if result.err != nil {
-					return result.err
-				}
+				currentReadResultDone = result.done
 				nextBatch = result.blocks
 				// Process rollback
 				// Note: We do NOT hold ls.Lock() here because rollback() calls
@@ -2408,8 +2486,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					if err = ls.processChainIteratorRollback(
 						result.rollbackPoint,
 					); err != nil {
+						completeReadResult()
 						return fmt.Errorf("process rollback: %w", err)
 					}
+					completeReadResult()
 					continue
 				}
 			case <-ctx.Done():
@@ -2639,6 +2719,21 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				return nil
 			}, true)
 			if err != nil {
+				recovered, recoverErr := ls.tryRecoverFromTxValidationError(
+					err,
+				)
+				if recoverErr != nil {
+					completeReadResult()
+					return fmt.Errorf(
+						"process block batch: %w",
+						recoverErr,
+					)
+				}
+				if recovered {
+					completeReadResult()
+					return errRestartLedgerPipeline
+				}
+				completeReadResult()
 				return fmt.Errorf("process block batch: %w", err)
 			}
 			// Transaction committed successfully - now update in-memory state.
@@ -2702,6 +2797,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// Periodic sync progress reporting
 			ls.logSyncProgress(tipForLog.Point.Slot)
 		}
+		completeReadResult()
 	}
 }
 
@@ -2749,7 +2845,12 @@ func (ls *LedgerState) ledgerProcessBlock(
 			delta.Offsets = offsets
 		}
 		// Validate transaction
-		if shouldValidate {
+		// Skip validation for phase-2 failed TXs (isValid=false).
+		// These are consensus-valid: the block producer already
+		// determined the script failure, collateral is consumed
+		// instead of regular inputs, and tx.Consumed()/Produced()
+		// return the correct collateral-based UTxO sets.
+		if shouldValidate && tx.IsValid() {
 			validationEra, err := resolveValidationEra(
 				tx,
 				currentEra,
@@ -2832,7 +2933,15 @@ func (ls *LedgerState) ledgerProcessBlock(
 						auxCborHex,
 					)
 					delta.Release()
-					return nil, fmt.Errorf("TX validation failure: %w", err)
+					return nil, &txValidationError{
+						BlockPoint: point,
+						TxHash: append(
+							[]byte(nil),
+							tx.Hash().Bytes()...,
+						),
+						Inputs: collectReferencedInputs(tx),
+						Cause:  err,
+					}
 				}
 			}
 		}
@@ -3206,18 +3315,13 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 		return nil
 	}
 	ls.config.Logger.Warn(
-		"primary chain tip ahead of ledger tip at startup, pruning speculative blocks",
+		"primary chain tip ahead of ledger tip at startup, replaying metadata from selected chain",
 		"component", "ledger",
 		"chain_tip_slot", chainTip.Point.Slot,
 		"ledger_tip_slot", ledgerTip.Point.Slot,
 		"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
 		"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
 	)
-	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
-		ledgerTip.Point,
-	); err != nil {
-		return fmt.Errorf("rewind primary chain: %w", err)
-	}
 	return nil
 }
 
@@ -3229,58 +3333,65 @@ func (ls *LedgerState) GetBlock(point ocommon.Point) (models.Block, error) {
 	return ret, nil
 }
 
-// RecentChainPoints returns the requested count of recent chain
-// points in descending order. This is used mostly for building a set
-// of intersect points when acting as a chainsync client.
-//
-// Points are first collected from the in-memory chain state, which is
-// always up-to-date even when the blob store has not yet flushed
-// recent writes. Database points are then appended to fill the
-// requested count, with duplicates removed.
-func (ls *LedgerState) RecentChainPoints(
+func (ls *LedgerState) chainTipMatchesLedgerTip() bool {
+	if ls.chain == nil {
+		return false
+	}
+	ls.RLock()
+	ledgerTip := ls.currentTip
+	ls.RUnlock()
+	chainTip := ls.chain.Tip()
+	return chainTip.Point.Slot == ledgerTip.Point.Slot &&
+		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash)
+}
+
+func (ls *LedgerState) authoritativeRecentChainPoints(
 	count int,
 ) ([]ocommon.Point, error) {
-	var points []ocommon.Point
-	// Collect points from the in-memory chain first. The chain's
-	// tip and recent blocks are always current, even when the
-	// underlying blob store has pending writes that are not yet
-	// visible to new read transactions.
-	if ls.chain != nil {
-		points = ls.chain.RecentPoints(count)
+	if count <= 0 {
+		return nil, nil
 	}
-	// Supplement with database points for deeper history
-	if len(points) < count {
-		remaining := count - len(points)
-		tmpBlocks, err := database.BlocksRecent(
-			ls.db, remaining,
-		)
+	ls.RLock()
+	currentTip := ls.currentTip
+	ls.RUnlock()
+	if currentTip.Point.Slot == 0 && len(currentTip.Point.Hash) == 0 {
+		return []ocommon.Point{ocommon.NewPointOrigin()}, nil
+	}
+	points := make([]ocommon.Point, 0, count)
+	nextHash := append([]byte(nil), currentTip.Point.Hash...)
+	var nextSlot uint64
+	for len(points) < count && len(nextHash) > 0 {
+		block, err := database.BlockByHash(ls.db, nextHash)
 		if err != nil {
-			// If we already have in-memory points, a database
-			// error is non-fatal: return what we have.
-			if len(points) > 0 {
-				return points, nil
-			}
 			return nil, err
 		}
-		// Build a set of existing points for deduplication
-		seen := make(map[string]struct{}, len(points))
-		for _, p := range points {
-			seen[pointKey(p)] = struct{}{}
+		points = append(
+			points,
+			ocommon.NewPoint(block.Slot, block.Hash),
+		)
+		if len(block.PrevHash) == 0 {
+			if len(points) < count {
+				points = append(points, ocommon.NewPointOrigin())
+			}
+			break
 		}
-		for _, blk := range tmpBlocks {
-			p := ocommon.NewPoint(blk.Slot, blk.Hash)
-			key := pointKey(p)
-			if _, exists := seen[key]; exists {
-				continue
-			}
-			seen[key] = struct{}{}
-			points = append(points, p)
-			if len(points) >= count {
-				break
-			}
+		nextHash = append(nextHash[:0], block.PrevHash...)
+		nextSlot = block.Slot
+		if nextSlot == 0 && len(nextHash) == 0 {
+			break
 		}
 	}
 	return points, nil
+}
+
+// RecentChainPoints returns the requested count of recent chain points in
+// descending order from the authoritative ledger tip. This avoids exposing
+// blob-backed primary-chain points that have not yet been replayed into the
+// metadata/ledger state.
+func (ls *LedgerState) RecentChainPoints(
+	count int,
+) ([]ocommon.Point, error) {
+	return ls.authoritativeRecentChainPoints(count)
 }
 
 // IntersectPoints returns chainsync FindIntersect candidates ordered from
@@ -3293,18 +3404,13 @@ func (ls *LedgerState) IntersectPoints(
 	if count <= 0 {
 		return nil, nil
 	}
-	if ls.chain != nil {
+	if ls.chain != nil && ls.chainTipMatchesLedgerTip() {
 		points := ls.chain.IntersectPoints(count)
 		if len(points) > 0 {
 			return points, nil
 		}
 	}
 	return ls.RecentChainPoints(count)
-}
-
-// pointKey returns a string key for deduplication of chain points.
-func pointKey(p ocommon.Point) string {
-	return fmt.Sprintf("%d:%x", p.Slot, p.Hash)
 }
 
 // GetIntersectPoint returns the intersect between the specified points and the current chain
@@ -3746,7 +3852,8 @@ func (ls *LedgerState) UtxosByAddress(
 	return ret, nil
 }
 
-// UtxosByAddressWithOrdering returns all UTxOs for an address with ordering metadata
+// UtxosByAddressWithOrdering returns all UTxOs for an address with
+// ordering metadata.
 func (ls *LedgerState) UtxosByAddressWithOrdering(
 	addr ledger.Address,
 ) ([]models.UtxoWithOrdering, error) {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -44,7 +43,9 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
 
-func TestLedgerProcessBlocksFromSourceReturnsReaderError(t *testing.T) {
+func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
+	t *testing.T,
+) {
 	ls := &LedgerState{
 		validationEnabled: true,
 		config: LedgerStateConfig{
@@ -52,16 +53,14 @@ func TestLedgerProcessBlocksFromSourceReturnsReaderError(t *testing.T) {
 		},
 	}
 
-	readErr := errors.New("reader failed")
 	readChainResultCh := make(chan readChainResult, 1)
-	readChainResultCh <- readChainResult{err: readErr}
 	close(readChainResultCh)
 
 	err := ls.ledgerProcessBlocksFromSource(
 		context.Background(),
 		readChainResultCh,
 	)
-	require.ErrorIs(t, err, readErr)
+	require.NoError(t, err)
 }
 
 // TestCalculateStabilityWindow_ByronEra tests the stability window calculation for Byron era
@@ -2159,7 +2158,9 @@ func TestCleanupOrphanedBlobs_SlotZero(t *testing.T) {
 	assert.Error(t, err, "block at slot 1 should be deleted")
 }
 
-func TestIntersectPointsReturnsStorageErrorWhenSampledListIsEmpty(t *testing.T) {
+func TestIntersectPointsReturnsNoPointsWhenLedgerTipIsEmpty(
+	t *testing.T,
+) {
 	db := newTestDB(t)
 	cm, err := chain.NewManager(db, nil)
 	require.NoError(t, err)
@@ -2179,8 +2180,55 @@ func TestIntersectPointsReturnsStorageErrorWhenSampledListIsEmpty(t *testing.T) 
 	}
 
 	points, err := ls.IntersectPoints(4)
-	require.Error(t, err)
-	assert.Nil(t, points)
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.Equal(t, ocommon.NewPointOrigin(), points[0])
+}
+
+func TestIntersectPointsUsesLedgerTipWhenPrimaryChainIsAhead(t *testing.T) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := make([]models.Block, 0, 5)
+	for slot := uint64(1); slot <= 5; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ledgerTipBlock := blocks[2]
+	ledgerTip := ochainsync.Tip{
+		Point:       makeTestPoint(ledgerTipBlock),
+		BlockNumber: ledgerTipBlock.Number,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+
+	ls := &LedgerState{
+		db:    db,
+		chain: cm.PrimaryChain(),
+	}
+	ls.currentTip = ledgerTip
+
+	points, err := ls.IntersectPoints(3)
+	require.NoError(t, err)
+	require.Len(t, points, 3)
+	assert.Equal(t, ledgerTipBlock.Slot, points[0].Slot)
+	assert.Equal(t, ledgerTipBlock.Hash, points[0].Hash)
+	assert.Equal(t, blocks[1].Slot, points[1].Slot)
+	assert.Equal(t, blocks[1].Hash, points[1].Hash)
+	assert.Equal(t, blocks[0].Slot, points[2].Slot)
+	assert.Equal(t, blocks[0].Hash, points[2].Hash)
 }
 
 func TestDensityWindow(t *testing.T) {
@@ -2250,7 +2298,7 @@ func TestDensityWindow(t *testing.T) {
 	assert.LessOrEqual(t, lastEntry.slot, rollbackSlot)
 }
 
-func TestReconcilePrimaryChainTipWithLedgerTipPrunesSpeculativeBlocks(
+func TestReconcilePrimaryChainTipWithLedgerTipPreservesSelectedChain(
 	t *testing.T,
 ) {
 	db, err := database.New(&database.Config{
@@ -2293,16 +2341,13 @@ func TestReconcilePrimaryChainTipWithLedgerTipPrunesSpeculativeBlocks(
 	require.NoError(t, ls.reconcilePrimaryChainTipWithLedgerTip())
 
 	chainTip := cm.PrimaryChain().Tip()
-	assert.Equal(t, ledgerTip.Point.Slot, chainTip.Point.Slot)
-	assert.Equal(t, ledgerTip.BlockNumber, chainTip.BlockNumber)
-	assert.Equal(t, ledgerTip.Point.Hash, chainTip.Point.Hash)
+	assert.Equal(t, blocks[len(blocks)-1].Slot, chainTip.Point.Slot)
+	assert.Equal(t, blocks[len(blocks)-1].Number, chainTip.BlockNumber)
+	assert.Equal(t, blocks[len(blocks)-1].Hash, chainTip.Point.Hash)
+	assert.Equal(t, ledgerTip, ls.currentTip)
 
-	for _, block := range blocks[:3] {
+	for _, block := range blocks {
 		_, err := database.BlockByPoint(db, makeTestPoint(block))
 		assert.NoError(t, err, "block at slot %d should still exist", block.Slot)
-	}
-	for _, block := range blocks[3:] {
-		_, err := database.BlockByPoint(db, makeTestPoint(block))
-		assert.Error(t, err, "block at slot %d should be pruned", block.Slot)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -82,6 +82,9 @@ func plateauThreshold(stallTimeout time.Duration) time.Duration {
 func (n *Node) isChainsyncIngressEligible(
 	connId ouroboros.ConnectionId,
 ) bool {
+	if n.peerGov != nil {
+		return n.peerGov.IsChainSelectionEligible(connId)
+	}
 	n.chainsyncIngressEligibilityMu.RLock()
 	defer n.chainsyncIngressEligibilityMu.RUnlock()
 	if n.chainsyncIngressEligibilityCache == nil {
@@ -212,19 +215,18 @@ func (n *Node) processChainsyncRecyclerTick(
 					plateauRecoveryThreshold,
 				) {
 					n.config.logger.Warn(
-						"local tip plateau detected, recycling chainsync connection",
+						"local tip plateau detected, resyncing chainsync client",
 						"connection_id", connKey,
 						"local_tip_slot", localTipSlot,
 						"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
 						"plateau_duration", now.Sub(*lastProgressAt),
 					)
-					n.eventBus.PublishAsync(
-						connmanager.ConnectionRecycleRequestedEventType,
+					n.eventBus.Publish(
+						event.ChainsyncResyncEventType,
 						event.NewEvent(
-							connmanager.ConnectionRecycleRequestedEventType,
-							connmanager.ConnectionRecycleRequestedEvent{
+							event.ChainsyncResyncEventType,
+							event.ChainsyncResyncEvent{
 								ConnectionId: *targetConn,
-								ConnKey:      connKey,
 								Reason:       "local_tip_plateau",
 							},
 						),
@@ -504,6 +506,20 @@ func (n *Node) Run(ctx context.Context) error {
 					)
 				}
 			},
+			ClearSeenHeadersFromFunc: func(fromSlot uint64) {
+				if n.chainsyncState != nil {
+					n.chainsyncState.ClearSeenHeadersFrom(fromSlot)
+				}
+			},
+			PeerHeaderLookupFunc: func(
+				connId ouroboros.ConnectionId,
+				hash []byte,
+			) (ledger.ChainsyncEvent, []byte, bool) {
+				if n.chainsyncState == nil {
+					return ledger.ChainsyncEvent{}, nil, false
+				}
+				return n.chainsyncState.LookupObservedHeader(connId, hash)
+			},
 			FatalErrorFunc: func(err error) {
 				n.config.logger.Error(
 					"fatal ledger error, initiating shutdown",
@@ -620,6 +636,29 @@ func (n *Node) Run(ctx context.Context) error {
 	n.eventBus.SubscribeFunc(
 		chainselection.PeerTipUpdateEventType,
 		n.chainSelector.HandlePeerTipUpdateEvent,
+	)
+	n.eventBus.SubscribeFunc(
+		chainselection.PeerTipUpdateEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(chainselection.PeerTipUpdateEvent)
+			if !ok || n.peerGov == nil {
+				return
+			}
+			n.peerGov.TouchPeerByConnId(e.ConnectionId)
+		},
+	)
+	n.eventBus.SubscribeFunc(
+		chainselection.PeerActivityEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(chainselection.PeerActivityEvent)
+			if !ok {
+				return
+			}
+			n.chainSelector.TouchPeerActivity(e.ConnectionId)
+			if n.peerGov != nil {
+				n.peerGov.TouchPeerByConnId(e.ConnectionId)
+			}
+		},
 	)
 	// Subscribe to chain switch events to update active connection
 	n.eventBus.SubscribeFunc(

--- a/node_test.go
+++ b/node_test.go
@@ -244,7 +244,7 @@ func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
 		assert.Equal(t, connId, recycleEvt.ConnectionId)
 		assert.Equal(
 			t,
-			"stalled_connection_no_active_selection",
+			"stalled_active_connection",
 			recycleEvt.Reason,
 		)
 	case <-time.After(200 * time.Millisecond):
@@ -255,8 +255,8 @@ func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
 func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(func() { bus.Stop() })
-	_, recycleCh := bus.Subscribe(
-		connmanager.ConnectionRecycleRequestedEventType,
+	_, resyncCh := bus.Subscribe(
+		event.ChainsyncResyncEventType,
 	)
 
 	connId := newNodeTestConnId(2)
@@ -311,13 +311,13 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 	)
 
 	select {
-	case evt := <-recycleCh:
-		recycleEvt, ok := evt.Data.(connmanager.ConnectionRecycleRequestedEvent)
+	case evt := <-resyncCh:
+		resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
 		require.True(t, ok)
-		assert.Equal(t, connId, recycleEvt.ConnectionId)
-		assert.Equal(t, "local_tip_plateau", recycleEvt.Reason)
+		assert.Equal(t, connId, resyncEvt.ConnectionId)
+		assert.Equal(t, "local_tip_plateau", resyncEvt.Reason)
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("expected plateau recycler event")
+		t.Fatal("expected plateau resync event")
 	}
 }
 

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -96,6 +97,16 @@ func normalizeIntersectPoints(points []ocommon.Point) []ocommon.Point {
 
 func isOriginPoint(point ocommon.Point) bool {
 	return point.Slot == 0 && len(point.Hash) == 0
+}
+
+func sameConnectionId(a, b ouroboros.ConnectionId) bool {
+	if a.LocalAddr == nil && a.RemoteAddr == nil {
+		return b.LocalAddr == nil && b.RemoteAddr == nil
+	}
+	if b.LocalAddr == nil && b.RemoteAddr == nil {
+		return false
+	}
+	return a.String() == b.String()
 }
 
 func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
@@ -498,6 +509,15 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				o.shouldPublishChainsyncToLedger(ctx.ConnectionId),
 			)
 		}
+		o.config.Logger.Debug(
+			"chainsync: header received",
+			"component", "ouroboros",
+			"slot", blockSlot,
+			"tip_slot", tip.Point.Slot,
+			"connection_id", ctx.ConnectionId.String(),
+			"inbound", isInbound,
+			"ingress_eligible", ingressEligible,
+		)
 		// Update tracked client state and deduplicate headers.
 		// If this header has already been reported by another
 		// eligible client, skip publishing it into the ledger.
@@ -523,6 +543,10 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// spurious switches when ephemeral inbound connections report
 		// tips and then disconnect.
 		if !isInbound {
+			observedTip := ochainsync.Tip{
+				Point:       point,
+				BlockNumber: v.BlockNumber(),
+			}
 			o.EventBus.Publish(
 				chainselection.PeerTipUpdateEventType,
 				event.NewEvent(
@@ -530,28 +554,53 @@ func (o *Ouroboros) chainsyncClientRollForward(
 					chainselection.PeerTipUpdateEvent{
 						ConnectionId: ctx.ConnectionId,
 						Tip:          tip,
+						ObservedTip:  observedTip,
 						VRFOutput:    vrfOutput,
 					},
 				),
 			)
 		}
+		if !isInbound && o.ChainsyncState != nil {
+			o.ChainsyncState.RecordObservedHeader(
+				ledger.ChainsyncEvent{
+					ConnectionId: ctx.ConnectionId,
+					Point:        point,
+					Type:         blockType,
+					BlockHeader:  v,
+					Tip:          tip,
+				},
+			)
+		}
 		if !ingressEligible {
+			o.config.Logger.Debug(
+				"chainsync: header dropped (not ingress eligible)",
+				"component", "ouroboros",
+				"slot", blockSlot,
+				"connection_id", ctx.ConnectionId.String(),
+			)
 			o.updateChainsyncMetrics(ctx.ConnectionId, tip)
 			return nil
 		}
 		if !isNew {
-			activeConnId := o.ChainsyncState.GetClientConnId()
-			if activeConnId != nil && *activeConnId == ctx.ConnectionId {
+			shouldReplayDuplicate := false
+			if o.ChainsyncState != nil {
+				activeConnId := o.ChainsyncState.GetClientConnId()
+				if activeConnId != nil &&
+					sameConnectionId(*activeConnId, ctx.ConnectionId) &&
+					o.ChainsyncState.HeaderPreviouslySeenFromOtherConn(
+						ctx.ConnectionId,
+						point,
+					) {
+					shouldReplayDuplicate = true
+				}
+			}
+			if !shouldReplayDuplicate {
 				o.config.Logger.Debug(
-					"publishing duplicate header from selected connection",
+					"chainsync: header dropped (duplicate)",
 					"component", "ouroboros",
+					"slot", blockSlot,
 					"connection_id", ctx.ConnectionId.String(),
-					"slot", point.Slot,
 				)
-			} else {
-				// Duplicate header already delivered by another
-				// eligible peer. Keep the peer tip fresh, but do not
-				// re-publish the same header into the ledger queue.
 				o.updateChainsyncMetrics(ctx.ConnectionId, tip)
 				return nil
 			}
@@ -569,6 +618,23 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				},
 			),
 		)
+		if point.Slot == tip.Point.Slot &&
+			bytes.Equal(point.Hash, tip.Point.Hash) {
+			if o.ChainsyncState != nil {
+				o.ChainsyncState.MarkClientSynced(ctx.ConnectionId)
+			}
+			if ingressEligible && o.EventBus != nil {
+				o.EventBus.Publish(
+					ledger.ChainsyncAwaitReplyEventType,
+					event.NewEvent(
+						ledger.ChainsyncAwaitReplyEventType,
+						ledger.ChainsyncAwaitReplyEvent{
+							ConnectionId: ctx.ConnectionId,
+						},
+					),
+				)
+			}
+		}
 		// Update ChainSync performance metrics for peer scoring
 		o.updateChainsyncMetrics(ctx.ConnectionId, tip)
 	default:
@@ -794,13 +860,11 @@ func (o *Ouroboros) restartChainsyncClientAsync(
 }
 
 // SubscribeChainsyncResync registers an EventBus subscriber that
-// handles chainsync re-sync events. When a resync is requested
-// (e.g. because the ledger detected a persistent fork), this
-// subscriber stops the chainsync client, clears the header dedup
-// cache, and restarts chainsync on the same TCP connection.
-//
-// This consolidates the stop/clear/restart orchestration in one
-// place rather than spreading it across node.go closures.
+// handles chainsync re-sync events. Ordinary resyncs restart the
+// ChainSync mini-protocol on the existing bearer after resetting
+// local dedup state. Local authoritative rollbacks additionally
+// rewind tracked client cursors and attempt ledger-side recovery
+// before recycling affected connections as a fallback.
 func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 	if o.EventBus == nil {
 		return
@@ -812,39 +876,123 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 			if !ok {
 				return
 			}
-			connId := e.ConnectionId
-			o.restartChainsyncClientAsync(
-				ctx,
-				connId,
-				e.Reason,
-				func() error {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			var connIds []ouroboros.ConnectionId
+			if e.ConnectionId != (ouroboros.ConnectionId{}) {
+				connIds = append(connIds, e.ConnectionId)
+			} else if o.ChainsyncState != nil {
+				connIds = o.ChainsyncState.RewindTrackedClientsTo(e.Point)
+				if e.Reason == "local ledger rollback" &&
+					len(connIds) == 0 {
+					connIds = o.ChainsyncState.GetClientConnIds()
+				}
+			}
+			if o.ChainsyncState != nil {
+				if e.Point.Slot > 0 || len(e.Point.Hash) > 0 {
+					o.ChainsyncState.ClearSeenHeadersFrom(e.Point.Slot)
+				} else {
+					o.ChainsyncState.ClearSeenHeaders()
+				}
+			}
+			if e.Reason == "local ledger rollback" {
+				if o.LedgerState == nil {
+					return
+				}
+				recovered := o.LedgerState.RecoverAfterLocalRollback(
+					connIds,
+					e.Point,
+				)
+				if recovered || len(connIds) == 0 {
+					return
+				}
+				// No recoverable peer history — close the affected
+				// connections so peer governance reconnects and starts
+				// fresh chainsync from the updated intersect points.
+				// Previous approach tried Stop→Start→Sync on each
+				// connection, but Stop() blocks for up to 30s when the
+				// protocol is in MustReply state (waiting for a server
+				// response). All connections would timeout and be closed
+				// anyway, wasting 30s during which stale events
+				// accumulated and prevented recovery after reconnect.
+				// RecoverAfterLocalRollback already cleaned up blockfetch
+				// state, so there are no in-flight lookups to break.
+				o.config.Logger.Info(
+					"local rollback had no recoverable peer history, closing connections for fresh chainsync",
+					"component", "ouroboros",
+					"rollback_slot", e.Point.Slot,
+					"connection_count", len(connIds),
+				)
+				for _, connId := range connIds {
+					if o.ChainsyncState != nil {
+						o.ChainsyncState.ClearObservedHeaderHistory(connId)
+					}
+					if o.ConnManager == nil {
+						continue
+					}
 					conn := o.ConnManager.GetConnectionById(connId)
 					if conn == nil {
-						return fmt.Errorf(
-							"connection not found: %s",
-							connId.String(),
-						)
+						continue
 					}
-					// Stop the chainsync client to halt
-					// mismatching headers.
-					cs := conn.ChainSync()
-					if cs != nil && cs.Client != nil {
-						if err := cs.Client.Stop(); err != nil {
+					o.config.Logger.Info(
+						"closing connection for fresh chainsync after local rollback",
+						"component", "ouroboros",
+						"connection_id", connId.String(),
+					)
+					conn.Close()
+				}
+				return
+			}
+			if len(connIds) == 0 {
+				return
+			}
+			for _, connId := range connIds {
+				if o.ChainsyncState != nil {
+					o.ChainsyncState.ClearObservedHeaderHistory(connId)
+				}
+				if o.ConnManager == nil {
+					continue
+				}
+				o.restartChainsyncClientAsync(
+					ctx,
+					connId,
+					e.Reason,
+					func() error {
+						intersectPoints, err := o.buildDefaultChainsyncIntersectPoints(
+							connId,
+						)
+						if err != nil {
 							return fmt.Errorf(
-								"stop chainsync client: %w",
+								"build default chainsync intersect points: %w",
 								err,
 							)
 						}
-					}
-					// Clear the header dedup cache so the
-					// new intersection can re-deliver
-					// headers.
-					if o.ChainsyncState != nil {
-						o.ChainsyncState.ClearSeenHeaders()
-					}
-					return o.RestartChainsyncClient(connId)
-				},
-			)
+						conn := o.ConnManager.GetConnectionById(connId)
+						if conn == nil {
+							return fmt.Errorf(
+								"connection not found: %s",
+								connId.String(),
+							)
+						}
+						cs := conn.ChainSync()
+						if cs != nil && cs.Client != nil {
+							if err := cs.Client.Stop(); err != nil {
+								return fmt.Errorf(
+									"stop chainsync client: %w",
+									err,
+								)
+							}
+						}
+						return o.RestartChainsyncClientWithPoints(
+							connId,
+							intersectPoints,
+						)
+					},
+				)
+			}
 		},
 	)
 }

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -15,11 +15,17 @@
 package ouroboros
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
 	dchainsync "github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/peergov"
@@ -100,6 +106,31 @@ func newTestConnId(local, remote string) ouroboros.ConnectionId {
 	}
 }
 
+func newTestLedgerState(t *testing.T) *ledger.LedgerState {
+	t.Helper()
+
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ls, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:     db,
+		ChainManager: cm,
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+	})
+	require.NoError(t, err)
+	return ls
+}
+
 func TestNormalizeIntersectPoints(t *testing.T) {
 	points := []ocommon.Point{
 		ocommon.NewPoint(20, []byte("b")),
@@ -122,7 +153,7 @@ func TestNormalizeIntersectPoints(t *testing.T) {
 	)
 }
 
-func TestChainsyncClientRollForwardPublishesDuplicateFromSelectedPeer(
+func TestChainsyncClientRollForwardReplaysDuplicateFromSelectedPeerSeenElsewhere(
 	t *testing.T,
 ) {
 	bus := event.NewEventBus(nil, nil)
@@ -158,14 +189,10 @@ func TestChainsyncClientRollForwardPublishesDuplicateFromSelectedPeer(
 		tip,
 	)
 	require.NoError(t, err)
-	select {
-	case evt1 := <-ch:
-		data1, ok := evt1.Data.(ledger.ChainsyncEvent)
-		require.True(t, ok)
-		require.Equal(t, connB, data1.ConnectionId)
-	case <-time.After(time.Second):
-		t.Fatal("expected initial header to be published")
-	}
+	evt1 := <-ch
+	data1, ok := evt1.Data.(ledger.ChainsyncEvent)
+	require.True(t, ok)
+	require.Equal(t, connB, data1.ConnectionId)
 
 	err = o.chainsyncClientRollForward(
 		ochainsync.CallbackContext{ConnectionId: connA},
@@ -180,7 +207,127 @@ func TestChainsyncClientRollForwardPublishesDuplicateFromSelectedPeer(
 		require.True(t, ok)
 		require.Equal(t, connA, data2.ConnectionId)
 	case <-time.After(time.Second):
-		t.Fatal("expected duplicate header from selected peer to publish")
+		t.Fatal(
+			"expected selected peer to replay duplicate header first seen elsewhere",
+		)
+	}
+}
+
+func TestChainsyncClientRollForwardReplaysDuplicateFromEquivalentSelectedPeerSeenElsewhere(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ch := bus.Subscribe(ledger.ChainsyncEventType)
+	state := dchainsync.NewState(bus, nil)
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connADup := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connADup))
+	require.True(t, state.AddClientConnId(connB))
+	state.SetClientConnId(connA)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connB},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	evt1 := <-ch
+	data1, ok := evt1.Data.(ledger.ChainsyncEvent)
+	require.True(t, ok)
+	require.Equal(t, connB, data1.ConnectionId)
+
+	err = o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connADup},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	select {
+	case evt2 := <-ch:
+		data2, ok := evt2.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connADup, data2.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal(
+			"expected equivalent selected peer to replay duplicate header first seen elsewhere",
+		)
+	}
+}
+
+func TestChainsyncClientRollForwardDropsDuplicateFromSameSelectedPeer(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ch := bus.Subscribe(ledger.ChainsyncEventType)
+	state := dchainsync.NewState(bus, nil)
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	require.True(t, state.AddClientConnId(connA))
+	state.SetClientConnId(connA)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connA},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	evt1 := <-ch
+	data1, ok := evt1.Data.(ledger.ChainsyncEvent)
+	require.True(t, ok)
+	require.Equal(t, connA, data1.ConnectionId)
+
+	err = o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connA},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+	select {
+	case evt2 := <-ch:
+		t.Fatalf(
+			"expected same-connection duplicate to be dropped, got event: %#v",
+			evt2,
+		)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 
@@ -351,4 +498,146 @@ func TestChainsyncClientRollForward_UntrackedPeerDoesNotPublishToLedger(
 		t.Fatalf("unexpected ledger event from untracked peer: %#v", evt)
 	default:
 	}
+}
+
+func TestSubscribeChainsyncResyncRewindsClientsWithoutRecycle(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	rollbackPoint := ocommon.NewPoint(90, []byte("rollback"))
+	point := ocommon.NewPoint(100, []byte("hdr"))
+	tip := ochainsync.Tip{Point: point}
+
+	state := dchainsync.NewState(bus, nil)
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connB))
+	state.UpdateClientTip(
+		connA,
+		ocommon.NewPoint(120, []byte("ahead")),
+		ochainsync.Tip{
+			Point: ocommon.NewPoint(120, []byte("ahead")),
+		},
+	)
+	state.UpdateClientTip(connB, point, tip)
+	require.True(
+		t,
+		state.HeaderPreviouslySeenFromOtherConn(connA, point),
+	)
+
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	_, recycleCh := bus.Subscribe(
+		connmanager.ConnectionRecycleRequestedEventType,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o.SubscribeChainsyncResync(ctx)
+
+	bus.Publish(
+		event.ChainsyncResyncEventType,
+		event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{
+				Reason: "local ledger rollback",
+				Point:  rollbackPoint,
+			},
+		),
+	)
+
+	select {
+	case evt := <-recycleCh:
+		t.Fatalf("unexpected recycle request: %#v", evt)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.False(
+		t,
+		state.HeaderPreviouslySeenFromOtherConn(connA, point),
+	)
+	tc := state.GetTrackedClient(connA)
+	require.NotNil(t, tc)
+	require.Equal(t, rollbackPoint, tc.Cursor)
+}
+
+func TestSubscribeChainsyncResyncRestartsClientsOnLocalRollbackWithoutPeerHistory(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	rollbackPoint := ocommon.NewPoint(90, []byte("rollback"))
+
+	state := dchainsync.NewState(bus, nil)
+	require.True(t, state.AddClientConnId(connA))
+	// Keep the tracked cursor at the rollback point so
+	// RewindTrackedClientsTo returns no connections. The local rollback
+	// still needs to resynchronize the live tracked session.
+	state.UpdateClientTip(
+		connA,
+		rollbackPoint,
+		ochainsync.Tip{Point: rollbackPoint},
+	)
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	o.ChainsyncState = state
+	o.EventBus = bus
+	o.LedgerState = newTestLedgerState(t)
+
+	_, recycleCh := bus.Subscribe(
+		connmanager.ConnectionRecycleRequestedEventType,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o.SubscribeChainsyncResync(ctx)
+
+	bus.Publish(
+		event.ChainsyncResyncEventType,
+		event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{
+				Reason: "local ledger rollback",
+				Point:  rollbackPoint,
+			},
+		),
+	)
+
+	// Connections should NOT be recycled — they should be restarted.
+	select {
+	case evt := <-recycleCh:
+		t.Fatalf("unexpected recycle request: %#v", evt)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Verify the tracked client's cursor was rewound to the rollback point,
+	// confirming the resync actually occurred.
+	tc := state.GetTrackedClient(connA)
+	require.NotNil(t, tc)
+	require.Equal(t, rollbackPoint, tc.Cursor)
+}
+
+func TestHeaderPreviouslySeenFromOtherConnTreatsEquivalentConnIdsAsSame(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connA := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connADup := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	point := ocommon.NewPoint(100, []byte("hdr"))
+	tip := ochainsync.Tip{Point: point}
+
+	state := dchainsync.NewState(bus, nil)
+	require.True(t, state.AddClientConnId(connA))
+	state.UpdateClientTip(connA, point, tip)
+
+	require.False(
+		t,
+		state.HeaderPreviouslySeenFromOtherConn(connADup, point),
+	)
 }

--- a/ouroboros/keepalive.go
+++ b/ouroboros/keepalive.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/event"
+	okeepalive "github.com/blinklabs-io/gouroboros/protocol/keepalive"
+)
+
+func (o *Ouroboros) keepaliveConnOpts() []okeepalive.KeepAliveOptionFunc {
+	return []okeepalive.KeepAliveOptionFunc{
+		okeepalive.WithKeepAliveResponseFunc(o.keepaliveClientResponse),
+	}
+}
+
+func (o *Ouroboros) keepaliveClientResponse(
+	ctx okeepalive.CallbackContext,
+	_ uint16,
+) error {
+	if o.EventBus == nil {
+		return nil
+	}
+	evt := event.NewEvent(
+		chainselection.PeerActivityEventType,
+		chainselection.PeerActivityEvent{
+			ConnectionId: ctx.ConnectionId,
+		},
+	)
+	o.EventBus.Publish(chainselection.PeerActivityEventType, evt)
+	return nil
+}

--- a/ouroboros/keepalive_test.go
+++ b/ouroboros/keepalive_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	okeepalive "github.com/blinklabs-io/gouroboros/protocol/keepalive"
+)
+
+func TestKeepaliveClientResponsePublishesPeerActivity(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	_, evtCh := bus.Subscribe(chainselection.PeerActivityEventType)
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.2"), Port: 3001},
+	}
+
+	err := o.keepaliveClientResponse(
+		okeepalive.CallbackContext{ConnectionId: connId},
+		42,
+	)
+	require.NoError(t, err)
+
+	select {
+	case evt := <-evtCh:
+		activityEvt, ok := evt.Data.(chainselection.PeerActivityEvent)
+		require.True(t, ok, "expected PeerActivityEvent")
+		assert.Equal(t, connId.String(), activityEvt.ConnectionId.String())
+	default:
+		t.Fatal("expected peer activity event")
+	}
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -33,6 +33,7 @@ import (
 	oblockfetch "github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	okeepalive "github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -216,6 +217,9 @@ func (o *Ouroboros) ConfigureListeners(
 				l.ConnectionOpts,
 				ouroboros.WithFullDuplex(true),
 				ouroboros.WithKeepAlive(true),
+				ouroboros.WithKeepAliveConfig(
+					okeepalive.NewConfig(o.keepaliveConnOpts()...),
+				),
 				ouroboros.WithPeerSharing(o.config.PeerSharing),
 				ouroboros.WithNetworkMagic(o.config.NetworkMagic),
 				ouroboros.WithPeerSharingConfig(
@@ -278,6 +282,9 @@ func (o *Ouroboros) OutboundConnOpts() []ouroboros.ConnectionOptionFunc {
 		ouroboros.WithNetworkMagic(o.config.NetworkMagic),
 		ouroboros.WithNodeToNode(true),
 		ouroboros.WithKeepAlive(true),
+		ouroboros.WithKeepAliveConfig(
+			okeepalive.NewConfig(o.keepaliveConnOpts()...),
+		),
 		ouroboros.WithFullDuplex(true),
 		ouroboros.WithPeerSharing(o.config.PeerSharing),
 		ouroboros.WithPeerSharingConfig(
@@ -513,23 +520,23 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	)
 
 	// Start chainsync client on this full-duplex inbound connection.
-	// If the chainsync client fails (e.g. intersection not found because
-	// the peer follows a different fork), close the connection so
-	// peergov stops tracking it and outbound retries are not blocked
-	// by a stale inbound.
+	// If the chainsync client fails (e.g. intersection not found,
+	// stale connection ID after rollback), close the connection so
+	// it doesn't consume a per-IP slot as a zombie. Zombie
+	// connections that lack chainsync but count toward the per-IP
+	// limit can prevent functional reconnections, causing permanent
+	// chainsync stalls after rollback events.
 	if o.ChainsyncState != nil {
 		if o.registerTrackedChainsyncClient(connId, false) {
 			if err := o.chainsyncClientStart(connId); err != nil {
 				o.ChainsyncState.RemoveClientConnId(connId)
 				o.config.Logger.Warn(
-					"chainsync client failed on inbound connection, keeping alive for other protocols",
+					"chainsync client failed on inbound connection, closing to free per-IP slot",
 					"error", err,
 					"connection_id", connId.String(),
 				)
-				// Don't close the connection — the peer may still be
-				// useful for keep-alive, peer-sharing, or other
-				// mini-protocols (e.g. cardano-cli ping or partial
-				// full-duplex peers).
+				conn.Close()
+				return
 			} else {
 				o.config.Logger.Debug(
 					"started chainsync client on inbound connection",

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -341,6 +341,37 @@ func TestPeerGovernor_Reconcile_Demotions(t *testing.T) {
 	// Event publishing is tested indirectly
 }
 
+func TestPeerGovernor_Reconcile_ConnectedLocalRootStaysHotWhenQuiet(t *testing.T) {
+	eventBus := newMockEventBus()
+	reg := prometheus.NewRegistry()
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     eventBus,
+		PromRegistry: reg,
+	})
+
+	localAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:6000")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:3001")
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+
+	pg.AddPeer("44.0.0.1:3001", PeerSourceTopologyLocalRoot)
+	pg.mu.Lock()
+	pg.peers[0].State = PeerStateHot
+	pg.peers[0].Connection = &PeerConnection{Id: connId, IsClient: true}
+	pg.peers[0].LastActivity = time.Now().Add(-15 * time.Minute)
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	assert.Equal(t, PeerStateHot, peers[0].State)
+}
+
 func TestPeerGovernor_Reconcile_Removal(t *testing.T) {
 	eventBus := newMockEventBus()
 	reg := prometheus.NewRegistry()
@@ -533,6 +564,49 @@ func TestPeerGovernor_SetPeerHotByConnId(t *testing.T) {
 	peers := pg.GetPeers()
 	assert.Equal(t, PeerStateHot, peers[0].State)
 	assert.True(t, peers[0].LastActivity.After(time.Now().Add(-1*time.Second)))
+}
+
+func TestPeerGovernor_TouchPeerByConnId(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+
+	pg.AddPeer("44.0.0.1:3001", PeerSourceTopologyLocalRoot)
+
+	localAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:6000")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:3001")
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+
+	pg.mu.Lock()
+	pg.peers[0].Connection = &PeerConnection{Id: connId, IsClient: true}
+	pg.peers[0].LastActivity = time.Now().Add(-30 * time.Minute)
+	oldActivity := pg.peers[0].LastActivity
+	pg.mu.Unlock()
+
+	// Add a second peer to verify isolation
+	pg.AddPeer("44.0.0.2:3001", PeerSourceTopologyLocalRoot)
+	localAddr2, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:6001")
+	remoteAddr2, _ := net.ResolveTCPAddr("tcp", "44.0.0.2:3001")
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  localAddr2,
+		RemoteAddr: remoteAddr2,
+	}
+	pg.mu.Lock()
+	pg.peers[1].Connection = &PeerConnection{Id: connId2, IsClient: true}
+	pg.peers[1].LastActivity = time.Now().Add(-30 * time.Minute)
+	otherActivity := pg.peers[1].LastActivity
+	pg.mu.Unlock()
+
+	pg.TouchPeerByConnId(connId)
+
+	peers := pg.GetPeers()
+	require.Len(t, peers, 2)
+	assert.True(t, peers[0].LastActivity.After(oldActivity))
+	// Second peer should be untouched
+	assert.Equal(t, otherActivity, peers[1].LastActivity)
 }
 
 func TestPeerGovernorAppendChainSelectionEventsLocked(t *testing.T) {
@@ -5352,7 +5426,7 @@ func TestPeerGovernor_Reconcile_ExitsBootstrap(t *testing.T) {
 		pg.bootstrapExited,
 		"bootstrap should be exited after reconcile",
 	)
-	// Find the bootstrap peer
+	// Find the reclassified peer
 	var bootstrapPeer *Peer
 	for _, peer := range pg.peers {
 		if peer.Address == "44.0.0.1:3001" {

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -303,6 +303,15 @@ func (p *PeerGovernor) SetPeerHotByConnId(connId ouroboros.ConnectionId) {
 	}
 }
 
+func (p *PeerGovernor) TouchPeerByConnId(connId ouroboros.ConnectionId) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	peerIdx := p.peerIndexByConnId(connId)
+	if peerIdx != -1 && p.peers[peerIdx] != nil {
+		p.peers[peerIdx].LastActivity = time.Now()
+	}
+}
+
 func (p *PeerGovernor) IsChainSelectionEligible(
 	connId ouroboros.ConnectionId,
 ) bool {

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -57,9 +57,14 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 		}
 		switch peer.State {
 		case PeerStateHot:
-			// Demote if inactive (no connection or last activity > timeout)
-			if peer.Connection == nil ||
-				now.Sub(peer.LastActivity) > p.config.InactivityTimeout {
+			// Demote on transport loss for all peers. For connected local roots,
+			// do not age them out just because they are quiet: they are
+			// explicitly configured peers and should only leave hot when the
+			// connection is actually bad or gone.
+			demoteForInactivity := !peer.hasClientConnection() ||
+				(peer.Source != PeerSourceTopologyLocalRoot &&
+					now.Sub(peer.LastActivity) > p.config.InactivityTimeout)
+			if demoteForInactivity {
 				p.peers[i].State = PeerStateWarm
 				warmDemotions++
 				activeDecreased++


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve chainsync resilience by resyncing without dropping connections, tracking per‑peer observed headers, and using keepalive to keep healthy peers eligible. Reduces stalls, avoids rollback loops, and steadies chain selection under churn.

- **New Features**
  - Add `event.ChainsyncResyncEventType` (with `Point` and `Reason`) and resync the active client in `ouroboros` without reconnecting.
  - Integrate keepalive; publish `chainselection.PeerActivityEventType` to refresh liveness; keep connected local‑root peers hot in `peergov`.
  - Track per‑connection observed headers in `chainsync` and hand them to `ledger` on connection switches; preserve queued headers.
  - Refine selector: accept new peers without implausibility checks, use `ObservedTip`, and prefer higher‑priority peers at equal tip.
  - Improve blockfetch when behind with a header runway and emit `ledger.ChainsyncAwaitReplyEventType`; add replay recovery to rebuild state after rollbacks.

- **Migration**
  - `connmanager.RemoveConnection` now requires the connection: call `RemoveConnection(connId, conn)`.
  - Node now emits `event.ChainsyncResyncEventType` instead of `connmanager.ConnectionRecycleRequestedEventType`.
  - `chainselection.PeerTipUpdateEvent` adds `ObservedTip`; new `PeerActivityEventType`. `ledger.LedgerStateConfig` adds callbacks to clear seen headers and to look up per‑peer observed headers.

<sup>Written for commit aebab7ee2c20092622776cac53110b53169c8142. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keepalive-based peer activity events and liveness touch to keep peer state current.
  * Per-connection observed-header tracking and replay to aid fork recovery and resync.
  * Local rollback recovery API to replay peer history and recover without full restart.

* **Bug Fixes**
  * Preserve incumbent peer on equal selection frontiers to avoid unnecessary switches.
  * Reject implausible same-peer tip jumps while accepting far-ahead new peers.

* **Improvements**
  * More robust blockfetch/chainsync pipeline, retry, and resync behavior; smarter duplicate-header replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->