### PR TITLE
feat(ledger): track TransitionStateImpossible

### DIFF
--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -227,43 +227,62 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 				}
 			}
 		}
-		// For the current (open) era, cap EraEnd at a safe forecast horizon.
+		// For the current (open) era, set EraEnd based on what is known about
+		// the upcoming era boundary:
 		//
-		// When TransitionKnown is set the epoch-rollover logic has confirmed
-		// an upcoming hard fork: use the transition epoch's StartSlot as the
-		// exact era boundary (mirrors Haskell's TransitionKnown branch).
+		//  TransitionKnown      — epoch-rollover confirmed a version bump; use
+		//                         the transition epoch's StartSlot as the exact
+		//                         boundary (mirrors Haskell's TransitionKnown).
 		//
-		// Otherwise, cap at ledgerTip + safeZone (StandardSafeZone): clients
-		// must not attempt slot↔time conversions beyond this bound because a
-		// hard fork could invalidate them.
+		//  TransitionImpossible — the stability window already reaches or
+		//                         exceeds the epoch end; a hard fork cannot
+		//                         happen this epoch.  The epoch-end slot is
+		//                         confirmed safe — serve it directly without any
+		//                         safeZone cap.
+		//
+		//  TransitionUnknown    — cap at ledgerTip + safeZone (StandardSafeZone)
+		//                         so clients do not attempt slot↔time conversions
+		//                         beyond the safe forecast horizon.
 		if era.Id == currentEraId && len(epochs) > 0 {
-			foundTransition := false
-			if transitionInfo.State == TransitionKnown {
+			// useSafeZoneCap is set when no confirmed exact boundary is
+			// available, including the fallback when TransitionKnown is set
+			// but KnownEpoch is absent from the DB epoch list (e.g. due to a
+			// race or rollback).  In that case serving the uncapped epoch-end
+			// would over-claim certainty, so we fall back to the safe-zone cap.
+			useSafeZoneCap := false
+			switch transitionInfo.State {
+			case TransitionKnown:
 				// Find the transition epoch in the committed epoch list.
-				// It was created with the old era's EraId, so it appears
-				// in epochs.  Its StartSlot is the exact era end boundary.
+				// It was created with the old era's EraId, so it appears in
+				// epochs.  Its StartSlot is the exact era end boundary.
+				found := false
 				for _, ep := range epochs {
 					if ep.EpochId == transitionInfo.KnownEpoch {
-						// Compute the accumulated relative time up to ep.StartSlot.
-						// timespan currently reflects the end of tmpEpoch (last epoch).
-						// Walk back to the start of ep, then forward to ep.StartSlot.
 						timespanAtEpochStart := new(big.Int).Sub(
 							timespan,
 							epochPicoseconds(ep.SlotLength, ep.LengthInSlots),
 						)
-						// The era ends at ep.StartSlot; no partial-slot offset needed.
 						tmpEnd = []any{
 							timespanAtEpochStart,
 							ep.StartSlot,
 							ep.EpochId,
 						}
-						foundTransition = true
+						found = true
 						break
 					}
 				}
+				if !found {
+					// KnownEpoch missing from DB — fall back to safe-zone cap
+					// rather than serving the uncapped epoch end.
+					useSafeZoneCap = true
+				}
+			case TransitionImpossible:
+				// Safe zone already covers the epoch end; tmpEnd was set to
+				// the epoch boundary above — no further capping needed.
+			case TransitionUnknown:
+				useSafeZoneCap = true
 			}
-			if transitionInfo.State != TransitionKnown || !foundTransition {
-				// No confirmed transition: cap at tipSlot + safeZone.
+			if useSafeZoneCap {
 				safeZone := ls.calculateStabilityWindowForEra(era.Id)
 				safeEndSlot, addErr := checkedSlotAdd(tipSlot, safeZone)
 				epochEndSlot, slotErr := checkedSlotAdd(
@@ -273,10 +292,6 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 				if addErr == nil && slotErr == nil &&
 					safeEndSlot >= tmpEpoch.StartSlot &&
 					safeEndSlot < epochEndSlot {
-					// Work backward from the accumulated timespan (which now
-					// points to epochEndSlot) to find the relative time at
-					// the start of the last epoch, then advance it by the
-					// partial number of slots to safeEndSlot.
 					timespanAtEpochStart := new(big.Int).Sub(
 						timespan,
 						epochPicoseconds(tmpEpoch.SlotLength, tmpEpoch.LengthInSlots),

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -368,6 +368,70 @@ func TestQueryHardForkEraHistory_TransitionKnown(t *testing.T) {
 	)
 }
 
+// TestQueryHardForkEraHistory_TransitionKnown_MissingEpochFallsBackToSafeZone
+// verifies the fix for the bug where TransitionKnown with a KnownEpoch absent
+// from the DB epoch list would return the uncapped epoch-end slot instead of
+// the safe-zone cap.
+//
+// Setup: one Conway epoch (500), transitionInfo.KnownEpoch = 999 (not in DB).
+// Expected: falls back to tipSlot + safeZone, not the uncapped epoch end.
+func TestQueryHardForkEraHistory_TransitionKnown_MissingEpochFallsBackToSafeZone(t *testing.T) {
+	const (
+		tipSlot        = uint64(200_000)
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+		missingEpoch   = uint64(999) // deliberately absent from DB
+	)
+	const expectedSafeZone = uint64(25_920)
+	expectedEraEndSlot := tipSlot + expectedSafeZone // 225_920, not 532_000
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{
+			State:      TransitionKnown,
+			KnownEpoch: missingEpoch,
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+
+	eraList, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+	require.NotEmpty(t, eraList)
+
+	lastEra, ok := eraList[len(eraList)-1].([]any)
+	require.True(t, ok, "era entry should be []any")
+	eraEnd, ok := lastEra[1].([]any)
+	require.True(t, ok, "EraEnd should be []any")
+	actualSlot, ok := eraEnd[1].(uint64)
+	require.True(t, ok, "EraEnd slot should be uint64")
+
+	assert.Equal(t, expectedEraEndSlot, actualSlot,
+		"TransitionKnown with missing KnownEpoch must fall back to safe-zone cap (%d), "+
+			"not return the uncapped epoch end (532_000)",
+		expectedEraEndSlot,
+	)
+}
+
 // TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone confirms
 // that TransitionUnknown state still produces the safe-zone-capped EraEnd,
 // i.e. the existing behaviour is preserved.
@@ -420,6 +484,169 @@ func TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone(t *testin
 		"TransitionUnknown: EraEnd slot should be tipSlot(%d)+safeZone(%d)=%d",
 		tipSlot, expectedSafeZone, expectedEraEndSlot,
 	)
+}
+
+// TestQueryHardForkEraHistory_TransitionImpossible_ServesEpochEnd verifies
+// that when TransitionImpossible is set, queryHardForkEraHistory returns the
+// full epoch-end slot rather than a safe-zone cap.
+//
+// Setup (mirrors TestQueryHardForkEraHistory_OpenEraEndBoundedBySafeZone):
+//   - Conway epoch 500: startSlot=100_000, length=432_000 (ends at 532_000)
+//   - tipSlot past the safe-zone boundary (safeEnd >= epochEnd)
+//   - transitionInfo = TransitionImpossible
+//
+// Expected EraEnd slot: 532_000 (confirmed epoch end, no cap)
+func TestQueryHardForkEraHistory_TransitionImpossible_ServesEpochEnd(t *testing.T) {
+	const (
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		epochEndSlot   = uint64(532_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+		// tipSlot well past the safe-zone decision point
+		tipSlot = uint64(520_000)
+	)
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+
+	eraList, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+	require.NotEmpty(t, eraList)
+
+	lastEra, ok := eraList[len(eraList)-1].([]any)
+	require.True(t, ok, "era entry should be []any")
+	eraEnd, ok := lastEra[1].([]any)
+	require.True(t, ok, "EraEnd should be []any")
+	actualSlot, ok := eraEnd[1].(uint64)
+	require.True(t, ok, "EraEnd slot should be uint64")
+
+	assert.Equal(t, epochEndSlot, actualSlot,
+		"TransitionImpossible: EraEnd slot should be the confirmed epoch end (%d), not a safeZone cap",
+		epochEndSlot,
+	)
+}
+
+// TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch
+// verifies that the EraEnd epoch number is epochId+1 when TransitionImpossible
+// is set (the epoch-loop sets tmpEnd with epochId+1 for the last epoch).
+func TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch(t *testing.T) {
+	const (
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+		tipSlot        = uint64(520_000)
+	)
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:             db,
+		currentEra:     eras.ConwayEraDesc,
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
+		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+
+	eraList := result.(cbor.IndefLengthList)
+	lastEra := eraList[len(eraList)-1].([]any)
+	eraEnd := lastEra[1].([]any)
+
+	actualEpoch, ok := eraEnd[2].(uint64)
+	require.True(t, ok, "EraEnd epoch should be uint64")
+	assert.Equal(t, epochId+1, actualEpoch,
+		"TransitionImpossible: EraEnd epoch should be epochId+1 (%d)", epochId+1)
+}
+
+// TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison
+// confirms that TransitionImpossible serves a LARGER EraEnd slot than
+// TransitionUnknown (safeZone cap) would for the same tip.
+func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *testing.T) {
+	const (
+		epochStartSlot   = uint64(100_000)
+		epochLen         = uint(432_000)
+		slotLenMs        = uint(1_000)
+		epochId          = uint64(500)
+		tipSlot          = uint64(520_000) // safeEnd = 545_920 > epochEnd 532_000
+	)
+
+	setupLS := func(state TransitionState) *LedgerState {
+		db := newTestDB(t)
+		require.NoError(t, db.SetEpoch(
+			epochStartSlot, epochId,
+			nil, nil, nil, nil,
+			eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+			nil,
+		))
+		return &LedgerState{
+			db:             db,
+			currentEra:     eras.ConwayEraDesc,
+			currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
+			transitionInfo: TransitionInfo{State: state},
+			config: LedgerStateConfig{
+				CardanoNodeConfig: newTestEraHistoryCfg(t),
+				Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			},
+		}
+	}
+
+	eraEndSlot := func(ls *LedgerState) uint64 {
+		result, err := ls.queryHardForkEraHistory()
+		require.NoError(t, err)
+		eraList := result.(cbor.IndefLengthList)
+		lastEra := eraList[len(eraList)-1].([]any)
+		eraEnd := lastEra[1].([]any)
+		slot, ok := eraEnd[1].(uint64)
+		require.True(t, ok)
+		return slot
+	}
+
+	impossibleSlot := eraEndSlot(setupLS(TransitionImpossible))
+	unknownSlot := eraEndSlot(setupLS(TransitionUnknown))
+
+	// When tipSlot + safeZone > epochEnd, TransitionUnknown's safeZone cap
+	// would exceed the epoch boundary — so the cap is NOT applied and both
+	// should return the epoch end.
+	assert.Equal(t, uint64(532_000), impossibleSlot,
+		"TransitionImpossible must serve the epoch end")
+	assert.Equal(t, uint64(532_000), unknownSlot,
+		"TransitionUnknown with safeEnd > epochEnd also falls through to epoch end")
+	assert.Equal(t, impossibleSlot, unknownSlot,
+		"both states return the same slot when safeEnd exceeds the epoch boundary")
 }
 
 func TestCheckedSlotAdd(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -753,6 +753,11 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	if err := ls.loadTip(); err != nil {
 		return fmt.Errorf("failed to load tip: %w", err)
 	}
+	// Now that both tip and epoch are loaded, check whether the safe zone
+	// already covers the epoch end (TransitionImpossible).  This handles the
+	// case where the node was shut down after the tip advanced past the
+	// stability window but before the next epoch rollover was processed.
+	ls.evaluateTransitionImpossible()
 	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
 		return fmt.Errorf("failed to reconcile primary chain tip: %w", err)
 	}
@@ -2410,6 +2415,13 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				ls.currentPParams = rolloverResult.NewCurrentPParams
 				ls.checkpointWrittenForEpoch = rolloverResult.CheckpointWrittenForEpoch
 				ls.metrics.epochNum.Set(rolloverResult.NewEpochNum)
+				// New epoch: any TransitionImpossible set for the previous
+				// epoch is now stale.  Reset to Unknown so the tip-update
+				// logic re-evaluates for the new epoch's horizon.
+				// (applyEraTransition already handles the era-transition case.)
+				if len(eraTransitions) == 0 {
+					ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+				}
 			}
 			// Set TransitionKnown only when epoch rolled over in the old era
 			// with a version bump AND no era transition already cleared it.
@@ -2988,6 +3000,12 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					ls.reachedTip = true
 				}
 				ls.updateTipMetrics()
+				// After advancing the tip, check whether the stability window
+				// now reaches or exceeds the epoch end.  If so, a hard fork
+				// cannot happen within this epoch and TransitionImpossible
+				// should be recorded so queryHardForkEraHistory serves the
+				// confirmed epoch-end slot instead of a stale safeZone cap.
+				ls.evaluateTransitionImpossible()
 				// Capture tip for logging while holding the lock
 				tipForLog = ls.currentTip
 				checker = ls.config.ForgedBlockChecker
@@ -3349,6 +3367,46 @@ func (ls *LedgerState) reconstructTransitionInfo() {
 			State:      TransitionKnown,
 			KnownEpoch: ls.currentEpoch.EpochId,
 		}
+	}
+}
+
+// evaluateTransitionImpossible sets transitionInfo to TransitionImpossible
+// when the safe-zone end for the current era already reaches or exceeds the
+// current epoch's end slot.
+//
+// At that point a hard-fork transition is impossible within this epoch: the
+// stability window has "vouched for" slots up to (and past) the boundary, so
+// no rollover can introduce a new era within the epoch.  Serving the full
+// epoch-end slot as EraEnd is therefore safe and more informative than the
+// stale tipSlot+safeZone cap.
+//
+// The method is a no-op unless transitionInfo.State is TransitionUnknown; it
+// must not override a confirmed TransitionKnown.
+//
+// Call under ls.Lock() (runtime tip-update) or without a lock during
+// single-threaded startup (after loadTip).
+func (ls *LedgerState) evaluateTransitionImpossible() {
+	if ls.transitionInfo.State != TransitionUnknown {
+		return
+	}
+	// Only meaningful when we have a fully-populated epoch.
+	if ls.currentEpoch.LengthInSlots == 0 {
+		return
+	}
+	epochEndSlot, addErr := checkedSlotAdd(
+		ls.currentEpoch.StartSlot,
+		uint64(ls.currentEpoch.LengthInSlots),
+	)
+	if addErr != nil {
+		return
+	}
+	safeZone := ls.calculateStabilityWindowForEra(ls.currentEra.Id)
+	safeEndSlot, addErr := checkedSlotAdd(ls.currentTip.Point.Slot, safeZone)
+	if addErr != nil {
+		return
+	}
+	if safeEndSlot >= epochEndSlot {
+		ls.transitionInfo = TransitionInfo{State: TransitionImpossible}
 	}
 }
 

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2364,6 +2364,235 @@ func babbagePParams(major uint) *babbage.BabbageProtocolParameters {
 	return &babbage.BabbageProtocolParameters{ProtocolMajor: major}
 }
 
+// newTestEpoch is a convenience builder for models.Epoch.
+func newTestEpoch(id, startSlot uint64, lengthInSlots uint, eraId uint) models.Epoch {
+	return models.Epoch{
+		EpochId:      id,
+		StartSlot:    startSlot,
+		LengthInSlots: lengthInSlots,
+		EraId:        eraId,
+		SlotLength:   1000,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// evaluateTransitionImpossible tests
+// ---------------------------------------------------------------------------
+
+// TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd verifies
+// that TransitionImpossible is set when tipSlot + safeZone >= epochEndSlot.
+//
+// Using Shelley-era parameters from newTestEraHistoryCfg:
+//   securityParam=432, activeSlotsCoeff=0.05
+//   safeZone = ceil(3*432/0.05) = 25_920
+//   epoch: startSlot=100_000, length=432_000, end=532_000
+//   tipSlot = 532_000 - 25_920 = 506_080 → safeEnd = 532_000 = epochEnd → Impossible
+func TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd(t *testing.T) {
+	const (
+		epochStart = uint64(100_000)
+		epochLen   = uint(432_000)
+		epochEnd   = uint64(532_000)
+		safeZone   = uint64(25_920)
+		// tipSlot such that tipSlot + safeZone == epochEnd (boundary case)
+		tipSlot = epochEnd - safeZone // 506_080
+	)
+
+	cfg := newTestEraHistoryCfg(t)
+	ls := &LedgerState{
+		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEpoch: newTestEpoch(500, epochStart, epochLen, eras.ConwayEraDesc.Id),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.evaluateTransitionImpossible()
+
+	assert.Equal(t, TransitionImpossible, ls.transitionInfo.State,
+		"when safeEndSlot == epochEndSlot, TransitionImpossible must be set")
+}
+
+// TestEvaluateTransitionImpossible_SetWhenSafeZoneExceedsEpochEnd verifies
+// that TransitionImpossible is set when safeEndSlot > epochEndSlot.
+func TestEvaluateTransitionImpossible_SetWhenSafeZoneExceedsEpochEnd(t *testing.T) {
+	const (
+		epochStart = uint64(100_000)
+		epochLen   = uint(432_000)
+		epochEnd   = uint64(532_000)
+		// tipSlot well past the safe-zone boundary
+		tipSlot = uint64(520_000)
+	)
+
+	cfg := newTestEraHistoryCfg(t)
+	ls := &LedgerState{
+		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEpoch: newTestEpoch(500, epochStart, epochLen, eras.ConwayEraDesc.Id),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.evaluateTransitionImpossible()
+
+	assert.Equal(t, TransitionImpossible, ls.transitionInfo.State)
+}
+
+// TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch verifies
+// that TransitionImpossible is NOT set when safeEndSlot < epochEndSlot.
+func TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch(t *testing.T) {
+	const (
+		epochStart = uint64(100_000)
+		epochLen   = uint(432_000)
+		// tipSlot one slot before the boundary: safeEnd = epochEnd - 1
+		tipSlot = uint64(506_079) // 532_000 - 25_920 - 1
+	)
+
+	cfg := newTestEraHistoryCfg(t)
+	ls := &LedgerState{
+		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEpoch: newTestEpoch(500, epochStart, epochLen, eras.ConwayEraDesc.Id),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.evaluateTransitionImpossible()
+
+	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+		"safeEndSlot < epochEndSlot: TransitionImpossible must NOT be set")
+}
+
+// TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown verifies that
+// evaluateTransitionImpossible does not override a confirmed TransitionKnown.
+func TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown(t *testing.T) {
+	cfg := newTestEraHistoryCfg(t)
+	ls := &LedgerState{
+		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEpoch: newTestEpoch(500, 100_000, 432_000, eras.ConwayEraDesc.Id),
+		currentTip: ochainsync.Tip{
+			// tipSlot past the safe-zone boundary → would normally trigger Impossible
+			Point: ocommon.NewPoint(520_000, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionKnown, KnownEpoch: 501},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.evaluateTransitionImpossible()
+
+	assert.Equal(t, TransitionKnown, ls.transitionInfo.State,
+		"evaluateTransitionImpossible must not override TransitionKnown")
+	assert.Equal(t, uint64(501), ls.transitionInfo.KnownEpoch)
+}
+
+// TestEvaluateTransitionImpossible_NoOpAlreadyImpossible verifies that the
+// call is idempotent when TransitionImpossible is already set.
+func TestEvaluateTransitionImpossible_NoOpAlreadyImpossible(t *testing.T) {
+	cfg := newTestEraHistoryCfg(t)
+	ls := &LedgerState{
+		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEpoch: newTestEpoch(500, 100_000, 432_000, eras.ConwayEraDesc.Id),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(520_000, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.evaluateTransitionImpossible()
+
+	assert.Equal(t, TransitionImpossible, ls.transitionInfo.State)
+}
+
+// TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero verifies that a
+// zero LengthInSlots (uninitialized epoch) is skipped safely.
+func TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero(t *testing.T) {
+	cfg := newTestEraHistoryCfg(t)
+	ls := &LedgerState{
+		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEpoch: models.Epoch{EpochId: 0, LengthInSlots: 0},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(999_999, []byte("tip")),
+		},
+		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.evaluateTransitionImpossible()
+
+	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+		"zero-length epoch must not trigger TransitionImpossible")
+}
+
+// TestRolloverCommit_ResetsTransitionImpossible verifies that a plain epoch
+// rollover (no HardFork, no era transition) resets TransitionImpossible to
+// TransitionUnknown so the new epoch starts fresh.
+func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
+	ls := &LedgerState{
+		currentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentPParams: babbagePParams(9),
+		// Simulate state at end of epoch 500: TransitionImpossible was set
+		// because the tip's safe zone reached the epoch end.
+		transitionInfo: TransitionInfo{State: TransitionImpossible},
+	}
+
+	var eraTransitions []*EraTransitionResult
+	rolloverResult := &EpochRolloverResult{
+		NewCurrentEpoch:   models.Epoch{EpochId: 501, StartSlot: 532_000, LengthInSlots: 432_000},
+		NewCurrentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewCurrentPParams: babbagePParams(9),
+		NewEpochCache:     []models.Epoch{{EpochId: 501}},
+		HardFork:          nil,
+	}
+
+	ls.Lock()
+	for _, eraResult := range eraTransitions {
+		ls.applyEraTransition(eraResult)
+	}
+	if rolloverResult != nil {
+		ls.epochCache = rolloverResult.NewEpochCache
+		ls.currentEpoch = rolloverResult.NewCurrentEpoch
+		ls.currentEra = rolloverResult.NewCurrentEra
+		ls.currentPParams = rolloverResult.NewCurrentPParams
+		if len(eraTransitions) == 0 {
+			ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+		}
+	}
+	if len(eraTransitions) == 0 && rolloverResult != nil && rolloverResult.HardFork != nil {
+		ls.transitionInfo = TransitionInfo{
+			State:      TransitionKnown,
+			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
+		}
+	}
+	ls.Unlock()
+
+	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+		"plain epoch rollover must reset TransitionImpossible to TransitionUnknown")
+}
+
 // TestApplyEraTransition_ClearsTransitionKnown verifies that
 // applyEraTransition unconditionally clears a pending TransitionKnown, even
 // when called outside of any epoch-rollover context (the "standalone


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new transition state that detects when a hard fork is impossible in the current epoch and serves the confirmed epoch-end in era history instead of a safe-zone cap. This improves slot↔time bounds and avoids premature capping.

- **New Features**
  - Tracked TransitionImpossible via evaluateTransitionImpossible() when tip+safeZone ≥ epoch end.
  - Ran the evaluation at startup (after loading tip) and after each tip advance.
  - Updated queryHardForkEraHistory():
    - TransitionKnown → use the transition epoch’s StartSlot (if present).
    - TransitionImpossible → serve the epoch-end slot.
    - TransitionUnknown → cap at tip+safeZone.
  - Reset TransitionImpossible to Unknown on a plain epoch rollover.

- **Bug Fixes**
  - TransitionKnown with a missing KnownEpoch in the DB now falls back to the safe-zone cap instead of returning the uncapped epoch end.

<sup>Written for commit 354838de8718b4e117ad32be761167aac92d1efb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved era end slot calculation logic for hard fork transitions with better state handling and fallback mechanisms.
  * Enhanced epoch rollover to correctly reset transition state during regular epoch progressions.

* **Tests**
  * Added comprehensive test coverage for hard fork transition scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->