### PR TITLE
feat(bark): add pruner to delete blocks outside of safety window

### DIFF
--- a/bark/pruner.go
+++ b/bark/pruner.go
@@ -16,6 +16,9 @@ package bark
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"sync"
 	"time"
@@ -42,16 +45,42 @@ type Pruner struct {
 	cancel context.CancelFunc
 }
 
-func NewPruner(config PrunerConfig) *Pruner {
+func NewPruner(cfg PrunerConfig) *Pruner {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
 	return &Pruner{
-		config:      config,
-		logger:      config.Logger,
-		ledgerState: config.LedgerState,
-		db:          config.DB,
+		config:      cfg,
+		logger:      cfg.Logger,
+		ledgerState: cfg.LedgerState,
+		db:          cfg.DB,
 	}
 }
 
-func (p *Pruner) prune() {
+func (p *Pruner) pruneBlock(next *database.BlobBlockResult) error {
+	txn := p.db.BlobTxn(true)
+	return txn.Do(func(txn *database.Txn) error {
+		_, metadata, err := p.db.Blob().GetBlock(txn, next.Slot, next.Hash)
+		if err != nil {
+			return fmt.Errorf(
+				"pruner: failed to get block metadata: %w",
+				err,
+			)
+		}
+		if err := p.db.Blob().DeleteBlock(
+			txn,
+			next.Slot,
+			next.Hash,
+			metadata.ID,
+		); err != nil {
+			return fmt.Errorf("pruner: failed to delete block: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (p *Pruner) prune(ctx context.Context) {
 	currentSlot, err := p.ledgerState.CurrentSlot()
 	if err != nil {
 		p.logger.Error(
@@ -62,51 +91,43 @@ func (p *Pruner) prune() {
 		return
 	}
 
-	if currentSlot < p.config.SecurityWindow {
+	if currentSlot <= p.config.SecurityWindow {
 		p.logger.Debug(
 			"pruner: skipped because current slot is not high enough")
 		return
 	}
-	iter := p.db.BlocksInRange(0, currentSlot-p.config.SecurityWindow)
+	iter := p.db.BlocksInRange(
+		0,
+		currentSlot-p.config.SecurityWindow-1,
+	)
 	defer iter.Close()
 
 	for {
-		next, err := iter.NextRaw()
-		if err != nil {
-			p.logger.Error(
-				"pruner: failed to get next block",
-				"error",
-				err,
-			)
+		select {
+		case <-ctx.Done():
 			return
-		}
-		if next == nil {
-			p.logger.Debug("pruner: completed round of pruning")
-			return
-		}
+		default:
+			next, err := iter.NextRaw()
+			if err != nil {
+				p.logger.Error(
+					"pruner: failed to prune block",
+					"error",
+					err,
+				)
+				return
+			}
+			if next == nil {
+				p.logger.Debug("pruner: completed round of pruning")
+				return
+			}
 
-		txn := p.db.BlobTxn(true)
-		_, metadata, err := p.db.Blob().GetBlock(txn, next.Slot, next.Hash)
-		if err != nil {
-			p.logger.Error(
-				"pruner: failed to get block",
-				"error",
-				err,
-			)
-			return
-		}
-		if err := p.db.Blob().DeleteBlock(
-			txn,
-			next.Slot,
-			next.Hash,
-			metadata.ID,
-		); err != nil {
-			p.logger.Error(
-				"pruner: failed to delete block",
-				"error",
-				err,
-			)
-			return
+			if err := p.pruneBlock(next); err != nil {
+				p.logger.Error(
+					"pruner: failed to prune block",
+					"error",
+					err,
+				)
+			}
 		}
 	}
 }
@@ -117,7 +138,7 @@ func (p *Pruner) run(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			p.prune()
+			p.prune(ctx)
 		case <-ctx.Done():
 			return
 		}
@@ -125,7 +146,20 @@ func (p *Pruner) run(ctx context.Context) {
 }
 
 func (p *Pruner) Start(ctx context.Context) error {
-	ctx, p.cancel = context.WithCancel(ctx)
+	if p.config.Frequency <= 0 {
+		return fmt.Errorf(
+			"pruner: invalid frequency %d (must be > 0)",
+			p.config.Frequency,
+		)
+	}
+	if p.ledgerState == nil {
+		return errors.New("pruner: ledger state must not be nil")
+	}
+	if p.db == nil {
+		return errors.New("pruner: database must not be nil")
+	}
+
+	ctx, p.cancel = context.WithCancel(ctx) //nolint:gosec
 
 	p.wg.Add(1)
 	go func() {
@@ -135,8 +169,23 @@ func (p *Pruner) Start(ctx context.Context) error {
 	return nil
 }
 
-func (p *Pruner) Close(ctx context.Context) error {
-	p.cancel()
-	p.wg.Wait()
-	return nil
+func (p *Pruner) Stop(ctx context.Context) error {
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.wg.Wait()
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf(
+			"pruner: failed to stop before context cancellation: %w",
+			ctx.Err(),
+		)
+	}
 }

--- a/node.go
+++ b/node.go
@@ -61,6 +61,7 @@ type Node struct {
 	snapshotMgr                      *snapshot.Manager
 	utxorpc                          *utxorpc.Utxorpc
 	bark                             *bark.Bark
+	barkPruner                       *bark.Pruner
 	blockfrostAPI                    *blockfrost.Blockfrost
 	meshAPI                          *mesh.Server
 	ouroboros                        *ouroborosPkg.Ouroboros
@@ -531,7 +532,7 @@ func (n *Node) Run(ctx context.Context) error {
 			Logger:      n.config.logger,
 		}, n.db.Blob()))
 
-		pruner := bark.NewPruner(bark.PrunerConfig{
+		n.barkPruner = bark.NewPruner(bark.PrunerConfig{
 			LedgerState:    state,
 			DB:             n.db,
 			Logger:         n.config.logger,
@@ -539,12 +540,12 @@ func (n *Node) Run(ctx context.Context) error {
 			Frequency:      time.Hour,
 		})
 
-		if err := pruner.Start(n.ctx); err != nil {
+		if err := n.barkPruner.Start(n.ctx); err != nil {
 			return fmt.Errorf("failed to start pruner: %w", err)
 		}
 
 		started = append(started, func() {
-			pruner.Close(context.Background())
+			_ = n.barkPruner.Stop(context.Background())
 		})
 	}
 
@@ -1115,6 +1116,14 @@ func (n *Node) shutdown() error {
 	if n.bark != nil {
 		if stopErr := n.bark.Stop(ctx); stopErr != nil {
 			err = errors.Join(err, fmt.Errorf("bark shutdown: %w", stopErr))
+		}
+	}
+
+	if n.barkPruner != nil {
+		if stopErr := n.barkPruner.Stop(ctx); stopErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("bark pruner shutdown: %w", stopErr))
 		}
 	}
 


### PR DESCRIPTION
closes #336


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a background pruner in `bark` that deletes block blobs older than the configured `barkSecurityWindow` to reduce disk usage. It runs hourly, starts with the node, and stops cleanly on shutdown.

- **New Features**
  - Added `Pruner` with `PrunerConfig` (`LedgerState`, `DB`, `Logger`, `SecurityWindow`, `Frequency`); wired into node start/stop.
  - Each tick gets the current slot and deletes blocks with slot < (currentSlot - `SecurityWindow`) in a DB transaction; validates `Frequency` > 0, requires `LedgerState` and `DB`, skips until the window is reached, and logs errors (aborts the round on iterator errors).

<sup>Written for commit 09f4d6dabae37ab37ab749714b38506598374b11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background pruning of old blockchain blobs to reduce database storage; runs periodically and respects a configurable safety window.

* **Bug Fixes**
  * Pruner starts with the node and is cleanly stopped during shutdown to improve reliability and surface errors in logs.
  * Pruning now logs and aborts individual rounds on retrieval or deletion errors to avoid partial/unsafe deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->