### PR TITLE
build(deps): gouroboros 0.165.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.165.0
+	github.com/blinklabs-io/gouroboros v0.165.1
 	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.1.7
 	github.com/blockfrost/blockfrost-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yU
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.165.0 h1:GO9uOJ+Sr/Y6ipVK6H72a5BSgfgHM0/4p0hB5ITb71o=
 github.com/blinklabs-io/gouroboros v0.165.0/go.mod h1:fKNdzXX6qvd9YjGpvI+lZgqN2smgRYJYo95E4stoQ1E=
+github.com/blinklabs-io/gouroboros v0.165.1 h1:CbxJUpXs2TFHqJitRGP+q+fYaasCOOAB0JZpzBeSIkc=
+github.com/blinklabs-io/gouroboros v0.165.1/go.mod h1:fKNdzXX6qvd9YjGpvI+lZgqN2smgRYJYo95E4stoQ1E=
 github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
 github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.1.7 h1:vzrzcHRcCEAyrHZaTo1UQUxQpmU8eM1jFvtwg7MxqMY=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `github.com/blinklabs-io/gouroboros` to v0.165.1 to pull in the latest patch fixes and maintain compatibility with upstream.
`go.mod` and `go.sum` updated accordingly.

<sup>Written for commit 3393c90ffcba321b298b0001305c33f0b13d55f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

