### PR TITLE
build: makefile help and docs + lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,51 +15,58 @@ VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' -X '$(GOMODULE)/internal/version.CommitHash=$(COMMIT_HASH)'"
 
-.PHONY: all build mod-tidy clean format golines test bench test-load test-load-log test-load-profile
+.PHONY: all build help mod-tidy clean format golines lint test bench test-load test-load-log test-load-profile
 
 # Default target
-all: format build
+all: format build ## Format and build (default)
+
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 # Build target
-build: $(BINARIES)
+build: $(BINARIES) ## Build the dingo binary
 
 # Builds and installs binary in ~/.local/bin
-install: build
+install: build ## Install binary to ~/.local/bin
 	mkdir -p $(HOME)/.local/bin
 	mv $(BINARIES) $(HOME)/.local/bin
 
-uninstall:
+uninstall: ## Remove installed binary from ~/.local/bin
 	rm -f $(HOME)/.local/bin/$(BINARIES)
 
-mod-tidy:
+mod-tidy: ## Run go mod tidy
 	# Needed to fetch new dependencies and add them to go.mod
 	go mod tidy
 
-clean:
+clean: ## Remove compiled binaries
 	rm -f $(BINARIES)
 
-format: mod-tidy
+format: mod-tidy ## Format code and tidy go.mod
 	go fmt ./...
 	gofmt -s -w $(GO_FILES)
 
-golines:
+golines: ## Enforce 80-character line limit
 	golines -w --ignore-generated --chain-split-dots --max-len=80 --reformat-tags .
 
-test: mod-tidy
+lint: ## Run linters (golangci-lint + modernize)
+	golangci-lint run ./...
+	modernize ./...
+
+test: mod-tidy ## Run tests with race detection
 	go test -v -race ./...
 
-bench: mod-tidy
+bench: mod-tidy ## Run benchmarks
 	go test -run=^$$ -bench=. -benchmem ./...
 
-test-load: build
+test-load: build ## Load test data into a fresh database
 	rm -rf .dingo
 	./dingo load database/immutable/testdata
 
-test-load-log: build
+test-load-log: build ## Load test data and capture log output
 	rm -rf .dingo dingo.log
 	./dingo load database/immutable/testdata 2>&1 | tee dingo.log
 
-test-load-profile: build
+test-load-profile: build ## Load test data with CPU/memory profiling
 	rm -rf .dingo
 	./dingo --cpuprofile=cpu.prof --memprofile=mem.prof load database/immutable/testdata
 	@echo "Profiling complete. Run 'go tool pprof cpu.prof' or 'go tool pprof mem.prof' to analyze"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a self-documenting Makefile with `make help` and a new `lint` target to standardize code checks and improve developer onboarding.

- New Features
  - Added `help` target that lists all targets from `##` comments.
  - Added `lint` target running `golangci-lint` and `modernize`.
  - Documented existing targets (build, install, clean, tests) and clarified the default `all` target.

<sup>Written for commit 100f5c197df47d84d56f3068383fa8ba81a9cdd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `help` command to view available build targets and their descriptions
  * Added `lint` command to run code quality checks

* **Chores**
  * Updated build target documentation with inline descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->