### PR TITLE
feat: ouroboros genesis support

### DIFF
--- a/chainselection/doc.go
+++ b/chainselection/doc.go
@@ -18,6 +18,10 @@
 // longer chain wins, then density within the security window, then VRF
 // tie-break.
 //
+// Genesis selection mode can be enabled at startup to prefer observed
+// density during bootstrap before automatically falling back to Praos once
+// the local tip is close enough to the best observed peer tip.
+//
 // ChainSelector is the top-level type. It consumes PeerTipUpdateEvent
 // events from chainsync, compares peer tips against the local tip, and
 // emits ChainSwitchEvent on the EventBus when the selected peer changes.

--- a/chainselection/genesis.go
+++ b/chainselection/genesis.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import "math"
+
+const defaultGenesisWindowSlots uint64 = 6480
+
+// SelectionMode describes the chain-selection strategy currently in use.
+type SelectionMode uint8
+
+const (
+	SelectionModePraos SelectionMode = iota
+	SelectionModeGenesis
+)
+
+func (m SelectionMode) String() string {
+	switch m {
+	case SelectionModePraos:
+		return "praos"
+	case SelectionModeGenesis:
+		return "genesis"
+	default:
+		return "praos"
+	}
+}
+
+// GenesisWindowSlotsForParams returns the Genesis density window in slots.
+// Shelley-style networks use 3k/f, where k is the security parameter and f is
+// the active slot coefficient.
+func GenesisWindowSlotsForParams(
+	securityParam uint64,
+	activeSlotsCoeff float64,
+) uint64 {
+	if securityParam == 0 ||
+		activeSlotsCoeff <= 0 ||
+		math.IsNaN(activeSlotsCoeff) ||
+		math.IsInf(activeSlotsCoeff, 0) {
+		return defaultGenesisWindowSlots
+	}
+	window := math.Ceil(3 * float64(securityParam) / activeSlotsCoeff)
+	if window <= 0 {
+		return defaultGenesisWindowSlots
+	}
+	if window >= float64(math.MaxUint64) {
+		return math.MaxUint64
+	}
+	return uint64(window)
+}

--- a/chainselection/genesis_test.go
+++ b/chainselection/genesis_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"math"
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisWindowSlotsForParams(t *testing.T) {
+	assert.Equal(t, uint64(129600), GenesisWindowSlotsForParams(2160, 0.05))
+	assert.Equal(t, defaultGenesisWindowSlots, GenesisWindowSlotsForParams(0, 0.05))
+	assert.Equal(t, defaultGenesisWindowSlots, GenesisWindowSlotsForParams(2160, 0))
+	assert.Equal(
+		t,
+		defaultGenesisWindowSlots,
+		GenesisWindowSlotsForParams(2160, math.NaN()),
+	)
+}
+
+func TestChainSelectorGenesisObservedDensityTracksRollingWindow(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 10,
+	})
+	require.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+	require.Equal(t, uint64(30), cs.GenesisWindowSlots())
+
+	connId := newTestConnectionId(1)
+	for _, tip := range []ochainsync.Tip{
+		{
+			Point:       ocommon.Point{Slot: 1, Hash: []byte("slot-1")},
+			BlockNumber: 1,
+		},
+		{
+			Point:       ocommon.Point{Slot: 6, Hash: []byte("slot-6")},
+			BlockNumber: 2,
+		},
+		{
+			Point:       ocommon.Point{Slot: 12, Hash: []byte("slot-12")},
+			BlockNumber: 3,
+		},
+	} {
+		cs.UpdatePeerTip(connId, tip, nil)
+	}
+
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, []uint64{1, 6, 12}, peerTip.observedSlots)
+	assert.Equal(t, uint64(3), peerTip.observedDensity(cs.GenesisWindowSlots()))
+
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 41, Hash: []byte("slot-41")},
+		BlockNumber: 4,
+	}, nil)
+
+	peerTip = cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, []uint64{12, 41}, peerTip.observedSlots)
+	assert.Equal(t, uint64(2), peerTip.observedDensity(cs.GenesisWindowSlots()))
+}
+
+func TestChainSelectorGenesisPrefersObservedDensity(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 20,
+	})
+
+	denseConn := newTestConnectionId(1)
+	sparseConn := newTestConnectionId(2)
+
+	for _, tip := range []ochainsync.Tip{
+		{
+			Point:       ocommon.Point{Slot: 90, Hash: []byte("dense-90")},
+			BlockNumber: 90,
+		},
+		{
+			Point:       ocommon.Point{Slot: 95, Hash: []byte("dense-95")},
+			BlockNumber: 95,
+		},
+		{
+			Point:       ocommon.Point{Slot: 100, Hash: []byte("dense-100")},
+			BlockNumber: 100,
+		},
+	} {
+		cs.UpdatePeerTip(denseConn, tip, nil)
+	}
+
+	cs.UpdatePeerTip(sparseConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 102, Hash: []byte("sparse-102")},
+		BlockNumber: 102,
+	}, nil)
+
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, denseConn, *cs.GetBestPeer())
+
+	denseTip := cs.GetPeerTip(denseConn)
+	sparseTip := cs.GetPeerTip(sparseConn)
+	require.NotNil(t, denseTip)
+	require.NotNil(t, sparseTip)
+	assert.Equal(t, uint64(3), denseTip.observedDensity(cs.GenesisWindowSlots()))
+	assert.Equal(t, uint64(1), sparseTip.observedDensity(cs.GenesisWindowSlots()))
+}
+
+func TestChainSelectorGenesisTransitionsBackToPraos(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 10,
+	})
+
+	connId := newTestConnectionId(1)
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("peer")},
+		BlockNumber: 100,
+	}, nil)
+
+	require.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 60, Hash: []byte("local-60")},
+		BlockNumber: 60,
+	})
+	require.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 75, Hash: []byte("local-75")},
+		BlockNumber: 75,
+	})
+	require.Equal(t, SelectionModePraos, cs.SelectionMode())
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId, *cs.GetBestPeer())
+}

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -23,11 +23,12 @@ import (
 
 // PeerChainTip tracks the chain tip reported by a specific peer.
 type PeerChainTip struct {
-	ConnectionId ouroboros.ConnectionId
-	Tip          ochainsync.Tip
-	ObservedTip  ochainsync.Tip
-	VRFOutput    []byte // VRF output from tip block for tie-breaking
-	LastUpdated  time.Time
+	ConnectionId  ouroboros.ConnectionId
+	Tip           ochainsync.Tip
+	ObservedTip   ochainsync.Tip
+	VRFOutput     []byte // VRF output from tip block for tie-breaking
+	LastUpdated   time.Time
+	observedSlots []uint64
 }
 
 // NewPeerChainTip creates a new PeerChainTip with the given connection ID,
@@ -62,6 +63,74 @@ func (p *PeerChainTip) UpdateTipWithObserved(
 	p.ObservedTip = observedTip
 	p.VRFOutput = vrfOutput
 	p.LastUpdated = time.Now()
+}
+
+func (p *PeerChainTip) recordObservedSlot(slot, window uint64) {
+	if p == nil {
+		return
+	}
+	if slot == 0 {
+		p.observedSlots = nil
+		return
+	}
+
+	// Keep the history monotonic and bounded even if the observed frontier
+	// rolls back. Genesis mode only needs the recent slot frontier, not the
+	// full chain history.
+	for len(p.observedSlots) > 0 &&
+		p.observedSlots[len(p.observedSlots)-1] > slot {
+		p.observedSlots = p.observedSlots[:len(p.observedSlots)-1]
+	}
+	if len(p.observedSlots) == 0 ||
+		p.observedSlots[len(p.observedSlots)-1] < slot {
+		p.observedSlots = append(p.observedSlots, slot)
+	}
+
+	if window == 0 {
+		if len(p.observedSlots) > 1 {
+			p.observedSlots = p.observedSlots[len(p.observedSlots)-1:]
+		}
+		return
+	}
+
+	var cutoff uint64
+	if slot > window {
+		cutoff = slot - window + 1
+	} else {
+		cutoff = 1
+	}
+	pruneIdx := 0
+	for pruneIdx < len(p.observedSlots) &&
+		p.observedSlots[pruneIdx] < cutoff {
+		pruneIdx++
+	}
+	if pruneIdx > 0 {
+		p.observedSlots = p.observedSlots[pruneIdx:]
+	}
+}
+
+func (p *PeerChainTip) observedDensity(window uint64) uint64 {
+	if p == nil || len(p.observedSlots) == 0 {
+		return 0
+	}
+	if window == 0 {
+		return uint64(len(p.observedSlots))
+	}
+
+	latestSlot := p.observedSlots[len(p.observedSlots)-1]
+	var cutoff uint64
+	if latestSlot > window {
+		cutoff = latestSlot - window + 1
+	} else {
+		cutoff = 1
+	}
+	for i, slot := range p.observedSlots {
+		if slot >= cutoff {
+			// #nosec G115 -- i < len(p.observedSlots), difference is non-negative
+			return uint64(len(p.observedSlots) - i)
+		}
+	}
+	return 0
 }
 
 // SelectionTip returns the best locally observed frontier for this peer.

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -82,6 +82,8 @@ type ChainSelectorConfig struct {
 	StaleTipThreshold  time.Duration
 	MinSwitchBlockDiff uint64
 	SecurityParam      uint64
+	GenesisMode        bool
+	GenesisWindowSlots uint64
 	ConnectionLive     func(ouroboros.ConnectionId) bool
 	ConnectionEligible func(ouroboros.ConnectionId) bool
 	ConnectionPriority func(ouroboros.ConnectionId) int
@@ -94,6 +96,7 @@ type ChainSelector struct {
 	config            ChainSelectorConfig
 	securityParam     uint64
 	maxTrackedPeers   int
+	mode              SelectionMode
 	peerTips          map[ouroboros.ConnectionId]*PeerChainTip
 	eligible          map[ouroboros.ConnectionId]bool
 	priority          map[ouroboros.ConnectionId]int
@@ -128,10 +131,14 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 		config:            cfg,
 		securityParam:     cfg.SecurityParam,
 		maxTrackedPeers:   maxPeers,
+		mode:              SelectionModePraos,
 		peerTips:          make(map[ouroboros.ConnectionId]*PeerChainTip),
 		eligible:          make(map[ouroboros.ConnectionId]bool),
 		priority:          make(map[ouroboros.ConnectionId]int),
 		evaluationTrigger: make(chan struct{}, 1),
+	}
+	if cfg.GenesisMode {
+		cs.mode = SelectionModeGenesis
 	}
 	if cfg.EventBus != nil {
 		cfg.EventBus.SubscribeFunc(
@@ -159,6 +166,61 @@ func (cs *ChainSelector) Stop() {
 	if cs.cancel != nil {
 		cs.cancel()
 	}
+}
+
+func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
+	if cs.config.GenesisWindowSlots > 0 {
+		return cs.config.GenesisWindowSlots
+	}
+	if cs.securityParam > 0 {
+		return safeAddUint64(
+			cs.securityParam,
+			safeAddUint64(cs.securityParam, cs.securityParam),
+		)
+	}
+	return defaultGenesisWindowSlots
+}
+
+func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
+	var best uint64
+	for connId, pt := range cs.peerTips {
+		if !cs.isPeerSelectableLocked(connId, pt, false) {
+			continue
+		}
+		tip := pt.SelectionTip()
+		if tip.Point.Slot > best {
+			best = tip.Point.Slot
+		}
+	}
+	return best
+}
+
+func (cs *ChainSelector) shouldExitGenesisModeLocked() bool {
+	if cs.mode != SelectionModeGenesis {
+		return false
+	}
+	bestSlot := cs.bestKnownGenesisSlotLocked()
+	if bestSlot == 0 {
+		return false
+	}
+	return safeAddUint64(
+		cs.localTip.Point.Slot,
+		cs.genesisWindowSlotsLocked(),
+	) >= bestSlot
+}
+
+func (cs *ChainSelector) advanceSelectionModeLocked() bool {
+	if !cs.shouldExitGenesisModeLocked() {
+		return false
+	}
+	cs.mode = SelectionModePraos
+	cs.config.Logger.Info(
+		"exiting Genesis selection mode",
+		"local_slot", cs.localTip.Point.Slot,
+		"best_known_slot", cs.bestKnownGenesisSlotLocked(),
+		"genesis_window_slots", cs.genesisWindowSlotsLocked(),
+	)
+	return true
 }
 
 // UpdatePeerTip updates the chain tip for a specific peer and triggers
@@ -199,6 +261,7 @@ func (cs *ChainSelector) updatePeerTipObserved(
 	shouldEvaluate := false
 	accepted := true
 	var evictedConn *ouroboros.ConnectionId
+	var modeChanged bool
 
 	func() {
 		cs.mutex.Lock()
@@ -271,6 +334,10 @@ func (cs *ChainSelector) updatePeerTipObserved(
 				observedTip,
 				vrfOutput,
 			)
+			peerTip.recordObservedSlot(
+				observedTip.Point.Slot,
+				cs.genesisWindowSlotsLocked(),
+			)
 		} else {
 			// Evict the least-recently-updated peer if at capacity
 			if len(cs.peerTips) >= cs.maxTrackedPeers {
@@ -288,8 +355,14 @@ func (cs *ChainSelector) updatePeerTipObserved(
 			}
 			peerTip := NewPeerChainTip(connId, tip, vrfOutput)
 			peerTip.ObservedTip = observedTip
+			peerTip.recordObservedSlot(
+				observedTip.Point.Slot,
+				cs.genesisWindowSlotsLocked(),
+			)
 			cs.peerTips[connId] = peerTip
 		}
+
+		modeChanged = cs.advanceSelectionModeLocked()
 
 		cs.config.Logger.Debug(
 			"updated peer tip",
@@ -299,22 +372,33 @@ func (cs *ChainSelector) updatePeerTipObserved(
 		)
 
 		// Check if this peer's tip is better than the current best peer's tip
-		if cs.bestPeerConn != nil {
+		if modeChanged {
+			shouldEvaluate = true
+		} else if cs.bestPeerConn != nil {
 			if bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]; ok {
-				comparison := CompareChains(
-					cs.peerTips[connId].SelectionTip(),
-					bestPeerTip.SelectionTip(),
-				)
-				if comparison == ChainABetter {
-					shouldEvaluate = true
-				} else if comparison == ChainEqual &&
-					cs.comparePeerTips(
+				if cs.mode == SelectionModeGenesis {
+					shouldEvaluate = cs.comparePeerTips(
 						connId,
 						cs.peerTips[connId],
 						*cs.bestPeerConn,
 						bestPeerTip,
-					) == ChainABetter {
-					shouldEvaluate = true
+					) == ChainABetter
+				} else {
+					comparison := CompareChains(
+						cs.peerTips[connId].SelectionTip(),
+						bestPeerTip.SelectionTip(),
+					)
+					if comparison == ChainABetter {
+						shouldEvaluate = true
+					} else if comparison == ChainEqual &&
+						cs.comparePeerTips(
+							connId,
+							cs.peerTips[connId],
+							*cs.bestPeerConn,
+							bestPeerTip,
+						) == ChainABetter {
+						shouldEvaluate = true
+					}
 				}
 			}
 		} else {
@@ -499,18 +583,42 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 
 // SetLocalTip updates the local chain tip for comparison.
 func (cs *ChainSelector) SetLocalTip(tip ochainsync.Tip) {
+	shouldEvaluate := false
 	cs.mutex.Lock()
-	defer cs.mutex.Unlock()
 	cs.localTip = tip
+	shouldEvaluate = cs.advanceSelectionModeLocked()
+	cs.mutex.Unlock()
+	if shouldEvaluate {
+		cs.EvaluateAndSwitch()
+	}
 }
 
 // SetSecurityParam updates the security parameter (k) dynamically.
 // This allows the selector to use protocol parameters for density-based
 // comparison.
 func (cs *ChainSelector) SetSecurityParam(k uint64) {
+	shouldEvaluate := false
 	cs.mutex.Lock()
-	defer cs.mutex.Unlock()
 	cs.securityParam = k
+	shouldEvaluate = cs.advanceSelectionModeLocked()
+	cs.mutex.Unlock()
+	if shouldEvaluate {
+		cs.EvaluateAndSwitch()
+	}
+}
+
+// SelectionMode returns the selector's current mode.
+func (cs *ChainSelector) SelectionMode() SelectionMode {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return cs.mode
+}
+
+// GenesisWindowSlots returns the slot window used for Genesis density checks.
+func (cs *ChainSelector) GenesisWindowSlots() uint64 {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return cs.genesisWindowSlotsLocked()
 }
 
 // GetBestPeer returns the connection ID of the peer with the best chain, or
@@ -537,6 +645,10 @@ func (cs *ChainSelector) GetPeerTip(
 		tipCopy.VRFOutput = make([]byte, len(pt.VRFOutput))
 		copy(tipCopy.VRFOutput, pt.VRFOutput)
 	}
+	if len(pt.observedSlots) > 0 {
+		tipCopy.observedSlots = make([]uint64, len(pt.observedSlots))
+		copy(tipCopy.observedSlots, pt.observedSlots)
+	}
 	return &tipCopy
 }
 
@@ -553,6 +665,10 @@ func (cs *ChainSelector) GetAllPeerTips() map[ouroboros.ConnectionId]*PeerChainT
 		if v.VRFOutput != nil {
 			tipCopy.VRFOutput = make([]byte, len(v.VRFOutput))
 			copy(tipCopy.VRFOutput, v.VRFOutput)
+		}
+		if len(v.observedSlots) > 0 {
+			tipCopy.observedSlots = make([]uint64, len(v.observedSlots))
+			copy(tipCopy.observedSlots, v.observedSlots)
 		}
 		result[k] = &tipCopy
 	}
@@ -651,6 +767,7 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 }
 
 func (cs *ChainSelector) selectBestChainLocked() *ouroboros.ConnectionId {
+	cs.advanceSelectionModeLocked()
 	if len(cs.peerTips) == 0 {
 		return nil
 	}
@@ -738,6 +855,31 @@ func (cs *ChainSelector) comparePeerTips(
 	if peerTipA == nil || peerTipB == nil {
 		return ChainComparisonUnknown
 	}
+	if cs.mode == SelectionModeGenesis {
+		genesisWindow := cs.genesisWindowSlotsLocked()
+		densityA := peerTipA.observedDensity(genesisWindow)
+		densityB := peerTipB.observedDensity(genesisWindow)
+		if densityA > densityB {
+			return ChainABetter
+		}
+		if densityB > densityA {
+			return ChainBBetter
+		}
+	}
+	return cs.comparePeerTipsPraos(
+		connIdA,
+		peerTipA,
+		connIdB,
+		peerTipB,
+	)
+}
+
+func (cs *ChainSelector) comparePeerTipsPraos(
+	connIdA ouroboros.ConnectionId,
+	peerTipA *PeerChainTip,
+	connIdB ouroboros.ConnectionId,
+	peerTipB *PeerChainTip,
+) ChainComparisonResult {
 	comparison := CompareChains(
 		peerTipA.SelectionTip(),
 		peerTipB.SelectionTip(),

--- a/config.go
+++ b/config.go
@@ -116,11 +116,14 @@ type Config struct {
 	// defaultLedgerPeerTarget, positive = target)
 	ledgerPeerTarget int
 	// Peer governor tuning (0 = use default)
-	minHotPeers         int
-	reconcileInterval   time.Duration
-	inactivityTimeout   time.Duration
-	maxConnectionsPerIP int
-	maxInboundConns     int
+	minHotPeers                          int
+	reconcileInterval                    time.Duration
+	inactivityTimeout                    time.Duration
+	bootstrapPromotionMinDiversityGroups int
+	maxConnectionsPerIP                  int
+	maxInboundConns                      int
+	genesisBootstrap                     bool
+	genesisWindowSlots                   uint64
 	// Block production configuration (SPO mode)
 	// Field names match cardano-node environment variable naming convention
 	blockProducer                 bool
@@ -363,7 +366,8 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 	c := Config{
 		// Default logger will throw away logs
 		// We do this so we don't have to add guards around every log operation
-		logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		genesisBootstrap: true,
 	}
 	// Apply options
 	for _, opt := range opts {
@@ -628,6 +632,15 @@ func WithMinHotPeers(n int) ConfigOptionFunc {
 	}
 }
 
+// WithBootstrapPromotionMinDiversityGroups sets the minimum number of
+// bootstrap-time peer diversity groups to prefer before falling back to pure
+// score ordering. Non-positive values use the peer-governor default.
+func WithBootstrapPromotionMinDiversityGroups(n int) ConfigOptionFunc {
+	return func(c *Config) {
+		c.bootstrapPromotionMinDiversityGroups = n
+	}
+}
+
 // WithReconcileInterval specifies how often the peer governor runs its
 // reconciliation loop. Non-positive values are ignored. Default: 5m.
 func WithReconcileInterval(d time.Duration) ConfigOptionFunc {
@@ -665,6 +678,24 @@ func WithMaxInboundConns(n int) ConfigOptionFunc {
 		if n > 0 {
 			c.maxInboundConns = n
 		}
+	}
+}
+
+// WithGenesisBootstrap enables Genesis-mode chain selection during from-origin
+// bootstrap. Genesis mode automatically exits once the local tip is within the
+// configured Genesis window of the best known peer tip.
+func WithGenesisBootstrap(enabled bool) ConfigOptionFunc {
+	return func(c *Config) {
+		c.genesisBootstrap = enabled
+	}
+}
+
+// WithGenesisWindowSlots overrides the Genesis density comparison window.
+// A zero value lets the node derive the window from Shelley genesis parameters
+// using 3k/f.
+func WithGenesisWindowSlots(slots uint64) ConfigOptionFunc {
+	return func(c *Config) {
+		c.genesisWindowSlots = slots
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -389,16 +389,40 @@ func (n *Node) Run(ctx context.Context) error {
 		n.chainsyncState.HandleClientRemoveRequestedEvent,
 	)
 	// Initialize chain selector for multi-peer chain selection
+	chainSelectorSecurityParam := uint64(0)
+	if k := n.ledgerState.SecurityParam(); k > 0 {
+		chainSelectorSecurityParam = uint64(k) //nolint:gosec
+	}
+	genesisWindowSlots := n.config.genesisWindowSlots
+	if genesisWindowSlots == 0 {
+		genesisWindowSlots = chainselection.GenesisWindowSlotsForParams(
+			chainSelectorSecurityParam,
+			n.ledgerState.ActiveSlotCoeff(),
+		)
+	}
+	genesisSelectionMode := n.config.genesisBootstrap &&
+		!n.config.intersectTip &&
+		len(n.config.intersectPoints) == 0
 	n.chainSelector = chainselection.NewChainSelector(
 		chainselection.ChainSelectorConfig{
-			Logger:   n.config.logger,
-			EventBus: n.eventBus,
+			Logger:             n.config.logger,
+			EventBus:           n.eventBus,
+			SecurityParam:      chainSelectorSecurityParam,
+			GenesisMode:        genesisSelectionMode,
+			GenesisWindowSlots: genesisWindowSlots,
 			ConnectionLive: func(connId ouroboros.ConnectionId) bool {
 				return n.connManager != nil &&
 					n.connManager.GetConnectionById(connId) != nil
 			},
 		},
 	)
+	if genesisSelectionMode {
+		n.config.logger.Info(
+			"Genesis chain selection enabled",
+			"genesis_window_slots", genesisWindowSlots,
+			"security_param", chainSelectorSecurityParam,
+		)
+	}
 	// Subscribe chain selector to peer tip update events
 	n.eventBus.SubscribeFunc(
 		chainselection.PeerTipUpdateEventType,
@@ -521,25 +545,26 @@ func (n *Node) Run(ctx context.Context) error {
 
 	n.peerGov = peergov.NewPeerGovernor(
 		peergov.PeerGovernorConfig{
-			Logger:                         n.config.logger,
-			EventBus:                       n.eventBus,
-			ConnManager:                    n.connManager,
-			DisableOutbound:                n.config.isDevMode(),
-			PromRegistry:                   n.config.promRegistry,
-			PeerRequestFunc:                n.ouroboros.RequestPeersFromPeer,
-			LedgerPeerProvider:             ledgerPeerProvider,
-			UseLedgerAfterSlot:             useLedgerAfterSlot,
-			LedgerPeerTarget:               n.config.ledgerPeerTarget,
-			TargetNumberOfKnownPeers:       n.config.targetNumberOfKnownPeers,
-			TargetNumberOfEstablishedPeers: n.config.targetNumberOfEstablishedPeers,
-			TargetNumberOfActivePeers:      n.config.targetNumberOfActivePeers,
-			ActivePeersTopologyQuota:       n.config.activePeersTopologyQuota,
-			ActivePeersGossipQuota:         n.config.activePeersGossipQuota,
-			ActivePeersLedgerQuota:         n.config.activePeersLedgerQuota,
-			MinHotPeers:                    n.config.minHotPeers,
-			ReconcileInterval:              n.config.reconcileInterval,
-			InactivityTimeout:              n.config.inactivityTimeout,
-			SyncProgressProvider:           n.ledgerState,
+			Logger:                               n.config.logger,
+			EventBus:                             n.eventBus,
+			ConnManager:                          n.connManager,
+			DisableOutbound:                      n.config.isDevMode(),
+			PromRegistry:                         n.config.promRegistry,
+			PeerRequestFunc:                      n.ouroboros.RequestPeersFromPeer,
+			LedgerPeerProvider:                   ledgerPeerProvider,
+			UseLedgerAfterSlot:                   useLedgerAfterSlot,
+			LedgerPeerTarget:                     n.config.ledgerPeerTarget,
+			TargetNumberOfKnownPeers:             n.config.targetNumberOfKnownPeers,
+			TargetNumberOfEstablishedPeers:       n.config.targetNumberOfEstablishedPeers,
+			TargetNumberOfActivePeers:            n.config.targetNumberOfActivePeers,
+			ActivePeersTopologyQuota:             n.config.activePeersTopologyQuota,
+			ActivePeersGossipQuota:               n.config.activePeersGossipQuota,
+			ActivePeersLedgerQuota:               n.config.activePeersLedgerQuota,
+			MinHotPeers:                          n.config.minHotPeers,
+			ReconcileInterval:                    n.config.reconcileInterval,
+			InactivityTimeout:                    n.config.inactivityTimeout,
+			SyncProgressProvider:                 n.ledgerState,
+			BootstrapPromotionMinDiversityGroups: n.config.bootstrapPromotionMinDiversityGroups,
 		},
 	)
 	n.ouroboros.PeerGov = n.peerGov

--- a/peergov/bootstrap_selection.go
+++ b/peergov/bootstrap_selection.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"net"
+	"strings"
+)
+
+func (p *PeerGovernor) bootstrapPromotionEnabled() bool {
+	return p.config.BootstrapPromotionEnabled == nil ||
+		*p.config.BootstrapPromotionEnabled
+}
+
+func (p *PeerGovernor) bootstrapPromotionMinDiversityGroups() int {
+	if p.config.BootstrapPromotionMinDiversityGroups <= 0 {
+		return defaultBootstrapPromotionMinDiversityGroups
+	}
+	return p.config.BootstrapPromotionMinDiversityGroups
+}
+
+// isBootstrapPromotionHistoricalPeer returns true for topology peers that are
+// likely to have historical chain data available during bootstrap.
+func (p *PeerGovernor) isBootstrapPromotionHistoricalPeer(peer *Peer) bool {
+	return peer != nil && p.isTopologyPeer(peer.Source)
+}
+
+// peerDiversityGroup derives a group label used to diversify hot promotions.
+// Topology peers use their configured GroupID. Other peers fall back to an IP
+// prefix or a normalized hostname.
+func (p *PeerGovernor) peerDiversityGroup(peer *Peer) string {
+	if peer == nil {
+		return ""
+	}
+	if peer.GroupID != "" {
+		return "group:" + peer.GroupID
+	}
+
+	address := peer.NormalizedAddress
+	if address == "" {
+		address = peer.Address
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	host = strings.ToLower(host)
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "host:" + host
+	}
+
+	if v4 := ip.To4(); v4 != nil {
+		masked := v4.Mask(net.CIDRMask(24, 32))
+		return "ipv4:" + masked.String() + "/24"
+	}
+
+	masked := ip.Mask(net.CIDRMask(64, 128))
+	if masked == nil {
+		return "ipv6:" + ip.String()
+	}
+	return "ipv6:" + masked.String() + "/64"
+}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -63,9 +63,10 @@ const (
 	defaultInboundMinTenure         = 10 * time.Minute
 
 	// Default bootstrap exit configuration
-	defaultMinLedgerPeersForExit     = 5
-	defaultSyncProgressForExit       = 0.95 // 95%
-	defaultBootstrapRecoveryCooldown = 2 * time.Minute
+	defaultMinLedgerPeersForExit                = 5
+	defaultSyncProgressForExit                  = 0.95 // 95%
+	defaultBootstrapRecoveryCooldown            = 2 * time.Minute
+	defaultBootstrapPromotionMinDiversityGroups = 2
 )
 
 const (
@@ -166,6 +167,12 @@ type PeerGovernorConfig struct {
 	AutoBootstrapRecovery     *bool                // Re-enable bootstrap if hot peers drop too low (nil = default true)
 	BootstrapRecoveryCooldown time.Duration        // Minimum time to wait after bootstrap exit before recovery
 	SyncProgressProvider      SyncProgressProvider // Provider for current sync progress
+
+	// Bootstrap promotion configuration
+	// While bootstrap is active, prefer historical topology peers and
+	// diversify hot promotion across multiple peer groups.
+	BootstrapPromotionEnabled            *bool // nil = default true
+	BootstrapPromotionMinDiversityGroups int   // 0 = default 2
 }
 
 // pendingEvent holds an event to publish after releasing locks.
@@ -275,6 +282,13 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	// AutoBootstrapRecovery: nil means use default (true), explicit false disables
 	if cfg.BootstrapRecoveryCooldown <= 0 {
 		cfg.BootstrapRecoveryCooldown = defaultBootstrapRecoveryCooldown
+	}
+	if cfg.BootstrapPromotionEnabled == nil {
+		b := true
+		cfg.BootstrapPromotionEnabled = &b
+	}
+	if cfg.BootstrapPromotionMinDiversityGroups <= 0 {
+		cfg.BootstrapPromotionMinDiversityGroups = defaultBootstrapPromotionMinDiversityGroups
 	}
 	cfg.Logger = cfg.Logger.With("component", "peergov")
 	p := &PeerGovernor{

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -155,6 +155,13 @@ func TestNewPeerGovernor(t *testing.T) {
 				tt.expected.BootstrapRecoveryCooldown,
 				pg.config.BootstrapRecoveryCooldown,
 			)
+			assert.NotNil(t, pg.config.BootstrapPromotionEnabled)
+			assert.True(t, *pg.config.BootstrapPromotionEnabled)
+			assert.Equal(
+				t,
+				defaultBootstrapPromotionMinDiversityGroups,
+				pg.config.BootstrapPromotionMinDiversityGroups,
+			)
 			assert.NotNil(t, pg.config.Logger)
 		})
 	}
@@ -3846,6 +3853,154 @@ func TestPeerGovernor_ReconcilePromotion_ValencyAware(t *testing.T) {
 		group2Hot,
 		"at-valency group should not get more promotions",
 	)
+}
+
+func TestPeerGovernor_ReconcilePromotion_PrefersHistoricalBootstrapPeers(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               1,
+		TargetNumberOfActivePeers: 1,
+	})
+
+	pg.peers = []*Peer{
+		{
+			Address:          "44.0.0.1:3001",
+			Source:           PeerSourceTopologyBootstrapPeer,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.10,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+		{
+			Address:          "44.0.0.2:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.90,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.reconcile(t.Context())
+
+	var bootstrapPeer *Peer
+	var gossipPeer *Peer
+	for _, peer := range pg.peers {
+		switch peer.Source {
+		case PeerSourceTopologyBootstrapPeer:
+			bootstrapPeer = peer
+		case PeerSourceP2PGossip:
+			gossipPeer = peer
+		}
+	}
+
+	assert.NotNil(t, bootstrapPeer)
+	assert.NotNil(t, gossipPeer)
+	assert.Equal(t, PeerStateHot, bootstrapPeer.State)
+	assert.NotEqual(t, PeerStateHot, gossipPeer.State)
+}
+
+func TestPeerGovernor_ReconcilePromotion_DiversifiesBootstrapPeers(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               2,
+		TargetNumberOfActivePeers: 2,
+	})
+
+	pg.peers = []*Peer{
+		{
+			Address:          "44.0.0.1:3001",
+			Source:           PeerSourceTopologyPublicRoot,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.90,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+		{
+			Address:          "44.0.0.2:3001",
+			Source:           PeerSourceTopologyPublicRoot,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.80,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+		{
+			Address:          "44.0.1.1:3001",
+			Source:           PeerSourceTopologyPublicRoot,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.10,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.reconcile(t.Context())
+
+	groupCounts := make(map[string]int)
+	hotCount := 0
+	for _, peer := range pg.peers {
+		if peer.State != PeerStateHot {
+			continue
+		}
+		hotCount++
+		groupCounts[pg.peerDiversityGroup(peer)]++
+	}
+
+	assert.Equal(t, 2, hotCount)
+	assert.Len(t, groupCounts, 2)
+	for group, count := range groupCounts {
+		assert.Equalf(
+			t,
+			1,
+			count,
+			"group %s should only contribute one hot peer",
+			group,
+		)
+	}
+}
+
+func TestPeerGovernor_ReconcilePromotion_IgnoresBootstrapBiasAfterExit(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               1,
+		TargetNumberOfActivePeers: 1,
+	})
+
+	pg.mu.Lock()
+	pg.bootstrapExited = true
+	pg.mu.Unlock()
+
+	pg.peers = []*Peer{
+		{
+			Address:          "44.0.0.1:3001",
+			Source:           PeerSourceTopologyBootstrapPeer,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.10,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+		{
+			Address:          "44.0.0.2:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateWarm,
+			PerformanceScore: 0.90,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.reconcile(t.Context())
+
+	var bootstrapPeer *Peer
+	var gossipPeer *Peer
+	for _, peer := range pg.peers {
+		switch peer.Source {
+		case PeerSourceTopologyBootstrapPeer:
+			bootstrapPeer = peer
+		case PeerSourceP2PGossip:
+			gossipPeer = peer
+		}
+	}
+
+	assert.NotNil(t, bootstrapPeer)
+	assert.NotNil(t, gossipPeer)
+	assert.NotEqual(t, PeerStateHot, bootstrapPeer.State)
+	assert.Equal(t, PeerStateHot, gossipPeer.State)
 }
 
 // TestPeerGovernor_InboundConfig_DefaultValues tests that default values

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -170,11 +170,11 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 		if refillTarget <= 0 {
 			refillTarget = p.config.MinHotPeers
 		}
-		// Score-based selection: collect warm peers with connections, compute scores,
-		// sort by valency priority then score, and promote top N to reach the refill target.
 		type promotionCandidate struct {
-			peer         *Peer
-			underValency bool
+			peer           *Peer
+			underValency   bool
+			historical     bool
+			diversityGroup string
 		}
 		candidates := make([]promotionCandidate, 0, len(p.peers))
 		for _, peer := range p.peers {
@@ -185,7 +185,11 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 					continue
 				}
 				peer.UpdatePeerScore()
-				candidates = append(candidates, promotionCandidate{peer: peer})
+				candidates = append(candidates, promotionCandidate{
+					peer:           peer,
+					historical:     p.isBootstrapPromotionHistoricalPeer(peer),
+					diversityGroup: p.peerDiversityGroup(peer),
+				})
 			}
 		}
 
@@ -198,18 +202,54 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 			)
 		}
 
-		// Comparator: under-valency groups first, then by score descending
-		rankCandidates := func(a, b promotionCandidate) int {
-			if a.underValency && !b.underValency {
-				return -1
+		bootstrapPromotion := !p.bootstrapExited &&
+			p.bootstrapPromotionEnabled()
+		selectedGroups := make(map[string]struct{})
+		if bootstrapPromotion {
+			for _, peer := range p.peers {
+				if peer == nil || peer.State != PeerStateHot {
+					continue
+				}
+				if diversityGroup := p.peerDiversityGroup(peer); diversityGroup != "" {
+					selectedGroups[diversityGroup] = struct{}{}
+				}
 			}
-			if !a.underValency && b.underValency {
+		}
+
+		rankCandidates := func(a, b promotionCandidate) int {
+			if bootstrapPromotion {
+				if a.historical != b.historical {
+					if a.historical {
+						return -1
+					}
+					return 1
+				}
+				if len(selectedGroups) < p.bootstrapPromotionMinDiversityGroups() {
+					_, aSeen := selectedGroups[a.diversityGroup]
+					_, bSeen := selectedGroups[b.diversityGroup]
+					aNew := a.diversityGroup != "" && !aSeen
+					bNew := b.diversityGroup != "" && !bSeen
+					if aNew != bNew {
+						if aNew {
+							return -1
+						}
+						return 1
+					}
+				}
+			}
+			if a.underValency != b.underValency {
+				if a.underValency {
+					return -1
+				}
 				return 1
 			}
-			return cmp.Compare(
-				b.peer.PerformanceScore,
-				a.peer.PerformanceScore,
-			)
+			if a.peer.PerformanceScore != b.peer.PerformanceScore {
+				return cmp.Compare(
+					b.peer.PerformanceScore,
+					a.peer.PerformanceScore,
+				)
+			}
+			return cmp.Compare(a.peer.Address, b.peer.Address)
 		}
 
 		// Initial sort
@@ -241,6 +281,9 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 			warmPromotions++
 			activeIncreased++
 			promoted++
+			if bootstrapPromotion && candidates[i].diversityGroup != "" {
+				selectedGroups[candidates[i].diversityGroup] = struct{}{}
+			}
 			// Update group counts after promotion
 			if gc, exists := groups[peer.GroupID]; exists {
 				gc.Hot++


### PR DESCRIPTION
This is the initial framework for issue #1858 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ouroboros Genesis chain selection to improve bootstrap reliability and speed. During bootstrap the node prefers observed density over a rolling slot window, then automatically falls back to Praos once the local tip is close to the best peer tip (addresses #1858).

- **New Features**
  - `chainselection`
    - Genesis mode with observed-density comparison over a slot window (default from genesis params: 3k/f; overridable).
    - Tracks each peer’s recently observed slots; exits Genesis when local tip + window ≥ best known peer slot.
    - New APIs: `SelectionMode()`, `GenesisWindowSlots()`. Mode advances on local tip or security param changes.
  - Config and Node
    - Options: `WithGenesisBootstrap(enabled)`, `WithGenesisWindowSlots(slots)`. Genesis bootstrap enabled by default when starting from origin (no intersect).
    - Window auto-computed from Shelley genesis parameters when not set and passed into the selector at startup.
  - `peergov`
    - Bootstrap promotion bias: prefer historical topology peers and diversify hot promotions across peer “diversity groups” (group ID, IPv4 /24, IPv6 /64, or hostname) until a small threshold is met.
    - Tuning: `WithBootstrapPromotionMinDiversityGroups(n)` (default 2). Bias applies only during bootstrap; normal scoring resumes after exit.

- **Migration**
  - No action required. Genesis mode is on by default for from-origin sync and exits automatically.
  - To disable: `WithGenesisBootstrap(false)`. To change the density window: `WithGenesisWindowSlots(slots)`.
  - Optional: tune bootstrap promotion diversity with `WithBootstrapPromotionMinDiversityGroups(n)`.

<sup>Written for commit ef40765037466dc7ce274e61f5023fa1c26f81cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

