### PR TITLE
fix(ledger): exempt forged-block rollbacks from loop detector

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -969,14 +969,31 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		}
 	}
 	if slotCount >= rollbackLoopThreshold {
-		ls.config.Logger.Warn(
-			"rollback loop detected, skipping rollback to break loop",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"count", slotCount,
-			"window", rollbackLoopWindow,
-		)
-		return nil
+		// Exempt rollbacks to slots where we forged a block — fork
+		// resolution on our own block is normal Ouroboros behavior
+		// (slot battles), not a pathological loop.
+		skipRollback := true
+		if checker := ls.loadForgedBlockChecker(); checker != nil {
+			if _, forged := checker.WasForgedByUs(e.Point.Slot); forged {
+				ls.config.Logger.Info(
+					"allowing rollback on forged slot (slot battle resolution)",
+					"component", "ledger",
+					"slot", e.Point.Slot,
+					"count", slotCount,
+				)
+				skipRollback = false
+			}
+		}
+		if skipRollback {
+			ls.config.Logger.Warn(
+				"rollback loop detected, skipping rollback to break loop",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"count", slotCount,
+				"window", rollbackLoopWindow,
+			)
+			return nil
+		}
 	}
 
 	// A rollback to the current tip is a no-op — the peer's


### PR DESCRIPTION
The rollback loop detector (2 rollbacks to same slot within 5 min) blocks all further rollbacks at that slot. This is correct for pathological post-Mithril cascade loops but wrong for block production: when a peer's fork wins over our forged block, rolling back through our slot is normal Ouroboros fork resolution (slot battle).

Check ForgedBlockChecker before suppressing the rollback. If we forged a block at the contested slot, allow the rollback so the node can follow the canonical chain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow rollbacks on slots where we forged a block by exempting them from the rollback loop detector. This prevents stalls during slot battles and lets the node follow the canonical chain.

- **Bug Fixes**
  - Check `ForgedBlockChecker` before suppressing rollbacks; if we forged at the contested slot, allow the rollback.
  - Log an info message when allowing the rollback; keep existing warn and suppression for true loop cases.
  - Loop protection is unchanged for non-forged slots.

<sup>Written for commit a7dd2a5c5e37a6997abdb7d70f69f798216526bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain synchronization rollback handling to properly manage cases where the local node forged blocks, reducing unnecessary warnings and ensuring more accurate synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->