### PR TITLE
fix(chain): reject unset or zero Ouroboros security parameter K

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -106,6 +106,8 @@ func (c *Chain) MaxQueuedHeaders() int {
 	if c == nil || c.manager == nil {
 		return DefaultMaxQueuedHeaders
 	}
+	// Before SetLedger succeeds, securityParam is zero and the default
+	// floor applies (tests or early bootstrap only).
 	if sp := c.manager.securityParam; sp > 0 {
 		return max(sp*2, DefaultMaxQueuedHeaders)
 	}
@@ -536,6 +538,9 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 	if err := c.reconcile(); err != nil {
 		return fmt.Errorf("reconcile chain: %w", err)
 	}
+	if c.persistent && c.manager.securityParam <= 0 {
+		return ErrSecurityParamNotConfigured
+	}
 	// Check headers for rollback point without mutating them
 	if len(c.headers) > 0 {
 		var header queuedHeader
@@ -566,12 +571,11 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 	forkDepth := c.tipBlockIndex - rollbackBlockIndex
 	// Reject rollbacks that exceed the security parameter K on
 	// the persistent chain. Ephemeral (fork-tracking) chains are
-	// not subject to this limit. The check is skipped when
-	// securityParam is 0 (ledger not yet initialized) or when
-	// the chain is shorter than K blocks (initial sync), since
-	// the entire chain can be safely replaced during sync.
+	// not subject to this limit. When the chain is shorter than K
+	// blocks (initial sync), the entire chain can be safely
+	// replaced during sync.
 	securityParam := c.manager.securityParam
-	if c.persistent && securityParam > 0 &&
+	if c.persistent &&
 		c.tipBlockIndex >= uint64(securityParam) && //nolint:gosec
 		forkDepth > uint64(securityParam) { //nolint:gosec
 		slog.Default().Warn(
@@ -599,6 +603,9 @@ func (c *Chain) rollbackLocked(
 	// Verify chain integrity
 	if err := c.reconcile(); err != nil {
 		return nil, fmt.Errorf("reconcile chain: %w", err)
+	}
+	if c.persistent && c.manager.securityParam <= 0 {
+		return nil, ErrSecurityParamNotConfigured
 	}
 	// Check headers for rollback point
 	if len(c.headers) > 0 {
@@ -637,12 +644,11 @@ func (c *Chain) rollbackLocked(
 	forkDepth := c.tipBlockIndex - rollbackBlockIndex
 	// Reject rollbacks that exceed the security parameter K on
 	// the persistent chain. Ephemeral (fork-tracking) chains are
-	// not subject to this limit. The check is skipped when
-	// securityParam is 0 (ledger not yet initialized) or when
-	// the chain is shorter than K blocks (initial sync), since
-	// the entire chain can be safely replaced during sync.
+	// not subject to this limit. When the chain is shorter than K
+	// blocks (initial sync), the entire chain can be safely
+	// replaced during sync.
 	securityParam := c.manager.securityParam
-	if c.persistent && securityParam > 0 &&
+	if c.persistent &&
 		c.tipBlockIndex >= uint64(securityParam) && //nolint:gosec
 		forkDepth > uint64(securityParam) { //nolint:gosec
 		slog.Default().Warn(
@@ -1095,7 +1101,6 @@ func (c *Chain) NotifyIterators() {
 }
 
 func (c *Chain) reconcile() error {
-	securityParam := c.manager.securityParam
 	// We reconcile against the primary/persistent chain, so no need to check if we are that chain
 	if c.persistent {
 		return nil
@@ -1104,6 +1109,10 @@ func (c *Chain) reconcile() error {
 	if !c.manager.chainNeedsReconcile(c.id, c.lastCommonBlockIndex) {
 		return nil
 	}
+	if c.manager.securityParam <= 0 {
+		return ErrSecurityParamNotConfigured
+	}
+	securityParam := c.manager.securityParam
 	// Check our blocks against primary chain until we find a match
 	primaryChain := c.manager.primaryChainLocked()
 	if primaryChain == nil {

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -881,7 +881,7 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 	if c.tipBlockIndex <= initialBlockIndex {
 		return points
 	}
-	for offset := uint64(denseCount); len(points) < count; offset *= 2 {
+	for offset := uint64(denseCount); len(points) < count; offset *= 2 { //nolint:gosec // denseCount is bounded to non-negative values
 		if offset == 0 || offset >= c.tipBlockIndex {
 			break
 		}

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -483,6 +483,34 @@ func (m *mockLedgerState) SecurityParam() int {
 	return m.securityParam
 }
 
+func mustSetLedger(t *testing.T, cm *chain.ChainManager, securityParam int) {
+	t.Helper()
+	if err := cm.SetLedger(&mockLedgerState{securityParam: securityParam}); err != nil {
+		t.Fatalf("SetLedger(%d): %v", securityParam, err)
+	}
+}
+
+func TestSetLedgerRejectsNonPositiveSecurityParam(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	err = cm.SetLedger(&mockLedgerState{securityParam: 0})
+	if err == nil {
+		t.Fatal("expected error for K=0")
+	}
+	if !errors.Is(err, chain.ErrInvalidSecurityParam) {
+		t.Fatalf("expected ErrInvalidSecurityParam, got %v", err)
+	}
+	err = cm.SetLedger(&mockLedgerState{securityParam: -1})
+	if err == nil {
+		t.Fatal("expected error for K=-1")
+	}
+	if !errors.Is(err, chain.ErrInvalidSecurityParam) {
+		t.Fatalf("expected ErrInvalidSecurityParam, got %v", err)
+	}
+}
+
 // makeLinkedHeaders builds n mock headers that chain together starting
 // from prevHash at the given slot/block number offsets.
 func makeLinkedHeaders(
@@ -510,11 +538,12 @@ func makeLinkedHeaders(
 }
 
 func TestHeaderQueueLimitDefault(t *testing.T) {
-	// Without securityParam the default limit applies
+	// K=1 yields max(2, DefaultMaxQueuedHeaders) == DefaultMaxQueuedHeaders
 	cm, err := chain.NewManager(nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error creating chain manager: %s", err)
 	}
+	mustSetLedger(t, cm, 1)
 	c := cm.PrimaryChain()
 
 	limit := chain.DefaultMaxQueuedHeaders
@@ -561,7 +590,7 @@ func TestHeaderQueueLimitFromSecurityParam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating chain manager: %s", err)
 	}
-	cm.SetLedger(&mockLedgerState{securityParam: securityParam})
+	mustSetLedger(t, cm, securityParam)
 	c := cm.PrimaryChain()
 
 	headers := makeLinkedHeaders(expectedLimit+1, 0, 1, "")
@@ -604,7 +633,7 @@ func TestHeaderQueueAcceptsWithinLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating chain manager: %s", err)
 	}
-	cm.SetLedger(&mockLedgerState{securityParam: securityParam})
+	mustSetLedger(t, cm, securityParam)
 	c := cm.PrimaryChain()
 
 	// Add fewer headers than the limit -- all should succeed
@@ -875,16 +904,6 @@ func TestIntersectPointsIncludesOlderSamples(t *testing.T) {
 	}
 }
 
-// mockLedger implements the interface{ SecurityParam() int }
-// interface used by ChainManager.SetLedger.
-type mockLedger struct {
-	securityParam int
-}
-
-func (m *mockLedger) SecurityParam() int {
-	return m.securityParam
-}
-
 // newTestDB creates an isolated database in a temporary
 // directory so that tests do not share in-memory state.
 func newTestDB(t *testing.T) *database.Database {
@@ -916,7 +935,7 @@ func TestChainRollbackExceedsSecurityParam(t *testing.T) {
 	}
 	// Set security parameter to 2 so that rolling back
 	// 3 blocks (from index 5 to index 2) exceeds it.
-	cm.SetLedger(&mockLedger{securityParam: 2})
+	mustSetLedger(t, cm, 2)
 	c := cm.PrimaryChain()
 	for _, testBlock := range testBlocks {
 		if err := c.AddBlock(testBlock, nil); err != nil {
@@ -971,7 +990,7 @@ func TestChainRollbackWithinSecurityParam(t *testing.T) {
 	// Set security parameter to 3. Rolling back 3 blocks
 	// (from index 5 to index 2) should be allowed since
 	// forkDepth == K is not strictly greater than K.
-	cm.SetLedger(&mockLedger{securityParam: 3})
+	mustSetLedger(t, cm, 3)
 	c := cm.PrimaryChain()
 	for _, testBlock := range testBlocks {
 		if err := c.AddBlock(testBlock, nil); err != nil {
@@ -1067,7 +1086,7 @@ func TestRewindPrimaryChainToPointPrunesPersistentTail(t *testing.T) {
 	}
 }
 
-func TestChainRollbackSecurityParamZeroAllowsAll(t *testing.T) {
+func TestChainRollbackRequiresSecurityParamConfigured(t *testing.T) {
 	db := newTestDB(t)
 	cm, err := chain.NewManager(db, nil)
 	if err != nil {
@@ -1076,8 +1095,6 @@ func TestChainRollbackSecurityParamZeroAllowsAll(t *testing.T) {
 			err,
 		)
 	}
-	// securityParam defaults to 0 (ledger not initialized).
-	// All rollbacks should be allowed.
 	c := cm.PrimaryChain()
 	for _, testBlock := range testBlocks {
 		if err := c.AddBlock(testBlock, nil); err != nil {
@@ -1087,17 +1104,16 @@ func TestChainRollbackSecurityParamZeroAllowsAll(t *testing.T) {
 			)
 		}
 	}
-	// Roll back all the way to block index 0
 	rollbackPoint := ocommon.Point{
 		Slot: testBlocks[0].SlotNumber(),
 		Hash: testBlocks[0].Hash().Bytes(),
 	}
-	if err := c.Rollback(rollbackPoint); err != nil {
-		t.Fatalf(
-			"rollback with securityParam=0 should "+
-				"always succeed, got: %s",
-			err,
-		)
+	err = c.Rollback(rollbackPoint)
+	if err == nil {
+		t.Fatal("expected error when security parameter K is not configured")
+	}
+	if !errors.Is(err, chain.ErrSecurityParamNotConfigured) {
+		t.Fatalf("expected ErrSecurityParamNotConfigured, got: %v", err)
 	}
 }
 
@@ -1113,7 +1129,7 @@ func TestChainRollbackEphemeralChainNotRestricted(
 		)
 	}
 	// Set a very small security param
-	cm.SetLedger(&mockLedger{securityParam: 1})
+	mustSetLedger(t, cm, 1)
 	c := cm.PrimaryChain()
 	for _, testBlock := range testBlocks {
 		if err := c.AddBlock(testBlock, nil); err != nil {

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -19,14 +19,26 @@ import (
 	"fmt"
 )
 
-// DefaultMaxQueuedHeaders is the fallback header queue limit when the
-// security parameter is not yet available (e.g. before ledger is wired).
+// DefaultMaxQueuedHeaders is the minimum header queue capacity (floor).
+// When the ledger security parameter K is configured, the limit is
+// max(2*K, DefaultMaxQueuedHeaders).
 const DefaultMaxQueuedHeaders = 10_000
 
 var (
 	ErrIntersectNotFound            = errors.New("chain intersect not found")
 	ErrRollbackBeyondEphemeralChain = errors.New(
 		"cannot rollback ephemeral chain beyond memory buffer",
+	)
+	// ErrInvalidSecurityParam is returned by ChainManager.SetLedger when the
+	// ledger reports a non-positive Ouroboros security parameter K.
+	ErrInvalidSecurityParam = errors.New(
+		"ledger security parameter K must be positive",
+	)
+	// ErrSecurityParamNotConfigured is returned when an operation requires K
+	// but ChainManager.SetLedger has not been called successfully.
+	ErrSecurityParamNotConfigured = errors.New(
+		"chain manager security parameter K is not configured; " +
+			"call SetLedger with a ledger that returns a positive SecurityParam()",
 	)
 	ErrRollbackExceedsSecurityParam = errors.New(
 		"rollback depth exceeds security parameter K",

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -76,10 +76,22 @@ func NewManager(
 	return cm, nil
 }
 
+// SetLedger configures the Ouroboros security parameter K from the ledger.
+// K must be positive; otherwise SetLedger returns ErrInvalidSecurityParam and
+// leaves the previous configuration unchanged.
 func (cm *ChainManager) SetLedger(
 	ledgerState interface{ SecurityParam() int },
-) {
-	cm.securityParam = ledgerState.SecurityParam()
+) error {
+	k := ledgerState.SecurityParam()
+	if k <= 0 {
+		return fmt.Errorf(
+			"%w: got %d",
+			ErrInvalidSecurityParam,
+			k,
+		)
+	}
+	cm.securityParam = k
+	return nil
 }
 
 func (cm *ChainManager) PrimaryChain() *Chain {

--- a/internal/integration/rollback_test.go
+++ b/internal/integration/rollback_test.go
@@ -158,7 +158,9 @@ func TestRollbackToSecurityParamDepth(t *testing.T) {
 	// For this test, we use a smaller value to avoid loading too many blocks
 	const testSecurityParam = 50
 	mockLedger := &mockLedgerState{securityParam: testSecurityParam}
-	cm.SetLedger(mockLedger)
+	if err := cm.SetLedger(mockLedger); err != nil {
+		t.Fatalf("SetLedger: %v", err)
+	}
 
 	// Get primary chain
 	c := cm.PrimaryChain()
@@ -284,7 +286,9 @@ func TestRollbackBeyondSecurityParam(t *testing.T) {
 	// For this test, we use a smaller value to avoid loading too many blocks
 	const testSecurityParam = 50
 	mockLedger := &mockLedgerState{securityParam: testSecurityParam}
-	cm.SetLedger(mockLedger)
+	if err := cm.SetLedger(mockLedger); err != nil {
+		t.Fatalf("SetLedger: %v", err)
+	}
 
 	// Get primary chain
 	c := cm.PrimaryChain()
@@ -415,7 +419,9 @@ func TestRollbackStateRestoration(t *testing.T) {
 	// (roughly half of numBlocks) stays within the allowed depth.
 	const testSecurityParam = 100
 	mockLedger := &mockLedgerState{securityParam: testSecurityParam}
-	cm.SetLedger(mockLedger)
+	if err := cm.SetLedger(mockLedger); err != nil {
+		t.Fatalf("SetLedger: %v", err)
+	}
 
 	// Get primary chain
 	c := cm.PrimaryChain()
@@ -619,7 +625,9 @@ func TestRollbackToOrigin(t *testing.T) {
 
 	// Set security parameter
 	mockLedger := &mockLedgerState{securityParam: 100}
-	cm.SetLedger(mockLedger)
+	if err := cm.SetLedger(mockLedger); err != nil {
+		t.Fatalf("SetLedger: %v", err)
+	}
 
 	// Get primary chain
 	c := cm.PrimaryChain()
@@ -717,7 +725,9 @@ func TestChainIteratorAfterRollback(t *testing.T) {
 
 	// Set security parameter
 	mockLedger := &mockLedgerState{securityParam: 50}
-	cm.SetLedger(mockLedger)
+	if err := cm.SetLedger(mockLedger); err != nil {
+		t.Fatalf("SetLedger: %v", err)
+	}
 
 	// Get primary chain
 	c := cm.PrimaryChain()

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -45,6 +45,14 @@ type chainsyncRollbackFixture struct {
 	forkPoint     ocommon.Point
 }
 
+type testSecurityParamLedger struct {
+	securityParam int
+}
+
+func (m testSecurityParamLedger) SecurityParam() int {
+	return m.securityParam
+}
+
 func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 
@@ -786,6 +794,10 @@ func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {
 	db := newTestDB(t)
 	cm, err := chain.NewManager(db, nil)
 	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{securityParam: 2}),
+	)
 
 	ancestorHash := testHashBytes("ancestor-block")
 	currentHash := testHashBytes("current-block")

--- a/node.go
+++ b/node.go
@@ -278,7 +278,9 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	n.ledgerState = state
 	n.ouroboros.LedgerState = n.ledgerState
-	n.chainManager.SetLedger(n.ledgerState)
+	if err := n.chainManager.SetLedger(n.ledgerState); err != nil {
+		return fmt.Errorf("failed to configure chain security parameter: %w", err)
+	}
 
 	if n.config.barkBaseUrl != "" {
 		n.db.SetBlobStore(bark.NewBarkBlobStore(bark.BlobStoreBarkConfig{

--- a/utxorpc/rpc_connect_test.go
+++ b/utxorpc/rpc_connect_test.go
@@ -184,7 +184,7 @@ func newUtxorpcConnectHarness(t *testing.T, opts utxorpcHarnessOptions) *utxorpc
 		},
 	})
 	require.NoError(t, err)
-	cm.SetLedger(ls)
+	require.NoError(t, cm.SetLedger(ls))
 
 	ledgerCtx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, ls.Start(ledgerCtx))


### PR DESCRIPTION
Closes #1520 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unset or non-positive Ouroboros security parameter K and enforce its initialization before chain operations. This prevents unsafe rollbacks and fails fast on misconfiguration during node startup.

- **Bug Fixes**
  - `ChainManager.SetLedger` validates `SecurityParam()` and returns `ErrInvalidSecurityParam` when K <= 0 (previous config remains unchanged).
  - Persistent-chain `Rollback`/`ValidateRollback` now require K and enforce K limits; fork-chain `reconcile` also requires K. When K is missing, return `ErrSecurityParamNotConfigured`. Ephemeral chains remain exempt from the K rollback limit.
  - `Node.Run` fails fast if `SetLedger` fails.
  - Tests and fixtures updated: added invalid/unset K cases, introduced a `mustSetLedger` helper, and updated integration/ledger/`utxorpc` tests to set K.

<sup>Written for commit ce4950ccd5dcde0032d3e99bfdaed795523f94b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration & Validation**
  * Security parameter must be explicitly configured with a positive value; K-dependent operations will now fail fast with clear errors if not set.

* **Behavior Changes**
  * Header-queue sizing now enforces a minimum floor while scaling with the configured security parameter.
  * Rollback and reconciliation now validate the security parameter before proceeding.

* **Tests**
  * Tests updated to require and validate ledger/security-parameter configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->