### PR TITLE
build(make): remove test from default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' 
 .PHONY: all build mod-tidy clean format golines test bench test-load test-load-log test-load-profile
 
 # Default target
-all: format test build
+all: format build
 
 # Build target
 build: $(BINARIES)


### PR DESCRIPTION
We use explicit checks in CI, so it's fine to remove here for faster local default builds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove tests from the default `all` target to speed up local builds while keeping CI test coverage. Run tests explicitly with `make test`.

<sup>Written for commit 1cf6f1dddce5c9d17eed5e13bc9709817b87df54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update modifies the build process workflow but does not affect application functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->