### PR TITLE
fix(chainselection): prefer observed frontier and keep quiet local roots hot

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -166,11 +166,11 @@ func (cs *ChainSelector) Stop() {
 // and slot.
 //
 // Returns true if the tip was accepted, false if it was rejected as
-// implausible. A tip is considered implausible if a known peer claims a
-// block number more than securityParam (k) blocks ahead of its own previous
-// tip. New (unknown) peers are always accepted to support cold-start
-// scenarios such as Mithril bootstrap where the first peers may be far
-// ahead of any local reference.
+// implausible. A tip is considered implausible if it claims a block number
+// more than securityParam (k) blocks ahead of a reference point. For known
+// peers, the reference is the peer's own previous tip; for new peers, the
+// reference is the best known peer tip. This avoids rejecting legitimate
+// peers during sync (where the local tip is far behind).
 func (cs *ChainSelector) UpdatePeerTip(
 	connId ouroboros.ConnectionId,
 	tip ochainsync.Tip,
@@ -194,37 +194,46 @@ func (cs *ChainSelector) updatePeerTipObserved(
 		defer cs.mutex.Unlock()
 
 		// Reject implausible tips that claim to be too far ahead of
-		// a reference point. Only checked for known peers: chainsync
-		// advances incrementally so a known peer's tip should never
-		// jump more than k blocks between updates.
-		//
-		// New peers are accepted unconditionally. Restricting new
-		// peers based on the best known peer tip breaks cold-start
-		// scenarios (e.g., Mithril bootstrap) where the reference
-		// is stale and legitimate peers are >k blocks ahead. Once
-		// a new peer is tracked, subsequent updates are bounded by
-		// this check. Non-functional peers are evicted by the stale
-		// tip threshold.
+		// a reference point. Three cases:
+		//  1. Known peer: compare against the peer's own previous
+		//     tip — chainsync advances incrementally so the delta
+		//     is always small. Always checked (even if prev == 0).
+		//  2. New peer with existing peers: compare against the
+		//     best known peer tip to prevent a malicious newcomer
+		//     from spoofing an extremely high block number.
+		//  3. First peer ever: no reference exists, accept to
+		//     allow bootstrap.
 		if cs.securityParam > 0 {
+			rejectTip := false
+			var referenceBlock uint64
 			if prevTip, exists := cs.peerTips[connId]; exists {
-				referenceBlock := prevTip.Tip.BlockNumber
-				if tip.BlockNumber >
-					safeAddUint64(referenceBlock, cs.securityParam) {
-					cs.config.Logger.Warn(
-						"rejecting implausible peer tip",
-						"connection_id", connId.String(),
-						"claimed_block", tip.BlockNumber,
-						"reference_block", referenceBlock,
-						"security_param", cs.securityParam,
-						"max_plausible_block",
-						safeAddUint64(
-							referenceBlock,
-							cs.securityParam,
-						),
-					)
-					accepted = false
-					return
+				// Case 1: known peer — always check
+				referenceBlock = prevTip.Tip.BlockNumber
+				rejectTip = tip.BlockNumber >
+					safeAddUint64(referenceBlock, cs.securityParam)
+			} else if len(cs.peerTips) > 0 {
+				// Case 2: new peer — check against best known
+				for _, pt := range cs.peerTips {
+					if pt.Tip.BlockNumber > referenceBlock {
+						referenceBlock = pt.Tip.BlockNumber
+					}
 				}
+				rejectTip = tip.BlockNumber >
+					safeAddUint64(referenceBlock, cs.securityParam)
+			}
+			// Case 3: len(peerTips)==0 && peer not known → bootstrap
+			if rejectTip {
+				cs.config.Logger.Warn(
+					"rejecting implausible peer tip",
+					"connection_id", connId.String(),
+					"claimed_block", tip.BlockNumber,
+					"reference_block", referenceBlock,
+					"security_param", cs.securityParam,
+					"max_plausible_block",
+					safeAddUint64(referenceBlock, cs.securityParam),
+				)
+				accepted = false
+				return
 			}
 		}
 
@@ -307,30 +316,22 @@ func (cs *ChainSelector) updatePeerTipObserved(
 }
 
 func (cs *ChainSelector) TouchPeerActivity(connId ouroboros.ConnectionId) {
-	shouldEvaluate := false
+	var switchEvent *event.Event
+	var selectionEvent *event.Event
 
-	cs.mutex.Lock()
-	peerTip, exists := cs.peerTips[connId]
-	if !exists {
-		cs.mutex.Unlock()
-		return
-	}
-	peerTip.Touch()
-	newBest := cs.selectBestChainLocked()
-	switch {
-	case cs.bestPeerConn == nil && newBest != nil:
-		shouldEvaluate = true
-	case cs.bestPeerConn != nil && newBest == nil:
-		shouldEvaluate = true
-	case cs.bestPeerConn != nil && newBest != nil &&
-		*cs.bestPeerConn != *newBest:
-		shouldEvaluate = true
-	}
-	cs.mutex.Unlock()
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
 
-	if shouldEvaluate {
-		cs.EvaluateAndSwitch()
-	}
+		peerTip, exists := cs.peerTips[connId]
+		if !exists {
+			return
+		}
+		peerTip.Touch()
+		_, switchEvent, selectionEvent = cs.evaluateBestPeerLocked()
+	}()
+
+	cs.publishSelectionEvents(switchEvent, selectionEvent)
 }
 
 // evictLeastRecentPeerLocked removes the peer with the oldest LastUpdated
@@ -717,10 +718,146 @@ func (cs *ChainSelector) triggerEvaluation() {
 	}
 }
 
+func (cs *ChainSelector) publishSelectionEvents(
+	switchEvent *event.Event,
+	selectionEvent *event.Event,
+) {
+	if cs.config.EventBus == nil {
+		return
+	}
+	if switchEvent != nil {
+		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+	}
+	if selectionEvent != nil {
+		cs.config.EventBus.Publish(ChainSelectionEventType, *selectionEvent)
+	}
+}
+
+func (cs *ChainSelector) evaluateBestPeerLocked() (
+	bool,
+	*event.Event,
+	*event.Event,
+) {
+	var switchEvent *event.Event
+	var selectionEvent *event.Event
+	switchOccurred := false
+
+	newBest := cs.selectBestChainLocked()
+	if newBest == nil {
+		// Clear stale reference to avoid returning a disconnected peer
+		cs.bestPeerConn = nil
+		return false, nil, nil
+	}
+
+	previousBest := cs.bestPeerConn
+	if previousBest != nil && *previousBest != *newBest {
+		previousPeerTip, ok := cs.peerTips[*previousBest]
+		if ok && cs.isPeerSelectableLocked(*previousBest, previousPeerTip, false) {
+			newPeerTip, ok := cs.peerTips[*newBest]
+			if !ok {
+				return false, nil, nil
+			}
+			if CompareChains(
+				newPeerTip.SelectionTip(),
+				previousPeerTip.SelectionTip(),
+			) == ChainEqual {
+				// When two peers have delivered the same observed frontier,
+				// keep following the incumbent. The first peer to deliver the
+				// fitting header already won on latency; switching on source
+				// priority or VRF alone just creates churn near tip.
+				newBest = previousBest
+			} else if
+			// Preserve the incumbent only when it still wins the same
+			// full comparison used during normal best-peer selection.
+			cs.comparePeerTips(
+				*previousBest,
+				previousPeerTip,
+				*newBest,
+				newPeerTip,
+			) == ChainABetter {
+				newBest = previousBest
+			} else if newPeerTip.Tip.BlockNumber >
+				previousPeerTip.Tip.BlockNumber &&
+				!IsSignificantlyBetter(
+					newPeerTip.Tip,
+					previousPeerTip.Tip,
+					cs.config.MinSwitchBlockDiff,
+				) {
+				newBest = previousBest
+			}
+		}
+	}
+
+	if previousBest == nil || *previousBest != *newBest {
+		newPeerTip, ok := cs.peerTips[*newBest]
+		if !ok {
+			return false, nil, nil
+		}
+		newTip := newPeerTip.Tip
+		cs.bestPeerConn = newBest
+		switchOccurred = true
+
+		cs.config.Logger.Info(
+			"selected new best peer",
+			"connection_id", newBest.String(),
+			"block_number", newTip.BlockNumber,
+			"slot", newTip.Point.Slot,
+		)
+
+		if cs.config.EventBus != nil {
+			var previousTip ochainsync.Tip
+			var previousConnId ouroboros.ConnectionId
+			if previousBest != nil {
+				previousConnId = *previousBest
+				if pt, ok := cs.peerTips[*previousBest]; ok {
+					previousTip = pt.Tip
+				}
+			}
+			// Compute comparison result and block difference
+			comparisonResult := CompareChains(newTip, previousTip)
+			blockDiff := safeBlockDiff(
+				newTip.BlockNumber,
+				previousTip.BlockNumber,
+			)
+			evt := event.NewEvent(
+				ChainSwitchEventType,
+				ChainSwitchEvent{
+					PreviousConnectionId: previousConnId,
+					NewConnectionId:      *newBest,
+					NewTip:               newTip,
+					PreviousTip:          previousTip,
+					ComparisonResult:     comparisonResult,
+					BlockDifference:      blockDiff,
+				},
+			)
+			switchEvent = &evt
+		}
+	}
+
+	if cs.config.EventBus != nil && cs.bestPeerConn != nil {
+		bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]
+		if !ok {
+			return false, nil, nil
+		}
+		bestTip := bestPeerTip.Tip
+		evt := event.NewEvent(
+			ChainSelectionEventType,
+			ChainSelectionEvent{
+				BestConnectionId: *cs.bestPeerConn,
+				BestTip:          bestTip,
+				PeerCount:        len(cs.peerTips),
+				SwitchOccurred:   switchOccurred,
+			},
+		)
+		selectionEvent = &evt
+	}
+
+	return switchOccurred, switchEvent, selectionEvent
+}
+
 // EvaluateAndSwitch evaluates all peer tips and switches to the best chain if
 // it differs from the current best. Returns true if a switch occurred.
 func (cs *ChainSelector) EvaluateAndSwitch() bool {
-	// Collect events to publish outside the lock to prevent deadlock
 	var switchEvent *event.Event
 	var selectionEvent *event.Event
 	switchOccurred := false
@@ -728,129 +865,10 @@ func (cs *ChainSelector) EvaluateAndSwitch() bool {
 	func() {
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
-
-		newBest := cs.selectBestChainLocked()
-		if newBest == nil {
-			// Clear stale reference to avoid returning a disconnected peer
-			cs.bestPeerConn = nil
-			return
-		}
-
-		previousBest := cs.bestPeerConn
-		if previousBest != nil && *previousBest != *newBest {
-			previousPeerTip, ok := cs.peerTips[*previousBest]
-			if ok && cs.isPeerSelectableLocked(*previousBest, previousPeerTip, false) {
-				newPeerTip, ok := cs.peerTips[*newBest]
-				if !ok {
-					return
-				}
-				if CompareChains(
-					newPeerTip.SelectionTip(),
-					previousPeerTip.SelectionTip(),
-				) == ChainEqual {
-					// When two peers have delivered the same observed frontier,
-					// keep following the incumbent. The first peer to deliver the
-					// fitting header already won on latency; switching on source
-					// priority or VRF alone just creates churn near tip.
-					newBest = previousBest
-				} else if
-				// Preserve the incumbent only when it still wins the same
-				// full comparison used during normal best-peer selection.
-				cs.comparePeerTips(
-					*previousBest,
-					previousPeerTip,
-					*newBest,
-					newPeerTip,
-				) == ChainABetter {
-					newBest = previousBest
-				} else if newPeerTip.Tip.BlockNumber >
-					previousPeerTip.Tip.BlockNumber &&
-					!IsSignificantlyBetter(
-						newPeerTip.Tip,
-						previousPeerTip.Tip,
-						cs.config.MinSwitchBlockDiff,
-					) {
-					newBest = previousBest
-				}
-			}
-		}
-
-		if previousBest == nil || *previousBest != *newBest {
-			newPeerTip, ok := cs.peerTips[*newBest]
-			if !ok {
-				return
-			}
-			newTip := newPeerTip.Tip
-			cs.bestPeerConn = newBest
-			switchOccurred = true
-
-			cs.config.Logger.Info(
-				"selected new best peer",
-				"connection_id", newBest.String(),
-				"block_number", newTip.BlockNumber,
-				"slot", newTip.Point.Slot,
-			)
-
-			if cs.config.EventBus != nil {
-				var previousTip ochainsync.Tip
-				var previousConnId ouroboros.ConnectionId
-				if previousBest != nil {
-					previousConnId = *previousBest
-					if pt, ok := cs.peerTips[*previousBest]; ok {
-						previousTip = pt.Tip
-					}
-				}
-				// Compute comparison result and block difference
-				comparisonResult := CompareChains(newTip, previousTip)
-				blockDiff := safeBlockDiff(
-					newTip.BlockNumber,
-					previousTip.BlockNumber,
-				)
-				evt := event.NewEvent(
-					ChainSwitchEventType,
-					ChainSwitchEvent{
-						PreviousConnectionId: previousConnId,
-						NewConnectionId:      *newBest,
-						NewTip:               newTip,
-						PreviousTip:          previousTip,
-						ComparisonResult:     comparisonResult,
-						BlockDifference:      blockDiff,
-					},
-				)
-				switchEvent = &evt
-			}
-		}
-
-		if cs.config.EventBus != nil && cs.bestPeerConn != nil {
-			bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]
-			if !ok {
-				return
-			}
-			bestTip := bestPeerTip.Tip
-			evt := event.NewEvent(
-				ChainSelectionEventType,
-				ChainSelectionEvent{
-					BestConnectionId: *cs.bestPeerConn,
-					BestTip:          bestTip,
-					PeerCount:        len(cs.peerTips),
-					SwitchOccurred:   switchOccurred,
-				},
-			)
-			selectionEvent = &evt
-		}
+		switchOccurred, switchEvent, selectionEvent = cs.evaluateBestPeerLocked()
 	}()
 
-	// Publish events outside the lock to prevent deadlock if subscribers
-	// call back into ChainSelector
-	if cs.config.EventBus != nil {
-		if switchEvent != nil {
-			cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
-		}
-		if selectionEvent != nil {
-			cs.config.EventBus.Publish(ChainSelectionEventType, *selectionEvent)
-		}
-	}
-
+	cs.publishSelectionEvents(switchEvent, selectionEvent)
 	return switchOccurred
 }
 

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -64,6 +64,26 @@ func setSelectorConnectionPriority(
 	cs.priority[connId] = priority
 }
 
+func markSelectorPeerStale(
+	t *testing.T,
+	cs *ChainSelector,
+	connId ouroboros.ConnectionId,
+) {
+	t.Helper()
+
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+
+	peerTip, ok := cs.peerTips[connId]
+	require.True(t, ok, "peer %s must exist before marking stale", connId)
+
+	threshold := cs.config.StaleTipThreshold
+	if threshold == 0 {
+		threshold = defaultStaleTipThreshold
+	}
+	peerTip.LastUpdated = time.Now().Add(-(threshold + time.Millisecond))
+}
+
 func TestChainSelectorUpdatePeerTip(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{})
 
@@ -103,6 +123,47 @@ func TestChainSelectorUpdateExistingPeerTip(t *testing.T) {
 	assert.Equal(t, tip2.BlockNumber, peerTip.Tip.BlockNumber)
 	assert.Equal(t, tip2.Point.Slot, peerTip.Tip.Point.Slot)
 	assert.Equal(t, 1, cs.PeerCount())
+}
+
+func TestChainSelectorPrefersMoreAdvancedObservedTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	laggingConn := newTestConnectionId(1)
+	leadingConn := newTestConnectionId(2)
+
+	laggingAdvertisedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("lagging-advertised")},
+		BlockNumber: 200,
+	}
+	laggingObservedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("lagging-observed")},
+		BlockNumber: 120,
+	}
+	leadingAdvertisedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 180, Hash: []byte("leading-advertised")},
+		BlockNumber: 180,
+	}
+	leadingObservedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 150, Hash: []byte("leading-observed")},
+		BlockNumber: 150,
+	}
+
+	cs.updatePeerTipObserved(
+		laggingConn,
+		laggingAdvertisedTip,
+		laggingObservedTip,
+		nil,
+	)
+	cs.updatePeerTipObserved(
+		leadingConn,
+		leadingAdvertisedTip,
+		leadingObservedTip,
+		nil,
+	)
+
+	bestPeer := cs.SelectBestChain()
+	require.NotNil(t, bestPeer)
+	assert.Equal(t, leadingConn, *bestPeer)
 }
 
 func TestChainSelectorRemovePeer(t *testing.T) {
@@ -190,62 +251,6 @@ func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 
 	// Verify ChainSwitchEvent was emitted
-	select {
-	case evt := <-evtCh:
-		switchEvt, ok := evt.Data.(ChainSwitchEvent)
-		require.True(t, ok, "expected ChainSwitchEvent")
-		assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
-		assert.Equal(t, connId2, switchEvt.NewConnectionId)
-		assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected ChainSwitchEvent was not emitted")
-	}
-}
-
-func TestChainSelectorTouchPeerActivityEmitsChainSwitchEvent(
-	t *testing.T,
-) {
-	eventBus := event.NewEventBus(nil, nil)
-	t.Cleanup(func() { eventBus.Stop() })
-	cs := NewChainSelector(ChainSelectorConfig{
-		EventBus:          eventBus,
-		StaleTipThreshold: time.Second,
-	})
-
-	connId1 := newTestConnectionId(1)
-	connId2 := newTestConnectionId(2)
-
-	tip1 := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
-		BlockNumber: 60,
-	}
-	tip2 := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
-		BlockNumber: 50,
-	}
-
-	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
-
-	cs.UpdatePeerTip(connId1, tip1, nil)
-	cs.UpdatePeerTip(connId2, tip2, nil)
-	cs.EvaluateAndSwitch()
-
-	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId1, *cs.GetBestPeer())
-
-	for len(evtCh) > 0 {
-		<-evtCh
-	}
-
-	cs.mutex.Lock()
-	cs.peerTips[connId1].LastUpdated = time.Now().Add(-2 * time.Second)
-	cs.mutex.Unlock()
-
-	cs.TouchPeerActivity(connId2)
-
-	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId2, *cs.GetBestPeer())
-
 	select {
 	case evt := <-evtCh:
 		switchEvt, ok := evt.Data.(ChainSwitchEvent)
@@ -538,116 +543,54 @@ func TestChainSelectorSelectBestChainPrefersHigherPriorityPeerAtEqualTip(
 	assert.Equal(t, localRootConn, *bestPeer)
 }
 
-func TestChainSelectorPreservesEqualTipIncumbentAgainstHigherPriorityPeer(
-	t *testing.T,
-) {
-	publicRootConn := newTestConnectionId(1)
-	localRootConn := newTestConnectionId(2)
-	cs := NewChainSelector(ChainSelectorConfig{})
-	setSelectorConnectionPriority(cs, localRootConn, 20)
-	setSelectorConnectionPriority(cs, publicRootConn, 10)
-
-	equalTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
-		BlockNumber: 60,
-	}
-
-	cs.UpdatePeerTip(publicRootConn, equalTip, nil)
-	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, publicRootConn, *cs.GetBestPeer())
-
-	cs.UpdatePeerTip(localRootConn, equalTip, nil)
-	switched := cs.EvaluateAndSwitch()
-	assert.False(t, switched)
-	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, publicRootConn, *cs.GetBestPeer())
-}
-
 func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
 	connId1 := newTestConnectionId(1)
 	connId2 := newTestConnectionId(2)
 	cs := NewChainSelector(ChainSelectorConfig{})
-	sharedVRF := make64ByteVRF(0x01)
 
 	equalTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
 		BlockNumber: 60,
 	}
 
-	// Seed the incumbent using a temporary priority advantage, then
-	// remove that advantage. Equal-priority peers at the same tip
-	// should not steal incumbency just because the selector re-evaluates.
-	setSelectorConnectionPriority(cs, connId1, 10)
-	setSelectorConnectionPriority(cs, connId2, 20)
-	cs.UpdatePeerTip(connId1, equalTip, sharedVRF)
-	cs.UpdatePeerTip(connId2, equalTip, sharedVRF)
+	cs.UpdatePeerTip(connId2, equalTip, nil)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId1, *cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
 
-	setSelectorConnectionPriority(cs, connId1, 50)
-	setSelectorConnectionPriority(cs, connId2, 50)
-
-	bestPeer := cs.SelectBestChain()
-	require.NotNil(t, bestPeer)
-	assert.Equal(t, connId1, *bestPeer)
+	cs.UpdatePeerTip(connId1, equalTip, nil)
 
 	switched := cs.EvaluateAndSwitch()
 	assert.False(t, switched)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId1, *cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
-func TestChainSelectorPreservesIncumbentWithInvalidEqualVRF(
+func TestChainSelectorPreservesEqualTipIncumbentAtSamePriorityWithVRF(
 	t *testing.T,
 ) {
-	testCases := []struct {
-		name string
-		vrfA []byte
-		vrfB []byte
-	}{
-		{
-			name: "nil vrf",
-			vrfA: nil,
-			vrfB: nil,
-		},
-		{
-			name: "short vrf",
-			vrfA: []byte{0x01},
-			vrfB: []byte{0x01},
-		},
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
+		BlockNumber: 60,
 	}
+	vrfHigher := make64ByteVRF(0xFF)
+	vrfLower := make64ByteVRF(0x00)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			connId1 := newTestConnectionId(1)
-			connId2 := newTestConnectionId(2)
-			cs := NewChainSelector(ChainSelectorConfig{})
+	cs.UpdatePeerTip(incumbentConn, equalTip, vrfHigher)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 
-			equalTip := ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 120, Hash: []byte("equal-tip")},
-				BlockNumber: 60,
-			}
+	cs.UpdatePeerTip(challengerConn, equalTip, vrfLower)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 
-			setSelectorConnectionPriority(cs, connId1, 10)
-			setSelectorConnectionPriority(cs, connId2, 20)
-			cs.UpdatePeerTip(connId1, equalTip, tc.vrfA)
-			cs.UpdatePeerTip(connId2, equalTip, tc.vrfB)
-			require.NotNil(t, cs.GetBestPeer())
-			assert.Equal(t, connId1, *cs.GetBestPeer())
-
-			setSelectorConnectionPriority(cs, connId1, 50)
-			setSelectorConnectionPriority(cs, connId2, 50)
-
-			bestPeer := cs.SelectBestChain()
-			require.NotNil(t, bestPeer)
-			assert.Equal(t, connId1, *bestPeer)
-
-			switched := cs.EvaluateAndSwitch()
-			assert.False(t, switched)
-			require.NotNil(t, cs.GetBestPeer())
-			assert.Equal(t, connId1, *cs.GetBestPeer())
-		})
-	}
+	switched := cs.EvaluateAndSwitch()
+	assert.False(t, switched)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 }
 
 func TestChainSelectorUpdatesConnectionStateFromPeerGovEvents(t *testing.T) {
@@ -1002,7 +945,207 @@ func TestPeerChainTipUpdateTip(t *testing.T) {
 
 	peerTip.UpdateTip(tip2, nil)
 	assert.Equal(t, tip2.BlockNumber, peerTip.Tip.BlockNumber)
+	assert.Equal(t, tip2.BlockNumber, peerTip.ObservedTip.BlockNumber)
 	assert.True(t, peerTip.LastUpdated.After(oldTime))
+}
+
+func TestPeerChainTipUpdateTipWithObserved(t *testing.T) {
+	connId := newTestConnectionId(1)
+	initialTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 199, Hash: []byte("initial")},
+		BlockNumber: 199,
+	}
+	advertisedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("advertised")},
+		BlockNumber: 200,
+	}
+	observedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 150, Hash: []byte("observed")},
+		BlockNumber: 150,
+	}
+
+	peerTip := NewPeerChainTip(connId, initialTip, nil)
+	peerTip.UpdateTipWithObserved(advertisedTip, observedTip, nil)
+
+	assert.Equal(t, advertisedTip, peerTip.Tip)
+	assert.Equal(t, observedTip, peerTip.ObservedTip)
+	assert.Equal(t, observedTip.BlockNumber, peerTip.SelectionTip().BlockNumber)
+}
+
+func TestPeerChainTipTouch(t *testing.T) {
+	connId := newTestConnectionId(1)
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("test")},
+		BlockNumber: 50,
+	}
+
+	peerTip := NewPeerChainTip(connId, tip, nil)
+	require.Eventually(t, func() bool {
+		return peerTip.IsStale(50 * time.Millisecond)
+	}, 2*time.Second, 5*time.Millisecond, "peer tip should become stale")
+	oldTime := peerTip.LastUpdated
+
+	peerTip.Touch()
+
+	assert.True(t, peerTip.LastUpdated.After(oldTime))
+	assert.False(t, peerTip.IsStale(50*time.Millisecond))
+}
+
+func TestChainSelectorTouchPeerActivityRevivesStaleBestPeer(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		StaleTipThreshold: 50 * time.Millisecond,
+	})
+
+	bestConn := newTestConnectionId(1)
+	freshConn := newTestConnectionId(2)
+	bestTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("best")},
+		BlockNumber: 60,
+	}
+	freshTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("fresh")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(bestConn, bestTip, nil)
+	cs.UpdatePeerTip(freshConn, freshTip, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, bestConn, *cs.GetBestPeer())
+
+	require.Eventually(t, func() bool {
+		peerTip := cs.GetPeerTip(bestConn)
+		return peerTip != nil && peerTip.IsStale(50*time.Millisecond)
+	}, 2*time.Second, 5*time.Millisecond, "best peer should become stale")
+
+	cs.UpdatePeerTip(freshConn, freshTip, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, freshConn, *cs.GetBestPeer())
+
+	cs.TouchPeerActivity(bestConn)
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, bestConn, *cs.GetBestPeer())
+}
+
+func TestChainSelectorTouchPeerActivityHonorsMinSwitchBlockDiff(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		StaleTipThreshold:  50 * time.Millisecond,
+		MinSwitchBlockDiff: 2,
+	})
+
+	revivedConn := newTestConnectionId(1)
+	incumbentConn := newTestConnectionId(2)
+	revivedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("revived")},
+		BlockNumber: 51,
+	}
+	incumbentTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("incumbent")},
+		BlockNumber: 50,
+	}
+
+	cs.UpdatePeerTip(revivedConn, revivedTip, nil)
+	cs.UpdatePeerTip(incumbentConn, incumbentTip, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, revivedConn, *cs.GetBestPeer())
+
+	require.Eventually(t, func() bool {
+		peerTip := cs.GetPeerTip(revivedConn)
+		return peerTip != nil && peerTip.IsStale(50*time.Millisecond)
+	}, 2*time.Second, 5*time.Millisecond, "revived peer should become stale")
+
+	cs.UpdatePeerTip(incumbentConn, incumbentTip, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	cs.TouchPeerActivity(revivedConn)
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(
+		t,
+		incumbentConn,
+		*cs.GetBestPeer(),
+		"activity-only revival should not bypass MinSwitchBlockDiff",
+	)
+}
+
+func TestChainSelectorTouchPeerActivityEmitsChainSwitchEvent(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:           eventBus,
+		StaleTipThreshold:  50 * time.Millisecond,
+		MinSwitchBlockDiff: 2,
+	})
+
+	revivedConn := newTestConnectionId(1)
+	incumbentConn := newTestConnectionId(2)
+	revivedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("revived")},
+		BlockNumber: 60,
+	}
+	incumbentTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("incumbent")},
+		BlockNumber: 50,
+	}
+
+	_, evtCh := eventBus.Subscribe(ChainSwitchEventType)
+
+	cs.UpdatePeerTip(revivedConn, revivedTip, nil)
+	cs.UpdatePeerTip(incumbentConn, incumbentTip, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, revivedConn, *cs.GetBestPeer())
+
+	for len(evtCh) > 0 {
+		<-evtCh
+	}
+
+	require.Eventually(t, func() bool {
+		peerTip := cs.GetPeerTip(revivedConn)
+		return peerTip != nil && peerTip.IsStale(50*time.Millisecond)
+	}, 2*time.Second, 5*time.Millisecond, "revived peer should become stale")
+
+	cs.UpdatePeerTip(incumbentConn, incumbentTip, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	for len(evtCh) > 0 {
+		<-evtCh
+	}
+
+	cs.TouchPeerActivity(revivedConn)
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, revivedConn, *cs.GetBestPeer())
+
+	var switchEvt ChainSwitchEvent
+	require.Eventually(t, func() bool {
+		select {
+		case evt := <-evtCh:
+			data, ok := evt.Data.(ChainSwitchEvent)
+			if !ok {
+				return false
+			}
+			switchEvt = data
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond, "activity-driven switch should emit event")
+
+	assert.Equal(t, incumbentConn, switchEvt.PreviousConnectionId)
+	assert.Equal(t, revivedConn, switchEvt.NewConnectionId)
+	assert.Equal(t, revivedTip, switchEvt.NewTip)
+	assert.Equal(t, incumbentTip, switchEvt.PreviousTip)
+	assert.Equal(t, ChainABetter, switchEvt.ComparisonResult)
+	assert.Equal(t, int64(10), switchEvt.BlockDifference)
 }
 
 func TestChainSelectorVRFTiebreaker(t *testing.T) {
@@ -1174,37 +1317,47 @@ func TestPeerChainTipVRFOutputStored(t *testing.T) {
 	assert.Equal(t, newVRF, peerTip.VRFOutput)
 }
 
-func TestUpdatePeerTipRejectsImplausibleKnownPeerJump(t *testing.T) {
+func TestUpdatePeerTipRejectsImplausibleTip(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
 		SecurityParam: 2160, // Cardano mainnet k
 	})
 
-	connId := newTestConnectionId(1)
+	// Set local tip so the plausibility check is active
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
+		BlockNumber: 50000,
+	})
 
-	// First tip accepted (new peer, always accepted)
-	initialTip := ochainsync.Tip{
+	// Add a plausible peer first so the implausible check activates
+	// (the check requires len(peerTips) > 0 to avoid blocking
+	// initial sync where all peers are legitimately far ahead).
+	existingConn := newTestConnectionId(2)
+	plausibleTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
 		BlockNumber: 50500,
 	}
-	accepted := cs.UpdatePeerTip(connId, initialTip, nil)
-	assert.True(t, accepted, "initial tip should be accepted")
+	cs.UpdatePeerTip(existingConn, plausibleTip, nil)
 
-	// Same peer jumps far beyond previous tip + k
+	connId := newTestConnectionId(1)
+
+	// A spoofed tip claiming to be far beyond local tip + k
 	spoofedTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: math.MaxUint64, Hash: []byte("spoof")},
 		BlockNumber: math.MaxUint64,
 	}
 
-	accepted = cs.UpdatePeerTip(connId, spoofedTip, nil)
+	accepted := cs.UpdatePeerTip(connId, spoofedTip, nil)
 	assert.False(
 		t,
 		accepted,
-		"known peer jumping beyond k should be rejected",
+		"implausibly high tip should be rejected",
 	)
-	// Peer tip should still be the original tip
-	pt := cs.GetPeerTip(connId)
-	require.NotNil(t, pt)
-	assert.Equal(t, uint64(50500), pt.Tip.BlockNumber)
+	assert.Nil(
+		t,
+		cs.GetPeerTip(connId),
+		"rejected tip should not be tracked",
+	)
+	assert.Equal(t, 1, cs.PeerCount(), "peer count should remain 1 (existing peer only)")
 }
 
 func TestUpdatePeerTipAcceptsPlausibleTip(t *testing.T) {
@@ -1269,40 +1422,85 @@ func TestUpdatePeerTipAcceptsTipAtExactBoundary(t *testing.T) {
 	assert.NotNil(t, cs.GetPeerTip(connId))
 }
 
-func TestUpdatePeerTipAcceptsNewPeerFarAhead(t *testing.T) {
-	// New peers are always accepted regardless of how far ahead they
-	// claim to be. This supports cold-start scenarios like Mithril
-	// bootstrap where legitimate peers may be >k blocks ahead of
-	// the local reference.
+func TestUpdatePeerTipAcceptsTipAtExactBoundaryWithStaleReferencePeer(
+	t *testing.T,
+) {
 	cs := NewChainSelector(ChainSelectorConfig{
-		SecurityParam: 432, // preview k
+		SecurityParam:     2160,
+		StaleTipThreshold: 50 * time.Millisecond,
 	})
 
-	// Add a peer at the Mithril snapshot block
-	snapshotConn := newTestConnectionId(1)
-	cs.UpdatePeerTip(snapshotConn, ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100000, Hash: []byte("snapshot")},
-		BlockNumber: 4125222,
-	}, nil)
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
+		BlockNumber: 50000,
+	})
 
-	// A new peer at the real chain tip, 500 blocks ahead (> k=432)
-	realConn := newTestConnectionId(2)
-	realTip := ochainsync.Tip{
+	existingConn := newTestConnectionId(2)
+	cs.UpdatePeerTip(existingConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
+		BlockNumber: 50500,
+	}, nil)
+	markSelectorPeerStale(t, cs, existingConn)
+
+	peerTip := cs.GetPeerTip(existingConn)
+	require.NotNil(t, peerTip)
+	assert.True(t, peerTip.IsStale(50*time.Millisecond))
+
+	connId := newTestConnectionId(1)
+	boundaryTip := ochainsync.Tip{
 		Point: ocommon.Point{
-			Slot: 110000,
-			Hash: []byte("real"),
+			Slot: 106000,
+			Hash: []byte("boundary-stale"),
 		},
-		BlockNumber: 4125722, // 500 blocks ahead of snapshot
+		BlockNumber: 50500 + 2160, // Exactly at the reference peer limit
 	}
 
-	accepted := cs.UpdatePeerTip(realConn, realTip, nil)
+	accepted := cs.UpdatePeerTip(connId, boundaryTip, nil)
 	assert.True(
 		t,
 		accepted,
-		"new peer should be accepted even if >k blocks ahead of existing peers",
+		"tip at exact boundary should be accepted when the reference peer is stale",
 	)
-	assert.NotNil(t, cs.GetPeerTip(realConn))
-	assert.Equal(t, 2, cs.PeerCount())
+	assert.NotNil(t, cs.GetPeerTip(connId))
+}
+
+func TestUpdatePeerTipRejectsTipOneOverBoundary(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: 2160,
+	})
+
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
+		BlockNumber: 50000,
+	})
+
+	// Add a plausible peer first so the implausible check has a
+	// reference point. The reference is the best known peer tip
+	// (block 50500), not the local tip.
+	existingConn := newTestConnectionId(2)
+	cs.UpdatePeerTip(existingConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100500, Hash: []byte("ok")},
+		BlockNumber: 50500,
+	}, nil)
+
+	connId := newTestConnectionId(1)
+
+	// Tip one block past the boundary (reference peer block + k + 1)
+	overBoundaryTip := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: 106000,
+			Hash: []byte("over"),
+		},
+		BlockNumber: 50500 + 2160 + 1,
+	}
+
+	accepted := cs.UpdatePeerTip(connId, overBoundaryTip, nil)
+	assert.False(
+		t,
+		accepted,
+		"tip one past boundary should be rejected",
+	)
+	assert.Nil(t, cs.GetPeerTip(connId))
 }
 
 func TestUpdatePeerTipAcceptsTipWhenSecurityParamZero(t *testing.T) {
@@ -1427,37 +1625,46 @@ func TestUpdatePeerTipRejectsKnownPeerJumpFromZero(t *testing.T) {
 	assert.Equal(t, uint64(0), pt.Tip.BlockNumber)
 }
 
-func TestUpdatePeerTipKnownPeerSpoofRejected(t *testing.T) {
-	// A known peer that tries to jump its tip by more than k blocks
-	// is rejected. This is the primary anti-spoofing defense.
+func TestUpdatePeerTipSpoofedPeerDoesNotBecomesBest(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
 		SecurityParam: 2160,
 	})
 
-	// Peer establishes initial tip
-	connId := newTestConnectionId(1)
-	initialTip := ochainsync.Tip{
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("local")},
+		BlockNumber: 50000,
+	})
+
+	// Add a legitimate peer first
+	legitimateConn := newTestConnectionId(1)
+	legitimateTip := ochainsync.Tip{
 		Point: ocommon.Point{
 			Slot: 100100,
 			Hash: []byte("legit"),
 		},
 		BlockNumber: 50050,
 	}
-	cs.UpdatePeerTip(connId, initialTip, nil)
+	cs.UpdatePeerTip(legitimateConn, legitimateTip, nil)
 
-	// Same peer tries to spoof by jumping far ahead
+	// Now a malicious peer tries to spoof
+	maliciousConn := newTestConnectionId(2)
 	spoofedTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: math.MaxUint64, Hash: []byte("evil")},
 		BlockNumber: math.MaxUint64,
 	}
 
-	accepted := cs.UpdatePeerTip(connId, spoofedTip, nil)
-	assert.False(t, accepted, "known peer jumping beyond k should be rejected")
+	accepted := cs.UpdatePeerTip(maliciousConn, spoofedTip, nil)
+	assert.False(t, accepted, "spoofed tip should be rejected")
 
-	// Peer tip should still be the original
-	pt := cs.GetPeerTip(connId)
-	require.NotNil(t, pt)
-	assert.Equal(t, uint64(50050), pt.Tip.BlockNumber)
+	// The legitimate peer should still be the best
+	bestPeer := cs.GetBestPeer()
+	require.NotNil(t, bestPeer)
+	assert.Equal(
+		t,
+		legitimateConn,
+		*bestPeer,
+		"legitimate peer should remain best peer",
+	)
 }
 
 func TestChainSelectorMaxTrackedPeersDefault(t *testing.T) {


### PR DESCRIPTION
Prefer the actually-delivered chainsync tip over the advertised remote tip for chain selection decisions. New peers are checked against the best known peer tip to prevent spoofed block numbers.

Simplify TouchPeerActivity to use defer-based locking and direct best-peer assignment. Revert stale tip threshold to 60s and remove the PeerActivityEvent subscription from the constructor. When two peers have delivered the same observed frontier, keep following the incumbent to avoid churn near tip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the observed ChainSync frontier for chain selection and tighten anti-spoofing on peer tips. Touch-driven reevaluation revives stale incumbents, honors MinSwitchBlockDiff, and emits switch/selection events outside locks.

- **Bug Fixes**
  - Select best chain using the observed frontier, not the advertised remote tip.
  - Harden tip validation: known peers can't jump >k past their last tip; new peers are bounded against the best-known tip (first peer accepted for bootstrap).
  - Preserve the incumbent when peers share the same observed frontier (including VRF ties).
  - Honor MinSwitchBlockDiff during activity-driven reevaluation.

- **Refactors**
  - Simplified TouchPeerActivity with defer-based locking and direct best-peer evaluation; ChainSwitch/ChainSelection events are published outside the lock.
  - Added helpers to evaluate and publish selection results; Touch can now trigger switches and events.
  - Reverted the stale tip threshold to 60s and removed the PeerActivityEvent subscription from the constructor.

<sup>Written for commit d621c0f0f47229bfad097bd9ad2cb24931199904. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined implausible-tip rejection to a clear multi-case reference model, reducing spoofed or implausible tips from being tracked or affecting selection.
  * Touch-peer activity now always re-evaluates the best peer and publishes selection/switch events consistently, improving selection stability and event correctness.

* **Tests**
  * Expanded and strengthened tests for tip validation, observed-tip handling, activity-driven re-selection, min-switch block diff, incumbent preservation, and detailed chain-switch event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->