### PR TITLE
fix(ouroboros): close connection on rollback point not found instead of restarting chainsync

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -980,7 +980,7 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 			// MustReply state, during which no recovery can happen.
 			// Closing lets peer governance reconnect with a fresh
 			// bearer and updated intersect points.
-			if e.Reason == "local_tip_plateau" {
+			if e.Reason == "local_tip_plateau" || e.Reason == "rollback point not found" {
 				for _, connId := range connIds {
 					if o.ChainsyncState != nil {
 						o.ChainsyncState.ClearObservedHeaderHistory(connId)


### PR DESCRIPTION
## Summary
- When a peer sends RollBackward to a point not in the local chain, the resync handler attempted to restart chainsync on the same connection
- This fails because the peer's protocol state is past the intersect phase, causing `MsgRollForwardNtN not allowed in state Intersect` errors
- The restart loop repeats indefinitely, preventing any chain progress even across node restarts

## Root cause
After a pipeline stall, the node falls behind. When chainsync resumes, the peer rolls back to a point the node never received. The current handler tries to restart chainsync on the same bearer, but the peer is already sending roll-forward messages while dingo is in the Intersect state.

## Fix
Close the connection on "rollback point not found" (same as plateau and local rollback handlers) instead of attempting in-place restart. Peer governance reconnects with a fresh bearer and updated intersect points from the current ledger tip.

One-line change: add `"rollback point not found"` to the connection-close path alongside `"local_tip_plateau"`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Deploy to mini-1 and verify recovery from stall without restart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close the chainsync connection in `ouroboros` when a peer rolls back to a point not on the local chain ("rollback point not found"), instead of restarting on the same connection. This prevents restart loops and protocol-state errors, and lets peer governance reconnect with fresh intersect points from the current tip.

<sup>Written for commit 1c839296c4c9ea1572bebe0e9c750f4241698dbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain synchronization handling to treat "rollback point not found" like immediate-closure plateau cases: affected connections now have observed header history cleared and are closed promptly, preventing the unnecessary restart/resync path and reducing unstable connection behavior during resynchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->