### PR TITLE
docs: add databasePath to example config

### DIFF
--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -11,6 +11,11 @@ bindAddr: "0.0.0.0"
 # Can be overridden with the config environment variable
 cardanoConfig: "./config/cardano/preview/config.json"
 
+# Global data directory for both blob and metadata storage plugins.
+# Can be overridden with CARDANO_DATABASE_PATH or --data-dir.
+# Plugin-specific data-dir settings below override this value.
+databasePath: ".dingo"
+
 # Database configuration
 database:
   # Blob storage plugin configuration


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add databasePath to dingo.yaml.example to document the global data directory for blob and metadata storage. Clarifies overrides: CARDANO_DATABASE_PATH or --data-dir, with plugin-specific data-dir settings taking precedence.

<sup>Written for commit c280cdd89f4db234751904a46f9906124b11169b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Added `databasePath` configuration option to specify a global data directory for storage operations. This can be overridden using the `CARDANO_DATABASE_PATH` environment variable or the `--data-dir` CLI flag. Plugin-specific settings maintain precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->