### PR TITLE
fix(txsubmission): disable rate limiter by default

### DIFF
--- a/ouroboros/txsubmission_rate_limiter.go
+++ b/ouroboros/txsubmission_rate_limiter.go
@@ -29,7 +29,7 @@ func connIdKey(c ouroboros.ConnectionId) string {
 
 // DefaultMaxTxSubmissionsPerSecond is the default maximum number of
 // transaction submissions accepted per peer per second.
-const DefaultMaxTxSubmissionsPerSecond = 30
+const DefaultMaxTxSubmissionsPerSecond = -1
 
 // tokenBucket implements a simple token bucket rate limiter.
 // Tokens are replenished at a fixed rate up to a maximum burst.

--- a/ouroboros/txsubmission_rate_limiter_test.go
+++ b/ouroboros/txsubmission_rate_limiter_test.go
@@ -289,22 +289,10 @@ func TestNewOuroboros_DefaultRateLimit(t *testing.T) {
 		EventBus: event.NewEventBus(nil, logger),
 	})
 
-	require.NotNil(
+	assert.Nil(
 		t,
 		o.txSubmissionRateLimiter,
-		"rate limiter should be initialized with default config",
-	)
-	assert.Equal(
-		t,
-		float64(DefaultMaxTxSubmissionsPerSecond),
-		o.txSubmissionRateLimiter.rate,
-		"rate should use default",
-	)
-	assert.Equal(
-		t,
-		float64(DefaultMaxTxSubmissionsPerSecond)*2,
-		o.txSubmissionRateLimiter.burst,
-		"burst should be 2x default rate",
+		"rate limiter should be nil when default is disabled (-1)",
 	)
 }
 
@@ -349,13 +337,15 @@ func TestNewOuroboros_DisabledRateLimit(t *testing.T) {
 func TestHandleConnClosedEvent_CleansUpRateLimiter(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	o := NewOuroboros(OuroborosConfig{
-		Logger:   logger,
-		EventBus: event.NewEventBus(nil, logger),
+		Logger:                    logger,
+		EventBus:                  event.NewEventBus(nil, logger),
+		MaxTxSubmissionsPerSecond: 30,
 	})
 
 	peer := testConnIdWithPort(4001)
 
 	// Create rate limiter state for this peer
+	require.NotNil(t, o.txSubmissionRateLimiter, "rate limiter should exist when explicitly configured")
 	o.txSubmissionRateLimiter.Allow(peer, 1)
 
 	// Verify the peer exists in the rate limiter

--- a/ouroboros/txsubmission_rate_limiter_test.go
+++ b/ouroboros/txsubmission_rate_limiter_test.go
@@ -345,7 +345,11 @@ func TestHandleConnClosedEvent_CleansUpRateLimiter(t *testing.T) {
 	peer := testConnIdWithPort(4001)
 
 	// Create rate limiter state for this peer
-	require.NotNil(t, o.txSubmissionRateLimiter, "rate limiter should exist when explicitly configured")
+	require.NotNil(
+		t,
+		o.txSubmissionRateLimiter,
+		"rate limiter should exist when explicitly configured",
+	)
 	o.txSubmissionRateLimiter.Allow(peer, 1)
 
 	// Verify the peer exists in the rate limiter


### PR DESCRIPTION
## Summary
- PR #1749 intended to remove the tx-submission rate limiter but only modified backoff behavior — **the limiter remained active at 30 TXs/sec**
- Under load, the limiter rejects TX batches after the initial burst window (60 TXs), then drops them entirely after 3 consecutive rejections
- This causes a "burst then empty" mempool pattern — nodes receive an initial batch then stop accepting TXs
- Dropped TXs are incorrectly ACKed to the peer, which clears them permanently from its cache

## Root cause
`DefaultMaxTxSubmissionsPerSecond = 30` creates the rate limiter for every node. When `MaxTxSubmissionsPerSecond` is 0 (unconfigured), it defaults to 30. Set to -1 to disable.

## Evidence
- Grafana shows cardano-node mempool with TXs but dingo mempool drops to 0 after initial burst
- mini-1 logs: `tx submission rate limit exceeded` from peer after just 10 TXs
- haskell node has 200 TXs in mempool, dingo nodes have 0

## Test plan
- [x] `go build ./...` clean
- [ ] Deploy to preview nodes and verify TXs flow continuously from haskell peers
- [ ] Monitor mempool under mini-gun load (5 TPS)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable tx-submission rate limiting by default to stop dropping TXs under load and keep mempools filling. The limiter now initializes only when `MaxTxSubmissionsPerSecond` is explicitly set (> 0).

- **Bug Fixes**
  - Set `DefaultMaxTxSubmissionsPerSecond` to -1 so unconfigured nodes no longer enforce a 30 TPS limit (set `MaxTxSubmissionsPerSecond` > 0 to enable).
  - Removes the burst-then-empty pattern caused by batch rejections and incorrect ACKs; nodes keep accepting TXs.
  - Updated tests to expect a nil limiter by default, require explicit config in cleanup paths, and wrap a long assertion for readability.

<sup>Written for commit 45b87d074e5edf80c52901cbeffdfdd92b4e752a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Transaction-submission rate limiting is disabled by default (default behavior changed).
* **Tests**
  * Tests updated to expect no rate limiter when defaults disable it and to verify proper limiter presence and cleanup when an explicit rate limit is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->