### PR TITLE
fix(database): blob delete batching

### DIFF
--- a/database/transaction.go
+++ b/database/transaction.go
@@ -479,28 +479,54 @@ func (d *Database) GetAddressesByStakingKey(
 }
 
 // deleteTxBlobs attempts to delete blob data for the given transaction hashes.
-// This is a best-effort operation; metadata remains the source of truth.
-// Blob deletions use the provided outer transaction so they participate in
-// the same atomic commit as metadata changes.
+// This is a best-effort operation; metadata remains the source of truth. When
+// the caller provides a blob transaction, deletions stay coupled to that outer
+// commit. A temporary blob-only transaction is used only as a fallback when no
+// blob handle is available.
 func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
+	const batchSize = 500
 	blob := d.Blob()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
-	blobTxn := txn.Blob()
-	if blobTxn == nil {
-		return types.ErrNilTxn
-	}
 
 	var deleteErrors int
-	for _, txHash := range txHashes {
-		if err := blob.DeleteTx(blobTxn, txHash); err != nil {
-			deleteErrors++
-			d.logger.Debug(
-				"failed to delete TX blob data",
-				"txHash", hex.EncodeToString(txHash),
-				"error", err,
-			)
+	deleteBatch := func(blobTxn types.Txn, batch [][]byte) int {
+		var batchDeleteErrors int
+		for _, txHash := range batch {
+			if err := blob.DeleteTx(blobTxn, txHash); err != nil {
+				deleteErrors++
+				batchDeleteErrors++
+				d.logger.Debug(
+					"failed to delete TX blob data",
+					"txHash", hex.EncodeToString(txHash),
+					"error", err,
+				)
+			}
+		}
+		return batchDeleteErrors
+	}
+
+	if txn != nil && txn.Blob() != nil {
+		deleteBatch(txn.Blob(), txHashes)
+	} else {
+		for start := 0; start < len(txHashes); start += batchSize {
+			end := start + batchSize
+			if end > len(txHashes) {
+				end = len(txHashes)
+			}
+			batch := txHashes[start:end]
+			batchTxn := NewBlobOnlyTxn(d, true)
+			batchBlobTxn := batchTxn.Blob()
+			if batchBlobTxn == nil {
+				return types.ErrNilTxn
+			}
+			batchDeleteErrors := deleteBatch(batchBlobTxn, batch)
+			if err := batchTxn.Commit(); err != nil {
+				deleteErrors += len(batch) - batchDeleteErrors
+				_ = batchTxn.Rollback()
+				d.logger.Debug("tx blob delete batch commit failed", "error", err)
+			}
 		}
 	}
 	if deleteErrors > 0 {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+type mockBlobStore struct {
+	deleteTxErrs map[string]error
+	commitErrs   []error
+	deleteTxnIDs []int
+	txns         []*mockBlobTxn
+}
+
+type mockBlobTxn struct {
+	id            int
+	commitErr     error
+	commitCount   int
+	rollbackCount int
+}
+
+func (m *mockBlobStore) Close() error {
+	return nil
+}
+
+func (m *mockBlobStore) NewTransaction(bool) types.Txn {
+	txn := &mockBlobTxn{id: len(m.txns) + 1}
+	if idx := len(m.txns); idx < len(m.commitErrs) {
+		txn.commitErr = m.commitErrs[idx]
+	}
+	m.txns = append(m.txns, txn)
+	return txn
+}
+
+func (m *mockBlobStore) Get(types.Txn, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockBlobStore) Set(types.Txn, []byte, []byte) error {
+	return nil
+}
+
+func (m *mockBlobStore) Delete(types.Txn, []byte) error {
+	return nil
+}
+
+func (m *mockBlobStore) NewIterator(
+	types.Txn,
+	types.BlobIteratorOptions,
+) types.BlobIterator {
+	return nil
+}
+
+func (m *mockBlobStore) GetCommitTimestamp() (int64, error) {
+	return 0, nil
+}
+
+func (m *mockBlobStore) SetCommitTimestamp(int64, types.Txn) error {
+	return nil
+}
+
+func (m *mockBlobStore) SetBlock(
+	types.Txn,
+	uint64,
+	[]byte,
+	[]byte,
+	uint64,
+	uint,
+	uint64,
+	[]byte,
+) error {
+	return nil
+}
+
+func (m *mockBlobStore) GetBlock(
+	types.Txn,
+	uint64,
+	[]byte,
+) ([]byte, types.BlockMetadata, error) {
+	return nil, types.BlockMetadata{}, nil
+}
+
+func (m *mockBlobStore) DeleteBlock(types.Txn, uint64, []byte, uint64) error {
+	return nil
+}
+
+func (m *mockBlobStore) GetBlockURL(
+	context.Context,
+	types.Txn,
+	ocommon.Point,
+) (types.SignedURL, types.BlockMetadata, error) {
+	return types.SignedURL{}, types.BlockMetadata{}, nil
+}
+
+func (m *mockBlobStore) SetUtxo(types.Txn, []byte, uint32, []byte) error {
+	return nil
+}
+
+func (m *mockBlobStore) GetUtxo(types.Txn, []byte, uint32) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockBlobStore) DeleteUtxo(types.Txn, []byte, uint32) error {
+	return nil
+}
+
+func (m *mockBlobStore) SetTx(types.Txn, []byte, []byte) error {
+	return nil
+}
+
+func (m *mockBlobStore) GetTx(types.Txn, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockBlobStore) DeleteTx(txn types.Txn, txHash []byte) error {
+	mockTxn, ok := txn.(*mockBlobTxn)
+	if !ok {
+		return types.ErrTxnWrongType
+	}
+	m.deleteTxnIDs = append(m.deleteTxnIDs, mockTxn.id)
+	if err, ok := m.deleteTxErrs[string(txHash)]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockBlobTxn) Commit() error {
+	m.commitCount++
+	return m.commitErr
+}
+
+func (m *mockBlobTxn) Rollback() error {
+	m.rollbackCount++
+	return nil
+}
+
+func TestDeleteTxBlobsUsesCallerBlobTxn(t *testing.T) {
+	t.Parallel()
+
+	store := &mockBlobStore{}
+	db := &Database{
+		blob: store,
+		logger: slog.New(
+			slog.NewJSONHandler(
+				io.Discard,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	}
+	txn := db.Transaction(true)
+
+	txHashes := [][]byte{{0x01}, {0x02}, {0x03}}
+	require.NoError(t, deleteTxBlobs(db, txHashes, txn))
+	require.Len(t, store.txns, 1)
+	require.Equal(t, []int{1, 1, 1}, store.deleteTxnIDs)
+	require.Zero(t, store.txns[0].commitCount)
+	require.Zero(t, store.txns[0].rollbackCount)
+
+	require.NoError(t, txn.Rollback())
+}
+
+func TestDeleteTxBlobsCountsFailedBatchCommit(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	store := &mockBlobStore{commitErrs: []error{errors.New("commit failed")}}
+	db := &Database{
+		blob: store,
+		logger: slog.New(
+			slog.NewJSONHandler(
+				&logs,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	}
+
+	txHashes := [][]byte{{0x01}, {0x02}, {0x03}}
+	require.NoError(t, deleteTxBlobs(db, txHashes, nil))
+	require.Len(t, store.txns, 1)
+	require.Equal(t, 1, store.txns[0].commitCount)
+	require.Contains(t, logs.String(), "\"failed\":3")
+	require.Contains(t, logs.String(), "\"total\":3")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch transaction-blob deletions and fall back to blob-only batch transactions when the outer transaction has no blob handle. This reduces large commit failures and makes blob cleanup more reliable.

- **Bug Fixes**
  - Split deletions into batches of 500; commit per batch.
  - Use the caller’s blob txn when present; no extra commits/rollbacks.
  - Create a blob-only txn via `NewBlobOnlyTxn` when needed; rollback and log on failed batch commits.
  - Add tests to cover caller-txn usage and failed batch commit accounting/logging.

<sup>Written for commit be483fcbd6d0c6ae2495f6659b7c24f507ec73aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved blob deletion with batched processing to make large-scale deletions more reliable and efficient.

* **Bug Fixes**
  * Deletion now tolerates missing caller transactions and falls back to safe, best-effort batched deletes to reduce failures and partial states.

* **Tests**
  * Added targeted tests validating transaction-scoped deletion behavior and failure counting/logging for batch commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->