### PR TITLE
Blockfrost API: Address and UTxO endpoints

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -561,7 +561,11 @@ func (a *NodeAdapter) AddressUTXOs(
 		)
 	}
 
-	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(addr)
+	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			Addresses: []lcommon.Address{addr},
+		},
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get address UTxOs for %q: %w",

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -577,10 +577,7 @@ func (a *NodeAdapter) AddressUTXOs(
 	}
 
 	paged := paginateUtxos(utxos, params)
-	txBlockHashes, err := a.addressUtxoBlockHashes(
-		addr,
-		paged,
-	)
+	txBlockHashes, err := a.addressUtxoBlockHashes(paged)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get block hashes for address UTxOs %q: %w",
@@ -681,7 +678,6 @@ func (a *NodeAdapter) AddressTransactions(
 }
 
 func (a *NodeAdapter) addressUtxoBlockHashes(
-	addr lcommon.Address,
 	utxos []models.UtxoWithOrdering,
 ) (map[string]string, error) {
 	ret := make(map[string]string, len(utxos))
@@ -689,11 +685,18 @@ func (a *NodeAdapter) addressUtxoBlockHashes(
 		return ret, nil
 	}
 
-	txs, err := a.ledgerState.GetTransactionsByAddress(
-		addr,
-		0,
-		0,
-	)
+	hashes := make([][]byte, 0, len(utxos))
+	seen := make(map[string]struct{}, len(utxos))
+	for _, utxo := range utxos {
+		txKey := hex.EncodeToString(utxo.TxId)
+		if _, ok := seen[txKey]; ok {
+			continue
+		}
+		seen[txKey] = struct{}{}
+		hashes = append(hashes, utxo.TxId)
+	}
+
+	txs, err := a.ledgerState.GetTransactionsByHashes(hashes)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"get transactions for address UTxO block mapping: %w",
@@ -760,7 +763,6 @@ func paginateUtxos(
 	}
 	return utxos[start:end]
 }
-
 
 func paginationRange(
 	total int,

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -605,25 +605,36 @@ func (a *NodeAdapter) AddressTransactions(
 		return nil, 0, ErrInvalidAddress
 	}
 
-	txs, err := a.ledgerState.GetTransactionsByAddress(
+	total, err := a.ledgerState.CountTransactionsByAddress(addr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	txs, err := a.ledgerState.GetTransactionsByAddressWithOrder(
 		addr,
-		0,
-		0,
+		params.Count,
+		(params.Page-1)*params.Count,
+		params.Order,
 	)
 	if err != nil {
 		return nil, 0, err
 	}
-	total := len(txs)
-	if params.Order == PaginationOrderAsc {
-		for left, right := 0, len(txs)-1; left < right; left, right = left+1, right-1 {
-			txs[left], txs[right] = txs[right], txs[left]
-		}
-	}
 
-	paged := paginateTransactions(txs, params)
-	ret := make([]AddressTransactionInfo, 0, len(paged))
-	for _, tx := range paged {
-		blockHeight, blockTime, err := a.transactionBlockInfo(tx)
+	blockNumbers := make(map[string]uint64, len(txs))
+	ret := make([]AddressTransactionInfo, 0, len(txs))
+	for _, tx := range txs {
+		blockHashKey := hex.EncodeToString(tx.BlockHash)
+		blockHeight, ok := blockNumbers[blockHashKey]
+		if !ok {
+			block, err := a.ledgerState.BlockByHash(tx.BlockHash)
+			if err != nil {
+				return nil, 0, err
+			}
+			blockHeight = block.Number
+			blockNumbers[blockHashKey] = blockHeight
+		}
+
+		blockTime, err := a.transactionBlockTime(tx)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -660,18 +671,14 @@ func (a *NodeAdapter) addressUtxoBlockHashes(
 	return ret, nil
 }
 
-func (a *NodeAdapter) transactionBlockInfo(
+func (a *NodeAdapter) transactionBlockTime(
 	tx models.Transaction,
-) (uint64, int64, error) {
-	block, err := a.ledgerState.BlockByHash(tx.BlockHash)
-	if err != nil {
-		return 0, 0, err
-	}
+) (int64, error) {
 	blockTime, err := a.ledgerState.SlotToTime(tx.Slot)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
-	return block.Number, blockTime.Unix(), nil
+	return blockTime.Unix(), nil
 }
 
 func addressAmountsFromUtxo(

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -766,6 +766,12 @@ func paginationRange(
 	total int,
 	params PaginationParams,
 ) (int, int) {
+	if total <= 0 || params.Count <= 0 || params.Page <= 0 {
+		return total, total
+	}
+	if params.Page-1 > (math.MaxInt / params.Count) {
+		return total, total
+	}
 	start := (params.Page - 1) * params.Count
 	if start >= total {
 		return total, total

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -554,12 +554,20 @@ func (a *NodeAdapter) AddressUTXOs(
 ) ([]AddressUTXOInfo, int, error) {
 	addr, err := lcommon.NewAddress(address)
 	if err != nil {
-		return nil, 0, ErrInvalidAddress
+		return nil, 0, fmt.Errorf(
+			"parse address %q: %w",
+			address,
+			ErrInvalidAddress,
+		)
 	}
 
 	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(addr)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf(
+			"get address UTxOs for %q: %w",
+			address,
+			err,
+		)
 	}
 	total := len(utxos)
 	if params.Order == PaginationOrderDesc {
@@ -574,7 +582,11 @@ func (a *NodeAdapter) AddressUTXOs(
 		paged,
 	)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf(
+			"get block hashes for address UTxOs %q: %w",
+			address,
+			err,
+		)
 	}
 
 	ret := make([]AddressUTXOInfo, 0, len(paged))
@@ -602,12 +614,20 @@ func (a *NodeAdapter) AddressTransactions(
 ) ([]AddressTransactionInfo, int, error) {
 	addr, err := lcommon.NewAddress(address)
 	if err != nil {
-		return nil, 0, ErrInvalidAddress
+		return nil, 0, fmt.Errorf(
+			"parse address %q: %w",
+			address,
+			ErrInvalidAddress,
+		)
 	}
 
 	total, err := a.ledgerState.CountTransactionsByAddress(addr)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf(
+			"count address transactions for %q: %w",
+			address,
+			err,
+		)
 	}
 
 	txs, err := a.ledgerState.GetTransactionsByAddressWithOrder(
@@ -617,7 +637,11 @@ func (a *NodeAdapter) AddressTransactions(
 		params.Order,
 	)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf(
+			"get address transactions for %q: %w",
+			address,
+			err,
+		)
 	}
 
 	blockNumbers := make(map[string]uint64, len(txs))
@@ -628,7 +652,11 @@ func (a *NodeAdapter) AddressTransactions(
 		if !ok {
 			block, err := a.ledgerState.BlockByHash(tx.BlockHash)
 			if err != nil {
-				return nil, 0, err
+				return nil, 0, fmt.Errorf(
+					"get block for transaction %x: %w",
+					tx.Hash,
+					err,
+				)
 			}
 			blockHeight = block.Number
 			blockNumbers[blockHashKey] = blockHeight
@@ -636,7 +664,11 @@ func (a *NodeAdapter) AddressTransactions(
 
 		blockTime, err := a.transactionBlockTime(tx)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf(
+				"get block time for transaction %x: %w",
+				tx.Hash,
+				err,
+			)
 		}
 		ret = append(ret, AddressTransactionInfo{
 			TxHash:      hex.EncodeToString(tx.Hash),
@@ -663,7 +695,10 @@ func (a *NodeAdapter) addressUtxoBlockHashes(
 		0,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"get transactions for address UTxO block mapping: %w",
+			err,
+		)
 	}
 	for _, tx := range txs {
 		ret[hex.EncodeToString(tx.Hash)] = hex.EncodeToString(tx.BlockHash)
@@ -676,7 +711,12 @@ func (a *NodeAdapter) transactionBlockTime(
 ) (int64, error) {
 	blockTime, err := a.ledgerState.SlotToTime(tx.Slot)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf(
+			"convert slot %d to block time for transaction %x: %w",
+			tx.Slot,
+			tx.Hash,
+			err,
+		)
 	}
 	return blockTime.Unix(), nil
 }

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -33,6 +33,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
+var ErrInvalidAddress = errors.New("invalid address")
+
 // NodeAdapter wraps a real dingo Node's LedgerState to
 // implement the BlockfrostNode interface.
 type NodeAdapter struct {
@@ -542,4 +544,198 @@ func uintToInt(v uint) int {
 		return math.MaxInt
 	}
 	return int(v)
+}
+
+// AddressUTXOs returns paginated current UTxOs for the
+// requested address.
+func (a *NodeAdapter) AddressUTXOs(
+	address string,
+	params PaginationParams,
+) ([]AddressUTXOInfo, int, error) {
+	addr, err := lcommon.NewAddress(address)
+	if err != nil {
+		return nil, 0, ErrInvalidAddress
+	}
+
+	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(addr)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(utxos)
+	if params.Order == PaginationOrderDesc {
+		for left, right := 0, len(utxos)-1; left < right; left, right = left+1, right-1 {
+			utxos[left], utxos[right] = utxos[right], utxos[left]
+		}
+	}
+
+	paged := paginateUtxos(utxos, params)
+	txBlockHashes, err := a.addressUtxoBlockHashes(
+		addr,
+		paged,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	ret := make([]AddressUTXOInfo, 0, len(paged))
+	for _, utxo := range paged {
+		txKey := hex.EncodeToString(utxo.TxId)
+		ret = append(ret, AddressUTXOInfo{
+			Address:             address,
+			TxHash:              txKey,
+			OutputIndex:         utxo.OutputIdx,
+			Amount:              addressAmountsFromUtxo(utxo.Utxo),
+			Block:               txBlockHashes[txKey],
+			DataHash:            optionalHexString(utxo.DatumHash),
+			InlineDatum:         nil,
+			ReferenceScriptHash: nil,
+		})
+	}
+	return ret, total, nil
+}
+
+// AddressTransactions returns paginated transaction
+// history for the requested address.
+func (a *NodeAdapter) AddressTransactions(
+	address string,
+	params PaginationParams,
+) ([]AddressTransactionInfo, int, error) {
+	addr, err := lcommon.NewAddress(address)
+	if err != nil {
+		return nil, 0, ErrInvalidAddress
+	}
+
+	txs, err := a.ledgerState.GetTransactionsByAddress(
+		addr,
+		0,
+		0,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(txs)
+	if params.Order == PaginationOrderAsc {
+		for left, right := 0, len(txs)-1; left < right; left, right = left+1, right-1 {
+			txs[left], txs[right] = txs[right], txs[left]
+		}
+	}
+
+	paged := paginateTransactions(txs, params)
+	ret := make([]AddressTransactionInfo, 0, len(paged))
+	for _, tx := range paged {
+		blockHeight, blockTime, err := a.transactionBlockInfo(tx)
+		if err != nil {
+			return nil, 0, err
+		}
+		ret = append(ret, AddressTransactionInfo{
+			TxHash:      hex.EncodeToString(tx.Hash),
+			TxIndex:     tx.BlockIndex,
+			BlockHeight: blockHeight,
+			BlockTime:   blockTime,
+		})
+	}
+	return ret, total, nil
+}
+
+func (a *NodeAdapter) addressUtxoBlockHashes(
+	addr lcommon.Address,
+	utxos []models.UtxoWithOrdering,
+) (map[string]string, error) {
+	ret := make(map[string]string, len(utxos))
+	if len(utxos) == 0 {
+		return ret, nil
+	}
+
+	txs, err := a.ledgerState.GetTransactionsByAddress(
+		addr,
+		0,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, tx := range txs {
+		ret[hex.EncodeToString(tx.Hash)] = hex.EncodeToString(tx.BlockHash)
+	}
+	return ret, nil
+}
+
+func (a *NodeAdapter) transactionBlockInfo(
+	tx models.Transaction,
+) (uint64, int64, error) {
+	block, err := a.ledgerState.BlockByHash(tx.BlockHash)
+	if err != nil {
+		return 0, 0, err
+	}
+	blockTime, err := a.ledgerState.SlotToTime(tx.Slot)
+	if err != nil {
+		return 0, 0, err
+	}
+	return block.Number, blockTime.Unix(), nil
+}
+
+func addressAmountsFromUtxo(
+	utxo models.Utxo,
+) []AddressAmountInfo {
+	ret := make([]AddressAmountInfo, 0, len(utxo.Assets)+1)
+	ret = append(ret, AddressAmountInfo{
+		Unit:     "lovelace",
+		Quantity: strconv.FormatUint(uint64(utxo.Amount), 10),
+	})
+	for _, asset := range utxo.Assets {
+		ret = append(ret, AddressAmountInfo{
+			Unit: hex.EncodeToString(asset.PolicyId) +
+				hex.EncodeToString(asset.Name),
+			Quantity: strconv.FormatUint(
+				uint64(asset.Amount),
+				10,
+			),
+		})
+	}
+	return ret
+}
+
+func optionalHexString(data []byte) *string {
+	if len(data) == 0 {
+		return nil
+	}
+	ret := hex.EncodeToString(data)
+	return &ret
+}
+
+func paginateUtxos(
+	utxos []models.UtxoWithOrdering,
+	params PaginationParams,
+) []models.UtxoWithOrdering {
+	start, end := paginationRange(len(utxos), params)
+	if start >= end {
+		return []models.UtxoWithOrdering{}
+	}
+	return utxos[start:end]
+}
+
+func paginateTransactions(
+	txs []models.Transaction,
+	params PaginationParams,
+) []models.Transaction {
+	start, end := paginationRange(len(txs), params)
+	if start >= end {
+		return []models.Transaction{}
+	}
+	return txs[start:end]
+}
+
+func paginationRange(
+	total int,
+	params PaginationParams,
+) (int, int) {
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return total, total
+	}
+	end := start + params.Count
+	if end > total {
+		end = total
+	}
+	return start, end
 }

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -761,16 +761,6 @@ func paginateUtxos(
 	return utxos[start:end]
 }
 
-func paginateTransactions(
-	txs []models.Transaction,
-	params PaginationParams,
-) []models.Transaction {
-	start, end := paginationRange(len(txs), params)
-	if start >= end {
-		return []models.Transaction{}
-	}
-	return txs[start:end]
-}
 
 func paginationRange(
 	total int,

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -94,6 +94,14 @@ func (b *Blockfrost) Start(
 		"GET /api/v0/pools/extended",
 		b.handlePoolsExtended,
 	)
+	mux.HandleFunc(
+		"GET /api/v0/addresses/{address}/utxos",
+		b.handleAddressUTXOs,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/addresses/{address}/transactions",
+		b.handleAddressTransactions,
+	)
 
 	// Wrap handler with a request body size limit (1 MB)
 	// as defense-in-depth against oversized payloads.

--- a/blockfrost/blockfrost_compat_test.go
+++ b/blockfrost/blockfrost_compat_test.go
@@ -260,6 +260,67 @@ func TestCompatProtocolParamsResponse(t *testing.T) {
 	assert.Equal(t, 3, *theirs.MaxCollateralInputs)
 }
 
+func TestCompatAddressUTXOResponse(t *testing.T) {
+	dataHash := "datumhash1"
+	inlineDatum := "d8799f"
+	refScriptHash := "scripthash1"
+	ours := AddressUTXOResponse{
+		Address:     "addr1...",
+		TxHash:      "txhash1",
+		OutputIndex: 1,
+		Amount: []AddressAmountResponse{
+			{Unit: "lovelace", Quantity: "1000"},
+			{Unit: "policyasset", Quantity: "5"},
+		},
+		Block:               "blockhash1",
+		DataHash:            &dataHash,
+		InlineDatum:         &inlineDatum,
+		ReferenceScriptHash: &refScriptHash,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.AddressUTXO
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "addr1...", theirs.Address)
+	assert.Equal(t, "txhash1", theirs.TxHash)
+	assert.Equal(t, 1, theirs.OutputIndex)
+	require.Len(t, theirs.Amount, 2)
+	assert.Equal(t, "lovelace", theirs.Amount[0].Unit)
+	assert.Equal(t, "1000", theirs.Amount[0].Quantity)
+	assert.Equal(t, "blockhash1", theirs.Block)
+	require.NotNil(t, theirs.DataHash)
+	assert.Equal(t, "datumhash1", *theirs.DataHash)
+	require.NotNil(t, theirs.InlineDatum)
+	assert.Equal(t, "d8799f", *theirs.InlineDatum)
+	require.NotNil(t, theirs.ReferenceScriptHash)
+	assert.Equal(t, "scripthash1", *theirs.ReferenceScriptHash)
+}
+
+func TestCompatAddressTransactionResponse(t *testing.T) {
+	ours := AddressTransactionResponse{
+		TxHash:      "txhash1",
+		TxIndex:     3,
+		BlockHeight: 99,
+		BlockTime:   1700000000,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.AddressTransactions
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "txhash1", theirs.TxHash)
+	assert.Equal(t, 3, theirs.TxIndex)
+	assert.Equal(t, 99, theirs.BlockHeight)
+	assert.Equal(t, 1700000000, theirs.BlockTime)
+}
+
 // TestCompatHealthResponse verifies that our
 // HealthResponse round-trips through blockfrost-go's
 // Health type.

--- a/blockfrost/blockfrost_compat_test.go
+++ b/blockfrost/blockfrost_compat_test.go
@@ -317,7 +317,7 @@ func TestCompatAddressTransactionResponse(t *testing.T) {
 
 	assert.Equal(t, "txhash1", theirs.TxHash)
 	assert.Equal(t, 3, theirs.TxIndex)
-	assert.Equal(t, 99, theirs.BlockHeight)
+	assert.EqualValues(t, 99, theirs.BlockHeight)
 	assert.Equal(t, 1700000000, theirs.BlockTime)
 }
 

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -33,18 +33,24 @@ func intPtr(v int) *int {
 
 // mockNode implements BlockfrostNode for testing.
 type mockNode struct {
-	chainTip    ChainTipInfo
-	block       BlockInfo
-	txHashes    []string
-	epoch       EpochInfo
-	params      ProtocolParamsInfo
-	pools       []PoolExtendedInfo
-	chainTipErr error
-	blockErr    error
-	txHashesErr error
-	epochErr    error
-	paramsErr   error
-	poolsErr    error
+	chainTip               ChainTipInfo
+	block                  BlockInfo
+	txHashes               []string
+	epoch                  EpochInfo
+	params                 ProtocolParamsInfo
+	pools                  []PoolExtendedInfo
+	addressUTXOs           []AddressUTXOInfo
+	addressTransactions    []AddressTransactionInfo
+	addressUTXOsTotal      int
+	addressTxsTotal        int
+	chainTipErr            error
+	blockErr               error
+	txHashesErr            error
+	epochErr               error
+	paramsErr              error
+	poolsErr               error
+	addressUTXOsErr        error
+	addressTransactionsErr error
 }
 
 func (m *mockNode) ChainTip() (
@@ -81,6 +87,20 @@ func (m *mockNode) PoolsExtended() (
 	[]PoolExtendedInfo, error,
 ) {
 	return m.pools, m.poolsErr
+}
+
+func (m *mockNode) AddressUTXOs(
+	_ string,
+	_ PaginationParams,
+) ([]AddressUTXOInfo, int, error) {
+	return m.addressUTXOs, m.addressUTXOsTotal, m.addressUTXOsErr
+}
+
+func (m *mockNode) AddressTransactions(
+	_ string,
+	_ PaginationParams,
+) ([]AddressTransactionInfo, int, error) {
+	return m.addressTransactions, m.addressTxsTotal, m.addressTransactionsErr
 }
 
 func newTestBlockfrost(
@@ -609,4 +629,118 @@ func TestDefaultListenAddress(t *testing.T) {
 		slog.Default(),
 	)
 	assert.Equal(t, ":3000", b.config.ListenAddress)
+}
+
+func TestHandleAddressUTXOs(t *testing.T) {
+	mock := &mockNode{
+		addressUTXOsTotal: 2,
+		addressUTXOs: []AddressUTXOInfo{
+			{
+				Address:     "addr_test1vr8nl4...",
+				TxHash:      "txhash1",
+				OutputIndex: 1,
+				Amount: []AddressAmountInfo{
+					{Unit: "lovelace", Quantity: "1000"},
+					{Unit: "policyasset", Quantity: "5"},
+				},
+				Block: "blockhash1",
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/addr_test1vr8nl4.../utxos?count=1&page=1&order=desc",
+		nil,
+	)
+	req.SetPathValue("address", "addr_test1vr8nl4...")
+	w := httptest.NewRecorder()
+	b.handleAddressUTXOs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Page-Total"))
+
+	var resp []AddressUTXOResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "addr_test1vr8nl4...", resp[0].Address)
+	assert.Equal(t, "txhash1", resp[0].TxHash)
+	assert.Equal(t, 1, resp[0].OutputIndex)
+	assert.Equal(t, "lovelace", resp[0].Amount[0].Unit)
+	assert.Equal(t, "1000", resp[0].Amount[0].Quantity)
+	assert.Equal(t, "blockhash1", resp[0].Block)
+}
+
+func TestHandleAddressUTXOsInvalidPagination(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/addr_test1vr8nl4.../utxos?count=abc",
+		nil,
+	)
+	req.SetPathValue("address", "addr_test1vr8nl4...")
+	w := httptest.NewRecorder()
+	b.handleAddressUTXOs(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "Invalid pagination parameters.", resp.Message)
+}
+
+func TestHandleAddressUTXOsInvalidAddress(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		addressUTXOsErr: ErrInvalidAddress,
+	})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/not_an_address/utxos",
+		nil,
+	)
+	req.SetPathValue("address", "not_an_address")
+	w := httptest.NewRecorder()
+	b.handleAddressUTXOs(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAddressTransactions(t *testing.T) {
+	mock := &mockNode{
+		addressTxsTotal: 3,
+		addressTransactions: []AddressTransactionInfo{
+			{
+				TxHash:      "txhash1",
+				TxIndex:     2,
+				BlockHeight: 55,
+				BlockTime:   1700000000,
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/addr_test1vr8nl4.../transactions?count=2&page=1",
+		nil,
+	)
+	req.SetPathValue("address", "addr_test1vr8nl4...")
+	w := httptest.NewRecorder()
+	b.handleAddressTransactions(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "3", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Page-Total"))
+
+	var resp []AddressTransactionResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "txhash1", resp[0].TxHash)
+	assert.Equal(t, 2, resp[0].TxIndex)
+	assert.Equal(t, 55, resp[0].BlockHeight)
+	assert.Equal(t, 1700000000, resp[0].BlockTime)
 }

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -741,6 +741,6 @@ func TestHandleAddressTransactions(t *testing.T) {
 	require.Len(t, resp, 1)
 	assert.Equal(t, "txhash1", resp[0].TxHash)
 	assert.Equal(t, 2, resp[0].TxIndex)
-	assert.Equal(t, 55, resp[0].BlockHeight)
+	assert.EqualValues(t, 55, resp[0].BlockHeight)
 	assert.Equal(t, 1700000000, resp[0].BlockTime)
 }

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -16,6 +16,7 @@ package blockfrost
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -358,4 +359,135 @@ func (b *Blockfrost) handlePoolsExtended(
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleAddressUTXOs handles GET /api/v0/addresses/{address}/utxos
+// and returns the current UTxOs for an address.
+func (b *Blockfrost) handleAddressUTXOs(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
+		return
+	}
+	address := r.PathValue("address")
+	utxos, total, err := b.node.AddressUTXOs(address, params)
+	if err != nil {
+		b.logger.Error(
+			"failed to get address utxos",
+			"address", address,
+			"error", err,
+		)
+		writeNodeQueryError(
+			w,
+			err,
+			"failed to retrieve address UTxOs",
+		)
+		return
+	}
+
+	SetPaginationHeaders(w, total, params)
+	resp := make([]AddressUTXOResponse, 0, len(utxos))
+	for _, utxo := range utxos {
+		resp = append(resp, AddressUTXOResponse{
+			Address:             utxo.Address,
+			TxHash:              utxo.TxHash,
+			OutputIndex:         int(utxo.OutputIndex),
+			Amount:              convertAddressAmounts(utxo.Amount),
+			Block:               utxo.Block,
+			DataHash:            utxo.DataHash,
+			InlineDatum:         utxo.InlineDatum,
+			ReferenceScriptHash: utxo.ReferenceScriptHash,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleAddressTransactions handles GET /api/v0/addresses/{address}/transactions
+// and returns transaction history for an address.
+func (b *Blockfrost) handleAddressTransactions(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
+		return
+	}
+	address := r.PathValue("address")
+	txs, total, err := b.node.AddressTransactions(address, params)
+	if err != nil {
+		b.logger.Error(
+			"failed to get address transactions",
+			"address", address,
+			"error", err,
+		)
+		writeNodeQueryError(
+			w,
+			err,
+			"failed to retrieve address transactions",
+		)
+		return
+	}
+
+	SetPaginationHeaders(w, total, params)
+	resp := make([]AddressTransactionResponse, 0, len(txs))
+	for _, tx := range txs {
+		resp = append(resp, AddressTransactionResponse{
+			TxHash:      tx.TxHash,
+			TxIndex:     int(tx.TxIndex),
+			BlockHeight: tx.BlockHeight,
+			BlockTime:   int(tx.BlockTime),
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func parsePaginationOrWriteError(
+	w http.ResponseWriter,
+	r *http.Request,
+) (PaginationParams, bool) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return PaginationParams{}, false
+	}
+	return params, true
+}
+
+func writeNodeQueryError(
+	w http.ResponseWriter,
+	err error,
+	message string,
+) {
+	if errors.Is(err, ErrInvalidAddress) {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid address provided.",
+		)
+		return
+	}
+	writeError(
+		w,
+		http.StatusInternalServerError,
+		"Internal Server Error",
+		message,
+	)
+}
+
+func convertAddressAmounts(
+	amounts []AddressAmountInfo,
+) []AddressAmountResponse {
+	ret := make([]AddressAmountResponse, 0, len(amounts))
+	for _, amount := range amounts {
+		ret = append(ret, AddressAmountResponse(amount))
+	}
+	return ret
 }

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -41,6 +41,22 @@ type BlockfrostNode interface {
 	// PoolsExtended returns the current active pools with
 	// extended details.
 	PoolsExtended() ([]PoolExtendedInfo, error)
+
+	// AddressUTXOs returns the paginated current UTxOs for
+	// an address along with the total number of matching
+	// results before pagination.
+	AddressUTXOs(
+		address string,
+		params PaginationParams,
+	) ([]AddressUTXOInfo, int, error)
+
+	// AddressTransactions returns the paginated transaction
+	// history for an address along with the total number of
+	// matching results before pagination.
+	AddressTransactions(
+		address string,
+		params PaginationParams,
+	) ([]AddressTransactionInfo, int, error)
 }
 
 // ChainTipInfo holds chain tip data needed by the API.
@@ -127,4 +143,33 @@ type PoolRelayInfo struct {
 	IPv6 string
 	DNS  string
 	Port *int
+}
+
+// AddressAmountInfo holds amount data needed by address
+// UTxO responses.
+type AddressAmountInfo struct {
+	Unit     string
+	Quantity string
+}
+
+// AddressUTXOInfo holds address UTxO data needed by the
+// API.
+type AddressUTXOInfo struct {
+	Address             string
+	TxHash              string
+	OutputIndex         uint32
+	Amount              []AddressAmountInfo
+	Block               string
+	DataHash            *string
+	InlineDatum         *string
+	ReferenceScriptHash *string
+}
+
+// AddressTransactionInfo holds address transaction data
+// needed by the API.
+type AddressTransactionInfo struct {
+	TxHash      string
+	TxIndex     uint32
+	BlockHeight uint64
+	BlockTime   int64
 }

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -145,7 +145,7 @@ type AddressUTXOResponse struct {
 type AddressTransactionResponse struct {
 	TxHash      string `json:"tx_hash"`
 	TxIndex     int    `json:"tx_index"`
-	BlockHeight int    `json:"block_height"`
+	BlockHeight uint64 `json:"block_height"`
 	BlockTime   int    `json:"block_time"`
 }
 

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -120,6 +120,35 @@ type NetworkStake struct {
 	Active string `json:"active"`
 }
 
+// AddressAmountResponse represents a Blockfrost address
+// amount object.
+type AddressAmountResponse struct {
+	Unit     string `json:"unit"`
+	Quantity string `json:"quantity"`
+}
+
+// AddressUTXOResponse represents a Blockfrost address
+// UTxO object.
+type AddressUTXOResponse struct {
+	Address             string                  `json:"address"`
+	TxHash              string                  `json:"tx_hash"`
+	OutputIndex         int                     `json:"output_index"`
+	Amount              []AddressAmountResponse `json:"amount"`
+	Block               string                  `json:"block"`
+	DataHash            *string                 `json:"data_hash"`
+	InlineDatum         *string                 `json:"inline_datum"`
+	ReferenceScriptHash *string                 `json:"reference_script_hash"`
+}
+
+// AddressTransactionResponse represents a Blockfrost
+// address transaction object.
+type AddressTransactionResponse struct {
+	TxHash      string `json:"tx_hash"`
+	TxIndex     int    `json:"tx_index"`
+	BlockHeight int    `json:"block_height"`
+	BlockTime   int    `json:"block_time"`
+}
+
 // ErrorResponse represents a Blockfrost error response.
 type ErrorResponse struct {
 	StatusCode int    `json:"status_code"`

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -222,6 +222,51 @@ func (d *MetadataStoreMysql) GetTransactionsByAddress(
 	return ret, nil
 }
 
+// CountTransactionsByAddress returns the total number of
+// distinct transactions involving the given
+// payment/staking key.
+func (d *MetadataStoreMysql) CountTransactionsByAddress(
+	paymentKey []byte,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(paymentKey) == 0 && len(stakingKey) == 0 {
+		return 0, nil
+	}
+
+	addrQuery := db.Model(&models.AddressTransaction{})
+	switch {
+	case len(paymentKey) > 0 && len(stakingKey) > 0:
+		addrQuery = addrQuery.Where(
+			"payment_key = ? AND staking_key = ?",
+			paymentKey,
+			stakingKey,
+		)
+	case len(paymentKey) > 0:
+		addrQuery = addrQuery.Where(
+			"payment_key = ? AND (staking_key IS NULL OR OCTET_LENGTH(staking_key) = 0)",
+			paymentKey,
+		)
+	default:
+		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+	}
+
+	var count int64
+	result := addrQuery.Distinct("transaction_id").Count(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"count txs by address: %w",
+			result.Error,
+		)
+	}
+	return int(count), nil
+}
+
 // GetAddressesByStakingKey returns distinct addresses mapped to a staking key.
 func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 	stakingKey []byte,

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -100,6 +100,33 @@ func (d *MetadataStoreMysql) GetTransactionByHash(
 	return ret, nil
 }
 
+// GetTransactionsByHashes returns transactions for the provided hashes.
+func (d *MetadataStoreMysql) GetTransactionsByHashes(
+	hashes [][]byte,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	if len(hashes) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where("hash IN ?", hashes).
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by hashes: %w", result.Error)
+	}
+	return ret, nil
+}
+
 // GetTransactionsByBlockHash returns all transactions in a block, ordered by index
 func (d *MetadataStoreMysql) GetTransactionsByBlockHash(
 	blockHash []byte,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -100,6 +100,33 @@ func (d *MetadataStorePostgres) GetTransactionByHash(
 	return ret, nil
 }
 
+// GetTransactionsByHashes returns transactions for the provided hashes.
+func (d *MetadataStorePostgres) GetTransactionsByHashes(
+	hashes [][]byte,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	if len(hashes) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where("hash IN ?", hashes).
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by hashes: %w", result.Error)
+	}
+	return ret, nil
+}
+
 // GetTransactionsByBlockHash returns all transactions in a block, ordered by index
 func (d *MetadataStorePostgres) GetTransactionsByBlockHash(
 	blockHash []byte,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -222,6 +222,51 @@ func (d *MetadataStorePostgres) GetTransactionsByAddress(
 	return ret, nil
 }
 
+// CountTransactionsByAddress returns the total number of
+// distinct transactions involving the given
+// payment/staking key.
+func (d *MetadataStorePostgres) CountTransactionsByAddress(
+	paymentKey []byte,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(paymentKey) == 0 && len(stakingKey) == 0 {
+		return 0, nil
+	}
+
+	addrQuery := db.Model(&models.AddressTransaction{})
+	switch {
+	case len(paymentKey) > 0 && len(stakingKey) > 0:
+		addrQuery = addrQuery.Where(
+			"payment_key = ? AND staking_key = ?",
+			paymentKey,
+			stakingKey,
+		)
+	case len(paymentKey) > 0:
+		addrQuery = addrQuery.Where(
+			"payment_key = ? AND (staking_key IS NULL OR OCTET_LENGTH(staking_key) = 0)",
+			paymentKey,
+		)
+	default:
+		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+	}
+
+	var count int64
+	result := addrQuery.Distinct("transaction_id").Count(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"count txs by address: %w",
+			result.Error,
+		)
+	}
+	return int(count), nil
+}
+
 // GetAddressesByStakingKey returns distinct addresses mapped to a staking key.
 func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 	stakingKey []byte,

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -245,6 +245,51 @@ func (d *MetadataStoreSqlite) GetTransactionsByAddress(
 	return ret, nil
 }
 
+// CountTransactionsByAddress returns the total number of
+// distinct transactions involving the given
+// payment/staking key.
+func (d *MetadataStoreSqlite) CountTransactionsByAddress(
+	paymentKey []byte,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(paymentKey) == 0 && len(stakingKey) == 0 {
+		return 0, nil
+	}
+
+	addrQuery := db.Model(&models.AddressTransaction{})
+	switch {
+	case len(paymentKey) > 0 && len(stakingKey) > 0:
+		addrQuery = addrQuery.Where(
+			"payment_key = ? AND staking_key = ?",
+			paymentKey,
+			stakingKey,
+		)
+	case len(paymentKey) > 0:
+		addrQuery = addrQuery.Where(
+			"payment_key = ? AND (staking_key IS NULL OR LENGTH(staking_key) = 0)",
+			paymentKey,
+		)
+	default:
+		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+	}
+
+	var count int64
+	result := addrQuery.Distinct("transaction_id").Count(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"count txs by address: %w",
+			result.Error,
+		)
+	}
+	return int(count), nil
+}
+
 // GetAddressesByStakingKey returns distinct addresses mapped to a staking key.
 func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 	stakingKey []byte,

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -122,6 +122,33 @@ func (d *MetadataStoreSqlite) GetTransactionByHash(
 	return ret, nil
 }
 
+// GetTransactionsByHashes returns transactions for the provided hashes.
+func (d *MetadataStoreSqlite) GetTransactionsByHashes(
+	hashes [][]byte,
+	txn types.Txn,
+) ([]models.Transaction, error) {
+	var ret []models.Transaction
+	if len(hashes) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where("hash IN ?", hashes).
+		Preload(clause.Associations).
+		Preload("Inputs.Assets").
+		Preload("Outputs.Assets").
+		Preload("Collateral.Assets").
+		Preload("ReferenceInputs.Assets").
+		Find(&ret)
+	if result.Error != nil {
+		return nil, fmt.Errorf("get txs by hashes: %w", result.Error)
+	}
+	return ret, nil
+}
+
 // GetTransactionsByBlockHash returns all transactions for a given
 // block hash, ordered by their position within the block.
 func (d *MetadataStoreSqlite) GetTransactionsByBlockHash(

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -258,6 +258,12 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Transaction, error)
 
+	// GetTransactionsByHashes retrieves transactions by their hashes.
+	GetTransactionsByHashes(
+		[][]byte, // hashes
+		types.Txn,
+	) ([]models.Transaction, error)
+
 	// GetTransactionsByBlockHash retrieves all transactions
 	// for a given block hash, ordered by block_index.
 	GetTransactionsByBlockHash(

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -276,6 +276,15 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.Transaction, error)
 
+	// CountTransactionsByAddress returns the total number of
+	// transactions involving the provided payment/staking
+	// key pair.
+	CountTransactionsByAddress(
+		[]byte, // paymentKey
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
+
 	// GetAddressesByStakingKey retrieves distinct address mappings for a staking key.
 	GetAddressesByStakingKey(
 		[]byte, // stakingKey

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -413,6 +413,34 @@ func (d *Database) GetTransactionsByAddress(
 	)
 }
 
+// GetTransactionsByAddressWithOrder returns transactions
+// involving a given address with explicit ordering.
+func (d *Database) GetTransactionsByAddressWithOrder(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+	order string,
+	txn *Txn,
+) ([]models.Transaction, error) {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	var paymentKey []byte
+	var stakingKey []byte
+	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
+		paymentKey = pkh.Bytes()
+	}
+	if skh := addr.StakeKeyHash(); skh != zeroHash {
+		stakingKey = skh.Bytes()
+	}
+	return d.GetTransactionsByAddressKeys(
+		paymentKey,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
 // GetTransactionsByAddressKeys returns transactions for a payment/staking key
 // tuple with pagination and explicit order (asc|desc).
 func (d *Database) GetTransactionsByAddressKeys(
@@ -447,6 +475,55 @@ func (d *Database) GetTransactionsByAddressKeys(
 		)
 	}
 	return txs, nil
+}
+
+// CountTransactionsByAddress returns the total number of
+// transactions involving a given address.
+func (d *Database) CountTransactionsByAddress(
+	addr lcommon.Address,
+	txn *Txn,
+) (int, error) {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	var paymentKey []byte
+	var stakingKey []byte
+	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
+		paymentKey = pkh.Bytes()
+	}
+	if skh := addr.StakeKeyHash(); skh != zeroHash {
+		stakingKey = skh.Bytes()
+	}
+	return d.CountTransactionsByAddressKeys(
+		paymentKey,
+		stakingKey,
+		txn,
+	)
+}
+
+// CountTransactionsByAddressKeys returns the total number
+// of transactions for a payment/staking key tuple.
+func (d *Database) CountTransactionsByAddressKeys(
+	paymentKey []byte,
+	stakingKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountTransactionsByAddress(
+		paymentKey,
+		stakingKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count txs by address payment=%x staking=%x: %w",
+			paymentKey,
+			stakingKey,
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetAddressesByStakingKey returns distinct address mappings for a staking key.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -360,6 +360,25 @@ func (d *Database) GetTransactionByHash(
 	return d.metadata.GetTransactionByHash(hash, txn.Metadata())
 }
 
+// GetTransactionsByHashes returns transactions for the provided hashes.
+func (d *Database) GetTransactionsByHashes(
+	hashes [][]byte,
+	txn *Txn,
+) ([]models.Transaction, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	txs, err := d.metadata.GetTransactionsByHashes(hashes, txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf("get txs by hashes: %w", err)
+	}
+	return txs, nil
+}
+
 // GetTransactionsByBlockHash returns all transactions for a given
 // block hash, ordered by their position within the block.
 func (d *Database) GetTransactionsByBlockHash(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4110,6 +4110,31 @@ func (ls *LedgerState) GetTransactionsByAddress(
 	return ls.db.GetTransactionsByAddress(addr, limit, offset, nil)
 }
 
+// GetTransactionsByAddressWithOrder returns transactions
+// involving the given address with explicit ordering.
+func (ls *LedgerState) GetTransactionsByAddressWithOrder(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+	order string,
+) ([]models.Transaction, error) {
+	return ls.db.GetTransactionsByAddressWithOrder(
+		addr,
+		limit,
+		offset,
+		order,
+		nil,
+	)
+}
+
+// CountTransactionsByAddress returns the total number of
+// transactions involving the given address.
+func (ls *LedgerState) CountTransactionsByAddress(
+	addr lcommon.Address,
+) (int, error) {
+	return ls.db.CountTransactionsByAddress(addr, nil)
+}
+
 // CountTransactionsInSlotRange returns the number of transactions whose slot
 // falls within the inclusive range [startSlot, endSlot].
 // Used by the Blockfrost adapter CurrentEpoch() path so epoch responses can

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4118,13 +4118,23 @@ func (ls *LedgerState) GetTransactionsByAddressWithOrder(
 	offset int,
 	order string,
 ) ([]models.Transaction, error) {
-	return ls.db.GetTransactionsByAddressWithOrder(
+	txs, err := ls.db.GetTransactionsByAddressWithOrder(
 		addr,
 		limit,
 		offset,
 		order,
 		nil,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get transactions by address (limit=%d offset=%d order=%s): %w",
+			limit,
+			offset,
+			order,
+			err,
+		)
+	}
+	return txs, nil
 }
 
 // CountTransactionsByAddress returns the total number of
@@ -4132,7 +4142,11 @@ func (ls *LedgerState) GetTransactionsByAddressWithOrder(
 func (ls *LedgerState) CountTransactionsByAddress(
 	addr lcommon.Address,
 ) (int, error) {
-	return ls.db.CountTransactionsByAddress(addr, nil)
+	count, err := ls.db.CountTransactionsByAddress(addr, nil)
+	if err != nil {
+		return 0, fmt.Errorf("count transactions by address: %w", err)
+	}
+	return count, nil
 }
 
 // CountTransactionsInSlotRange returns the number of transactions whose slot

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4100,6 +4100,17 @@ func (ls *LedgerState) GetTransactionsByBlockHash(
 	return ls.db.GetTransactionsByBlockHash(blockHash, nil)
 }
 
+// GetTransactionsByHashes returns transactions for the provided hashes.
+func (ls *LedgerState) GetTransactionsByHashes(
+	hashes [][]byte,
+) ([]models.Transaction, error) {
+	txs, err := ls.db.GetTransactionsByHashes(hashes, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get transactions by hashes: %w", err)
+	}
+	return txs, nil
+}
+
 // GetTransactionsByAddress returns transactions involving the given
 // address.
 func (ls *LedgerState) GetTransactionsByAddress(


### PR DESCRIPTION
1. Added `GET /api/v0/addresses/{address}/utxos` route in blockfrost.go.
2. Added `GET /api/v0/addresses/{address}/transactions` route in blockfrost.go.
3. Added `handleAddressUTXOs()` in handlers.go to parse pagination, call the node layer, and return paginated blockfrost UTxO json data.
4. Added `handleAddressTransactions()` in handlers.go to parse pagination, call the node layer, and return paginated blockfrost transaction history json data.
5. Added new blockfrost response structs in types.go such as `AddressAmountResponse`, `AddressUTXOResponse`, and `AddressTransactionResponse`.
6. Extended the blockfrost node contract in `node_interface.go` where i have added `AddressUTXOs(address, params)`, `AddressTransactions(address, params)` and some helper functions such as `AddressAmountInfo, AddressUTXOInfo, AddressTransactionInfo`.
7. Implemented NodeAdapter.AddressUTXOs(...), NodeAdapter.AddressTransactions(...) in adapter.go.
8. Added UTxO amount conversion logic in adapter.go to emit lovelace and native assets in blockfrost format.
9. Added block metadata lookup logic in adapter.go so transaction history can return `block_height` and `block_time`.
10. Added pagination helpers in adapter.go to slice returned results by count and page.
11. Fixed sqlite `GetUtxosByAddressWithOrdering()` in utxo.go by replacing raw transaction identifier usage with a quoted alias join. Also, updated the sqlite ordered UTxO query in utxo.go to use tx.slot and tx.block_index in SELECT and ORDER BY.
12. Added blockfrost handler tests in `blockfrost_test.go` for successful UTxO and transaction-history responses.
13. Added Blockfrost handler tests in `blockfrost_test.go` for invalid pagination and invalid address handling.
14. Added Blockfrost SDK compatibility tests in blockfrost_compat_test.go for AddressUTXOResponse., AddressTransactionResponse.

Closes #1366 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blockfrost-compatible address UTxO and transaction endpoints with server-side pagination and total headers. Improves performance and correctness with ordered queries, batched lookups, exact totals, and stricter input validation.

- **New Features**
  - Added GET /api/v0/addresses/{address}/utxos and /transactions with count, page, order; sets X-Pagination-Count-Total and X-Pagination-Page-Total.
  - Responses match Blockfrost: UTxOs include lovelace/native assets and optional datum/reference fields; transactions include block height/time; validates pagination and address; tests cover handlers and `blockfrost-go` shapes.

- **Bug Fixes & Refactors**
  - UTxO retrieval now uses the ordered query API and respects asc/desc; batches per-page block-hash mapping via `GetTransactionsByHashes` to avoid N+1.
  - Transaction pagination uses DB `CountTransactionsByAddress` with ordered queries for exact totals; pagination arithmetic is overflow-safe; invalid addresses and bad pagination return HTTP 400; ledger errors wrapped with context.

<sup>Written for commit 5060c9453bc1651a03da38f8fdd7cb9179270d01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /api/v0/addresses/{address}/utxos to list paginated UTXOs with amount breakdowns and optional datum/reference fields.
  * Added GET /api/v0/addresses/{address}/transactions to list paginated transactions with block height and block time.

* **Tests**
  * Added compatibility tests ensuring address UTXO and transaction responses serialize/deserialize as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->