### PR TITLE
fix(utxorpc): prevent infinite recursion in predicate processing

### DIFF
--- a/utxorpc/tx_predicate.go
+++ b/utxorpc/tx_predicate.go
@@ -32,6 +32,8 @@ const (
 	predMatch
 )
 
+const maxTxPredicateDepth = 64
+
 // txPredicateNode is the Cardano evaluation shape for utxorpc TxPredicate
 // (submit and watch protos share the same fields). Conversion from generated
 // *TxPredicate types happens once at the API boundary; recursion uses only
@@ -62,8 +64,28 @@ func buildTxPredicateNodeFromProto[T txPredicateProto[T, M], M txPatternProto](
 	isNilPredicate func(T) bool,
 	isNilMatch func(M) bool,
 ) *txPredicateNode {
+	return buildTxPredicateNodeFromProtoWithDepth(
+		p,
+		isNilPredicate,
+		isNilMatch,
+		0,
+	)
+}
+
+func buildTxPredicateNodeFromProtoWithDepth[
+	T txPredicateProto[T, M],
+	M txPatternProto,
+](
+	p T,
+	isNilPredicate func(T) bool,
+	isNilMatch func(M) bool,
+	depth int,
+) *txPredicateNode {
 	if isNilPredicate(p) {
 		return nil
+	}
+	if depth >= maxTxPredicateDepth {
+		return &txPredicateNode{matchNonCardano: true}
 	}
 	n := &txPredicateNode{}
 	if m := p.GetMatch(); !isNilMatch(m) {
@@ -77,7 +99,12 @@ func buildTxPredicateNodeFromProto[T txPredicateProto[T, M], M txPatternProto](
 		if !isNilPredicate(c) {
 			n.not = append(
 				n.not,
-				buildTxPredicateNodeFromProto(c, isNilPredicate, isNilMatch),
+				buildTxPredicateNodeFromProtoWithDepth(
+					c,
+					isNilPredicate,
+					isNilMatch,
+					depth+1,
+				),
 			)
 		}
 	}
@@ -85,7 +112,12 @@ func buildTxPredicateNodeFromProto[T txPredicateProto[T, M], M txPatternProto](
 		if !isNilPredicate(c) {
 			n.allOf = append(
 				n.allOf,
-				buildTxPredicateNodeFromProto(c, isNilPredicate, isNilMatch),
+				buildTxPredicateNodeFromProtoWithDepth(
+					c,
+					isNilPredicate,
+					isNilMatch,
+					depth+1,
+				),
 			)
 		}
 	}
@@ -93,7 +125,12 @@ func buildTxPredicateNodeFromProto[T txPredicateProto[T, M], M txPatternProto](
 		if !isNilPredicate(c) {
 			n.anyOf = append(
 				n.anyOf,
-				buildTxPredicateNodeFromProto(c, isNilPredicate, isNilMatch),
+				buildTxPredicateNodeFromProtoWithDepth(
+					c,
+					isNilPredicate,
+					isNilMatch,
+					depth+1,
+				),
 			)
 		}
 	}
@@ -215,8 +252,20 @@ func evalTxPredicateOutcome(
 	p *txPredicateNode,
 	leaf txPatternLeaf,
 ) predOutcome {
+	return evalTxPredicateOutcomeWithDepth(tx, p, leaf, 0)
+}
+
+func evalTxPredicateOutcomeWithDepth(
+	tx gledger.Transaction,
+	p *txPredicateNode,
+	leaf txPatternLeaf,
+	depth int,
+) predOutcome {
 	if p == nil {
 		return predNoMatch
+	}
+	if depth >= maxTxPredicateDepth {
+		return predUnevaluable
 	}
 	parts := make([]predOutcome, 0, 4)
 	if p.matchNonCardano {
@@ -225,19 +274,28 @@ func evalTxPredicateOutcome(
 		parts = append(parts, leaf(tx, p.match))
 	}
 	for _, c := range p.not {
-		parts = append(parts, notOutcome(evalTxPredicateOutcome(tx, c, leaf)))
+		parts = append(
+			parts,
+			notOutcome(evalTxPredicateOutcomeWithDepth(tx, c, leaf, depth+1)),
+		)
 	}
 	if len(p.allOf) > 0 {
 		sub := make([]predOutcome, 0, len(p.allOf))
 		for _, c := range p.allOf {
-			sub = append(sub, evalTxPredicateOutcome(tx, c, leaf))
+			sub = append(
+				sub,
+				evalTxPredicateOutcomeWithDepth(tx, c, leaf, depth+1),
+			)
 		}
 		parts = append(parts, combineANDBranches(sub))
 	}
 	if len(p.anyOf) > 0 {
 		sub := make([]predOutcome, 0, len(p.anyOf))
 		for _, c := range p.anyOf {
-			sub = append(sub, evalTxPredicateOutcome(tx, c, leaf))
+			sub = append(
+				sub,
+				evalTxPredicateOutcomeWithDepth(tx, c, leaf, depth+1),
+			)
 		}
 		parts = append(parts, combineORBranches(sub))
 	}

--- a/utxorpc/tx_predicate_test.go
+++ b/utxorpc/tx_predicate_test.go
@@ -312,3 +312,27 @@ func TestWatchHandlers_nilProtobufPredicateSkipsEval(t *testing.T) {
 	predicate := (*submit.TxPredicate)(nil)
 	require.Nil(t, txPredicateFromSubmit(predicate))
 }
+
+func TestEvalTxPredicate_MaxDepthExceeded(t *testing.T) {
+	pred := matchSubmit(&cardano.TxPattern{})
+	for i := 0; i < maxTxPredicateDepth; i++ {
+		pred = &submit.TxPredicate{
+			Not: []*submit.TxPredicate{pred},
+		}
+	}
+	require.Equal(
+		t,
+		predUnevaluable,
+		evalTxPredicateOutcome(nil, txPredicateFromSubmit(pred), stubLeaf(nil)),
+	)
+}
+
+func TestEvalTxPredicate_CycleBecomesUnevaluable(t *testing.T) {
+	node := &txPredicateNode{}
+	node.not = []*txPredicateNode{node}
+	require.Equal(
+		t,
+		predUnevaluable,
+		evalTxPredicateOutcome(nil, node, stubLeaf(nil)),
+	)
+}


### PR DESCRIPTION
Closes #1878 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite recursion in `utxorpc` Tx predicate processing by enforcing a max recursion depth (64) in build and eval. Deep or cyclic predicates now resolve to an unevaluable outcome instead of hanging.

- **Bug Fixes**
  - Added `maxTxPredicateDepth = 64`; stop building at limit and mark as non-Cardano; eval returns unevaluable at limit.
  - Introduced depth-aware recursion: `buildTxPredicateNodeFromProtoWithDepth` and `evalTxPredicateOutcomeWithDepth`, used across `not`, `allOf`, and `anyOf`.
  - Added tests to cover depth overflow and self-referential cycles, ensuring they return unevaluable.

<sup>Written for commit 1b50f7ac604cce6fa55a0946469a0db3b4287745. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added recursion depth limits to transaction predicate processing to enhance stability and prevent potential stack overflow conditions when handling deeply nested predicates.

* **Tests**
  * Added test coverage for transaction predicate evaluation with deeply nested structures and cyclic predicate references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->