### PR TITLE
feat: ouroboros genesis peer rollback event

### DIFF
--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -18,11 +18,13 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 const (
 	PeerTipUpdateEventType  event.EventType = "chainselection.peer_tip_update"
 	PeerActivityEventType   event.EventType = "chainselection.peer_activity"
+	PeerRollbackEventType   event.EventType = "chainselection.peer_rollback"
 	ChainSwitchEventType    event.EventType = "chainselection.chain_switch"
 	ChainSelectionEventType event.EventType = "chainselection.selection"
 	PeerEvictedEventType    event.EventType = "chainselection.peer_evicted"
@@ -42,6 +44,15 @@ type PeerTipUpdateEvent struct {
 // selector liveness for healthy but temporarily quiet peers.
 type PeerActivityEvent struct {
 	ConnectionId ouroboros.ConnectionId
+}
+
+// PeerRollbackEvent is published when an ingress-eligible chainsync peer
+// reports a rollback. Point is the rollback point; Tip is the peer's current
+// chainsync tip after the rollback.
+type PeerRollbackEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	Point        ocommon.Point
+	Tip          ochainsync.Tip
 }
 
 // ChainSwitchEvent is published when the chain selector decides to switch

--- a/chainselection/genesis_test.go
+++ b/chainselection/genesis_test.go
@@ -17,7 +17,9 @@ package chainselection
 import (
 	"math"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/dingo/event"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -146,4 +148,65 @@ func TestChainSelectorGenesisTransitionsBackToPraos(t *testing.T) {
 	require.Equal(t, SelectionModePraos, cs.SelectionMode())
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, connId, *cs.GetBestPeer())
+}
+
+func TestChainSelectorGenesisRollbackTrimsObservedHistory(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 10,
+		EventBus:      bus,
+	})
+
+	connId := newTestConnectionId(1)
+	for _, tip := range []ochainsync.Tip{
+		{
+			Point:       ocommon.Point{Slot: 1, Hash: []byte("slot-1")},
+			BlockNumber: 1,
+		},
+		{
+			Point:       ocommon.Point{Slot: 6, Hash: []byte("slot-6")},
+			BlockNumber: 2,
+		},
+		{
+			Point:       ocommon.Point{Slot: 12, Hash: []byte("slot-12")},
+			BlockNumber: 3,
+		},
+	} {
+		cs.UpdatePeerTip(connId, tip, nil)
+	}
+
+	rollbackEvent := PeerRollbackEvent{
+		ConnectionId: connId,
+		Point:        ocommon.Point{Slot: 6, Hash: []byte("slot-6")},
+		Tip: ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 18, Hash: []byte("slot-18")},
+			BlockNumber: 4,
+		},
+	}
+	bus.Publish(
+		PeerRollbackEventType,
+		event.NewEvent(PeerRollbackEventType, rollbackEvent),
+	)
+
+	require.Eventually(t, func() bool {
+		peerTip := cs.GetPeerTip(connId)
+		return peerTip != nil &&
+			len(peerTip.observedSlots) == 2 &&
+			peerTip.observedSlots[0] == 1 &&
+			peerTip.observedSlots[1] == 6 &&
+			peerTip.observedDensity(cs.GenesisWindowSlots()) == 2
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 20, Hash: []byte("slot-20")},
+		BlockNumber: 5,
+	}, nil)
+
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, []uint64{1, 6, 20}, peerTip.observedSlots)
+	assert.Equal(t, uint64(3), peerTip.observedDensity(cs.GenesisWindowSlots()))
 }

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -19,6 +19,7 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // PeerChainTip tracks the chain tip reported by a specific peer.
@@ -63,6 +64,36 @@ func (p *PeerChainTip) UpdateTipWithObserved(
 	p.ObservedTip = observedTip
 	p.VRFOutput = vrfOutput
 	p.LastUpdated = time.Now()
+}
+
+// ApplyRollback trims observed history at the rollback point and refreshes the
+// peer tip to the chainsync tip reported with the rollback.
+func (p *PeerChainTip) ApplyRollback(
+	point ocommon.Point,
+	tip ochainsync.Tip,
+) {
+	if p == nil {
+		return
+	}
+	p.Tip = tip
+	p.ObservedTip = tip
+	p.VRFOutput = nil
+	p.LastUpdated = time.Now()
+	if point.Slot == 0 || len(p.observedSlots) == 0 {
+		p.observedSlots = nil
+		return
+	}
+
+	keepUntil := 0
+	for keepUntil < len(p.observedSlots) &&
+		p.observedSlots[keepUntil] <= point.Slot {
+		keepUntil++
+	}
+	if keepUntil == 0 {
+		p.observedSlots = nil
+		return
+	}
+	p.observedSlots = p.observedSlots[:keepUntil]
 }
 
 func (p *PeerChainTip) recordObservedSlot(slot, window uint64) {

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -149,6 +149,10 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 			peergov.PeerPriorityChangedEventType,
 			cs.handlePeerPriorityChangedEvent,
 		)
+		cfg.EventBus.SubscribeFunc(
+			PeerRollbackEventType,
+			cs.handlePeerRollbackEvent,
+		)
 	}
 	return cs
 }
@@ -1139,6 +1143,31 @@ func (cs *ChainSelector) HandlePeerActivityEvent(evt event.Event) {
 		return
 	}
 	cs.TouchPeerActivity(e.ConnectionId)
+}
+
+// handlePeerRollbackEvent trims Genesis observed history and refreshes the
+// tracked peer tip after a rollback.
+func (cs *ChainSelector) handlePeerRollbackEvent(evt event.Event) {
+	e, ok := evt.Data.(PeerRollbackEvent)
+	if !ok {
+		cs.config.Logger.Warn(
+			"received unexpected event data type",
+			"expected", "PeerRollbackEvent",
+		)
+		return
+	}
+
+	var shouldEvaluate bool
+	cs.mutex.Lock()
+	if peerTip, exists := cs.peerTips[e.ConnectionId]; exists {
+		peerTip.ApplyRollback(e.Point, e.Tip)
+		shouldEvaluate = true
+	}
+	cs.mutex.Unlock()
+
+	if shouldEvaluate {
+		cs.EvaluateAndSwitch()
+	}
 }
 
 func (cs *ChainSelector) evaluationLoop() {

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -269,6 +269,19 @@ activePeersGossipQuota: 0
 # Active peer slots for ledger sources
 activePeersLedgerQuota: 0
 
+# Genesis bootstrap configuration
+# Used only for from-origin sync. Default behavior keeps this enabled and
+# exits Genesis mode automatically near the best known peer tip.
+genesisBootstrap:
+  # Enable/disable Genesis bootstrap mode (default: true).
+  enabled: true
+  # Override the Genesis comparison window in slots.
+  # 0 auto-derives the window from genesis params (3k/f).
+  windowSlots: 0
+  # Minimum diversity groups to prefer while promoting peers during bootstrap.
+  # 0 uses the peer-governor default.
+  promotionMinDiversityGroups: 0
+
 # Cache configuration for tiered CBOR cache system
 # This controls the in-memory caching of UTxO and transaction CBOR data
 cache:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,20 @@ type ChainsyncConfig struct {
 	StallTimeout string `yaml:"stallTimeout" envconfig:"DINGO_CHAINSYNC_STALL_TIMEOUT"`
 }
 
+// GenesisBootstrapConfig holds configuration for Genesis-mode chain
+// selection and bootstrap-time peer promotion.
+type GenesisBootstrapConfig struct {
+	// Enabled controls whether Genesis bootstrap mode is used when the node
+	// starts from origin.
+	Enabled bool `yaml:"enabled" envconfig:"DINGO_GENESIS_BOOTSTRAP_ENABLED"`
+	// WindowSlots overrides the Genesis density comparison window in slots.
+	// A zero value derives the window from Shelley genesis parameters (3k/f).
+	WindowSlots uint64 `yaml:"windowSlots" envconfig:"DINGO_GENESIS_BOOTSTRAP_WINDOW_SLOTS"`
+	// PromotionMinDiversityGroups sets the minimum number of diversity groups
+	// to prefer while promoting peers during bootstrap.
+	PromotionMinDiversityGroups int `yaml:"promotionMinDiversityGroups" envconfig:"DINGO_GENESIS_BOOTSTRAP_PROMOTION_MIN_DIVERSITY_GROUPS"`
+}
+
 // DefaultChainsyncConfig returns the default chainsync configuration.
 // StallTimeout must match chainsync.DefaultStallTimeout and the
 // fallback in internal/node/node.go.
@@ -144,6 +158,14 @@ func DefaultChainsyncConfig() ChainsyncConfig {
 	return ChainsyncConfig{
 		MaxClients:   3,
 		StallTimeout: "2m",
+	}
+}
+
+// DefaultGenesisBootstrapConfig returns the default Genesis bootstrap
+// configuration values.
+func DefaultGenesisBootstrapConfig() GenesisBootstrapConfig {
+	return GenesisBootstrapConfig{
+		Enabled: true,
 	}
 }
 
@@ -233,6 +255,9 @@ type Config struct {
 
 	// Chainsync configuration for multi-client support
 	Chainsync ChainsyncConfig `yaml:"chainsync"`
+
+	// Genesis bootstrap configuration for from-origin chain selection.
+	GenesisBootstrap GenesisBootstrapConfig `yaml:"genesisBootstrap"`
 
 	// KES (Key Evolving Signature) configuration for block production
 	// SlotsPerKESPeriod is the number of slots in a KES period.
@@ -394,6 +419,8 @@ var globalConfig = &Config{
 	Cache: DefaultCacheConfig(),
 	// Chainsync configuration defaults
 	Chainsync: DefaultChainsyncConfig(),
+	// Genesis bootstrap defaults
+	GenesisBootstrap: DefaultGenesisBootstrapConfig(),
 	// KES configuration defaults (mainnet values)
 	SlotsPerKESPeriod: 129600, // 1.5 days at 1 second per slot
 	MaxKESEvolutions:  62,     // 2^6 - 2 for KES depth 6

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,7 @@ func resetGlobalConfig() {
 		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
 		DatabaseWorkers:             5,
 		DatabaseQueueSize:           50,
+		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
@@ -86,6 +87,10 @@ ledgerCatchupTimeout: "90m"
 topology: ""
 tlsCertFilePath: "cert1.pem"
 tlsKeyFilePath: "key1.pem"
+genesisBootstrap:
+  enabled: false
+  windowSlots: 4321
+  promotionMinDiversityGroups: 4
 mithril:
   enabled: false
   aggregatorUrl: "https://mithril.example.net"
@@ -107,34 +112,39 @@ mithril:
 	defer os.Remove(tmpFile)
 
 	expected := &Config{
-		MempoolCapacity:             2097152,
-		EvictionWatermark:           0.90,
-		RejectionWatermark:          0.95,
-		BindAddr:                    "127.0.0.1",
-		CardanoConfig:               "./cardano/preview/config.json",
-		DatabasePath:                ".dingo",
-		SocketPath:                  "env.socket",
-		IntersectTip:                true,
-		ValidateHistorical:          false,
-		Network:                     "preview",
-		MetricsPort:                 8088,
-		PrivateBindAddr:             "127.0.0.1",
-		PrivatePort:                 8000,
-		RelayPort:                   4000,
-		UtxorpcPort:                 9940, // explicit override from YAML
-		BlockfrostPort:              3000, // default
-		MeshPort:                    8080, // default
-		Topology:                    "",
-		TlsCertFilePath:             "cert1.pem",
-		TlsKeyFilePath:              "key1.pem",
-		BlobPlugin:                  DefaultBlobPlugin,
-		MetadataPlugin:              DefaultMetadataPlugin,
-		RunMode:                     RunModeServe,
-		ImmutableDbPath:             "/tmp/immutable",
-		ShutdownTimeout:             "45s",
-		LedgerCatchupTimeout:        "90m",
-		DatabaseWorkers:             11,
-		DatabaseQueueSize:           77,
+		MempoolCapacity:      2097152,
+		EvictionWatermark:    0.90,
+		RejectionWatermark:   0.95,
+		BindAddr:             "127.0.0.1",
+		CardanoConfig:        "./cardano/preview/config.json",
+		DatabasePath:         ".dingo",
+		SocketPath:           "env.socket",
+		IntersectTip:         true,
+		ValidateHistorical:   false,
+		Network:              "preview",
+		MetricsPort:          8088,
+		PrivateBindAddr:      "127.0.0.1",
+		PrivatePort:          8000,
+		RelayPort:            4000,
+		UtxorpcPort:          9940, // explicit override from YAML
+		BlockfrostPort:       3000, // default
+		MeshPort:             8080, // default
+		Topology:             "",
+		TlsCertFilePath:      "cert1.pem",
+		TlsKeyFilePath:       "key1.pem",
+		BlobPlugin:           DefaultBlobPlugin,
+		MetadataPlugin:       DefaultMetadataPlugin,
+		RunMode:              RunModeServe,
+		ImmutableDbPath:      "/tmp/immutable",
+		ShutdownTimeout:      "45s",
+		LedgerCatchupTimeout: "90m",
+		DatabaseWorkers:      11,
+		DatabaseQueueSize:    77,
+		GenesisBootstrap: GenesisBootstrapConfig{
+			Enabled:                     false,
+			WindowSlots:                 4321,
+			PromotionMinDiversityGroups: 4,
+		},
 		ForgeSyncToleranceSlots:     321,
 		ForgeStaleGapThresholdSlots: 654,
 		Mithril: MithrilConfig{
@@ -198,6 +208,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
 		DatabaseWorkers:             5,
 		DatabaseQueueSize:           50,
+		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
@@ -243,6 +254,39 @@ network: "preview"
 	}
 	if !cfg.RunMode.IsDevMode() {
 		t.Error("expected IsDevMode() to return true for 'dev' mode")
+	}
+}
+
+func TestLoad_GenesisBootstrapEnvVars(t *testing.T) {
+	resetGlobalConfig()
+	globalConfig.RunMode = RunModeDev
+
+	t.Setenv("DINGO_GENESIS_BOOTSTRAP_ENABLED", "false")
+	t.Setenv("DINGO_GENESIS_BOOTSTRAP_WINDOW_SLOTS", "1234")
+	t.Setenv(
+		"DINGO_GENESIS_BOOTSTRAP_PROMOTION_MIN_DIVERSITY_GROUPS",
+		"6",
+	)
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if cfg.GenesisBootstrap.Enabled {
+		t.Fatal("expected GenesisBootstrap.Enabled to be false")
+	}
+	if cfg.GenesisBootstrap.WindowSlots != 1234 {
+		t.Fatalf(
+			"expected GenesisBootstrap.WindowSlots to be 1234, got %d",
+			cfg.GenesisBootstrap.WindowSlots,
+		)
+	}
+	if cfg.GenesisBootstrap.PromotionMinDiversityGroups != 6 {
+		t.Fatalf(
+			"expected GenesisBootstrap.PromotionMinDiversityGroups to be 6, got %d",
+			cfg.GenesisBootstrap.PromotionMinDiversityGroups,
+		)
 	}
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -292,6 +292,11 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				cfg.TargetNumberOfEstablishedPeers,
 				cfg.TargetNumberOfActivePeers,
 			),
+			dingo.WithGenesisBootstrap(cfg.GenesisBootstrap.Enabled),
+			dingo.WithGenesisWindowSlots(cfg.GenesisBootstrap.WindowSlots),
+			dingo.WithBootstrapPromotionMinDiversityGroups(
+				cfg.GenesisBootstrap.PromotionMinDiversityGroups,
+			),
 			dingo.WithActivePeersQuotas(
 				cfg.ActivePeersTopologyQuota,
 				cfg.ActivePeersGossipQuota,

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -500,6 +500,17 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 			},
 		),
 	)
+	o.EventBus.Publish(
+		chainselection.PeerRollbackEventType,
+		event.NewEvent(
+			chainselection.PeerRollbackEventType,
+			chainselection.PeerRollbackEvent{
+				ConnectionId: ctx.ConnectionId,
+				Point:        point,
+				Tip:          tip,
+			},
+		),
+	)
 	return nil
 }
 

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1040,6 +1040,9 @@ func TestChainsyncClientRollBackward_InboundUpstreamProcessesRollback(
 	require.True(t, o.registerTrackedChainsyncClient(connInbound, true, false))
 
 	_, rollbackCh := bus.Subscribe(ledger.ChainsyncEventType)
+	_, chainSelectionRollbackCh := bus.Subscribe(
+		chainselection.PeerRollbackEventType,
+	)
 	rollbackPoint := ocommon.NewPoint(90, []byte("rollback"))
 	tip := ochainsync.Tip{
 		Point:       ocommon.NewPoint(95, []byte("tip")),
@@ -1063,6 +1066,19 @@ func TestChainsyncClientRollBackward_InboundUpstreamProcessesRollback(
 	case <-time.After(2 * time.Second):
 		t.Fatal(
 			"expected rollback event from eligible inbound peer",
+		)
+	}
+
+	select {
+	case evt := <-chainSelectionRollbackCh:
+		data, ok := evt.Data.(chainselection.PeerRollbackEvent)
+		require.True(t, ok)
+		require.Equal(t, connInbound, data.ConnectionId)
+		require.Equal(t, rollbackPoint.Slot, data.Point.Slot)
+		require.Equal(t, tip.BlockNumber, data.Tip.BlockNumber)
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"expected chainselection rollback event from eligible inbound peer",
 		)
 	}
 }


### PR DESCRIPTION
Closes #1858 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a peer rollback event into Genesis chain selection so bootstrap density resets correctly on rollbacks, improving early sync accuracy. Introduces `genesisBootstrap` config and wires it through node startup.

- **New Features**
  - Emits `chainselection.peer_rollback` from `ouroboros/chainsync` when an ingress-eligible peer rolls back.
  - `ChainSelector` subscribes to this event, trims Genesis observed history, refreshes the tracked tip, and re-evaluates selection.
  - Adds `genesisBootstrap` config (`enabled`, `windowSlots`, `promotionMinDiversityGroups`) with defaults and env vars; plumbed via `internal/node` using `dingo.WithGenesisBootstrap`, `dingo.WithGenesisWindowSlots`, and `dingo.WithBootstrapPromotionMinDiversityGroups`.
  - Updates `dingo.yaml.example` and adds tests for rollback handling and config loading.

<sup>Written for commit 46583ec4693427fd5c6272041814ca820c733e8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

