### PR TITLE
fix(ledger): resolve post-Mithril leader election failures

### DIFF
--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -320,6 +320,42 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		return fmt.Errorf("calculate genesis distribution: %w", err)
 	}
 
+	// After Mithril import, slot 0 has no pool data. Fall back to
+	// the latest epoch's start slot where imported pools are visible.
+	if distribution.TotalPools == 0 {
+		epochs, epErr := m.db.GetEpochs(nil)
+		if epErr != nil {
+			m.logger.Warn(
+				"failed to load epochs for genesis stake fallback",
+				"component", "snapshot",
+				"error", epErr,
+				"total_pools", distribution.TotalPools,
+			)
+		} else if len(epochs) > 0 {
+			lastEpoch := epochs[len(epochs)-1]
+			m.logger.Debug(
+				"attempting genesis stake fallback from latest epoch",
+				"component", "snapshot",
+				"start_slot", lastEpoch.StartSlot,
+				"total_pools", distribution.TotalPools,
+			)
+			dist2, err2 := calculator.CalculateStakeDistribution(
+				ctx, lastEpoch.StartSlot,
+			)
+			if err2 != nil {
+				m.logger.Warn(
+					"failed to calculate fallback genesis stake distribution",
+					"component", "snapshot",
+					"error", err2,
+					"start_slot", lastEpoch.StartSlot,
+					"total_pools", distribution.TotalPools,
+				)
+			} else if dist2.TotalPools > 0 {
+				distribution = dist2
+			}
+		}
+	}
+
 	if distribution.TotalPools == 0 {
 		m.logger.Info(
 			"no genesis pools; leader election disabled"+

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3567,13 +3567,29 @@ func (ls *LedgerState) EpochNonce(epoch uint64) []byte {
 	ls.RLock()
 	// Check current epoch under read lock; copy nonce if it matches
 	if epoch == ls.currentEpoch.EpochId {
-		if len(ls.currentEpoch.Nonce) == 0 {
+		if len(ls.currentEpoch.Nonce) > 0 {
+			nonce := make([]byte, len(ls.currentEpoch.Nonce))
+			copy(nonce, ls.currentEpoch.Nonce)
 			ls.RUnlock()
+			return nonce
+		}
+		// In-memory nonce empty (e.g. after Mithril import) —
+		// fall through to DB lookup
+		ls.RUnlock()
+		ep, err := ls.db.GetEpoch(epoch, nil)
+		if err != nil {
+			ls.config.Logger.Error(
+				"failed to look up epoch nonce from DB",
+				"epoch", epoch,
+				"error", err,
+			)
 			return nil
 		}
-		nonce := make([]byte, len(ls.currentEpoch.Nonce))
-		copy(nonce, ls.currentEpoch.Nonce)
-		ls.RUnlock()
+		if ep == nil || len(ep.Nonce) == 0 {
+			return nil
+		}
+		nonce := make([]byte, len(ep.Nonce))
+		copy(nonce, ep.Nonce)
 		return nonce
 	}
 	// If the requested epoch is ahead of the ledger state (slot clock


### PR DESCRIPTION
After Mithril bootstrap, two bugs prevent block production:

1. EpochNonce() returns nil when the in-memory nonce is empty for the current epoch, even though the DB has the correct value. Fall through to DB lookup instead of returning nil early.

2. CaptureGenesisSnapshot() queries slot 0 for pool registrations, but after Mithril import epochs start at a much later slot. Fall back to the latest epoch's start slot when slot 0 yields no pools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leader election and block production after Mithril bootstrap by falling back to the DB for the current-epoch nonce when memory is empty and by deriving genesis stake from the latest epoch when slot 0 has none.

- **Bug Fixes**
  - `EpochNonce`: If the current epoch’s in-memory nonce is empty, fetch from DB and return a copy; avoid early nil.
  - `CaptureGenesisSnapshot`: When slot 0 has zero pools, recalculate stake distribution at the latest epoch’s start slot to enable leader election.

<sup>Written for commit ed3ef72c960661764b4622b7e095a714360156ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genesis snapshot handling to address edge cases with zero pools during initialization
  * Enhanced epoch nonce retrieval logic for current epochs to ensure proper data consistency and fallback mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->