### PR TITLE
ci(antithesis): update configurator image build

### DIFF
--- a/internal/test/antithesis/Dockerfile.configurator
+++ b/internal/test/antithesis/Dockerfile.configurator
@@ -1,8 +1,70 @@
-FROM ghcr.io/cardano-foundation/testnet-generation-tool:v0.1.0
-RUN useradd -m configurator
+# Antithesis configurator for ARM64/AMD64.
+#
+# Builds from cardano-foundation/testnet-generation-tool to generate
+# unique pool keys and genesis files for Antithesis testing.
 
-COPY --chown=configurator:configurator scripts/configurator.sh /configurator.sh
-COPY --chown=configurator:configurator testnet.yaml /testnet.yaml
+# Pin to same version used in docker-compose.yaml
+FROM ghcr.io/blinklabs-io/cardano-node:10.5.4
 
-USER configurator
+ARG UV_VERSION=0.11.2
+ARG TESTNET_GENERATION_TOOL_VERSION=v0.1.0
+ARG TESTNET_GENERATION_TOOL_COMMIT=abab0b3ce616928cae4ea5c36a41654ec068e2e4
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        tar \
+        tree \
+        python3 \
+        python3-pip \
+        jq && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages \
+        "uv==${UV_VERSION}"
+
+RUN useradd --system --create-home --home-dir /home/cardano \
+        --shell /bin/bash --user-group cardano && \
+    install --directory --owner=root --group=root --mode=0755 \
+        /usr/local/src /usr/local/src/cardano-node
+
+WORKDIR /usr/local/src
+# Pin to v0.1.0 and fail the build if the tag no longer resolves to the
+# expected commit.
+RUN git clone --branch "${TESTNET_GENERATION_TOOL_VERSION}" --depth 1 \
+        https://github.com/cardano-foundation/testnet-generation-tool.git && \
+    git -C testnet-generation-tool checkout --detach \
+        "${TESTNET_GENERATION_TOOL_COMMIT}" && \
+    test "$(git -C testnet-generation-tool rev-parse HEAD)" = \
+        "${TESTNET_GENERATION_TOOL_COMMIT}"
+
+WORKDIR /usr/local/src/testnet-generation-tool
+RUN uv sync && mkdir -p cardano-node && ln -sf /usr/local/bin ./cardano-node/bin
+
+COPY scripts/configurator.sh /configurator.sh
+COPY testnet.yaml /testnet.yaml
+RUN chmod 0755 /configurator.sh && \
+    install --directory --owner=cardano --group=cardano --mode=0755 \
+        /configs \
+        /configs/1 /configs/1/configs \
+        /configs/2 /configs/2/configs \
+        /configs/3 /configs/3/configs \
+        /configs/4 /configs/4/configs \
+        /configs/5 /configs/5/configs \
+        /configs/utxo-keys \
+        /tmp/testnet && \
+    chown -R cardano:cardano \
+        /home/cardano \
+        /usr/local/src \
+        /configurator.sh \
+        /testnet.yaml
+
+ENV HOME=/home/cardano
+
+USER cardano
+
 ENTRYPOINT ["/bin/bash", "/configurator.sh"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the Antithesis configurator image on `ghcr.io/blinklabs-io/cardano-node:10.5.4`, pins `cardano-foundation/testnet-generation-tool` `v0.1.0` to commit `abab0b3`, and runs as a non-root `cardano` user with pre-created config dirs for reproducible ARM64/AMD64 runs. Adds strict tag-to-commit checks and stays aligned with docker-compose.

- **Refactors**
  - Switch base image to `ghcr.io/blinklabs-io/cardano-node:10.5.4`.
  - Clone and pin `cardano-foundation/testnet-generation-tool` at `v0.1.0`/`abab0b3`; set up with `uv` `0.11.2`; link `cardano-node/bin` to `/usr/local/bin`.
  - Install minimal packages (`ca-certificates`, `curl`, `git`, `tar`, `tree`, `python3`, `python3-pip`, `jq`) and clean apt caches.
  - Create system user `cardano`, set `HOME`, chown sources, pre-create `/configs/*` and `/tmp/testnet`, and run the container as `cardano`.
  - Copy `configurator.sh` and `testnet.yaml`, set execute bit; keep the existing entrypoint.

<sup>Written for commit 5259fb66ad0316fe53f4f7fec4307b282e041cad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use a new base image and perform required tool installations at build time.
  * Changed runtime user and permissions handling so test scripts and configuration directories are prepared and executable before tests run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->