### PR TITLE
fix(database): wire cache config through to database layer

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,6 +135,11 @@ type Config struct {
 	meshPort uint
 	// Storage mode: "core" or "api"
 	storageMode StorageMode
+	// CBOR cache configuration
+	cacheBlockLRUEntries int
+	cacheHotUtxoEntries  int
+	cacheHotTxEntries    int
+	cacheHotTxMaxBytes   int64
 }
 
 // configPopulateNetworkMagic uses the named network (if specified) to determine the network magic value (if not specified)
@@ -677,5 +682,16 @@ func WithMeshPort(port uint) ConfigOptionFunc {
 func WithStorageMode(mode StorageMode) ConfigOptionFunc {
 	return func(c *Config) {
 		c.storageMode = mode
+	}
+}
+
+// WithCacheConfig sets the CBOR cache sizes for block LRU,
+// hot UTxO, and hot TX caches.
+func WithCacheConfig(blockLRU, hotUtxo, hotTx int, hotTxMaxBytes int64) ConfigOptionFunc {
+	return func(c *Config) {
+		c.cacheBlockLRUEntries = blockLRU
+		c.cacheHotUtxoEntries = hotUtxo
+		c.cacheHotTxEntries = hotTx
+		c.cacheHotTxMaxBytes = hotTxMaxBytes
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -314,6 +314,12 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithInactivityTimeout(cfg.InactivityTimeout),
 			dingo.WithMaxConnectionsPerIP(cfg.MaxConnectionsPerIP),
 			dingo.WithMaxInboundConns(cfg.MaxInboundConns),
+			dingo.WithCacheConfig(
+				cfg.Cache.BlockLRUEntries,
+				cfg.Cache.HotUtxoEntries,
+				cfg.Cache.HotTxEntries,
+				cfg.Cache.HotTxMaxBytes,
+			),
 			dingo.WithChainsyncMaxClients(
 				cfg.Chainsync.MaxClients,
 			),

--- a/node.go
+++ b/node.go
@@ -419,6 +419,12 @@ func (n *Node) Run(ctx context.Context) error {
 		MetadataPlugin: n.config.metadataPlugin,
 		MaxConnections: n.config.DatabaseWorkerPoolConfig.WorkerPoolSize,
 		StorageMode:    string(n.config.storageMode),
+		CacheConfig: database.CborCacheConfig{
+			BlockLRUEntries: n.config.cacheBlockLRUEntries,
+			HotUtxoEntries:  n.config.cacheHotUtxoEntries,
+			HotTxEntries:    n.config.cacheHotTxEntries,
+			HotTxMaxBytes:   n.config.cacheHotTxMaxBytes,
+		},
 	}
 	db, err := database.New(dbConfig)
 	if db == nil {


### PR DESCRIPTION
## Summary
- CBOR cache configuration (`DINGO_CACHE_BLOCK_LRU_ENTRIES`, `DINGO_CACHE_HOT_UTXO_ENTRIES`, `DINGO_CACHE_HOT_TX_ENTRIES`) was parsed from config/env vars but never passed to the database layer
- All cache sizes defaulted to zero, disabling the block LRU cache entirely
- All 4 nodes showed `dingo_cbor_cache_block_lru_hits_total=0` despite `DINGO_CACHE_BLOCK_LRU_ENTRIES=5000` being configured

## Fix
- Add `WithCacheConfig()` option to node `Config`
- Pass cache values to `database.CborCacheConfig` in `node.go`
- Wire `cfg.Cache` fields through `dingo.New()` in `internal/node/node.go`

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Deploy to mr-slave and verify `block_lru_hits_total` starts incrementing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CBOR cache settings: block LRU entry count, hot UTXO entry count, hot transaction entry count, and hot transaction max-bytes to allow tuning memory/performance for different deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->