### PR TITLE
fix(leader): precompute VRF threshold once per epoch in CalculateSchedule

### DIFF
--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -179,20 +179,32 @@ func (c *Calculator) CalculateSchedule(
 		return nil, fmt.Errorf("invalid active slot coefficient: %w", err)
 	}
 
+	// Precompute the leadership threshold once. It depends only on poolStake,
+	// totalStake, and activeSlotCoeff — all constant for the epoch — so computing
+	// it inside the 86,400-slot loop (which is what IsSlotLeader does) wastes
+	// two 20-term big.Rat Taylor series and a 2^256 multiply per slot.
+	threshold := consensus.CertifiedNatThresholdWithMode(
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+		consensus.ConsensusModeCPraos,
+	)
+
 	// Check each slot in the epoch
 	for slot := epochStartSlot; slot < epochEndSlot; slot++ {
-		result, err := consensus.IsSlotLeader(
-			slot,
-			epochNonce,
-			poolStake,
-			totalStake,
-			activeSlotCoeff,
-			vrfSigner,
-		)
+		vrfInput := consensus.ComputeVRFInput(slot, epochNonce)
+		if vrfInput == nil {
+			return nil, fmt.Errorf("check slot %d: failed to compute VRF input", slot)
+		}
+		_, output, err := vrfSigner.Prove(vrfInput)
 		if err != nil {
 			return nil, fmt.Errorf("check slot %d: %w", slot, err)
 		}
-		if result.Eligible {
+		if consensus.IsVRFOutputBelowThresholdWithMode(
+			output,
+			threshold,
+			consensus.ConsensusModeCPraos,
+		) {
 			schedule.AddLeaderSlot(slot)
 		}
 	}


### PR DESCRIPTION
## Problem

`CalculateSchedule` checks every slot in an epoch for leadership eligibility. Internally it calls `consensus.IsSlotLeader` per slot, which calls `CertifiedNatThresholdWithMode` on every invocation.

`CertifiedNatThresholdWithMode` computes:

```
T = 2^256 × (1 - (1-f)^σ)
```

using two 20-term big.Rat Taylor series (ln and exp) plus a 2^256 big.Int multiply. **All of its inputs — `poolStake`, `totalStake`, `activeSlotCoeff` — are constant for the entire epoch.** They come from the epoch snapshot and don't change slot-to-slot.

On preview (86,400 slots/epoch) this means 86,399 identical threshold computations are wasted. On mainnet (432,000 slots/epoch) it's 431,999. On ARM hardware (e.g. Raspberry Pi 4) where big.Rat is ~100ms/call, this makes schedule computation take ~3 hours. On x86 it's faster but still unnecessary.

## Fix

Compute the threshold once before the slot loop using `CertifiedNatThresholdWithMode` directly, then call `ComputeVRFInput` + `vrfSigner.Prove` + `IsVRFOutputBelowThresholdWithMode` per slot. Functionally identical — the epoch nonce still feeds into the per-slot VRF input computation, not the threshold.

## Verification

The threshold formula has no dependence on slot number or epoch nonce. The epoch nonce is already finalized when `CalculateSchedule` is called (passed in as a fixed `[]byte`). All existing tests pass unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Precompute the VRF leadership threshold once per epoch in `leader.CalculateSchedule` to remove redundant per-slot big.Rat math. Behavior is unchanged, but schedule generation is much faster (e.g., hours → minutes on ARM).

- **Refactors**
  - Compute threshold via `consensus.CertifiedNatThresholdWithMode` before the slot loop and reuse it.
  - Replace per-slot `consensus.IsSlotLeader` with `consensus.ComputeVRFInput` + `vrfSigner.Prove` + `consensus.IsVRFOutputBelowThresholdWithMode`; epoch nonce still feeds the per-slot input.

<sup>Written for commit b362e5d39840e64c9717aba1e839892c803ea6a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

