### PR TITLE
feat(database): configurable badger compression

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -247,6 +247,7 @@ type BlobStoreBadger struct {
 	memTableSize         int64
 	valueThreshold       int64
 	compactBlockMetadata bool
+	compressionEnabled   bool
 	gcEnabled            bool
 	deferOpen            bool // when true, Badger is opened in Start() not New()
 }
@@ -257,12 +258,13 @@ type BlobStoreBadger struct {
 func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 	db := &BlobStoreBadger{
 		// Set defaults
-		gcEnabled:        true, // Enable GC by default for disk-backed stores
-		blockCacheSize:   DefaultBlockCacheSize,
-		indexCacheSize:   DefaultIndexCacheSize,
-		valueLogFileSize: int64(DefaultValueLogFileSize),
-		memTableSize:     int64(DefaultMemTableSize),
-		valueThreshold:   int64(DefaultValueThreshold),
+		gcEnabled:          true, // Enable GC by default for disk-backed stores
+		compressionEnabled: true, // Snappy compression by default
+		blockCacheSize:     DefaultBlockCacheSize,
+		indexCacheSize:     DefaultIndexCacheSize,
+		valueLogFileSize:   int64(DefaultValueLogFileSize),
+		memTableSize:       int64(DefaultMemTableSize),
+		valueThreshold:     int64(DefaultValueThreshold),
 	}
 	for _, opt := range opts {
 		opt(db)
@@ -289,7 +291,8 @@ func (db *BlobStoreBadger) open() error {
 			// The default INFO logging is a bit verbose
 			WithLoggingLevel(badger.WARNING).
 			WithInMemory(true).
-			WithValueThreshold(db.valueThreshold)
+			WithValueThreshold(db.valueThreshold).
+			WithCompression(db.badgerCompression())
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
 			return fmt.Errorf("badger open in-memory: %w", err)
@@ -317,7 +320,7 @@ func (db *BlobStoreBadger) open() error {
 			WithValueLogFileSize(db.valueLogFileSize).
 			WithMemTableSize(db.memTableSize).
 			WithValueThreshold(db.valueThreshold).
-			WithCompression(options.Snappy)
+			WithCompression(db.badgerCompression())
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
 			return fmt.Errorf("badger open on-disk: %w", err)
@@ -337,6 +340,13 @@ func (db *BlobStoreBadger) open() error {
 		)
 	}
 	return nil
+}
+
+func (db *BlobStoreBadger) badgerCompression() options.CompressionType {
+	if db.compressionEnabled {
+		return options.Snappy
+	}
+	return options.None
 }
 
 func (d *BlobStoreBadger) init() error {

--- a/database/plugin/blob/badger/options.go
+++ b/database/plugin/blob/badger/options.go
@@ -94,6 +94,14 @@ func WithCompactBlockMetadata(enabled bool) BlobStoreBadgerOptionFunc {
 	}
 }
 
+// WithCompressionEnabled controls Snappy compression of SSTable blocks.
+// Disabling compression allows block cache size 0 (pure mmap).
+func WithCompressionEnabled(enabled bool) BlobStoreBadgerOptionFunc {
+	return func(b *BlobStoreBadger) {
+		b.compressionEnabled = enabled
+	}
+}
+
 // WithDeferOpen defers opening Badger until Start() is called.
 // This allows a logger to be injected via SetLogger before Badger
 // emits any startup logs.

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -23,8 +23,9 @@ import (
 
 // Default cache sizes for BadgerDB (in bytes).
 //
-// Block cache is needed because we use Snappy compression. Badger's
+// Block cache is needed when Snappy compression is enabled. Badger's
 // own default is 256 MB block cache and 0 (unlimited) index cache.
+// Set compression=false and block-cache-size=0 for mmap-only mode.
 // Setting IndexCacheSize to 0 lets Badger memory-map the full index
 // without eviction, which is preferable to capping it.
 //
@@ -55,15 +56,16 @@ type ProfileSettings struct {
 
 var (
 	cmdlineOptions struct {
-		dataDir          string
-		runMode          string
-		storageMode      string
-		blockCacheSize   uint64
-		indexCacheSize   uint64
-		valueLogFileSize uint64
-		memTableSize     uint64
-		valueThreshold   uint64
-		gcEnabled        bool
+		dataDir            string
+		runMode            string
+		storageMode        string
+		blockCacheSize     uint64
+		indexCacheSize     uint64
+		valueLogFileSize   uint64
+		memTableSize       uint64
+		valueThreshold     uint64
+		gcEnabled          bool
+		compressionEnabled bool
 	}
 	cmdlineOptionsMutex sync.RWMutex
 )
@@ -145,6 +147,7 @@ func initCmdlineOptions() {
 	cmdlineOptions.runMode = ""
 	cmdlineOptions.storageMode = "core"
 	cmdlineOptions.gcEnabled = true
+	cmdlineOptions.compressionEnabled = true
 	cmdlineOptions.dataDir = ".dingo"
 }
 
@@ -221,6 +224,13 @@ func init() {
 					DefaultValue: uint64(DefaultValueThreshold),
 					Dest:         &(cmdlineOptions.valueThreshold),
 				},
+				{
+					Name:         "compression",
+					Type:         plugin.PluginOptionTypeBool,
+					Description:  "Enable Snappy compression (disable for mmap-only mode; set block-cache-size=0 for mmap-only)",
+					DefaultValue: true,
+					Dest:         &(cmdlineOptions.compressionEnabled),
+				},
 			},
 		},
 	)
@@ -274,6 +284,7 @@ func NewFromCmdlineOptions() plugin.Plugin {
 			int64(valueThreshold),
 		),
 		WithGc(cmdlineOptions.gcEnabled),
+		WithCompressionEnabled(cmdlineOptions.compressionEnabled),
 		WithDeferOpen(),
 	}
 	cmdlineOptionsMutex.Unlock()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `badger` compression configurable across in-memory and on-disk stores, supporting Snappy or no compression. Default stays Snappy; disable it for mmap-only mode.

- **New Features**
  - Added WithCompressionEnabled(bool) option.
  - Added `compression` CLI flag (default: true), wired through NewFromCmdlineOptions.
  - Applied WithCompression(db.badgerCompression()) in both open paths.
  - For mmap-only, set `compression=false` and `block-cache-size=0`.

<sup>Written for commit 38f39821f85aed2b673c5f511a5c0f1e64305c2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable compression for the Badger blob storage backend (enabled by default)
  * New CLI/YAML option to toggle compression for deployments

* **Documentation**
  * Clarified block cache requirements when compression is enabled and added guidance for mmap-only mode (set compression off and block cache to 0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->