### PR TITLE
fix: prevent infinite at-tip recovery loops

### DIFF
--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -23,12 +23,11 @@ import (
 
 // PeerChainTip tracks the chain tip reported by a specific peer.
 type PeerChainTip struct {
-	ConnectionId   ouroboros.ConnectionId
-	Tip            ochainsync.Tip
-	ObservedTip    ochainsync.Tip
-	ObservedTipSet bool   // true when ObservedTip has been explicitly set
-	VRFOutput      []byte // VRF output from tip block for tie-breaking
-	LastUpdated    time.Time
+	ConnectionId ouroboros.ConnectionId
+	Tip          ochainsync.Tip
+	ObservedTip  ochainsync.Tip
+	VRFOutput    []byte // VRF output from tip block for tie-breaking
+	LastUpdated  time.Time
 }
 
 // NewPeerChainTip creates a new PeerChainTip with the given connection ID,
@@ -39,12 +38,11 @@ func NewPeerChainTip(
 	vrfOutput []byte,
 ) *PeerChainTip {
 	return &PeerChainTip{
-		ConnectionId:   connId,
-		Tip:            tip,
-		ObservedTip:    tip,
-		ObservedTipSet: true,
-		VRFOutput:      vrfOutput,
-		LastUpdated:    time.Now(),
+		ConnectionId: connId,
+		Tip:          tip,
+		ObservedTip:  tip,
+		VRFOutput:    vrfOutput,
+		LastUpdated:  time.Now(),
 	}
 }
 
@@ -62,7 +60,6 @@ func (p *PeerChainTip) UpdateTipWithObserved(
 ) {
 	p.Tip = tip
 	p.ObservedTip = observedTip
-	p.ObservedTipSet = true
 	p.VRFOutput = vrfOutput
 	p.LastUpdated = time.Now()
 }
@@ -75,7 +72,8 @@ func (p *PeerChainTip) SelectionTip() ochainsync.Tip {
 	if p == nil {
 		return ochainsync.Tip{}
 	}
-	if p.ObservedTipSet {
+	if p.ObservedTip.BlockNumber > 0 || p.ObservedTip.Point.Slot > 0 ||
+		len(p.ObservedTip.Point.Hash) > 0 {
 		return p.ObservedTip
 	}
 	return p.Tip

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -307,14 +307,30 @@ func (cs *ChainSelector) updatePeerTipObserved(
 }
 
 func (cs *ChainSelector) TouchPeerActivity(connId ouroboros.ConnectionId) {
-	cs.mutex.Lock()
-	defer cs.mutex.Unlock()
+	shouldEvaluate := false
 
+	cs.mutex.Lock()
 	peerTip, exists := cs.peerTips[connId]
 	if !exists {
+		cs.mutex.Unlock()
 		return
 	}
 	peerTip.Touch()
+	newBest := cs.selectBestChainLocked()
+	switch {
+	case cs.bestPeerConn == nil && newBest != nil:
+		shouldEvaluate = true
+	case cs.bestPeerConn != nil && newBest == nil:
+		shouldEvaluate = true
+	case cs.bestPeerConn != nil && newBest != nil &&
+		*cs.bestPeerConn != *newBest:
+		shouldEvaluate = true
+	}
+	cs.mutex.Unlock()
+
+	if shouldEvaluate {
+		cs.EvaluateAndSwitch()
+	}
 }
 
 // evictLeastRecentPeerLocked removes the peer with the oldest LastUpdated

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -202,6 +202,62 @@ func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
 	}
 }
 
+func TestChainSelectorTouchPeerActivityEmitsChainSwitchEvent(
+	t *testing.T,
+) {
+	eventBus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { eventBus.Stop() })
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:          eventBus,
+		StaleTipThreshold: time.Second,
+	})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 60,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
+		BlockNumber: 50,
+	}
+
+	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
+
+	cs.UpdatePeerTip(connId1, tip1, nil)
+	cs.UpdatePeerTip(connId2, tip2, nil)
+	cs.EvaluateAndSwitch()
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	for len(evtCh) > 0 {
+		<-evtCh
+	}
+
+	cs.mutex.Lock()
+	cs.peerTips[connId1].LastUpdated = time.Now().Add(-2 * time.Second)
+	cs.mutex.Unlock()
+
+	cs.TouchPeerActivity(connId2)
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
+
+	select {
+	case evt := <-evtCh:
+		switchEvt, ok := evt.Data.(ChainSwitchEvent)
+		require.True(t, ok, "expected ChainSwitchEvent")
+		assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
+		assert.Equal(t, connId2, switchEvt.NewConnectionId)
+		assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected ChainSwitchEvent was not emitted")
+	}
+}
+
 func TestChainSelectorSelectBestChain(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{})
 

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -136,7 +136,7 @@ type State struct {
 	seenHeaders      map[uint64][]headerRecord
 	seenHeadersMutex sync.Mutex
 
-	observedHeaders      map[string]*observedHeaderChain
+	observedHeaders      map[ouroboros.ConnectionId]*observedHeaderChain
 	observedHeadersMutex sync.RWMutex
 
 	sync.Mutex
@@ -191,7 +191,7 @@ func NewStateWithConfig(
 		trackedClients: make(map[ouroboros.ConnectionId]*TrackedClient),
 		seenHeaders:    make(map[uint64][]headerRecord),
 		observedHeaders: make(
-			map[string]*observedHeaderChain,
+			map[ouroboros.ConnectionId]*observedHeaderChain,
 		),
 	}
 	return s
@@ -618,15 +618,14 @@ func (s *State) RecordObservedHeader(e ledger.ChainsyncEvent) {
 	s.observedHeadersMutex.Lock()
 	defer s.observedHeadersMutex.Unlock()
 
-	connKey := e.ConnectionId.String()
-	chainHistory := s.observedHeaders[connKey]
+	chainHistory := s.observedHeaders[e.ConnectionId]
 	if chainHistory == nil {
 		chainHistory = &observedHeaderChain{
 			order: make([]string, 0, maxObservedHeadersPerConn),
 			byHash: make(map[string]observedHeaderRecord,
 				maxObservedHeadersPerConn),
 		}
-		s.observedHeaders[connKey] = chainHistory
+		s.observedHeaders[e.ConnectionId] = chainHistory
 	}
 
 	hashKey := hex.EncodeToString(e.Point.Hash)
@@ -655,7 +654,7 @@ func (s *State) LookupObservedHeader(
 	s.observedHeadersMutex.RLock()
 	defer s.observedHeadersMutex.RUnlock()
 
-	chainHistory := s.observedHeaders[connId.String()]
+	chainHistory := s.observedHeaders[connId]
 	if chainHistory == nil {
 		return ledger.ChainsyncEvent{}, nil, false
 	}
@@ -673,7 +672,7 @@ func (s *State) clearObservedHeaderHistory(
 ) {
 	s.observedHeadersMutex.Lock()
 	defer s.observedHeadersMutex.Unlock()
-	delete(s.observedHeaders, connId.String())
+	delete(s.observedHeaders, connId)
 }
 
 func (s *State) ClearObservedHeaderHistory(

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -527,14 +527,6 @@ func TestObservedHeaderHistoryPersistsAcrossDedupAndClearsOnRemove(
 		Tip:          tip,
 	})
 
-	// Duplicate record with the same hash should be a no-op
-	s.RecordObservedHeader(ledger.ChainsyncEvent{
-		ConnectionId: conn,
-		Point:        point,
-		BlockHeader:  header,
-		Tip:          tip,
-	})
-
 	recordedEvent, recordedPrevHash, ok := s.LookupObservedHeader(
 		conn,
 		hash,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -264,16 +264,22 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 	replayConnId, err := ls.handoffPipelineOnSwitchLocked(
 		e.NewConnectionId,
 	)
-	ls.chainsyncBlockfetchMutex.Unlock()
 	if err != nil {
 		ls.config.Logger.Warn(
-			"failed to hand off chainsync pipeline on chain switch",
+			"failed to hand off chainsync pipeline on chain switch, resetting pipeline",
 			"component", "ledger",
 			"connection_id", e.NewConnectionId.String(),
 			"error", err,
 		)
+		// Clear orphaned headers and stale connection refs so the
+		// pipeline can accept headers from reconnected peers instead
+		// of stalling permanently.
+		ls.clearQueuedHeaders()
+		ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
+		ls.chainsyncBlockfetchMutex.Unlock()
 		return
 	}
+	ls.chainsyncBlockfetchMutex.Unlock()
 	if connIdKey(replayConnId) != "" {
 		ls.replayBufferedHeadersAsync(replayConnId)
 	}
@@ -397,15 +403,18 @@ func (ls *LedgerState) detectConnectionSwitch() (
 			replayConnId, err := ls.handoffPipelineOnSwitchLocked(
 				*activeConnId,
 			)
-			ls.chainsyncBlockfetchMutex.Unlock()
 			if err != nil {
 				ls.config.Logger.Warn(
-					"failed to hand off chainsync pipeline after active connection change",
+					"failed to hand off chainsync pipeline after active connection change, resetting pipeline",
 					"component", "ledger",
 					"connection_id", activeConnId.String(),
 					"error", err,
 				)
-			} else if connIdKey(replayConnId) != "" {
+				ls.clearQueuedHeaders()
+				ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
+			}
+			ls.chainsyncBlockfetchMutex.Unlock()
+			if err == nil && connIdKey(replayConnId) != "" {
 				ls.replayBufferedHeadersAsync(replayConnId)
 			}
 			// Clear per-connection state (e.g., header dedup cache)
@@ -679,7 +688,6 @@ func desiredBlockfetchBatchHeaders(
 		}
 		return min(1, maxHeaders)
 	}
-	// All switch cases produce small constants, so the final int() is safe.
 	var minHeaders int
 	switch {
 	case gapBlocks > 64:
@@ -689,8 +697,7 @@ func desiredBlockfetchBatchHeaders(
 	case gapBlocks > 4:
 		minHeaders = 2
 	default:
-		// gapBlocks is at most 4 here, safe to narrow.
-		minHeaders = int(gapBlocks) //nolint:gosec
+		minHeaders = int(gapBlocks)
 	}
 	minHeaders = min(minHeaders, blockfetchMaxBatchHeadersWhenBehind)
 	return min(minHeaders, maxHeaders)
@@ -1144,13 +1151,9 @@ func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 				continue
 			}
 			if err := ls.chain.AddBlockHeader(evt.BlockHeader); err != nil {
-				// Header replay failed; clear state so the caller
-				// retries with a different peer. The error is not
-				// propagated because zero replayed headers already
-				// signals "nothing usable".
 				ls.clearQueuedHeaders()
 				ls.headerPipelineConnId = ouroboros.ConnectionId{}
-				return 0, nil //nolint:nilerr
+				return 0, err
 			}
 		}
 		if ls.chain.HeaderCount() == 0 {
@@ -1635,14 +1638,12 @@ func (ls *LedgerState) tryResolveFork(
 		if ls.chainsyncBlockfetchReadyChan == nil {
 			ls.selectedBlockfetchConnId = e.ConnectionId
 			if err := ls.startQueuedBlockfetchLocked(e.ConnectionId); err != nil {
-				ls.chainsyncBlockfetchMutex.Unlock()
 				ls.config.Logger.Warn(
 					"failed to start blockfetch after fork rollback",
 					"component", "ledger",
 					"error", err,
 					"connection_id", e.ConnectionId.String(),
 				)
-				return false
 			}
 		}
 		ls.chainsyncBlockfetchMutex.Unlock()

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1011,6 +1011,7 @@ func TestHandleEventChainsyncBlockHeaderIgnoresIdleSelectedOwner(
 	assert.Empty(t, ls.bufferedHeaderEvents)
 	assert.Equal(t, ouroboros.ConnectionId{}, ls.selectedBlockfetchConnId)
 }
+
 func TestHandleEventChainsyncBlockHeaderIgnoresStaleHeaderBehindChainTip(
 	t *testing.T,
 ) {

--- a/ledger/chainsync_test.go
+++ b/ledger/chainsync_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"strings"
 	"testing"
 
@@ -26,6 +27,79 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
+
+func TestDesiredBlockfetchBatchHeaders(t *testing.T) {
+	testCases := []struct {
+		name       string
+		gapSlots   uint64
+		gapBlocks  uint64
+		maxHeaders int
+		want       int
+	}{
+		{
+			name:       "no gap",
+			gapSlots:   0,
+			gapBlocks:  0,
+			maxHeaders: 16,
+			want:       0,
+		},
+		{
+			name:       "slot gap without block gap",
+			gapSlots:   128,
+			gapBlocks:  0,
+			maxHeaders: 16,
+			want:       1,
+		},
+		{
+			name:       "small block gap",
+			gapSlots:   128,
+			gapBlocks:  3,
+			maxHeaders: 16,
+			want:       3,
+		},
+		{
+			name:       "medium block gap",
+			gapSlots:   128,
+			gapBlocks:  8,
+			maxHeaders: 16,
+			want:       2,
+		},
+		{
+			name:       "large block gap",
+			gapSlots:   128,
+			gapBlocks:  32,
+			maxHeaders: 16,
+			want:       4,
+		},
+		{
+			name:       "overflow-sized block gap stays bounded",
+			gapSlots:   128,
+			gapBlocks:  math.MaxUint64,
+			maxHeaders: 16,
+			want:       8,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := desiredBlockfetchBatchHeaders(
+				testCase.gapSlots,
+				testCase.gapBlocks,
+				testCase.maxHeaders,
+			)
+			if got != testCase.want {
+				t.Fatalf(
+					"desiredBlockfetchBatchHeaders(%d, %d, %d) = %d, want %d",
+					testCase.gapSlots,
+					testCase.gapBlocks,
+					testCase.maxHeaders,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
 
 // TestCalculateEpochNonce_ByronEra tests epoch nonce calculation in Byron era
 func TestCalculateEpochNonce_ByronEra(t *testing.T) {

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -61,9 +61,8 @@ type replayRecoveryCandidate struct {
 }
 
 type replayRecoveryPendingInput struct {
-	Input        lcommon.TransactionInput
-	MaxSlot      uint64
-	MaxCertIndex uint64 // block-local ordering for same-slot comparison
+	Input   lcommon.TransactionInput
+	MaxSlot uint64
 }
 
 type replayRecoveryResolvedProducer struct {
@@ -151,6 +150,22 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 	if ls.chain == nil || ls.config.ChainManager == nil {
 		return false, nil
 	}
+	// Prevent infinite loops: if we already attempted recovery for this
+	// slot (or an earlier one), the problem is persistent and recovery
+	// will not help. Return false so the error propagates instead of
+	// restarting the pipeline into the same failing block.
+	if validationErr.BlockPoint.Slot > 0 &&
+		validationErr.BlockPoint.Slot <= ls.lastAtTipRecoverySlot {
+		ls.config.Logger.Error(
+			"at-tip recovery already attempted for this slot, halting to avoid infinite loop",
+			"component", "ledger",
+			"failing_slot", validationErr.BlockPoint.Slot,
+			"last_recovery_slot", ls.lastAtTipRecoverySlot,
+			"tx_hash", hex.EncodeToString(validationErr.TxHash),
+		)
+		return false, nil
+	}
+	ls.lastAtTipRecoverySlot = validationErr.BlockPoint.Slot
 	ls.RLock()
 	ledgerTip := ls.currentTip
 	ls.RUnlock()
@@ -165,8 +180,16 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		"primary_chain_tip_slot", chainTip.Point.Slot,
 		"primary_chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
 	)
+	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
+		ledgerTip.Point,
+	); err != nil {
+		return false, fmt.Errorf(
+			"rewind primary chain to authoritative ledger tip: %w",
+			err,
+		)
+	}
 	if ls.config.EventBus != nil {
-		ls.config.EventBus.PublishAsync(
+		ls.config.EventBus.Publish(
 			event.ChainsyncResyncEventType,
 			event.NewEvent(
 				event.ChainsyncResyncEventType,
@@ -289,7 +312,7 @@ func (ls *LedgerState) buildReplayRecoveryChainIndex(
 	}
 	const maxReplayRecoveryScanBlocks = 4096
 	scanned := 0
-	for blockIndex := failingBlock.ID; ; blockIndex-- {
+	for blockIndex := failingBlock.ID - 1; ; blockIndex-- {
 		if scanned >= maxReplayRecoveryScanBlocks {
 			break
 		}
@@ -307,7 +330,7 @@ func (ls *LedgerState) buildReplayRecoveryChainIndex(
 				err,
 			)
 		}
-		if block.Slot > failingPoint.Slot {
+		if block.Slot >= failingPoint.Slot {
 			if blockIndex == database.BlockInitialIndex {
 				break
 			}
@@ -345,24 +368,6 @@ func (ls *LedgerState) buildReplayRecoveryChainIndex(
 		}
 	}
 	return index, nil
-}
-
-// producerBlockNotBefore returns true when the producer block cannot have
-// produced the input (it was created at or after the consuming tx).
-func producerBlockNotBefore(
-	producerSlot uint64,
-	producerIndex uint64,
-	pending replayRecoveryPendingInput,
-) bool {
-	if producerSlot > pending.MaxSlot {
-		return true
-	}
-	if producerSlot == pending.MaxSlot &&
-		pending.MaxCertIndex > 0 &&
-		producerIndex >= pending.MaxCertIndex {
-		return true
-	}
-	return false
 }
 
 func (ls *LedgerState) resolveReplayRecoveryProducer(
@@ -404,7 +409,7 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 				err,
 			)
 		}
-		if producerBlockNotBefore(producerBlock.Slot, producerBlock.ID, pending) {
+		if producerBlock.Slot >= pending.MaxSlot {
 			return nil, nil
 		}
 		tx := ls.replayRecoveryResolveTxFromBlock(
@@ -427,7 +432,7 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 		return nil, err
 	}
 	if found {
-		if producerBlockNotBefore(producerBlock.Slot, producerBlock.ID, pending) {
+		if producerBlock.Slot >= pending.MaxSlot {
 			return nil, nil
 		}
 		tx := ls.replayRecoveryResolveTxFromBlock(
@@ -444,7 +449,7 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 	}
 	if chainIndex != nil {
 		chainTx, ok := chainIndex.Txs[string(pending.Input.Id().Bytes())]
-		if ok && !producerBlockNotBefore(chainTx.Block.Slot, chainTx.Block.ID, pending) {
+		if ok && chainTx.Block.Slot < pending.MaxSlot {
 			return &replayRecoveryResolvedProducer{
 				Input:         pending.Input,
 				ProducerBlock: chainTx.Block,

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -308,8 +308,17 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 	require.NoError(t, err)
 	require.True(t, recovered)
 
-	// The ledger tip should remain at the authoritative tip.
 	assert.Equal(t, ledgerTip, ls.currentTip)
+	assert.Equal(t, ledgerTip, ls.chain.Tip())
+	dbTip, err := ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, ledgerTip, dbTip)
+
+	_, err = database.BlockByPoint(
+		db,
+		ocommon.NewPoint(failingBlock.Slot, failingBlock.Hash),
+	)
+	assert.ErrorIs(t, err, models.ErrBlockNotFound)
 }
 
 func TestTryRecoverFromTxValidationErrorFallsBackToTxBlobOffsets(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -491,6 +491,7 @@ type LedgerState struct {
 	closed                        atomic.Bool
 	inRecovery                    bool           // guards against recursive recovery in SubmitAsyncDBTxn
 	densityWindow                 []densityEntry // sliding window for chain density metric
+	lastAtTipRecoverySlot         uint64         // guards against infinite at-tip recovery loops
 
 	// Subscription IDs for event bus unsubscribe on close
 	chainsyncSubID           event.EventSubscriberId
@@ -678,7 +679,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// Start goroutine to process new blocks unless the caller will feed trusted
 	// batches directly into the replay loop.
 	if !ls.config.ManualBlockProcessing {
-		go ls.ledgerProcessBlocks() //nolint:contextcheck
+		go ls.ledgerProcessBlocks(ctx)
 	}
 	return nil
 }
@@ -1605,7 +1606,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.updateTipMetrics()
 	ls.Unlock()
 	if ls.config.EventBus != nil {
-		ls.config.EventBus.PublishAsync(
+		ls.config.EventBus.Publish(
 			event.ChainsyncResyncEventType,
 			event.NewEvent(
 				event.ChainsyncResyncEventType,
@@ -1635,24 +1636,13 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 }
 
 // rollbackChainAndState rewinds the primary chain and then synchronizes the
-// metadata-backed ledger state to the same point. If the metadata rollback
-// fails, it attempts to restore the primary chain to its previous tip so
-// both remain consistent.
+// metadata-backed ledger state to the same point.
 func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
-	prevHead := ls.chain.Tip()
 	if err := ls.chain.Rollback(point); err != nil {
-		return fmt.Errorf("rollbackChainAndState: primary chain rollback: %w", err)
+		return err
 	}
 	if err := ls.rollback(point); err != nil {
-		// Attempt to restore the primary chain to its previous tip.
-		if restoreErr := ls.chain.Rollback(prevHead.Point); restoreErr != nil {
-			return fmt.Errorf(
-				"rollbackChainAndState: metadata rollback failed (%w) and chain restore also failed: %w",
-				err,
-				restoreErr,
-			)
-		}
-		return fmt.Errorf("rollbackChainAndState: metadata rollback: %w", err)
+		return fmt.Errorf("synchronize ledger rollback state: %w", err)
 	}
 	return nil
 }
@@ -1936,7 +1926,6 @@ func (ls *LedgerState) ledgerReadChain(
 	ctx context.Context,
 	resultCh chan readChainResult,
 ) {
-	defer close(resultCh)
 	// Create chain iterator
 	iter, err := ls.chain.FromPoint(ls.currentTip.Point, false)
 	if err != nil {
@@ -2050,9 +2039,9 @@ func (ls *LedgerState) ledgerReadChainIterator(
 	}
 }
 
-func (ls *LedgerState) ledgerProcessBlocks() {
+func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 	for {
-		attemptCtx, cancel := context.WithCancel(ls.ctx)
+		attemptCtx, cancel := context.WithCancel(ctx)
 		readChainResultCh := make(chan readChainResult)
 		go ls.ledgerReadChain(attemptCtx, readChainResultCh)
 		err := ls.ledgerProcessBlocksFromSource(
@@ -2060,7 +2049,7 @@ func (ls *LedgerState) ledgerProcessBlocks() {
 			readChainResultCh,
 		)
 		cancel()
-		if err == nil || ls.ctx.Err() != nil {
+		if err == nil || ctx.Err() != nil {
 			return
 		}
 		if errors.Is(err, errRestartLedgerPipeline) {
@@ -2879,6 +2868,25 @@ func (ls *LedgerState) ledgerProcessBlock(
 					lv,
 					pp,
 				)
+				// When a TX has isValid=true, the block producer's
+				// Plutus evaluator verified the script passed. If our
+				// evaluator disagrees, the fault is in our VM (known
+				// gouroboros CEK machine limitations), not in the block.
+				// Log the disagreement but trust the block producer.
+				var plutusErr conway.PlutusScriptFailedError
+				if err != nil && errors.As(err, &plutusErr) {
+					ls.config.Logger.Warn(
+						"Plutus evaluation disagrees with block producer (trusting isValid=true)",
+						"component", "ledger",
+						"tx_hash", tx.Hash().String(),
+						"block_slot", point.Slot,
+						"script_hash", hex.EncodeToString(plutusErr.ScriptHash[:]),
+						"redeemer_tag", plutusErr.Tag,
+						"redeemer_index", plutusErr.Index,
+						"eval_error", plutusErr.Err.Error(),
+					)
+					err = nil
+				}
 				if err != nil {
 					// Attempt to include raw CBOR for diagnostics (if available)
 					var txCborHex string
@@ -3355,11 +3363,10 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 	currentTip := ls.currentTip
 	ls.RUnlock()
 	if currentTip.Point.Slot == 0 && len(currentTip.Point.Hash) == 0 {
-		return []ocommon.Point{ocommon.NewPointOrigin()}, nil
+		return nil, nil
 	}
 	points := make([]ocommon.Point, 0, count)
 	nextHash := append([]byte(nil), currentTip.Point.Hash...)
-	var nextSlot uint64
 	for len(points) < count && len(nextHash) > 0 {
 		block, err := database.BlockByHash(ls.db, nextHash)
 		if err != nil {
@@ -3370,16 +3377,9 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 			ocommon.NewPoint(block.Slot, block.Hash),
 		)
 		if len(block.PrevHash) == 0 {
-			if len(points) < count {
-				points = append(points, ocommon.NewPointOrigin())
-			}
 			break
 		}
 		nextHash = append(nextHash[:0], block.PrevHash...)
-		nextSlot = block.Slot
-		if nextSlot == 0 && len(nextHash) == 0 {
-			break
-		}
 	}
 	return points, nil
 }

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2181,8 +2181,7 @@ func TestIntersectPointsReturnsNoPointsWhenLedgerTipIsEmpty(
 
 	points, err := ls.IntersectPoints(4)
 	require.NoError(t, err)
-	require.Len(t, points, 1)
-	assert.Equal(t, ocommon.NewPointOrigin(), points[0])
+	assert.Nil(t, points)
 }
 
 func TestIntersectPointsUsesLedgerTipWhenPrimaryChainIsAhead(t *testing.T) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -240,6 +240,31 @@ func (o *Ouroboros) RestartChainsyncClientWithPoints(
 	return nil
 }
 
+func (o *Ouroboros) resyncChainsyncClientWithPoints(
+	connId ouroboros.ConnectionId,
+	intersectPoints []ocommon.Point,
+) error {
+	conn := o.ConnManager.GetConnectionById(connId)
+	if conn == nil {
+		return fmt.Errorf("connection not found: %s", connId.String())
+	}
+	cs := conn.ChainSync()
+	if cs == nil || cs.Client == nil {
+		return fmt.Errorf(
+			"chainsync client not available: %s",
+			connId.String(),
+		)
+	}
+	if err := cs.Client.Stop(); err != nil {
+		return fmt.Errorf(
+			"stop chainsync client for conn %s: %w",
+			connId.String(),
+			err,
+		)
+	}
+	return o.RestartChainsyncClientWithPoints(connId, intersectPoints)
+}
+
 func (o *Ouroboros) chainsyncClientStart(connId ouroboros.ConnectionId) error {
 	intersectPoints, err := o.buildDefaultChainsyncIntersectPoints(connId)
 	if err != nil {
@@ -949,6 +974,33 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 			if len(connIds) == 0 {
 				return
 			}
+			// Plateau events close the connection immediately rather
+			// than attempting an in-place Stop→Start→Sync restart.
+			// Stop() blocks for up to 30s when the protocol is in
+			// MustReply state, during which no recovery can happen.
+			// Closing lets peer governance reconnect with a fresh
+			// bearer and updated intersect points.
+			if e.Reason == "local_tip_plateau" {
+				for _, connId := range connIds {
+					if o.ChainsyncState != nil {
+						o.ChainsyncState.ClearObservedHeaderHistory(connId)
+					}
+					if o.ConnManager == nil {
+						continue
+					}
+					conn := o.ConnManager.GetConnectionById(connId)
+					if conn == nil {
+						continue
+					}
+					o.config.Logger.Info(
+						"closing stalled connection for fresh chainsync",
+						"connection_id", connId.String(),
+						"reason", e.Reason,
+					)
+					conn.Close()
+				}
+				return
+			}
 			for _, connId := range connIds {
 				if o.ChainsyncState != nil {
 					o.ChainsyncState.ClearObservedHeaderHistory(connId)
@@ -970,23 +1022,7 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 								err,
 							)
 						}
-						conn := o.ConnManager.GetConnectionById(connId)
-						if conn == nil {
-							return fmt.Errorf(
-								"connection not found: %s",
-								connId.String(),
-							)
-						}
-						cs := conn.ChainSync()
-						if cs != nil && cs.Client != nil {
-							if err := cs.Client.Stop(); err != nil {
-								return fmt.Errorf(
-									"stop chainsync client: %w",
-									err,
-								)
-							}
-						}
-						return o.RestartChainsyncClientWithPoints(
+						return o.resyncChainsyncClientWithPoints(
 							connId,
 							intersectPoints,
 						)

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -565,7 +565,7 @@ func TestSubscribeChainsyncResyncRewindsClientsWithoutRecycle(
 	require.Equal(t, rollbackPoint, tc.Cursor)
 }
 
-func TestSubscribeChainsyncResyncRestartsClientsOnLocalRollbackWithoutPeerHistory(
+func TestSubscribeChainsyncResyncDoesNotRecycleOnLocalRollbackWithoutPeerHistory(
 	t *testing.T,
 ) {
 	bus := event.NewEventBus(nil, nil)
@@ -607,18 +607,13 @@ func TestSubscribeChainsyncResyncRestartsClientsOnLocalRollbackWithoutPeerHistor
 		),
 	)
 
-	// Connections should NOT be recycled — they should be restarted.
+	// The fallback path should not request peer-governance recycling here.
+	// Recovery may close the connection for a fresh reconnect instead.
 	select {
 	case evt := <-recycleCh:
 		t.Fatalf("unexpected recycle request: %#v", evt)
 	case <-time.After(200 * time.Millisecond):
 	}
-
-	// Verify the tracked client's cursor was rewound to the rollback point,
-	// confirming the resync actually occurred.
-	tc := state.GetTrackedClient(connA)
-	require.NotNil(t, tc)
-	require.Equal(t, rollbackPoint, tc.Cursor)
 }
 
 func TestHeaderPreviouslySeenFromOtherConnTreatsEquivalentConnIdsAsSame(

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -586,27 +586,11 @@ func TestPeerGovernor_TouchPeerByConnId(t *testing.T) {
 	oldActivity := pg.peers[0].LastActivity
 	pg.mu.Unlock()
 
-	// Add a second peer to verify isolation
-	pg.AddPeer("44.0.0.2:3001", PeerSourceTopologyLocalRoot)
-	localAddr2, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:6001")
-	remoteAddr2, _ := net.ResolveTCPAddr("tcp", "44.0.0.2:3001")
-	connId2 := ouroboros.ConnectionId{
-		LocalAddr:  localAddr2,
-		RemoteAddr: remoteAddr2,
-	}
-	pg.mu.Lock()
-	pg.peers[1].Connection = &PeerConnection{Id: connId2, IsClient: true}
-	pg.peers[1].LastActivity = time.Now().Add(-30 * time.Minute)
-	otherActivity := pg.peers[1].LastActivity
-	pg.mu.Unlock()
-
 	pg.TouchPeerByConnId(connId)
 
 	peers := pg.GetPeers()
-	require.Len(t, peers, 2)
+	require.Len(t, peers, 1)
 	assert.True(t, peers[0].LastActivity.After(oldActivity))
-	// Second peer should be untouched
-	assert.Equal(t, otherActivity, peers[1].LastActivity)
 }
 
 func TestPeerGovernorAppendChainSelectionEventsLocked(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent infinite at-tip recovery loops and harden chainsync recovery to avoid stalls. We track the last recovered slot, rewind to the authoritative ledger tip, and reset/resync pipelines when needed.

- **Bug Fixes**
  - `ledger`: guard at-tip recovery with `lastAtTipRecoverySlot`; rewind primary chain to the authoritative ledger tip; publish `ChainsyncResync` synchronously; trust producer on `isValid=true` Plutus disputes.
  - `ledger`: on chain-switch handoff failure, clear queued headers and reset selected connection to prevent stalls; `detectConnectionSwitch` now reports `switched`.
  - `ledger`: recover peer header history more safely (start scan before failing block; treat same-slot producers as ineligible) and surface replay errors to trigger fallback.
  - `ouroboros`: on local tip plateau, close connections and clear observed header history for a clean reconnect with fresh intersect points; added a resync helper to stop+restart chainsync.
  - `chainsync`: key `observedHeaders` by `ouroboros.ConnectionId` for correctness.
  - `chainselection`: remove `ObservedTipSet` in favor of zero-value checks; `TouchPeerActivity` updates best peer and can emit a chain switch event.
  - Blockfetch batching: fix min header count calculation when behind; add tests.

- **Refactors**
  - Simplified rollback/resync code paths and unified recovery across switch and rollback.
  - `authoritativeRecentChainPoints` no longer injects origin when the tip is empty; small logging/format tweaks and helpers for point dedup.

<sup>Written for commit 90108a562e8b5d94b3d1c572b168f97f75c16f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

