### PR TITLE
fix(blockfrost): panic in NewNodeAdapter constructor

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -47,15 +47,16 @@ type NodeAdapter struct {
 }
 
 // NewNodeAdapter creates a NodeAdapter that queries the
-// given LedgerState for blockchain data. Panics if ls is
-// nil.
+// given LedgerState for blockchain data.
 func NewNodeAdapter(
 	ls *ledger.LedgerState,
-) *NodeAdapter {
+) (*NodeAdapter, error) {
 	if ls == nil {
-		panic("NewNodeAdapter: LedgerState must not be nil")
+		return nil, errors.New(
+			"new node adapter: ledger state must not be nil",
+		)
 	}
-	return &NodeAdapter{ledgerState: ls}
+	return &NodeAdapter{ledgerState: ls}, nil
 }
 
 // ChainTip returns the current chain tip from the ledger

--- a/node.go
+++ b/node.go
@@ -684,7 +684,15 @@ func (n *Node) Run(ctx context.Context) error {
 			n.config.bindAddr,
 			strconv.FormatUint(uint64(n.config.blockfrostPort), 10),
 		)
-		adapter := blockfrost.NewNodeAdapter(n.ledgerState)
+		adapter, err := blockfrost.NewNodeAdapter(
+			n.ledgerState,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"creating blockfrost node adapter: %w",
+				err,
+			)
+		}
 		n.blockfrostAPI = blockfrost.New(
 			blockfrost.BlockfrostConfig{
 				ListenAddress: listenAddr,


### PR DESCRIPTION
1. Made the changes in `NewNodeAdapter` to return an error instead of panicking when *ledger.LedgerState is nil, and updated the Blockfrost startup path to handle that error.

Closes #1523 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop panic in `blockfrost` startup. `NewNodeAdapter` now returns an error when `*ledger.LedgerState` is nil, and `Node.Run` surfaces it cleanly.

- **Bug Fixes**
  - Changed `blockfrost.NewNodeAdapter` signature to `(*NodeAdapter, error)` and return a clear error instead of panicking on nil ledger state.
  - Updated `Node.Run` to handle and wrap the adapter creation error to fail startup gracefully.

<sup>Written for commit 9e425f4a8214e04cbf11e3d8daa328690de8a5da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

