### PR TITLE
ci(docker): fix version identity

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -37,4 +37,6 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+            COMMIT_HASH=${{ github.sha }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Docker image version identity by passing `VERSION` and `COMMIT_HASH` as build args in CI. `VERSION` is set to the tag name on tag builds (else empty), and `COMMIT_HASH` is set to the Git SHA for traceability.

<sup>Written for commit 44f7d6ca0c3b67518fdc73cace77c84ead61ea88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build process to automatically include version and commit hash metadata in generated images, improving build traceability and image identification throughout the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->