### PR TITLE
build(docker): remove mount type=cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,19 @@ WORKDIR /code
 RUN go env -w GOCACHE=/go-cache
 RUN go env -w GOMODCACHE=/gomod-cache
 COPY go.* .
-RUN --mount=type=cache,target=/gomod-cache go mod download
+RUN go mod download
 COPY . .
-RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache make build
+RUN make build
 
 FROM build AS antithesis-build
 RUN go get github.com/antithesishq/antithesis-sdk-go@latest
 RUN go install github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-instrumentor@latest
-RUN --mount=type=cache,target=/gomod-cache make mod-tidy
+RUN make mod-tidy
 RUN mkdir -p /antithesis
 # Create instrumented code in /antithesis
-RUN --mount=type=cache,target=/gomod-cache `go env GOPATH`/bin/antithesis-go-instrumentor /code /antithesis
+RUN `go env GOPATH`/bin/antithesis-go-instrumentor /code /antithesis
 WORKDIR /antithesis/customer
-RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache make build
+RUN make build
 
 FROM ghcr.io/blinklabs-io/cardano-cli:10.14.0.0-1 AS cardano-cli
 FROM ghcr.io/blinklabs-io/cardano-configs:20251128-1 AS cardano-configs


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed BuildKit cache mounts from the Dockerfile so builds succeed in environments without BuildKit support. Dropped all `--mount=type=cache` flags and now run plain `go mod download`, `make build`, `make mod-tidy`, and the instrumentor command.

<sup>Written for commit c41e5a032807894643b7884deeb8a45ca371a9a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to remove caching from build stages, potentially affecting build performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->