### PR TITLE
perf(database): use mmap cache in core mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ CARDANO_BLOCK_PRODUCER=true \
   ./dingo
 ```
 
+When `storageMode=core`, the Badger blob store defaults to mmap-only settings: `block-cache-size=0`, `index-cache-size=0`, and `compression=false`. When `storageMode=api`, the default Badger profile is `block-cache-size=268435456`, `index-cache-size=0`, and `compression=true`. YAML, environment variable, and CLI Badger options override those defaults only when explicitly set.
+
 See `dingo.yaml.example` for the full set of configuration options.
 
 ## Fast Bootstrapping with Mithril
@@ -313,7 +315,10 @@ BadgerDB Options:
 - `data-dir` - Directory for database files
 - `block-cache-size` - Block cache size in bytes
 - `index-cache-size` - Index cache size in bytes
+- `compression` - Enable Snappy compression
 - `gc` - Enable garbage collection
+
+Leave the mode-sensitive Badger settings unset if you want Dingo's storage-mode defaults. `storageMode=core` uses `block-cache-size=0`, `index-cache-size=0`, and `compression=false`; `storageMode=api` uses `block-cache-size=268435456`, `index-cache-size=0`, and `compression=true`.
 
 Google Cloud Storage Options:
 - `bucket` - GCS bucket name

--- a/database/plugin/blob/badger/options_test.go
+++ b/database/plugin/blob/badger/options_test.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -131,69 +132,71 @@ func TestOptionsCombination(t *testing.T) {
 	}
 }
 
-func TestApplyOperationalDefaultsCore(t *testing.T) {
-	blockCache := uint64(DefaultBlockCacheSize)
-	indexCache := uint64(DefaultIndexCacheSize)
-	memtable := uint64(DefaultMemTableSize)
+func TestApplyStorageModeDefaultsAPIWhenUnset(t *testing.T) {
+	blockCache := uint64(DefaultCoreBlockCacheSize)
+	indexCache := uint64(DefaultCoreIndexCacheSize)
+	compressionEnabled := DefaultCoreCompressionEnabled
 
-	applyOperationalDefaults(
-		"",
-		string(ProfileCore),
+	applyStorageModeDefaults(
+		"api",
 		&blockCache,
 		&indexCache,
-		&memtable,
+		&compressionEnabled,
+		false,
+		false,
+		false,
 	)
 
-	if blockCache != DefaultBlockCacheSize {
+	if blockCache != DefaultAPIBlockCacheSize {
+		t.Fatalf("expected api block cache size %d, got %d", DefaultAPIBlockCacheSize, blockCache)
+	}
+	if indexCache != DefaultAPIIndexCacheSize {
+		t.Fatalf("expected api index cache size %d, got %d", DefaultAPIIndexCacheSize, indexCache)
+	}
+	if compressionEnabled != DefaultAPICompressionEnabled {
+		t.Fatalf(
+			"expected api compression %v, got %v",
+			DefaultAPICompressionEnabled,
+			compressionEnabled,
+		)
+	}
+}
+
+func TestApplyStorageModeDefaultsCoreWhenUnset(t *testing.T) {
+	blockCache := uint64(DefaultBlockCacheSize)
+	indexCache := uint64(DefaultIndexCacheSize)
+	compressionEnabled := true
+
+	applyStorageModeDefaults(
+		"core",
+		&blockCache,
+		&indexCache,
+		&compressionEnabled,
+		false,
+		false,
+		false,
+	)
+
+	if blockCache != DefaultCoreBlockCacheSize {
 		t.Fatalf(
 			"expected core block cache size %d, got %d",
-			DefaultBlockCacheSize,
+			DefaultCoreBlockCacheSize,
 			blockCache,
 		)
 	}
-	if indexCache != DefaultIndexCacheSize {
+	if indexCache != DefaultCoreIndexCacheSize {
 		t.Fatalf(
 			"expected core index cache size %d, got %d",
-			DefaultIndexCacheSize,
+			DefaultCoreIndexCacheSize,
 			indexCache,
 		)
 	}
-	if memtable != DefaultMemTableSize {
+	if compressionEnabled != DefaultCoreCompressionEnabled {
 		t.Fatalf(
-			"expected core memtable size %d, got %d",
-			DefaultMemTableSize,
-			memtable,
+			"expected core compression %v, got %v",
+			DefaultCoreCompressionEnabled,
+			compressionEnabled,
 		)
-	}
-}
-
-func TestApplyOperationalDefaultsLoadPreservesOverrides(t *testing.T) {
-	blockCache := uint64(123)
-	indexCache := uint64(456)
-	memtable := uint64(789)
-
-	applyOperationalDefaults(
-		string(ProfileLoad),
-		string(ProfileAPI),
-		&blockCache,
-		&indexCache,
-		&memtable,
-	)
-
-	if blockCache != 123 {
-		t.Fatalf("expected block cache override to be preserved, got %d", blockCache)
-	}
-	if indexCache != 456 {
-		t.Fatalf("expected index cache override to be preserved, got %d", indexCache)
-	}
-	if memtable != 789 {
-		t.Fatalf("expected memtable override to be preserved, got %d", memtable)
-	}
-}
-
-func TestResolveProfilePrefersLoadRunMode(t *testing.T) {
-	if profile := resolveProfile(string(ProfileLoad), string(ProfileAPI)); profile != ProfileLoad {
-		t.Fatalf("expected load profile, got %q", profile)
 	}
 }
 
@@ -204,11 +207,11 @@ func TestUseCompactBlockMetadata(t *testing.T) {
 		storageMode string
 		expected    bool
 	}{
-		{name: "serve core", runMode: "serve", storageMode: string(ProfileCore), expected: true},
-		{name: "leios core", runMode: "leios", storageMode: string(ProfileCore), expected: true},
-		{name: "load core", runMode: string(ProfileLoad), storageMode: string(ProfileCore), expected: false},
-		{name: "serve api", runMode: "serve", storageMode: string(ProfileAPI), expected: false},
-		{name: "empty run mode", runMode: "", storageMode: string(ProfileCore), expected: false},
+		{name: "serve core", runMode: "serve", storageMode: "core", expected: true},
+		{name: "leios core", runMode: "leios", storageMode: "core", expected: true},
+		{name: "load core", runMode: "load", storageMode: "core", expected: false},
+		{name: "serve api", runMode: "serve", storageMode: "api", expected: false},
+		{name: "empty run mode", runMode: "", storageMode: "core", expected: false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -219,27 +222,12 @@ func TestUseCompactBlockMetadata(t *testing.T) {
 	}
 }
 
-func TestApplyOperationalDefaultsPreservesExplicitEqualToDefault(t *testing.T) {
-	// An explicit override that happens to equal the API-profile default
-	// must NOT be overwritten when a different profile is resolved.
+func TestApplyStorageModeDefaultsPreservesExplicitOverrides(t *testing.T) {
 	blockCache := uint64(DefaultBlockCacheSize)
 	indexCache := uint64(DefaultIndexCacheSize)
-	memtable := uint64(DefaultMemTableSize)
-
-	// With load profile, core/load sizes differ from the defaults (which
-	// match the API profile). If the caller explicitly set the API-default
-	// values, applyOperationalDefaults will still overwrite them because it
-	// compares against the constants. This test documents the current
-	// limitation: callers that need to preserve explicit overrides must
-	// copy values to locals before calling applyOperationalDefaults (as
-	// NewFromCmdlineOptions does).
-	//
-	// The important invariant: cmdlineOptions must NOT be mutated.
+	compressionEnabled := true
 	cmdlineOptionsMutex.Lock()
 	saved := cmdlineOptions
-	cmdlineOptions.blockCacheSize = DefaultBlockCacheSize
-	cmdlineOptions.indexCacheSize = DefaultIndexCacheSize
-	cmdlineOptions.memTableSize = DefaultMemTableSize
 	cmdlineOptionsMutex.Unlock()
 	t.Cleanup(func() {
 		cmdlineOptionsMutex.Lock()
@@ -247,41 +235,130 @@ func TestApplyOperationalDefaultsPreservesExplicitEqualToDefault(t *testing.T) {
 		cmdlineOptionsMutex.Unlock()
 	})
 
-	applyOperationalDefaults(
-		string(ProfileLoad),
-		"",
+	applyStorageModeDefaults(
+		"core",
 		&blockCache,
 		&indexCache,
-		&memtable,
+		&compressionEnabled,
+		true,
+		true,
+		true,
 	)
 
-	// Verify that the global cmdlineOptions were NOT mutated
-	if cmdlineOptions.blockCacheSize != saved.blockCacheSize {
+	if blockCache != DefaultBlockCacheSize {
 		t.Fatalf(
-			"cmdlineOptions.blockCacheSize mutated: want %d, got %d",
-			saved.blockCacheSize,
-			cmdlineOptions.blockCacheSize,
+			"expected explicit block cache override %d, got %d",
+			DefaultBlockCacheSize,
+			blockCache,
 		)
 	}
-	if cmdlineOptions.indexCacheSize != saved.indexCacheSize {
+	if indexCache != DefaultIndexCacheSize {
 		t.Fatalf(
-			"cmdlineOptions.indexCacheSize mutated: want %d, got %d",
-			saved.indexCacheSize,
-			cmdlineOptions.indexCacheSize,
+			"expected explicit index cache override %d, got %d",
+			DefaultIndexCacheSize,
+			indexCache,
 		)
 	}
-	if cmdlineOptions.memTableSize != saved.memTableSize {
+	if !compressionEnabled {
+		t.Fatal("expected explicit compression override to remain enabled")
+	}
+}
+
+func TestNewFromCmdlineOptionsUsesAPIDefaultsWhenCompressionUnset(t *testing.T) {
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		"badger",
+		"storage-mode",
+		"api",
+	); err != nil {
+		t.Fatalf("set storage-mode: %v", err)
+	}
+
+	p := NewFromCmdlineOptions()
+	b, ok := p.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if b.blockCacheSize != DefaultAPIBlockCacheSize {
 		t.Fatalf(
-			"cmdlineOptions.memTableSize mutated: want %d, got %d",
-			saved.memTableSize,
-			cmdlineOptions.memTableSize,
+			"blockCacheSize: want api default %d, got %d",
+			DefaultAPIBlockCacheSize,
+			b.blockCacheSize,
+		)
+	}
+	if b.indexCacheSize != DefaultAPIIndexCacheSize {
+		t.Fatalf(
+			"indexCacheSize: want api default %d, got %d",
+			DefaultAPIIndexCacheSize,
+			b.indexCacheSize,
+		)
+	}
+	if b.compressionEnabled != DefaultAPICompressionEnabled {
+		t.Fatalf(
+			"compressionEnabled: want api default %v, got %v",
+			DefaultAPICompressionEnabled,
+			b.compressionEnabled,
 		)
 	}
 }
 
+func TestNewFromCmdlineOptionsPreservesExplicitCompressionDisableInAPIStorageMode(t *testing.T) {
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		"badger",
+		"storage-mode",
+		"api",
+	); err != nil {
+		t.Fatalf("set storage-mode: %v", err)
+	}
+	if err := plugin.ProcessConfig(map[string]map[string]map[string]any{
+		"blob": {
+			"badger": {
+				"compression": false,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("process plugin config: %v", err)
+	}
+
+	p := NewFromCmdlineOptions()
+	b, ok := p.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if b.blockCacheSize != DefaultAPIBlockCacheSize {
+		t.Fatalf(
+			"blockCacheSize: want api default %d, got %d",
+			DefaultAPIBlockCacheSize,
+			b.blockCacheSize,
+		)
+	}
+	if b.compressionEnabled {
+		t.Fatal("compressionEnabled: expected explicit false override")
+	}
+}
+
 func TestNewFromCmdlineOptionsDoesNotMutateGlobals(t *testing.T) {
-	// Run NewFromCmdlineOptions twice with different profiles and verify
-	// the second call does not inherit the first profile's derived sizes.
 	cmdlineOptionsMutex.Lock()
 	saved := cmdlineOptions
 	cmdlineOptionsMutex.Unlock()
@@ -292,7 +369,7 @@ func TestNewFromCmdlineOptionsDoesNotMutateGlobals(t *testing.T) {
 	})
 	initCmdlineOptions()
 	cmdlineOptionsMutex.Lock()
-	cmdlineOptions.runMode = string(ProfileLoad)
+	cmdlineOptions.storageMode = "core"
 	cmdlineOptionsMutex.Unlock()
 
 	p1 := NewFromCmdlineOptions()
@@ -306,36 +383,56 @@ func TestNewFromCmdlineOptionsDoesNotMutateGlobals(t *testing.T) {
 	cmdlineOptionsMutex.Lock()
 	blockAfterFirst := cmdlineOptions.blockCacheSize
 	indexAfterFirst := cmdlineOptions.indexCacheSize
-	memAfterFirst := cmdlineOptions.memTableSize
+	compressionAfterFirst := cmdlineOptions.compressionEnabled
 	cmdlineOptionsMutex.Unlock()
 
-	// Globals should still be at init defaults
-	if blockAfterFirst != DefaultBlockCacheSize {
+	if blockAfterFirst != DefaultCoreBlockCacheSize {
 		t.Fatalf(
 			"blockCacheSize mutated after first call: want %d, got %d",
-			DefaultBlockCacheSize,
+			DefaultCoreBlockCacheSize,
 			blockAfterFirst,
 		)
 	}
-	if indexAfterFirst != DefaultIndexCacheSize {
+	if indexAfterFirst != DefaultCoreIndexCacheSize {
 		t.Fatalf(
 			"indexCacheSize mutated after first call: want %d, got %d",
-			DefaultIndexCacheSize,
+			DefaultCoreIndexCacheSize,
 			indexAfterFirst,
 		)
 	}
-	if memAfterFirst != DefaultMemTableSize {
+	if compressionAfterFirst != DefaultCoreCompressionEnabled {
 		t.Fatalf(
-			"memTableSize mutated after first call: want %d, got %d",
-			DefaultMemTableSize,
-			memAfterFirst,
+			"compressionEnabled mutated after first call: want %v, got %v",
+			DefaultCoreCompressionEnabled,
+			compressionAfterFirst,
 		)
 	}
 
-	// Second call with API profile should get API defaults, not load sizes
+	b1, ok := p1.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from first NewFromCmdlineOptions")
+	}
+	if b1.blockCacheSize != DefaultCoreBlockCacheSize {
+		t.Fatalf(
+			"first call blockCacheSize: want %d, got %d",
+			DefaultCoreBlockCacheSize,
+			b1.blockCacheSize,
+		)
+	}
+	if b1.compressionEnabled != DefaultCoreCompressionEnabled {
+		t.Fatalf(
+			"first call compressionEnabled: want %v, got %v",
+			DefaultCoreCompressionEnabled,
+			b1.compressionEnabled,
+		)
+	}
+
 	cmdlineOptionsMutex.Lock()
-	cmdlineOptions.runMode = ""
-	cmdlineOptions.storageMode = string(ProfileAPI)
+	cmdlineOptions.storageMode = "core"
+	cmdlineOptions.blockCacheSize = DefaultBlockCacheSize
+	cmdlineOptions.blockCacheSizeSet = true
+	cmdlineOptions.compressionEnabled = true
+	cmdlineOptions.compressionEnabledSet = true
 	cmdlineOptionsMutex.Unlock()
 
 	p2 := NewFromCmdlineOptions()
@@ -351,9 +448,12 @@ func TestNewFromCmdlineOptionsDoesNotMutateGlobals(t *testing.T) {
 	}
 	if b2.blockCacheSize != DefaultBlockCacheSize {
 		t.Fatalf(
-			"second call blockCacheSize: want %d (API default), got %d",
+			"second call blockCacheSize: want explicit override %d, got %d",
 			DefaultBlockCacheSize,
 			b2.blockCacheSize,
 		)
+	}
+	if !b2.compressionEnabled {
+		t.Fatal("second call compressionEnabled: expected explicit true override")
 	}
 }

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -32,122 +32,92 @@ import (
 // Operators can override via block-cache-size / index-cache-size CLI
 // flags or YAML config.
 const (
-	DefaultBlockCacheSize   = 268435456  // 256 MB — Badger's own default; sufficient for core nodes
-	DefaultIndexCacheSize   = 0          // 0 = unlimited; Badger memory-maps the full index
-	DefaultValueLogFileSize = 1073741824 // 1 GB
-	DefaultMemTableSize     = 134217728  // 128 MB
-	DefaultValueThreshold   = 1048576    // 1 MB
+	DefaultBlockCacheSize         = 268435456  // 256 MB
+	DefaultIndexCacheSize         = 0          // 0 = unlimited
+	DefaultValueLogFileSize       = 1073741824 // 1 GB
+	DefaultMemTableSize           = 134217728  // 128 MB
+	DefaultValueThreshold         = 1048576    // 1 MB
+	DefaultCoreBlockCacheSize     = 0
+	DefaultCoreIndexCacheSize     = 0
+	DefaultCoreCompressionEnabled = false
+	DefaultAPIBlockCacheSize      = DefaultBlockCacheSize
+	DefaultAPIIndexCacheSize      = DefaultIndexCacheSize
+	DefaultAPICompressionEnabled  = true
 )
-
-type Profile string
-
-const (
-	ProfileCore Profile = "core"
-	ProfileAPI  Profile = "api"
-	ProfileLoad Profile = "load"
-)
-
-type ProfileSettings struct {
-	BlockCacheSize       uint64
-	IndexCacheSize       uint64
-	MemTableSize         uint64
-	CompactBlockMetadata bool
-}
 
 var (
 	cmdlineOptions struct {
-		dataDir            string
-		runMode            string
-		storageMode        string
-		blockCacheSize     uint64
-		indexCacheSize     uint64
-		valueLogFileSize   uint64
-		memTableSize       uint64
-		valueThreshold     uint64
-		gcEnabled          bool
-		compressionEnabled bool
+		dataDir               string
+		runMode               string
+		storageMode           string
+		blockCacheSize        uint64
+		indexCacheSize        uint64
+		valueLogFileSize      uint64
+		memTableSize          uint64
+		valueThreshold        uint64
+		gcEnabled             bool
+		compressionEnabled    bool
+		blockCacheSizeSet     bool
+		indexCacheSizeSet     bool
+		compressionEnabledSet bool
 	}
 	cmdlineOptionsMutex sync.RWMutex
 )
 
-func profileSettings(profile Profile) ProfileSettings {
-	switch profile {
-	case ProfileLoad:
-		return ProfileSettings{
-			BlockCacheSize:       268435456, // 256MB
-			IndexCacheSize:       67108864,  // 64MB
-			MemTableSize:         67108864,  // 64MB
-			CompactBlockMetadata: false,
-		}
-	case ProfileCore:
-		// Core mode keeps Badger's normal cache sizing. Low-memory
-		// validation belongs in dedicated constrained-memory test runs,
-		// not in production defaults for serve/core nodes.
-		return ProfileSettings{
-			BlockCacheSize:       DefaultBlockCacheSize,
-			IndexCacheSize:       DefaultIndexCacheSize,
-			MemTableSize:         DefaultMemTableSize,
-			CompactBlockMetadata: false,
-		}
-	case ProfileAPI:
-		fallthrough
-	default:
-		return ProfileSettings{
-			BlockCacheSize:       DefaultBlockCacheSize,
-			IndexCacheSize:       DefaultIndexCacheSize,
-			MemTableSize:         DefaultMemTableSize,
-			CompactBlockMetadata: false,
-		}
-	}
-}
-
-func resolveProfile(runMode, storageMode string) Profile {
-	if runMode == string(ProfileLoad) {
-		return ProfileLoad
-	}
-	if storageMode == string(ProfileAPI) {
-		return ProfileAPI
-	}
-	return ProfileCore
-}
-
-func applyOperationalDefaults(
-	runMode string,
+func applyStorageModeDefaults(
 	storageMode string,
 	blockCacheSize *uint64,
 	indexCacheSize *uint64,
-	memTableSize *uint64,
+	compressionEnabled *bool,
+	blockCacheSizeSet bool,
+	indexCacheSizeSet bool,
+	compressionEnabledSet bool,
 ) {
-	settings := profileSettings(resolveProfile(runMode, storageMode))
-	if *blockCacheSize == DefaultBlockCacheSize {
-		*blockCacheSize = settings.BlockCacheSize
-	}
-	if *indexCacheSize == DefaultIndexCacheSize {
-		*indexCacheSize = settings.IndexCacheSize
-	}
-	if *memTableSize == DefaultMemTableSize {
-		*memTableSize = settings.MemTableSize
+	switch storageMode {
+	case "api":
+		if !blockCacheSizeSet {
+			*blockCacheSize = DefaultAPIBlockCacheSize
+		}
+		if !indexCacheSizeSet {
+			*indexCacheSize = DefaultAPIIndexCacheSize
+		}
+		if !compressionEnabledSet {
+			*compressionEnabled = DefaultAPICompressionEnabled
+		}
+	default:
+		if !blockCacheSizeSet {
+			*blockCacheSize = DefaultCoreBlockCacheSize
+		}
+		if !indexCacheSizeSet {
+			*indexCacheSize = DefaultCoreIndexCacheSize
+		}
+		if !compressionEnabledSet {
+			*compressionEnabled = DefaultCoreCompressionEnabled
+		}
 	}
 }
 
 func useCompactBlockMetadata(runMode, storageMode string) bool {
 	return (runMode == "serve" || runMode == "leios") &&
-		storageMode == string(ProfileCore)
+		storageMode == "core"
 }
 
 // initCmdlineOptions sets default values for cmdlineOptions
 func initCmdlineOptions() {
 	cmdlineOptionsMutex.Lock()
 	defer cmdlineOptionsMutex.Unlock()
-	cmdlineOptions.blockCacheSize = DefaultBlockCacheSize
-	cmdlineOptions.indexCacheSize = DefaultIndexCacheSize
+	cmdlineOptions.blockCacheSize = DefaultCoreBlockCacheSize
+	cmdlineOptions.indexCacheSize = DefaultCoreIndexCacheSize
 	cmdlineOptions.valueLogFileSize = DefaultValueLogFileSize
 	cmdlineOptions.memTableSize = DefaultMemTableSize
 	cmdlineOptions.valueThreshold = DefaultValueThreshold
 	cmdlineOptions.runMode = ""
 	cmdlineOptions.storageMode = "core"
 	cmdlineOptions.gcEnabled = true
-	cmdlineOptions.compressionEnabled = true
+	cmdlineOptions.compressionEnabled = DefaultCoreCompressionEnabled
+	cmdlineOptions.blockCacheSizeSet = false
+	cmdlineOptions.indexCacheSizeSet = false
+	cmdlineOptions.compressionEnabledSet = false
 	cmdlineOptions.dataDir = ".dingo"
 }
 
@@ -185,9 +155,10 @@ func init() {
 				{
 					Name:         "block-cache-size",
 					Type:         plugin.PluginOptionTypeUint,
-					Description:  "Badger block cache size",
-					DefaultValue: uint64(DefaultBlockCacheSize),
+					Description:  "Badger block cache size (runtime default: 0 in core mode, 268435456 in api mode)",
+					DefaultValue: uint64(DefaultCoreBlockCacheSize),
 					Dest:         &(cmdlineOptions.blockCacheSize),
+					SetIndicator: &(cmdlineOptions.blockCacheSizeSet),
 				},
 				{
 					Name:         "index-cache-size",
@@ -195,6 +166,7 @@ func init() {
 					Description:  "Badger index cache size",
 					DefaultValue: uint64(DefaultIndexCacheSize),
 					Dest:         &(cmdlineOptions.indexCacheSize),
+					SetIndicator: &(cmdlineOptions.indexCacheSizeSet),
 				},
 				{
 					Name:         "gc",
@@ -227,9 +199,10 @@ func init() {
 				{
 					Name:         "compression",
 					Type:         plugin.PluginOptionTypeBool,
-					Description:  "Enable Snappy compression (disable for mmap-only mode; set block-cache-size=0 for mmap-only)",
-					DefaultValue: true,
+					Description:  "Enable Snappy compression (runtime default: false in core mode, true in api mode)",
+					DefaultValue: DefaultCoreCompressionEnabled,
 					Dest:         &(cmdlineOptions.compressionEnabled),
+					SetIndicator: &(cmdlineOptions.compressionEnabledSet),
 				},
 			},
 		},
@@ -238,53 +211,48 @@ func init() {
 
 func NewFromCmdlineOptions() plugin.Plugin {
 	cmdlineOptionsMutex.Lock()
-	// Copy cmdline values to locals so applyOperationalDefaults does not
-	// mutate the shared cmdlineOptions struct.
 	blockCacheSize := cmdlineOptions.blockCacheSize
 	indexCacheSize := cmdlineOptions.indexCacheSize
 	memTableSize := cmdlineOptions.memTableSize
-	profile := resolveProfile(cmdlineOptions.runMode, cmdlineOptions.storageMode)
-	settings := profileSettings(profile)
-	applyOperationalDefaults(
-		cmdlineOptions.runMode,
+	compressionEnabled := cmdlineOptions.compressionEnabled
+	applyStorageModeDefaults(
 		cmdlineOptions.storageMode,
 		&blockCacheSize,
 		&indexCacheSize,
-		&memTableSize,
+		&compressionEnabled,
+		cmdlineOptions.blockCacheSizeSet,
+		cmdlineOptions.indexCacheSizeSet,
+		cmdlineOptions.compressionEnabledSet,
 	)
 	// Safe conversion from uint64 to int64 with bounds checking
-	valueLogFileSize := min(cmdlineOptions.valueLogFileSize,
-		// Cap at max int64
-		uint64(math.MaxInt64))
-	memTableSizeCapped := min(memTableSize,
-		// Cap at max int64
-		uint64(math.MaxInt64))
-	valueThreshold := min(cmdlineOptions.valueThreshold,
-		// Cap at max int64
-		uint64(math.MaxInt64))
+	valueLogFileSize := min(
+		cmdlineOptions.valueLogFileSize,
+		uint64(math.MaxInt64),
+	)
+	memTableSizeCapped := min(
+		memTableSize,
+		uint64(math.MaxInt64),
+	)
+	valueThreshold := min(
+		cmdlineOptions.valueThreshold,
+		uint64(math.MaxInt64),
+	)
 	// #nosec G115
 	opts := []BlobStoreBadgerOptionFunc{
 		WithDataDir(cmdlineOptions.dataDir),
 		WithBlockCacheSize(blockCacheSize),
 		WithIndexCacheSize(indexCacheSize),
-		WithValueLogFileSize(
-			int64(valueLogFileSize),
-		),
-		WithMemTableSize(
-			int64(memTableSizeCapped),
-		),
+		WithValueLogFileSize(int64(valueLogFileSize)),
+		WithMemTableSize(int64(memTableSizeCapped)),
 		WithCompactBlockMetadata(
-			settings.CompactBlockMetadata ||
-				useCompactBlockMetadata(
-					cmdlineOptions.runMode,
-					cmdlineOptions.storageMode,
-				),
+			useCompactBlockMetadata(
+				cmdlineOptions.runMode,
+				cmdlineOptions.storageMode,
+			),
 		),
-		WithValueThreshold(
-			int64(valueThreshold),
-		),
+		WithValueThreshold(int64(valueThreshold)),
 		WithGc(cmdlineOptions.gcEnabled),
-		WithCompressionEnabled(cmdlineOptions.compressionEnabled),
+		WithCompressionEnabled(compressionEnabled),
 		WithDeferOpen(),
 	}
 	cmdlineOptionsMutex.Unlock()

--- a/database/plugin/option.go
+++ b/database/plugin/option.go
@@ -39,6 +39,8 @@ type PluginOption struct {
 	CustomEnvVar string
 	CustomFlag   string
 	Description  string
+	RuntimeOnly  bool
+	SetIndicator *bool
 	Type         PluginOptionType
 }
 
@@ -47,6 +49,9 @@ func (p *PluginOption) AddToFlagSet(
 	pluginType string,
 	pluginName string,
 ) error {
+	if p.RuntimeOnly {
+		return nil
+	}
 	var flagName string
 	if p.CustomFlag != "" {
 		flagName = fmt.Sprintf("%s-%s", pluginType, p.CustomFlag)
@@ -55,26 +60,49 @@ func (p *PluginOption) AddToFlagSet(
 	}
 	switch p.Type {
 	case PluginOptionTypeString:
-		fs.StringVar(
-			p.Dest.(*string),
+		dest := p.Dest.(*string)
+		*dest = p.DefaultValue.(string)
+		fs.Var(
+			&trackedStringValue{
+				dest:         dest,
+				setIndicator: p.SetIndicator,
+			},
 			flagName,
-			p.DefaultValue.(string),
 			p.Description,
 		)
 	case PluginOptionTypeBool:
-		fs.BoolVar(
-			p.Dest.(*bool),
+		dest := p.Dest.(*bool)
+		*dest = p.DefaultValue.(bool)
+		flag := fs.VarPF(
+			&trackedBoolValue{
+				dest:         dest,
+				setIndicator: p.SetIndicator,
+			},
 			flagName,
-			p.DefaultValue.(bool),
+			"",
 			p.Description,
 		)
+		flag.NoOptDefVal = "true"
 	case PluginOptionTypeInt:
-		fs.IntVar(p.Dest.(*int), flagName, p.DefaultValue.(int), p.Description)
-	case PluginOptionTypeUint:
-		fs.Uint64Var(
-			p.Dest.(*uint64),
+		dest := p.Dest.(*int)
+		*dest = p.DefaultValue.(int)
+		fs.Var(
+			&trackedIntValue{
+				dest:         dest,
+				setIndicator: p.SetIndicator,
+			},
 			flagName,
-			p.DefaultValue.(uint64),
+			p.Description,
+		)
+	case PluginOptionTypeUint:
+		dest := p.Dest.(*uint64)
+		*dest = p.DefaultValue.(uint64)
+		fs.Var(
+			&trackedUint64Value{
+				dest:         dest,
+				setIndicator: p.SetIndicator,
+			},
+			flagName,
 			p.Description,
 		)
 	default:
@@ -88,6 +116,9 @@ func (p *PluginOption) AddToFlagSet(
 }
 
 func (p *PluginOption) ProcessEnvVars(envPrefix string) error {
+	if p.RuntimeOnly {
+		return nil
+	}
 	envVars := []string{
 		// Automatically generate env var from specified prefix and option name
 		strings.ToUpper(
@@ -137,6 +168,7 @@ func (p *PluginOption) ProcessEnvVars(envPrefix string) error {
 					p.Name,
 				)
 			}
+			markOptionSet(p.SetIndicator)
 		}
 	}
 	return nil
@@ -145,6 +177,9 @@ func (p *PluginOption) ProcessEnvVars(envPrefix string) error {
 func (p *PluginOption) ProcessConfig(
 	pluginData map[string]any,
 ) error {
+	if p.RuntimeOnly {
+		return nil
+	}
 	if optionData, ok := pluginData[p.Name]; ok {
 		switch p.Type {
 		case PluginOptionTypeString:
@@ -188,6 +223,113 @@ func (p *PluginOption) ProcessConfig(
 				p.Name,
 			)
 		}
+		markOptionSet(p.SetIndicator)
 	}
 	return nil
+}
+
+func markOptionSet(setIndicator *bool) {
+	if setIndicator != nil {
+		*setIndicator = true
+	}
+}
+
+type trackedStringValue struct {
+	dest         *string
+	setIndicator *bool
+}
+
+func (v *trackedStringValue) Set(value string) error {
+	*(v.dest) = value
+	markOptionSet(v.setIndicator)
+	return nil
+}
+
+func (v *trackedStringValue) String() string {
+	if v.dest == nil {
+		return ""
+	}
+	return *(v.dest)
+}
+
+func (v *trackedStringValue) Type() string {
+	return "string"
+}
+
+type trackedBoolValue struct {
+	dest         *bool
+	setIndicator *bool
+}
+
+func (v *trackedBoolValue) Set(value string) error {
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	*(v.dest) = parsed
+	markOptionSet(v.setIndicator)
+	return nil
+}
+
+func (v *trackedBoolValue) String() string {
+	if v.dest == nil {
+		return "false"
+	}
+	return strconv.FormatBool(*(v.dest))
+}
+
+func (v *trackedBoolValue) Type() string {
+	return "bool"
+}
+
+type trackedIntValue struct {
+	dest         *int
+	setIndicator *bool
+}
+
+func (v *trackedIntValue) Set(value string) error {
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return err
+	}
+	*(v.dest) = int(parsed)
+	markOptionSet(v.setIndicator)
+	return nil
+}
+
+func (v *trackedIntValue) String() string {
+	if v.dest == nil {
+		return "0"
+	}
+	return strconv.Itoa(*(v.dest))
+}
+
+func (v *trackedIntValue) Type() string {
+	return "int"
+}
+
+type trackedUint64Value struct {
+	dest         *uint64
+	setIndicator *bool
+}
+
+func (v *trackedUint64Value) Set(value string) error {
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return err
+	}
+	*(v.dest) = parsed
+	markOptionSet(v.setIndicator)
+	return nil
+}
+
+func (v *trackedUint64Value) String() string {
+	if v.dest == nil {
+		return "0"
+	}
+	return strconv.FormatUint(*(v.dest), 10)
+}
+
+func (v *trackedUint64Value) Type() string {
+	return "uint"
 }

--- a/database/plugin/plugin.go
+++ b/database/plugin/plugin.go
@@ -120,6 +120,7 @@ func SetPluginOption(
 					)
 				}
 				*dest = v
+				markOptionSet(opt.SetIndicator)
 				return nil
 			case PluginOptionTypeBool:
 				v, ok := value.(bool)
@@ -149,6 +150,7 @@ func SetPluginOption(
 					)
 				}
 				*dest = v
+				markOptionSet(opt.SetIndicator)
 				return nil
 			case PluginOptionTypeInt:
 				v, ok := value.(int)
@@ -178,6 +180,7 @@ func SetPluginOption(
 					)
 				}
 				*dest = v
+				markOptionSet(opt.SetIndicator)
 				return nil
 			case PluginOptionTypeUint:
 				// accept uint64 or int
@@ -194,6 +197,7 @@ func SetPluginOption(
 						return fmt.Errorf("nil destination pointer for option %s", optionName)
 					}
 					*dest = tv
+					markOptionSet(opt.SetIndicator)
 					return nil
 				case int:
 					if tv < 0 {
@@ -210,6 +214,7 @@ func SetPluginOption(
 						return fmt.Errorf("nil destination pointer for option %s", optionName)
 					}
 					*dest = uint64(tv)
+					markOptionSet(opt.SetIndicator)
 					return nil
 				default:
 					return fmt.Errorf("invalid type for option %s: expected uint64 or int", optionName)

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -1,5 +1,7 @@
 # Example config file for dingo
-# The values shown below correspond to the in-code defaults
+# The values shown below correspond to the in-code defaults unless a
+# setting is left commented out to preserve a storage-mode-specific
+# runtime default.
 
 # Public bind address for the Dingo server
 bindAddr: "0.0.0.0"
@@ -19,12 +21,21 @@ database:
     badger:
       # Data directory for BadgerDB storage
       data-dir: ".dingo/badger"
-      # Block cache size in bytes (default: 1610612736 ~1.5GB)
-      block-cache-size: 1610612736
-      # Index cache size in bytes (default: 536870912 ~512MB)
-      index-cache-size: 536870912
+      # Block cache size in bytes.
+      # Leave unset to use the storage-mode default:
+      # - 0 when storageMode: "core"
+      # - 268435456 (256MB) when storageMode: "api"
+      # block-cache-size: 0
+      # Index cache size in bytes.
+      # Leave unset to use the runtime default (0 in both core and api modes).
+      # index-cache-size: 0
       # Enable garbage collection (default: true)
       gc: true
+      # Enable Snappy compression.
+      # Leave unset to use the storage-mode default:
+      # - false when storageMode: "core"
+      # - true when storageMode: "api"
+      # compression: false
     gcs:
       # Google Cloud Storage bucket name
       bucket: ""
@@ -170,6 +181,10 @@ barkPort: 0
 #   storageMode: "api"
 #   utxorpcPort: 9090
 #   blockfrostPort: 3100
+#   # With storageMode: "api", leave mode-sensitive Badger settings unset to keep:
+#   #   block-cache-size: 268435456
+#   #   index-cache-size: 0
+#   #   compression: true
 #
 # Validator / block producer (core storage, no APIs):
 #   storageMode: "core"
@@ -177,6 +192,11 @@ barkPort: 0
 #   shelleyVrfKey: "/keys/vrf.skey"
 #   shelleyKesKey: "/keys/kes.skey"
 #   shelleyOperationalCertificate: "/keys/opcert.cert"
+#   # With storageMode: "core", Badger blob defaults switch to mmap-only:
+#   #   block-cache-size: 0
+#   #   index-cache-size: 0
+#   #   compression: false
+#   # You can still override any of those explicitly under database.blob.badger.
 #   # Optional forging tolerances (0 = defaults)
 #   forgeSyncToleranceSlots: 0
 #   forgeStaleGapThresholdSlots: 0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Badger blob-store defaults storage-mode aware: core now uses mmap-only caching (block-cache-size=0, index-cache-size=0, compression=false) to reduce memory; api keeps 256MB block cache and compression enabled. Explicit YAML/env/CLI settings are preserved and only override when set.

- **New Features**
  - Apply storage-mode defaults only when options are unset; added `SetIndicator` to track explicit `block-cache-size`, `index-cache-size`, and `compression`.
  - Updated CLI flag parsing and env/config processing to mark options as set without mutating globals; `NewFromCmdlineOptions` applies mode defaults accordingly.
  - Kept compact block metadata for serve/leios in core mode; simplified to string-based modes.
  - Updated README and `dingo.yaml.example` to document mode-sensitive defaults; added tests for api/core defaulting and override behavior.

- **Migration**
  - No action required. Leave `block-cache-size`, `index-cache-size`, and `compression` unset to use mode defaults.
  - If you want previous core behavior, set `block-cache-size=268435456` and `compression=true` explicitly.

<sup>Written for commit e9863d614980c58d7b135f5d1170dee949ccb932. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and example configuration to describe storage-mode-sensitive Badger blob storage defaults, with core and API modes having distinct cache and compression settings.
  * Added guidance advising users to leave mode-sensitive settings unset to maintain automatic defaults.
  * Documented new compression option for Badger.

* **Refactor**
  * Replaced profile-based configuration system with storage-mode-sensitive defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->