### PR TITLE
fix: remove duplicated flags

### DIFF
--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -102,9 +102,6 @@ var flagSpecs = []flagSpec{
 	durationFlag("InboundPruneAfter", "inbound-prune-after", "inbound prune grace duration"),
 	boolFlag("InboundDuplexOnlyForHot", "inbound-duplex-only-for-hot", "restrict duplex inbound handling to hot peers"),
 	durationFlag("InboundCooldown", "inbound-cooldown", "inbound governance cooldown duration"),
-	boolFlag("GenesisBootstrap.Enabled", "genesis-bootstrap-enabled", "enable genesis bootstrap mode"),
-	uint64Flag("GenesisBootstrap.WindowSlots", "genesis-bootstrap-window-slots", "genesis bootstrap comparison window in slots"),
-	intFlag("GenesisBootstrap.PromotionMinDiversityGroups", "genesis-bootstrap-promotion-min-diversity-groups", "minimum bootstrap diversity groups for promotion"),
 	intFlag("MaxConnectionsPerIP", "max-connections-per-ip", "max simultaneous connections per IP"),
 	intFlag("MaxInboundConns", "max-inbound-conns", "max inbound connections"),
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed duplicated genesis bootstrap CLI flags to prevent double registration and reduce confusion in config flags. No behavior change expected.

- **Bug Fixes**
  - Removed duplicate flags: `genesis-bootstrap-enabled`, `genesis-bootstrap-window-slots`, `genesis-bootstrap-promotion-min-diversity-groups`.

<sup>Written for commit 33bf109b6c02f5724ce644a8c09d507db7edcc65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate configuration flag declarations to streamline settings management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->