### PR TITLE
fix(ouroboros): gate Leios protocols behind EnableLeios config

### DIFF
--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -254,23 +254,28 @@ func (o *Ouroboros) ConfigureListeners(
 						)...,
 					),
 				),
-				ouroboros.WithLeiosFetchConfig(
-					oleiosfetch.NewConfig(
-						slices.Concat(
-							o.leiosfetchClientConnOpts(),
-							o.leiosfetchServerConnOpts(),
-						)...,
-					),
-				),
-				ouroboros.WithLeiosNotifyConfig(
-					oleiosnotify.NewConfig(
-						slices.Concat(
-							o.leiosnotifyClientConnOpts(),
-							o.leiosnotifyServerConnOpts(),
-						)...,
-					),
-				),
 			)
+			if o.config.EnableLeios {
+				l.ConnectionOpts = append(
+					l.ConnectionOpts,
+					ouroboros.WithLeiosFetchConfig(
+						oleiosfetch.NewConfig(
+							slices.Concat(
+								o.leiosfetchClientConnOpts(),
+								o.leiosfetchServerConnOpts(),
+							)...,
+						),
+					),
+					ouroboros.WithLeiosNotifyConfig(
+						oleiosnotify.NewConfig(
+							slices.Concat(
+								o.leiosnotifyClientConnOpts(),
+								o.leiosnotifyServerConnOpts(),
+							)...,
+						),
+					),
+				)
+			}
 		}
 		tmpListeners[idx] = l
 	}
@@ -278,7 +283,7 @@ func (o *Ouroboros) ConfigureListeners(
 }
 
 func (o *Ouroboros) OutboundConnOpts() []ouroboros.ConnectionOptionFunc {
-	return []ouroboros.ConnectionOptionFunc{
+	opts := []ouroboros.ConnectionOptionFunc{
 		ouroboros.WithNetworkMagic(o.config.NetworkMagic),
 		ouroboros.WithNodeToNode(true),
 		ouroboros.WithKeepAlive(true),
@@ -319,23 +324,29 @@ func (o *Ouroboros) OutboundConnOpts() []ouroboros.ConnectionOptionFunc {
 				)...,
 			),
 		),
-		ouroboros.WithLeiosFetchConfig(
-			oleiosfetch.NewConfig(
-				slices.Concat(
-					o.leiosfetchClientConnOpts(),
-					o.leiosfetchServerConnOpts(),
-				)...,
-			),
-		),
-		ouroboros.WithLeiosNotifyConfig(
-			oleiosnotify.NewConfig(
-				slices.Concat(
-					o.leiosnotifyClientConnOpts(),
-					o.leiosnotifyServerConnOpts(),
-				)...,
-			),
-		),
 	}
+	if o.config.EnableLeios {
+		opts = append(
+			opts,
+			ouroboros.WithLeiosFetchConfig(
+				oleiosfetch.NewConfig(
+					slices.Concat(
+						o.leiosfetchClientConnOpts(),
+						o.leiosfetchServerConnOpts(),
+					)...,
+				),
+			),
+			ouroboros.WithLeiosNotifyConfig(
+				oleiosnotify.NewConfig(
+					slices.Concat(
+						o.leiosnotifyClientConnOpts(),
+						o.leiosnotifyServerConnOpts(),
+					)...,
+				),
+			),
+		)
+	}
+	return opts
 }
 
 func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {


### PR DESCRIPTION
Leios mini-protocols (LeiosFetch, LeiosNotify) were unconditionally registered on all connections. Non-Leios peers (e.g. cardano-node) reject the unknown MiniProtocolNum 10 with a muxer error and immediately reset the connection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Leios mini-protocols behind the `EnableLeios` config to prevent non-Leios peers from rejecting unknown protocols and resetting connections. Leios is now enabled only when explicitly configured, avoiding muxer errors with cardano-node.

- **Bug Fixes**
  - Register `LeiosFetch` and `LeiosNotify` only when `o.config.EnableLeios` is true for listeners and outbound connections.
  - Prevent MiniProtocolNum 10 “unknown” muxer errors and connection resets with non-Leios peers.

<sup>Written for commit 91c4cc91515c983715e85f32d8b7823b26fb91b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Leios mini-protocols are now conditionally registered based on configuration settings. Connection option construction has been updated to include Leios components only when explicitly enabled, providing more flexible control over node-to-node network protocols for both listener and outbound connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->