### PR TITLE
fix(node): extend stall detection thresholds during catch-up

### DIFF
--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -118,6 +118,18 @@ func (n *Node) processChainsyncRecyclerTick(
 		*lastProgressSlot = localTipSlot
 		*lastProgressAt = now
 	}
+	// During catch-up, extend all recycling thresholds to avoid
+	// churning connections while the node is making progress.
+	// Connection recycling during bulk sync causes pipeline resets,
+	// TIME_WAIT socket exhaustion, and dropped rollbacks that slow
+	// catch-up far more than the stall itself.
+	catchUpMultiplier := 1
+	if n.ledgerState != nil && !n.ledgerState.IsAtTip() {
+		catchUpMultiplier = 5
+	}
+	effectiveGrace := time.Duration(catchUpMultiplier) * grace
+	effectivePlateau := time.Duration(catchUpMultiplier) * plateauRecoveryThreshold
+	effectiveCooldown := time.Duration(catchUpMultiplier) * cooldown
 	n.chainsyncState.CheckStalledClients()
 	trackedClients := n.chainsyncState.GetTrackedClients()
 	trackedByID := make(
@@ -138,7 +150,7 @@ func (n *Node) processChainsyncRecyclerTick(
 	// Prune expired cooldown entries so this map does
 	// not grow without bound over long runtimes.
 	for connKey, last := range lastRecycled {
-		if now.Sub(last) >= cooldown {
+		if now.Sub(last) >= effectiveCooldown {
 			delete(lastRecycled, connKey)
 		}
 	}
@@ -166,8 +178,8 @@ func (n *Node) processChainsyncRecyclerTick(
 					localTipSlot,
 					bestPeerTip.Tip.Point.Slot,
 					lastRecycledAt,
-					cooldown,
-					plateauRecoveryThreshold,
+					effectiveCooldown,
+					effectivePlateau,
 				) {
 					n.config.logger.Warn(
 						"local tip plateau detected, resyncing chainsync client",
@@ -198,14 +210,19 @@ func (n *Node) processChainsyncRecyclerTick(
 			continue
 		}
 		connKey := conn.ConnId.String()
-		if _, exists := recycleAt[connKey]; !exists {
-			recycleAt[connKey] = now.Add(grace)
+		desiredDueAt := now.Add(effectiveGrace)
+		if dueAt, exists := recycleAt[connKey]; !exists {
+			recycleAt[connKey] = desiredDueAt
 			n.config.logger.Info(
 				"chainsync client stalled, scheduling guarded recycle",
 				"connection_id", connKey,
 				"stall_timeout", chainsyncCfg.StallTimeout,
-				"grace_period", grace,
+				"grace_period", effectiveGrace,
 			)
+		} else if dueAt.After(desiredDueAt) {
+			// Shrink deadline when transitioning from catch-up
+			// to at-tip so stalls aren't delayed unnecessarily.
+			recycleAt[connKey] = desiredDueAt
 		}
 	}
 	for connKey, dueAt := range recycleAt {
@@ -219,8 +236,8 @@ func (n *Node) processChainsyncRecyclerTick(
 		}
 		connId := tracked.ConnId
 		if last, ok := lastRecycled[connKey]; ok &&
-			now.Sub(last) < cooldown {
-			recycleAt[connKey] = now.Add(cooldown - now.Sub(last))
+			now.Sub(last) < effectiveCooldown {
+			recycleAt[connKey] = now.Add(effectiveCooldown - now.Sub(last))
 			continue
 		}
 		// Never recycle the only eligible peer. A block producer


### PR DESCRIPTION
## Summary
- During catch-up, stall detection fires at 2min and recycles connections
- Each recycle resets the chainsync pipeline and creates TIME_WAIT sockets on the source port (3001)
- This causes nodes to fall further behind instead of catching up
- Extend grace (2min→10min), plateau (4min→20min), and cooldown (4min→20min) by 5x when not at tip
- Once at tip, thresholds return to normal

## Evidence
- Preview nodes with this fix catch up from Mithril in minutes
- Without it, nodes stall at 40-60k gap indefinitely from connection churn
- The multiplier reduces TIME_WAIT accumulation by keeping connections alive longer during bulk sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend chainsync stall detection timeouts by 5x during catch-up to reduce connection churn and speed bulk sync. Thresholds switch on a live catch-up signal and revert at tip; scheduled recycle deadlines are tightened on exit.

- **Bug Fixes**
  - Apply 5x multiplier when not at tip: grace 2m→10m, plateau 4m→20m, cooldown 4m→20m; use effectiveGrace/effectivePlateau/effectiveCooldown across plateau checks, cooldown pruning, and scheduling.
  - Shrink existing recycleAt deadlines when transitioning to at-tip so stalls aren’t delayed; respect effectiveCooldown when rate-limiting recycling and expiring cooldown entries.
  - Declare catchUpMultiplier as int with short var; compute durations via time.Duration(catchUpMultiplier) * base.

<sup>Written for commit a14cc247aa51fcfd524cbe94a4c76695c65b7928. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blockfrost-compatible API: epoch params, asset lookup, address UTXOs/transactions, and metadata (JSON/CBOR) endpoints.
  * Bark archive/pruner service for periodic archive cleanup and an opt-in Bark interface.
  * Improved UTxO RPC: richer predicates, server-side ordering/pagination, and more robust query semantics.
  * Runtime metrics: optional periodic RTS (Go runtime) gauges.

* **Bug Fixes**
  * Enhanced chainsync recycler and connection handling for faster, more reliable resyncs and cleaner shutdowns.

* **Documentation**
  * Updated architecture, README, release notes, and new contributor guidance files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->