### PR TITLE
feat: persistent global settings

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/plugin"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/version"
 	"github.com/spf13/cobra"
@@ -218,9 +219,10 @@ Data Directory:
           --metadata-sqlite-data-dir /nvme/indexes
 
 Storage Mode:
-  --blob-badger-storage-mode and --metadata-*-storage-mode override the
-  global storageMode config. Use "core" for minimal validation data or
-  "api" for full indexing (witnesses, scripts, datums, redeemers).
+  --storage-mode sets the global storage mode for all plugins. Use "core"
+  for minimal validation data or "api" for full indexing (witnesses,
+  scripts, datums, redeemers). Dev mode always enables "api" mode.
+  Per-plugin overrides: --blob-badger-storage-mode, --metadata-*-storage-mode.
 
 Network:
   --network sets the Cardano network name and automatically derives the
@@ -278,6 +280,8 @@ DSN Override:
 		Int("db-queue-size", 50, "database worker pool task queue size")
 	rootCmd.PersistentFlags().
 		String("data-dir", "", "data directory for all storage plugins (overrides CARDANO_DATABASE_PATH)")
+	rootCmd.PersistentFlags().
+		String("storage-mode", "", "storage mode: \"core\" (minimal) or \"api\" (full indexing)")
 
 	// Add plugin-specific flags
 	if err := plugin.PopulateCmdlineOptions(rootCmd.PersistentFlags()); err != nil {
@@ -346,6 +350,29 @@ DSN Override:
 		if cmd.Root().PersistentFlags().Changed("db-queue-size") {
 			if queueSize, err := cmd.Root().PersistentFlags().GetInt("db-queue-size"); err == nil {
 				cfg.DatabaseQueueSize = queueSize
+			}
+		}
+
+		// Override storage mode if flag is provided
+		if cmd.Root().PersistentFlags().Changed("storage-mode") {
+			storageMode, err := cmd.Root().PersistentFlags().GetString("storage-mode")
+			if err != nil {
+				return fmt.Errorf(
+					"reading storage-mode flag: %w", err,
+				)
+			}
+			storageMode = strings.ToLower(storageMode)
+			switch storageMode {
+			case types.StorageModeCore, types.StorageModeAPI:
+				cfg.StorageMode = storageMode
+			default:
+				return fmt.Errorf(
+					"invalid storage mode %q: "+
+						"must be %q or %q",
+					storageMode,
+					types.StorageModeCore,
+					types.StorageModeAPI,
+				)
 			}
 		}
 

--- a/database/commit_timestamp.go
+++ b/database/commit_timestamp.go
@@ -15,7 +15,9 @@
 package database
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/types"
 )
@@ -79,6 +81,110 @@ func (b *Database) updateCommitTimestamp(txn *Txn, timestamp int64) error {
 	blobTxn := txn.Blob()
 	if err := b.Blob().SetCommitTimestamp(timestamp, blobTxn); err != nil {
 		return err
+	}
+	return nil
+}
+
+// NodeSettingsError is returned when the configured node settings differ
+// from those persisted in the database. Changing immutable settings after
+// initial sync would leave the database in an inconsistent state.
+type NodeSettingsError struct {
+	Mismatches []string
+}
+
+func (e NodeSettingsError) Error() string {
+	return fmt.Sprintf(
+		"node settings mismatch: %s; changing these settings requires "+
+			"re-syncing from scratch",
+		strings.Join(e.Mismatches, "; "),
+	)
+}
+
+// checkNodeSettings validates that immutable settings (storage mode,
+// network) have not changed since the database was first initialised.
+// On first start it persists the configured values.
+func (d *Database) checkNodeSettings() error {
+	persisted, err := d.Metadata().GetNodeSettings()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to get node settings from metadata: %w", err,
+		)
+	}
+
+	configured := &types.NodeSettings{
+		StorageMode: d.config.StorageMode,
+		Network:     d.config.Network,
+	}
+
+	firstStart := persisted == nil
+	if firstStart {
+		// First start: persist the configured settings. Re-read
+		// afterwards so concurrent initialisation cannot silently
+		// continue with a conflicting configuration.
+		if err := d.Metadata().SetNodeSettings(configured); err != nil {
+			return fmt.Errorf(
+				"failed to persist node settings: %w", err,
+			)
+		}
+		persisted, err = d.Metadata().GetNodeSettings()
+		if err != nil {
+			return fmt.Errorf(
+				"failed to re-read node settings from metadata: %w",
+				err,
+			)
+		}
+		if persisted == nil {
+			return errors.New("node settings were not found after persistence")
+		}
+	}
+
+	var mismatches []string
+	if persisted.StorageMode != configured.StorageMode {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"storage mode was %q but configured as %q",
+			persisted.StorageMode, configured.StorageMode,
+		))
+	}
+
+	// Some database open paths do not know the network yet. In that case,
+	// preserve the persisted value and skip network validation. When the
+	// network later becomes available, fill it in exactly once.
+	if configured.Network != "" &&
+		persisted.Network == "" &&
+		len(mismatches) == 0 {
+		if err := d.Metadata().SetNodeSettings(configured); err != nil {
+			return fmt.Errorf(
+				"failed to persist node settings: %w",
+				err,
+			)
+		}
+		persisted, err = d.Metadata().GetNodeSettings()
+		if err != nil {
+			return fmt.Errorf(
+				"failed to re-read node settings from metadata: %w",
+				err,
+			)
+		}
+		if persisted == nil {
+			return errors.New("node settings were not found after persistence")
+		}
+	}
+
+	if configured.Network != "" && persisted.Network != configured.Network {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"network was %q but configured as %q",
+			persisted.Network, configured.Network,
+		))
+	}
+	if len(mismatches) > 0 {
+		return NodeSettingsError{Mismatches: mismatches}
+	}
+	if firstStart {
+		d.logger.Info(
+			"node settings initialized",
+			"storageMode", configured.StorageMode,
+			"network", configured.Network,
+		)
 	}
 	return nil
 }

--- a/database/database.go
+++ b/database/database.go
@@ -44,6 +44,7 @@ type Config struct {
 	MetadataPlugin string
 	MaxConnections int    // Connection pool size for metadata plugin (should match DatabaseWorkers)
 	StorageMode    string // "core" or "api"
+	Network        string // Cardano network name (e.g. "preview", "mainnet")
 	CacheConfig    CborCacheConfig
 }
 
@@ -123,6 +124,10 @@ func (d *Database) init() error {
 	}
 	// Check commit timestamp
 	if err := d.checkCommitTimestamp(); err != nil {
+		return err
+	}
+	// Check immutable settings have not changed since initial sync
+	if err := d.checkNodeSettings(); err != nil {
 		return err
 	}
 	return nil

--- a/database/plugin/metadata/mysql/commit_timestamp.go
+++ b/database/plugin/metadata/mysql/commit_timestamp.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
@@ -24,6 +25,7 @@ import (
 
 const (
 	commitTimestampRowId = 1
+	nodeSettingsRowId    = 1
 )
 
 // CommitTimestamp represents the MySQL record used to track the current commit timestamp
@@ -68,6 +70,72 @@ func (d *MetadataStoreMysql) SetCommitTimestamp(
 	}).Create(&tmpCommitTimestamp)
 	if result.Error != nil {
 		return result.Error
+	}
+	return nil
+}
+
+// NodeSettings persists immutable node configuration so that storage mode
+// and network cannot be changed after the database has been initialised.
+type NodeSettings struct {
+	ID          uint   `gorm:"primarykey"`
+	StorageMode string `gorm:"size:16;not null"`
+	Network     string `gorm:"size:64;not null"`
+}
+
+func (NodeSettings) TableName() string {
+	return "node_settings"
+}
+
+// GetNodeSettings returns the persisted node settings, or nil if the
+// database has never been initialised.
+func (d *MetadataStoreMysql) GetNodeSettings() (*types.NodeSettings, error) {
+	var row NodeSettings
+	result := d.DB().
+		Where("id = ?", nodeSettingsRowId).
+		First(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("GetNodeSettings failed: %w", result.Error)
+	}
+	return &types.NodeSettings{
+		StorageMode: row.StorageMode,
+		Network:     row.Network,
+	}, nil
+}
+
+// SetNodeSettings persists the immutable node settings, inserting the
+// singleton row if it does not already exist.
+func (d *MetadataStoreMysql) SetNodeSettings(
+	s *types.NodeSettings,
+) error {
+	row := NodeSettings{
+		ID:          nodeSettingsRowId,
+		StorageMode: s.StorageMode,
+		Network:     s.Network,
+	}
+	result := d.DB().Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoNothing: true,
+	}).Create(&row)
+	if result.Error != nil {
+		return fmt.Errorf("SetNodeSettings failed: %w", result.Error)
+	}
+	if result.RowsAffected > 0 || s.Network == "" {
+		return nil
+	}
+	result = d.DB().
+		Model(&NodeSettings{}).
+		Where(
+			"id = ? AND storage_mode = ? AND network = ?",
+			nodeSettingsRowId,
+			s.StorageMode,
+			"",
+		).
+		Update("network", s.Network)
+	if result.Error != nil {
+		return fmt.Errorf("SetNodeSettings failed: %w", result.Error)
 	}
 	return nil
 }

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -316,6 +316,13 @@ func (d *MetadataStoreMysql) Start() error {
 	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
 		return err
 	}
+	d.logger.Debug(
+		"creating table",
+		"model", fmt.Sprintf("%T", &NodeSettings{}),
+	)
+	if err := d.db.AutoMigrate(&NodeSettings{}); err != nil {
+		return err
+	}
 
 	for _, model := range models.MigrateModels {
 		d.logger.Debug(

--- a/database/plugin/metadata/postgres/commit_timestamp.go
+++ b/database/plugin/metadata/postgres/commit_timestamp.go
@@ -16,6 +16,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
@@ -24,6 +25,7 @@ import (
 
 const (
 	commitTimestampRowId = 1
+	nodeSettingsRowId    = 1
 )
 
 // CommitTimestamp represents the postgres used to track the current commit timestamp
@@ -68,6 +70,72 @@ func (d *MetadataStorePostgres) SetCommitTimestamp(
 	}).Create(&tmpCommitTimestamp)
 	if result.Error != nil {
 		return result.Error
+	}
+	return nil
+}
+
+// NodeSettings persists immutable node configuration so that storage mode
+// and network cannot be changed after the database has been initialised.
+type NodeSettings struct {
+	ID          uint   `gorm:"primarykey"`
+	StorageMode string `gorm:"size:16;not null"`
+	Network     string `gorm:"size:64;not null"`
+}
+
+func (NodeSettings) TableName() string {
+	return "node_settings"
+}
+
+// GetNodeSettings returns the persisted node settings, or nil if the
+// database has never been initialised.
+func (d *MetadataStorePostgres) GetNodeSettings() (*types.NodeSettings, error) {
+	var row NodeSettings
+	result := d.DB().
+		Where("id = ?", nodeSettingsRowId).
+		First(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("GetNodeSettings failed: %w", result.Error)
+	}
+	return &types.NodeSettings{
+		StorageMode: row.StorageMode,
+		Network:     row.Network,
+	}, nil
+}
+
+// SetNodeSettings persists the immutable node settings, inserting the
+// singleton row if it does not already exist.
+func (d *MetadataStorePostgres) SetNodeSettings(
+	s *types.NodeSettings,
+) error {
+	row := NodeSettings{
+		ID:          nodeSettingsRowId,
+		StorageMode: s.StorageMode,
+		Network:     s.Network,
+	}
+	result := d.DB().Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoNothing: true,
+	}).Create(&row)
+	if result.Error != nil {
+		return fmt.Errorf("SetNodeSettings failed: %w", result.Error)
+	}
+	if result.RowsAffected > 0 || s.Network == "" {
+		return nil
+	}
+	result = d.DB().
+		Model(&NodeSettings{}).
+		Where(
+			"id = ? AND storage_mode = ? AND network = ?",
+			nodeSettingsRowId,
+			s.StorageMode,
+			"",
+		).
+		Update("network", s.Network)
+	if result.Error != nil {
+		return fmt.Errorf("SetNodeSettings failed: %w", result.Error)
 	}
 	return nil
 }

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -276,6 +276,13 @@ func (d *MetadataStorePostgres) Start() error {
 	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
 		return err
 	}
+	d.logger.Debug(
+		"creating table",
+		"model", fmt.Sprintf("%T", &NodeSettings{}),
+	)
+	if err := d.db.AutoMigrate(&NodeSettings{}); err != nil {
+		return err
+	}
 	for _, model := range models.MigrateModels {
 		d.logger.Debug(
 			"creating table",

--- a/database/plugin/metadata/sqlite/commit_timestamp.go
+++ b/database/plugin/metadata/sqlite/commit_timestamp.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
@@ -24,6 +25,7 @@ import (
 
 const (
 	commitTimestampRowId = 1
+	nodeSettingsRowId    = 1
 )
 
 // CommitTimestamp represents the sqlite table used to track the current commit timestamp
@@ -68,6 +70,72 @@ func (d *MetadataStoreSqlite) SetCommitTimestamp(
 	}).Create(&tmpCommitTimestamp)
 	if result.Error != nil {
 		return result.Error
+	}
+	return nil
+}
+
+// NodeSettings persists immutable node configuration so that storage mode
+// and network cannot be changed after the database has been initialised.
+type NodeSettings struct {
+	ID          uint   `gorm:"primarykey"`
+	StorageMode string `gorm:"size:16;not null"`
+	Network     string `gorm:"size:64;not null"`
+}
+
+func (NodeSettings) TableName() string {
+	return "node_settings"
+}
+
+// GetNodeSettings returns the persisted node settings, or nil if the
+// database has never been initialised.
+func (d *MetadataStoreSqlite) GetNodeSettings() (*types.NodeSettings, error) {
+	var row NodeSettings
+	result := d.ReadDB().
+		Where("id = ?", nodeSettingsRowId).
+		First(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("GetNodeSettings failed: %w", result.Error)
+	}
+	return &types.NodeSettings{
+		StorageMode: row.StorageMode,
+		Network:     row.Network,
+	}, nil
+}
+
+// SetNodeSettings persists the immutable node settings, inserting the
+// singleton row if it does not already exist.
+func (d *MetadataStoreSqlite) SetNodeSettings(
+	s *types.NodeSettings,
+) error {
+	row := NodeSettings{
+		ID:          nodeSettingsRowId,
+		StorageMode: s.StorageMode,
+		Network:     s.Network,
+	}
+	result := d.DB().Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoNothing: true,
+	}).Create(&row)
+	if result.Error != nil {
+		return fmt.Errorf("SetNodeSettings failed: %w", result.Error)
+	}
+	if result.RowsAffected > 0 || s.Network == "" {
+		return nil
+	}
+	result = d.DB().
+		Model(&NodeSettings{}).
+		Where(
+			"id = ? AND storage_mode = ? AND network = ?",
+			nodeSettingsRowId,
+			s.StorageMode,
+			"",
+		).
+		Update("network", s.Network)
+	if result.Error != nil {
+		return fmt.Errorf("SetNodeSettings failed: %w", result.Error)
 	}
 	return nil
 }

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -445,6 +445,13 @@ func (d *MetadataStoreSqlite) Start() error {
 	if err := d.db.AutoMigrate(&CommitTimestamp{}); err != nil {
 		return err
 	}
+	d.logger.Debug(
+		"creating table",
+		"model", fmt.Sprintf("%T", &NodeSettings{}),
+	)
+	if err := d.db.AutoMigrate(&NodeSettings{}); err != nil {
+		return err
+	}
 	for _, model := range models.MigrateModels {
 		d.logger.Debug(
 			"creating table",

--- a/database/plugin/metadata/sqlite/storage_mode_test.go
+++ b/database/plugin/metadata/sqlite/storage_mode_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 // setupTestDBWithMode creates and initializes a test SQLite database with the
@@ -163,4 +164,78 @@ func TestStorageMode_CaseNormalized(t *testing.T) {
 	store, err := NewWithOptions(WithStorageMode("API"))
 	require.NoError(t, err)
 	assert.Equal(t, "api", store.storageMode, "storage mode should be lowercased")
+}
+
+func TestNodeSettingsNilBeforeFirstSet(t *testing.T) {
+	store := setupTestDBWithMode(t, "core")
+
+	settings, err := store.GetNodeSettings()
+	require.NoError(t, err)
+	require.Nil(t, settings)
+}
+
+func TestNodeSettingsRemainImmutable(t *testing.T) {
+	store := setupTestDBWithMode(t, "core")
+
+	original := &types.NodeSettings{
+		StorageMode: "core",
+		Network:     "preview",
+	}
+	require.NoError(t, store.SetNodeSettings(original))
+
+	require.NoError(t, store.SetNodeSettings(&types.NodeSettings{
+		StorageMode: "api",
+		Network:     "mainnet",
+	}))
+
+	persisted, err := store.GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, original, persisted)
+}
+
+func TestNodeSettingsAllowDeferredNetworkInitialization(t *testing.T) {
+	store := setupTestDBWithMode(t, "core")
+
+	require.NoError(t, store.SetNodeSettings(&types.NodeSettings{
+		StorageMode: "core",
+		Network:     "",
+	}))
+
+	require.NoError(t, store.SetNodeSettings(&types.NodeSettings{
+		StorageMode: "core",
+		Network:     "preview",
+	}))
+
+	persisted, err := store.GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, &types.NodeSettings{
+		StorageMode: "core",
+		Network:     "preview",
+	}, persisted)
+}
+
+func TestNodeSettingsReadsOnlySingletonRow(t *testing.T) {
+	store := setupTestDBWithMode(t, "core")
+
+	require.NoError(t, store.DB().Create(&NodeSettings{
+		ID:          nodeSettingsRowId + 1,
+		StorageMode: "api",
+		Network:     "mainnet",
+	}).Error)
+
+	persisted, err := store.GetNodeSettings()
+	require.NoError(t, err)
+	require.Nil(t, persisted)
+
+	require.NoError(t, store.SetNodeSettings(&types.NodeSettings{
+		StorageMode: "core",
+		Network:     "preview",
+	}))
+
+	persisted, err = store.GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, &types.NodeSettings{
+		StorageMode: "core",
+		Network:     "preview",
+	}, persisted)
 }

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -40,6 +40,18 @@ type MetadataStore interface {
 	// the transaction is the final parameter.
 	SetCommitTimestamp(int64, types.Txn) error
 
+	// GetNodeSettings returns the persisted immutable node settings, or
+	// nil if the database has never been initialised.
+	GetNodeSettings() (*types.NodeSettings, error)
+
+	// SetNodeSettings persists the immutable node settings via an
+	// idempotent insert that succeeds on repeated calls. If the row
+	// already exists, implementations must not overwrite immutable
+	// fields and should only populate network fields when they are
+	// currently unset so callers like checkNodeSettings can perform
+	// a one-time network backfill.
+	SetNodeSettings(*types.NodeSettings) error
+
 	// Transaction creates a new metadata transaction on the write
 	// connection pool. Use ReadTransaction for read-only access to
 	// avoid contending with writers.

--- a/database/storage_mode_test.go
+++ b/database/storage_mode_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newSettingsTestDB(t *testing.T, dataDir, storageMode, network string) (*Database, error) {
+	t.Helper()
+	return New(&Config{
+		DataDir:        dataDir,
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		StorageMode:    storageMode,
+		Network:        network,
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+}
+
+func TestNodeSettingsPersistence(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// First open: persists settings
+	db, err := newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+
+	s, err := db.Metadata().GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, "core", s.StorageMode)
+	require.Equal(t, "preview", s.Network)
+	require.NoError(t, db.Close())
+
+	// Reopen with same settings: succeeds
+	db, err = newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func TestNodeSettingsRejectStorageModeChange(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Change storage mode → error
+	db, err = newSettingsTestDB(t, dataDir, "api", "preview")
+	require.Error(t, err)
+	var nsErr NodeSettingsError
+	require.True(t, errors.As(err, &nsErr))
+	require.Len(t, nsErr.Mismatches, 1)
+	require.Contains(t, nsErr.Mismatches[0], "storage mode")
+	if db != nil {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestNodeSettingsRejectNetworkChange(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Change network → error
+	db, err = newSettingsTestDB(t, dataDir, "core", "mainnet")
+	require.Error(t, err)
+	var nsErr NodeSettingsError
+	require.True(t, errors.As(err, &nsErr))
+	require.Len(t, nsErr.Mismatches, 1)
+	require.Contains(t, nsErr.Mismatches[0], "network")
+	if db != nil {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestNodeSettingsAllowOpenWithoutConfiguredNetwork(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = newSettingsTestDB(t, dataDir, "core", "")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func TestNodeSettingsAllowDeferredNetworkInitialization(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "")
+	require.NoError(t, err)
+
+	s, err := db.Metadata().GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, "core", s.StorageMode)
+	require.Equal(t, "", s.Network)
+	require.NoError(t, db.Close())
+
+	db, err = newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+
+	s, err = db.Metadata().GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, "core", s.StorageMode)
+	require.Equal(t, "preview", s.Network)
+	require.NoError(t, db.Close())
+}
+
+func TestNodeSettingsRejectStorageModeChangeWhenNetworkUnset(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = newSettingsTestDB(t, dataDir, "api", "")
+	require.Error(t, err)
+	var nsErr NodeSettingsError
+	require.True(t, errors.As(err, &nsErr))
+	require.Len(t, nsErr.Mismatches, 1)
+	require.Contains(t, nsErr.Mismatches[0], "storage mode")
+	if db != nil {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestNodeSettingsRejectBothChanged(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Change both → error with 2 mismatches
+	db, err = newSettingsTestDB(t, dataDir, "api", "mainnet")
+	require.Error(t, err)
+	var nsErr NodeSettingsError
+	require.True(t, errors.As(err, &nsErr))
+	require.Len(t, nsErr.Mismatches, 2)
+	if db != nil {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestNodeSettingsAPIMode(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// First open with "api" + "mainnet"
+	db, err := newSettingsTestDB(t, dataDir, "api", "mainnet")
+	require.NoError(t, err)
+
+	s, err := db.Metadata().GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, "api", s.StorageMode)
+	require.Equal(t, "mainnet", s.Network)
+	require.NoError(t, db.Close())
+
+	// Reopen: succeeds
+	db, err = newSettingsTestDB(t, dataDir, "api", "mainnet")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Attempt downgrade → error
+	db, err = newSettingsTestDB(t, dataDir, "core", "mainnet")
+	require.Error(t, err)
+	var nsErr NodeSettingsError
+	require.True(t, errors.As(err, &nsErr))
+	if db != nil {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestNodeSettingsMetadataSetDoesNotOverwrite(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+
+	err = db.Metadata().SetNodeSettings(&types.NodeSettings{
+		StorageMode: "api",
+		Network:     "mainnet",
+	})
+	require.NoError(t, err)
+
+	s, err := db.Metadata().GetNodeSettings()
+	require.NoError(t, err)
+	require.Equal(t, "core", s.StorageMode)
+	require.Equal(t, "preview", s.Network)
+	require.NoError(t, db.Close())
+
+	db, err = newSettingsTestDB(t, dataDir, "core", "preview")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = newSettingsTestDB(t, dataDir, "api", "mainnet")
+	require.Error(t, err)
+	var nsErr NodeSettingsError
+	require.True(t, errors.As(err, &nsErr))
+	if db != nil {
+		require.NoError(t, db.Close())
+	}
+}

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -131,6 +131,13 @@ const (
 	StorageModeAPI = "api"
 )
 
+// NodeSettings holds immutable node configuration that is persisted on first
+// sync and enforced on every subsequent startup.
+type NodeSettings struct {
+	StorageMode string
+	Network     string
+}
+
 // ErrBlobKeyNotFound is returned by blob operations when a key is missing
 var ErrBlobKeyNotFound = errors.New("blob key not found")
 

--- a/node.go
+++ b/node.go
@@ -419,6 +419,7 @@ func (n *Node) Run(ctx context.Context) error {
 		MetadataPlugin: n.config.metadataPlugin,
 		MaxConnections: n.config.DatabaseWorkerPoolConfig.WorkerPoolSize,
 		StorageMode:    string(n.config.storageMode),
+		Network:        n.config.network,
 		CacheConfig: database.CborCacheConfig{
 			BlockLRUEntries: n.config.cacheBlockLRUEntries,
 			HotUtxoEntries:  n.config.cacheHotUtxoEntries,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and enforce immutable node settings (storage mode and network) in the metadata database across restarts. Adds a global `--storage-mode` flag and auto-migrates a `node_settings` table for `sqlite`, `postgres`, and `mysql`.

- **New Features**
  - Persist `storageMode` and `network` on first start; validate on startup and fail with a `NodeSettingsError` listing mismatches.
  - Support deferred network init: if network is unknown on first start, backfill it exactly once when known.
  - New `--storage-mode` flag (`core` or `api`); dev mode always uses `api`; per-plugin overrides still work. Metadata exposes `GetNodeSettings`/`SetNodeSettings`; `node_settings` is auto-migrated across backends with a one-time network update when empty.

- **Migration**
  - Changing `storageMode` or `network` requires a fresh sync.
  - To switch: stop the node, delete the metadata database (or the data directory), then restart with the new settings.

<sup>Written for commit eb72a4cd9505647b70a1a7184657f67b54a2d2c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added root-wide --storage-mode flag (dev mode forces "api")
  * Persisted immutable node settings (storage mode + network); incompatible restarts are rejected
  * Database metadata now stores a singleton node settings row and auto-migrates its table
  * Node startup now supplies network to the database

* **Tests**
  * Added tests for node settings persistence, immutability, deferred network init, and startup validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->