### PR TITLE
fix: chain/ledger sync

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -38,6 +38,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
@@ -1140,6 +1141,12 @@ func pointMatches(a, b ocommon.Point) bool {
 	return a.Slot == b.Slot && bytes.Equal(a.Hash, b.Hash)
 }
 
+type LocalRollbackRecoveryResult struct {
+	Recovered           bool
+	SkipConnectionClose bool
+	PrimaryChainTipSlot uint64
+}
+
 func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 	connId ouroboros.ConnectionId,
 	point ocommon.Point,
@@ -1186,19 +1193,33 @@ func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 // RecoverAfterLocalRollback resets chainsync-local queued state after a ledger
 // rollback, then replays any peer-local header history that still fits the new
 // tip. This keeps rollback recovery local to the node instead of re-entering
-// FindIntersect on live ChainSync sessions. It returns true when it seeded a
-// new local header fragment from peer history.
+// FindIntersect on live ChainSync sessions. The result reports whether peer
+// history was replayed and whether connection closure should be skipped because
+// the primary chain tip is already past the completed rollback point.
 func (ls *LedgerState) RecoverAfterLocalRollback(
 	connIds []ouroboros.ConnectionId,
 	point ocommon.Point,
-) bool {
+) LocalRollbackRecoveryResult {
 	ls.chainsyncMutex.Lock()
 	defer ls.chainsyncMutex.Unlock()
 
-	ls.resetChainsyncResyncState()
 	if ls.chain == nil {
-		return false
+		return LocalRollbackRecoveryResult{}
 	}
+	ls.RLock()
+	lastLocalRollbackSeq := ls.lastLocalRollbackSeq
+	lastLocalRollbackPoint := ls.lastLocalRollbackPoint
+	ls.RUnlock()
+	if lastLocalRollbackSeq > 0 &&
+		pointMatches(lastLocalRollbackPoint, point) {
+		if chainTipSlot := ls.PrimaryChainTipSlot(); chainTipSlot > point.Slot {
+			return LocalRollbackRecoveryResult{
+				SkipConnectionClose: true,
+				PrimaryChainTipSlot: chainTipSlot,
+			}
+		}
+	}
+	ls.resetChainsyncResyncState()
 
 	preferredConnIds := make([]ouroboros.ConnectionId, 0, len(connIds)+1)
 	seenConnIds := make(map[string]struct{}, len(connIds)+1)
@@ -1260,9 +1281,9 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 			}
 		}
 		ls.chainsyncBlockfetchMutex.Unlock()
-		return true
+		return LocalRollbackRecoveryResult{Recovered: true}
 	}
-	return false
+	return LocalRollbackRecoveryResult{}
 }
 
 func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
@@ -1408,10 +1429,16 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	// far enough out from upstream tip
 	// Use security window as slot threshold if available
 	headersReady := headerCount + 1
-	localTipSlot := ls.Tip().Point.Slot
+	// Use the primary chain header tip so the slot and block-number gaps reflect
+	// fetched-but-unprocessed blocks that are already queued in ls.chain.
+	localChainTip := ochainsync.Tip{}
+	if ls.chain != nil {
+		localChainTip = ls.chain.HeaderTip()
+	}
+	localTipSlot := localChainTip.Point.Slot
 	blockGap := uint64(0)
-	if e.Tip.BlockNumber > ls.Tip().BlockNumber {
-		blockGap = e.Tip.BlockNumber - ls.Tip().BlockNumber
+	if e.Tip.BlockNumber > localChainTip.BlockNumber {
+		blockGap = e.Tip.BlockNumber - localChainTip.BlockNumber
 	}
 	if e.Tip.Point.Slot > localTipSlot &&
 		e.Tip.Point.Slot-localTipSlot >= blockfetchMinBatchGapSlots {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -460,12 +460,13 @@ func TestRecoverAfterLocalRollbackReplaysPeerHeaderHistory(
 		BlockHeader: header2,
 	})
 
-	recovered := fixture.ls.RecoverAfterLocalRollback(
+	result := fixture.ls.RecoverAfterLocalRollback(
 		[]ouroboros.ConnectionId{fixture.connId},
 		fixture.ancestorTip.Point,
 	)
 
-	require.True(t, recovered)
+	require.True(t, result.Recovered)
+	assert.False(t, result.SkipConnectionClose)
 	assert.Equal(t, 2, fixture.ls.chain.HeaderCount())
 	assert.True(
 		t,
@@ -523,12 +524,13 @@ func TestRecoverAfterLocalRollbackResetsStateWithoutTrackedClients(t *testing.T)
 		},
 	}
 
-	recovered := fixture.ls.RecoverAfterLocalRollback(
+	result := fixture.ls.RecoverAfterLocalRollback(
 		nil,
 		fixture.ancestorTip.Point,
 	)
 
-	require.False(t, recovered)
+	require.False(t, result.Recovered)
+	assert.False(t, result.SkipConnectionClose)
 	assert.Zero(t, fixture.ls.chain.HeaderCount())
 	assert.Zero(t, fixture.ls.headerMismatchCount)
 	assert.Nil(t, fixture.ls.rollbackHistory)
@@ -545,6 +547,74 @@ func TestRecoverAfterLocalRollbackResetsStateWithoutTrackedClients(t *testing.T)
 		t,
 		fixture.ls.activeBlockfetchConnId == (ouroboros.ConnectionId{}),
 	)
+}
+
+func TestRecoverAfterLocalRollbackDoesNotUsePreRollbackTipAsStalenessSignal(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	result := fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+
+	require.False(t, result.Recovered)
+	assert.False(t, result.SkipConnectionClose)
+	assert.Zero(t, result.PrimaryChainTipSlot)
+}
+
+func TestRecoverAfterLocalRollbackReturnsEmptyResultWhenChainNil(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.chain = nil
+
+	result := fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+
+	assert.Equal(t, LocalRollbackRecoveryResult{}, result)
+}
+
+func TestRecoverAfterLocalRollbackSkipsConnectionCloseWhenPrimaryChainTipPastRollbackPoint(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	queuedHeader := mockHeader{
+		hash:        lcommon.NewBlake2b256(testHashBytes("rollback-stale-queued")),
+		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 1,
+	}
+	require.NoError(t, fixture.ls.chain.AddBlockHeader(queuedHeader))
+
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+	fixture.ls.headerMismatchCount = 7
+	fixture.ls.lastLocalRollbackSeq = 1
+	fixture.ls.lastLocalRollbackPoint = ocommon.Point{
+		Slot: fixture.ancestorTip.Point.Slot,
+		Hash: append([]byte(nil), fixture.ancestorTip.Point.Hash...),
+	}
+
+	result := fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+
+	require.False(t, result.Recovered)
+	assert.True(t, result.SkipConnectionClose)
+	assert.Equal(
+		t,
+		fixture.currentTip.Point.Slot,
+		result.PrimaryChainTipSlot,
+	)
+	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
+	assert.Equal(t, 7, fixture.ls.headerMismatchCount)
 }
 
 func TestHandleEventChainsyncBlockHeaderIgnoresStaleRollForwardBehindTip(

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1117,7 +1117,7 @@ func TestHandleEventChainsyncBlockHeaderStartsBlockfetchForSmallBlockGap(
 				requestCount++
 				assert.Equal(t, connId, requestConnId)
 				assert.Equal(t, uint64(1064), start.Slot)
-				assert.Equal(t, uint64(1068), end.Slot)
+				assert.Equal(t, uint64(1064), end.Slot)
 				return nil
 			},
 		},
@@ -1174,7 +1174,7 @@ func TestHandleEventChainsyncBlockHeaderStartsBlockfetchForSparseBlockGap(
 				requestCount++
 				assert.Equal(t, connId, requestConnId)
 				assert.Equal(t, uint64(107374026), start.Slot)
-				assert.Equal(t, uint64(107374530), end.Slot)
+				assert.Equal(t, uint64(107374047), end.Slot)
 				return nil
 			},
 		},

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -503,6 +503,8 @@ type LedgerState struct {
 	densityWindow                 []densityEntry // sliding window for chain density metric
 	lastAtTipRecoverySlot         uint64         // guards against infinite at-tip recovery loops
 	mithrilLedgerSlot             uint64         // blocks at or below this slot are Mithril-verified; skip validation
+	lastLocalRollbackSeq          uint64
+	lastLocalRollbackPoint        ocommon.Point
 
 	// Subscription IDs for event bus unsubscribe on close
 	chainsyncSubID           event.EventSubscriberId
@@ -1656,6 +1658,11 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	if newPParams != nil {
 		ls.currentPParams = newPParams
 		ls.prevEraPParams = newPrevPParams
+	}
+	ls.lastLocalRollbackSeq++
+	ls.lastLocalRollbackPoint = ocommon.Point{
+		Slot: point.Slot,
+		Hash: append([]byte(nil), point.Hash...),
 	}
 	ls.currentTip = newTip
 	// If rolling back behind the Mithril trust boundary, clear it.
@@ -3639,6 +3646,26 @@ func (ls *LedgerState) ChainTipSlot() uint64 {
 	ls.RLock()
 	defer ls.RUnlock()
 	return ls.currentTip.Point.Slot
+}
+
+// PrimaryChainTip returns the tip of the primary chain. This can be ahead of
+// Tip() while the ledger pipeline is still replaying blocks into committed
+// metadata state.
+func (ls *LedgerState) PrimaryChainTip() ochainsync.Tip {
+	ls.RLock()
+	chain := ls.chain
+	ls.RUnlock()
+	if chain == nil {
+		return ochainsync.Tip{}
+	}
+	return chain.Tip()
+}
+
+// PrimaryChainTipSlot returns the slot number of the primary chain tip. This
+// can be ahead of ChainTipSlot() while the ledger pipeline is still replaying
+// blocks into committed metadata state.
+func (ls *LedgerState) PrimaryChainTipSlot() uint64 {
+	return ls.PrimaryChainTip().Point.Slot
 }
 
 // UpstreamTipSlot returns the latest known tip slot from upstream peers.

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -927,11 +927,20 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 				if o.LedgerState == nil {
 					return
 				}
-				recovered := o.LedgerState.RecoverAfterLocalRollback(
+				recovery := o.LedgerState.RecoverAfterLocalRollback(
 					connIds,
 					e.Point,
 				)
-				if recovered || len(connIds) == 0 {
+				if recovery.Recovered || len(connIds) == 0 {
+					return
+				}
+				if recovery.SkipConnectionClose {
+					o.config.Logger.Info(
+						"skipping connection closure: chain already past rollback point",
+						"component", "ouroboros",
+						"rollback_slot", e.Point.Slot,
+						"chain_tip_slot", recovery.PrimaryChainTipSlot,
+					)
 					return
 				}
 				// No recoverable peer history — close the affected


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves chain/ledger sync by making local rollback recovery smarter and by gating blockfetch using the primary chain header tip for accurate batching. Prevents unnecessary connection closures when the chain is already past the rollback point.

- **Bug Fixes**
  - `RecoverAfterLocalRollback` now returns `LocalRollbackRecoveryResult` and skips closing connections when the primary chain tip is already ahead of the rollback point; logs rollback and chain tip slots in `ouroboros` resync. Tracks `lastLocalRollbackSeq` and `lastLocalRollbackPoint` and safely no-ops when the chain is nil.
  - Chainsync computes slot/block gaps from the primary chain header tip (includes queued headers) and fixes blockfetch end-slot calculations; tests updated and added to cover recovery results, skip behavior, and range selection.

<sup>Written for commit cc776fdb83309d599c029deae7754dcbd8baebc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust local rollback recovery: avoids unnecessary connection closures, logs decisions with rollback and chain-tip slots, and correctly skips closing connections when the primary chain tip already passes the rollback point.
  * Blockfetch batching now uses the primary chain header tip for more accurate slot-gap calculations.

* **Tests**
  * Updated and added tests validating rollback recovery outcomes, skip-closure behavior, and reported chain-tip values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->