### PR TITLE
fix(ouroboros): do not ask for peer sharing from peers with it disabled

### DIFF
--- a/ouroboros/peersharing.go
+++ b/ouroboros/peersharing.go
@@ -101,6 +101,14 @@ func (o *Ouroboros) RequestPeersFromPeer(peer *peergov.Peer) []string {
 	if conn == nil {
 		return nil
 	}
+	// Skip peers that didn't advertise willingness to share. Sending
+	// MsgShareRequest to a remote with PeerSharing disabled (or on a
+	// negotiated version that doesn't carry mini-protocol 10) triggers
+	// UnknownMiniProtocol on the remote muxer and resets the connection.
+	_, versionData := conn.ProtocolVersion()
+	if versionData == nil || !versionData.PeerSharing() {
+		return nil
+	}
 	// Get the peer sharing client
 	ps := conn.PeerSharing()
 	if ps == nil || ps.Client == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip sending peer sharing requests in `ouroboros` to peers that don’t advertise PeerSharing (or negotiated a version without mini-protocol 10). This prevents UnknownMiniProtocol errors on the remote and avoids connection resets.

<sup>Written for commit 3fb54a2a20e42b5115f4ee233c39706796ab4556. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-sharing protocol handling by validating version compatibility before attempting peer requests, preventing unnecessary peer discovery operations when peer-sharing is unsupported and enhancing system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->