### PR TITLE
fix(chainselection): skip peers whose tip is far behind best known

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -594,7 +594,8 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 	// further behind are not useful for syncing.
 	if cs.securityParam > 0 {
 		bestBlock := cs.bestKnownBlockNumber()
-		if bestBlock > 0 && peerTip.Tip.BlockNumber+cs.securityParam < bestBlock {
+		if bestBlock > 0 &&
+			safeAddUint64(peerTip.Tip.BlockNumber, cs.securityParam) < bestBlock {
 			if logSkip {
 				cs.config.Logger.Debug(
 					"skipping peer behind best known tip",


### PR DESCRIPTION
## Summary
- During catch-up, the chain selector could switch to a peer thousands of blocks behind the best known peer tip
- This caused pipeline stalls and dropped rollbacks, costing minutes of sync time per cycle
- Add a check in `isPeerSelectableLocked` that skips peers more than K (securityParam) blocks behind the highest known peer tip
- Peers within K blocks are still considered (legitimate fork variance)

## Context
Observed on preview testnet: texas BP had az1 (39k behind) in its topology. Chain selector kept switching from haskell relay (at tip) to az1, causing dropped rollbacks and pipeline freezes. With this fix, az1 is connected but never selected — texas synced to tip in under a minute.

## Test plan
- [x] Deployed to preview BP with behind-tip peer (az1) in topology — peer connected but never selected
- [x] Node synced to tip in <1 minute vs stalling indefinitely before
- [ ] Verify peers within K blocks of best are still selectable (normal fork operation)
- [ ] Existing chainselection tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent chain selection from switching to far-behind peers during catch-up, avoiding stalls and dropped rollbacks. Peers >K behind the best eligible tip are skipped; peers within K remain selectable.

- **Bug Fixes**
  - Skip peers whose tip is more than K behind the highest known eligible, non-stale peer.
  - Compute the best known block with `bestKnownBlockNumber()` filtering out stale/ineligible peers and log details when skipping.
  - Use `safeAddUint64` for an overflow-safe behind-best comparison.

<sup>Written for commit 4b9a48f223b18a9e98b759f4da7999060f0c78e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced peer selection to exclude nodes whose reported progress significantly lags behind the network's best observed state. This improves synchronization reliability by prioritizing connections to better-synced peers, reducing the risk of syncing from nodes that are notably behind the network consensus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->