### PR TITLE
fix(ledger): LedgerView stub methods return success with zero values

### DIFF
--- a/ledger/view.go
+++ b/ledger/view.go
@@ -36,6 +36,9 @@ var ErrNilDecodedOutput = errors.New("nil decoded output")
 // ErrUtxoAlreadyConsumed is returned when a UTxO has been consumed by a pending transaction.
 var ErrUtxoAlreadyConsumed = errors.New("UTxO already consumed")
 
+// ErrNotImplemented marks LedgerView stubs that are not implemented yet.
+var ErrNotImplemented = errors.New("not implemented")
+
 type LedgerView struct {
 	ls  *LedgerState
 	txn *database.Txn
@@ -280,7 +283,7 @@ func (lv *LedgerView) CalculateRewards(
 	rewardSnapshot lcommon.RewardSnapshot,
 	rewardParams lcommon.RewardParameters,
 ) (*lcommon.RewardCalculationResult, error) {
-	return nil, nil
+	return nil, ErrNotImplemented
 }
 
 // GetAdaPots returns the current Ada pots.
@@ -296,13 +299,13 @@ func (lv *LedgerView) GetAdaPots() lcommon.AdaPots {
 func (lv *LedgerView) GetRewardSnapshot(
 	epoch uint64,
 ) (lcommon.RewardSnapshot, error) {
-	return lcommon.RewardSnapshot{}, nil
+	return lcommon.RewardSnapshot{}, ErrNotImplemented
 }
 
 // UpdateAdaPots updates the Ada pots.
 // TODO: implement Ada pots update. Requires Ada pots storage in the database.
 func (lv *LedgerView) UpdateAdaPots(adaPots lcommon.AdaPots) error {
-	return nil
+	return ErrNotImplemented
 }
 
 // IsRewardAccountRegistered checks if a reward account is registered
@@ -330,7 +333,7 @@ func (lv *LedgerView) IsRewardAccountRegistered(
 func (lv *LedgerView) RewardAccountBalance(
 	cred lcommon.Credential,
 ) (*uint64, error) {
-	return nil, nil
+	return nil, ErrNotImplemented
 }
 
 // CostModels returns which Plutus language versions have cost
@@ -612,7 +615,7 @@ func (lv *LedgerView) Constitution() (*lcommon.Constitution, error) {
 // which is not yet stored in the database. The treasury value is part of
 // the Ada pots (reserves, treasury, fees, rewards).
 func (lv *LedgerView) TreasuryValue() (uint64, error) {
-	return 0, nil
+	return 0, ErrNotImplemented
 }
 
 // GovActionById returns a governance action by its ID.

--- a/ledger/view_test.go
+++ b/ledger/view_test.go
@@ -25,6 +25,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLedgerViewUnimplementedMethodsReturnSentinelError(t *testing.T) {
+	lv := &LedgerView{}
+
+	rewards, err := lv.CalculateRewards(
+		lcommon.AdaPots{},
+		lcommon.RewardSnapshot{},
+		lcommon.RewardParameters{},
+	)
+	require.ErrorIs(t, err, ErrNotImplemented)
+	require.Nil(t, rewards)
+
+	snapshot, err := lv.GetRewardSnapshot(0)
+	require.ErrorIs(t, err, ErrNotImplemented)
+	require.Equal(t, lcommon.RewardSnapshot{}, snapshot)
+
+	err = lv.UpdateAdaPots(lcommon.AdaPots{})
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	balance, err := lv.RewardAccountBalance(lcommon.Credential{})
+	require.ErrorIs(t, err, ErrNotImplemented)
+	require.Nil(t, balance)
+
+	treasury, err := lv.TreasuryValue()
+	require.ErrorIs(t, err, ErrNotImplemented)
+	require.Zero(t, treasury)
+}
+
 func TestExtractCostModelsFromPParams_Nil(t *testing.T) {
 	result := extractCostModelsFromPParams(nil)
 	require.Empty(t, result)


### PR DESCRIPTION
1. Added ErrNotImplemented and return it from unimplemented LedgerView methods that already support errors, avoiding silent zero-value success.
2. Added a unit-test to verify reward, Ada pots update, reward snapshot, reward balance, and treasury stubs return the sentinel error.

Closes #1517 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `ErrNotImplemented` from unimplemented `LedgerView` methods to avoid silent zero-value success and make failures explicit. Added tests to confirm consistent errors for rewards, Ada pots, reward snapshot/balance, and treasury stubs.

- **Bug Fixes**
  - Introduced `ErrNotImplemented`; applied to: CalculateRewards, GetRewardSnapshot, UpdateAdaPots, RewardAccountBalance, TreasuryValue.
  - Added unit test `TestLedgerViewUnimplementedMethodsReturnSentinelError`.

<sup>Written for commit cae4686173f1739113c5432521022ba902f4e4fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ledger operations now properly signal when functionality is not yet implemented, instead of silently succeeding with empty results.

* **Tests**
  * Added test coverage to verify unimplemented ledger methods consistently return not-implemented error status with appropriate return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->