### PR TITLE
fix(connmanager): skip source port binding and reduce recycling during catch-up

### DIFF
--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -87,7 +87,13 @@ type ConnectionManagerConfig struct {
 	Listeners          []ListenerConfig
 	OutboundConnOpts   []ouroboros.ConnectionOptionFunc
 	OutboundSourcePort uint
-	MaxInboundConns    int // 0 means use DefaultMaxInboundConnections
+	// IsAtTipFunc returns whether the node is synced to tip. When
+	// provided and returning false, outbound connections skip source
+	// port binding to avoid TIME_WAIT socket exhaustion during
+	// catch-up. Source port binding is only needed for peer sharing
+	// which is not useful while the node is behind.
+	IsAtTipFunc     func() bool
+	MaxInboundConns int // 0 means use DefaultMaxInboundConnections
 	// MaxConnectionsPerIP limits the number of concurrent inbound
 	// connections from the same IP address. IPv6 addresses are grouped
 	// by /64 prefix. A value of 0 means use DefaultMaxConnectionsPerIP.

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -42,9 +42,13 @@ func (c *ConnectionManager) CreateOutboundConn(
 	dialer := net.Dialer{
 		Timeout: 10 * time.Second,
 	}
-	if c.config.OutboundSourcePort > 0 {
-		// Setup connection to use our listening port as the source port
-		// This is required for peer sharing to be useful
+	atTip := c.config.IsAtTipFunc == nil || c.config.IsAtTipFunc()
+	if c.config.OutboundSourcePort > 0 && atTip {
+		// Setup connection to use our listening port as the source port.
+		// This is required for peer sharing to be useful.
+		// Skip during catch-up to avoid TIME_WAIT socket exhaustion
+		// from connection churn — peer sharing is not useful while
+		// the node is behind tip anyway.
 		clientAddr, _ = net.ResolveTCPAddr(
 			"tcp",
 			fmt.Sprintf(":%d", c.config.OutboundSourcePort),

--- a/node.go
+++ b/node.go
@@ -167,6 +167,18 @@ func (n *Node) processChainsyncRecyclerTick(
 		*lastProgressSlot = localTipSlot
 		*lastProgressAt = now
 	}
+	// During catch-up, extend all recycling thresholds to avoid
+	// churning connections while the node is making progress.
+	// Connection recycling during bulk sync causes pipeline resets,
+	// TIME_WAIT socket exhaustion, and dropped rollbacks that slow
+	// catch-up far more than the stall itself.
+	catchUpMultiplier := time.Duration(1)
+	if n.ledgerState != nil && !n.ledgerState.IsAtTip() {
+		catchUpMultiplier = 5
+	}
+	effectiveGrace := grace * catchUpMultiplier
+	effectivePlateau := plateauRecoveryThreshold * catchUpMultiplier
+	effectiveCooldown := cooldown * catchUpMultiplier
 	n.chainsyncState.CheckStalledClients()
 	trackedClients := n.chainsyncState.GetTrackedClients()
 	trackedByID := make(
@@ -183,7 +195,7 @@ func (n *Node) processChainsyncRecyclerTick(
 	// Prune expired cooldown entries so this map does
 	// not grow without bound over long runtimes.
 	for connKey, last := range lastRecycled {
-		if now.Sub(last) >= cooldown {
+		if now.Sub(last) >= effectiveCooldown {
 			delete(lastRecycled, connKey)
 		}
 	}
@@ -211,8 +223,8 @@ func (n *Node) processChainsyncRecyclerTick(
 					localTipSlot,
 					bestPeerTip.Tip.Point.Slot,
 					lastRecycledAt,
-					cooldown,
-					plateauRecoveryThreshold,
+					effectiveCooldown,
+					effectivePlateau,
 				) {
 					n.config.logger.Warn(
 						"local tip plateau detected, resyncing chainsync client",
@@ -244,12 +256,12 @@ func (n *Node) processChainsyncRecyclerTick(
 		}
 		connKey := conn.ConnId.String()
 		if _, exists := recycleAt[connKey]; !exists {
-			recycleAt[connKey] = now.Add(grace)
+			recycleAt[connKey] = now.Add(effectiveGrace)
 			n.config.logger.Info(
 				"chainsync client stalled, scheduling guarded recycle",
 				"connection_id", connKey,
 				"stall_timeout", chainsyncCfg.StallTimeout,
-				"grace_period", grace,
+				"grace_period", effectiveGrace,
 			)
 		}
 	}
@@ -264,8 +276,8 @@ func (n *Node) processChainsyncRecyclerTick(
 		}
 		connId := tracked.ConnId
 		if last, ok := lastRecycled[connKey]; ok &&
-			now.Sub(last) < cooldown {
-			recycleAt[connKey] = now.Add(cooldown - now.Sub(last))
+			now.Sub(last) < effectiveCooldown {
+			recycleAt[connKey] = now.Add(effectiveCooldown - now.Sub(last))
 			continue
 		}
 		active := n.chainsyncState.GetClientConnId()
@@ -718,6 +730,7 @@ func (n *Node) Run(ctx context.Context) error {
 			EventBus:            n.eventBus,
 			Listeners:           tmpListeners,
 			OutboundSourcePort:  n.config.outboundSourcePort,
+			IsAtTipFunc:         func() bool { return n.ledgerState != nil && n.ledgerState.IsAtTip() },
 			OutboundConnOpts:    n.ouroboros.OutboundConnOpts(),
 			PromRegistry:        n.config.promRegistry,
 			MaxConnectionsPerIP: n.config.maxConnectionsPerIP,


### PR DESCRIPTION
## Summary
Two changes to improve catch-up stability:

1. **Skip source port binding during catch-up** — outbound connections bind to listen port 3001 for peer sharing. During catch-up, connection churn creates TIME_WAIT sockets that block reconnection (60s per peer). When `IsAtTipFunc` returns false, connections use ephemeral ports instead. Peer sharing is useless during catch-up.

2. **5x stall detection thresholds during catch-up** — stall grace period (2min→10min), plateau detection (4min→20min), and recycle cooldown (4min→20min) are extended when not at tip. Connection recycling during bulk sync causes pipeline resets and dropped rollbacks that slow catch-up far more than the stall itself.

## Root cause
`OutboundSourcePort` (set in `internal/node/node.go:269`) binds every outbound dial to `:3001` with `SO_REUSEPORT`. When connections close, the 4-tuple enters TIME_WAIT for 60s. New dials to the same peer fail with `cannot assign requested address`. During catch-up with many peers churning, this exhausts available connections and the node falls further behind.

## Evidence
- All preview nodes hit `cannot assign requested address` during catch-up
- Nodes that started with ephemeral ports (source port fix) caught up in minutes
- Nodes without the fix stall indefinitely at 40-60k gap
- Tested on texas (SATA HDD), az1 (arm64 control-1), mini-1 (arm64), Pi (arm64 RPi4)

## Test plan
- [x] `go build ./...` clean
- [x] All tests pass
- [x] Deployed to preview fleet — nodes with fix catch up, nodes without stall
- [ ] Verify peer sharing works correctly once node reaches tip (source port re-enabled)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve catch-up stability by using ephemeral source ports while behind tip and relaxing chainsync stall thresholds to reduce recycling. This prevents TIME_WAIT socket exhaustion and cuts connection churn so nodes catch up faster.

- **Bug Fixes**
  - `connmanager`: Added `IsAtTipFunc`; when not at tip, outbound dials skip binding to `:3001` and use ephemeral ports. Peer sharing resumes automatically at tip.
  - `node`: Increased chainsync stall grace, plateau detection, and recycle cooldown by 5x during catch-up, and wired `IsAtTipFunc` into the connection manager.

<sup>Written for commit 21a70b42ec1e439d3dececaba0c1eea5bc2ce924. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outbound connections now intelligently manage binding based on synchronization status to optimize resource usage and reduce connection churn during blockchain synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->