### PR TITLE
fix(database): utxo helper

### DIFF
--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -15,10 +15,49 @@
 package models
 
 import (
+	"errors"
+
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
+
+// Sentinel errors for UtxoWithOrderingQuery validation.
+var (
+	ErrNilUtxoWithOrderingQuery = errors.New(
+		"nil UtxoWithOrderingQuery",
+	)
+	ErrEmptyAssetPolicyID = errors.New("empty asset policy id")
+)
+
+// AppendUtxoAddressOrBranch appends an OR branch for the given address
+// to the ors/args slices. It uses standard "?" placeholders that work
+// across SQLite, MySQL, and Postgres via GORM.
+func AppendUtxoAddressOrBranch(
+	ors *[]string,
+	args *[]any,
+	addr ledger.Address,
+) {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	pk := addr.PaymentKeyHash()
+	sk := addr.StakeKeyHash()
+	hasPayment := pk != zeroHash
+	hasStake := sk != zeroHash
+	switch {
+	case hasPayment && hasStake:
+		*ors = append(
+			*ors,
+			"(utxo.payment_key = ? AND utxo.staking_key = ?)",
+		)
+		*args = append(*args, pk.Bytes(), sk.Bytes())
+	case hasPayment:
+		*ors = append(*ors, "(utxo.payment_key = ?)")
+		*args = append(*args, pk.Bytes())
+	case hasStake:
+		*ors = append(*ors, "(utxo.staking_key = ?)")
+		*args = append(*args, sk.Bytes())
+	}
+}
 
 // Utxo represents an unspent transaction output
 type Utxo struct {

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -176,35 +176,16 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	return ret, nil
 }
 
-func appendUtxoAddressOrBranchMysql(ors *[]string, args *[]any, addr ledger.Address) {
-	zeroHash := lcommon.NewBlake2b224(nil)
-	pk := addr.PaymentKeyHash()
-	sk := addr.StakeKeyHash()
-	hasPayment := pk != zeroHash
-	hasStake := sk != zeroHash
-	switch {
-	case hasPayment && hasStake:
-		*ors = append(
-			*ors,
-			"(utxo.payment_key = ? AND utxo.staking_key = ?)",
-		)
-		*args = append(*args, pk.Bytes(), sk.Bytes())
-	case hasPayment:
-		*ors = append(*ors, "(utxo.payment_key = ?)")
-		*args = append(*args, pk.Bytes())
-	case hasStake:
-		*ors = append(*ors, "(utxo.staking_key = ?)")
-		*args = append(*args, sk.Bytes())
-	}
-}
-
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,
 	txn types.Txn,
 ) ([]models.UtxoWithOrdering, error) {
 	if q == nil {
-		return nil, errors.New("nil UtxoWithOrderingQuery")
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrNilUtxoWithOrderingQuery,
+		)
 	}
 	var ret []models.UtxoWithOrdering
 	db, err := d.resolveDB(txn)
@@ -225,7 +206,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 		var ors []string
 		var args []any
 		for i := range addrs {
-			appendUtxoAddressOrBranchMysql(&ors, &args, addrs[i])
+			models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i])
 		}
 		if len(ors) == 0 {
 			base = base.Where("1 = 0")
@@ -236,7 +217,10 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 
 	if q.FilterByAsset {
 		if len(q.AssetPolicyID) == 0 {
-			return nil, errors.New("asset filter requires non-empty policy id")
+			return nil, fmt.Errorf(
+				"GetUtxosByAddressWithOrdering: asset filter requires non-empty policy id: %w",
+				models.ErrEmptyAssetPolicyID,
+			)
 		}
 		assetSub := db.Table("asset").Select("utxo_id").Where(
 			"policy_id = ?",

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -176,35 +176,16 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 	return ret, nil
 }
 
-func appendUtxoAddressOrBranchPostgres(ors *[]string, args *[]any, addr ledger.Address) {
-	zeroHash := lcommon.NewBlake2b224(nil)
-	pk := addr.PaymentKeyHash()
-	sk := addr.StakeKeyHash()
-	hasPayment := pk != zeroHash
-	hasStake := sk != zeroHash
-	switch {
-	case hasPayment && hasStake:
-		*ors = append(
-			*ors,
-			"(utxo.payment_key = ? AND utxo.staking_key = ?)",
-		)
-		*args = append(*args, pk.Bytes(), sk.Bytes())
-	case hasPayment:
-		*ors = append(*ors, "(utxo.payment_key = ?)")
-		*args = append(*args, pk.Bytes())
-	case hasStake:
-		*ors = append(*ors, "(utxo.staking_key = ?)")
-		*args = append(*args, sk.Bytes())
-	}
-}
-
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,
 	txn types.Txn,
 ) ([]models.UtxoWithOrdering, error) {
 	if q == nil {
-		return nil, errors.New("nil UtxoWithOrderingQuery")
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrNilUtxoWithOrderingQuery,
+		)
 	}
 	var ret []models.UtxoWithOrdering
 	db, err := d.resolveDB(txn)
@@ -225,7 +206,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 		var ors []string
 		var args []any
 		for i := range addrs {
-			appendUtxoAddressOrBranchPostgres(&ors, &args, addrs[i])
+			models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i])
 		}
 		if len(ors) == 0 {
 			base = base.Where("1 = 0")
@@ -236,7 +217,10 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 
 	if q.FilterByAsset {
 		if len(q.AssetPolicyID) == 0 {
-			return nil, errors.New("asset filter requires non-empty policy id")
+			return nil, fmt.Errorf(
+				"GetUtxosByAddressWithOrdering: asset filter requires non-empty policy id: %w",
+				models.ErrEmptyAssetPolicyID,
+			)
 		}
 		assetSub := db.Table("asset").Select("utxo_id").Where(
 			"policy_id = ?",

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -236,35 +236,16 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 	return ret, nil
 }
 
-func appendUtxoAddressOrBranch(ors *[]string, args *[]any, addr ledger.Address) {
-	zeroHash := lcommon.NewBlake2b224(nil)
-	pk := addr.PaymentKeyHash()
-	sk := addr.StakeKeyHash()
-	hasPayment := pk != zeroHash
-	hasStake := sk != zeroHash
-	switch {
-	case hasPayment && hasStake:
-		*ors = append(
-			*ors,
-			"(utxo.payment_key = ? AND utxo.staking_key = ?)",
-		)
-		*args = append(*args, pk.Bytes(), sk.Bytes())
-	case hasPayment:
-		*ors = append(*ors, "(utxo.payment_key = ?)")
-		*args = append(*args, pk.Bytes())
-	case hasStake:
-		*ors = append(*ors, "(utxo.staking_key = ?)")
-		*args = append(*args, sk.Bytes())
-	}
-}
-
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,
 	txn types.Txn,
 ) ([]models.UtxoWithOrdering, error) {
 	if q == nil {
-		return nil, errors.New("nil UtxoWithOrderingQuery")
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrNilUtxoWithOrderingQuery,
+		)
 	}
 	var ret []models.UtxoWithOrdering
 	db, err := d.resolveReadDB(txn)
@@ -286,7 +267,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 		var ors []string
 		var args []any
 		for i := range addrs {
-			appendUtxoAddressOrBranch(&ors, &args, addrs[i])
+			models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i])
 		}
 		if len(ors) == 0 {
 			base = base.Where("1 = 0")
@@ -297,7 +278,10 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 
 	if q.FilterByAsset {
 		if len(q.AssetPolicyID) == 0 {
-			return nil, errors.New("asset filter requires non-empty policy id")
+			return nil, fmt.Errorf(
+				"GetUtxosByAddressWithOrdering: asset filter requires non-empty policy id: %w",
+				models.ErrEmptyAssetPolicyID,
+			)
 		}
 		assetSub := db.Table("asset").Select("utxo_id").Where(
 			"policy_id = ?",

--- a/utxorpc/submit_test.go
+++ b/utxorpc/submit_test.go
@@ -916,7 +916,7 @@ func TestMatchesTxPattern_HasCertificateEmptyStakeDelegationWrongCertType(t *tes
 	var ch common.CredentialHash
 	copy(ch[:], h)
 	regCert := &common.StakeRegistrationCertificate{
-		CertType:        uint(common.CertificateTypeStakeRegistration),
+		CertType: uint(common.CertificateTypeStakeRegistration),
 		StakeCredential: common.Credential{
 			CredType:   common.CredentialTypeAddrKeyHash,
 			Credential: ch,
@@ -940,7 +940,7 @@ func TestMatchesTxPattern_HasCertificateEmptyStakeRegistrationTypeOnly(t *testin
 	var ch common.CredentialHash
 	copy(ch[:], h)
 	regCert := &common.StakeRegistrationCertificate{
-		CertType:        uint(common.CertificateTypeStakeRegistration),
+		CertType: uint(common.CertificateTypeStakeRegistration),
 		StakeCredential: common.Credential{
 			CredType:   common.CredentialTypeAddrKeyHash,
 			Credential: ch,

--- a/utxorpc/watch_test.go
+++ b/utxorpc/watch_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
-	watch "github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch"
 	"github.com/stretchr/testify/require"
+	watch "github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch"
 )
 
 func TestWatchTxBuildRollbackMessages_EmitsUndoWhenPointNotFound(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized UTXO address filtering into `models.AppendUtxoAddressOrBranch` and tightened validation for ordered UTXO queries to ensure consistent behavior across SQLite, MySQL, and Postgres.

- **Bug Fixes**
  - Removed per-dialect helpers; all backends now use `models.AppendUtxoAddressOrBranch` with `?` placeholders.
  - Added sentinel errors `models.ErrNilUtxoWithOrderingQuery` and `models.ErrEmptyAssetPolicyID`; wrap with context in `GetUtxosByAddressWithOrdering`.

<sup>Written for commit 4316d191e2379d19df090ac7372866afa6b6ed0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate address-query construction across all database backends into a shared utility to improve consistency and maintainability.

* **Bug Fixes**
  * Standardized and strengthened validation/error handling by returning wrapped sentinel errors for nil queries and missing asset policy IDs, providing clearer, consistent context across implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->