### PR TITLE
feat: ledger peers

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,6 +111,9 @@ type Config struct {
 	activePeersTopologyQuota int
 	activePeersGossipQuota   int
 	activePeersLedgerQuota   int
+	// Ledger peer discovery (negative = disabled, 0 = use
+	// defaultLedgerPeerTarget, positive = target)
+	ledgerPeerTarget int
 	// Peer governor tuning (0 = use default)
 	minHotPeers         int
 	reconcileInterval   time.Duration
@@ -507,6 +510,16 @@ func WithActivePeersQuotas(
 		c.activePeersTopologyQuota = topologyQuota
 		c.activePeersGossipQuota = gossipQuota
 		c.activePeersLedgerQuota = ledgerQuota
+	}
+}
+
+// WithLedgerPeerTarget specifies the target number of known ledger peers.
+// Discovery will add peers only until this target is reached.
+// Negative values disable ledger peer discovery, 0 uses
+// defaultLedgerPeerTarget, and positive values use that target. Default: 20.
+func WithLedgerPeerTarget(n int) ConfigOptionFunc {
+	return func(c *Config) {
+		c.ledgerPeerTarget = n
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -774,6 +774,7 @@ func (n *Node) Run(ctx context.Context) error {
 			PeerRequestFunc:                n.ouroboros.RequestPeersFromPeer,
 			LedgerPeerProvider:             ledgerPeerProvider,
 			UseLedgerAfterSlot:             useLedgerAfterSlot,
+			LedgerPeerTarget:               n.config.ledgerPeerTarget,
 			TargetNumberOfKnownPeers:       n.config.targetNumberOfKnownPeers,
 			TargetNumberOfEstablishedPeers: n.config.targetNumberOfEstablishedPeers,
 			TargetNumberOfActivePeers:      n.config.targetNumberOfActivePeers,

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -14,10 +14,16 @@
 
 package peergov
 
-import "time"
+import (
+	"math/rand/v2"
+	"time"
+)
 
 // discoverLedgerPeers discovers peers from on-chain stake pool relay registrations.
 // This method is called during reconciliation if ledger peers are enabled.
+//
+// Selection is bounded: only enough peers are added to reach LedgerPeerTarget.
+// Candidates are shuffled uniformly so no single pool dominates across refreshes.
 func (p *PeerGovernor) discoverLedgerPeers() {
 	// Check if ledger peer provider is configured
 	if p.config.LedgerPeerProvider == nil {
@@ -41,6 +47,16 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 			)
 			return
 		}
+	}
+
+	// Count existing ledger peers to determine how many we need.
+	needed := p.ledgerPeerDeficit()
+	if needed <= 0 {
+		p.config.Logger.Debug(
+			"ledger peer target already satisfied",
+			"target", p.config.LedgerPeerTarget,
+		)
+		return
 	}
 
 	// Atomically check and claim the refresh to prevent concurrent discoveries.
@@ -68,16 +84,22 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 		return
 	}
 
-	// Track how many peers we added
-	addedCount := 0
+	// Flatten relays into candidate addresses, deduplicate them, and
+	// shuffle so we do not always pick the same relays in provider-returned
+	// order.
+	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
+	rand.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
 
-	// Add each relay as a peer (with deduplication)
-	for _, relay := range relays {
-		addresses := relay.Addresses()
-		for _, addr := range addresses {
-			if p.addLedgerPeer(addr) {
-				addedCount++
-			}
+	// Add candidates until we reach the target or exhaust the list.
+	addedCount := 0
+	for _, addr := range candidates {
+		if p.ledgerPeerDeficit() <= 0 {
+			break
+		}
+		if p.addLedgerPeer(addr) {
+			addedCount++
 		}
 	}
 
@@ -85,15 +107,83 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 		p.config.Logger.Info(
 			"discovered ledger peers",
 			"added", addedCount,
-			"total_relays", len(relays),
+			"target", p.config.LedgerPeerTarget,
+			"candidates", len(candidates),
 		)
 	} else {
 		p.config.Logger.Debug(
 			"ledger peer discovery complete",
-			"total_relays", len(relays),
+			"candidates", len(candidates),
 			"new_peers", 0,
 		)
 	}
+}
+
+// ledgerPeerDeficit returns how many more ledger peers are needed to reach
+// the configured target. Returns 0 when the target is already satisfied.
+func (p *PeerGovernor) ledgerPeerDeficit() int {
+	target := p.config.LedgerPeerTarget
+	if target <= 0 {
+		return 0
+	}
+	p.mu.Lock()
+	current := p.countLedgerPeersLocked()
+	p.mu.Unlock()
+	deficit := target - current
+	if deficit < 0 {
+		return 0
+	}
+	return deficit
+}
+
+// countLedgerPeersLocked returns the number of known peers that satisfy the
+// ledger peer target. A peer counts if its source is PeerSourceP2PLedger or
+// its address was seen during ledger discovery (covering peers that were
+// already known from another source such as topology). Must be called with
+// p.mu held.
+func (p *PeerGovernor) countLedgerPeersLocked() int {
+	count := 0
+	for _, peer := range p.peers {
+		if peer == nil {
+			continue
+		}
+		if peer.Source == PeerSourceP2PLedger {
+			count++
+			continue
+		}
+		if _, ok := p.ledgerKnownAddrs[peer.NormalizedAddress]; ok {
+			count++
+		}
+	}
+	return count
+}
+
+// flattenRelayCandidates converts a slice of PoolRelays into a flat list
+// of "host:port" address strings suitable for addLedgerPeer.
+func flattenRelayCandidates(relays []PoolRelay) []string {
+	// Pre-size: most relays have 1-2 addresses.
+	candidates := make([]string, 0, len(relays)*2)
+	for _, relay := range relays {
+		candidates = append(candidates, relay.Addresses()...)
+	}
+	return candidates
+}
+
+func dedupeRelayCandidates(candidates []string) []string {
+	if len(candidates) < 2 {
+		return candidates
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	unique := candidates[:0]
+	for _, candidate := range candidates {
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		unique = append(unique, candidate)
+	}
+	return unique
 }
 
 // addLedgerPeer adds a peer from ledger discovery with deduplication.
@@ -117,6 +207,10 @@ func (p *PeerGovernor) addLedgerPeer(address string) bool {
 		p.mu.Unlock()
 		return false
 	}
+
+	// Track this address as ledger-discovered so peers from other
+	// sources at the same address count toward the ledger target.
+	p.ledgerKnownAddrs[normalized] = struct{}{}
 
 	// Check for existing peer using cached NormalizedAddress
 	exists := false

--- a/peergov/ledger_discovery_test.go
+++ b/peergov/ledger_discovery_test.go
@@ -1,0 +1,322 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverLedgerPeers_BoundedByTarget(t *testing.T) {
+	// Provide 50 relays but set target to 5
+	relays := make([]PoolRelay, 50)
+	for i := range relays {
+		ip := net.ParseIP("44.0.0." + strconv.Itoa(i+1))
+		relays[i] = PoolRelay{IPv4: &ip, Port: 3001}
+	}
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		LedgerPeerTarget:   5,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      relays,
+			currentSlot: 1000,
+		},
+	})
+
+	pg.discoverLedgerPeers()
+
+	// Should add exactly 5 peers, not all 50
+	assert.Len(t, pg.peers, 5)
+	for _, peer := range pg.peers {
+		assert.Equal(t, PeerSource(PeerSourceP2PLedger), peer.Source)
+	}
+}
+
+func TestDiscoverLedgerPeers_TargetAlreadySatisfied(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		LedgerPeerTarget:   2,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays: func() []PoolRelay {
+				r := make([]PoolRelay, 3)
+				for i := range r {
+					ip := net.ParseIP("44.0.1." + strconv.Itoa(i+1))
+					r[i] = PoolRelay{IPv4: &ip, Port: 3001}
+				}
+				return r
+			}(),
+			currentSlot: 1000,
+		},
+	})
+
+	// First discovery: adds 2 to reach target
+	pg.discoverLedgerPeers()
+	assert.Len(t, pg.peers, 2)
+
+	// Reset refresh timestamp
+	pg.lastLedgerPeerRefresh.Store(
+		time.Now().Add(-2 * time.Hour).UnixNano(),
+	)
+
+	// Second discovery: target already satisfied, should not add more
+	pg.discoverLedgerPeers()
+	assert.Len(t, pg.peers, 2)
+}
+
+func TestDiscoverLedgerPeers_PartialRefill(t *testing.T) {
+	ip1 := net.ParseIP("44.0.0.1")
+	ip2 := net.ParseIP("44.0.0.2")
+	ip3 := net.ParseIP("44.0.0.3")
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		LedgerPeerTarget:   3,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays: []PoolRelay{
+				{IPv4: &ip1, Port: 3001},
+				{IPv4: &ip2, Port: 3001},
+				{IPv4: &ip3, Port: 3001},
+			},
+			currentSlot: 1000,
+		},
+	})
+
+	// Fill to target
+	pg.discoverLedgerPeers()
+	require.Len(t, pg.peers, 3)
+
+	// Simulate peer removal (disconnect/churn)
+	pg.mu.Lock()
+	pg.peers = pg.peers[:1] // Keep only 1 peer
+	pg.mu.Unlock()
+
+	// Reset refresh timestamp
+	pg.lastLedgerPeerRefresh.Store(
+		time.Now().Add(-2 * time.Hour).UnixNano(),
+	)
+
+	// Discovery should refill: deficit is 3 - 1 = 2.
+	// The kept peer matches exactly one candidate (dedup), and the
+	// other two distinct candidates are added, bringing total to 3.
+	pg.discoverLedgerPeers()
+
+	ledgerCount := 0
+	for _, peer := range pg.peers {
+		if peer != nil && peer.Source == PeerSourceP2PLedger {
+			ledgerCount++
+		}
+	}
+	assert.Equal(t, 3, ledgerCount)
+}
+
+func TestDiscoverLedgerPeers_NegativeTargetDisables(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		LedgerPeerTarget:   -1, // Explicitly disabled
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays: []PoolRelay{
+				{Hostname: "relay.example.com", Port: 3001},
+			},
+			currentSlot: 1000,
+		},
+	})
+
+	pg.discoverLedgerPeers()
+
+	// With a negative target, deficit is 0, so no peers should be added
+	assert.Len(t, pg.peers, 0)
+}
+
+func TestDiscoverLedgerPeers_DefaultTarget(t *testing.T) {
+	// Verify default target is applied
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		UseLedgerAfterSlot: 0,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			currentSlot: 1000,
+		},
+	})
+
+	assert.Equal(t, defaultLedgerPeerTarget, pg.config.LedgerPeerTarget)
+}
+
+func TestDiscoverLedgerPeers_PeerCapInteraction(t *testing.T) {
+	// Set a very low peer cap and a higher ledger target
+	relays := make([]PoolRelay, 20)
+	for i := range relays {
+		ip := net.ParseIP("44.0.0." + strconv.Itoa(i+1))
+		relays[i] = PoolRelay{IPv4: &ip, Port: 3001}
+	}
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                 newMockEventBus(),
+		UseLedgerAfterSlot:       0,
+		LedgerPeerTarget:         15,
+		TargetNumberOfKnownPeers: 5, // Peer cap = max(2*5, 200) = 200
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      relays,
+			currentSlot: 1000,
+		},
+	})
+
+	pg.discoverLedgerPeers()
+
+	// Should respect ledger target (15), not the peer cap (200)
+	assert.Len(t, pg.peers, 15)
+}
+
+func TestLedgerPeerDeficit(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		LedgerPeerTarget: 5,
+	})
+
+	// No peers yet, full deficit
+	assert.Equal(t, 5, pg.ledgerPeerDeficit())
+
+	// Add some ledger peers
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Source:            PeerSourceP2PLedger,
+		Address:           "44.0.0.1:3001",
+		NormalizedAddress: "44.0.0.1:3001",
+	})
+	pg.peers = append(pg.peers, &Peer{
+		Source:            PeerSourceP2PLedger,
+		Address:           "44.0.0.2:3001",
+		NormalizedAddress: "44.0.0.2:3001",
+	})
+	// Add a gossip peer at a ledger-known address, so it still counts
+	// toward the ledger target via ledgerKnownAddrs.
+	pg.peers = append(pg.peers, &Peer{
+		Source:            PeerSourceP2PGossip,
+		Address:           "44.0.0.3:3001",
+		NormalizedAddress: "44.0.0.3:3001",
+	})
+	pg.ledgerKnownAddrs["44.0.0.3:3001"] = struct{}{}
+	pg.mu.Unlock()
+
+	assert.Equal(t, 2, pg.ledgerPeerDeficit())
+}
+
+func TestLedgerPeerDeficit_Satisfied(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		LedgerPeerTarget: 2,
+	})
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Source:            PeerSourceP2PLedger,
+		Address:           "44.0.0.1:3001",
+		NormalizedAddress: "44.0.0.1:3001",
+	})
+	pg.peers = append(pg.peers, &Peer{
+		Source:            PeerSourceP2PLedger,
+		Address:           "44.0.0.2:3001",
+		NormalizedAddress: "44.0.0.2:3001",
+	})
+	pg.peers = append(pg.peers, &Peer{
+		Source:            PeerSourceP2PLedger,
+		Address:           "44.0.0.3:3001",
+		NormalizedAddress: "44.0.0.3:3001",
+	})
+	pg.mu.Unlock()
+
+	// Already exceeds target, deficit should be 0
+	assert.Equal(t, 0, pg.ledgerPeerDeficit())
+}
+
+func TestFlattenRelayCandidates(t *testing.T) {
+	ip4 := net.ParseIP("44.0.0.1")
+	ip6 := net.ParseIP("2001:db8::1")
+
+	relays := []PoolRelay{
+		{Hostname: "relay.example.com", Port: 3001},
+		{IPv4: &ip4, Port: 3002},
+		{IPv6: &ip6, Port: 3003},
+		{IPv4: &ip4, IPv6: &ip6, Port: 3004}, // Multiple addresses
+	}
+
+	candidates := flattenRelayCandidates(relays)
+
+	// relay.example.com:3001, 44.0.0.1:3002, [2001:db8::1]:3003,
+	// 44.0.0.1:3004, [2001:db8::1]:3004
+	assert.Len(t, candidates, 5)
+}
+
+func TestFlattenRelayCandidates_Empty(t *testing.T) {
+	candidates := flattenRelayCandidates(nil)
+	assert.Empty(t, candidates)
+
+	candidates = flattenRelayCandidates([]PoolRelay{})
+	assert.Empty(t, candidates)
+}
+
+func TestDedupeRelayCandidates(t *testing.T) {
+	candidates := dedupeRelayCandidates([]string{
+		"relay.example.com:3001",
+		"44.0.0.1:3001",
+		"relay.example.com:3001",
+		"[2001:db8::1]:3001",
+		"44.0.0.1:3001",
+	})
+
+	assert.Equal(t, []string{
+		"relay.example.com:3001",
+		"44.0.0.1:3001",
+		"[2001:db8::1]:3001",
+	}, candidates)
+}
+
+func TestCountLedgerPeersLocked(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{Source: PeerSourceP2PLedger},
+		{
+			Source:            PeerSourceP2PGossip,
+			NormalizedAddress: "44.0.0.10:3001",
+		},
+		{Source: PeerSourceP2PLedger},
+		nil, // nil entries should be skipped
+		{Source: PeerSourceTopologyLocalRoot},
+		{Source: PeerSourceP2PLedger},
+	}
+	pg.ledgerKnownAddrs["44.0.0.10:3001"] = struct{}{}
+	count := pg.countLedgerPeersLocked()
+	pg.mu.Unlock()
+	assert.Equal(t, 4, count)
+}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -35,6 +35,7 @@ const (
 	defaultTestCooldown                 = 5 * time.Minute
 	defaultDenyDuration                 = 30 * time.Minute
 	defaultLedgerPeerRefreshInterval    = 1 * time.Hour
+	defaultLedgerPeerTarget             = 20
 
 	// Default peer targets match cardano-node config.json defaults.
 	defaultTargetNumberOfKnownPeers       = 150
@@ -95,9 +96,10 @@ type PeerGovernor struct {
 	denyList              map[string]time.Time // address -> expiry time
 	peers                 []*Peer
 	config                PeerGovernorConfig
-	lastLedgerPeerRefresh atomic.Int64 // UnixNano timestamp of last ledger peer discovery
-	bootstrapExited       bool         // Whether bootstrap peers have been exited
-	lastBootstrapExit     time.Time    // Timestamp of most recent bootstrap exit
+	lastLedgerPeerRefresh atomic.Int64        // UnixNano timestamp of last ledger peer discovery
+	ledgerKnownAddrs      map[string]struct{} // addresses seen from ledger discovery
+	bootstrapExited       bool                // Whether bootstrap peers have been exited
+	lastBootstrapExit     time.Time           // Timestamp of most recent bootstrap exit
 	mu                    sync.Mutex
 }
 
@@ -120,6 +122,7 @@ type PeerGovernorConfig struct {
 	LedgerPeerProvider        LedgerPeerProvider // Provider for ledger peer information
 	UseLedgerAfterSlot        int64              // Slot after which to enable ledger peers (-1 = disabled)
 	LedgerPeerRefreshInterval time.Duration      // How often to refresh ledger peers
+	LedgerPeerTarget          int                // Negative disables ledger discovery, 0 uses defaultLedgerPeerTarget, positive uses that target
 
 	// Peer targets (0 = use default, -1 = unlimited)
 	// These are goals the system works toward, not hard limits.
@@ -196,6 +199,11 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	if cfg.LedgerPeerRefreshInterval == 0 {
 		cfg.LedgerPeerRefreshInterval = defaultLedgerPeerRefreshInterval
 	}
+	// Ledger peer target mapping: negative disables discovery, 0 uses
+	// defaultLedgerPeerTarget, positive uses the explicit target.
+	if cfg.LedgerPeerTarget == 0 {
+		cfg.LedgerPeerTarget = defaultLedgerPeerTarget
+	}
 	// Peer targets: 0 means use default, -1 means unlimited
 	if cfg.TargetNumberOfKnownPeers == 0 {
 		cfg.TargetNumberOfKnownPeers = defaultTargetNumberOfKnownPeers
@@ -270,9 +278,10 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	}
 	cfg.Logger = cfg.Logger.With("component", "peergov")
 	p := &PeerGovernor{
-		config:   cfg,
-		peers:    []*Peer{},
-		denyList: make(map[string]time.Time),
+		config:           cfg,
+		peers:            []*Peer{},
+		denyList:         make(map[string]time.Time),
+		ledgerKnownAddrs: make(map[string]struct{}),
 	}
 	if cfg.PromRegistry != nil {
 		p.initMetrics()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded, fair ledger peer discovery with a configurable target (default 20). Discovery flattens, dedupes, and shuffles relay candidates, counts peers from other sources toward the target, and only adds up to the deficit; negative targets disable it.

- **New Features**
  - Added `LedgerPeerTarget` to `peergov.PeerGovernorConfig` and `WithLedgerPeerTarget(n)`; mapped 0 → 20; wired through the node.
  - Target-bounded selection via `ledgerPeerDeficit()`; tracks `ledgerKnownAddrs` so matching peers from other sources count; randomized candidate order.
  - Added helpers (`flattenRelayCandidates`, `dedupeRelayCandidates`, `countLedgerPeersLocked`) and tests for target enforcement, partial refills, disabling with negatives, default mapping, peer-cap interaction, and helper behavior.

<sup>Written for commit 14223319f89bc281a73562d1cb8c7ad18a81abb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configuration option and helper to set the target number of ledger peers (negative = disabled; 0 = use default).
  * Discovery now caps additions to the configured target and refills when peers drop below the target.
  * Default ledger-peer target set to 20 when omitted.

* **Tests**
  * Added comprehensive unit tests covering ledger peer discovery, target enforcement, refill behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->