### PR TITLE
fix(utxorpc): wrap submit errors

### DIFF
--- a/utxorpc/submit.go
+++ b/utxorpc/submit.go
@@ -682,11 +682,13 @@ func (u *Utxorpc) lookupSpentOutput(
 		in.Index(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"UtxoByRef(%x, %d): %w", in.Id().Bytes(), in.Index(), err,
+		)
 	}
 	out, err := rec.Decode()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode: %w", err)
 	}
 	if out == nil {
 		return nil, errors.New("decoded utxo is nil")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap submit-path errors in `utxorpc` with clearer context for easier debugging. In lookupSpentOutput, wrap UtxoByRef errors with the input id/index and wrap Decode errors using %w for proper chaining.

<sup>Written for commit 07eb501dabb63e14e4d21622e683ff3347344291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting with more detailed diagnostic information during transaction submission operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->