### PR TITLE
fix(database): badger prometheus metrics wiring

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -355,10 +355,13 @@ func (d *BlobStoreBadger) init() error {
 		// We do this so we don't have to add guards around every log operation
 		d.logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
-	// Configure metrics
-	if d.promRegistry != nil {
-		d.registerBlobMetrics()
+	// Configure metrics — fall back to the default registry so that
+	// plugins created via NewFromCmdlineOptions (which does not
+	// receive a prometheus.Registerer) still export metrics.
+	if d.promRegistry == nil {
+		d.promRegistry = prometheus.DefaultRegisterer
 	}
+	d.registerBlobMetrics()
 	// Configure GC
 	if d.gcEnabled {
 		d.gcTicker = time.NewTicker(5 * time.Minute)

--- a/database/plugin/blob/badger/metrics.go
+++ b/database/plugin/blob/badger/metrics.go
@@ -15,6 +15,8 @@
 package badger
 
 import (
+	"errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 )
@@ -22,6 +24,18 @@ import (
 const (
 	badgerMetricNamePrefix = "database_blob_"
 )
+
+// safeRegister registers a collector, silently ignoring duplicates.
+func safeRegister(reg prometheus.Registerer, c prometheus.Collector) {
+	if err := reg.Register(c); err != nil {
+		// Ignore AlreadyRegisteredError — a second blob store instance
+		// (e.g. chain-manager store) shares the same default registry.
+		var are prometheus.AlreadyRegisteredError
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+	}
+}
 
 func (d *BlobStoreBadger) registerBlobMetrics() {
 	// Badger exposes metrics via expvar, so we need to set up some translation
@@ -94,5 +108,120 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			),
 		},
 	)
-	d.promRegistry.MustRegister(collector)
+	safeRegister(d.promRegistry, collector)
+
+	// Ristretto block/index cache metrics from Badger's DB handle
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "block_cache_hits_total",
+			Help: "Total block cache hits",
+		},
+		func() float64 {
+			if m := d.DB().BlockCacheMetrics(); m != nil {
+				return float64(m.Hits())
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "block_cache_misses_total",
+			Help: "Total block cache misses",
+		},
+		func() float64 {
+			if m := d.DB().BlockCacheMetrics(); m != nil {
+				return float64(m.Misses())
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "block_cache_hit_ratio",
+			Help: "Block cache hit ratio (0.0-1.0)",
+		},
+		func() float64 {
+			if m := d.DB().BlockCacheMetrics(); m != nil {
+				return m.Ratio()
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "block_cache_cost_bytes",
+			Help: "Current block cache cost in bytes (added - evicted)",
+		},
+		func() float64 {
+			if m := d.DB().BlockCacheMetrics(); m != nil {
+				added := m.CostAdded()
+				evicted := m.CostEvicted()
+				if added >= evicted {
+					return float64(added - evicted)
+				}
+				return 0
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "block_cache_keys_added_total",
+			Help: "Total keys added to block cache",
+		},
+		func() float64 {
+			if m := d.DB().BlockCacheMetrics(); m != nil {
+				return float64(m.KeysAdded())
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "block_cache_keys_evicted_total",
+			Help: "Total keys evicted from block cache",
+		},
+		func() float64 {
+			if m := d.DB().BlockCacheMetrics(); m != nil {
+				return float64(m.KeysEvicted())
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "index_cache_hits_total",
+			Help: "Total index cache hits",
+		},
+		func() float64 {
+			if m := d.DB().IndexCacheMetrics(); m != nil {
+				return float64(m.Hits())
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "index_cache_misses_total",
+			Help: "Total index cache misses",
+		},
+		func() float64 {
+			if m := d.DB().IndexCacheMetrics(); m != nil {
+				return float64(m.Misses())
+			}
+			return 0
+		},
+	))
+	safeRegister(d.promRegistry, prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "index_cache_hit_ratio",
+			Help: "Index cache hit ratio (0.0-1.0)",
+		},
+		func() float64 {
+			if m := d.DB().IndexCacheMetrics(); m != nil {
+				return m.Ratio()
+			}
+			return 0
+		},
+	))
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Prometheus metrics wiring in the Badger blob store so metrics are always exported without panics. Adds block and index cache metrics for better visibility into cache performance.

- **Bug Fixes**
  - Fallback to `prometheus.DefaultRegisterer` when no registerer is provided (e.g., `NewFromCmdlineOptions`), ensuring metrics export.
  - Introduced `safeRegister` to ignore `AlreadyRegisteredError`, preventing panics when multiple stores share a registry; replaced `MustRegister` with this for all collectors.

- **New Features**
  - Expose Badger/Ristretto cache metrics via Prometheus: block/index cache hits, misses, hit ratio, cost bytes, and keys added/evicted.

<sup>Written for commit 3729066ec330d0640a6ca138079f08f1981237f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure blob storage metrics always initialize so monitoring is consistent across configurations; metrics registration is now more robust to duplicate registrations.

* **Chores**
  * Added additional database cache metrics for blob storage: cache hits, misses, hit ratios, cost/bytes changes, keys added/evicted, and index cache statistics to improve performance visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->