### PR TITLE
fix(ledger): emit LedgerErrorEvent when rollback tx undo decode fails

### DIFF
--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -59,10 +60,31 @@ func (ls *LedgerState) emitTransactionRollbackEvents(
 	for _, block := range rollbackEvt.RolledBackBlocks {
 		blk, err := block.Decode()
 		if err != nil {
-			ls.config.Logger.Warn(
-				fmt.Sprintf(
-					"ledger: failed to decode block for undo events: %s",
-					err,
+			blockPoint := ocommon.Point{
+				Slot: block.Slot,
+				Hash: block.Hash,
+			}
+			decodeErr := fmt.Errorf(
+				"decode rolled-back block for tx undo events: %w",
+				err,
+			)
+			ls.config.Logger.Error(
+				"failed to decode block for rollback tx undo events",
+				"component", "ledger",
+				"error", decodeErr,
+				"slot", block.Slot,
+				"hash", hex.EncodeToString(block.Hash),
+				"block_number", block.Number,
+			)
+			ls.config.EventBus.Publish(
+				LedgerErrorEventType,
+				event.NewEvent(
+					LedgerErrorEventType,
+					LedgerErrorEvent{
+						Error:     decodeErr,
+						Operation: "rollback_tx_undo_decode",
+						Point:     blockPoint,
+					},
 				),
 			)
 			continue

--- a/ledger/block_event_test.go
+++ b/ledger/block_event_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmitTransactionRollbackEvents_decodeFailureEmitsLedgerErrorPerBlock(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+
+	subID, errCh := bus.Subscribe(LedgerErrorEventType)
+	require.NotEqual(t, event.EventSubscriberId(0), subID)
+	require.NotNil(t, errCh)
+	t.Cleanup(func() {
+		bus.Unsubscribe(LedgerErrorEventType, subID)
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   logger,
+		},
+	}
+	ls.rollbackWG.Add(1)
+
+	rollbackEvt := chain.ChainRollbackEvent{
+		RolledBackBlocks: []models.Block{
+			{
+				Slot:   100,
+				Hash:   []byte{0x01, 0x02},
+				Number: 10,
+				Type:   0,
+				Cbor:   []byte{0xff},
+			},
+			{
+				Slot:   200,
+				Hash:   []byte{0x03, 0x04},
+				Number: 20,
+				Type:   0,
+				Cbor:   []byte{0xfe},
+			},
+		},
+	}
+
+	ls.emitTransactionRollbackEvents(rollbackEvt)
+
+	for i, wantSlot := range []uint64{100, 200} {
+		select {
+		case evt := <-errCh:
+			le, ok := evt.Data.(LedgerErrorEvent)
+			require.True(t, ok, "event %d type", i)
+			require.Equal(t, "rollback_tx_undo_decode", le.Operation)
+			require.Equal(t, wantSlot, le.Point.Slot)
+			require.Error(t, le.Error)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for ledger error event %d", i)
+		}
+	}
+}

--- a/ledger/block_event_test.go
+++ b/ledger/block_event_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,15 +74,16 @@ func TestEmitTransactionRollbackEvents_decodeFailureEmitsLedgerErrorPerBlock(
 	ls.emitTransactionRollbackEvents(rollbackEvt)
 
 	for i, wantSlot := range []uint64{100, 200} {
-		select {
-		case evt := <-errCh:
-			le, ok := evt.Data.(LedgerErrorEvent)
-			require.True(t, ok, "event %d type", i)
-			require.Equal(t, "rollback_tx_undo_decode", le.Operation)
-			require.Equal(t, wantSlot, le.Point.Slot)
-			require.Error(t, le.Error)
-		case <-time.After(2 * time.Second):
-			t.Fatalf("timeout waiting for ledger error event %d", i)
-		}
+		evt := testutil.RequireReceive(
+			t,
+			errCh,
+			2*time.Second,
+			fmt.Sprintf("ledger error event %d (want slot %d)", i, wantSlot),
+		)
+		le, ok := evt.Data.(LedgerErrorEvent)
+		require.True(t, ok, "event %d type", i)
+		require.Equal(t, "rollback_tx_undo_decode", le.Operation)
+		require.Equal(t, wantSlot, le.Point.Slot)
+		require.Error(t, le.Error)
 	}
 }


### PR DESCRIPTION
Closes #1518 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a `LedgerErrorEvent` when decoding a rolled-back block fails during transaction undo, and log structured error details for easier troubleshooting. Adds a test to confirm one error event is emitted per failed block.

- **Bug Fixes**
  - Publish `LedgerErrorEvent` with `operation: rollback_tx_undo_decode` and `Point` (slot, hash) on decode failure.
  - Log at error level with `component=ledger`, wrapped error, slot, hex-encoded hash (`encoding/hex`), and block number.
  - Add test to verify an error event is emitted per failed rolled-back block and includes the expected operation and slot.

<sup>Written for commit ed50c07c53e894cc00f39042bfe61cbbc1ae27af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error tracking and reporting for block rollback operations with structured logging of decode failures and event-based error emission, providing better observability of transaction rollback issues.

* **Tests**
  * Added comprehensive test coverage for block rollback event error handling, including validation of proper error reporting during decode failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->