### PR TITLE
docs: CLAUDE.md for agentic coding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Go-based Cardano node implementing Ouroboros. Most of what you need is derivable from code (`Makefile`, `go.mod`, `node.go`, `dingo.yaml.example`). Below is what isn't.
+
+## Testing rules
+
+- **Never use `time.Sleep()` for synchronization.** Use helpers in `internal/test/testutil/`:
+  - `WaitForCondition` / `require.Eventually` for polling (2–5s timeout, 5–10ms interval, lock shared state inside the condition fn)
+  - `RequireReceive` / `RequireNoReceive` for channel assertions
+  - `context.WithTimeout` for graceful shutdown — not sleep
+- Race detection is on by default in `make test`.
+- Integration tests in `internal/integration/` load real blocks from `database/immutable/testdata/`.
+
+## Before committing
+
+```bash
+golangci-lint run ./...   # .golangci.yml configured
+nilaway ./...
+modernize ./...           # --fix to auto-apply
+```
+
+## Non-obvious architecture
+
+- **CBOR offset storage**: UTxOs/txs store 52-byte `CborOffset` refs (magic `"DOFF"`, slot, hash, offset, length), not full CBOR. Resolved via `TieredCborCache` (hot → block LRU → cold extract from blob store). See `database/cbor_offset.go`, `database/cbor_cache.go`, `database/block_indexer.go`.
+- **Plugins** (`database/plugin/`): blob = `badger` (default) / `gcs` / `s3`; metadata = `sqlite` (default) / `mysql` / `postgres`.
+- **Event bus**: components communicate via `event.EventBus.SubscribeFunc()`, not direct calls.
+
+## Profiling
+
+```bash
+./dingo --cpuprofile=cpu.prof --memprofile=mem.prof load database/immutable/testdata
+go tool pprof cpu.prof
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development guidelines documentation covering testing standards, code quality procedures, and profiling practices for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `CLAUDE.md` to document engineering guardrails for the Go-based Cardano node. It covers testing rules, pre-commit linting, key architecture (CBOR offset storage, plugins, event bus), and profiling commands for `dingo`.

<sup>Written for commit a3b0f8d7ec466ef7f27020a34b986ff6f6a749d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

