### PR TITLE
fix(ledger): cancel chain iterator on pipeline reader exit

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2036,6 +2036,7 @@ func (ls *LedgerState) ledgerReadChain(
 		)
 		return
 	}
+	defer iter.Cancel()
 	ls.ledgerReadChainIterator(ctx, iter, resultCh)
 }
 


### PR DESCRIPTION
## Summary

The `ChainIterator` created in `ledgerReadChain` was never cancelled. This caused two issues:

1. **Iterator memory leak**: Each pipeline restart (via `errRestartLedgerPipeline` or error recovery) leaked one iterator entry in `chain.iterators`. Over time this grows unbounded.

2. **Delayed goroutine cleanup**: The iterator's context is derived from `context.Background()`, not the caller's context. When blocked inside `iter.Next(true)`, cancelling the pipeline context does not unblock the reader — it waits until the next chain event (block or rollback) triggers `notifyWaitingIterators`.

**Fix:** `defer iter.Cancel()` after iterator creation. This removes the iterator from the chain's tracking list and cancels its context when the reader goroutine exits.

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go vet ./...` no warnings
- [x] `go test ./chain/... ./ledger/...` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel the `ChainIterator` when the ledger pipeline reader exits to prevent leaks and ensure fast shutdown. This stops unbounded iterator growth and avoids blocking on cancellation.

- **Bug Fixes**
  - Added `defer iter.Cancel()` in `ledgerReadChain` to remove the iterator from `chain.iterators` and cancel its context promptly.

<sup>Written for commit 4707e6e10c3dbd4620ec598156c73d39bd26a00b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup to enhance system stability and prevent potential resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->