### PR TITLE
fix(ledger): add stake snapshot and leader observability metrics

### DIFF
--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/blinklabs-io/dingo/event"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // StakeDistributionProvider provides stake distribution data for leader election.
@@ -94,6 +96,7 @@ type Election struct {
 	computeCh      chan uint64   // requests background schedule computation
 	subscriptionId event.EventSubscriberId
 	nonceReadySub  event.EventSubscriberId
+	metrics        *electionMetrics
 }
 
 // NewElection creates a new leader election manager for a stake pool.
@@ -123,6 +126,18 @@ func (e *Election) SetScheduleStore(store ScheduleStore) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.scheduleStore = store
+}
+
+// SetPromRegistry enables leader election metrics.
+func (e *Election) SetPromRegistry(reg prometheus.Registerer) {
+	if reg == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.metrics == nil {
+		e.metrics = initElectionMetrics(reg)
+	}
 }
 
 // Start begins listening for epoch transitions and maintaining schedules.
@@ -572,8 +587,12 @@ func (e *Election) computeSchedule(
 	snapshotEpoch := scheduleSnapshotEpoch(currentEpoch)
 
 	// Get pool stake from Go snapshot
+	stakeLookupStart := time.Now()
 	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
 	if err != nil {
+		if e.metrics != nil {
+			e.metrics.stakeLookupDuration.Observe(time.Since(stakeLookupStart).Seconds())
+		}
 		return nil, fmt.Errorf("get pool stake: %w", err)
 	}
 
@@ -596,6 +615,9 @@ func (e *Election) computeSchedule(
 
 	// Get total stake from Go snapshot
 	totalStake, err := e.stakeProvider.GetTotalActiveStake(snapshotEpoch)
+	if e.metrics != nil {
+		e.metrics.stakeLookupDuration.Observe(time.Since(stakeLookupStart).Seconds())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("get total stake: %w", err)
 	}
@@ -631,6 +653,7 @@ func (e *Election) computeSchedule(
 		e.epochProvider.SlotsPerEpoch(),
 	)
 
+	vrfEvalStart := time.Now()
 	schedule, err := calc.CalculateSchedule(
 		currentEpoch,
 		e.poolId,
@@ -639,6 +662,9 @@ func (e *Election) computeSchedule(
 		totalStake,
 		epochNonce,
 	)
+	if e.metrics != nil {
+		e.metrics.vrfEvalDurationSeconds.Observe(time.Since(vrfEvalStart).Seconds())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("calculate schedule: %w", err)
 	}
@@ -654,6 +680,21 @@ func (e *Election) computeSchedule(
 		"leader_slots", schedule.SlotCount(),
 		"leader_slot_list", schedule.LeaderSlotsSnapshot(),
 	)
+	if e.metrics != nil {
+		slotsChecked := e.epochProvider.SlotsPerEpoch()
+		slotsWon := uint64(schedule.SlotCount()) // #nosec G115 -- SlotCount() is bounded by slots-per-epoch on this network
+		slotsNotWon := uint64(0)
+		if slotsWon <= slotsChecked {
+			slotsNotWon = slotsChecked - slotsWon
+		}
+		e.metrics.slotChecksTotal.Add(float64(slotsChecked))
+		e.metrics.slotWonTotal.Add(float64(slotsWon))
+		e.metrics.slotNotWonTotal.Add(float64(slotsNotWon))
+		e.metrics.lastEpochSlotsChecked.Set(float64(slotsChecked))
+		e.metrics.lastEpochSlotsWon.Set(float64(slotsWon))
+		e.metrics.lastEpochSlotsNotWon.Set(float64(slotsNotWon))
+		e.metrics.lastEvaluatedEpochNumber.Set(float64(currentEpoch))
+	}
 
 	return schedule, nil
 }

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -682,14 +682,11 @@ func (e *Election) computeSchedule(
 	)
 	if e.metrics != nil {
 		slotsChecked := e.epochProvider.SlotsPerEpoch()
-		slotsWon := uint64(schedule.SlotCount()) // #nosec G115 -- SlotCount() is bounded by slots-per-epoch on this network
+		slotsWon := uint64(len(schedule.LeaderSlotsSnapshot()))
 		slotsNotWon := uint64(0)
 		if slotsWon <= slotsChecked {
 			slotsNotWon = slotsChecked - slotsWon
 		}
-		e.metrics.slotChecksTotal.Add(float64(slotsChecked))
-		e.metrics.slotWonTotal.Add(float64(slotsWon))
-		e.metrics.slotNotWonTotal.Add(float64(slotsNotWon))
 		e.metrics.lastEpochSlotsChecked.Set(float64(slotsChecked))
 		e.metrics.lastEpochSlotsWon.Set(float64(slotsWon))
 		e.metrics.lastEpochSlotsNotWon.Set(float64(slotsNotWon))
@@ -772,7 +769,16 @@ func (e *Election) ShouldProduceBlock(slot uint64) bool {
 		}
 		return false
 	}
-	return schedule.IsLeaderForSlot(slot)
+	isLeader := schedule.IsLeaderForSlot(slot)
+	if e.metrics != nil {
+		e.metrics.slotChecksTotal.Inc()
+		if isLeader {
+			e.metrics.slotWonTotal.Inc()
+		} else {
+			e.metrics.slotNotWonTotal.Inc()
+		}
+	}
+	return isLeader
 }
 
 // CurrentSchedule returns the leader schedule for the current epoch, or nil.

--- a/ledger/leader/metrics.go
+++ b/ledger/leader/metrics.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leader
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type electionMetrics struct {
+	slotChecksTotal          prometheus.Counter
+	slotWonTotal             prometheus.Counter
+	slotNotWonTotal          prometheus.Counter
+	vrfEvalDurationSeconds   prometheus.Histogram
+	stakeLookupDuration      prometheus.Histogram
+	lastEpochSlotsChecked    prometheus.Gauge
+	lastEpochSlotsWon        prometheus.Gauge
+	lastEpochSlotsNotWon     prometheus.Gauge
+	lastEvaluatedEpochNumber prometheus.Gauge
+}
+
+func initElectionMetrics(reg prometheus.Registerer) *electionMetrics {
+	factory := promauto.With(reg)
+	return &electionMetrics{
+		slotChecksTotal: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_leader_slot_checks_total",
+			Help: "number of leader slot checks executed",
+		}),
+		slotWonTotal: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_leader_slot_won_total",
+			Help: "number of leader checks that won a slot",
+		}),
+		slotNotWonTotal: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_leader_slot_not_won_total",
+			Help: "number of leader checks that did not win a slot",
+		}),
+		vrfEvalDurationSeconds: factory.NewHistogram(prometheus.HistogramOpts{
+			Name: "dingo_leader_vrf_eval_duration_seconds",
+			Help: "duration spent evaluating VRF over an epoch schedule",
+			Buckets: prometheus.ExponentialBuckets(
+				0.001, 2, 16,
+			), // 1ms to ~32s
+		}),
+		stakeLookupDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Name: "dingo_leader_stake_lookup_duration_seconds",
+			Help: "duration spent loading stake data for leader schedule computation",
+			Buckets: prometheus.ExponentialBuckets(
+				0.0001, 2, 16,
+			), // 100us to ~3.2s
+		}),
+		lastEpochSlotsChecked: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_leader_last_epoch_slots_checked_int",
+			Help: "slots evaluated in the most recently computed epoch schedule",
+		}),
+		lastEpochSlotsWon: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_leader_last_epoch_slots_won_int",
+			Help: "winning slots in the most recently computed epoch schedule",
+		}),
+		lastEpochSlotsNotWon: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_leader_last_epoch_slots_not_won_int",
+			Help: "non-winning slots in the most recently computed epoch schedule",
+		}),
+		lastEvaluatedEpochNumber: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_leader_last_evaluated_epoch_int",
+			Help: "most recent epoch for which leader schedule was evaluated",
+		}),
+	}
+}

--- a/ledger/leader/metrics.go
+++ b/ledger/leader/metrics.go
@@ -35,45 +35,45 @@ func initElectionMetrics(reg prometheus.Registerer) *electionMetrics {
 	factory := promauto.With(reg)
 	return &electionMetrics{
 		slotChecksTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "dingo_leader_slot_checks_total",
+			Name: "cardano_node_metrics_leader_slot_checks_total",
 			Help: "number of leader slot checks executed",
 		}),
 		slotWonTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "dingo_leader_slot_won_total",
+			Name: "cardano_node_metrics_leader_slot_won_total",
 			Help: "number of leader checks that won a slot",
 		}),
 		slotNotWonTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "dingo_leader_slot_not_won_total",
+			Name: "cardano_node_metrics_leader_slot_not_won_total",
 			Help: "number of leader checks that did not win a slot",
 		}),
 		vrfEvalDurationSeconds: factory.NewHistogram(prometheus.HistogramOpts{
-			Name: "dingo_leader_vrf_eval_duration_seconds",
+			Name: "cardano_node_metrics_leader_vrf_eval_duration_seconds",
 			Help: "duration spent evaluating VRF over an epoch schedule",
 			Buckets: prometheus.ExponentialBuckets(
 				0.001, 2, 16,
 			), // 1ms to ~32s
 		}),
 		stakeLookupDuration: factory.NewHistogram(prometheus.HistogramOpts{
-			Name: "dingo_leader_stake_lookup_duration_seconds",
+			Name: "cardano_node_metrics_leader_stake_lookup_duration_seconds",
 			Help: "duration spent loading stake data for leader schedule computation",
 			Buckets: prometheus.ExponentialBuckets(
 				0.0001, 2, 16,
 			), // 100us to ~3.2s
 		}),
 		lastEpochSlotsChecked: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_leader_last_epoch_slots_checked_int",
+			Name: "cardano_node_metrics_leader_last_epoch_slots_checked_int",
 			Help: "slots evaluated in the most recently computed epoch schedule",
 		}),
 		lastEpochSlotsWon: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_leader_last_epoch_slots_won_int",
+			Name: "cardano_node_metrics_leader_last_epoch_slots_won_int",
 			Help: "winning slots in the most recently computed epoch schedule",
 		}),
 		lastEpochSlotsNotWon: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_leader_last_epoch_slots_not_won_int",
+			Name: "cardano_node_metrics_leader_last_epoch_slots_not_won_int",
 			Help: "non-winning slots in the most recently computed epoch schedule",
 		}),
 		lastEvaluatedEpochNumber: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_leader_last_evaluated_epoch_int",
+			Name: "cardano_node_metrics_leader_last_evaluated_epoch_int",
 			Help: "most recent epoch for which leader schedule was evaluated",
 		}),
 	}

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -349,6 +349,8 @@ func (m *Manager) captureMarkSnapshot(
 func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	start := time.Now()
 	calculator := NewCalculator(m.db)
+	successCount := uint64(0)
+	lastSuccessfulEpoch := uint64(0)
 
 	distribution, err := calculator.CalculateStakeDistribution(ctx, 0)
 	if err != nil {
@@ -433,6 +435,7 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		}
 		return fmt.Errorf("save genesis snapshot: %w", err)
 	}
+	successCount++
 
 	// After Mithril bootstrap: seed the Mark/Set/Go window for the
 	// current epoch so leader election works immediately. Leader
@@ -461,6 +464,10 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 					seedEpoch, err,
 				)
 			}
+			successCount++
+			if seedEpoch > lastSuccessfulEpoch {
+				lastSuccessfulEpoch = seedEpoch
+			}
 			m.logger.Info(
 				"seeded post-Mithril snapshot",
 				"component", "snapshot",
@@ -479,10 +486,10 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	)
 	if m.metrics != nil {
 		m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
-		m.metrics.captureSuccessTotal.Inc()
+		m.metrics.captureSuccessTotal.Add(float64(successCount))
 		m.metrics.capturePoolsTotal.Set(float64(distribution.TotalPools))
 		m.metrics.captureTotalStakeLovelace.Set(float64(distribution.TotalStake))
-		m.metrics.lastSuccessfulEpoch.Set(0)
+		m.metrics.lastSuccessfulEpoch.Set(float64(lastSuccessfulEpoch))
 	}
 	return nil
 }

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Manager handles stake snapshot capture and rotation at epoch boundaries.
@@ -43,6 +45,7 @@ type Manager struct {
 	cancel         context.CancelFunc
 	subscriptionId event.EventSubscriberId
 	loopWg         sync.WaitGroup
+	metrics        *managerMetrics
 }
 
 // NewManager creates a new snapshot manager.
@@ -58,6 +61,18 @@ func NewManager(
 		db:       db,
 		eventBus: eventBus,
 		logger:   logger,
+	}
+}
+
+// SetPromRegistry enables snapshot manager metrics.
+func (m *Manager) SetPromRegistry(reg prometheus.Registerer) {
+	if reg == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.metrics == nil {
+		m.metrics = initManagerMetrics(reg)
 	}
 }
 
@@ -275,6 +290,7 @@ func (m *Manager) captureMarkSnapshot(
 	ctx context.Context,
 	evt event.EpochTransitionEvent,
 ) error {
+	start := time.Now()
 	calculator := NewCalculator(m.db)
 
 	// Calculate stake distribution at the snapshot slot
@@ -283,6 +299,10 @@ func (m *Manager) captureMarkSnapshot(
 		evt.SnapshotSlot,
 	)
 	if err != nil {
+		if m.metrics != nil {
+			m.metrics.captureFailureTotal.Inc()
+			m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		}
 		return fmt.Errorf("calculate stake distribution: %w", err)
 	}
 
@@ -294,7 +314,19 @@ func (m *Manager) captureMarkSnapshot(
 		distribution,
 		evt,
 	); err != nil {
+		if m.metrics != nil {
+			m.metrics.captureFailureTotal.Inc()
+			m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		}
 		return fmt.Errorf("save mark snapshot: %w", err)
+	}
+
+	if m.metrics != nil {
+		m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		m.metrics.captureSuccessTotal.Inc()
+		m.metrics.capturePoolsTotal.Set(float64(len(distribution.PoolStakes)))
+		m.metrics.captureTotalStakeLovelace.Set(float64(distribution.TotalStake))
+		m.metrics.lastSuccessfulEpoch.Set(float64(evt.NewEpoch))
 	}
 
 	m.logger.Info(
@@ -315,10 +347,15 @@ func (m *Manager) captureMarkSnapshot(
 // (epochs N, N-1, N-2) to ensure leader election can find its "Go"
 // snapshot immediately.
 func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
+	start := time.Now()
 	calculator := NewCalculator(m.db)
 
 	distribution, err := calculator.CalculateStakeDistribution(ctx, 0)
 	if err != nil {
+		if m.metrics != nil {
+			m.metrics.captureFailureTotal.Inc()
+			m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		}
 		return fmt.Errorf("calculate genesis distribution: %w", err)
 	}
 
@@ -364,6 +401,9 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	}
 
 	if distribution.TotalPools == 0 {
+		if m.metrics != nil {
+			m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		}
 		m.logger.Info(
 			"no genesis pools; leader election disabled"+
 				" until pool stake is registered",
@@ -387,6 +427,10 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		SnapshotSlot: 0,
 	}
 	if err := m.saveSnapshot(ctx, 0, "mark", distribution, evt); err != nil {
+		if m.metrics != nil {
+			m.metrics.captureFailureTotal.Inc()
+			m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		}
 		return fmt.Errorf("save genesis snapshot: %w", err)
 	}
 
@@ -408,6 +452,10 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 			if err := m.saveSnapshot(
 				ctx, seedEpoch, "mark", distribution, seedEvt,
 			); err != nil {
+				if m.metrics != nil {
+					m.metrics.captureFailureTotal.Inc()
+					m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+				}
 				return fmt.Errorf(
 					"save bootstrap snapshot for epoch %d: %w",
 					seedEpoch, err,
@@ -429,5 +477,12 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		"total_pools", distribution.TotalPools,
 		"total_stake", distribution.TotalStake,
 	)
+	if m.metrics != nil {
+		m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
+		m.metrics.captureSuccessTotal.Inc()
+		m.metrics.capturePoolsTotal.Set(float64(distribution.TotalPools))
+		m.metrics.captureTotalStakeLovelace.Set(float64(distribution.TotalStake))
+		m.metrics.lastSuccessfulEpoch.Set(0)
+	}
 	return nil
 }

--- a/ledger/snapshot/metrics.go
+++ b/ledger/snapshot/metrics.go
@@ -32,30 +32,30 @@ func initManagerMetrics(reg prometheus.Registerer) *managerMetrics {
 	factory := promauto.With(reg)
 	return &managerMetrics{
 		captureDurationSeconds: factory.NewHistogram(prometheus.HistogramOpts{
-			Name: "dingo_snapshot_capture_duration_seconds",
+			Name: "cardano_node_metrics_stake_snapshot_capture_duration_seconds",
 			Help: "duration of stake snapshot capture runs",
 			Buckets: prometheus.ExponentialBuckets(
 				0.001, 2, 16,
 			), // 1ms to ~32s
 		}),
 		captureSuccessTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "dingo_snapshot_capture_success_total",
+			Name: "cardano_node_metrics_stake_snapshot_capture_success_total",
 			Help: "successful stake snapshot captures",
 		}),
 		captureFailureTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "dingo_snapshot_capture_failure_total",
+			Name: "cardano_node_metrics_stake_snapshot_capture_failure_total",
 			Help: "failed stake snapshot captures",
 		}),
 		capturePoolsTotal: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_snapshot_pool_count_int",
+			Name: "cardano_node_metrics_stake_snapshot_pool_count_int",
 			Help: "number of pools in the latest captured snapshot",
 		}),
 		captureTotalStakeLovelace: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_snapshot_total_active_stake_lovelace",
+			Name: "cardano_node_metrics_stake_snapshot_total_active_stake_lovelace",
 			Help: "total active stake in the latest captured snapshot",
 		}),
 		lastSuccessfulEpoch: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "dingo_snapshot_last_successful_epoch_int",
+			Name: "cardano_node_metrics_stake_snapshot_last_successful_epoch_int",
 			Help: "epoch of the latest successful snapshot capture",
 		}),
 	}

--- a/ledger/snapshot/metrics.go
+++ b/ledger/snapshot/metrics.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type managerMetrics struct {
+	captureDurationSeconds    prometheus.Histogram
+	captureSuccessTotal       prometheus.Counter
+	captureFailureTotal       prometheus.Counter
+	capturePoolsTotal         prometheus.Gauge
+	captureTotalStakeLovelace prometheus.Gauge
+	lastSuccessfulEpoch       prometheus.Gauge
+}
+
+func initManagerMetrics(reg prometheus.Registerer) *managerMetrics {
+	factory := promauto.With(reg)
+	return &managerMetrics{
+		captureDurationSeconds: factory.NewHistogram(prometheus.HistogramOpts{
+			Name: "dingo_snapshot_capture_duration_seconds",
+			Help: "duration of stake snapshot capture runs",
+			Buckets: prometheus.ExponentialBuckets(
+				0.001, 2, 16,
+			), // 1ms to ~32s
+		}),
+		captureSuccessTotal: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_snapshot_capture_success_total",
+			Help: "successful stake snapshot captures",
+		}),
+		captureFailureTotal: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_snapshot_capture_failure_total",
+			Help: "failed stake snapshot captures",
+		}),
+		capturePoolsTotal: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_snapshot_pool_count_int",
+			Help: "number of pools in the latest captured snapshot",
+		}),
+		captureTotalStakeLovelace: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_snapshot_total_active_stake_lovelace",
+			Help: "total active stake in the latest captured snapshot",
+		}),
+		lastSuccessfulEpoch: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_snapshot_last_successful_epoch_int",
+			Help: "epoch of the latest successful snapshot capture",
+		}),
+	}
+}

--- a/node.go
+++ b/node.go
@@ -327,6 +327,7 @@ func (n *Node) Run(ctx context.Context) error {
 		n.eventBus,
 		n.config.logger,
 	)
+	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
 	// Capture genesis stake snapshot (epoch 0) so leader election works at epoch 2
 	if err := n.snapshotMgr.CaptureGenesisSnapshot(ctx); err != nil {
 		n.config.logger.Warn(

--- a/node_forging.go
+++ b/node_forging.go
@@ -109,6 +109,7 @@ func (n *Node) initBlockForger(
 		n.eventBus,
 		n.config.logger,
 	)
+	election.SetPromRegistry(n.config.promRegistry)
 	if n.db != nil {
 		if scheduleStore := leader.NewSyncStateScheduleStore(
 			n.db.Metadata(),


### PR DESCRIPTION
Closes #1527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for leader election monitoring, tracking slot evaluation results, VRF computation timing, and stake lookup performance.
  * Added Prometheus metrics for snapshot capture operations, tracking success/failure rates, capture duration, and pool/stake statistics.
  * Integrated metrics collection throughout node startup for enhanced observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus metrics for leader election and stake snapshot capture, wired to `n.config.promRegistry` to improve visibility into schedule computation and snapshot health.

- **New Features**
  - Leader election metrics: counters for slot checks/won/not-won, histograms for VRF evaluation and stake lookup, and gauges for last evaluated epoch and last-epoch slots checked/won/not-won.
  - Snapshot manager metrics: histogram for capture duration, counters for success/failure, and gauges for pool count, total active stake, and last successful epoch; both capture and genesis seeding paths are instrumented.
  - Metrics are enabled only when a Prometheus `Registerer` is provided via `SetPromRegistry(...)` on both the election and snapshot manager.

<sup>Written for commit 4a860c4c89b636ce9e0dcba0502c91d2be79e0fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

