### PR TITLE
ci(antithesis): disable automatic runs

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -1,16 +1,16 @@
 name: antithesis
 
 on:
-  push:
-    branches: ['main']
-  schedule:
-    - cron: '5 1,7,13,19 * * *'
+  # push:
+  #   branches: ['main']
+  # schedule:
+  #   - cron: '5 5,17 * * *'
   workflow_dispatch:
     inputs:
       duration:
         description: 'Test duration in hours'
         type: string
-        default: '3'
+        default: '1'
       no_faults:
         description: 'Disable fault injection'
         type: boolean


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable automatic runs for the `antithesis` CI workflow. It now runs only when triggered manually via `workflow_dispatch`, and the default test duration is reduced from 3h to 1h.

<sup>Written for commit 4f270ccbc22f2f41e624a2c98ff1a59a79d8527b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow automation configuration with adjustments to automatic triggers and scheduled execution timing.
  * Modified default parameters for manual workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->