### PR TITLE
fix(ledger): suppress near-tip sync log

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3086,6 +3086,12 @@ func (ls *LedgerState) logSyncProgress(currentSlot uint64) {
 			pct = 100
 		}
 	}
+	// Suppress progress logging when we're near the tip
+	if pct >= 99.9 {
+		ls.syncProgressLastLog = now
+		ls.syncProgressLastSlot = currentSlot
+		return
+	}
 	ls.config.Logger.Info(
 		fmt.Sprintf(
 			"sync progress: slot %d/%d (%.1f%%), %.0f slots/sec",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Suppress sync progress logs when progress is ≥99.9% (near tip) to cut noise and avoid spammy updates. This only changes logging; sync behavior is unchanged.

<sup>Written for commit 374b6b1dd803ad7f67695656436840cca125a316. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized progress logging during synchronization to reduce verbosity when completion percentage reaches 99.9% or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->