### PR TITLE
fix: ledger replay recovery

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4 https://github.com/actions/cache/releases/tag/v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4 https://github.com/actions/cache/releases/tag/v5.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0
         with:
           go-version: 1.25.x
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4 https://github.com/actions/cache/releases/tag/v5.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0
         with:
           go-version: 1.25.x
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 https://github.com/actions/cache/releases/tag/v5.0.3
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4 https://github.com/actions/cache/releases/tag/v5.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/blinklabs-io/go:1.25.7-1 AS build
+FROM ghcr.io/blinklabs-io/go:1.25.8-1 AS build
 
 ARG VERSION
 ARG COMMIT_HASH

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -479,30 +479,22 @@ func (d *Database) GetAddressesByStakingKey(
 }
 
 // deleteTxBlobs attempts to delete blob data for the given transaction hashes.
-// This is a best-effort operation; metadata remains the source of truth. If the
-// provided transaction does not include a blob handle, a temporary blob-only
-// transaction is used instead.
+// This is a best-effort operation; metadata remains the source of truth.
+// Blob deletions use the provided outer transaction so they participate in
+// the same atomic commit as metadata changes.
 func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 	blob := d.Blob()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
-
-	useTxn := txn
-	owned := false
-	if useTxn == nil || useTxn.Blob() == nil {
-		useTxn = NewBlobOnlyTxn(d, true)
-		owned = true
-		defer func() {
-			if owned {
-				useTxn.Rollback() //nolint:errcheck
-			}
-		}()
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return types.ErrNilTxn
 	}
 
 	var deleteErrors int
 	for _, txHash := range txHashes {
-		if err := blob.DeleteTx(useTxn.Blob(), txHash); err != nil {
+		if err := blob.DeleteTx(blobTxn, txHash); err != nil {
 			deleteErrors++
 			d.logger.Debug(
 				"failed to delete TX blob data",
@@ -519,14 +511,6 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 			"total",
 			len(txHashes),
 		)
-	}
-
-	if owned {
-		owned = false // prevent deferred rollback
-		if err := useTxn.Commit(); err != nil {
-			_ = useTxn.Rollback() // explicit rollback on commit failure
-			d.logger.Debug("tx blob delete commit failed", "error", err)
-		}
 	}
 
 	return nil

--- a/database/txn.go
+++ b/database/txn.go
@@ -122,6 +122,11 @@ func (t *Txn) Blob() types.Txn {
 	return t.blobTxn
 }
 
+// IsReadWrite reports whether the transaction was opened for writing.
+func (t *Txn) IsReadWrite() bool {
+	return t.readWrite
+}
+
 // Do executes the specified function in the context of the transaction. Any errors returned will result
 // in the transaction being rolled back. If the function panics, the transaction is rolled back and the
 // panic is re-raised after logging.

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -23,42 +24,45 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 var ErrUtxoNotFound = errors.New("utxo not found")
 
-// deleteUtxoBlobs attempts to delete blob data for the given UTxOs.
-// This is a best-effort operation; metadata remains the source of truth. If the
-// provided transaction does not include a blob handle, a temporary blob-only
-// transaction is used instead.
-func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
+// deleteUtxoBlobs performs best-effort deletion of blob data for the given
+// [models.Utxo] entries. Metadata remains the authoritative source of truth;
+// blob deletions are supplementary. The caller [*Txn] is ignored — this
+// function always creates and commits its own blob-only batches via the
+// [Database], so callers should not expect blob deletes to participate in any
+// outer transaction.
+func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
+	const batchSize = 500
 	blob := d.Blob()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
 
-	useTxn := txn
-	owned := false
-	if useTxn == nil || useTxn.Blob() == nil {
-		useTxn = NewBlobOnlyTxn(d, true)
-		owned = true
-		defer func() {
-			if owned {
-				useTxn.Rollback() //nolint:errcheck
-			}
-		}()
-	}
-
 	var deleteErrors int
-	for _, utxo := range utxos {
-		if err := blob.DeleteUtxo(useTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {
-			deleteErrors++
-			d.logger.Debug(
-				"failed to delete UTxO blob data",
-				"txid", hex.EncodeToString(utxo.TxId),
-				"output_idx", utxo.OutputIdx,
-				"error", err,
-			)
+	for start := 0; start < len(utxos); start += batchSize {
+		end := start + batchSize
+		if end > len(utxos) {
+			end = len(utxos)
+		}
+		batchTxn := NewBlobOnlyTxn(d, true)
+		for _, utxo := range utxos[start:end] {
+			if err := blob.DeleteUtxo(batchTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {
+				deleteErrors++
+				d.logger.Debug(
+					"failed to delete UTxO blob data",
+					"txid", hex.EncodeToString(utxo.TxId),
+					"output_idx", utxo.OutputIdx,
+					"error", err,
+				)
+			}
+		}
+		if err := batchTxn.Commit(); err != nil {
+			_ = batchTxn.Rollback()
+			d.logger.Debug("blob delete batch commit failed", "error", err)
 		}
 	}
 	if deleteErrors > 0 {
@@ -69,14 +73,6 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
 			"total",
 			len(utxos),
 		)
-	}
-
-	if owned {
-		owned = false // prevent deferred rollback
-		if err := useTxn.Commit(); err != nil {
-			_ = useTxn.Rollback() // explicit rollback on commit failure
-			d.logger.Debug("blob delete commit failed", "error", err)
-		}
 	}
 
 	return nil
@@ -91,9 +87,18 @@ func loadCbor(u *models.Utxo, txn *Txn) error {
 		blobTxn := txn.Blob()
 		cbor, err := db.cborCache.ResolveUtxoCbor(u.TxId, u.OutputIdx, blobTxn)
 		if err != nil {
-			// Map blob-key-not-found to ErrUtxoNotFound
 			if errors.Is(err, types.ErrBlobKeyNotFound) {
-				return ErrUtxoNotFound
+				recoveredCbor, recoverErr := recoverUtxoCbor(
+					db,
+					txn,
+					u.TxId,
+					u.OutputIdx,
+				)
+				if recoverErr == nil {
+					u.Cbor = recoveredCbor
+					return nil
+				}
+				return recoverErr
 			}
 			return fmt.Errorf(
 				"resolve UTxO cbor tx=%x idx=%d: %w",
@@ -113,9 +118,18 @@ func loadCbor(u *models.Utxo, txn *Txn) error {
 	}
 	val, err := blob.GetUtxo(txn.Blob(), u.TxId, u.OutputIdx)
 	if err != nil {
-		// Map blob-key-not-found to ErrUtxoNotFound since it means the UTxO's blob is missing
 		if errors.Is(err, types.ErrBlobKeyNotFound) {
-			return ErrUtxoNotFound
+			recoveredCbor, recoverErr := recoverUtxoCbor(
+				db,
+				txn,
+				u.TxId,
+				u.OutputIdx,
+			)
+			if recoverErr == nil {
+				u.Cbor = recoveredCbor
+				return nil
+			}
+			return recoverErr
 		}
 		return fmt.Errorf(
 			"resolve UTxO cbor tx=%x idx=%d: %w",
@@ -155,6 +169,205 @@ func loadCbor(u *models.Utxo, txn *Txn) error {
 
 	// Legacy format: raw CBOR data
 	u.Cbor = val
+	return nil
+}
+
+func recoverUtxoCbor(
+	db *Database,
+	txn *Txn,
+	txId []byte,
+	outputIdx uint32,
+) ([]byte, error) {
+	block, err := utxoRecoveryBlockForTx(db, txn, txId)
+	if err != nil {
+		return nil, err
+	}
+	if block == nil {
+		return nil, ErrUtxoNotFound
+	}
+
+	// Decode the block once for both CBOR extraction and offset computation
+	decodedBlock, err := block.Decode()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode producer block for utxo recovery at slot %d: %w",
+			block.Slot,
+			err,
+		)
+	}
+
+	// Extract the UTxO CBOR from the decoded block
+	recoveredCbor, err := utxoCborFromDecodedBlock(
+		decodedBlock, txId, outputIdx,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute the DOFF offset so the repair stores a proper offset reference
+	indexer := NewBlockIndexer(block.Slot, block.Hash)
+	offsets, indexErr := indexer.ComputeOffsets(block.Cbor, decodedBlock)
+	if indexErr == nil {
+		var txHashArray [32]byte
+		copy(txHashArray[:], txId)
+		ref := UtxoRef{TxId: txHashArray, OutputIdx: outputIdx}
+		if offset, ok := offsets.UtxoOffsets[ref]; ok {
+			if repairErr := repairUtxoBlob(
+				db, txn, txId, outputIdx, &offset,
+			); repairErr != nil {
+				db.logger.Debug(
+					"failed to repair missing UTxO blob",
+					"txid", hex.EncodeToString(txId),
+					"output_idx", outputIdx,
+					"error", repairErr,
+				)
+			}
+		}
+	}
+
+	return recoveredCbor, nil
+}
+
+func utxoRecoveryBlockForTx(
+	db *Database,
+	txn *Txn,
+	txId []byte,
+) (*models.Block, error) {
+	// Try the blob-based path when both the blob store and a blob
+	// transaction handle are available; otherwise skip straight to the
+	// metadata-based lookup below.
+	blob := db.Blob()
+	blobTxn := txn.Blob()
+	if blob != nil && blobTxn != nil {
+		if txData, err := blob.GetTx(blobTxn, txId); err == nil {
+			switch {
+			case IsTxOffsetStorage(txData):
+				offset, err := DecodeTxOffset(txData)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"decode tx offset for utxo recovery %x: %w",
+						txId[:8],
+						err,
+					)
+				}
+				block, err := BlockByPointTxn(
+					txn,
+					ocommon.NewPoint(offset.BlockSlot, offset.BlockHash[:]),
+				)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"lookup producer block from tx offset %x: %w",
+						txId[:8],
+						err,
+					)
+				}
+				return &block, nil
+			case IsTxCborPartsStorage(txData):
+				parts, err := DecodeTxCborParts(txData)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"decode tx parts for utxo recovery %x: %w",
+						txId[:8],
+						err,
+					)
+				}
+				block, err := BlockByPointTxn(
+					txn,
+					ocommon.NewPoint(parts.BlockSlot, parts.BlockHash[:]),
+				)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"lookup producer block from tx parts %x: %w",
+						txId[:8],
+						err,
+					)
+				}
+				return &block, nil
+			}
+		} else if !errors.Is(err, types.ErrBlobKeyNotFound) {
+			return nil, fmt.Errorf(
+				"lookup tx blob for utxo recovery %x: %w",
+				txId[:8],
+				err,
+			)
+		}
+	}
+	producerTx, err := db.metadata.GetTransactionByHash(txId, txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"lookup producer tx metadata for utxo recovery %x: %w",
+			txId[:8],
+			err,
+		)
+	}
+	if producerTx == nil || len(producerTx.BlockHash) == 0 {
+		return nil, nil
+	}
+	block, err := BlockByPointTxn(
+		txn,
+		ocommon.NewPoint(producerTx.Slot, producerTx.BlockHash),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"lookup producer block from tx metadata %x: %w",
+			txId[:8],
+			err,
+		)
+	}
+	return &block, nil
+}
+
+func utxoCborFromDecodedBlock(
+	decodedBlock ledger.Block,
+	txId []byte,
+	outputIdx uint32,
+) ([]byte, error) {
+	for _, tx := range decodedBlock.Transactions() {
+		if !bytes.Equal(tx.Hash().Bytes(), txId) {
+			continue
+		}
+		for _, produced := range tx.Produced() {
+			if produced.Id.Index() == outputIdx {
+				return produced.Output.Cbor(), nil
+			}
+		}
+		return nil, ErrUtxoNotFound
+	}
+	return nil, ErrUtxoNotFound
+}
+
+func repairUtxoBlob(
+	db *Database,
+	txn *Txn,
+	txId []byte,
+	outputIdx uint32,
+	offset *CborOffset,
+) error {
+	blob := db.Blob()
+	if blob == nil {
+		return nil
+	}
+
+	offsetData := EncodeUtxoOffset(offset)
+
+	// Use the caller's blob txn when it is write-capable
+	if txn != nil && txn.Blob() != nil && txn.IsReadWrite() {
+		return blob.SetUtxo(txn.Blob(), txId, outputIdx, offsetData)
+	}
+
+	// Open a dedicated write transaction when the caller txn is
+	// nil or its blob handle is read-only / absent.
+	writeTxn := NewBlobOnlyTxn(db, true)
+	if err := blob.SetUtxo(
+		writeTxn.Blob(), txId, outputIdx, offsetData,
+	); err != nil {
+		_ = writeTxn.Rollback()
+		return err
+	}
+	if err := writeTxn.Commit(); err != nil {
+		_ = writeTxn.Rollback()
+		return err
+	}
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.163.0
+	github.com/blinklabs-io/gouroboros v0.163.1
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.27
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.163.0 h1:P5I6nA0riUDxk/qMjD49fdTFlE81O9x2SgN4++ZEuCk=
-github.com/blinklabs-io/gouroboros v0.163.0/go.mod h1:J8m943TBvY+ZfYmIsI94ipvE8XHNhV1V5PNtywr9YAo=
+github.com/blinklabs-io/gouroboros v0.163.1 h1:nYHjzuHQLJ1e5lot3XDIlLkAvMENaXi8rbPM9jkuBjk=
+github.com/blinklabs-io/gouroboros v0.163.1/go.mod h1:J8m943TBvY+ZfYmIsI94ipvE8XHNhV1V5PNtywr9YAo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.27 h1:/leKVzb2XrgXo2yGsgpynpw/fh2sB8RNom+k3mXUwhA=

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -482,3 +482,139 @@ func TestUtxoByRefAfterSetTransaction(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestUtxoByRefRecoversMissingBlobFromProducerBlock(t *testing.T) {
+	for _, deleteTxBlob := range []bool{false, true} {
+		t.Run(fmt.Sprintf("delete_tx_blob=%t", deleteTxBlob), func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "utxo_byref_recover_test")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+
+			logger := slog.New(
+				slog.NewTextHandler(
+					io.Discard,
+					&slog.HandlerOptions{Level: slog.LevelDebug},
+				),
+			)
+
+			dbConfig := &database.Config{
+				DataDir:        tmpDir,
+				Logger:         logger,
+				BlobPlugin:     "badger",
+				MetadataPlugin: "sqlite",
+			}
+			db, err := database.New(dbConfig)
+			require.NoError(t, err)
+			defer db.Close()
+
+			imm, err := immutable.New("../database/immutable/testdata")
+			require.NoError(t, err)
+
+			iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
+			require.NoError(t, err)
+			defer iter.Close()
+
+			var block lcommon.Block
+			var blockCbor []byte
+			for {
+				immBlock, err := iter.Next()
+				require.NoError(t, err)
+				if immBlock == nil {
+					t.Fatal("no blocks with transactions found")
+				}
+				block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+				require.NoError(t, err)
+				if len(block.Transactions()) == 0 {
+					continue
+				}
+				if len(block.Transactions()[0].Produced()) == 0 {
+					continue
+				}
+				blockCbor = immBlock.Cbor
+				break
+			}
+
+			point := ocommon.Point{
+				Slot: block.SlotNumber(),
+				Hash: block.Hash().Bytes(),
+			}
+			tx := block.Transactions()[0]
+			expectedUtxo := tx.Produced()[0]
+			txId := tx.Hash().Bytes()
+			outputIdx := expectedUtxo.Id.Index()
+
+			txn := db.Transaction(true)
+			err = txn.Do(func(txn *database.Txn) error {
+				blockRecord := models.Block{
+					Slot:     point.Slot,
+					Hash:     point.Hash,
+					Number:   block.BlockNumber(),
+					Type:     uint(block.Type()),
+					PrevHash: block.PrevHash().Bytes(),
+					Cbor:     blockCbor,
+				}
+				if err := db.BlockCreate(blockRecord, txn); err != nil {
+					return err
+				}
+				indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+				offsets, err := indexer.ComputeOffsets(blockCbor, block)
+				if err != nil {
+					return fmt.Errorf("compute offsets: %w", err)
+				}
+				return db.SetTransaction(
+					tx,
+					point,
+					0,
+					0,
+					nil,
+					nil,
+					&database.BlockIngestionResult{
+						TxOffsets:   offsets.TxOffsets,
+						UtxoOffsets: offsets.UtxoOffsets,
+					},
+					txn,
+				)
+			})
+			require.NoError(t, err)
+
+			deleteTxn := db.Transaction(true)
+			err = deleteTxn.Do(func(txn *database.Txn) error {
+				if err := db.Blob().DeleteUtxo(txn.Blob(), txId, outputIdx); err != nil {
+					return err
+				}
+				if deleteTxBlob {
+					if err := db.Blob().DeleteTx(txn.Blob(), txId); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			require.NoError(t, err)
+
+			metaUtxo, err := db.Metadata().GetUtxo(txId, outputIdx, nil)
+			require.NoError(t, err)
+			require.NotNil(t, metaUtxo)
+
+			lookupTxn := db.Transaction(true)
+			err = lookupTxn.Do(func(txn *database.Txn) error {
+				retrieved, err := db.UtxoByRef(txId, outputIdx, txn)
+				require.NoError(t, err)
+				require.Equal(t, expectedUtxo.Output.Cbor(), retrieved.Cbor)
+
+				// The recovery path should heal the missing blob so future
+				// lookups do not need to re-derive it from the producer block.
+				// Verify by checking the blob key exists (the stored value is a
+				// DOFF offset reference, not raw CBOR).
+				_, err = db.Blob().GetUtxo(txn.Blob(), txId, outputIdx)
+				require.NoError(t, err)
+
+				// A second UtxoByRef should succeed without recovery.
+				retrieved2, err := db.UtxoByRef(txId, outputIdx, txn)
+				require.NoError(t, err)
+				require.Equal(t, expectedUtxo.Output.Cbor(), retrieved2.Cbor)
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ledger replay recovery by reconstructing missing UTxO CBOR from producer blocks during `UtxoByRef`, then healing the blob store with a DOFF offset reference. Also batches UTxO blob deletions and ensures TX blob deletions use the caller transaction for atomic commits.

- **Bug Fixes**
  - Recover missing UTxO CBOR by locating the producer block via TX blob offsets/CBOR parts or metadata; extract CBOR and heal by writing an offset reference.
  - Batch-delete UTxO blobs in groups of 500 with blob-only transactions; TX blob deletions now require and use the outer transaction so metadata and blobs commit together.
  - Added tests to verify UTxO recovery with and without the TX blob.

- **Dependencies**
  - Bumped `github.com/blinklabs-io/gouroboros` to v0.163.1.
  - Updated CI to `actions/cache` v5.0.4 and build image to `1.25.8-1`.

<sup>Written for commit 5c7c2a531a0c673326be078135f25966809fe44f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI cache action pin to v5.0.4 across workflows
  * Bumped Go toolchain in build image to 1.25.8
  * Updated a Go module dependency version
  * Added a transaction read/write introspection method

* **Bug Fixes**
  * Added automatic recovery/repair of missing UTxO blob data from producer block information

* **Tests**
  * Added test covering UTxO data recovery and repair behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->