### PR TITLE
test(devnet): update parameters

### DIFF
--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - ./testnet.yaml:/testnet.yaml
       - p1-configs:/configs/1
       - p2-configs:/configs/2
+      - utxo-keys:/configs/utxo-keys
 
   dingo-producer:
     build:
@@ -123,6 +124,32 @@ services:
       retries: 30
       start_period: 10s
 
+  txpump:
+    build:
+      context: ../../..
+      dockerfile: internal/test/antithesis/Dockerfile.txpump
+    container_name: devnet-txpump
+    depends_on:
+      dingo-producer:
+        condition: service_healthy
+    environment:
+      TXPUMP_NODE_ADDR: "/ipc/dingo.socket"
+      TXPUMP_NETWORK_MAGIC: "42"
+      TXPUMP_TX_COUNT_MIN: "10"
+      TXPUMP_TX_COUNT_MAX: "50"
+      TXPUMP_COOLDOWN_MIN: "5"
+      TXPUMP_COOLDOWN_MAX: "15"
+      TXPUMP_TYPES: "payment"
+      TXPUMP_LOG_DIR: "/logs"
+      TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
+    volumes:
+      - dingo-producer-ipc:/ipc:ro
+      - logs:/logs
+      - utxo-keys:/utxo-keys:ro
+    networks:
+      devnet:
+        ipv4_address: 172.20.0.20
+
   cardano-relay:
     image: ghcr.io/blinklabs-io/cardano-node:10.5.4
     container_name: cardano-relay
@@ -170,6 +197,8 @@ networks:
 volumes:
   p1-configs:
   p2-configs:
+  utxo-keys:
+  logs:
   dingo-producer-data:
   dingo-producer-ipc:
   cardano-producer-data:

--- a/internal/test/devnet/testnet.yaml
+++ b/internal/test/devnet/testnet.yaml
@@ -24,19 +24,19 @@ testnetDomain: devnet
 
 --- # Byron Genesis Override
 protocolConsts:
-  k: 100
+  k: 40
 
 --- # Shelley Genesis Override
-# 1s slots, 25 min epochs, block every ~5s per pool (~2.5s total)
-# nonceStabilityWindow = 4k/f = 4*100/0.4 = 1000 < 1500 = epochLength ✓
-# blockfetchStabilityWindow = 3k/f = 3*100/0.4 = 750
-# Candidate nonce freezes 1000 slots before epoch end (at slot 500).
+# 1s slots, ~8 min epochs, block every ~5s per pool (~2.5s total)
+# nonceStabilityWindow = 4k/f = 4*40/0.4 = 400 < 500 = epochLength ✓
+# blockfetchStabilityWindow = 3k/f = 3*40/0.4 = 300 < 500 = epochLength ✓
+# Candidate nonce freezes 400 slots before epoch end (at slot 100).
 # Partition tolerance: K / per-pool-rate where per-pool-rate = 1-(1-f)^(1/n)
-# With f=0.4, n=2: per-pool-rate ≈ 0.225, so K / per-pool-rate ≈ 100/0.225 ≈ 444s (~7.4 min)
-epochLength: 1500
+# With f=0.4, n=2: per-pool-rate ≈ 0.225, so K / per-pool-rate ≈ 40/0.225 ≈ 178s (~3 min)
+epochLength: 500
 slotLength: 1
 activeSlotsCoeff: 0.4
-securityParam: 100
+securityParam: 40
 maxLovelaceSupply: 2000000000000
 protocolParams:
   decentralisationParam: 0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a transaction pump to generate steady payment traffic and shorten devnet epochs for faster testing. Epochs are now ~8 minutes with lower security parameters to speed up cycles.

- New Features
  - Added `txpump` container to send payment transactions; depends on `dingo-producer`, uses IPC, and writes to a `logs` volume; shares a new `utxo-keys` volume with the producer for genesis UTXO keys.
  - Updated devnet params: set `k`/`securityParam` to 40 and `epochLength` to 500 (1s slots), keeping `activeSlotsCoeff` at 0.4.

<sup>Written for commit c86282a90218bb7a0766ec4334d37c9635a4a24d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

