### PR TITLE
ci(go): update test labels for non-Linux

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -99,7 +99,7 @@ jobs:
 
   # macOS and Windows jobs without Postgres service
   go-test-other:
-    name: go-test (${{ matrix.platform }})
+    name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
     strategy:
       matrix:
         go-version: [1.25.x, 1.26.x]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include the Go version in macOS and Windows `go-test` job names in GitHub Actions so CI labels clearly show both platform and Go version.

<sup>Written for commit b4f2d5808e8f1b3674e12463817e9564feee316b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

