### PR TITLE
fix: random small fixes from review nitpicks

### DIFF
--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -512,12 +512,39 @@ func (d *MetadataStoreSqlite) DiskSize() (int64, error) {
 	}
 	var pageCount, pageSize int64
 	if err := d.DB().Raw("PRAGMA page_count").Scan(&pageCount).Error; err != nil {
-		return 0, err
+		return 0, fmt.Errorf("sqlite disk size: query PRAGMA page_count: %w", err)
 	}
 	if err := d.DB().Raw("PRAGMA page_size").Scan(&pageSize).Error; err != nil {
+		return 0, fmt.Errorf("sqlite disk size: query PRAGMA page_size: %w", err)
+	}
+	fileSize := func(path string, optional bool) (int64, error) {
+		info, err := os.Stat(path)
+		if err != nil {
+			if optional && errors.Is(err, fs.ErrNotExist) {
+				return 0, nil
+			}
+			return 0, fmt.Errorf("sqlite disk size: stat %s: %w", path, err)
+		}
+		return info.Size(), nil
+	}
+
+	metadataDbPath := filepath.Join(d.dataDir, "metadata.sqlite")
+	totalSize := pageCount * pageSize
+	dbFileSize, err := fileSize(metadataDbPath, false)
+	if err != nil {
 		return 0, err
 	}
-	return pageCount * pageSize, nil
+	if dbFileSize > totalSize {
+		totalSize = dbFileSize
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		extraSize, err := fileSize(metadataDbPath+suffix, true)
+		if err != nil {
+			return 0, err
+		}
+		totalSize += extraSize
+	}
+	return totalSize, nil
 }
 
 // Create creates a record

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -183,6 +184,7 @@ func TestCopyBlocksRaw_PreservesByronEbbLinkageAtOrigin(t *testing.T) {
 	)
 	importedEbb, err := cm.BlockByPoint(ebbPoint, nil)
 	require.NoError(t, err)
+	require.NotNil(t, importedEbb)
 	assert.Equal(t, ebbPoint.Hash, importedEbb.Hash)
 
 	nextPoint := ocommon.NewPoint(
@@ -191,6 +193,7 @@ func TestCopyBlocksRaw_PreservesByronEbbLinkageAtOrigin(t *testing.T) {
 	)
 	importedNext, err := cm.BlockByPoint(nextPoint, nil)
 	require.NoError(t, err)
+	require.NotNil(t, importedNext)
 	assert.Equal(t, ebbPoint.Hash, importedNext.PrevHash)
 }
 
@@ -199,7 +202,18 @@ func decodeImmutableBlockHeader(
 ) (gledger.BlockHeader, error) {
 	headerCbor, err := extractHeaderCbor(block.Cbor)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"decodeImmutableBlockHeader: extractHeaderCbor failed: %w",
+			err,
+		)
 	}
-	return gledger.NewBlockHeaderFromCbor(block.Type, headerCbor)
+	header, err := gledger.NewBlockHeaderFromCbor(block.Type, headerCbor)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decodeImmutableBlockHeader: NewBlockHeaderFromCbor failed for type %v: %w",
+			block.Type,
+			err,
+		)
+	}
+	return header, nil
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1603,16 +1603,13 @@ func (ls *LedgerState) tryResolveFork(
 		if ls.config.BlockfetchRequestRangeFunc != nil &&
 			ls.chain.HeaderCount() > 0 {
 			ls.chainsyncBlockfetchMutex.Lock()
-			if ls.chainsyncBlockfetchReadyChan == nil {
-				ls.selectedBlockfetchConnId = e.ConnectionId
-				if err := ls.startQueuedBlockfetchLocked(e.ConnectionId); err != nil {
-					ls.config.Logger.Warn(
-						"failed to start blockfetch after fork extension",
-						"component", "ledger",
-						"error", err,
-						"connection_id", e.ConnectionId.String(),
-					)
-				}
+			if err := ls.restartQueuedBlockfetchAfterForkLocked(e.ConnectionId); err != nil {
+				ls.config.Logger.Warn(
+					"failed to start blockfetch after fork extension",
+					"component", "ledger",
+					"error", err,
+					"connection_id", e.ConnectionId.String(),
+				)
 			}
 			ls.chainsyncBlockfetchMutex.Unlock()
 		}
@@ -1700,16 +1697,13 @@ func (ls *LedgerState) tryResolveFork(
 	if ls.config.BlockfetchRequestRangeFunc != nil &&
 		ls.chain.HeaderCount() > 0 {
 		ls.chainsyncBlockfetchMutex.Lock()
-		if ls.chainsyncBlockfetchReadyChan == nil {
-			ls.selectedBlockfetchConnId = e.ConnectionId
-			if err := ls.startQueuedBlockfetchLocked(e.ConnectionId); err != nil {
-				ls.config.Logger.Warn(
-					"failed to start blockfetch after fork rollback",
-					"component", "ledger",
-					"error", err,
-					"connection_id", e.ConnectionId.String(),
-				)
-			}
+		if err := ls.restartQueuedBlockfetchAfterForkLocked(e.ConnectionId); err != nil {
+			ls.config.Logger.Warn(
+				"failed to start blockfetch after fork rollback",
+				"component", "ledger",
+				"error", err,
+				"connection_id", e.ConnectionId.String(),
+			)
 		}
 		ls.chainsyncBlockfetchMutex.Unlock()
 	}
@@ -1780,6 +1774,35 @@ func (ls *LedgerState) nextBlockfetchConnIdExcept(
 		return ouroboros.ConnectionId{}, false
 	}
 	return ls.activeBlockfetchConnId, true
+}
+
+func (ls *LedgerState) restartQueuedBlockfetchAfterForkLocked(
+	connId ouroboros.ConnectionId,
+) error {
+	if ls.chainsyncBlockfetchReadyChan != nil {
+		if ls.chainsyncBlockfetchTimeoutTimer != nil {
+			ls.chainsyncBlockfetchTimeoutTimer.Stop()
+			ls.chainsyncBlockfetchTimeoutTimer = nil
+		}
+		ls.chainsyncBlockfetchTimerGeneration++
+		ls.chainsyncBlockfetchReadyMutex.Lock()
+		if ls.chainsyncBlockfetchReadyChan != nil {
+			close(ls.chainsyncBlockfetchReadyChan)
+			ls.chainsyncBlockfetchReadyChan = nil
+		}
+		ls.chainsyncBlockfetchReadyMutex.Unlock()
+		if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+			ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
+			return fmt.Errorf(
+				"failed to flush stale blockfetch batch before restart: %w",
+				err,
+			)
+		}
+		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+	}
+	ls.selectedBlockfetchConnId = connId
+	return ls.startQueuedBlockfetchLocked(connId)
 }
 
 func (ls *LedgerState) startQueuedBlockfetchLocked(

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -41,6 +41,14 @@ var electionTestNonce = func() []byte {
 	return nonce
 }()
 
+func makeDistinctNonce(nonce []byte) []byte {
+	distinct := append([]byte(nil), nonce...)
+	if len(distinct) > 0 {
+		distinct[0] ^= 0xff
+	}
+	return distinct
+}
+
 // electionTestVRFSeed is a 32-byte VRF seed for election tests.
 var electionTestVRFSeed = []byte("election_vrf_seed_32_bytes_ok!!!")
 
@@ -441,8 +449,7 @@ func TestElectionPrecomputesNextEpochAtStartupWhenNonceReady(t *testing.T) {
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
 	epochProvider.nextEpochReady.Store(11)
-	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
-	electionTestNonce11[0] ^= 0xff
+	electionTestNonce11 := makeDistinctNonce(electionTestNonce)
 	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	eventBus := event.NewEventBus(nil, nil)
@@ -488,8 +495,7 @@ func TestElectionZeroPoolStake(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
-	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
-	electionTestNonce11[0] ^= 0xff
+	electionTestNonce11 := makeDistinctNonce(electionTestNonce)
 	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	eventBus := event.NewEventBus(nil, nil)
@@ -527,8 +533,7 @@ func TestElectionShouldProduceBlock(t *testing.T) {
 	// we reliably get leader slots despite the small sample size.
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
-	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
-	electionTestNonce11[0] ^= 0xff
+	electionTestNonce11 := makeDistinctNonce(electionTestNonce)
 	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 	epochProvider.activeSlotCoeff = 0.9
 
@@ -612,8 +617,7 @@ func TestElectionEpochTransition(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
-	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
-	electionTestNonce11[0] ^= 0xff
+	electionTestNonce11 := makeDistinctNonce(electionTestNonce)
 	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	eventBus := event.NewEventBus(nil, nil)
@@ -683,8 +687,7 @@ func TestElectionPrecomputesNextEpochOnNonceReady(t *testing.T) {
 
 	epochProvider := newMockEpochProvider()
 	epochProvider.currentEpoch.Store(10)
-	electionTestNonce11 := append([]byte(nil), electionTestNonce...)
-	electionTestNonce11[0] ^= 0xff
+	electionTestNonce11 := makeDistinctNonce(electionTestNonce)
 	epochProvider.SetEpochNonceForEpoch(11, electionTestNonce11)
 
 	store := newMockScheduleStore()
@@ -796,8 +799,7 @@ func TestElectionRollbackKeepsPrecomputedNextSchedule(t *testing.T) {
 	epochProvider := newMockEpochProvider()
 	epochProvider.activeSlotCoeff = 1.0
 	epochProvider.nextEpochReady.Store(11)
-	nextEpochNonce := append([]byte(nil), electionTestNonce...)
-	nextEpochNonce[0] ^= 0xff
+	nextEpochNonce := makeDistinctNonce(electionTestNonce)
 	epochProvider.SetEpochNonceForEpoch(11, nextEpochNonce)
 
 	eventBus := event.NewEventBus(nil, nil)

--- a/utxorpc/plutusdata_cardano.go
+++ b/utxorpc/plutusdata_cardano.go
@@ -16,6 +16,7 @@ package utxorpc
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -32,7 +33,7 @@ func plutusDatumCBORToCardano(raw []byte) (*cardano.PlutusData, error) {
 	}
 	pd, err := pdata.Decode(raw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode plutus data: %w", err)
 	}
 	proto := plutusDataToCardano(pd)
 	if proto == nil {

--- a/utxorpc/tx_predicate.go
+++ b/utxorpc/tx_predicate.go
@@ -46,13 +46,27 @@ type txPredicateNode struct {
 	anyOf           []*txPredicateNode
 }
 
-// txPredicateFromSubmit maps submit.TxPredicate into txPredicateNode.
-func txPredicateFromSubmit(p *submit.TxPredicate) *txPredicateNode {
-	if p == nil {
+type txPatternProto interface {
+	GetCardano() *cardano.TxPattern
+}
+
+type txPredicateProto[T any, M txPatternProto] interface {
+	GetMatch() M
+	GetNot() []T
+	GetAllOf() []T
+	GetAnyOf() []T
+}
+
+func buildTxPredicateNodeFromProto[T txPredicateProto[T, M], M txPatternProto](
+	p T,
+	isNilPredicate func(T) bool,
+	isNilMatch func(M) bool,
+) *txPredicateNode {
+	if isNilPredicate(p) {
 		return nil
 	}
 	n := &txPredicateNode{}
-	if m := p.GetMatch(); m != nil {
+	if m := p.GetMatch(); !isNilMatch(m) {
 		if c := m.GetCardano(); c != nil {
 			n.match = c
 		} else {
@@ -60,52 +74,52 @@ func txPredicateFromSubmit(p *submit.TxPredicate) *txPredicateNode {
 		}
 	}
 	for _, c := range p.GetNot() {
-		if c != nil {
-			n.not = append(n.not, txPredicateFromSubmit(c))
+		if !isNilPredicate(c) {
+			n.not = append(
+				n.not,
+				buildTxPredicateNodeFromProto(c, isNilPredicate, isNilMatch),
+			)
 		}
 	}
 	for _, c := range p.GetAllOf() {
-		if c != nil {
-			n.allOf = append(n.allOf, txPredicateFromSubmit(c))
+		if !isNilPredicate(c) {
+			n.allOf = append(
+				n.allOf,
+				buildTxPredicateNodeFromProto(c, isNilPredicate, isNilMatch),
+			)
 		}
 	}
 	for _, c := range p.GetAnyOf() {
-		if c != nil {
-			n.anyOf = append(n.anyOf, txPredicateFromSubmit(c))
+		if !isNilPredicate(c) {
+			n.anyOf = append(
+				n.anyOf,
+				buildTxPredicateNodeFromProto(c, isNilPredicate, isNilMatch),
+			)
 		}
 	}
 	return n
 }
 
+func isNilPtr[T any](p *T) bool {
+	return p == nil
+}
+
+// txPredicateFromSubmit maps submit.TxPredicate into txPredicateNode.
+func txPredicateFromSubmit(p *submit.TxPredicate) *txPredicateNode {
+	return buildTxPredicateNodeFromProto(
+		p,
+		isNilPtr[submit.TxPredicate],
+		isNilPtr[submit.AnyChainTxPattern],
+	)
+}
+
 // txPredicateFromWatch maps watch.TxPredicate into txPredicateNode.
 func txPredicateFromWatch(p *watch.TxPredicate) *txPredicateNode {
-	if p == nil {
-		return nil
-	}
-	n := &txPredicateNode{}
-	if m := p.GetMatch(); m != nil {
-		if c := m.GetCardano(); c != nil {
-			n.match = c
-		} else {
-			n.matchNonCardano = true
-		}
-	}
-	for _, c := range p.GetNot() {
-		if c != nil {
-			n.not = append(n.not, txPredicateFromWatch(c))
-		}
-	}
-	for _, c := range p.GetAllOf() {
-		if c != nil {
-			n.allOf = append(n.allOf, txPredicateFromWatch(c))
-		}
-	}
-	for _, c := range p.GetAnyOf() {
-		if c != nil {
-			n.anyOf = append(n.anyOf, txPredicateFromWatch(c))
-		}
-	}
-	return n
+	return buildTxPredicateNodeFromProto(
+		p,
+		isNilPtr[watch.TxPredicate],
+		isNilPtr[watch.AnyChainTxPattern],
+	)
 }
 
 // txPatternLeaf matches a transaction against a Cardano TxPattern (outputs,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves stability and clarity across the codebase: safely restarts blockfetch after forks, reports SQLite disk usage accurately, adds clearer errors, and removes duplicate predicate-building logic.

- **Bug Fixes**
  - `ledger/chainsync`: Added `restartQueuedBlockfetchAfterForkLocked` to fully reset timers/channels, flush stale batches, and restart blockfetch after fork extension/rollback.
  - `database/plugin/metadata/sqlite`: `DiskSize()` now sums `metadata.sqlite`, `-wal`, and `-shm` files and wraps PRAGMA/file errors with context.
  - `utxorpc/plutusdata_cardano`: Wraps Plutus data decode errors with context.
  - `internal/node` tests: Added `NotNil` assertions and clearer error wrapping during block header decoding.

- **Refactors**
  - `utxorpc/tx_predicate`: Introduced a generic builder to construct predicate trees for both `submit` and `watch`, removing duplicated logic.
  - `ledger/leader` tests: Added `makeDistinctNonce` helper to reduce repetition.

<sup>Written for commit 25a508036446544d823be1dfb5dd01363ed4fac8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of disk size calculations by including filesystem metadata and optional sidecar files.
  * Enhanced error handling with more descriptive contextual messages across multiple operations.

* **Tests**
  * Strengthened test assertions with improved null-safety checks.

* **Refactor**
  * Consolidated blockfetch restart logic into a shared helper function for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->