### PR TITLE
ci(antithesis): fix configuration copying in container

### DIFF
--- a/internal/test/antithesis/scripts/configurator.sh
+++ b/internal/test/antithesis/scripts/configurator.sh
@@ -215,5 +215,5 @@ echo "copying utxo keys to /configs/utxo-keys"
 cp -r /tmp/testnet/utxos /configs/utxo-keys
 
 # Copy testnet.yaml to shared volume for analysis/txpump genesis config
-echo "copying testnet.yaml to /configs/testnet.yaml"
-cp /testnet.yaml /configs/testnet.yaml
+echo "copying testnet.yaml to /testnet-config/testnet.yaml"
+cp /testnet.yaml /testnet-config/testnet.yaml

--- a/internal/test/antithesis/scripts/configurator.sh
+++ b/internal/test/antithesis/scripts/configurator.sh
@@ -216,4 +216,6 @@ cp -r /tmp/testnet/utxos /configs/utxo-keys
 
 # Copy testnet.yaml to shared volume for analysis/txpump genesis config
 echo "copying testnet.yaml to /testnet-config/testnet.yaml"
-cp /testnet.yaml /testnet-config/testnet.yaml
+if [ -d /testnet-config ]; then
+    cp /testnet.yaml /testnet-config/testnet.yaml
+fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `testnet.yaml` copy to `/testnet-config/testnet.yaml` and adds checks for the shared mount/file before copying. Prevents `analysis/txpump` from missing the genesis config and avoids CI copy errors.

<sup>Written for commit a652d9b3c969edabab7f6ae4c296bebd9ed4da68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

