### PR TITLE
fix: connection ID collision avoidance

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -94,6 +94,12 @@ type TrackedClient struct {
 	// tip/activity metrics but must not consume the eligible
 	// client pool or become active for ledger ingress.
 	ObservabilityOnly bool
+	// StartedAsOutbound records whether the connection was
+	// initiated by us (outbound). This is stamped at
+	// registration time and can be refreshed only when the
+	// same ConnectionId is explicitly re-registered after a
+	// connmanager collision replacement.
+	StartedAsOutbound bool
 	LastActivity      time.Time
 	HeadersRecv       uint64
 	// TODO: BytesRecv needs to be wired to the underlying
@@ -358,11 +364,13 @@ func (s *State) promoteBestClientLocked() {
 func (s *State) addTrackedClientLocked(
 	connId ouroboros.ConnectionId,
 	observabilityOnly bool,
+	startedAsOutbound bool,
 ) {
 	s.trackedClients[connId] = &TrackedClient{
 		ConnId:            connId,
 		Status:            ClientStatusSyncing,
 		ObservabilityOnly: observabilityOnly,
+		StartedAsOutbound: startedAsOutbound,
 		LastActivity:      time.Now(),
 	}
 	// Set as active if there's no active client
@@ -389,10 +397,15 @@ func (s *State) addTrackedClientLocked(
 // Returns true if the client was added, false if rejected
 // (already tracked or at capacity). If no active client exists,
 // this connection is automatically set as the active client.
+// The client is recorded as outbound (StartedAsOutbound=true).
 func (s *State) AddClientConnId(
 	connId ouroboros.ConnectionId,
 ) bool {
-	return s.TryAddClientConnId(connId, s.config.MaxClients)
+	return s.TryAddClientConnIdWithDirection(
+		connId,
+		s.config.MaxClients,
+		true,
+	)
 }
 
 // TryAddObservedClientConnId adds a connection to observability-only tracking.
@@ -401,12 +414,22 @@ func (s *State) AddClientConnId(
 func (s *State) TryAddObservedClientConnId(
 	connId ouroboros.ConnectionId,
 ) bool {
+	return s.TryAddObservedClientConnIdWithDirection(connId, false)
+}
+
+// TryAddObservedClientConnIdWithDirection adds a connection to
+// observability-only tracking and records whether it was started
+// as outbound.
+func (s *State) TryAddObservedClientConnIdWithDirection(
+	connId ouroboros.ConnectionId,
+	startedAsOutbound bool,
+) bool {
 	s.clientConnIdMutex.Lock()
 	defer s.clientConnIdMutex.Unlock()
 	if _, exists := s.trackedClients[connId]; exists {
 		return false
 	}
-	s.addTrackedClientLocked(connId, true)
+	s.addTrackedClientLocked(connId, true, startedAsOutbound)
 	return true
 }
 
@@ -463,7 +486,31 @@ func (s *State) TryAddClientConnId(
 	if s.eligibleClientCountLocked() >= maxClients {
 		return false
 	}
-	s.addTrackedClientLocked(connId, false)
+	s.addTrackedClientLocked(connId, false, false)
+	return true
+}
+
+// TryAddClientConnIdWithDirection is like TryAddClientConnId but
+// additionally records whether the connection was started as
+// outbound. This is used to stamp each tracked client with its
+// connection direction at registration time, providing a reliable
+// flag that survives ConnectionId collisions.
+func (s *State) TryAddClientConnIdWithDirection(
+	connId ouroboros.ConnectionId,
+	maxClients int,
+	startedAsOutbound bool,
+) bool {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+	// Check if already tracked
+	if _, exists := s.trackedClients[connId]; exists {
+		return false
+	}
+	// Check client limit
+	if s.eligibleClientCountLocked() >= maxClients {
+		return false
+	}
+	s.addTrackedClientLocked(connId, false, startedAsOutbound)
 	return true
 }
 
@@ -479,6 +526,39 @@ func (s *State) ClientObservabilityOnly(
 		return false, false
 	}
 	return tc.ObservabilityOnly, true
+}
+
+// ClientStartedAsOutbound reports whether a tracked client was
+// registered as an outbound connection. The second return value
+// reports whether the client exists.
+func (s *State) ClientStartedAsOutbound(
+	connId ouroboros.ConnectionId,
+) (bool, bool) {
+	s.clientConnIdMutex.RLock()
+	defer s.clientConnIdMutex.RUnlock()
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		return false, false
+	}
+	return tc.StartedAsOutbound, true
+}
+
+// SetClientStartedAsOutbound updates the recorded connection
+// direction for an existing tracked client. This is used when a
+// ConnectionId collision causes a new physical connection to replace
+// an older tracked connection under the same ID.
+func (s *State) SetClientStartedAsOutbound(
+	connId ouroboros.ConnectionId,
+	startedAsOutbound bool,
+) bool {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		return false
+	}
+	tc.StartedAsOutbound = startedAsOutbound
+	return true
 }
 
 // SetClientObservabilityOnly toggles whether a tracked client participates in

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1231,3 +1231,102 @@ func TestRewindTrackedClientsToRewindsAheadClients(t *testing.T) {
 	require.NotNil(t, behindClient)
 	require.Equal(t, behindPoint, behindClient.Cursor)
 }
+
+// --- StartedAsOutbound direction flag tests ---
+
+func TestTryAddClientConnIdWithDirection_RecordsOutboundFlag(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	connOutbound := newTestConnId(1)
+	connInbound := newTestConnId(2)
+
+	// Add an outbound client
+	require.True(t, s.TryAddClientConnIdWithDirection(connOutbound, 10, true))
+	// Add an inbound (non-outbound) client
+	require.True(t, s.TryAddClientConnIdWithDirection(connInbound, 10, false))
+
+	// Verify outbound flag is recorded
+	outbound, exists := s.ClientStartedAsOutbound(connOutbound)
+	require.True(t, exists)
+	require.True(t, outbound, "outbound client should have StartedAsOutbound=true")
+
+	inbound, exists := s.ClientStartedAsOutbound(connInbound)
+	require.True(t, exists)
+	require.False(t, inbound, "inbound client should have StartedAsOutbound=false")
+
+	// Verify non-existent client returns false, false
+	_, exists = s.ClientStartedAsOutbound(newTestConnId(99))
+	require.False(t, exists)
+}
+
+func TestTryAddClientConnId_DefaultsOutboundFalse(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	require.True(t, s.TryAddClientConnId(conn, 10))
+
+	outbound, exists := s.ClientStartedAsOutbound(conn)
+	require.True(t, exists)
+	require.False(t, outbound, "TryAddClientConnId should default to StartedAsOutbound=false")
+}
+
+func TestTryAddObservedClientConnId_DefaultsOutboundFalse(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	require.True(t, s.TryAddObservedClientConnId(conn))
+
+	outbound, exists := s.ClientStartedAsOutbound(conn)
+	require.True(t, exists)
+	require.False(t, outbound, "TryAddObservedClientConnId should default to StartedAsOutbound=false")
+}
+
+func TestTryAddObservedClientConnIdWithDirection_RecordsOutboundFlag(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	require.True(t, s.TryAddObservedClientConnIdWithDirection(conn, true))
+
+	outbound, exists := s.ClientStartedAsOutbound(conn)
+	require.True(t, exists)
+	require.True(t, outbound)
+
+	require.True(t, s.SetClientStartedAsOutbound(conn, false))
+	outbound, exists = s.ClientStartedAsOutbound(conn)
+	require.True(t, exists)
+	require.False(t, outbound)
+}
+
+func TestTryAddClientConnIdWithDirection_DuplicateRejected(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(1)
+	require.True(t, s.TryAddClientConnIdWithDirection(conn, 10, true))
+	require.False(t, s.TryAddClientConnIdWithDirection(conn, 10, true))
+	require.Equal(t, 1, s.ClientConnCount())
+}
+
+func TestTryAddClientConnIdWithDirection_LimitEnforced(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.Config{
+		MaxClients:   1,
+		StallTimeout: 30 * time.Second,
+	})
+
+	connA := newTestConnId(1)
+	connB := newTestConnId(2)
+	require.True(t, s.TryAddClientConnIdWithDirection(connA, 1, true))
+	require.False(t, s.TryAddClientConnIdWithDirection(connB, 1, true))
+	require.Equal(t, 1, s.ClientConnCount())
+}

--- a/connmanager/connection_collision_test.go
+++ b/connmanager/connection_collision_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/stretchr/testify/require"
+)
+
+func newUnstartedConnection(t *testing.T) *ouroboros.Connection {
+	t.Helper()
+	conn, err := ouroboros.NewConnection()
+	require.NoError(t, err)
+	return conn
+}
+
+func waitForConnectionManagerWatchers(
+	t *testing.T,
+	cm *ConnectionManager,
+) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		cm.goroutineWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection manager watchers")
+	}
+}
+
+func TestAddConnectionRejectsInboundCollisionWithOutbound(t *testing.T) {
+	cm := NewConnectionManager(ConnectionManagerConfig{})
+	outbound := newUnstartedConnection(t)
+	inbound := newUnstartedConnection(t)
+
+	require.True(t, cm.AddConnection(outbound, false, "1.2.3.4:3001"))
+	require.False(t, cm.AddConnection(inbound, true, "1.2.3.4:3001"))
+	require.Same(t, outbound, cm.GetConnectionById(outbound.Id()))
+	require.False(t, cm.IsInboundConnection(outbound.Id()))
+
+	outbound.ErrorChan() <- nil
+	waitForConnectionManagerWatchers(t, cm)
+}
+
+func TestReplacedConnectionCloseDoesNotPublishStaleEvent(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+	_, closeEvents := bus.Subscribe(ConnectionClosedEventType)
+
+	cm := NewConnectionManager(ConnectionManagerConfig{EventBus: bus})
+	inbound := newUnstartedConnection(t)
+	outbound := newUnstartedConnection(t)
+	staleErr := errors.New("stale connection closed")
+	liveErr := errors.New("live connection closed")
+
+	require.True(t, cm.AddConnection(inbound, true, "1.2.3.4:3001"))
+	require.True(t, cm.AddConnection(outbound, false, "1.2.3.4:3001"))
+	require.Same(t, outbound, cm.GetConnectionById(outbound.Id()))
+
+	inbound.ErrorChan() <- staleErr
+	select {
+	case evt := <-closeEvents:
+		data, ok := evt.Data.(ConnectionClosedEvent)
+		require.True(t, ok)
+		t.Fatalf("received stale close event: %v", data.Error)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	outbound.ErrorChan() <- liveErr
+	select {
+	case evt := <-closeEvents:
+		data, ok := evt.Data.(ConnectionClosedEvent)
+		require.True(t, ok)
+		require.ErrorIs(t, data.Error, liveErr)
+	case <-time.After(time.Second):
+		t.Fatal("expected close event for live connection")
+	}
+
+	select {
+	case evt := <-closeEvents:
+		data, ok := evt.Data.(ConnectionClosedEvent)
+		require.True(t, ok)
+		t.Fatalf("received unexpected extra close event: %v", data.Error)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	waitForConnectionManagerWatchers(t, cm)
+}

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -335,8 +335,12 @@ func (c *ConnectionManager) updatePeerConnectivityLocked(
 	} else {
 		after = after.withoutOutbound()
 	}
-	beforeDuplex, beforeUnidirectional, beforePrunable := connectionSummaryTotals(before)
-	afterDuplex, afterUnidirectional, afterPrunable := connectionSummaryTotals(after)
+	beforeDuplex, beforeUnidirectional, beforePrunable := connectionSummaryTotals(
+		before,
+	)
+	afterDuplex, afterUnidirectional, afterPrunable := connectionSummaryTotals(
+		after,
+	)
 	c.duplexPeers += afterDuplex - beforeDuplex
 	c.unidirectional += afterUnidirectional - beforeUnidirectional
 	c.prunableConns += afterPrunable - beforePrunable
@@ -509,8 +513,8 @@ func (c *ConnectionManager) AddConnection(
 	conn *ouroboros.Connection,
 	isInbound bool,
 	peerAddr string,
-) {
-	c.addConnectionImpl(conn, isInbound, false, peerAddr, "")
+) bool {
+	return c.addConnectionImpl(conn, isInbound, false, peerAddr, "")
 }
 
 func (c *ConnectionManager) addConnectionWithIPKey(
@@ -518,8 +522,8 @@ func (c *ConnectionManager) addConnectionWithIPKey(
 	isInbound bool,
 	peerAddr string,
 	ipKey string,
-) {
-	c.addConnectionImpl(conn, isInbound, false, peerAddr, ipKey)
+) bool {
+	return c.addConnectionImpl(conn, isInbound, false, peerAddr, ipKey)
 }
 
 func (c *ConnectionManager) addNtCConnectionWithIPKey(
@@ -527,8 +531,8 @@ func (c *ConnectionManager) addNtCConnectionWithIPKey(
 	isInbound bool,
 	peerAddr string,
 	ipKey string,
-) {
-	c.addConnectionImpl(conn, isInbound, true, peerAddr, ipKey)
+) bool {
+	return c.addConnectionImpl(conn, isInbound, true, peerAddr, ipKey)
 }
 
 func (c *ConnectionManager) addConnectionImpl(
@@ -537,7 +541,7 @@ func (c *ConnectionManager) addConnectionImpl(
 	isNtC bool,
 	peerAddr string,
 	ipKey string,
-) {
+) bool {
 	// Check if shutting down before adding to WaitGroup to prevent panic
 	// during Stop()'s Wait() call. Must hold the same lock used to set closing.
 	c.listenersMutex.Lock()
@@ -548,13 +552,101 @@ func (c *ConnectionManager) addConnectionImpl(
 		if conn != nil {
 			conn.Close()
 		}
-		return
+		return false
 	}
 	c.goroutineWg.Add(1)
 	c.listenersMutex.Unlock()
 
 	connId := conn.Id()
 	c.connectionsMutex.Lock()
+
+	// Detect ConnectionId collision. When both sides use listen-port
+	// reuse (OutboundSourcePort), the inbound and outbound connections
+	// produce identical ConnectionIds. Without dedup the inbound
+	// silently overwrites the outbound, corrupting IsInboundConnection
+	// and causing chainsync client callbacks to be dropped.
+	if existing, ok := c.connections[connId]; ok && existing.conn != nil {
+		switch {
+		case !existing.isInbound && isInbound:
+			// Existing outbound + new inbound: keep outbound.
+			// Outbound connections carry the chainsync client (chain
+			// truth source). Matches cardano-node dedup behavior.
+			c.connectionsMutex.Unlock()
+			c.config.Logger.Warn(
+				"closing inbound connection that collides with existing outbound",
+				"peer_addr",
+				peerAddr,
+			)
+			conn.Close()
+			c.releaseIPSlot(ipKey)
+			c.goroutineWg.Done()
+			return false
+
+		case existing.isInbound && !isInbound:
+			// Existing inbound + new outbound: outbound wins.
+			// Clean up inbound peer address tracking for the evicted
+			// connection before replacing it.
+			c.config.Logger.Info(
+				"replacing inbound connection with outbound on ConnectionId collision",
+				"peer_addr",
+				peerAddr,
+			)
+			if existing.isInbound &&
+				!existing.isNtC &&
+				c.tracksInboundPeerAddresses() {
+				if peerKey := normalizePeerAddr(existing.peerAddr); peerKey != "" {
+					c.inboundPeerAddrs[peerKey]--
+					if c.inboundPeerAddrs[peerKey] <= 0 {
+						delete(c.inboundPeerAddrs, peerKey)
+					}
+				}
+			}
+			c.updateConnectionMetricsLocked(existing, false)
+			existingConn := existing.conn
+			existingIPKey := existing.ipKey
+			// Remove the old entry so the evicted connection's
+			// error-watcher goroutine cannot double-decrement
+			// metrics via RemoveConnection.
+			delete(c.connections, connId)
+			c.connectionsMutex.Unlock()
+			existingConn.Close()
+			if existingIPKey != "" {
+				c.releaseIPSlot(existingIPKey)
+			}
+			c.connectionsMutex.Lock()
+
+		default:
+			// Same direction — allow overwrite (reconnect/replacement).
+			// Clean up old connection to avoid leaking metrics, IP slots,
+			// and inbound peer counters.
+			c.config.Logger.Info(
+				"replacing same-direction connection on ConnectionId collision",
+				"peer_addr", peerAddr,
+				"direction_inbound", isInbound,
+			)
+			if existing.isInbound &&
+				!existing.isNtC &&
+				c.tracksInboundPeerAddresses() {
+				if peerKey := normalizePeerAddr(existing.peerAddr); peerKey != "" {
+					c.inboundPeerAddrs[peerKey]--
+					if c.inboundPeerAddrs[peerKey] <= 0 {
+						delete(c.inboundPeerAddrs, peerKey)
+					}
+				}
+			}
+			c.updateConnectionMetricsLocked(existing, false)
+			existingConn := existing.conn
+			existingIPKey := existing.ipKey
+			delete(c.connections, connId)
+			c.connectionsMutex.Unlock()
+			existingConn.Close()
+			if existingIPKey != "" {
+				c.releaseIPSlot(existingIPKey)
+			}
+			c.connectionsMutex.Lock()
+		}
+	}
+
 	c.connections[connId] = &connectionInfo{
 		conn:      conn,
 		isInbound: isInbound,
@@ -575,7 +667,9 @@ func (c *ConnectionManager) addConnectionImpl(
 		defer c.goroutineWg.Done()
 		err := <-conn.ErrorChan()
 		// Remove connection (also releases IP slot)
-		c.RemoveConnection(connId, conn)
+		if !c.RemoveConnection(connId, conn) {
+			return
+		}
 		// Generate event
 		if c.config.EventBus != nil {
 			c.config.EventBus.Publish(
@@ -594,12 +688,13 @@ func (c *ConnectionManager) addConnectionImpl(
 			c.config.ConnClosedFunc(connId, err)
 		}
 	}()
+	return true
 }
 
 func (c *ConnectionManager) RemoveConnection(
 	connId ouroboros.ConnectionId,
 	conn *ouroboros.Connection,
-) {
+) bool {
 	c.connectionsMutex.Lock()
 	info := c.connections[connId]
 	// Only remove if the map still holds this exact connection.
@@ -607,7 +702,7 @@ func (c *ConnectionManager) RemoveConnection(
 	// same ID (OutboundSourcePort reuse).
 	if info == nil || info.conn != conn {
 		c.connectionsMutex.Unlock()
-		return
+		return false
 	}
 	delete(c.connections, connId)
 	if info != nil &&
@@ -628,6 +723,7 @@ func (c *ConnectionManager) RemoveConnection(
 		c.releaseIPSlot(info.ipKey)
 	}
 	c.updateConnectionMetrics()
+	return true
 }
 
 // HasInboundPeerAddress returns true if there is already an inbound connection
@@ -685,7 +781,9 @@ func (c *ConnectionManager) GetConnectionById(
 // IsInboundConnection returns true if the given connection ID is an inbound
 // connection (a remote peer connected to us). Inbound peers are clients
 // pulling data from us and should not be treated as chain truth sources.
-func (c *ConnectionManager) IsInboundConnection(connId ouroboros.ConnectionId) bool {
+func (c *ConnectionManager) IsInboundConnection(
+	connId ouroboros.ConnectionId,
+) bool {
 	c.connectionsMutex.Lock()
 	defer c.connectionsMutex.Unlock()
 	if info, exists := c.connections[connId]; exists {

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -240,9 +240,11 @@ func (c *ConnectionManager) startListener(
 				if conn.RemoteAddr() != nil {
 					peerAddr = conn.RemoteAddr().String()
 				}
-				c.addNtCConnectionWithIPKey(
+				if !c.addNtCConnectionWithIPKey(
 					oConn, true, peerAddr, "",
-				)
+				) {
+					continue
+				}
 				// Generate event
 				if c.config.EventBus != nil {
 					c.config.EventBus.Publish(
@@ -337,9 +339,11 @@ func (c *ConnectionManager) startListener(
 			if conn.RemoteAddr() != nil {
 				peerAddr = conn.RemoteAddr().String()
 			}
-			c.addConnectionWithIPKey(
+			if !c.addConnectionWithIPKey(
 				oConn, true, peerAddr, ipKey,
-			)
+			) {
+				continue
+			}
 			// Generate event
 			if c.config.EventBus != nil {
 				c.config.EventBus.Publish(

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -105,6 +105,12 @@ func (c *ConnectionManager) CreateOutboundConn(
 		"resolved_address", peerAddr,
 		"connection_id", oConn.Id().String(),
 	)
-	c.AddConnection(oConn, false, peerAddr)
+	if !c.AddConnection(oConn, false, peerAddr) {
+		oConn.Close()
+		return nil, fmt.Errorf(
+			"connection rejected (shutdown or collision): %s",
+			address,
+		)
+	}
 	return oConn, nil
 }

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -481,8 +481,7 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	point ocommon.Point,
 	tip ochainsync.Tip,
 ) error {
-	if o.ConnManager != nil &&
-		o.ConnManager.IsInboundConnection(ctx.ConnectionId) {
+	if o.isInboundChainsyncClient(ctx.ConnectionId) {
 		return nil
 	}
 	if !o.reconcileChainsyncIngressAdmission(
@@ -525,8 +524,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// Inbound connections are clients pulling data from us.
 		// They are not sources of chain truth and should not
 		// influence chain selection or the blockfetch pipeline.
-		isInbound := o.ConnManager != nil &&
-			o.ConnManager.IsInboundConnection(ctx.ConnectionId)
+		isInbound := o.isInboundChainsyncClient(ctx.ConnectionId)
 		ingressEligible := false
 		if !isInbound {
 			ingressEligible = o.reconcileChainsyncIngressAdmission(
@@ -677,6 +675,26 @@ func (o *Ouroboros) shouldPublishChainsyncToLedger(
 	return o.config.ChainsyncIngressEligible(connId)
 }
 
+// isInboundChainsyncClient returns true if the chainsync client for
+// connId was started on an inbound connection. This uses the tracked
+// client's recorded direction instead of connmanager.IsInboundConnection,
+// making it immune to ConnectionId collisions under listen-port reuse.
+// Returns true (treat as inbound) if the client is not tracked.
+func (o *Ouroboros) isInboundChainsyncClient(
+	connId ouroboros.ConnectionId,
+) bool {
+	if o.ChainsyncState == nil {
+		return false
+	}
+	outbound, exists := o.ChainsyncState.ClientStartedAsOutbound(connId)
+	if !exists {
+		// Unknown client — treat as inbound (conservative: don't
+		// feed untracked connections into the ledger).
+		return true
+	}
+	return !outbound
+}
+
 func (o *Ouroboros) maxTrackedChainsyncClients() int {
 	maxClients := defaultMaxChainsyncClients
 	if o.ChainsyncState != nil && o.ChainsyncState.MaxClients() > 0 {
@@ -688,18 +706,24 @@ func (o *Ouroboros) maxTrackedChainsyncClients() int {
 func (o *Ouroboros) registerTrackedChainsyncClient(
 	connId ouroboros.ConnectionId,
 	ingressEligible bool,
+	startedAsOutbound bool,
 ) bool {
 	if o.ChainsyncState == nil {
 		return false
 	}
 	if ingressEligible {
-		if o.ChainsyncState.TryAddClientConnId(
+		if o.ChainsyncState.TryAddClientConnIdWithDirection(
 			connId,
 			o.maxTrackedChainsyncClients(),
+			startedAsOutbound,
 		) {
 			return true
 		}
 		if o.ChainsyncState.HasClientConnId(connId) {
+			o.ChainsyncState.SetClientStartedAsOutbound(
+				connId,
+				startedAsOutbound,
+			)
 			observabilityOnly, exists := o.ChainsyncState.ClientObservabilityOnly(
 				connId,
 			)
@@ -713,7 +737,10 @@ func (o *Ouroboros) registerTrackedChainsyncClient(
 		}
 		return false
 	}
-	if o.ChainsyncState.TryAddObservedClientConnId(connId) {
+	if o.ChainsyncState.TryAddObservedClientConnIdWithDirection(
+		connId,
+		startedAsOutbound,
+	) {
 		return true
 	}
 	return o.reconcileChainsyncIngressAdmission(connId, false)

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -429,18 +429,52 @@ func TestRegisterTrackedChainsyncClient_ObservabilityOnlyDoesNotConsumePool(
 	o := NewOuroboros(OuroborosConfig{EventBus: bus})
 	o.ChainsyncState = state
 
-	require.True(t, o.registerTrackedChainsyncClient(connObserved, false))
+	require.True(t, o.registerTrackedChainsyncClient(connObserved, false, true))
 	observabilityOnly, exists := state.ClientObservabilityOnly(connObserved)
 	require.True(t, exists)
 	require.True(t, observabilityOnly)
+	outbound, exists := state.ClientStartedAsOutbound(connObserved)
+	require.True(t, exists)
+	require.True(t, outbound)
+	require.False(t, o.isInboundChainsyncClient(connObserved))
 	require.Equal(t, 0, state.ClientConnCount())
 
-	require.True(t, o.registerTrackedChainsyncClient(connEligible, true))
+	require.True(t, o.registerTrackedChainsyncClient(connEligible, true, true))
 	require.Equal(t, 1, state.ClientConnCount())
 
 	active := state.GetClientConnId()
 	require.NotNil(t, active)
 	require.Equal(t, connEligible, *active)
+}
+
+func TestRegisterTrackedChainsyncClient_PromotedObservedKeepsDirection(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connId := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	state := dchainsync.NewStateWithConfig(bus, nil, dchainsync.Config{
+		MaxClients:   1,
+		StallTimeout: time.Minute,
+	})
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	o.ChainsyncState = state
+
+	require.True(t, o.registerTrackedChainsyncClient(connId, false, true))
+	observabilityOnly, exists := state.ClientObservabilityOnly(connId)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+	require.False(t, o.isInboundChainsyncClient(connId))
+
+	require.True(t, o.registerTrackedChainsyncClient(connId, true, true))
+	observabilityOnly, exists = state.ClientObservabilityOnly(connId)
+	require.True(t, exists)
+	require.False(t, observabilityOnly)
+	outbound, exists := state.ClientStartedAsOutbound(connId)
+	require.True(t, exists)
+	require.True(t, outbound)
+	require.False(t, o.isInboundChainsyncClient(connId))
 }
 
 func TestHandlePeerEligibilityChangedEvent_DemotesObservedIngress(t *testing.T) {

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -436,6 +436,7 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 		shouldStartChainsync := o.registerTrackedChainsyncClient(
 			connId,
 			o.shouldPublishChainsyncToLedger(connId),
+			true, // startedAsOutbound
 		)
 		if shouldStartChainsync {
 			if err := o.chainsyncClientStart(connId); err != nil {
@@ -537,7 +538,7 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	// limit can prevent functional reconnections, causing permanent
 	// chainsync stalls after rollback events.
 	if o.ChainsyncState != nil {
-		if o.registerTrackedChainsyncClient(connId, false) {
+		if o.registerTrackedChainsyncClient(connId, false, false) {
 			if err := o.chainsyncClientStart(connId); err != nil {
 				o.ChainsyncState.RemoveClientConnId(connId)
 				o.config.Logger.Warn(


### PR DESCRIPTION
Closes #1912 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal connection management by adding directional tracking for client connections, enabling better distinction between outbound and inbound initiated connections.
  * Enhanced collision handling for duplicate connection scenarios.

* **Tests**
  * Added comprehensive test coverage for connection direction tracking, collision detection, and event publishing during connection lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ConnectionId collisions that could overwrite live connections and misclassify chainsync direction. Outbound now wins collisions, chainsync records connection direction, and stale close events from evicted connections are suppressed.

- **Bug Fixes**
  - `connmanager`: Detect and resolve ConnectionId collisions.
    - Keep existing outbound when a new inbound collides; replace existing inbound when a new outbound collides; safely clean up metrics/IP slots and inbound peer counters; replace on same-direction collision.
    - Make `RemoveConnection` idempotent and return a bool; error watcher exits on false to prevent double cleanup.
    - Make `AddConnection`/`addConnectionWithIPKey`/`addNtCConnectionWithIPKey` return a bool to reject on shutdown/collision; listeners and outbound paths honor this and close or skip as needed.
    - Do not publish close events for evicted (stale) connections.
  - `chainsync`: Track connection direction at registration (`StartedAsOutbound`) and expose getters/setters.
    - Add direction-aware APIs: `TryAddClientConnIdWithDirection`, `TryAddObservedClientConnIdWithDirection`.
  - `ouroboros`: Use tracked direction (`isInboundChainsyncClient`) to ignore inbound chainsync clients and avoid feeding them into ledger; treat untracked clients as inbound. Pass direction when registering clients.

- **Migration**
  - Update callers of `connmanager.AddConnection`, `addConnectionWithIPKey`, and `addNtCConnectionWithIPKey` to check the returned bool and close the connection on false.
  - Update callers of `connmanager.RemoveConnection` to check the returned bool to avoid duplicate cleanup.

<sup>Written for commit da33b556be9e8295bbe1979047adee7ddb565b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

