### PR TITLE
fix(database): block hash index

### DIFF
--- a/database/block.go
+++ b/database/block.go
@@ -303,6 +303,13 @@ func BlockByHashTxn(txn *Txn, hash []byte) (models.Block, error) {
 	if blob == nil {
 		return models.Block{}, types.ErrBlobStoreUnavailable
 	}
+	// Try O(1) hash index lookup first
+	hashIndexKey := types.BlockHashIndexKey(hash)
+	blockKey, err := blob.Get(blobTxn, hashIndexKey)
+	if err == nil && len(blockKey) > 0 {
+		return blockByKey(txn, blockKey)
+	}
+	// Fallback to sequential scan for blocks written before the index existed
 	iterOpts := types.BlobIteratorOptions{
 		Prefix: []byte(types.BlockBlobKeyPrefix),
 	}

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -284,6 +284,11 @@ func (d *BlobStoreS3) SetBlock(
 	if err := d.Put(ctx, string(indexKey), key); err != nil {
 		return err
 	}
+	// Hash-to-block-key index for O(1) BlockByHash lookups
+	hashIndexKey := types.BlockHashIndexKey(hash)
+	if err := d.Put(ctx, string(hashIndexKey), key); err != nil {
+		return err
+	}
 	// Block metadata by point
 	metadataKey := types.BlockBlobMetadataKey(key)
 	tmpMetadata := types.BlockMetadata{
@@ -370,6 +375,13 @@ func (d *BlobStoreS3) DeleteBlock(
 	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
 		Key:    awsString(d.fullKey(string(metadataKey))),
+	}); err != nil && !isS3NotFound(err) {
+		return err
+	}
+	hashIndexKey := types.BlockHashIndexKey(hash)
+	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    awsString(d.fullKey(string(hashIndexKey))),
 	}); err != nil && !isS3NotFound(err) {
 		return err
 	}

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -539,7 +539,8 @@ func (d *BlobStoreBadger) SetBlock(
 	keyLen := len(types.BlockBlobKeyPrefix) + 8 + len(hash)
 	indexKeyLen := len(types.BlockBlobIndexKeyPrefix) + 8
 	metadataKeyLen := keyLen + len(types.BlockBlobMetadataKeySuffix)
-	packedLen := keyLen + indexKeyLen + metadataKeyLen
+	hashIndexKeyLen := len(types.BlockHashIndexKeyPrefix) + len(hash)
+	packedLen := keyLen + indexKeyLen + metadataKeyLen + hashIndexKeyLen
 	if d.compactBlockMetadata {
 		packedLen += 32 + len(prevHash)
 	}
@@ -557,8 +558,17 @@ func (d *BlobStoreBadger) SetBlock(
 	if err := badgerTxn.tx.Set(indexKey, key); err != nil {
 		return err
 	}
+	// Hash-to-block-key index for O(1) BlockByHash lookups
+	hashIndexStart := indexKeyEnd
+	hashIndexEnd := hashIndexStart + hashIndexKeyLen
+	hashIndexKey := packed[hashIndexStart:hashIndexEnd]
+	copy(hashIndexKey, types.BlockHashIndexKeyPrefix)
+	copy(hashIndexKey[len(types.BlockHashIndexKeyPrefix):], hash)
+	if err := badgerTxn.tx.Set(hashIndexKey, key); err != nil {
+		return err
+	}
 	// Block metadata by point
-	metadataKeyStart := indexKeyEnd
+	metadataKeyStart := hashIndexEnd
 	metadataKeyEnd := metadataKeyStart + metadataKeyLen
 	metadataKey := packed[metadataKeyStart:metadataKeyEnd]
 	buildBlockBlobMetadataKey(metadataKey, key)
@@ -642,6 +652,11 @@ func (d *BlobStoreBadger) DeleteBlock(
 	}
 	metadataKey := types.BlockBlobMetadataKey(key)
 	if err := badgerTxn.tx.Delete(metadataKey); err != nil {
+		return err
+	}
+	// Clean up hash-to-block-key index
+	hashIndexKey := types.BlockHashIndexKey(hash)
+	if err := badgerTxn.tx.Delete(hashIndexKey); err != nil {
 		return err
 	}
 	return nil

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -343,6 +343,22 @@ func (d *BlobStoreGCS) SetBlock(
 	}
 	writtenObjects = append(writtenObjects, string(indexKey))
 
+	// Hash-to-block-key index for O(1) BlockByHash lookups
+	hashIndexKey := types.BlockHashIndexKey(hash)
+	w = d.object(hashIndexKey).NewWriter(ctx)
+	if _, err := w.Write(key); err != nil {
+		_ = w.Close()
+		d.logger.Errorf("failed to write object %q: %v", string(hashIndexKey), err)
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		d.logger.Errorf("failed to close writer for %q: %v", string(hashIndexKey), err)
+		d.cleanupObjects(ctx, writtenObjects)
+		return err
+	}
+	writtenObjects = append(writtenObjects, string(hashIndexKey))
+
 	// Block metadata by point
 	metadataKey := types.BlockBlobMetadataKey(key)
 	tmpMetadata := types.BlockMetadata{
@@ -515,6 +531,12 @@ func (d *BlobStoreGCS) DeleteBlock(
 	if err := d.object(metadataKey).Delete(ctx); err != nil &&
 		!errors.Is(err, storage.ErrObjectNotExist) {
 		d.logger.Errorf("gcs delete %q failed: %v", string(metadataKey), err)
+		return err
+	}
+	hashIndexKey := types.BlockHashIndexKey(hash)
+	if err := d.object(hashIndexKey).Delete(ctx); err != nil &&
+		!errors.Is(err, storage.ErrObjectNotExist) {
+		d.logger.Errorf("gcs delete %q failed: %v", string(hashIndexKey), err)
 		return err
 	}
 	return nil

--- a/database/types/keys.go
+++ b/database/types/keys.go
@@ -54,6 +54,18 @@ func BlockBlobMetadataKey(baseKey []byte) []byte {
 	return slices.Concat(baseKey, []byte(BlockBlobMetadataKeySuffix))
 }
 
+// BlockHashIndexKeyPrefix is the key prefix for the hash→block-key index.
+// Key format: "bh" + hash(32 bytes), value: BlockBlobKey (slot+hash).
+const BlockHashIndexKeyPrefix = "bh"
+
+// BlockHashIndexKey builds the key for a hash→slot lookup index entry.
+func BlockHashIndexKey(hash []byte) []byte {
+	key := make([]byte, 0, len(BlockHashIndexKeyPrefix)+len(hash))
+	key = append(key, BlockHashIndexKeyPrefix...)
+	key = append(key, hash...)
+	return key
+}
+
 func UtxoBlobKey(txId []byte, outputIdx uint32) []byte {
 	key := []byte(UtxoBlobKeyPrefix)
 	key = append(key, txId...)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a hash→block-key index to make BlockByHash lookups O(1) and avoid full scans by default. Implemented for Badger, S3, and GCS with cleanup on delete and a safe fallback for legacy blocks.

- **Bug Fixes**
  - Introduced `BlockHashIndexKey` with `"bh"` prefix for hash→block-key mapping.
  - On SetBlock/DeleteBlock, write/remove index entries in Badger, S3, and GCS.
  - BlockByHash now checks the index first and falls back to a scan for pre-index data.
  - Updated Badger key sizing to account for the new index key.

<sup>Written for commit 96f195bec30f0a260a1ed8ef05ec1635d47920a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

