### PR TITLE
feat(metrics): expose Haskell-style RTS memory metrics

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@
 package dingo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -201,6 +202,100 @@ func (n *Node) registerBuildInfo() {
 		version.CommitHash,
 		runtime.Version(),
 	).Set(1)
+}
+
+// rtsMetricsUpdateInterval is how often the background updater refreshes
+// the RTS-style gauges from runtime.MemStats. Chosen to stay comfortably
+// under the default Prometheus scrape interval (15s) so consecutive
+// scrapes always see a fresh sample, without paying ReadMemStats
+// stop-the-world cost more often than necessary.
+const rtsMetricsUpdateInterval = 10 * time.Second
+
+// rtsMetrics holds Haskell-cardano-node-style RTS memory gauges backed
+// by Go runtime.MemStats. Matching the Haskell naming lets existing
+// cardano-node dashboards and alert rules work against Dingo without
+// rewriting queries. See docs/plans/RTS_METRICS.md for the semantic
+// mapping between Go and Haskell GC concepts.
+type rtsMetrics struct {
+	gcLiveBytes prometheus.Gauge
+	gcHeapBytes prometheus.Gauge
+	gcMajorNum  prometheus.Gauge
+	gcMinorNum  prometheus.Gauge
+}
+
+// registerRTSMetrics creates the four RTS gauges on the node's Prometheus
+// registry. Safe to call when promRegistry is nil — in that case it
+// returns early and leaves n.rtsMetrics nil, matching the registerBuildInfo
+// nil-guard pattern.
+func (n *Node) registerRTSMetrics() {
+	if n.config.promRegistry == nil {
+		return
+	}
+	factory := promauto.With(n.config.promRegistry)
+	n.rtsMetrics = &rtsMetrics{
+		gcLiveBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_RTS_gcLiveBytes_int",
+			Help: "live heap bytes currently in use (Go runtime.MemStats.HeapAlloc)",
+		}),
+		gcHeapBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_RTS_gcHeapBytes_int",
+			Help: "heap memory bytes obtained from the OS (Go runtime.MemStats.HeapSys)",
+		}),
+		gcMajorNum: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_RTS_gcMajorNum_int",
+			Help: "count of forced GCs (Go runtime.MemStats.NumForcedGC)",
+		}),
+		gcMinorNum: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_RTS_gcMinorNum_int",
+			Help: "count of automatic GCs (Go runtime.MemStats.NumGC - NumForcedGC)",
+		}),
+	}
+}
+
+// updateRTSMetrics writes the four gauge values from a runtime.MemStats
+// snapshot. Kept as a pure function (no ReadMemStats call, no timer) so
+// unit tests can drive it with crafted MemStats values. The Go runtime
+// guarantees NumForcedGC <= NumGC, so the subtraction never underflows.
+func updateRTSMetrics(m *rtsMetrics, stats *runtime.MemStats) {
+	m.gcLiveBytes.Set(float64(stats.HeapAlloc))
+	m.gcHeapBytes.Set(float64(stats.HeapSys))
+	m.gcMajorNum.Set(float64(stats.NumForcedGC))
+	m.gcMinorNum.Set(float64(stats.NumGC - stats.NumForcedGC))
+}
+
+// runRTSMetricsUpdater samples runtime.MemStats on a ticker and writes
+// the values into the RTS gauges. Collection happens on this goroutine
+// rather than at Prometheus scrape time so a scrape never pays the
+// ReadMemStats stop-the-world cost. Exits when ctx is cancelled.
+//
+// The interval parameter is accepted explicitly so tests can drive the
+// updater with a much shorter tick without changing production cadence;
+// production callers pass rtsMetricsUpdateInterval.
+func (n *Node) runRTSMetricsUpdater(
+	ctx context.Context,
+	interval time.Duration,
+) {
+	if n.rtsMetrics == nil {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Prime the gauges immediately so a scrape arriving before the
+	// first tick returns real values instead of zero.
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	updateRTSMetrics(n.rtsMetrics, &stats)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runtime.ReadMemStats(&stats)
+			updateRTSMetrics(n.rtsMetrics, &stats)
+		}
+	}
 }
 
 // isDevMode returns true if running in development mode

--- a/config_test.go
+++ b/config_test.go
@@ -15,10 +15,17 @@
 package dingo
 
 import (
+	"context"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStorageModeValid(t *testing.T) {
@@ -86,4 +93,73 @@ func TestPeerGovernorOptionsApplyPositiveValues(t *testing.T) {
 	assert.Equal(t, 2*time.Minute, cfg.inactivityTimeout)
 	assert.Equal(t, 4, cfg.maxConnectionsPerIP)
 	assert.Equal(t, 25, cfg.maxInboundConns)
+}
+
+// TestUpdateRTSMetrics verifies the pure-function mapping from
+// runtime.MemStats fields to the four cardano_node_metrics_RTS_* gauges.
+// Specifically exercises the NumGC - NumForcedGC subtraction so a future
+// typo that inverts the operands is caught immediately.
+func TestUpdateRTSMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	factory := promauto.With(reg)
+	m := &rtsMetrics{
+		gcLiveBytes: factory.NewGauge(
+			prometheus.GaugeOpts{Name: "test_live"},
+		),
+		gcHeapBytes: factory.NewGauge(
+			prometheus.GaugeOpts{Name: "test_heap"},
+		),
+		gcMajorNum: factory.NewGauge(
+			prometheus.GaugeOpts{Name: "test_major"},
+		),
+		gcMinorNum: factory.NewGauge(
+			prometheus.GaugeOpts{Name: "test_minor"},
+		),
+	}
+	stats := &runtime.MemStats{
+		HeapAlloc:   1024,
+		HeapSys:     4096,
+		Sys:         8192,
+		NumGC:       10,
+		NumForcedGC: 3,
+	}
+
+	updateRTSMetrics(m, stats)
+
+	require.Equal(t, float64(1024), promtestutil.ToFloat64(m.gcLiveBytes))
+	require.Equal(t, float64(4096), promtestutil.ToFloat64(m.gcHeapBytes))
+	require.Equal(t, float64(3), promtestutil.ToFloat64(m.gcMajorNum))
+	// 10 total - 3 forced = 7 automatic
+	require.Equal(t, float64(7), promtestutil.ToFloat64(m.gcMinorNum))
+}
+
+// TestRunRTSMetricsUpdater_Lifecycle verifies the background updater
+// populates the gauges after its initial prime and exits cleanly when
+// the context is cancelled.
+func TestRunRTSMetricsUpdater_Lifecycle(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	n := &Node{config: Config{promRegistry: reg}}
+	n.registerRTSMetrics()
+	require.NotNil(t, n.rtsMetrics, "registerRTSMetrics must populate n.rtsMetrics")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		n.runRTSMetricsUpdater(ctx, 5*time.Millisecond)
+		close(done)
+	}()
+
+	// Wait for the initial prime (or first tick) to populate real values.
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(n.rtsMetrics.gcHeapBytes) > 0
+	}, 2*time.Second, 10*time.Millisecond, "gcHeapBytes should be populated by the updater")
+
+	cancel()
+	testutil.RequireReceive(
+		t,
+		done,
+		2*time.Second,
+		"updater should exit after ctx cancel",
+	)
 }

--- a/node.go
+++ b/node.go
@@ -67,6 +67,7 @@ type Node struct {
 	ouroboros                        *ouroborosPkg.Ouroboros
 	blockForger                      *forging.BlockForger
 	leaderElection                   *leader.Election
+	rtsMetrics                       *rtsMetrics
 	shutdownFuncs                    []func(context.Context) error
 	config                           Config
 	ctx                              context.Context
@@ -370,6 +371,7 @@ func New(cfg Config) (*Node, error) {
 	// This must happen before any component registers metrics.
 	n.configWrapPromRegistry()
 	n.registerBuildInfo()
+	n.registerRTSMetrics()
 	n.eventBus = event.NewEventBus(n.config.promRegistry, n.config.logger)
 	if err := n.configValidate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
@@ -387,18 +389,30 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	n.ctx, n.cancel = context.WithCancel(ctx)
 
+	// Start the RTS metrics updater goroutine. It samples runtime.MemStats
+	// on a ticker and exits when n.ctx is cancelled by the existing
+	// shutdown or startup-failure cleanup, so it does not need an entry in
+	// the `started` cleanup stack.
+	go n.runRTSMetricsUpdater(n.ctx, rtsMetricsUpdateInterval)
+
 	// Track started components for cleanup on failure
 	var started []func()
 	success := false
 	defer func() {
 		r := recover()
 		if r != nil {
+			if n.cancel != nil {
+				n.cancel()
+			}
 			// Cleanup on panic, then re-panic
 			for i := len(started) - 1; i >= 0; i-- {
 				started[i]()
 			}
 			panic(r)
 		} else if !success {
+			if n.cancel != nil {
+				n.cancel()
+			}
 			// Cleanup on failure (non-panic)
 			for i := len(started) - 1; i >= 0; i-- {
 				started[i]()


### PR DESCRIPTION
Closes #62 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Haskell-style RTS memory metrics from Go `runtime.MemStats`, matching `cardano_node_metrics_RTS_*` names for drop-in dashboard and alert compatibility. Metrics update in a background goroutine every 10s to avoid scrape-time `runtime.ReadMemStats` pauses and are registered only when a Prometheus registry is present.

<sup>Written for commit 589f40291c7edb681da07bf71f66578e3fe39308. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Application now automatically exports Prometheus metrics for runtime memory and garbage collection monitoring, including heap allocation, system heap memory, and garbage collection operation counts, with metrics collected at regular intervals throughout operation.

## Tests
* Added comprehensive tests to validate metrics collection logic, initialization, and proper lifecycle management with graceful shutdown verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->