### PR TITLE
fix(chain): rewind batching

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 func decodeHex(hexData string) []byte {
@@ -1003,6 +1004,66 @@ func TestChainRollbackWithinSecurityParam(t *testing.T) {
 			rollbackPoint.Slot,
 			rollbackPoint.Hash,
 		)
+	}
+}
+
+func TestRewindPrimaryChainToPointPrunesPersistentTail(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf(
+			"unexpected error creating chain manager: %s",
+			err,
+		)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf(
+				"unexpected error adding block to chain: %s",
+				err,
+			)
+		}
+	}
+	rewindBlock := testBlocks[2]
+	rewindPoint := ocommon.Point{
+		Slot: rewindBlock.SlotNumber(),
+		Hash: rewindBlock.Hash().Bytes(),
+	}
+	if err := cm.RewindPrimaryChainToPoint(rewindPoint); err != nil {
+		t.Fatalf(
+			"unexpected error rewinding primary chain: %s",
+			err,
+		)
+	}
+	tip := c.Tip()
+	if tip.Point.Slot != rewindPoint.Slot ||
+		string(tip.Point.Hash) != string(rewindPoint.Hash) {
+		t.Fatalf(
+			"chain tip should match rewind point: got %d.%x, wanted %d.%x",
+			tip.Point.Slot,
+			tip.Point.Hash,
+			rewindPoint.Slot,
+			rewindPoint.Hash,
+		)
+	}
+	for idx := uint64(1); idx <= 3; idx++ {
+		if _, err := db.BlockByIndex(idx, nil); err != nil {
+			t.Fatalf(
+				"expected block index %d to remain after rewind: %s",
+				idx,
+				err,
+			)
+		}
+	}
+	for idx := uint64(4); idx <= 6; idx++ {
+		if _, err := db.BlockByIndex(idx, nil); !errors.Is(err, models.ErrBlockNotFound) {
+			t.Fatalf(
+				"expected block index %d to be pruned after rewind, got: %v",
+				idx,
+				err,
+			)
+		}
 	}
 }
 

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -34,6 +34,9 @@ type ChainId uint64
 
 const (
 	primaryChainId ChainId = 1
+	// primaryChainRewindBatchSize bounds startup reconciliation work per
+	// write transaction when pruning a speculative primary-chain tail.
+	primaryChainRewindBatchSize = 512
 )
 
 type ChainManager struct {
@@ -331,74 +334,68 @@ func (cm *ChainManager) RewindPrimaryChainToPoint(
 	rollbackBlockNumber := uint64(0)
 	targetTip := ochainsync.Tip{}
 	err := func() error {
-		txn := cm.db.BlobTxn(true)
-		return txn.Do(func(txn *database.Txn) error {
-			currentTip := primaryChain.currentTip
-			if point.Slot > 0 || len(point.Hash) > 0 {
-				tmpBlock, err := cm.blockByPoint(point, txn)
-				if err != nil {
-					return fmt.Errorf("lookup rewind point: %w", err)
-				}
-				rollbackIndex = tmpBlock.ID
-				rollbackBlockNumber = tmpBlock.Number
-				if primaryChain.tipBlockIndex < rollbackIndex {
-					return fmt.Errorf(
-						"primary chain tip index %d is behind rewind point index %d",
-						primaryChain.tipBlockIndex,
-						rollbackIndex,
-					)
-				}
-				if primaryChain.tipBlockIndex == rollbackIndex &&
-					primaryChain.currentTip.Point.Slot == point.Slot &&
-					bytes.Equal(primaryChain.currentTip.Point.Hash, point.Hash) {
-					targetTip = primaryChain.currentTip
-					return nil
-				}
-				targetTip = ochainsync.Tip{
-					Point:       point,
-					BlockNumber: rollbackBlockNumber,
-				}
+		if point.Slot > 0 || len(point.Hash) > 0 {
+			readTxn := cm.db.BlobTxn(false)
+			defer readTxn.Rollback() //nolint:errcheck
+			tmpBlock, err := cm.blockByPoint(point, readTxn)
+			if err != nil {
+				return fmt.Errorf("lookup rewind point: %w", err)
 			}
-			for currentTip.Point.Slot != point.Slot ||
-				!bytes.Equal(currentTip.Point.Hash, point.Hash) {
-				currentBlock, err := cm.blockByPoint(currentTip.Point, txn)
-				if err != nil {
-					return fmt.Errorf(
-						"lookup current primary block: %w",
-						err,
-					)
-				}
-				if err := database.BlockDeleteTxn(txn, currentBlock); err != nil {
-					return fmt.Errorf(
-						"delete primary block %d: %w",
-						currentBlock.ID,
-						err,
-					)
-				}
-				if len(currentBlock.PrevHash) == 0 {
-					currentTip = ochainsync.Tip{}
-					break
-				}
-				prevBlock, err := database.BlockByHashTxn(txn, currentBlock.PrevHash)
-				if err != nil {
-					return fmt.Errorf(
-						"lookup previous primary block: %w",
-						err,
-					)
-				}
-				currentTip = ochainsync.Tip{
-					Point: ocommon.NewPoint(
-						prevBlock.Slot,
-						prevBlock.Hash,
-					),
-					BlockNumber: prevBlock.Number,
-				}
+			rollbackIndex = tmpBlock.ID
+			rollbackBlockNumber = tmpBlock.Number
+			if primaryChain.tipBlockIndex < rollbackIndex {
+				return fmt.Errorf(
+					"primary chain tip index %d is behind rewind point index %d",
+					primaryChain.tipBlockIndex,
+					rollbackIndex,
+				)
 			}
-			if targetTip.Point.Slot == 0 && len(targetTip.Point.Hash) == 0 {
-				targetTip = currentTip
+			if primaryChain.tipBlockIndex == rollbackIndex &&
+				primaryChain.currentTip.Point.Slot == point.Slot &&
+				bytes.Equal(primaryChain.currentTip.Point.Hash, point.Hash) {
+				targetTip = primaryChain.currentTip
+				return nil
 			}
-			return nil
-		})
+			targetTip = ochainsync.Tip{
+				Point:       point,
+				BlockNumber: rollbackBlockNumber,
+			}
+		}
+		currentIndex := primaryChain.tipBlockIndex
+		for currentIndex > rollbackIndex {
+			batchFloor := rollbackIndex
+			if currentIndex-rollbackIndex > primaryChainRewindBatchSize {
+				batchFloor = currentIndex - primaryChainRewindBatchSize
+			}
+			txn := cm.db.BlobTxn(true)
+			if err := txn.Do(func(txn *database.Txn) error {
+				for idx := currentIndex; idx > batchFloor; idx-- {
+					currentBlock, err := cm.db.BlockByIndex(idx, txn)
+					if err != nil {
+						return fmt.Errorf(
+							"lookup current primary block by index %d: %w",
+							idx,
+							err,
+						)
+					}
+					if err := database.BlockDeleteTxn(txn, currentBlock); err != nil {
+						return fmt.Errorf(
+							"delete primary block %d: %w",
+							currentBlock.ID,
+							err,
+						)
+					}
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+			currentIndex = batchFloor
+		}
+		if targetTip.Point.Slot == 0 && len(targetTip.Point.Hash) == 0 {
+			targetTip = ochainsync.Tip{}
+		}
+		return nil
 	}()
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Batch primary-chain rewind deletions to prune the speculative tail and avoid long write transactions during startup reconciliation. Adds a test to verify the tip matches the rewind point and that blocks past the point are removed.

- **Bug Fixes**
  - Rework `RewindPrimaryChainToPoint` to delete blocks by index in batches (512 per write txn) instead of walking predecessors in one long txn.
  - Look up the rewind point in a read txn and refine tip handling (no-op rewinds and rewinds to genesis).
  - Add `TestRewindPrimaryChainToPointPrunesPersistentTail` to ensure blocks after the rewind point are pruned and earlier blocks remain.

<sup>Written for commit a13ae8e02334bc1225cb2b186ec5ecba43517c46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

