### PR TITLE
ci(antithesis): publish latest tags for antithesis use

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -61,7 +61,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
           flavor: |
-            latest=false
+            latest=auto
             suffix=-antithesis
           tags: |
             type=sha,format=long
@@ -92,7 +92,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/dingo-configurator
           flavor: |
-            latest=false
+            latest=auto
           tags: |
             type=sha,format=long
             type=ref,event=branch
@@ -121,7 +121,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/dingo-txpump
           flavor: |
-            latest=false
+            latest=auto
           tags: |
             type=sha,format=long
             type=ref,event=branch
@@ -150,7 +150,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/dingo-analysis
           flavor: |
-            latest=false
+            latest=auto
           tags: |
             type=sha,format=long
             type=ref,event=branch


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable automatic publishing of `latest` tags in the Antithesis CI workflow by switching Docker metadata flavor from `latest=false` to `latest=auto`. Antithesis can now pull `latest` for the main image and for `dingo-configurator`, `dingo-txpump`, and `dingo-analysis`.

<sup>Written for commit 09e6b2eef40c1cdfc1a50d232deac9125ad40c82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

