### PR TITLE
feat(ledger): introduce hardfork combinator shapes and refactor ledger

### DIFF
--- a/ledger/eras/shape.go
+++ b/ledger/eras/shape.go
@@ -63,6 +63,12 @@ func StabilityWindowForEra(cfg *cardano.CardanoNodeConfig, eraId uint) (uint64, 
 			activeSlotsCoeff.String(),
 		)
 	}
+	if activeSlotsCoeff.Cmp(big.NewRat(1, 1)) > 0 {
+		return 0, fmt.Errorf(
+			"eras: ActiveSlotsCoeff must be <= 1, got %s",
+			activeSlotsCoeff.String(),
+		)
+	}
 	// ceil(3 * k / f) where f = num/denom → ceil(3 * k * denom / num)
 	numerator := new(big.Int).SetUint64(uint64(k))
 	numerator.Mul(numerator, big.NewInt(3))
@@ -115,7 +121,9 @@ func BuildEraParams(cfg *cardano.CardanoNodeConfig, era EraDesc) (hardfork.EraPa
 		)
 	}
 	return hardfork.EraParams{
-		EpochSize:     uint64(epochLen),
+		EpochSize: uint64(epochLen),
+		// slotLenMs is protocol-bounded (milliseconds per slot, 1–20s range).
+		// #nosec G115
 		SlotLength:    time.Duration(slotLenMs) * time.Millisecond,
 		SafeZoneSlots: safeZone,
 		// GenesisWindow is not yet tracked per era in dingo; defaulting to

--- a/ledger/eras/shape.go
+++ b/ledger/eras/shape.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+)
+
+// StabilityWindowForEra returns the stability window (in slots) for the given
+// era. For Byron, this is 2k; for Shelley and later eras, 3k/f (rounded up).
+//
+// Returns an error if the required genesis data is unavailable or malformed.
+// This is the pure, LedgerState-free version of the stability-window
+// computation used by the HFC Shape builder.
+func StabilityWindowForEra(cfg *cardano.CardanoNodeConfig, eraId uint) (uint64, error) {
+	if cfg == nil {
+		return 0, errors.New("eras: nil CardanoNodeConfig")
+	}
+	if eraId == ByronEraDesc.Id {
+		byronGenesis := cfg.ByronGenesis()
+		if byronGenesis == nil {
+			return 0, errors.New("eras: Byron genesis unavailable")
+		}
+		k := byronGenesis.ProtocolConsts.K
+		if k <= 0 {
+			return 0, fmt.Errorf("eras: invalid Byron security parameter k=%d", k)
+		}
+		return uint64(k) * 2, nil // #nosec G115
+	}
+	shelleyGenesis := cfg.ShelleyGenesis()
+	if shelleyGenesis == nil {
+		return 0, errors.New("eras: Shelley genesis unavailable")
+	}
+	k := shelleyGenesis.SecurityParam
+	if k <= 0 {
+		return 0, fmt.Errorf("eras: invalid Shelley security parameter k=%d", k)
+	}
+	activeSlotsCoeff := shelleyGenesis.ActiveSlotsCoeff.Rat
+	if activeSlotsCoeff == nil {
+		return 0, errors.New("eras: Shelley ActiveSlotsCoeff is nil")
+	}
+	if activeSlotsCoeff.Num().Sign() <= 0 {
+		return 0, fmt.Errorf(
+			"eras: ActiveSlotsCoeff must be positive, got %s",
+			activeSlotsCoeff.String(),
+		)
+	}
+	// ceil(3 * k / f) where f = num/denom → ceil(3 * k * denom / num)
+	numerator := new(big.Int).SetUint64(uint64(k))
+	numerator.Mul(numerator, big.NewInt(3))
+	numerator.Mul(numerator, activeSlotsCoeff.Denom())
+	denominator := new(big.Int).Set(activeSlotsCoeff.Num())
+	window, remainder := new(big.Int).QuoRem(numerator, denominator, new(big.Int))
+	if remainder.Sign() != 0 {
+		window.Add(window, big.NewInt(1))
+	}
+	if window.Sign() <= 0 {
+		return 0, fmt.Errorf(
+			"eras: stability window non-positive (k=%d, f=%s)",
+			k, activeSlotsCoeff.String(),
+		)
+	}
+	if !window.IsUint64() {
+		return 0, fmt.Errorf(
+			"eras: stability window overflows uint64 (k=%d, f=%s)",
+			k, activeSlotsCoeff.String(),
+		)
+	}
+	return window.Uint64(), nil
+}
+
+// BuildEraParams assembles a hardfork.EraParams value for the given era,
+// using the node configuration for the era-specific epoch length, slot length,
+// and safe-zone (stability-window) values.
+func BuildEraParams(cfg *cardano.CardanoNodeConfig, era EraDesc) (hardfork.EraParams, error) {
+	if cfg == nil {
+		return hardfork.EraParams{}, errors.New("eras: nil CardanoNodeConfig")
+	}
+	if era.EpochLengthFunc == nil {
+		return hardfork.EraParams{}, fmt.Errorf(
+			"eras: era %q has no EpochLengthFunc",
+			era.Name,
+		)
+	}
+	slotLenMs, epochLen, err := era.EpochLengthFunc(cfg)
+	if err != nil {
+		return hardfork.EraParams{}, fmt.Errorf(
+			"eras: era %q EpochLengthFunc: %w",
+			era.Name, err,
+		)
+	}
+	safeZone, err := StabilityWindowForEra(cfg, era.Id)
+	if err != nil {
+		return hardfork.EraParams{}, fmt.Errorf(
+			"eras: era %q stability window: %w",
+			era.Name, err,
+		)
+	}
+	return hardfork.EraParams{
+		EpochSize:     uint64(epochLen),
+		SlotLength:    time.Duration(slotLenMs) * time.Millisecond,
+		SafeZoneSlots: safeZone,
+		// GenesisWindow is not yet tracked per era in dingo; defaulting to
+		// the safe-zone value mirrors the Haskell default for Shelley.
+		GenesisWindow: safeZone,
+	}, nil
+}
+
+// BuildShape constructs a hardfork.Shape from dingo's static era table.
+// The shape's SystemStart comes from the Shelley genesis; each entry's
+// EraParams are built via BuildEraParams; the protocol-version range
+// (MinMajorVersion/MaxMajorVersion) is derived by inverting
+// ProtocolMajorVersionToEra.
+func BuildShape(cfg *cardano.CardanoNodeConfig) (hardfork.Shape, error) {
+	if cfg == nil {
+		return hardfork.Shape{}, errors.New("eras: nil CardanoNodeConfig")
+	}
+	shelleyGenesis := cfg.ShelleyGenesis()
+	if shelleyGenesis == nil {
+		return hardfork.Shape{}, errors.New("eras: Shelley genesis unavailable (required for SystemStart)")
+	}
+
+	// Invert ProtocolMajorVersionToEra to compute {min,max} per era ID.
+	type versionRange struct {
+		min, max uint
+		hasAny   bool
+	}
+	ranges := map[uint]*versionRange{}
+	for v, e := range ProtocolMajorVersionToEra {
+		r, ok := ranges[e.Id]
+		if !ok {
+			r = &versionRange{min: v, max: v, hasAny: true}
+			ranges[e.Id] = r
+			continue
+		}
+		if v < r.min {
+			r.min = v
+		}
+		if v > r.max {
+			r.max = v
+		}
+	}
+
+	entries := make([]hardfork.ShapeEntry, 0, len(Eras))
+	for _, era := range Eras {
+		params, err := BuildEraParams(cfg, era)
+		if err != nil {
+			return hardfork.Shape{}, err
+		}
+		r, ok := ranges[era.Id]
+		if !ok {
+			return hardfork.Shape{}, fmt.Errorf(
+				"eras: era %q (id=%d) has no entry in ProtocolMajorVersionToEra",
+				era.Name, era.Id,
+			)
+		}
+		entries = append(entries, hardfork.ShapeEntry{
+			EraID:           era.Id,
+			EraName:         era.Name,
+			MinMajorVersion: r.min,
+			MaxMajorVersion: r.max,
+			Params:          params,
+		})
+	}
+
+	return hardfork.Shape{
+		SystemStart: shelleyGenesis.SystemStart,
+		Eras:        entries,
+	}, nil
+}

--- a/ledger/eras/shape_bugs_test.go
+++ b/ledger/eras/shape_bugs_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStabilityWindowForEra_RejectsActiveSlotsCoeffAbove1 verifies that
+// StabilityWindowForEra treats ActiveSlotsCoeff > 1 as malformed.
+//
+// ActiveSlotsCoeff is the "active slot coefficient" f in the Praos
+// stability-window formula ceil(3*k/f). The protocol requires f in (0, 1].
+// An f > 1 silently shrinks the safe zone below the protocol floor — a bad
+// genesis file should be rejected, not accepted with a subtle security
+// regression.
+func TestStabilityWindowForEra_RejectsActiveSlotsCoeffAbove1(t *testing.T) {
+	shelley := `{
+		"activeSlotsCoeff": 2.0,
+		"securityParam": 432,
+		"slotLength": 1,
+		"epochLength": 432000,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelley)))
+	_, err := eras.StabilityWindowForEra(cfg, eras.ShelleyEraDesc.Id)
+	assert.Error(t, err,
+		"StabilityWindowForEra must reject ActiveSlotsCoeff > 1 (would silently shrink safe zone)")
+}

--- a/ledger/eras/shape_test.go
+++ b/ledger/eras/shape_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Full mainnet-ish config with both genesis files present.
+func newTestCfg(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+	byron := `{"blockVersionData":{"slotDuration":"20000"},"protocolConsts":{"k":432}}`
+	shelley := `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"slotLength": 1,
+		"epochLength": 432000,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadByronGenesisFromReader(strings.NewReader(byron)))
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelley)))
+	return cfg
+}
+
+// Config with only Shelley genesis loaded (no Byron).
+func newShelleyOnlyCfg(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+	shelley := `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"slotLength": 1,
+		"epochLength": 432000,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelley)))
+	return cfg
+}
+
+// ---------------------------------------------------------------- StabilityWindow
+
+// Byron: window = 2k = 864 for k=432.
+func TestStabilityWindowForEra_Byron(t *testing.T) {
+	cfg := newTestCfg(t)
+	w, err := eras.StabilityWindowForEra(cfg, eras.ByronEraDesc.Id)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(864), w)
+}
+
+// Shelley: window = ceil(3k/f) = ceil(3*432/0.05) = 25_920.
+func TestStabilityWindowForEra_Shelley(t *testing.T) {
+	cfg := newTestCfg(t)
+	w, err := eras.StabilityWindowForEra(cfg, eras.ShelleyEraDesc.Id)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(25_920), w)
+}
+
+// Post-Shelley eras use the same computation.
+func TestStabilityWindowForEra_Conway(t *testing.T) {
+	cfg := newTestCfg(t)
+	w, err := eras.StabilityWindowForEra(cfg, eras.ConwayEraDesc.Id)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(25_920), w)
+}
+
+// Byron era but no Byron genesis in config — error.
+func TestStabilityWindowForEra_Byron_MissingGenesis(t *testing.T) {
+	cfg := newShelleyOnlyCfg(t)
+	_, err := eras.StabilityWindowForEra(cfg, eras.ByronEraDesc.Id)
+	assert.Error(t, err)
+}
+
+// Nil config — error.
+func TestStabilityWindowForEra_NilConfig(t *testing.T) {
+	_, err := eras.StabilityWindowForEra(nil, eras.ShelleyEraDesc.Id)
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------- BuildEraParams
+
+func TestBuildEraParams_Byron(t *testing.T) {
+	cfg := newTestCfg(t)
+	p, err := eras.BuildEraParams(cfg, eras.ByronEraDesc)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(4320), p.EpochSize) // k=432 → 10k = 4320 slots
+	assert.Equal(t, 20*time.Second, p.SlotLength)
+	assert.Equal(t, uint64(864), p.SafeZoneSlots)
+}
+
+func TestBuildEraParams_Shelley(t *testing.T) {
+	cfg := newTestCfg(t)
+	p, err := eras.BuildEraParams(cfg, eras.ShelleyEraDesc)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(432_000), p.EpochSize)
+	assert.Equal(t, time.Second, p.SlotLength)
+	assert.Equal(t, uint64(25_920), p.SafeZoneSlots)
+}
+
+// Missing genesis for the era — error.
+func TestBuildEraParams_MissingGenesis(t *testing.T) {
+	cfg := newShelleyOnlyCfg(t)
+	_, err := eras.BuildEraParams(cfg, eras.ByronEraDesc)
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------- BuildShape
+
+func TestBuildShape_OK(t *testing.T) {
+	cfg := newTestCfg(t)
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+
+	// SystemStart comes from Shelley genesis.
+	expectedStart := time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, expectedStart, shape.SystemStart)
+
+	// All 7 Cardano eras present in declaration order.
+	require.Len(t, shape.Eras, 7)
+	assert.Equal(t, "Byron", shape.Eras[0].EraName)
+	assert.Equal(t, "Shelley", shape.Eras[1].EraName)
+	assert.Equal(t, "Conway", shape.Eras[6].EraName)
+
+	// Version ranges derived from ProtocolMajorVersionToEra.
+	type vr struct{ min, max uint }
+	want := map[string]vr{
+		"Byron":   {0, 1},
+		"Shelley": {2, 2},
+		"Allegra": {3, 3},
+		"Mary":    {4, 4},
+		"Alonzo":  {5, 6},
+		"Babbage": {7, 8},
+		"Conway":  {9, 10},
+	}
+	for _, e := range shape.Eras {
+		w, ok := want[e.EraName]
+		require.True(t, ok, "unexpected era %q", e.EraName)
+		assert.Equal(t, w.min, e.MinMajorVersion, "%s MinMajorVersion", e.EraName)
+		assert.Equal(t, w.max, e.MaxMajorVersion, "%s MaxMajorVersion", e.EraName)
+	}
+
+	assert.NoError(t, shape.Validate(), "BuildShape must produce a valid Shape")
+}
+
+// EraForVersion from the resulting Shape matches the legacy EraForVersion lookup.
+func TestBuildShape_EraForVersionMatchesLegacy(t *testing.T) {
+	cfg := newTestCfg(t)
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+
+	for v := uint(0); v <= 10; v++ {
+		got, found := shape.EraForVersion(v)
+		require.True(t, found, "version %d should resolve", v)
+		legacy := eras.ProtocolMajorVersionToEra[v]
+		assert.Equal(t, legacy.Id, got.EraID, "version %d EraID", v)
+	}
+
+	_, found := shape.EraForVersion(99)
+	assert.False(t, found)
+}
+
+func TestBuildShape_MissingShelleyGenesis(t *testing.T) {
+	cfg := &cardano.CardanoNodeConfig{}
+	_, err := eras.BuildShape(cfg)
+	assert.Error(t, err)
+}

--- a/ledger/hardfork/bugs_test.go
+++ b/ledger/hardfork/bugs_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSummary_Validate_RejectsZeroEpochSize ensures Summary.Validate() catches
+// a per-era EraParams with EpochSize==0 before SlotToEpoch panics on division
+// by zero. Without per-era Params validation inside Validate(), a malformed
+// Summary can be "valid" and then panic at use.
+func TestSummary_Validate_RejectsZeroEpochSize(t *testing.T) {
+	s := hardfork.Summary{
+		SystemStart: time.Now(),
+		Eras: []hardfork.EraSummary{{
+			EraID:  1,
+			Start:  hardfork.Bound{},
+			End:    nil,
+			Params: hardfork.EraParams{EpochSize: 0, SlotLength: time.Second},
+		}},
+	}
+	assert.Error(t, s.Validate(),
+		"Validate must reject a Summary with a zero-EpochSize era (SlotToEpoch would divide by zero)")
+}
+
+// TestSummary_Validate_RejectsZeroSlotLength mirrors the EpochSize check for
+// SlotLength, which TimeToSlot divides by.
+func TestSummary_Validate_RejectsZeroSlotLength(t *testing.T) {
+	s := hardfork.Summary{
+		SystemStart: time.Now(),
+		Eras: []hardfork.EraSummary{{
+			EraID:  1,
+			Start:  hardfork.Bound{},
+			End:    nil,
+			Params: hardfork.EraParams{EpochSize: 10, SlotLength: 0},
+		}},
+	}
+	assert.Error(t, s.Validate(),
+		"Validate must reject a Summary with a zero-SlotLength era (TimeToSlot would divide by zero)")
+}
+
+// TestSummary_Validate_ErrorMessageFormatsEraIDAsDecimal pins that the
+// "unbounded but not last" error uses %d, not %q. %q on a uint formats as a
+// rune literal (e.g., '\x05'), which is unreadable and incorrect for an
+// ordinal era ID.
+func TestSummary_Validate_ErrorMessageFormatsEraIDAsDecimal(t *testing.T) {
+	end := hardfork.Bound{RelativeTime: 100, Slot: 10, Epoch: 1}
+	s := hardfork.Summary{
+		SystemStart: time.Now(),
+		Eras: []hardfork.EraSummary{
+			{
+				EraID:  5,
+				Start:  hardfork.Bound{},
+				End:    nil, // unbounded, but not the last era
+				Params: hardfork.EraParams{EpochSize: 10, SlotLength: time.Second},
+			},
+			{
+				EraID:  7,
+				Start:  end,
+				End:    nil,
+				Params: hardfork.EraParams{EpochSize: 10, SlotLength: time.Second},
+			},
+		},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "5",
+		"error message should include the decimal era ID (5), got: %s", msg)
+	// %q on uint(5) produces '\x05' — should never appear in a well-formatted
+	// error message.
+	assert.NotContains(t, msg, `'\x05'`,
+		"error message should NOT contain a rune literal, got: %s", msg)
+}
+
+// TestShape_Validate_VersionContiguityHandlesUintOverflow guards against the
+// subtle bug in `prev.MaxMajorVersion + 1` when MaxMajorVersion is MaxUint:
+// the arithmetic wraps to 0 and a subsequent era with MinMajorVersion=0 is
+// incorrectly accepted.
+func TestShape_Validate_VersionContiguityHandlesUintOverflow(t *testing.T) {
+	s := hardfork.Shape{
+		SystemStart: time.Now(),
+		Eras: []hardfork.ShapeEntry{
+			{
+				EraID: 0, EraName: "A",
+				MinMajorVersion: 0, MaxMajorVersion: math.MaxUint,
+				Params: hardfork.EraParams{EpochSize: 10, SlotLength: time.Second, SafeZoneSlots: 1},
+			},
+			{
+				EraID: 1, EraName: "B",
+				MinMajorVersion: 0, MaxMajorVersion: 0,
+				Params: hardfork.EraParams{EpochSize: 10, SlotLength: time.Second, SafeZoneSlots: 1},
+			},
+		},
+	}
+	err := s.Validate()
+	require.Error(t, err,
+		"Validate must reject a shape where the contiguity check would overflow uint (prev.Max=MaxUint, cur.Min=0)")
+	// The message should reference the era name so the operator can spot the bad entry.
+	assert.True(t, strings.Contains(err.Error(), "\"B\"") || strings.Contains(err.Error(), "B"),
+		"error should identify the offending era, got: %s", err.Error())
+}
+

--- a/ledger/hardfork/build.go
+++ b/ledger/hardfork/build.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork
+
+import (
+	"fmt"
+	"time"
+)
+
+// BuildSummary constructs a Summary from a Shape, the confirmed closed past
+// eras, the current (open) era, the ledger tip slot, and the current
+// TransitionInfo.
+//
+// The current era's End is computed per the HFC safe-zone rules:
+//
+//   - TransitionUnknown    — apply SafeZoneSlots from max(tipSlot+1, era start),
+//     then snap up to the next epoch boundary.
+//   - TransitionKnown      — pin the end at KnownEpoch's start (mkUpperBound).
+//   - TransitionImpossible — apply SafeZoneSlots from the era start, snapped.
+//
+// If Params.SafeZoneSlots == 0 the era is treated as UnsafeIndefiniteSafeZone
+// and its End remains nil.
+//
+// Mirrors Ouroboros.Consensus.HardFork.Combinator.State.Infra.reconstructSummary.
+func BuildSummary(
+	shape Shape,
+	past []EraSummary,
+	current EraSummary,
+	tipSlot uint64,
+	transition TransitionInfo,
+) (Summary, error) {
+	if err := current.Params.Validate(); err != nil {
+		return Summary{}, fmt.Errorf("hardfork: current era params invalid: %w", err)
+	}
+	for i, p := range past {
+		if p.End == nil {
+			return Summary{}, fmt.Errorf(
+				"hardfork: past era %d (%q) is unbounded",
+				i, p.EraID,
+			)
+		}
+	}
+
+	// Compute the current era's End.
+	var end *Bound
+	switch transition.State {
+	case TransitionKnown:
+		if transition.KnownEpoch <= current.Start.Epoch {
+			return Summary{}, fmt.Errorf(
+				"hardfork: TransitionKnown epoch %d must be > era start epoch %d",
+				transition.KnownEpoch, current.Start.Epoch,
+			)
+		}
+		b := mkUpperBound(current.Params, current.Start, transition.KnownEpoch)
+		end = &b
+	case TransitionUnknown:
+		// Measure safe zone from max(tipSlot+1, era start).
+		fromSlot := tipSlot + 1
+		if fromSlot < current.Start.Slot {
+			fromSlot = current.Start.Slot
+		}
+		end = applySafeZone(current.Params, current.Start, fromSlot)
+	case TransitionImpossible:
+		end = applySafeZone(current.Params, current.Start, current.Start.Slot)
+	default:
+		return Summary{}, fmt.Errorf(
+			"hardfork: unknown TransitionState %v",
+			transition.State,
+		)
+	}
+	current.End = end
+
+	eras := make([]EraSummary, 0, len(past)+1)
+	eras = append(eras, past...)
+	eras = append(eras, current)
+
+	return Summary{
+		SystemStart: shape.SystemStart,
+		Eras:        eras,
+		Transition:  transition,
+	}, nil
+}
+
+// mkUpperBound computes a Bound at the start of hiEpoch, given the era's
+// lower bound lo and its params. Mirrors Haskell's mkUpperBound.
+func mkUpperBound(params EraParams, lo Bound, hiEpoch uint64) Bound {
+	epochsInEra := hiEpoch - lo.Epoch
+	slotsInEra := epochsInEra * params.EpochSize
+	inEraTime := time.Duration(slotsInEra) * params.SlotLength
+	return Bound{
+		RelativeTime: lo.RelativeTime + inEraTime,
+		Slot:         lo.Slot + slotsInEra,
+		Epoch:        hiEpoch,
+	}
+}
+
+// slotToEpochBound returns the smallest absolute epoch whose first slot is
+// >= hiSlot. Mirrors Haskell's slotToEpochBound.
+func slotToEpochBound(params EraParams, lo Bound, hiSlot uint64) uint64 {
+	if hiSlot < lo.Slot {
+		return lo.Epoch
+	}
+	slotsFromLo := hiSlot - lo.Slot
+	epochs := slotsFromLo / params.EpochSize
+	inEpoch := slotsFromLo % params.EpochSize
+	bump := uint64(0)
+	if inEpoch != 0 {
+		bump = 1
+	}
+	return lo.Epoch + epochs + bump
+}
+
+// applySafeZone returns the era End for StandardSafeZone, computed from the
+// given fromSlot. Returns nil if SafeZoneSlots == 0 (UnsafeIndefiniteSafeZone).
+func applySafeZone(params EraParams, lo Bound, fromSlot uint64) *Bound {
+	if params.SafeZoneSlots == 0 {
+		return nil
+	}
+	target := fromSlot + params.SafeZoneSlots
+	hiEpoch := slotToEpochBound(params, lo, target)
+	b := mkUpperBound(params, lo, hiEpoch)
+	return &b
+}
+

--- a/ledger/hardfork/build.go
+++ b/ledger/hardfork/build.go
@@ -98,6 +98,9 @@ func BuildSummary(
 func mkUpperBound(params EraParams, lo Bound, hiEpoch uint64) Bound {
 	epochsInEra := hiEpoch - lo.Epoch
 	slotsInEra := epochsInEra * params.EpochSize
+	// slotsInEra is bounded by the era's epoch span; real-chain values remain
+	// well under int64 (292 years at 1s/slot).
+	// #nosec G115
 	inEraTime := time.Duration(slotsInEra) * params.SlotLength
 	return Bound{
 		RelativeTime: lo.RelativeTime + inEraTime,
@@ -133,4 +136,3 @@ func applySafeZone(params EraParams, lo Bound, fromSlot uint64) *Bound {
 	b := mkUpperBound(params, lo, hiEpoch)
 	return &b
 }
-

--- a/ledger/hardfork/build_test.go
+++ b/ledger/hardfork/build_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ------------------------------------------------------------------ helpers
+
+// singleEraShape returns a shape with only the provided era, useful for
+// unit-testing Summary construction without having to reason about past eras.
+func singleEraShape(entry hardfork.ShapeEntry) hardfork.Shape {
+	return hardfork.Shape{SystemStart: testSysStart, Eras: []hardfork.ShapeEntry{entry}}
+}
+
+func conwayShapeEntry() hardfork.ShapeEntry {
+	return hardfork.ShapeEntry{
+		EraID:           6,
+		EraName:         "Conway",
+		MinMajorVersion: 9,
+		MaxMajorVersion: 10,
+		Params:          shelleyParams,
+	}
+}
+
+// ------------------------------------------------------------------ single era
+
+// BuildSummary with no past eras and TransitionUnknown: the current era's
+// End is tipSlot + SafeZoneSlots snapped to the next epoch boundary.
+func TestBuildSummary_SingleEra_TransitionUnknown(t *testing.T) {
+	shape := singleEraShape(conwayShapeEntry())
+	current := hardfork.EraSummary{
+		EraID:  6,
+		Start:  hardfork.Bound{RelativeTime: 0, Slot: 100_000, Epoch: 500},
+		End:    nil,
+		Params: shelleyParams,
+	}
+	tipSlot := uint64(200_000)
+	// SafeZoneSlots = 25_920 → safeEnd = 225_920. Snap to next epoch boundary.
+	// Epoch 500 spans slots [100_000, 532_000). 225_920 is inside epoch 500,
+	// so the end snaps to 532_000 (epoch 501).
+	s, err := hardfork.BuildSummary(shape, nil, current, tipSlot, hardfork.NewTransitionUnknown())
+	require.NoError(t, err)
+	require.Len(t, s.Eras, 1)
+
+	cur := s.Eras[0]
+	require.NotNil(t, cur.End, "TransitionUnknown with finite SafeZoneSlots produces bounded end")
+	assert.Equal(t, uint64(532_000), cur.End.Slot)
+	assert.Equal(t, uint64(501), cur.End.Epoch)
+}
+
+// BuildSummary with TransitionKnown: the end is set to the KnownEpoch's start.
+func TestBuildSummary_SingleEra_TransitionKnown(t *testing.T) {
+	shape := singleEraShape(conwayShapeEntry())
+	current := hardfork.EraSummary{
+		EraID:  6,
+		Start:  hardfork.Bound{RelativeTime: 0, Slot: 100_000, Epoch: 500},
+		End:    nil,
+		Params: shelleyParams,
+	}
+	tipSlot := uint64(200_000)
+	s, err := hardfork.BuildSummary(shape, nil, current, tipSlot, hardfork.NewTransitionKnown(501))
+	require.NoError(t, err)
+	require.Len(t, s.Eras, 1)
+
+	cur := s.Eras[0]
+	require.NotNil(t, cur.End)
+	assert.Equal(t, uint64(532_000), cur.End.Slot, "TransitionKnown should pin the end at epoch 501's start")
+	assert.Equal(t, uint64(501), cur.End.Epoch)
+}
+
+// BuildSummary with TransitionImpossible: safe zone applies from era start.
+func TestBuildSummary_SingleEra_TransitionImpossible(t *testing.T) {
+	shape := singleEraShape(conwayShapeEntry())
+	current := hardfork.EraSummary{
+		EraID:  6,
+		Start:  hardfork.Bound{RelativeTime: 0, Slot: 100_000, Epoch: 500},
+		End:    nil,
+		Params: shelleyParams,
+	}
+	tipSlot := uint64(200_000)
+	s, err := hardfork.BuildSummary(shape, nil, current, tipSlot, hardfork.NewTransitionImpossible())
+	require.NoError(t, err)
+	require.Len(t, s.Eras, 1)
+
+	cur := s.Eras[0]
+	require.NotNil(t, cur.End)
+	// Safe zone from era start slot 100_000: 100_000 + 25_920 = 125_920, snap
+	// to next epoch boundary. Epoch 500 = [100_000, 532_000).
+	assert.Equal(t, uint64(532_000), cur.End.Slot)
+	assert.Equal(t, uint64(501), cur.End.Epoch)
+}
+
+// SafeZoneSlots == 0 denotes UnsafeIndefiniteSafeZone: unbounded.
+func TestBuildSummary_UnsafeIndefiniteSafeZone(t *testing.T) {
+	entry := conwayShapeEntry()
+	entry.Params.SafeZoneSlots = 0
+	shape := singleEraShape(entry)
+	current := hardfork.EraSummary{
+		EraID:  6,
+		Start:  hardfork.Bound{RelativeTime: 0, Slot: 100_000, Epoch: 500},
+		End:    nil,
+		Params: entry.Params,
+	}
+	s, err := hardfork.BuildSummary(shape, nil, current, 200_000, hardfork.NewTransitionUnknown())
+	require.NoError(t, err)
+	require.Len(t, s.Eras, 1)
+	assert.Nil(t, s.Eras[0].End, "zero SafeZoneSlots ⇒ unbounded end")
+}
+
+// A past era gets carried through verbatim.
+func TestBuildSummary_WithPastEra(t *testing.T) {
+	shape := sampleShape()
+	// Byron: closed past era, slot 0..100 (5 epochs: each epoch = 20s * 21_600 = 432_000s).
+	// We keep the arithmetic simple by using a short synthetic Byron.
+	byronStart := hardfork.Bound{}
+	byronEnd := hardfork.Bound{
+		RelativeTime: 100 * 20 * time.Second,
+		Slot:         100,
+		Epoch:        1,
+	}
+	past := []hardfork.EraSummary{{
+		EraID:  0,
+		Start:  byronStart,
+		End:    &byronEnd,
+		Params: byronParams,
+	}}
+	current := hardfork.EraSummary{
+		EraID:  1,
+		Start:  byronEnd,
+		End:    nil,
+		Params: shelleyParams,
+	}
+	// tipSlot = 150 (50 Shelley slots past the era start).
+	s, err := hardfork.BuildSummary(shape, past, current, 150, hardfork.NewTransitionUnknown())
+	require.NoError(t, err)
+	require.Len(t, s.Eras, 2)
+
+	assert.Equal(t, uint(0), s.Eras[0].EraID)
+	require.NotNil(t, s.Eras[0].End)
+	assert.Equal(t, uint64(100), s.Eras[0].End.Slot)
+
+	assert.Equal(t, uint(1), s.Eras[1].EraID)
+	require.NotNil(t, s.Eras[1].End, "TransitionUnknown + finite SafeZoneSlots ⇒ bounded end")
+	// safe end = 150 + 25_920 = 26_070. Shelley epoch 1 = [100, 432_100).
+	// snap to next epoch boundary → 432_100, epoch 2.
+	assert.Equal(t, uint64(432_100), s.Eras[1].End.Slot)
+	assert.Equal(t, uint64(2), s.Eras[1].End.Epoch)
+}
+
+// BuildSummary copies over transition info onto the summary.
+func TestBuildSummary_CarriesTransitionInfo(t *testing.T) {
+	shape := singleEraShape(conwayShapeEntry())
+	current := hardfork.EraSummary{
+		EraID:  6,
+		Start:  hardfork.Bound{RelativeTime: 0, Slot: 100_000, Epoch: 500},
+		Params: shelleyParams,
+	}
+	ti := hardfork.NewTransitionKnown(501)
+	s, err := hardfork.BuildSummary(shape, nil, current, 200_000, ti)
+	require.NoError(t, err)
+	assert.Equal(t, ti, s.Transition)
+}
+
+// Sanity-check: after BuildSummary, SlotToTime/TimeToSlot work on the result.
+func TestBuildSummary_RoundTripSlotTime(t *testing.T) {
+	shape := singleEraShape(conwayShapeEntry())
+	current := hardfork.EraSummary{
+		EraID:  6,
+		Start:  hardfork.Bound{RelativeTime: 0, Slot: 100_000, Epoch: 500},
+		Params: shelleyParams,
+	}
+	s, err := hardfork.BuildSummary(shape, nil, current, 200_000, hardfork.NewTransitionKnown(501))
+	require.NoError(t, err)
+
+	when, err := s.SlotToTime(150_000)
+	require.NoError(t, err)
+	// 150_000 - 100_000 = 50_000 seconds past system start.
+	assert.Equal(t, testSysStart.Add(50_000*time.Second), when)
+
+	back, err := s.TimeToSlot(when)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(150_000), back)
+}

--- a/ledger/hardfork/params.go
+++ b/ledger/hardfork/params.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hardfork provides the HardFork Combinator primitives used by the
+// ledger to reason about multi-era chain time, epoch, and slot conversions.
+//
+// This package mirrors the structure of Ouroboros.Consensus.HardFork.History
+// and Ouroboros.Consensus.HardFork.Combinator in the Haskell consensus
+// implementation, but is deliberately decoupled from any specific era or
+// genesis configuration. Callers build an EraParams + Shape + Summary from
+// their own sources and then use the conversion methods on Summary.
+package hardfork
+
+import (
+	"errors"
+	"time"
+)
+
+// EraParams describes the fixed per-era protocol parameters needed to
+// translate between slot, epoch, and wall-clock time.
+//
+// SafeZoneSlots == 0 denotes UnsafeIndefiniteSafeZone: the era has no known
+// upper bound, and Summary will produce a nil End for it.
+type EraParams struct {
+	// EpochSize is the number of slots per epoch in this era.
+	EpochSize uint64
+	// SlotLength is the wall-clock duration of one slot.
+	SlotLength time.Duration
+	// SafeZoneSlots is the number of slots from the ledger tip (or era start)
+	// within which no hard fork can occur. Zero means unbounded (the era has
+	// no forecasted end).
+	SafeZoneSlots uint64
+	// GenesisWindow is the Ouroboros Genesis density-disconnection window,
+	// also expressed in slots. Unused by Summary today but carried for
+	// future callers.
+	GenesisWindow uint64
+}
+
+// Validate returns nil if the EraParams values are internally consistent.
+func (p EraParams) Validate() error {
+	if p.EpochSize == 0 {
+		return errors.New("hardfork: EraParams.EpochSize must be > 0")
+	}
+	if p.SlotLength <= 0 {
+		return errors.New("hardfork: EraParams.SlotLength must be > 0")
+	}
+	return nil
+}
+
+// Bound identifies a point in chain coordinates along all three axes: relative
+// time (since SystemStart), absolute slot, and absolute epoch. Every EraSummary
+// has a Start Bound, and a closed era also has an End Bound.
+type Bound struct {
+	RelativeTime time.Duration
+	Slot         uint64
+	Epoch        uint64
+}

--- a/ledger/hardfork/params_test.go
+++ b/ledger/hardfork/params_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBound_Zero(t *testing.T) {
+	var b hardfork.Bound
+	assert.Equal(t, time.Duration(0), b.RelativeTime)
+	assert.Equal(t, uint64(0), b.Slot)
+	assert.Equal(t, uint64(0), b.Epoch)
+}
+
+func TestEraParams_Zero(t *testing.T) {
+	var p hardfork.EraParams
+	assert.Equal(t, uint64(0), p.EpochSize)
+	assert.Equal(t, time.Duration(0), p.SlotLength)
+	assert.Equal(t, uint64(0), p.SafeZoneSlots)
+	assert.Equal(t, uint64(0), p.GenesisWindow)
+}
+
+func TestEraParams_Valid(t *testing.T) {
+	p := hardfork.EraParams{
+		EpochSize:     432_000,
+		SlotLength:    time.Second,
+		SafeZoneSlots: 25_920,
+		GenesisWindow: 25_920,
+	}
+	assert.NoError(t, p.Validate())
+}
+
+func TestEraParams_ValidateRejectsZeroEpochSize(t *testing.T) {
+	p := hardfork.EraParams{
+		EpochSize:  0,
+		SlotLength: time.Second,
+	}
+	assert.Error(t, p.Validate())
+}
+
+func TestEraParams_ValidateRejectsZeroSlotLength(t *testing.T) {
+	p := hardfork.EraParams{
+		EpochSize:  432_000,
+		SlotLength: 0,
+	}
+	assert.Error(t, p.Validate())
+}

--- a/ledger/hardfork/shape.go
+++ b/ledger/hardfork/shape.go
@@ -65,7 +65,10 @@ func (s Shape) Validate() error {
 			continue
 		}
 		prev := s.Eras[i-1]
-		if e.MinMajorVersion != prev.MaxMajorVersion+1 {
+		// Check contiguity without computing prev.MaxMajorVersion+1 directly —
+		// that addition can wrap uint if MaxMajorVersion == math.MaxUint and
+		// silently accept e.MinMajorVersion == 0 as a valid successor.
+		if e.MinMajorVersion == 0 || e.MinMajorVersion-1 != prev.MaxMajorVersion {
 			return fmt.Errorf(
 				"hardfork: era %q: MinMajorVersion (%d) must be prev (%q) MaxMajorVersion (%d) + 1",
 				e.EraName, e.MinMajorVersion, prev.EraName, prev.MaxMajorVersion,

--- a/ledger/hardfork/shape.go
+++ b/ledger/hardfork/shape.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ShapeEntry describes one era's static identity and parameters: the era ID,
+// the span of protocol major versions it covers, and its EraParams.
+//
+// Protocol major version ranges must be contiguous and non-overlapping across
+// a valid Shape.
+type ShapeEntry struct {
+	EraID           uint
+	EraName         string
+	MinMajorVersion uint
+	MaxMajorVersion uint
+	Params          EraParams
+}
+
+// Shape is the static, compile-time-known era table: the set of eras this node
+// binary knows how to handle, in chronological order. Mirrors Haskell's
+// Ouroboros.Consensus.HardFork.History.Summary.Shape.
+type Shape struct {
+	SystemStart time.Time
+	Eras        []ShapeEntry
+}
+
+// Validate returns nil if the Shape is structurally consistent:
+//   - At least one era entry.
+//   - Each entry's protocol-version range is well-formed (min ≤ max).
+//   - Consecutive entries' version ranges meet without gap and without overlap
+//     (cur.Min == prev.Max + 1).
+//   - Each entry's EraParams validate.
+func (s Shape) Validate() error {
+	if len(s.Eras) == 0 {
+		return errors.New("hardfork: Shape must have at least one era")
+	}
+	for i, e := range s.Eras {
+		if e.MinMajorVersion > e.MaxMajorVersion {
+			return fmt.Errorf(
+				"hardfork: era %q: MinMajorVersion (%d) > MaxMajorVersion (%d)",
+				e.EraName, e.MinMajorVersion, e.MaxMajorVersion,
+			)
+		}
+		if err := e.Params.Validate(); err != nil {
+			return fmt.Errorf("hardfork: era %q: %w", e.EraName, err)
+		}
+		if i == 0 {
+			continue
+		}
+		prev := s.Eras[i-1]
+		if e.MinMajorVersion != prev.MaxMajorVersion+1 {
+			return fmt.Errorf(
+				"hardfork: era %q: MinMajorVersion (%d) must be prev (%q) MaxMajorVersion (%d) + 1",
+				e.EraName, e.MinMajorVersion, prev.EraName, prev.MaxMajorVersion,
+			)
+		}
+	}
+	return nil
+}
+
+// EraForVersion returns the ShapeEntry whose version range contains
+// majorVersion, or (_, false) if no era covers it.
+func (s Shape) EraForVersion(majorVersion uint) (ShapeEntry, bool) {
+	for _, e := range s.Eras {
+		if majorVersion >= e.MinMajorVersion && majorVersion <= e.MaxMajorVersion {
+			return e, true
+		}
+	}
+	return ShapeEntry{}, false
+}
+
+// EraForID returns the ShapeEntry with the given EraID, or (_, false).
+func (s Shape) EraForID(eraID uint) (ShapeEntry, bool) {
+	for _, e := range s.Eras {
+		if e.EraID == eraID {
+			return e, true
+		}
+	}
+	return ShapeEntry{}, false
+}
+
+// EraIndex returns the zero-based position of the era with the given EraID in
+// the shape, or (_, false) if no such era is present.
+func (s Shape) EraIndex(eraID uint) (int, bool) {
+	for i, e := range s.Eras {
+		if e.EraID == eraID {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/ledger/hardfork/shape_test.go
+++ b/ledger/hardfork/shape_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleShape() hardfork.Shape {
+	return hardfork.Shape{
+		SystemStart: testSysStart,
+		Eras: []hardfork.ShapeEntry{
+			{EraID: 0, EraName: "Byron", MinMajorVersion: 0, MaxMajorVersion: 1, Params: byronParams},
+			{EraID: 1, EraName: "Shelley", MinMajorVersion: 2, MaxMajorVersion: 2, Params: shelleyParams},
+			{EraID: 2, EraName: "Allegra", MinMajorVersion: 3, MaxMajorVersion: 3, Params: shelleyParams},
+			{EraID: 3, EraName: "Mary", MinMajorVersion: 4, MaxMajorVersion: 4, Params: shelleyParams},
+			{EraID: 4, EraName: "Alonzo", MinMajorVersion: 5, MaxMajorVersion: 6, Params: shelleyParams},
+			{EraID: 5, EraName: "Babbage", MinMajorVersion: 7, MaxMajorVersion: 8, Params: shelleyParams},
+			{EraID: 6, EraName: "Conway", MinMajorVersion: 9, MaxMajorVersion: 10, Params: shelleyParams},
+		},
+	}
+}
+
+func TestShape_Validate_OK(t *testing.T) {
+	s := sampleShape()
+	assert.NoError(t, s.Validate())
+}
+
+func TestShape_Validate_RejectsEmpty(t *testing.T) {
+	s := hardfork.Shape{SystemStart: testSysStart}
+	assert.Error(t, s.Validate())
+}
+
+func TestShape_Validate_RejectsVersionGap(t *testing.T) {
+	// Byron's MaxMajorVersion=1, but Shelley's Min=3 (gap at version 2).
+	s := hardfork.Shape{
+		SystemStart: testSysStart,
+		Eras: []hardfork.ShapeEntry{
+			{EraID: 0, EraName: "Byron", MinMajorVersion: 0, MaxMajorVersion: 1, Params: byronParams},
+			{EraID: 1, EraName: "Shelley", MinMajorVersion: 3, MaxMajorVersion: 3, Params: shelleyParams},
+		},
+	}
+	assert.Error(t, s.Validate())
+}
+
+func TestShape_Validate_RejectsVersionOverlap(t *testing.T) {
+	// Byron.Max=2, Shelley.Min=2 — overlap.
+	s := hardfork.Shape{
+		SystemStart: testSysStart,
+		Eras: []hardfork.ShapeEntry{
+			{EraID: 0, EraName: "Byron", MinMajorVersion: 0, MaxMajorVersion: 2, Params: byronParams},
+			{EraID: 1, EraName: "Shelley", MinMajorVersion: 2, MaxMajorVersion: 2, Params: shelleyParams},
+		},
+	}
+	assert.Error(t, s.Validate())
+}
+
+func TestShape_EraForVersion(t *testing.T) {
+	s := sampleShape()
+	tests := []struct {
+		version uint
+		wantID  uint
+		found   bool
+	}{
+		{0, 0, true},   // Byron
+		{1, 0, true},   // Byron
+		{2, 1, true},   // Shelley
+		{3, 2, true},   // Allegra
+		{9, 6, true},   // Conway
+		{10, 6, true},  // Conway
+		{11, 0, false}, // unknown
+	}
+	for _, tc := range tests {
+		entry, ok := s.EraForVersion(tc.version)
+		assert.Equal(t, tc.found, ok, "version=%d", tc.version)
+		if ok {
+			assert.Equal(t, tc.wantID, entry.EraID)
+		}
+	}
+}
+
+func TestShape_EraForID(t *testing.T) {
+	s := sampleShape()
+	entry, ok := s.EraForID(1)
+	require.True(t, ok)
+	assert.Equal(t, "Shelley", entry.EraName)
+
+	_, ok = s.EraForID(99)
+	assert.False(t, ok)
+}
+
+func TestShape_EraIndex(t *testing.T) {
+	s := sampleShape()
+	idx, ok := s.EraIndex(0)
+	require.True(t, ok)
+	assert.Equal(t, 0, idx)
+
+	idx, ok = s.EraIndex(6)
+	require.True(t, ok)
+	assert.Equal(t, 6, idx)
+
+	_, ok = s.EraIndex(99)
+	assert.False(t, ok)
+}

--- a/ledger/hardfork/summary.go
+++ b/ledger/hardfork/summary.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrBeforeGenesis is returned by TimeToSlot when the given time is before
+// the chain's SystemStart.
+var ErrBeforeGenesis = errors.New("hardfork: time is before system start")
+
+// ErrPastHorizon is returned when a slot or time falls past the last bounded
+// era's end and no unbounded era follows. Mirrors Haskell's PastHorizonException.
+var ErrPastHorizon = errors.New("hardfork: slot/time past era horizon")
+
+// EraSummary describes the bounds and parameters of a single era within a
+// chain's confirmed history.
+//
+// End == nil denotes an unbounded era (the current era under
+// UnsafeIndefiniteSafeZone). Every past era MUST have a non-nil End.
+type EraSummary struct {
+	EraID  uint
+	Start  Bound
+	End    *Bound // nil ⇒ unbounded
+	Params EraParams
+}
+
+// EpochInfo is a lightweight SlotToEpoch answer combining the absolute epoch
+// number with the era parameters needed to reason about it.
+type EpochInfo struct {
+	Epoch         uint64
+	StartSlot     uint64
+	LengthInSlots uint64
+	SlotLength    time.Duration
+	EraID         uint
+}
+
+// Summary is the confirmed per-chain era history. It is derived from the
+// ledger state + TransitionInfo by BuildSummary and then consulted for all
+// slot/epoch/time conversions.
+//
+// Summary mirrors the semantics of Ouroboros.Consensus.HardFork.History.Summary
+// but in a Go-idiomatic, non-generic form.
+type Summary struct {
+	SystemStart time.Time
+	Eras        []EraSummary // chronological; last element is the current era
+	Transition  TransitionInfo
+}
+
+// CurrentEra returns a pointer to the last (open) era, or nil if the Summary
+// has no eras.
+func (s *Summary) CurrentEra() *EraSummary {
+	if len(s.Eras) == 0 {
+		return nil
+	}
+	return &s.Eras[len(s.Eras)-1]
+}
+
+// Validate checks structural invariants:
+//   - Summary has at least one era.
+//   - Each non-first era's Start equals the previous era's End.
+//   - Only the last era may have a nil End.
+//
+// It does NOT check the per-era INV-1b / INV-2b invariants (end.Slot ==
+// start.Slot + epochs*epochSize, etc.) — those are left to the builder.
+func (s *Summary) Validate() error {
+	if len(s.Eras) == 0 {
+		return errors.New("hardfork: Summary must have at least one era")
+	}
+	for i := 1; i < len(s.Eras); i++ {
+		prev := s.Eras[i-1]
+		cur := s.Eras[i]
+		if prev.End == nil {
+			return fmt.Errorf("hardfork: era %d (%q) is unbounded but not last",
+				i-1, prev.EraID)
+		}
+		if *prev.End != cur.Start {
+			return fmt.Errorf(
+				"hardfork: era %d end %+v does not match era %d start %+v",
+				i-1, *prev.End, i, cur.Start,
+			)
+		}
+	}
+	return nil
+}
+
+// eraForSlot returns the era containing the given absolute slot, or
+// ErrPastHorizon if the slot falls outside every era's range.
+func (s *Summary) eraForSlot(slot uint64) (*EraSummary, error) {
+	for i := range s.Eras {
+		era := &s.Eras[i]
+		if slot < era.Start.Slot {
+			return nil, ErrPastHorizon
+		}
+		if era.End == nil || slot < era.End.Slot {
+			return era, nil
+		}
+	}
+	return nil, ErrPastHorizon
+}
+
+// eraForRelTime returns the era containing the given relative time.
+func (s *Summary) eraForRelTime(rt time.Duration) (*EraSummary, error) {
+	for i := range s.Eras {
+		era := &s.Eras[i]
+		if rt < era.Start.RelativeTime {
+			return nil, ErrPastHorizon
+		}
+		if era.End == nil || rt < era.End.RelativeTime {
+			return era, nil
+		}
+	}
+	return nil, ErrPastHorizon
+}
+
+// SlotToTime converts an absolute slot number to its wall-clock start time.
+func (s *Summary) SlotToTime(slot uint64) (time.Time, error) {
+	era, err := s.eraForSlot(slot)
+	if err != nil {
+		return time.Time{}, err
+	}
+	slotsIntoEra := slot - era.Start.Slot
+	rel := era.Start.RelativeTime + time.Duration(slotsIntoEra)*era.Params.SlotLength
+	return s.SystemStart.Add(rel), nil
+}
+
+// TimeToSlot converts a wall-clock time to the slot in which it falls.
+// Returns ErrBeforeGenesis if t is before SystemStart.
+func (s *Summary) TimeToSlot(t time.Time) (uint64, error) {
+	rel := t.Sub(s.SystemStart)
+	if rel < 0 {
+		return 0, ErrBeforeGenesis
+	}
+	era, err := s.eraForRelTime(rel)
+	if err != nil {
+		return 0, err
+	}
+	relInEra := rel - era.Start.RelativeTime
+	slotsInEra := uint64(relInEra / era.Params.SlotLength)
+	return era.Start.Slot + slotsInEra, nil
+}
+
+// SlotToEpoch converts an absolute slot number to an EpochInfo.
+func (s *Summary) SlotToEpoch(slot uint64) (EpochInfo, error) {
+	era, err := s.eraForSlot(slot)
+	if err != nil {
+		return EpochInfo{}, err
+	}
+	slotsIntoEra := slot - era.Start.Slot
+	epochsIntoEra := slotsIntoEra / era.Params.EpochSize
+	return EpochInfo{
+		Epoch:         era.Start.Epoch + epochsIntoEra,
+		StartSlot:     era.Start.Slot + epochsIntoEra*era.Params.EpochSize,
+		LengthInSlots: era.Params.EpochSize,
+		SlotLength:    era.Params.SlotLength,
+		EraID:         era.EraID,
+	}, nil
+}

--- a/ledger/hardfork/summary.go
+++ b/ledger/hardfork/summary.go
@@ -82,11 +82,19 @@ func (s *Summary) Validate() error {
 	if len(s.Eras) == 0 {
 		return errors.New("hardfork: Summary must have at least one era")
 	}
+	for i, era := range s.Eras {
+		if err := era.Params.Validate(); err != nil {
+			return fmt.Errorf(
+				"hardfork: era %d (id=%d) params: %w",
+				i, era.EraID, err,
+			)
+		}
+	}
 	for i := 1; i < len(s.Eras); i++ {
 		prev := s.Eras[i-1]
 		cur := s.Eras[i]
 		if prev.End == nil {
-			return fmt.Errorf("hardfork: era %d (%q) is unbounded but not last",
+			return fmt.Errorf("hardfork: era %d (id=%d) is unbounded but not last",
 				i-1, prev.EraID)
 		}
 		if *prev.End != cur.Start {
@@ -135,6 +143,9 @@ func (s *Summary) SlotToTime(slot uint64) (time.Time, error) {
 		return time.Time{}, err
 	}
 	slotsIntoEra := slot - era.Start.Slot
+	// slotsIntoEra is bounded by the era slot range; at Cardano slot lengths
+	// the product stays well within time.Duration's int64 nanosecond range.
+	// #nosec G115
 	rel := era.Start.RelativeTime + time.Duration(slotsIntoEra)*era.Params.SlotLength
 	return s.SystemStart.Add(rel), nil
 }
@@ -151,6 +162,9 @@ func (s *Summary) TimeToSlot(t time.Time) (uint64, error) {
 		return 0, err
 	}
 	relInEra := rel - era.Start.RelativeTime
+	// eraForRelTime guarantees rel >= era.Start.RelativeTime, and Validate
+	// requires SlotLength > 0, so the quotient is non-negative.
+	// #nosec G115
 	slotsInEra := uint64(relInEra / era.Params.SlotLength)
 	return era.Start.Slot + slotsInEra, nil
 }

--- a/ledger/hardfork/summary_test.go
+++ b/ledger/hardfork/summary_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// systemStart used by most summary tests.
+var testSysStart = time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC)
+
+// boundedAt is a helper to build a Bound.
+func boundedAt(rel time.Duration, slot, epoch uint64) hardfork.Bound {
+	return hardfork.Bound{RelativeTime: rel, Slot: slot, Epoch: epoch}
+}
+
+// byronParams mimic Byron mainnet (20s slots, 21600 slots per epoch).
+var byronParams = hardfork.EraParams{
+	EpochSize:     21_600,
+	SlotLength:    20 * time.Second,
+	SafeZoneSlots: 4320,
+	GenesisWindow: 4320,
+}
+
+// shelleyParams mimic Shelley mainnet (1s slots, 432000 slots per epoch).
+var shelleyParams = hardfork.EraParams{
+	EpochSize:     432_000,
+	SlotLength:    time.Second,
+	SafeZoneSlots: 25_920,
+	GenesisWindow: 25_920,
+}
+
+// twoEraSummary builds a Summary with Byron closed at slot 100 epoch 5 and
+// Shelley open, unbounded.
+func twoEraSummary() hardfork.Summary {
+	end := boundedAt(100*20*time.Second, 100, 5)
+	return hardfork.Summary{
+		SystemStart: testSysStart,
+		Eras: []hardfork.EraSummary{
+			{
+				EraID:  0,
+				Start:  hardfork.Bound{},
+				End:    &end,
+				Params: byronParams,
+			},
+			{
+				EraID:  6,
+				Start:  end,
+				End:    nil, // unbounded
+				Params: shelleyParams,
+			},
+		},
+	}
+}
+
+// ------------------------------------------------------------------ SlotToTime
+
+func TestSummary_SlotToTime_Genesis(t *testing.T) {
+	s := twoEraSummary()
+	got, err := s.SlotToTime(0)
+	require.NoError(t, err)
+	assert.Equal(t, testSysStart, got)
+}
+
+func TestSummary_SlotToTime_InFirstEra(t *testing.T) {
+	s := twoEraSummary()
+	// Byron slot 50 → 50 * 20s = 1000s past system start.
+	got, err := s.SlotToTime(50)
+	require.NoError(t, err)
+	want := testSysStart.Add(1000 * time.Second)
+	assert.Equal(t, want, got)
+}
+
+func TestSummary_SlotToTime_AtEraBoundary(t *testing.T) {
+	s := twoEraSummary()
+	// Slot 100 is the start of the Shelley era.
+	got, err := s.SlotToTime(100)
+	require.NoError(t, err)
+	want := testSysStart.Add(100 * 20 * time.Second) // 2000s
+	assert.Equal(t, want, got)
+}
+
+func TestSummary_SlotToTime_InSecondEra(t *testing.T) {
+	s := twoEraSummary()
+	// Slot 150 = 100 (era start) + 50 Shelley slots * 1s each.
+	got, err := s.SlotToTime(150)
+	require.NoError(t, err)
+	want := testSysStart.Add(100*20*time.Second + 50*time.Second)
+	assert.Equal(t, want, got)
+}
+
+func TestSummary_SlotToTime_PastHorizon_BoundedLastEra(t *testing.T) {
+	// Summary whose only era has a closed End at slot 100.
+	end := boundedAt(100*20*time.Second, 100, 5)
+	s := hardfork.Summary{
+		SystemStart: testSysStart,
+		Eras: []hardfork.EraSummary{{
+			EraID:  0,
+			Start:  hardfork.Bound{},
+			End:    &end,
+			Params: byronParams,
+		}},
+	}
+	_, err := s.SlotToTime(100)
+	// Slot 100 is *at* the boundary: treated as not belonging to this era.
+	assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+}
+
+// ------------------------------------------------------------------ TimeToSlot
+
+func TestSummary_TimeToSlot_Genesis(t *testing.T) {
+	s := twoEraSummary()
+	got, err := s.TimeToSlot(testSysStart)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), got)
+}
+
+func TestSummary_TimeToSlot_BeforeGenesis(t *testing.T) {
+	s := twoEraSummary()
+	_, err := s.TimeToSlot(testSysStart.Add(-time.Second))
+	assert.True(t, errors.Is(err, hardfork.ErrBeforeGenesis))
+}
+
+func TestSummary_TimeToSlot_InFirstEra(t *testing.T) {
+	s := twoEraSummary()
+	got, err := s.TimeToSlot(testSysStart.Add(1000 * time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(50), got) // 1000s / 20s
+}
+
+func TestSummary_TimeToSlot_InSecondEra(t *testing.T) {
+	s := twoEraSummary()
+	// Shelley starts at 2000s; 2000s + 50s → slot 150.
+	got, err := s.TimeToSlot(testSysStart.Add(2050 * time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(150), got)
+}
+
+func TestSummary_TimeToSlot_AtEraBoundary(t *testing.T) {
+	s := twoEraSummary()
+	// Exactly at boundary → belongs to second era at slot 100.
+	got, err := s.TimeToSlot(testSysStart.Add(2000 * time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), got)
+}
+
+// ------------------------------------------------------------------ SlotToEpoch
+
+func TestSummary_SlotToEpoch_InFirstEra(t *testing.T) {
+	// Byron era starts at epoch 0 slot 0. Epoch size 21_600.
+	end := boundedAt(100_000*20*time.Second, 100_000, 20)
+	s := hardfork.Summary{
+		SystemStart: testSysStart,
+		Eras: []hardfork.EraSummary{{
+			EraID:  0,
+			Start:  hardfork.Bound{},
+			End:    &end,
+			Params: byronParams,
+		}},
+	}
+	got, err := s.SlotToEpoch(21_600 + 100)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), got.Epoch)
+	assert.Equal(t, uint64(21_600), got.StartSlot)
+	assert.Equal(t, uint64(21_600), got.LengthInSlots)
+	assert.Equal(t, 20*time.Second, got.SlotLength)
+	assert.Equal(t, uint(0), got.EraID)
+}
+
+func TestSummary_SlotToEpoch_InSecondEra(t *testing.T) {
+	s := twoEraSummary()
+	// Slot 100 is Shelley epoch 5 (carried over from Byron's end).
+	got, err := s.SlotToEpoch(100)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), got.Epoch)
+	assert.Equal(t, uint64(100), got.StartSlot)
+	assert.Equal(t, uint64(432_000), got.LengthInSlots)
+	assert.Equal(t, time.Second, got.SlotLength)
+	assert.Equal(t, uint(6), got.EraID)
+}
+
+func TestSummary_SlotToEpoch_PastHorizon(t *testing.T) {
+	end := boundedAt(100*20*time.Second, 100, 5)
+	s := hardfork.Summary{
+		SystemStart: testSysStart,
+		Eras: []hardfork.EraSummary{{
+			EraID:  0,
+			Start:  hardfork.Bound{},
+			End:    &end,
+			Params: byronParams,
+		}},
+	}
+	_, err := s.SlotToEpoch(101)
+	assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+}
+
+// ------------------------------------------------------------------ misc
+
+func TestSummary_CurrentEra(t *testing.T) {
+	s := twoEraSummary()
+	cur := s.CurrentEra()
+	require.NotNil(t, cur)
+	assert.Equal(t, uint(6), cur.EraID)
+	assert.Nil(t, cur.End, "current era is unbounded in this summary")
+}
+
+func TestSummary_Validate_Empty(t *testing.T) {
+	s := hardfork.Summary{SystemStart: testSysStart}
+	assert.Error(t, s.Validate())
+}
+
+func TestSummary_Validate_BoundsLineUp(t *testing.T) {
+	s := twoEraSummary()
+	assert.NoError(t, s.Validate())
+}
+
+func TestSummary_Validate_BoundsMismatch(t *testing.T) {
+	// Byron.End.Slot = 100; Shelley.Start.Slot = 101 — mismatch.
+	end := boundedAt(100*20*time.Second, 100, 5)
+	badStart := boundedAt(100*20*time.Second, 101, 5)
+	s := hardfork.Summary{
+		SystemStart: testSysStart,
+		Eras: []hardfork.EraSummary{
+			{EraID: 0, Start: hardfork.Bound{}, End: &end, Params: byronParams},
+			{EraID: 6, Start: badStart, End: nil, Params: shelleyParams},
+		},
+	}
+	assert.Error(t, s.Validate())
+}

--- a/ledger/hardfork/transition.go
+++ b/ledger/hardfork/transition.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork
+
+// TransitionState encodes which of the three HFC TransitionInfo cases currently
+// applies to the open (current) era. Mirrors Haskell's
+// Ouroboros.Consensus.HardFork.Combinator.State.Types.TransitionInfo.
+type TransitionState uint8
+
+const (
+	// TransitionUnknown means no confirmed upcoming hard fork is known. The
+	// open era's EraEnd will be capped at tipSlot + SafeZoneSlots, snapped to
+	// the next epoch boundary.
+	TransitionUnknown TransitionState = iota
+	// TransitionKnown means the epoch-rollover logic has observed a
+	// protocol-version bump confirmed to be stable. KnownEpoch is the first
+	// epoch of the next era; its start slot is the exact era boundary.
+	TransitionKnown
+	// TransitionImpossible means a hard fork cannot happen within the current
+	// safe zone (e.g. we're past the epoch's voting deadline, or in the
+	// final known era). The safe zone applies from the era start.
+	TransitionImpossible
+)
+
+// String returns a human-readable label for the state.
+func (s TransitionState) String() string {
+	switch s {
+	case TransitionUnknown:
+		return "TransitionUnknown"
+	case TransitionKnown:
+		return "TransitionKnown"
+	case TransitionImpossible:
+		return "TransitionImpossible"
+	default:
+		return "TransitionState(?)"
+	}
+}
+
+// TransitionInfo describes the current era's known-transition state. It mirrors
+// Haskell's HFC TransitionInfo but uses an explicit tag + payload rather than
+// a sum type.
+type TransitionInfo struct {
+	State      TransitionState
+	KnownEpoch uint64 // valid when State == TransitionKnown
+}
+
+// NewTransitionUnknown constructs the TransitionUnknown variant.
+func NewTransitionUnknown() TransitionInfo {
+	return TransitionInfo{State: TransitionUnknown}
+}
+
+// NewTransitionKnown constructs the TransitionKnown variant with the given
+// target epoch (the first epoch of the next era).
+func NewTransitionKnown(epoch uint64) TransitionInfo {
+	return TransitionInfo{State: TransitionKnown, KnownEpoch: epoch}
+}
+
+// NewTransitionImpossible constructs the TransitionImpossible variant.
+func NewTransitionImpossible() TransitionInfo {
+	return TransitionInfo{State: TransitionImpossible}
+}

--- a/ledger/hardfork/transition_test.go
+++ b/ledger/hardfork/transition_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransitionInfo_ZeroIsUnknown(t *testing.T) {
+	var ti hardfork.TransitionInfo
+	assert.Equal(t, hardfork.TransitionUnknown, ti.State)
+	assert.Equal(t, uint64(0), ti.KnownEpoch)
+}
+
+func TestTransitionState_String(t *testing.T) {
+	tests := []struct {
+		state hardfork.TransitionState
+		want  string
+	}{
+		{hardfork.TransitionUnknown, "TransitionUnknown"},
+		{hardfork.TransitionKnown, "TransitionKnown"},
+		{hardfork.TransitionImpossible, "TransitionImpossible"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, tc.state.String())
+	}
+}
+
+func TestTransitionInfo_Constructors(t *testing.T) {
+	u := hardfork.NewTransitionUnknown()
+	assert.Equal(t, hardfork.TransitionUnknown, u.State)
+
+	k := hardfork.NewTransitionKnown(501)
+	assert.Equal(t, hardfork.TransitionKnown, k.State)
+	assert.Equal(t, uint64(501), k.KnownEpoch)
+
+	i := hardfork.NewTransitionImpossible()
+	assert.Equal(t, hardfork.TransitionImpossible, i.State)
+}

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+)
+
+// HardForkSummary constructs a hardfork.Summary describing the chain's era
+// history from the LedgerState's current epoch cache, tip, current era, and
+// transition info.
+//
+// The returned Summary's past eras are closed with bounds computed by walking
+// the epoch cache grouped by EraId. The current era (the last group) is left
+// unbounded (SafeZoneSlots == 0), preserving the existing "project forward
+// using the current era's parameters" behavior of LedgerState.SlotToTime and
+// friends. Once dingo tracks per-era safe zones end-to-end, this will flip to
+// a bounded end sourced from BuildSummary + the real TransitionInfo.
+func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
+	if ls.config.CardanoNodeConfig == nil {
+		return nil, errors.New("ledger: nil CardanoNodeConfig")
+	}
+	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if shelleyGenesis == nil {
+		return nil, errors.New("ledger: Shelley genesis unavailable")
+	}
+
+	ls.RLock()
+	cache := make([]models.Epoch, len(ls.epochCache))
+	copy(cache, ls.epochCache)
+	transitionInfo := ls.transitionInfo
+	ls.RUnlock()
+
+	if len(cache) == 0 {
+		return nil, errors.New("ledger: no epochs in cache")
+	}
+
+	// Walk the epoch cache grouping contiguous epochs by EraId. Each group
+	// becomes one EraSummary; its Start is derived from the first epoch of
+	// the group, and its End (for past eras) is the Start of the next group.
+	var eras []hardfork.EraSummary
+	relTime := time.Duration(0)
+
+	i := 0
+	for i < len(cache) {
+		first := cache[i]
+		eraID := first.EraId
+		// Per-epoch params within an era are expected to be constant; we use
+		// the first epoch's values as the era-level params.
+		slotLen := time.Duration(first.SlotLength) * time.Millisecond
+		epochSize := uint64(first.LengthInSlots)
+
+		start := hardfork.Bound{
+			RelativeTime: relTime,
+			Slot:         first.StartSlot,
+			Epoch:        first.EpochId,
+		}
+
+		// Advance through all contiguous epochs with the same EraId,
+		// accumulating relTime.
+		j := i
+		for j < len(cache) && cache[j].EraId == eraID {
+			ep := cache[j]
+			relTime += time.Duration(ep.LengthInSlots) *
+				time.Duration(ep.SlotLength) * time.Millisecond
+			j++
+		}
+
+		last := cache[j-1]
+		end := hardfork.Bound{
+			RelativeTime: relTime,
+			Slot:         last.StartSlot + uint64(last.LengthInSlots),
+			Epoch:        last.EpochId + 1,
+		}
+
+		era := hardfork.EraSummary{
+			EraID: eraID,
+			Start: start,
+			Params: hardfork.EraParams{
+				EpochSize:     epochSize,
+				SlotLength:    slotLen,
+				SafeZoneSlots: 0, // UnsafeIndefiniteSafeZone — preserve projection
+				GenesisWindow: 0,
+			},
+		}
+
+		isLast := j == len(cache)
+		if !isLast {
+			// Close this era at the next era's start.
+			era.End = &end
+		}
+		eras = append(eras, era)
+
+		i = j
+	}
+
+	return &hardfork.Summary{
+		SystemStart: shelleyGenesis.SystemStart,
+		Eras:        eras,
+		Transition:  transitionInfo,
+	}, nil
+}

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -66,6 +66,8 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		eraID := first.EraId
 		// Per-epoch params within an era are expected to be constant; we use
 		// the first epoch's values as the era-level params.
+		// first.SlotLength is protocol-bounded (milliseconds per slot).
+		// #nosec G115
 		slotLen := time.Duration(first.SlotLength) * time.Millisecond
 		epochSize := uint64(first.LengthInSlots)
 
@@ -80,6 +82,8 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		j := i
 		for j < len(cache) && cache[j].EraId == eraID {
 			ep := cache[j]
+			// LengthInSlots and SlotLength are protocol-bounded uints.
+			// #nosec G115
 			relTime += time.Duration(ep.LengthInSlots) *
 				time.Duration(ep.SlotLength) * time.Millisecond
 			j++

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -33,12 +33,15 @@ import (
 // friends. Once dingo tracks per-era safe zones end-to-end, this will flip to
 // a bounded end sourced from BuildSummary + the real TransitionInfo.
 func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
-	if ls.config.CardanoNodeConfig == nil {
-		return nil, errors.New("ledger: nil CardanoNodeConfig")
-	}
-	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
-	if shelleyGenesis == nil {
-		return nil, errors.New("ledger: Shelley genesis unavailable")
+	// SystemStart is sourced from the Shelley genesis when available. When it
+	// isn't (e.g. SlotToEpoch-style callers that work from the epoch cache
+	// alone), SystemStart stays at the zero time.Time and callers must avoid
+	// using Summary.SlotToTime / TimeToSlot.
+	var systemStart time.Time
+	if ls.config.CardanoNodeConfig != nil {
+		if sg := ls.config.CardanoNodeConfig.ShelleyGenesis(); sg != nil {
+			systemStart = sg.SystemStart
+		}
 	}
 
 	ls.RLock()
@@ -111,7 +114,7 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 	}
 
 	return &hardfork.Summary{
-		SystemStart: shelleyGenesis.SystemStart,
+		SystemStart: systemStart,
 		Eras:        eras,
 		Transition:  transitionInfo,
 	}, nil

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -131,8 +131,8 @@ func TestHardForkSummary_EmptyCache(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestHardForkSummary_MissingShelleyGenesis errors.
-// Tolerates a config without a shelley genesis: SystemStart stays at the
+// TestHardForkSummary_MissingShelleyGenesis tolerates a config without a
+// Shelley genesis: SystemStart stays at the
 // zero time. Callers that need wall-clock conversions must provide the
 // genesis, but epoch-cache-only callers (like SlotToEpoch) can still get a
 // meaningful Summary.

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -132,6 +132,10 @@ func TestHardForkSummary_EmptyCache(t *testing.T) {
 }
 
 // TestHardForkSummary_MissingShelleyGenesis errors.
+// Tolerates a config without a shelley genesis: SystemStart stays at the
+// zero time. Callers that need wall-clock conversions must provide the
+// genesis, but epoch-cache-only callers (like SlotToEpoch) can still get a
+// meaningful Summary.
 func TestHardForkSummary_MissingShelleyGenesis(t *testing.T) {
 	ls := &LedgerState{
 		epochCache: []models.Epoch{
@@ -139,8 +143,11 @@ func TestHardForkSummary_MissingShelleyGenesis(t *testing.T) {
 		},
 		config: LedgerStateConfig{CardanoNodeConfig: &cardano.CardanoNodeConfig{}},
 	}
-	_, err := ls.HardForkSummary()
-	assert.Error(t, err)
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	assert.True(t, sum.SystemStart.IsZero(),
+		"missing shelley genesis ⇒ SystemStart is zero time")
+	require.Len(t, sum.Eras, 1)
 }
 
 // TestHardForkSummary_CarriesTransitionInfo ensures the current transitionInfo

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalShelleyGenesisCfg loads a shelley genesis with only SystemStart
+// populated — matching the pattern used by slot_test.go.
+func minimalShelleyGenesisCfg(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(
+		strings.NewReader(`{"systemStart": "2022-10-25T00:00:00Z"}`),
+	))
+	return cfg
+}
+
+// TestHardForkSummary_SingleEra verifies the simple case: one era spanning
+// multiple contiguous epochs, built from epochCache alone.
+func TestHardForkSummary_SingleEra(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{EpochId: 0, StartSlot: 0, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+			{EpochId: 1, StartSlot: 100, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+			{EpochId: 2, StartSlot: 200, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+		},
+		currentEra: eras.EraDesc{Id: 1, Name: "Shelley"},
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(250, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	require.NotNil(t, sum)
+	assert.Equal(t, time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC), sum.SystemStart)
+
+	require.Len(t, sum.Eras, 1)
+	era := sum.Eras[0]
+	assert.Equal(t, uint(1), era.EraID)
+	assert.Equal(t, hardfork.Bound{RelativeTime: 0, Slot: 0, Epoch: 0}, era.Start)
+	assert.Nil(t, era.End, "current era should be unbounded")
+	assert.Equal(t, uint64(100), era.Params.EpochSize)
+	assert.Equal(t, time.Second, era.Params.SlotLength)
+	assert.Equal(t, uint64(0), era.Params.SafeZoneSlots, "current era unbounded ⇒ SafeZoneSlots=0")
+}
+
+// TestHardForkSummary_TwoEras verifies two contiguous eras produce a Summary
+// with the first era bounded and the second (current) era unbounded.
+func TestHardForkSummary_TwoEras(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			// Byron-ish: EraId=0, 20s slots, 100 slots/epoch
+			{EpochId: 0, StartSlot: 0, SlotLength: 20_000, LengthInSlots: 100, EraId: 0},
+			{EpochId: 1, StartSlot: 100, SlotLength: 20_000, LengthInSlots: 100, EraId: 0},
+			// Shelley-ish: EraId=1, starts at slot 200, 1s slots, 432 slots/epoch
+			{EpochId: 2, StartSlot: 200, SlotLength: 1000, LengthInSlots: 432, EraId: 1},
+			{EpochId: 3, StartSlot: 632, SlotLength: 1000, LengthInSlots: 432, EraId: 1},
+		},
+		currentEra: eras.EraDesc{Id: 1, Name: "Shelley"},
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(700, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	require.Len(t, sum.Eras, 2)
+
+	byron := sum.Eras[0]
+	assert.Equal(t, uint(0), byron.EraID)
+	assert.Equal(t, hardfork.Bound{RelativeTime: 0, Slot: 0, Epoch: 0}, byron.Start)
+	require.NotNil(t, byron.End, "past era must be bounded")
+	// Byron spans 2 epochs × 100 slots × 20s = 4000s, ending at slot 200, epoch 2.
+	assert.Equal(t, hardfork.Bound{
+		RelativeTime: 4000 * time.Second,
+		Slot:         200,
+		Epoch:        2,
+	}, *byron.End)
+
+	shelley := sum.Eras[1]
+	assert.Equal(t, uint(1), shelley.EraID)
+	// Shelley's Start must line up with Byron's End.
+	assert.Equal(t, *byron.End, shelley.Start)
+	assert.Nil(t, shelley.End, "current era unbounded")
+	assert.Equal(t, uint64(432), shelley.Params.EpochSize)
+	assert.Equal(t, time.Second, shelley.Params.SlotLength)
+
+	// End-to-end: the summary's SlotToTime should agree with the manual walk.
+	// Slot 250 is 50 Shelley slots past era start (slot 200) → 4000s + 50s after SystemStart.
+	got, err := sum.SlotToTime(250)
+	require.NoError(t, err)
+	assert.Equal(t, sum.SystemStart.Add(4000*time.Second+50*time.Second), got)
+}
+
+// TestHardForkSummary_EmptyCache errors.
+func TestHardForkSummary_EmptyCache(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	_, err := ls.HardForkSummary()
+	assert.Error(t, err)
+}
+
+// TestHardForkSummary_MissingShelleyGenesis errors.
+func TestHardForkSummary_MissingShelleyGenesis(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{EpochId: 0, StartSlot: 0, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+		},
+		config: LedgerStateConfig{CardanoNodeConfig: &cardano.CardanoNodeConfig{}},
+	}
+	_, err := ls.HardForkSummary()
+	assert.Error(t, err)
+}
+
+// TestHardForkSummary_CarriesTransitionInfo ensures the current transitionInfo
+// is reflected in the returned Summary.
+func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{EpochId: 5, StartSlot: 500, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+		},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(7),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(550, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	assert.Equal(t, hardfork.NewTransitionKnown(7), sum.Transition)
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
@@ -146,6 +147,16 @@ func checkedSlotAdd(
 	return startSlot + length, nil
 }
 
+// eraBoundData captures the per-era bound info computed during the epoch
+// walk. All three axes (relTime as picoseconds, slot, epoch) are tracked in
+// the CBOR-output domain; hardfork.BuildSummary is used only to compute the
+// current era's End under its TransitionInfo rules, then translated back.
+type eraBoundData struct {
+	epochs []models.Epoch
+	start  []any // [picosecondsBigInt, slot, epoch] or nil if era is empty
+	end    []any // same shape; nil for empty eras and populated current era
+}
+
 func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 	// Snapshot the tip, current era, and transition info under the read lock
 	// so we can use them without holding the lock during the (potentially
@@ -156,223 +167,257 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 	transitionInfo := ls.transitionInfo
 	ls.RUnlock()
 
-	retData := []any{}
+	cfg := ls.config.CardanoNodeConfig
+	shape, err := eras.BuildShape(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(shape.Eras) != len(eras.Eras) {
+		return nil, fmt.Errorf(
+			"era history: shape has %d eras, eras.Eras has %d",
+			len(shape.Eras), len(eras.Eras),
+		)
+	}
+
+	perEra := make([]eraBoundData, len(shape.Eras))
 	timespan := big.NewInt(0)
-	var epochs []models.Epoch
-	var era eras.EraDesc
-	var err error
-	var tmpStart, tmpEnd []any
-	var tmpEpoch models.Epoch
-	var tmpEra, tmpParams []any
-	var epochSlotLength, epochLength uint
-	var idx int
-	for _, era = range eras.Eras {
-		epochSlotLength, epochLength, err = era.EpochLengthFunc(
-			ls.config.CardanoNodeConfig,
+	currentIdx := -1
+
+	for i, entry := range shape.Eras {
+		eraDesc := eras.Eras[i]
+		epochs, dbErr := ls.db.GetEpochsByEra(entry.EraID, nil)
+		if dbErr != nil {
+			return nil, dbErr
+		}
+		perEra[i].epochs = epochs
+		if len(epochs) == 0 {
+			continue
+		}
+
+		firstEp := epochs[0]
+		perEra[i].start = []any{
+			new(big.Int).Set(timespan),
+			firstEp.StartSlot,
+			firstEp.EpochId,
+		}
+		for _, ep := range epochs {
+			timespan.Add(
+				timespan,
+				epochPicoseconds(ep.SlotLength, ep.LengthInSlots),
+			)
+		}
+
+		if entry.EraID == currentEraId {
+			// Defer End to the BuildSummary step below.
+			currentIdx = i
+			continue
+		}
+
+		// Past era: default End = (accumulated timespan, lastEp end, epoch+1).
+		lastEp := epochs[len(epochs)-1]
+		endSlot, slotErr := checkedSlotAdd(
+			lastEp.StartSlot,
+			uint64(lastEp.LengthInSlots),
+		)
+		if slotErr != nil {
+			return nil, fmt.Errorf(
+				"epoch %d (start=%d, length=%d): %w",
+				lastEp.EpochId, lastEp.StartSlot, lastEp.LengthInSlots, slotErr,
+			)
+		}
+		perEra[i].end = []any{
+			new(big.Int).Set(timespan),
+			endSlot,
+			lastEp.EpochId + 1,
+		}
+
+		// Transition-epoch detection: a past era whose last epoch's pparams
+		// already carry a later-era protocol version is a TransitionKnown
+		// window that completed. The confirmed boundary is at lastEp.StartSlot,
+		// not lastEp.StartSlot + length; roll back timespan accordingly so the
+		// next era's Start.relTime stays contiguous.
+		if eraDesc.DecodePParamsFunc == nil {
+			continue
+		}
+		pp, ppErr := ls.db.GetPParams(
+			lastEp.EpochId, eraDesc.DecodePParamsFunc, nil,
+		)
+		if ppErr != nil {
+			return nil, fmt.Errorf(
+				"getting pparams for epoch %d: %w", lastEp.EpochId, ppErr,
+			)
+		}
+		if pp == nil {
+			continue
+		}
+		ver, verErr := GetProtocolVersion(pp)
+		if verErr != nil {
+			return nil, fmt.Errorf(
+				"extracting protocol version for epoch %d: %w",
+				lastEp.EpochId, verErr,
+			)
+		}
+		pparamsEraId, ok := EraForVersion(ver.Major)
+		if !ok || pparamsEraId <= entry.EraID {
+			continue
+		}
+		epPc := epochPicoseconds(lastEp.SlotLength, lastEp.LengthInSlots)
+		perEra[i].end = []any{
+			new(big.Int).Sub(timespan, epPc),
+			lastEp.StartSlot,
+			lastEp.EpochId,
+		}
+		// In-place Sub so a later Add on timespan doesn't corrupt the value
+		// already stored in perEra[i].end[0].
+		timespan.Sub(timespan, epPc)
+	}
+
+	// Compute the current era's End via hardfork.BuildSummary, mirroring the
+	// Haskell HFC TransitionKnown/Unknown/Impossible semantics.
+	if currentIdx >= 0 {
+		end, err := ls.currentEraEnd(
+			shape, perEra[currentIdx], currentIdx, tipSlot, transitionInfo,
 		)
 		if err != nil {
 			return nil, err
 		}
-		epochs, err = ls.db.GetEpochsByEra(era.Id, nil)
-		if err != nil {
-			return nil, err
+		perEra[currentIdx].end = end
+	}
+
+	retData := make([]any, 0, len(shape.Eras))
+	for i, entry := range shape.Eras {
+		tmpParams := eraParamsCBOR(entry.Params)
+		if perEra[i].start == nil || perEra[i].end == nil {
+			retData = append(retData, []any{
+				[]any{0, 0, 0},
+				[]any{0, 0, 0},
+				tmpParams,
+			})
+			continue
 		}
-		tmpStart = []any{0, 0, 0}
-		tmpEnd = tmpStart
-		tmpParams = []any{
-			epochLength,
-			epochSlotLength,
-			[]any{
-				0,
-				0,
-				[]any{0},
-			},
-			0,
-		}
-		for idx, tmpEpoch = range epochs {
-			// Update era start
-			if idx == 0 {
-				tmpStart = []any{
-					new(big.Int).Set(timespan),
-					tmpEpoch.StartSlot,
-					tmpEpoch.EpochId,
-				}
-			}
-			// Add epoch length in picoseconds to timespan
-			timespan.Add(
-				timespan,
-				epochPicoseconds(
-					tmpEpoch.SlotLength,
-					tmpEpoch.LengthInSlots,
-				),
-			)
-			// Update era end
-			if idx == len(epochs)-1 {
-				endSlot, slotErr := checkedSlotAdd(
-					tmpEpoch.StartSlot,
-					uint64(tmpEpoch.LengthInSlots),
-				)
-				if slotErr != nil {
-					return nil, fmt.Errorf(
-						"epoch %d (start=%d, length=%d): %w",
-						tmpEpoch.EpochId,
-						tmpEpoch.StartSlot,
-						tmpEpoch.LengthInSlots,
-						slotErr,
-					)
-				}
-				tmpEnd = []any{
-					new(big.Int).Set(timespan),
-					endSlot,
-					tmpEpoch.EpochId + 1,
-				}
-			}
-		}
-		// For closed past eras, check whether the last epoch is a "transition
-		// epoch" — created under this era's EraId during a TransitionKnown
-		// window whose pparams already carry the next-era version.  In that
-		// case the raw epoch-end (StartSlot+LengthInSlots) overshoots the
-		// confirmed boundary; the correct EraEnd is lastEp.StartSlot.
-		if era.Id < currentEraId && len(epochs) > 0 &&
-			era.DecodePParamsFunc != nil {
-			lastEp := epochs[len(epochs)-1]
-			pp, ppErr := ls.db.GetPParams(
-				lastEp.EpochId,
-				era.DecodePParamsFunc,
-				nil,
-			)
-			if ppErr != nil {
-				return nil, fmt.Errorf(
-					"getting pparams for epoch %d: %w",
-					lastEp.EpochId,
-					ppErr,
-				)
-			}
-			if pp != nil {
-				ver, verErr := GetProtocolVersion(pp)
-				if verErr != nil {
-					return nil, fmt.Errorf(
-						"extracting protocol version for epoch %d: %w",
-						lastEp.EpochId,
-						verErr,
-					)
-				}
-				if pparamsEraId, ok := EraForVersion(ver.Major); ok &&
-					pparamsEraId > era.Id {
-					epPc := epochPicoseconds(
-						lastEp.SlotLength,
-						lastEp.LengthInSlots,
-					)
-					timespanAtLastEpochStart := new(big.Int).Sub(
-						timespan,
-						epPc,
-					)
-					tmpEnd = []any{
-						timespanAtLastEpochStart,
-						lastEp.StartSlot,
-						lastEp.EpochId,
-					}
-					// Roll back timespan to match the corrected EraEnd so
-					// the next era's tmpStart.relTime is contiguous with
-					// this era's tmpEnd.relTime.  Must use in-place Sub
-					// (not timespan = timespanAtLastEpochStart) because
-					// timespanAtLastEpochStart is already referenced by
-					// tmpEnd[0] and a later timespan.Add would corrupt it.
-					timespan.Sub(timespan, epPc)
-				}
-			}
-		}
-		// For the current (open) era, set EraEnd based on what is known about
-		// the upcoming era boundary:
-		//
-		//  TransitionKnown      — epoch-rollover confirmed a version bump; use
-		//                         the transition epoch's StartSlot as the exact
-		//                         boundary (mirrors Haskell's TransitionKnown).
-		//
-		//  TransitionImpossible — the stability window already reaches or
-		//                         exceeds the epoch end; a hard fork cannot
-		//                         happen this epoch.  The epoch-end slot is
-		//                         confirmed safe — serve it directly without any
-		//                         safeZone cap.
-		//
-		//  TransitionUnknown    — snap to the end of the epoch containing
-		//                         ledgerTip + safeZone.  Within a single epoch
-		//                         slot↔time is linear (constant slot length), so
-		//                         the epoch-end boundary is the safe forecast
-		//                         limit.  Uncertainty begins at the boundary
-		//                         itself, where a hard fork could alter epoch
-		//                         parameters.
-		if era.Id == currentEraId && len(epochs) > 0 {
-			// useSafeZoneCap is set when no confirmed exact boundary is
-			// available, including the fallback when TransitionKnown is set
-			// but KnownEpoch is absent from the DB epoch list (e.g. due to a
-			// race or rollback).  In that case serving the uncapped epoch-end
-			// would over-claim certainty, so we fall back to the safe-zone cap.
-			useSafeZoneCap := false
-			switch transitionInfo.State {
-			case hardfork.TransitionKnown:
-				// Find the transition epoch in the committed epoch list.
-				// It was created with the old era's EraId, so it appears in
-				// epochs.  Its StartSlot is the exact era end boundary.
-				found := false
-				for _, ep := range epochs {
-					if ep.EpochId == transitionInfo.KnownEpoch {
-						timespanAtEpochStart := new(big.Int).Sub(
-							timespan,
-							epochPicoseconds(ep.SlotLength, ep.LengthInSlots),
-						)
-						tmpEnd = []any{
-							timespanAtEpochStart,
-							ep.StartSlot,
-							ep.EpochId,
-						}
-						found = true
-						break
-					}
-				}
-				if !found {
-					// KnownEpoch missing from DB — fall back to safe-zone cap
-					// rather than serving the uncapped epoch end.
-					useSafeZoneCap = true
-				}
-			case hardfork.TransitionImpossible:
-				// Safe zone already covers the epoch end; tmpEnd was set to
-				// the epoch boundary above — no further capping needed.
-			case hardfork.TransitionUnknown:
-				useSafeZoneCap = true
-			}
-			if useSafeZoneCap {
-				safeZone := ls.calculateStabilityWindowForEra(era.Id)
-				safeEndSlot, addErr := checkedSlotAdd(tipSlot, safeZone)
-				epochEndSlot, slotErr := checkedSlotAdd(
-					tmpEpoch.StartSlot,
-					uint64(tmpEpoch.LengthInSlots),
-				)
-				// Snap to the epoch-end boundary containing safeEndSlot.
-				// Within a single epoch slot↔time is linear (constant slot
-				// length), so uncertainty begins only at the epoch boundary.
-				// timespan already holds the accumulated relTime through the
-				// end of tmpEpoch (set by the epoch loop), so it is the
-				// correct relTime for epochEndSlot.  The epoch number follows
-				// the same +1 convention as the epoch loop.
-				if addErr == nil && slotErr == nil &&
-					safeEndSlot >= tmpEpoch.StartSlot {
-					tmpEnd = []any{
-						new(big.Int).Set(timespan),
-						epochEndSlot,
-						tmpEpoch.EpochId + 1,
-					}
-				}
-			}
-		}
-		tmpEra = []any{
-			tmpStart,
-			tmpEnd,
-			tmpParams,
-		}
-		retData = append(retData, tmpEra)
+		retData = append(retData, []any{
+			perEra[i].start, perEra[i].end, tmpParams,
+		})
 	}
 	return cbor.IndefLengthList(retData), nil
+}
+
+// currentEraEnd computes the open era's End tuple (picosecondRelTime, slot,
+// epoch) from the HFC Summary, with a pre-check that falls back to
+// TransitionUnknown when TransitionKnown's KnownEpoch is missing from the DB
+// (e.g. a race or rollback). Without the fallback, serving the
+// BuildSummary-computed boundary would over-claim certainty about an epoch
+// the node hasn't actually seen.
+func (ls *LedgerState) currentEraEnd(
+	shape hardfork.Shape,
+	era eraBoundData,
+	idx int,
+	tipSlot uint64,
+	ti hardfork.TransitionInfo,
+) ([]any, error) {
+	firstEp := era.epochs[0]
+	startRel, ok := era.start[0].(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf(
+			"current era start[0] has unexpected type %T", era.start[0],
+		)
+	}
+
+	// dingo sets TransitionImpossible when evaluateTransitionImpossible has
+	// confirmed the current epoch's end is within the safe-zone horizon
+	// (safeEndSlot >= epochEndSlot). The intended answer is the current
+	// epoch end. BuildSummary's TransitionImpossible branch, however,
+	// applies the safe zone from current.Start (= the *first* epoch of
+	// the era) and can return an EraEnd behind the tip for a long-running
+	// era. Serve the confirmed epoch-end directly instead.
+	if ti.State == hardfork.TransitionImpossible {
+		endRel := new(big.Int).Set(startRel)
+		for _, ep := range era.epochs {
+			endRel.Add(endRel, epochPicoseconds(ep.SlotLength, ep.LengthInSlots))
+		}
+		lastEp := era.epochs[len(era.epochs)-1]
+		endSlot, err := checkedSlotAdd(
+			lastEp.StartSlot,
+			uint64(lastEp.LengthInSlots),
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"current era epoch %d (start=%d, length=%d): %w",
+				lastEp.EpochId, lastEp.StartSlot, lastEp.LengthInSlots, err,
+			)
+		}
+		return []any{
+			endRel,
+			endSlot,
+			lastEp.EpochId + 1,
+		}, nil
+	}
+
+	effectiveTI := ti
+	if ti.State == hardfork.TransitionKnown {
+		found := false
+		for _, ep := range era.epochs {
+			if ep.EpochId == ti.KnownEpoch &&
+				ep.EpochId > firstEp.EpochId {
+				found = true
+				break
+			}
+		}
+		if !found {
+			effectiveTI = hardfork.NewTransitionUnknown()
+		}
+	}
+
+	curr := hardfork.EraSummary{
+		EraID: shape.Eras[idx].EraID,
+		Start: hardfork.Bound{
+			RelativeTime: picosecondsToDuration(startRel),
+			Slot:         firstEp.StartSlot,
+			Epoch:        firstEp.EpochId,
+		},
+		Params: shape.Eras[idx].Params,
+	}
+	summ, err := hardfork.BuildSummary(shape, nil, curr, tipSlot, effectiveTI)
+	if err != nil {
+		return nil, err
+	}
+	endBound := summ.Eras[0].End
+	if endBound == nil {
+		return nil, errors.New(
+			"hardfork: current era End unbounded (SafeZoneSlots==0)",
+		)
+	}
+	return []any{
+		durationToPicoseconds(endBound.RelativeTime),
+		endBound.Slot,
+		endBound.Epoch,
+	}, nil
+}
+
+// eraParamsCBOR builds the fixed 4-tuple params shape clients expect:
+// [epochLength, slotLengthMs, [0,0,[0]], 0]. The third and fourth positions
+// are placeholders preserved from the legacy encoding.
+func eraParamsCBOR(p hardfork.EraParams) []any {
+	return []any{
+		uint(p.EpochSize),                     // #nosec G115
+		uint(p.SlotLength / time.Millisecond), // #nosec G115
+		[]any{0, 0, []any{0}},
+		0,
+	}
+}
+
+// durationToPicoseconds converts a time.Duration (ns) to picoseconds as a
+// *big.Int, matching the CBOR relTime encoding used by callers.
+func durationToPicoseconds(d time.Duration) *big.Int {
+	return new(big.Int).Mul(big.NewInt(int64(d)), big.NewInt(1000))
+}
+
+// picosecondsToDuration converts a picosecond *big.Int to a time.Duration
+// (ns). Loses no precision for inputs produced by epochPicoseconds (which
+// are always multiples of 1_000 picoseconds).
+func picosecondsToDuration(p *big.Int) time.Duration {
+	ns := new(big.Int).Quo(p, big.NewInt(1000))
+	return time.Duration(ns.Int64())
 }
 
 func (ls *LedgerState) queryShelley(

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -309,7 +310,7 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 			// would over-claim certainty, so we fall back to the safe-zone cap.
 			useSafeZoneCap := false
 			switch transitionInfo.State {
-			case TransitionKnown:
+			case hardfork.TransitionKnown:
 				// Find the transition epoch in the committed epoch list.
 				// It was created with the old era's EraId, so it appears in
 				// epochs.  Its StartSlot is the exact era end boundary.
@@ -334,10 +335,10 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 					// rather than serving the uncapped epoch end.
 					useSafeZoneCap = true
 				}
-			case TransitionImpossible:
+			case hardfork.TransitionImpossible:
 				// Safe zone already covers the epoch end; tmpEnd was set to
 				// the epoch boundary above — no further capping needed.
-			case TransitionUnknown:
+			case hardfork.TransitionUnknown:
 				useSafeZoneCap = true
 			}
 			if useSafeZoneCap {

--- a/ledger/queries_hfc_test.go
+++ b/ledger/queries_hfc_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryHardForkEraHistory_EmitsAllKnownEras pins an invariant that
+// existing tests don't: the CBOR result always contains one entry per era in
+// eras.Eras (7 entries for Cardano), even when most eras have no epochs in the
+// DB. Clients rely on this shape.
+func TestQueryHardForkEraHistory_EmitsAllKnownEras(t *testing.T) {
+	const (
+		tipSlot        = uint64(200_000)
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+	)
+
+	db := newTestDB(t)
+	// Populate only Conway — every other era is empty.
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: hardfork.NewTransitionUnknown(),
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+	list, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+	require.Len(t, list, len(eras.Eras),
+		"era history must emit one entry per era in eras.Eras")
+
+	// Inspect each entry: [start, end, params].
+	for i, entry := range list {
+		era, ok := entry.([]any)
+		require.True(t, ok, "entry %d is not []any", i)
+		require.Len(t, era, 3, "entry %d must have [start, end, params]", i)
+
+		start, ok := era[0].([]any)
+		require.True(t, ok, "entry %d start is not []any", i)
+		require.Len(t, start, 3, "entry %d start must be 3-tuple", i)
+
+		end, ok := era[1].([]any)
+		require.True(t, ok, "entry %d end is not []any", i)
+		require.Len(t, end, 3, "entry %d end must be 3-tuple", i)
+
+		params, ok := era[2].([]any)
+		require.True(t, ok, "entry %d params is not []any", i)
+		require.Len(t, params, 4, "entry %d params must be 4-tuple", i)
+	}
+}
+
+// TestQueryHardForkEraHistory_TransitionUnknown_TipNearEpochEnd pins the
+// Haskell HFC semantics: when tipSlot + safeZone crosses into a later epoch,
+// the forecast boundary extends to *that* epoch's end rather than clamping
+// to the current epoch's end. This is the behavior unlocked by delegating
+// the safe-zone computation to hardfork.BuildSummary; dingo's legacy
+// pre-HFC-adapter code clamped too conservatively to the last-in-DB epoch's
+// end.
+func TestQueryHardForkEraHistory_TransitionUnknown_TipNearEpochEnd(t *testing.T) {
+	const (
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+		// tipSlot near the epoch end: tip + safeZone (25_920) = 545_920
+		// crosses into epoch 501 (which spans [532_000, 964_000)).
+		tipSlot = uint64(520_000)
+	)
+	const expectedEraEndSlot = uint64(964_000) // start of epoch 502
+	const expectedEraEndEpoch = uint64(502)
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:             db,
+		currentEra:     eras.ConwayEraDesc,
+		transitionInfo: hardfork.NewTransitionUnknown(),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+	eraList := result.(cbor.IndefLengthList)
+	lastEra := eraList[len(eraList)-1].([]any)
+	eraEnd := lastEra[1].([]any)
+
+	slot, ok := eraEnd[1].(uint64)
+	require.True(t, ok)
+	epoch, ok := eraEnd[2].(uint64)
+	require.True(t, ok)
+
+	assert.Equal(t, expectedEraEndSlot, slot,
+		"Unknown: tip+safeZone crossing into next epoch should extend EraEnd to that epoch's end")
+	assert.Equal(t, expectedEraEndEpoch, epoch,
+		"Unknown: EraEnd epoch should be the epoch *after* the one containing tip+safeZone")
+}
+
+// TestQueryHardForkEraHistory_AdjacentErasContiguous pins that whenever two
+// adjacent eras both carry real data, era[i].End bounds match era[i+1].Start
+// on all three axes (relTime, slot, epoch). This is the invariant that would
+// catch a timespan-accumulation bug like the one the legacy code flagged with
+// a hand-written "timespan.Sub" after the transition-epoch detection.
+func TestQueryHardForkEraHistory_AdjacentErasContiguous(t *testing.T) {
+	const (
+		byronEpoch0     = uint64(0)
+		byronEpoch0Len  = uint(21_600)
+		byronSlotLenMs  = uint(20_000)
+		shelleyEpoch1   = uint64(1)
+		shelleyStart    = uint64(21_600) // after Byron epoch 0
+		shelleyEpochLen = uint(432_000)
+		slotLenMs       = uint(1_000)
+		tipSlot         = shelleyStart + 100
+	)
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		0, byronEpoch0, nil, nil, nil, nil,
+		eras.ByronEraDesc.Id, byronSlotLenMs, byronEpoch0Len, nil,
+	))
+	require.NoError(t, db.SetEpoch(
+		shelleyStart, shelleyEpoch1, nil, nil, nil, nil,
+		eras.ShelleyEraDesc.Id, slotLenMs, shelleyEpochLen, nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ShelleyEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: hardfork.NewTransitionUnknown(),
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+	list, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+
+	// Entry 0 = Byron (populated, closed), entry 1 = Shelley (populated, open).
+	byronEra := list[0].([]any)
+	shelleyEra := list[1].([]any)
+	byronEnd := byronEra[1].([]any)
+	shelleyStartBound := shelleyEra[0].([]any)
+
+	// relTime — *big.Int picoseconds
+	byronEndRel, ok := byronEnd[0].(*big.Int)
+	require.True(t, ok, "byron end relTime must be *big.Int, got %T", byronEnd[0])
+	shelleyStartRel, ok := shelleyStartBound[0].(*big.Int)
+	require.True(t, ok, "shelley start relTime must be *big.Int, got %T", shelleyStartBound[0])
+	assert.Equal(t, 0, byronEndRel.Cmp(shelleyStartRel),
+		"byron end relTime (%s) must equal shelley start relTime (%s)",
+		byronEndRel, shelleyStartRel,
+	)
+
+	assert.Equal(t, byronEnd[1], shelleyStartBound[1],
+		"byron end slot must equal shelley start slot")
+	assert.Equal(t, byronEnd[2], shelleyStartBound[2],
+		"byron end epoch must equal shelley start epoch")
+}

--- a/ledger/queries_impossible_multiepoch_test.go
+++ b/ledger/queries_impossible_multiepoch_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryHardForkEraHistory_TransitionImpossible_MultiEpochEra reproduces
+// the real-world case that the single-epoch TransitionImpossible tests miss:
+// the current era has been running for several epochs, and the current
+// epoch is well past the first.
+//
+// dingo sets TransitionImpossible in `evaluateTransitionImpossible` when the
+// CURRENT epoch's end is inside the safe-zone horizon. The caller therefore
+// expects `queryHardForkEraHistory` to serve the CURRENT epoch's end as
+// EraEnd. But if the caller naively forwards `TransitionImpossible` into
+// `hardfork.BuildSummary`, BuildSummary's Haskell-aligned semantics apply
+// the safe zone from `current.Start` (the *first* epoch of the era) — and
+// the resulting EraEnd lags many epochs behind the tip.
+func TestQueryHardForkEraHistory_TransitionImpossible_MultiEpochEra(t *testing.T) {
+	const (
+		slotLenMs = uint(1_000)
+		epochLen  = uint(432_000)
+
+		// Conway era has epochs 500, 501, 502 in the DB. Current epoch is 502.
+		firstEpochId    = uint64(500)
+		firstEpochSlot  = uint64(100_000)
+		secondEpochId   = uint64(501)
+		secondEpochSlot = uint64(532_000) // 100_000 + 432_000
+		thirdEpochId    = uint64(502)
+		thirdEpochSlot  = uint64(964_000) // 532_000 + 432_000
+		thirdEpochEnd   = uint64(1_396_000)
+
+		// Tip well inside epoch 502.
+		tipSlot = uint64(1_100_000)
+	)
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		firstEpochSlot, firstEpochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+	require.NoError(t, db.SetEpoch(
+		secondEpochSlot, secondEpochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+	require.NoError(t, db.SetEpoch(
+		thirdEpochSlot, thirdEpochId,
+		nil, nil, nil, nil,
+		eras.ConwayEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: hardfork.NewTransitionImpossible(),
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+	eraList := result.(cbor.IndefLengthList)
+	lastEra := eraList[len(eraList)-1].([]any)
+	eraEnd := lastEra[1].([]any)
+
+	slot, ok := eraEnd[1].(uint64)
+	require.True(t, ok, "EraEnd slot should be uint64")
+	epoch, ok := eraEnd[2].(uint64)
+	require.True(t, ok, "EraEnd epoch should be uint64")
+
+	assert.Equal(t, thirdEpochEnd, slot,
+		"TransitionImpossible with a multi-epoch era must serve the CURRENT epoch's end "+
+			"(slot %d, end of epoch %d), not a safe-zone projection from the era's first epoch",
+		thirdEpochEnd, thirdEpochId)
+	assert.Equal(t, thirdEpochId+1, epoch,
+		"TransitionImpossible EraEnd epoch must be the current epoch + 1 (%d)",
+		thirdEpochId+1)
+	assert.GreaterOrEqual(t, slot, tipSlot,
+		"TransitionImpossible EraEnd (%d) must never lag the tip (%d)",
+		slot, tipSlot)
+}

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -25,14 +25,15 @@ import (
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
-	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
-	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -299,13 +300,13 @@ func TestEpochPicoseconds_OverflowSafe(t *testing.T) {
 // Without TransitionKnown: EraEnd would be 200_000 + 25_920 = 225_920
 func TestQueryHardForkEraHistory_TransitionKnown(t *testing.T) {
 	const (
-		tipSlot          = uint64(200_000)
-		epoch500Start    = uint64(100_000)
-		epoch501Start    = uint64(532_000)
-		epochLen         = uint(432_000)
-		slotLenMs        = uint(1_000)
-		epoch500Id       = uint64(500)
-		epoch501Id       = uint64(501)
+		tipSlot       = uint64(200_000)
+		epoch500Start = uint64(100_000)
+		epoch501Start = uint64(532_000)
+		epochLen      = uint(432_000)
+		slotLenMs     = uint(1_000)
+		epoch500Id    = uint64(500)
+		epoch501Id    = uint64(501)
 	)
 
 	db := newTestDB(t)
@@ -330,8 +331,8 @@ func TestQueryHardForkEraHistory_TransitionKnown(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{
-			State:      TransitionKnown,
+		transitionInfo: hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: epoch501Id,
 		},
 		config: LedgerStateConfig{
@@ -403,8 +404,8 @@ func TestQueryHardForkEraHistory_TransitionKnown_MissingEpochFallsBackToSafeZone
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{
-			State:      TransitionKnown,
+		transitionInfo: hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: missingEpoch,
 		},
 		config: LedgerStateConfig{
@@ -465,7 +466,7 @@ func TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone(t *testin
 	ls := &LedgerState{
 		db:             db,
 		currentEra:     eras.ConwayEraDesc,
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
@@ -534,7 +535,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_ServesEpochEnd(t *testing.
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -585,7 +586,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch(t *
 		db:             db,
 		currentEra:     eras.ConwayEraDesc,
 		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
-		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -610,14 +611,14 @@ func TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch(t *
 // epoch-end slot when safeEndSlot >= epochStartSlot (both snap to epoch end).
 func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *testing.T) {
 	const (
-		epochStartSlot   = uint64(100_000)
-		epochLen         = uint(432_000)
-		slotLenMs        = uint(1_000)
-		epochId          = uint64(500)
-		tipSlot          = uint64(520_000) // safeEnd = 545_920 > epochEnd 532_000
+		epochStartSlot = uint64(100_000)
+		epochLen       = uint(432_000)
+		slotLenMs      = uint(1_000)
+		epochId        = uint64(500)
+		tipSlot        = uint64(520_000) // safeEnd = 545_920 > epochEnd 532_000
 	)
 
-	setupLS := func(state TransitionState) *LedgerState {
+	setupLS := func(state hardfork.TransitionState) *LedgerState {
 		db := newTestDB(t)
 		require.NoError(t, db.SetEpoch(
 			epochStartSlot, epochId,
@@ -629,7 +630,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *t
 			db:             db,
 			currentEra:     eras.ConwayEraDesc,
 			currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
-			transitionInfo: TransitionInfo{State: state},
+			transitionInfo: hardfork.TransitionInfo{State: state},
 			config: LedgerStateConfig{
 				CardanoNodeConfig: newTestEraHistoryCfg(t),
 				Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -648,8 +649,8 @@ func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *t
 		return slot
 	}
 
-	impossibleSlot := eraEndSlot(setupLS(TransitionImpossible))
-	unknownSlot := eraEndSlot(setupLS(TransitionUnknown))
+	impossibleSlot := eraEndSlot(setupLS(hardfork.TransitionImpossible))
+	unknownSlot := eraEndSlot(setupLS(hardfork.TransitionUnknown))
 
 	// Both states snap to the epoch-end boundary.  TransitionImpossible is
 	// set directly; TransitionUnknown snaps because safeEndSlot >= epochStartSlot.
@@ -750,7 +751,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 		currentEra     eras.EraDesc
 		currentEpoch   models.Epoch
 		currentPParams lcommon.ProtocolParameters
-		expectedState  TransitionState
+		expectedState  hardfork.TransitionState
 		expectedEpoch  uint64
 	}{
 		{
@@ -765,7 +766,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 			currentPParams: &babbage.BabbageProtocolParameters{
 				ProtocolMajor: 9, // Conway major version, stored under Babbage era
 			},
-			expectedState: TransitionKnown,
+			expectedState: hardfork.TransitionKnown,
 			expectedEpoch: 500,
 		},
 		{
@@ -779,7 +780,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 			currentPParams: &babbage.BabbageProtocolParameters{
 				ProtocolMajor: 8,
 			},
-			expectedState: TransitionUnknown,
+			expectedState: hardfork.TransitionUnknown,
 		},
 		{
 			// Conway pparams in Conway era: pparamsEra == currentEra, no transition.
@@ -794,15 +795,15 @@ func TestReconstructTransitionInfo(t *testing.T) {
 					Major: 9,
 				},
 			},
-			expectedState: TransitionUnknown,
+			expectedState: hardfork.TransitionUnknown,
 		},
 		{
 			// Nil pparams: must not panic, leave TransitionUnknown.
-			name:          "nil pparams → TransitionUnknown",
-			currentEra:    *eras.GetEraById(eras.BabbageEraDesc.Id),
-			currentEpoch:  models.Epoch{EpochId: 400, EraId: eras.BabbageEraDesc.Id},
+			name:           "nil pparams → TransitionUnknown",
+			currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEpoch:   models.Epoch{EpochId: 400, EraId: eras.BabbageEraDesc.Id},
 			currentPParams: nil,
-			expectedState: TransitionUnknown,
+			expectedState:  hardfork.TransitionUnknown,
 		},
 	}
 
@@ -817,7 +818,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 			ls.reconstructTransitionInfo()
 
 			assert.Equal(t, tc.expectedState, ls.transitionInfo.State)
-			if tc.expectedState == TransitionKnown {
+			if tc.expectedState == hardfork.TransitionKnown {
 				assert.Equal(t, tc.expectedEpoch, ls.transitionInfo.KnownEpoch)
 			}
 		})
@@ -837,11 +838,11 @@ func TestReconstructTransitionInfo(t *testing.T) {
 // Expected Babbage EraEnd slot: 64_432_000
 func TestQueryHardForkEraHistory_PastEra_NormalEpochEnd(t *testing.T) {
 	const (
-		epochId       = uint64(499)
-		epochStart    = uint64(64_000_000)
-		epochLen      = uint(432_000)
-		slotLenMs     = uint(1_000)
-		rawEraEnd     = epochStart + uint64(epochLen) // 64_432_000
+		epochId    = uint64(499)
+		epochStart = uint64(64_000_000)
+		epochLen   = uint(432_000)
+		slotLenMs  = uint(1_000)
+		rawEraEnd  = epochStart + uint64(epochLen) // 64_432_000
 	)
 
 	db := newTestDB(t)
@@ -870,7 +871,7 @@ func TestQueryHardForkEraHistory_PastEra_NormalEpochEnd(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(epochStart+1, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -968,7 +969,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(epochStart+1, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -1093,7 +1094,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch_Contiguity(t *testing.T
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(conwayEpochStart+1, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -331,10 +331,7 @@ func TestQueryHardForkEraHistory_TransitionKnown(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: epoch501Id,
-		},
+		transitionInfo: hardfork.NewTransitionKnown(epoch501Id),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -404,10 +401,7 @@ func TestQueryHardForkEraHistory_TransitionKnown_MissingEpochFallsBackToSafeZone
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: missingEpoch,
-		},
+		transitionInfo: hardfork.NewTransitionKnown(missingEpoch),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -466,7 +460,7 @@ func TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone(t *testin
 	ls := &LedgerState{
 		db:             db,
 		currentEra:     eras.ConwayEraDesc,
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
@@ -535,7 +529,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_ServesEpochEnd(t *testing.
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
+		transitionInfo: hardfork.NewTransitionImpossible(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -586,7 +580,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch(t *
 		db:             db,
 		currentEra:     eras.ConwayEraDesc,
 		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
+		transitionInfo: hardfork.NewTransitionImpossible(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -607,15 +601,22 @@ func TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch(t *
 }
 
 // TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison
-// confirms that both TransitionImpossible and TransitionUnknown serve the
-// epoch-end slot when safeEndSlot >= epochStartSlot (both snap to epoch end).
+// confirms that TransitionImpossible and TransitionUnknown converge on the
+// same epoch-end boundary when tipSlot + safeZone still lies within the
+// current epoch — the common steady-state early-in-epoch case.
+//
+// Divergence at late-in-epoch tips (tip + safeZone crossing into the next
+// epoch) is covered by TransitionUnknown_FallsBackToSafeZone and matches
+// Haskell HFC's slotToEpochBound semantics.
 func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *testing.T) {
 	const (
 		epochStartSlot = uint64(100_000)
 		epochLen       = uint(432_000)
 		slotLenMs      = uint(1_000)
 		epochId        = uint64(500)
-		tipSlot        = uint64(520_000) // safeEnd = 545_920 > epochEnd 532_000
+		// tipSlot well inside the epoch so tip + safeZone (25_920) stays in
+		// the same epoch — both states snap to the same epoch-end boundary.
+		tipSlot = uint64(200_000)
 	)
 
 	setupLS := func(state hardfork.TransitionState) *LedgerState {
@@ -652,12 +653,10 @@ func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *t
 	impossibleSlot := eraEndSlot(setupLS(hardfork.TransitionImpossible))
 	unknownSlot := eraEndSlot(setupLS(hardfork.TransitionUnknown))
 
-	// Both states snap to the epoch-end boundary.  TransitionImpossible is
-	// set directly; TransitionUnknown snaps because safeEndSlot >= epochStartSlot.
 	assert.Equal(t, uint64(532_000), impossibleSlot,
 		"TransitionImpossible must serve the epoch end")
 	assert.Equal(t, uint64(532_000), unknownSlot,
-		"TransitionUnknown snaps to epoch end (safeEndSlot >= epochStartSlot)")
+		"TransitionUnknown snaps to epoch end when tip+safeZone stays in the same epoch")
 	assert.Equal(t, impossibleSlot, unknownSlot,
 		"both states return the same epoch-end slot")
 }
@@ -871,7 +870,7 @@ func TestQueryHardForkEraHistory_PastEra_NormalEpochEnd(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(epochStart+1, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -969,7 +968,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(epochStart+1, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -1094,7 +1093,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch_Contiguity(t *testing.T
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(conwayEpochStart+1, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: newTestEraHistoryCfg(t),
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -71,7 +71,10 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 	}
 	sum, err := ls.HardForkSummary()
 	if err != nil {
-		if time.Since(t) < 5*time.Second {
+		// time.Since(t) == now - t, so it is negative for future times.
+		// Guard both directions so arbitrary future times don't match the
+		// "near now" fallback.
+		if d := time.Since(t); d >= -5*time.Second && d < 5*time.Second {
 			return nearNowSlot(shelleyGenesis), nil
 		}
 		return 0, errors.New("time not found in known epochs")
@@ -100,16 +103,22 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	info, err := sum.SlotToEpoch(slot)
 	if err != nil {
 		if errors.Is(err, hardfork.ErrPastHorizon) {
+			// ErrPastHorizon fires for slots outside every era's bounds —
+			// either below the first era's start or past the last bounded
+			// era's end. Don't claim a direction we don't know.
 			return models.Epoch{}, errors.New(
-				"slot is before the first known epoch",
+				"slot is outside the known epoch range",
 			)
 		}
 		return models.Epoch{}, err
 	}
 	return models.Epoch{
-		EpochId:       info.Epoch,
-		StartSlot:     info.StartSlot,
-		EraId:         info.EraID,
+		EpochId:   info.Epoch,
+		StartSlot: info.StartSlot,
+		EraId:     info.EraID,
+		// info.SlotLength is a positive, protocol-bounded duration; the
+		// millisecond quotient fits in uint.
+		// #nosec G115
 		SlotLength:    uint(info.SlotLength / time.Millisecond),
 		LengthInSlots: uint(info.LengthInSlots),
 		// Nonce stays nil: unknown for projected epochs, and callers must
@@ -133,7 +142,13 @@ func nearNowSlot(sg *shelley.ShelleyGenesis) uint64 {
 	if slotLenMs == 0 {
 		return 0
 	}
-	//nolint:gosec // time.Since is bounded; conversion is safe.
-	sinceStartMs := uint64(time.Since(sg.SystemStart) / time.Millisecond)
+	// If SystemStart is in the future (clock skew or node started before the
+	// configured genesis), time.Since is negative; don't wrap it through
+	// uint64 — return 0 so callers see "genesis hasn't happened yet".
+	elapsed := time.Since(sg.SystemStart)
+	if elapsed <= 0 {
+		return 0
+	}
+	sinceStartMs := uint64(elapsed / time.Millisecond)
 	return sinceStartMs / slotLenMs
 }

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -21,13 +21,22 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
 // ErrBeforeGenesis is returned by TimeToSlot when the given time is before
 // the chain's genesis start. The caller should wait until genesis.
 var ErrBeforeGenesis = errors.New("time is before genesis start")
 
-// SlotToTime returns the current time for a given slot based on known epochs
+// SlotToTime returns the wall-clock start time of the given slot.
+//
+// Slot 0 always maps to Shelley genesis SystemStart, regardless of whether
+// the epoch cache is populated. Other slots are resolved via the
+// hardfork.Summary built from the LedgerState's epoch cache; slots past the
+// last known epoch are projected using the current era's slot length (the
+// Summary's current era is unbounded, mirroring the legacy projection
+// behavior).
 func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 	if slot > math.MaxInt64 {
 		return time.Time{}, errors.New("slot is larger than time.Duration")
@@ -36,198 +45,95 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 	if shelleyGenesis == nil {
 		return time.Time{}, errors.New("could not get genesis config")
 	}
-	slotTime := shelleyGenesis.SystemStart
-	// Special case for chain genesis
 	if slot == 0 {
-		return slotTime, nil
+		return shelleyGenesis.SystemStart, nil
 	}
-
-	// Take a deep copy of epochCache while holding the read lock
-	ls.RLock()
-	epochCacheCopy := make([]models.Epoch, len(ls.epochCache))
-	copy(epochCacheCopy, ls.epochCache)
-	ls.RUnlock()
-
-	foundSlot := false
-	for _, epoch := range epochCacheCopy {
-		if epoch.StartSlot > math.MaxInt64 ||
-			epoch.LengthInSlots > math.MaxInt64 ||
-			epoch.SlotLength > math.MaxInt64 {
-			return time.Time{}, errors.New(
-				"epoch slot values are larger than time.Duration",
-			)
-		}
-		if slot < epoch.StartSlot+uint64(epoch.LengthInSlots) {
-			slotTime = slotTime.Add(
-				time.Duration(
-					int64(slot)-int64(epoch.StartSlot),
-				) * (time.Duration(epoch.SlotLength) * time.Millisecond),
-			)
-			foundSlot = true
-			break
-		}
-		slotTime = slotTime.Add(
-			time.Duration(
-				epoch.LengthInSlots,
-			) * (time.Duration(epoch.SlotLength) * time.Millisecond),
-		)
+	sum, err := ls.HardForkSummary()
+	if err != nil {
+		return time.Time{}, err
 	}
-	if !foundSlot {
-		// Project the current slot length forward to calculate future slots
-		lastEpoch := epochCacheCopy[len(epochCacheCopy)-1]
-		leftoverSlots := slot - (lastEpoch.StartSlot + uint64(lastEpoch.LengthInSlots))
-		slotTime = slotTime.Add(
-			// nolint:gosec
-			time.Duration(
-				leftoverSlots,
-			) * (time.Duration(lastEpoch.SlotLength) * time.Millisecond),
-		)
-	}
-	return slotTime, nil
+	return sum.SlotToTime(slot)
 }
 
-// TimeToSlot returns the slot number for a given time based on known epochs
+// TimeToSlot returns the slot containing the given wall-clock time.
+//
+// Returns ErrBeforeGenesis when t is before SystemStart. When the epoch cache
+// is empty but t is within 5 seconds of now, falls back to a coarse
+// approximation using the Shelley genesis slot length — this is useful at
+// chain genesis before any epochs have been persisted.
 func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil {
 		return 0, errors.New("could not get genesis config")
 	}
-
-	// Take a deep copy of epochCache while holding the read lock
-	ls.RLock()
-	epochCacheCopy := make([]models.Epoch, len(ls.epochCache))
-	copy(epochCacheCopy, ls.epochCache)
-	ls.RUnlock()
-
-	epochStartTime := shelleyGenesis.SystemStart
-	var timeSlot uint64
-	foundTime := false
-	for _, epoch := range epochCacheCopy {
-		if epoch.LengthInSlots > math.MaxInt64 ||
-			epoch.SlotLength > math.MaxInt64 {
-			return 0, errors.New(
-				"epoch slot values are larger than time.Duration",
-			)
-		}
-		slotDuration := time.Duration(epoch.SlotLength) * time.Millisecond
-		if slotDuration < 0 {
-			return 0, errors.New("slot duration is negative")
-		}
-		epochEndTime := epochStartTime.Add(
-			time.Duration(epoch.LengthInSlots) * slotDuration,
-		)
-		if (t.Equal(epochStartTime) || t.After(epochStartTime)) &&
-			t.Before(epochEndTime) {
-			// Figure out how far into the epoch the specified time is
-			timeDiff := t.Sub(epochStartTime)
-			//nolint:gosec
-			// This will never overflow using 2 positive int64 values, but gosec seems determined
-			// to complain about it
-			timeSlot += uint64(timeDiff / slotDuration)
-			foundTime = true
-			break
-		}
-		epochStartTime = epochEndTime
-		timeSlot += uint64(epoch.LengthInSlots)
+	if t.Before(shelleyGenesis.SystemStart) {
+		return 0, ErrBeforeGenesis
 	}
-	if !foundTime {
-		// Before genesis: the chain hasn't started yet
-		if t.Before(shelleyGenesis.SystemStart) {
-			return 0, ErrBeforeGenesis
+	sum, err := ls.HardForkSummary()
+	if err != nil {
+		if time.Since(t) < 5*time.Second {
+			return nearNowSlot(shelleyGenesis), nil
 		}
-		// Special case for current time
-		// This is mostly useful at chain genesis
-		if time.Since(t) < (5 * time.Second) {
-			sinceStart := time.Since(
-				shelleyGenesis.SystemStart,
-			) / time.Millisecond
-			slotLength := uint(
-				new(big.Int).Div(
-					new(big.Int).Mul(
-						big.NewInt(1000),
-						shelleyGenesis.SlotLength.Num(),
-					),
-					shelleyGenesis.SlotLength.Denom(),
-				).Uint64(),
-			)
-			// nolint:gosec
-			// Slot length is small enough to not overflow int64
-			timeSlot := uint64(sinceStart / time.Duration(slotLength))
-			return timeSlot, nil
-		}
-		return timeSlot, errors.New("time not found in known epochs")
+		return 0, errors.New("time not found in known epochs")
 	}
-	return timeSlot, nil
+	slot, sumErr := sum.TimeToSlot(t)
+	if sumErr != nil {
+		// With an unbounded current era in HardForkSummary this is
+		// unreachable for t >= SystemStart, but we preserve the legacy
+		// error message for any future bounded-summary configuration.
+		return 0, errors.New("time not found in known epochs")
+	}
+	return slot, nil
 }
 
-// SlotToEpoch returns an epoch by slot number.
-// For slots within known epochs, returns the exact epoch.
-// For slots beyond known epochs, projects forward using the last known epoch's
-// parameters (epoch length, slot length) to calculate the future epoch.
+// SlotToEpoch returns the epoch containing the given slot.
+//
+// Slots within the known epoch cache resolve to the cached epoch's
+// parameters; slots past the cache are projected using the current era's
+// parameters. Returns an error for an empty cache or for slots before the
+// first known epoch (matching legacy error messages).
 func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
-	// Take a deep copy of epochCache while holding the read lock
-	ls.RLock()
-	epochCacheCopy := make([]models.Epoch, len(ls.epochCache))
-	copy(epochCacheCopy, ls.epochCache)
-	ls.RUnlock()
-
-	if len(epochCacheCopy) == 0 {
+	sum, err := ls.HardForkSummary()
+	if err != nil {
 		return models.Epoch{}, errors.New("no epochs in cache")
 	}
-
-	// Guard: reject slots before the first known epoch
-	firstEpoch := epochCacheCopy[0]
-	if slot < firstEpoch.StartSlot {
-		return models.Epoch{}, errors.New(
-			"slot is before the first known epoch",
-		)
-	}
-
-	for _, epoch := range epochCacheCopy {
-		if slot < epoch.StartSlot {
-			continue
+	info, err := sum.SlotToEpoch(slot)
+	if err != nil {
+		if errors.Is(err, hardfork.ErrPastHorizon) {
+			return models.Epoch{}, errors.New(
+				"slot is before the first known epoch",
+			)
 		}
-		if slot < epoch.StartSlot+uint64(epoch.LengthInSlots) {
-			return epoch, nil
-		}
+		return models.Epoch{}, err
 	}
-
-	// Project forward for future slots using the last known epoch's parameters
-	lastEpoch := epochCacheCopy[len(epochCacheCopy)-1]
-	lastEpochEndSlot := lastEpoch.StartSlot + uint64(lastEpoch.LengthInSlots)
-
-	if lastEpoch.LengthInSlots == 0 {
-		return models.Epoch{}, errors.New(
-			"cannot project epoch: last known epoch has LengthInSlots=0",
-		)
-	}
-
-	// Calculate how many epochs past the last known epoch this slot is
-	slotsPastLastEpoch := slot - lastEpochEndSlot
-	epochsPastLast := slotsPastLastEpoch / uint64(lastEpoch.LengthInSlots)
-	slotInProjectedEpoch := slotsPastLastEpoch % uint64(lastEpoch.LengthInSlots)
-
-	// Build projected epoch info
-	projectedEpochId := lastEpoch.EpochId + 1 + epochsPastLast
-	projectedStartSlot := lastEpochEndSlot + (epochsPastLast * uint64(lastEpoch.LengthInSlots))
-
-	// Verify our calculation is correct (slot should be within the projected epoch)
-	if slot < projectedStartSlot ||
-		slot >= projectedStartSlot+uint64(lastEpoch.LengthInSlots) {
-		// This shouldn't happen, but return error if our math is wrong
-		return models.Epoch{}, errors.New(
-			"internal error: projected epoch calculation mismatch",
-		)
-	}
-	_ = slotInProjectedEpoch // Used only for verification
-
 	return models.Epoch{
-		EpochId:       projectedEpochId,
-		StartSlot:     projectedStartSlot,
-		EraId:         lastEpoch.EraId,
-		SlotLength:    lastEpoch.SlotLength,
-		LengthInSlots: lastEpoch.LengthInSlots,
-		// Nonce is unknown for future epochs
-		Nonce: nil,
+		EpochId:       info.Epoch,
+		StartSlot:     info.StartSlot,
+		EraId:         info.EraID,
+		SlotLength:    uint(info.SlotLength / time.Millisecond),
+		LengthInSlots: uint(info.LengthInSlots),
+		// Nonce stays nil: unknown for projected epochs, and callers must
+		// consult the DB for the persisted nonce of known epochs.
 	}, nil
+}
+
+// nearNowSlot estimates the current slot from the Shelley genesis slot length,
+// used as a fallback when the epoch cache is empty and the caller asks about
+// a time within 5s of now.
+func nearNowSlot(sg *shelley.ShelleyGenesis) uint64 {
+	if sg == nil || sg.SlotLength.Rat == nil ||
+		sg.SlotLength.Num().Sign() <= 0 {
+		return 0
+	}
+	// Shelley genesis stores slot length as seconds per slot; compute ms.
+	slotLenMs := new(big.Int).Div(
+		new(big.Int).Mul(big.NewInt(1000), sg.SlotLength.Num()),
+		sg.SlotLength.Denom(),
+	).Uint64()
+	if slotLenMs == 0 {
+		return 0
+	}
+	//nolint:gosec // time.Since is bounded; conversion is safe.
+	sinceStartMs := uint64(time.Since(sg.SystemStart) / time.Millisecond)
+	return sinceStartMs / slotLenMs
 }

--- a/ledger/slot_bugs_test.go
+++ b/ledger/slot_bugs_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// futureSystemStartCfg returns a CardanoNodeConfig whose Shelley
+// SystemStart is in the future, simulating a node that booted before the
+// configured genesis time (clock skew, misconfig, or early bring-up).
+func futureSystemStartCfg(t *testing.T, future time.Time) *cardano.CardanoNodeConfig {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString(`{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"slotLength": 1,
+		"epochLength": 432000,
+		"systemStart": "`)
+	sb.WriteString(future.UTC().Format(time.RFC3339))
+	sb.WriteString(`"
+	}`)
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(sb.String())))
+	return cfg
+}
+
+// TestTimeToSlot_FutureTimeWithEmptyCacheReturnsError pins that when the
+// epoch cache is empty, TimeToSlot rejects arbitrary future times instead of
+// silently returning a "now"-ish approximation.
+//
+// The implementation falls through to nearNowSlot whenever `time.Since(t) <
+// 5*time.Second`. Because `time.Since` is `now - t`, that is NEGATIVE (and
+// therefore always `< 5*time.Second`) for any t in the future — so a caller
+// asking about a time one day ahead gets the current slot, not an error.
+func TestTimeToSlot_FutureTimeWithEmptyCacheReturnsError(t *testing.T) {
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"slotLength": 1,
+		"epochLength": 432000,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`)))
+
+	ls := &LedgerState{
+		// epochCache empty — HardForkSummary will error.
+		config: LedgerStateConfig{CardanoNodeConfig: cfg},
+	}
+
+	// Far-future time; well past any "near now" tolerance.
+	future := time.Now().Add(24 * time.Hour)
+	_, err := ls.TimeToSlot(future)
+	assert.Error(t, err,
+		"TimeToSlot must reject far-future times when the epoch cache is empty; "+
+			"the nearNowSlot fallback is only for times within ±5s of now")
+}
+
+// TestNearNowSlot_FutureSystemStartReturnsZero pins that nearNowSlot does
+// not silently wrap a negative `time.Since` to a huge uint64. Under clock
+// skew or node-before-genesis boot, `time.Since(SystemStart)` is negative,
+// and `uint64(negative)` produces a near-MaxUint value — bogus and
+// indistinguishable from a valid slot.
+func TestNearNowSlot_FutureSystemStartReturnsZero(t *testing.T) {
+	cfg := futureSystemStartCfg(t, time.Now().Add(time.Hour))
+	got := nearNowSlot(cfg.ShelleyGenesis())
+	assert.Equal(t, uint64(0), got,
+		"nearNowSlot with SystemStart in the future must return 0, not a huge wrapped uint64")
+}

--- a/ledger/slot_crossera_test.go
+++ b/ledger/slot_crossera_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// crossEraLedger returns a LedgerState with two eras:
+//   - Byron-ish: EraId=0, 20s slots, 100 slots/epoch, 2 epochs → slots 0..199
+//   - Shelley-ish: EraId=1, 1s slots, 432 slots/epoch, 2 epochs → slots 200..1063
+//
+// Total Byron time = 2 × 100 × 20s = 4000s.
+func crossEraLedger(t *testing.T) *LedgerState {
+	t.Helper()
+	return &LedgerState{
+		epochCache: []models.Epoch{
+			{EpochId: 0, StartSlot: 0, SlotLength: 20_000, LengthInSlots: 100, EraId: 0},
+			{EpochId: 1, StartSlot: 100, SlotLength: 20_000, LengthInSlots: 100, EraId: 0},
+			{EpochId: 2, StartSlot: 200, SlotLength: 1000, LengthInSlots: 432, EraId: 1},
+			{EpochId: 3, StartSlot: 632, SlotLength: 1000, LengthInSlots: 432, EraId: 1},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+}
+
+// TestSlotToTime_CrossEra covers multi-era chains where per-era slot length
+// differs. Any implementation that reads slot length from the epoch currently
+// being traversed — whether the legacy loop or the new Summary-backed
+// delegation — must return the same absolute times.
+func TestSlotToTime_CrossEra(t *testing.T) {
+	ls := crossEraLedger(t)
+	sysStart := time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		slot uint64
+		want time.Duration // offset from SystemStart
+	}{
+		{"byron genesis", 0, 0},
+		{"byron mid", 50, 1000 * time.Second}, // 50 × 20s
+		{"byron end", 199, 3980 * time.Second},
+		{"boundary", 200, 4000 * time.Second}, // Shelley's first slot
+		{"shelley mid", 250, 4050 * time.Second},
+		{"shelley end of first epoch", 631, 4431 * time.Second},
+		{"shelley second epoch", 700, 4500 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ls.SlotToTime(tc.slot)
+			require.NoError(t, err)
+			assert.Equal(t, sysStart.Add(tc.want), got)
+		})
+	}
+}
+
+// TestTimeToSlot_CrossEra round-trips cross-era slot→time→slot.
+func TestTimeToSlot_CrossEra(t *testing.T) {
+	ls := crossEraLedger(t)
+	for _, slot := range []uint64{0, 50, 199, 200, 250, 631, 700} {
+		t.Run("", func(t *testing.T) {
+			tt, err := ls.SlotToTime(slot)
+			require.NoError(t, err)
+			got, err := ls.TimeToSlot(tt)
+			require.NoError(t, err)
+			assert.Equal(t, slot, got)
+		})
+	}
+}
+
+// TestSlotToEpoch_CrossEra verifies epoch lookup spans both eras correctly.
+func TestSlotToEpoch_CrossEra(t *testing.T) {
+	ls := crossEraLedger(t)
+	tests := []struct {
+		name      string
+		slot      uint64
+		wantEpoch uint64
+		wantStart uint64
+		wantEra   uint
+	}{
+		{"byron epoch 0", 50, 0, 0, 0},
+		{"byron epoch 1", 150, 1, 100, 0},
+		{"shelley epoch 2", 250, 2, 200, 1},
+		{"shelley epoch 3", 700, 3, 632, 1},
+		// Project forward using Shelley params (432 slots/epoch, 1s each).
+		{"future projected epoch", 1200, 4, 1064, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ls.SlotToEpoch(tc.slot)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantEpoch, got.EpochId)
+			assert.Equal(t, tc.wantStart, got.StartSlot)
+			assert.Equal(t, tc.wantEra, got.EraId)
+		})
+	}
+}

--- a/ledger/slot_crossera_test.go
+++ b/ledger/slot_crossera_test.go
@@ -77,7 +77,7 @@ func TestSlotToTime_CrossEra(t *testing.T) {
 func TestTimeToSlot_CrossEra(t *testing.T) {
 	ls := crossEraLedger(t)
 	for _, slot := range []uint64{0, 50, 199, 200, 250, 631, 700} {
-		t.Run("", func(t *testing.T) {
+		t.Run((time.Duration(slot) * time.Second).String(), func(t *testing.T) {
 			tt, err := ls.SlotToTime(slot)
 			require.NoError(t, err)
 			got, err := ls.TimeToSlot(tt)

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -298,7 +298,7 @@ func TestSlotToEpochBeforeFirstEpoch(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for slot before first known epoch")
 	}
-	if err.Error() != "slot is before the first known epoch" {
+	if err.Error() != "slot is outside the known epoch range" {
 		t.Errorf("unexpected error message: %s", err.Error())
 	}
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -41,6 +41,7 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/dingo/mempool"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -409,7 +410,7 @@ type LedgerState struct {
 	chainsyncBlockfetchTimerGeneration uint64      // generation counter to detect stale timer callbacks
 	currentPParams                     lcommon.ProtocolParameters
 	prevEraPParams                     lcommon.ProtocolParameters // pparams from the immediately previous era (for era-1 TX validation)
-	transitionInfo                     TransitionInfo             // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
+	transitionInfo                     hardfork.TransitionInfo    // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
 	mempool                            MempoolProvider
 	timerCleanupConsumedUtxos          *time.Timer
 	Scheduler                          *Scheduler
@@ -487,34 +488,6 @@ type LedgerState struct {
 type EraTransitionResult struct {
 	NewPParams lcommon.ProtocolParameters
 	NewEra     eras.EraDesc
-}
-
-// TransitionState encodes which of the three HFC TransitionInfo
-// cases currently applies to the open (current) era.
-type TransitionState uint8
-
-const (
-	// TransitionUnknown means no confirmed upcoming hard fork is
-	// known.  The open era's EraEnd is capped at tipSlot + safeZone.
-	TransitionUnknown TransitionState = iota
-	// TransitionKnown means the epoch-rollover logic has detected a
-	// protocol-version bump in the upcoming epoch's pparams, but the
-	// first block of the new era has not arrived yet.  KnownEpoch is
-	// the first epoch number of the next era; its StartSlot is the
-	// exact era boundary.
-	TransitionKnown
-	// TransitionImpossible means a hard fork cannot occur in the
-	// current epoch (e.g. the safe-zone has already passed the epoch
-	// end).  Reserved for future use; treated like TransitionUnknown
-	// for query purposes.
-	TransitionImpossible
-)
-
-// TransitionInfo mirrors Haskell's HFC TransitionInfo, tracking
-// whether a confirmed upcoming era transition is known.
-type TransitionInfo struct {
-	State      TransitionState
-	KnownEpoch uint64 // first epoch of the next era; valid when State == TransitionKnown
 }
 
 // HardForkInfo holds details about a detected hard fork
@@ -1671,7 +1644,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.currentTip = newTip
 	// A rollback invalidates any pending TransitionKnown because the
 	// epoch-rollover block that set it may no longer be on the chain.
-	ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+	ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
 	// If rolling back behind the Mithril trust boundary, clear it.
 	// A rollback inside the gap means replacement blocks on the new
 	// fork were NOT processed by SetGapBlockTransaction and must go
@@ -1856,7 +1829,7 @@ func (ls *LedgerState) applyEraTransition(result *EraTransitionResult) {
 	ls.currentPParams = result.NewPParams
 	ls.currentEra = result.NewEra
 	// Any pending TransitionKnown is consumed: the new era is now active.
-	ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+	ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
 }
 
 // IsAtTip reports whether the node has caught up to the chain tip at least
@@ -1975,7 +1948,7 @@ func (ls *LedgerState) calculateStabilityWindowForEra(eraId uint) uint64 {
 
 // CurrentTransitionInfo returns a snapshot of the current TransitionInfo
 // under a read lock.  Callers must not hold ls.RLock() when calling this.
-func (ls *LedgerState) CurrentTransitionInfo() TransitionInfo {
+func (ls *LedgerState) CurrentTransitionInfo() hardfork.TransitionInfo {
 	ls.RLock()
 	ti := ls.transitionInfo
 	ls.RUnlock()
@@ -2376,7 +2349,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// logic re-evaluates for the new epoch's horizon.
 				// (applyEraTransition already handles the era-transition case.)
 				if len(eraTransitions) == 0 {
-					ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+					ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
 				}
 			}
 			// Set TransitionKnown only when epoch rolled over in the old era
@@ -2385,8 +2358,8 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			if len(eraTransitions) == 0 &&
 				rolloverResult != nil &&
 				rolloverResult.HardFork != nil {
-				ls.transitionInfo = TransitionInfo{
-					State:      TransitionKnown,
+				ls.transitionInfo = hardfork.TransitionInfo{
+					State:      hardfork.TransitionKnown,
 					KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
 				}
 			}
@@ -3319,8 +3292,8 @@ func (ls *LedgerState) reconstructTransitionInfo() {
 	// was created with the old EraId but its StartSlot is the exact
 	// upcoming era boundary.
 	if pparamsEraId > ls.currentEra.Id {
-		ls.transitionInfo = TransitionInfo{
-			State:      TransitionKnown,
+		ls.transitionInfo = hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: ls.currentEpoch.EpochId,
 		}
 	}
@@ -3342,7 +3315,7 @@ func (ls *LedgerState) reconstructTransitionInfo() {
 // Call under ls.Lock() (runtime tip-update) or without a lock during
 // single-threaded startup (after loadTip).
 func (ls *LedgerState) evaluateTransitionImpossible() {
-	if ls.transitionInfo.State != TransitionUnknown {
+	if ls.transitionInfo.State != hardfork.TransitionUnknown {
 		return
 	}
 	// Only meaningful when we have a fully-populated epoch.
@@ -3362,7 +3335,7 @@ func (ls *LedgerState) evaluateTransitionImpossible() {
 		return
 	}
 	if safeEndSlot >= epochEndSlot {
-		ls.transitionInfo = TransitionInfo{State: TransitionImpossible}
+		ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionImpossible}
 	}
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1644,7 +1644,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.currentTip = newTip
 	// A rollback invalidates any pending TransitionKnown because the
 	// epoch-rollover block that set it may no longer be on the chain.
-	ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
+	ls.transitionInfo = hardfork.NewTransitionUnknown()
 	// If rolling back behind the Mithril trust boundary, clear it.
 	// A rollback inside the gap means replacement blocks on the new
 	// fork were NOT processed by SetGapBlockTransaction and must go
@@ -1829,7 +1829,7 @@ func (ls *LedgerState) applyEraTransition(result *EraTransitionResult) {
 	ls.currentPParams = result.NewPParams
 	ls.currentEra = result.NewEra
 	// Any pending TransitionKnown is consumed: the new era is now active.
-	ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
+	ls.transitionInfo = hardfork.NewTransitionUnknown()
 }
 
 // IsAtTip reports whether the node has caught up to the chain tip at least
@@ -2349,7 +2349,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// logic re-evaluates for the new epoch's horizon.
 				// (applyEraTransition already handles the era-transition case.)
 				if len(eraTransitions) == 0 {
-					ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
+					ls.transitionInfo = hardfork.NewTransitionUnknown()
 				}
 			}
 			// Set TransitionKnown only when epoch rolled over in the old era
@@ -2358,10 +2358,9 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			if len(eraTransitions) == 0 &&
 				rolloverResult != nil &&
 				rolloverResult.HardFork != nil {
-				ls.transitionInfo = hardfork.TransitionInfo{
-					State:      hardfork.TransitionKnown,
-					KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
-				}
+				ls.transitionInfo = hardfork.NewTransitionKnown(
+					rolloverResult.NewCurrentEpoch.EpochId,
+				)
 			}
 			ls.Unlock()
 
@@ -3292,10 +3291,7 @@ func (ls *LedgerState) reconstructTransitionInfo() {
 	// was created with the old EraId but its StartSlot is the exact
 	// upcoming era boundary.
 	if pparamsEraId > ls.currentEra.Id {
-		ls.transitionInfo = hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: ls.currentEpoch.EpochId,
-		}
+		ls.transitionInfo = hardfork.NewTransitionKnown(ls.currentEpoch.EpochId)
 	}
 }
 
@@ -3335,7 +3331,7 @@ func (ls *LedgerState) evaluateTransitionImpossible() {
 		return
 	}
 	if safeEndSlot >= epochEndSlot {
-		ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionImpossible}
+		ls.transitionInfo = hardfork.NewTransitionImpossible()
 	}
 }
 

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2459,7 +2459,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd(t *testing.
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2490,7 +2490,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneExceedsEpochEnd(t *testing.
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2519,7 +2519,7 @@ func TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch(t *testing.T
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2543,7 +2543,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown(t *testing.T) {
 			// tipSlot past the safe-zone boundary → would normally trigger Impossible
 			Point: ocommon.NewPoint(520_000, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 501},
+		transitionInfo: hardfork.NewTransitionKnown(501),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2567,7 +2567,7 @@ func TestEvaluateTransitionImpossible_NoOpAlreadyImpossible(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(520_000, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
+		transitionInfo: hardfork.NewTransitionImpossible(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2589,7 +2589,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(999_999, []byte("tip")),
 		},
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2611,7 +2611,7 @@ func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 		currentPParams: babbagePParams(9),
 		// Simulate state at end of epoch 500: TransitionImpossible was set
 		// because the tip's safe zone reached the epoch end.
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
+		transitionInfo: hardfork.NewTransitionImpossible(),
 	}
 
 	var eraTransitions []*EraTransitionResult
@@ -2633,14 +2633,11 @@ func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 		ls.currentEra = rolloverResult.NewCurrentEra
 		ls.currentPParams = rolloverResult.NewCurrentPParams
 		if len(eraTransitions) == 0 {
-			ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
+			ls.transitionInfo = hardfork.NewTransitionUnknown()
 		}
 	}
 	if len(eraTransitions) == 0 && rolloverResult != nil && rolloverResult.HardFork != nil {
-		ls.transitionInfo = hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
-		}
+		ls.transitionInfo = hardfork.NewTransitionKnown(rolloverResult.NewCurrentEpoch.EpochId)
 	}
 	ls.Unlock()
 
@@ -2656,10 +2653,7 @@ func TestApplyEraTransition_ClearsTransitionKnown(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: 500,
-		},
+		transitionInfo: hardfork.NewTransitionKnown(500),
 	}
 
 	result := &EraTransitionResult{
@@ -2685,7 +2679,7 @@ func TestApplyEraTransition_ClearsTransitionUnknown(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 	}
 
 	result := &EraTransitionResult{
@@ -2710,7 +2704,7 @@ func TestApplyEraTransition_PreservesAndUpdatesFields(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: lcommon.ProtocolParameters(oldPParams),
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 500},
+		transitionInfo: hardfork.NewTransitionKnown(500),
 	}
 
 	result := &EraTransitionResult{
@@ -2739,7 +2733,7 @@ func TestApplyEraTransition_MultipleSteps_AllCleared(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.AlonzoEraDesc.Id),
 		currentPParams: babbagePParams(6),
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 300},
+		transitionInfo: hardfork.NewTransitionKnown(300),
 	}
 
 	steps := []*EraTransitionResult{
@@ -2772,7 +2766,7 @@ func TestRolloverCommit_EraTransitionClearsTransitionInfo(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 499},
+		transitionInfo: hardfork.NewTransitionKnown(499),
 	}
 
 	eraTransitions := []*EraTransitionResult{
@@ -2802,10 +2796,7 @@ func TestRolloverCommit_EraTransitionClearsTransitionInfo(t *testing.T) {
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	if len(eraTransitions) == 0 && rolloverResult.HardFork != nil {
-		ls.transitionInfo = hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
-		}
+		ls.transitionInfo = hardfork.NewTransitionKnown(rolloverResult.NewCurrentEpoch.EpochId)
 	}
 	ls.Unlock()
 
@@ -2820,7 +2811,7 @@ func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 	}
 
 	var eraTransitions []*EraTransitionResult // empty — no standalone transition
@@ -2844,10 +2835,7 @@ func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	if len(eraTransitions) == 0 && rolloverResult.HardFork != nil {
-		ls.transitionInfo = hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
-		}
+		ls.transitionInfo = hardfork.NewTransitionKnown(rolloverResult.NewCurrentEpoch.EpochId)
 	}
 	ls.Unlock()
 
@@ -2862,7 +2850,7 @@ func TestRolloverCommit_NoHardFork_TransitionInfoUnchanged(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
 		currentPParams: babbagePParams(9),
-		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
+		transitionInfo: hardfork.NewTransitionUnknown(),
 	}
 
 	var eraTransitions []*EraTransitionResult
@@ -2883,10 +2871,7 @@ func TestRolloverCommit_NoHardFork_TransitionInfoUnchanged(t *testing.T) {
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	if len(eraTransitions) == 0 && rolloverResult.HardFork != nil {
-		ls.transitionInfo = hardfork.TransitionInfo{
-			State:      hardfork.TransitionKnown,
-			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
-		}
+		ls.transitionInfo = hardfork.NewTransitionKnown(rolloverResult.NewCurrentEpoch.EpochId)
 	}
 	ls.Unlock()
 

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -42,8 +42,9 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger/eras"
-	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
@@ -2420,11 +2421,11 @@ func babbagePParams(major uint) *babbage.BabbageProtocolParameters {
 // newTestEpoch is a convenience builder for models.Epoch.
 func newTestEpoch(id, startSlot uint64, lengthInSlots uint, eraId uint) models.Epoch {
 	return models.Epoch{
-		EpochId:      id,
-		StartSlot:    startSlot,
+		EpochId:       id,
+		StartSlot:     startSlot,
 		LengthInSlots: lengthInSlots,
-		EraId:        eraId,
-		SlotLength:   1000,
+		EraId:         eraId,
+		SlotLength:    1000,
 	}
 }
 
@@ -2436,10 +2437,11 @@ func newTestEpoch(id, startSlot uint64, lengthInSlots uint, eraId uint) models.E
 // that TransitionImpossible is set when tipSlot + safeZone >= epochEndSlot.
 //
 // Using Shelley-era parameters from newTestEraHistoryCfg:
-//   securityParam=432, activeSlotsCoeff=0.05
-//   safeZone = ceil(3*432/0.05) = 25_920
-//   epoch: startSlot=100_000, length=432_000, end=532_000
-//   tipSlot = 532_000 - 25_920 = 506_080 → safeEnd = 532_000 = epochEnd → Impossible
+//
+//	securityParam=432, activeSlotsCoeff=0.05
+//	safeZone = ceil(3*432/0.05) = 25_920
+//	epoch: startSlot=100_000, length=432_000, end=532_000
+//	tipSlot = 532_000 - 25_920 = 506_080 → safeEnd = 532_000 = epochEnd → Impossible
 func TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd(t *testing.T) {
 	const (
 		epochStart = uint64(100_000)
@@ -2457,7 +2459,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd(t *testing.
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2466,7 +2468,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd(t *testing.
 
 	ls.evaluateTransitionImpossible()
 
-	assert.Equal(t, TransitionImpossible, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionImpossible, ls.transitionInfo.State,
 		"when safeEndSlot == epochEndSlot, TransitionImpossible must be set")
 }
 
@@ -2488,7 +2490,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneExceedsEpochEnd(t *testing.
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2497,7 +2499,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneExceedsEpochEnd(t *testing.
 
 	ls.evaluateTransitionImpossible()
 
-	assert.Equal(t, TransitionImpossible, ls.transitionInfo.State)
+	assert.Equal(t, hardfork.TransitionImpossible, ls.transitionInfo.State)
 }
 
 // TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch verifies
@@ -2517,7 +2519,7 @@ func TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch(t *testing.T
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2526,7 +2528,7 @@ func TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch(t *testing.T
 
 	ls.evaluateTransitionImpossible()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"safeEndSlot < epochEndSlot: TransitionImpossible must NOT be set")
 }
 
@@ -2541,7 +2543,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown(t *testing.T) {
 			// tipSlot past the safe-zone boundary → would normally trigger Impossible
 			Point: ocommon.NewPoint(520_000, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionKnown, KnownEpoch: 501},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 501},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2550,7 +2552,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown(t *testing.T) {
 
 	ls.evaluateTransitionImpossible()
 
-	assert.Equal(t, TransitionKnown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State,
 		"evaluateTransitionImpossible must not override TransitionKnown")
 	assert.Equal(t, uint64(501), ls.transitionInfo.KnownEpoch)
 }
@@ -2565,7 +2567,7 @@ func TestEvaluateTransitionImpossible_NoOpAlreadyImpossible(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(520_000, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2574,7 +2576,7 @@ func TestEvaluateTransitionImpossible_NoOpAlreadyImpossible(t *testing.T) {
 
 	ls.evaluateTransitionImpossible()
 
-	assert.Equal(t, TransitionImpossible, ls.transitionInfo.State)
+	assert.Equal(t, hardfork.TransitionImpossible, ls.transitionInfo.State)
 }
 
 // TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero verifies that a
@@ -2587,7 +2589,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero(t *testing.T) {
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(999_999, []byte("tip")),
 		},
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -2596,7 +2598,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero(t *testing.T) {
 
 	ls.evaluateTransitionImpossible()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"zero-length epoch must not trigger TransitionImpossible")
 }
 
@@ -2609,7 +2611,7 @@ func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 		currentPParams: babbagePParams(9),
 		// Simulate state at end of epoch 500: TransitionImpossible was set
 		// because the tip's safe zone reached the epoch end.
-		transitionInfo: TransitionInfo{State: TransitionImpossible},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionImpossible},
 	}
 
 	var eraTransitions []*EraTransitionResult
@@ -2631,18 +2633,18 @@ func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 		ls.currentEra = rolloverResult.NewCurrentEra
 		ls.currentPParams = rolloverResult.NewCurrentPParams
 		if len(eraTransitions) == 0 {
-			ls.transitionInfo = TransitionInfo{State: TransitionUnknown}
+			ls.transitionInfo = hardfork.TransitionInfo{State: hardfork.TransitionUnknown}
 		}
 	}
 	if len(eraTransitions) == 0 && rolloverResult != nil && rolloverResult.HardFork != nil {
-		ls.transitionInfo = TransitionInfo{
-			State:      TransitionKnown,
+		ls.transitionInfo = hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
 		}
 	}
 	ls.Unlock()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"plain epoch rollover must reset TransitionImpossible to TransitionUnknown")
 }
 
@@ -2654,8 +2656,8 @@ func TestApplyEraTransition_ClearsTransitionKnown(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: TransitionInfo{
-			State:      TransitionKnown,
+		transitionInfo: hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: 500,
 		},
 	}
@@ -2671,7 +2673,7 @@ func TestApplyEraTransition_ClearsTransitionKnown(t *testing.T) {
 	ls.applyEraTransition(result)
 	ls.Unlock()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"TransitionKnown must be cleared when the new era becomes active")
 	assert.Equal(t, eras.ConwayEraDesc.Id, ls.currentEra.Id)
 }
@@ -2683,7 +2685,7 @@ func TestApplyEraTransition_ClearsTransitionUnknown(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 	}
 
 	result := &EraTransitionResult{
@@ -2695,7 +2697,7 @@ func TestApplyEraTransition_ClearsTransitionUnknown(t *testing.T) {
 	ls.applyEraTransition(result)
 	ls.Unlock()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State)
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State)
 }
 
 // TestApplyEraTransition_PreservesAndUpdatesFields verifies that
@@ -2708,7 +2710,7 @@ func TestApplyEraTransition_PreservesAndUpdatesFields(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: lcommon.ProtocolParameters(oldPParams),
-		transitionInfo: TransitionInfo{State: TransitionKnown, KnownEpoch: 500},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 500},
 	}
 
 	result := &EraTransitionResult{
@@ -2726,7 +2728,7 @@ func TestApplyEraTransition_PreservesAndUpdatesFields(t *testing.T) {
 		"new pparams must become currentPParams")
 	assert.Equal(t, eras.ConwayEraDesc.Id, ls.currentEra.Id,
 		"currentEra must be updated to the new era")
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"transitionInfo must be cleared")
 }
 
@@ -2737,7 +2739,7 @@ func TestApplyEraTransition_MultipleSteps_AllCleared(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.AlonzoEraDesc.Id),
 		currentPParams: babbagePParams(6),
-		transitionInfo: TransitionInfo{State: TransitionKnown, KnownEpoch: 300},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 300},
 	}
 
 	steps := []*EraTransitionResult{
@@ -2757,7 +2759,7 @@ func TestApplyEraTransition_MultipleSteps_AllCleared(t *testing.T) {
 	}
 	ls.Unlock()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State)
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State)
 	assert.Equal(t, eras.ConwayEraDesc.Id, ls.currentEra.Id)
 }
 
@@ -2770,7 +2772,7 @@ func TestRolloverCommit_EraTransitionClearsTransitionInfo(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: TransitionInfo{State: TransitionKnown, KnownEpoch: 499},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionKnown, KnownEpoch: 499},
 	}
 
 	eraTransitions := []*EraTransitionResult{
@@ -2800,14 +2802,14 @@ func TestRolloverCommit_EraTransitionClearsTransitionInfo(t *testing.T) {
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	if len(eraTransitions) == 0 && rolloverResult.HardFork != nil {
-		ls.transitionInfo = TransitionInfo{
-			State:      TransitionKnown,
+		ls.transitionInfo = hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
 		}
 	}
 	ls.Unlock()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"era transition must clear transitionInfo even when rolloverResult.HardFork is set")
 }
 
@@ -2818,7 +2820,7 @@ func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 	}
 
 	var eraTransitions []*EraTransitionResult // empty — no standalone transition
@@ -2842,14 +2844,14 @@ func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	if len(eraTransitions) == 0 && rolloverResult.HardFork != nil {
-		ls.transitionInfo = TransitionInfo{
-			State:      TransitionKnown,
+		ls.transitionInfo = hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
 		}
 	}
 	ls.Unlock()
 
-	assert.Equal(t, TransitionKnown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State,
 		"version bump at epoch boundary without era transition must set TransitionKnown")
 	assert.Equal(t, uint64(500), ls.transitionInfo.KnownEpoch)
 }
@@ -2860,7 +2862,7 @@ func TestRolloverCommit_NoHardFork_TransitionInfoUnchanged(t *testing.T) {
 	ls := &LedgerState{
 		currentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
 		currentPParams: babbagePParams(9),
-		transitionInfo: TransitionInfo{State: TransitionUnknown},
+		transitionInfo: hardfork.TransitionInfo{State: hardfork.TransitionUnknown},
 	}
 
 	var eraTransitions []*EraTransitionResult
@@ -2881,13 +2883,13 @@ func TestRolloverCommit_NoHardFork_TransitionInfoUnchanged(t *testing.T) {
 	ls.currentEra = rolloverResult.NewCurrentEra
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	if len(eraTransitions) == 0 && rolloverResult.HardFork != nil {
-		ls.transitionInfo = TransitionInfo{
-			State:      TransitionKnown,
+		ls.transitionInfo = hardfork.TransitionInfo{
+			State:      hardfork.TransitionKnown,
 			KnownEpoch: rolloverResult.NewCurrentEpoch.EpochId,
 		}
 	}
 	ls.Unlock()
 
-	assert.Equal(t, TransitionUnknown, ls.transitionInfo.State,
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"plain epoch rollover must not change transitionInfo")
 }


### PR DESCRIPTION
Relates to #1857 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a new `ledger/hardfork` module with HFC shapes, summaries, and transition handling. Slot/time/epoch conversions and era history now use it, fixing cross‑era mappings and enforcing safe‑zone and stability‑window rules.

- **New Features**
  - Added `ledger/hardfork` with `Shape`, `Summary`, `EraParams`, `TransitionInfo`/`TransitionState`, and `BuildSummary`, with validation and tests.
  - Added `eras.StabilityWindowForEra` and `LedgerState.HardForkSummary` to compute era bounds from the epoch cache, tip, current era, and transition info.

- **Refactors**
  - Routed `SlotToTime`, `TimeToSlot`, `SlotToEpoch`, and `queryHardforkEraHistory` through `hardfork.Summary` for boundary‑safe cross‑era behavior and correct projection past tip.
  - Moved all transition types and references to `hardfork`; tightened error handling for before‑genesis and malformed era params.

<sup>Written for commit 5a51015e383005730bcafb2820e5af90fefbcb9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-era hardfork support: accurate time/slot/epoch conversions, era summaries, and era lookups.
  * Exposed transition states (Unknown/Known/Impossible) with clearer transition reporting.

* **Refactoring**
  * Unified shape-based hardfork model and consolidated transition handling; ledger now builds and uses hardfork summaries.

* **Bug Fixes**
  * Safer validations and edge-case handling for slot/time conversions and malformed genesis parameters.

* **Tests**
  * Extensive regression and cross-era test coverage added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->