### PR TITLE
build(deps): gouroboros 0.163.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.163.4
+	github.com/blinklabs-io/gouroboros v0.163.5
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.1.0
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yU
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.163.4 h1:yQBy5m08ZtgxHrQN44+6Pzss7gFbePmjdU9k4wLi9rI=
 github.com/blinklabs-io/gouroboros v0.163.4/go.mod h1:BVspqM17W2TkiCeL3NhIi8K3F0+xVgpujK122kOhQd4=
+github.com/blinklabs-io/gouroboros v0.163.5 h1:Tukj9H7NYpj5J8C7O8ub3diQHQBOED3FA6JTygYEQH0=
+github.com/blinklabs-io/gouroboros v0.163.5/go.mod h1:KWqLmfbdHhuH1pKsAm/Lkl6AzvhFG66J0cIGu2TmB7g=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.1.0 h1:zbaCefLWOpq8/z2ctHww9ZBzX/9qEv7zCvHnsgE+FqI=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the Cardano client library `github.com/blinklabs-io/gouroboros` from v0.163.4 to v0.163.5 to pick up the latest patch fixes and keep dependencies current.

- **Dependencies**
  - Bump `github.com/blinklabs-io/gouroboros` to v0.163.5 in `go.mod` and `go.sum`.

<sup>Written for commit d47311654a2f3d7acfc3e1d1de2935da4f9a0826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

