### PR TITLE
fix(chainselection): use stable remote address for equal-tip tiebreaker

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -763,10 +763,22 @@ func (cs *ChainSelector) comparePeerTips(
 			return vrfComparison
 		case ChainEqual, ChainComparisonUnknown:
 		}
-		if connIdA.String() < connIdB.String() {
+		// Use stable remote address for final tiebreak rather than the full
+		// connection ID string. The full string includes the local ephemeral TCP
+		// port, which changes on every reconnect. That causes the sort order to
+		// flip whenever a peer reconnects — triggering spurious chain switches
+		// and pipeline stalls on resource-constrained nodes (e.g. Raspberry Pi).
+		var remoteA, remoteB string
+		if connIdA.RemoteAddr != nil {
+			remoteA = connIdA.RemoteAddr.String()
+		}
+		if connIdB.RemoteAddr != nil {
+			remoteB = connIdB.RemoteAddr.String()
+		}
+		if remoteA < remoteB {
 			return ChainABetter
 		}
-		if connIdB.String() < connIdA.String() {
+		if remoteB < remoteA {
 			return ChainBBetter
 		}
 		return ChainEqual

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -1275,7 +1275,9 @@ func TestChainSelectorVRFTiebreakerWithNilVRF(t *testing.T) {
 	cs.UpdatePeerTip(connId2, tip, nil)
 
 	// When VRF comparison returns equal (due to nil), fall back to remote address
-	// tiebreaker. connId1 remote (127.0.0.1:10001) < connId2 remote (127.0.0.1:10002).
+	// tiebreaker. Test peers use localhost with distinct ports (n+10000) as
+	// stand-ins for real peer addresses; connId1 (port 10001) sorts before
+	// connId2 (port 10002) so connId1 wins.
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
 	// Since VRF comparison returns ChainEqual when one is nil,

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -1274,17 +1274,17 @@ func TestChainSelectorVRFTiebreakerWithNilVRF(t *testing.T) {
 	cs.UpdatePeerTip(connId1, tip, vrf)
 	cs.UpdatePeerTip(connId2, tip, nil)
 
-	// When VRF comparison returns equal (due to nil), fall back to connection ID
-	// connId1 vs connId2 - the one with lexicographically smaller string wins
+	// When VRF comparison returns equal (due to nil), fall back to remote address
+	// tiebreaker. connId1 remote (127.0.0.1:10001) < connId2 remote (127.0.0.1:10002).
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
 	// Since VRF comparison returns ChainEqual when one is nil,
-	// it falls back to connection ID comparison
+	// it falls back to remote address comparison
 	assert.Equal(
 		t,
 		connId1,
 		*bestPeer,
-		"should fall back to connection ID ordering when one peer has nil VRF",
+		"should fall back to remote address ordering when one peer has nil VRF",
 	)
 }
 


### PR DESCRIPTION
## Problem

`comparePeerTips` uses `ConnectionId.String()` as the final tiebreaker when two peers have chains that are otherwise equal (same block number, slot, VRF output). `ConnectionId.String()` formats as `localAddr<->remoteAddr`, e.g.:

```
192.168.9.127:42550<->35.188.35.224:3001
```

The local address includes the **ephemeral TCP port**, which changes on every reconnect. When a peer reconnects, its new `ConnectionId` may sort differently than the old one, flipping the tiebreaker result and triggering a chain switch.

The incumbent preservation in `evaluateBestPeerLocked` can't catch this because it looks up the *previous best* connection ID in `peerTips` — which is already gone after the reconnect. So the spurious switch goes through.

On nodes with only 2 peers (e.g. block producers) where both peers frequently reach the equal-tip tiebreaker, this produces continuous chain switches on every peer reconnect — pipeline churn with no benefit.

## Fix

Replace the full connection ID string with `RemoteAddr.String()` only. The remote address (`35.188.35.224:3001`) is stable across reconnects — it identifies the actual peer, not the transport-level connection. The tiebreaker result is now deterministic regardless of how many times a peer has reconnected.

Nil guards are included for the zero-value `ConnectionId` case, though in practice `RemoteAddr` is always set when a connection is active.

## Test update

`TestChainSelectorVRFTiebreakerWithNilVRF` comment updated to reflect that the fallback is now remote address ordering (result unchanged — test connection IDs have distinct remote ports so ordering is preserved).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the peer’s stable `RemoteAddr` for the final equal-tip tiebreaker in `comparePeerTips` to stop chain flip-flops on reconnect. This makes ordering deterministic and prevents spurious switches on 2‑peer nodes.

- **Bug Fixes**
  - Compare `RemoteAddr.String()` instead of `ConnectionId.String()` when tips are otherwise equal.
  - Add nil guards for zero-value `ConnectionId`.
  - Clarify test comments for the remote-address tiebreaker (behavior unchanged).

<sup>Written for commit 5daf2765e41c73758927be772560824063b8f198. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

