### PR TITLE
fix(ledger): use parts vs encoding cbor and tighten at-tip guard

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -158,8 +158,12 @@ func ValidateTxAlonzo(
 	if !ok {
 		return ErrIncompatibleProtocolParams
 	}
+	normalizedTx, err := normalizeScriptDataHashCbor(tx)
+	if err != nil {
+		return fmt.Errorf("normalize script data hash CBOR: %w", err)
+	}
+	tx = normalizedTx
 	errs := []error{}
-	var err error
 	for _, validationFunc := range alonzo.UtxoValidationRules {
 		err = validationFunc(tx, slot, ls, pp)
 		if err != nil {

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -194,8 +194,12 @@ func ValidateTxBabbage(
 	if !ok {
 		return ErrIncompatibleProtocolParams
 	}
+	normalizedTx, err := normalizeScriptDataHashCbor(tx)
+	if err != nil {
+		return fmt.Errorf("normalize script data hash CBOR: %w", err)
+	}
+	tx = normalizedTx
 	errs := []error{}
-	var err error
 	for _, validationFunc := range babbage.UtxoValidationRules {
 		err = validationFunc(tx, slot, ls, pp)
 		if err != nil {

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -170,11 +170,15 @@ func ValidateTxConway(
 	if _, ok := pp.(*conway.ConwayProtocolParameters); !ok {
 		return ErrIncompatibleProtocolParams
 	}
+	normalizedTx, err := normalizeScriptDataHashCbor(tx)
+	if err != nil {
+		return fmt.Errorf("normalize script data hash CBOR: %w", err)
+	}
+	tx = normalizedTx
 	// Validate TX through ledger validation rules (Phase-1).
 	// These must run even for isValid=false transactions, which still
 	// require valid structure, fees, and UTxO references for collateral.
 	errs := []error{}
-	var err error
 	for idx, validationFunc := range conway.UtxoValidationRules {
 		err = validationFunc(tx, slot, ls, pp)
 		if err != nil {

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -20,7 +20,10 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
 
 // ErrExUnitsOverflow is returned when ExUnits
@@ -136,6 +139,66 @@ func ValidateTxExUnits(
 		)
 	}
 	return nil
+}
+
+func normalizeScriptDataHashCbor(
+	tx lcommon.Transaction,
+) (lcommon.Transaction, error) {
+	if tx.ScriptDataHash() == nil {
+		return tx, nil
+	}
+	switch tmpTx := tx.(type) {
+	case *alonzo.AlonzoTransaction:
+		if !alonzoScriptDataHashCborMissing(tmpTx) {
+			return tx, nil
+		}
+		txCbor := tmpTx.Cbor()
+		if len(txCbor) == 0 {
+			return tx, nil
+		}
+		return alonzo.NewAlonzoTransactionFromCbor(txCbor)
+	case *babbage.BabbageTransaction:
+		if !babbageScriptDataHashCborMissing(tmpTx) {
+			return tx, nil
+		}
+		txCbor := tmpTx.Cbor()
+		if len(txCbor) == 0 {
+			return tx, nil
+		}
+		return babbage.NewBabbageTransactionFromCbor(txCbor)
+	case *conway.ConwayTransaction:
+		if !conwayScriptDataHashCborMissing(tmpTx) {
+			return tx, nil
+		}
+		txCbor := tmpTx.Cbor()
+		if len(txCbor) == 0 {
+			return tx, nil
+		}
+		return conway.NewConwayTransactionFromCbor(txCbor)
+	default:
+		return tx, nil
+	}
+}
+
+func alonzoScriptDataHashCborMissing(tx *alonzo.AlonzoTransaction) bool {
+	return (len(tx.WitnessSet.WsRedeemers.Redeemers) > 0 &&
+		len(tx.WitnessSet.WsRedeemers.Cbor()) == 0) ||
+		(len(tx.WitnessSet.WsPlutusData.Items) > 0 &&
+			len(tx.WitnessSet.WsPlutusData.Cbor()) == 0)
+}
+
+func babbageScriptDataHashCborMissing(tx *babbage.BabbageTransaction) bool {
+	return (len(tx.WitnessSet.WsRedeemers.Redeemers) > 0 &&
+		len(tx.WitnessSet.WsRedeemers.Cbor()) == 0) ||
+		(len(tx.WitnessSet.WsPlutusData.Items) > 0 &&
+			len(tx.WitnessSet.WsPlutusData.Cbor()) == 0)
+}
+
+func conwayScriptDataHashCborMissing(tx *conway.ConwayTransaction) bool {
+	return (tx.WitnessSet.WsRedeemers.Len() > 0 &&
+		len(tx.WitnessSet.WsRedeemers.Cbor()) == 0) ||
+		(len(tx.WitnessSet.WsPlutusData.Items()) > 0 &&
+			len(tx.WitnessSet.WsPlutusData.Cbor()) == 0)
 }
 
 // CalculateMinFee computes the minimum fee for a

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -32,6 +32,10 @@ var errRestartLedgerPipeline = errors.New(
 	"restart ledger pipeline after local state recovery",
 )
 
+var errHaltLedgerPipeline = errors.New(
+	"halt ledger pipeline after persistent tx validation failure",
+)
+
 type txValidationError struct {
 	BlockPoint ocommon.Point
 	TxHash     []byte
@@ -50,6 +54,31 @@ func (e *txValidationError) Error() string {
 
 func (e *txValidationError) Unwrap() error {
 	return e.Cause
+}
+
+type atTipRecoveryAttempt struct {
+	BlockPoint ocommon.Point
+	TxHash     []byte
+}
+
+func newAtTipRecoveryAttempt(
+	validationErr *txValidationError,
+) *atTipRecoveryAttempt {
+	blockPoint := validationErr.BlockPoint
+	blockPoint.Hash = append([]byte(nil), blockPoint.Hash...)
+	return &atTipRecoveryAttempt{
+		BlockPoint: blockPoint,
+		TxHash:     append([]byte(nil), validationErr.TxHash...),
+	}
+}
+
+func (a *atTipRecoveryAttempt) matches(
+	validationErr *txValidationError,
+) bool {
+	return a != nil &&
+		validationErr.BlockPoint.Slot == a.BlockPoint.Slot &&
+		bytes.Equal(validationErr.BlockPoint.Hash, a.BlockPoint.Hash) &&
+		bytes.Equal(validationErr.TxHash, a.TxHash)
 }
 
 type replayRecoveryCandidate struct {
@@ -150,22 +179,28 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 	if ls.chain == nil || ls.config.ChainManager == nil {
 		return false, nil
 	}
-	// Prevent infinite loops: if we already attempted recovery for this
-	// slot (or an earlier one), the problem is persistent and recovery
-	// will not help. Return false so the error propagates instead of
+	// Prevent infinite loops: if we already attempted recovery for this exact
+	// block/tx failure, the problem is persistent and recovery will not help.
+	// Return a sentinel error so the block processor halts instead of
 	// restarting the pipeline into the same failing block.
-	if validationErr.BlockPoint.Slot > 0 &&
-		validationErr.BlockPoint.Slot <= ls.lastAtTipRecoverySlot {
+	if ls.lastAtTipRecovery != nil &&
+		ls.lastAtTipRecovery.matches(validationErr) {
 		ls.config.Logger.Error(
-			"at-tip recovery already attempted for this slot, halting to avoid infinite loop",
+			"at-tip recovery already attempted for this validation failure, halting to avoid infinite loop",
 			"component", "ledger",
 			"failing_slot", validationErr.BlockPoint.Slot,
-			"last_recovery_slot", ls.lastAtTipRecoverySlot,
+			"failing_block_hash", hex.EncodeToString(
+				validationErr.BlockPoint.Hash,
+			),
 			"tx_hash", hex.EncodeToString(validationErr.TxHash),
 		)
-		return false, nil
+		return false, fmt.Errorf(
+			"%w: %w",
+			errHaltLedgerPipeline,
+			validationErr,
+		)
 	}
-	ls.lastAtTipRecoverySlot = validationErr.BlockPoint.Slot
+	ls.lastAtTipRecovery = newAtTipRecoveryAttempt(validationErr)
 	ls.RLock()
 	ledgerTip := ls.currentTip
 	ls.RUnlock()

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -289,22 +289,23 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 		}).Error,
 	)
 
-	recovered, err := ls.tryRecoverFromTxValidationError(
-		&txValidationError{
-			BlockPoint: ocommon.NewPoint(
-				failingBlock.Slot,
-				failingBlock.Hash,
-			),
-			TxHash: testHashBytes("failing-live-tx"),
-			Inputs: []lcommon.TransactionInput{
-				&replayRecoveryInput{
-					txId:  testHashBytes("producer-tx-live"),
-					index: 0,
-				},
+	validationErr := &txValidationError{
+		BlockPoint: ocommon.NewPoint(
+			failingBlock.Slot,
+			failingBlock.Hash,
+		),
+		TxHash: testHashBytes("failing-live-tx"),
+		Inputs: []lcommon.TransactionInput{
+			&replayRecoveryInput{
+				txId:  testHashBytes("producer-tx-live"),
+				index: 0,
 			},
-			Cause: errors.New("missing input"),
 		},
-	)
+		Cause: errors.New(
+			"conway utxo validation rule 38: delegation state mismatch",
+		),
+	}
+	recovered, err := ls.tryRecoverFromTxValidationError(validationErr)
 	require.NoError(t, err)
 	require.True(t, recovered)
 
@@ -319,6 +320,13 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 		ocommon.NewPoint(failingBlock.Slot, failingBlock.Hash),
 	)
 	assert.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	recovered, err = ls.tryRecoverFromTxValidationError(validationErr)
+	require.ErrorIs(t, err, errHaltLedgerPipeline)
+	require.False(t, recovered)
+	var txErr *txValidationError
+	require.ErrorAs(t, err, &txErr)
+	assert.Equal(t, validationErr, txErr)
 }
 
 func TestTryRecoverFromTxValidationErrorFallsBackToTxBlobOffsets(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -507,8 +507,8 @@ type LedgerState struct {
 	closed                        atomic.Bool
 	inRecovery                    bool           // guards against recursive recovery in SubmitAsyncDBTxn
 	densityWindow                 []densityEntry // sliding window for chain density metric
-	lastAtTipRecoverySlot         uint64         // guards against infinite at-tip recovery loops
-	mithrilLedgerSlot             uint64         // blocks at or below this slot are Mithril-verified; skip validation
+	lastAtTipRecovery             *atTipRecoveryAttempt
+	mithrilLedgerSlot             uint64 // blocks at or below this slot are Mithril-verified; skip validation
 	lastLocalRollbackSeq          uint64
 	lastLocalRollbackPoint        ocommon.Point
 
@@ -2170,6 +2170,13 @@ func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 		}
 		if errors.Is(err, errRestartLedgerPipeline) {
 			continue
+		}
+		if errors.Is(err, errHaltLedgerPipeline) {
+			ls.config.Logger.Error(
+				"block processing halted after persistent validation failure",
+				"error", err,
+			)
+			return
 		}
 		ls.config.Logger.Warn(
 			"block processing failed, restarting pipeline",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize transaction validation by rebuilding the tx from its CBOR when witness-set CBOR blobs are missing, preventing ScriptDataHash mismatches; also tighten the at-tip recovery guard to avoid infinite retries and halt on persistent failures.

- **Bug Fixes**
  - Validation: Added `normalizeScriptDataHashCbor` and call it in `ValidateTx` for `alonzo`, `babbage`, and `conway` to reparse the tx when redeemers or Plutus data exist but their CBOR is empty, ensuring consistent ScriptDataHash.
  - Recovery: Replaced slot-based guard with exact block+tx matching; introduced `errHaltLedgerPipeline` to stop restarting on the same failure; updated tests to assert halting behavior.

<sup>Written for commit 831e8c5b754ec318fcf7e09098f34998124a6ed2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

