### PR TITLE
docs: optimized AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,115 +1,51 @@
 # AGENTS.md
 
-Concise guide for AI agents working with Dingo. For full details, see `ARCHITECTURE.md`.
+Go Cardano node (Ouroboros). See `CLAUDE.md` for detailed rules; this file has additional content (Build/test section, `make golines` in pre-commit, Key events table) and a different structure — the two are related but not exact copies. Package layout, targets, and flags are derivable from `Makefile`, `go.mod`, `node.go`.
 
-## Quick Reference
+## Build / test
 
-**Dingo**: Go-based Cardano blockchain node by Blink Labs (Ouroboros protocol, UTxO tracking, pluggable storage).
-
-```bash
-make              # Format, test, build
-make test         # Tests with race detection
-make bench        # Run benchmarks
-go run ./cmd/dingo/         # Run without building
-go test -v -race -run TestName ./path/to/package/  # Single test
+```
+make              # fmt, test, build
+make test         # tests with -race
+go test -v -race -run TestName ./path/to/pkg/
 ```
 
-## Key Packages
+## Pre-commit
 
-| Package | Purpose |
-|---------|---------|
-| `chain/` | Blockchain state, fork detection, rollback |
-| `chainselection/` | Multi-peer chain comparison (Ouroboros Praos) |
-| `chainsync/` | Block sync state tracking |
-| `connmanager/` | Network connection lifecycle |
-| `database/` | Storage plugins (badger, sqlite, postgres, mysql, gcs, s3) |
-| `event/` | Event bus (async pub/sub, 4 workers) |
-| `ledger/` | UTxO state, protocol params, Plutus execution |
-| `mempool/` | Transaction pool & validation |
-| `ouroboros/` | Protocol handlers (N2N, N2C) |
-| `peergov/` | Peer governance, churn, quotas |
-| `utxorpc/` | UTxO RPC gRPC server |
-
-## Code Quality (Run Before Committing)
-
-```bash
-golangci-lint run ./...    # Linters (39 via .golangci.yml)
-nilaway ./...              # Nil-safety analyzer
-modernize ./...            # Modern Go idioms
-make golines               # 80 char line limit
+```
+golangci-lint run ./...
+nilaway ./...
+modernize ./...
+make golines
 ```
 
-## Essential Patterns
+## Testing rules
 
-### Error Handling
-```go
-// Wrap errors with context
-return fmt.Errorf("failed to process block: %w", err)
-```
+- No `time.Sleep()` for sync — use `internal/test/testutil/` (`WaitForCondition`, `RequireReceive`, `context.WithTimeout`).
+- Integration tests: `internal/integration/` + `database/immutable/testdata/` (real blocks, slots 0–1.3M).
+- Mock fixtures come from `github.com/blinklabs-io/ouroboros-mock` (`fixtures/`, `ledger/`, `conformance/`). Never duplicate mocks inside dingo — extend the shared library so every Blink Labs app (dingo, gouroboros, adder, ...) reuses the same test surface.
 
-### Event-Driven Communication
-```go
-// Subscribe to events (never call components directly)
-eventBus.SubscribeFunc(chain.ChainForkEventType, handler)
-```
+## Non-obvious invariants
 
-### Database Queries
-```go
-// GOOD: Batch fetch (single query)
-db.Where("id IN ?", ids).Find(&records)
+- EventBus for async cross-component notifications: use `event.EventBus.SubscribeFunc()` for block/chain/mempool/peer events. Synchronous state queries between components still use direct method calls.
+- CBOR offsets: UTxOs/txs stored as 52-byte refs (magic `"DOFF"` + slot + hash + offset + length), resolved by `TieredCborCache` (hot → block LRU → cold extract). See `database/cbor_offset.go`.
+- Cert ordering: `Order("added_slot DESC, block_index DESC, cert_index DESC")` — `cert_index` resets per tx, so `block_index` is required to disambiguate across txs in the same block.
+- Rollbacks: delivered on `chain.update` as a `chain.ChainRollbackEvent` payload (no separate `chain.rollback` topic); also subscribe to `chain.fork_detected` for fork metrics. Check `TransactionEvent.Rollback` for undo.
+- Stake snapshots: mark/set/go rotation at epoch boundaries (Praos). `LedgerView.GetStakeDistribution(epoch)` for leader election. Per-pool stake in `PoolStakeSnapshot`; aggregates in `EpochSummary`.
+- Plugins (`database/plugin/`): blob = `badger` | `gcs` | `s3`; metadata = `sqlite` | `mysql` | `postgres`.
 
-// BAD: N+1 queries
-for _, id := range ids {
-    db.Where("id = ?", id).First(&record)
-}
+## Key events
 
-// Certificate ordering: use cert_index as tie-breaker
-Order("added_slot DESC, cert_index DESC")
-```
+| Event | Meaning |
+|---|---|
+| `chain.update` | block added |
+| `chain.fork_detected` | fork |
+| `chainselection.chain_switch` | active peer changed |
+| `epoch.transition` | epoch boundary — triggers stake snapshot |
+| `mempool.add_tx` / `mempool.remove_tx` | tx lifecycle |
+| `connmanager.conn_closed` | connection closed |
+| `peergov.peer_churn` | peer rotation |
 
-### Rollback Handling
-- `Chain.Rollback(point)` emits `ChainRollbackEvent`
-- State restoration in `database/plugin/metadata/sqlite/`
-- Use `TransactionEvent.Rollback` field to detect undo operations
+## Config
 
-### CBOR Storage
-- UTxOs/TXs stored as 52-byte `CborOffset` (magic "DOFF" + slot + hash + offset + length)
-- `TieredCborCache` resolves: hot cache → block LRU → cold extraction
-
-### Stake Snapshots
-- Mark/Set/Go rotation at epoch boundaries (Ouroboros Praos)
-- `LedgerView.GetStakeDistribution(epoch)` for leader election queries
-- `PoolStakeSnapshot` model stores per-pool stake
-- `EpochSummary` stores network aggregates
-
-## Key Event Types
-
-| Event | Purpose |
-|-------|---------|
-| `chain.update` | Block added to chain |
-| `chain.fork-detected` | Fork detected |
-| `chainselection.chain_switch` | Active peer changed |
-| `epoch.transition` | Epoch boundary crossed (triggers stake snapshot) |
-| `mempool.add_tx` / `mempool.remove_tx` | Transaction lifecycle |
-| `connmanager.conn-closed` | Connection lifecycle |
-| `peergov.peer-churn` | Peer rotation |
-
-## Configuration
-
-Priority: CLI flags > Env vars > YAML config > Defaults
-
-Key env vars: `CARDANO_NETWORK`, `CARDANO_DATABASE_PATH`, `DINGO_DATABASE_BLOB_PLUGIN`, `DINGO_DATABASE_METADATA_PLUGIN`
-
-## Critical Anti-Patterns
-
-1. **Don't bypass EventBus** - Components communicate via events, not direct calls
-2. **Don't use N+1 queries** - Batch fetch with `WHERE id IN ?`
-3. **Don't forget cert_index** - Multiple certs in same slot need ordering
-4. **Don't ignore rollbacks** - Check `TransactionEvent.Rollback` field
-5. **Don't skip linting** - Run `golangci-lint`, `nilaway`, `modernize` before commits
-
-## Testing
-
-- Integration tests: `internal/integration/`
-- Test data: `database/immutable/testdata/` (real blocks slots 0-1.3M)
-- Benchmarks: `make bench` (28+ benchmarks)
+Priority: CLI > env > YAML > defaults. Key env vars: `CARDANO_NETWORK`, `CARDANO_DATABASE_PATH`, `DINGO_DATABASE_BLOB_PLUGIN`, `DINGO_DATABASE_METADATA_PLUGIN`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,37 @@
 # CLAUDE.md
 
-Go-based Cardano node implementing Ouroboros. Most of what you need is derivable from code (`Makefile`, `go.mod`, `node.go`, `dingo.yaml.example`). Below is what isn't.
+Go Cardano node (Ouroboros). Derivable info (build targets, flags, package layout) lives in `Makefile`, `go.mod`, `node.go`, `dingo.yaml.example`. This file is only what isn't derivable.
 
-## Testing rules
+## Testing
 
-- **Never use `time.Sleep()` for synchronization.** Use helpers in `internal/test/testutil/`:
-  - `WaitForCondition` / `require.Eventually` for polling (2–5s timeout, 5–10ms interval, lock shared state inside the condition fn)
+- No `time.Sleep()` for sync. Use `internal/test/testutil/`:
+  - `WaitForCondition` / `require.Eventually` — 2–5s timeout, 5–10ms interval, lock shared state inside the condition fn
   - `RequireReceive` / `RequireNoReceive` for channel assertions
-  - `context.WithTimeout` for graceful shutdown — not sleep
-- Race detection is on by default in `make test`.
+  - `context.WithTimeout` for graceful shutdown
+- `make test` runs with `-race`.
 - Integration tests in `internal/integration/` load real blocks from `database/immutable/testdata/`.
+- Mock fixtures come from `github.com/blinklabs-io/ouroboros-mock` (`fixtures/`, `ledger/`, `conformance/`). Never add local ledger/consensus/network mocks — extend the shared library.
 
-## Before committing
+## Pre-commit
 
-```bash
-golangci-lint run ./...   # .golangci.yml configured
+```shell
+golangci-lint run ./...
 nilaway ./...
-modernize ./...           # --fix to auto-apply
+modernize ./...   # --fix to auto-apply
 ```
 
-## Non-obvious architecture
+## Non-obvious invariants
 
-- **CBOR offset storage**: UTxOs/txs store 52-byte `CborOffset` refs (magic `"DOFF"`, slot, hash, offset, length), not full CBOR. Resolved via `TieredCborCache` (hot → block LRU → cold extract from blob store). See `database/cbor_offset.go`, `database/cbor_cache.go`, `database/block_indexer.go`.
-- **Plugins** (`database/plugin/`): blob = `badger` (default) / `gcs` / `s3`; metadata = `sqlite` (default) / `mysql` / `postgres`.
-- **Event bus**: components communicate via `event.EventBus.SubscribeFunc()`, not direct calls.
+- CBOR offsets: UTxOs/txs store 52-byte `CborOffset` refs (magic `"DOFF"` + slot + hash + offset + length), not full CBOR. Resolved via `TieredCborCache` (hot → block LRU → cold blob extract). See `database/cbor_offset.go`, `database/cbor_cache.go`, `database/block_indexer.go`.
+- EventBus for async cross-component notifications: block/chain/mempool/peer events go through `event.EventBus.SubscribeFunc()`. Synchronous state queries between components still use direct method calls.
+- Cert ordering: multiple certs per slot — tie-break with `Order("added_slot DESC, block_index DESC, cert_index DESC")` (`cert_index` resets per tx, so `block_index` is required to disambiguate across txs in the same block).
+- Rollbacks: `Chain.Rollback(point)` emits `ChainRollbackEvent`; check `TransactionEvent.Rollback` for undo.
+- Plugins (`database/plugin/`): blob = `badger` (default) | `gcs` | `s3`; metadata = `sqlite` (default) | `mysql` | `postgres`.
+- Config priority: CLI > env > YAML > defaults.
 
 ## Profiling
 
-```bash
+```shell
 ./dingo --cpuprofile=cpu.prof --memprofile=mem.prof load database/immutable/testdata
 go tool pprof cpu.prof
 ```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `AGENTS.md` and `CLAUDE.md` to reduce duplication and clarify testing, pre-commit, invariants, event names, and config precedence for the Go Cardano node.

- **Refactors**
  - Tightened scope: `AGENTS.md` links to `CLAUDE.md` and points to `Makefile`/`go.mod`/`node.go`; added concise build/test notes (`make test` runs with `-race`) and `make golines`.
  - Testing: no `time.Sleep()`; use `internal/test/testutil/`; integration data paths; shared mocks from `github.com/blinklabs-io/ouroboros-mock` (no local duplicates).
  - Invariants: EventBus for async notifications (direct calls allowed for sync queries); CBOR offsets via `TieredCborCache`; cert ordering set to `added_slot DESC, block_index DESC, cert_index DESC`; rollback via `ChainRollbackEvent` and `TransactionEvent.Rollback`.
  - Events/config: standardized event keys (`chain.update`, `chain.fork_detected`, `connmanager.conn_closed`, `peergov.peer_churn`); config priority CLI > env > YAML > defaults with key env vars.

<sup>Written for commit 559e25f1ff7ca0440dffb4264fb03f7c8c99d1c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major rewrite of developer guides: simplified build/test workflow, consolidated pre-commit checks, clearer testing rules and invariants, and streamlined configuration precedence (CLI > env > YAML > defaults).
  * Removed older quick-reference/anti-pattern sections; added testing rules, non-obvious invariants, and an updated key-events summary for clearer contributor guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->