### PR TITLE
feat: governance committee quorum persistence

### DIFF
--- a/database/committee.go
+++ b/database/committee.go
@@ -164,6 +164,40 @@ func (d *Database) SetCommitteeQuorum(
 	return nil
 }
 
+// ClearCommitteeQuorum records at the given slot that no quorum is
+// in effect (e.g. after a NoConfidence action is enacted). A later
+// GetCommitteeQuorum will return nil until a subsequent
+// SetCommitteeQuorum writes a new positive value.
+func (d *Database) ClearCommitteeQuorum(
+	slot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.ClearCommitteeQuorum(
+		slot, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("failed to clear committee quorum: %w", err)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"failed to commit cleared committee quorum: %w", err,
+			)
+		}
+		owned = false
+	}
+	return nil
+}
+
 // GetCommitteeQuorum returns the latest enacted committee quorum.
 func (d *Database) GetCommitteeQuorum(
 	txn *Txn,

--- a/database/plugin/metadata/mysql/committee_member.go
+++ b/database/plugin/metadata/mysql/committee_member.go
@@ -17,6 +17,7 @@ package mysql
 import (
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -55,6 +56,11 @@ func (d *MetadataStoreMysql) SetCommitteeMembers(
 }
 
 // SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+// Invariant: at most one committee-quorum mutation per slot (added_slot is
+// uniquely indexed). Governance ratifies at most one committee-purpose
+// action per epoch tick, so SetCommitteeQuorum and ClearCommitteeQuorum
+// cannot race at the same slot under normal operation; the upsert's
+// overwrite semantics exist to keep import/replay idempotent.
 func (d *MetadataStoreMysql) SetCommitteeQuorum(
 	quorum *types.Rat,
 	slot uint64,
@@ -86,7 +92,42 @@ func (d *MetadataStoreMysql) SetCommitteeQuorum(
 	return nil
 }
 
+// ClearCommitteeQuorum records that no quorum is in effect from the
+// given slot onward. It inserts a zero-valued marker row so a later
+// GetCommitteeQuorum returns nil (and callers fall back to Conway
+// genesis) until a subsequent UpdateCommittee sets a new positive
+// quorum. Shares the one-mutation-per-slot invariant documented on
+// SetCommitteeQuorum.
+func (d *MetadataStoreMysql) ClearCommitteeQuorum(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("ClearCommitteeQuorum: resolve db: %w", err)
+	}
+	state := &models.CommitteeQuorum{
+		Quorum:    &types.Rat{Rat: new(big.Rat)},
+		AddedSlot: slot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "added_slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"quorum",
+		}),
+	}
+	if result := db.Clauses(onConflict).Create(state); result.Error != nil {
+		return fmt.Errorf(
+			"ClearCommitteeQuorum: upsert failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
 // GetCommitteeQuorum retrieves the latest enacted committee quorum.
+// A most-recent marker row with a non-positive quorum represents a
+// NoConfidence-driven clear and is reported as "no quorum enacted".
 func (d *MetadataStoreMysql) GetCommitteeQuorum(
 	txn types.Txn,
 ) (*types.Rat, error) {
@@ -106,6 +147,10 @@ func (d *MetadataStoreMysql) GetCommitteeQuorum(
 			"GetCommitteeQuorum: query failed: %w",
 			result.Error,
 		)
+	}
+	if state.Quorum == nil || state.Quorum.Rat == nil ||
+		state.Quorum.Sign() <= 0 {
+		return nil, nil
 	}
 	return state.Quorum, nil
 }

--- a/database/plugin/metadata/postgres/committee_member.go
+++ b/database/plugin/metadata/postgres/committee_member.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -55,6 +56,11 @@ func (d *MetadataStorePostgres) SetCommitteeMembers(
 }
 
 // SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+// Invariant: at most one committee-quorum mutation per slot (added_slot is
+// uniquely indexed). Governance ratifies at most one committee-purpose
+// action per epoch tick, so SetCommitteeQuorum and ClearCommitteeQuorum
+// cannot race at the same slot under normal operation; the upsert's
+// overwrite semantics exist to keep import/replay idempotent.
 func (d *MetadataStorePostgres) SetCommitteeQuorum(
 	quorum *types.Rat,
 	slot uint64,
@@ -86,7 +92,42 @@ func (d *MetadataStorePostgres) SetCommitteeQuorum(
 	return nil
 }
 
+// ClearCommitteeQuorum records that no quorum is in effect from the
+// given slot onward. It inserts a zero-valued marker row so a later
+// GetCommitteeQuorum returns nil (and callers fall back to Conway
+// genesis) until a subsequent UpdateCommittee sets a new positive
+// quorum. Shares the one-mutation-per-slot invariant documented on
+// SetCommitteeQuorum.
+func (d *MetadataStorePostgres) ClearCommitteeQuorum(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("ClearCommitteeQuorum: resolve db: %w", err)
+	}
+	state := &models.CommitteeQuorum{
+		Quorum:    &types.Rat{Rat: new(big.Rat)},
+		AddedSlot: slot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "added_slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"quorum",
+		}),
+	}
+	if result := db.Clauses(onConflict).Create(state); result.Error != nil {
+		return fmt.Errorf(
+			"ClearCommitteeQuorum: upsert failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
 // GetCommitteeQuorum retrieves the latest enacted committee quorum.
+// A most-recent marker row with a non-positive quorum represents a
+// NoConfidence-driven clear and is reported as "no quorum enacted".
 func (d *MetadataStorePostgres) GetCommitteeQuorum(
 	txn types.Txn,
 ) (*types.Rat, error) {
@@ -106,6 +147,10 @@ func (d *MetadataStorePostgres) GetCommitteeQuorum(
 			"GetCommitteeQuorum: query failed: %w",
 			result.Error,
 		)
+	}
+	if state.Quorum == nil || state.Quorum.Rat == nil ||
+		state.Quorum.Sign() <= 0 {
+		return nil, nil
 	}
 	return state.Quorum, nil
 }

--- a/database/plugin/metadata/sqlite/committee_member.go
+++ b/database/plugin/metadata/sqlite/committee_member.go
@@ -17,6 +17,7 @@ package sqlite
 import (
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -56,6 +57,11 @@ func (d *MetadataStoreSqlite) SetCommitteeMembers(
 }
 
 // SetCommitteeQuorum stores the quorum threshold enacted with a committee.
+// Invariant: at most one committee-quorum mutation per slot (added_slot is
+// uniquely indexed). Governance ratifies at most one committee-purpose
+// action per epoch tick, so SetCommitteeQuorum and ClearCommitteeQuorum
+// cannot race at the same slot under normal operation; the upsert's
+// overwrite semantics exist to keep import/replay idempotent.
 func (d *MetadataStoreSqlite) SetCommitteeQuorum(
 	quorum *types.Rat,
 	slot uint64,
@@ -87,7 +93,42 @@ func (d *MetadataStoreSqlite) SetCommitteeQuorum(
 	return nil
 }
 
+// ClearCommitteeQuorum records that no quorum is in effect from the
+// given slot onward. It inserts a zero-valued marker row so a later
+// GetCommitteeQuorum returns nil (and callers fall back to Conway
+// genesis) until a subsequent UpdateCommittee sets a new positive
+// quorum. Shares the one-mutation-per-slot invariant documented on
+// SetCommitteeQuorum.
+func (d *MetadataStoreSqlite) ClearCommitteeQuorum(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("ClearCommitteeQuorum: resolve db: %w", err)
+	}
+	state := &models.CommitteeQuorum{
+		Quorum:    &types.Rat{Rat: new(big.Rat)},
+		AddedSlot: slot,
+	}
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "added_slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"quorum",
+		}),
+	}
+	if result := db.Clauses(onConflict).Create(state); result.Error != nil {
+		return fmt.Errorf(
+			"ClearCommitteeQuorum: upsert failed: %w",
+			result.Error,
+		)
+	}
+	return nil
+}
+
 // GetCommitteeQuorum retrieves the latest enacted committee quorum.
+// A most-recent marker row with a non-positive quorum represents a
+// NoConfidence-driven clear and is reported as "no quorum enacted".
 func (d *MetadataStoreSqlite) GetCommitteeQuorum(
 	txn types.Txn,
 ) (*types.Rat, error) {
@@ -107,6 +148,10 @@ func (d *MetadataStoreSqlite) GetCommitteeQuorum(
 			"GetCommitteeQuorum: query failed: %w",
 			result.Error,
 		)
+	}
+	if state.Quorum == nil || state.Quorum.Rat == nil ||
+		state.Quorum.Sign() <= 0 {
+		return nil, nil
 	}
 	return state.Quorum, nil
 }

--- a/database/plugin/metadata/sqlite/committee_member_test.go
+++ b/database/plugin/metadata/sqlite/committee_member_test.go
@@ -264,6 +264,72 @@ func TestDeleteCommitteeMembersAfterSlotDeletesQuorum(t *testing.T) {
 	assert.Equal(t, big.NewRat(2, 3), got.Rat)
 }
 
+func TestClearCommitteeQuorum(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Seed a quorum.
+	require.NoError(t, store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(2, 3)}, 100, nil,
+	))
+
+	// Clear at a later slot.
+	require.NoError(t, store.ClearCommitteeQuorum(200, nil))
+
+	// GetCommitteeQuorum hides the cleared marker.
+	got, err := store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// A subsequent positive quorum is reported again.
+	require.NoError(t, store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(3, 5)}, 300, nil,
+	))
+	got, err = store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, big.NewRat(3, 5), got.Rat)
+}
+
+func TestClearCommitteeQuorumWhenNoPrior(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Clearing without any prior Set must still leave GetCommitteeQuorum
+	// reporting "no quorum enacted" so conwayRatifyQuorum falls back to
+	// Conway genesis.
+	require.NoError(t, store.ClearCommitteeQuorum(100, nil))
+
+	got, err := store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// A later positive SetCommitteeQuorum must override the earlier
+	// clear marker.
+	require.NoError(t, store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(2, 3)}, 200, nil,
+	))
+	got, err = store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, big.NewRat(2, 3), got.Rat)
+}
+
+func TestClearCommitteeQuorumRollbackRestoresPrior(t *testing.T) {
+	store := setupTestStore(t)
+
+	require.NoError(t, store.SetCommitteeQuorum(
+		&types.Rat{Rat: big.NewRat(2, 3)}, 100, nil,
+	))
+	require.NoError(t, store.ClearCommitteeQuorum(200, nil))
+
+	// Rollback past the clear should restore the earlier positive quorum.
+	require.NoError(t, store.DeleteCommitteeMembersAfterSlot(150, nil))
+
+	got, err := store.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, big.NewRat(2, 3), got.Rat)
+}
+
 func TestDeleteCommitteeMembersAfterSlotClearsDeletedSlot(t *testing.T) {
 	store := setupTestStore(t)
 

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -724,7 +724,16 @@ type MetadataStore interface {
 	// committee update.
 	SetCommitteeQuorum(*types.Rat, uint64, types.Txn) error
 
+	// ClearCommitteeQuorum records that the committee has no
+	// enacted quorum as of the given slot. Used by NoConfidence
+	// enactment so GetCommitteeQuorum falls back to Conway
+	// genesis until a subsequent UpdateCommittee sets a new
+	// quorum.
+	ClearCommitteeQuorum(uint64, types.Txn) error
+
 	// GetCommitteeQuorum retrieves the latest enacted committee quorum.
+	// Returns (nil, nil) when no quorum has been enacted or when the
+	// most recent record is a ClearCommitteeQuorum marker.
 	GetCommitteeQuorum(types.Txn) (*types.Rat, error)
 
 	// GetCommitteeMembers retrieves all active (non-deleted)

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -110,6 +110,11 @@ var flagSpecs = []flagSpec{
 	intFlag("Chainsync.MaxClients", "chainsync-max-clients", "max chainsync clients"),
 	stringFlag("Chainsync.StallTimeout", "chainsync-stall-timeout", "", "chainsync stall timeout"),
 
+	// Genesis bootstrap
+	boolFlag("GenesisBootstrap.Enabled", "genesis-bootstrap-enabled", "enable Genesis bootstrap mode when starting from origin"),
+	uint64Flag("GenesisBootstrap.WindowSlots", "genesis-bootstrap-window-slots", "Genesis density comparison window in slots (0 derives from Shelley genesis 3k/f)"),
+	intFlag("GenesisBootstrap.PromotionMinDiversityGroups", "genesis-bootstrap-promotion-min-diversity-groups", "minimum diversity groups preferred during Genesis bootstrap peer promotion"),
+
 	// Database workers
 	intFlag("DatabaseWorkers", "db-workers", "database worker pool worker count"),
 	intFlag("DatabaseQueueSize", "db-queue-size", "database worker pool task queue size"),

--- a/ledger/governance/enact.go
+++ b/ledger/governance/enact.go
@@ -103,6 +103,14 @@ func EnactProposal(
 		); err != nil {
 			return nil, fmt.Errorf("no confidence: %w", err)
 		}
+		// Drop the enacted committee quorum so ratification falls back
+		// to Conway genesis until a subsequent UpdateCommittee enacts
+		// a new positive threshold.
+		if err := ctx.DB.ClearCommitteeQuorum(
+			ctx.Slot, ctx.Txn,
+		); err != nil {
+			return nil, fmt.Errorf("no confidence: clear quorum: %w", err)
+		}
 
 	case *lcommon.UpdateCommitteeGovAction:
 		if err := applyUpdateCommittee(ctx, a); err != nil {

--- a/ledger/governance/enact_test.go
+++ b/ledger/governance/enact_test.go
@@ -15,6 +15,7 @@
 package governance
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -176,6 +177,70 @@ func TestStakeEpochFor(t *testing.T) {
 // Expiry is exercised end-to-end via the DB query and ProcessEpoch
 // integration rather than a split-in-memory helper, so there is no unit
 // test for a partition function here.
+
+func TestApplyUpdateCommittee_PersistsEnactedQuorum(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+
+	action := &lcommon.UpdateCommitteeGovAction{
+		Credentials: []lcommon.Credential{},
+		CredEpochs:  map[*lcommon.Credential]uint{},
+		Quorum:      cbor.Rat{Rat: big.NewRat(3, 5)},
+	}
+	err := applyUpdateCommittee(
+		&EnactmentContext{DB: db, Slot: 4242},
+		action,
+	)
+	require.NoError(t, err)
+
+	got, err := db.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0, got.Cmp(big.NewRat(3, 5)))
+}
+
+func TestEnactProposal_NoConfidence_ClearsCommitteeQuorum(
+	t *testing.T,
+) {
+	db, _ := newTallyTestDB(t)
+
+	// Seed an enacted quorum from a prior UpdateCommittee.
+	require.NoError(
+		t,
+		db.SetCommitteeQuorum(big.NewRat(3, 5), 1000, nil),
+	)
+
+	// Build a NoConfidence proposal with a zero deposit so the
+	// reward-account refund path short-circuits.
+	action := &lcommon.NoConfidenceGovAction{
+		Type: uint(lcommon.GovActionTypeNoConfidence),
+	}
+	encoded, err := cbor.Encode(action)
+	require.NoError(t, err)
+	proposal := &models.GovernanceProposal{
+		TxHash:        testBytes(32, 7),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeNoConfidence),
+		GovActionCbor: encoded,
+		AddedSlot:     500,
+		ExpiresEpoch:  100,
+		AnchorURL:     "https://example.invalid/noconf",
+		AnchorHash:    testBytes(32, 8),
+		ReturnAddress: testBytes(29, 9),
+		// Zero deposit keeps the refund path a no-op so this test
+		// isolates the committee-quorum clear behavior.
+		Deposit: 0,
+	}
+
+	_, err = EnactProposal(
+		&EnactmentContext{DB: db, Slot: 2000, Epoch: 42},
+		proposal,
+	)
+	require.NoError(t, err)
+
+	got, err := db.GetCommitteeQuorum(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got, "NoConfidence should clear the enacted quorum")
+}
 
 func TestApplyTreasuryWithdrawal_CreditsRewardsAndDebitsTreasury(
 	t *testing.T,

--- a/ledger/governance/ratify_test.go
+++ b/ledger/governance/ratify_test.go
@@ -23,6 +23,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newRat is a test helper that builds a cbor.Rat from num/denom.
@@ -516,4 +517,49 @@ func TestConwayRatifyQuorum_FallbackWhenThresholdMissing(t *testing.T) {
 	got, err := conwayRatifyQuorum(nil, nil, nil, genesis)
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewRat(2, 3), got)
+}
+
+func TestConwayRatifyQuorum_PrefersDBOverGenesis(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+
+	// An enacted quorum must win over the Conway genesis default so
+	// the ratify loop tracks on-chain state rather than the initial
+	// bootstrap threshold.
+	require.NoError(t, db.SetCommitteeQuorum(big.NewRat(3, 5), 1000, nil))
+
+	threshold := cbor.Rat{Rat: big.NewRat(2, 3)}
+	genesis := &conway.ConwayGenesis{
+		Committee: conway.ConwayGenesisCommittee{
+			Threshold: &threshold,
+		},
+	}
+	got, err := conwayRatifyQuorum(nil, db, nil, genesis)
+	require.NoError(t, err)
+	assert.Equal(t, big.NewRat(3, 5), got)
+}
+
+func TestConwayRatifyQuorum_FallsBackToGenesisAfterClear(
+	t *testing.T,
+) {
+	db, _ := newTallyTestDB(t)
+
+	// Enact then immediately clear. Ratify must fall back to Conway
+	// genesis until the next UpdateCommittee writes a new positive
+	// quorum, matching the cardano-ledger ENACT semantics for
+	// NoConfidence.
+	require.NoError(t, db.SetCommitteeQuorum(big.NewRat(3, 5), 1000, nil))
+	require.NoError(t, db.ClearCommitteeQuorum(2000, nil))
+
+	// Pick a genesis threshold distinct from defaultCCQuorum (2/3) so
+	// the assertion fails if the code path slipped to the last-resort
+	// default instead of the genesis branch.
+	threshold := cbor.Rat{Rat: big.NewRat(4, 7)}
+	genesis := &conway.ConwayGenesis{
+		Committee: conway.ConwayGenesisCommittee{
+			Threshold: &threshold,
+		},
+	}
+	got, err := conwayRatifyQuorum(nil, db, nil, genesis)
+	require.NoError(t, err)
+	assert.Equal(t, big.NewRat(4, 7), got)
 }


### PR DESCRIPTION
Closes #1967 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to mark an enacted committee quorum as cleared; cleared state is treated as “no quorum enacted” so the system falls back to genesis thresholds until a new quorum is set.
  * No-confidence enactments now clear the enacted committee quorum as part of enactment.

* **Platform Support**
  * Clear-quorum support implemented across metadata backends (SQLite, MySQL, Postgres).

* **Tests**
  * Added tests for clearing behavior, persistence, rollback recovery, and fallback-to-genesis.

* **Chores**
  * New CLI flags for genesis/bootstrap configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist committee quorum updates and add a clear state. No-confidence clears the quorum; ratification prefers the DB quorum and falls back to Conway genesis after a clear.

- **New Features**
  - Add `ClearCommitteeQuorum(slot, txn)` to `MetadataStore` and database; `GetCommitteeQuorum` returns nil after a clear/non-positive marker across `mysql`/`postgres`/`sqlite`.
  - Persist quorum on `UpdateCommittee`; `NoConfidence` clears it in `EnactProposal`.
  - Ratification prefers the DB quorum; after a clear it falls back to Conway genesis until a new quorum is set.
  - Upsert by `added_slot` enforces one mutation per slot and keeps import/replay idempotent. Add genesis bootstrap flags: `--genesis-bootstrap-enabled`, `--genesis-bootstrap-window-slots`, `--genesis-bootstrap-promotion-min-diversity-groups`.

<sup>Written for commit 92761cb52d371fc612ea1701a39b92d522ddf5df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

