### PR TITLE
feat(metrics): add network label to all prometheus metrics

### DIFF
--- a/config.go
+++ b/config.go
@@ -147,6 +147,29 @@ func (n *Node) configPopulateNetworkMagic() error {
 	return nil
 }
 
+// configWrapPromRegistry wraps the prometheus registry with a "network" label
+// so that all metrics registered through it carry the network name automatically.
+func (n *Node) configWrapPromRegistry() {
+	if n.config.promRegistry == nil {
+		return
+	}
+	// Determine the network name: prefer the configured name, fall back to
+	// reverse-lookup by network magic.
+	networkName := n.config.network
+	if networkName == "" {
+		if net, ok := ouroboros.NetworkByNetworkMagic(n.config.networkMagic); ok {
+			networkName = net.String()
+		}
+	}
+	if networkName == "" {
+		return
+	}
+	n.config.promRegistry = prometheus.WrapRegistererWith(
+		prometheus.Labels{"network": networkName},
+		n.config.promRegistry,
+	)
+}
+
 // isDevMode returns true if running in development mode
 func (c *Config) isDevMode() bool {
 	return c.runMode == runModeDev

--- a/node.go
+++ b/node.go
@@ -366,6 +366,9 @@ func New(cfg Config) (*Node, error) {
 	if err := n.configPopulateNetworkMagic(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
+	// Wrap the prometheus registry with a "network" label so all metrics
+	// registered by subsystems carry the network name automatically.
+	n.configWrapPromRegistry()
 	if err := n.configValidate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}

--- a/node.go
+++ b/node.go
@@ -358,17 +358,17 @@ func (n *Node) handleChainSwitchEvent(evt event.Event) {
 }
 
 func New(cfg Config) (*Node, error) {
-	eventBus := event.NewEventBus(cfg.promRegistry, cfg.logger)
 	n := &Node{
-		config:   cfg,
-		eventBus: eventBus,
+		config: cfg,
 	}
 	if err := n.configPopulateNetworkMagic(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 	// Wrap the prometheus registry with a "network" label so all metrics
 	// registered by subsystems carry the network name automatically.
+	// This must happen before any component registers metrics.
 	n.configWrapPromRegistry()
+	n.eventBus = event.NewEventBus(n.config.promRegistry, n.config.logger)
 	if err := n.configValidate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Wraps the prometheus registry with a constant `network` label after the network magic is resolved
- Every metric registered by subsystems automatically carries `network="mainnet"` (or preview, preprod, etc.) with zero changes to individual metric definitions
- If network was configured by name, that name is used; if only magic number was provided, reverse-lookups via `ouroboros.NetworkByNetworkMagic()`

## Motivation
Enables Grafana dashboards to use a `$network` template variable for filtering metrics by Cardano network. This is essential for operators running multiple networks or for portable dashboard sets that need to distinguish between mainnet/preview/preprod.

## Changes
- `config.go`: new `configWrapPromRegistry()` method that wraps the registry with `prometheus.WrapRegistererWith(prometheus.Labels{"network": networkName}, registry)`
- `node.go`: single call to `configWrapPromRegistry()` between `configPopulateNetworkMagic()` and `configValidate()` in `New()`

## Test plan
- [ ] Verify build: `go build ./...` passes
- [ ] Start dingo on preview network, confirm `curl localhost:12798/metrics | grep network=` shows `network="preview"` on all metrics
- [ ] Start dingo with magic number only, confirm network name is resolved via reverse-lookup
- [ ] Start dingo with no registry configured, confirm no panic (nil check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Prometheus metrics monitoring infrastructure by adding network identification labels, enabling operators to better track and distinguish metrics across different network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->