### PR TITLE
feat(blockfrost): Epoch and protocol parameter endpoints

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -34,8 +34,10 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
-var ErrInvalidAddress = errors.New("invalid address")
-var ErrEpochNotFound = errors.New("epoch not found")
+var (
+	ErrInvalidAddress = errors.New("invalid address")
+	ErrEpochNotFound  = errors.New("epoch not found")
+)
 
 // NodeAdapter wraps a real dingo Node's LedgerState to
 // implement the BlockfrostNode interface.

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -34,6 +35,7 @@ import (
 )
 
 var ErrInvalidAddress = errors.New("invalid address")
+var ErrEpochNotFound = errors.New("epoch not found")
 
 // NodeAdapter wraps a real dingo Node's LedgerState to
 // implement the BlockfrostNode interface.
@@ -241,6 +243,70 @@ func (a *NodeAdapter) CurrentProtocolParams() (
 	if err != nil {
 		return ProtocolParamsInfo{}, fmt.Errorf(
 			"convert current protocol parameters: %w",
+			err,
+		)
+	}
+	return info, nil
+}
+
+// EpochProtocolParams returns protocol parameters for the
+// requested epoch.
+func (a *NodeAdapter) EpochProtocolParams(
+	epoch uint64,
+) (ProtocolParamsInfo, error) {
+	pparamRows, err := a.ledgerState.Database().Metadata().GetPParams(
+		epoch,
+		nil,
+	)
+	if err != nil {
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"get protocol parameters for epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	if len(pparamRows) == 0 {
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"get protocol parameters for epoch %d: %w",
+			epoch,
+			ErrEpochNotFound,
+		)
+	}
+	pparamRow := pparamRows[0]
+	era := eras.GetEraById(pparamRow.EraId)
+	if era == nil {
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"get protocol parameters for epoch %d: unknown era ID %d",
+			epoch,
+			pparamRow.EraId,
+		)
+	}
+	pparams, err := era.DecodePParamsFunc(
+		pparamRow.Cbor,
+	)
+	if err != nil {
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"decode protocol parameters for epoch %d from row epoch %d: %w",
+			epoch,
+			pparamRow.Epoch,
+			err,
+		)
+	}
+	if pparams == nil {
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"get protocol parameters for epoch %d: %w",
+			epoch,
+			ErrEpochNotFound,
+		)
+	}
+	info, err := protocolParamsInfoFromNative(
+		pparams,
+		epoch,
+	)
+	if err != nil {
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"convert protocol parameters for epoch %d: %w",
+			epoch,
 			err,
 		)
 	}

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -87,6 +87,10 @@ func (b *Blockfrost) Start(
 		b.handleLatestEpochParams,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/epochs/{number}/parameters",
+		b.handleEpochParams,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/network",
 		b.handleNetwork,
 	)

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -38,6 +38,7 @@ type mockNode struct {
 	txHashes               []string
 	epoch                  EpochInfo
 	params                 ProtocolParamsInfo
+	epochParams            ProtocolParamsInfo
 	pools                  []PoolExtendedInfo
 	addressUTXOs           []AddressUTXOInfo
 	addressTransactions    []AddressTransactionInfo
@@ -48,6 +49,7 @@ type mockNode struct {
 	txHashesErr            error
 	epochErr               error
 	paramsErr              error
+	epochParamsErr         error
 	poolsErr               error
 	addressUTXOsErr        error
 	addressTransactionsErr error
@@ -81,6 +83,12 @@ func (m *mockNode) CurrentProtocolParams() (
 	ProtocolParamsInfo, error,
 ) {
 	return m.params, m.paramsErr
+}
+
+func (m *mockNode) EpochProtocolParams(
+	_ uint64,
+) (ProtocolParamsInfo, error) {
+	return m.epochParams, m.epochParamsErr
 }
 
 func (m *mockNode) PoolsExtended() (
@@ -571,6 +579,106 @@ func TestHandleLatestEpochParams(t *testing.T) {
 	assert.Equal(t, 150, *resp.CollateralPercent)
 	require.NotNil(t, resp.MaxCollateralInputs)
 	assert.Equal(t, 3, *resp.MaxCollateralInputs)
+}
+
+func TestHandleEpochParams(t *testing.T) {
+	mock := &mockNode{
+		epochParams: ProtocolParamsInfo{
+			Epoch:               42,
+			MinFeeA:             44,
+			MinFeeB:             155381,
+			MaxBlockSize:        65536,
+			MaxTxSize:           16384,
+			MaxBlockHeaderSize:  1100,
+			KeyDeposit:          "2000000",
+			PoolDeposit:         "500000000",
+			EMax:                18,
+			NOpt:                150,
+			A0:                  0.3,
+			Rho:                 0.003,
+			Tau:                 0.2,
+			ProtocolMajorVer:    8,
+			ProtocolMinorVer:    0,
+			MinPoolCost:         "170000000",
+			CoinsPerUtxoSize:    "4310",
+			PriceMem:            0.0577,
+			PriceStep:           0.0000721,
+			MaxTxExMem:          "10000000000",
+			MaxTxExSteps:        "10000000000000",
+			MaxBlockExMem:       "50000000000",
+			MaxBlockExSteps:     "40000000000000",
+			MaxValSize:          "5000",
+			CollateralPercent:   150,
+			MaxCollateralInputs: 3,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/42/parameters",
+		nil,
+	)
+	req.SetPathValue("number", "42")
+	w := httptest.NewRecorder()
+	b.handleEpochParams(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ProtocolParamsResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), resp.Epoch)
+	assert.Equal(t, 44, resp.MinFeeA)
+	assert.Equal(t, 155381, resp.MinFeeB)
+	assert.Equal(t, "4310", resp.CoinsPerUtxoWord)
+}
+
+func TestHandleEpochParamsInvalidEpoch(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/not-a-number/parameters",
+		nil,
+	)
+	req.SetPathValue("number", "not-a-number")
+	w := httptest.NewRecorder()
+	b.handleEpochParams(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, "Bad Request", resp.Error)
+	assert.Equal(t, "Invalid epoch number.", resp.Message)
+}
+
+func TestHandleEpochParamsNotFound(t *testing.T) {
+	mock := &mockNode{
+		epochParamsErr: ErrEpochNotFound,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/42/parameters",
+		nil,
+	)
+	req.SetPathValue("number", "42")
+	w := httptest.NewRecorder()
+	b.handleEpochParams(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp.StatusCode)
+	assert.Equal(t, "Not Found", resp.Error)
 }
 
 func TestHandleNetwork(t *testing.T) {

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"strconv"
 )
 
 const apiVersion = "0.1.0"
@@ -209,39 +210,54 @@ func (b *Blockfrost) handleLatestEpochParams(
 		)
 		return
 	}
-	writeJSON(w, http.StatusOK, ProtocolParamsResponse{
-		Epoch:                 info.Epoch,
-		MinFeeA:               info.MinFeeA,
-		MinFeeB:               info.MinFeeB,
-		MaxBlockSize:          info.MaxBlockSize,
-		MaxTxSize:             info.MaxTxSize,
-		MaxBlockHeaderSize:    info.MaxBlockHeaderSize,
-		KeyDeposit:            info.KeyDeposit,
-		PoolDeposit:           info.PoolDeposit,
-		EMax:                  info.EMax,
-		NOpt:                  info.NOpt,
-		A0:                    info.A0,
-		Rho:                   info.Rho,
-		Tau:                   info.Tau,
-		ProtocolMajorVer:      info.ProtocolMajorVer,
-		ProtocolMinorVer:      info.ProtocolMinorVer,
-		MinPoolCost:           info.MinPoolCost,
-		CoinsPerUtxoSize:      &info.CoinsPerUtxoSize,
-		CoinsPerUtxoWord:      info.CoinsPerUtxoSize,
-		PriceMem:              &info.PriceMem,
-		PriceStep:             &info.PriceStep,
-		MaxTxExMem:            &info.MaxTxExMem,
-		MaxTxExSteps:          &info.MaxTxExSteps,
-		MaxBlockExMem:         &info.MaxBlockExMem,
-		MaxBlockExSteps:       &info.MaxBlockExSteps,
-		MaxValSize:            &info.MaxValSize,
-		CollateralPercent:     &info.CollateralPercent,
-		MaxCollateralInputs:   &info.MaxCollateralInputs,
-		MinUtxo:               "0",
-		Nonce:                 "",
-		DecentralisationParam: 0,
-		ExtraEntropy:          nil,
-	})
+	writeJSON(w, http.StatusOK, protocolParamsResponse(info))
+}
+
+// handleEpochParams handles GET /api/v0/epochs/{number}/parameters and
+// returns the protocol parameters for a specific epoch.
+func (b *Blockfrost) handleEpochParams(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	epoch, err := strconv.ParseUint(
+		r.PathValue("number"),
+		10,
+		64,
+	)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid epoch number.",
+		)
+		return
+	}
+	info, err := b.node.EpochProtocolParams(epoch)
+	if err != nil {
+		b.logger.Error(
+			"failed to get protocol params for epoch",
+			"epoch", epoch,
+			"error", err,
+		)
+		if errors.Is(err, ErrEpochNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested epoch could not be found.",
+			)
+			return
+		}
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve protocol parameters",
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, protocolParamsResponse(info))
 }
 
 // handleNetwork handles GET /api/v0/network and returns
@@ -490,4 +506,42 @@ func convertAddressAmounts(
 		ret = append(ret, AddressAmountResponse(amount))
 	}
 	return ret
+}
+
+func protocolParamsResponse(
+	info ProtocolParamsInfo,
+) ProtocolParamsResponse {
+	return ProtocolParamsResponse{
+		Epoch:                 info.Epoch,
+		MinFeeA:               info.MinFeeA,
+		MinFeeB:               info.MinFeeB,
+		MaxBlockSize:          info.MaxBlockSize,
+		MaxTxSize:             info.MaxTxSize,
+		MaxBlockHeaderSize:    info.MaxBlockHeaderSize,
+		KeyDeposit:            info.KeyDeposit,
+		PoolDeposit:           info.PoolDeposit,
+		EMax:                  info.EMax,
+		NOpt:                  info.NOpt,
+		A0:                    info.A0,
+		Rho:                   info.Rho,
+		Tau:                   info.Tau,
+		ProtocolMajorVer:      info.ProtocolMajorVer,
+		ProtocolMinorVer:      info.ProtocolMinorVer,
+		MinPoolCost:           info.MinPoolCost,
+		CoinsPerUtxoSize:      &info.CoinsPerUtxoSize,
+		CoinsPerUtxoWord:      info.CoinsPerUtxoSize,
+		PriceMem:              &info.PriceMem,
+		PriceStep:             &info.PriceStep,
+		MaxTxExMem:            &info.MaxTxExMem,
+		MaxTxExSteps:          &info.MaxTxExSteps,
+		MaxBlockExMem:         &info.MaxBlockExMem,
+		MaxBlockExSteps:       &info.MaxBlockExSteps,
+		MaxValSize:            &info.MaxValSize,
+		CollateralPercent:     &info.CollateralPercent,
+		MaxCollateralInputs:   &info.MaxCollateralInputs,
+		MinUtxo:               "0",
+		Nonce:                 "",
+		DecentralisationParam: 0,
+		ExtraEntropy:          nil,
+	}
 }

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -38,6 +38,10 @@ type BlockfrostNode interface {
 	// parameters.
 	CurrentProtocolParams() (ProtocolParamsInfo, error)
 
+	// EpochProtocolParams returns protocol parameters for a
+	// specific epoch.
+	EpochProtocolParams(epoch uint64) (ProtocolParamsInfo, error)
+
 	// PoolsExtended returns the current active pools with
 	// extended details.
 	PoolsExtended() ([]PoolExtendedInfo, error)

--- a/database/pparams.go
+++ b/database/pparams.go
@@ -154,7 +154,7 @@ func (d *Database) ApplyPParamUpdates(
 		"pparams", fmt.Sprintf("%#v", currentPParams),
 	)
 	// Write pparams update to DB
-	pparamsCbor, err := cbor.Encode(&currentPParams)
+	pparamsCbor, err := cbor.Encode(*currentPParams)
 	if err != nil {
 		return fmt.Errorf("encode updated pparams: %w", err)
 	}
@@ -262,7 +262,7 @@ func (d *Database) ComputeAndApplyPParamUpdates(
 		"pparams", fmt.Sprintf("%#v", newPParams),
 	)
 	// Write pparams update to DB
-	pparamsCbor, err := cbor.Encode(&newPParams)
+	pparamsCbor, err := cbor.Encode(newPParams)
 	if err != nil {
 		return nil, fmt.Errorf("encode updated pparams: %w", err)
 	}

--- a/database/pparams_test.go
+++ b/database/pparams_test.go
@@ -181,6 +181,21 @@ func TestComputeAndApplyPParamUpdates_QuorumMet(
 		updateApplied,
 		"update should be applied when quorum is met",
 	)
+
+	stored, err := db.GetPParams(
+		4,
+		func(data []byte) (lcommon.ProtocolParameters, error) {
+			var params shelley.ShelleyProtocolParameters
+			_, err := cbor.Decode(data, &params)
+			if err != nil {
+				return nil, err
+			}
+			return &params, nil
+		},
+		txn,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
 }
 
 func TestComputeAndApplyPParamUpdates_FiltersEpoch(


### PR DESCRIPTION
1. Added `/api/v0/epochs/{number}/parameters` in the blockfrost HTTP router.
2. Added `handleEpochParams()` to parse the epoch path parameter and serve historical protocol-parameter responses.
3. Added `EpochProtocolParams()` to node adapter interface where the blockfrost layer can request protocol parameters for a specific historical epoch. It looks up the effective pparams row for a requested epoch.
4. EpochProtocolParams queried protocol parameters through Metadata().GetPParams() where it resolves the latest effective row with epoch <= requested_epoch. Also, switched historical decoding to use the selected pparams row’s eraId instead of the epoch table’s era, fixing boundary-era decode failures. Decoded the selected pparams row’s cbor directly through the era-specific decode function before mapping it to blockfrost output.
5. Returned 400 Bad Request when the requested epoch path value is not a valid unsigned integer.
6. Returned 404 Not Found when no effective protocol-parameter row exists for the requested epoch.
7. Added blockfrost handler tests for successful historical protocol-parameter lookup, invalid epoch-number requests returning 400 and for missing epoch protocol-parameter requests returning 404.

Closes #1365 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `blockfrost` endpoint to fetch protocol parameters for a historical epoch, and fixes era-boundary and CBOR decode issues to return accurate data.

- **New Features**
  - Added GET `/api/v0/epochs/{number}/parameters` to `blockfrost`.
  - Returns 400 for invalid epoch numbers and 404 when no parameters exist for the epoch.
  - Introduced `EpochProtocolParams(epoch uint64)` in the node interface and implemented it using `Metadata().GetPParams` with era-specific decoding.
  - Added handler tests for success, 400, and 404 cases.

- **Bug Fixes**
  - Historical decoding now uses the selected pparams row’s `eraId` and era-specific CBOR decoder to avoid boundary-era failures.
  - Unified response shape via `protocolParamsResponse()` to keep latest and historical outputs consistent.
  - Fixed pparams CBOR encode/decode to use value types, resolving decode failures; added database test coverage.

<sup>Written for commit b27e63eadb2ce935fefaed5a4dbbf30c6e8728a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added REST API endpoint to retrieve protocol parameters for any specified epoch, enabling historical protocol data access with appropriate HTTP status codes (200 success, 400 bad request, 404 epoch not found).

* **Tests**
  * Expanded test coverage for new epoch parameters endpoint, including success validation, invalid input handling, and missing epoch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->