### PR TITLE
fix: do not recycle only peer

### DIFF
--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -124,11 +124,15 @@ func (n *Node) processChainsyncRecyclerTick(
 		map[string]chainsync.TrackedClient,
 		len(trackedClients),
 	)
+	eligibleCount := 0
 	for _, conn := range trackedClients {
 		connKey := conn.ConnId.String()
 		trackedByID[connKey] = conn
 		if conn.Status != chainsync.ClientStatusStalled {
 			delete(recycleAt, connKey)
+		}
+		if !conn.ObservabilityOnly {
+			eligibleCount++
 		}
 	}
 	// Prune expired cooldown entries so this map does
@@ -217,6 +221,20 @@ func (n *Node) processChainsyncRecyclerTick(
 		if last, ok := lastRecycled[connKey]; ok &&
 			now.Sub(last) < cooldown {
 			recycleAt[connKey] = now.Add(cooldown - now.Sub(last))
+			continue
+		}
+		// Never recycle the only eligible peer. A block producer
+		// with a single relay would lose its only propagation
+		// path during the reconnect window. Observability-only
+		// connections are not eligible, so recycling them does
+		// not reduce the eligible count.
+		if eligibleCount <= 1 && !tracked.ObservabilityOnly {
+			n.config.logger.Warn(
+				"chainsync client stalled but is only eligible peer, skipping recycle",
+				"connection_id", connKey,
+				"stall_timeout", chainsyncCfg.StallTimeout,
+			)
+			recycleAt[connKey] = now.Add(grace)
 			continue
 		}
 		active := n.chainsyncState.GetClientConnId()

--- a/node_test.go
+++ b/node_test.go
@@ -183,15 +183,23 @@ func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
 		connmanager.ConnectionRecycleRequestedEventType,
 	)
 
+	// Two eligible peers so the stall guard does not suppress
+	// the recycle (single-peer guard is tested separately).
+	// Add connId2 first so connId has a more recent LastActivity;
+	// promoteBestClientLocked will then select connId as active
+	// after both clients stall, making the recycle deterministic.
 	connId := newNodeTestConnId(1)
+	connId2 := newNodeTestConnId(2)
 	state := chainsync.NewStateWithConfig(
 		bus,
 		nil,
 		chainsync.Config{
-			MaxClients:   1,
+			MaxClients:   2,
 			StallTimeout: time.Millisecond,
 		},
 	)
+	require.True(t, state.AddClientConnId(connId2))
+	time.Sleep(time.Millisecond)
 	require.True(t, state.AddClientConnId(connId))
 
 	selector := chainselection.NewChainSelector(
@@ -225,7 +233,7 @@ func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
 		now,
 		100,
 		chainsync.Config{
-			MaxClients:   1,
+			MaxClients:   2,
 			StallTimeout: time.Millisecond,
 		},
 		recycleAt,
@@ -250,6 +258,88 @@ func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected stalled recycler event")
 	}
+}
+
+func TestProcessChainsyncRecyclerTickSkipsRecycleOnlyPeer(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, recycleCh := bus.Subscribe(
+		connmanager.ConnectionRecycleRequestedEventType,
+	)
+
+	connId := newNodeTestConnId(1)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Millisecond,
+		},
+	)
+	require.True(t, state.AddClientConnId(connId))
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("best")},
+		BlockNumber: 60,
+	}, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	now := time.Now()
+	lastProgressSlot := uint64(100)
+	lastProgressAt := now
+	grace := time.Second
+	recycleAt := map[string]time.Time{
+		connId.String(): now.Add(-time.Second),
+	}
+	lastRecycled := make(map[string]time.Time)
+
+	n.processChainsyncRecyclerTick(
+		now,
+		100,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Millisecond,
+		},
+		recycleAt,
+		lastRecycled,
+		&lastProgressSlot,
+		&lastProgressAt,
+		plateauThreshold(2*time.Minute),
+		grace,
+		2*time.Minute,
+	)
+
+	// No recycle event should be emitted for the only peer.
+	select {
+	case evt := <-recycleCh:
+		t.Fatalf("unexpected recycle event: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: recycle suppressed.
+	}
+
+	// Grace timer should be rescheduled.
+	dueAt, ok := recycleAt[connId.String()]
+	require.True(t, ok, "recycle entry should still exist")
+	assert.True(
+		t,
+		dueAt.After(now),
+		"due time should be pushed forward",
+	)
 }
 
 func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent recycling the only eligible `chainsync` peer to avoid losing the last relay during stalls. Count non-`ObservabilityOnly` peers and skip recycle when only one is eligible.

- **Bug Fixes**
  - In `chainsync` recycler: track eligible peer count; if `<= 1` and not observability-only, log a warning, push `recycleAt` by grace, and skip recycle.
  - Tests: make stalled-recycler test use two eligible peers for deterministic recycle; add test to ensure the only peer is not recycled and `recycleAt` is pushed forward.

<sup>Written for commit 272982bf2c606c52bcce1f8a3ddf0f93c4f29e8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed chainSync stability issue where stalled clients would be recycled even when they're the only eligible propagation peer. The system now reschedules recycling and logs a warning instead, ensuring connectivity resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->