### PR TITLE
fix(chainselection): use SelectionTip instead of Tip for switch guard

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -862,13 +862,22 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 				newPeerTip,
 			) == ChainABetter {
 				newBest = previousBest
-			} else if newPeerTip.Tip.BlockNumber >
-				previousPeerTip.Tip.BlockNumber &&
+			} else if newPeerTip.SelectionTip().BlockNumber >
+				previousPeerTip.SelectionTip().BlockNumber &&
 				!IsSignificantlyBetter(
-					newPeerTip.Tip,
-					previousPeerTip.Tip,
+					newPeerTip.SelectionTip(),
+					previousPeerTip.SelectionTip(),
 					cs.config.MinSwitchBlockDiff,
 				) {
+				// Suppress switches where the challenger is only marginally
+				// ahead in SelectionTip (observed frontier, which includes
+				// in-flight headers from RollForward). The original guard used
+				// Tip.BlockNumber (the peer's claimed remote tip), which can be
+				// ahead of ObservedTip when a peer advertises N+1 in a
+				// RollForward tip claim before actually delivering the N+1
+				// header. That caused both peers to show Tip.BlockNumber=N+1
+				// while only one had SelectionTip=N+1, making the `>` guard
+				// fail and allowing a switch for a 1-block observed lead.
 				newBest = previousBest
 			}
 		}

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -617,6 +617,54 @@ func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
+func TestChainSelectorDoesNotSwitchOnOneBlockObservedTipLead(t *testing.T) {
+	// Regression: when two peers track the same chain, the one that announces
+	// the next block header milliseconds sooner gains a 1-block ObservedTip
+	// (SelectionTip) lead. The old guard used Tip.BlockNumber (confirmed only)
+	// and missed this case, causing a switch per block near tip.
+	incumbentConn := newTestConnectionId(1)
+	challengerConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{
+		MinSwitchBlockDiff: 2,
+	})
+
+	confirmedTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("confirmed")},
+		BlockNumber: 50,
+	}
+
+	// Incumbent is established at the confirmed tip.
+	cs.UpdatePeerTip(incumbentConn, confirmedTip, nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+
+	// Challenger has the same confirmed Tip but has received one block header
+	// ahead via ObservedTip — simulating "announced header before incumbent did".
+	// This is done by calling updatePeerTipObserved directly.
+	oneAheadTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("one-ahead")},
+		BlockNumber: 51,
+	}
+	cs.mutex.Lock()
+	if pt, ok := cs.peerTips[challengerConn]; ok {
+		pt.UpdateTipWithObserved(confirmedTip, oneAheadTip, nil)
+	} else {
+		cs.mutex.Unlock()
+		// Add via normal path first, then update observed
+		cs.UpdatePeerTip(challengerConn, confirmedTip, nil)
+		cs.mutex.Lock()
+		if pt, ok := cs.peerTips[challengerConn]; ok {
+			pt.UpdateTipWithObserved(confirmedTip, oneAheadTip, nil)
+		}
+	}
+	cs.mutex.Unlock()
+
+	switched := cs.EvaluateAndSwitch()
+	assert.False(t, switched, "should not switch for a 1-block observed tip lead with MinSwitchBlockDiff=2")
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+}
+
 func TestChainSelectorPreservesEqualTipIncumbentAtSamePriorityWithVRF(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## Problem

The switch-suppression guard in `evaluateBestPeerLocked` compared `Tip.BlockNumber` (the peer's claimed remote chain tip as advertised in RollForward messages) rather than `SelectionTip().BlockNumber` (the highest block header actually delivered to the chain selector).

These values can diverge: a peer announces `Tip=N+1` in a RollForward message at the same time it delivers the N+1 header. When two peers are at the same chain position, peer A may announce `Tip.BlockNumber=N+1` milliseconds before peer B, while both `SelectionTip`s are still N.

With the old code:
- `Tip.BlockNumber` comparison: `N+1 > N` → true
- `IsSignificantlyBetter` for a 1-block lead → false (below MinSwitchBlockDiff)
- Guard fires → keep incumbent

On the next cycle peer B catches up, the same logic fires in reverse, and the node oscillates between peers on every block near the chain tip.

## Fix

Use `SelectionTip().BlockNumber` for both the `>` precondition and the `IsSignificantlyBetter` call. `SelectionTip` returns `ObservedTip` when available (actual delivered headers), falling back to `Tip` otherwise. The guard now only suppresses switches based on headers that have been concretely observed, not just claimed.

## Unaffected cases

The chain density comparison (same `BlockNumber`, different slots — fork resolution): `N > N` is false, so the guard does not fire and the density tiebreaker path proceeds normally.

## Testing

Added `TestChainSelectorDoesNotSwitchOnOneBlockObservedTipLead` which directly exercises the regression scenario.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented peer oscillation near the chain tip by using observed headers for the switch guard. The selector now relies on `SelectionTip` instead of the claimed `Tip` to decide if a peer is far enough ahead to switch.

- **Bug Fixes**
  - In `evaluateBestPeerLocked`, compare `SelectionTip().BlockNumber` and pass `SelectionTip` to `IsSignificantlyBetter`.
  - Suppress switches for a 1-block observed lead when below `MinSwitchBlockDiff`.
  - Fork-density tiebreaker unchanged.
  - Added `TestChainSelectorDoesNotSwitchOnOneBlockObservedTipLead`.

<sup>Written for commit 5d0964f0e9e61ca1e5862dbba1c4b5bdafa31e98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the chain selector could incorrectly switch to a peer with only a 1-block observed lead, even when the configured switch threshold was not met. The selector now uses consistent block information when evaluating switch candidates.

* **Tests**
  * Added regression test to ensure chain selection switching behavior remains stable under minimal observed lead scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->