### PR TITLE
feat(ledger): track transition state in ledger

### DIFF
--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -146,11 +146,13 @@ func checkedSlotAdd(
 }
 
 func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
-	// Snapshot the tip and current era under the read lock so we can use them
-	// without holding the lock during the (potentially slow) DB queries below.
+	// Snapshot the tip, current era, and transition info under the read lock
+	// so we can use them without holding the lock during the (potentially
+	// slow) DB queries below.
 	ls.RLock()
 	tipSlot := ls.currentTip.Point.Slot
 	currentEraId := ls.currentEra.Id
+	transitionInfo := ls.transitionInfo
 	ls.RUnlock()
 
 	retData := []any{}
@@ -225,46 +227,78 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 				}
 			}
 		}
-		// For the current (open) era, cap EraEnd at ledgerTip + safeZone.
-		// The Haskell node uses StandardSafeZone for this: clients must not
-		// attempt slot↔time conversions beyond this bound because a hard fork
-		// could invalidate them.  Without this cap, dingo serves the full
-		// epoch-end slot, over-claiming certainty about the future.
+		// For the current (open) era, cap EraEnd at a safe forecast horizon.
+		//
+		// When TransitionKnown is set the epoch-rollover logic has confirmed
+		// an upcoming hard fork: use the transition epoch's StartSlot as the
+		// exact era boundary (mirrors Haskell's TransitionKnown branch).
+		//
+		// Otherwise, cap at ledgerTip + safeZone (StandardSafeZone): clients
+		// must not attempt slot↔time conversions beyond this bound because a
+		// hard fork could invalidate them.
 		if era.Id == currentEraId && len(epochs) > 0 {
-			safeZone := ls.calculateStabilityWindowForEra(era.Id)
-			safeEndSlot, addErr := checkedSlotAdd(tipSlot, safeZone)
-			epochEndSlot, slotErr := checkedSlotAdd(
-				tmpEpoch.StartSlot,
-				uint64(tmpEpoch.LengthInSlots),
-			)
-			if addErr == nil && slotErr == nil &&
-				safeEndSlot >= tmpEpoch.StartSlot &&
-				safeEndSlot < epochEndSlot {
-				// Work backward from the accumulated timespan (which now
-				// points to epochEndSlot) to find the relative time at
-				// the start of the last epoch, then advance it by the
-				// partial number of slots to safeEndSlot.
-				timespanAtEpochStart := new(big.Int).Sub(
-					timespan,
-					epochPicoseconds(tmpEpoch.SlotLength, tmpEpoch.LengthInSlots),
+			foundTransition := false
+			if transitionInfo.State == TransitionKnown {
+				// Find the transition epoch in the committed epoch list.
+				// It was created with the old era's EraId, so it appears
+				// in epochs.  Its StartSlot is the exact era end boundary.
+				for _, ep := range epochs {
+					if ep.EpochId == transitionInfo.KnownEpoch {
+						// Compute the accumulated relative time up to ep.StartSlot.
+						// timespan currently reflects the end of tmpEpoch (last epoch).
+						// Walk back to the start of ep, then forward to ep.StartSlot.
+						timespanAtEpochStart := new(big.Int).Sub(
+							timespan,
+							epochPicoseconds(ep.SlotLength, ep.LengthInSlots),
+						)
+						// The era ends at ep.StartSlot; no partial-slot offset needed.
+						tmpEnd = []any{
+							timespanAtEpochStart,
+							ep.StartSlot,
+							ep.EpochId,
+						}
+						foundTransition = true
+						break
+					}
+				}
+			}
+			if transitionInfo.State != TransitionKnown || !foundTransition {
+				// No confirmed transition: cap at tipSlot + safeZone.
+				safeZone := ls.calculateStabilityWindowForEra(era.Id)
+				safeEndSlot, addErr := checkedSlotAdd(tipSlot, safeZone)
+				epochEndSlot, slotErr := checkedSlotAdd(
+					tmpEpoch.StartSlot,
+					uint64(tmpEpoch.LengthInSlots),
 				)
-				slotsIntoEpoch := safeEndSlot - tmpEpoch.StartSlot
-				safeRelTime := new(big.Int).Add(
-					timespanAtEpochStart,
-					new(big.Int).Mul(
-						new(big.Int).SetUint64(slotsIntoEpoch),
+				if addErr == nil && slotErr == nil &&
+					safeEndSlot >= tmpEpoch.StartSlot &&
+					safeEndSlot < epochEndSlot {
+					// Work backward from the accumulated timespan (which now
+					// points to epochEndSlot) to find the relative time at
+					// the start of the last epoch, then advance it by the
+					// partial number of slots to safeEndSlot.
+					timespanAtEpochStart := new(big.Int).Sub(
+						timespan,
+						epochPicoseconds(tmpEpoch.SlotLength, tmpEpoch.LengthInSlots),
+					)
+					slotsIntoEpoch := safeEndSlot - tmpEpoch.StartSlot
+					safeRelTime := new(big.Int).Add(
+						timespanAtEpochStart,
 						new(big.Int).Mul(
-							new(big.Int).SetUint64(uint64(tmpEpoch.SlotLength)),
-							big.NewInt(1_000_000_000),
+							new(big.Int).SetUint64(slotsIntoEpoch),
+							new(big.Int).Mul(
+								new(big.Int).SetUint64(uint64(tmpEpoch.SlotLength)),
+								big.NewInt(1_000_000_000),
+							),
 						),
-					),
-				)
-				// safeEndSlot is within tmpEpoch, so the epoch number is
-				// tmpEpoch.EpochId (not +1).
-				tmpEnd = []any{
-					safeRelTime,
-					safeEndSlot,
-					tmpEpoch.EpochId,
+					)
+					// safeEndSlot is within tmpEpoch, so the epoch number is
+					// tmpEpoch.EpochId (not +1).
+					tmpEnd = []any{
+						safeRelTime,
+						safeEndSlot,
+						tmpEpoch.EpochId,
+					}
 				}
 			}
 		}

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -23,9 +23,13 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -277,6 +281,147 @@ func TestEpochPicoseconds_OverflowSafe(t *testing.T) {
 	)
 }
 
+// TestQueryHardForkEraHistory_TransitionKnown proves that when TransitionInfo
+// is set to TransitionKnown the era history response uses the transition
+// epoch's StartSlot as the exact EraEnd, rather than the safe-zone cap.
+//
+// Setup:
+//   - Two Conway epochs: epoch 500 (startSlot=100_000, length=432_000) and
+//     epoch 501 (startSlot=532_000, length=432_000) — epoch 501 is the
+//     transition epoch (stored with the old era's EraId).
+//   - transitionInfo = {State: TransitionKnown, KnownEpoch: 501}
+//   - ledgerTip at slot 200_000 (well inside epoch 500)
+//
+// Expected EraEnd slot: 532_000 (epoch 501's StartSlot — the exact boundary)
+// Without TransitionKnown: EraEnd would be 200_000 + 25_920 = 225_920
+func TestQueryHardForkEraHistory_TransitionKnown(t *testing.T) {
+	const (
+		tipSlot          = uint64(200_000)
+		epoch500Start    = uint64(100_000)
+		epoch501Start    = uint64(532_000)
+		epochLen         = uint(432_000)
+		slotLenMs        = uint(1_000)
+		epoch500Id       = uint64(500)
+		epoch501Id       = uint64(501)
+	)
+
+	db := newTestDB(t)
+	// Epoch 500: the active epoch in the old era
+	require.NoError(t, db.SetEpoch(
+		epoch500Start, epoch500Id,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+	// Epoch 501: the transition epoch, still stored with Conway era's EraId
+	require.NoError(t, db.SetEpoch(
+		epoch501Start, epoch501Id,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{
+			State:      TransitionKnown,
+			KnownEpoch: epoch501Id,
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+
+	eraList, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+	require.NotEmpty(t, eraList)
+
+	// The last entry in the list is the Conway (current, open) era.
+	lastEra, ok := eraList[len(eraList)-1].([]any)
+	require.True(t, ok, "era entry should be []any")
+	require.Len(t, lastEra, 3, "era entry should be [start, end, params]")
+
+	eraEnd, ok := lastEra[1].([]any)
+	require.True(t, ok, "EraEnd should be []any")
+	require.Len(t, eraEnd, 3, "EraEnd should be [relTime, slot, epoch]")
+
+	actualSlot, ok := eraEnd[1].(uint64)
+	require.True(t, ok, "EraEnd slot should be uint64")
+	assert.Equal(t, epoch501Start, actualSlot,
+		"TransitionKnown: EraEnd slot should be transition epoch's StartSlot (%d), not safe-zone cap",
+		epoch501Start,
+	)
+
+	// Verify EraEnd epoch number is the transition epoch ID
+	actualEpoch, ok := eraEnd[2].(uint64)
+	require.True(t, ok, "EraEnd epoch should be uint64")
+	assert.Equal(t, epoch501Id, actualEpoch,
+		"TransitionKnown: EraEnd epoch should be the transition epoch ID",
+	)
+}
+
+// TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone confirms
+// that TransitionUnknown state still produces the safe-zone-capped EraEnd,
+// i.e. the existing behaviour is preserved.
+func TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone(t *testing.T) {
+	const (
+		tipSlot        = uint64(200_000)
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+	)
+	const expectedSafeZone = uint64(25_920)
+	expectedEraEndSlot := tipSlot + expectedSafeZone
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:             db,
+		currentEra:     eras.ConwayEraDesc,
+		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+
+	eraList, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+	require.NotEmpty(t, eraList)
+
+	lastEra, ok := eraList[len(eraList)-1].([]any)
+	require.True(t, ok)
+	eraEnd, ok := lastEra[1].([]any)
+	require.True(t, ok)
+	actualSlot, ok := eraEnd[1].(uint64)
+	require.True(t, ok)
+	assert.Equal(t, expectedEraEndSlot, actualSlot,
+		"TransitionUnknown: EraEnd slot should be tipSlot(%d)+safeZone(%d)=%d",
+		tipSlot, expectedSafeZone, expectedEraEndSlot,
+	)
+}
+
 func TestCheckedSlotAdd(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -351,6 +496,91 @@ func TestCheckedSlotAdd(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestReconstructTransitionInfo verifies that reconstructTransitionInfo sets
+// TransitionKnown when the loaded pparams carry a protocol version that maps
+// to a later era than the current epoch's stored EraId — i.e., the node was
+// stopped in the window between an epoch-rollover version bump and the first
+// block of the new era.
+func TestReconstructTransitionInfo(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentEra     eras.EraDesc
+		currentEpoch   models.Epoch
+		currentPParams lcommon.ProtocolParameters
+		expectedState  TransitionState
+		expectedEpoch  uint64
+	}{
+		{
+			// Babbage pparams with Conway major version (9): TransitionKnown.
+			// This is the pre-Conway restart window scenario.
+			name:       "babbage era pparams with conway version → TransitionKnown",
+			currentEra: *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEpoch: models.Epoch{
+				EpochId: 500,
+				EraId:   eras.BabbageEraDesc.Id,
+			},
+			currentPParams: &babbage.BabbageProtocolParameters{
+				ProtocolMajor: 9, // Conway major version, stored under Babbage era
+			},
+			expectedState: TransitionKnown,
+			expectedEpoch: 500,
+		},
+		{
+			// Babbage pparams with normal Babbage version: no transition.
+			name:       "babbage era pparams with babbage version → TransitionUnknown",
+			currentEra: *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEpoch: models.Epoch{
+				EpochId: 499,
+				EraId:   eras.BabbageEraDesc.Id,
+			},
+			currentPParams: &babbage.BabbageProtocolParameters{
+				ProtocolMajor: 8,
+			},
+			expectedState: TransitionUnknown,
+		},
+		{
+			// Conway pparams in Conway era: pparamsEra == currentEra, no transition.
+			name:       "conway era pparams with conway version → TransitionUnknown",
+			currentEra: *eras.GetEraById(eras.ConwayEraDesc.Id),
+			currentEpoch: models.Epoch{
+				EpochId: 600,
+				EraId:   eras.ConwayEraDesc.Id,
+			},
+			currentPParams: &conway.ConwayProtocolParameters{
+				ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+					Major: 9,
+				},
+			},
+			expectedState: TransitionUnknown,
+		},
+		{
+			// Nil pparams: must not panic, leave TransitionUnknown.
+			name:          "nil pparams → TransitionUnknown",
+			currentEra:    *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEpoch:  models.Epoch{EpochId: 400, EraId: eras.BabbageEraDesc.Id},
+			currentPParams: nil,
+			expectedState: TransitionUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ls := &LedgerState{
+				currentEra:     tc.currentEra,
+				currentEpoch:   tc.currentEpoch,
+				currentPParams: tc.currentPParams,
+				// transitionInfo starts at zero value (TransitionUnknown)
+			}
+			ls.reconstructTransitionInfo()
+
+			assert.Equal(t, tc.expectedState, ls.transitionInfo.State)
+			if tc.expectedState == TransitionKnown {
+				assert.Equal(t, tc.expectedEpoch, ls.transitionInfo.KnownEpoch)
+			}
 		})
 	}
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -474,6 +474,7 @@ type LedgerState struct {
 	chainsyncBlockfetchTimerGeneration uint64      // generation counter to detect stale timer callbacks
 	currentPParams                     lcommon.ProtocolParameters
 	prevEraPParams                     lcommon.ProtocolParameters // pparams from the immediately previous era (for era-1 TX validation)
+	transitionInfo                     TransitionInfo             // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
 	mempool                            MempoolProvider
 	timerCleanupConsumedUtxos          *time.Timer
 	Scheduler                          *Scheduler
@@ -551,6 +552,34 @@ type LedgerState struct {
 type EraTransitionResult struct {
 	NewPParams lcommon.ProtocolParameters
 	NewEra     eras.EraDesc
+}
+
+// TransitionState encodes which of the three HFC TransitionInfo
+// cases currently applies to the open (current) era.
+type TransitionState uint8
+
+const (
+	// TransitionUnknown means no confirmed upcoming hard fork is
+	// known.  The open era's EraEnd is capped at tipSlot + safeZone.
+	TransitionUnknown TransitionState = iota
+	// TransitionKnown means the epoch-rollover logic has detected a
+	// protocol-version bump in the upcoming epoch's pparams, but the
+	// first block of the new era has not arrived yet.  KnownEpoch is
+	// the first epoch number of the next era; its StartSlot is the
+	// exact era boundary.
+	TransitionKnown
+	// TransitionImpossible means a hard fork cannot occur in the
+	// current epoch (e.g. the safe-zone has already passed the epoch
+	// end).  Reserved for future use; treated like TransitionUnknown
+	// for query purposes.
+	TransitionImpossible
+)
+
+// TransitionInfo mirrors Haskell's HFC TransitionInfo, tracking
+// whether a confirmed upcoming era transition is known.
+type TransitionInfo struct {
+	State      TransitionState
+	KnownEpoch uint64 // first epoch of the next era; valid when State == TransitionKnown
 }
 
 // HardForkInfo holds details about a detected hard fork
@@ -712,6 +741,13 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	if err := ls.loadPParams(); err != nil {
 		return fmt.Errorf("failed to load pparams: %w", err)
 	}
+	// Reconstruct TransitionInfo from loaded state.  After restart, the
+	// in-memory field is zero (TransitionUnknown), but if the node shut down
+	// while in the window between an epoch-boundary version bump and the first
+	// block of the new era, the pparams will report a major version that maps
+	// to a later era than currentEpoch.EraId.  Detecting this here restores
+	// the correct TransitionKnown state without persisting extra data.
+	ls.reconstructTransitionInfo()
 	// Load current tip
 	if err := ls.loadTip(); err != nil {
 		return fmt.Errorf("failed to load tip: %w", err)
@@ -1671,6 +1707,9 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 		Hash: append([]byte(nil), point.Hash...),
 	}
 	ls.currentTip = newTip
+	// A rollback invalidates any pending TransitionKnown because the
+	// epoch-rollover block that set it may no longer be on the chain.
+	ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
 	// If rolling back behind the Mithril trust boundary, clear it.
 	// A rollback inside the gap means replacement blocks on the new
 	// fork were NOT processed by SetGapBlockTransaction and must go
@@ -1950,6 +1989,15 @@ func (ls *LedgerState) calculateStabilityWindowForEra(eraId uint) uint64 {
 		return blockfetchBatchSlotThresholdDefault
 	}
 	return window.Uint64()
+}
+
+// CurrentTransitionInfo returns a snapshot of the current TransitionInfo
+// under a read lock.  Callers must not hold ls.RLock() when calling this.
+func (ls *LedgerState) CurrentTransitionInfo() TransitionInfo {
+	ls.RLock()
+	ti := ls.transitionInfo
+	ls.RUnlock()
+	return ti
 }
 
 // SecurityParam returns the security parameter for the current era
@@ -2341,6 +2389,28 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				ls.currentPParams = rolloverResult.NewCurrentPParams
 				ls.checkpointWrittenForEpoch = rolloverResult.CheckpointWrittenForEpoch
 				ls.metrics.epochNum.Set(rolloverResult.NewEpochNum)
+			}
+			// Update TransitionInfo based on rollover outcome.
+			//
+			// Case 1: epoch rollover detected a version bump AND no era
+			// transition has occurred yet (we're still in the old era at
+			// the boundary block).  The transition epoch exists in the DB
+			// under the old era's EraId; its StartSlot is the exact
+			// upcoming era boundary.
+			//
+			// Case 2: an era transition happened this block (eraTransitions
+			// non-empty).  The new era is already active — clear any
+			// pending TransitionKnown.
+			if len(eraTransitions) > 0 {
+				// New era is active; previous TransitionKnown (if any) is consumed.
+				ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+			} else if rolloverResult != nil && rolloverResult.HardFork != nil {
+				// Epoch committed in the old era and version bump detected.
+				// The transition epoch number is the new (just-committed) epoch.
+				ls.transitionInfo = TransitionInfo{
+					State:      TransitionKnown,
+					KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
+				}
 			}
 			ls.Unlock()
 
@@ -3232,6 +3302,44 @@ func (ls *LedgerState) loadPParams() error {
 	ls.currentPParams = pp
 	ls.prevEraPParams = prevPP
 	return nil
+}
+
+// reconstructTransitionInfo infers the correct TransitionInfo from the
+// already-loaded currentPParams, currentEra, and currentEpoch.
+//
+// This is called once during Start() after loadPParams(), while the
+// LedgerState is still single-threaded (no lock required).
+//
+// The window that needs reconstruction: when an epoch boundary committed
+// protocol-parameter updates that bump the major protocol version (signalling
+// an upcoming era transition), but the node was stopped before the first
+// block of the new era arrived.  After restart, currentEpoch.EraId is still
+// the OLD era, but currentPParams carries the bumped version.  If those
+// pparams map to a later era than currentEra, we restore TransitionKnown.
+func (ls *LedgerState) reconstructTransitionInfo() {
+	if ls.currentPParams == nil {
+		return
+	}
+	ver, err := GetProtocolVersion(ls.currentPParams)
+	if err != nil {
+		// Not all era pparams are versioned (e.g. Byron falls through);
+		// silently leave transitionInfo at TransitionUnknown.
+		return
+	}
+	pparamsEraId, ok := EraForVersion(ver.Major)
+	if !ok {
+		return
+	}
+	// If the pparams version maps to a later era than the epoch's stored
+	// era, restore TransitionKnown.  KnownEpoch is the current epoch: it
+	// was created with the old EraId but its StartSlot is the exact
+	// upcoming era boundary.
+	if pparamsEraId > ls.currentEra.Id {
+		ls.transitionInfo = TransitionInfo{
+			State:      TransitionKnown,
+			KnownEpoch: ls.currentEpoch.EpochId,
+		}
+	}
 }
 
 // computePParams loads protocol parameters for the given epoch/era


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track upcoming era transitions in the ledger so era history returns exact boundaries when a transition is confirmed; otherwise cap at tip + stability window. On restart, reconstruct the transition state from protocol parameters to keep era boundaries accurate.

- **New Features**
  - Added `TransitionInfo` and `TransitionState` to `LedgerState` (`TransitionUnknown`, `TransitionKnown`, `TransitionImpossible`).
  - `queryHardForkEraHistory` uses the transition epoch’s `StartSlot` as the current era end when `TransitionKnown`; otherwise caps at tip + safe-zone.
  - Set `transitionInfo` at epoch rollover when a version bump is committed; clear on era transition and on rollback. Added `CurrentTransitionInfo()`.
  - Added `reconstructTransitionInfo()` to restore `TransitionKnown` on startup when pparams indicate a later era than the stored epoch era.
  - Tests cover `TransitionKnown`, safe-zone fallback, and transition reconstruction on restart.

<sup>Written for commit 2b74277e32e07176ac7996cf61fc76ba61c28ea9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced hard fork transition tracking with improved era boundary calculations.
  * System now accurately determines era-end boundaries when transition information is available, with graceful fallback to conservative estimates when transition state is unknown.

* **Tests**
  * Added test coverage for hard fork transition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->