### PR TITLE
feat(metrics): add network-labelled prometheus metrics and build info

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,15 +19,19 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type ListenerConfig = connmanager.ListenerConfig
@@ -145,6 +149,50 @@ func (n *Node) configPopulateNetworkMagic() error {
 		n.config = tmpCfg
 	}
 	return nil
+}
+
+// configWrapPromRegistry wraps the prometheus registry with a "network" label
+// so that all metrics registered through it carry the network name automatically.
+func (n *Node) configWrapPromRegistry() {
+	if n.config.promRegistry == nil {
+		return
+	}
+	// Determine the network name: prefer the configured name, fall back to
+	// reverse-lookup by network magic.
+	networkName := n.config.network
+	if networkName == "" {
+		if net, ok := ouroboros.NetworkByNetworkMagic(n.config.networkMagic); ok {
+			networkName = net.String()
+		} else {
+			networkName = strconv.FormatUint(uint64(n.config.networkMagic), 10)
+		}
+	}
+	if networkName == "" {
+		return
+	}
+	n.config.promRegistry = prometheus.WrapRegistererWith(
+		prometheus.Labels{"network": networkName},
+		n.config.promRegistry,
+	)
+}
+
+// registerBuildInfo registers a dingo_build_info gauge with version and
+// commit labels. The gauge is always set to 1; Grafana reads the labels.
+func (n *Node) registerBuildInfo() {
+	if n.config.promRegistry == nil {
+		return
+	}
+	promauto.With(n.config.promRegistry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "dingo_build_info",
+			Help: "dingo build information",
+		},
+		[]string{"version", "commit", "goversion"},
+	).WithLabelValues(
+		version.GetVersionString(),
+		version.CommitHash,
+		runtime.Version(),
+	).Set(1)
 }
 
 // isDevMode returns true if running in development mode

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -30,6 +30,9 @@ type stateMetrics struct {
 	blockForgingLatency prometheus.Histogram
 	forgingEnabled      prometheus.Gauge
 	nodeStartTime       prometheus.Gauge
+	tipGapSlots         prometheus.Gauge
+	shelleyStartTime    prometheus.Gauge
+	epochLengthSlots    prometheus.Gauge
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -79,6 +82,24 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.GaugeOpts{
 			Name: "cardano_node_metrics_nodeStartTime_int",
 			Help: "unix timestamp when the node started",
+		},
+	)
+	m.tipGapSlots = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "dingo_tip_gap_slots",
+			Help: "slots between wall-clock slot and chain tip",
+		},
+	)
+	m.shelleyStartTime = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "dingo_shelley_start_time",
+			Help: "Shelley genesis start as unix timestamp",
+		},
+	)
+	m.epochLengthSlots = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "dingo_epoch_length_slots",
+			Help: "slots per epoch for the current network",
 		},
 	)
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -597,6 +597,13 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	ls.metrics.nodeStartTime.Set(
 		float64(time.Now().Unix()),
 	)
+	// Set Shelley start time and epoch length from genesis config
+	if sg := ls.config.CardanoNodeConfig.ShelleyGenesis(); sg != nil {
+		ls.metrics.shelleyStartTime.Set(float64(sg.SystemStart.Unix()))
+	}
+	if ls.currentEpoch.LengthInSlots > 0 {
+		ls.metrics.epochLengthSlots.Set(float64(ls.currentEpoch.LengthInSlots))
+	}
 
 	// Initialize database worker pool for async operations
 	if !ls.config.DatabaseWorkerPoolConfig.Disabled {
@@ -1083,6 +1090,17 @@ func (ls *LedgerState) handleSlotTicks() {
 		currentEra := ls.currentEra
 		tipSlot := ls.currentTip.Point.Slot
 		ls.RUnlock()
+
+		// Update wall-clock-based metrics every tick
+		// (must run even when chain is stalled or catching up)
+		if tick.Slot > tipSlot {
+			ls.metrics.tipGapSlots.Set(float64(tick.Slot - tipSlot))
+		} else {
+			ls.metrics.tipGapSlots.Set(0)
+		}
+		if currentEpoch.LengthInSlots > 0 {
+			ls.metrics.epochLengthSlots.Set(float64(currentEpoch.LengthInSlots))
+		}
 
 		// During catch up, don't emit slot-based epoch events. Block
 		// processing handles epoch transitions for historical data. We

--- a/node.go
+++ b/node.go
@@ -358,14 +358,18 @@ func (n *Node) handleChainSwitchEvent(evt event.Event) {
 }
 
 func New(cfg Config) (*Node, error) {
-	eventBus := event.NewEventBus(cfg.promRegistry, cfg.logger)
 	n := &Node{
-		config:   cfg,
-		eventBus: eventBus,
+		config: cfg,
 	}
 	if err := n.configPopulateNetworkMagic(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
+	// Wrap the prometheus registry with a "network" label so all metrics
+	// registered by subsystems carry the network name automatically.
+	// This must happen before any component registers metrics.
+	n.configWrapPromRegistry()
+	n.registerBuildInfo()
+	n.eventBus = event.NewEventBus(n.config.promRegistry, n.config.logger)
 	if err := n.configValidate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}


### PR DESCRIPTION
Wrap the prometheus registry with a constant "network" label so every metric carries the network name automatically. Move event bus creation after registry wrapping so event bus metrics also receive the label.

Add dingo_build_info gauge (version, commit, goversion labels) and three node-level gauges for dashboard sync tracking:
  - dingo_tip_gap_slots: wall-clock slot minus chain tip
  - dingo_shelley_start_time: Shelley genesis start as unix timestamp
  - dingo_epoch_length_slots: slots per epoch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a constant `network` label to all Prometheus metrics and introduces build and sync-tracking gauges for better, multi-network observability. Event bus metrics now include the `network` label too.

- New Features
  - Wrapped Prometheus registerer with a `network` label (uses configured name or falls back to network magic); event bus is created after wrapping so its metrics are labeled.
  - Added gauges: `dingo_build_info` (labels: `version`, `commit`, `goversion`), `dingo_tip_gap_slots`, `dingo_shelley_start_time`, `dingo_epoch_length_slots` (set on start and updated on slot ticks).

- Migration
  - Update dashboards/PromQL to include the `network="<name>"` selector where needed.

<sup>Written for commit e6d121f028d5ba5128538a1330212b44016df67d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

