### PR TITLE
ci(antithesis): set --try 1

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -262,6 +262,7 @@ jobs:
             -c "${GITHUB_SHA}" \
             -r "${GITHUB_REPOSITORY}" \
             -t "$DURATION" \
+            -y 1 \
             $NO_FAULTS_FLAG
         env:
           MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configure the Antithesis CI job to run with a single try by adding `-y 1` to the runner command. This enforces one-attempt runs for more predictable results and simpler reporting.

<sup>Written for commit f3ee1a56a020d88fca5e9fea09e9d86fb81d0691. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test submission configuration to optimize testing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->