### PR TITLE
build(deps): gouroboros 0.163.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.163.3
+	github.com/blinklabs-io/gouroboros v0.163.4
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.29
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.163.3 h1:so0DufDXbH5reF7vTBrivFpXXPndtRSw1Hbnh72wuZo=
-github.com/blinklabs-io/gouroboros v0.163.3/go.mod h1:BVspqM17W2TkiCeL3NhIi8K3F0+xVgpujK122kOhQd4=
+github.com/blinklabs-io/gouroboros v0.163.4 h1:yQBy5m08ZtgxHrQN44+6Pzss7gFbePmjdU9k4wLi9rI=
+github.com/blinklabs-io/gouroboros v0.163.4/go.mod h1:BVspqM17W2TkiCeL3NhIi8K3F0+xVgpujK122kOhQd4=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.29 h1:1SuM/cbGr8Cf6sCxyTU/dj8iiKuk/DtaTwsblOApiRU=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades `github.com/blinklabs-io/gouroboros` from v0.163.3 to v0.163.4 to stay current with upstream.
Updates `go.mod` and `go.sum` only.

<sup>Written for commit 1a9fc22697c72ff01b198a708a7ca3dde78f691f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

