### PR TITLE
fix(event): queue size to 100k

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	EventQueueSize       = 10000
+	EventQueueSize       = 100000
 	AsyncQueueSize       = 1000
 	AsyncWorkerPoolSize  = 4
 	RemoteDeliverTimeout = 5 * time.Second


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased event queue capacity from 10,000 to 100,000 entries, reducing the likelihood of dropped events during high-volume processing. This improves overall system reliability and event delivery consistency, ensuring more robust performance under sustained load conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase event queue capacity from 10k to 100k to prevent dropped events during spikes and improve reliability.

<sup>Written for commit 6718d33cc0ffaec1875ab9258858e9f844abd36f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

