### PR TITLE
fix(ledger): prevent chainsync pipeline deadlock after reader exit

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2012,6 +2012,11 @@ func (ls *LedgerState) ledgerReadChain(
 	ctx context.Context,
 	resultCh chan readChainResult,
 ) {
+	// Ensure the channel is closed when the reader exits for any
+	// reason (error, context cancellation, iterator exhaustion).
+	// Without this, the consumer blocks forever on the channel
+	// read if the reader goroutine exits silently on an error.
+	defer close(resultCh)
 	// Create chain iterator
 	iter, err := ls.chain.FromPoint(ls.currentTip.Point, false)
 	if err != nil {
@@ -2538,12 +2543,15 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				}
 			}
 		}
-		currentReadResultDone = nil
 		if cachedNextBatch != nil {
-			// Use cached block batch
+			// Use cached block batch — keep the original
+			// currentReadResultDone so the reader goroutine
+			// is signalled when all cached blocks are processed.
 			nextBatch = cachedNextBatch
 			cachedNextBatch = nil
 		} else {
+			// Only reset when reading fresh from the channel
+			currentReadResultDone = nil
 			// Read next result from readChain channel
 			select {
 			case result, ok := <-readChainResultCh:


### PR DESCRIPTION
## Summary

- Reader goroutine (`ledgerReadChain`) could exit on errors without closing `resultCh`, permanently blocking the consumer goroutine
- Epoch rollover batch caching reset `currentReadResultDone` to nil, preventing the reader's done channel from being closed
- Both caused silent pipeline death: no errors, no logs, just stops advancing

## Root cause

The chainsync pipeline has a reader goroutine that sends block batches through a channel. When the reader exited (chain reconcile error, block decode failure, nil iterator), `resultCh` was never closed. The consumer blocked on `case result, ok := <-readChainResultCh` forever. The stall detector would recycle connections but that only affected the network layer — the blocked goroutine couldn't recover.

## Fix

1. `defer close(resultCh)` in `ledgerReadChain()` — consumer receives `ok == false` and returns, allowing the caller to create a fresh reader
2. Move `currentReadResultDone = nil` inside the `else` branch so cached batch processing preserves the done channel reference

## Test plan

- [x] All 4 preview nodes deployed with fix and monitored for 15 minutes
- [x] Previously texas and chris stalled within 5-10 minutes — now all 4 sustained continuous advancement
- [x] `go build ./ledger/` passes
- [ ] CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent chainsync deadlocks when the reader exits or after an epoch rollover. We now close the result channel and keep the done signal for cached batches so the consumer unblocks and the pipeline keeps advancing.

- **Bug Fixes**
  - Close `resultCh` on any reader exit (`defer close(resultCh)` in `ledgerReadChain`) so the consumer sees `ok == false` and returns cleanly.
  - Only reset `currentReadResultDone` when reading fresh from the channel; preserve it for cached batches (e.g., after epoch rollover) so the reader is properly signaled.

<sup>Written for commit b17e221b226124ca5f966cec36a3b5dc36fa1717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of ledger reading by ensuring proper cleanup when the reader goroutine exits, preventing potential deadlocks for downstream consumers.
  * Enhanced block batching control flow to correctly manage reader signaling between cached and fresh block processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->