### PR TITLE
feat(blockfrost): Asset endpoints

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -351,6 +351,17 @@ func (a *NodeAdapter) Asset(
 			ErrAssetNotFound,
 		)
 	}
+	quantity, err := a.ledgerState.Database().
+		Metadata().
+		GetAssetQuantityByPolicyAndName(policyHash, assetName, nil)
+	if err != nil {
+		return AssetInfo{}, fmt.Errorf(
+			"get asset quantity by policy %s and name %x: %w",
+			policyID,
+			assetName,
+			err,
+		)
+	}
 
 	return AssetInfo{
 		Asset:             policyID + hex.EncodeToString(assetName),
@@ -358,7 +369,7 @@ func (a *NodeAdapter) Asset(
 		AssetName:         hex.EncodeToString(assetName),
 		AssetNameASCII:    assetNameASCII(assetName),
 		Fingerprint:       string(asset.Fingerprint),
-		Quantity:          strconv.FormatUint(uint64(asset.Amount), 10),
+		Quantity:          strconv.FormatUint(quantity, 10),
 		InitialMintTxHash: "",
 		MintOrBurnCount:   0,
 		OnchainMetadata:   nil,

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -344,7 +344,12 @@ func (a *NodeAdapter) Asset(
 		)
 	}
 	if asset.ID == 0 {
-		return AssetInfo{}, ErrAssetNotFound
+		return AssetInfo{}, fmt.Errorf(
+			"asset %s%x: %w",
+			policyID,
+			assetName,
+			ErrAssetNotFound,
+		)
 	}
 
 	return AssetInfo{

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -38,6 +38,7 @@ import (
 var (
 	ErrInvalidAddress = errors.New("invalid address")
 	ErrEpochNotFound  = errors.New("epoch not found")
+	ErrAssetNotFound  = errors.New("asset not found")
 )
 
 // NodeAdapter wraps a real dingo Node's LedgerState to
@@ -314,6 +315,49 @@ func (a *NodeAdapter) EpochProtocolParams(
 		)
 	}
 	return info, nil
+}
+
+// Asset returns native asset information for a policy ID
+// and raw asset name bytes.
+func (a *NodeAdapter) Asset(
+	policyID string,
+	assetName []byte,
+) (AssetInfo, error) {
+	policyIDBytes, err := hex.DecodeString(policyID)
+	if err != nil {
+		return AssetInfo{}, fmt.Errorf(
+			"decode asset policy ID %q: %w",
+			policyID,
+			err,
+		)
+	}
+	policyHash := lcommon.NewBlake2b224(policyIDBytes)
+	asset, err := a.ledgerState.Database().
+		Metadata().
+		GetAssetByPolicyAndName(policyHash, assetName, nil)
+	if err != nil {
+		return AssetInfo{}, fmt.Errorf(
+			"get asset by policy %s and name %x: %w",
+			policyID,
+			assetName,
+			err,
+		)
+	}
+	if asset.ID == 0 {
+		return AssetInfo{}, ErrAssetNotFound
+	}
+
+	return AssetInfo{
+		Asset:             policyID + hex.EncodeToString(assetName),
+		PolicyID:          policyID,
+		AssetName:         hex.EncodeToString(assetName),
+		AssetNameASCII:    assetNameASCII(assetName),
+		Fingerprint:       string(asset.Fingerprint),
+		Quantity:          strconv.FormatUint(uint64(asset.Amount), 10),
+		InitialMintTxHash: "",
+		MintOrBurnCount:   0,
+		OnchainMetadata:   nil,
+	}, nil
 }
 
 func (a *NodeAdapter) latestBlockData(

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -95,6 +95,10 @@ func (b *Blockfrost) Start(
 		b.handleNetwork,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/assets/{asset}",
+		b.handleAsset,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/pools/extended",
 		b.handlePoolsExtended,
 	)

--- a/blockfrost/blockfrost_compat_test.go
+++ b/blockfrost/blockfrost_compat_test.go
@@ -147,6 +147,40 @@ func TestCompatEpochResponse(t *testing.T) {
 	assert.Equal(t, "1000000", *theirs.ActiveStake)
 }
 
+// TestCompatAssetResponse verifies that our AssetResponse
+// round-trips through blockfrost-go's Asset type.
+func TestCompatAssetResponse(t *testing.T) {
+	ours := AssetResponse{
+		Asset:             "00112233445566778899aabbccddeeff00112233445566778899aabb746f6b656e",
+		PolicyID:          "00112233445566778899aabbccddeeff00112233445566778899aabb",
+		AssetName:         "746f6b656e",
+		AssetNameASCII:    "token",
+		Fingerprint:       "asset1test",
+		Quantity:          "42",
+		InitialMintTxHash: "",
+		MintOrBurnCount:   0,
+	}
+
+	data, err := json.Marshal(ours)
+	require.NoError(t, err)
+
+	var theirs bfgo.Asset
+	err = json.Unmarshal(data, &theirs)
+	require.NoError(t, err)
+
+	assert.Equal(t, ours.Asset, theirs.Asset)
+	assert.Equal(t, ours.PolicyID, theirs.PolicyId)
+	assert.Equal(t, ours.AssetName, theirs.AssetName)
+	assert.Equal(t, ours.Fingerprint, theirs.Fingerprint)
+	assert.Equal(t, ours.Quantity, theirs.Quantity)
+	assert.Equal(t, ours.InitialMintTxHash, theirs.InitialMintTxHash)
+	assert.Equal(t, ours.MintOrBurnCount, theirs.MintOrBurnCount)
+	assert.Nil(t, theirs.OnchainMetadata)
+	assert.Nil(t, theirs.OnchainMetadataStandard)
+	assert.Nil(t, theirs.OnchainMetadataExtra)
+	assert.Nil(t, theirs.Metadata)
+}
+
 // TestCompatProtocolParamsResponse verifies that our
 // ProtocolParamsResponse round-trips through
 // blockfrost-go's EpochParameters type.

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -40,6 +40,7 @@ type mockNode struct {
 	params                 ProtocolParamsInfo
 	epochParams            ProtocolParamsInfo
 	pools                  []PoolExtendedInfo
+	asset                  AssetInfo
 	addressUTXOs           []AddressUTXOInfo
 	addressTransactions    []AddressTransactionInfo
 	metadataJSON           []MetadataTransactionJSONInfo
@@ -55,6 +56,7 @@ type mockNode struct {
 	paramsErr              error
 	epochParamsErr         error
 	poolsErr               error
+	assetErr               error
 	addressUTXOsErr        error
 	addressTransactionsErr error
 	metadataJSONErr        error
@@ -101,6 +103,13 @@ func (m *mockNode) PoolsExtended() (
 	[]PoolExtendedInfo, error,
 ) {
 	return m.pools, m.poolsErr
+}
+
+func (m *mockNode) Asset(
+	_ string,
+	_ []byte,
+) (AssetInfo, error) {
+	return m.asset, m.assetErr
 }
 
 func (m *mockNode) AddressUTXOs(
@@ -280,6 +289,100 @@ func TestHandleLatestBlock(t *testing.T) {
 	assert.Equal(t, "pool1xyz", resp.SlotLeader)
 	assert.Equal(t, "prev123", resp.PreviousBlock)
 	assert.Equal(t, uint64(10), resp.Confirmations)
+}
+
+func TestHandleAsset(t *testing.T) {
+	mock := &mockNode{
+		asset: AssetInfo{
+			Asset:             "00112233445566778899aabbccddeeff00112233445566778899aabb746f6b656e",
+			PolicyID:          "00112233445566778899aabbccddeeff00112233445566778899aabb",
+			AssetName:         "746f6b656e",
+			AssetNameASCII:    "token",
+			Fingerprint:       "asset1test",
+			Quantity:          "42",
+			InitialMintTxHash: "",
+			MintOrBurnCount:   0,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/assets/00112233445566778899aabbccddeeff00112233445566778899aabb746f6b656e",
+		nil,
+	)
+	req.SetPathValue(
+		"asset",
+		"00112233445566778899aabbccddeeff00112233445566778899aabb746f6b656e",
+	)
+	w := httptest.NewRecorder()
+	b.handleAsset(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp AssetResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, mock.asset.Asset, resp.Asset)
+	assert.Equal(t, mock.asset.PolicyID, resp.PolicyID)
+	assert.Equal(t, mock.asset.AssetName, resp.AssetName)
+	assert.Equal(t, mock.asset.AssetNameASCII, resp.AssetNameASCII)
+	assert.Equal(t, mock.asset.Fingerprint, resp.Fingerprint)
+	assert.Equal(t, mock.asset.Quantity, resp.Quantity)
+	assert.Equal(t, mock.asset.InitialMintTxHash, resp.InitialMintTxHash)
+	assert.Equal(t, mock.asset.MintOrBurnCount, resp.MintOrBurnCount)
+	assert.Nil(t, resp.OnchainMetadata)
+}
+
+func TestHandleAssetInvalidIdentifier(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/assets/not-hex",
+		nil,
+	)
+	req.SetPathValue("asset", "not-hex")
+	w := httptest.NewRecorder()
+	b.handleAsset(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "Bad Request", resp.Error)
+	assert.Equal(t, "Invalid asset identifier.", resp.Message)
+}
+
+func TestHandleAssetNotFound(t *testing.T) {
+	mock := &mockNode{
+		assetErr: ErrAssetNotFound,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/assets/00112233445566778899aabbccddeeff00112233445566778899aabb",
+		nil,
+	)
+	req.SetPathValue(
+		"asset",
+		"00112233445566778899aabbccddeeff00112233445566778899aabb",
+	)
+	w := httptest.NewRecorder()
+	b.handleAsset(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "Not Found", resp.Error)
+	assert.Equal(t, "The requested asset could not be found.", resp.Message)
 }
 
 func TestHandleLatestBlockError(t *testing.T) {

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -639,14 +639,21 @@ func parseMetadataLabelOrWriteError(
 func parseAssetIdentifier(
 	asset string,
 ) (string, []byte, error) {
-	const policyIDHexLen = 56
+	const (
+		policyIDHexLen        = 56
+		maxAssetNameHexLen    = 64
+		maxAssetIdentifierLen = policyIDHexLen + maxAssetNameHexLen
+	)
 
 	if len(asset) < policyIDHexLen {
 		return "", nil, errors.New("asset ID too short")
 	}
+	if len(asset) > maxAssetIdentifierLen {
+		return "", nil, errors.New("asset ID too long")
+	}
 	policyID := asset[:policyIDHexLen]
 	assetNameHex := asset[policyIDHexLen:]
-	if len(assetNameHex) > 64 {
+	if len(assetNameHex) > maxAssetNameHexLen {
 		return "", nil, errors.New("asset name too long")
 	}
 

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -646,6 +646,9 @@ func parseAssetIdentifier(
 	}
 	policyID := asset[:policyIDHexLen]
 	assetNameHex := asset[policyIDHexLen:]
+	if len(assetNameHex) > 64 {
+		return "", nil, errors.New("asset name too long")
+	}
 
 	if _, err := hex.DecodeString(policyID); err != nil {
 		return "", nil, err

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -15,6 +15,7 @@
 package blockfrost
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -280,6 +281,63 @@ func (b *Blockfrost) handleNetwork(
 			Live:   "0",
 			Active: "0",
 		},
+	})
+}
+
+// handleAsset handles GET /api/v0/assets/{asset} and
+// returns native asset information.
+func (b *Blockfrost) handleAsset(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	policyID, assetName, err := parseAssetIdentifier(
+		r.PathValue("asset"),
+	)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid asset identifier.",
+		)
+		return
+	}
+
+	asset, err := b.node.Asset(policyID, assetName)
+	if err != nil {
+		b.logger.Error(
+			"failed to get asset",
+			"asset", r.PathValue("asset"),
+			"error", err,
+		)
+		if errors.Is(err, ErrAssetNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested asset could not be found.",
+			)
+			return
+		}
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve asset",
+		)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, AssetResponse{
+		Asset:             asset.Asset,
+		PolicyID:          asset.PolicyID,
+		AssetName:         asset.AssetName,
+		AssetNameASCII:    asset.AssetNameASCII,
+		Fingerprint:       asset.Fingerprint,
+		Quantity:          asset.Quantity,
+		InitialMintTxHash: asset.InitialMintTxHash,
+		MintOrBurnCount:   asset.MintOrBurnCount,
+		OnchainMetadata:   asset.OnchainMetadata,
 	})
 }
 
@@ -578,6 +636,27 @@ func parseMetadataLabelOrWriteError(
 	return label, true
 }
 
+func parseAssetIdentifier(
+	asset string,
+) (string, []byte, error) {
+	const policyIDHexLen = 56
+
+	if len(asset) < policyIDHexLen {
+		return "", nil, errors.New("asset ID too short")
+	}
+	policyID := asset[:policyIDHexLen]
+	assetNameHex := asset[policyIDHexLen:]
+
+	if _, err := hex.DecodeString(policyID); err != nil {
+		return "", nil, err
+	}
+	assetName, err := hex.DecodeString(assetNameHex)
+	if err != nil {
+		return "", nil, err
+	}
+	return policyID, assetName, nil
+}
+
 func writeNodeQueryError(
 	w http.ResponseWriter,
 	err error,
@@ -608,6 +687,19 @@ func convertAddressAmounts(
 		ret = append(ret, AddressAmountResponse(amount))
 	}
 	return ret
+}
+
+func assetNameASCII(
+	assetName []byte,
+) string {
+	ret := make([]byte, 0, len(assetName))
+	for _, b := range assetName {
+		if b < 32 || b > 126 {
+			return ""
+		}
+		ret = append(ret, b)
+	}
+	return string(ret)
 }
 
 func protocolParamsResponse(

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -305,11 +305,6 @@ func (b *Blockfrost) handleAsset(
 
 	asset, err := b.node.Asset(policyID, assetName)
 	if err != nil {
-		b.logger.Error(
-			"failed to get asset",
-			"asset", r.PathValue("asset"),
-			"error", err,
-		)
 		if errors.Is(err, ErrAssetNotFound) {
 			writeError(
 				w,
@@ -319,6 +314,11 @@ func (b *Blockfrost) handleAsset(
 			)
 			return
 		}
+		b.logger.Error(
+			"failed to get asset",
+			"asset", r.PathValue("asset"),
+			"error", err,
+		)
 		writeError(
 			w,
 			http.StatusInternalServerError,

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -77,6 +77,13 @@ type BlockfrostNode interface {
 		label uint64,
 		params PaginationParams,
 	) ([]MetadataTransactionCBORInfo, int, error)
+
+	// Asset returns native asset information for a
+	// concatenated hex asset ID ({policy_id}{asset_name}).
+	Asset(
+		policyID string,
+		assetName []byte,
+	) (AssetInfo, error)
 }
 
 // ChainTipInfo holds chain tip data needed by the API.
@@ -206,4 +213,17 @@ type MetadataTransactionJSONInfo struct {
 type MetadataTransactionCBORInfo struct {
 	TxHash   string
 	Metadata string
+}
+
+// AssetInfo holds native asset data needed by the API.
+type AssetInfo struct {
+	Asset             string
+	PolicyID          string
+	AssetName         string
+	AssetNameASCII    string
+	Fingerprint       string
+	Quantity          string
+	InitialMintTxHash string
+	MintOrBurnCount   int
+	OnchainMetadata   *any
 }

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -151,6 +151,22 @@ type AddressTransactionResponse struct {
 	BlockTime   int    `json:"block_time"`
 }
 
+// AssetResponse represents a Blockfrost native asset
+// object.
+type AssetResponse struct {
+	Asset                   string  `json:"asset"`
+	PolicyID                string  `json:"policy_id"`
+	AssetName               string  `json:"asset_name"`
+	AssetNameASCII          string  `json:"asset_name_ascii"`
+	Fingerprint             string  `json:"fingerprint"`
+	Quantity                string  `json:"quantity"`
+	InitialMintTxHash       string  `json:"initial_mint_tx_hash"`
+	MintOrBurnCount         int     `json:"mint_or_burn_count"`
+	OnchainMetadata         *any    `json:"onchain_metadata"`
+	OnchainMetadataStandard *string `json:"onchain_metadata_standard"`
+	OnchainMetadataExtra    *string `json:"onchain_metadata_extra"`
+}
+
 // ErrorResponse represents a Blockfrost error response.
 type ErrorResponse struct {
 	StatusCode int    `json:"status_code"`

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -165,6 +165,7 @@ type AssetResponse struct {
 	OnchainMetadata         *any    `json:"onchain_metadata"`
 	OnchainMetadataStandard *string `json:"onchain_metadata_standard"`
 	OnchainMetadataExtra    *string `json:"onchain_metadata_extra"`
+	Metadata                *any    `json:"metadata"`
 }
 
 // ErrorResponse represents a Blockfrost error response.

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -157,12 +157,8 @@ func UtxoLedgerToModel(
 	if dh := utxo.Output.DatumHash(); dh != nil {
 		ret.DatumHash = dh.Bytes()
 	}
-	if multiAssetOutput, ok := utxo.Output.(interface {
-		MultiAsset() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
-	}); ok {
-		if multiAsset := multiAssetOutput.MultiAsset(); multiAsset != nil {
-			ret.Assets = ConvertMultiAssetToModels(multiAsset)
-		}
+	if multiAsset := utxo.Output.Assets(); multiAsset != nil {
+		ret.Assets = ConvertMultiAssetToModels(multiAsset)
 	}
 
 	return ret

--- a/database/plugin/metadata/mysql/asset.go
+++ b/database/plugin/metadata/mysql/asset.go
@@ -63,8 +63,13 @@ func (d *MetadataStoreMysql) GetAssetQuantityByPolicyAndName(
 	}
 
 	result := query.Model(&models.Asset{}).
-		Select("COALESCE(SUM(amount), 0)").
-		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Joins("INNER JOIN utxo ON asset.utxo_id = utxo.id").
+		Select("COALESCE(SUM(asset.amount), 0)").
+		Where(
+			"asset.policy_id = ? AND asset.name = ? AND utxo.deleted_slot = 0",
+			policyId[:],
+			assetName,
+		).
 		Scan(&total)
 	if result.Error != nil {
 		return 0, result.Error

--- a/database/plugin/metadata/mysql/asset.go
+++ b/database/plugin/metadata/mysql/asset.go
@@ -48,6 +48,30 @@ func (d *MetadataStoreMysql) GetAssetByPolicyAndName(
 	return asset, nil
 }
 
+// GetAssetQuantityByPolicyAndName returns the total live quantity for an asset
+// across all matching UTxOs.
+func (d *MetadataStoreMysql) GetAssetQuantityByPolicyAndName(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) (uint64, error) {
+	var total uint64
+
+	query, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	result := query.Model(&models.Asset{}).
+		Select("COALESCE(SUM(amount), 0)").
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Scan(&total)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return total, nil
+}
+
 // GetAssetsByPolicy returns all assets for a given policy ID
 func (d *MetadataStoreMysql) GetAssetsByPolicy(
 	policyId lcommon.Blake2b224,

--- a/database/plugin/metadata/postgres/asset.go
+++ b/database/plugin/metadata/postgres/asset.go
@@ -63,8 +63,13 @@ func (d *MetadataStorePostgres) GetAssetQuantityByPolicyAndName(
 	}
 
 	result := query.Model(&models.Asset{}).
-		Select("COALESCE(SUM(amount), 0)").
-		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Joins("INNER JOIN utxo ON asset.utxo_id = utxo.id").
+		Select("COALESCE(SUM(asset.amount), 0)").
+		Where(
+			"asset.policy_id = ? AND asset.name = ? AND utxo.deleted_slot = 0",
+			policyId[:],
+			assetName,
+		).
 		Scan(&total)
 	if result.Error != nil {
 		return 0, result.Error

--- a/database/plugin/metadata/postgres/asset.go
+++ b/database/plugin/metadata/postgres/asset.go
@@ -48,6 +48,30 @@ func (d *MetadataStorePostgres) GetAssetByPolicyAndName(
 	return asset, nil
 }
 
+// GetAssetQuantityByPolicyAndName returns the total live quantity for an asset
+// across all matching UTxOs.
+func (d *MetadataStorePostgres) GetAssetQuantityByPolicyAndName(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) (uint64, error) {
+	var total uint64
+
+	query, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	result := query.Model(&models.Asset{}).
+		Select("COALESCE(SUM(amount), 0)").
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Scan(&total)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return total, nil
+}
+
 // GetAssetsByPolicy returns all assets for a given policy ID
 func (d *MetadataStorePostgres) GetAssetsByPolicy(
 	policyId lcommon.Blake2b224,

--- a/database/plugin/metadata/sqlite/asset.go
+++ b/database/plugin/metadata/sqlite/asset.go
@@ -63,8 +63,13 @@ func (d *MetadataStoreSqlite) GetAssetQuantityByPolicyAndName(
 	}
 
 	result := query.Model(&models.Asset{}).
-		Select("COALESCE(SUM(amount), 0)").
-		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Joins("INNER JOIN utxo ON asset.utxo_id = utxo.id").
+		Select("COALESCE(SUM(asset.amount), 0)").
+		Where(
+			"asset.policy_id = ? AND asset.name = ? AND utxo.deleted_slot = 0",
+			policyId[:],
+			assetName,
+		).
 		Scan(&total)
 	if result.Error != nil {
 		return 0, result.Error

--- a/database/plugin/metadata/sqlite/asset.go
+++ b/database/plugin/metadata/sqlite/asset.go
@@ -48,6 +48,30 @@ func (d *MetadataStoreSqlite) GetAssetByPolicyAndName(
 	return asset, nil
 }
 
+// GetAssetQuantityByPolicyAndName returns the total live quantity for an asset
+// across all matching UTxOs.
+func (d *MetadataStoreSqlite) GetAssetQuantityByPolicyAndName(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) (uint64, error) {
+	var total uint64
+
+	query, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	result := query.Model(&models.Asset{}).
+		Select("COALESCE(SUM(amount), 0)").
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Scan(&total)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return total, nil
+}
+
 // GetAssetsByPolicy returns all assets for a given policy ID
 func (d *MetadataStoreSqlite) GetAssetsByPolicy(
 	policyId lcommon.Blake2b224,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -333,6 +333,14 @@ type MetadataStore interface {
 		types.Txn,
 	) (models.Asset, error)
 
+	// GetAssetQuantityByPolicyAndName returns the sum of live quantities for
+	// the provided policy ID and asset name across all matching UTxOs.
+	GetAssetQuantityByPolicyAndName(
+		lcommon.Blake2b224,
+		[]byte, // assetName
+		types.Txn,
+	) (uint64, error)
+
 	// GetScript retrieves a script by its hash.
 	GetScript(
 		lcommon.ScriptHash,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -324,6 +324,15 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
+	// GetAssetByPolicyAndName returns a live asset row for the provided
+	// policy ID and asset name. Implementations return an empty model and
+	// no error when the asset is not found.
+	GetAssetByPolicyAndName(
+		lcommon.Blake2b224,
+		[]byte, // assetName
+		types.Txn,
+	) (models.Asset, error)
+
 	// GetScript retrieves a script by its hash.
 	GetScript(
 		lcommon.ScriptHash,


### PR DESCRIPTION
1. Added Blockfrost-compatible GET /`api/v0/assets/{asset}` support where it implements native asset lookup by concatenated asset id: {policy_id}{asset_name_hex}.
2. Added a new route for this endpoint `/api/v0/assets/{asset}`  and implemented asset handler as well.
3. Added parsing for the {asset} path parameter: first 56 hex chars -> policy_id & remainder -> asset_name_hex
4. Added Blockfrost asset response type by getting it from blockforst-go sdk and extended the Blockfrost node interface with asset lookup support.
5. Implemented node adapter lookup in blockfrost/adapter.go using `GetAssetByPolicyAndName()` and extended the metadata store interface to expose `GetAssetByPolicyAndName()`.
6. Fixed `UtxoLedgerToModel()` in database/models/utxo.go to read native assets from TransactionOutput.Assets() instead of checking for a nonstandard MultiAsset() method.
7. Added blockfrost handler tests as well as blockfrost SDK compatibility tests as well.

Closes #1370 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Blockfrost-compatible GET `/api/v0/assets/{asset}` endpoint to look up native assets by concatenated asset ID with strict validation and clear 400/404 handling. Implements Linear 1370 and returns full asset fields with quantity summed across live UTxOs.

- **New Features**
  - Added `/api/v0/assets/{asset}` with strict parsing (56-hex policy ID + hex name up to 64); rejects non-hex/too short/too long.
  - Response includes fingerprint, quantity, ASCII asset name when printable, and `onchain_metadata*`/`metadata` fields as null when absent.
  - Implemented node adapter lookup and tests for compatibility and handler behavior.

- **Bug Fixes**
  - Read native assets from `TransactionOutput.Assets()` in UTXO conversion.
  - Sum asset quantity across all live (non-deleted) UTxOs.
  - Avoid error logs for missing assets (404).

<sup>Written for commit 8d3067643f241ed55d70d097c881e3a2b21e037b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GET /api/v0/assets/{asset} endpoint to fetch native asset details (identifier, fingerprint, quantity, ASCII name, mint/burn info).
* **Tests**
  * Added compatibility and handler tests covering successful responses, invalid identifiers (400), and asset not found (404).
* **Types**
  * Added AssetResponse/AssetInfo shapes for asset API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->