### PR TITLE
fix(peergov): use ledger peers before gossip

### DIFF
--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -27,8 +27,17 @@ import (
 func (p *PeerGovernor) discoverLedgerPeers() {
 	// Check if ledger peer provider is configured
 	if p.config.LedgerPeerProvider == nil {
+		p.config.Logger.Debug(
+			"ledger peer discovery skipped: provider is nil",
+			"component", "peergov",
+		)
 		return
 	}
+	p.config.Logger.Debug(
+		"ledger peer discovery starting",
+		"component", "peergov",
+		"use_ledger_after_slot", p.config.UseLedgerAfterSlot,
+	)
 
 	// Check UseLedgerAfterSlot threshold first (before claiming refresh)
 	if p.config.UseLedgerAfterSlot < 0 {

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -345,11 +345,15 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 		coldPromotions+warmPromotions+warmDemotions+knownRemoved,
 	)
 
-	// Peer Discovery via Peer Sharing (outside lock)
+	// Peer Discovery (outside lock)
 	p.mu.Unlock()
 
 	// Publish all collected events after releasing the lock (avoid deadlock)
 	p.publishPendingEvents(events)
+
+	// Discover peers from ledger (stake pool relays) before peer sharing,
+	// which can block on unresponsive peers.
+	p.discoverLedgerPeers()
 
 	for i := range eligiblePeersCopy {
 		addrs := p.config.PeerRequestFunc(&eligiblePeersCopy[i])
@@ -359,9 +363,6 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 			_ = p.AddPeer(addr, PeerSourceP2PGossip)
 		}
 	}
-
-	// Discover peers from ledger (stake pool relays)
-	p.discoverLedgerPeers()
 }
 
 // enforcePeerLimits removes excess peers when targets are exceeded.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prioritizes ledger-based peer discovery in `peergov` before gossip-based peer sharing to avoid stalls and connect to stake pool relays sooner. Adds debug logs for when ledger discovery starts or is skipped.

- **Bug Fixes**
  - Call `discoverLedgerPeers()` before peer sharing to prevent blocking on unresponsive peers.
  - Add debug logs when the provider is nil and when discovery starts, including `UseLedgerAfterSlot`.

<sup>Written for commit 782e0012e6c6d9ee58445d9d4a46fca131e60257. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized peer discovery sequence in governance operations.

* **Chores**
  * Added debug logging for peer discovery state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->