### PR TITLE
fix(utxorpc): evaluate TxPredicate not, all_of, and any_of for WatchT…

### DIFF
--- a/utxorpc/submit.go
+++ b/utxorpc/submit.go
@@ -412,11 +412,10 @@ func (s *submitServiceServer) WatchMempool(
 			}
 			resp.Tx = record
 
-			shouldSend := predicate == nil ||
-				s.utxorpc.matchesTxPattern(
-					tx,
-					predicate.GetMatch().GetCardano(),
-				)
+			shouldSend := s.utxorpc.matchesSubmitTxPredicate(
+				tx,
+				predicate,
+			)
 			if !shouldSend {
 				return
 			}

--- a/utxorpc/tx_predicate.go
+++ b/utxorpc/tx_predicate.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	submit "github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit"
+	watch "github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch"
+)
+
+// txPredicateNode is the Cardano evaluation shape for utxorpc TxPredicate
+// (submit and watch protos share the same fields). Conversion from generated
+// *TxPredicate types happens once at the API boundary; recursion uses only
+// this struct.
+type txPredicateNode struct {
+	match *cardano.TxPattern
+	not   []*txPredicateNode
+	allOf []*txPredicateNode
+	anyOf []*txPredicateNode
+}
+
+// txPredicateFromSubmit maps submit.TxPredicate into txPredicateNode.
+func txPredicateFromSubmit(p *submit.TxPredicate) *txPredicateNode {
+	if p == nil {
+		return nil
+	}
+	n := &txPredicateNode{}
+	if m := p.GetMatch(); m != nil {
+		n.match = m.GetCardano()
+	}
+	for _, c := range p.GetNot() {
+		if c != nil {
+			n.not = append(n.not, txPredicateFromSubmit(c))
+		}
+	}
+	for _, c := range p.GetAllOf() {
+		if c != nil {
+			n.allOf = append(n.allOf, txPredicateFromSubmit(c))
+		}
+	}
+	for _, c := range p.GetAnyOf() {
+		if c != nil {
+			n.anyOf = append(n.anyOf, txPredicateFromSubmit(c))
+		}
+	}
+	return n
+}
+
+// txPredicateFromWatch maps watch.TxPredicate into txPredicateNode.
+func txPredicateFromWatch(p *watch.TxPredicate) *txPredicateNode {
+	if p == nil {
+		return nil
+	}
+	n := &txPredicateNode{}
+	if m := p.GetMatch(); m != nil {
+		n.match = m.GetCardano()
+	}
+	for _, c := range p.GetNot() {
+		if c != nil {
+			n.not = append(n.not, txPredicateFromWatch(c))
+		}
+	}
+	for _, c := range p.GetAllOf() {
+		if c != nil {
+			n.allOf = append(n.allOf, txPredicateFromWatch(c))
+		}
+	}
+	for _, c := range p.GetAnyOf() {
+		if c != nil {
+			n.anyOf = append(n.anyOf, txPredicateFromWatch(c))
+		}
+	}
+	return n
+}
+
+// txPatternLeaf matches a transaction against a Cardano TxPattern (outputs,
+// inputs via ledger state, mint/move asset filters).
+type txPatternLeaf func(tx gledger.Transaction, pat *cardano.TxPattern) bool
+
+// matchesSubmitTxPredicate evaluates a submit.TxPredicate for WatchMempool.
+// A nil predicate matches all transactions.
+func (u *Utxorpc) matchesSubmitTxPredicate(
+	tx gledger.Transaction,
+	p *submit.TxPredicate,
+) bool {
+	if p == nil {
+		return true
+	}
+	return evalTxPredicate(tx, txPredicateFromSubmit(p), u.matchesTxPattern)
+}
+
+// matchesWatchTxPredicate evaluates a watch.TxPredicate for WatchTx.
+// A nil predicate matches all transactions.
+func (u *Utxorpc) matchesWatchTxPredicate(
+	tx gledger.Transaction,
+	p *watch.TxPredicate,
+) bool {
+	if p == nil {
+		return true
+	}
+	return evalTxPredicate(tx, txPredicateFromWatch(p), u.matchesTxPattern)
+}
+
+// evalTxPredicate recursively applies match, not, all_of, and any_of per
+// utxorpc TxPredicate:
+//   - match: leaf match on Cardano TxPattern
+//   - not: for each child c, require ¬eval(c); multiple entries are ANDed
+//   - all_of: every child must match; empty all_of adds no constraint
+//   - any_of: at least one child must match; empty any_of cannot be satisfied
+//
+// If several of these are set on the same node, results are AND-combined.
+// A node with no constraints (no match, no not children, no non-empty
+// all_of/any_of) does not match.
+func evalTxPredicate(
+	tx gledger.Transaction,
+	p *txPredicateNode,
+	leaf txPatternLeaf,
+) bool {
+	if p == nil {
+		return false
+	}
+	var active bool
+	ok := true
+	if p.match != nil {
+		active = true
+		ok = leaf(tx, p.match)
+	}
+	for _, c := range p.not {
+		active = true
+		ok = ok && !evalTxPredicate(tx, c, leaf)
+	}
+	if len(p.allOf) > 0 {
+		active = true
+		allOk := true
+		for _, c := range p.allOf {
+			if !evalTxPredicate(tx, c, leaf) {
+				allOk = false
+				break
+			}
+		}
+		ok = ok && allOk
+	}
+	if len(p.anyOf) > 0 {
+		active = true
+		anyOk := false
+		for _, c := range p.anyOf {
+			if evalTxPredicate(tx, c, leaf) {
+				anyOk = true
+				break
+			}
+		}
+		ok = ok && anyOk
+	}
+	if !active {
+		return false
+	}
+	return ok
+}

--- a/utxorpc/tx_predicate_test.go
+++ b/utxorpc/tx_predicate_test.go
@@ -1,0 +1,248 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	submit "github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit"
+	watch "github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch"
+)
+
+// stubLeaf returns true only when the pattern pointer equals pMatch.
+func stubLeaf(pMatch *cardano.TxPattern) txPatternLeaf {
+	return func(_ gledger.Transaction, p *cardano.TxPattern) bool {
+		return p == pMatch
+	}
+}
+
+func matchSubmit(p *cardano.TxPattern) *submit.TxPredicate {
+	return &submit.TxPredicate{
+		Match: &submit.AnyChainTxPattern{
+			Chain: &submit.AnyChainTxPattern_Cardano{Cardano: p},
+		},
+	}
+}
+
+func matchWatch(p *cardano.TxPattern) *watch.TxPredicate {
+	return &watch.TxPredicate{
+		Match: &watch.AnyChainTxPattern{
+			Chain: &watch.AnyChainTxPattern_Cardano{Cardano: p},
+		},
+	}
+}
+
+func evalSubmit(
+	tx gledger.Transaction,
+	p *submit.TxPredicate,
+	leaf txPatternLeaf,
+) bool {
+	return evalTxPredicate(tx, txPredicateFromSubmit(p), leaf)
+}
+
+func TestEvalTxPredicate_Match(t *testing.T) {
+	pA := &cardano.TxPattern{}
+	pB := &cardano.TxPattern{}
+	leaf := stubLeaf(pA)
+
+	require.True(t, evalSubmit(nil, matchSubmit(pA), leaf))
+	require.False(t, evalSubmit(nil, matchSubmit(pB), leaf))
+}
+
+func TestEvalTxPredicate_Not(t *testing.T) {
+	pA := &cardano.TxPattern{}
+	pB := &cardano.TxPattern{}
+	leaf := stubLeaf(pA)
+
+	t.Run("single_inverts", func(t *testing.T) {
+		pred := &submit.TxPredicate{Not: []*submit.TxPredicate{matchSubmit(pA)}}
+		require.False(t, evalSubmit(nil, pred, leaf))
+
+		pred2 := &submit.TxPredicate{Not: []*submit.TxPredicate{matchSubmit(pB)}}
+		require.True(t, evalSubmit(nil, pred2, leaf))
+	})
+
+	t.Run("multiple_not_and_combined", func(t *testing.T) {
+		// Inner matches pA: both ¬match(pA) and ¬match(pB) must hold.
+		pred := &submit.TxPredicate{
+			Not: []*submit.TxPredicate{
+				matchSubmit(pA),
+				matchSubmit(pB),
+			},
+		}
+		require.False(t, evalSubmit(nil, pred, leaf))
+
+		// Leaf never matches: each ¬inner is true, so the full not is true.
+		leafNever := func(_ gledger.Transaction, _ *cardano.TxPattern) bool {
+			return false
+		}
+		require.True(t, evalSubmit(nil, pred, leafNever))
+	})
+}
+
+func TestEvalTxPredicate_AllOf(t *testing.T) {
+	pA := &cardano.TxPattern{}
+	pB := &cardano.TxPattern{}
+	leaf := func(_ gledger.Transaction, p *cardano.TxPattern) bool {
+		return p == pA || p == pB
+	}
+
+	t.Run("all_must_hold", func(t *testing.T) {
+		pred := &submit.TxPredicate{
+			AllOf: []*submit.TxPredicate{
+				matchSubmit(pA),
+				matchSubmit(pB),
+			},
+		}
+		require.True(t, evalSubmit(nil, pred, leaf))
+	})
+
+	t.Run("one_fails", func(t *testing.T) {
+		pC := &cardano.TxPattern{}
+		pred := &submit.TxPredicate{
+			AllOf: []*submit.TxPredicate{
+				matchSubmit(pA),
+				matchSubmit(pC),
+			},
+		}
+		require.False(t, evalSubmit(nil, pred, leaf))
+	})
+}
+
+func TestEvalTxPredicate_AnyOf(t *testing.T) {
+	pA := &cardano.TxPattern{}
+	pB := &cardano.TxPattern{}
+	pC := &cardano.TxPattern{}
+	leaf := stubLeaf(pA)
+
+	pred := &submit.TxPredicate{
+		AnyOf: []*submit.TxPredicate{
+			matchSubmit(pB),
+			matchSubmit(pA),
+			matchSubmit(pC),
+		},
+	}
+	require.True(t, evalSubmit(nil, pred, leaf))
+
+	predNone := &submit.TxPredicate{
+		AnyOf: []*submit.TxPredicate{
+			matchSubmit(pB),
+			matchSubmit(pC),
+		},
+	}
+	require.False(t, evalSubmit(nil, predNone, leaf))
+}
+
+func TestEvalTxPredicate_Nested(t *testing.T) {
+	pA := &cardano.TxPattern{}
+	pB := &cardano.TxPattern{}
+	leaf := stubLeaf(pA)
+
+	// all_of( any_of(match pB, match pA), not(match pA) )
+	// any_of -> true (pA); not(match pA) -> false -> whole false
+	pred := &submit.TxPredicate{
+		AllOf: []*submit.TxPredicate{
+			{
+				AnyOf: []*submit.TxPredicate{
+					matchSubmit(pB),
+					matchSubmit(pA),
+				},
+			},
+			{Not: []*submit.TxPredicate{matchSubmit(pA)}},
+		},
+	}
+	require.False(t, evalSubmit(nil, pred, leaf))
+
+	// all_of( not(match pB), any_of(match pB, match pA) )
+	// not(pB) true, any_of true -> true
+	pred2 := &submit.TxPredicate{
+		AllOf: []*submit.TxPredicate{
+			{Not: []*submit.TxPredicate{matchSubmit(pB)}},
+			{
+				AnyOf: []*submit.TxPredicate{
+					matchSubmit(pB),
+					matchSubmit(pA),
+				},
+			},
+		},
+	}
+	require.True(t, evalSubmit(nil, pred2, leaf))
+}
+
+func TestEvalTxPredicate_WatchParity(t *testing.T) {
+	pA := &cardano.TxPattern{}
+	pB := &cardano.TxPattern{}
+	leaf := stubLeaf(pA)
+
+	s := &submit.TxPredicate{
+		AnyOf: []*submit.TxPredicate{
+			matchSubmit(pB),
+			matchSubmit(pA),
+		},
+	}
+	w := &watch.TxPredicate{
+		AnyOf: []*watch.TxPredicate{
+			matchWatch(pB),
+			matchWatch(pA),
+		},
+	}
+	require.Equal(
+		t,
+		evalTxPredicate(nil, txPredicateFromSubmit(s), leaf),
+		evalTxPredicate(nil, txPredicateFromWatch(w), leaf),
+	)
+}
+
+func TestEvalTxPredicate_EmptyNode(t *testing.T) {
+	pred := &submit.TxPredicate{}
+	require.False(
+		t,
+		evalSubmit(nil, pred, stubLeaf(&cardano.TxPattern{})),
+	)
+}
+
+func TestEvalTxPredicate_NilTree(t *testing.T) {
+	require.False(
+		t,
+		evalTxPredicate(nil, nil, stubLeaf(&cardano.TxPattern{})),
+	)
+}
+
+func TestEvalTxPredicate_FromSubmitNil(t *testing.T) {
+	require.Nil(t, txPredicateFromSubmit(nil))
+}
+
+func TestMatchesSubmitTxPredicate_NilPredicate(t *testing.T) {
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil, nil),
+	})
+	require.True(t, u.matchesSubmitTxPredicate(nil, nil))
+}
+
+func TestMatchesWatchTxPredicate_NilPredicate(t *testing.T) {
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil, nil),
+	})
+	require.True(t, u.matchesWatchTxPredicate(nil, nil))
+}

--- a/utxorpc/watch.go
+++ b/utxorpc/watch.go
@@ -151,11 +151,10 @@ func (s *watchServiceServer) WatchTx(
 						Apply: &act,
 					},
 				}
-				shouldSend := predicate == nil ||
-					s.utxorpc.matchesTxPattern(
-						tx,
-						predicate.GetMatch().GetCardano(),
-					)
+				shouldSend := s.utxorpc.matchesWatchTxPredicate(
+					tx,
+					predicate,
+				)
 				if shouldSend {
 					err := stream.Send(resp)
 					if err != nil {


### PR DESCRIPTION
Closes #1480 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TxPredicate handling in `utxorpc` so `not`, `all_of`, and `any_of` are correctly evaluated for WatchTx and WatchMempool. This enables reliable, composable filters; a nil predicate still matches all transactions.

- **Bug Fixes**
  - Added a recursive evaluator for `match`, `not`, `all_of`, and `any_of` with clear edge-case rules (empty `any_of` is false; empty `all_of` is neutral).
  - Introduced internal mapping of `submit.TxPredicate` and `watch.TxPredicate` into a common node type for evaluation.
  - Updated WatchTx and WatchMempool to use `matchesWatchTxPredicate`/`matchesSubmitTxPredicate` instead of direct `match` checks.
  - Added unit tests covering match, negation, all/any combinations, nesting, empty nodes, nil trees, and submit/watch parity.

<sup>Written for commit 31fd3afdca841d1ec956fa2e4fef3e024a4024c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal transaction predicate evaluation logic by centralizing matching functionality.

* **Tests**
  * Added comprehensive test suite for transaction predicate evaluation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->