### PR TITLE
feat(blockfrost): Blockfrost API Account (stake address) endpoints

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -989,22 +989,24 @@ func (a *NodeAdapter) Account(
 	}
 
 	var activeEpoch *int64
-	epoch, err := a.ledgerState.SlotToEpoch(account.AddedSlot)
-	if err != nil {
-		return AccountInfo{}, fmt.Errorf(
-			"get account active epoch for slot %d: %w",
-			account.AddedSlot,
-			err,
+	if account.Active {
+		epoch, err := a.ledgerState.SlotToEpoch(account.AddedSlot)
+		if err != nil {
+			return AccountInfo{}, fmt.Errorf(
+				"get account active epoch for slot %d: %w",
+				account.AddedSlot,
+				err,
+			)
+		}
+		epochID, err := uint64ToInt64(
+			epoch.EpochId,
+			"account active epoch",
 		)
+		if err != nil {
+			return AccountInfo{}, err
+		}
+		activeEpoch = &epochID
 	}
-	epochID, err := uint64ToInt64(
-		epoch.EpochId,
-		"account active epoch",
-	)
-	if err != nil {
-		return AccountInfo{}, err
-	}
-	activeEpoch = &epochID
 
 	var poolID *string
 	if account.Active && len(account.Pool) > 0 {

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 
 	"github.com/blinklabs-io/dingo/database"

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -52,6 +52,7 @@ var (
 	ErrMempoolUnavailable  = errors.New("mempool unavailable")
 	ErrMempoolFull         = errors.New("mempool full")
 	ErrTransactionNotFound = errors.New("transaction not found")
+	ErrInvalidStakeAddress = errors.New("invalid stake address")
 )
 
 // TransactionSubmitter accepts raw transaction CBOR for mempool admission.
@@ -81,6 +82,55 @@ func NewNodeAdapter(
 		ledgerState: ls,
 		submitter:   submitter,
 	}, nil
+}
+
+func uintToUint8(v uint, fieldName string) (uint8, error) {
+	if v > math.MaxUint8 {
+		return 0, fmt.Errorf(
+			"%s out of range for uint8: %d",
+			fieldName,
+			v,
+		)
+	}
+	return uint8(v), nil
+}
+
+func uint64ToInt64(v uint64, fieldName string) (int64, error) {
+	if v > math.MaxInt64 {
+		return 0, fmt.Errorf(
+			"%s out of range for int64: %d",
+			fieldName,
+			v,
+		)
+	}
+	return int64(v), nil
+}
+
+func uint64ToInt32(v uint64, fieldName string) (int32, error) {
+	if v > math.MaxInt32 {
+		return 0, fmt.Errorf(
+			"%s out of range for int32: %d",
+			fieldName,
+			v,
+		)
+	}
+	return int32(v), nil
+}
+
+func delegationActivationEpoch(
+	ls *ledger.LedgerState,
+	slot uint64,
+) (int32, error) {
+	epoch, err := ls.SlotToEpoch(slot)
+	if err != nil {
+		return 0, err
+	}
+	// Stake delegation becomes active after snapshot
+	// rotation, two epochs after the certificate epoch.
+	return uint64ToInt32(
+		epoch.EpochId+2,
+		"delegation active epoch",
+	)
 }
 
 // ChainTip returns the current chain tip from the ledger
@@ -912,11 +962,326 @@ func (a *NodeAdapter) PoolsExtended() (
 	return ret, nil
 }
 
+// Account returns stake-account information for the
+// requested stake address.
+func (a *NodeAdapter) Account(
+	stakeAddress string,
+) (AccountInfo, error) {
+	stakeAddr, stakeKey, err := parseStakeAddress(
+		stakeAddress,
+	)
+	if err != nil {
+		return AccountInfo{}, err
+	}
+
+	db := a.ledgerState.Database()
+	account, err := db.GetAccount(stakeKey, true, nil)
+	if err != nil {
+		return AccountInfo{}, err
+	}
+	networkID, err := uintToUint8(
+		stakeAddr.NetworkId(),
+		"stake address network id",
+	)
+	if err != nil {
+		return AccountInfo{}, err
+	}
+
+	rows, err := a.ledgerState.Database().
+		GetAddressesByStakingKey(stakeKey, 0, 0, PaginationOrderAsc, nil)
+	if err != nil {
+		return AccountInfo{}, fmt.Errorf(
+			"get associated addresses: %w",
+			err,
+		)
+	}
+	var controlledAmount uint64
+	for _, row := range rows {
+		if len(row.PaymentKey) == 0 {
+			continue
+		}
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyKey,
+			networkID,
+			row.PaymentKey,
+			stakeKey,
+		)
+		if err != nil {
+			return AccountInfo{}, fmt.Errorf(
+				"build associated address: %w",
+				err,
+			)
+		}
+		utxos, err := a.ledgerState.UtxosByAddress(addr)
+		if err != nil {
+			return AccountInfo{}, fmt.Errorf(
+				"get controlled utxos: %w",
+				err,
+			)
+		}
+		for _, utxo := range utxos {
+			controlledAmount += uint64(utxo.Amount)
+		}
+	}
+
+	var activeEpoch *int64
+	epoch, err := a.ledgerState.SlotToEpoch(account.AddedSlot)
+	if err != nil {
+		return AccountInfo{}, fmt.Errorf(
+			"get account active epoch for slot %d: %w",
+			account.AddedSlot,
+			err,
+		)
+	}
+	epochID, err := uint64ToInt64(
+		epoch.EpochId,
+		"account active epoch",
+	)
+	if err != nil {
+		return AccountInfo{}, err
+	}
+	activeEpoch = &epochID
+
+	var poolID *string
+	if account.Active && len(account.Pool) > 0 {
+		pool := lcommon.PoolId(
+			lcommon.NewBlake2b224(account.Pool),
+		).String()
+		poolID = &pool
+	}
+
+	reward := strconv.FormatUint(uint64(account.Reward), 10)
+	return AccountInfo{
+		StakeAddress:       stakeAddress,
+		Active:             account.Active,
+		ActiveEpoch:        activeEpoch,
+		ControlledAmount:   strconv.FormatUint(controlledAmount, 10),
+		RewardsSum:         reward,
+		WithdrawalsSum:     "0",
+		ReservesSum:        "0",
+		TreasurySum:        "0",
+		WithdrawableAmount: reward,
+		PoolID:             poolID,
+	}, nil
+}
+
+// AccountAssociatedAddresses returns payment addresses
+// associated with the requested stake address.
+func (a *NodeAdapter) AccountAssociatedAddresses(
+	stakeAddress string,
+	params PaginationParams,
+) ([]AccountAssociatedAddressInfo, int, error) {
+	stakeAddr, stakeKey, err := parseStakeAddress(
+		stakeAddress,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	networkID, err := uintToUint8(
+		stakeAddr.NetworkId(),
+		"stake address network id",
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccount(stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+	total, err := a.ledgerState.Database().
+		CountAddressesByStakingKey(stakeKey, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count associated addresses: %w",
+			err,
+		)
+	}
+	offset := (params.Page - 1) * params.Count
+
+	rows, err := a.ledgerState.Database().
+		GetAddressesByStakingKey(
+			stakeKey,
+			params.Count,
+			offset,
+			params.Order,
+			nil,
+		)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get associated addresses: %w",
+			err,
+		)
+	}
+
+	ret := make(
+		[]AccountAssociatedAddressInfo,
+		0,
+		len(rows),
+	)
+	for _, row := range rows {
+		if len(row.PaymentKey) == 0 {
+			continue
+		}
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyKey,
+			networkID,
+			row.PaymentKey,
+			stakeKey,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf(
+				"build associated address: %w",
+				err,
+			)
+		}
+		ret = append(ret, AccountAssociatedAddressInfo{
+			Address: addr.String(),
+		})
+	}
+	return ret, total, nil
+}
+
+// AccountDelegationHistory returns delegation history
+// rows for the requested stake address.
+func (a *NodeAdapter) AccountDelegationHistory(
+	stakeAddress string,
+	params PaginationParams,
+) ([]AccountDelegationHistoryInfo, int, error) {
+	_, stakeKey, err := parseStakeAddress(stakeAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccount(stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+	rows, err := a.ledgerState.Database().
+		GetAccountDelegationHistory(stakeKey, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get account delegation history: %w",
+			err,
+		)
+	}
+
+	ret := make([]AccountDelegationHistoryInfo, 0, len(rows))
+	for _, row := range rows {
+		activeEpoch, err := delegationActivationEpoch(
+			a.ledgerState,
+			row.AddedSlot,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf(
+				"get activation epoch for delegation slot %d: %w",
+				row.AddedSlot,
+				err,
+			)
+		}
+		ret = append(ret, AccountDelegationHistoryInfo{
+			ActiveEpoch: activeEpoch,
+			TxHash:      hex.EncodeToString(row.TxHash),
+			Amount:      "0",
+			PoolID: lcommon.PoolId(
+				lcommon.NewBlake2b224(row.PoolKeyHash),
+			).String(),
+		})
+	}
+	if params.Order == PaginationOrderAsc {
+		slices.Reverse(ret)
+	}
+	total := len(ret)
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountDelegationHistoryInfo{}, total, nil
+	}
+	end := min(start+params.Count, total)
+	return ret[start:end], total, nil
+}
+
+// AccountRegistrationHistory returns registration
+// history rows for the requested stake address.
+func (a *NodeAdapter) AccountRegistrationHistory(
+	stakeAddress string,
+	params PaginationParams,
+) ([]AccountRegistrationHistoryInfo, int, error) {
+	_, stakeKey, err := parseStakeAddress(stakeAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccount(stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+	rows, err := a.ledgerState.Database().
+		GetAccountRegistrationHistory(stakeKey, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get account registration history: %w",
+			err,
+		)
+	}
+
+	ret := make(
+		[]AccountRegistrationHistoryInfo,
+		0,
+		len(rows),
+	)
+	for _, row := range rows {
+		ret = append(ret, AccountRegistrationHistoryInfo{
+			TxHash: hex.EncodeToString(row.TxHash),
+			Action: row.Action,
+		})
+	}
+	if params.Order == PaginationOrderAsc {
+		slices.Reverse(ret)
+	}
+	total := len(ret)
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountRegistrationHistoryInfo{}, total, nil
+	}
+	end := min(start+params.Count, total)
+	return ret[start:end], total, nil
+}
+
+// AccountRewardHistory returns reward history rows for
+// the requested stake address.
+func (a *NodeAdapter) AccountRewardHistory(
+	stakeAddress string,
+	params PaginationParams,
+) ([]AccountRewardHistoryInfo, int, error) {
+	_, stakeKey, err := parseStakeAddress(stakeAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccount(stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+	return []AccountRewardHistoryInfo{}, 0, nil
+}
+
 func blockIssuer(issuer lcommon.IssuerVkey) string {
 	if bytes.Equal(issuer[:], make([]byte, len(issuer))) {
 		return ""
 	}
 	return issuer.PoolId()
+}
+
+func parseStakeAddress(
+	stakeAddress string,
+) (lcommon.Address, []byte, error) {
+	addr, err := lcommon.NewAddress(stakeAddress)
+	if err != nil {
+		return lcommon.Address{}, nil, ErrInvalidStakeAddress
+	}
+	zeroHash := lcommon.NewBlake2b224(nil)
+	if addr.PaymentKeyHash() != zeroHash ||
+		addr.StakeKeyHash() == zeroHash {
+		return lcommon.Address{}, nil, ErrInvalidStakeAddress
+	}
+	stakeKey := addr.StakeKeyHash().Bytes()
+	return addr, stakeKey, nil
 }
 
 func blockHashString(hash []byte) string {

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1033,6 +1033,7 @@ func (a *NodeAdapter) Account(
 			err,
 		)
 	}
+
 	epochID, err := uint64ToInt64(
 		epoch.EpochId,
 		"account active epoch",
@@ -1176,6 +1177,13 @@ func (a *NodeAdapter) AccountDelegationHistory(
 				row.AddedSlot,
 				err,
 			)
+		}
+		activeEpoch, err := uint64ToInt32(
+			epoch.EpochId,
+			"delegation active epoch",
+		)
+		if err != nil {
+			return nil, err
 		}
 		ret = append(ret, AccountDelegationHistoryInfo{
 			ActiveEpoch: activeEpoch,

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -967,7 +967,7 @@ func (a *NodeAdapter) PoolsExtended() (
 func (a *NodeAdapter) Account(
 	stakeAddress string,
 ) (AccountInfo, error) {
-	stakeAddr, stakeKey, err := parseStakeAddress(
+	_, stakeKey, err := parseStakeAddress(
 		stakeAddress,
 	)
 	if err != nil {
@@ -979,49 +979,13 @@ func (a *NodeAdapter) Account(
 	if err != nil {
 		return AccountInfo{}, err
 	}
-	networkID, err := uintToUint8(
-		stakeAddr.NetworkId(),
-		"stake address network id",
-	)
-	if err != nil {
-		return AccountInfo{}, err
-	}
-
-	rows, err := a.ledgerState.Database().
-		GetAddressesByStakingKey(stakeKey, 0, 0, PaginationOrderAsc, nil)
+	controlledAmount, err := a.ledgerState.Database().
+		GetControlledAmountByStakingKey(stakeKey, nil)
 	if err != nil {
 		return AccountInfo{}, fmt.Errorf(
-			"get associated addresses: %w",
+			"get controlled amount: %w",
 			err,
 		)
-	}
-	var controlledAmount uint64
-	for _, row := range rows {
-		if len(row.PaymentKey) == 0 {
-			continue
-		}
-		addr, err := lcommon.NewAddressFromParts(
-			lcommon.AddressTypeKeyKey,
-			networkID,
-			row.PaymentKey,
-			stakeKey,
-		)
-		if err != nil {
-			return AccountInfo{}, fmt.Errorf(
-				"build associated address: %w",
-				err,
-			)
-		}
-		utxos, err := a.ledgerState.UtxosByAddress(addr)
-		if err != nil {
-			return AccountInfo{}, fmt.Errorf(
-				"get controlled utxos: %w",
-				err,
-			)
-		}
-		for _, utxo := range utxos {
-			controlledAmount += uint64(utxo.Amount)
-		}
 	}
 
 	var activeEpoch *int64
@@ -1262,6 +1226,10 @@ func (a *NodeAdapter) AccountRewardHistory(
 		GetAccount(stakeKey, true, nil); err != nil {
 		return nil, 0, err
 	}
+	// TODO(#1875): Implement reward history once Dingo persists
+	// per-account, per-epoch reward records. This endpoint remains
+	// stubbed in this PR because the backing reward-history storage
+	// and rollback-safe ledger/database plumbing do not exist yet.
 	return []AccountRewardHistoryInfo{}, 0, nil
 }
 

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1119,8 +1119,26 @@ func (a *NodeAdapter) AccountDelegationHistory(
 		GetAccount(stakeKey, true, nil); err != nil {
 		return nil, 0, err
 	}
+	offset := (params.Page - 1) * params.Count
+	total, err := a.ledgerState.Database().
+		CountAccountDelegationHistory(stakeKey, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count account delegation history: %w",
+			err,
+		)
+	}
+	if offset >= total {
+		return []AccountDelegationHistoryInfo{}, total, nil
+	}
 	rows, err := a.ledgerState.Database().
-		GetAccountDelegationHistory(stakeKey, nil)
+		GetAccountDelegationHistory(
+			stakeKey,
+			params.Count,
+			offset,
+			params.Order,
+			nil,
+		)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get account delegation history: %w",
@@ -1150,17 +1168,7 @@ func (a *NodeAdapter) AccountDelegationHistory(
 			).String(),
 		})
 	}
-
-	if params.Order == PaginationOrderAsc {
-		slices.Reverse(ret)
-	}
-	total := len(ret)
-	start := (params.Page - 1) * params.Count
-	if start >= total {
-		return []AccountDelegationHistoryInfo{}, total, nil
-	}
-	end := min(start+params.Count, total)
-	return ret[start:end], total, nil
+	return ret, total, nil
 }
 
 // AccountRegistrationHistory returns registration

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"slices"
 	"strconv"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -1186,8 +1185,26 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 		GetAccount(stakeKey, true, nil); err != nil {
 		return nil, 0, err
 	}
+	offset := (params.Page - 1) * params.Count
+	total, err := a.ledgerState.Database().
+		CountAccountRegistrationHistory(stakeKey, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count account registration history: %w",
+			err,
+		)
+	}
+	if offset >= total {
+		return []AccountRegistrationHistoryInfo{}, total, nil
+	}
 	rows, err := a.ledgerState.Database().
-		GetAccountRegistrationHistory(stakeKey, nil)
+		GetAccountRegistrationHistory(
+			stakeKey,
+			params.Count,
+			offset,
+			params.Order,
+			nil,
+		)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get account registration history: %w",
@@ -1206,17 +1223,7 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 			Action: row.Action,
 		})
 	}
-
-	if params.Order == PaginationOrderAsc {
-		slices.Reverse(ret)
-	}
-	total := len(ret)
-	start := (params.Page - 1) * params.Count
-	if start >= total {
-		return []AccountRegistrationHistoryInfo{}, total, nil
-	}
-	end := min(start+params.Count, total)
-	return ret[start:end], total, nil
+	return ret, total, nil
 }
 
 // AccountRewardHistory returns reward history rows for

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1042,15 +1042,6 @@ func (a *NodeAdapter) Account(
 	}
 	activeEpoch = &epochID
 
-	epochID, err := uint64ToInt64(
-		epoch.EpochId,
-		"account active epoch",
-	)
-	if err != nil {
-		return AccountInfo{}, err
-	}
-	activeEpoch = &epochID
-
 	var poolID *string
 	if account.Active && len(account.Pool) > 0 {
 		pool := lcommon.PoolId(

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1152,6 +1152,7 @@ func (a *NodeAdapter) AccountDelegationHistory(
 	if err != nil {
 		return nil, 0, err
 	}
+
 	if _, err := a.ledgerState.Database().
 		GetAccount(stakeKey, true, nil); err != nil {
 		return nil, 0, err
@@ -1178,13 +1179,6 @@ func (a *NodeAdapter) AccountDelegationHistory(
 				err,
 			)
 		}
-		activeEpoch, err := uint64ToInt32(
-			epoch.EpochId,
-			"delegation active epoch",
-		)
-		if err != nil {
-			return nil, err
-		}
 		ret = append(ret, AccountDelegationHistoryInfo{
 			ActiveEpoch: activeEpoch,
 			TxHash:      hex.EncodeToString(row.TxHash),
@@ -1194,6 +1188,7 @@ func (a *NodeAdapter) AccountDelegationHistory(
 			).String(),
 		})
 	}
+
 	if params.Order == PaginationOrderAsc {
 		slices.Reverse(ret)
 	}
@@ -1216,6 +1211,7 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 	if err != nil {
 		return nil, 0, err
 	}
+
 	if _, err := a.ledgerState.Database().
 		GetAccount(stakeKey, true, nil); err != nil {
 		return nil, 0, err
@@ -1240,6 +1236,7 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 			Action: row.Action,
 		})
 	}
+
 	if params.Order == PaginationOrderAsc {
 		slices.Reverse(ret)
 	}

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1085,9 +1085,6 @@ func (a *NodeAdapter) AccountAssociatedAddresses(
 		len(rows),
 	)
 	for _, row := range rows {
-		if len(row.PaymentKey) == 0 {
-			continue
-		}
 		addr, err := lcommon.NewAddressFromParts(
 			lcommon.AddressTypeKeyKey,
 			networkID,

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1033,6 +1033,14 @@ func (a *NodeAdapter) Account(
 			err,
 		)
 	}
+	epochID, err := uint64ToInt64(
+		epoch.EpochId,
+		"account active epoch",
+	)
+	if err != nil {
+		return AccountInfo{}, err
+	}
+	activeEpoch = &epochID
 
 	epochID, err := uint64ToInt64(
 		epoch.EpochId,

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -190,6 +190,26 @@ func (b *Blockfrost) Start(
 		"GET /api/v0/txs/{hash}/required_signers",
 		b.handleTransactionRequiredSigners,
 	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}",
+		b.handleAccount,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/addresses",
+		b.handleAccountAssociatedAddresses,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/delegations",
+		b.handleAccountDelegationHistory,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/registrations",
+		b.handleAccountRegistrationHistory,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/rewards",
+		b.handleAccountRewardHistory,
+	)
 
 	// Wrap handler with a request body size limit (1 MB)
 	// as defense-in-depth against oversized payloads.

--- a/blockfrost/blockfrost_compat_test.go
+++ b/blockfrost/blockfrost_compat_test.go
@@ -527,3 +527,156 @@ func TestCompatNetworkResponse(t *testing.T) {
 		t, "22000000000000000", theirs.Stake.Active,
 	)
 }
+
+// TestCompatAccountResponse verifies that our
+// AccountResponse round-trips through blockfrost-go's
+// Account type.
+func TestCompatAccountResponse(t *testing.T) {
+	activeEpoch := int64(42)
+	poolID := "pool1xyz"
+	ours := AccountResponse{
+		StakeAddress:       "stake_test1upugeuz3jdy0a7hncusutadavzcetdzylgxcldz39hp9n0s0xy0n5",
+		Active:             true,
+		ActiveEpoch:        &activeEpoch,
+		ControlledAmount:   "1000000",
+		RewardsSum:         "123",
+		WithdrawalsSum:     "45",
+		ReservesSum:        "6",
+		TreasurySum:        "7",
+		WithdrawableAmount: "89",
+		PoolID:             &poolID,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Account
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, ours.StakeAddress, theirs.StakeAddress)
+	assert.Equal(t, ours.Active, theirs.Active)
+	require.NotNil(t, theirs.ActiveEpoch)
+	assert.Equal(t, activeEpoch, *theirs.ActiveEpoch)
+	assert.Equal(
+		t, ours.ControlledAmount, theirs.ControlledAmount,
+	)
+	assert.Equal(t, ours.RewardsSum, theirs.RewardsSum)
+	assert.Equal(
+		t, ours.WithdrawalsSum, theirs.WithdrawalsSum,
+	)
+	assert.Equal(t, ours.ReservesSum, theirs.ReservesSum)
+	assert.Equal(t, ours.TreasurySum, theirs.TreasurySum)
+	assert.Equal(
+		t, ours.WithdrawableAmount, theirs.WithdrawableAmount,
+	)
+	require.NotNil(t, theirs.PoolID)
+	assert.Equal(t, poolID, *theirs.PoolID)
+}
+
+// TestCompatAccountAssociatedAddressesResponse verifies
+// that our AccountAssociatedAddressResponse round-trips
+// through blockfrost-go's AccountAssociatedAddress type.
+func TestCompatAccountAssociatedAddressesResponse(t *testing.T) {
+	ours := []AccountAssociatedAddressResponse{
+		{Address: "addr_test1qqqexample"},
+		{Address: "addr_test1qqqexample2"},
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs []bfgo.AccountAssociatedAddress
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	require.Len(t, theirs, 2)
+	assert.Equal(t, ours[0].Address, theirs[0].Address)
+	assert.Equal(t, ours[1].Address, theirs[1].Address)
+}
+
+// TestCompatAccountDelegationHistoryResponse verifies
+// that our AccountDelegationHistoryResponse round-trips
+// through blockfrost-go's AccountDelegationHistory type.
+func TestCompatAccountDelegationHistoryResponse(t *testing.T) {
+	ours := []AccountDelegationHistoryResponse{
+		{
+			ActiveEpoch: 7,
+			TxHash:      "abc123",
+			Amount:      "1000000",
+			PoolID:      "pool1xyz",
+		},
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs []bfgo.AccountDelegationHistory
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	require.Len(t, theirs, 1)
+	assert.Equal(
+		t, int32(ours[0].ActiveEpoch), theirs[0].ActiveEpoch,
+	)
+	assert.Equal(t, ours[0].TxHash, theirs[0].TXHash)
+	assert.Equal(t, ours[0].Amount, theirs[0].Amount)
+	assert.Equal(t, ours[0].PoolID, theirs[0].PoolID)
+}
+
+// TestCompatAccountRegistrationHistoryResponse verifies
+// that our AccountRegistrationHistoryResponse
+// round-trips through blockfrost-go's
+// AccountRegistrationHistory type.
+func TestCompatAccountRegistrationHistoryResponse(
+	t *testing.T,
+) {
+	ours := []AccountRegistrationHistoryResponse{
+		{
+			TxHash: "abc123",
+			Action: "registered",
+		},
+		{
+			TxHash: "def456",
+			Action: "deregistered",
+		},
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs []bfgo.AccountRegistrationHistory
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	require.Len(t, theirs, 2)
+	assert.Equal(t, ours[0].TxHash, theirs[0].TXHash)
+	assert.Equal(t, ours[0].Action, theirs[0].Action)
+	assert.Equal(t, ours[1].TxHash, theirs[1].TXHash)
+	assert.Equal(t, ours[1].Action, theirs[1].Action)
+}
+
+// TestCompatAccountRewardHistoryResponse verifies that
+// our AccountRewardHistoryResponse round-trips through
+// blockfrost-go's AccountRewardsHistory type.
+func TestCompatAccountRewardHistoryResponse(t *testing.T) {
+	ours := []AccountRewardHistoryResponse{
+		{
+			Epoch:  11,
+			Amount: "500",
+			PoolID: "pool1xyz",
+		},
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs []bfgo.AccountRewardsHistory
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	require.Len(t, theirs, 1)
+	assert.Equal(t, int32(ours[0].Epoch), theirs[0].Epoch)
+	assert.Equal(t, ours[0].Amount, theirs[0].Amount)
+	assert.Equal(t, ours[0].PoolID, theirs[0].PoolID)
+}

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +70,11 @@ type mockNode struct {
 	addressTxsTotal               int
 	metadataJSONTotal             int
 	metadataCBORTotal             int
+	account                       AccountInfo
+	addresses                     []AccountAssociatedAddressInfo
+	delegations                   []AccountDelegationHistoryInfo
+	regs                          []AccountRegistrationHistoryInfo
+	rewards                       []AccountRewardHistoryInfo
 	chainTipErr                   error
 	blockErr                      error
 	blockByIDErr                  error
@@ -100,6 +106,11 @@ type mockNode struct {
 	transactionPoolRetiresErr     error
 	transactionRedeemersErr       error
 	transactionRequiredSignersErr error
+	accountErr                    error
+	addressesErr                  error
+	delegationsErr                error
+	regsErr                       error
+	rewardsErr                    error
 }
 
 func (m *mockNode) ChainTip() (
@@ -291,6 +302,88 @@ func (m *mockNode) TransactionRequiredSigners(
 	_ []byte,
 ) ([]TransactionRequiredSignerInfo, error) {
 	return m.transactionRequiredSigners, m.transactionRequiredSignersErr
+}
+
+func (m *mockNode) Account(
+	_ string,
+) (AccountInfo, error) {
+	return m.account, m.accountErr
+}
+
+func (m *mockNode) AccountAssociatedAddresses(
+	_ string,
+	params PaginationParams,
+) ([]AccountAssociatedAddressInfo, int, error) {
+	items := append([]AccountAssociatedAddressInfo(nil), m.addresses...)
+	total := len(items)
+	if params.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountAssociatedAddressInfo{}, total, m.addressesErr
+	}
+	end := min(start+params.Count, total)
+	return items[start:end], total, m.addressesErr
+}
+
+func (m *mockNode) AccountDelegationHistory(
+	_ string,
+	params PaginationParams,
+) ([]AccountDelegationHistoryInfo, int, error) {
+	items := append([]AccountDelegationHistoryInfo(nil), m.delegations...)
+	total := len(items)
+	if params.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountDelegationHistoryInfo{}, total, m.delegationsErr
+	}
+	end := min(start+params.Count, total)
+	return items[start:end], total, m.delegationsErr
+}
+
+func (m *mockNode) AccountRegistrationHistory(
+	_ string,
+	params PaginationParams,
+) ([]AccountRegistrationHistoryInfo, int, error) {
+	items := append([]AccountRegistrationHistoryInfo(nil), m.regs...)
+	total := len(items)
+	if params.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountRegistrationHistoryInfo{}, total, m.regsErr
+	}
+	end := min(start+params.Count, total)
+	return items[start:end], total, m.regsErr
+}
+
+func (m *mockNode) AccountRewardHistory(
+	_ string,
+	params PaginationParams,
+) ([]AccountRewardHistoryInfo, int, error) {
+	items := append([]AccountRewardHistoryInfo(nil), m.rewards...)
+	total := len(items)
+	if params.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountRewardHistoryInfo{}, total, m.rewardsErr
+	}
+	end := min(start+params.Count, total)
+	return items[start:end], total, m.rewardsErr
 }
 
 func newTestBlockfrost(
@@ -1631,6 +1724,207 @@ func TestHandleEpochParamsNotFound(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 404, resp.StatusCode)
 	assert.Equal(t, "Not Found", resp.Error)
+}
+
+func TestHandleAccount(t *testing.T) {
+	mock := &mockNode{
+		account: AccountInfo{
+			StakeAddress:       "stake_test1",
+			Active:             true,
+			ControlledAmount:   "123",
+			RewardsSum:         "10",
+			WithdrawalsSum:     "0",
+			ReservesSum:        "0",
+			TreasurySum:        "0",
+			WithdrawableAmount: "10",
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/stake_test1",
+		nil,
+	)
+	req.SetPathValue("stake_address", "stake_test1")
+	w := httptest.NewRecorder()
+	b.handleAccount(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp AccountResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "stake_test1", resp.StakeAddress)
+	assert.True(t, resp.Active)
+	assert.Equal(t, "123", resp.ControlledAmount)
+	assert.Equal(t, "10", resp.RewardsSum)
+	assert.Equal(t, "10", resp.WithdrawableAmount)
+}
+
+func TestHandleAccountInvalidStakeAddress(t *testing.T) {
+	mock := &mockNode{
+		accountErr: ErrInvalidStakeAddress,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/invalid",
+		nil,
+	)
+	req.SetPathValue("stake_address", "invalid")
+	w := httptest.NewRecorder()
+	b.handleAccount(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, "Invalid stake address.", resp.Message)
+}
+
+func TestHandleAccountNotFound(t *testing.T) {
+	mock := &mockNode{
+		accountErr: models.ErrAccountNotFound,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/stake_missing",
+		nil,
+	)
+	req.SetPathValue("stake_address", "stake_missing")
+	w := httptest.NewRecorder()
+	b.handleAccount(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleAccountAssociatedAddresses(t *testing.T) {
+	mock := &mockNode{
+		addresses: []AccountAssociatedAddressInfo{
+			{Address: "addr_test1"},
+			{Address: "addr_test2"},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/stake_test1/addresses?count=1&page=2&order=asc",
+		nil,
+	)
+	req.SetPathValue("stake_address", "stake_test1")
+	w := httptest.NewRecorder()
+	b.handleAccountAssociatedAddresses(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Page-Total"))
+
+	var resp []AccountAssociatedAddressResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "addr_test2", resp[0].Address)
+}
+
+func TestHandleAccountDelegationHistory(t *testing.T) {
+	mock := &mockNode{
+		delegations: []AccountDelegationHistoryInfo{
+			{
+				ActiveEpoch: 1,
+				TxHash:      "tx1",
+				Amount:      "0",
+				PoolID:      "pool1",
+			},
+			{
+				ActiveEpoch: 2,
+				TxHash:      "tx2",
+				Amount:      "0",
+				PoolID:      "pool2",
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/stake_test1/delegations?count=1&page=1&order=desc",
+		nil,
+	)
+	req.SetPathValue("stake_address", "stake_test1")
+	w := httptest.NewRecorder()
+	b.handleAccountDelegationHistory(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []AccountDelegationHistoryResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, int32(2), resp[0].ActiveEpoch)
+	assert.Equal(t, "tx2", resp[0].TxHash)
+	assert.Equal(t, "pool2", resp[0].PoolID)
+}
+
+func TestHandleAccountRegistrationHistory(t *testing.T) {
+	mock := &mockNode{
+		regs: []AccountRegistrationHistoryInfo{
+			{TxHash: "tx1", Action: "registered"},
+			{TxHash: "tx2", Action: "deregistered"},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/stake_test1/registrations?count=2&page=1&order=asc",
+		nil,
+	)
+	req.SetPathValue("stake_address", "stake_test1")
+	w := httptest.NewRecorder()
+	b.handleAccountRegistrationHistory(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []AccountRegistrationHistoryResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 2)
+	assert.Equal(t, "registered", resp[0].Action)
+	assert.Equal(t, "deregistered", resp[1].Action)
+}
+
+func TestHandleAccountRewardHistory(t *testing.T) {
+	mock := &mockNode{
+		rewards: []AccountRewardHistoryInfo{
+			{Epoch: 3, Amount: "12", PoolID: "pool1"},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/accounts/stake_test1/rewards",
+		nil,
+	)
+	req.SetPathValue("stake_address", "stake_test1")
+	w := httptest.NewRecorder()
+	b.handleAccountRewardHistory(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []AccountRewardHistoryResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, int32(3), resp[0].Epoch)
+	assert.Equal(t, "12", resp[0].Amount)
 }
 
 func TestHandleNetwork(t *testing.T) {

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -27,9 +27,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/btcsuite/btcd/btcutil/bech32"
-
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
 const (

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcd/btcutil/bech32"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 const (
@@ -1678,5 +1680,200 @@ func protocolParamsResponse(
 		Nonce:                 "",
 		DecentralisationParam: 0,
 		ExtraEntropy:          nil,
+	}
+}
+
+func (b *Blockfrost) handleAccount(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	account, err := b.node.Account(r.PathValue("stake_address"))
+	if err != nil {
+		b.writeAccountError(w, err, "failed to retrieve account")
+		return
+	}
+	writeJSON(w, http.StatusOK, AccountResponse(account))
+}
+
+func (b *Blockfrost) handleAccountAssociatedAddresses(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	items, total, err := b.node.AccountAssociatedAddresses(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(
+			w, err, "failed to retrieve account addresses",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make(
+		[]AccountAssociatedAddressResponse,
+		0,
+		len(items),
+	)
+	for _, item := range items {
+		resp = append(
+			resp,
+			AccountAssociatedAddressResponse(item),
+		)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (b *Blockfrost) handleAccountDelegationHistory(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	items, total, err := b.node.AccountDelegationHistory(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(
+			w, err, "failed to retrieve account delegation history",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make(
+		[]AccountDelegationHistoryResponse,
+		0,
+		len(items),
+	)
+	for _, item := range items {
+		resp = append(
+			resp,
+			AccountDelegationHistoryResponse(item),
+		)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (b *Blockfrost) handleAccountRegistrationHistory(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	items, total, err := b.node.AccountRegistrationHistory(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(
+			w, err, "failed to retrieve account registration history",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make(
+		[]AccountRegistrationHistoryResponse,
+		0,
+		len(items),
+	)
+	for _, item := range items {
+		resp = append(
+			resp,
+			AccountRegistrationHistoryResponse(item),
+		)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (b *Blockfrost) handleAccountRewardHistory(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	items, total, err := b.node.AccountRewardHistory(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(
+			w, err, "failed to retrieve account reward history",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make([]AccountRewardHistoryResponse, 0, len(items))
+	for _, item := range items {
+		resp = append(
+			resp,
+			AccountRewardHistoryResponse(item),
+		)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (b *Blockfrost) writeAccountError(
+	w http.ResponseWriter,
+	err error,
+	internalMessage string,
+) {
+	switch {
+	case errors.Is(err, ErrInvalidStakeAddress):
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid stake address.",
+		)
+	case errors.Is(err, models.ErrAccountNotFound):
+		writeError(
+			w,
+			http.StatusNotFound,
+			"Not Found",
+			"The requested component has not been found.",
+		)
+	default:
+		b.logger.Error(internalMessage, "error", err)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			internalMessage,
+		)
 	}
 }

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -143,6 +143,38 @@ type BlockfrostNode interface {
 	// DRep returns governance DRep information for a parsed
 	// DRep credential.
 	DRep(DRepCredential) (DRepInfo, error)
+
+	// Account returns stake-account information for the
+	// requested stake address.
+	Account(string) (AccountInfo, error)
+
+	// AccountAssociatedAddresses returns payment addresses
+	// associated with the requested stake address.
+	AccountAssociatedAddresses(
+		string,
+		PaginationParams,
+	) ([]AccountAssociatedAddressInfo, int, error)
+
+	// AccountDelegationHistory returns delegation history
+	// rows for the requested stake address.
+	AccountDelegationHistory(
+		string,
+		PaginationParams,
+	) ([]AccountDelegationHistoryInfo, int, error)
+
+	// AccountRegistrationHistory returns registration
+	// history rows for the requested stake address.
+	AccountRegistrationHistory(
+		string,
+		PaginationParams,
+	) ([]AccountRegistrationHistoryInfo, int, error)
+
+	// AccountRewardHistory returns reward history rows for
+	// the requested stake address.
+	AccountRewardHistory(
+		string,
+		PaginationParams,
+	) ([]AccountRewardHistoryInfo, int, error)
 }
 
 // ChainTipInfo holds chain tip data needed by the API.
@@ -515,4 +547,48 @@ type DRepInfo struct {
 	Active      bool
 	ActiveEpoch uint64
 	LiveStake   string
+}
+
+// AccountInfo holds stake-account data needed by the API.
+type AccountInfo struct {
+	StakeAddress       string
+	Active             bool
+	ActiveEpoch        *int64
+	ControlledAmount   string
+	RewardsSum         string
+	WithdrawalsSum     string
+	ReservesSum        string
+	TreasurySum        string
+	WithdrawableAmount string
+	PoolID             *string
+}
+
+// AccountAssociatedAddressInfo holds a payment address
+// associated with a stake key.
+type AccountAssociatedAddressInfo struct {
+	Address string
+}
+
+// AccountDelegationHistoryInfo holds a stake-account
+// delegation history row.
+type AccountDelegationHistoryInfo struct {
+	ActiveEpoch int32
+	TxHash      string
+	Amount      string
+	PoolID      string
+}
+
+// AccountRegistrationHistoryInfo holds a stake-account
+// registration history row.
+type AccountRegistrationHistoryInfo struct {
+	TxHash string
+	Action string
+}
+
+// AccountRewardHistoryInfo holds a stake-account reward
+// history row.
+type AccountRewardHistoryInfo struct {
+	Epoch  int32
+	Amount string
+	PoolID string
 }

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -422,3 +422,47 @@ type TransactionRedeemerResponse struct {
 type TransactionRequiredSignerResponse struct {
 	WitnessHash string `json:"witness_hash"`
 }
+
+// AccountResponse represents a Blockfrost stake account.
+type AccountResponse struct {
+	StakeAddress       string  `json:"stake_address"`
+	Active             bool    `json:"active"`
+	ActiveEpoch        *int64  `json:"active_epoch"`
+	ControlledAmount   string  `json:"controlled_amount"`
+	RewardsSum         string  `json:"rewards_sum"`
+	WithdrawalsSum     string  `json:"withdrawals_sum"`
+	ReservesSum        string  `json:"reserves_sum"`
+	TreasurySum        string  `json:"treasury_sum"`
+	WithdrawableAmount string  `json:"withdrawable_amount"`
+	PoolID             *string `json:"pool_id"`
+}
+
+// AccountAssociatedAddressResponse represents a stake
+// account associated payment address.
+type AccountAssociatedAddressResponse struct {
+	Address string `json:"address"`
+}
+
+// AccountDelegationHistoryResponse represents a
+// stake-account delegation history row.
+type AccountDelegationHistoryResponse struct {
+	ActiveEpoch int32  `json:"active_epoch"`
+	TxHash      string `json:"tx_hash"`
+	Amount      string `json:"amount"`
+	PoolID      string `json:"pool_id"`
+}
+
+// AccountRegistrationHistoryResponse represents a
+// stake-account registration history row.
+type AccountRegistrationHistoryResponse struct {
+	TxHash string `json:"tx_hash"`
+	Action string `json:"action"`
+}
+
+// AccountRewardHistoryResponse represents a stake-account
+// reward history row.
+type AccountRewardHistoryResponse struct {
+	Epoch  int32  `json:"epoch"`
+	Amount string `json:"amount"`
+	PoolID string `json:"pool_id"`
+}

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// GetAccountDelegationHistory returns delegation history rows for a staking key.
+func (d *Database) GetAccountDelegationHistory(
+	stakeKey []byte,
+	txn *Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	rows, err := d.metadata.GetAccountDelegationHistory(
+		stakeKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get account delegation history: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// GetAccountRegistrationHistory returns registration history rows for a staking key.
+func (d *Database) GetAccountRegistrationHistory(
+	stakeKey []byte,
+	txn *Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	rows, err := d.metadata.GetAccountRegistrationHistory(
+		stakeKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get account registration history: %w",
+			err,
+		)
+	}
+	return rows, nil
+}

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -74,6 +74,9 @@ func (d *Database) CountAccountDelegationHistory(
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
 func (d *Database) GetAccountRegistrationHistory(
 	stakeKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn *Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	if txn == nil {
@@ -82,6 +85,9 @@ func (d *Database) GetAccountRegistrationHistory(
 	}
 	rows, err := d.metadata.GetAccountRegistrationHistory(
 		stakeKey,
+		limit,
+		offset,
+		order,
 		txn.Metadata(),
 	)
 	if err != nil {
@@ -91,4 +97,27 @@ func (d *Database) GetAccountRegistrationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountRegistrationHistory returns the total number of
+// registration history rows for a staking key.
+func (d *Database) CountAccountRegistrationHistory(
+	stakeKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountAccountRegistrationHistory(
+		stakeKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account registration history: %w",
+			err,
+		)
+	}
+	return count, nil
 }

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -23,6 +23,9 @@ import (
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *Database) GetAccountDelegationHistory(
 	stakeKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn *Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
 	if txn == nil {
@@ -31,6 +34,9 @@ func (d *Database) GetAccountDelegationHistory(
 	}
 	rows, err := d.metadata.GetAccountDelegationHistory(
 		stakeKey,
+		limit,
+		offset,
+		order,
 		txn.Metadata(),
 	)
 	if err != nil {
@@ -40,6 +46,29 @@ func (d *Database) GetAccountDelegationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountDelegationHistory returns the total number of delegation
+// history rows for a staking key.
+func (d *Database) CountAccountDelegationHistory(
+	stakeKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountAccountDelegationHistory(
+		stakeKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account delegation history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// AccountDelegationHistoryRow holds delegation history
+// query results for a stake account.
+type AccountDelegationHistoryRow struct {
+	AddedSlot   uint64
+	CertIndex   uint32
+	TxHash      []byte
+	PoolKeyHash []byte
+}
+
+// AccountRegistrationHistoryRow holds registration
+// history query results for a stake account.
+type AccountRegistrationHistoryRow struct {
+	AddedSlot uint64
+	CertIndex uint32
+	TxHash    []byte
+	Action    string
+}

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -18,6 +18,7 @@ package models
 // query results for a stake account.
 type AccountDelegationHistoryRow struct {
 	AddedSlot   uint64
+	BlockIndex  uint32
 	CertIndex   uint32
 	TxHash      []byte
 	PoolKeyHash []byte
@@ -27,6 +28,7 @@ type AccountDelegationHistoryRow struct {
 // history query results for a stake account.
 type AccountRegistrationHistoryRow struct {
 	AddedSlot uint64
+	BlockIndex uint32
 	CertIndex uint32
 	TxHash    []byte
 	Action    string

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -27,9 +27,9 @@ type AccountDelegationHistoryRow struct {
 // AccountRegistrationHistoryRow holds registration
 // history query results for a stake account.
 type AccountRegistrationHistoryRow struct {
-	AddedSlot uint64
+	AddedSlot  uint64
 	BlockIndex uint32
-	CertIndex uint32
-	TxHash    []byte
-	Action    string
+	CertIndex  uint32
+	TxHash     []byte
+	Action     string
 }

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -116,7 +116,7 @@ func QueryRegistrationHistory(
 }
 
 func transactionJoinClause(db *gorm.DB) string {
-	switch strings.ToLower(db.Dialector.Name()) {
+	switch strings.ToLower(db.Name()) {
 	case "mysql":
 		return "INNER JOIN `transaction` tx ON tx.id = certs.transaction_id"
 	default:
@@ -187,13 +187,17 @@ func CompareDelegationRows(
 ) int {
 	switch {
 	case a.AddedSlot < b.AddedSlot:
-		return -1
+		return 1
 	case a.AddedSlot > b.AddedSlot:
-		return 1
-	case a.CertIndex < b.CertIndex:
 		return -1
-	case a.CertIndex > b.CertIndex:
+	case a.CertIndex < b.CertIndex:
 		return 1
+	case a.CertIndex > b.CertIndex:
+		return -1
+	case bytes.Compare(a.TxHash, b.TxHash) < 0:
+		return 1
+	case bytes.Compare(a.TxHash, b.TxHash) > 0:
+		return -1
 	default:
 		return 0
 	}
@@ -204,21 +208,21 @@ func CompareRegistrationRows(
 ) int {
 	switch {
 	case a.AddedSlot < b.AddedSlot:
-		return -1
+		return 1
 	case a.AddedSlot > b.AddedSlot:
-		return 1
+		return -1
 	case a.CertIndex < b.CertIndex:
-		return -1
+		return 1
 	case a.CertIndex > b.CertIndex:
-		return 1
+		return -1
 	case bytes.Compare(a.TxHash, b.TxHash) < 0:
-		return -1
+		return 1
 	case bytes.Compare(a.TxHash, b.TxHash) > 0:
-		return 1
-	case a.Action < b.Action:
 		return -1
-	case a.Action > b.Action:
+	case a.Action < b.Action:
 		return 1
+	case a.Action > b.Action:
+		return -1
 	default:
 		return 0
 	}

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -15,6 +15,7 @@
 package accounthistory
 
 import (
+	"bytes"
 	"fmt"
 	"slices"
 
@@ -199,6 +200,14 @@ func CompareRegistrationRows(
 	case a.CertIndex < b.CertIndex:
 		return -1
 	case a.CertIndex > b.CertIndex:
+		return 1
+	case bytes.Compare(a.TxHash, b.TxHash) < 0:
+		return -1
+	case bytes.Compare(a.TxHash, b.TxHash) > 0:
+		return 1
+	case a.Action < b.Action:
+		return -1
+	case a.Action > b.Action:
 		return 1
 	default:
 		return 0

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -50,7 +51,7 @@ func QueryDelegationHistory(
 				"INNER JOIN certs ON certs.certificate_id = "+table+".id",
 			).
 			Joins(
-				`INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`,
+				transactionJoinClause(db),
 			).
 			Where(
 				table+".staking_key = ? AND certs.cert_type IN ?",
@@ -90,7 +91,7 @@ func QueryRegistrationHistory(
 				"INNER JOIN certs ON certs.certificate_id = "+table+".id",
 			).
 			Joins(
-				`INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`,
+				transactionJoinClause(db),
 			).
 			Where(
 				table+".staking_key = ? AND certs.cert_type IN ?",
@@ -112,6 +113,15 @@ func QueryRegistrationHistory(
 
 	slices.SortFunc(ret, CompareRegistrationRows)
 	return ret, nil
+}
+
+func transactionJoinClause(db *gorm.DB) string {
+	switch strings.ToLower(db.Dialector.Name()) {
+	case "mysql":
+		return "INNER JOIN `transaction` tx ON tx.id = certs.transaction_id"
+	default:
+		return `INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`
+	}
 }
 
 func DelegationCertTypes() []uint {

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounthistory
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+)
+
+func QueryDelegationHistory(
+	db *gorm.DB,
+	stakingKey []byte,
+) ([]models.AccountDelegationHistoryRow, error) {
+	ret := make([]models.AccountDelegationHistoryRow, 0)
+	if len(stakingKey) == 0 {
+		return ret, nil
+	}
+
+	tables := []string{
+		"stake_delegation",
+		"stake_registration_delegation",
+		"stake_vote_delegation",
+		"stake_vote_registration_delegation",
+	}
+	for _, table := range tables {
+		var tmp []models.AccountDelegationHistoryRow
+		if err := db.Table(table).
+			Select(
+				table+".added_slot, certs.cert_index, tx.hash AS tx_hash, "+
+					table+".pool_key_hash",
+			).
+			Joins(
+				"INNER JOIN certs ON certs.certificate_id = "+table+".id",
+			).
+			Joins(
+				`INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`,
+			).
+			Where(
+				table+".staking_key = ? AND certs.cert_type IN ?",
+				stakingKey,
+				DelegationCertTypes(),
+			).
+			Scan(&tmp).Error; err != nil {
+			return nil, fmt.Errorf(
+				"get account delegation history from %s: %w",
+				table,
+				err,
+			)
+		}
+		ret = append(ret, tmp...)
+	}
+
+	slices.SortFunc(ret, CompareDelegationRows)
+	return ret, nil
+}
+
+func QueryRegistrationHistory(
+	db *gorm.DB,
+	stakingKey []byte,
+) ([]models.AccountRegistrationHistoryRow, error) {
+	ret := make([]models.AccountRegistrationHistoryRow, 0)
+	if len(stakingKey) == 0 {
+		return ret, nil
+	}
+
+	for table, action := range RegistrationHistoryTables() {
+		var tmp []models.AccountRegistrationHistoryRow
+		if err := db.Table(table).
+			Select(
+				table+".added_slot, certs.cert_index, tx.hash AS tx_hash",
+			).
+			Joins(
+				"INNER JOIN certs ON certs.certificate_id = "+table+".id",
+			).
+			Joins(
+				`INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`,
+			).
+			Where(
+				table+".staking_key = ? AND certs.cert_type IN ?",
+				stakingKey,
+				RegistrationTableCertTypes(table),
+			).
+			Scan(&tmp).Error; err != nil {
+			return nil, fmt.Errorf(
+				"get account registration history from %s: %w",
+				table,
+				err,
+			)
+		}
+		for i := range tmp {
+			tmp[i].Action = action
+		}
+		ret = append(ret, tmp...)
+	}
+
+	slices.SortFunc(ret, CompareRegistrationRows)
+	return ret, nil
+}
+
+func DelegationCertTypes() []uint {
+	return []uint{
+		uint(lcommon.CertificateTypeStakeDelegation),
+		uint(lcommon.CertificateTypeStakeRegistrationDelegation),
+		uint(lcommon.CertificateTypeStakeVoteDelegation),
+		uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
+	}
+}
+
+func RegistrationHistoryTables() map[string]string {
+	return map[string]string{
+		"deregistration":                     "deregistered",
+		"registration":                       "registered",
+		"stake_deregistration":               "deregistered",
+		"stake_registration":                 "registered",
+		"stake_registration_delegation":      "registered",
+		"stake_vote_registration_delegation": "registered",
+		"vote_registration_delegation":       "registered",
+	}
+}
+
+func RegistrationTableCertTypes(
+	table string,
+) []uint {
+	switch table {
+	case "stake_registration":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeRegistration),
+		}
+	case "stake_registration_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeRegistrationDelegation),
+		}
+	case "stake_vote_registration_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
+		}
+	case "vote_registration_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeVoteRegistrationDelegation),
+		}
+	case "registration":
+		return []uint{
+			uint(lcommon.CertificateTypeRegistration),
+		}
+	case "stake_deregistration":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeDeregistration),
+		}
+	case "deregistration":
+		return []uint{
+			uint(lcommon.CertificateTypeDeregistration),
+		}
+	default:
+		return nil
+	}
+}
+
+func CompareDelegationRows(
+	a, b models.AccountDelegationHistoryRow,
+) int {
+	switch {
+	case a.AddedSlot < b.AddedSlot:
+		return -1
+	case a.AddedSlot > b.AddedSlot:
+		return 1
+	case a.CertIndex < b.CertIndex:
+		return -1
+	case a.CertIndex > b.CertIndex:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func CompareRegistrationRows(
+	a, b models.AccountRegistrationHistoryRow,
+) int {
+	switch {
+	case a.AddedSlot < b.AddedSlot:
+		return -1
+	case a.AddedSlot > b.AddedSlot:
+		return 1
+	case a.CertIndex < b.CertIndex:
+		return -1
+	case a.CertIndex > b.CertIndex:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -28,48 +28,87 @@ import (
 func QueryDelegationHistory(
 	db *gorm.DB,
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 ) ([]models.AccountDelegationHistoryRow, error) {
 	ret := make([]models.AccountDelegationHistoryRow, 0)
 	if len(stakingKey) == 0 {
 		return ret, nil
 	}
 
+	query, args := delegationHistoryUnionQuery(db, stakingKey)
+	if strings.EqualFold(order, "asc") {
+		query += " ORDER BY added_slot ASC, cert_index ASC, tx_hash ASC"
+	} else {
+		query += " ORDER BY added_slot DESC, cert_index DESC, tx_hash DESC"
+	}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	if offset > 0 {
+		query += " OFFSET ?"
+		args = append(args, offset)
+	}
+	if err := db.Raw(query, args...).Scan(&ret).Error; err != nil {
+		return nil, fmt.Errorf("get account delegation history: %w", err)
+	}
+	return ret, nil
+}
+
+func CountDelegationHistory(
+	db *gorm.DB,
+	stakingKey []byte,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	query, args := delegationHistoryUnionQuery(db, stakingKey)
+	var count int64
+	if err := db.Raw(
+		"SELECT COUNT(*) AS count FROM ("+query+") AS delegation_history",
+		args...,
+	).Scan(&count).Error; err != nil {
+		return 0, fmt.Errorf("count account delegation history: %w", err)
+	}
+	return int(count), nil
+}
+
+func delegationHistoryUnionQuery(
+	db *gorm.DB,
+	stakingKey []byte,
+) (string, []any) {
 	tables := []string{
 		"stake_delegation",
 		"stake_registration_delegation",
 		"stake_vote_delegation",
 		"stake_vote_registration_delegation",
 	}
+	parts := make([]string, 0, len(tables))
+	args := make([]any, 0, len(tables)*2)
 	for _, table := range tables {
-		var tmp []models.AccountDelegationHistoryRow
-		if err := db.Table(table).
-			Select(
-				table+".added_slot, certs.cert_index, tx.hash AS tx_hash, "+
-					table+".pool_key_hash",
-			).
-			Joins(
-				"INNER JOIN certs ON certs.certificate_id = "+table+".id",
-			).
-			Joins(
-				transactionJoinClause(db),
-			).
-			Where(
-				table+".staking_key = ? AND certs.cert_type IN ?",
-				stakingKey,
-				DelegationTableCertTypes(table),
-			).
-			Scan(&tmp).Error; err != nil {
-			return nil, fmt.Errorf(
-				"get account delegation history from %s: %w",
-				table,
-				err,
-			)
-		}
-		ret = append(ret, tmp...)
+		parts = append(parts, fmt.Sprintf(
+			`SELECT %[1]s.added_slot AS added_slot,
+				certs.cert_index AS cert_index,
+				tx.hash AS tx_hash,
+				%[1]s.pool_key_hash AS pool_key_hash
+			FROM %[1]s
+			INNER JOIN certs
+				ON certs.certificate_id = %[1]s.id
+				AND certs.cert_type = ?
+			%[2]s
+			WHERE %[1]s.staking_key = ?`,
+			table,
+			transactionJoinClause(db),
+		))
+		args = append(
+			args,
+			DelegationTableCertTypes(table)[0],
+			stakingKey,
+		)
 	}
-
-	slices.SortFunc(ret, CompareDelegationRows)
-	return ret, nil
+	return strings.Join(parts, " UNION ALL "), args
 }
 
 func QueryRegistrationHistory(
@@ -116,6 +155,9 @@ func QueryRegistrationHistory(
 }
 
 func transactionJoinClause(db *gorm.DB) string {
+	if db == nil {
+		return `INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`
+	}
 	switch strings.ToLower(db.Name()) {
 	case "mysql":
 		return "INNER JOIN `transaction` tx ON tx.id = certs.transaction_id"
@@ -123,6 +165,7 @@ func transactionJoinClause(db *gorm.DB) string {
 		return `INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`
 	}
 }
+
 
 func DelegationTableCertTypes(table string) []uint {
 	switch table {

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -17,7 +17,6 @@ package accounthistory
 import (
 	"bytes"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -114,43 +113,32 @@ func delegationHistoryUnionQuery(
 func QueryRegistrationHistory(
 	db *gorm.DB,
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	ret := make([]models.AccountRegistrationHistoryRow, 0)
 	if len(stakingKey) == 0 {
 		return ret, nil
 	}
 
-	for table, action := range RegistrationHistoryTables() {
-		var tmp []models.AccountRegistrationHistoryRow
-		if err := db.Table(table).
-			Select(
-				table+".added_slot, certs.cert_index, tx.hash AS tx_hash",
-			).
-			Joins(
-				"INNER JOIN certs ON certs.certificate_id = "+table+".id",
-			).
-			Joins(
-				transactionJoinClause(db),
-			).
-			Where(
-				table+".staking_key = ? AND certs.cert_type IN ?",
-				stakingKey,
-				RegistrationTableCertTypes(table),
-			).
-			Scan(&tmp).Error; err != nil {
-			return nil, fmt.Errorf(
-				"get account registration history from %s: %w",
-				table,
-				err,
-			)
-		}
-		for i := range tmp {
-			tmp[i].Action = action
-		}
-		ret = append(ret, tmp...)
+	query, args := registrationHistoryUnionQuery(db, stakingKey)
+	if strings.EqualFold(order, "asc") {
+		query += " ORDER BY added_slot ASC, cert_index ASC, tx_hash ASC, action ASC"
+	} else {
+		query += " ORDER BY added_slot DESC, cert_index DESC, tx_hash DESC, action DESC"
 	}
-
-	slices.SortFunc(ret, CompareRegistrationRows)
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	if offset > 0 {
+		query += " OFFSET ?"
+		args = append(args, offset)
+	}
+	if err := db.Raw(query, args...).Scan(&ret).Error; err != nil {
+		return nil, fmt.Errorf("get account registration history: %w", err)
+	}
 	return ret, nil
 }
 
@@ -190,15 +178,70 @@ func DelegationTableCertTypes(table string) []uint {
 	}
 }
 
-func RegistrationHistoryTables() map[string]string {
-	return map[string]string{
-		"deregistration":                     "deregistered",
-		"registration":                       "registered",
-		"stake_deregistration":               "deregistered",
-		"stake_registration":                 "registered",
-		"stake_registration_delegation":      "registered",
-		"stake_vote_registration_delegation": "registered",
-		"vote_registration_delegation":       "registered",
+func CountRegistrationHistory(
+	db *gorm.DB,
+	stakingKey []byte,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	query, args := registrationHistoryUnionQuery(db, stakingKey)
+	var count int64
+	if err := db.Raw(
+		"SELECT COUNT(*) AS count FROM ("+query+") AS registration_history",
+		args...,
+	).Scan(&count).Error; err != nil {
+		return 0, fmt.Errorf("count account registration history: %w", err)
+	}
+	return int(count), nil
+}
+
+type registrationHistorySource struct {
+	table  string
+	action string
+}
+
+func registrationHistoryUnionQuery(
+	db *gorm.DB,
+	stakingKey []byte,
+) (string, []any) {
+	sources := registrationHistorySources()
+	parts := make([]string, 0, len(sources))
+	args := make([]any, 0, len(sources)*3)
+	for _, source := range sources {
+		parts = append(parts, fmt.Sprintf(
+			`SELECT %[1]s.added_slot AS added_slot,
+				certs.cert_index AS cert_index,
+				tx.hash AS tx_hash,
+				? AS action
+			FROM %[1]s
+			INNER JOIN certs
+				ON certs.certificate_id = %[1]s.id
+				AND certs.cert_type = ?
+			%[2]s
+			WHERE %[1]s.staking_key = ?`,
+			source.table,
+			transactionJoinClause(db),
+		))
+		args = append(
+			args,
+			source.action,
+			RegistrationTableCertTypes(source.table)[0],
+			stakingKey,
+		)
+	}
+	return strings.Join(parts, " UNION ALL "), args
+}
+
+func registrationHistorySources() []registrationHistorySource {
+	return []registrationHistorySource{
+		{table: "deregistration", action: "deregistered"},
+		{table: "registration", action: "registered"},
+		{table: "stake_deregistration", action: "deregistered"},
+		{table: "stake_registration", action: "registered"},
+		{table: "stake_registration_delegation", action: "registered"},
+		{table: "stake_vote_registration_delegation", action: "registered"},
+		{table: "vote_registration_delegation", action: "registered"},
 	}
 }
 

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -94,7 +94,7 @@ func delegationHistoryUnionQuery(
 				%[1]s.pool_key_hash AS pool_key_hash
 			FROM %[1]s
 			INNER JOIN certs
-				ON certs.certificate_id = %[1]s.id
+				ON certs.id = %[1]s.certificate_id
 				AND certs.cert_type = ?
 			%[2]s
 			WHERE %[1]s.staking_key = ?`,
@@ -215,7 +215,7 @@ func registrationHistoryUnionQuery(
 				? AS action
 			FROM %[1]s
 			INNER JOIN certs
-				ON certs.certificate_id = %[1]s.id
+				ON certs.id = %[1]s.certificate_id
 				AND certs.cert_type = ?
 			%[2]s
 			WHERE %[1]s.staking_key = ?`,

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -38,9 +38,9 @@ func QueryDelegationHistory(
 
 	query, args := delegationHistoryUnionQuery(db, stakingKey)
 	if strings.EqualFold(order, "asc") {
-		query += " ORDER BY added_slot ASC, cert_index ASC, tx_hash ASC"
+		query += " ORDER BY added_slot ASC, block_index ASC, cert_index ASC, tx_hash ASC"
 	} else {
-		query += " ORDER BY added_slot DESC, cert_index DESC, tx_hash DESC"
+		query += " ORDER BY added_slot DESC, block_index DESC, cert_index DESC, tx_hash DESC"
 	}
 	if limit > 0 {
 		query += " LIMIT ?"
@@ -89,6 +89,7 @@ func delegationHistoryUnionQuery(
 	for _, table := range tables {
 		parts = append(parts, fmt.Sprintf(
 			`SELECT %[1]s.added_slot AS added_slot,
+				tx.block_index AS block_index,
 				certs.cert_index AS cert_index,
 				tx.hash AS tx_hash,
 				%[1]s.pool_key_hash AS pool_key_hash
@@ -124,9 +125,9 @@ func QueryRegistrationHistory(
 
 	query, args := registrationHistoryUnionQuery(db, stakingKey)
 	if strings.EqualFold(order, "asc") {
-		query += " ORDER BY added_slot ASC, cert_index ASC, tx_hash ASC, action ASC"
+		query += " ORDER BY added_slot ASC, block_index ASC, cert_index ASC, tx_hash ASC, action ASC"
 	} else {
-		query += " ORDER BY added_slot DESC, cert_index DESC, tx_hash DESC, action DESC"
+		query += " ORDER BY added_slot DESC, block_index DESC, cert_index DESC, tx_hash DESC, action DESC"
 	}
 	if limit > 0 {
 		query += " LIMIT ?"
@@ -210,6 +211,7 @@ func registrationHistoryUnionQuery(
 	for _, source := range sources {
 		parts = append(parts, fmt.Sprintf(
 			`SELECT %[1]s.added_slot AS added_slot,
+				tx.block_index AS block_index,
 				certs.cert_index AS cert_index,
 				tx.hash AS tx_hash,
 				? AS action
@@ -289,6 +291,10 @@ func CompareDelegationRows(
 		return 1
 	case a.AddedSlot > b.AddedSlot:
 		return -1
+	case a.BlockIndex < b.BlockIndex:
+		return 1
+	case a.BlockIndex > b.BlockIndex:
+		return -1
 	case a.CertIndex < b.CertIndex:
 		return 1
 	case a.CertIndex > b.CertIndex:
@@ -309,6 +315,10 @@ func CompareRegistrationRows(
 	case a.AddedSlot < b.AddedSlot:
 		return 1
 	case a.AddedSlot > b.AddedSlot:
+		return -1
+	case a.BlockIndex < b.BlockIndex:
+		return 1
+	case a.BlockIndex > b.BlockIndex:
 		return -1
 	case a.CertIndex < b.CertIndex:
 		return 1

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -56,7 +56,7 @@ func QueryDelegationHistory(
 			Where(
 				table+".staking_key = ? AND certs.cert_type IN ?",
 				stakingKey,
-				DelegationCertTypes(),
+				DelegationTableCertTypes(table),
 			).
 			Scan(&tmp).Error; err != nil {
 			return nil, fmt.Errorf(
@@ -124,12 +124,26 @@ func transactionJoinClause(db *gorm.DB) string {
 	}
 }
 
-func DelegationCertTypes() []uint {
-	return []uint{
-		uint(lcommon.CertificateTypeStakeDelegation),
-		uint(lcommon.CertificateTypeStakeRegistrationDelegation),
-		uint(lcommon.CertificateTypeStakeVoteDelegation),
-		uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
+func DelegationTableCertTypes(table string) []uint {
+	switch table {
+	case "stake_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeDelegation),
+		}
+	case "stake_registration_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeRegistrationDelegation),
+		}
+	case "stake_vote_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeVoteDelegation),
+		}
+	case "stake_vote_registration_delegation":
+		return []uint{
+			uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
+		}
+	default:
+		return nil
 	}
 }
 

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -154,7 +154,6 @@ func transactionJoinClause(db *gorm.DB) string {
 	}
 }
 
-
 func DelegationTableCertTypes(table string) []uint {
 	switch table {
 	case "stake_delegation":

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -467,6 +467,9 @@ func (d *MetadataStoreMysql) CountAccountDelegationHistory(
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
 func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
@@ -479,6 +482,9 @@ func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
 	rows, err := accounthistory.QueryRegistrationHistory(
 		db,
 		stakingKey,
+		limit,
+		offset,
+		order,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -487,6 +493,29 @@ func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountRegistrationHistory returns the total number of
+// registration history rows for a staking key.
+func (d *MetadataStoreMysql) CountAccountRegistrationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count account registration history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountRegistrationHistory(db, stakingKey)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account registration history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -374,6 +375,36 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 		return nil, fmt.Errorf("get addresses by staking key: %w", result.Error)
 	}
 	return ret, nil
+}
+
+// GetAccountDelegationHistory returns delegation history rows for a staking key.
+func (d *MetadataStoreMysql) GetAccountDelegationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accounthistory.QueryDelegationHistory(
+		db,
+		stakingKey,
+	)
+}
+
+// GetAccountRegistrationHistory returns registration history rows for a staking key.
+func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accounthistory.QueryRegistrationHistory(
+		db,
+		stakingKey,
+	)
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -388,7 +388,10 @@ func (d *MetadataStoreMysql) CountAddressesByStakingKey(
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf(
+			"resolve DB for count addresses by staking key: %w",
+			err,
+		)
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -363,7 +363,7 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 	}
 	query := db.Model(&models.AddressTransaction{}).
 		Select("MIN(id) AS id, payment_key, staking_key").
-		Where("staking_key = ?", stakingKey).
+		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
 		Group("payment_key, staking_key").
 		Order(addressOrderClause(order))
 	if limit > 0 {

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -395,7 +395,7 @@ func (d *MetadataStoreMysql) CountAddressesByStakingKey(
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).
-		Where("staking_key = ?", stakingKey).
+		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
 		Distinct("payment_key").
 		Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("count addresses by staking key: %w", err)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -413,6 +413,9 @@ func addressOrderClause(order string) string {
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
@@ -425,6 +428,9 @@ func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 	rows, err := accounthistory.QueryDelegationHistory(
 		db,
 		stakingKey,
+		limit,
+		offset,
+		order,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -433,6 +439,29 @@ func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountDelegationHistory returns the total number of
+// delegation history rows for a staking key.
+func (d *MetadataStoreMysql) CountAccountDelegationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count account delegation history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountDelegationHistory(db, stakingKey)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account delegation history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -350,6 +350,7 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 	stakingKey []byte,
 	limit int,
 	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AddressTransaction, error) {
 	var ret []models.AddressTransaction
@@ -364,7 +365,7 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 		Select("MIN(id) AS id, payment_key, staking_key").
 		Where("staking_key = ?", stakingKey).
 		Group("payment_key, staking_key").
-		Order("payment_key ASC")
+		Order(addressOrderClause(order))
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -377,6 +378,35 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 	return ret, nil
 }
 
+// CountAddressesByStakingKey returns the total number of distinct addresses mapped to a staking key.
+func (d *MetadataStoreMysql) CountAddressesByStakingKey(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	var count int64
+	if err := db.Model(&models.AddressTransaction{}).
+		Where("staking_key = ?", stakingKey).
+		Distinct("payment_key").
+		Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("count addresses by staking key: %w", err)
+	}
+	return int(count), nil
+}
+
+func addressOrderClause(order string) string {
+	if strings.EqualFold(order, "desc") {
+		return "payment_key DESC"
+	}
+	return "payment_key ASC"
+}
+
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 	stakingKey []byte,
@@ -384,12 +414,22 @@ func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 ) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"resolve DB for account delegation history: %w",
+			err,
+		)
 	}
-	return accounthistory.QueryDelegationHistory(
+	rows, err := accounthistory.QueryDelegationHistory(
 		db,
 		stakingKey,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account delegation history: %w",
+			err,
+		)
+	}
+	return rows, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
@@ -399,12 +439,22 @@ func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"resolve DB for account registration history: %w",
+			err,
+		)
 	}
-	return accounthistory.QueryRegistrationHistory(
+	rows, err := accounthistory.QueryRegistrationHistory(
 		db,
 		stakingKey,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account registration history: %w",
+			err,
+		)
+	}
+	return rows, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -615,6 +615,7 @@ func saveAccount(account *models.Account, db *gorm.DB) error {
 			Columns: []clause.Column{{Name: "staking_key"}},
 			DoUpdates: clause.AssignmentColumns(
 				[]string{
+					"added_slot",
 					"pool",
 					"drep",
 					"drep_type",

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -205,6 +205,35 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	return ret, nil
 }
 
+// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
+// controlled by the given staking key.
+func (d *MetadataStoreMysql) GetControlledAmountByStakingKey(
+	stakingKey []byte,
+	txn types.Txn,
+) (uint64, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for controlled amount by staking key: %w",
+			err,
+		)
+	}
+	var total uint64
+	if err := db.Model(&models.Utxo{}).
+		Where("staking_key = ? AND deleted_slot = 0", stakingKey).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf(
+			"get controlled amount by staking key: %w",
+			err,
+		)
+	}
+	return total, nil
+}
+
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -395,7 +395,7 @@ func (d *MetadataStorePostgres) CountAddressesByStakingKey(
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).
-		Where("staking_key = ?", stakingKey).
+		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
 		Distinct("payment_key").
 		Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("count addresses by staking key: %w", err)

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -413,6 +413,9 @@ func addressOrderClause(order string) string {
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
@@ -425,6 +428,9 @@ func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 	rows, err := accounthistory.QueryDelegationHistory(
 		db,
 		stakingKey,
+		limit,
+		offset,
+		order,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -433,6 +439,29 @@ func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountDelegationHistory returns the total number of
+// delegation history rows for a staking key.
+func (d *MetadataStorePostgres) CountAccountDelegationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count account delegation history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountDelegationHistory(db, stakingKey)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account delegation history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -350,6 +350,7 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 	stakingKey []byte,
 	limit int,
 	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AddressTransaction, error) {
 	var ret []models.AddressTransaction
@@ -364,7 +365,7 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 		Select("MIN(id) AS id, payment_key, staking_key").
 		Where("staking_key = ?", stakingKey).
 		Group("payment_key, staking_key").
-		Order("payment_key ASC")
+		Order(addressOrderClause(order))
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -377,6 +378,35 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 	return ret, nil
 }
 
+// CountAddressesByStakingKey returns the total number of distinct addresses mapped to a staking key.
+func (d *MetadataStorePostgres) CountAddressesByStakingKey(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	var count int64
+	if err := db.Model(&models.AddressTransaction{}).
+		Where("staking_key = ?", stakingKey).
+		Distinct("payment_key").
+		Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("count addresses by staking key: %w", err)
+	}
+	return int(count), nil
+}
+
+func addressOrderClause(order string) string {
+	if strings.EqualFold(order, "desc") {
+		return "payment_key DESC"
+	}
+	return "payment_key ASC"
+}
+
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 	stakingKey []byte,
@@ -384,12 +414,22 @@ func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 ) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"resolve DB for account delegation history: %w",
+			err,
+		)
 	}
-	return accounthistory.QueryDelegationHistory(
+	rows, err := accounthistory.QueryDelegationHistory(
 		db,
 		stakingKey,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account delegation history: %w",
+			err,
+		)
+	}
+	return rows, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
@@ -399,12 +439,22 @@ func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"resolve DB for account registration history: %w",
+			err,
+		)
 	}
-	return accounthistory.QueryRegistrationHistory(
+	rows, err := accounthistory.QueryRegistrationHistory(
 		db,
 		stakingKey,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account registration history: %w",
+			err,
+		)
+	}
+	return rows, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -467,6 +467,9 @@ func (d *MetadataStorePostgres) CountAccountDelegationHistory(
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
 func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
@@ -479,6 +482,9 @@ func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
 	rows, err := accounthistory.QueryRegistrationHistory(
 		db,
 		stakingKey,
+		limit,
+		offset,
+		order,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -487,6 +493,29 @@ func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountRegistrationHistory returns the total number of
+// registration history rows for a staking key.
+func (d *MetadataStorePostgres) CountAccountRegistrationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count account registration history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountRegistrationHistory(db, stakingKey)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account registration history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -363,7 +363,7 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 	}
 	query := db.Model(&models.AddressTransaction{}).
 		Select("MIN(id) AS id, payment_key, staking_key").
-		Where("staking_key = ?", stakingKey).
+		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
 		Group("payment_key, staking_key").
 		Order(addressOrderClause(order))
 	if limit > 0 {

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -374,6 +375,36 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 		return nil, fmt.Errorf("get addresses by staking key: %w", result.Error)
 	}
 	return ret, nil
+}
+
+// GetAccountDelegationHistory returns delegation history rows for a staking key.
+func (d *MetadataStorePostgres) GetAccountDelegationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accounthistory.QueryDelegationHistory(
+		db,
+		stakingKey,
+	)
+}
+
+// GetAccountRegistrationHistory returns registration history rows for a staking key.
+func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accounthistory.QueryRegistrationHistory(
+		db,
+		stakingKey,
+	)
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -388,7 +388,10 @@ func (d *MetadataStorePostgres) CountAddressesByStakingKey(
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf(
+			"resolve DB for count addresses by staking key: %w",
+			err,
+		)
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -615,6 +615,7 @@ func saveAccount(account *models.Account, db *gorm.DB) error {
 			Columns: []clause.Column{{Name: "staking_key"}},
 			DoUpdates: clause.AssignmentColumns(
 				[]string{
+					"added_slot",
 					"pool",
 					"drep",
 					"drep_type",

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -76,6 +76,35 @@ func (d *MetadataStorePostgres) GetUtxoIncludingSpent(
 	return ret, nil
 }
 
+// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
+// controlled by the given staking key.
+func (d *MetadataStorePostgres) GetControlledAmountByStakingKey(
+	stakingKey []byte,
+	txn types.Txn,
+) (uint64, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for controlled amount by staking key: %w",
+			err,
+		)
+	}
+	var total uint64
+	if err := db.Model(&models.Utxo{}).
+		Where("staking_key = ? AND deleted_slot = 0", stakingKey).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf(
+			"get controlled amount by staking key: %w",
+			err,
+		)
+	}
+	return total, nil
+}
+
 // GetUtxosAddedAfterSlot returns a list of Utxos added after a given slot
 func (d *MetadataStorePostgres) GetUtxosAddedAfterSlot(
 	slot uint64,

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -490,7 +490,7 @@ func TestGetAddressesByStakingKey(t *testing.T) {
 		t.Fatalf("failed to create address_tx rows: %v", err)
 	}
 
-	addrs, err := store.GetAddressesByStakingKey(stake, 10, 0, nil)
+	addrs, err := store.GetAddressesByStakingKey(stake, 10, 0, "asc", nil)
 	if err != nil {
 		t.Fatalf("GetAddressesByStakingKey failed: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestGetAddressesByStakingKey(t *testing.T) {
 		t.Fatalf("expected 2 distinct addresses, got %d", len(addrs))
 	}
 
-	page, err := store.GetAddressesByStakingKey(stake, 1, 1, nil)
+	page, err := store.GetAddressesByStakingKey(stake, 1, 1, "asc", nil)
 	if err != nil {
 		t.Fatalf("GetAddressesByStakingKey pagination failed: %v", err)
 	}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -374,6 +374,7 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 	stakingKey []byte,
 	limit int,
 	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AddressTransaction, error) {
 	var ret []models.AddressTransaction
@@ -389,7 +390,7 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 		Select("MIN(id) AS id, payment_key, staking_key").
 		Where("staking_key = ?", stakingKey).
 		Group("payment_key, staking_key").
-		Order("payment_key ASC")
+		Order(addressOrderClause(order))
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -402,6 +403,35 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 	return ret, nil
 }
 
+// CountAddressesByStakingKey returns the total number of distinct addresses mapped to a staking key.
+func (d *MetadataStoreSqlite) CountAddressesByStakingKey(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	var count int64
+	if err := db.Model(&models.AddressTransaction{}).
+		Where("staking_key = ?", stakingKey).
+		Distinct("payment_key").
+		Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("count addresses by staking key: %w", err)
+	}
+	return int(count), nil
+}
+
+func addressOrderClause(order string) string {
+	if strings.EqualFold(order, "desc") {
+		return "payment_key DESC"
+	}
+	return "payment_key ASC"
+}
+
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 	stakingKey []byte,
@@ -409,12 +439,22 @@ func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 ) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"resolve read DB for account delegation history: %w",
+			err,
+		)
 	}
-	return accounthistory.QueryDelegationHistory(
+	rows, err := accounthistory.QueryDelegationHistory(
 		db,
 		stakingKey,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account delegation history: %w",
+			err,
+		)
+	}
+	return rows, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
@@ -424,12 +464,22 @@ func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"resolve read DB for account registration history: %w",
+			err,
+		)
 	}
-	return accounthistory.QueryRegistrationHistory(
+	rows, err := accounthistory.QueryRegistrationHistory(
 		db,
 		stakingKey,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account registration history: %w",
+			err,
+		)
+	}
+	return rows, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -399,6 +400,36 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 		return nil, fmt.Errorf("get addresses by staking key: %w", result.Error)
 	}
 	return ret, nil
+}
+
+// GetAccountDelegationHistory returns delegation history rows for a staking key.
+func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accounthistory.QueryDelegationHistory(
+		db,
+		stakingKey,
+	)
+}
+
+// GetAccountRegistrationHistory returns registration history rows for a staking key.
+func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accounthistory.QueryRegistrationHistory(
+		db,
+		stakingKey,
+	)
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -420,7 +420,7 @@ func (d *MetadataStoreSqlite) CountAddressesByStakingKey(
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).
-		Where("staking_key = ?", stakingKey).
+		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
 		Distinct("payment_key").
 		Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("count addresses by staking key: %w", err)

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -413,7 +413,10 @@ func (d *MetadataStoreSqlite) CountAddressesByStakingKey(
 	}
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf(
+			"resolve read DB for count addresses by staking key: %w",
+			err,
+		)
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -438,6 +438,9 @@ func addressOrderClause(order string) string {
 // GetAccountDelegationHistory returns delegation history rows for a staking key.
 func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveReadDB(txn)
@@ -450,6 +453,9 @@ func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 	rows, err := accounthistory.QueryDelegationHistory(
 		db,
 		stakingKey,
+		limit,
+		offset,
+		order,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -458,6 +464,29 @@ func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountDelegationHistory returns the total number of
+// delegation history rows for a staking key.
+func (d *MetadataStoreSqlite) CountAccountDelegationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count account delegation history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountDelegationHistory(db, stakingKey)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account delegation history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetAccountRegistrationHistory returns registration history rows for a staking key.

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -492,6 +492,9 @@ func (d *MetadataStoreSqlite) CountAccountDelegationHistory(
 // GetAccountRegistrationHistory returns registration history rows for a staking key.
 func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
 	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
 	txn types.Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveReadDB(txn)
@@ -504,6 +507,9 @@ func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
 	rows, err := accounthistory.QueryRegistrationHistory(
 		db,
 		stakingKey,
+		limit,
+		offset,
+		order,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -512,6 +518,29 @@ func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
 		)
 	}
 	return rows, nil
+}
+
+// CountAccountRegistrationHistory returns the total number of
+// registration history rows for a staking key.
+func (d *MetadataStoreSqlite) CountAccountRegistrationHistory(
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count account registration history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountRegistrationHistory(db, stakingKey)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account registration history: %w",
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -388,7 +388,7 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 
 	query := db.Model(&models.AddressTransaction{}).
 		Select("MIN(id) AS id, payment_key, staking_key").
-		Where("staking_key = ?", stakingKey).
+		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
 		Group("payment_key, staking_key").
 		Order(addressOrderClause(order))
 	if limit > 0 {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -677,6 +677,7 @@ func saveAccount(account *models.Account, db *gorm.DB) error {
 			Columns: []clause.Column{{Name: "staking_key"}},
 			DoUpdates: clause.AssignmentColumns(
 				[]string{
+					"added_slot",
 					"pool",
 					"drep",
 					"drep_type",

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -265,6 +265,35 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 	return ret, nil
 }
 
+// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
+// controlled by the given staking key.
+func (d *MetadataStoreSqlite) GetControlledAmountByStakingKey(
+	stakingKey []byte,
+	txn types.Txn,
+) (uint64, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for controlled amount by staking key: %w",
+			err,
+		)
+	}
+	var total uint64
+	if err := db.Model(&models.Utxo{}).
+		Where("staking_key = ? AND deleted_slot = 0", stakingKey).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf(
+			"get controlled amount by staking key: %w",
+			err,
+		)
+	}
+	return total, nil
+}
+
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -584,6 +584,10 @@ type MetadataStore interface {
 	// GetUtxosByAddress retrieves all UTxOs for a given address.
 	GetUtxosByAddress(ledger.Address, types.Txn) ([]models.Utxo, error)
 
+	// GetControlledAmountByStakingKey returns the sum of live UTxO
+	// amounts controlled by the given staking key.
+	GetControlledAmountByStakingKey([]byte, types.Txn) (uint64, error)
+
 	// GetUtxosByAddressWithOrdering runs q against live UTxOs with ordering metadata.
 	// See models.UtxoWithOrderingQuery. q must be non-nil.
 	GetUtxosByAddressWithOrdering(

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -384,8 +384,18 @@ type MetadataStore interface {
 	// GetAccountDelegationHistory retrieves delegation history rows for a staking key.
 	GetAccountDelegationHistory(
 		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
 		types.Txn,
 	) ([]models.AccountDelegationHistoryRow, error)
+
+	// CountAccountDelegationHistory retrieves the total count of
+	// delegation history rows for a staking key.
+	CountAccountDelegationHistory(
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
 
 	// GetAccountRegistrationHistory retrieves registration history rows for a staking key.
 	GetAccountRegistrationHistory(

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -371,8 +371,15 @@ type MetadataStore interface {
 		[]byte, // stakingKey
 		int, // limit
 		int, // offset
+		string, // order (asc|desc)
 		types.Txn,
 	) ([]models.AddressTransaction, error)
+
+	// CountAddressesByStakingKey retrieves the total count of distinct address mappings for a staking key.
+	CountAddressesByStakingKey(
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
 
 	// GetAccountDelegationHistory retrieves delegation history rows for a staking key.
 	GetAccountDelegationHistory(

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -374,6 +374,18 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.AddressTransaction, error)
 
+	// GetAccountDelegationHistory retrieves delegation history rows for a staking key.
+	GetAccountDelegationHistory(
+		[]byte, // stakingKey
+		types.Txn,
+	) ([]models.AccountDelegationHistoryRow, error)
+
+	// GetAccountRegistrationHistory retrieves registration history rows for a staking key.
+	GetAccountRegistrationHistory(
+		[]byte, // stakingKey
+		types.Txn,
+	) ([]models.AccountRegistrationHistoryRow, error)
+
 	// GetTransactionsByMetadataLabel retrieves transactions that include
 	// metadata for the given label.
 	GetTransactionsByMetadataLabel(

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -400,8 +400,18 @@ type MetadataStore interface {
 	// GetAccountRegistrationHistory retrieves registration history rows for a staking key.
 	GetAccountRegistrationHistory(
 		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
 		types.Txn,
 	) ([]models.AccountRegistrationHistoryRow, error)
+
+	// CountAccountRegistrationHistory retrieves the total count of
+	// registration history rows for a staking key.
+	CountAccountRegistrationHistory(
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
 
 	// GetTransactionsByMetadataLabel retrieves transactions that include
 	// metadata for the given label.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -924,6 +924,7 @@ func (d *Database) GetAddressesByStakingKey(
 	stakingKey []byte,
 	limit int,
 	offset int,
+	order string,
 	txn *Txn,
 ) ([]models.AddressTransaction, error) {
 	if txn == nil {
@@ -934,6 +935,7 @@ func (d *Database) GetAddressesByStakingKey(
 		stakingKey,
 		limit,
 		offset,
+		order,
 		txn.Metadata(),
 	)
 	if err != nil {
@@ -946,6 +948,29 @@ func (d *Database) GetAddressesByStakingKey(
 		)
 	}
 	return addresses, nil
+}
+
+// CountAddressesByStakingKey returns the total number of distinct address mappings for a staking key.
+func (d *Database) CountAddressesByStakingKey(
+	stakingKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountAddressesByStakingKey(
+		stakingKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count addresses by staking key=%x: %w",
+			stakingKey,
+			err,
+		)
+	}
+	return count, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions that include metadata

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -518,6 +518,30 @@ func (d *Database) UtxosByAddress(
 	return utxos, nil
 }
 
+// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
+// controlled by the given staking key.
+func (d *Database) GetControlledAmountByStakingKey(
+	stakingKey []byte,
+	txn *Txn,
+) (uint64, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	total, err := d.metadata.GetControlledAmountByStakingKey(
+		stakingKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"get controlled amount by staking key=%x: %w",
+			stakingKey,
+			err,
+		)
+	}
+	return total, nil
+}
+
 func (d *Database) UtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,
 	txn *Txn,


### PR DESCRIPTION
1. Added blockfrost stake account endpoints for account info, associated addresses, delegation history, registration history, and rewards history.
2. Added stake address parsing/validation for all the endpoints.
3. Added account response mapping for current account state, active status, delegation, and controlled amount.
4. Added associated-address lookup, delegation-history lookup and registration-history lookup for stake accounts.
5. Added blockfrost-style error handling for invalid stake addresses and missing accounts.
6. Added new blockfrost response types for account endpoints.
7. Extended the blockfrost node interface with account endpoint methods.
8. Registered the new /accounts/{stake_address}* routes in the blockfrost router.
9. Added database facade methods for account delegation and registration history.
10. Added shared database row models for account delegation and registration history.
11. Added metadata store interface methods for account delegation and registration history.
12. Implemented account history methods in SQLite metadata store, Postgres metadata store and MySQL metadata store.
13. Extracted duplicated account-history query logic into a shared metadata internal helper.
14. Added handler tests for the new account endpoints.
15. Added blockfrost-go compatibility tests for account response payloads.
16. Delegation and registration endpoints initially returned 500 on real data due to the unquoted transaction table join and fixed it now. It is working fine now.

Closes #1368


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blockfrost stake-account endpoints for account info, associated addresses, delegation/registration history, and rewards (empty for now). Validates stake addresses, computes controlled_amount from live UTXOs, and sets correct activation epochs with asc/desc pagination and totals.

- **New Features**
  - Routes: GET /api/v0/accounts/{stake_address}, /addresses, /delegations, /registrations, /rewards.
  - Pagination: asc|desc with X-Pagination-* headers; totals use distinct payment-key counts; empty pages return [].
  - Account data: controlled_amount via live UTXOs; active_epoch only when active (from added slot); delegation active_epoch = cert epoch + 2; pool_id only when active.
  - Cross‑DB: shared delegation/registration queries with deterministic ordering; updated node interface/handlers; `blockfrost-go` compatibility tests.

- **Bug Fixes**
  - Correct cert joins, ordering, and MySQL quoting on `transaction`; tighter filtering.
  - Fixed active_epoch for inactive/re-registered accounts and delegation activation; resolved account history 404s.
  - Address totals and pagination aligned; ignore empty payment_key rows.
  - 400 for invalid stake addresses; 404 for missing accounts; improved error context/logging.

<sup>Written for commit 6e69b6348410d8521d6a41c156739e799896c3b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stake-account API endpoints: account, associated addresses (asc/desc ordering + totals), delegation history, registration history, and reward history (currently returns empty). Responses surface controlled UTxO amount, computed active epoch, and optional pool ID. Invalid stake addresses return 400; missing accounts return 404.

* **Tests**
  * Added handler and JSON compatibility tests covering endpoints, pagination, ordering, and response mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->