### PR TITLE
fix(ledger): mithril backfill N-2 stake snapshots

### DIFF
--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -308,10 +308,12 @@ func (m *Manager) captureMarkSnapshot(
 	return nil
 }
 
-// CaptureGenesisSnapshot captures the initial stake distribution from genesis
-// as a mark snapshot for epoch 0. This ensures the "Go" snapshot is available
-// at epoch 2 for leader election, matching the Cardano spec which uses the
-// genesis stake distribution for the first two epochs.
+// CaptureGenesisSnapshot captures the initial stake distribution as mark
+// snapshots. For a fresh sync this seeds epoch 0 so that leader election
+// works at epoch 2. After a Mithril bootstrap the node starts at a much
+// later epoch, so the method also seeds the current Mark/Set/Go window
+// (epochs N, N-1, N-2) to ensure leader election can find its "Go"
+// snapshot immediately.
 func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	calculator := NewCalculator(m.db)
 
@@ -322,6 +324,9 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 
 	// After Mithril import, slot 0 has no pool data. Fall back to
 	// the latest epoch's start slot where imported pools are visible.
+	// Also remember the latest epoch so we can seed the Mark/Set/Go
+	// window below.
+	var currentEpochId uint64
 	if distribution.TotalPools == 0 {
 		epochs, epErr := m.db.GetEpochs(nil)
 		if epErr != nil {
@@ -333,9 +338,11 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 			)
 		} else if len(epochs) > 0 {
 			lastEpoch := epochs[len(epochs)-1]
+			currentEpochId = lastEpoch.EpochId
 			m.logger.Debug(
 				"attempting genesis stake fallback from latest epoch",
 				"component", "snapshot",
+				"epoch", currentEpochId,
 				"start_slot", lastEpoch.StartSlot,
 				"total_pools", distribution.TotalPools,
 			)
@@ -372,6 +379,8 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		"total_stake", distribution.TotalStake,
 	)
 
+	// Always save epoch 0 for normal bootstrap (leader election at
+	// epochs 0 and 1 uses genesis snapshot directly).
 	evt := event.EpochTransitionEvent{
 		NewEpoch:     0,
 		BoundarySlot: 0,
@@ -379,6 +388,39 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	}
 	if err := m.saveSnapshot(ctx, 0, "mark", distribution, evt); err != nil {
 		return fmt.Errorf("save genesis snapshot: %w", err)
+	}
+
+	// After Mithril bootstrap: seed the Mark/Set/Go window for the
+	// current epoch so leader election works immediately. Leader
+	// election for epoch N queries the "mark" snapshot at epoch N-2
+	// (the "Go" snapshot), so we need mark snapshots at N, N-1, and
+	// N-2. Without these the pool shows pool_stake=0 and cannot
+	// forge until two epoch transitions pass.
+	if currentEpochId > 0 {
+		for offset := uint64(0); offset <= 2 && offset <= currentEpochId; offset++ {
+			seedEpoch := currentEpochId - offset
+			if seedEpoch == 0 {
+				continue // already saved above
+			}
+			seedEvt := event.EpochTransitionEvent{
+				NewEpoch: seedEpoch,
+			}
+			if err := m.saveSnapshot(
+				ctx, seedEpoch, "mark", distribution, seedEvt,
+			); err != nil {
+				return fmt.Errorf(
+					"save bootstrap snapshot for epoch %d: %w",
+					seedEpoch, err,
+				)
+			}
+			m.logger.Info(
+				"seeded post-Mithril snapshot",
+				"component", "snapshot",
+				"epoch", seedEpoch,
+				"total_pools", distribution.TotalPools,
+				"total_stake", distribution.TotalStake,
+			)
+		}
 	}
 
 	m.logger.Info(

--- a/ledger/snapshot/manager_test.go
+++ b/ledger/snapshot/manager_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// TestCaptureGenesisSnapshot_PostMithril verifies that after a Mithril
+// bootstrap (where slot 0 has no pools but later epochs exist), the
+// snapshot manager seeds the Mark/Set/Go window for the current epoch.
+// Without this, leader election at epoch N queries epoch N-2 and finds
+// pool_stake=0.
+func TestCaptureGenesisSnapshot_PostMithril(t *testing.T) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	// Simulate post-Mithril state: epoch 0 exists (from ledger state
+	// import) but has no pool data at slot 0. The latest epoch is 150.
+	for _, e := range []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+		{EpochId: 148, StartSlot: 63936000, LengthInSlots: 432000},
+		{EpochId: 149, StartSlot: 64368000, LengthInSlots: 432000},
+		{EpochId: 150, StartSlot: 64800000, LengthInSlots: 432000},
+	} {
+		require.NoError(t, gormDB.Create(&e).Error)
+	}
+
+	// Seed a pool registered at a post-Mithril slot with delegations
+	poolHash := []byte("poolM_12345678901234567890AB")
+	seedPoolAndDelegations(t, sqliteStore, poolHash, []struct {
+		stakingKey  []byte
+		utxoAmounts []types.Uint64
+	}{
+		{
+			stakingKey:  []byte("alice_staking_key_1234567890"),
+			utxoAmounts: []types.Uint64{50000000},
+		},
+	}, 64800000) // registered at epoch 150's start slot
+
+	eventBus := event.NewEventBus(nil, nil)
+	mgr := NewManager(db, eventBus, nil)
+
+	err := mgr.CaptureGenesisSnapshot(context.Background())
+	require.NoError(t, err)
+
+	// Leader election for epoch 150 queries epoch 148 (N-2).
+	// Verify that mark snapshots exist for the full window.
+	for _, epoch := range []uint64{0, 148, 149, 150} {
+		snapshot, sErr := db.Metadata().GetPoolStakeSnapshot(
+			epoch, "mark", poolHash, nil,
+		)
+		require.NoError(t, sErr, "epoch %d lookup should not error", epoch)
+		require.NotNil(t, snapshot,
+			"epoch %d must have a mark snapshot after Mithril bootstrap",
+			epoch)
+		require.NotZero(t, snapshot.TotalStake,
+			"epoch %d snapshot must have non-zero stake", epoch)
+	}
+}
+
+// TestCaptureGenesisSnapshot_FreshSync verifies that on a fresh sync
+// (no Mithril), only epoch 0 gets a snapshot and no extra epochs are
+// seeded.
+func TestCaptureGenesisSnapshot_FreshSync(t *testing.T) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	// Fresh sync: only epoch 0 exists
+	epoch := models.Epoch{
+		EpochId:       0,
+		StartSlot:     0,
+		LengthInSlots: 432000,
+	}
+	require.NoError(t, gormDB.Create(&epoch).Error)
+
+	// Seed a pool at slot 0
+	poolHash := []byte("poolG_12345678901234567890AB")
+	seedPoolAndDelegations(t, sqliteStore, poolHash, []struct {
+		stakingKey  []byte
+		utxoAmounts []types.Uint64
+	}{
+		{
+			stakingKey:  []byte("bob___staking_key_1234567890"),
+			utxoAmounts: []types.Uint64{10000000},
+		},
+	}, 0)
+
+	eventBus := event.NewEventBus(nil, nil)
+	mgr := NewManager(db, eventBus, nil)
+
+	err := mgr.CaptureGenesisSnapshot(context.Background())
+	require.NoError(t, err)
+
+	// Epoch 0 should have a snapshot
+	snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+		0, "mark", poolHash, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, snapshot, "epoch 0 must have a snapshot")
+	require.NotZero(t, snapshot.TotalStake)
+
+	// No spurious snapshots for epochs that don't exist
+	snapshot2, err := db.Metadata().GetPoolStakeSnapshot(
+		1, "mark", poolHash, nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, snapshot2,
+		"epoch 1 should not have a snapshot on fresh sync")
+}
+
+// TestCaptureGenesisSnapshot_NoPools verifies that when no pools exist
+// at all, no snapshots are created and no error is returned.
+func TestCaptureGenesisSnapshot_NoPools(t *testing.T) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	// Epochs exist but no pools
+	for _, e := range []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+		{EpochId: 10, StartSlot: 4320000, LengthInSlots: 432000},
+	} {
+		require.NoError(t, gormDB.Create(&e).Error)
+	}
+
+	eventBus := event.NewEventBus(nil, nil)
+	mgr := NewManager(db, eventBus, nil)
+
+	err := mgr.CaptureGenesisSnapshot(context.Background())
+	require.NoError(t, err, "no pools should not be an error")
+}
+
+// TestCaptureGenesisSnapshot_SmallEpoch verifies correct behavior when
+// the current epoch is less than 2 (edge case for the offset loop).
+func TestCaptureGenesisSnapshot_SmallEpoch(t *testing.T) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	// Simulate Mithril bootstrap to epoch 1 (no pools at slot 0)
+	for _, e := range []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+		{EpochId: 1, StartSlot: 432000, LengthInSlots: 432000},
+	} {
+		require.NoError(t, gormDB.Create(&e).Error)
+	}
+
+	poolHash := []byte("poolS_12345678901234567890AB")
+	seedPoolAndDelegations(t, sqliteStore, poolHash, []struct {
+		stakingKey  []byte
+		utxoAmounts []types.Uint64
+	}{
+		{
+			stakingKey:  []byte("eve___staking_key_1234567890"),
+			utxoAmounts: []types.Uint64{25000000},
+		},
+	}, 432000) // registered at epoch 1
+
+	eventBus := event.NewEventBus(nil, nil)
+	mgr := NewManager(db, eventBus, nil)
+
+	err := mgr.CaptureGenesisSnapshot(context.Background())
+	require.NoError(t, err)
+
+	// Epoch 0 and 1 should both have snapshots
+	for _, epoch := range []uint64{0, 1} {
+		snapshot, sErr := db.Metadata().GetPoolStakeSnapshot(
+			epoch, "mark", poolHash, nil,
+		)
+		require.NoError(t, sErr, "epoch %d lookup", epoch)
+		require.NotNil(t, snapshot,
+			"epoch %d must have a snapshot", epoch)
+	}
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes leader election after a Mithril bootstrap by backfilling mark snapshots for epochs N, N-1, and N-2 so pools don’t show zero stake. Still seeds epoch 0 on fresh sync for normal startup.

- **Bug Fixes**
  - Update `CaptureGenesisSnapshot` to detect Mithril imports and seed the Mark/Set/Go window (epochs N, N-1, N-2) so epoch N can use the N-2 “Go” snapshot.
  - When slot 0 has no pools, compute the stake distribution from the latest epoch’s start slot and record its `epochId` for seeding.
  - Always save epoch 0; do not create snapshots when no pools exist or epochs are missing.
  - Add tests for post-Mithril seeding, fresh sync, no-pools, and small-epoch edge cases.

<sup>Written for commit ef95fd0f21ed012eed80f1bb132feeb741784629. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot capture during genesis initialization to handle multiple epoch scenarios and Mithril bootstrap cases more robustly.

* **Tests**
  * Added comprehensive test coverage for genesis snapshot capture across various scenarios, including fresh sync, post-Mithril bootstrap, and empty pool states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->