### PR TITLE
fix(utxorpc): add parsed datume for readData result

### DIFF
--- a/utxorpc/plutusdata_cardano.go
+++ b/utxorpc/plutusdata_cardano.go
@@ -15,6 +15,7 @@
 package utxorpc
 
 import (
+	"errors"
 	"math/big"
 
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -22,6 +23,23 @@ import (
 	pdata "github.com/blinklabs-io/plutigo/data"
 	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
+
+// plutusDatumCBORToCardano decodes Cardano datum CBOR and maps it to
+// utxorpc.cardano.PlutusData for AnyChainDatum parsed_state (cardano).
+func plutusDatumCBORToCardano(raw []byte) (*cardano.PlutusData, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	pd, err := pdata.Decode(raw)
+	if err != nil {
+		return nil, err
+	}
+	proto := plutusDataToCardano(pd)
+	if proto == nil {
+		return nil, errors.New("unsupported PlutusData type for utxorpc mapping")
+	}
+	return proto, nil
+}
 
 // redeemerPlutusDataByKey returns Plutus redeemer payloads from the
 // transaction witness set, keyed by redeemer tag and index.

--- a/utxorpc/plutusdata_cardano_test.go
+++ b/utxorpc/plutusdata_cardano_test.go
@@ -93,6 +93,25 @@ func TestPlutusDataToCardano_ConstrLargeTagUsesAnyConstructor(t *testing.T) {
 	require.Equal(t, uint64(200), cv.Constr.AnyConstructor)
 }
 
+func TestPlutusDatumCBORToCardano_Integer(t *testing.T) {
+	raw, err := pdata.Encode(pdata.NewInteger(big.NewInt(42)))
+	require.NoError(t, err)
+	proto, err := plutusDatumCBORToCardano(raw)
+	require.NoError(t, err)
+	require.NotNil(t, proto)
+	intv, ok := proto.GetPlutusData().(*cardano.PlutusData_BigInt)
+	require.True(t, ok)
+	iv, ok := intv.BigInt.GetBigInt().(*cardano.BigInt_Int)
+	require.True(t, ok)
+	require.Equal(t, int64(42), iv.Int)
+}
+
+func TestPlutusDatumCBORToCardano_EmptyRaw(t *testing.T) {
+	proto, err := plutusDatumCBORToCardano(nil)
+	require.NoError(t, err)
+	require.Nil(t, proto)
+}
+
 // TestRedeemerPlutusDataByKey_DecodedWitness verifies that redeemer
 // Plutus data from a decoded Conway transaction is keyed identically to
 // ledger evaluation (tag + index).

--- a/utxorpc/query.go
+++ b/utxorpc/query.go
@@ -705,13 +705,21 @@ func (s *queryServiceServer) ReadData(
 			}
 			return nil, fmt.Errorf("get datum %x: %w", key, err)
 		}
-		resp.Values = append(
-			resp.Values,
-			&query.AnyChainDatum{
-				Key:         datum.Hash,
-				NativeBytes: datum.RawDatum,
-			},
-		)
+		parsed, err := plutusDatumCBORToCardano(datum.RawDatum)
+		if err != nil {
+			return nil, connect.NewError(
+				connect.CodeInternal,
+				fmt.Errorf("decode datum plutus data %x: %w", key, err),
+			)
+		}
+		acd := &query.AnyChainDatum{
+			Key:         datum.Hash,
+			NativeBytes: datum.RawDatum,
+		}
+		if parsed != nil {
+			acd.ParsedState = &query.AnyChainDatum_Cardano{Cardano: parsed}
+		}
+		resp.Values = append(resp.Values, acd)
 	}
 
 	// Get chain point (slot and hash)


### PR DESCRIPTION
Closes #1479 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add parsed Cardano datum to `ReadData` responses so clients can use structured `cardano.PlutusData` without decoding CBOR. `NativeBytes` remain unchanged for compatibility.

- **New Features**
  - `ReadData` decodes datum CBOR via `plutusDatumCBORToCardano` and sets `AnyChainDatum.ParsedState` (Cardano) when available; empty input yields nil; decode failures return an internal error.
  - Added tests for integer datum parsing and empty raw input.

<sup>Written for commit a3711d24644c3d2d0fc5bb00171d94dc952afc0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `ReadData` query now returns parsed Plutus data representations alongside raw bytes, improving data accessibility and readability.

* **Bug Fixes**
  * Enhanced error handling for malformed Plutus data decoding with detailed error reporting.

* **Tests**
  * Added comprehensive test coverage for Plutus data parsing scenarios, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->