### PR TITLE
fix: single-relay block producer connection hang

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -481,9 +481,6 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	point ocommon.Point,
 	tip ochainsync.Tip,
 ) error {
-	if o.isInboundChainsyncClient(ctx.ConnectionId) {
-		return nil
-	}
 	if !o.reconcileChainsyncIngressAdmission(
 		ctx.ConnectionId,
 		o.shouldPublishChainsyncToLedger(ctx.ConnectionId),
@@ -521,24 +518,23 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// selection tie-breaking (used in both dedup and normal
 		// paths below).
 		vrfOutput := chainselection.GetVRFOutput(v)
-		// Inbound connections are clients pulling data from us.
-		// They are not sources of chain truth and should not
-		// influence chain selection or the blockfetch pipeline.
-		isInbound := o.isInboundChainsyncClient(ctx.ConnectionId)
-		ingressEligible := false
-		if !isInbound {
-			ingressEligible = o.reconcileChainsyncIngressAdmission(
-				ctx.ConnectionId,
-				o.shouldPublishChainsyncToLedger(ctx.ConnectionId),
-			)
-		}
+		// Ingress eligibility is the sole gate for feeding the ledger
+		// and chain selection. reconcileChainsyncIngressAdmission
+		// defers to ChainsyncIngressEligible (peergov), which already
+		// filters random inbound peers via chainSelectionEligible.
+		// A full-duplex inbound from a configured upstream remains
+		// eligible here, so the node doesn't stall when the relay
+		// dials us first after a crash.
+		ingressEligible := o.reconcileChainsyncIngressAdmission(
+			ctx.ConnectionId,
+			o.shouldPublishChainsyncToLedger(ctx.ConnectionId),
+		)
 		o.config.Logger.Debug(
 			"chainsync: header received",
 			"component", "ouroboros",
 			"slot", blockSlot,
 			"tip_slot", tip.Point.Slot,
 			"connection_id", ctx.ConnectionId.String(),
-			"inbound", isInbound,
 			"ingress_eligible", ingressEligible,
 		)
 		// Update tracked client state and deduplicate headers.
@@ -560,12 +556,12 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				)
 			}
 		}
-		// Publish peer tip update for chain selection (outbound only).
-		// Inbound peers are clients pulling data from us, not sources
-		// of chain truth. Letting them into chain selection causes
-		// spurious switches when ephemeral inbound connections report
-		// tips and then disconnect.
-		if !isInbound {
+		// Publish peer tip update for chain selection only for
+		// ingress-eligible peers. Random inbound peers reporting
+		// ephemeral tips would cause spurious chain switches; peergov
+		// filters them via chainSelectionEligible so they fail the
+		// reconcile above and get skipped here.
+		if ingressEligible {
 			observedTip := ochainsync.Tip{
 				Point:       point,
 				BlockNumber: v.BlockNumber(),
@@ -583,7 +579,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				),
 			)
 		}
-		if !isInbound && o.ChainsyncState != nil {
+		if ingressEligible && o.ChainsyncState != nil {
 			o.ChainsyncState.RecordObservedHeader(
 				ledger.ChainsyncEvent{
 					ConnectionId: ctx.ConnectionId,
@@ -666,13 +662,25 @@ func (o *Ouroboros) chainsyncClientRollForward(
 	return nil
 }
 
+// shouldPublishChainsyncToLedger reports whether headers from connId should
+// feed the ledger / chain selector. When ChainsyncIngressEligible is wired,
+// it is always authoritative. When no policy is wired we fall back to the
+// tracked client's recorded direction: outbound-started chainsync defaults
+// to eligible (legacy behaviour) while inbound-started chainsync defaults
+// to observability-only. The inbound default is intentionally fail-closed
+// so a misconfigured node cannot accept chain headers from random inbound
+// peers that happen to negotiate full-duplex.
 func (o *Ouroboros) shouldPublishChainsyncToLedger(
 	connId ouroboros.ConnectionId,
 ) bool {
-	if o.config.ChainsyncIngressEligible == nil {
-		return true
+	if o.config.ChainsyncIngressEligible != nil {
+		return o.config.ChainsyncIngressEligible(connId)
 	}
-	return o.config.ChainsyncIngressEligible(connId)
+	if o.ChainsyncState == nil {
+		return false
+	}
+	outbound, exists := o.ChainsyncState.ClientStartedAsOutbound(connId)
+	return exists && outbound
 }
 
 // isInboundChainsyncClient returns true if the chainsync client for
@@ -680,6 +688,8 @@ func (o *Ouroboros) shouldPublishChainsyncToLedger(
 // client's recorded direction instead of connmanager.IsInboundConnection,
 // making it immune to ConnectionId collisions under listen-port reuse.
 // Returns true (treat as inbound) if the client is not tracked.
+//
+//nolint:unused // Retained as a test helper and for future diagnostics.
 func (o *Ouroboros) isInboundChainsyncClient(
 	connId ouroboros.ConnectionId,
 ) bool {

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/chainselection"
 	dchainsync "github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
@@ -789,4 +790,279 @@ func TestHeaderPreviouslySeenFromOtherConnTreatsEquivalentConnIdsAsSame(
 		t,
 		state.HeaderPreviouslySeenFromOtherConn(connADup, point),
 	)
+}
+
+// TestChainsyncClientRollForward_InboundUpstreamPublishesWhenEligible
+// exercises a full-duplex inbound connection from a configured upstream peer
+// (one that ChainsyncIngressEligible recognises as eligible). Even though the
+// chainsync client is registered inbound (startedAsOutbound=false), headers
+// should flow into the ledger and a PeerTipUpdateEvent should be emitted.
+// This covers the single-relay block producer scenario where the relay wins
+// the dial race after a crash.
+func TestChainsyncClientRollForward_InboundUpstreamPublishesWhenEligible(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connInbound := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	state := dchainsync.NewState(bus, nil)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(connId ouroboros.ConnectionId) bool {
+			return connId == connInbound
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	// Register as inbound + ingress-eligible to model a full-duplex inbound
+	// from a trusted upstream peer.
+	require.True(t, o.registerTrackedChainsyncClient(connInbound, true, false))
+	observabilityOnly, exists := state.ClientObservabilityOnly(connInbound)
+	require.True(t, exists)
+	require.False(
+		t,
+		observabilityOnly,
+		"eligible inbound should not be observability-only",
+	)
+	require.True(t, o.isInboundChainsyncClient(connInbound))
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connInbound},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+
+	select {
+	case evt := <-ledgerCh:
+		data, ok := evt.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connInbound, data.ConnectionId)
+		require.Equal(t, tip.Point.Slot, data.Point.Slot)
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"expected eligible inbound header to feed the ledger; " +
+				"single-relay producer would stay stuck at tip otherwise",
+		)
+	}
+
+	select {
+	case evt := <-tipCh:
+		data, ok := evt.Data.(chainselection.PeerTipUpdateEvent)
+		require.True(t, ok)
+		require.Equal(t, connInbound, data.ConnectionId)
+		require.Equal(t, tip.Point.Slot, data.Tip.Point.Slot)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected PeerTipUpdateEvent for eligible inbound peer")
+	}
+}
+
+// TestChainsyncClientRollForward_InboundIneligiblePeerStaysObservabilityOnly
+// verifies the fix preserves the protection added in #1699: when peergov
+// reports the peer as ineligible (e.g. a random downstream client pulling
+// data from us), its headers must not feed the ledger even though chainsync
+// is running against it.
+func TestChainsyncClientRollForward_InboundIneligiblePeerStaysObservabilityOnly(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connInbound := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	state := dchainsync.NewState(bus, nil)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return false
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	require.True(t, o.registerTrackedChainsyncClient(connInbound, false, false))
+	observabilityOnly, exists := state.ClientObservabilityOnly(connInbound)
+	require.True(t, exists)
+	require.True(t, observabilityOnly)
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	err := o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connInbound},
+		0,
+		header,
+		tip,
+	)
+	require.NoError(t, err)
+
+	select {
+	case evt := <-ledgerCh:
+		t.Fatalf(
+			"unexpected ledger event from ineligible inbound peer: %#v",
+			evt,
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+	select {
+	case evt := <-tipCh:
+		t.Fatalf(
+			"unexpected PeerTipUpdateEvent from ineligible inbound peer: %#v",
+			evt,
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestShouldPublishChainsyncToLedger_InboundFailsClosedWithNilCallback
+// verifies that when no ChainsyncIngressEligible policy is wired, an inbound
+// full-duplex chainsync client is not treated as ingress-eligible. Outbound
+// chainsync retains its legacy default of eligible so the fix does not
+// regress existing callers that don't pass a policy. Regression guard for
+// the review feedback on issue #1982.
+func TestShouldPublishChainsyncToLedger_InboundFailsClosedWithNilCallback(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connInbound := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	connOutbound := newTestConnId("127.0.0.1:6000", "2.2.2.2:3001")
+	state := dchainsync.NewState(bus, nil)
+
+	o := NewOuroboros(OuroborosConfig{EventBus: bus})
+	o.ChainsyncState = state
+	o.EventBus = bus
+	require.Nil(t, o.config.ChainsyncIngressEligible)
+
+	require.True(t, o.registerTrackedChainsyncClient(connOutbound, true, true))
+	require.True(t, o.registerTrackedChainsyncClient(connInbound, false, false))
+
+	require.True(
+		t,
+		o.shouldPublishChainsyncToLedger(connOutbound),
+		"outbound default must remain eligible when no policy is wired",
+	)
+	require.False(
+		t,
+		o.shouldPublishChainsyncToLedger(connInbound),
+		"inbound default must be observability-only when no policy is wired",
+	)
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+
+	require.NoError(
+		t,
+		o.chainsyncClientRollForward(
+			ochainsync.CallbackContext{ConnectionId: connInbound},
+			0,
+			header,
+			tip,
+		),
+	)
+
+	select {
+	case evt := <-ledgerCh:
+		t.Fatalf(
+			"inbound peer with nil policy must not feed ledger: %#v",
+			evt,
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+	select {
+	case evt := <-tipCh:
+		t.Fatalf(
+			"inbound peer with nil policy must not emit PeerTipUpdateEvent: %#v",
+			evt,
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	observabilityOnly, exists := state.ClientObservabilityOnly(connInbound)
+	require.True(t, exists)
+	require.True(
+		t,
+		observabilityOnly,
+		"reconcile must not upgrade inbound under nil policy",
+	)
+}
+
+// TestChainsyncClientRollBackward_InboundUpstreamProcessesRollback verifies
+// that rollbacks received on an eligible inbound chainsync client are
+// forwarded to the ledger. Without the fix, isInboundChainsyncClient
+// short-circuits before reconcileChainsyncIngressAdmission and rollbacks are
+// silently dropped, so the node can't react to chain reorganisations reported
+// by a configured upstream when the relay dialed first.
+func TestChainsyncClientRollBackward_InboundUpstreamProcessesRollback(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	connInbound := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	state := dchainsync.NewState(bus, nil)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	require.True(t, o.registerTrackedChainsyncClient(connInbound, true, false))
+
+	_, rollbackCh := bus.Subscribe(ledger.ChainsyncEventType)
+	rollbackPoint := ocommon.NewPoint(90, []byte("rollback"))
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(95, []byte("tip")),
+		BlockNumber: 5,
+	}
+
+	err := o.chainsyncClientRollBackward(
+		ochainsync.CallbackContext{ConnectionId: connInbound},
+		rollbackPoint,
+		tip,
+	)
+	require.NoError(t, err)
+
+	select {
+	case evt := <-rollbackCh:
+		data, ok := evt.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connInbound, data.ConnectionId)
+		require.Equal(t, rollbackPoint.Slot, data.Point.Slot)
+		require.True(t, data.Rollback)
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"expected rollback event from eligible inbound peer",
+		)
+	}
 }

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -433,9 +433,17 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	// the Ouroboros handshake/protocol negotiation has already failed and the
 	// peer will reject further mini-protocol starts on this connection.
 	if o.ChainsyncState != nil {
+		// Registration runs before the tracked client exists, so the
+		// direction-aware fallback in shouldPublishChainsyncToLedger
+		// cannot see us yet. Outbound keeps its legacy default of
+		// eligible when no ChainsyncIngressEligible policy is wired.
+		ingressEligible := true
+		if o.config.ChainsyncIngressEligible != nil {
+			ingressEligible = o.config.ChainsyncIngressEligible(connId)
+		}
 		shouldStartChainsync := o.registerTrackedChainsyncClient(
 			connId,
-			o.shouldPublishChainsyncToLedger(connId),
+			ingressEligible,
 			true, // startedAsOutbound
 		)
 		if shouldStartChainsync {
@@ -537,8 +545,19 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	// connections that lack chainsync but count toward the per-IP
 	// limit can prevent functional reconnections, causing permanent
 	// chainsync stalls after rollback events.
+	//
+	// Ingress eligibility is delegated to ChainsyncIngressEligible so a
+	// trusted upstream peer that happens to dial us first still feeds
+	// the ledger. Random inbound peers remain observability-only because
+	// peergov filters them at chainSelectionEligible. The default when no
+	// policy is wired is fail-closed for inbound: we will not feed the
+	// ledger from a peer we never decided to trust.
 	if o.ChainsyncState != nil {
-		if o.registerTrackedChainsyncClient(connId, false, false) {
+		ingressEligible := false
+		if o.config.ChainsyncIngressEligible != nil {
+			ingressEligible = o.config.ChainsyncIngressEligible(connId)
+		}
+		if o.registerTrackedChainsyncClient(connId, ingressEligible, false) {
 			if err := o.chainsyncClientStart(connId); err != nil {
 				o.ChainsyncState.RemoveClientConnId(connId)
 				o.config.Logger.Warn(

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -675,10 +675,10 @@ func TestPeerGovernorAppendChainSelectionEventsLocked(t *testing.T) {
 		events := pg.appendChainSelectionEventsLocked(
 			nil,
 			pg.bootstrapExited,
-			PeerSourceInboundConn,
+			PeerSourceP2PGossip,
 			&PeerConnection{Id: connId, IsClient: true},
 			&Peer{
-				Source:     PeerSourceInboundConn,
+				Source:     PeerSourceP2PGossip,
 				Connection: &PeerConnection{Id: connId, IsClient: false},
 			},
 		)

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -337,8 +337,14 @@ func clonePeerConnection(conn *PeerConnection) *PeerConnection {
 }
 
 func chainSelectionEligible(source PeerSource, conn *PeerConnection) bool {
-	_ = source
-	return conn != nil && conn.IsClient
+	if conn == nil || !conn.IsClient {
+		return false
+	}
+	// A peer whose only record comes from an unsolicited inbound
+	// connection is not a trusted source of chain truth. Topology and
+	// P2P-discovered peers keep their source even when they happen to
+	// dial us first, so they stay eligible on full-duplex inbound.
+	return source != PeerSourceInboundConn
 }
 
 func chainSelectionPriority(source PeerSource) int {

--- a/peergov/peers_test.go
+++ b/peergov/peers_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import "testing"
+
+// TestChainSelectionEligible_FiltersRandomInboundSource ensures that inbound
+// connections from peers we don't know about (PeerSourceInboundConn) are not
+// treated as chain-selection sources even when the connection is a full-duplex
+// client. This preserves the protection added in #1699 against random
+// downstream peers polluting chain selection while still allowing topology
+// and P2P-discovered peers who happen to dial us first to drive chain sync.
+func TestChainSelectionEligible_FiltersRandomInboundSource(t *testing.T) {
+	duplexClient := &PeerConnection{IsClient: true}
+	responderOnly := &PeerConnection{IsClient: false}
+
+	cases := []struct {
+		name   string
+		source PeerSource
+		conn   *PeerConnection
+		want   bool
+	}{
+		{
+			name:   "topology local root duplex is eligible",
+			source: PeerSourceTopologyLocalRoot,
+			conn:   duplexClient,
+			want:   true,
+		},
+		{
+			name:   "topology public root duplex is eligible",
+			source: PeerSourceTopologyPublicRoot,
+			conn:   duplexClient,
+			want:   true,
+		},
+		{
+			name:   "topology bootstrap duplex is eligible",
+			source: PeerSourceTopologyBootstrapPeer,
+			conn:   duplexClient,
+			want:   true,
+		},
+		{
+			name:   "p2p gossip duplex is eligible",
+			source: PeerSourceP2PGossip,
+			conn:   duplexClient,
+			want:   true,
+		},
+		{
+			name:   "p2p ledger duplex is eligible",
+			source: PeerSourceP2PLedger,
+			conn:   duplexClient,
+			want:   true,
+		},
+		{
+			name:   "random inbound-only peer is not eligible",
+			source: PeerSourceInboundConn,
+			conn:   duplexClient,
+			want:   false,
+		},
+		{
+			name:   "responder-only connection is not eligible",
+			source: PeerSourceTopologyLocalRoot,
+			conn:   responderOnly,
+			want:   false,
+		},
+		{
+			name:   "nil connection is not eligible",
+			source: PeerSourceTopologyLocalRoot,
+			conn:   nil,
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chainSelectionEligible(tc.source, tc.conn)
+			if got != tc.want {
+				t.Fatalf(
+					"chainSelectionEligible(%v, %+v) = %v, want %v",
+					tc.source,
+					tc.conn,
+					got,
+					tc.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1982 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized peer connection eligibility validation for chain synchronization, ensuring consistent handling of inbound peer connections during rollback and roll-forward operations across the system.

* **Tests**
  * Added comprehensive test coverage for chain synchronization events with inbound peer connections, validating proper event publication behavior for both eligible and ineligible connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stall where a single-relay block producer stops syncing when the relay dials us first and chainsync runs inbound. Eligible inbound upstream peers now feed the ledger and chain selection; random inbound peers remain observability-only. Addresses #1982.

- **Bug Fixes**
  - `ouroboros`: Gate ledger and `PeerTipUpdateEvent` on ingress eligibility for roll-forward and rollback; remove inbound short-circuits. Introduce `shouldPublishChainsyncToLedger` fallback: when no policy is configured, outbound defaults to eligible and inbound defaults to observability-only; apply this during inbound/outbound registration.
  - `peergov`: Update `chainSelectionEligible` to reject `PeerSourceInboundConn` while keeping topology/P2P-discovered peers eligible even if the connection is inbound.
  - Tests: Add coverage for eligible inbound roll-forward/rollback publishing, ineligible inbound peers staying observability-only, and nil-policy inbound failing closed.

<sup>Written for commit 8723e95b4ce28dc3b57a1f034332293f3220ddf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

