### PR TITLE
feat: added batchAccumulator type for bulk metadata writes during backfill

### DIFF
--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// utxoSpend captures the information needed to mark a UTxO as spent.
+type utxoSpend struct {
+	TxId          []byte
+	OutputIdx     uint32
+	Slot          uint64
+	SpentByTxHash []byte
+}
+
+// BatchAccumulator collects metadata rows across multiple transactions
+// for bulk database insertion. It is the foundational data structure for
+// the backfill batching optimization that reduces per-block SQL statements
+// from 30-150 down to 2-5 by batching writes across 50-100 blocks.
+type BatchAccumulator struct {
+	KeyWitnesses   []models.KeyWitness
+	WitnessScripts []models.WitnessScripts
+	Scripts        []models.Script
+	PlutusData     []models.PlutusData
+	Redeemers      []models.Redeemer
+	AddressTxs     []models.AddressTransaction
+	UtxoOutputs    []models.Utxo
+	UtxoSpends     []utxoSpend
+	CollateralRets []models.Utxo
+	DeleteTxIDs    []uint
+}
+
+// NewBatchAccumulator returns an empty BatchAccumulator ready for use.
+func NewBatchAccumulator() *BatchAccumulator {
+	return &BatchAccumulator{}
+}
+
+// AddKeyWitness appends a key witness record to the batch.
+func (b *BatchAccumulator) AddKeyWitness(kw models.KeyWitness) {
+	b.KeyWitnesses = append(b.KeyWitnesses, kw)
+}
+
+// AddWitnessScript appends a witness script record to the batch.
+func (b *BatchAccumulator) AddWitnessScript(ws models.WitnessScripts) {
+	b.WitnessScripts = append(b.WitnessScripts, ws)
+}
+
+// AddScript appends a script record to the batch.
+func (b *BatchAccumulator) AddScript(s models.Script) {
+	b.Scripts = append(b.Scripts, s)
+}
+
+// AddPlutusData appends a plutus data record to the batch.
+func (b *BatchAccumulator) AddPlutusData(pd models.PlutusData) {
+	b.PlutusData = append(b.PlutusData, pd)
+}
+
+// AddRedeemer appends a redeemer record to the batch.
+func (b *BatchAccumulator) AddRedeemer(r models.Redeemer) {
+	b.Redeemers = append(b.Redeemers, r)
+}
+
+// AddAddressTx appends an address-transaction record to the batch.
+func (b *BatchAccumulator) AddAddressTx(at models.AddressTransaction) {
+	b.AddressTxs = append(b.AddressTxs, at)
+}
+
+// AddUtxoOutput appends a produced UTxO record to the batch.
+func (b *BatchAccumulator) AddUtxoOutput(u models.Utxo) {
+	b.UtxoOutputs = append(b.UtxoOutputs, u)
+}
+
+// AddUtxoSpend appends a consumed UTxO record to the batch.
+func (b *BatchAccumulator) AddUtxoSpend(s utxoSpend) {
+	b.UtxoSpends = append(b.UtxoSpends, s)
+}
+
+// AddCollateralReturn appends a collateral return UTxO to the batch.
+func (b *BatchAccumulator) AddCollateralReturn(u models.Utxo) {
+	b.CollateralRets = append(b.CollateralRets, u)
+}
+
+// AddDeleteTxID appends a transaction ID scheduled for idempotent
+// retry deletion.
+func (b *BatchAccumulator) AddDeleteTxID(id uint) {
+	b.DeleteTxIDs = append(b.DeleteTxIDs, id)
+}
+
+// Reset clears all accumulated slices, reusing backing arrays to
+// reduce GC pressure across flush cycles.
+func (b *BatchAccumulator) Reset() {
+	b.KeyWitnesses = b.KeyWitnesses[:0]
+	b.WitnessScripts = b.WitnessScripts[:0]
+	b.Scripts = b.Scripts[:0]
+	b.PlutusData = b.PlutusData[:0]
+	b.Redeemers = b.Redeemers[:0]
+	b.AddressTxs = b.AddressTxs[:0]
+	b.UtxoOutputs = b.UtxoOutputs[:0]
+	b.UtxoSpends = b.UtxoSpends[:0]
+	b.CollateralRets = b.CollateralRets[:0]
+	b.DeleteTxIDs = b.DeleteTxIDs[:0]
+}

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchAccumulator_AddAndReset(t *testing.T) {
+	ba := NewBatchAccumulator()
+	require.NotNil(t, ba)
+
+	// --- Add one record of each type ---
+
+	ba.AddKeyWitness(models.KeyWitness{
+		Vkey:          []byte{0x01},
+		Signature:     []byte{0x02},
+		TransactionID: 1,
+		Type:          0,
+	})
+	ba.AddWitnessScript(models.WitnessScripts{
+		ScriptHash:    []byte{0x03},
+		TransactionID: 1,
+		Type:          1,
+	})
+	ba.AddScript(models.Script{
+		Hash:        []byte{0x04},
+		Content:     []byte{0x05},
+		CreatedSlot: 100,
+		Type:        2,
+	})
+	ba.AddPlutusData(models.PlutusData{
+		Data:          []byte{0x06},
+		TransactionID: 2,
+	})
+	ba.AddRedeemer(models.Redeemer{
+		Data:          []byte{0x07},
+		TransactionID: 2,
+		Index:         0,
+		Tag:           1,
+	})
+	ba.AddAddressTx(models.AddressTransaction{
+		PaymentKey:    []byte{0x08},
+		TransactionID: 3,
+		Slot:          200,
+	})
+	ba.AddUtxoOutput(models.Utxo{
+		TxId:      []byte{0x09},
+		OutputIdx: 0,
+		AddedSlot: 200,
+	})
+	ba.AddUtxoSpend(utxoSpend{
+		TxId:          []byte{0x0a},
+		OutputIdx:     1,
+		Slot:          200,
+		SpentByTxHash: []byte{0x0b},
+	})
+	ba.AddCollateralReturn(models.Utxo{
+		TxId:      []byte{0x0c},
+		OutputIdx: 0,
+		AddedSlot: 200,
+	})
+	ba.AddDeleteTxID(42)
+
+	// --- Verify counts ---
+
+	assert.Len(t, ba.KeyWitnesses, 1)
+	assert.Len(t, ba.WitnessScripts, 1)
+	assert.Len(t, ba.Scripts, 1)
+	assert.Len(t, ba.PlutusData, 1)
+	assert.Len(t, ba.Redeemers, 1)
+	assert.Len(t, ba.AddressTxs, 1)
+	assert.Len(t, ba.UtxoOutputs, 1)
+	assert.Len(t, ba.UtxoSpends, 1)
+	assert.Len(t, ba.CollateralRets, 1)
+	assert.Len(t, ba.DeleteTxIDs, 1)
+
+	// --- Spot-check values ---
+
+	assert.Equal(t, []byte{0x01}, ba.KeyWitnesses[0].Vkey)
+	assert.Equal(t, uint32(1), ba.UtxoSpends[0].OutputIdx)
+	assert.Equal(t, uint(42), ba.DeleteTxIDs[0])
+
+	// --- Reset and verify all slices are empty ---
+
+	ba.Reset()
+
+	assert.Empty(t, ba.KeyWitnesses)
+	assert.Empty(t, ba.WitnessScripts)
+	assert.Empty(t, ba.Scripts)
+	assert.Empty(t, ba.PlutusData)
+	assert.Empty(t, ba.Redeemers)
+	assert.Empty(t, ba.AddressTxs)
+	assert.Empty(t, ba.UtxoOutputs)
+	assert.Empty(t, ba.UtxoSpends)
+	assert.Empty(t, ba.CollateralRets)
+	assert.Empty(t, ba.DeleteTxIDs)
+
+	// --- Verify backing arrays are reused (cap > 0) ---
+
+	assert.Greater(t, cap(ba.KeyWitnesses), 0)
+	assert.Greater(t, cap(ba.WitnessScripts), 0)
+	assert.Greater(t, cap(ba.Scripts), 0)
+	assert.Greater(t, cap(ba.PlutusData), 0)
+	assert.Greater(t, cap(ba.Redeemers), 0)
+	assert.Greater(t, cap(ba.AddressTxs), 0)
+	assert.Greater(t, cap(ba.UtxoOutputs), 0)
+	assert.Greater(t, cap(ba.UtxoSpends), 0)
+	assert.Greater(t, cap(ba.CollateralRets), 0)
+	assert.Greater(t, cap(ba.DeleteTxIDs), 0)
+
+	// --- Verify re-add after reset works ---
+
+	ba.AddKeyWitness(models.KeyWitness{
+		Vkey:          []byte{0xff},
+		TransactionID: 99,
+	})
+	assert.Len(t, ba.KeyWitnesses, 1)
+	assert.Equal(t, []byte{0xff}, ba.KeyWitnesses[0].Vkey)
+}


### PR DESCRIPTION
closes #1797 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `BatchAccumulator` to `database/plugin/metadata/sqlite` to batch metadata writes during backfill. This cuts per-block SQL statements from 30–150 to ~2–5 by aggregating across many blocks.

- **New Features**
  - Introduced `BatchAccumulator` with append helpers for key witnesses, witness scripts, scripts, Plutus data, redeemers, address-tx links, UTxO outputs, UTxO spends (via `utxoSpend`), collateral returns, and delete IDs.
  - Added `Reset()` to clear slices while reusing backing arrays to reduce GC pressure across flush cycles.
  - Added `batch_accumulator_test.go` to validate add/reset behavior, counts, and capacity reuse.

<sup>Written for commit f8c2e5f4bbf2e730eabc43032179ac8d4a17432e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database operations with improved batch processing for SQLite metadata, optimizing the collection and bulk insertion of transaction-related records.

* **Tests**
  * Added comprehensive test coverage for batch accumulation and reset functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->