### PR TITLE
fix(utxorpc): evaluate CertificatePattern in tx predicates

### DIFF
--- a/utxorpc/certificate_pattern.go
+++ b/utxorpc/certificate_pattern.go
@@ -1,0 +1,425 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"bytes"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	"google.golang.org/protobuf/proto"
+)
+
+// Certificate pattern matching notes (utxorpc Cardano TxPattern.has_certificate):
+//   - StakeDelegationPattern: only non-empty stake_credential fields (addr or
+//     script hash) and non-empty pool_keyhash slices count as constraints.
+//   - PoolRegistrationPattern: operator and pool_keyhash both compare against
+//     the pool cold key (operator) bytes on PoolRegistrationCert.
+//   - PoolRetirementPattern: epoch 0 means “match any epoch”; non-zero epoch
+//     requires an exact match.
+//   - AnyPoolKeyhash: enumerates operator/pool key hashes from delegation and
+//     pool registration/retirement; VRF key hashes are not included.
+
+// txPatternMatchHasCertificate reports whether any certificate on the
+// transaction matches the given utxorpc CertificatePattern.
+func (u *Utxorpc) txPatternMatchHasCertificate(
+	tx gledger.Transaction,
+	pat *cardano.CertificatePattern,
+) predOutcome {
+	if pat == nil || pat.GetCertificateType() == nil {
+		return predUnevaluable
+	}
+	certs := tx.Certificates()
+	if len(certs) == 0 {
+		return predNoMatch
+	}
+	var sawUnevaluable bool
+	for _, c := range certs {
+		uc, err := c.Utxorpc()
+		if err != nil {
+			u.config.Logger.Error(
+				"failed to convert certificate for tx predicate",
+				"error", err,
+			)
+			sawUnevaluable = true
+			continue
+		}
+		switch certificatePatternMatches(uc, pat) {
+		case predMatch:
+			return predMatch
+		case predUnevaluable:
+			sawUnevaluable = true
+		case predNoMatch:
+		}
+	}
+	if sawUnevaluable {
+		return predUnevaluable
+	}
+	return predNoMatch
+}
+
+func certificatePatternMatches(
+	uc *cardano.Certificate,
+	pat *cardano.CertificatePattern,
+) predOutcome {
+	if uc == nil {
+		return predNoMatch
+	}
+	switch pat.GetCertificateType().(type) {
+	case *cardano.CertificatePattern_StakeRegistration:
+		want := pat.GetStakeRegistration()
+		if want == nil {
+			return predUnevaluable
+		}
+		got := uc.GetStakeRegistration()
+		if got == nil {
+			return predNoMatch
+		}
+		if proto.Equal(want, got) {
+			return predMatch
+		}
+		return predNoMatch
+
+	case *cardano.CertificatePattern_StakeDeregistration:
+		want := pat.GetStakeDeregistration()
+		if want == nil {
+			return predUnevaluable
+		}
+		got := uc.GetStakeDeregistration()
+		if got == nil {
+			return predNoMatch
+		}
+		if proto.Equal(want, got) {
+			return predMatch
+		}
+		return predNoMatch
+
+	case *cardano.CertificatePattern_StakeDelegation:
+		sdp := pat.GetStakeDelegation()
+		if sdp == nil {
+			return predUnevaluable
+		}
+		got := uc.GetStakeDelegation()
+		if got == nil {
+			return predNoMatch
+		}
+		var hasConstraint bool
+		if sc := sdp.GetStakeCredential(); stakeCredentialHasConstraint(sc) {
+			hasConstraint = true
+			if !proto.Equal(sc, got.GetStakeCredential()) {
+				return predNoMatch
+			}
+		}
+		if pkh := sdp.GetPoolKeyhash(); len(pkh) > 0 {
+			hasConstraint = true
+			if !bytes.Equal(pkh, got.GetPoolKeyhash()) {
+				return predNoMatch
+			}
+		}
+		if !hasConstraint {
+			return predUnevaluable
+		}
+		return predMatch
+
+	case *cardano.CertificatePattern_PoolRegistration:
+		prp := pat.GetPoolRegistration()
+		if prp == nil {
+			return predUnevaluable
+		}
+		got := uc.GetPoolRegistration()
+		if got == nil {
+			return predNoMatch
+		}
+		var hasConstraint bool
+		if op := prp.GetOperator(); len(op) > 0 {
+			hasConstraint = true
+			if !bytes.Equal(op, got.GetOperator()) {
+				return predNoMatch
+			}
+		}
+		if pkh := prp.GetPoolKeyhash(); len(pkh) > 0 {
+			hasConstraint = true
+			if !bytes.Equal(pkh, got.GetOperator()) {
+				return predNoMatch
+			}
+		}
+		if !hasConstraint {
+			return predUnevaluable
+		}
+		return predMatch
+
+	case *cardano.CertificatePattern_PoolRetirement:
+		prt := pat.GetPoolRetirement()
+		if prt == nil {
+			return predUnevaluable
+		}
+		if len(prt.GetPoolKeyhash()) == 0 {
+			return predUnevaluable
+		}
+		got := uc.GetPoolRetirement()
+		if got == nil {
+			return predNoMatch
+		}
+		if !bytes.Equal(prt.GetPoolKeyhash(), got.GetPoolKeyhash()) {
+			return predNoMatch
+		}
+		if wantEp := prt.GetEpoch(); wantEp != 0 && wantEp != got.GetEpoch() {
+			return predNoMatch
+		}
+		return predMatch
+
+	case *cardano.CertificatePattern_AnyStakeCredential:
+		h := pat.GetAnyStakeCredential()
+		if len(h) == 0 {
+			return predUnevaluable
+		}
+		if anyStakeCredentialMatches(h, uc) {
+			return predMatch
+		}
+		return predNoMatch
+
+	case *cardano.CertificatePattern_AnyPoolKeyhash:
+		h := pat.GetAnyPoolKeyhash()
+		if len(h) == 0 {
+			return predUnevaluable
+		}
+		if anyPoolKeyhashMatches(h, uc) {
+			return predMatch
+		}
+		return predNoMatch
+
+	case *cardano.CertificatePattern_AnyDrep:
+		h := pat.GetAnyDrep()
+		if len(h) == 0 {
+			return predUnevaluable
+		}
+		if anyDrepMatches(h, uc) {
+			return predMatch
+		}
+		return predNoMatch
+
+	default:
+		return predUnevaluable
+	}
+}
+
+// stakeCredentialHasConstraint reports whether the protobuf carries an actual
+// addr key hash or script hash (a non-nil but empty StakeCredential is ignored).
+func stakeCredentialHasConstraint(sc *cardano.StakeCredential) bool {
+	if sc == nil {
+		return false
+	}
+	return len(sc.GetAddrKeyHash()) > 0 || len(sc.GetScriptHash()) > 0
+}
+
+func anyStakeCredentialMatches(want []byte, uc *cardano.Certificate) bool {
+	if uc == nil || len(want) == 0 {
+		return false
+	}
+	var found bool
+	forEachStakeHashInCert(uc, func(h []byte) {
+		if found {
+			return
+		}
+		if bytes.Equal(want, h) {
+			found = true
+		}
+	})
+	return found
+}
+
+func forEachStakeHashInCert(uc *cardano.Certificate, fn func([]byte)) {
+	if uc == nil {
+		return
+	}
+	addSC := func(sc *cardano.StakeCredential) {
+		if sc == nil {
+			return
+		}
+		if b := sc.GetAddrKeyHash(); len(b) > 0 {
+			fn(b)
+		}
+		if b := sc.GetScriptHash(); len(b) > 0 {
+			fn(b)
+		}
+	}
+	switch {
+	case uc.GetStakeRegistration() != nil:
+		addSC(uc.GetStakeRegistration())
+	case uc.GetStakeDeregistration() != nil:
+		addSC(uc.GetStakeDeregistration())
+	case uc.GetStakeDelegation() != nil:
+		addSC(uc.GetStakeDelegation().GetStakeCredential())
+	case uc.GetRegCert() != nil:
+		addSC(uc.GetRegCert().GetStakeCredential())
+	case uc.GetUnregCert() != nil:
+		addSC(uc.GetUnregCert().GetStakeCredential())
+	case uc.GetVoteDelegCert() != nil:
+		addSC(uc.GetVoteDelegCert().GetStakeCredential())
+	case uc.GetStakeVoteDelegCert() != nil:
+		addSC(uc.GetStakeVoteDelegCert().GetStakeCredential())
+	case uc.GetStakeRegDelegCert() != nil:
+		addSC(uc.GetStakeRegDelegCert().GetStakeCredential())
+	case uc.GetVoteRegDelegCert() != nil:
+		addSC(uc.GetVoteRegDelegCert().GetStakeCredential())
+	case uc.GetStakeVoteRegDelegCert() != nil:
+		addSC(uc.GetStakeVoteRegDelegCert().GetStakeCredential())
+	case uc.GetPoolRegistration() != nil:
+		pr := uc.GetPoolRegistration()
+		if ra := pr.GetRewardAccount(); len(ra) > 0 {
+			fn(ra)
+		}
+		for _, o := range pr.GetPoolOwners() {
+			if len(o) > 0 {
+				fn(o)
+			}
+		}
+	case uc.GetAuthCommitteeHotCert() != nil:
+		h := uc.GetAuthCommitteeHotCert()
+		addSC(h.GetCommitteeColdCredential())
+		addSC(h.GetCommitteeHotCredential())
+	case uc.GetResignCommitteeColdCert() != nil:
+		addSC(uc.GetResignCommitteeColdCert().GetCommitteeColdCredential())
+	case uc.GetRegDrepCert() != nil:
+		addSC(uc.GetRegDrepCert().GetDrepCredential())
+	case uc.GetUnregDrepCert() != nil:
+		addSC(uc.GetUnregDrepCert().GetDrepCredential())
+	case uc.GetUpdateDrepCert() != nil:
+		addSC(uc.GetUpdateDrepCert().GetDrepCredential())
+	case uc.GetMirCert() != nil:
+		for _, mt := range uc.GetMirCert().GetTo() {
+			addSC(mt.GetStakeCredential())
+		}
+	}
+}
+
+func anyPoolKeyhashMatches(want []byte, uc *cardano.Certificate) bool {
+	if uc == nil || len(want) == 0 {
+		return false
+	}
+	var found bool
+	forEachPoolKeyhashInCert(uc, func(h []byte) {
+		if found {
+			return
+		}
+		if bytes.Equal(want, h) {
+			found = true
+		}
+	})
+	return found
+}
+
+func forEachPoolKeyhashInCert(uc *cardano.Certificate, fn func([]byte)) {
+	if uc == nil {
+		return
+	}
+	switch {
+	case uc.GetStakeDelegation() != nil:
+		if p := uc.GetStakeDelegation().GetPoolKeyhash(); len(p) > 0 {
+			fn(p)
+		}
+	case uc.GetStakeVoteDelegCert() != nil:
+		if p := uc.GetStakeVoteDelegCert().GetPoolKeyhash(); len(p) > 0 {
+			fn(p)
+		}
+	case uc.GetStakeRegDelegCert() != nil:
+		if p := uc.GetStakeRegDelegCert().GetPoolKeyhash(); len(p) > 0 {
+			fn(p)
+		}
+	case uc.GetStakeVoteRegDelegCert() != nil:
+		if p := uc.GetStakeVoteRegDelegCert().GetPoolKeyhash(); len(p) > 0 {
+			fn(p)
+		}
+	case uc.GetPoolRegistration() != nil:
+		if op := uc.GetPoolRegistration().GetOperator(); len(op) > 0 {
+			fn(op)
+		}
+	case uc.GetPoolRetirement() != nil:
+		if p := uc.GetPoolRetirement().GetPoolKeyhash(); len(p) > 0 {
+			fn(p)
+		}
+	}
+}
+
+func drepBytesFromDRep(d *cardano.DRep) [][]byte {
+	if d == nil {
+		return nil
+	}
+	var out [][]byte
+	if b := d.GetAddrKeyHash(); len(b) > 0 {
+		out = append(out, b)
+	}
+	if b := d.GetScriptHash(); len(b) > 0 {
+		out = append(out, b)
+	}
+	return out
+}
+
+func anyDrepMatches(want []byte, uc *cardano.Certificate) bool {
+	if uc == nil || len(want) == 0 {
+		return false
+	}
+	var found bool
+	forEachDrepHashInCert(uc, func(h []byte) {
+		if found {
+			return
+		}
+		if bytes.Equal(want, h) {
+			found = true
+		}
+	})
+	return found
+}
+
+func forEachDrepHashInCert(uc *cardano.Certificate, fn func([]byte)) {
+	if uc == nil {
+		return
+	}
+	addSC := func(sc *cardano.StakeCredential) {
+		if sc == nil {
+			return
+		}
+		if b := sc.GetAddrKeyHash(); len(b) > 0 {
+			fn(b)
+		}
+		if b := sc.GetScriptHash(); len(b) > 0 {
+			fn(b)
+		}
+	}
+	switch {
+	case uc.GetVoteDelegCert() != nil:
+		for _, b := range drepBytesFromDRep(uc.GetVoteDelegCert().GetDrep()) {
+			fn(b)
+		}
+	case uc.GetStakeVoteDelegCert() != nil:
+		for _, b := range drepBytesFromDRep(uc.GetStakeVoteDelegCert().GetDrep()) {
+			fn(b)
+		}
+	case uc.GetVoteRegDelegCert() != nil:
+		for _, b := range drepBytesFromDRep(uc.GetVoteRegDelegCert().GetDrep()) {
+			fn(b)
+		}
+	case uc.GetStakeVoteRegDelegCert() != nil:
+		for _, b := range drepBytesFromDRep(uc.GetStakeVoteRegDelegCert().GetDrep()) {
+			fn(b)
+		}
+	case uc.GetRegDrepCert() != nil:
+		addSC(uc.GetRegDrepCert().GetDrepCredential())
+	case uc.GetUnregDrepCert() != nil:
+		addSC(uc.GetUnregDrepCert().GetDrepCredential())
+	case uc.GetUpdateDrepCert() != nil:
+		addSC(uc.GetUpdateDrepCert().GetDrepCredential())
+	}
+}

--- a/utxorpc/certificate_pattern.go
+++ b/utxorpc/certificate_pattern.go
@@ -23,14 +23,20 @@ import (
 )
 
 // Certificate pattern matching notes (utxorpc Cardano TxPattern.has_certificate):
-//   - StakeDelegationPattern: only non-empty stake_credential fields (addr or
-//     script hash) and non-empty pool_keyhash slices count as constraints.
-//   - PoolRegistrationPattern: operator and pool_keyhash both compare against
-//     the pool cold key (operator) bytes on PoolRegistrationCert.
-//   - PoolRetirementPattern: epoch 0 means “match any epoch”; non-zero epoch
-//     requires an exact match.
+//   - Empty nested messages (no populated inner fields) mean “match this
+//     certificate type only” (e.g. any stake delegation, any pool retirement).
+//   - StakeDelegationPattern: optional stake_credential and pool_keyhash; when
+//     both are absent, any StakeDelegationCert matches.
+//   - PoolRegistrationPattern: optional operator and pool_keyhash (each compared
+//     to the pool cold key on PoolRegistrationCert); when both absent, any
+//     pool registration matches.
+//   - PoolRetirementPattern: optional pool_keyhash. With no pool key, any
+//     retirement matches unless epoch is non-zero (then epoch must match).
+//     With a pool key set, epoch 0 means any epoch for that pool.
 //   - AnyPoolKeyhash: enumerates operator/pool key hashes from delegation and
 //     pool registration/retirement; VRF key hashes are not included.
+//   - any_stake_credential / any_pool_keyhash / any_drep: empty []byte remains
+//     unevaluable (not a nested message; no wildcard semantics).
 
 // txPatternMatchHasCertificate reports whether any certificate on the
 // transaction matches the given utxorpc CertificatePattern.
@@ -87,6 +93,9 @@ func certificatePatternMatches(
 		if got == nil {
 			return predNoMatch
 		}
+		if !stakeCredentialHasConstraint(want) {
+			return predMatch
+		}
 		if proto.Equal(want, got) {
 			return predMatch
 		}
@@ -100,6 +109,9 @@ func certificatePatternMatches(
 		got := uc.GetStakeDeregistration()
 		if got == nil {
 			return predNoMatch
+		}
+		if !stakeCredentialHasConstraint(want) {
+			return predMatch
 		}
 		if proto.Equal(want, got) {
 			return predMatch
@@ -115,21 +127,15 @@ func certificatePatternMatches(
 		if got == nil {
 			return predNoMatch
 		}
-		var hasConstraint bool
 		if sc := sdp.GetStakeCredential(); stakeCredentialHasConstraint(sc) {
-			hasConstraint = true
 			if !proto.Equal(sc, got.GetStakeCredential()) {
 				return predNoMatch
 			}
 		}
 		if pkh := sdp.GetPoolKeyhash(); len(pkh) > 0 {
-			hasConstraint = true
 			if !bytes.Equal(pkh, got.GetPoolKeyhash()) {
 				return predNoMatch
 			}
-		}
-		if !hasConstraint {
-			return predUnevaluable
 		}
 		return predMatch
 
@@ -142,21 +148,15 @@ func certificatePatternMatches(
 		if got == nil {
 			return predNoMatch
 		}
-		var hasConstraint bool
 		if op := prp.GetOperator(); len(op) > 0 {
-			hasConstraint = true
 			if !bytes.Equal(op, got.GetOperator()) {
 				return predNoMatch
 			}
 		}
 		if pkh := prp.GetPoolKeyhash(); len(pkh) > 0 {
-			hasConstraint = true
 			if !bytes.Equal(pkh, got.GetOperator()) {
 				return predNoMatch
 			}
-		}
-		if !hasConstraint {
-			return predUnevaluable
 		}
 		return predMatch
 
@@ -165,12 +165,15 @@ func certificatePatternMatches(
 		if prt == nil {
 			return predUnevaluable
 		}
-		if len(prt.GetPoolKeyhash()) == 0 {
-			return predUnevaluable
-		}
 		got := uc.GetPoolRetirement()
 		if got == nil {
 			return predNoMatch
+		}
+		if len(prt.GetPoolKeyhash()) == 0 {
+			if wantEp := prt.GetEpoch(); wantEp != 0 && wantEp != got.GetEpoch() {
+				return predNoMatch
+			}
+			return predMatch
 		}
 		if !bytes.Equal(prt.GetPoolKeyhash(), got.GetPoolKeyhash()) {
 			return predNoMatch

--- a/utxorpc/submit.go
+++ b/utxorpc/submit.go
@@ -472,7 +472,8 @@ func (s *submitServiceServer) WatchMempool(
 // treat it as a definite non-match.
 //
 // Set fields are combined with AND: consumes ∧ produces ∧ has_address ∧
-// mints_asset ∧ moves_asset (each present sub-pattern must match).
+// mints_asset ∧ moves_asset ∧ has_certificate (each present sub-pattern must
+// match).
 func (u *Utxorpc) matchesTxPattern(
 	tx gledger.Transaction,
 	pattern *cardano.TxPattern,
@@ -495,6 +496,9 @@ func (u *Utxorpc) matchesTxPattern(
 	}
 	if p := pattern.GetMovesAsset(); p != nil {
 		parts = append(parts, u.txPatternMatchAsset(tx, p))
+	}
+	if p := pattern.GetHasCertificate(); p != nil {
+		parts = append(parts, u.txPatternMatchHasCertificate(tx, p))
 	}
 	if len(parts) == 0 {
 		return predUnevaluable

--- a/utxorpc/submit_test.go
+++ b/utxorpc/submit_test.go
@@ -797,6 +797,10 @@ func certPatternHash28(seed byte) []byte {
 	return bytes.Repeat([]byte{seed}, 28)
 }
 
+func certPatternHash32(seed byte) []byte {
+	return bytes.Repeat([]byte{seed}, 32)
+}
+
 func TestMatchesTxPattern_HasCertificateStakeRegistration(t *testing.T) {
 	t.Parallel()
 	u := txPatternTestUtxorpc(t)
@@ -853,6 +857,173 @@ func TestMatchesTxPattern_HasCertificateStakeRegistrationMismatch(t *testing.T) 
 		},
 	}
 	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
+}
+
+func testCertPoolRegistration(t *testing.T) *common.PoolRegistrationCertificate {
+	t.Helper()
+	var op common.PoolKeyHash
+	copy(op[:], certPatternHash28(0x20))
+	var vrf common.VrfKeyHash
+	copy(vrf[:], certPatternHash32(0x21))
+	var reward common.AddrKeyHash
+	copy(reward[:], certPatternHash28(0x22))
+	return &common.PoolRegistrationCertificate{
+		CertType:      uint(common.CertificateTypePoolRegistration),
+		Operator:      op,
+		VrfKeyHash:    vrf,
+		Pledge:        0,
+		Cost:          0,
+		Margin:        cbor.Rat{Rat: big.NewRat(0, 1)},
+		RewardAccount: reward,
+		PoolMetadata: &common.PoolMetadata{
+			Url:  "",
+			Hash: common.PoolMetadataHash{},
+		},
+	}
+}
+
+func TestMatchesTxPattern_HasCertificateEmptyStakeDelegationTypeOnly(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	stake := certPatternHash28(3)
+	var stakeCH common.CredentialHash
+	copy(stakeCH[:], stake)
+	var poolKH common.PoolKeyHash
+	copy(poolKH[:], certPatternHash28(4))
+	deleg := &common.StakeDelegationCertificate{
+		CertType: uint(common.CertificateTypeStakeDelegation),
+		StakeCredential: &common.Credential{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: stakeCH,
+		},
+		PoolKeyHash: poolKH,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{deleg}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_StakeDelegation{
+				StakeDelegation: &cardano.StakeDelegationPattern{},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateEmptyStakeDelegationWrongCertType(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(3)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	regCert := &common.StakeRegistrationCertificate{
+		CertType:        uint(common.CertificateTypeStakeRegistration),
+		StakeCredential: common.Credential{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: ch,
+		},
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_StakeDelegation{
+				StakeDelegation: &cardano.StakeDelegationPattern{},
+			},
+		},
+	}
+	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateEmptyStakeRegistrationTypeOnly(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(9)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	regCert := &common.StakeRegistrationCertificate{
+		CertType:        uint(common.CertificateTypeStakeRegistration),
+		StakeCredential: common.Credential{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: ch,
+		},
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_StakeRegistration{
+				StakeRegistration: &cardano.StakeCredential{},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateEmptyPoolRetirementTypeOnly(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	var poolKH common.PoolKeyHash
+	copy(poolKH[:], certPatternHash28(5))
+	retire := &common.PoolRetirementCertificate{
+		CertType:    uint(common.CertificateTypePoolRetirement),
+		PoolKeyHash: poolKH,
+		Epoch:       42,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{retire}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_PoolRetirement{
+				PoolRetirement: &cardano.PoolRetirementPattern{},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificatePoolRetirementEpochOnlyNoPoolKey(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	var poolKH common.PoolKeyHash
+	copy(poolKH[:], certPatternHash28(5))
+	retire := &common.PoolRetirementCertificate{
+		CertType:    uint(common.CertificateTypePoolRetirement),
+		PoolKeyHash: poolKH,
+		Epoch:       300,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{retire}}
+	match := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_PoolRetirement{
+				PoolRetirement: &cardano.PoolRetirementPattern{
+					Epoch: 300,
+				},
+			},
+		},
+	}
+	noMatch := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_PoolRetirement{
+				PoolRetirement: &cardano.PoolRetirementPattern{
+					Epoch: 301,
+				},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, match))
+	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, noMatch))
+}
+
+func TestMatchesTxPattern_HasCertificateEmptyPoolRegistrationTypeOnly(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	poolCert := testCertPoolRegistration(t)
+	tx := &txPatternTestTx{certs: []common.Certificate{poolCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_PoolRegistration{
+				PoolRegistration: &cardano.PoolRegistrationPattern{},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
 }
 
 func TestMatchesTxPattern_HasCertificateStakeDelegationPoolOnly(t *testing.T) {

--- a/utxorpc/submit_test.go
+++ b/utxorpc/submit_test.go
@@ -15,6 +15,7 @@
 package utxorpc
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"io"
@@ -332,6 +333,14 @@ type txPatternTestTx struct {
 	consumed []common.TransactionInput
 	outs     []common.TransactionOutput
 	collRet  common.TransactionOutput
+	certs    []common.Certificate
+}
+
+func (t *txPatternTestTx) Certificates() []common.Certificate {
+	if t == nil {
+		return nil
+	}
+	return t.certs
 }
 
 func (t *txPatternTestTx) ProtocolParameterUpdates() (
@@ -782,4 +791,227 @@ func TestMatchesTxPattern_HasAddressANDMismatch(t *testing.T) {
 		},
 	}
 	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
+}
+
+func certPatternHash28(seed byte) []byte {
+	return bytes.Repeat([]byte{seed}, 28)
+}
+
+func TestMatchesTxPattern_HasCertificateStakeRegistration(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(9)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	cred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: ch,
+	}
+	regCert := &common.StakeRegistrationCertificate{
+		CertType:        uint(common.CertificateTypeStakeRegistration),
+		StakeCredential: cred,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_StakeRegistration{
+				StakeRegistration: &cardano.StakeCredential{
+					StakeCredential: &cardano.StakeCredential_AddrKeyHash{
+						AddrKeyHash: h,
+					},
+				},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateStakeRegistrationMismatch(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(1)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	cred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: ch,
+	}
+	regCert := &common.StakeRegistrationCertificate{
+		CertType:        uint(common.CertificateTypeStakeRegistration),
+		StakeCredential: cred,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_StakeRegistration{
+				StakeRegistration: &cardano.StakeCredential{
+					StakeCredential: &cardano.StakeCredential_AddrKeyHash{
+						AddrKeyHash: certPatternHash28(2),
+					},
+				},
+			},
+		},
+	}
+	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateStakeDelegationPoolOnly(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	stake := certPatternHash28(3)
+	var stakeCH common.CredentialHash
+	copy(stakeCH[:], stake)
+	var poolKH common.PoolKeyHash
+	copy(poolKH[:], certPatternHash28(4))
+	deleg := &common.StakeDelegationCertificate{
+		CertType: uint(common.CertificateTypeStakeDelegation),
+		StakeCredential: &common.Credential{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: stakeCH,
+		},
+		PoolKeyHash: poolKH,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{deleg}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_StakeDelegation{
+				StakeDelegation: &cardano.StakeDelegationPattern{
+					PoolKeyhash: certPatternHash28(4),
+				},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificatePoolRetirementEpochWildcard(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	var poolKH common.PoolKeyHash
+	copy(poolKH[:], certPatternHash28(5))
+	retire := &common.PoolRetirementCertificate{
+		CertType:    uint(common.CertificateTypePoolRetirement),
+		PoolKeyHash: poolKH,
+		Epoch:       200,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{retire}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_PoolRetirement{
+				PoolRetirement: &cardano.PoolRetirementPattern{
+					PoolKeyhash: certPatternHash28(5),
+					Epoch:       0,
+				},
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateAnyStakeCredential(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(6)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	cred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: ch,
+	}
+	regCert := &common.StakeRegistrationCertificate{
+		CertType:        uint(common.CertificateTypeStakeRegistration),
+		StakeCredential: cred,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_AnyStakeCredential{
+				AnyStakeCredential: h,
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateAnyStakeCredential_IgnoresGenesisDelegation(
+	t *testing.T,
+) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(0xAA)
+	genesis := &common.GenesisKeyDelegationCertificate{
+		CertType:            uint(common.CertificateTypeGenesisKeyDelegation),
+		GenesisHash:         certPatternHash28(0xAB),
+		GenesisDelegateHash: h,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{genesis}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_AnyStakeCredential{
+				AnyStakeCredential: h,
+			},
+		},
+	}
+	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateAnyDrep(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(8)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	cred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: ch,
+	}
+	regDrep := &common.RegistrationDrepCertificate{
+		CertType:       uint(common.CertificateTypeRegistrationDrep),
+		DrepCredential: cred,
+		Amount:         1,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regDrep}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_AnyDrep{
+				AnyDrep: h,
+			},
+		},
+	}
+	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateNoCerts(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	tx := &txPatternTestTx{}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{
+			CertificateType: &cardano.CertificatePattern_AnyStakeCredential{
+				AnyStakeCredential: certPatternHash28(7),
+			},
+		},
+	}
+	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_HasCertificateMalformedPatternUnevaluable(t *testing.T) {
+	t.Parallel()
+	u := txPatternTestUtxorpc(t)
+	h := certPatternHash28(7)
+	var ch common.CredentialHash
+	copy(ch[:], h)
+	cred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: ch,
+	}
+	regCert := &common.StakeRegistrationCertificate{
+		CertType:        uint(common.CertificateTypeStakeRegistration),
+		StakeCredential: cred,
+	}
+	tx := &txPatternTestTx{certs: []common.Certificate{regCert}}
+	p := &cardano.TxPattern{
+		HasCertificate: &cardano.CertificatePattern{},
+	}
+	require.Equal(t, predUnevaluable, u.matchesTxPattern(tx, p))
 }

--- a/utxorpc/tx_predicate.go
+++ b/utxorpc/tx_predicate.go
@@ -123,7 +123,8 @@ func txPredicateFromWatch(p *watch.TxPredicate) *txPredicateNode {
 }
 
 // txPatternLeaf matches a transaction against a Cardano TxPattern (consumes,
-// produces, has_address; inputs resolved via ledger where needed).
+// produces, has_address, has_certificate; inputs resolved via ledger where
+// needed).
 type txPatternLeaf func(tx gledger.Transaction, pat *cardano.TxPattern) predOutcome
 
 // matchTxPredicateNode evaluates a prebuilt txPredicateNode (from


### PR DESCRIPTION
Closes #1482 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tx predicate logic to evaluate `has_certificate` in `cardano.TxPattern`, adding type-only certificate filters for accurate, flexible certificate-based matching.

- **Bug Fixes**
  - Implemented `CertificatePattern` matcher in `utxorpc` and wired `has_certificate` into `matchesTxPattern` AND logic.
  - Supports StakeRegistration/Deregistration, StakeDelegation, PoolRegistration/Retirement, `AnyStakeCredential`, `AnyPoolKeyhash`, and `AnyDrep`.
  - Type-only filters: empty nested messages match any cert of that type; only non-empty fields constrain results.
  - Rules: PoolRegistration `operator`/`pool_keyhash` compare to pool cold key; PoolRetirement epoch=0 is a wildcard; `AnyPoolKeyhash` ignores VRF keys; empty `any_*` bytes are unevaluable; `AnyStakeCredential` ignores genesis delegation.

<sup>Written for commit e2a05cbc85df04abcda094eca33929e7c57a6fae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction pattern matching now supports Cardano certificates and honors an optional has_certificate predicate when present, allowing filtering by certificate type and configurable constraints (stake, delegation, pool, DRep).

* **Tests**
  * Added comprehensive tests covering certificate matching, epoch/edge behaviors, wildcard cases, no-certificate no-match, and malformed-pattern unevaluable outcomes.

* **Documentation**
  * Updated tx pattern docs to note has_certificate is now evaluated alongside consumes/produces/has_address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->