### PR TITLE
fix(ledger): fix pipeline restart race conditions causing permanent stalls

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -708,7 +708,14 @@ func (c *Chain) rollbackLocked(
 	c.tipBlockIndex = rollbackBlockIndex
 	// Update iterators for rollback
 	for _, iter := range c.iterators {
-		if iter.lastPoint.Slot > point.Slot {
+		// Use startPoint for iterators that haven't delivered any blocks
+		// yet (lastPoint is zero-value). Without this, newly created
+		// iterators miss rollback signals entirely.
+		refSlot := iter.lastPoint.Slot
+		if refSlot == 0 && len(iter.lastPoint.Hash) == 0 {
+			refSlot = iter.startPoint.Slot
+		}
+		if refSlot > point.Slot {
 			// Don't update rollback point if the iterator already has an older one pending
 			if iter.needsRollback && point.Slot > iter.rollbackPoint.Slot {
 				continue
@@ -717,6 +724,9 @@ func (c *Chain) rollbackLocked(
 			iter.needsRollback = true
 		}
 	}
+	// Wake any iterators that are blocked waiting for new blocks so
+	// they can process the rollback signal promptly.
+	c.notifyWaitingIterators()
 	// Build events for caller to publish after locks are released
 	var pendingEvents []event.Event
 	if len(rolledBackBlocks) > 0 {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2012,11 +2012,27 @@ func (ls *LedgerState) ledgerReadChain(
 	ctx context.Context,
 	resultCh chan readChainResult,
 ) {
+	// Ensure the channel is closed when the reader exits for any
+	// reason (error, context cancellation, iterator exhaustion).
+	// Without this, the consumer blocks forever on the channel
+	// read if the reader goroutine exits silently on an error.
+	defer close(resultCh)
+	// Snapshot the current tip under lock to avoid a data race with
+	// concurrent rollbacks that update ls.currentTip.
+	ls.RLock()
+	startPoint := ls.currentTip.Point
+	ls.RUnlock()
 	// Create chain iterator
-	iter, err := ls.chain.FromPoint(ls.currentTip.Point, false)
+	iter, err := ls.chain.FromPoint(startPoint, false)
 	if err != nil {
-		ls.config.Logger.Error(
-			"failed to create chain iterator: " + err.Error(),
+		// The start point may have been rolled back off the chain
+		// between the snapshot and iterator creation. Log and return —
+		// the outer loop in ledgerProcessBlocks will retry after the
+		// rollback updates ls.currentTip.
+		ls.config.Logger.Warn(
+			"chain iterator start point not on chain, will retry",
+			"error", err,
+			"start_slot", startPoint.Slot,
 		)
 		return
 	}
@@ -2538,12 +2554,15 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				}
 			}
 		}
-		currentReadResultDone = nil
 		if cachedNextBatch != nil {
-			// Use cached block batch
+			// Use cached block batch — keep the original
+			// currentReadResultDone so the reader goroutine
+			// is signalled when all cached blocks are processed.
 			nextBatch = cachedNextBatch
 			cachedNextBatch = nil
 		} else {
+			// Only reset when reading fresh from the channel
+			currentReadResultDone = nil
 			// Read next result from readChain channel
 			select {
 			case result, ok := <-readChainResultCh:


### PR DESCRIPTION
## Summary

Deep concurrency audit of the chainsync-to-ledger pipeline revealed three interconnected bugs that cause nodes to enter unrecoverable stall states after rollbacks. The immediate trigger was a node stuck in an infinite fork resolution loop, but these bugs affect all nodes under rollback + connection churn.

### Fix 1: Iterator rollback signal missed on new iterators
`rollbackLocked()` checked `iter.lastPoint.Slot > point.Slot` to decide whether to set `needsRollback`, but freshly created iterators have zero-value `lastPoint` (slot 0). The condition is always false, so new iterators never receive rollback signals. When the pipeline restarts after a "block does not fit" error, the new iterator reads stale/deleted blocks → same error → infinite loop.

**Fix:** Fall back to `iter.startPoint.Slot` when `lastPoint` is zero-value.

### Fix 2: Pipeline reader reads `currentTip` without lock
`ledgerReadChain()` read `ls.currentTip.Point` without holding `RLock()`, racing with `ls.rollback()` which writes under `Lock()`. This could read torn struct data.

**Fix:** Snapshot `currentTip` under `RLock()`, handle `FromPoint` failure gracefully (point rolled off chain — return and let outer loop retry).

### Fix 3: Rollback doesn't wake blocked iterators
`rollbackLocked()` set `needsRollback` but never called `notifyWaitingIterators()`. If an iterator was blocked waiting for new blocks and all connections died after a rollback, the iterator would block forever.

**Fix:** Call `notifyWaitingIterators()` after setting rollback flags.

Also includes the `defer close(resultCh)` and cached batch done-channel fixes from #1782, which this PR supersedes.

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go vet ./...` no warnings  
- [x] `go test ./chain/...` passes
- [x] `go test ./ledger/...` passes
- [ ] Deploy to test nodes, verify chain advances through rollbacks
- [ ] Verify recovery from stall without PVC wipe

Supersedes #1782