### PR TITLE
fix(ledger): set minor protocol version in block headers

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@ var (
 	Version    string
 	CommitHash string
 )
+
+// BlockHeaderProtocolMinor identifies Dingo-forged blocks without changing
+// the ledger protocol major version used for era selection.
+const BlockHeaderProtocolMinor uint64 = 69
 
 func GetVersionString() string {
 	if Version != "" {

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"math"
 
+	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -510,7 +511,7 @@ func (b *DefaultBlockBuilder) BuildBlock(
 		OpCert:        opCertBody,
 		ProtoVersion: babbage.BabbageProtoVersion{
 			Major: uint64(conwayPParams.ProtocolVersion.Major),
-			Minor: uint64(conwayPParams.ProtocolVersion.Minor),
+			Minor: dingoversion.BlockHeaderProtocolMinor,
 		},
 	}
 

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"testing"
 
+	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -205,6 +206,82 @@ func TestBuildBlockEmptyMempool(t *testing.T) {
 	assert.Equal(t, uint64(1001), block.SlotNumber())
 	assert.Equal(t, uint64(101), block.BlockNumber())
 	assert.Equal(t, 0, len(block.Transactions()))
+}
+
+func TestBuildBlockUsesDingoProtocolMinor(t *testing.T) {
+	creds := setupTestCredentials(t)
+
+	tests := []struct {
+		name         string
+		major        uint
+		pparamMinor  uint
+		expectedSlot uint64
+	}{
+		{
+			name:         "overwrites zero pparam minor",
+			major:        9,
+			pparamMinor:  0,
+			expectedSlot: 1001,
+		},
+		{
+			name:         "overwrites non-zero pparam minor",
+			major:        9,
+			pparamMinor:  5,
+			expectedSlot: 1002,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pparams := &conway.ConwayProtocolParameters{
+				ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+					Major: tt.major,
+					Minor: tt.pparamMinor,
+				},
+				MaxTxSize:        16384,
+				MaxBlockBodySize: 90112,
+				MaxBlockExUnits: lcommon.ExUnits{
+					Memory: 62000000,
+					Steps:  20000000000,
+				},
+			}
+			builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+				Mempool: &mockMempool{
+					transactions: []MempoolTransaction{},
+				},
+				PParamsProvider: &mockPParamsProvider{pparams: pparams},
+				ChainTip: &mockChainTip{
+					tip: ochainsync.Tip{
+						Point: ocommon.Point{
+							Slot: 1000,
+							Hash: make([]byte, 32),
+						},
+						BlockNumber: 100,
+					},
+				},
+				EpochNonce: &mockEpochNonceProvider{
+					epoch: 1,
+					nonce: make([]byte, 32),
+				},
+				Credentials: creds,
+			})
+			require.NoError(t, err)
+
+			_, blockCbor, err := builder.BuildBlock(tt.expectedSlot, 0)
+			require.NoError(t, err)
+
+			decodedBlock, err := conway.NewConwayBlockFromCbor(blockCbor)
+			require.NoError(t, err)
+
+			protoVersion := decodedBlock.BlockHeader.Body.ProtoVersion
+			assert.Equal(t, uint64(tt.major), protoVersion.Major)
+			assert.Equal(
+				t,
+				dingoversion.BlockHeaderProtocolMinor,
+				protoVersion.Minor,
+			)
+		})
+	}
 }
 
 func TestBuildBlockMissingVRFKey(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -39,6 +39,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
+	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/mempool"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -4782,9 +4783,12 @@ func (ls *LedgerState) forgeBlock() {
 		BlockBodySize: blockSize,
 		BlockBodyHash: lcommon.Blake2b256{},
 		OpCert:        babbage.BabbageOpCert{},
+		// Keep header-field changes in sync with ledger/forging/builder.go:
+		// this dev-mode path duplicates mempool iteration, ExUnits accounting,
+		// metadata encoding, and header assembly.
 		ProtoVersion: babbage.BabbageProtoVersion{
-			Major: 8,
-			Minor: 0,
+			Major: uint64(conwayPParams.ProtocolVersion.Major),
+			Minor: dingoversion.BlockHeaderProtocolMinor,
 		},
 	}
 


### PR DESCRIPTION
Sticking this in place until we have cardano-foundation/CIPs#1157 ready. This will allow us to identify Dingo easily on preview.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a Dingo-specific minor protocol version in all forged block headers to tag Dingo blocks without affecting era selection. Major still comes from on-chain protocol params; minor is now a constant.

- **Bug Fixes**
  - Added `BlockHeaderProtocolMinor` (69) in `internal/version` and used it for `ProtoVersion.Minor` in `ledger/forging` and `ledger/state`; `ProtoVersion.Major` remains from current params.
  - Added tests in `ledger/forging/builder_test.go` to verify the minor override and major preservation.

<sup>Written for commit 1de74513c737f3def1a67b5cfc96e2a38389301f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated block header protocol version handling to use a new protocol minor version constant across block creation and ledger state operations.

* **Tests**
  * Added test to verify protocol version compatibility in forged block headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->