### PR TITLE
feat(ledger): governance ratification, tally, and enactment

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -80,3 +80,76 @@ func (d *Database) GetAccount(
 	}
 	return account, nil
 }
+
+// AddAccountReward credits the reward balance for a registered account.
+func (d *Database) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn *Txn,
+) error {
+	if amount == 0 {
+		return nil
+	}
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.AddAccountReward(
+		stakeKey,
+		amount,
+		slot,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("failed to add account reward: %w", err)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return nil
+}
+
+// DeleteAccountRewardsAfterSlot reverts reward-account credits recorded after
+// the given slot. Used during chain rollback for governance deposit refunds
+// and treasury withdrawals.
+func (d *Database) DeleteAccountRewardsAfterSlot(
+	slot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.DeleteAccountRewardsAfterSlot(
+		slot,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"failed to delete account reward deltas after slot %d: %w",
+			slot,
+			err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return nil
+}

--- a/database/committee.go
+++ b/database/committee.go
@@ -15,7 +15,12 @@
 package database
 
 import (
+	"errors"
+	"fmt"
+	"math/big"
+
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 // GetCommitteeMember returns a committee member by cold key
@@ -60,6 +65,22 @@ func (d *Database) IsCommitteeMemberResigned(
 	return d.metadata.IsCommitteeMemberResigned(coldKey, txn.Metadata())
 }
 
+// GetResignedCommitteeMembers returns cold credentials whose latest
+// resignation follows their latest authorization.
+func (d *Database) GetResignedCommitteeMembers(
+	coldKeys [][]byte,
+	txn *Txn,
+) (map[string]bool, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetResignedCommitteeMembers(
+		coldKeys,
+		txn.Metadata(),
+	)
+}
+
 // GetCommitteeActiveCount returns the number of active (non-resigned)
 // committee members.
 func (d *Database) GetCommitteeActiveCount(
@@ -70,4 +91,236 @@ func (d *Database) GetCommitteeActiveCount(
 		defer txn.Release()
 	}
 	return d.metadata.GetCommitteeActiveCount(txn.Metadata())
+}
+
+// SetCommitteeMembers upserts governance-enacted committee members. Used
+// by UpdateCommittee action enactment and snapshot import.
+func (d *Database) SetCommitteeMembers(
+	members []*models.CommitteeMember,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.SetCommitteeMembers(
+		members, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("failed to set committee members: %w", err)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"failed to commit committee members: %w", err,
+			)
+		}
+		owned = false
+	}
+	return nil
+}
+
+// SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+func (d *Database) SetCommitteeQuorum(
+	quorum *big.Rat,
+	slot uint64,
+	txn *Txn,
+) error {
+	if quorum == nil {
+		return errors.New("committee quorum cannot be nil")
+	}
+	if quorum.Sign() <= 0 {
+		return errors.New("committee quorum must be positive")
+	}
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	stored := &types.Rat{Rat: new(big.Rat).Set(quorum)}
+	if err := d.metadata.SetCommitteeQuorum(
+		stored, slot, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("failed to set committee quorum: %w", err)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"failed to commit committee quorum: %w", err,
+			)
+		}
+		owned = false
+	}
+	return nil
+}
+
+// GetCommitteeQuorum returns the latest enacted committee quorum.
+func (d *Database) GetCommitteeQuorum(
+	txn *Txn,
+) (*big.Rat, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	quorum, err := d.metadata.GetCommitteeQuorum(txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get committee quorum: %w", err)
+	}
+	if quorum == nil || quorum.Rat == nil {
+		return nil, nil
+	}
+	return new(big.Rat).Set(quorum.Rat), nil
+}
+
+// GetCommitteeMembers returns all active (non-deleted) governance-enacted
+// committee members.
+func (d *Database) GetCommitteeMembers(
+	txn *Txn,
+) ([]*models.CommitteeMember, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	members, err := d.metadata.GetCommitteeMembers(txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get committee members: %w", err)
+	}
+	return members, nil
+}
+
+// GetCommitteeMembersIncludeDeleted returns all committee members
+// including soft-deleted rows. Used to detect whether a committee
+// was ever seated — after a NoConfidence action, GetCommitteeMembers
+// returns no rows, but the committee was seated previously.
+func (d *Database) GetCommitteeMembersIncludeDeleted(
+	txn *Txn,
+) ([]*models.CommitteeMember, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	members, err := d.metadata.GetCommitteeMembersIncludeDeleted(
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get committee members (include deleted): %w", err,
+		)
+	}
+	return members, nil
+}
+
+// DeleteCommitteeMembersAfterSlot removes committee state added after
+// the given slot and clears deleted_slot for any members soft-deleted
+// after that slot. Used during chain rollbacks.
+func (d *Database) DeleteCommitteeMembersAfterSlot(
+	slot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.DeleteCommitteeMembersAfterSlot(
+		slot, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"failed to delete committee members after slot %d: %w",
+			slot,
+			err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return nil
+}
+
+// SoftDeleteCommitteeMembers marks the given cold credential hashes as
+// removed. Used by UpdateCommittee action enactment to remove members.
+func (d *Database) SoftDeleteCommitteeMembers(
+	coldCredHashes [][]byte,
+	slot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.SoftDeleteCommitteeMembers(
+		coldCredHashes, slot, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"failed to soft-delete committee members: %w", err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"failed to commit soft-delete committee members: %w", err,
+			)
+		}
+		owned = false
+	}
+	return nil
+}
+
+// SoftDeleteAllCommitteeMembers marks all active committee members as
+// removed. Used by NoConfidence action enactment.
+func (d *Database) SoftDeleteAllCommitteeMembers(
+	slot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.SoftDeleteAllCommitteeMembers(
+		slot, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"failed to soft-delete all committee members: %w", err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"failed to commit soft-delete all committee members: %w",
+				err,
+			)
+		}
+		owned = false
+	}
+	return nil
 }

--- a/database/drep.go
+++ b/database/drep.go
@@ -88,8 +88,8 @@ func (d *Database) GetActiveDreps(
 }
 
 // GetDRepVotingPower calculates the voting power for a DRep by summing
-// the stake of all accounts delegated to it. Uses the current live
-// UTxO set (deleted_slot = 0) for the calculation.
+// the current stake of all delegated accounts, approximated from live
+// UTxO balance plus reward-account balance.
 func (d *Database) GetDRepVotingPower(
 	drepCredential []byte,
 	txn *Txn,
@@ -102,6 +102,56 @@ func (d *Database) GetDRepVotingPower(
 		drepCredential,
 		txn.Metadata(),
 	)
+}
+
+// GetDRepVotingPowerBatch is the batch form of GetDRepVotingPower; see
+// the metadata-store interface for the contract.
+func (d *Database) GetDRepVotingPowerBatch(
+	drepCredentials [][]byte,
+	txn *Txn,
+) (map[string]uint64, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	result, err := d.metadata.GetDRepVotingPowerBatch(
+		drepCredentials,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return result, fmt.Errorf(
+			"Database.GetDRepVotingPowerBatch: failed to get "+
+				"voting power for %d credentials: %w",
+			len(drepCredentials),
+			err,
+		)
+	}
+	return result, nil
+}
+
+// GetDRepVotingPowerByType returns voting power grouped by DRep
+// delegation type.
+func (d *Database) GetDRepVotingPowerByType(
+	drepTypes []uint64,
+	txn *Txn,
+) (map[uint64]uint64, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	result, err := d.metadata.GetDRepVotingPowerByType(
+		drepTypes,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return result, fmt.Errorf(
+			"Database.GetDRepVotingPowerByType: failed to get "+
+				"voting power for types %v: %w",
+			drepTypes,
+			err,
+		)
+	}
+	return result, nil
 }
 
 // UpdateDRepActivity updates the DRep's last activity epoch and

--- a/database/governance.go
+++ b/database/governance.go
@@ -117,7 +117,8 @@ func (d *Database) GetGovernanceProposal(
 	return proposal, nil
 }
 
-// GetActiveGovernanceProposals returns all governance proposals that haven't expired
+// GetActiveGovernanceProposals returns all governance proposals that are
+// still in the active pool (not expired, not enacted, not soft-deleted).
 func (d *Database) GetActiveGovernanceProposals(
 	epoch uint64,
 	txn *Txn,
@@ -131,6 +132,70 @@ func (d *Database) GetActiveGovernanceProposals(
 		return nil, fmt.Errorf("failed to get active governance proposals: %w", err)
 	}
 	return proposals, nil
+}
+
+// GetExpiringGovernanceProposals returns proposals whose expires_epoch is
+// strictly less than the given epoch and that have not yet been enacted,
+// expired, or soft-deleted.
+func (d *Database) GetExpiringGovernanceProposals(
+	epoch uint64,
+	txn *Txn,
+) ([]*models.GovernanceProposal, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	proposals, err := d.metadata.GetExpiringGovernanceProposals(
+		epoch, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get expiring governance proposals: %w", err,
+		)
+	}
+	return proposals, nil
+}
+
+// GetRatifiedGovernanceProposals returns proposals ratified but not yet
+// enacted, ordered by (ratified_epoch, ratified_slot, id). Used at epoch
+// start for enactment.
+func (d *Database) GetRatifiedGovernanceProposals(
+	txn *Txn,
+) ([]*models.GovernanceProposal, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	proposals, err := d.metadata.GetRatifiedGovernanceProposals(txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get ratified governance proposals: %w", err,
+		)
+	}
+	return proposals, nil
+}
+
+// GetLastEnactedGovernanceProposal returns the most recently enacted
+// proposal whose action_type is in actionTypes, or nil if none exist.
+// Callers group per-purpose action types (CIP-1694 chain roots) in
+// the slice; the single-type case passes a one-element slice.
+func (d *Database) GetLastEnactedGovernanceProposal(
+	actionTypes []uint8,
+	txn *Txn,
+) (*models.GovernanceProposal, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	proposal, err := d.metadata.GetLastEnactedGovernanceProposal(
+		actionTypes, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get last enacted governance proposal: %w", err,
+		)
+	}
+	return proposal, nil
 }
 
 // SetGovernanceProposal creates or updates a governance proposal

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -24,6 +24,48 @@ import (
 
 var ErrAccountNotFound = errors.New("account not found")
 
+const (
+	DrepTypeAddrKeyHash uint64 = iota
+	DrepTypeScriptHash
+	DrepTypeAlwaysAbstain
+	DrepTypeAlwaysNoConfidence
+)
+
+func DrepTypeFromInt(drepType int) (uint64, error) {
+	switch drepType {
+	case 0:
+		return DrepTypeAddrKeyHash, nil
+	case 1:
+		return DrepTypeScriptHash, nil
+	case 2:
+		return DrepTypeAlwaysAbstain, nil
+	case 3:
+		return DrepTypeAlwaysNoConfidence, nil
+	default:
+		return 0, fmt.Errorf("unknown drep type: %d", drepType)
+	}
+}
+
+// ValidatePredefinedDrepTypes rejects credential-backed DRep delegation
+// types. GetDRepVotingPowerByType is only for predefined, credentialless
+// DRep options.
+func ValidatePredefinedDrepTypes(drepTypes []uint64) error {
+	for _, drepType := range drepTypes {
+		switch drepType {
+		case DrepTypeAddrKeyHash, DrepTypeScriptHash:
+			return fmt.Errorf(
+				"drep type %d is credential-backed; use credential voting power",
+				drepType,
+			)
+		case DrepTypeAlwaysAbstain, DrepTypeAlwaysNoConfidence:
+			continue
+		default:
+			return fmt.Errorf("unknown predefined drep type: %d", drepType)
+		}
+	}
+	return nil
+}
+
 type Account struct {
 	StakingKey    []byte `gorm:"uniqueIndex;size:28"`
 	Pool          []byte `gorm:"index;size:28"`
@@ -32,7 +74,8 @@ type Account struct {
 	AddedSlot     uint64 `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
 	Reward        types.Uint64
-	// DrepType is the CBOR-encoded DRep delegation type:
+	// DrepType is the DRep delegation type code, an internal enum
+	// matching the Cardano ledger CBOR sum-type tag:
 	//   0 = key credential, 1 = script credential,
 	//   2 = AlwaysAbstain, 3 = AlwaysNoConfidence.
 	// A zero value (0) means either "key credential" or "no delegation set",
@@ -43,6 +86,20 @@ type Account struct {
 
 func (a *Account) TableName() string {
 	return "account"
+}
+
+// AccountRewardDelta records reward-account credits that are not otherwise
+// represented by a rollback-aware certificate row. Rollback subtracts deltas
+// added after the rollback slot before deleting the journal entries.
+type AccountRewardDelta struct {
+	StakingKey []byte       `gorm:"index;size:28;not null"`
+	Amount     types.Uint64 `gorm:"not null"`
+	ID         uint         `gorm:"primarykey"`
+	AddedSlot  uint64       `gorm:"index;not null"`
+}
+
+func (AccountRewardDelta) TableName() string {
+	return "account_reward_delta"
 }
 
 // String returns the bech32-encoded representation of the Account's StakingKey
@@ -140,6 +197,7 @@ type StakeVoteDelegation struct {
 	StakingKey    []byte `gorm:"index;size:28"`
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	Drep          []byte `gorm:"index;size:28"`
+	DrepType      uint64 `gorm:"default:0"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -153,6 +211,7 @@ type StakeVoteRegistrationDelegation struct {
 	StakingKey    []byte `gorm:"index;size:28"`
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	Drep          []byte `gorm:"index;size:28"`
+	DrepType      uint64 `gorm:"default:0"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -166,6 +225,7 @@ func (StakeVoteRegistrationDelegation) TableName() string {
 type VoteDelegation struct {
 	StakingKey    []byte `gorm:"index;size:28"`
 	Drep          []byte `gorm:"index;size:28"`
+	DrepType      uint64 `gorm:"default:0"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -178,6 +238,7 @@ func (VoteDelegation) TableName() string {
 type VoteRegistrationDelegation struct {
 	StakingKey    []byte `gorm:"index;size:28"`
 	Drep          []byte `gorm:"index;size:28"`
+	DrepType      uint64 `gorm:"default:0"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`

--- a/database/models/auth_committee_hot.go
+++ b/database/models/auth_committee_hot.go
@@ -22,10 +22,13 @@ var ErrCommitteeMemberNotFound = errors.New("committee member not found")
 
 type AuthCommitteeHot struct {
 	ColdCredential []byte `gorm:"index;size:28"`
-	HostCredential []byte `gorm:"index;size:28"`
-	ID             uint   `gorm:"primarykey"`
-	CertificateID  uint   `gorm:"index"`
-	AddedSlot      uint64 `gorm:"index"`
+	// Column is "host_credential" for backward compatibility with
+	// existing databases; the Go field uses the canonical Cardano
+	// terminology ("hot credential" for committee voting keys).
+	HotCredential []byte `gorm:"column:host_credential;index;size:28"`
+	ID            uint   `gorm:"primarykey"`
+	CertificateID uint   `gorm:"index"`
+	AddedSlot     uint64 `gorm:"index"`
 }
 
 func (AuthCommitteeHot) TableName() string {

--- a/database/models/committee_member.go
+++ b/database/models/committee_member.go
@@ -14,6 +14,8 @@
 
 package models
 
+import "github.com/blinklabs-io/dingo/database/types"
+
 // CommitteeMember represents a Constitutional Committee member imported
 // from a Mithril snapshot. This is separate from the certificate-based
 // AuthCommitteeHot/ResignCommitteeCold tables, which track committee
@@ -30,4 +32,16 @@ type CommitteeMember struct {
 // TableName returns the table name for CommitteeMember.
 func (CommitteeMember) TableName() string {
 	return "committee_member"
+}
+
+// CommitteeQuorum records the quorum threshold enacted with a committee.
+type CommitteeQuorum struct {
+	Quorum    *types.Rat
+	ID        uint   `gorm:"primarykey"`
+	AddedSlot uint64 `gorm:"uniqueIndex;not null"`
+}
+
+// TableName returns the table name for CommitteeQuorum.
+func (CommitteeQuorum) TableName() string {
+	return "committee_quorum"
 }

--- a/database/models/governance.go
+++ b/database/models/governance.go
@@ -69,8 +69,15 @@ type GovernanceProposal struct {
 	AnchorHash      []byte  `gorm:"size:32;not null"`
 	Deposit         uint64  `gorm:"not null"`
 	ReturnAddress   []byte  `gorm:"size:29;not null"` // Reward account for deposit return (1 byte header + 28 bytes hash)
-	AddedSlot       uint64  `gorm:"index;not null"`
-	DeletedSlot     *uint64 `gorm:"index"`
+	// GovActionCbor holds the CBOR-encoded GovAction needed at enactment
+	// time to extract type-specific fields (ParamUpdate, ProtocolVersion,
+	// Withdrawals, Committee changes, Constitution). Populated on proposal
+	// submission so enactment does not need to re-fetch the transaction.
+	GovActionCbor []byte
+	ExpiredEpoch  *uint64 `gorm:"index"`
+	ExpiredSlot   *uint64 `gorm:"index"` // Slot when expired (for rollback safety)
+	AddedSlot     uint64  `gorm:"index;not null"`
+	DeletedSlot   *uint64 `gorm:"index"`
 }
 
 // TableName returns the table name

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -17,6 +17,7 @@ package models
 // MigrateModels contains a list of model objects that should have DB migrations applied
 var MigrateModels = []any{
 	&Account{},
+	&AccountRewardDelta{},
 	&AddressTransaction{},
 	&Asset{},
 	&AuthCommitteeHot{},
@@ -24,6 +25,7 @@ var MigrateModels = []any{
 	&BlockNonce{},
 	&Certificate{},
 	&CommitteeMember{},
+	&CommitteeQuorum{},
 	&Constitution{},
 	&Datum{},
 	&Deregistration{},

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -46,6 +47,136 @@ func (d *MetadataStoreMysql) GetAccount(
 		return nil, result.Error
 	}
 	return ret, nil
+}
+
+// AddAccountReward credits a registered reward account.
+func (d *MetadataStoreMysql) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if amount == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	// Wrap the read-check-write and the journal insert in a single
+	// transaction so the on-disk reward and the AccountRewardDelta
+	// journal stay in sync: if the journal insert fails, the reward
+	// update rolls back. The overflow check runs in Go because the
+	// reward column is stored as a decimal string (see
+	// types.Uint64.Value), which makes SQL `reward + ? <= ?`
+	// comparisons lexicographic, not numeric, and unsafe as a guard.
+	credit := func(tx *gorm.DB) error {
+		var account models.Account
+		if err := tx.Where(
+			"staking_key = ? AND active = ?",
+			stakeKey,
+			true,
+		).First(&account).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return models.ErrAccountNotFound
+			}
+			return err
+		}
+		current := uint64(account.Reward)
+		if current > ^uint64(0)-amount {
+			return fmt.Errorf(
+				"account reward overflow for stake key %x",
+				stakeKey,
+			)
+		}
+		result := tx.Model(&models.Account{}).
+			Where("id = ?", account.ID).
+			Update("reward", types.Uint64(current+amount))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return models.ErrAccountNotFound
+		}
+		delta := &models.AccountRewardDelta{
+			StakingKey: stakeKey,
+			Amount:     types.Uint64(amount),
+			AddedSlot:  slot,
+		}
+		return tx.Create(delta).Error
+	}
+	if txn != nil {
+		return credit(db)
+	}
+	return db.Transaction(credit)
+}
+
+// DeleteAccountRewardsAfterSlot reverts account reward credits recorded
+// after the given slot and deletes their journal rows.
+func (d *MetadataStoreMysql) DeleteAccountRewardsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	rollback := func(tx *gorm.DB) error {
+		var deltas []models.AccountRewardDelta
+		if result := tx.Where(
+			"added_slot > ?",
+			slot,
+		).Find(&deltas); result.Error != nil {
+			return result.Error
+		}
+		byStakeKey := make(map[string]uint64, len(deltas))
+		for _, delta := range deltas {
+			key := string(delta.StakingKey)
+			amount := uint64(delta.Amount)
+			if byStakeKey[key] > ^uint64(0)-amount {
+				return fmt.Errorf(
+					"account reward rollback overflow for stake key %x",
+					delta.StakingKey,
+				)
+			}
+			byStakeKey[key] += amount
+		}
+		for key, amount := range byStakeKey {
+			var account models.Account
+			if result := tx.Where(
+				"staking_key = ?",
+				[]byte(key),
+			).First(&account); result.Error != nil {
+				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+					return models.ErrAccountNotFound
+				}
+				return result.Error
+			}
+			current := uint64(account.Reward)
+			if current < amount {
+				return fmt.Errorf(
+					"account reward rollback underflow for stake key %x",
+					[]byte(key),
+				)
+			}
+			if result := tx.Model(&models.Account{}).
+				Where("id = ?", account.ID).
+				Update("reward", types.Uint64(current-amount)); result.Error != nil {
+				return result.Error
+			}
+		}
+		if result := tx.Where(
+			"added_slot > ?",
+			slot,
+		).Delete(&models.AccountRewardDelta{}); result.Error != nil {
+			return result.Error
+		}
+		return nil
+	}
+	if txn != nil {
+		return rollback(db)
+	}
+	return db.Transaction(rollback)
 }
 
 // SetAccount saves an account
@@ -84,6 +215,7 @@ func (d *MetadataStoreMysql) SetAccount(
 type certRecord struct {
 	pool      []byte
 	drep      []byte
+	drepType  uint64
 	addedSlot uint64
 	certIndex uint32
 }
@@ -304,13 +436,14 @@ func batchFetchStakeVoteRegistrationDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		Drep        []byte
+		DrepType    uint64
 		AddedSlot   uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -319,7 +452,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -329,6 +462,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 		rec := certRecord{
 			pool:      r.PoolKeyHash,
 			drep:      r.Drep,
+			drepType:  r.DrepType,
 			addedSlot: r.AddedSlot,
 			certIndex: r.CertIndex,
 		}
@@ -338,6 +472,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 			key,
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -355,13 +490,14 @@ func batchFetchVoteRegistrationDelegation(
 	type result struct {
 		StakingKey []byte
 		Drep       []byte
+		DrepType   uint64
 		AddedSlot  uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -370,7 +506,7 @@ func batchFetchVoteRegistrationDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -379,6 +515,7 @@ func batchFetchVoteRegistrationDelegation(
 		key := string(r.StakingKey)
 		rec := certRecord{
 			drep:      r.Drep,
+			drepType:  r.DrepType,
 			addedSlot: r.AddedSlot,
 			certIndex: r.CertIndex,
 		}
@@ -551,13 +688,14 @@ func batchFetchStakeVoteDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		Drep        []byte
+		DrepType    uint64
 		AddedSlot   uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -566,7 +704,7 @@ func batchFetchStakeVoteDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -585,6 +723,7 @@ func batchFetchStakeVoteDelegation(
 			key,
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -602,13 +741,14 @@ func batchFetchVoteDelegation(
 	type result struct {
 		StakingKey []byte
 		Drep       []byte
+		DrepType   uint64
 		AddedSlot  uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -617,7 +757,7 @@ func batchFetchVoteDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -627,6 +767,7 @@ func batchFetchVoteDelegation(
 			string(r.StakingKey),
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -700,9 +841,11 @@ func (d *MetadataStoreMysql) RestoreAccountStateAtSlot(
 
 		// Get DRep delegation from cache
 		var drep []byte
+		var drepType uint64
 		var drepRec certRecord
 		if rec, ok := cache.drepDelegation[key]; ok {
 			drep = rec.drep
+			drepType = rec.drepType
 			drepRec = rec
 		}
 
@@ -733,6 +876,7 @@ func (d *MetadataStoreMysql) RestoreAccountStateAtSlot(
 		if result := db.Model(&account).Updates(map[string]any{
 			"pool":       pool,
 			"drep":       drep,
+			"drep_type":  drepType,
 			"active":     active,
 			"added_slot": lastModSlot,
 		}); result.Error != nil {

--- a/database/plugin/metadata/mysql/committee_member.go
+++ b/database/plugin/metadata/mysql/committee_member.go
@@ -15,6 +15,7 @@
 package mysql
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -53,6 +54,62 @@ func (d *MetadataStoreMysql) SetCommitteeMembers(
 	return nil
 }
 
+// SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+func (d *MetadataStoreMysql) SetCommitteeQuorum(
+	quorum *types.Rat,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if quorum == nil || quorum.Rat == nil {
+		return errors.New("committee quorum cannot be nil")
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("SetCommitteeQuorum: resolve db: %w", err)
+	}
+	state := &models.CommitteeQuorum{
+		Quorum:    quorum,
+		AddedSlot: slot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "added_slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"quorum",
+		}),
+	}
+	if result := db.Clauses(onConflict).Create(state); result.Error != nil {
+		return fmt.Errorf(
+			"SetCommitteeQuorum: upsert failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// GetCommitteeQuorum retrieves the latest enacted committee quorum.
+func (d *MetadataStoreMysql) GetCommitteeQuorum(
+	txn types.Txn,
+) (*types.Rat, error) {
+	var state models.CommitteeQuorum
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeQuorum: resolve db: %w", err,
+		)
+	}
+	if result := db.Order("added_slot DESC, id DESC").
+		First(&state); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"GetCommitteeQuorum: query failed: %w",
+			result.Error,
+		)
+	}
+	return state.Quorum, nil
+}
+
 // GetCommitteeMembers retrieves all active (non-deleted) snapshot-imported
 // committee members.
 func (d *MetadataStoreMysql) GetCommitteeMembers(
@@ -76,8 +133,80 @@ func (d *MetadataStoreMysql) GetCommitteeMembers(
 	return members, nil
 }
 
-// DeleteCommitteeMembersAfterSlot removes committee members added after
-// the given slot and clears deleted_slot for any that were soft-deleted
+// GetCommitteeMembersIncludeDeleted returns every committee member
+// row including soft-deleted ones. See sqlite variant for rationale.
+func (d *MetadataStoreMysql) GetCommitteeMembersIncludeDeleted(
+	txn types.Txn,
+) ([]*models.CommitteeMember, error) {
+	var members []*models.CommitteeMember
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeMembersIncludeDeleted: resolve db: %w", err,
+		)
+	}
+	if result := db.Find(&members); result.Error != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeMembersIncludeDeleted: query failed: %w",
+			result.Error,
+		)
+	}
+	return members, nil
+}
+
+// SoftDeleteCommitteeMembers marks the given cold credential hashes as
+// removed by setting deleted_slot. Used by governance enactment to remove
+// members listed in an UpdateCommittee action.
+func (d *MetadataStoreMysql) SoftDeleteCommitteeMembers(
+	coldCredHashes [][]byte,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if len(coldCredHashes) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"SoftDeleteCommitteeMembers: resolve db: %w", err,
+		)
+	}
+	if result := db.Model(&models.CommitteeMember{}).
+		Where("cold_cred_hash IN ? AND deleted_slot IS NULL", coldCredHashes).
+		Update("deleted_slot", slot); result.Error != nil {
+		return fmt.Errorf(
+			"SoftDeleteCommitteeMembers: update failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// SoftDeleteAllCommitteeMembers marks all active committee members as
+// removed. Used by governance enactment for NoConfidence actions.
+func (d *MetadataStoreMysql) SoftDeleteAllCommitteeMembers(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"SoftDeleteAllCommitteeMembers: resolve db: %w", err,
+		)
+	}
+	if result := db.Model(&models.CommitteeMember{}).
+		Where("deleted_slot IS NULL").
+		Update("deleted_slot", slot); result.Error != nil {
+		return fmt.Errorf(
+			"SoftDeleteAllCommitteeMembers: update failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// DeleteCommitteeMembersAfterSlot removes committee state added after
+// the given slot and clears deleted_slot for any members soft-deleted
 // after that slot.
 func (d *MetadataStoreMysql) DeleteCommitteeMembersAfterSlot(
 	slot uint64,
@@ -97,6 +226,15 @@ func (d *MetadataStoreMysql) DeleteCommitteeMembersAfterSlot(
 		).Delete(&models.CommitteeMember{}); result.Error != nil {
 			return fmt.Errorf(
 				"DeleteCommitteeMembersAfterSlot: delete failed: %w",
+				result.Error,
+			)
+		}
+
+		if result := tx.Where(
+			"added_slot > ?", slot,
+		).Delete(&models.CommitteeQuorum{}); result.Error != nil {
+			return fmt.Errorf(
+				"DeleteCommitteeMembersAfterSlot: delete quorum failed: %w",
 				result.Error,
 			)
 		}

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -98,10 +98,10 @@ func (d *MetadataStoreMysql) SetDrep(
 }
 
 // GetDRepVotingPower calculates the voting power for a DRep by summing the
-// stake of all accounts delegated to it. Uses the current live UTxO set
-// (deleted_slot = 0) for the calculation.
+// current stake of all accounts delegated to it, including live UTxO balance
+// plus reward-account balance.
 //
-// TODO: This implementation uses the current live UTxO set as an
+// TODO: This implementation uses current live balances as an
 // approximation. A future implementation should accept an epoch
 // parameter and use epoch-based stake snapshots for accurate
 // voting power at a specific point in time.
@@ -115,18 +115,136 @@ func (d *MetadataStoreMysql) GetDRepVotingPower(
 	}
 	var totalStake uint64
 	if err := db.Raw(`
-		SELECT COALESCE(SUM(CAST(u.amount AS UNSIGNED)), 0)
-		FROM utxo u
-		WHERE u.deleted_slot = 0
-		AND u.staking_key IN (
-			SELECT a.staking_key
-			FROM account a
-			WHERE a.drep = ? AND a.active = 1
-		)
-	`, drepCredential).Scan(&totalStake).Error; err != nil {
+		SELECT COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
+			   ), 0)
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE drep = ? AND active = 1
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.drep = ? AND a.active = 1
+	`, drepCredential, drepCredential).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 	return totalStake, nil
+}
+
+// GetDRepVotingPowerBatch returns voting power for each DRep credential
+// in a single query. See sqlite/drep.go for the documented contract.
+func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
+	drepCredentials [][]byte,
+	txn types.Txn,
+) (map[string]uint64, error) {
+	out := make(map[string]uint64, len(drepCredentials))
+	if len(drepCredentials) == 0 {
+		return out, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		Drep  []byte
+		Stake uint64
+	}
+	var rows []row
+	// Aggregate UTxO amounts per staking_key in a subquery before
+	// adding account.reward, otherwise the LEFT JOIN would multiply
+	// the per-account reward by the number of live UTxOs and inflate
+	// the totals. Each account contributes (utxo_sum + reward) once
+	// to its DRep bucket.
+	if err := db.Raw(`
+		SELECT a.drep AS drep,
+			   COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
+			   ), 0) AS stake
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE active = 1 AND drep IN ?
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.active = 1 AND a.drep IN ?
+		GROUP BY a.drep
+	`, drepCredentials, drepCredentials).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get drep voting power batch: %w", err)
+	}
+	for _, r := range rows {
+		out[string(r.Drep)] = r.Stake
+	}
+	return out, nil
+}
+
+// GetDRepVotingPowerByType returns voting power grouped by DRep delegation
+// type. It is used for predefined DRep options, which carry no credential.
+func (d *MetadataStoreMysql) GetDRepVotingPowerByType(
+	drepTypes []uint64,
+	txn types.Txn,
+) (map[uint64]uint64, error) {
+	out := make(map[uint64]uint64, len(drepTypes))
+	if len(drepTypes) == 0 {
+		return out, nil
+	}
+	if err := models.ValidatePredefinedDrepTypes(drepTypes); err != nil {
+		return nil, err
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		DrepType uint64
+		Stake    uint64
+	}
+	var rows []row
+	// Aggregate UTxO amounts per staking_key in a subquery before
+	// adding account.reward, otherwise the LEFT JOIN would multiply
+	// the per-account reward by the number of live UTxOs and inflate
+	// the totals. Each account contributes (utxo_sum + reward) once
+	// to its drep_type bucket.
+	if err := db.Raw(`
+		SELECT a.drep_type AS drep_type,
+			   COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
+			   ), 0) AS stake
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE active = 1 AND drep_type IN ?
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.active = 1 AND a.drep_type IN ?
+		GROUP BY a.drep_type
+	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get drep voting power by type: %w", err)
+	}
+	for _, r := range rows {
+		out[r.DrepType] = r.Stake
+	}
+	return out, nil
 }
 
 // UpdateDRepActivity updates the DRep's last activity epoch and

--- a/database/plugin/metadata/mysql/drep_test.go
+++ b/database/plugin/metadata/mysql/drep_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupDRepVotingPowerTestData(t *testing.T, store *MetadataStoreMysql) {
+	t.Helper()
+
+	db := store.DB()
+	db.Where("1 = 1").Delete(&models.Utxo{})
+	db.Where("1 = 1").Delete(&models.Account{})
+	db.Where("1 = 1").Delete(&models.Drep{})
+}
+
+func TestMysqlGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	cleanupDRepVotingPowerTestData(t, store)
+
+	rewardOnlyCred := testHash28("drep_reward_only")
+	rewardOnlyStake := testHash28("stake_reward_only")
+	multiUtxoCred := testHash28("drep_multi_utxo")
+	multiUtxoStake := testHash28("stake_multi_utxo")
+
+	require.NoError(t, store.SetDrep(rewardOnlyCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(multiUtxoCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardOnlyStake,
+		Drep:       rewardOnlyCred,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: multiUtxoStake,
+		Drep:       multiUtxoCred,
+		Reward:     500,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       testHash32("tx_reward_1"),
+		StakingKey: multiUtxoStake,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       testHash32("tx_reward_2"),
+		StakingKey: multiUtxoStake,
+		Amount:     200,
+		OutputIdx:  1,
+		AddedSlot:  1000,
+	}).Error)
+
+	powers, err := store.GetDRepVotingPowerBatch(
+		[][]byte{rewardOnlyCred, multiUtxoCred},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), powers[string(rewardOnlyCred)])
+	assert.Equal(t, uint64(1000), powers[string(multiUtxoCred)])
+
+	singlePower, err := store.GetDRepVotingPower(rewardOnlyCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), singlePower)
+
+	singlePower, err = store.GetDRepVotingPower(multiUtxoCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), singlePower)
+}
+
+func TestMysqlGetDRepVotingPowerByTypeIncludesReward(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	cleanupDRepVotingPowerTestData(t, store)
+
+	abstainStake := testHash28("stake_abstain_reward")
+	noConfidenceStake := testHash28("stake_no_conf_reward")
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: abstainStake,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: noConfidenceStake,
+		DrepType:   models.DrepTypeAlwaysNoConfidence,
+		Reward:     500,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       testHash32("tx_type_1"),
+		StakingKey: noConfidenceStake,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       testHash32("tx_type_2"),
+		StakingKey: noConfidenceStake,
+		Amount:     200,
+		OutputIdx:  1,
+		AddedSlot:  1000,
+	}).Error)
+
+	powers, err := store.GetDRepVotingPowerByType(
+		[]uint64{
+			models.DrepTypeAlwaysAbstain,
+			models.DrepTypeAlwaysNoConfidence,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), powers[models.DrepTypeAlwaysAbstain])
+	assert.Equal(t, uint64(1000), powers[models.DrepTypeAlwaysNoConfidence])
+}

--- a/database/plugin/metadata/mysql/governance.go
+++ b/database/plugin/metadata/mysql/governance.go
@@ -48,7 +48,9 @@ func (d *MetadataStoreMysql) GetGovernanceProposal(
 	return &proposal, nil
 }
 
-// GetActiveGovernanceProposals retrieves all governance proposals that haven't expired.
+// GetActiveGovernanceProposals retrieves all governance proposals that
+// are still in the active pool: not expired past the given epoch, not
+// enacted, not marked expired, not soft-deleted.
 func (d *MetadataStoreMysql) GetActiveGovernanceProposals(
 	epoch uint64,
 	txn types.Txn,
@@ -59,12 +61,159 @@ func (d *MetadataStoreMysql) GetActiveGovernanceProposals(
 		return nil, err
 	}
 	if result := db.Where(
-		"expires_epoch >= ? AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+		"expires_epoch >= ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
 		epoch,
-	).Find(&proposals); result.Error != nil {
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
 		return nil, result.Error
 	}
 	return proposals, nil
+}
+
+// GetExpiringGovernanceProposals returns proposals whose expires_epoch is
+// strictly less than the given epoch and that have not yet been enacted,
+// expired, or soft-deleted.
+func (d *MetadataStoreMysql) GetExpiringGovernanceProposals(
+	epoch uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"expires_epoch < ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
+		epoch,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// governanceProposalOrder is the stable row order used when iterating
+// active/expiring proposals at epoch boundaries. Consensus-critical:
+// the epoch tick enforces at-most-one ratification per purpose, so
+// nodes must see proposals in the same order to agree on which one
+// ratifies.
+const governanceProposalOrder = "proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC"
+
+// ratifiedGovernanceProposalOrder is the row order used when iterating
+// ratified-but-not-yet-enacted proposals at epoch start. Consensus-critical:
+// ratification time comes first so older ratifications enact first; the
+// remainder is the chain-deterministic tie-break shared by
+// governanceProposalOrder so all nodes (regardless of insertion order or
+// restored backups) agree on enactment order within a single tick.
+const ratifiedGovernanceProposalOrder = "ratified_epoch ASC, ratified_slot ASC, proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC"
+
+// GetRatifiedGovernanceProposals returns proposals that have been ratified
+// but not yet enacted.
+func (d *MetadataStoreMysql) GetRatifiedGovernanceProposals(
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"ratified_epoch IS NOT NULL AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// GetLastEnactedGovernanceProposal returns the most recently enacted
+// proposal whose action_type is in actionTypes, or nil if none exist.
+// See the sqlite variant for the per-purpose grouping rationale.
+func (d *MetadataStoreMysql) GetLastEnactedGovernanceProposal(
+	actionTypes []uint8,
+	txn types.Txn,
+) (*models.GovernanceProposal, error) {
+	if len(actionTypes) == 0 {
+		return nil, nil
+	}
+	// GORM serialises []uint8 as a single binary blob, so expand to
+	// []int before passing to IN ?.
+	params := make([]int, len(actionTypes))
+	for i, t := range actionTypes {
+		params[i] = int(t)
+	}
+	var proposal models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"action_type IN ? AND enacted_epoch IS NOT NULL AND deleted_slot IS NULL",
+		params,
+	).Order("enacted_epoch DESC, enacted_slot DESC, id DESC").First(&proposal); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &proposal, nil
+}
+
+// govProposalUpsertColumns is the list of columns whose values are
+// always replaced on upsert. Lifecycle columns (enacted_*, ratified_*,
+// expired_*, deleted_slot) and gov_action_cbor are handled separately
+// (see govProposalUpsertAssignments) so a re-submission of the base
+// proposal record (e.g., a resumable import) does not clobber a
+// previously-recorded state transition.
+var govProposalUpsertColumns = []string{
+	"action_type",
+	"proposed_epoch",
+	"expires_epoch",
+	"parent_tx_hash",
+	"parent_action_idx",
+	"policy_hash",
+	"anchor_url",
+	"anchor_hash",
+	"deposit",
+	"return_address",
+}
+
+// govProposalLifecycleColumns are nullable columns that carry state
+// transitions written by governance enactment/ratification/expiry/
+// deletion. They must only be updated when the incoming value is
+// non-NULL so an unrelated upsert cannot revert a transition to NULL.
+var govProposalLifecycleColumns = []string{
+	"enacted_epoch",
+	"enacted_slot",
+	"ratified_epoch",
+	"ratified_slot",
+	"expired_epoch",
+	"expired_slot",
+	"deleted_slot",
+}
+
+// govProposalUpsertAssignments builds the on-conflict Set for
+// SetGovernanceProposal. MySQL's ON DUPLICATE KEY UPDATE refers to
+// the incoming row with VALUES(col); we guard the gov_action_cbor
+// assignment so an empty incoming payload keeps the stored value,
+// and we guard each lifecycle column the same way so a NULL incoming
+// value preserves the prior transition.
+func govProposalUpsertAssignments() clause.Set {
+	set := clause.AssignmentColumns(govProposalUpsertColumns)
+	set = append(set, clause.Assignment{
+		Column: clause.Column{Name: "gov_action_cbor"},
+		Value: gorm.Expr(
+			"IF(LENGTH(VALUES(gov_action_cbor)) > 0, " +
+				"VALUES(gov_action_cbor), gov_action_cbor)",
+		),
+	})
+	for _, col := range govProposalLifecycleColumns {
+		set = append(set, clause.Assignment{
+			Column: clause.Column{Name: col},
+			Value: gorm.Expr(
+				"IF(VALUES(" + col + ") IS NOT NULL, " +
+					"VALUES(" + col + "), " + col + ")",
+			),
+		})
+	}
+	return set
 }
 
 // SetGovernanceProposal creates or updates a governance proposal.
@@ -81,26 +230,12 @@ func (d *MetadataStoreMysql) SetGovernanceProposal(
 			{Name: "tx_hash"},
 			{Name: "action_index"},
 		},
-		// Note: added_slot is NOT updated on conflict to preserve rollback safety.
-		// The original added_slot represents when the proposal was first submitted.
-		// enacted_slot and ratified_slot track when status changes occur for rollback.
-		DoUpdates: clause.AssignmentColumns([]string{
-			"action_type",
-			"proposed_epoch",
-			"expires_epoch",
-			"parent_tx_hash",
-			"parent_action_idx",
-			"enacted_epoch",
-			"enacted_slot",
-			"ratified_epoch",
-			"ratified_slot",
-			"policy_hash",
-			"anchor_url",
-			"anchor_hash",
-			"deposit",
-			"return_address",
-			"deleted_slot",
-		}),
+		// Note: added_slot is NOT updated on conflict to preserve
+		// rollback safety. enacted_slot and ratified_slot track when
+		// status changes occur for rollback. gov_action_cbor uses a
+		// conditional update so an empty incoming payload (from a
+		// resumable import) doesn't overwrite stored CBOR.
+		DoUpdates: govProposalUpsertAssignments(),
 	}
 	if result := db.Clauses(onConflict).Create(proposal); result.Error != nil {
 		return result.Error
@@ -263,6 +398,95 @@ func (d *MetadataStoreMysql) IsCommitteeMemberResigned(
 	return false, nil
 }
 
+// GetResignedCommitteeMembers returns cold credentials whose latest
+// resignation is after their latest authorization.
+func (d *MetadataStoreMysql) GetResignedCommitteeMembers(
+	coldKeys [][]byte,
+	txn types.Txn,
+) (map[string]bool, error) {
+	resigned := make(map[string]bool)
+	if len(coldKeys) == 0 {
+		return resigned, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	var auths []models.AuthCommitteeHot
+	if result := db.Where(
+		"cold_credential IN ?",
+		coldKeys,
+	).Find(&auths); result.Error != nil {
+		return nil, result.Error
+	}
+	latestAuth := make(map[string]models.AuthCommitteeHot, len(auths))
+	for _, auth := range auths {
+		key := string(auth.ColdCredential)
+		prev, ok := latestAuth[key]
+		if !ok || committeeEventAfter(
+			auth.AddedSlot,
+			auth.CertificateID,
+			prev.AddedSlot,
+			prev.CertificateID,
+		) {
+			latestAuth[key] = auth
+		}
+	}
+
+	var resigns []models.ResignCommitteeCold
+	if result := db.Where(
+		"cold_credential IN ?",
+		coldKeys,
+	).Find(&resigns); result.Error != nil {
+		return nil, result.Error
+	}
+	latestResign := make(
+		map[string]models.ResignCommitteeCold,
+		len(resigns),
+	)
+	for _, resign := range resigns {
+		key := string(resign.ColdCredential)
+		prev, ok := latestResign[key]
+		if !ok || committeeEventAfter(
+			resign.AddedSlot,
+			resign.CertificateID,
+			prev.AddedSlot,
+			prev.CertificateID,
+		) {
+			latestResign[key] = resign
+		}
+	}
+
+	for key, resign := range latestResign {
+		auth, ok := latestAuth[key]
+		if !ok {
+			continue
+		}
+		if committeeEventAfter(
+			resign.AddedSlot,
+			resign.CertificateID,
+			auth.AddedSlot,
+			auth.CertificateID,
+		) {
+			resigned[key] = true
+		}
+	}
+	return resigned, nil
+}
+
+func committeeEventAfter(
+	addedSlot uint64,
+	certificateID uint,
+	otherAddedSlot uint64,
+	otherCertificateID uint,
+) bool {
+	if addedSlot > otherAddedSlot {
+		return true
+	}
+	return addedSlot == otherAddedSlot && certificateID > otherCertificateID
+}
+
 // GetConstitution retrieves the current constitution.
 // Returns nil if the constitution has been soft-deleted.
 func (d *MetadataStoreMysql) GetConstitution(
@@ -347,39 +571,54 @@ func (d *MetadataStoreMysql) DeleteGovernanceProposalsAfterSlot(
 		return err
 	}
 
-	// Delete proposals added after the rollback slot
-	if result := db.Where("added_slot > ?", slot).Delete(&models.GovernanceProposal{}); result.Error != nil {
-		return result.Error
+	rollback := func(tx *gorm.DB) error {
+		// Delete proposals added after the rollback slot
+		if result := tx.Where("added_slot > ?", slot).Delete(&models.GovernanceProposal{}); result.Error != nil {
+			return result.Error
+		}
+		// Clear deleted_slot for proposals soft-deleted after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("deleted_slot > ?", slot).
+			Update("deleted_slot", nil); result.Error != nil {
+			return result.Error
+		}
+		// Revert ratification that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("ratified_slot > ?", slot).
+			Updates(map[string]any{
+				"ratified_epoch": nil,
+				"ratified_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		// Revert enactment that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("enacted_slot > ?", slot).
+			Updates(map[string]any{
+				"enacted_epoch": nil,
+				"enacted_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		// Revert expiry that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("expired_slot > ?", slot).
+			Updates(map[string]any{
+				"expired_epoch": nil,
+				"expired_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		return nil
 	}
 
-	// Clear deleted_slot for proposals soft-deleted after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", nil); result.Error != nil {
-		return result.Error
+	// If caller provided a transaction, use it directly. Otherwise wrap
+	// in a single transaction so a partial failure cannot leave the
+	// table half-rolled-back.
+	if txn != nil {
+		return rollback(db)
 	}
-
-	// Revert ratification that occurred after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("ratified_slot > ?", slot).
-		Updates(map[string]any{
-			"ratified_epoch": nil,
-			"ratified_slot":  nil,
-		}); result.Error != nil {
-		return result.Error
-	}
-
-	// Revert enactment that occurred after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("enacted_slot > ?", slot).
-		Updates(map[string]any{
-			"enacted_epoch": nil,
-			"enacted_slot":  nil,
-		}); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	return db.Transaction(rollback)
 }
 
 // DeleteGovernanceVotesAfterSlot removes votes added after the given slot
@@ -401,24 +640,28 @@ func (d *MetadataStoreMysql) DeleteGovernanceVotesAfterSlot(
 		return err
 	}
 
-	// Delete votes added after the rollback slot
-	if result := db.Where("added_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
-		return result.Error
+	rollback := func(tx *gorm.DB) error {
+		// Delete votes added after the rollback slot
+		if result := tx.Where("added_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
+			return result.Error
+		}
+		// Delete votes that were updated (changed) after the rollback slot
+		// Since we can't restore the previous vote value, removing the vote is safer
+		// than keeping a potentially incorrect value
+		if result := tx.Where("vote_updated_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
+			return result.Error
+		}
+		// Clear deleted_slot for votes soft-deleted after the rollback slot
+		if result := tx.Model(&models.GovernanceVote{}).
+			Where("deleted_slot > ?", slot).
+			Update("deleted_slot", nil); result.Error != nil {
+			return result.Error
+		}
+		return nil
 	}
 
-	// Delete votes that were updated (changed) after the rollback slot
-	// Since we can't restore the previous vote value, removing the vote is safer
-	// than keeping a potentially incorrect value
-	if result := db.Where("vote_updated_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
-		return result.Error
+	if txn != nil {
+		return rollback(db)
 	}
-
-	// Clear deleted_slot for votes soft-deleted after the rollback slot
-	if result := db.Model(&models.GovernanceVote{}).
-		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", nil); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	return db.Transaction(rollback)
 }

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -483,6 +483,7 @@ func saveAccount(account *models.Account, db *gorm.DB) error {
 				[]string{
 					"pool",
 					"drep",
+					"drep_type",
 					"active",
 					"certificate_id",
 				},
@@ -1601,15 +1602,26 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
 						PoolKeyHash:   c.PoolKeyHash[:],
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1778,15 +1790,26 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
 						PoolKeyHash:   c.PoolKeyHash[:],
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1808,13 +1831,24 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1836,13 +1870,24 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1863,7 +1908,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpAuth := models.AuthCommitteeHot{
 						ColdCredential: coldCredential,
-						HostCredential: hotCredential,
+						HotCredential:  hotCredential,
 						CertificateID:  certIDMap[i],
 						AddedSlot:      point.Slot,
 					}

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -16,6 +16,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -46,6 +47,136 @@ func (d *MetadataStorePostgres) GetAccount(
 		return nil, result.Error
 	}
 	return ret, nil
+}
+
+// AddAccountReward credits a registered reward account.
+func (d *MetadataStorePostgres) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if amount == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	// Wrap the read-check-write and the journal insert in a single
+	// transaction so the on-disk reward and the AccountRewardDelta
+	// journal stay in sync: if the journal insert fails, the reward
+	// update rolls back. The overflow check runs in Go because the
+	// reward column is stored as a decimal string (see
+	// types.Uint64.Value), which makes SQL `reward + ? <= ?`
+	// comparisons lexicographic, not numeric, and unsafe as a guard.
+	credit := func(tx *gorm.DB) error {
+		var account models.Account
+		if err := tx.Where(
+			"staking_key = ? AND active = ?",
+			stakeKey,
+			true,
+		).First(&account).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return models.ErrAccountNotFound
+			}
+			return err
+		}
+		current := uint64(account.Reward)
+		if current > ^uint64(0)-amount {
+			return fmt.Errorf(
+				"account reward overflow for stake key %x",
+				stakeKey,
+			)
+		}
+		result := tx.Model(&models.Account{}).
+			Where("id = ?", account.ID).
+			Update("reward", types.Uint64(current+amount))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return models.ErrAccountNotFound
+		}
+		delta := &models.AccountRewardDelta{
+			StakingKey: stakeKey,
+			Amount:     types.Uint64(amount),
+			AddedSlot:  slot,
+		}
+		return tx.Create(delta).Error
+	}
+	if txn != nil {
+		return credit(db)
+	}
+	return db.Transaction(credit)
+}
+
+// DeleteAccountRewardsAfterSlot reverts account reward credits recorded
+// after the given slot and deletes their journal rows.
+func (d *MetadataStorePostgres) DeleteAccountRewardsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	rollback := func(tx *gorm.DB) error {
+		var deltas []models.AccountRewardDelta
+		if result := tx.Where(
+			"added_slot > ?",
+			slot,
+		).Find(&deltas); result.Error != nil {
+			return result.Error
+		}
+		byStakeKey := make(map[string]uint64, len(deltas))
+		for _, delta := range deltas {
+			key := string(delta.StakingKey)
+			amount := uint64(delta.Amount)
+			if byStakeKey[key] > ^uint64(0)-amount {
+				return fmt.Errorf(
+					"account reward rollback overflow for stake key %x",
+					delta.StakingKey,
+				)
+			}
+			byStakeKey[key] += amount
+		}
+		for key, amount := range byStakeKey {
+			var account models.Account
+			if result := tx.Where(
+				"staking_key = ?",
+				[]byte(key),
+			).First(&account); result.Error != nil {
+				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+					return models.ErrAccountNotFound
+				}
+				return result.Error
+			}
+			current := uint64(account.Reward)
+			if current < amount {
+				return fmt.Errorf(
+					"account reward rollback underflow for stake key %x",
+					[]byte(key),
+				)
+			}
+			if result := tx.Model(&models.Account{}).
+				Where("id = ?", account.ID).
+				Update("reward", types.Uint64(current-amount)); result.Error != nil {
+				return result.Error
+			}
+		}
+		if result := tx.Where(
+			"added_slot > ?",
+			slot,
+		).Delete(&models.AccountRewardDelta{}); result.Error != nil {
+			return result.Error
+		}
+		return nil
+	}
+	if txn != nil {
+		return rollback(db)
+	}
+	return db.Transaction(rollback)
 }
 
 // SetAccount saves an account
@@ -84,6 +215,7 @@ func (d *MetadataStorePostgres) SetAccount(
 type certRecord struct {
 	pool      []byte
 	drep      []byte
+	drepType  uint64
 	addedSlot uint64
 	certIndex uint32
 }
@@ -304,13 +436,14 @@ func batchFetchStakeVoteRegistrationDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		Drep        []byte
+		DrepType    uint64
 		AddedSlot   uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -319,7 +452,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -329,6 +462,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 		rec := certRecord{
 			pool:      r.PoolKeyHash,
 			drep:      r.Drep,
+			drepType:  r.DrepType,
 			addedSlot: r.AddedSlot,
 			certIndex: r.CertIndex,
 		}
@@ -338,6 +472,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 			key,
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -355,13 +490,14 @@ func batchFetchVoteRegistrationDelegation(
 	type result struct {
 		StakingKey []byte
 		Drep       []byte
+		DrepType   uint64
 		AddedSlot  uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -370,7 +506,7 @@ func batchFetchVoteRegistrationDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -379,6 +515,7 @@ func batchFetchVoteRegistrationDelegation(
 		key := string(r.StakingKey)
 		rec := certRecord{
 			drep:      r.Drep,
+			drepType:  r.DrepType,
 			addedSlot: r.AddedSlot,
 			certIndex: r.CertIndex,
 		}
@@ -551,13 +688,14 @@ func batchFetchStakeVoteDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		Drep        []byte
+		DrepType    uint64
 		AddedSlot   uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -566,7 +704,7 @@ func batchFetchStakeVoteDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -585,6 +723,7 @@ func batchFetchStakeVoteDelegation(
 			key,
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -602,13 +741,14 @@ func batchFetchVoteDelegation(
 	type result struct {
 		StakingKey []byte
 		Drep       []byte
+		DrepType   uint64
 		AddedSlot  uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -617,7 +757,7 @@ func batchFetchVoteDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -627,6 +767,7 @@ func batchFetchVoteDelegation(
 			string(r.StakingKey),
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -700,9 +841,11 @@ func (d *MetadataStorePostgres) RestoreAccountStateAtSlot(
 
 		// Get DRep delegation from cache
 		var drep []byte
+		var drepType uint64
 		var drepRec certRecord
 		if rec, ok := cache.drepDelegation[key]; ok {
 			drep = rec.drep
+			drepType = rec.drepType
 			drepRec = rec
 		}
 
@@ -733,6 +876,7 @@ func (d *MetadataStorePostgres) RestoreAccountStateAtSlot(
 		if result := db.Model(&account).Updates(map[string]any{
 			"pool":       pool,
 			"drep":       drep,
+			"drep_type":  drepType,
 			"active":     active,
 			"added_slot": lastModSlot,
 		}); result.Error != nil {

--- a/database/plugin/metadata/postgres/committee_member.go
+++ b/database/plugin/metadata/postgres/committee_member.go
@@ -15,6 +15,7 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -53,6 +54,62 @@ func (d *MetadataStorePostgres) SetCommitteeMembers(
 	return nil
 }
 
+// SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+func (d *MetadataStorePostgres) SetCommitteeQuorum(
+	quorum *types.Rat,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if quorum == nil || quorum.Rat == nil {
+		return errors.New("committee quorum cannot be nil")
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("SetCommitteeQuorum: resolve db: %w", err)
+	}
+	state := &models.CommitteeQuorum{
+		Quorum:    quorum,
+		AddedSlot: slot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "added_slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"quorum",
+		}),
+	}
+	if result := db.Clauses(onConflict).Create(state); result.Error != nil {
+		return fmt.Errorf(
+			"SetCommitteeQuorum: upsert failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// GetCommitteeQuorum retrieves the latest enacted committee quorum.
+func (d *MetadataStorePostgres) GetCommitteeQuorum(
+	txn types.Txn,
+) (*types.Rat, error) {
+	var state models.CommitteeQuorum
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeQuorum: resolve db: %w", err,
+		)
+	}
+	if result := db.Order("added_slot DESC, id DESC").
+		First(&state); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"GetCommitteeQuorum: query failed: %w",
+			result.Error,
+		)
+	}
+	return state.Quorum, nil
+}
+
 // GetCommitteeMembers retrieves all active (non-deleted) snapshot-imported
 // committee members.
 func (d *MetadataStorePostgres) GetCommitteeMembers(
@@ -76,8 +133,80 @@ func (d *MetadataStorePostgres) GetCommitteeMembers(
 	return members, nil
 }
 
-// DeleteCommitteeMembersAfterSlot removes committee members added after
-// the given slot and clears deleted_slot for any that were soft-deleted
+// GetCommitteeMembersIncludeDeleted returns every committee member
+// row including soft-deleted ones. See sqlite variant for rationale.
+func (d *MetadataStorePostgres) GetCommitteeMembersIncludeDeleted(
+	txn types.Txn,
+) ([]*models.CommitteeMember, error) {
+	var members []*models.CommitteeMember
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeMembersIncludeDeleted: resolve db: %w", err,
+		)
+	}
+	if result := db.Find(&members); result.Error != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeMembersIncludeDeleted: query failed: %w",
+			result.Error,
+		)
+	}
+	return members, nil
+}
+
+// SoftDeleteCommitteeMembers marks the given cold credential hashes as
+// removed by setting deleted_slot. Used by governance enactment to remove
+// members listed in an UpdateCommittee action.
+func (d *MetadataStorePostgres) SoftDeleteCommitteeMembers(
+	coldCredHashes [][]byte,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if len(coldCredHashes) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"SoftDeleteCommitteeMembers: resolve db: %w", err,
+		)
+	}
+	if result := db.Model(&models.CommitteeMember{}).
+		Where("cold_cred_hash IN ? AND deleted_slot IS NULL", coldCredHashes).
+		Update("deleted_slot", slot); result.Error != nil {
+		return fmt.Errorf(
+			"SoftDeleteCommitteeMembers: update failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// SoftDeleteAllCommitteeMembers marks all active committee members as
+// removed. Used by governance enactment for NoConfidence actions.
+func (d *MetadataStorePostgres) SoftDeleteAllCommitteeMembers(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"SoftDeleteAllCommitteeMembers: resolve db: %w", err,
+		)
+	}
+	if result := db.Model(&models.CommitteeMember{}).
+		Where("deleted_slot IS NULL").
+		Update("deleted_slot", slot); result.Error != nil {
+		return fmt.Errorf(
+			"SoftDeleteAllCommitteeMembers: update failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// DeleteCommitteeMembersAfterSlot removes committee state added after
+// the given slot and clears deleted_slot for any members soft-deleted
 // after that slot.
 func (d *MetadataStorePostgres) DeleteCommitteeMembersAfterSlot(
 	slot uint64,
@@ -97,6 +226,15 @@ func (d *MetadataStorePostgres) DeleteCommitteeMembersAfterSlot(
 		).Delete(&models.CommitteeMember{}); result.Error != nil {
 			return fmt.Errorf(
 				"DeleteCommitteeMembersAfterSlot: delete failed: %w",
+				result.Error,
+			)
+		}
+
+		if result := tx.Where(
+			"added_slot > ?", slot,
+		).Delete(&models.CommitteeQuorum{}); result.Error != nil {
+			return fmt.Errorf(
+				"DeleteCommitteeMembersAfterSlot: delete quorum failed: %w",
 				result.Error,
 			)
 		}

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -98,10 +98,10 @@ func (d *MetadataStorePostgres) SetDrep(
 }
 
 // GetDRepVotingPower calculates the voting power for a DRep by summing the
-// stake of all accounts delegated to it. Uses the current live UTxO set
-// (deleted_slot = 0) for the calculation.
+// current stake of all accounts delegated to it, including live UTxO balance
+// plus reward-account balance.
 //
-// TODO: This implementation uses the current live UTxO set as an
+// TODO: This implementation uses current live balances as an
 // approximation. A future implementation should accept an epoch
 // parameter and use epoch-based stake snapshots for accurate
 // voting power at a specific point in time.
@@ -115,18 +115,136 @@ func (d *MetadataStorePostgres) GetDRepVotingPower(
 	}
 	var totalStake uint64
 	if err := db.Raw(`
-		SELECT COALESCE(SUM(CAST(u.amount AS BIGINT)), 0)
-		FROM utxo u
-		WHERE u.deleted_slot = 0
-		AND u.staking_key IN (
-			SELECT a.staking_key
-			FROM account a
-			WHERE a.drep = $1 AND a.active = true
-		)
+		SELECT COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS BIGINT), 0)
+			   ), 0)
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE drep = $1 AND active = true
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.drep = $1 AND a.active = true
 	`, drepCredential).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 	return totalStake, nil
+}
+
+// GetDRepVotingPowerBatch returns voting power for each DRep credential
+// in a single query. See sqlite/drep.go for the documented contract.
+func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
+	drepCredentials [][]byte,
+	txn types.Txn,
+) (map[string]uint64, error) {
+	out := make(map[string]uint64, len(drepCredentials))
+	if len(drepCredentials) == 0 {
+		return out, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		Drep  []byte
+		Stake uint64
+	}
+	var rows []row
+	// Aggregate UTxO amounts per staking_key in a subquery before
+	// adding account.reward, otherwise the LEFT JOIN would multiply
+	// the per-account reward by the number of live UTxOs and inflate
+	// the totals. Each account contributes (utxo_sum + reward) once
+	// to its DRep bucket.
+	if err := db.Raw(`
+		SELECT a.drep AS drep,
+			   COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS BIGINT), 0)
+			   ), 0) AS stake
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE active = true AND drep IN ?
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.active = true AND a.drep IN ?
+		GROUP BY a.drep
+	`, drepCredentials, drepCredentials).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get drep voting power batch: %w", err)
+	}
+	for _, r := range rows {
+		out[string(r.Drep)] = r.Stake
+	}
+	return out, nil
+}
+
+// GetDRepVotingPowerByType returns voting power grouped by DRep delegation
+// type. It is used for predefined DRep options, which carry no credential.
+func (d *MetadataStorePostgres) GetDRepVotingPowerByType(
+	drepTypes []uint64,
+	txn types.Txn,
+) (map[uint64]uint64, error) {
+	out := make(map[uint64]uint64, len(drepTypes))
+	if len(drepTypes) == 0 {
+		return out, nil
+	}
+	if err := models.ValidatePredefinedDrepTypes(drepTypes); err != nil {
+		return nil, err
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		DrepType uint64
+		Stake    uint64
+	}
+	var rows []row
+	// Aggregate UTxO amounts per staking_key in a subquery before
+	// adding account.reward, otherwise the LEFT JOIN would multiply
+	// the per-account reward by the number of live UTxOs and inflate
+	// the totals. Each account contributes (utxo_sum + reward) once
+	// to its drep_type bucket.
+	if err := db.Raw(`
+		SELECT a.drep_type AS drep_type,
+			   COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS BIGINT), 0)
+			   ), 0) AS stake
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE active = true AND drep_type IN ?
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.active = true AND a.drep_type IN ?
+		GROUP BY a.drep_type
+	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get drep voting power by type: %w", err)
+	}
+	for _, r := range rows {
+		out[r.DrepType] = r.Stake
+	}
+	return out, nil
 }
 
 // UpdateDRepActivity updates the DRep's last activity epoch and

--- a/database/plugin/metadata/postgres/drep_test.go
+++ b/database/plugin/metadata/postgres/drep_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupDRepVotingPowerTestData(t *testing.T, store *MetadataStorePostgres) {
+	t.Helper()
+
+	db := store.DB()
+	db.Where("1 = 1").Delete(&models.Utxo{})
+	db.Where("1 = 1").Delete(&models.Account{})
+	db.Where("1 = 1").Delete(&models.Drep{})
+}
+
+func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+	cleanupDRepVotingPowerTestData(t, pgStore)
+
+	rewardOnlyCred := []byte("drep_reward_only_123456789012345678901234")
+	rewardOnlyStake := []byte("stake_reward_only_123456789012345678901")
+
+	require.NoError(t, pgStore.SetDrep(rewardOnlyCred, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.DB().Create(&models.Account{
+		StakingKey: rewardOnlyStake,
+		Drep:       rewardOnlyCred,
+		Reward:     types.Uint64(700),
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+
+	multiUtxoCred := []byte("drep_multi_utxo_1234567890123456789012345")
+	multiUtxoStake := []byte("stake_multi_utxo_123456789012345678901234")
+
+	require.NoError(t, pgStore.SetDrep(multiUtxoCred, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.DB().Create(&models.Account{
+		StakingKey: multiUtxoStake,
+		Drep:       multiUtxoCred,
+		Reward:     types.Uint64(500),
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, pgStore.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_reward_123456789012345678901234567890"),
+		StakingKey: multiUtxoStake,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, pgStore.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_reward_223456789012345678901234567890"),
+		StakingKey: multiUtxoStake,
+		Amount:     200,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+
+	powers, err := pgStore.GetDRepVotingPowerBatch(
+		[][]byte{rewardOnlyCred, multiUtxoCred},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), powers[string(rewardOnlyCred)])
+	assert.Equal(t, uint64(1000), powers[string(multiUtxoCred)])
+
+	singlePower, err := pgStore.GetDRepVotingPower(rewardOnlyCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), singlePower)
+
+	singlePower, err = pgStore.GetDRepVotingPower(multiUtxoCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), singlePower)
+}
+
+func TestPostgresGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+	cleanupDRepVotingPowerTestData(t, pgStore)
+
+	drepCred := []byte("drep_multi_reward_12345678901234567890123")
+	stakeKey := []byte("stake_multi_reward_1234567890123456789012")
+
+	require.NoError(t, pgStore.SetDrep(drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.DB().Create(&models.Account{
+		StakingKey: stakeKey,
+		Drep:       drepCred,
+		Reward:     types.Uint64(700),
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, pgStore.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_multi_12345678901234567890123456789012"),
+		StakingKey: stakeKey,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, pgStore.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_multi_22345678901234567890123456789012"),
+		StakingKey: stakeKey,
+		Amount:     200,
+		OutputIdx:  1,
+		AddedSlot:  1000,
+	}).Error)
+
+	powers, err := pgStore.GetDRepVotingPowerBatch([][]byte{drepCred}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1200), powers[string(drepCred)])
+
+	singlePower, err := pgStore.GetDRepVotingPower(drepCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1200), singlePower)
+}

--- a/database/plugin/metadata/postgres/governance.go
+++ b/database/plugin/metadata/postgres/governance.go
@@ -48,7 +48,9 @@ func (d *MetadataStorePostgres) GetGovernanceProposal(
 	return &proposal, nil
 }
 
-// GetActiveGovernanceProposals retrieves all governance proposals that haven't expired.
+// GetActiveGovernanceProposals retrieves all governance proposals that
+// are still in the active pool: not expired past the given epoch, not
+// enacted, not marked expired, not soft-deleted.
 func (d *MetadataStorePostgres) GetActiveGovernanceProposals(
 	epoch uint64,
 	txn types.Txn,
@@ -59,12 +61,163 @@ func (d *MetadataStorePostgres) GetActiveGovernanceProposals(
 		return nil, err
 	}
 	if result := db.Where(
-		"expires_epoch >= ? AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+		"expires_epoch >= ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
 		epoch,
-	).Find(&proposals); result.Error != nil {
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
 		return nil, result.Error
 	}
 	return proposals, nil
+}
+
+// GetExpiringGovernanceProposals returns proposals whose expires_epoch is
+// strictly less than the given epoch and that have not yet been enacted,
+// expired, or soft-deleted.
+func (d *MetadataStorePostgres) GetExpiringGovernanceProposals(
+	epoch uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"expires_epoch < ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
+		epoch,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// governanceProposalOrder is the stable row order used when iterating
+// active/expiring proposals at epoch boundaries. Consensus-critical:
+// the epoch tick enforces at-most-one ratification per purpose, so
+// nodes must see proposals in the same order to agree on which one
+// ratifies.
+const governanceProposalOrder = "proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC"
+
+// ratifiedGovernanceProposalOrder is the row order used when iterating
+// ratified-but-not-yet-enacted proposals at epoch start. Consensus-critical:
+// ratification time comes first so older ratifications enact first; the
+// remainder is the chain-deterministic tie-break shared by
+// governanceProposalOrder so all nodes (regardless of insertion order or
+// restored backups) agree on enactment order within a single tick.
+const ratifiedGovernanceProposalOrder = "ratified_epoch ASC, ratified_slot ASC, proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC"
+
+// GetRatifiedGovernanceProposals returns proposals that have been ratified
+// but not yet enacted.
+func (d *MetadataStorePostgres) GetRatifiedGovernanceProposals(
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"ratified_epoch IS NOT NULL AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// GetLastEnactedGovernanceProposal returns the most recently enacted
+// proposal whose action_type is in actionTypes, or nil if none exist.
+// See the sqlite variant for the per-purpose grouping rationale.
+func (d *MetadataStorePostgres) GetLastEnactedGovernanceProposal(
+	actionTypes []uint8,
+	txn types.Txn,
+) (*models.GovernanceProposal, error) {
+	if len(actionTypes) == 0 {
+		return nil, nil
+	}
+	// GORM serialises []uint8 as a single binary blob, so expand to
+	// []int before passing to IN ?.
+	params := make([]int, len(actionTypes))
+	for i, t := range actionTypes {
+		params[i] = int(t)
+	}
+	var proposal models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"action_type IN ? AND enacted_epoch IS NOT NULL AND deleted_slot IS NULL",
+		params,
+	).Order("enacted_epoch DESC, enacted_slot DESC, id DESC").First(&proposal); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &proposal, nil
+}
+
+// govProposalUpsertColumns is the list of columns whose values are
+// always replaced on upsert. Lifecycle columns (enacted_*, ratified_*,
+// expired_*, deleted_slot) and gov_action_cbor are handled separately
+// (see govProposalUpsertAssignments) so a re-submission of the base
+// proposal record (e.g., a resumable import) does not clobber a
+// previously-recorded state transition.
+var govProposalUpsertColumns = []string{
+	"action_type",
+	"proposed_epoch",
+	"expires_epoch",
+	"parent_tx_hash",
+	"parent_action_idx",
+	"policy_hash",
+	"anchor_url",
+	"anchor_hash",
+	"deposit",
+	"return_address",
+}
+
+// govProposalLifecycleColumns are nullable columns that carry state
+// transitions written by governance enactment/ratification/expiry/
+// deletion. They must only be updated when the incoming value is
+// non-NULL so an unrelated upsert (e.g., resumable import of the base
+// proposal record) cannot revert a recorded transition to NULL.
+var govProposalLifecycleColumns = []string{
+	"enacted_epoch",
+	"enacted_slot",
+	"ratified_epoch",
+	"ratified_slot",
+	"expired_epoch",
+	"expired_slot",
+	"deleted_slot",
+}
+
+// govProposalUpsertAssignments builds the on-conflict Set for
+// SetGovernanceProposal. Postgres's ON CONFLICT ... DO UPDATE refers
+// to the incoming row with excluded.col; we guard the
+// gov_action_cbor assignment so an empty incoming payload keeps the
+// stored value, and we guard each lifecycle column with the same
+// pattern so a NULL incoming value preserves the prior transition.
+func govProposalUpsertAssignments() clause.Set {
+	set := clause.AssignmentColumns(govProposalUpsertColumns)
+	set = append(set, clause.Assignment{
+		Column: clause.Column{Name: "gov_action_cbor"},
+		Value: gorm.Expr(
+			"CASE WHEN excluded.gov_action_cbor IS NOT NULL AND " +
+				"length(excluded.gov_action_cbor) > 0 " +
+				"THEN excluded.gov_action_cbor " +
+				"ELSE governance_proposal.gov_action_cbor END",
+		),
+	})
+	for _, col := range govProposalLifecycleColumns {
+		set = append(set, clause.Assignment{
+			Column: clause.Column{Name: col},
+			Value: gorm.Expr(
+				"CASE WHEN excluded." + col + " IS NOT NULL " +
+					"THEN excluded." + col + " " +
+					"ELSE governance_proposal." + col + " END",
+			),
+		})
+	}
+	return set
 }
 
 // SetGovernanceProposal creates or updates a governance proposal.
@@ -81,26 +234,12 @@ func (d *MetadataStorePostgres) SetGovernanceProposal(
 			{Name: "tx_hash"},
 			{Name: "action_index"},
 		},
-		// Note: added_slot is NOT updated on conflict to preserve rollback safety.
-		// The original added_slot represents when the proposal was first submitted.
-		// enacted_slot and ratified_slot track when status changes occur for rollback.
-		DoUpdates: clause.AssignmentColumns([]string{
-			"action_type",
-			"proposed_epoch",
-			"expires_epoch",
-			"parent_tx_hash",
-			"parent_action_idx",
-			"enacted_epoch",
-			"enacted_slot",
-			"ratified_epoch",
-			"ratified_slot",
-			"policy_hash",
-			"anchor_url",
-			"anchor_hash",
-			"deposit",
-			"return_address",
-			"deleted_slot",
-		}),
+		// Note: added_slot is NOT updated on conflict to preserve
+		// rollback safety. enacted_slot and ratified_slot track when
+		// status changes occur for rollback. gov_action_cbor uses a
+		// conditional update so an empty incoming payload (from a
+		// resumable import) doesn't overwrite stored CBOR.
+		DoUpdates: govProposalUpsertAssignments(),
 	}
 	if result := db.Clauses(onConflict).Create(proposal); result.Error != nil {
 		return result.Error
@@ -263,6 +402,95 @@ func (d *MetadataStorePostgres) IsCommitteeMemberResigned(
 	return false, nil
 }
 
+// GetResignedCommitteeMembers returns cold credentials whose latest
+// resignation is after their latest authorization.
+func (d *MetadataStorePostgres) GetResignedCommitteeMembers(
+	coldKeys [][]byte,
+	txn types.Txn,
+) (map[string]bool, error) {
+	resigned := make(map[string]bool)
+	if len(coldKeys) == 0 {
+		return resigned, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	var auths []models.AuthCommitteeHot
+	if result := db.Where(
+		"cold_credential IN ?",
+		coldKeys,
+	).Find(&auths); result.Error != nil {
+		return nil, result.Error
+	}
+	latestAuth := make(map[string]models.AuthCommitteeHot, len(auths))
+	for _, auth := range auths {
+		key := string(auth.ColdCredential)
+		prev, ok := latestAuth[key]
+		if !ok || committeeEventAfter(
+			auth.AddedSlot,
+			auth.CertificateID,
+			prev.AddedSlot,
+			prev.CertificateID,
+		) {
+			latestAuth[key] = auth
+		}
+	}
+
+	var resigns []models.ResignCommitteeCold
+	if result := db.Where(
+		"cold_credential IN ?",
+		coldKeys,
+	).Find(&resigns); result.Error != nil {
+		return nil, result.Error
+	}
+	latestResign := make(
+		map[string]models.ResignCommitteeCold,
+		len(resigns),
+	)
+	for _, resign := range resigns {
+		key := string(resign.ColdCredential)
+		prev, ok := latestResign[key]
+		if !ok || committeeEventAfter(
+			resign.AddedSlot,
+			resign.CertificateID,
+			prev.AddedSlot,
+			prev.CertificateID,
+		) {
+			latestResign[key] = resign
+		}
+	}
+
+	for key, resign := range latestResign {
+		auth, ok := latestAuth[key]
+		if !ok {
+			continue
+		}
+		if committeeEventAfter(
+			resign.AddedSlot,
+			resign.CertificateID,
+			auth.AddedSlot,
+			auth.CertificateID,
+		) {
+			resigned[key] = true
+		}
+	}
+	return resigned, nil
+}
+
+func committeeEventAfter(
+	addedSlot uint64,
+	certificateID uint,
+	otherAddedSlot uint64,
+	otherCertificateID uint,
+) bool {
+	if addedSlot > otherAddedSlot {
+		return true
+	}
+	return addedSlot == otherAddedSlot && certificateID > otherCertificateID
+}
+
 // GetConstitution retrieves the current constitution.
 // Returns nil if the constitution has been soft-deleted.
 func (d *MetadataStorePostgres) GetConstitution(
@@ -347,39 +575,54 @@ func (d *MetadataStorePostgres) DeleteGovernanceProposalsAfterSlot(
 		return err
 	}
 
-	// Delete proposals added after the rollback slot
-	if result := db.Where("added_slot > ?", slot).Delete(&models.GovernanceProposal{}); result.Error != nil {
-		return result.Error
+	rollback := func(tx *gorm.DB) error {
+		// Delete proposals added after the rollback slot
+		if result := tx.Where("added_slot > ?", slot).Delete(&models.GovernanceProposal{}); result.Error != nil {
+			return result.Error
+		}
+		// Clear deleted_slot for proposals soft-deleted after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("deleted_slot > ?", slot).
+			Update("deleted_slot", nil); result.Error != nil {
+			return result.Error
+		}
+		// Revert ratification that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("ratified_slot > ?", slot).
+			Updates(map[string]any{
+				"ratified_epoch": nil,
+				"ratified_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		// Revert enactment that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("enacted_slot > ?", slot).
+			Updates(map[string]any{
+				"enacted_epoch": nil,
+				"enacted_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		// Revert expiry that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("expired_slot > ?", slot).
+			Updates(map[string]any{
+				"expired_epoch": nil,
+				"expired_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		return nil
 	}
 
-	// Clear deleted_slot for proposals soft-deleted after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", nil); result.Error != nil {
-		return result.Error
+	// If caller provided a transaction, use it directly. Otherwise wrap
+	// in a single transaction so a partial failure cannot leave the
+	// table half-rolled-back.
+	if txn != nil {
+		return rollback(db)
 	}
-
-	// Revert ratification that occurred after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("ratified_slot > ?", slot).
-		Updates(map[string]any{
-			"ratified_epoch": nil,
-			"ratified_slot":  nil,
-		}); result.Error != nil {
-		return result.Error
-	}
-
-	// Revert enactment that occurred after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("enacted_slot > ?", slot).
-		Updates(map[string]any{
-			"enacted_epoch": nil,
-			"enacted_slot":  nil,
-		}); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	return db.Transaction(rollback)
 }
 
 // DeleteGovernanceVotesAfterSlot removes votes added after the given slot
@@ -401,24 +644,28 @@ func (d *MetadataStorePostgres) DeleteGovernanceVotesAfterSlot(
 		return err
 	}
 
-	// Delete votes added after the rollback slot
-	if result := db.Where("added_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
-		return result.Error
+	rollback := func(tx *gorm.DB) error {
+		// Delete votes added after the rollback slot
+		if result := tx.Where("added_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
+			return result.Error
+		}
+		// Delete votes that were updated (changed) after the rollback slot
+		// Since we can't restore the previous vote value, removing the vote is safer
+		// than keeping a potentially incorrect value
+		if result := tx.Where("vote_updated_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
+			return result.Error
+		}
+		// Clear deleted_slot for votes soft-deleted after the rollback slot
+		if result := tx.Model(&models.GovernanceVote{}).
+			Where("deleted_slot > ?", slot).
+			Update("deleted_slot", nil); result.Error != nil {
+			return result.Error
+		}
+		return nil
 	}
 
-	// Delete votes that were updated (changed) after the rollback slot
-	// Since we can't restore the previous vote value, removing the vote is safer
-	// than keeping a potentially incorrect value
-	if result := db.Where("vote_updated_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
-		return result.Error
+	if txn != nil {
+		return rollback(db)
 	}
-
-	// Clear deleted_slot for votes soft-deleted after the rollback slot
-	if result := db.Model(&models.GovernanceVote{}).
-		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", nil); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	return db.Transaction(rollback)
 }

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -483,6 +483,7 @@ func saveAccount(account *models.Account, db *gorm.DB) error {
 				[]string{
 					"pool",
 					"drep",
+					"drep_type",
 					"active",
 					"certificate_id",
 				},
@@ -1584,15 +1585,26 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
 						PoolKeyHash:   c.PoolKeyHash[:],
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1761,14 +1773,25 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
 						PoolKeyHash:   c.PoolKeyHash[:],
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1790,12 +1813,23 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1817,12 +1851,23 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1843,7 +1888,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpAuth := models.AuthCommitteeHot{
 						ColdCredential: coldCredential,
-						HostCredential: hotCredential,
+						HotCredential:  hotCredential,
 						CertificateID:  certIDMap[i],
 						AddedSlot:      point.Slot,
 					}

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -29,6 +30,7 @@ import (
 type certRecord struct {
 	pool      []byte
 	drep      []byte
+	drepType  uint64
 	addedSlot uint64
 	certIndex uint32
 }
@@ -257,6 +259,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		Drep        []byte
+		DrepType    uint64
 		AddedSlot   uint64
 		CertIndex   uint32
 	}
@@ -264,7 +267,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -273,7 +276,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -283,6 +286,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 		rec := certRecord{
 			pool:      r.PoolKeyHash,
 			drep:      r.Drep,
+			drepType:  r.DrepType,
 			addedSlot: r.AddedSlot,
 			certIndex: r.CertIndex,
 		}
@@ -292,6 +296,7 @@ func batchFetchStakeVoteRegistrationDelegation(
 			key,
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -309,6 +314,7 @@ func batchFetchVoteRegistrationDelegation(
 	type result struct {
 		StakingKey []byte
 		Drep       []byte
+		DrepType   uint64
 		AddedSlot  uint64
 		CertIndex  uint32
 	}
@@ -316,7 +322,7 @@ func batchFetchVoteRegistrationDelegation(
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -325,7 +331,7 @@ func batchFetchVoteRegistrationDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -334,6 +340,7 @@ func batchFetchVoteRegistrationDelegation(
 		key := string(r.StakingKey)
 		rec := certRecord{
 			drep:      r.Drep,
+			drepType:  r.DrepType,
 			addedSlot: r.AddedSlot,
 			certIndex: r.CertIndex,
 		}
@@ -509,6 +516,7 @@ func batchFetchVoteDelegation(
 	type result struct {
 		StakingKey []byte
 		Drep       []byte
+		DrepType   uint64
 		AddedSlot  uint64
 		CertIndex  uint32
 	}
@@ -516,7 +524,7 @@ func batchFetchVoteDelegation(
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -525,7 +533,7 @@ func batchFetchVoteDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -535,6 +543,7 @@ func batchFetchVoteDelegation(
 			string(r.StakingKey),
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -553,6 +562,7 @@ func batchFetchStakeVoteDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		Drep        []byte
+		DrepType    uint64
 		AddedSlot   uint64
 		CertIndex   uint32
 	}
@@ -560,7 +570,7 @@ func batchFetchStakeVoteDelegation(
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
 					ORDER BY t.added_slot DESC, c.cert_index DESC
@@ -569,7 +579,7 @@ func batchFetchStakeVoteDelegation(
 			INNER JOIN certs c ON c.id = t.certificate_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -588,6 +598,7 @@ func batchFetchStakeVoteDelegation(
 			key,
 			certRecord{
 				drep:      r.Drep,
+				drepType:  r.DrepType,
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
 			},
@@ -619,6 +630,136 @@ func (d *MetadataStoreSqlite) GetAccount(
 		return nil, result.Error
 	}
 	return ret, nil
+}
+
+// AddAccountReward credits a registered reward account.
+func (d *MetadataStoreSqlite) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if amount == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	// Wrap the read-check-write and the journal insert in a single
+	// transaction so the on-disk reward and the AccountRewardDelta
+	// journal stay in sync: if the journal insert fails, the reward
+	// update rolls back. The overflow check runs in Go because the
+	// reward column is stored as a decimal string (see
+	// types.Uint64.Value), which makes SQL `reward + ? <= ?`
+	// comparisons lexicographic, not numeric, and unsafe as a guard.
+	credit := func(tx *gorm.DB) error {
+		var account models.Account
+		if err := tx.Where(
+			"staking_key = ? AND active = ?",
+			stakeKey,
+			true,
+		).First(&account).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return models.ErrAccountNotFound
+			}
+			return err
+		}
+		current := uint64(account.Reward)
+		if current > ^uint64(0)-amount {
+			return fmt.Errorf(
+				"account reward overflow for stake key %x",
+				stakeKey,
+			)
+		}
+		result := tx.Model(&models.Account{}).
+			Where("id = ?", account.ID).
+			Update("reward", types.Uint64(current+amount))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return models.ErrAccountNotFound
+		}
+		delta := &models.AccountRewardDelta{
+			StakingKey: stakeKey,
+			Amount:     types.Uint64(amount),
+			AddedSlot:  slot,
+		}
+		return tx.Create(delta).Error
+	}
+	if txn != nil {
+		return credit(db)
+	}
+	return db.Transaction(credit)
+}
+
+// DeleteAccountRewardsAfterSlot reverts account reward credits recorded
+// after the given slot and deletes their journal rows.
+func (d *MetadataStoreSqlite) DeleteAccountRewardsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	rollback := func(tx *gorm.DB) error {
+		var deltas []models.AccountRewardDelta
+		if result := tx.Where(
+			"added_slot > ?",
+			slot,
+		).Find(&deltas); result.Error != nil {
+			return result.Error
+		}
+		byStakeKey := make(map[string]uint64, len(deltas))
+		for _, delta := range deltas {
+			key := string(delta.StakingKey)
+			amount := uint64(delta.Amount)
+			if byStakeKey[key] > ^uint64(0)-amount {
+				return fmt.Errorf(
+					"account reward rollback overflow for stake key %x",
+					delta.StakingKey,
+				)
+			}
+			byStakeKey[key] += amount
+		}
+		for key, amount := range byStakeKey {
+			var account models.Account
+			if result := tx.Where(
+				"staking_key = ?",
+				[]byte(key),
+			).First(&account); result.Error != nil {
+				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+					return models.ErrAccountNotFound
+				}
+				return result.Error
+			}
+			current := uint64(account.Reward)
+			if current < amount {
+				return fmt.Errorf(
+					"account reward rollback underflow for stake key %x",
+					[]byte(key),
+				)
+			}
+			if result := tx.Model(&models.Account{}).
+				Where("id = ?", account.ID).
+				Update("reward", types.Uint64(current-amount)); result.Error != nil {
+				return result.Error
+			}
+		}
+		if result := tx.Where(
+			"added_slot > ?",
+			slot,
+		).Delete(&models.AccountRewardDelta{}); result.Error != nil {
+			return result.Error
+		}
+		return nil
+	}
+	if txn != nil {
+		return rollback(db)
+	}
+	return db.Transaction(rollback)
 }
 
 // SetAccount saves an account
@@ -716,9 +857,11 @@ func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
 
 		// Get DRep delegation from cache
 		var drep []byte
+		var drepType uint64
 		var drepRec certRecord
 		if rec, ok := cache.drepDelegation[key]; ok {
 			drep = rec.drep
+			drepType = rec.drepType
 			drepRec = rec
 		}
 
@@ -749,6 +892,7 @@ func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
 		if result := db.Model(&account).Updates(map[string]any{
 			"pool":       pool,
 			"drep":       drep,
+			"drep_type":  drepType,
 			"active":     active,
 			"added_slot": lastModSlot,
 		}); result.Error != nil {

--- a/database/plugin/metadata/sqlite/committee.go
+++ b/database/plugin/metadata/sqlite/committee.go
@@ -125,3 +125,92 @@ func (d *MetadataStoreSqlite) IsCommitteeMemberResigned(
 	}
 	return false, nil
 }
+
+// GetResignedCommitteeMembers returns cold credentials whose latest
+// resignation is after their latest authorization.
+func (d *MetadataStoreSqlite) GetResignedCommitteeMembers(
+	coldKeys [][]byte,
+	txn types.Txn,
+) (map[string]bool, error) {
+	resigned := make(map[string]bool)
+	if len(coldKeys) == 0 {
+		return resigned, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	var auths []models.AuthCommitteeHot
+	if result := db.Where(
+		"cold_credential IN ?",
+		coldKeys,
+	).Find(&auths); result.Error != nil {
+		return nil, result.Error
+	}
+	latestAuth := make(map[string]models.AuthCommitteeHot, len(auths))
+	for _, auth := range auths {
+		key := string(auth.ColdCredential)
+		prev, ok := latestAuth[key]
+		if !ok || committeeEventAfter(
+			auth.AddedSlot,
+			auth.CertificateID,
+			prev.AddedSlot,
+			prev.CertificateID,
+		) {
+			latestAuth[key] = auth
+		}
+	}
+
+	var resigns []models.ResignCommitteeCold
+	if result := db.Where(
+		"cold_credential IN ?",
+		coldKeys,
+	).Find(&resigns); result.Error != nil {
+		return nil, result.Error
+	}
+	latestResign := make(
+		map[string]models.ResignCommitteeCold,
+		len(resigns),
+	)
+	for _, resign := range resigns {
+		key := string(resign.ColdCredential)
+		prev, ok := latestResign[key]
+		if !ok || committeeEventAfter(
+			resign.AddedSlot,
+			resign.CertificateID,
+			prev.AddedSlot,
+			prev.CertificateID,
+		) {
+			latestResign[key] = resign
+		}
+	}
+
+	for key, resign := range latestResign {
+		auth, ok := latestAuth[key]
+		if !ok {
+			continue
+		}
+		if committeeEventAfter(
+			resign.AddedSlot,
+			resign.CertificateID,
+			auth.AddedSlot,
+			auth.CertificateID,
+		) {
+			resigned[key] = true
+		}
+	}
+	return resigned, nil
+}
+
+func committeeEventAfter(
+	addedSlot uint64,
+	certificateID uint,
+	otherAddedSlot uint64,
+	otherCertificateID uint,
+) bool {
+	if addedSlot > otherAddedSlot {
+		return true
+	}
+	return addedSlot == otherAddedSlot && certificateID > otherCertificateID
+}

--- a/database/plugin/metadata/sqlite/committee_member.go
+++ b/database/plugin/metadata/sqlite/committee_member.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -54,6 +55,62 @@ func (d *MetadataStoreSqlite) SetCommitteeMembers(
 	return nil
 }
 
+// SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+func (d *MetadataStoreSqlite) SetCommitteeQuorum(
+	quorum *types.Rat,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if quorum == nil || quorum.Rat == nil {
+		return errors.New("committee quorum cannot be nil")
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("SetCommitteeQuorum: resolve db: %w", err)
+	}
+	state := &models.CommitteeQuorum{
+		Quorum:    quorum,
+		AddedSlot: slot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "added_slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"quorum",
+		}),
+	}
+	if result := db.Clauses(onConflict).Create(state); result.Error != nil {
+		return fmt.Errorf(
+			"SetCommitteeQuorum: upsert failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// GetCommitteeQuorum retrieves the latest enacted committee quorum.
+func (d *MetadataStoreSqlite) GetCommitteeQuorum(
+	txn types.Txn,
+) (*types.Rat, error) {
+	var state models.CommitteeQuorum
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeQuorum: resolve db: %w", err,
+		)
+	}
+	if result := db.Order("added_slot DESC, id DESC").
+		First(&state); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"GetCommitteeQuorum: query failed: %w",
+			result.Error,
+		)
+	}
+	return state.Quorum, nil
+}
+
 // GetCommitteeMembers retrieves all active (non-deleted) snapshot-imported
 // committee members.
 func (d *MetadataStoreSqlite) GetCommitteeMembers(
@@ -77,8 +134,81 @@ func (d *MetadataStoreSqlite) GetCommitteeMembers(
 	return members, nil
 }
 
-// DeleteCommitteeMembersAfterSlot removes committee members added after
-// the given slot and clears deleted_slot for any that were soft-deleted
+// GetCommitteeMembersIncludeDeleted returns every committee member
+// row including soft-deleted ones. ccEverSeated uses this to
+// distinguish "never seated" from "voted out by NoConfidence".
+func (d *MetadataStoreSqlite) GetCommitteeMembersIncludeDeleted(
+	txn types.Txn,
+) ([]*models.CommitteeMember, error) {
+	var members []*models.CommitteeMember
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeMembersIncludeDeleted: resolve db: %w", err,
+		)
+	}
+	if result := db.Find(&members); result.Error != nil {
+		return nil, fmt.Errorf(
+			"GetCommitteeMembersIncludeDeleted: query failed: %w",
+			result.Error,
+		)
+	}
+	return members, nil
+}
+
+// SoftDeleteCommitteeMembers marks the given cold credential hashes as
+// removed by setting deleted_slot. Used by governance enactment to remove
+// members listed in an UpdateCommittee action.
+func (d *MetadataStoreSqlite) SoftDeleteCommitteeMembers(
+	coldCredHashes [][]byte,
+	slot uint64,
+	txn types.Txn,
+) error {
+	if len(coldCredHashes) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"SoftDeleteCommitteeMembers: resolve db: %w", err,
+		)
+	}
+	if result := db.Model(&models.CommitteeMember{}).
+		Where("cold_cred_hash IN ? AND deleted_slot IS NULL", coldCredHashes).
+		Update("deleted_slot", slot); result.Error != nil {
+		return fmt.Errorf(
+			"SoftDeleteCommitteeMembers: update failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// SoftDeleteAllCommitteeMembers marks all active committee members as
+// removed. Used by governance enactment for NoConfidence actions.
+func (d *MetadataStoreSqlite) SoftDeleteAllCommitteeMembers(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"SoftDeleteAllCommitteeMembers: resolve db: %w", err,
+		)
+	}
+	if result := db.Model(&models.CommitteeMember{}).
+		Where("deleted_slot IS NULL").
+		Update("deleted_slot", slot); result.Error != nil {
+		return fmt.Errorf(
+			"SoftDeleteAllCommitteeMembers: update failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
+// DeleteCommitteeMembersAfterSlot removes committee state added after
+// the given slot and clears deleted_slot for any members soft-deleted
 // after that slot. This is used during chain rollbacks.
 func (d *MetadataStoreSqlite) DeleteCommitteeMembersAfterSlot(
 	slot uint64,
@@ -99,6 +229,16 @@ func (d *MetadataStoreSqlite) DeleteCommitteeMembersAfterSlot(
 		).Delete(&models.CommitteeMember{}); result.Error != nil {
 			return fmt.Errorf(
 				"DeleteCommitteeMembersAfterSlot: delete failed: %w",
+				result.Error,
+			)
+		}
+
+		// Delete quorum updates added after the rollback slot.
+		if result := tx.Where(
+			"added_slot > ?", slot,
+		).Delete(&models.CommitteeQuorum{}); result.Error != nil {
+			return fmt.Errorf(
+				"DeleteCommitteeMembersAfterSlot: delete quorum failed: %w",
 				result.Error,
 			)
 		}

--- a/database/plugin/metadata/sqlite/committee_member_test.go
+++ b/database/plugin/metadata/sqlite/committee_member_test.go
@@ -15,8 +15,10 @@
 package sqlite
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -46,6 +48,87 @@ func TestSetCommitteeMembers(t *testing.T) {
 	result, err := store.GetCommitteeMembers(nil)
 	require.NoError(t, err)
 	assert.Len(t, result, 2)
+}
+
+func TestSetCommitteeQuorum(t *testing.T) {
+	store := setupTestStore(t)
+
+	got, err := store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	err = store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(2, 3)}, 100, nil,
+	)
+	require.NoError(t, err)
+
+	err = store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(3, 5)}, 200, nil,
+	)
+	require.NoError(t, err)
+
+	got, err = store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, big.NewRat(3, 5), got.Rat)
+}
+
+func TestSoftDeleteCommitteeMembers(t *testing.T) {
+	store := setupTestStore(t)
+
+	credA := []byte("cred_hash_a_1234567890123456")
+	credB := []byte("cred_hash_b_1234567890123456")
+	credC := []byte("cred_hash_c_1234567890123456")
+
+	err := store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: credA, ExpiresEpoch: 300, AddedSlot: 100},
+		{ColdCredHash: credB, ExpiresEpoch: 300, AddedSlot: 100},
+		{ColdCredHash: credC, ExpiresEpoch: 300, AddedSlot: 100},
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.SoftDeleteCommitteeMembers(
+		[][]byte{credA, credC}, 200, nil,
+	)
+	require.NoError(t, err)
+
+	remaining, err := store.GetCommitteeMembers(nil)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, credB, remaining[0].ColdCredHash)
+}
+
+func TestSoftDeleteAllCommitteeMembers(t *testing.T) {
+	store := setupTestStore(t)
+
+	err := store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: []byte("aa_1234567890123456789012345"), ExpiresEpoch: 300, AddedSlot: 100},
+		{ColdCredHash: []byte("bb_1234567890123456789012345"), ExpiresEpoch: 300, AddedSlot: 100},
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.SoftDeleteAllCommitteeMembers(200, nil)
+	require.NoError(t, err)
+
+	remaining, err := store.GetCommitteeMembers(nil)
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+}
+
+func TestSoftDeleteCommitteeMembersEmpty(t *testing.T) {
+	store := setupTestStore(t)
+
+	err := store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: []byte("aa_1234567890123456789012345"), ExpiresEpoch: 300, AddedSlot: 100},
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.SoftDeleteCommitteeMembers(nil, 200, nil)
+	require.NoError(t, err)
+
+	remaining, err := store.GetCommitteeMembers(nil)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
 }
 
 func TestSetCommitteeMembersEmpty(t *testing.T) {
@@ -160,6 +243,25 @@ func TestDeleteCommitteeMembersAfterSlot(t *testing.T) {
 		[]byte("cred_hash_1_2345678901234567"),
 		members[0].ColdCredHash,
 	)
+}
+
+func TestDeleteCommitteeMembersAfterSlotDeletesQuorum(t *testing.T) {
+	store := setupTestStore(t)
+
+	require.NoError(t, store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(2, 3)}, 5000, nil,
+	))
+	require.NoError(t, store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(3, 5)}, 7000, nil,
+	))
+
+	err := store.DeleteCommitteeMembersAfterSlot(6000, nil)
+	require.NoError(t, err)
+
+	got, err := store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, big.NewRat(2, 3), got.Rat)
 }
 
 func TestDeleteCommitteeMembersAfterSlotClearsDeletedSlot(t *testing.T) {

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -400,10 +400,10 @@ func (d *MetadataStoreSqlite) SetDrep(
 }
 
 // GetDRepVotingPower calculates the voting power for a DRep by summing the
-// stake of all accounts delegated to it. Uses the current live UTxO set
-// (deleted_slot = 0) for the calculation.
+// current stake of all accounts delegated to it, including live UTxO balance
+// plus reward-account balance.
 //
-// TODO: This implementation uses the current live UTxO set as an
+// TODO: This implementation uses current live balances as an
 // approximation. A future implementation should accept an epoch
 // parameter and use epoch-based stake snapshots for accurate
 // voting power at a specific point in time.
@@ -422,26 +422,150 @@ func (d *MetadataStoreSqlite) GetDRepVotingPower(
 		return 0, err
 	}
 
-	// Sum the stake of all accounts delegated to this DRep.
-	// Each account's stake contribution is approximated by summing
-	// the value of all UTxOs associated with the account's staking key.
-	// This uses a subquery to find staking keys delegated to the DRep,
-	// then sums the UTxO values for those staking keys.
 	var totalStake uint64
 	if err := db.Raw(`
-		SELECT COALESCE(SUM(CAST(u.amount AS INTEGER)), 0)
-		FROM utxo u
-		WHERE u.deleted_slot = 0
-		AND u.staking_key IN (
-			SELECT a.staking_key
-			FROM account a
-			WHERE a.drep = ? AND a.active = 1
-		)
-	`, drepCredential).Scan(&totalStake).Error; err != nil {
+		SELECT COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS INTEGER), 0)
+			   ), 0)
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE drep = ? AND active = 1
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.drep = ? AND a.active = 1
+	`, drepCredential, drepCredential).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 
 	return totalStake, nil
+}
+
+// GetDRepVotingPowerBatch returns a credential-to-voting-power map for
+// the given DRep credentials in a single query. Credentials with no
+// active delegators are omitted; credentials with active delegators whose
+// delegated stake sums to zero are present with stake = 0. This is the
+// batch variant of GetDRepVotingPower and avoids N+1 queries when
+// tallying governance votes across many active DReps.
+func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
+	drepCredentials [][]byte,
+	txn types.Txn,
+) (map[string]uint64, error) {
+	out := make(map[string]uint64, len(drepCredentials))
+	if len(drepCredentials) == 0 {
+		return out, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		Drep  []byte
+		Stake uint64
+	}
+	// Chunk credentials to stay under SQLite's default bind variable
+	// limit (SQLITE_MAX_VARIABLE_NUMBER = 999). A large active DRep
+	// set on mainnet can easily exceed this in a single IN clause.
+	for start := 0; start < len(drepCredentials); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(drepCredentials))
+		chunk := drepCredentials[start:end]
+		var rows []row
+		// Aggregate UTxO amounts per staking_key in a subquery before
+		// adding account.reward, otherwise the LEFT JOIN would multiply
+		// the per-account reward by the number of live UTxOs and inflate
+		// the totals. Each account contributes (utxo_sum + reward) once
+		// to its DRep bucket.
+		if err := db.Raw(`
+			SELECT a.drep AS drep,
+				   COALESCE(SUM(
+					   COALESCE(u.utxo_sum, 0)
+					   + COALESCE(CAST(a.reward AS INTEGER), 0)
+				   ), 0) AS stake
+			FROM account a
+			LEFT JOIN (
+				SELECT staking_key,
+					   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
+				FROM utxo
+				WHERE deleted_slot = 0
+				  AND staking_key IN (
+					  SELECT staking_key FROM account
+					  WHERE active = 1 AND drep IN ?
+				  )
+				GROUP BY staking_key
+			) u ON u.staking_key = a.staking_key
+			WHERE a.active = 1 AND a.drep IN ?
+			GROUP BY a.drep
+		`, chunk, chunk).Scan(&rows).Error; err != nil {
+			return nil, fmt.Errorf("get drep voting power batch: %w", err)
+		}
+		for _, r := range rows {
+			out[string(r.Drep)] = r.Stake
+		}
+	}
+	return out, nil
+}
+
+// GetDRepVotingPowerByType returns voting power grouped by DRep delegation
+// type. It is used for predefined DRep options, which carry no credential.
+func (d *MetadataStoreSqlite) GetDRepVotingPowerByType(
+	drepTypes []uint64,
+	txn types.Txn,
+) (map[uint64]uint64, error) {
+	out := make(map[uint64]uint64, len(drepTypes))
+	if len(drepTypes) == 0 {
+		return out, nil
+	}
+	if err := models.ValidatePredefinedDrepTypes(drepTypes); err != nil {
+		return nil, err
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		DrepType uint64
+		Stake    uint64
+	}
+	var rows []row
+	// Aggregate UTxO amounts per staking_key in a subquery before
+	// adding account.reward, otherwise the LEFT JOIN would multiply
+	// the per-account reward by the number of live UTxOs and inflate
+	// the totals. Each account contributes (utxo_sum + reward) once
+	// to its drep_type bucket.
+	if err := db.Raw(`
+		SELECT a.drep_type AS drep_type,
+			   COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS INTEGER), 0)
+			   ), 0) AS stake
+		FROM account a
+		LEFT JOIN (
+			SELECT staking_key,
+				   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND staking_key IN (
+				  SELECT staking_key FROM account
+				  WHERE active = 1 AND drep_type IN ?
+			  )
+			GROUP BY staking_key
+		) u ON u.staking_key = a.staking_key
+		WHERE a.active = 1 AND a.drep_type IN ?
+		GROUP BY a.drep_type
+	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get drep voting power by type: %w", err)
+	}
+	for _, r := range rows {
+		out[r.DrepType] = r.Stake
+	}
+	return out, nil
 }
 
 // UpdateDRepActivity updates the DRep's last activity epoch and recalculates

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqliteGetDRepVotingPowerIncludesReward(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := []byte("drep_reward_only_123456789012345678901234")
+	rewardOnlyStake := []byte("stake_reward_only_123456789012345678901")
+	multiUtxoStake := []byte("stake_multi_utxo_123456789012345678901234")
+
+	require.NoError(t, store.SetDrep(drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardOnlyStake,
+		Drep:       drepCred,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: multiUtxoStake,
+		Drep:       drepCred,
+		Reward:     500,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_reward_123456789012345678901234567890"),
+		StakingKey: multiUtxoStake,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_reward_223456789012345678901234567890"),
+		StakingKey: multiUtxoStake,
+		Amount:     200,
+		OutputIdx:  1,
+		AddedSlot:  1000,
+	}).Error)
+
+	power, err := store.GetDRepVotingPower(drepCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1700), power)
+}
+
+func TestSqliteGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
+	store := setupTestStore(t)
+
+	rewardOnlyCred := []byte("drep_reward_only_22345678901234567890123")
+	rewardOnlyStake := []byte("stake_reward_only_2234567890123456789012")
+	multiUtxoCred := []byte("drep_multi_utxo_1234567890123456789012345")
+	multiUtxoStake := []byte("stake_multi_utxo_223456789012345678901234")
+
+	require.NoError(t, store.SetDrep(rewardOnlyCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(multiUtxoCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardOnlyStake,
+		Drep:       rewardOnlyCred,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: multiUtxoStake,
+		Drep:       multiUtxoCred,
+		Reward:     500,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_multi_12345678901234567890123456789012"),
+		StakingKey: multiUtxoStake,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_multi_22345678901234567890123456789012"),
+		StakingKey: multiUtxoStake,
+		Amount:     200,
+		OutputIdx:  1,
+		AddedSlot:  1000,
+	}).Error)
+
+	powers, err := store.GetDRepVotingPowerBatch(
+		[][]byte{rewardOnlyCred, multiUtxoCred},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), powers[string(rewardOnlyCred)])
+	assert.Equal(t, uint64(1000), powers[string(multiUtxoCred)])
+}
+
+func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := []byte("drep_multi_reward_12345678901234567890123")
+	stakeKey := []byte("stake_multi_reward_1234567890123456789012")
+
+	require.NoError(t, store.SetDrep(drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKey,
+		Drep:       drepCred,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_multi_32345678901234567890123456789012"),
+		StakingKey: stakeKey,
+		Amount:     300,
+		OutputIdx:  0,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       []byte("tx_multi_42345678901234567890123456789012"),
+		StakingKey: stakeKey,
+		Amount:     200,
+		OutputIdx:  1,
+		AddedSlot:  1000,
+	}).Error)
+
+	powers, err := store.GetDRepVotingPowerBatch([][]byte{drepCred}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1200), powers[string(drepCred)])
+}

--- a/database/plugin/metadata/sqlite/governance.go
+++ b/database/plugin/metadata/sqlite/governance.go
@@ -23,6 +23,68 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// govProposalUpsertColumns is the list of columns whose values are
+// always replaced on upsert. Lifecycle columns (enacted_*, ratified_*,
+// expired_*, deleted_slot) and gov_action_cbor are handled separately
+// (see govProposalUpsertAssignments) so a re-submission of the base
+// proposal record (e.g., a resumable ledgerstate import) does not
+// clobber a previously-recorded state transition.
+var govProposalUpsertColumns = []string{
+	"action_type",
+	"proposed_epoch",
+	"expires_epoch",
+	"parent_tx_hash",
+	"parent_action_idx",
+	"policy_hash",
+	"anchor_url",
+	"anchor_hash",
+	"deposit",
+	"return_address",
+}
+
+// govProposalLifecycleColumns are nullable columns that carry state
+// transitions written by governance enactment/ratification/expiry/
+// deletion. They must only be updated when the incoming value is
+// non-NULL so an unrelated upsert cannot revert a transition to NULL.
+var govProposalLifecycleColumns = []string{
+	"enacted_epoch",
+	"enacted_slot",
+	"ratified_epoch",
+	"ratified_slot",
+	"expired_epoch",
+	"expired_slot",
+	"deleted_slot",
+}
+
+// govProposalUpsertAssignments builds the on-conflict Set used by
+// SetGovernanceProposal. It uses AssignmentColumns for the plain
+// columns and appends a CASE expression for gov_action_cbor and each
+// lifecycle column so empty/NULL incoming values preserve the stored
+// values rather than clobbering them.
+func govProposalUpsertAssignments() clause.Set {
+	set := clause.AssignmentColumns(govProposalUpsertColumns)
+	set = append(set, clause.Assignment{
+		Column: clause.Column{Name: "gov_action_cbor"},
+		Value: gorm.Expr(
+			"CASE WHEN excluded.gov_action_cbor IS NOT NULL AND " +
+				"length(excluded.gov_action_cbor) > 0 " +
+				"THEN excluded.gov_action_cbor " +
+				"ELSE governance_proposal.gov_action_cbor END",
+		),
+	})
+	for _, col := range govProposalLifecycleColumns {
+		set = append(set, clause.Assignment{
+			Column: clause.Column{Name: col},
+			Value: gorm.Expr(
+				"CASE WHEN excluded." + col + " IS NOT NULL " +
+					"THEN excluded." + col + " " +
+					"ELSE governance_proposal." + col + " END",
+			),
+		})
+	}
+	return set
+}
+
 // GetGovernanceProposal retrieves a governance proposal by transaction hash and action index.
 // Returns nil if the proposal has been soft-deleted.
 func (d *MetadataStoreSqlite) GetGovernanceProposal(
@@ -48,7 +110,9 @@ func (d *MetadataStoreSqlite) GetGovernanceProposal(
 	return &proposal, nil
 }
 
-// GetActiveGovernanceProposals retrieves all governance proposals that haven't expired.
+// GetActiveGovernanceProposals retrieves all governance proposals that
+// are still in the active pool: not expired past the given epoch, not
+// enacted, not marked expired, not soft-deleted.
 func (d *MetadataStoreSqlite) GetActiveGovernanceProposals(
 	epoch uint64,
 	txn types.Txn,
@@ -59,12 +123,102 @@ func (d *MetadataStoreSqlite) GetActiveGovernanceProposals(
 		return nil, err
 	}
 	if result := db.Where(
-		"expires_epoch >= ? AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+		"expires_epoch >= ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
 		epoch,
-	).Find(&proposals); result.Error != nil {
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
 		return nil, result.Error
 	}
 	return proposals, nil
+}
+
+// GetExpiringGovernanceProposals returns proposals whose expires_epoch is
+// strictly less than the given epoch and that have not yet been enacted,
+// expired, or soft-deleted. Used at epoch boundaries to mark expired
+// proposals and trigger deposit returns.
+func (d *MetadataStoreSqlite) GetExpiringGovernanceProposals(
+	epoch uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"expires_epoch < ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
+		epoch,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// governanceProposalOrder is the stable row order used when iterating
+// active/expiring proposals at epoch boundaries. Consensus-critical:
+// the epoch tick enforces at-most-one ratification per purpose, so
+// nodes must see proposals in the same order to agree on which one
+// ratifies. Sort by submission epoch, then chain position, then the
+// fully-qualified action id to break any remaining ties.
+const governanceProposalOrder = "proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC"
+
+// GetRatifiedGovernanceProposals returns proposals that have been ratified
+// but not yet enacted. Used at epoch start to apply enactment effects.
+func (d *MetadataStoreSqlite) GetRatifiedGovernanceProposals(
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"ratified_epoch IS NOT NULL AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// ratifiedGovernanceProposalOrder is the row order used when iterating
+// ratified-but-not-yet-enacted proposals at epoch start. Consensus-critical:
+// ratification time comes first so older ratifications enact first; the
+// remainder is the chain-deterministic tie-break shared by
+// governanceProposalOrder so all nodes (regardless of insertion order or
+// restored backups) agree on enactment order within a single tick.
+const ratifiedGovernanceProposalOrder = "ratified_epoch ASC, ratified_slot ASC, proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC"
+
+// GetLastEnactedGovernanceProposal returns the most recently enacted
+// proposal whose action_type is in actionTypes, or nil if none exist.
+// The set form lets callers group action types that share a chain
+// root per CIP-1694 (e.g., NoConfidence and UpdateCommittee).
+func (d *MetadataStoreSqlite) GetLastEnactedGovernanceProposal(
+	actionTypes []uint8,
+	txn types.Txn,
+) (*models.GovernanceProposal, error) {
+	if len(actionTypes) == 0 {
+		return nil, nil
+	}
+	// GORM serialises []uint8 as a single binary blob, so we expand
+	// the slice into a []int before passing it to IN ?.
+	params := make([]int, len(actionTypes))
+	for i, t := range actionTypes {
+		params[i] = int(t)
+	}
+	var proposal models.GovernanceProposal
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"action_type IN ? AND enacted_epoch IS NOT NULL AND deleted_slot IS NULL",
+		params,
+	).Order("enacted_epoch DESC, enacted_slot DESC, id DESC").First(&proposal); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &proposal, nil
 }
 
 // SetGovernanceProposal creates or updates a governance proposal.
@@ -81,26 +235,15 @@ func (d *MetadataStoreSqlite) SetGovernanceProposal(
 			{Name: "tx_hash"},
 			{Name: "action_index"},
 		},
-		// Note: added_slot is NOT updated on conflict to preserve rollback safety.
-		// The original added_slot represents when the proposal was first submitted.
-		// enacted_slot and ratified_slot track when status changes occur for rollback.
-		DoUpdates: clause.AssignmentColumns([]string{
-			"action_type",
-			"proposed_epoch",
-			"expires_epoch",
-			"parent_tx_hash",
-			"parent_action_idx",
-			"enacted_epoch",
-			"enacted_slot",
-			"ratified_epoch",
-			"ratified_slot",
-			"policy_hash",
-			"anchor_url",
-			"anchor_hash",
-			"deposit",
-			"return_address",
-			"deleted_slot",
-		}),
+		// Note: added_slot is NOT updated on conflict to preserve
+		// rollback safety. The original added_slot represents when
+		// the proposal was first submitted. enacted_slot and
+		// ratified_slot track when status changes occur for rollback.
+		// gov_action_cbor uses a conditional update (see
+		// govProposalUpsertAssignments) so an empty incoming payload
+		// from a resumable import doesn't clobber previously-stored
+		// CBOR, but a later non-empty value can still backfill.
+		DoUpdates: govProposalUpsertAssignments(),
 	}
 	if result := db.Clauses(onConflict).Create(proposal); result.Error != nil {
 		return result.Error
@@ -163,6 +306,13 @@ func (d *MetadataStoreSqlite) SetGovernanceVote(
 // clears deleted_slot for any that were soft-deleted after that slot, and reverts
 // status changes (ratified/enacted) that occurred after the rollback slot.
 // This is used during chain rollbacks.
+//
+// Transactional contract: when txn is nil this function wraps the rollback in
+// its own transaction so partial failures cannot leave the table half-rolled.
+// When txn is non-nil the operations execute directly against the caller's
+// transaction. On error the caller MUST abort/rollback that outer transaction
+// itself; this function will not undo updates that already succeeded within
+// the caller-supplied txn.
 func (d *MetadataStoreSqlite) DeleteGovernanceProposalsAfterSlot(
 	slot uint64,
 	txn types.Txn,
@@ -172,39 +322,54 @@ func (d *MetadataStoreSqlite) DeleteGovernanceProposalsAfterSlot(
 		return err
 	}
 
-	// Delete proposals added after the rollback slot
-	if result := db.Where("added_slot > ?", slot).Delete(&models.GovernanceProposal{}); result.Error != nil {
-		return result.Error
+	rollback := func(tx *gorm.DB) error {
+		// Delete proposals added after the rollback slot
+		if result := tx.Where("added_slot > ?", slot).Delete(&models.GovernanceProposal{}); result.Error != nil {
+			return result.Error
+		}
+		// Clear deleted_slot for proposals soft-deleted after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("deleted_slot > ?", slot).
+			Update("deleted_slot", nil); result.Error != nil {
+			return result.Error
+		}
+		// Revert ratification that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("ratified_slot > ?", slot).
+			Updates(map[string]any{
+				"ratified_epoch": nil,
+				"ratified_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		// Revert enactment that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("enacted_slot > ?", slot).
+			Updates(map[string]any{
+				"enacted_epoch": nil,
+				"enacted_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		// Revert expiry that occurred after the rollback slot
+		if result := tx.Model(&models.GovernanceProposal{}).
+			Where("expired_slot > ?", slot).
+			Updates(map[string]any{
+				"expired_epoch": nil,
+				"expired_slot":  nil,
+			}); result.Error != nil {
+			return result.Error
+		}
+		return nil
 	}
 
-	// Clear deleted_slot for proposals soft-deleted after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", nil); result.Error != nil {
-		return result.Error
+	// If caller provided a transaction, use it directly. Otherwise wrap
+	// in a single transaction so a partial failure cannot leave the
+	// table half-rolled-back.
+	if txn != nil {
+		return rollback(db)
 	}
-
-	// Revert ratification that occurred after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("ratified_slot > ?", slot).
-		Updates(map[string]any{
-			"ratified_epoch": nil,
-			"ratified_slot":  nil,
-		}); result.Error != nil {
-		return result.Error
-	}
-
-	// Revert enactment that occurred after the rollback slot
-	if result := db.Model(&models.GovernanceProposal{}).
-		Where("enacted_slot > ?", slot).
-		Updates(map[string]any{
-			"enacted_epoch": nil,
-			"enacted_slot":  nil,
-		}); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	return db.Transaction(rollback)
 }
 
 // DeleteGovernanceVotesAfterSlot removes votes added after the given slot
@@ -226,24 +391,28 @@ func (d *MetadataStoreSqlite) DeleteGovernanceVotesAfterSlot(
 		return err
 	}
 
-	// Delete votes added after the rollback slot
-	if result := db.Where("added_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
-		return result.Error
+	rollback := func(tx *gorm.DB) error {
+		// Delete votes added after the rollback slot
+		if result := tx.Where("added_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
+			return result.Error
+		}
+		// Delete votes that were updated (changed) after the rollback slot
+		// Since we can't restore the previous vote value, removing the vote is safer
+		// than keeping a potentially incorrect value
+		if result := tx.Where("vote_updated_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
+			return result.Error
+		}
+		// Clear deleted_slot for votes soft-deleted after the rollback slot
+		if result := tx.Model(&models.GovernanceVote{}).
+			Where("deleted_slot > ?", slot).
+			Update("deleted_slot", nil); result.Error != nil {
+			return result.Error
+		}
+		return nil
 	}
 
-	// Delete votes that were updated (changed) after the rollback slot
-	// Since we can't restore the previous vote value, removing the vote is safer
-	// than keeping a potentially incorrect value
-	if result := db.Where("vote_updated_slot > ?", slot).Delete(&models.GovernanceVote{}); result.Error != nil {
-		return result.Error
+	if txn != nil {
+		return rollback(db)
 	}
-
-	// Clear deleted_slot for votes soft-deleted after the rollback slot
-	if result := db.Model(&models.GovernanceVote{}).
-		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", nil); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+	return db.Transaction(rollback)
 }

--- a/database/plugin/metadata/sqlite/governance_test.go
+++ b/database/plugin/metadata/sqlite/governance_test.go
@@ -112,7 +112,7 @@ func TestGetCommitteeMember(t *testing.T) {
 	// Add a committee member
 	result := store.DB().Create(&models.AuthCommitteeHot{
 		ColdCredential: coldKey,
-		HostCredential: hotKey,
+		HotCredential:  hotKey,
 		CertificateID:  1,
 		AddedSlot:      1000,
 	})
@@ -123,7 +123,7 @@ func TestGetCommitteeMember(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, member)
 	assert.Equal(t, coldKey, member.ColdCredential)
-	assert.Equal(t, hotKey, member.HostCredential)
+	assert.Equal(t, hotKey, member.HotCredential)
 }
 
 func TestGetActiveCommitteeMembers(t *testing.T) {
@@ -137,7 +137,7 @@ func TestGetActiveCommitteeMembers(t *testing.T) {
 	// Add two committee members
 	result := store.DB().Create(&models.AuthCommitteeHot{
 		ColdCredential: coldKey1,
-		HostCredential: hotKey1,
+		HotCredential:  hotKey1,
 		CertificateID:  1,
 		AddedSlot:      1000,
 	})
@@ -145,7 +145,7 @@ func TestGetActiveCommitteeMembers(t *testing.T) {
 
 	result = store.DB().Create(&models.AuthCommitteeHot{
 		ColdCredential: coldKey2,
-		HostCredential: hotKey2,
+		HotCredential:  hotKey2,
 		CertificateID:  2,
 		AddedSlot:      1000,
 	})
@@ -171,7 +171,7 @@ func TestIsCommitteeMemberResigned(t *testing.T) {
 	// Add a committee member
 	result := store.DB().Create(&models.AuthCommitteeHot{
 		ColdCredential: coldKey,
-		HostCredential: hotKey,
+		HotCredential:  hotKey,
 		CertificateID:  1,
 		AddedSlot:      1000,
 	})
@@ -194,6 +194,62 @@ func TestIsCommitteeMemberResigned(t *testing.T) {
 	resigned, err = store.IsCommitteeMemberResigned(coldKey, nil)
 	require.NoError(t, err)
 	assert.True(t, resigned)
+}
+
+func TestGetResignedCommitteeMembers(t *testing.T) {
+	store := setupTestStore(t)
+
+	resignedCold := []byte("cold_credential_12345678901234567890123456")
+	activeCold := []byte("cold_credential_22345678901234567890123456")
+	rejoinedCold := []byte("cold_credential_32345678901234567890123456")
+
+	require.NoError(t, store.DB().Create(&[]models.AuthCommitteeHot{
+		{
+			ColdCredential: resignedCold,
+			HotCredential:  []byte("hot_credential_123456789012345678901"),
+			CertificateID:  1,
+			AddedSlot:      1000,
+		},
+		{
+			ColdCredential: activeCold,
+			HotCredential:  []byte("hot_credential_223456789012345678901"),
+			CertificateID:  2,
+			AddedSlot:      1000,
+		},
+		{
+			ColdCredential: rejoinedCold,
+			HotCredential:  []byte("hot_credential_323456789012345678901"),
+			CertificateID:  3,
+			AddedSlot:      1000,
+		},
+		{
+			ColdCredential: rejoinedCold,
+			HotCredential:  []byte("hot_credential_423456789012345678901"),
+			CertificateID:  5,
+			AddedSlot:      3000,
+		},
+	}).Error)
+	require.NoError(t, store.DB().Create(&[]models.ResignCommitteeCold{
+		{
+			ColdCredential: resignedCold,
+			CertificateID:  4,
+			AddedSlot:      2000,
+		},
+		{
+			ColdCredential: rejoinedCold,
+			CertificateID:  4,
+			AddedSlot:      2000,
+		},
+	}).Error)
+
+	resigned, err := store.GetResignedCommitteeMembers(
+		[][]byte{resignedCold, activeCold, rejoinedCold},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, resigned[string(resignedCold)])
+	assert.False(t, resigned[string(activeCold)])
+	assert.False(t, resigned[string(rejoinedCold)])
 }
 
 func TestGetActiveDreps(t *testing.T) {
@@ -391,6 +447,301 @@ func TestGetActiveGovernanceProposals(t *testing.T) {
 	assert.Len(t, proposals, 2)
 }
 
+// TestGetActiveGovernanceProposals_DeterministicOrder verifies the stable
+// sort used by the epoch tick (proposed_epoch, added_slot, tx_hash,
+// action_index). This is consensus-critical: the ratification loop
+// enforces at-most-one ratification per purpose per tick, so nodes
+// must see proposals in the same order.
+func TestGetActiveGovernanceProposals_DeterministicOrder(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Insert in reverse-sorted order; the query must return them in
+	// sorted (proposed_epoch ASC, added_slot ASC, tx_hash ASC,
+	// action_index ASC) order regardless.
+	inputs := []models.GovernanceProposal{
+		{
+			TxHash:        []byte("tx_hash_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+			ActionIndex:   1,
+			ActionType:    uint8(6),
+			ProposedEpoch: 200,
+			ExpiresEpoch:  300,
+			AnchorURL:     "https://c.example.com",
+			AnchorHash:    []byte("anchor_hash_c23456789012345678901c"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_0000000000000000000"),
+			AddedSlot:     9000,
+		},
+		{
+			TxHash:        []byte("tx_hash_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			ActionIndex:   0,
+			ActionType:    uint8(6),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  300,
+			AnchorURL:     "https://a.example.com",
+			AnchorHash:    []byte("anchor_hash_a23456789012345678901a"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_0000000000000000000"),
+			AddedSlot:     5000,
+		},
+		{
+			TxHash:        []byte("tx_hash_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			ActionIndex:   1,
+			ActionType:    uint8(6),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  300,
+			AnchorURL:     "https://b.example.com",
+			AnchorHash:    []byte("anchor_hash_b23456789012345678901b"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_0000000000000000000"),
+			AddedSlot:     5000,
+		},
+	}
+	for i := range inputs {
+		require.NoError(t, store.SetGovernanceProposal(&inputs[i], nil))
+	}
+
+	got, err := store.GetActiveGovernanceProposals(100, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	// Expected order:
+	// (100, 5000, aaa, 0), (100, 5000, aaa, 1),
+	// (200, 9000, bbb, 1)
+	assert.Equal(t, "https://a.example.com", got[0].AnchorURL)
+	assert.Equal(t, "https://b.example.com", got[1].AnchorURL)
+	assert.Equal(t, "https://c.example.com", got[2].AnchorURL)
+}
+
+func TestGetRatifiedGovernanceProposals(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Active (not ratified)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash:        []byte("tx_hash_active_12345678901234567890123456"),
+			ActionIndex:   0,
+			ActionType:    uint8(6),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  200,
+			AnchorURL:     "https://active.example.com",
+			AnchorHash:    []byte("anchor_hash_1234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_1234567890123456789"),
+			AddedSlot:     1000,
+		}, nil,
+	))
+
+	ratifiedEpoch := uint64(105)
+	ratifiedSlot := uint64(3000)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash:        []byte("tx_hash_ratifiedA_1234567890123456789012"),
+			ActionIndex:   0,
+			ActionType:    uint8(6),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  200,
+			RatifiedEpoch: &ratifiedEpoch,
+			RatifiedSlot:  &ratifiedSlot,
+			AnchorURL:     "https://ratifiedA.example.com",
+			AnchorHash:    []byte("anchor_hash_2234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_2234567890123456789"),
+			AddedSlot:     2000,
+		}, nil,
+	))
+
+	// Already enacted: must be excluded.
+	enactedEpoch := uint64(110)
+	enactedSlot := uint64(4000)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash:        []byte("tx_hash_enacted_12345678901234567890123456"),
+			ActionIndex:   0,
+			ActionType:    uint8(6),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  200,
+			RatifiedEpoch: &ratifiedEpoch,
+			RatifiedSlot:  &ratifiedSlot,
+			EnactedEpoch:  &enactedEpoch,
+			EnactedSlot:   &enactedSlot,
+			AnchorURL:     "https://enacted.example.com",
+			AnchorHash:    []byte("anchor_hash_3234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_3234567890123456789"),
+			AddedSlot:     1500,
+		}, nil,
+	))
+
+	ratified, err := store.GetRatifiedGovernanceProposals(nil)
+	require.NoError(t, err)
+	require.Len(t, ratified, 1)
+	assert.Equal(
+		t,
+		"https://ratifiedA.example.com",
+		ratified[0].AnchorURL,
+	)
+}
+
+func TestGetLastEnactedGovernanceProposal(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Enact two ParameterChange proposals at different slots.
+	enacted1Epoch := uint64(100)
+	enacted1Slot := uint64(1000)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash:        []byte("tx_hash_paramA_1234567890123456789012345"),
+			ActionIndex:   0,
+			ActionType:    uint8(0), // ParameterChange
+			ProposedEpoch: 80,
+			ExpiresEpoch:  200,
+			EnactedEpoch:  &enacted1Epoch,
+			EnactedSlot:   &enacted1Slot,
+			AnchorURL:     "https://paramA.example.com",
+			AnchorHash:    []byte("anchor_hash_1234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_1234567890123456789"),
+			AddedSlot:     500,
+		}, nil,
+	))
+	enacted2Epoch := uint64(110)
+	enacted2Slot := uint64(2000)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash:        []byte("tx_hash_paramB_1234567890123456789012345"),
+			ActionIndex:   0,
+			ActionType:    uint8(0),
+			ProposedEpoch: 90,
+			ExpiresEpoch:  210,
+			EnactedEpoch:  &enacted2Epoch,
+			EnactedSlot:   &enacted2Slot,
+			AnchorURL:     "https://paramB.example.com",
+			AnchorHash:    []byte("anchor_hash_2234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_2234567890123456789"),
+			AddedSlot:     700,
+		}, nil,
+	))
+	// Enact a different type so it should not leak into ParameterChange root.
+	enacted3Epoch := uint64(115)
+	enacted3Slot := uint64(2500)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash:        []byte("tx_hash_info_12345678901234567890123456aa"),
+			ActionIndex:   0,
+			ActionType:    uint8(6),
+			ProposedEpoch: 95,
+			ExpiresEpoch:  215,
+			EnactedEpoch:  &enacted3Epoch,
+			EnactedSlot:   &enacted3Slot,
+			AnchorURL:     "https://info.example.com",
+			AnchorHash:    []byte("anchor_hash_3234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_3234567890123456789"),
+			AddedSlot:     800,
+		}, nil,
+	))
+
+	latest, err := store.GetLastEnactedGovernanceProposal(
+		[]uint8{0}, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(
+		t,
+		"https://paramB.example.com",
+		latest.AnchorURL,
+	)
+
+	// Action type with no enacted proposal returns nil, no error.
+	latest, err = store.GetLastEnactedGovernanceProposal(
+		[]uint8{3}, nil,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, latest)
+
+	// Empty set returns nil with no error (defensive).
+	latest, err = store.GetLastEnactedGovernanceProposal(nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, latest)
+}
+
+// TestGetLastEnactedGovernanceProposal_CommitteePurpose confirms that
+// NoConfidence and UpdateCommittee share a chain root: querying for
+// either via the purpose's action-type set must find the most
+// recently enacted of both.
+func TestGetLastEnactedGovernanceProposal_CommitteePurpose(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Enact a NoConfidence, then a later UpdateCommittee. Both belong
+	// to the committee purpose per CIP-1694.
+	enactedNCEpoch := uint64(100)
+	enactedNCSlot := uint64(1000)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash: []byte(
+				"tx_hash_nc_12345678901234567890123456aaaa",
+			),
+			ActionIndex:   0,
+			ActionType:    uint8(3), // NoConfidence
+			ProposedEpoch: 80,
+			ExpiresEpoch:  200,
+			EnactedEpoch:  &enactedNCEpoch,
+			EnactedSlot:   &enactedNCSlot,
+			AnchorURL:     "https://nc.example.com",
+			AnchorHash:    []byte("anchor_hash_1234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_1234567890123456789"),
+			AddedSlot:     500,
+		}, nil,
+	))
+	enactedUCEpoch := uint64(110)
+	enactedUCSlot := uint64(2000)
+	require.NoError(t, store.SetGovernanceProposal(
+		&models.GovernanceProposal{
+			TxHash: []byte(
+				"tx_hash_uc_12345678901234567890123456bbbb",
+			),
+			ActionIndex:   0,
+			ActionType:    uint8(4), // UpdateCommittee
+			ProposedEpoch: 90,
+			ExpiresEpoch:  210,
+			EnactedEpoch:  &enactedUCEpoch,
+			EnactedSlot:   &enactedUCSlot,
+			AnchorURL:     "https://uc.example.com",
+			AnchorHash:    []byte("anchor_hash_2234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_2234567890123456789"),
+			AddedSlot:     700,
+		}, nil,
+	))
+
+	// Query with both types: expect the most recent (UpdateCommittee).
+	latest, err := store.GetLastEnactedGovernanceProposal(
+		[]uint8{3, 4}, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, "https://uc.example.com", latest.AnchorURL)
+
+	// Single-type query misses the cross-type root — demonstrates
+	// why the purpose-aware form is required.
+	singleType, err := store.GetLastEnactedGovernanceProposal(
+		[]uint8{4}, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, singleType)
+	assert.Equal(t, "https://uc.example.com", singleType.AnchorURL)
+	// But querying just NoConfidence also finds NoConfidence even
+	// though a later UpdateCommittee exists — that's the bug the
+	// purpose-aware form fixes when used together in practice.
+	singleType, err = store.GetLastEnactedGovernanceProposal(
+		[]uint8{3}, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, singleType)
+	assert.Equal(t, "https://nc.example.com", singleType.AnchorURL)
+}
+
 func TestUpdateDRepActivity(t *testing.T) {
 	store := setupTestStore(t)
 
@@ -563,6 +914,28 @@ func TestGetDRepVotingPower(t *testing.T) {
 	assert.Equal(t, uint64(10000000), power)
 }
 
+func TestGetDRepVotingPowerByTypeRejectsCredentialTypes(t *testing.T) {
+	store := setupTestStore(t)
+
+	_, err := store.GetDRepVotingPowerByType(
+		[]uint64{models.DrepTypeAddrKeyHash},
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential-backed")
+
+	_, err = store.GetDRepVotingPowerByType(
+		[]uint64{models.DrepTypeScriptHash},
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential-backed")
+
+	_, err = store.GetDRepVotingPowerByType([]uint64{99}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown predefined drep type")
+}
+
 func TestGetCommitteeActiveCount(t *testing.T) {
 	store := setupTestStore(t)
 
@@ -618,7 +991,7 @@ func TestGetCommitteeActiveCount(t *testing.T) {
 	// Add two committee members
 	result = store.DB().Create(&models.AuthCommitteeHot{
 		ColdCredential: []byte("cold_credential_1234567890123456789012345a"),
-		HostCredential: []byte("hot_credential_12345678901234567890123456a"),
+		HotCredential:  []byte("hot_credential_12345678901234567890123456a"),
 		CertificateID:  1,
 		AddedSlot:      1000,
 	})
@@ -626,7 +999,7 @@ func TestGetCommitteeActiveCount(t *testing.T) {
 
 	result = store.DB().Create(&models.AuthCommitteeHot{
 		ColdCredential: []byte("cold_credential_1234567890123456789012345b"),
-		HostCredential: []byte("hot_credential_12345678901234567890123456b"),
+		HotCredential:  []byte("hot_credential_12345678901234567890123456b"),
 		CertificateID:  2,
 		AddedSlot:      1000,
 	})

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -544,6 +544,7 @@ func saveAccount(account *models.Account, db *gorm.DB) error {
 				[]string{
 					"pool",
 					"drep",
+					"drep_type",
 					"active",
 					"certificate_id",
 				},
@@ -1752,15 +1753,26 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
 						PoolKeyHash:   c.PoolKeyHash[:],
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1928,15 +1940,26 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
 					tmpAccount.Pool = c.PoolKeyHash[:]
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
 						PoolKeyHash:   c.PoolKeyHash[:],
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1958,13 +1981,24 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1986,13 +2020,24 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
 
-					tmpAccount.Drep = c.Drep.Credential[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
 					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
-						Drep:          c.Drep.Credential[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -2013,7 +2058,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpAuth := models.AuthCommitteeHot{
 						ColdCredential: coldCredential,
-						HostCredential: hotCredential,
+						HotCredential:  hotCredential,
 						CertificateID:  certIDMap[i],
 						AddedSlot:      point.Slot,
 					}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -196,6 +196,18 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Account, error)
 
+	// AddAccountReward credits a reward account by stake credential.
+	AddAccountReward(
+		[]byte, // stakeKey
+		uint64, // amount
+		uint64, // slot
+		types.Txn,
+	) error
+
+	// DeleteAccountRewardsAfterSlot reverts reward credits recorded after
+	// the given slot and deletes their journal entries.
+	DeleteAccountRewardsAfterSlot(uint64, types.Txn) error
+
 	// GetBlockNonce retrieves a block nonce for a given point.
 	GetBlockNonce(
 		ocommon.Point,
@@ -601,11 +613,39 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.GovernanceProposal, error)
 
-	// GetActiveGovernanceProposals retrieves all governance proposals that haven't expired.
+	// GetActiveGovernanceProposals retrieves all governance proposals that
+	// are still in the active pool (not expired, not enacted, not marked
+	// expired, not soft-deleted).
 	GetActiveGovernanceProposals(
 		uint64, // epoch
 		types.Txn,
 	) ([]*models.GovernanceProposal, error)
+
+	// GetRatifiedGovernanceProposals returns proposals that have been
+	// ratified but not yet enacted. Used at epoch start by enactment.
+	GetRatifiedGovernanceProposals(
+		types.Txn,
+	) ([]*models.GovernanceProposal, error)
+
+	// GetExpiringGovernanceProposals returns proposals whose
+	// `expires_epoch` is strictly less than the given epoch and that
+	// have not yet been enacted, expired, or soft-deleted. Used at
+	// epoch boundaries to mark expired proposals and return deposits.
+	GetExpiringGovernanceProposals(
+		epoch uint64,
+		txn types.Txn,
+	) ([]*models.GovernanceProposal, error)
+
+	// GetLastEnactedGovernanceProposal returns the most recently enacted
+	// proposal whose action_type is in the given set, or nil if none
+	// exist. Callers pass the set of action types that share a chain
+	// root per CIP-1694 (e.g., NoConfidence + UpdateCommittee together).
+	// Used to resolve governance action chain roots at ratification
+	// time.
+	GetLastEnactedGovernanceProposal(
+		actionTypes []uint8,
+		txn types.Txn,
+	) (*models.GovernanceProposal, error)
 
 	// SetGovernanceProposal creates or updates a governance proposal.
 	SetGovernanceProposal(
@@ -642,6 +682,13 @@ type MetadataStore interface {
 		types.Txn,
 	) (bool, error)
 
+	// GetResignedCommitteeMembers returns the cold credentials whose
+	// latest resignation is after their latest authorization.
+	GetResignedCommitteeMembers(
+		[][]byte, // coldKeys
+		types.Txn,
+	) (map[string]bool, error)
+
 	// GetCommitteeActiveCount returns the number of active (non-resigned)
 	// committee members.
 	GetCommitteeActiveCount(types.Txn) (int, error)
@@ -656,24 +703,74 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// SetCommitteeQuorum stores the quorum threshold enacted with a
+	// committee update.
+	SetCommitteeQuorum(*types.Rat, uint64, types.Txn) error
+
+	// GetCommitteeQuorum retrieves the latest enacted committee quorum.
+	GetCommitteeQuorum(types.Txn) (*types.Rat, error)
+
 	// GetCommitteeMembers retrieves all active (non-deleted)
 	// snapshot-imported committee members.
 	GetCommitteeMembers(types.Txn) ([]*models.CommitteeMember, error)
 
-	// DeleteCommitteeMembersAfterSlot removes committee members added
-	// after the given slot and clears deleted_slot for any that were
+	// GetCommitteeMembersIncludeDeleted retrieves every committee
+	// member row, including rows whose deleted_slot is set. Used to
+	// distinguish "committee never seated" from "committee voted out
+	// via NoConfidence" — the latter leaves every row soft-deleted,
+	// which GetCommitteeMembers would hide.
+	GetCommitteeMembersIncludeDeleted(
+		types.Txn,
+	) ([]*models.CommitteeMember, error)
+
+	// DeleteCommitteeMembersAfterSlot removes committee state added
+	// after the given slot and clears deleted_slot for any members
 	// soft-deleted after that slot. Used during chain rollbacks.
 	DeleteCommitteeMembersAfterSlot(uint64, types.Txn) error
+
+	// SoftDeleteCommitteeMembers marks the given cold credential hashes
+	// as removed by setting deleted_slot. Used by governance enactment
+	// to remove members (UpdateCommittee/NoConfidence action).
+	SoftDeleteCommitteeMembers(
+		coldCredHashes [][]byte,
+		slot uint64,
+		txn types.Txn,
+	) error
+
+	// SoftDeleteAllCommitteeMembers marks all active committee members as
+	// removed. Used by governance enactment for NoConfidence actions.
+	SoftDeleteAllCommitteeMembers(
+		slot uint64,
+		txn types.Txn,
+	) error
 
 	// DRep voting power and activity methods
 
 	// GetDRepVotingPower calculates the voting power for a DRep by summing
-	// the stake of all accounts delegated to it. Uses the current live
-	// UTxO set (deleted_slot = 0) for the calculation.
+	// the current stake of all delegated accounts, approximated from live
+	// UTxO balance plus reward-account balance.
 	GetDRepVotingPower(
 		[]byte, // drepCredential
 		types.Txn,
 	) (uint64, error)
+
+	// GetDRepVotingPowerBatch is the batch form of GetDRepVotingPower.
+	// Returns a credential-to-power map; credentials with no delegated
+	// stake are omitted. Used by governance tallying to avoid N+1
+	// per-DRep lookups.
+	GetDRepVotingPowerBatch(
+		drepCredentials [][]byte,
+		txn types.Txn,
+	) (map[string]uint64, error)
+
+	// GetDRepVotingPowerByType returns voting power grouped by DRep
+	// delegation type. This is used for predefined DRep options such
+	// as AlwaysAbstain and AlwaysNoConfidence, which do not have a
+	// credential hash.
+	GetDRepVotingPowerByType(
+		drepTypes []uint64,
+		txn types.Txn,
+	) (map[uint64]uint64, error)
 
 	// UpdateDRepActivity updates the DRep's last activity epoch and
 	// recalculates the expiry epoch.

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -24,8 +24,8 @@ import (
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/governance"
 	ouroboros_cbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -480,7 +480,7 @@ func (b *Backfill) processBlockGovernance(
 		return nil
 	}
 	if len(proposals) > 0 {
-		if err := ledger.ProcessGovernanceProposals(
+		if err := governance.ProcessProposals(
 			tx, point, epochId,
 			conwayPP.GovActionValidityPeriod,
 			b.db, txn,
@@ -491,7 +491,7 @@ func (b *Backfill) processBlockGovernance(
 		}
 	}
 	if len(votes) > 0 {
-		if err := ledger.ProcessGovernanceVotes(
+		if err := governance.ProcessVotes(
 			tx, point, epochId,
 			conwayPP.DRepInactivityPeriod,
 			b.db, txn,

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/ouroboros-mock/conformance"
@@ -31,8 +32,16 @@ import (
 	"github.com/glebarez/sqlite"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 )
+
+// conformanceSlotsPerEpoch is the slots-per-epoch constant used by the
+// conformance state manager to translate between epochs and the slot
+// values stored in deleted_slot / added_slot columns. Conformance tests
+// use it purely as a monotonic marker — the real slot count for a
+// given network is irrelevant here — so a single fixed value is fine.
+const conformanceSlotsPerEpoch uint64 = 432000
 
 // DingoStateManager implements conformance.StateManager using dingo's database
 // with an in-memory SQLite backend for testing.
@@ -66,6 +75,18 @@ type DingoStateManager struct {
 
 	// hotKeyAuthorizations tracks hot key authorizations (cold key -> hot key)
 	hotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
+
+	// committeeRemovals tracks the remove-set of pending UpdateCommittee
+	// proposals, keyed by gov action id. The upstream conformance
+	// GovActionInfo only carries the add-set (ProposedMembers), so we
+	// stash the removed cold credentials locally and consume them on
+	// enactment to honor CIP-1694 incremental committee updates.
+	committeeRemovals map[string]map[common.Blake2b224]struct{}
+
+	// committeeQuorums tracks the new quorum of pending UpdateCommittee
+	// proposals, keyed by gov action id. Persisted to committee_quorum
+	// at enactment time so the DB state mirrors production.
+	committeeQuorums map[string]*big.Rat
 }
 
 // NewDingoStateManager creates a new DingoStateManager with an in-memory SQLite database.
@@ -92,6 +113,8 @@ func NewDingoStateManager() (*DingoStateManager, error) {
 		drepRegistrations:    make(map[common.Blake2b224]bool),
 		committeeMembers:     make(map[common.Blake2b224]uint64),
 		hotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
+		committeeRemovals:    make(map[string]map[common.Blake2b224]struct{}),
+		committeeQuorums:     make(map[string]*big.Rat),
 	}, nil
 }
 
@@ -110,6 +133,8 @@ func (m *DingoStateManager) LoadInitialState(
 	m.drepRegistrations = make(map[common.Blake2b224]bool)
 	m.committeeMembers = make(map[common.Blake2b224]uint64)
 	m.hotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
+	m.committeeRemovals = make(map[string]map[common.Blake2b224]struct{})
+	m.committeeQuorums = make(map[string]*big.Rat)
 
 	// Clear database tables
 	if err := m.clearDatabaseTables(); err != nil {
@@ -127,6 +152,7 @@ func (m *DingoStateManager) LoadInitialState(
 				StakingKey: hash[:],
 				AddedSlot:  0,
 				Active:     true,
+				Reward:     types.Uint64(balance),
 			}
 			if err := m.db.Create(&account).Error; err != nil {
 				return fmt.Errorf("failed to insert account: %w", err)
@@ -166,6 +192,16 @@ func (m *DingoStateManager) LoadInitialState(
 
 	// Load committee members
 	maps.Copy(m.committeeMembers, state.CommitteeMembers)
+	for coldKey, expiry := range state.CommitteeMembers {
+		member := models.CommitteeMember{
+			ColdCredHash: coldKey[:],
+			ExpiresEpoch: expiry,
+			AddedSlot:    0,
+		}
+		if err := m.db.Create(&member).Error; err != nil {
+			return fmt.Errorf("failed to insert committee_member: %w", err)
+		}
+	}
 
 	// Load hot key authorizations
 	maps.Copy(m.hotKeyAuthorizations, state.HotKeyAuthorizations)
@@ -174,7 +210,7 @@ func (m *DingoStateManager) LoadInitialState(
 	for coldKey, hotKey := range state.HotKeyAuthorizations {
 		auth := models.AuthCommitteeHot{
 			ColdCredential: coldKey[:],
-			HostCredential: hotKey[:],
+			HotCredential:  hotKey[:],
 			AddedSlot:      0,
 		}
 		if err := m.db.Create(&auth).Error; err != nil {
@@ -362,6 +398,21 @@ func (m *DingoStateManager) ApplyTransaction(
 
 			// Extract action-specific data including parent action ID
 			extractActionSpecificData(action, &info)
+
+			// CIP-1694 UpdateCommittee carries a remove-set and a new
+			// quorum alongside the add-set. GovActionInfo only tracks
+			// the add-set, so stash the remove-set and quorum in local
+			// maps keyed by gov action id for use at enactment time.
+			if uca, ok := action.(*common.UpdateCommitteeGovAction); ok {
+				removed := make(map[common.Blake2b224]struct{}, len(uca.Credentials))
+				for _, cred := range uca.Credentials {
+					removed[cred.Credential] = struct{}{}
+				}
+				m.committeeRemovals[govActionId] = removed
+				if uca.Quorum.Rat != nil {
+					m.committeeQuorums[govActionId] = new(big.Rat).Set(uca.Quorum.Rat)
+				}
+			}
 
 			m.govState.AddProposal(govActionId, info)
 
@@ -577,7 +628,7 @@ func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uin
 			// Insert into database
 			auth := models.AuthCommitteeHot{
 				ColdCredential: coldKey[:],
-				HostCredential: hotKey[:],
+				HotCredential:  hotKey[:],
 				AddedSlot:      slot,
 			}
 			m.db.Create(&auth)
@@ -661,7 +712,7 @@ func (m *DingoStateManager) ProcessEpochBoundary(newEpoch uint64) error {
 			// Update database
 			m.db.Model(&models.GovernanceProposal{}).
 				Where("tx_hash = ?", parseProposalTxHash(id)).
-				Update("deleted_slot", newEpoch*432000) // Approximate slot
+				Update("deleted_slot", newEpoch*conformanceSlotsPerEpoch)
 		}
 	}
 
@@ -777,16 +828,71 @@ func (m *DingoStateManager) enactProposal(
 		}
 	case common.GovActionTypeHardForkInitiation:
 		m.govState.Roots.HardFork = &id
-	case common.GovActionTypeNoConfidence, common.GovActionTypeUpdateCommittee:
+	case common.GovActionTypeNoConfidence:
 		m.govState.Roots.ConstitutionalCommittee = &id
-		if proposal.ActionType == common.GovActionTypeUpdateCommittee {
-			for coldKey, expiry := range proposal.ProposedMembers {
-				m.govState.CommitteeMembers[coldKey] = &conformance.CommitteeMemberInfo{
-					ColdKey:     coldKey,
-					ExpiryEpoch: expiry,
-				}
-				m.committeeMembers[coldKey] = expiry
+		for coldKey := range m.committeeMembers {
+			delete(m.committeeMembers, coldKey)
+		}
+		for coldKey := range m.govState.CommitteeMembers {
+			delete(m.govState.CommitteeMembers, coldKey)
+		}
+		deletedSlot := m.currentEpoch * conformanceSlotsPerEpoch
+		m.db.Model(&models.CommitteeMember{}).
+			Where("deleted_slot IS NULL").
+			Update("deleted_slot", deletedSlot)
+	case common.GovActionTypeUpdateCommittee:
+		m.govState.Roots.ConstitutionalCommittee = &id
+		// Apply the remove-set first per cardano-ledger semantics
+		// (Conway Enact.hs updatedCommittee: add-set takes precedence
+		// on overlap, so remove-then-add lets a re-addition with a
+		// new expiry win).
+		deletedSlot := m.currentEpoch * conformanceSlotsPerEpoch
+		if removed, ok := m.committeeRemovals[id]; ok {
+			for coldKey := range removed {
+				delete(m.committeeMembers, coldKey)
+				delete(m.govState.CommitteeMembers, coldKey)
+				m.db.Model(&models.CommitteeMember{}).
+					Where("cold_cred_hash = ? AND deleted_slot IS NULL", coldKey[:]).
+					Update("deleted_slot", deletedSlot)
 			}
+			delete(m.committeeRemovals, id)
+		}
+		dbMembers := make(
+			[]*models.CommitteeMember,
+			0,
+			len(proposal.ProposedMembers),
+		)
+		for coldKey, expiry := range proposal.ProposedMembers {
+			m.govState.CommitteeMembers[coldKey] = &conformance.CommitteeMemberInfo{
+				ColdKey:     coldKey,
+				ExpiryEpoch: expiry,
+			}
+			m.committeeMembers[coldKey] = expiry
+			dbMembers = append(dbMembers, &models.CommitteeMember{
+				ColdCredHash: coldKey[:],
+				ExpiresEpoch: expiry,
+				AddedSlot:    m.currentEpoch * conformanceSlotsPerEpoch,
+			})
+		}
+		if len(dbMembers) > 0 {
+			m.db.Clauses(clause.OnConflict{
+				Columns: []clause.Column{{Name: "cold_cred_hash"}},
+				DoUpdates: clause.AssignmentColumns([]string{
+					"expires_epoch",
+					"added_slot",
+					"deleted_slot",
+				}),
+			}).Create(&dbMembers)
+		}
+		if quorum, ok := m.committeeQuorums[id]; ok {
+			m.db.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "added_slot"}},
+				DoUpdates: clause.AssignmentColumns([]string{"quorum"}),
+			}).Create(&models.CommitteeQuorum{
+				Quorum:    &types.Rat{Rat: new(big.Rat).Set(quorum)},
+				AddedSlot: deletedSlot,
+			})
+			delete(m.committeeQuorums, id)
 		}
 	}
 
@@ -817,6 +923,9 @@ func (m *DingoStateManager) SetRewardBalances(
 	for cred, balance := range balances {
 		if _, exists := m.stakeRegistrations[cred]; exists {
 			m.stakeRegistrations[cred] = balance
+			m.db.Model(&models.Account{}).
+				Where("staking_key = ?", cred[:]).
+				Update("reward", types.Uint64(balance))
 		}
 	}
 	if m.govState != nil {
@@ -843,6 +952,8 @@ func (m *DingoStateManager) Reset() error {
 	m.drepRegistrations = make(map[common.Blake2b224]bool)
 	m.committeeMembers = make(map[common.Blake2b224]uint64)
 	m.hotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
+	m.committeeRemovals = make(map[string]map[common.Blake2b224]struct{})
+	m.committeeQuorums = make(map[string]*big.Rat)
 	m.govState = conformance.NewGovernanceState()
 
 	// Clear database tables
@@ -859,6 +970,8 @@ func (m *DingoStateManager) clearDatabaseTables() error {
 		"pool_retirement",
 		"drep",
 		"auth_committee_hot",
+		"committee_member",
+		"committee_quorum",
 		"resign_committee_cold",
 		"governance_proposal",
 	}
@@ -924,7 +1037,12 @@ func parseProposalActionIdx(id string) uint32 {
 }
 
 func getActionType(action common.GovAction) common.GovActionType {
+	// The Conway parameter-change action is a distinct concrete type; it
+	// is handled explicitly rather than relying on the default so a
+	// future era adds-a-type doesn't silently misclassify.
 	switch action.(type) {
+	case *conway.ConwayParameterChangeGovAction:
+		return common.GovActionTypeParameterChange
 	case *common.HardForkInitiationGovAction:
 		return common.GovActionTypeHardForkInitiation
 	case *common.TreasuryWithdrawalGovAction:

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -33,10 +33,12 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/forging"
+	"github.com/blinklabs-io/dingo/ledger/governance"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -2710,6 +2712,50 @@ func (ls *LedgerState) processEpochRollover(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("apply pparam updates: %w", err)
+	}
+
+	// Run the CIP-1694 governance tick: enact proposals ratified in the
+	// previous epoch (possibly mutating pparams), expire stale proposals,
+	// and ratify active proposals whose tallies meet threshold. Any
+	// pparams change from enactment is persisted via SetPParams so the
+	// next epoch's pparams reflect the enacted state.
+	var conwayGenesis *conway.ConwayGenesis
+	if ls.config.CardanoNodeConfig != nil {
+		conwayGenesis = ls.config.CardanoNodeConfig.ConwayGenesis()
+	}
+	govOut, err := governance.ProcessEpoch(&governance.EpochInput{
+		DB:            ls.db,
+		Txn:           txn,
+		Logger:        ls.config.Logger,
+		PrevEpoch:     currentEpoch.EpochId,
+		NewEpoch:      currentEpoch.EpochId + 1,
+		BoundarySlot:  epochStartSlot,
+		PParams:       newPParams,
+		UpdateFn:      currentEra.PParamsUpdateFunc,
+		ConwayGenesis: conwayGenesis,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("process governance epoch: %w", err)
+	}
+	if govOut.PParamsChanged {
+		newPParams = govOut.UpdatedPParams
+		pparamsCbor, encErr := cbor.Encode(&newPParams)
+		if encErr != nil {
+			return nil, fmt.Errorf(
+				"encode post-enactment pparams: %w", encErr,
+			)
+		}
+		if err := ls.db.SetPParams(
+			pparamsCbor,
+			epochStartSlot,
+			currentEpoch.EpochId+1,
+			currentEra.Id,
+			txn,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"persist post-enactment pparams: %w", err,
+			)
+		}
 	}
 	result.NewCurrentPParams = newPParams
 

--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/governance"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -219,7 +220,7 @@ func (d *LedgerDelta) processGovernance(
 
 	// Process governance proposals
 	if len(proposals) > 0 {
-		if err := ProcessGovernanceProposals(
+		if err := governance.ProcessProposals(
 			tx,
 			d.Point,
 			currentEpoch,
@@ -233,7 +234,7 @@ func (d *LedgerDelta) processGovernance(
 
 	// Process governance votes
 	if len(votes) > 0 {
-		if err := ProcessGovernanceVotes(
+		if err := governance.ProcessVotes(
 			tx,
 			d.Point,
 			currentEpoch,

--- a/ledger/governance/enact.go
+++ b/ledger/governance/enact.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+)
+
+// EnactmentContext carries the inputs enactment needs: a writable
+// transaction, the epoch and slot at which enactment takes effect,
+// and the protocol-parameter update function for the current era.
+type EnactmentContext struct {
+	DB       *database.Database
+	Txn      *database.Txn
+	Epoch    uint64
+	Slot     uint64
+	PParams  lcommon.ProtocolParameters
+	UpdateFn func(lcommon.ProtocolParameters, any) (lcommon.ProtocolParameters, error)
+}
+
+// EnactmentResult is returned from EnactProposal when an action mutates
+// the in-memory protocol parameters (ParameterChange, HardForkInitiation).
+// The caller is responsible for persisting UpdatedPParams via SetPParams.
+type EnactmentResult struct {
+	UpdatedPParams lcommon.ProtocolParameters
+	PParamsChanged bool
+}
+
+// EnactProposal applies the side effects of a ratified governance
+// proposal and marks it as enacted at the given epoch/slot. It
+// returns an EnactmentResult reflecting any in-memory pparam change.
+func EnactProposal(
+	ctx *EnactmentContext,
+	proposal *models.GovernanceProposal,
+) (*EnactmentResult, error) {
+	if ctx == nil || ctx.DB == nil {
+		return nil, errors.New("nil enactment context")
+	}
+	if proposal == nil {
+		return nil, errors.New("nil proposal")
+	}
+	result := &EnactmentResult{UpdatedPParams: ctx.PParams}
+
+	action, err := decodeGovAction(
+		proposal.GovActionCbor,
+		proposal.ActionType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decode gov action: %w", err)
+	}
+
+	switch a := action.(type) {
+	case *conway.ConwayParameterChangeGovAction:
+		updated, err := ctx.UpdateFn(ctx.PParams, &a.ParamUpdate)
+		if err != nil {
+			return nil, fmt.Errorf("apply param update: %w", err)
+		}
+		result.UpdatedPParams = updated
+		result.PParamsChanged = true
+
+	case *lcommon.HardForkInitiationGovAction:
+		updated, err := setProtocolVersion(
+			ctx.PParams,
+			a.ProtocolVersion.Major,
+			a.ProtocolVersion.Minor,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("schedule hard fork: %w", err)
+		}
+		result.UpdatedPParams = updated
+		result.PParamsChanged = true
+
+	case *lcommon.TreasuryWithdrawalGovAction:
+		if err := applyTreasuryWithdrawal(ctx, a); err != nil {
+			return nil, fmt.Errorf("treasury withdrawal: %w", err)
+		}
+
+	case *lcommon.NoConfidenceGovAction:
+		if err := ctx.DB.SoftDeleteAllCommitteeMembers(
+			ctx.Slot, ctx.Txn,
+		); err != nil {
+			return nil, fmt.Errorf("no confidence: %w", err)
+		}
+
+	case *lcommon.UpdateCommitteeGovAction:
+		if err := applyUpdateCommittee(ctx, a); err != nil {
+			return nil, fmt.Errorf("update committee: %w", err)
+		}
+
+	case *lcommon.NewConstitutionGovAction:
+		anchor := a.Constitution.Anchor
+		constitution := &models.Constitution{
+			AnchorURL:  anchor.Url,
+			AnchorHash: anchor.DataHash[:],
+			PolicyHash: a.Constitution.ScriptHash,
+			AddedSlot:  ctx.Slot,
+		}
+		if err := ctx.DB.SetConstitution(
+			constitution, ctx.Txn,
+		); err != nil {
+			return nil, fmt.Errorf("set constitution: %w", err)
+		}
+
+	case *lcommon.InfoGovAction:
+		// Info actions have no on-chain effect; they stay ratified
+		// until they expire.
+
+	default:
+		return nil, fmt.Errorf(
+			"unsupported gov action type: %T", action,
+		)
+	}
+
+	// Per CIP-1694, the deposit is returned to the proposer's reward
+	// account when the proposal is finalized (enactment here, or
+	// expiry in the EpochInput expiry path).
+	if err := refundProposalDeposit(
+		ctx.DB, ctx.Txn, proposal, ctx.Slot,
+	); err != nil {
+		return nil, fmt.Errorf("refund proposal deposit: %w", err)
+	}
+
+	// Mark the proposal as enacted so it is no longer considered active
+	// and the next ratification tick picks up a new root.
+	enactedEpoch := ctx.Epoch
+	enactedSlot := ctx.Slot
+	proposal.EnactedEpoch = &enactedEpoch
+	proposal.EnactedSlot = &enactedSlot
+	if err := ctx.DB.SetGovernanceProposal(
+		proposal, ctx.Txn,
+	); err != nil {
+		return nil, fmt.Errorf("mark proposal enacted: %w", err)
+	}
+
+	return result, nil
+}
+
+// applyTreasuryWithdrawal debits the treasury by the sum of the
+// per-address amounts and credits each destination reward account.
+func applyTreasuryWithdrawal(
+	ctx *EnactmentContext,
+	a *lcommon.TreasuryWithdrawalGovAction,
+) error {
+	if ctx == nil || ctx.DB == nil {
+		return errors.New("nil enactment context")
+	}
+	var metaTxn types.Txn
+	if ctx.Txn != nil {
+		metaTxn = ctx.Txn.Metadata()
+	}
+	state, err := ctx.DB.Metadata().GetNetworkState(metaTxn)
+	if err != nil {
+		return fmt.Errorf("get network state: %w", err)
+	}
+	var treasury, reserves uint64
+	if state != nil {
+		treasury = uint64(state.Treasury)
+		reserves = uint64(state.Reserves)
+	}
+	var total uint64
+	for _, amount := range a.Withdrawals {
+		if total > ^uint64(0)-amount {
+			return errors.New("treasury withdrawal amount overflow")
+		}
+		total += amount
+	}
+	if total > treasury {
+		return fmt.Errorf(
+			"treasury withdrawal of %d exceeds tracked treasury balance %d",
+			total, treasury,
+		)
+	}
+	for rewardAddr, amount := range a.Withdrawals {
+		if amount == 0 {
+			continue
+		}
+		if rewardAddr == nil {
+			return errors.New("nil treasury withdrawal reward address")
+		}
+		rewardAddrBytes, err := rewardAddr.Bytes()
+		if err != nil {
+			return fmt.Errorf("encode treasury withdrawal reward address: %w", err)
+		}
+		stakeCredential, err := rewardAccountStakeCredential(
+			rewardAddrBytes,
+		)
+		if err != nil {
+			return fmt.Errorf("treasury withdrawal reward account: %w", err)
+		}
+		if err := ctx.DB.AddAccountReward(
+			stakeCredential,
+			amount,
+			ctx.Slot,
+			ctx.Txn,
+		); err != nil {
+			return fmt.Errorf("credit reward account: %w", err)
+		}
+	}
+	return ctx.DB.Metadata().SetNetworkState(
+		treasury-total,
+		reserves,
+		ctx.Slot,
+		metaTxn,
+	)
+}
+
+// applyUpdateCommittee removes the requested cold credentials and
+// adds or updates new members with their expiry epochs from the
+// action's credential-to-epoch map, then records the enacted quorum.
+func applyUpdateCommittee(
+	ctx *EnactmentContext,
+	a *lcommon.UpdateCommitteeGovAction,
+) error {
+	removeHashes := make([][]byte, 0, len(a.Credentials))
+	for _, c := range a.Credentials {
+		hash := c.Credential
+		removeHashes = append(removeHashes, hash[:])
+	}
+	if err := ctx.DB.SoftDeleteCommitteeMembers(
+		removeHashes, ctx.Slot, ctx.Txn,
+	); err != nil {
+		return fmt.Errorf("remove members: %w", err)
+	}
+	if err := ctx.DB.SetCommitteeQuorum(
+		a.Quorum.Rat, ctx.Slot, ctx.Txn,
+	); err != nil {
+		return fmt.Errorf("set committee quorum: %w", err)
+	}
+	if len(a.CredEpochs) == 0 {
+		return nil
+	}
+	members := make([]*models.CommitteeMember, 0, len(a.CredEpochs))
+	for cred, expiry := range a.CredEpochs {
+		if cred == nil {
+			continue
+		}
+		hash := cred.Credential
+		members = append(members, &models.CommitteeMember{
+			ColdCredHash: hash[:],
+			ExpiresEpoch: uint64(expiry),
+			AddedSlot:    ctx.Slot,
+		})
+	}
+	if len(members) == 0 {
+		return nil
+	}
+	// Sort by cold credential hash so the auto-increment ID assigned
+	// by the DB is stable across nodes (Go map iteration is random).
+	sort.Slice(members, func(i, j int) bool {
+		return bytes.Compare(members[i].ColdCredHash, members[j].ColdCredHash) < 0
+	})
+	return ctx.DB.SetCommitteeMembers(members, ctx.Txn)
+}
+
+// decodeGovAction re-hydrates the GovAction value from its CBOR form.
+// We switch on the action type recorded in the proposal model to
+// pick the concrete target type.
+func decodeGovAction(
+	data []byte,
+	actionType uint8,
+) (lcommon.GovAction, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf(
+			"empty gov action cbor (action type %d)",
+			actionType,
+		)
+	}
+	switch lcommon.GovActionType(actionType) {
+	case lcommon.GovActionTypeParameterChange:
+		var a conway.ConwayParameterChangeGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case lcommon.GovActionTypeHardForkInitiation:
+		var a lcommon.HardForkInitiationGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case lcommon.GovActionTypeTreasuryWithdrawal:
+		var a lcommon.TreasuryWithdrawalGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case lcommon.GovActionTypeNoConfidence:
+		var a lcommon.NoConfidenceGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case lcommon.GovActionTypeUpdateCommittee:
+		var a lcommon.UpdateCommitteeGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case lcommon.GovActionTypeNewConstitution:
+		var a lcommon.NewConstitutionGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case lcommon.GovActionTypeInfo:
+		var a lcommon.InfoGovAction
+		if _, err := cbor.Decode(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	}
+	return nil, fmt.Errorf("unknown action type: %d", actionType)
+}
+
+// setProtocolVersion rebuilds the pparams with a new protocol version
+// using the era's update function. We construct a minimal update that
+// only touches the protocol version.
+func setProtocolVersion(
+	current lcommon.ProtocolParameters,
+	major, minor uint,
+) (lcommon.ProtocolParameters, error) {
+	switch p := current.(type) {
+	case *conway.ConwayProtocolParameters:
+		updated := *p
+		updated.ProtocolVersion.Major = major
+		updated.ProtocolVersion.Minor = minor
+		return &updated, nil
+	}
+	return nil, fmt.Errorf(
+		"protocol version update unsupported for pparams type %T",
+		current,
+	)
+}

--- a/ledger/governance/enact_test.go
+++ b/ledger/governance/enact_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeGovAction_InfoRoundtrip(t *testing.T) {
+	original := &lcommon.InfoGovAction{Type: 6}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeInfo),
+	)
+	require.NoError(t, err)
+	_, ok := decoded.(*lcommon.InfoGovAction)
+	assert.True(t, ok)
+}
+
+func TestDecodeGovAction_ParameterChangeRoundtrip(t *testing.T) {
+	fee := uint(1234)
+	original := &conway.ConwayParameterChangeGovAction{
+		Type: 0,
+		ParamUpdate: conway.ConwayProtocolParameterUpdate{
+			MinFeeA: &fee,
+		},
+	}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeParameterChange),
+	)
+	require.NoError(t, err)
+	concrete, ok := decoded.(*conway.ConwayParameterChangeGovAction)
+	require.True(t, ok)
+	require.NotNil(t, concrete.ParamUpdate.MinFeeA)
+	assert.Equal(t, uint(1234), *concrete.ParamUpdate.MinFeeA)
+}
+
+func TestDecodeGovAction_HardForkRoundtrip(t *testing.T) {
+	original := &lcommon.HardForkInitiationGovAction{Type: 1}
+	original.ProtocolVersion.Major = 10
+	original.ProtocolVersion.Minor = 0
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeHardForkInitiation),
+	)
+	require.NoError(t, err)
+	concrete, ok := decoded.(*lcommon.HardForkInitiationGovAction)
+	require.True(t, ok)
+	assert.Equal(t, uint(10), concrete.ProtocolVersion.Major)
+}
+
+func TestDecodeGovAction_TreasuryWithdrawalRoundtrip(t *testing.T) {
+	original := &lcommon.TreasuryWithdrawalGovAction{
+		Type:       2,
+		PolicyHash: []byte{0xAB, 0xCD, 0xEF},
+	}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	)
+	require.NoError(t, err)
+	concrete, ok := decoded.(*lcommon.TreasuryWithdrawalGovAction)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0xAB, 0xCD, 0xEF}, concrete.PolicyHash)
+}
+
+func TestDecodeGovAction_NoConfidenceRoundtrip(t *testing.T) {
+	original := &lcommon.NoConfidenceGovAction{Type: 3}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeNoConfidence),
+	)
+	require.NoError(t, err)
+	_, ok := decoded.(*lcommon.NoConfidenceGovAction)
+	assert.True(t, ok)
+}
+
+func TestDecodeGovAction_UpdateCommitteeRoundtrip(t *testing.T) {
+	original := &lcommon.UpdateCommitteeGovAction{
+		Type:        4,
+		Credentials: []lcommon.Credential{},
+		Quorum:      newRat(2, 3),
+	}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeUpdateCommittee),
+	)
+	require.NoError(t, err)
+	_, ok := decoded.(*lcommon.UpdateCommitteeGovAction)
+	assert.True(t, ok)
+}
+
+func TestDecodeGovAction_NewConstitutionRoundtrip(t *testing.T) {
+	original := &lcommon.NewConstitutionGovAction{Type: 5}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+	decoded, err := decodeGovAction(
+		encoded, uint8(lcommon.GovActionTypeNewConstitution),
+	)
+	require.NoError(t, err)
+	_, ok := decoded.(*lcommon.NewConstitutionGovAction)
+	assert.True(t, ok)
+}
+
+func TestDecodeGovAction_EmptyCbor(t *testing.T) {
+	_, err := decodeGovAction(
+		nil, uint8(lcommon.GovActionTypeInfo),
+	)
+	assert.Error(t, err)
+}
+
+func TestDecodeGovAction_UnknownType(t *testing.T) {
+	_, err := decodeGovAction(
+		[]byte{0x00}, 99,
+	)
+	assert.Error(t, err)
+}
+
+func TestSetProtocolVersion_ConwayParams(t *testing.T) {
+	pparams := &conway.ConwayProtocolParameters{}
+	pparams.ProtocolVersion.Major = 9
+	pparams.ProtocolVersion.Minor = 0
+	updated, err := setProtocolVersion(pparams, 10, 0)
+	require.NoError(t, err)
+	concrete, ok := updated.(*conway.ConwayProtocolParameters)
+	require.True(t, ok)
+	assert.Equal(t, uint(10), concrete.ProtocolVersion.Major)
+	// Original must remain unmutated to preserve the previous epoch's
+	// pparams for rollback safety.
+	assert.Equal(t, uint(9), pparams.ProtocolVersion.Major)
+}
+
+func TestStakeEpochFor(t *testing.T) {
+	tests := []struct {
+		newEpoch uint64
+		expected uint64
+	}{
+		{0, 0},
+		{1, 0},
+		{2, 0},
+		{3, 1},
+		{10, 8},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, stakeEpochFor(tt.newEpoch))
+	}
+}
+
+// Expiry is exercised end-to-end via the DB query and ProcessEpoch
+// integration rather than a split-in-memory helper, so there is no unit
+// test for a partition function here.
+
+func TestApplyTreasuryWithdrawal_CreditsRewardsAndDebitsTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 1)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	a := &lcommon.TreasuryWithdrawalGovAction{
+		Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 7},
+	}
+	err = applyTreasuryWithdrawal(&EnactmentContext{
+		DB:   db,
+		Slot: 123,
+	}, a)
+	require.NoError(t, err)
+
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(12), uint64(account.Reward))
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(93), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -1,0 +1,539 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"sort"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+)
+
+// EpochInput collects the inputs needed at an epoch boundary
+// to drive the governance state machine.
+type EpochInput struct {
+	DB        *database.Database
+	Txn       *database.Txn
+	Logger    *slog.Logger
+	PrevEpoch uint64 // epoch being closed out
+	NewEpoch  uint64 // epoch being opened
+	// Slot at which enactment/ratification records its effect. The
+	// boundary slot is used so rollback-to-slot-N-1 correctly reverts
+	// this tick's changes.
+	BoundarySlot uint64
+	// PParams coming out of the legacy (Byron) pparam-update pass.
+	// Enactment may mutate and return a new pparams.
+	PParams  lcommon.ProtocolParameters
+	UpdateFn func(lcommon.ProtocolParameters, any) (lcommon.ProtocolParameters, error)
+	// ConwayGenesis supplies the initial committee quorum threshold
+	// used until a live per-committee quorum is persisted in state.
+	// Nil falls back to the hardcoded default.
+	ConwayGenesis *conway.ConwayGenesis
+}
+
+// EpochOutput reports what happened during the tick so the
+// caller can persist updated pparams and emit metrics.
+type EpochOutput struct {
+	UpdatedPParams    lcommon.ProtocolParameters
+	PParamsChanged    bool
+	EnactedCount      int
+	RatifiedCount     int
+	ExpiredCount      int
+	HardForkInitiated bool
+}
+
+// ProcessEpoch runs the ordered governance tick at an epoch
+// boundary: enact proposals ratified in the previous epoch, expire
+// overdue proposals, then ratify currently active proposals whose
+// tallies meet threshold. The order matches the Cardano spec:
+// ENACT first (so the current root reflects the new state), then
+// RATIFY (which uses the updated root).
+func ProcessEpoch(
+	in *EpochInput,
+) (*EpochOutput, error) {
+	if in == nil {
+		return nil, errors.New("nil governance epoch input")
+	}
+	out := &EpochOutput{UpdatedPParams: in.PParams}
+
+	conwayPParams, ok := in.PParams.(*conway.ConwayProtocolParameters)
+	if !ok {
+		// Pre-Conway: nothing to do, governance state machine is
+		// not yet active.
+		return out, nil
+	}
+	// Conway path requires database access for proposal lookups and
+	// an UpdateFn for parameter-change enactment. A missing DB or
+	// UpdateFn here would surface as a nil pointer panic deep inside
+	// EnactProposal or in.DB.GetRatifiedGovernanceProposals; fail fast
+	// with a descriptive error instead. A nil Txn would let each DB
+	// call open its own transaction, which could leave the tick half-
+	// applied on error (e.g., enacted proposal marked as enacted but
+	// its side effects not persisted), so require it too.
+	if in.DB == nil {
+		return nil, errors.New("nil governance epoch database")
+	}
+	if in.Txn == nil {
+		return nil, errors.New("nil governance epoch transaction")
+	}
+	if in.UpdateFn == nil {
+		return nil, errors.New("nil governance epoch pparams update fn")
+	}
+
+	// --- ENACTMENT ----------------------------------------------------
+	enactCtx := &EnactmentContext{
+		DB:       in.DB,
+		Txn:      in.Txn,
+		Epoch:    in.NewEpoch,
+		Slot:     in.BoundarySlot,
+		PParams:  in.PParams,
+		UpdateFn: in.UpdateFn,
+	}
+	ratified, err := in.DB.GetRatifiedGovernanceProposals(in.Txn)
+	if err != nil {
+		return nil, fmt.Errorf("get ratified proposals: %w", err)
+	}
+	for _, proposal := range ratified {
+		enactCtx.PParams = out.UpdatedPParams
+		res, err := EnactProposal(enactCtx, proposal)
+		if err != nil {
+			// Abort the tick: enactment may have partially applied
+			// side effects (committee changes, treasury debit), and
+			// continuing would leave the proposal unmarked-enacted,
+			// so the next tick would re-apply it. Returning the
+			// error lets the surrounding DB transaction roll back.
+			return nil, fmt.Errorf(
+				"enact proposal %s#%d: %w",
+				shortHash(proposal.TxHash),
+				proposal.ActionIndex,
+				err,
+			)
+		}
+		out.EnactedCount++
+		if res.PParamsChanged {
+			out.UpdatedPParams = res.UpdatedPParams
+			out.PParamsChanged = true
+			if lcommon.GovActionType(proposal.ActionType) ==
+				lcommon.GovActionTypeHardForkInitiation {
+				out.HardForkInitiated = true
+			}
+		}
+	}
+
+	// --- EXPIRY -------------------------------------------------------
+	// Fetch proposals whose expiry epoch is in the past but which have
+	// not yet been enacted, expired, or deleted. The active-proposals
+	// query used below excludes these by construction (it filters
+	// `expires_epoch >= NewEpoch`), so we need a dedicated read to mark
+	// them expired and return their deposits.
+	expired, err := in.DB.GetExpiringGovernanceProposals(
+		in.NewEpoch, in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get expiring proposals: %w", err)
+	}
+	for _, p := range expired {
+		if err := refundProposalDeposit(
+			in.DB,
+			in.Txn,
+			p,
+			in.BoundarySlot,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"refund expired proposal deposit %s#%d: %w",
+				shortHash(p.TxHash),
+				p.ActionIndex,
+				err,
+			)
+		}
+		expiredEpoch := in.NewEpoch
+		expiredSlot := in.BoundarySlot
+		p.ExpiredEpoch = &expiredEpoch
+		p.ExpiredSlot = &expiredSlot
+		if err := in.DB.SetGovernanceProposal(p, in.Txn); err != nil {
+			return nil, fmt.Errorf("mark expired: %w", err)
+		}
+		out.ExpiredCount++
+	}
+
+	// Active proposals still in play: not expired past the new epoch,
+	// not enacted, not marked expired, not soft-deleted.
+	stillActive, err := in.DB.GetActiveGovernanceProposals(
+		in.NewEpoch, in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get active proposals: %w", err)
+	}
+
+	// --- RATIFICATION -------------------------------------------------
+	tallyCtx := &TallyContext{
+		DB:           in.DB,
+		Txn:          in.Txn,
+		StakeEpoch:   stakeEpochFor(in.NewEpoch),
+		CurrentEpoch: in.NewEpoch,
+	}
+
+	// Active set changes as we ratify; snapshot once.
+	activeDRepCount, err := countActiveDReps(in)
+	if err != nil {
+		return nil, fmt.Errorf("count active dreps: %w", err)
+	}
+
+	// Pre-fetch the current chain root for each chained purpose. The
+	// root cannot change during the RATIFY loop (ratifications are
+	// marks, not enactments), so one read per purpose replaces the
+	// old per-proposal call to GetLastEnactedGovernanceProposal.
+	// Querying by purpose (not bare action type) lets NoConfidence
+	// and UpdateCommittee share the same committee-purpose root.
+	rootsByPurpose := make(
+		map[govActionPurpose]*models.GovernanceProposal,
+		len(chainedPurposes),
+	)
+	for _, p := range chainedPurposes {
+		root, err := in.DB.GetLastEnactedGovernanceProposal(
+			purposeActionTypes(p), in.Txn,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"get current root for purpose %d: %w", p, err,
+			)
+		}
+		rootsByPurpose[p] = root
+	}
+
+	committeeState, err := LoadCommitteeVotingState(
+		in.DB, in.Txn, in.NewEpoch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load committee voting state: %w", err)
+	}
+	tallyCtx.CommitteeState = committeeState
+	activeCCCount := committeeState.ActiveMemberCount
+	ccInNoConfidence := committeeNoConfidenceState(
+		rootsByPurpose[purposeCommittee],
+	)
+
+	// Per the Conway spec, RATIFY operates on post-ENACT state. If the
+	// enactment loop mutated pparams (e.g., ParameterChange or
+	// HardForkInitiation), refresh the Conway pparams view so major
+	// version and threshold reads reflect the updated values.
+	if out.PParamsChanged {
+		if p, ok := out.UpdatedPParams.(*conway.ConwayProtocolParameters); ok {
+			conwayPParams = p
+		}
+	}
+
+	majorVersion := conwayPParams.ProtocolVersion.Major
+	// Computed after ENACT and reused across the RATIFY loop. The
+	// RATIFY loop marks proposals but does not enact committee state.
+	ccQuorum, err := conwayRatifyQuorum(
+		in.Logger, in.DB, in.Txn, in.ConwayGenesis,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get committee quorum: %w", err)
+	}
+
+	// Track ratifications per purpose (not per action type) so
+	// NoConfidence and UpdateCommittee in the same tick don't both
+	// fire — the spec allows at most one ratification per purpose.
+	ratifiedThisTickByPurpose := make(map[govActionPurpose]bool)
+
+	sort.SliceStable(stillActive, func(i, j int) bool {
+		return govActionPriority(stillActive[i]) <
+			govActionPriority(stillActive[j])
+	})
+
+	for _, proposal := range stillActive {
+		actionType := lcommon.GovActionType(proposal.ActionType)
+		purpose := govActionPurposeOf(actionType)
+		if purpose != purposeNone && ratifiedThisTickByPurpose[purpose] {
+			// The spec ratifies at most one action per purpose per
+			// epoch tick. Skip to avoid double-enacting next tick.
+			continue
+		}
+
+		// Parent chain check: look up the root by purpose so that,
+		// e.g., an UpdateCommittee validates against the most recent
+		// enacted committee-purpose action (which may be a
+		// NoConfidence).
+		var root *models.GovernanceProposal
+		if purpose != purposeNone {
+			root = rootsByPurpose[purpose]
+		}
+		if !validateParentChain(proposal, root) {
+			continue
+		}
+
+		tally, err := TallyProposal(tallyCtx, proposal)
+		if err != nil {
+			return nil, fmt.Errorf("tally: %w", err)
+		}
+		// For ParameterChange, decode the action so thresholds can
+		// take the touched parameter groups into account (especially
+		// so SPOs only gate security-group changes, and DReps select
+		// the most restrictive touched group).
+		var paramUpdate *conway.ConwayProtocolParameterUpdate
+		if lcommon.GovActionType(proposal.ActionType) ==
+			lcommon.GovActionTypeParameterChange {
+			action, decodeErr := decodeGovAction(
+				proposal.GovActionCbor, proposal.ActionType,
+			)
+			if decodeErr != nil {
+				// A decode failure means we cannot tell which
+				// parameter groups are touched; silently falling
+				// through with paramUpdate==nil would let SPO
+				// checks return nil and allow security-group
+				// changes to ratify without SPO approval. Skip
+				// this proposal and surface the error so it is
+				// investigated.
+				if in.Logger != nil {
+					in.Logger.Error(
+						"skipping proposal: failed to decode parameter change action",
+						"tx_hash", shortHash(proposal.TxHash),
+						"action_index", proposal.ActionIndex,
+						"error", decodeErr,
+						"component", "governance",
+					)
+				}
+				continue
+			}
+			a, ok := action.(*conway.ConwayParameterChangeGovAction)
+			if !ok {
+				if in.Logger != nil {
+					in.Logger.Error(
+						"skipping proposal: decoded action is not a parameter change",
+						"tx_hash", shortHash(proposal.TxHash),
+						"action_index", proposal.ActionIndex,
+						"got_type", fmt.Sprintf("%T", action),
+						"component", "governance",
+					)
+				}
+				continue
+			}
+			paramUpdate = &a.ParamUpdate
+		}
+		decision := ShouldRatify(RatifyInputs{
+			Tally:                 tally,
+			PParams:               conwayPParams,
+			ParamUpdate:           paramUpdate,
+			ActiveDRepCount:       activeDRepCount,
+			ActiveCCCount:         activeCCCount,
+			CCQuorum:              ccQuorum,
+			MajorVersion:          majorVersion,
+			CommitteeNoConfidence: ccInNoConfidence,
+		})
+		if !decision.Ratified {
+			continue
+		}
+		// Per CIP-1694, the deposit is returned at enactment (or
+		// expiry), not at ratification. EnactProposal handles the
+		// refund on the next epoch tick.
+		ratifiedEpoch := in.NewEpoch
+		ratifiedSlot := in.BoundarySlot
+		proposal.RatifiedEpoch = &ratifiedEpoch
+		proposal.RatifiedSlot = &ratifiedSlot
+		if err := in.DB.SetGovernanceProposal(
+			proposal, in.Txn,
+		); err != nil {
+			return nil, fmt.Errorf("mark ratified: %w", err)
+		}
+		if purpose != purposeNone {
+			ratifiedThisTickByPurpose[purpose] = true
+		}
+		out.RatifiedCount++
+		if isDelayingActionPurpose(purpose) {
+			break
+		}
+	}
+
+	return out, nil
+}
+
+// stakeEpochFor returns the epoch whose "mark" snapshot should be used
+// for vote-weight calculations in the given new epoch. Mark captured
+// at end of N is used for voting in N+2, hence newEpoch-2. For early
+// epochs we fall back to newEpoch-1 or 0.
+func stakeEpochFor(newEpoch uint64) uint64 {
+	switch {
+	case newEpoch >= 2:
+		return newEpoch - 2
+	case newEpoch >= 1:
+		return newEpoch - 1
+	}
+	return 0
+}
+
+// countActiveDReps returns the number of DReps eligible to vote in the
+// current tick. AlwaysAbstain / AlwaysNoConfidence virtual DReps are
+// not included.
+func countActiveDReps(in *EpochInput) (int, error) {
+	dreps, err := in.DB.GetActiveDreps(in.Txn)
+	if err != nil {
+		return 0, err
+	}
+	active := 0
+	for _, drep := range dreps {
+		if drepActiveAtEpoch(drep, in.NewEpoch) {
+			active++
+		}
+	}
+	return active, nil
+}
+
+func drepActiveAtEpoch(drep *models.Drep, currentEpoch uint64) bool {
+	return drep != nil &&
+		(drep.ExpiryEpoch == 0 || drep.ExpiryEpoch > currentEpoch)
+}
+
+func committeeNoConfidenceState(
+	committeeRoot *models.GovernanceProposal,
+) bool {
+	return committeeRoot != nil &&
+		lcommon.GovActionType(committeeRoot.ActionType) ==
+			lcommon.GovActionTypeNoConfidence
+}
+
+func govActionPriority(proposal *models.GovernanceProposal) int {
+	if proposal == nil {
+		return 5
+	}
+	actionType := lcommon.GovActionType(proposal.ActionType)
+	if actionType == lcommon.GovActionTypeNoConfidence {
+		return 0
+	}
+	switch govActionPurposeOf(actionType) {
+	case purposeCommittee:
+		return 1
+	case purposeConstitution:
+		return 2
+	case purposeHardFork:
+		return 3
+	case purposeNone, purposeParameterChange:
+		return 4
+	default:
+		return 5
+	}
+}
+
+func isDelayingActionPurpose(purpose govActionPurpose) bool {
+	switch purpose {
+	case purposeCommittee, purposeConstitution, purposeHardFork:
+		return true
+	case purposeNone, purposeParameterChange:
+		return false
+	default:
+		return false
+	}
+}
+
+// refundProposalDeposit credits the proposal deposit back to the
+// proposer's reward account. The caller marks the proposal final only
+// after this succeeds so a failed credit rolls back the epoch tick.
+func refundProposalDeposit(
+	db *database.Database,
+	txn *database.Txn,
+	proposal *models.GovernanceProposal,
+	slot uint64,
+) error {
+	if proposal == nil || proposal.Deposit == 0 {
+		return nil
+	}
+	if db == nil {
+		return errors.New("nil database")
+	}
+	stakeCredential, err := rewardAccountStakeCredential(
+		proposal.ReturnAddress,
+	)
+	if err != nil {
+		return err
+	}
+	if err := db.AddAccountReward(
+		stakeCredential,
+		proposal.Deposit,
+		slot,
+		txn,
+	); err != nil {
+		return fmt.Errorf("credit reward account: %w", err)
+	}
+	return nil
+}
+
+func rewardAccountStakeCredential(returnAddress []byte) ([]byte, error) {
+	addr, err := lcommon.NewAddressFromBytes(returnAddress)
+	if err != nil {
+		return nil, fmt.Errorf("decode return reward account: %w", err)
+	}
+	switch addr.Type() {
+	case lcommon.AddressTypeNoneKey, lcommon.AddressTypeNoneScript:
+	default:
+		return nil, fmt.Errorf(
+			"return address is not a reward account: address type %d",
+			addr.Type(),
+		)
+	}
+	stakeHash := addr.StakeKeyHash()
+	return append([]byte(nil), stakeHash[:]...), nil
+}
+
+// shortHash returns a hex-encoded prefix of a tx hash for logging.
+// Safe when the hash is shorter than 8 bytes (malformed DB rows).
+func shortHash(h []byte) string {
+	return hex.EncodeToString(h[:min(len(h), 8)])
+}
+
+// defaultCCQuorum is the last-resort fallback when Conway genesis is
+// unavailable (e.g., pre-Conway networks or in tests). Matches the
+// common Conway genesis default so CC-gated actions cannot silently
+// auto-approve.
+var defaultCCQuorum = big.NewRat(2, 3)
+
+// conwayRatifyQuorum returns the CC quorum used by ShouldRatify. It
+// prefers enacted committee state, reads the initial threshold from
+// Conway genesis when available, and falls back to the 2/3 default.
+func conwayRatifyQuorum(
+	logger *slog.Logger,
+	db *database.Database,
+	txn *database.Txn,
+	genesis *conway.ConwayGenesis,
+) (*big.Rat, error) {
+	if db != nil {
+		quorum, err := db.GetCommitteeQuorum(txn)
+		if err != nil {
+			return nil, err
+		}
+		if quorum != nil {
+			return quorum, nil
+		}
+	}
+	if genesis != nil && genesis.Committee.Threshold != nil &&
+		genesis.Committee.Threshold.Rat != nil {
+		return genesis.Committee.Threshold.Rat, nil
+	}
+	if logger != nil {
+		logger.Debug(
+			"using fallback CC quorum (Conway genesis unavailable)",
+			"quorum", "2/3",
+			"component", "governance",
+		)
+	}
+	return defaultCCQuorum, nil
+}

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefundProposalDepositCreditsRewardAccount(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 1)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	rewardAddrBytes, err := rewardAddr.Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+
+	err = refundProposalDeposit(db, nil, &models.GovernanceProposal{
+		Deposit:       7,
+		ReturnAddress: rewardAddrBytes,
+	}, 123)
+	require.NoError(t, err)
+
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(12), uint64(account.Reward))
+}
+
+func TestRewardCreditsRollbackBySlot(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 1)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	rewardAddrBytes, err := rewardAddr.Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+
+	err = refundProposalDeposit(db, nil, &models.GovernanceProposal{
+		Deposit:       7,
+		ReturnAddress: rewardAddrBytes,
+	}, 123)
+	require.NoError(t, err)
+
+	require.NoError(t, db.DeleteAccountRewardsAfterSlot(122, nil))
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(5), uint64(account.Reward))
+}
+
+func TestCountActiveDRepsFiltersExpiredDReps(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	require.NoError(t, store.DB().Create(&[]models.Drep{
+		{
+			Credential:  testBytes(28, 1),
+			ExpiryEpoch: 0,
+			Active:      true,
+		},
+		{
+			Credential:  testBytes(28, 2),
+			ExpiryEpoch: 10,
+			Active:      true,
+		},
+		{
+			Credential:  testBytes(28, 3),
+			ExpiryEpoch: 11,
+			Active:      true,
+		},
+	}).Error)
+
+	count, err := countActiveDReps(&EpochInput{DB: db, NewEpoch: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCommitteeNoConfidenceStateUsesEnactedCommitteeRoot(t *testing.T) {
+	assert.False(t, committeeNoConfidenceState(nil))
+	assert.False(t, committeeNoConfidenceState(&models.GovernanceProposal{
+		ActionType: uint8(lcommon.GovActionTypeUpdateCommittee),
+	}))
+	assert.True(t, committeeNoConfidenceState(&models.GovernanceProposal{
+		ActionType: uint8(lcommon.GovActionTypeNoConfidence),
+	}))
+}

--- a/ledger/governance/processing.go
+++ b/ledger/governance/processing.go
@@ -12,26 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger
+package governance
 
 import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
-// ProcessGovernanceProposals extracts governance proposals from a Conway-era
+// ProcessProposals extracts governance proposals from a Conway-era
 // transaction and persists them to the database. Each proposal procedure in the
 // transaction body is mapped to a GovernanceProposal model with the appropriate
 // action type, parent action, anchor, and deposit information.
 //
 // The govActionLifetime parameter determines how many epochs a proposal remains
 // active before expiring.
-func ProcessGovernanceProposals(
+func ProcessProposals(
 	tx lcommon.Transaction,
 	point ocommon.Point,
 	currentEpoch uint64,
@@ -45,16 +46,19 @@ func ProcessGovernanceProposals(
 	}
 
 	txHash := tx.Hash().Bytes()
+	if len(txHash) != 32 {
+		return fmt.Errorf("invalid tx hash length: got %d", len(txHash))
+	}
+	txHashForLog := shortHash(txHash)
 
 	for i, proposal := range proposals {
-		actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(
-			proposal.GovAction(),
-		)
+		govAction := proposal.GovAction()
+		actionType, parentTxHash, parentActionIdx, policyHash, err := extractGovActionInfo(govAction)
 		if err != nil {
 			return fmt.Errorf(
-				"proposal %d in tx %x: %w",
+				"proposal %d in tx %s: %w",
 				i,
-				txHash[:8],
+				txHashForLog,
 				err,
 			)
 		}
@@ -66,9 +70,19 @@ func ProcessGovernanceProposals(
 		rewardAddrBytes, err := rewardAddr.Bytes()
 		if err != nil {
 			return fmt.Errorf(
-				"encode reward address for proposal %d in tx %x: %w",
+				"encode reward address for proposal %d in tx %s: %w",
 				i,
-				txHash[:8],
+				txHashForLog,
+				err,
+			)
+		}
+
+		actionCbor, err := cbor.Encode(govAction)
+		if err != nil {
+			return fmt.Errorf(
+				"encode gov action cbor for proposal %d in tx %s: %w",
+				i,
+				txHashForLog,
 				err,
 			)
 		}
@@ -83,6 +97,7 @@ func ProcessGovernanceProposals(
 			AnchorHash:    anchorHash[:],
 			Deposit:       proposal.Deposit(),
 			ReturnAddress: rewardAddrBytes,
+			GovActionCbor: actionCbor,
 			AddedSlot:     point.Slot,
 		}
 
@@ -97,9 +112,9 @@ func ProcessGovernanceProposals(
 
 		if err := db.SetGovernanceProposal(govProposal, txn); err != nil {
 			return fmt.Errorf(
-				"set governance proposal %d in tx %x: %w",
+				"set governance proposal %d in tx %s: %w",
 				i,
-				txHash[:8],
+				txHashForLog,
 				err,
 			)
 		}
@@ -108,13 +123,13 @@ func ProcessGovernanceProposals(
 	return nil
 }
 
-// ProcessGovernanceVotes extracts voting procedures from a Conway-era
+// ProcessVotes extracts voting procedures from a Conway-era
 // transaction and persists them to the database. Each vote maps a voter
 // (CC member, DRep, or SPO) and a governance action to a vote choice.
 //
 // When a DRep votes, their activity epoch is updated to the current epoch,
 // which resets their expiry countdown based on the dRepInactivityPeriod.
-func ProcessGovernanceVotes(
+func ProcessVotes(
 	tx lcommon.Transaction,
 	point ocommon.Point,
 	currentEpoch uint64,
@@ -128,6 +143,10 @@ func ProcessGovernanceVotes(
 	}
 
 	txHash := tx.Hash().Bytes()
+	if len(txHash) != 32 {
+		return fmt.Errorf("invalid tx hash length: got %d", len(txHash))
+	}
+	txHashForLog := shortHash(txHash)
 
 	// Cache proposal lookups to avoid redundant DB queries when multiple
 	// voters vote on the same governance action within a single transaction.
@@ -149,8 +168,8 @@ func ProcessGovernanceVotes(
 		voterType, err := mapVoterType(voter.Type)
 		if err != nil {
 			return fmt.Errorf(
-				"vote in tx %x: %w",
-				txHash[:8],
+				"vote in tx %s: %w",
+				txHashForLog,
 				err,
 			)
 		}
@@ -166,8 +185,8 @@ func ProcessGovernanceVotes(
 					txn,
 				); err != nil {
 					return fmt.Errorf(
-						"update drep activity in tx %x: %w",
-						txHash[:8],
+						"update drep activity in tx %s: %w",
+						txHashForLog,
 						err,
 					)
 				}
@@ -195,8 +214,8 @@ func ProcessGovernanceVotes(
 				)
 				if err != nil {
 					return fmt.Errorf(
-						"lookup governance proposal for vote in tx %x: %w",
-						txHash[:8],
+						"lookup governance proposal for vote in tx %s: %w",
+						txHashForLog,
 						err,
 					)
 				}
@@ -225,8 +244,8 @@ func ProcessGovernanceVotes(
 
 			if err := db.SetGovernanceVote(vote, txn); err != nil {
 				return fmt.Errorf(
-					"set governance vote in tx %x: %w",
-					txHash[:8],
+					"set governance vote in tx %s: %w",
+					txHashForLog,
 					err,
 				)
 			}

--- a/ledger/governance/processing_test.go
+++ b/ledger/governance/processing_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger
+package governance
 
 import (
 	"testing"

--- a/ledger/governance/purpose.go
+++ b/ledger/governance/purpose.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// govActionPurpose groups action types that share a chain root per
+// CIP-1694. NoConfidence and UpdateCommittee both chain off the same
+// "committee" root; treating them as distinct action types at the
+// storage layer would lose the chain after a NoConfidence is enacted,
+// letting a subsequent UpdateCommittee bypass parent validation.
+type govActionPurpose int
+
+const (
+	purposeNone govActionPurpose = iota
+	purposeParameterChange
+	purposeHardFork
+	purposeCommittee
+	purposeConstitution
+)
+
+// govActionPurposeOf maps an action type to its chain-root purpose.
+// Actions without a chain (Info, TreasuryWithdrawal) return purposeNone.
+func govActionPurposeOf(t lcommon.GovActionType) govActionPurpose {
+	switch t {
+	case lcommon.GovActionTypeParameterChange:
+		return purposeParameterChange
+	case lcommon.GovActionTypeHardForkInitiation:
+		return purposeHardFork
+	case lcommon.GovActionTypeNoConfidence,
+		lcommon.GovActionTypeUpdateCommittee:
+		return purposeCommittee
+	case lcommon.GovActionTypeNewConstitution:
+		return purposeConstitution
+	case lcommon.GovActionTypeTreasuryWithdrawal,
+		lcommon.GovActionTypeInfo:
+		return purposeNone
+	default:
+		return purposeNone
+	}
+}
+
+// purposeActionTypes returns the action type discriminators that share
+// the given purpose's chain root.
+func purposeActionTypes(p govActionPurpose) []uint8 {
+	switch p {
+	case purposeParameterChange:
+		return []uint8{uint8(lcommon.GovActionTypeParameterChange)}
+	case purposeHardFork:
+		return []uint8{uint8(lcommon.GovActionTypeHardForkInitiation)}
+	case purposeCommittee:
+		return []uint8{
+			uint8(lcommon.GovActionTypeNoConfidence),
+			uint8(lcommon.GovActionTypeUpdateCommittee),
+		}
+	case purposeConstitution:
+		return []uint8{uint8(lcommon.GovActionTypeNewConstitution)}
+	case purposeNone:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// chainedPurposes enumerates the purposes whose roots must be looked
+// up at the start of the RATIFY loop. Info and TreasuryWithdrawal are
+// omitted because they don't chain.
+var chainedPurposes = []govActionPurpose{
+	purposeParameterChange,
+	purposeHardFork,
+	purposeCommittee,
+	purposeConstitution,
+}

--- a/ledger/governance/ratify.go
+++ b/ledger/governance/ratify.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+)
+
+// bootstrapProtocolVersion is the highest protocol major version during
+// the Conway bootstrap phase where governance voting thresholds are not
+// yet enforced and any yes vote ratifies a proposal.
+const bootstrapProtocolVersion = 9
+
+// RatifyDecision holds the outcome of evaluating a proposal's tally
+// against the thresholds defined in protocol parameters.
+type RatifyDecision struct {
+	Ratified      bool
+	DRepApproved  bool
+	SPOApproved   bool
+	CCApproved    bool
+	FailureReason string
+}
+
+// RatifyInputs is the decoded-action-aware shape callers pass to
+// ShouldRatify. The paramUpdate pointer is consulted for ParameterChange
+// proposals so DRep and SPO thresholds can be selected precisely.
+type RatifyInputs struct {
+	Tally                 *ProposalTally
+	PParams               *conway.ConwayProtocolParameters
+	ParamUpdate           *conway.ConwayProtocolParameterUpdate
+	ActiveDRepCount       int // reserved for future min-DRep-count gate
+	ActiveCCCount         int
+	CCQuorum              *big.Rat
+	MajorVersion          uint
+	CommitteeNoConfidence bool
+}
+
+// ShouldRatify evaluates whether the proposal should be ratified given
+// its current tally, the protocol parameters, and the active state of
+// DReps and CC. Follows CIP-1694 bootstrap and post-bootstrap logic.
+//
+// MajorVersion is the current protocol major version; before and
+// including version 9 (bootstrap), thresholds are effectively zero.
+func ShouldRatify(in RatifyInputs) RatifyDecision {
+	decision := RatifyDecision{}
+	if in.Tally == nil || in.PParams == nil {
+		decision.FailureReason = "missing tally or pparams"
+		return decision
+	}
+	actionType := lcommon.GovActionType(in.Tally.ActionType)
+
+	// Info actions are non-binding and cannot be enacted.
+	if actionType == lcommon.GovActionTypeInfo {
+		decision.FailureReason = "info actions cannot be ratified"
+		return decision
+	}
+
+	// Bootstrap phase: any yes vote ratifies.
+	if in.MajorVersion <= bootstrapProtocolVersion {
+		// #nosec G115 -- CCYesCount is bounded by CC size (< 100).
+		yes := in.Tally.DRepYesStake + in.Tally.SPOYesStake +
+			uint64(in.Tally.CCYesCount)
+		if yes == 0 {
+			decision.FailureReason = "bootstrap: no yes vote"
+			return decision
+		}
+		decision.Ratified = true
+		decision.DRepApproved = true
+		decision.SPOApproved = true
+		decision.CCApproved = true
+		return decision
+	}
+
+	// DRep approval: actions with no DRep gate or a zero threshold pass
+	// automatically. Otherwise requires
+	// yesStake/(totalStake-abstainStake) >= threshold per CIP-1694.
+	drepThreshold := getDRepThreshold(
+		actionType, in.PParams, in.ParamUpdate, in.CommitteeNoConfidence,
+	)
+	if drepThreshold == nil ||
+		drepThreshold.Sign() == 0 {
+		decision.DRepApproved = true
+	} else {
+		ratio := in.Tally.DRepYesRatio()
+		decision.DRepApproved = ratio.Cmp(drepThreshold) >= 0
+	}
+
+	// SPO approval: some actions do not require SPO votes; for those,
+	// threshold is nil and approval is automatic. Others require
+	// yesStake/(totalStake-abstainStake) >= threshold of the pool snapshot.
+	spoThreshold := getSPOThreshold(
+		actionType, in.PParams, in.ParamUpdate, in.CommitteeNoConfidence,
+	)
+	if spoThreshold == nil || spoThreshold.Sign() == 0 {
+		decision.SPOApproved = true
+	} else {
+		ratio := in.Tally.SPOYesRatio()
+		decision.SPOApproved = ratio.Cmp(spoThreshold) >= 0
+	}
+
+	// CC approval: skipped entirely for NoConfidence and UpdateCommittee.
+	// For other actions, require the CC to be seated (!noConfidence),
+	// satisfy the minimum committee size, and meet quorum.
+	switch {
+	case !needsCCApproval(actionType):
+		decision.CCApproved = true
+	case in.CommitteeNoConfidence:
+		decision.CCApproved = false
+		decision.FailureReason = "cc in no-confidence state"
+	case in.ActiveCCCount == 0:
+		// Check zero-members before the min-size comparison so the
+		// failure reason distinguishes "no members" from "below
+		// minimum" even when MinCommitteeSize >= 1.
+		decision.CCApproved = false
+		decision.FailureReason = "cc has no active members"
+	case in.ActiveCCCount < int(in.PParams.MinCommitteeSize): //nolint:gosec
+		decision.CCApproved = false
+		decision.FailureReason = "cc below minimum committee size"
+	case in.CCQuorum == nil || in.CCQuorum.Sign() == 0:
+		// Fail-safe: a missing or zero quorum signals a plumbing bug,
+		// not "no quorum required". Auto-approving here would silently
+		// ratify CC-gated actions (ParameterChange, HardForkInitiation,
+		// TreasuryWithdrawal, NewConstitution) whenever the caller
+		// forgot to pass a quorum.
+		decision.CCApproved = false
+		decision.FailureReason = "cc quorum missing or zero"
+	default:
+		ratio := in.Tally.CCYesRatio()
+		decision.CCApproved = ratio.Cmp(in.CCQuorum) >= 0
+	}
+
+	decision.Ratified = decision.DRepApproved && decision.SPOApproved &&
+		decision.CCApproved
+	if !decision.Ratified && decision.FailureReason == "" {
+		decision.FailureReason = "threshold not met"
+	}
+	return decision
+}
+
+// getDRepThreshold returns the DRep yes-ratio threshold for the action
+// type, or nil if DReps do not vote on this action. For ParameterChange
+// the threshold depends on which parameter groups are touched; paramUpdate
+// may be nil when the caller just wants the most restrictive group.
+// committeeNoConfidence selects CommitteeNoConfidence over CommitteeNormal
+// for UpdateCommittee when the committee is in a no-confidence state.
+func getDRepThreshold(
+	actionType lcommon.GovActionType,
+	pparams *conway.ConwayProtocolParameters,
+	paramUpdate *conway.ConwayProtocolParameterUpdate,
+	committeeNoConfidence bool,
+) *big.Rat {
+	t := &pparams.DRepVotingThresholds
+	switch actionType {
+	case lcommon.GovActionTypeNoConfidence:
+		// CIP-1694 Motion of No Confidence uses MotionNoConfidence.
+		return rateToRat(t.MotionNoConfidence)
+	case lcommon.GovActionTypeUpdateCommittee:
+		// Per CIP-1694: when the committee is already in an
+		// explicitly enacted no-confidence state, proposals to seat a
+		// new committee are evaluated against CommitteeNoConfidence;
+		// otherwise CommitteeNormal applies.
+		if committeeNoConfidence {
+			return rateToRat(t.CommitteeNoConfidence)
+		}
+		return rateToRat(t.CommitteeNormal)
+	case lcommon.GovActionTypeNewConstitution:
+		return rateToRat(t.UpdateToConstitution)
+	case lcommon.GovActionTypeHardForkInitiation:
+		return rateToRat(t.HardForkInitiation)
+	case lcommon.GovActionTypeTreasuryWithdrawal:
+		return rateToRat(t.TreasuryWithdrawal)
+	case lcommon.GovActionTypeParameterChange:
+		return mostRestrictiveDRepParamThreshold(t, paramUpdate)
+	case lcommon.GovActionTypeInfo:
+		return nil
+	default:
+		// Fail-closed: unknown/future action types require an
+		// unachievable 1/1 yes ratio so they cannot silently ratify
+		// without an explicit case being added here.
+		return big.NewRat(1, 1)
+	}
+}
+
+// getSPOThreshold returns the SPO yes-ratio threshold for the action
+// type. SPOs vote on a limited subset of actions; nil means SPOs do
+// not vote and approval is automatic. For ParameterChange, the SPO
+// threshold only applies when the update touches the security
+// parameter group; callers without the decoded update receive nil.
+// committeeNoConfidence selects CommitteeNoConfidence over CommitteeNormal
+// for UpdateCommittee when the committee is in a no-confidence state.
+func getSPOThreshold(
+	actionType lcommon.GovActionType,
+	pparams *conway.ConwayProtocolParameters,
+	paramUpdate *conway.ConwayProtocolParameterUpdate,
+	committeeNoConfidence bool,
+) *big.Rat {
+	t := &pparams.PoolVotingThresholds
+	switch actionType {
+	case lcommon.GovActionTypeNoConfidence:
+		// CIP-1694 Motion of No Confidence uses MotionNoConfidence
+		// for SPOs as well.
+		return rateToRat(t.MotionNoConfidence)
+	case lcommon.GovActionTypeUpdateCommittee:
+		// Per CIP-1694: use CommitteeNoConfidence when the committee
+		// is in a no-confidence state, CommitteeNormal otherwise.
+		if committeeNoConfidence {
+			return rateToRat(t.CommitteeNoConfidence)
+		}
+		return rateToRat(t.CommitteeNormal)
+	case lcommon.GovActionTypeHardForkInitiation:
+		return rateToRat(t.HardForkInitiation)
+	case lcommon.GovActionTypeParameterChange:
+		if paramUpdate == nil || !touchesSecurityGroup(paramUpdate) {
+			return nil
+		}
+		return rateToRat(t.PpSecurityGroup)
+	case lcommon.GovActionTypeNewConstitution,
+		lcommon.GovActionTypeTreasuryWithdrawal,
+		lcommon.GovActionTypeInfo:
+		return nil
+	default:
+		// Fail-closed: unknown/future action types require an
+		// unachievable 1/1 yes ratio so they cannot silently ratify
+		// without an explicit case being added here.
+		return big.NewRat(1, 1)
+	}
+}
+
+// touchesSecurityGroup reports whether the parameter update changes any
+// security-relevant parameter per CIP-1694: max block body size, max tx
+// size, max block header size, max value size, max block ex-units, min
+// fee coefficients, UTxO cost per byte, governance action deposit, and
+// min fee ref script cost per byte.
+func touchesSecurityGroup(u *conway.ConwayProtocolParameterUpdate) bool {
+	return u.MaxBlockBodySize != nil ||
+		u.MaxTxSize != nil ||
+		u.MaxBlockHeaderSize != nil ||
+		u.MaxValueSize != nil ||
+		u.MaxBlockExUnits != nil ||
+		u.MinFeeA != nil ||
+		u.MinFeeB != nil ||
+		u.AdaPerUtxoByte != nil ||
+		u.GovActionDeposit != nil ||
+		u.MinFeeRefScriptCostPerByte != nil
+}
+
+// needsCCApproval returns true if the action type requires
+// constitutional committee approval.
+func needsCCApproval(actionType lcommon.GovActionType) bool {
+	switch actionType {
+	case lcommon.GovActionTypeNewConstitution,
+		lcommon.GovActionTypeHardForkInitiation,
+		lcommon.GovActionTypeParameterChange,
+		lcommon.GovActionTypeTreasuryWithdrawal:
+		return true
+	case lcommon.GovActionTypeNoConfidence,
+		lcommon.GovActionTypeUpdateCommittee,
+		lcommon.GovActionTypeInfo:
+		return false
+	default:
+		// Fail-closed: require CC approval for unknown/future action
+		// types so they cannot silently bypass the committee gate.
+		return true
+	}
+}
+
+// mostRestrictiveDRepParamThreshold selects the maximum DRep threshold
+// across all parameter groups touched by the update. If the update is
+// nil the caller can't tell which groups are touched, so we return the
+// maximum across all four groups — the most conservative choice, which
+// matches the documented intent ("most restrictive").
+func mostRestrictiveDRepParamThreshold(
+	t *conway.DRepVotingThresholds,
+	update *conway.ConwayProtocolParameterUpdate,
+) *big.Rat {
+	var best *big.Rat
+	consider := func(r cbor.Rat) {
+		candidate := rateToRat(r)
+		if best == nil || candidate.Cmp(best) > 0 {
+			best = candidate
+		}
+	}
+	if update == nil {
+		consider(t.PpNetworkGroup)
+		consider(t.PpEconomicGroup)
+		consider(t.PpTechnicalGroup)
+		consider(t.PpGovGroup)
+		return best
+	}
+	if touchesNetworkGroup(update) {
+		consider(t.PpNetworkGroup)
+	}
+	if touchesEconomicGroup(update) {
+		consider(t.PpEconomicGroup)
+	}
+	if touchesTechnicalGroup(update) {
+		consider(t.PpTechnicalGroup)
+	}
+	if touchesGovGroup(update) {
+		consider(t.PpGovGroup)
+	}
+	if best == nil {
+		// Parameter change touches no known group; require gov
+		// threshold as a safe default.
+		return rateToRat(t.PpGovGroup)
+	}
+	return best
+}
+
+// touchesNetworkGroup covers max block body/tx/header size, max value
+// size, ex-unit limits, and max collateral inputs. Collateral percentage
+// belongs to the technical group and is handled in touchesTechnicalGroup.
+func touchesNetworkGroup(u *conway.ConwayProtocolParameterUpdate) bool {
+	return u.MaxBlockBodySize != nil ||
+		u.MaxTxSize != nil ||
+		u.MaxBlockHeaderSize != nil ||
+		u.MaxValueSize != nil ||
+		u.MaxTxExUnits != nil ||
+		u.MaxBlockExUnits != nil ||
+		u.MaxCollateralInputs != nil
+}
+
+// touchesEconomicGroup covers fees, deposits, minting, rewards,
+// min pool cost, monetary policy.
+func touchesEconomicGroup(u *conway.ConwayProtocolParameterUpdate) bool {
+	return u.MinFeeA != nil ||
+		u.MinFeeB != nil ||
+		u.KeyDeposit != nil ||
+		u.PoolDeposit != nil ||
+		u.Rho != nil ||
+		u.Tau != nil ||
+		u.MinPoolCost != nil ||
+		u.AdaPerUtxoByte != nil ||
+		u.ExecutionCosts != nil ||
+		u.MinFeeRefScriptCostPerByte != nil
+}
+
+// touchesTechnicalGroup covers technical parameters: nopt, a0, max epoch,
+// collateral percentage, cost models, protocol version minor.
+func touchesTechnicalGroup(u *conway.ConwayProtocolParameterUpdate) bool {
+	return u.NOpt != nil ||
+		u.A0 != nil ||
+		u.MaxEpoch != nil ||
+		u.CollateralPercentage != nil ||
+		u.CostModels != nil
+}
+
+// touchesGovGroup covers governance-era parameters: voting thresholds,
+// deposits, lifetimes, committee sizes.
+func touchesGovGroup(u *conway.ConwayProtocolParameterUpdate) bool {
+	return u.PoolVotingThresholds != nil ||
+		u.DRepVotingThresholds != nil ||
+		u.MinCommitteeSize != nil ||
+		u.CommitteeTermLimit != nil ||
+		u.GovActionValidityPeriod != nil ||
+		u.GovActionDeposit != nil ||
+		u.DRepDeposit != nil ||
+		u.DRepInactivityPeriod != nil
+}
+
+// rateToRat converts the zero-value of cbor.Rat (Rat == nil) into a
+// zero *big.Rat. A non-nil Rat is returned directly.
+func rateToRat(r cbor.Rat) *big.Rat {
+	if r.Rat == nil {
+		return new(big.Rat)
+	}
+	return r.Rat
+}
+
+// validateParentChain verifies that the proposal's parent action ID
+// matches the current root for its action type. Actions with no parent
+// chain (Info, TreasuryWithdrawal) always pass. Returns true if the
+// proposal is eligible for ratification based on its parent chain.
+func validateParentChain(
+	proposal *models.GovernanceProposal,
+	currentRoot *models.GovernanceProposal,
+) bool {
+	actionType := lcommon.GovActionType(proposal.ActionType)
+	switch actionType {
+	case lcommon.GovActionTypeInfo,
+		lcommon.GovActionTypeTreasuryWithdrawal:
+		return true
+	case lcommon.GovActionTypeParameterChange,
+		lcommon.GovActionTypeHardForkInitiation,
+		lcommon.GovActionTypeNoConfidence,
+		lcommon.GovActionTypeUpdateCommittee,
+		lcommon.GovActionTypeNewConstitution:
+		// These action types chain through the purpose root; fall
+		// through to the root-matching logic below.
+	default:
+		return false
+	}
+
+	// No current root: the proposal must also have no parent.
+	if currentRoot == nil {
+		return proposal.ParentTxHash == nil &&
+			proposal.ParentActionIdx == nil
+	}
+	// Current root exists: proposal must reference it exactly.
+	if proposal.ParentTxHash == nil || proposal.ParentActionIdx == nil {
+		return false
+	}
+	if !bytes.Equal(proposal.ParentTxHash, currentRoot.TxHash) {
+		return false
+	}
+	return *proposal.ParentActionIdx == currentRoot.ActionIndex
+}

--- a/ledger/governance/ratify_test.go
+++ b/ledger/governance/ratify_test.go
@@ -1,0 +1,519 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/assert"
+)
+
+// newRat is a test helper that builds a cbor.Rat from num/denom.
+func newRat(num, denom int64) cbor.Rat {
+	return cbor.Rat{Rat: big.NewRat(num, denom)}
+}
+
+// conwayPParamsFixture returns a ConwayProtocolParameters with the
+// threshold fields populated at realistic Conway values. Post-bootstrap
+// (major >= 10) the thresholds must be met; bootstrap thresholds are 0.
+func conwayPParamsFixture(major uint) *conway.ConwayProtocolParameters {
+	p := &conway.ConwayProtocolParameters{}
+	p.ProtocolVersion.Major = major
+	p.MinCommitteeSize = 3
+	p.DRepVotingThresholds = conway.DRepVotingThresholds{
+		MotionNoConfidence:    newRat(67, 100),
+		CommitteeNormal:       newRat(67, 100),
+		CommitteeNoConfidence: newRat(60, 100),
+		UpdateToConstitution:  newRat(75, 100),
+		HardForkInitiation:    newRat(60, 100),
+		PpNetworkGroup:        newRat(67, 100),
+		PpEconomicGroup:       newRat(67, 100),
+		PpTechnicalGroup:      newRat(67, 100),
+		PpGovGroup:            newRat(75, 100),
+		TreasuryWithdrawal:    newRat(67, 100),
+	}
+	p.PoolVotingThresholds = conway.PoolVotingThresholds{
+		MotionNoConfidence:    newRat(51, 100),
+		CommitteeNormal:       newRat(51, 100),
+		CommitteeNoConfidence: newRat(51, 100),
+		HardForkInitiation:    newRat(51, 100),
+		PpSecurityGroup:       newRat(51, 100),
+	}
+	return p
+}
+
+// ratifyInputs is a small helper to reduce keyword-argument noise in the
+// per-case tests below. The default MajorVersion is 10 (post-bootstrap).
+func ratifyInputs(
+	tally *ProposalTally,
+	pparams *conway.ConwayProtocolParameters,
+	activeDReps, activeCC int,
+	ccQuorum *big.Rat,
+	majorVersion uint,
+	committeeNoConfidence bool,
+) RatifyInputs {
+	return RatifyInputs{
+		Tally:                 tally,
+		PParams:               pparams,
+		ActiveDRepCount:       activeDReps,
+		ActiveCCCount:         activeCC,
+		CCQuorum:              ccQuorum,
+		MajorVersion:          majorVersion,
+		CommitteeNoConfidence: committeeNoConfidence,
+	}
+}
+
+func TestShouldRatify_BootstrapAnyYesPasses(t *testing.T) {
+	pparams := conwayPParamsFixture(9)
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeParameterChange),
+		DRepYesStake:   1,
+		DRepTotalStake: 100,
+	}
+	d := ShouldRatify(ratifyInputs(tally, pparams, 5, 0, nil, 9, false))
+	assert.True(t, d.Ratified)
+}
+
+func TestShouldRatify_BootstrapZeroYesFails(t *testing.T) {
+	pparams := conwayPParamsFixture(9)
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeParameterChange),
+	}
+	d := ShouldRatify(ratifyInputs(tally, pparams, 5, 0, nil, 9, false))
+	assert.False(t, d.Ratified)
+}
+
+func TestShouldRatify_InfoActionCannotRatify(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeInfo),
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 5, 5, big.NewRat(1, 2), 10, false,
+	))
+	assert.False(t, d.Ratified)
+}
+
+func TestShouldRatify_DRepOnlyActionPasses(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// TreasuryWithdrawal: CC-gated, no SPO. threshold 67/100.
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		DRepYesStake:   70,
+		DRepNoStake:    30,
+		DRepTotalStake: 100,
+		CCYesCount:     4,
+		CCNoCount:      1,
+		CCTotalCount:   5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.True(t, d.Ratified)
+}
+
+func TestShouldRatify_DRepBelowThreshold(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		DRepYesStake:   60,
+		DRepNoStake:    40,
+		DRepTotalStake: 100,
+		CCYesCount:     4,
+		CCNoCount:      1,
+		CCTotalCount:   5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.False(t, d.Ratified)
+	assert.False(t, d.DRepApproved)
+}
+
+func TestShouldRatify_NoActiveDRepsRejectsNonZeroThreshold(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	tally := &ProposalTally{
+		ActionType:   uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		CCYesCount:   4,
+		CCNoCount:    1,
+		CCTotalCount: 5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 0, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.False(t, d.DRepApproved)
+	assert.False(t, d.Ratified)
+}
+
+func TestShouldRatify_NoActiveDRepsApprovesZeroThreshold(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	pparams.DRepVotingThresholds.TreasuryWithdrawal = newRat(0, 1)
+	tally := &ProposalTally{
+		ActionType:   uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		CCYesCount:   4,
+		CCNoCount:    1,
+		CCTotalCount: 5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 0, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.True(t, d.DRepApproved)
+	assert.True(t, d.Ratified)
+}
+
+func TestShouldRatify_NoAuthorizedCCFails(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	pparams.MinCommitteeSize = 0
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		DRepYesStake:   70,
+		DRepNoStake:    30,
+		DRepTotalStake: 100,
+	}
+	// No active CC members (activeCC = 0).
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 0, big.NewRat(2, 3), 10, false,
+	))
+	assert.False(t, d.Ratified)
+	assert.False(t, d.CCApproved)
+}
+
+func TestShouldRatify_CCBelowMinimumSizeFails(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	pparams.MinCommitteeSize = 6
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		DRepYesStake:   70,
+		DRepNoStake:    30,
+		DRepTotalStake: 100,
+		CCYesCount:     5,
+		CCTotalCount:   5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.False(t, d.CCApproved)
+	assert.False(t, d.Ratified)
+	assert.Equal(t, "cc below minimum committee size", d.FailureReason)
+}
+
+func TestShouldRatify_NoConfidenceSkipsCCCheck(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeNoConfidence),
+		DRepYesStake:   70,
+		DRepNoStake:    30,
+		DRepTotalStake: 100,
+		SPOYesStake:    60,
+		SPONoStake:     40,
+		SPOTotalStake:  100,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 0, big.NewRat(2, 3), 10, true,
+	))
+	assert.True(t, d.CCApproved, "no confidence skips CC check")
+	assert.True(t, d.Ratified)
+}
+
+func TestShouldRatify_HardForkRequiresAllThree(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	tally := &ProposalTally{
+		ActionType:     uint8(lcommon.GovActionTypeHardForkInitiation),
+		DRepYesStake:   70,
+		DRepNoStake:    30,
+		DRepTotalStake: 100,
+		SPOYesStake:    60,
+		SPONoStake:     40,
+		SPOTotalStake:  100,
+		CCYesCount:     4,
+		CCNoCount:      1,
+		CCTotalCount:   5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.True(t, d.Ratified)
+
+	// Drop SPO below threshold -> fail
+	tally.SPOYesStake = 50
+	tally.SPONoStake = 50
+	d = ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, big.NewRat(2, 3), 10, false,
+	))
+	assert.False(t, d.Ratified)
+	assert.False(t, d.SPOApproved)
+}
+
+func TestValidateParentChain_NoParentNoRoot(t *testing.T) {
+	proposal := &models.GovernanceProposal{
+		ActionType: uint8(lcommon.GovActionTypeParameterChange),
+	}
+	assert.True(t, validateParentChain(proposal, nil))
+}
+
+func TestValidateParentChain_ParentRequiredButMissing(t *testing.T) {
+	proposal := &models.GovernanceProposal{
+		ActionType: uint8(lcommon.GovActionTypeParameterChange),
+	}
+	root := &models.GovernanceProposal{
+		TxHash:      []byte{1, 2, 3},
+		ActionIndex: 0,
+	}
+	assert.False(t, validateParentChain(proposal, root))
+}
+
+func TestValidateParentChain_MatchingParent(t *testing.T) {
+	idx := uint32(0)
+	proposal := &models.GovernanceProposal{
+		ActionType:      uint8(lcommon.GovActionTypeParameterChange),
+		ParentTxHash:    []byte{1, 2, 3},
+		ParentActionIdx: &idx,
+	}
+	root := &models.GovernanceProposal{
+		TxHash:      []byte{1, 2, 3},
+		ActionIndex: 0,
+	}
+	assert.True(t, validateParentChain(proposal, root))
+}
+
+func TestValidateParentChain_MismatchedParent(t *testing.T) {
+	idx := uint32(0)
+	proposal := &models.GovernanceProposal{
+		ActionType:      uint8(lcommon.GovActionTypeParameterChange),
+		ParentTxHash:    []byte{9, 9, 9},
+		ParentActionIdx: &idx,
+	}
+	root := &models.GovernanceProposal{
+		TxHash:      []byte{1, 2, 3},
+		ActionIndex: 0,
+	}
+	assert.False(t, validateParentChain(proposal, root))
+}
+
+func TestValidateParentChain_TreasuryWithdrawalNoChain(t *testing.T) {
+	proposal := &models.GovernanceProposal{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	root := &models.GovernanceProposal{
+		TxHash:      []byte{1, 2, 3},
+		ActionIndex: 0,
+	}
+	// Treasury withdrawals don't chain, so any root state passes.
+	assert.True(t, validateParentChain(proposal, root))
+}
+
+func TestProposalTally_DRepYesRatio(t *testing.T) {
+	tally := &ProposalTally{
+		DRepYesStake: 70,
+		DRepNoStake:  30,
+		// Abstain is excluded from the denominator; total includes it.
+		DRepAbstainStake: 1000,
+		DRepTotalStake:   1100,
+	}
+	ratio := tally.DRepYesRatio()
+	assert.Equal(t, big.NewRat(7, 10), ratio)
+}
+
+func TestProposalTally_DRepYesRatioZeroParticipation(t *testing.T) {
+	tally := &ProposalTally{}
+	ratio := tally.DRepYesRatio()
+	assert.Equal(t, 0, ratio.Sign())
+}
+
+func TestGetDRepThreshold_ParameterGroupSelection(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// Update touches both economic (MinFeeA) and gov (GovActionDeposit).
+	fee := uint(100)
+	deposit := uint64(500)
+	update := &conway.ConwayProtocolParameterUpdate{
+		MinFeeA:          &fee,
+		GovActionDeposit: &deposit,
+	}
+	got := getDRepThreshold(
+		lcommon.GovActionTypeParameterChange, pparams, update, false,
+	)
+	// Gov group (75/100) > economic (67/100), so we expect 75/100.
+	assert.Equal(t, big.NewRat(75, 100), got)
+}
+
+func TestGetDRepThreshold_NilUpdateTakesMaxAcrossGroups(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// Make technical the strictest so we can observe max behaviour
+	// rather than the fixture's implicit gov-is-highest ordering.
+	pparams.DRepVotingThresholds.PpTechnicalGroup = newRat(90, 100)
+	got := getDRepThreshold(
+		lcommon.GovActionTypeParameterChange, pparams, nil, false,
+	)
+	assert.Equal(t, big.NewRat(90, 100), got)
+}
+
+func TestGetSPOThreshold_InfoReturnsNil(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	got := getSPOThreshold(lcommon.GovActionTypeInfo, pparams, nil, false)
+	assert.Nil(t, got)
+}
+
+func TestGetSPOThreshold_NoConfidenceUsesMotionNoConfidence(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// Distinguish MotionNoConfidence from CommitteeNoConfidence so we
+	// can assert the correct field is used for NoConfidence actions.
+	pparams.PoolVotingThresholds.MotionNoConfidence = newRat(40, 100)
+	pparams.PoolVotingThresholds.CommitteeNoConfidence = newRat(70, 100)
+	got := getSPOThreshold(
+		lcommon.GovActionTypeNoConfidence, pparams, nil, false,
+	)
+	assert.Equal(t, big.NewRat(40, 100), got)
+}
+
+func TestGetDRepThreshold_NoConfidenceUsesMotionNoConfidence(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	pparams.DRepVotingThresholds.MotionNoConfidence = newRat(40, 100)
+	pparams.DRepVotingThresholds.CommitteeNoConfidence = newRat(90, 100)
+	got := getDRepThreshold(
+		lcommon.GovActionTypeNoConfidence, pparams, nil, false,
+	)
+	assert.Equal(t, big.NewRat(40, 100), got)
+}
+
+func TestGetSPOThreshold_ParameterChangeSecurityGroup(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// An update that touches only technical-group (A0) should not
+	// trigger an SPO vote.
+	a0 := newRat(1, 100)
+	nonSecurity := &conway.ConwayProtocolParameterUpdate{A0: &a0}
+	assert.Nil(t, getSPOThreshold(
+		lcommon.GovActionTypeParameterChange, pparams, nonSecurity, false,
+	))
+	// An update that touches a security-group parameter (MaxTxSize)
+	// must return the security-group threshold.
+	maxTxSize := uint(16384)
+	securityUpdate := &conway.ConwayProtocolParameterUpdate{
+		MaxTxSize: &maxTxSize,
+	}
+	got := getSPOThreshold(
+		lcommon.GovActionTypeParameterChange, pparams, securityUpdate, false,
+	)
+	assert.Equal(t, big.NewRat(51, 100), got)
+	adaPerUtxoByte := uint64(4310)
+	assert.Equal(t, big.NewRat(51, 100), getSPOThreshold(
+		lcommon.GovActionTypeParameterChange,
+		pparams,
+		&conway.ConwayProtocolParameterUpdate{
+			AdaPerUtxoByte: &adaPerUtxoByte,
+		},
+		false,
+	))
+	govActionDeposit := uint64(1000000000)
+	assert.Equal(t, big.NewRat(51, 100), getSPOThreshold(
+		lcommon.GovActionTypeParameterChange,
+		pparams,
+		&conway.ConwayProtocolParameterUpdate{
+			GovActionDeposit: &govActionDeposit,
+		},
+		false,
+	))
+	// No update at all means the caller cannot prove security-group
+	// involvement, so no SPO vote is required.
+	assert.Nil(t, getSPOThreshold(
+		lcommon.GovActionTypeParameterChange, pparams, nil, false,
+	))
+}
+
+func TestGetDRepThreshold_UpdateCommitteeNoConfidenceState(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// Fixture sets CommitteeNormal=67/100, CommitteeNoConfidence=60/100.
+	normal := getDRepThreshold(
+		lcommon.GovActionTypeUpdateCommittee, pparams, nil, false,
+	)
+	assert.Equal(t, big.NewRat(67, 100), normal)
+	noConf := getDRepThreshold(
+		lcommon.GovActionTypeUpdateCommittee, pparams, nil, true,
+	)
+	assert.Equal(t, big.NewRat(60, 100), noConf)
+}
+
+func TestGetSPOThreshold_UpdateCommitteeNoConfidenceState(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	// Distinguish the two thresholds so the switch is observable.
+	pparams.PoolVotingThresholds.CommitteeNormal = newRat(51, 100)
+	pparams.PoolVotingThresholds.CommitteeNoConfidence = newRat(65, 100)
+	normal := getSPOThreshold(
+		lcommon.GovActionTypeUpdateCommittee, pparams, nil, false,
+	)
+	assert.Equal(t, big.NewRat(51, 100), normal)
+	noConf := getSPOThreshold(
+		lcommon.GovActionTypeUpdateCommittee, pparams, nil, true,
+	)
+	assert.Equal(t, big.NewRat(65, 100), noConf)
+}
+
+func TestShouldRatify_CCQuorumMissingFailsSafe(t *testing.T) {
+	pparams := conwayPParamsFixture(10)
+	tally := &ProposalTally{
+		// CC-gated action (TreasuryWithdrawal); passes DRep threshold
+		// and CC has authorized members, but the caller supplied a
+		// nil quorum. We must NOT silently approve.
+		ActionType:     uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		DRepYesStake:   70,
+		DRepNoStake:    30,
+		DRepTotalStake: 100,
+		CCYesCount:     4,
+		CCNoCount:      1,
+		CCTotalCount:   5,
+	}
+	d := ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, nil, 10, false,
+	))
+	assert.False(t, d.CCApproved)
+	assert.False(t, d.Ratified)
+	assert.Equal(t, "cc quorum missing or zero", d.FailureReason)
+
+	// Same, but with an explicit zero quorum.
+	d = ShouldRatify(ratifyInputs(
+		tally, pparams, 10, 5, big.NewRat(0, 1), 10, false,
+	))
+	assert.False(t, d.CCApproved)
+	assert.False(t, d.Ratified)
+}
+
+func TestConwayRatifyQuorum_FromGenesis(t *testing.T) {
+	threshold := cbor.Rat{Rat: big.NewRat(3, 5)}
+	genesis := &conway.ConwayGenesis{
+		Committee: conway.ConwayGenesisCommittee{
+			Threshold: &threshold,
+		},
+	}
+	got, err := conwayRatifyQuorum(nil, nil, nil, genesis)
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewRat(3, 5), got)
+}
+
+func TestConwayRatifyQuorum_FallbackWhenGenesisNil(t *testing.T) {
+	got, err := conwayRatifyQuorum(nil, nil, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewRat(2, 3), got)
+}
+
+func TestConwayRatifyQuorum_FallbackWhenThresholdMissing(t *testing.T) {
+	genesis := &conway.ConwayGenesis{}
+	got, err := conwayRatifyQuorum(nil, nil, nil, genesis)
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewRat(2, 3), got)
+}

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -1,0 +1,435 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ProposalTally captures the aggregated vote totals for a governance
+// proposal across DReps, stake pools, and the constitutional committee.
+// Stake values are lovelace; CC counts are member counts.
+type ProposalTally struct {
+	// Proposal identity
+	ProposalID uint
+	ActionType uint8
+
+	// DRep tallies (stake-weighted, lovelace)
+	DRepYesStake     uint64
+	DRepNoStake      uint64
+	DRepAbstainStake uint64
+	DRepTotalStake   uint64
+
+	// SPO tallies (stake-weighted, lovelace)
+	SPOYesStake     uint64
+	SPONoStake      uint64
+	SPOAbstainStake uint64
+	SPOTotalStake   uint64
+
+	// CC tallies (member counts)
+	CCYesCount     int
+	CCNoCount      int
+	CCAbstainCount int
+	CCTotalCount   int // active, non-resigned members
+}
+
+// TallyContext carries the inputs needed to tally a proposal.
+// StakeEpoch is the epoch whose "mark" snapshot provides SPO stake
+// distribution — callers should pass currentEpoch-2 so the rotation
+// lines up with the "Go" snapshot used for voting.
+type TallyContext struct {
+	DB             *database.Database
+	Txn            *database.Txn
+	StakeEpoch     uint64
+	CurrentEpoch   uint64
+	CommitteeState *CommitteeVotingState
+}
+
+// CommitteeVotingState is the ratification view of the seated CC:
+// non-expired, non-deleted cold credentials count in the denominator,
+// while only members with a current hot-key authorization may cast votes.
+type CommitteeVotingState struct {
+	ActiveMemberCount     int
+	MemberHotCredentials  []string
+	HotCredentialPresence map[string]struct{}
+}
+
+// LoadCommitteeVotingState builds the current voting view of the CC by
+// intersecting the seated committee membership table with the latest
+// hot-key authorization certificates. Authorizations for removed or
+// expired cold credentials are ignored.
+func LoadCommitteeVotingState(
+	db *database.Database,
+	txn *database.Txn,
+	currentEpoch uint64,
+) (*CommitteeVotingState, error) {
+	if db == nil {
+		return nil, errors.New("nil database")
+	}
+	members, err := db.GetCommitteeMembers(txn)
+	if err != nil {
+		return nil, fmt.Errorf("get seated committee members: %w", err)
+	}
+	// Collect non-expired cold credentials so we can batch-check
+	// resignation status. ExpiresEpoch is the first epoch the member
+	// is no longer active; a member with ExpiresEpoch == currentEpoch
+	// has just aged out and must not contribute to the CC denominator
+	// this epoch (matches Cardano-ledger Haskell: active iff
+	// currentEpoch < termEpoch).
+	coldKeys := make([][]byte, 0, len(members))
+	for _, member := range members {
+		if member.ExpiresEpoch <= currentEpoch {
+			continue
+		}
+		coldKeys = append(coldKeys, member.ColdCredHash)
+	}
+	// Resigned members must be excluded from the CC denominator per
+	// CIP-1694; otherwise they act as implicit No votes because they
+	// cannot cast a vote (no active hot-key authorization) but would
+	// still occupy a slot in ActiveMemberCount.
+	resigned, err := db.GetResignedCommitteeMembers(coldKeys, txn)
+	if err != nil {
+		return nil, fmt.Errorf("get resigned committee members: %w", err)
+	}
+	seated := make(map[string]struct{}, len(coldKeys))
+	for _, key := range coldKeys {
+		if resigned[string(key)] {
+			continue
+		}
+		seated[string(key)] = struct{}{}
+	}
+
+	authorized, err := db.GetActiveCommitteeMembers(txn)
+	if err != nil {
+		return nil, fmt.Errorf("get active cc hot credentials: %w", err)
+	}
+	memberHotCredentials := make([]string, 0, len(authorized))
+	hotCredentialPresence := make(map[string]struct{}, len(authorized))
+	for _, member := range authorized {
+		if _, ok := seated[string(member.ColdCredential)]; !ok {
+			continue
+		}
+		hotCredential := string(member.HotCredential)
+		memberHotCredentials = append(memberHotCredentials, hotCredential)
+		hotCredentialPresence[hotCredential] = struct{}{}
+	}
+
+	return &CommitteeVotingState{
+		ActiveMemberCount:     len(seated),
+		MemberHotCredentials:  memberHotCredentials,
+		HotCredentialPresence: hotCredentialPresence,
+	}, nil
+}
+
+// TallyProposal computes the current tally for a single proposal. The
+// tally excludes votes from voters who are no longer active (expired
+// DReps, resigned CC members, retired pools) per the "live" view at
+// the time of tallying.
+func TallyProposal(
+	ctx *TallyContext,
+	proposal *models.GovernanceProposal,
+) (*ProposalTally, error) {
+	if ctx == nil || ctx.DB == nil {
+		return nil, errors.New("nil tally context")
+	}
+	if proposal == nil {
+		return nil, errors.New("nil proposal")
+	}
+	tally := &ProposalTally{
+		ProposalID: proposal.ID,
+		ActionType: proposal.ActionType,
+	}
+
+	votes, err := ctx.DB.GetGovernanceVotes(proposal.ID, ctx.Txn)
+	if err != nil {
+		return nil, fmt.Errorf("get votes: %w", err)
+	}
+
+	// Partition votes by voter type for downstream tally functions.
+	var drepVotes, spoVotes, ccVotes []*models.GovernanceVote
+	for _, v := range votes {
+		switch v.VoterType {
+		case models.VoterTypeDRep:
+			drepVotes = append(drepVotes, v)
+		case models.VoterTypeSPO:
+			spoVotes = append(spoVotes, v)
+		case models.VoterTypeCC:
+			ccVotes = append(ccVotes, v)
+		}
+	}
+
+	if err := tallyDRepVotes(ctx, drepVotes, tally); err != nil {
+		return nil, fmt.Errorf("tally drep votes: %w", err)
+	}
+	if err := tallySPOVotes(ctx, spoVotes, tally); err != nil {
+		return nil, fmt.Errorf("tally spo votes: %w", err)
+	}
+	if err := tallyCCVotes(ctx, ccVotes, tally); err != nil {
+		return nil, fmt.Errorf("tally cc votes: %w", err)
+	}
+
+	return tally, nil
+}
+
+// tallyDRepVotes sums voting power for regular DReps and the predefined
+// AlwaysAbstain / AlwaysNoConfidence DRep options. Non-voting regular
+// DReps are not counted toward any bucket.
+func tallyDRepVotes(
+	ctx *TallyContext,
+	votes []*models.GovernanceVote,
+	tally *ProposalTally,
+) error {
+	allDreps, err := ctx.DB.GetActiveDreps(ctx.Txn)
+	if err != nil {
+		return fmt.Errorf("get active dreps: %w", err)
+	}
+
+	// GetActiveDreps filters by the `active` flag (cleared only on
+	// deregistration); expired-by-inactivity DReps still return active
+	// and would inflate the tally denominator. Skip any whose
+	// expiry_epoch has passed. A zero expiry_epoch means the DRep has
+	// never had activity recorded and is treated as unexpired.
+	dreps := make([]*models.Drep, 0, len(allDreps))
+	for _, drep := range allDreps {
+		if !drepActiveAtEpoch(drep, ctx.CurrentEpoch) {
+			continue
+		}
+		dreps = append(dreps, drep)
+	}
+
+	if len(dreps) > 0 {
+		// Batch-fetch voting power for all active DReps in one query to
+		// avoid the N+1 round-trip that the per-DRep lookup produced.
+		creds := make([][]byte, len(dreps))
+		for i, drep := range dreps {
+			creds[i] = drep.Credential
+		}
+		powers, err := ctx.DB.GetDRepVotingPowerBatch(creds, ctx.Txn)
+		if err != nil {
+			return fmt.Errorf("batch drep voting power: %w", err)
+		}
+
+		// Index votes by DRep credential for O(1) lookup.
+		voteByCred := make(map[string]uint8, len(votes))
+		for _, v := range votes {
+			voteByCred[string(v.VoterCredential)] = v.Vote
+		}
+
+		for _, drep := range dreps {
+			power := powers[string(drep.Credential)]
+			tally.DRepTotalStake += power
+
+			vote, voted := voteByCred[string(drep.Credential)]
+			if !voted {
+				continue
+			}
+			switch vote {
+			case models.VoteYes:
+				tally.DRepYesStake += power
+			case models.VoteNo:
+				tally.DRepNoStake += power
+			case models.VoteAbstain:
+				tally.DRepAbstainStake += power
+			}
+		}
+	}
+
+	virtualPowers, err := ctx.DB.GetDRepVotingPowerByType(
+		[]uint64{
+			models.DrepTypeAlwaysAbstain,
+			models.DrepTypeAlwaysNoConfidence,
+		},
+		ctx.Txn,
+	)
+	if err != nil {
+		return fmt.Errorf("predefined drep voting power: %w", err)
+	}
+	abstainPower := virtualPowers[models.DrepTypeAlwaysAbstain]
+	noConfidencePower := virtualPowers[models.DrepTypeAlwaysNoConfidence]
+	tally.DRepTotalStake += abstainPower + noConfidencePower
+	tally.DRepAbstainStake += abstainPower
+	if noConfidencePower > 0 {
+		if lcommon.GovActionType(tally.ActionType) ==
+			lcommon.GovActionTypeNoConfidence {
+			tally.DRepYesStake += noConfidencePower
+		} else {
+			tally.DRepNoStake += noConfidencePower
+		}
+	}
+	return nil
+}
+
+// tallySPOVotes sums pool stake for votes matched against the stake
+// distribution snapshot at StakeEpoch. Pools that did not vote are not
+// counted.
+//
+// TODO(#1988): account for the SPO reward-account delegation rules from
+// CIP-1694. Pools whose reward account delegates to AlwaysNoConfidence
+// auto-vote per the action's NoConfidence handling, and pools delegating
+// to AlwaysAbstain count toward abstain stake (excluded from the
+// denominator). Wiring this requires the reward-account credit/lookup
+// path tracked alongside #1988.
+func tallySPOVotes(
+	ctx *TallyContext,
+	votes []*models.GovernanceVote,
+	tally *ProposalTally,
+) error {
+	var metaTxn types.Txn
+	if ctx.Txn != nil {
+		metaTxn = ctx.Txn.Metadata()
+	}
+	dist, err := ctx.DB.Metadata().GetPoolStakeSnapshotsByEpoch(
+		ctx.StakeEpoch,
+		"mark",
+		metaTxn,
+	)
+	if err != nil {
+		return fmt.Errorf("get pool stake snapshot: %w", err)
+	}
+
+	poolStake := make(map[string]uint64, len(dist))
+	var total uint64
+	for _, s := range dist {
+		stake := uint64(s.TotalStake)
+		poolStake[string(s.PoolKeyHash)] = stake
+		total += stake
+	}
+	tally.SPOTotalStake = total
+
+	for _, v := range votes {
+		stake, ok := poolStake[string(v.VoterCredential)]
+		if !ok {
+			continue
+		}
+		switch v.Vote {
+		case models.VoteYes:
+			tally.SPOYesStake += stake
+		case models.VoteNo:
+			tally.SPONoStake += stake
+		case models.VoteAbstain:
+			tally.SPOAbstainStake += stake
+		}
+	}
+	return nil
+}
+
+// tallyCCVotes counts per-member votes restricted to currently active
+// (non-resigned) CC members. CC members vote via their hot credential
+// after key authorization.
+func tallyCCVotes(
+	ctx *TallyContext,
+	votes []*models.GovernanceVote,
+	tally *ProposalTally,
+) error {
+	committeeState := ctx.CommitteeState
+	if committeeState == nil {
+		var err error
+		committeeState, err = LoadCommitteeVotingState(
+			ctx.DB, ctx.Txn, ctx.CurrentEpoch,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	tally.CCTotalCount = committeeState.ActiveMemberCount
+
+	votesByHotCredential := make(map[string]uint8, len(votes))
+	for _, vote := range votes {
+		if _, ok := committeeState.HotCredentialPresence[string(vote.VoterCredential)]; ok {
+			votesByHotCredential[string(vote.VoterCredential)] = vote.Vote
+		}
+	}
+
+	for _, hotCredential := range committeeState.MemberHotCredentials {
+		// Distinguish "no vote cast" from VoteNo. Both vote, voted are
+		// needed because models.VoteNo is the zero value of uint8 and
+		// would otherwise count every non-voting active CC member as
+		// a No vote, inflating CCNoCount.
+		vote, voted := votesByHotCredential[hotCredential]
+		if !voted {
+			continue
+		}
+		switch vote {
+		case models.VoteYes:
+			tally.CCYesCount++
+		case models.VoteNo:
+			tally.CCNoCount++
+		case models.VoteAbstain:
+			tally.CCAbstainCount++
+		}
+	}
+	return nil
+}
+
+// DRepYesRatio returns yesStake / (totalActiveStake - abstainStake) per
+// CIP-1694. Non-voting active DReps count implicitly against the proposal
+// (in the denominator but not the numerator). Returns zero if every active
+// DRep abstained or there is no active DRep stake.
+func (t *ProposalTally) DRepYesRatio() *big.Rat {
+	return ratioOf(
+		t.DRepYesStake,
+		saturatingSub(t.DRepTotalStake, t.DRepAbstainStake),
+	)
+}
+
+// SPOYesRatio returns yesStake / (totalStake - abstainStake) per CIP-1694.
+// Non-voting active pools count implicitly against the proposal.
+func (t *ProposalTally) SPOYesRatio() *big.Rat {
+	return ratioOf(
+		t.SPOYesStake,
+		saturatingSub(t.SPOTotalStake, t.SPOAbstainStake),
+	)
+}
+
+// CCYesRatio returns yesCount / (totalActiveCount - abstainCount) per
+// CIP-1694. Non-voting active CC members count implicitly against the
+// proposal.
+func (t *ProposalTally) CCYesRatio() *big.Rat {
+	// #nosec G115 -- CC member counts bounded by CC size (< 100).
+	yes := uint64(t.CCYesCount)
+	// #nosec G115 -- same bound.
+	denom := saturatingSub(
+		uint64(t.CCTotalCount),
+		uint64(t.CCAbstainCount),
+	)
+	return ratioOf(yes, denom)
+}
+
+func ratioOf(num, denom uint64) *big.Rat {
+	if denom == 0 {
+		return new(big.Rat)
+	}
+	return new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(num),
+		new(big.Int).SetUint64(denom),
+	)
+}
+
+// saturatingSub returns a-b, or 0 when b > a. Guards the ratio
+// denominators against a malformed tally where abstain would exceed
+// the total (which should never happen but is cheap to defend against).
+func saturatingSub(a, b uint64) uint64 {
+	if b >= a {
+		return 0
+	}
+	return a - b
+}

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -1,0 +1,428 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTallyDRepVotesIncludesAlwaysAbstain(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	drepCred := testBytes(28, 1)
+	stakeCred := testBytes(28, 2)
+	abstainStakeCred := testBytes(28, 3)
+
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential: drepCred,
+		Active:     true,
+	}).Error)
+	seedDRepStake(
+		t, store, stakeCred, drepCred, models.DrepTypeAddrKeyHash, 60,
+		1,
+	)
+	seedDRepStake(
+		t, store, abstainStakeCred, nil, models.DrepTypeAlwaysAbstain,
+		40, 2,
+	)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallyDRepVotes(
+		&TallyContext{DB: db},
+		[]*models.GovernanceVote{{
+			VoterType:       models.VoterTypeDRep,
+			VoterCredential: drepCred,
+			Vote:            models.VoteYes,
+		}},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(100), tally.DRepTotalStake)
+	assert.Equal(t, uint64(60), tally.DRepYesStake)
+	assert.Equal(t, uint64(0), tally.DRepNoStake)
+	assert.Equal(t, uint64(40), tally.DRepAbstainStake)
+	assert.Equal(t, "1/1", tally.DRepYesRatio().String())
+}
+
+func TestTallyDRepVotesIncludesAlwaysNoConfidence(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 4)
+	seedDRepStake(
+		t, store, stakeCred, nil, models.DrepTypeAlwaysNoConfidence,
+		30, 3,
+	)
+
+	noConfidenceTally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeNoConfidence),
+	}
+	err := tallyDRepVotes(
+		&TallyContext{DB: db},
+		nil,
+		noConfidenceTally,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(30), noConfidenceTally.DRepTotalStake)
+	assert.Equal(t, uint64(30), noConfidenceTally.DRepYesStake)
+	assert.Equal(t, uint64(0), noConfidenceTally.DRepNoStake)
+
+	updateCommitteeTally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeUpdateCommittee),
+	}
+	err = tallyDRepVotes(
+		&TallyContext{DB: db},
+		nil,
+		updateCommitteeTally,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(30), updateCommitteeTally.DRepTotalStake)
+	assert.Equal(t, uint64(0), updateCommitteeTally.DRepYesStake)
+	assert.Equal(t, uint64(30), updateCommitteeTally.DRepNoStake)
+
+	pparams := conwayPParamsFixture(10)
+	noConfidenceDecision := ShouldRatify(RatifyInputs{
+		Tally:           noConfidenceTally,
+		PParams:         pparams,
+		ActiveDRepCount: 0,
+		MajorVersion:    10,
+	})
+	assert.True(t, noConfidenceDecision.DRepApproved)
+
+	updateCommitteeDecision := ShouldRatify(RatifyInputs{
+		Tally:           updateCommitteeTally,
+		PParams:         pparams,
+		ActiveDRepCount: 0,
+		MajorVersion:    10,
+	})
+	assert.False(t, updateCommitteeDecision.DRepApproved)
+}
+
+func TestTallyCCVotesRequiresSeatedAuthorizedCommitteeMembers(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	coldA := testBytes(28, 10)
+	hotA := testBytes(28, 11)
+	coldB := testBytes(28, 12)
+	unseatedCold := testBytes(28, 13)
+	unseatedHot := testBytes(28, 14)
+
+	require.NoError(t, store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: coldA, ExpiresEpoch: 20, AddedSlot: 1},
+		{ColdCredHash: coldB, ExpiresEpoch: 20, AddedSlot: 1},
+	}, nil))
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: coldA,
+		HotCredential:  hotA,
+		CertificateID:  1,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: unseatedCold,
+		HotCredential:  unseatedHot,
+		CertificateID:  2,
+		AddedSlot:      1,
+	}).Error)
+
+	tally := &ProposalTally{}
+	err := tallyCCVotes(
+		&TallyContext{DB: db, CurrentEpoch: 10},
+		[]*models.GovernanceVote{
+			{
+				VoterType:       models.VoterTypeCC,
+				VoterCredential: hotA,
+				Vote:            models.VoteYes,
+			},
+			{
+				VoterType:       models.VoterTypeCC,
+				VoterCredential: unseatedHot,
+				Vote:            models.VoteYes,
+			},
+		},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, tally.CCTotalCount)
+	assert.Equal(t, 1, tally.CCYesCount)
+	assert.Equal(t, big.NewRat(1, 2), tally.CCYesRatio())
+}
+
+func TestLoadCommitteeVotingStateCountsSeatedMembersWithoutHotAuth(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	coldA := testBytes(28, 21)
+	hotA := testBytes(28, 22)
+	coldB := testBytes(28, 23)
+	unseatedCold := testBytes(28, 24)
+	unseatedHot := testBytes(28, 25)
+
+	require.NoError(t, store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: coldA, ExpiresEpoch: 20, AddedSlot: 1},
+		{ColdCredHash: coldB, ExpiresEpoch: 20, AddedSlot: 1},
+	}, nil))
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: coldA,
+		HotCredential:  hotA,
+		CertificateID:  1,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: unseatedCold,
+		HotCredential:  unseatedHot,
+		CertificateID:  2,
+		AddedSlot:      1,
+	}).Error)
+
+	state, err := LoadCommitteeVotingState(db, nil, 10)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, state.ActiveMemberCount)
+	assert.Equal(t, []string{string(hotA)}, state.MemberHotCredentials)
+	assert.Contains(t, state.HotCredentialPresence, string(hotA))
+	assert.NotContains(t, state.HotCredentialPresence, string(unseatedHot))
+}
+
+// TestLoadCommitteeVotingStateExcludesResignedMembers asserts that a
+// seated member whose latest resignation postdates their latest hot-key
+// authorization is not counted in ActiveMemberCount. Resigned members
+// cannot vote, so including them in the denominator per CIP-1694 would
+// make them act as implicit No votes.
+func TestLoadCommitteeVotingStateExcludesResignedMembers(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	activeCold := testBytes(28, 30)
+	activeHot := testBytes(28, 31)
+	resignedCold := testBytes(28, 32)
+	resignedHot := testBytes(28, 33)
+
+	require.NoError(t, store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: activeCold, ExpiresEpoch: 20, AddedSlot: 1},
+		{ColdCredHash: resignedCold, ExpiresEpoch: 20, AddedSlot: 1},
+	}, nil))
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: activeCold,
+		HotCredential:  activeHot,
+		CertificateID:  1,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: resignedCold,
+		HotCredential:  resignedHot,
+		CertificateID:  2,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.ResignCommitteeCold{
+		ColdCredential: resignedCold,
+		CertificateID:  3,
+		AddedSlot:      2,
+	}).Error)
+
+	state, err := LoadCommitteeVotingState(db, nil, 10)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, state.ActiveMemberCount)
+	assert.Equal(t, []string{string(activeHot)}, state.MemberHotCredentials)
+	assert.NotContains(t, state.HotCredentialPresence, string(resignedHot))
+}
+
+// TestTallyCCVotesExcludesResignedFromDenominator asserts that a
+// resigned member is not counted in CCTotalCount when tallying votes,
+// so the yes-ratio uses only active members as the denominator.
+func TestTallyCCVotesExcludesResignedFromDenominator(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	yesCold := testBytes(28, 40)
+	yesHot := testBytes(28, 41)
+	resignedCold := testBytes(28, 42)
+	resignedHot := testBytes(28, 43)
+
+	require.NoError(t, store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: yesCold, ExpiresEpoch: 20, AddedSlot: 1},
+		{ColdCredHash: resignedCold, ExpiresEpoch: 20, AddedSlot: 1},
+	}, nil))
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: yesCold,
+		HotCredential:  yesHot,
+		CertificateID:  1,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: resignedCold,
+		HotCredential:  resignedHot,
+		CertificateID:  2,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.ResignCommitteeCold{
+		ColdCredential: resignedCold,
+		CertificateID:  3,
+		AddedSlot:      2,
+	}).Error)
+
+	tally := &ProposalTally{}
+	err := tallyCCVotes(
+		&TallyContext{DB: db, CurrentEpoch: 10},
+		[]*models.GovernanceVote{{
+			VoterType:       models.VoterTypeCC,
+			VoterCredential: yesHot,
+			Vote:            models.VoteYes,
+		}},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, tally.CCTotalCount)
+	assert.Equal(t, 1, tally.CCYesCount)
+	assert.Equal(t, big.NewRat(1, 1), tally.CCYesRatio())
+}
+
+func TestTallyCCVotesExcludesExpiredCommitteeMembers(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	cold := testBytes(28, 15)
+	hot := testBytes(28, 16)
+
+	require.NoError(t, store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: cold, ExpiresEpoch: 9, AddedSlot: 1},
+	}, nil))
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: cold,
+		HotCredential:  hot,
+		CertificateID:  1,
+		AddedSlot:      1,
+	}).Error)
+
+	tally := &ProposalTally{}
+	err := tallyCCVotes(
+		&TallyContext{DB: db, CurrentEpoch: 10},
+		[]*models.GovernanceVote{{
+			VoterType:       models.VoterTypeCC,
+			VoterCredential: hot,
+			Vote:            models.VoteYes,
+		}},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Zero(t, tally.CCTotalCount)
+	assert.Zero(t, tally.CCYesCount)
+}
+
+// TestTallyCCVotesNonVotingMembersAreNotCountedAsNo guards against the
+// zero-value collision where models.VoteNo == 0 would silently equal a
+// missing map entry. A seated, authorized CC member who has not cast
+// any vote must contribute to CCTotalCount but to none of the
+// Yes/No/Abstain bucket counts.
+func TestTallyCCVotesNonVotingMembersAreNotCountedAsNo(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	voterCold := testBytes(28, 17)
+	voterHot := testBytes(28, 18)
+	silentCold := testBytes(28, 19)
+	silentHot := testBytes(28, 20)
+
+	require.NoError(t, store.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: voterCold, ExpiresEpoch: 20, AddedSlot: 1},
+		{ColdCredHash: silentCold, ExpiresEpoch: 20, AddedSlot: 1},
+	}, nil))
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: voterCold,
+		HotCredential:  voterHot,
+		CertificateID:  1,
+		AddedSlot:      1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.AuthCommitteeHot{
+		ColdCredential: silentCold,
+		HotCredential:  silentHot,
+		CertificateID:  2,
+		AddedSlot:      1,
+	}).Error)
+
+	tally := &ProposalTally{}
+	err := tallyCCVotes(
+		&TallyContext{DB: db, CurrentEpoch: 10},
+		[]*models.GovernanceVote{
+			{
+				VoterType:       models.VoterTypeCC,
+				VoterCredential: voterHot,
+				Vote:            models.VoteYes,
+			},
+		},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, tally.CCTotalCount)
+	assert.Equal(t, 1, tally.CCYesCount)
+	assert.Equal(t, 0, tally.CCNoCount, "silent member must not be counted as No")
+	assert.Equal(t, 0, tally.CCAbstainCount)
+	assert.Equal(t, big.NewRat(1, 2), tally.CCYesRatio())
+}
+
+func newTallyTestDB(
+	t *testing.T,
+) (*database.Database, *sqliteplugin.MetadataStoreSqlite) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		DataDir:        "",
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+	return db, store
+}
+
+func seedDRepStake(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	stakeCred []byte,
+	drepCred []byte,
+	drepType uint64,
+	amount uint64,
+	id byte,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Drep:       drepCred,
+		DrepType:   drepType,
+		AddedSlot:  1,
+		Reward:     0,
+		Active:     true,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       testBytes(32, id),
+		OutputIdx:  0,
+		StakingKey: stakeCred,
+		AddedSlot:  1,
+		Amount:     types.Uint64(amount),
+	}).Error)
+}
+
+func testBytes(length int, seed byte) []byte {
+	out := make([]byte, length)
+	for i := range out {
+		out[i] = seed
+	}
+	return out
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1392,6 +1392,18 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 				err,
 			)
 		}
+		// Revert reward-account credits from rolled-back governance
+		// finalization before account restoration can delete accounts
+		// registered after the rollback slot.
+		if err := ls.db.DeleteAccountRewardsAfterSlot(
+			point.Slot,
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"delete account reward deltas after rollback: %w",
+				err,
+			)
+		}
 		// Restore account delegation state
 		if err := ls.db.RestoreAccountStateAtSlot(
 			point.Slot,
@@ -1469,6 +1481,16 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 		); err != nil {
 			return fmt.Errorf(
 				"delete constitutions after rollback: %w",
+				err,
+			)
+		}
+		// Delete rolled-back committee state
+		if err := ls.db.DeleteCommitteeMembersAfterSlot(
+			point.Slot,
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"delete committee state after rollback: %w",
 				err,
 			)
 		}

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -421,18 +421,39 @@ func extractRawCostModels(
 	}
 }
 
-// CommitteeMember returns a committee member by cold key.
-// Returns nil if the cold key is not an authorized committee member.
+// CommitteeMember returns a seated committee member by cold key.
+// Returns nil if the cold key is not in the current committee.
 func (lv *LedgerView) CommitteeMember(
 	coldKey lcommon.Blake2b224,
 ) (*lcommon.CommitteeMember, error) {
-	member, err := lv.ls.db.GetCommitteeMember(coldKey[:], lv.txn)
+	dbMembers, err := lv.ls.db.GetCommitteeMembers(lv.txn)
 	if err != nil {
-		if errors.Is(err, models.ErrCommitteeMemberNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("get committee member: %w", err)
+		return nil, fmt.Errorf("get committee members: %w", err)
 	}
+	var found *models.CommitteeMember
+	for _, member := range dbMembers {
+		if string(member.ColdCredHash) == string(coldKey[:]) {
+			found = member
+			break
+		}
+	}
+	if found == nil {
+		return nil, nil
+	}
+
+	hotByCold, err := lv.committeeHotCredentialsByCold()
+	if err != nil {
+		return nil, err
+	}
+	member := &lcommon.CommitteeMember{
+		ColdKey:     coldKey,
+		ExpiryEpoch: found.ExpiresEpoch,
+	}
+	if hotKey, ok := hotByCold[string(coldKey[:])]; ok {
+		member.HotKey = &hotKey
+		return member, nil
+	}
+
 	resigned, err := lv.ls.db.IsCommitteeMemberResigned(coldKey[:], lv.txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -440,31 +461,73 @@ func (lv *LedgerView) CommitteeMember(
 			err,
 		)
 	}
-	hotKey := lcommon.NewBlake2b224(member.HostCredential)
-	return &lcommon.CommitteeMember{
-		ColdKey:  coldKey,
-		HotKey:   &hotKey,
-		Resigned: resigned,
-	}, nil
+	member.Resigned = resigned
+	return member, nil
 }
 
-// CommitteeMembers returns all active (non-resigned) committee members.
+// CommitteeMembers returns all seated committee members.
 func (lv *LedgerView) CommitteeMembers() ([]lcommon.CommitteeMember, error) {
-	dbMembers, err := lv.ls.db.GetActiveCommitteeMembers(lv.txn)
+	dbMembers, err := lv.ls.db.GetCommitteeMembers(lv.txn)
 	if err != nil {
-		return nil, fmt.Errorf("get active committee members: %w", err)
+		return nil, fmt.Errorf("get committee members: %w", err)
 	}
+	hotByCold, err := lv.committeeHotCredentialsByCold()
+	if err != nil {
+		return nil, err
+	}
+
+	coldKeysWithoutHot := make([][]byte, 0, len(dbMembers))
+	for _, m := range dbMembers {
+		if _, ok := hotByCold[string(m.ColdCredHash)]; !ok {
+			coldKeysWithoutHot = append(
+				coldKeysWithoutHot,
+				m.ColdCredHash,
+			)
+		}
+	}
+	resignedByCold, err := lv.ls.db.GetResignedCommitteeMembers(
+		coldKeysWithoutHot,
+		lv.txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"check committee member resignations: %w",
+			err,
+		)
+	}
+
 	members := make([]lcommon.CommitteeMember, 0, len(dbMembers))
 	for _, m := range dbMembers {
-		coldKey := lcommon.NewBlake2b224(m.ColdCredential)
-		hotKey := lcommon.NewBlake2b224(m.HostCredential)
-		members = append(members, lcommon.CommitteeMember{
-			ColdKey:  coldKey,
-			HotKey:   &hotKey,
-			Resigned: false, // Active members are not resigned
-		})
+		coldKey := lcommon.NewBlake2b224(m.ColdCredHash)
+		member := lcommon.CommitteeMember{
+			ColdKey:     coldKey,
+			ExpiryEpoch: m.ExpiresEpoch,
+		}
+		if hotKey, ok := hotByCold[string(m.ColdCredHash)]; ok {
+			member.HotKey = &hotKey
+		} else {
+			member.Resigned = resignedByCold[string(m.ColdCredHash)]
+		}
+		members = append(members, member)
 	}
 	return members, nil
+}
+
+func (lv *LedgerView) committeeHotCredentialsByCold() (
+	map[string]lcommon.Blake2b224,
+	error,
+) {
+	dbMembers, err := lv.ls.db.GetActiveCommitteeMembers(lv.txn)
+	if err != nil {
+		return nil, fmt.Errorf("get active committee hot keys: %w", err)
+	}
+	hotByCold := make(map[string]lcommon.Blake2b224, len(dbMembers))
+	for _, member := range dbMembers {
+		hotByCold[string(member.ColdCredential)] = lcommon.NewBlake2b224(
+			member.HotCredential,
+		)
+	}
+	return hotByCold, nil
 }
 
 // DRepRegistration returns a DRep registration by credential.
@@ -654,11 +717,12 @@ func (lv *LedgerView) GetTotalActiveStake(epoch uint64) (uint64, error) {
 }
 
 // GetDRepVotingPower returns the voting power for a DRep by summing the
-// stake of all accounts delegated to it. Uses the current live UTxO set.
+// current stake of all delegated accounts, approximated from live UTxO
+// balance plus reward-account balance.
 //
 // TODO: Accept an epoch parameter and use epoch-based stake snapshots
 // for accurate voting power. The current implementation approximates
-// voting power using the live UTxO set.
+// voting power using current live balances.
 func (lv *LedgerView) GetDRepVotingPower(
 	drepCredential []byte,
 ) (uint64, error) {

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1311,9 +1311,10 @@ type ParsedGovProposal struct {
 
 // ParsedGovState holds all decoded governance state components.
 type ParsedGovState struct {
-	Constitution *ParsedConstitution
-	Committee    []ParsedCommitteeMember
-	Proposals    []ParsedGovProposal
+	Constitution    *ParsedConstitution
+	Committee       []ParsedCommitteeMember
+	CommitteeQuorum *cbor.Rat
+	Proposals       []ParsedGovProposal
 }
 
 // ParseGovState decodes governance state from raw CBOR.
@@ -1371,13 +1372,14 @@ func ParseGovState(
 	}
 
 	// Parse committee (field 1) — best-effort
-	committee, err := parseCommittee(fields[1])
+	committee, quorum, err := parseCommittee(fields[1])
 	if err != nil {
 		warnings = append(warnings, fmt.Errorf(
 			"parsing committee: %w", err,
 		))
 	}
 	result.Committee = committee
+	result.CommitteeQuorum = quorum
 
 	// Parse proposals (field 0) — best-effort
 	proposals, err := parseProposals(fields[0])
@@ -1490,20 +1492,20 @@ func parseConstitution(data []byte) (
 //
 // where committee_body = [members_map, quorum].
 func parseCommittee(data []byte) (
-	[]ParsedCommitteeMember, error,
+	[]ParsedCommitteeMember, *cbor.Rat, error,
 ) {
 	outer, err := decodeRawArray(data)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"decoding committee: %w", err,
 		)
 	}
 	// StrictMaybe: empty array = SNothing, 1-element = SJust
 	if len(outer) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if len(outer) != 1 {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"StrictMaybe committee has %d elements, "+
 				"expected 0 or 1",
 			len(outer),
@@ -1514,22 +1516,34 @@ func parseCommittee(data []byte) (
 	// [members_map, quorum]
 	fields, err := decodeRawArray(outer[0])
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"decoding committee body: %w", err,
 		)
 	}
 	if len(fields) < 2 {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"committee body has %d elements, expected 2",
 			len(fields),
 		)
 	}
 
+	var quorum cbor.Rat
+	if _, err := cbor.Decode(fields[1], &quorum); err != nil {
+		return nil, nil, fmt.Errorf(
+			"decoding committee quorum: %w", err,
+		)
+	}
+	if quorum.Rat == nil {
+		return nil, nil, errors.New("committee quorum is nil")
+	}
+
 	// Decode the committee map using decodeMapEntries to
-	// handle credential array keys.
+	// handle credential array keys. Preserve the already-decoded
+	// quorum on failure so best-effort governance import can still
+	// surface it.
 	entries, err := decodeMapEntries(fields[0])
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, &quorum, fmt.Errorf(
 			"decoding committee members map: %w", err,
 		)
 	}
@@ -1564,7 +1578,7 @@ func parseCommittee(data []byte) (
 	}
 
 	// Return parsed members even if some failed
-	return members, errors.Join(memberErrs...)
+	return members, &quorum, errors.Join(memberErrs...)
 }
 
 // parseProposals decodes governance proposals from CBOR.

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1856,51 +1856,69 @@ func importGovState(
 		)
 	}
 
-	// Import committee members
-	if len(govState.Committee) > 0 {
+	// Import committee members and quorum.
+	if len(govState.Committee) > 0 || govState.CommitteeQuorum != nil {
 		if err := func() error {
 			txn := cfg.Database.MetadataTxn(true)
 			defer txn.Release()
-			members := make(
-				[]*models.CommitteeMember,
-				len(govState.Committee),
-			)
-			for i, cm := range govState.Committee {
-				if len(cm.ColdCredential.Hash) != 28 {
+			if len(govState.Committee) > 0 {
+				members := make(
+					[]*models.CommitteeMember,
+					len(govState.Committee),
+				)
+				for i, cm := range govState.Committee {
+					if len(cm.ColdCredential.Hash) != 28 {
+						return fmt.Errorf(
+							"committee member %d: credential hash is %d bytes, expected 28",
+							i, len(cm.ColdCredential.Hash),
+						)
+					}
+					members[i] = &models.CommitteeMember{
+						ColdCredHash: cm.ColdCredential.Hash,
+						ExpiresEpoch: cm.ExpiresEpoch,
+						AddedSlot:    slot,
+					}
+				}
+				if err := store.SetCommitteeMembers(
+					members, txn.Metadata(),
+				); err != nil {
 					return fmt.Errorf(
-						"committee member %d: credential hash is %d bytes, expected 28",
-						i, len(cm.ColdCredential.Hash),
+						"importing committee members: %w", err,
 					)
 				}
-				members[i] = &models.CommitteeMember{
-					ColdCredHash: cm.ColdCredential.Hash,
-					ExpiresEpoch: cm.ExpiresEpoch,
-					AddedSlot:    slot,
-				}
 			}
-			if err := store.SetCommitteeMembers(
-				members, txn.Metadata(),
-			); err != nil {
-				return fmt.Errorf(
-					"importing committee members: %w", err,
-				)
+			if govState.CommitteeQuorum != nil {
+				if govState.CommitteeQuorum.Rat == nil {
+					return errors.New("committee quorum present but missing Rat")
+				}
+				quorum := &types.Rat{
+					Rat: new(big.Rat).Set(govState.CommitteeQuorum.Rat),
+				}
+				if err := store.SetCommitteeQuorum(
+					quorum, slot, txn.Metadata(),
+				); err != nil {
+					return fmt.Errorf(
+						"importing committee quorum: %w", err,
+					)
+				}
 			}
 			if err := txn.Commit(); err != nil {
 				return fmt.Errorf(
-					"committing committee members transaction: %w",
+					"committing committee state transaction: %w",
 					err,
 				)
 			}
 			return nil
 		}(); err != nil {
 			return fmt.Errorf(
-				"saving committee members: %w", err,
+				"saving committee state: %w", err,
 			)
 		}
 		cfg.Logger.Info(
-			"imported committee members",
+			"imported committee state",
 			"component", "ledgerstate",
 			"count", len(govState.Committee),
+			"quorum", govState.CommitteeQuorum != nil,
 		)
 	}
 


### PR DESCRIPTION
Closes #1955 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the full CIP‑1694 governance tick at epoch rollover to ratify, tally, enact, and expire proposals with rollback‑safe refunds and persisted committee quorum. Adds a dedicated `ledger/governance` pipeline integrated with chainsync, deltas, backfill, `view`, rollback, and snapshot import.

- **New Features**
  - Epoch tick: enact previous‑epoch ratified, expire stale (`expired_epoch`/`expired_slot`), then tally/ratify; enforce parent‑chain roots, single ratification per purpose, deterministic ordering.
  - Enactment and refunds: apply protocol params and committee + quorum; credit deposit refunds to reward accounts via a journal; rollback removes post‑slot reward credits and committee updates.
  - Voting/tally: DRep voting power now = live UTxO + reward balances; batch by credential and predefined types; detect resigned members; bootstrap/post‑bootstrap CC/SPO/DRep rules.
  - Storage/API: persist `gov_action_cbor`; ordered active/expiring proposal queries; store committee quorum; normalize committee hot key to `HotCredential`; `view` returns seated members with hot keys; moved `ProcessProposals`/`ProcessVotes` into `ledger/governance`; snapshot import ingests committee and quorum.

- **Migration**
  - Run DB migrations to add `gov_action_cbor`, `expired_epoch`/`expired_slot`, `drep_type`, `committee_quorum`, and the `account_reward_delta` journal; enable committee soft‑delete. Restart the node.

<sup>Written for commit 28e3a90433de64fb90f33df417a82ffe95856659. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full governance pipeline: enactment, expiry, ratification with deterministic ordering; proposal payload persistence.
  * Committee & quorum management: persisted quorum, resigned-member detection, soft-delete/include-deleted views, rollback-aware restoration.
  * Voting & rewards: DRep voting-power now includes reward balances with batch/by-type queries; account reward journaling with rollback.
  * DB migrations: new reward-journal and committee-quorum tables.

* **Refactor**
  * Governance logic moved into a dedicated package and integrated into epoch/chain processing.

* **Tests**
  * Expanded unit/integration coverage across enactment, ratify/tally, quorum, soft-delete, rewards, and rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->