### PR TITLE
fix(ledgerstate): support newer mithril snapshot shapes

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -145,6 +145,23 @@ is_first_run() {
   return 1
 }
 
+has_incomplete_sync() {
+  # The Docker image defaults to sqlite metadata storage. If a previous
+  # Mithril bootstrap failed after creating the DB, serve will refuse to
+  # start until the sync is resumed.
+  local sqlite_db="${CARDANO_DATABASE_PATH}/metadata.sqlite"
+  if [[ ! -f "${sqlite_db}" ]]; then
+    return 1
+  fi
+
+  local status
+  status="$(sqlite3 "${sqlite_db}" "SELECT value FROM sync_state WHERE sync_key = 'sync_status' LIMIT 1;" 2>/dev/null || true)"
+  if [[ -n "${status}" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 bootstrap_if_needed() {
   # Only bootstrap on first run when RESTORE_SNAPSHOT is set
   if [[ -n "${RESTORE_SNAPSHOT:-}" ]] && is_first_run; then
@@ -160,6 +177,21 @@ bootstrap_if_needed() {
     dingo "${sync_args[@]}"
 
     log "Mithril bootstrap complete"
+    return 0
+  fi
+
+  if [[ -n "${RESTORE_SNAPSHOT:-}" ]] && has_incomplete_sync; then
+    log "Incomplete Mithril sync detected, resuming..."
+
+    local sync_args=()
+    if [[ -n "${DINGO_DEBUG:-}" ]]; then
+      sync_args+=("--debug")
+    fi
+    sync_args+=("mithril" "sync")
+
+    dingo "${sync_args[@]}"
+
+    log "Mithril sync resume complete"
     return 0
   fi
 

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -39,6 +39,7 @@ import (
 	"github.com/blinklabs-io/dingo/ledgerstate"
 	"github.com/blinklabs-io/dingo/mithril"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
@@ -1043,6 +1044,90 @@ func processGapBlocks(
 	return nil
 }
 
+const txBodyKeyCollateralReturn uint64 = 16
+
+// extractInvalidTxIndices returns the set of transaction indices flagged as
+// script-invalid in the block (blockArray[4] for Alonzo+ blocks). The
+// collateral-return UTxO is produced only for invalid transactions — see
+// gouroboros ConwayTransaction.Produced(). Eras without invalid_transactions
+// (Byron/Shelley/Allegra/Mary) return an empty set.
+func extractInvalidTxIndices(blockCbor []byte) (map[int]struct{}, error) {
+	var blockArray []cbor.RawMessage
+	if _, err := cbor.Decode(blockCbor, &blockArray); err != nil {
+		return nil, err
+	}
+	if len(blockArray) < 5 {
+		return nil, nil
+	}
+	var invalidTxs []uint
+	if _, err := cbor.Decode([]byte(blockArray[4]), &invalidTxs); err != nil {
+		return nil, err
+	}
+	if len(invalidTxs) == 0 {
+		return nil, nil
+	}
+	set := make(map[int]struct{}, len(invalidTxs))
+	for _, idx := range invalidTxs {
+		set[int(idx)] = struct{}{} // #nosec G115 -- gouroboros bounds to 1M
+	}
+	return set, nil
+}
+
+func txBodyMapValueRange(
+	bodyCbor []byte,
+	bodyOffset uint32,
+	key uint64,
+) (uint32, uint32, bool, error) {
+	decoder, err := cbor.NewStreamDecoder(bodyCbor)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	count, _, _, err := decoder.DecodeMapHeader()
+	if err != nil {
+		return 0, 0, false, err
+	}
+	for range count {
+		var currentKey uint64
+		if _, _, err := decoder.Decode(&currentKey); err != nil {
+			return 0, 0, false, err
+		}
+		valueOffset, valueLen, err := decoder.Skip()
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if currentKey != key {
+			continue
+		}
+		valueOffset32, err := checkedUint32(valueOffset)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		valueLen32, err := checkedUint32(valueLen)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if valueOffset32 > ^uint32(0)-bodyOffset {
+			return 0, 0, false, fmt.Errorf(
+				"value offset %d overflows body offset %d",
+				valueOffset32,
+				bodyOffset,
+			)
+		}
+		return bodyOffset + valueOffset32, valueLen32, true, nil
+	}
+	return 0, 0, false, nil
+}
+
+func checkedUint32(v int) (uint32, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("negative value %d", v)
+	}
+	if uint64(v) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("value %d overflows uint32", v)
+	}
+	return uint32(v), nil // #nosec G115 -- checked above
+}
+
 // postProcessUtxoOffsets iterates all ImmutableDB blocks and
 // computes byte offset references for every transaction output.
 // This enables UtxoByRef() to extract UTxO CBOR on-demand from
@@ -1150,7 +1235,15 @@ func postProcessUtxoOffsets(
 			next.Cbor,
 		)
 		if extractErr == nil {
-			for _, txLoc := range offsets.Transactions {
+			invalidTxs, invErr := extractInvalidTxIndices(next.Cbor)
+			if invErr != nil {
+				txn.Rollback() //nolint:errcheck
+				return fmt.Errorf(
+					"block at slot %d: decoding invalid tx indices: %w",
+					next.Slot, invErr,
+				)
+			}
+			for txIdx, txLoc := range offsets.Transactions {
 				bodyEnd := txLoc.Body.Offset +
 					txLoc.Body.Length
 				if int(bodyEnd) > len(next.Cbor) {
@@ -1167,30 +1260,80 @@ func postProcessUtxoOffsets(
 				}
 				bodyBytes := next.Cbor[txLoc.Body.Offset:bodyEnd]
 				txHash := lcommon.Blake2b256Hash(bodyBytes)
+				_, txIsInvalid := invalidTxs[txIdx]
 
-				for i, outLoc := range txLoc.Outputs {
-					if outLoc.Length == 0 {
-						continue
+				if !txIsInvalid {
+					for i, outLoc := range txLoc.Outputs {
+						if outLoc.Length == 0 {
+							continue
+						}
+						offset := database.CborOffset{
+							BlockSlot:  next.Slot,
+							BlockHash:  blockHash,
+							ByteOffset: outLoc.Offset,
+							ByteLength: outLoc.Length,
+						}
+						offsetData := database.EncodeUtxoOffset(
+							&offset,
+						)
+						// #nosec G115
+						if err := blob.SetUtxo(
+							blobTxn,
+							txHash[:],
+							uint32(i),
+							offsetData,
+						); err != nil {
+							txn.Rollback() //nolint:errcheck
+							return fmt.Errorf(
+								"storing UTxO offset: %w",
+								err,
+							)
+						}
+						totalUtxos++
+						utxosInBatch++
+						if utxosInBatch >= batchUtxoOffsets {
+							if err := flushTxn(); err != nil {
+								return err
+							}
+							blobTxn = txn.Blob()
+						}
 					}
+					continue
+				}
+				collReturnOffset, collReturnLen, found, err := txBodyMapValueRange(
+					next.Cbor[txLoc.Body.Offset:bodyEnd],
+					txLoc.Body.Offset,
+					txBodyKeyCollateralReturn,
+				)
+				if err != nil {
+					txn.Rollback() //nolint:errcheck
+					return fmt.Errorf(
+						"block at slot %d: transaction %x collateral return offset: %w",
+						next.Slot,
+						txHash[:8],
+						err,
+					)
+				}
+				if found {
 					offset := database.CborOffset{
 						BlockSlot:  next.Slot,
 						BlockHash:  blockHash,
-						ByteOffset: outLoc.Offset,
-						ByteLength: outLoc.Length,
+						ByteOffset: collReturnOffset,
+						ByteLength: collReturnLen,
 					}
 					offsetData := database.EncodeUtxoOffset(
 						&offset,
 					)
-					// #nosec G115
+					outputIdx := uint32(len(txLoc.Outputs)) // #nosec G115
 					if err := blob.SetUtxo(
 						blobTxn,
 						txHash[:],
-						uint32(i),
+						outputIdx,
 						offsetData,
 					); err != nil {
 						txn.Rollback() //nolint:errcheck
 						return fmt.Errorf(
-							"storing UTxO offset: %w",
+							"storing collateral return UTxO offset: %w",
 							err,
 						)
 					}

--- a/cmd/dingo/mithril_test.go
+++ b/cmd/dingo/mithril_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxBodyMapValueRangeFindsCollateralReturn(t *testing.T) {
+	// Preview invalid Conway tx with one regular output and one
+	// collateral return. The live collateral-return UTxO index is 1.
+	const txHex = "84a700818258200c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8010181a20058390073a817bb425cbe179af824529d96ceb93c41c3ab507380095d1be4ebd64c93ef0094f5c179e5380109ebeef022245944e3914f5bcca3a793011a02dc6c00021a001e84800b5820192d0c0c2c2320e843e080b5f91a9ca35155bc50f3ef3bfdbc72c1711b86367e0d818258203af629a5cd75f76d0cc21172e1193b85f199ca78e837c3965d77d7d6bc90206b0010a20058390073a817bb425cbe179af824529d96ceb93c41c3ab507380095d1be4ebd64c93ef0094f5c179e5380109ebeef022245944e3914f5bcca3a793011a006acfc0111a002dc6c0a4008182582025fcacade3fffc096b53bdaf4c7d012bded303c9edbee686d24b372dae60aa1b58409da928a064ff9f795110bdcb8ab05d2a7a023dd15ebc42044f102ce366c0c9077024c7951c2d63584b7d2eea7bf1da4a7453bde4c99dd083889c1e2e2e3db804048119077a0581840000187b820a0a06814746010000222601f4f6"
+
+	txBytes, err := hex.DecodeString(txHex)
+	require.NoError(t, err)
+
+	var txParts []cbor.RawMessage
+	_, err = cbor.Decode(txBytes, &txParts)
+	require.NoError(t, err)
+	require.NotEmpty(t, txParts)
+	bodyCbor := []byte(txParts[0])
+
+	tx, err := gledger.NewTransactionFromCbor(
+		uint(conway.EraIdConway),
+		txBytes,
+	)
+	require.NoError(t, err)
+	require.Len(t, tx.Outputs(), 1)
+	require.Len(t, tx.Produced(), 1)
+	require.Equal(t, uint32(1), tx.Produced()[0].Id.Index())
+	collateralReturn := tx.CollateralReturn()
+	if collateralReturn == nil {
+		t.Fatal("expected collateral return")
+	}
+
+	offset, length, found, err := txBodyMapValueRange(
+		bodyCbor,
+		0,
+		txBodyKeyCollateralReturn,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(
+		t,
+		collateralReturn.Cbor(),
+		bodyCbor[offset:offset+length],
+	)
+}
+
+func TestTxBodyMapValueRangeHonorsBaseOffset(t *testing.T) {
+	// Same fixture as above, but called with a non-zero bodyOffset.
+	// Guards against absolute-offset regressions (e.g. if the returned
+	// offset were interpreted relative to the body slice rather than
+	// the outer buffer).
+	const txHex = "84a700818258200c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8010181a20058390073a817bb425cbe179af824529d96ceb93c41c3ab507380095d1be4ebd64c93ef0094f5c179e5380109ebeef022245944e3914f5bcca3a793011a02dc6c00021a001e84800b5820192d0c0c2c2320e843e080b5f91a9ca35155bc50f3ef3bfdbc72c1711b86367e0d818258203af629a5cd75f76d0cc21172e1193b85f199ca78e837c3965d77d7d6bc90206b0010a20058390073a817bb425cbe179af824529d96ceb93c41c3ab507380095d1be4ebd64c93ef0094f5c179e5380109ebeef022245944e3914f5bcca3a793011a006acfc0111a002dc6c0a4008182582025fcacade3fffc096b53bdaf4c7d012bded303c9edbee686d24b372dae60aa1b58409da928a064ff9f795110bdcb8ab05d2a7a023dd15ebc42044f102ce366c0c9077024c7951c2d63584b7d2eea7bf1da4a7453bde4c99dd083889c1e2e2e3db804048119077a0581840000187b820a0a06814746010000222601f4f6"
+
+	txBytes, err := hex.DecodeString(txHex)
+	require.NoError(t, err)
+
+	var txParts []cbor.RawMessage
+	_, err = cbor.Decode(txBytes, &txParts)
+	require.NoError(t, err)
+	require.NotEmpty(t, txParts)
+	bodyCbor := []byte(txParts[0])
+
+	tx, err := gledger.NewTransactionFromCbor(
+		uint(conway.EraIdConway),
+		txBytes,
+	)
+	require.NoError(t, err)
+	collateralReturn := tx.CollateralReturn()
+	require.NotNil(t, collateralReturn)
+
+	const bodyOffset uint32 = 42
+	prefix := bytes.Repeat([]byte{0xaa}, int(bodyOffset))
+	prefixed := append(prefix, bodyCbor...)
+
+	offset, length, found, err := txBodyMapValueRange(
+		bodyCbor,
+		bodyOffset,
+		txBodyKeyCollateralReturn,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.GreaterOrEqual(t, offset, bodyOffset)
+	require.Equal(
+		t,
+		collateralReturn.Cbor(),
+		prefixed[offset:offset+length],
+	)
+}
+
+func TestTxBodyMapValueRangeMissingKey(t *testing.T) {
+	bodyCbor := []byte{
+		0xa2,
+		0x00, 0x80,
+		0x01, 0x80,
+	}
+
+	_, _, found, err := txBodyMapValueRange(
+		bodyCbor,
+		0,
+		txBodyKeyCollateralReturn,
+	)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestExtractInvalidTxIndices_PreAlonzo(t *testing.T) {
+	const blockHex = "8480808080"
+
+	blockBytes, err := hex.DecodeString(blockHex)
+	require.NoError(t, err)
+
+	var blockArray []cbor.RawMessage
+	_, err = cbor.Decode(blockBytes, &blockArray)
+	require.NoError(t, err)
+	require.Len(t, blockArray, 4)
+
+	invalidTxs, err := extractInvalidTxIndices(blockBytes)
+	require.NoError(t, err)
+	require.Empty(t, invalidTxs)
+}
+
+func TestExtractInvalidTxIndices_AlonzoEmpty(t *testing.T) {
+	const blockHex = "858080808080"
+
+	blockBytes, err := hex.DecodeString(blockHex)
+	require.NoError(t, err)
+
+	var blockArray []cbor.RawMessage
+	_, err = cbor.Decode(blockBytes, &blockArray)
+	require.NoError(t, err)
+	require.Len(t, blockArray, 5)
+
+	invalidTxs, err := extractInvalidTxIndices(blockBytes)
+	require.NoError(t, err)
+	require.Empty(t, invalidTxs)
+}
+
+func TestExtractInvalidTxIndices_AlonzoMultiple(t *testing.T) {
+	const blockHex = "858080808083010307"
+
+	blockBytes, err := hex.DecodeString(blockHex)
+	require.NoError(t, err)
+
+	var blockArray []cbor.RawMessage
+	_, err = cbor.Decode(blockBytes, &blockArray)
+	require.NoError(t, err)
+	require.Len(t, blockArray, 5)
+
+	invalidTxs, err := extractInvalidTxIndices(blockBytes)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		map[int]struct{}{
+			1: {},
+			3: {},
+			7: {},
+		},
+		invalidTxs,
+	)
+}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -635,26 +635,24 @@ func (d *MetadataStoreSqlite) SetGapBlockTransaction(
 	for i := range tmpTx.Outputs {
 		tmpTx.Outputs[i].ID = 0
 		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
-		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-			DoNothing: true,
-		}).Create(&tmpTx.Outputs[i])
-		if result.Error != nil {
+	}
+	if len(tmpTx.Outputs) > 0 {
+		if err := d.ImportUtxos(tmpTx.Outputs, txn); err != nil {
 			return fmt.Errorf(
-				"create gap block utxo output %d for tx %x: %w",
-				i, txHash, result.Error,
+				"create gap block utxo outputs for tx %x: %w",
+				txHash, err,
 			)
 		}
 	}
 	if tmpTx.CollateralReturn != nil {
 		tmpTx.CollateralReturn.CollateralReturnForTxID = &tmpTx.ID
-		if result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-			DoNothing: true,
-		}).Create(tmpTx.CollateralReturn); result.Error != nil {
+		if err := d.ImportUtxos(
+			[]models.Utxo{*tmpTx.CollateralReturn},
+			txn,
+		); err != nil {
 			return fmt.Errorf(
-				"create gap block collateral return: %w",
-				result.Error,
+				"create gap block collateral return for tx %x: %w",
+				txHash, err,
 			)
 		}
 	}

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -341,7 +341,7 @@ func parseCertPoolParamsMap(data []byte) ([]ParsedPool, error) {
 			continue
 		}
 
-		pool, err := parsePoolParams(
+		pool, err := parsePoolParamsOrDistr(
 			poolKeyHash, entry.ValueRaw,
 		)
 		if err != nil {
@@ -696,7 +696,7 @@ func parsePState(data []byte) ([]ParsedPool, error) {
 			continue
 		}
 
-		pool, err := parsePoolParams(
+		pool, err := parsePoolParamsOrDistr(
 			poolKeyHash, entry.ValueRaw,
 		)
 		if err != nil {
@@ -773,6 +773,14 @@ func looksLikeDeposits(m map[string]uint64) bool {
 	return large*2 >= len(m)
 }
 
+// ErrNotPoolParams signals that the input CBOR is not shaped like a full
+// PoolParams registration (either not an array or too short). Callers can
+// use errors.Is(err, ErrNotPoolParams) to decide whether to try decoding
+// the input as the compact PoolDistr shape. Any other decode failure
+// indicates the value looked like PoolParams but was malformed, and must
+// not silently fall back.
+var ErrNotPoolParams = errors.New("not pool params shape")
+
 // parsePoolParams decodes a single pool's parameters.
 // PoolParams = [
 //
@@ -793,12 +801,15 @@ func parsePoolParams(
 ) (*ParsedPool, error) {
 	var params []cbor.RawMessage
 	if _, err := cbor.Decode(data, &params); err != nil {
-		return nil, fmt.Errorf("decoding pool params: %w", err)
+		return nil, fmt.Errorf(
+			"%w: decoding pool params array: %w",
+			ErrNotPoolParams, err,
+		)
 	}
 	if len(params) < 7 {
 		return nil, fmt.Errorf(
-			"pool params has %d elements, expected at least 7",
-			len(params),
+			"%w: pool params has %d elements, expected at least 7",
+			ErrNotPoolParams, len(params),
 		)
 	}
 
@@ -806,12 +817,24 @@ func parsePoolParams(
 		PoolKeyHash: poolKeyHash,
 	}
 
-	// VRF key hash (index 1)
+	// VRF key hash (index 1). A valid full PoolParams registration
+	// always has a 32-byte hash here; anything else means the value
+	// is actually the compact PoolDistr shape (VRF lives elsewhere)
+	// and should trigger the fallback via ErrNotPoolParams.
 	if _, err := cbor.Decode(
 		params[1],
 		&pool.VrfKeyHash,
 	); err != nil {
-		return nil, fmt.Errorf("decoding VRF key hash: %w", err)
+		return nil, fmt.Errorf(
+			"%w: decoding VRF key hash: %w",
+			ErrNotPoolParams, err,
+		)
+	}
+	if len(pool.VrfKeyHash) != 32 {
+		return nil, fmt.Errorf(
+			"%w: VRF key hash is %d bytes, expected 32",
+			ErrNotPoolParams, len(pool.VrfKeyHash),
+		)
 	}
 
 	// Pledge (index 2)
@@ -879,6 +902,88 @@ func parsePoolParams(
 	}
 
 	return pool, nil
+}
+
+func parsePoolParamsOrDistr(
+	poolKeyHash []byte,
+	data []byte,
+) (*ParsedPool, error) {
+	pool, err := parsePoolParams(poolKeyHash, data)
+	if err == nil {
+		return pool, nil
+	}
+	// Only fall back to the compact PoolDistr shape when the input
+	// clearly isn't a full PoolParams registration. A malformed full
+	// registration (e.g. bad VRF key, bad pledge) must surface its
+	// own error rather than getting reinterpreted as PoolDistr, whose
+	// decoder will happily latch onto any 32-byte field it finds.
+	if !errors.Is(err, ErrNotPoolParams) {
+		return nil, err
+	}
+	pool, distrErr := parsePoolDistrEntry(poolKeyHash, data)
+	if distrErr == nil {
+		return pool, nil
+	}
+	return nil, fmt.Errorf(
+		"parsing pool params: %w; parsing pool distribution: %w",
+		err,
+		distrErr,
+	)
+}
+
+// parsePoolDistrEntry decodes the compact PoolDistr/UTxO-HD pool
+// state shape used by current snapshots. The full registration
+// parameters are not present in the legacy order, but the pool key and
+// VRF key are enough to restore pool identity for header validation.
+func parsePoolDistrEntry(
+	poolKeyHash []byte,
+	data []byte,
+) (*ParsedPool, error) {
+	const preferredVrfFieldIdx = 4
+
+	fields, err := decodeRawArray(data)
+	if err != nil {
+		return nil, fmt.Errorf("decoding pool distribution: %w", err)
+	}
+
+	var vrfKeyHash []byte
+	if len(fields) > preferredVrfFieldIdx {
+		if _, err := cbor.Decode(
+			fields[preferredVrfFieldIdx],
+			&vrfKeyHash,
+		); err == nil && len(vrfKeyHash) == 32 {
+			return &ParsedPool{
+				PoolKeyHash: slices.Clone(poolKeyHash),
+				VrfKeyHash:  vrfKeyHash,
+			}, nil
+		}
+	}
+
+	for idx, field := range fields {
+		if idx == preferredVrfFieldIdx {
+			continue
+		}
+		var candidate []byte
+		if _, err := cbor.Decode(
+			field,
+			&candidate,
+		); err == nil && len(candidate) == 32 {
+			slog.Warn(
+				"pool distribution VRF key hash found outside preferred field",
+				"pool", hex.EncodeToString(poolKeyHash),
+				"preferred_index", preferredVrfFieldIdx,
+				"actual_index", idx,
+			)
+			return &ParsedPool{
+				PoolKeyHash: slices.Clone(poolKeyHash),
+				VrfKeyHash:  candidate,
+			}, nil
+		}
+	}
+
+	return nil, errors.New(
+		"pool distribution does not contain a 32-byte VRF key hash",
+	)
 }
 
 // parseRelays decodes an array of relay entries from CBOR.

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -100,6 +100,11 @@ type RawLedgerState struct {
 	// format). When set, UTxOs are streamed from this file instead
 	// of from UTxOData.
 	UTxOTablePath string
+	// UTxOHD indicates that the snapshot used the UTxO-HD ledger
+	// state wrapper. These snapshots keep the real UTxO set in an
+	// external table file and the inline UTxO field is only a
+	// placeholder.
+	UTxOHD bool
 }
 
 // EraBound represents the start boundary of an era in the
@@ -321,6 +326,11 @@ func ImportLedgerState(
 		completedPhase,
 		models.ImportPhaseUTxO,
 	) {
+		if cfg.State.UTxOHD && cfg.State.UTxOTablePath == "" {
+			return errors.New(
+				"UTxO-HD ledger state requires external UTxO table file",
+			)
+		}
 		if cfg.State.UTxOTablePath != "" ||
 			cfg.State.UTxOData != nil {
 			if err := importUTxOs(

--- a/ledgerstate/snapshot.go
+++ b/ledgerstate/snapshot.go
@@ -110,8 +110,9 @@ func stripLedgerSuffix(name string) string {
 }
 
 // FindUTxOTableFile searches for the UTxO table file in UTxO-HD
-// format. Returns the path to tables/tvar if it exists, or empty
-// string if not found (legacy format).
+// format. Current snapshots store the table as ledger/<slot>/tables,
+// while older exports used ledger/<slot>/tables/tvar. Returns an
+// empty string if not found (legacy format).
 func FindUTxOTableFile(extractedDir string) string {
 	ledgerDir, err := findLedgerDir(extractedDir)
 	if err != nil {
@@ -129,10 +130,9 @@ func FindUTxOTableFile(extractedDir string) string {
 		if !e.IsDir() {
 			continue
 		}
-		tvarPath := filepath.Join(
-			ledgerDir, e.Name(), "tables", "tvar",
-		)
-		if _, err := os.Stat(tvarPath); err == nil {
+		if _, ok := findUTxOTableInSlot(
+			filepath.Join(ledgerDir, e.Name()),
+		); ok {
 			dirs = append(dirs, e.Name())
 		}
 	}
@@ -142,9 +142,24 @@ func FindUTxOTableFile(extractedDir string) string {
 		return ""
 	}
 
-	return filepath.Join(
-		ledgerDir, dirs[0], "tables", "tvar",
+	path, _ := findUTxOTableInSlot(
+		filepath.Join(ledgerDir, dirs[0]),
 	)
+	return path
+}
+
+func findUTxOTableInSlot(slotDir string) (string, bool) {
+	candidates := []string{
+		filepath.Join(slotDir, "tables"),
+		filepath.Join(slotDir, "tables", "tvar"),
+	}
+	for _, path := range candidates {
+		info, err := os.Stat(path)
+		if err == nil && !info.IsDir() {
+			return path, true
+		}
+	}
+	return "", false
 }
 
 // findLedgerDir locates the ledger directory within an extracted
@@ -285,7 +300,9 @@ func parseSnapshotData(data []byte) (*RawLedgerState, error) {
 	// Detect UTxO-HD format: first element is a small integer
 	// (version number), not an array (the telescope).
 	var version uint64
+	isUTxOHD := false
 	if _, err := cbor.Decode(outer[0], &version); err == nil {
+		isUTxOHD = true
 		// UTxO-HD format: [version, ExtLedgerState]
 		inner, err := decodeRawArray(outer[1])
 		if err != nil {
@@ -334,6 +351,7 @@ func parseSnapshotData(data []byte) (*RawLedgerState, error) {
 	if err != nil {
 		return nil, err
 	}
+	result.UTxOHD = isUTxOHD
 
 	result.EraBounds = eraBounds
 	result.EraBoundsWarning = boundsWarning
@@ -917,7 +935,9 @@ func decodeNonce(data []byte) ([]byte, error) {
 // ParseSnapShots decodes the stake distribution snapshots
 // (mark, set, go) from the EpochState.
 // SnapShots = [mark, set, go, fee]
-// Each SnapShot = [Stake, Delegations, PoolParams]
+// Each SnapShot is [Stake, Delegations, PoolParams] in older ledger
+// states. Current UTxO-HD snapshots encode [StakeWithPool, PoolParams],
+// where each stake value is [Coin, PoolKeyHash].
 func ParseSnapShots(data cbor.RawMessage) (*ParsedSnapShots, error) {
 	ss, err := decodeRawArray(data)
 	if err != nil {
@@ -986,7 +1006,8 @@ func ParseSnapShots(data cbor.RawMessage) (*ParsedSnapShots, error) {
 }
 
 // parseSnapShot decodes a single SnapShot.
-// SnapShot = [Stake, Delegations, PoolParams]
+// SnapShot = [Stake, Delegations, PoolParams] or
+// [StakeWithPool, PoolParams].
 func parseSnapShot(
 	data []byte,
 ) (*ParsedSnapShot, error) {
@@ -994,47 +1015,74 @@ func parseSnapShot(
 	if err != nil {
 		return nil, fmt.Errorf("decoding SnapShot: %w", err)
 	}
-	if len(snap) < 3 {
+	if len(snap) < 2 {
 		return nil, fmt.Errorf(
-			"SnapShot has %d elements, expected 3",
+			"SnapShot has %d elements, expected at least 2",
 			len(snap),
 		)
 	}
 
-	// Parse Stake: map[Credential]Coin
-	// Warnings from these parsers indicate skipped entries,
-	// not fatal errors, so we collect them.
 	var warnings []error
-	stake, err := parseStakeMap(snap[0])
-	if err != nil {
-		if stake == nil {
-			return nil, fmt.Errorf(
-				"parsing stake map: %w", err,
-			)
-		}
-		warnings = append(warnings, err)
-	}
+	var stake map[string]uint64
+	var delegations map[string][]byte
+	var poolParams map[string]*ParsedPool
 
-	// Parse Delegations: map[Credential]PoolKeyHash
-	delegations, err := parseDelegationMap(snap[1])
-	if err != nil {
-		if delegations == nil {
-			return nil, fmt.Errorf(
-				"parsing delegation map: %w", err,
-			)
+	if len(snap) == 2 {
+		stake, delegations, err = parseStakeWithPoolMap(snap[0])
+		if err != nil {
+			if stake == nil || delegations == nil {
+				return nil, fmt.Errorf(
+					"parsing stake-with-pool map: %w", err,
+				)
+			}
+			warnings = append(warnings, err)
 		}
-		warnings = append(warnings, err)
-	}
 
-	// Parse PoolParams: map[PoolKeyHash]PoolParams
-	poolParams, err := parsePoolParamsMap(snap[2])
-	if err != nil {
-		if poolParams == nil {
-			return nil, fmt.Errorf(
-				"parsing pool params map: %w", err,
-			)
+		poolParams, err = parsePoolParamsMap(snap[1])
+		if err != nil {
+			if poolParams == nil {
+				return nil, fmt.Errorf(
+					"parsing pool params map: %w",
+					err,
+				)
+			}
+			warnings = append(warnings, err)
 		}
-		warnings = append(warnings, err)
+	} else {
+		// Parse Stake: map[Credential]Coin
+		// Warnings from these parsers indicate skipped entries,
+		// not fatal errors, so we collect them.
+		stake, err = parseStakeMap(snap[0])
+		if err != nil {
+			if stake == nil {
+				return nil, fmt.Errorf(
+					"parsing stake map: %w", err,
+				)
+			}
+			warnings = append(warnings, err)
+		}
+
+		// Parse Delegations: map[Credential]PoolKeyHash
+		delegations, err = parseDelegationMap(snap[1])
+		if err != nil {
+			if delegations == nil {
+				return nil, fmt.Errorf(
+					"parsing delegation map: %w", err,
+				)
+			}
+			warnings = append(warnings, err)
+		}
+
+		// Parse PoolParams: map[PoolKeyHash]PoolParams
+		poolParams, err = parsePoolParamsMap(snap[2])
+		if err != nil {
+			if poolParams == nil {
+				return nil, fmt.Errorf(
+					"parsing pool params map: %w", err,
+				)
+			}
+			warnings = append(warnings, err)
+		}
 	}
 
 	return &ParsedSnapShot{
@@ -1089,6 +1137,63 @@ func parseStakeMap(
 		)
 	}
 	return result, warning
+}
+
+// parseStakeWithPoolMap decodes the UTxO-HD compact snapshot map:
+// map[Credential][Coin, PoolKeyHash].
+func parseStakeWithPoolMap(
+	data cbor.RawMessage,
+) (map[string]uint64, map[string][]byte, error) {
+	entries, err := decodeMapEntries(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"decoding stake-with-pool map: %w", err,
+		)
+	}
+
+	stake := make(map[string]uint64, len(entries))
+	delegations := make(map[string][]byte, len(entries))
+	var skipped int
+	for _, entry := range entries {
+		cred, err := parseCredential(entry.KeyRaw)
+		if err != nil || cred.Hash == nil {
+			skipped++
+			continue
+		}
+
+		value, err := decodeRawArray(entry.ValueRaw)
+		if err != nil || len(value) < 2 {
+			skipped++
+			continue
+		}
+
+		var amount uint64
+		if _, err := cbor.Decode(value[0], &amount); err != nil {
+			skipped++
+			continue
+		}
+
+		var poolHash []byte
+		if _, err := cbor.Decode(
+			value[1], &poolHash,
+		); err != nil || len(poolHash) != 28 {
+			skipped++
+			continue
+		}
+
+		credKey := hex.EncodeToString(cred.Hash)
+		stake[credKey] = amount
+		delegations[credKey] = poolHash
+	}
+
+	var warning error
+	if skipped > 0 {
+		warning = fmt.Errorf(
+			"stake-with-pool map: skipped %d of %d entries",
+			skipped, len(entries),
+		)
+	}
+	return stake, delegations, warning
 }
 
 // parseDelegationMap decodes a credential -> pool key hash map.
@@ -1166,7 +1271,7 @@ func parsePoolParamsMap(
 			continue
 		}
 
-		pool, err := parsePoolParams(
+		pool, err := parsePoolParamsOrDistr(
 			poolKeyHash, entry.ValueRaw,
 		)
 		if err != nil {

--- a/ledgerstate/snapshot_test.go
+++ b/ledgerstate/snapshot_test.go
@@ -144,6 +144,20 @@ func TestFindUTxOTableFile(t *testing.T) {
 	require.Equal(t, tvarPath, found)
 }
 
+func TestFindUTxOTableFileCurrentTablesFile(t *testing.T) {
+	dir := t.TempDir()
+	slotDir := filepath.Join(dir, "ledger", "99999")
+	err := os.MkdirAll(slotDir, 0o750)
+	require.NoError(t, err)
+
+	tablesPath := filepath.Join(slotDir, "tables")
+	err = os.WriteFile(tablesPath, []byte("data"), 0o640)
+	require.NoError(t, err)
+
+	found := FindUTxOTableFile(dir)
+	require.Equal(t, tablesPath, found)
+}
+
 func TestFindUTxOTableFileNotFound(t *testing.T) {
 	dir := t.TempDir()
 	ledgerDir := filepath.Join(dir, "ledger")
@@ -188,6 +202,99 @@ func TestEraName(t *testing.T) {
 	require.Equal(t, "Babbage", EraName(EraBabbage))
 	require.Equal(t, "Conway", EraName(EraConway))
 	require.Contains(t, EraName(99), "Unknown")
+}
+
+func TestParseSnapShotsAcceptsTwoElementSnapshots(t *testing.T) {
+	emptyMap, err := cbor.Encode(map[uint64]uint64{})
+	require.NoError(t, err)
+
+	snapshot, err := cbor.Encode([]any{
+		cbor.RawMessage(emptyMap),
+		cbor.RawMessage(emptyMap),
+	})
+	require.NoError(t, err)
+
+	data, err := cbor.Encode([]any{
+		cbor.RawMessage(snapshot),
+		cbor.RawMessage(snapshot),
+		cbor.RawMessage(snapshot),
+	})
+	require.NoError(t, err)
+
+	snapshots, err := ParseSnapShots(data)
+	require.NoError(t, err)
+	require.NotNil(t, snapshots)
+	require.Empty(t, snapshots.Mark.PoolParams)
+	require.Empty(t, snapshots.Set.PoolParams)
+	require.Empty(t, snapshots.Go.PoolParams)
+}
+
+func TestParseSnapShotsAcceptsUTxOHDStakeWithPool(t *testing.T) {
+	credHash := toFixed28([]byte("credential hash for snapshot"))
+	poolHash := toFixed28([]byte("pool hash for snapshot"))
+	stakeMap := encodeCredentialMapEntry(
+		t,
+		[]any{uint64(0), credHash[:]},
+		[]any{uint64(42), poolHash[:]},
+	)
+
+	emptyMap, err := cbor.Encode(map[uint64]uint64{})
+	require.NoError(t, err)
+
+	snapshot, err := cbor.Encode([]any{
+		cbor.RawMessage(stakeMap),
+		cbor.RawMessage(emptyMap),
+	})
+	require.NoError(t, err)
+
+	data, err := cbor.Encode([]any{
+		cbor.RawMessage(snapshot),
+		cbor.RawMessage(snapshot),
+		cbor.RawMessage(snapshot),
+	})
+	require.NoError(t, err)
+
+	snapshots, err := ParseSnapShots(data)
+	require.NoError(t, err)
+
+	credKey := hex.EncodeToString(credHash[:])
+	require.Equal(t, uint64(42), snapshots.Mark.Stake[credKey])
+	require.Equal(t, poolHash[:], snapshots.Mark.Delegations[credKey])
+	require.Equal(t, uint64(42), snapshots.Set.Stake[credKey])
+	require.Equal(t, poolHash[:], snapshots.Set.Delegations[credKey])
+	require.Equal(t, uint64(42), snapshots.Go.Stake[credKey])
+	require.Equal(t, poolHash[:], snapshots.Go.Delegations[credKey])
+}
+
+func TestParsePoolParamsMapAcceptsPoolDistrEntry(t *testing.T) {
+	poolHash := toFixed28([]byte("pool hash for distribution"))
+	vrfHash := [32]byte{}
+	copy(vrfHash[:], []byte("vrf hash for distribution entry"))
+
+	poolMap := encodeCredentialMapEntry(
+		t,
+		poolHash[:],
+		[]any{
+			uint64(0),
+			[]any{uint64(0), uint64(1)},
+			[]any{},
+			uint64(0),
+			vrfHash[:],
+			uint64(0),
+			uint64(0),
+			[]any{uint64(0), uint64(1)},
+			uint64(0),
+			[]any{},
+		},
+	)
+
+	pools, err := parsePoolParamsMap(poolMap)
+	require.NoError(t, err)
+
+	pool := pools[hex.EncodeToString(poolHash[:])]
+	require.NotNil(t, pool)
+	require.Equal(t, poolHash[:], pool.PoolKeyHash)
+	require.Equal(t, vrfHash[:], pool.VrfKeyHash)
 }
 
 func TestVerifySnapshotDigest(t *testing.T) {


### PR DESCRIPTION
Closes #2012 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for newer Mithril snapshot shapes (UTxO‑HD and compact stake/pool) and improves UTxO indexing by storing collateral‑return offsets for invalid transactions. Also auto‑resumes incomplete Mithril syncs during snapshot restore.

- **New Features**
  - Detect UTxO‑HD snapshots and stream UTxOs from the external `tables` file; fail fast if missing.
  - Auto‑locate the UTxO table at ledger/<slot>/tables (current) or ledger/<slot>/tables/tvar (legacy).
  - Accept 2‑element snapshots [StakeWithPool, PoolParams]; parse compact StakeWithPool and compact PoolDistr with VRF extraction.
  - Index CBOR offsets for collateral‑return outputs from invalid transactions to enable on‑demand UTxO retrieval.
  - In `entrypoint.sh`, resume an incomplete Mithril sync when `RESTORE_SNAPSHOT` is set and a sqlite `sync_state` exists.

- **Migration**
  - For UTxO‑HD snapshots, pass `UTxOTablePath` to the `tables` file (new path) or `tables/tvar` (legacy).

<sup>Written for commit 166fc93ae3743d5aacbc2c3eb83b488c060dc9a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UTxO‑HD snapshot recognition and automatic resume of incomplete Mithril bootstrap during snapshot restore.

* **Improvements**
  * Broader snapshot table discovery for current and legacy layouts.
  * Robust stake/pool parsing with fallback for compact encodings.
  * Faster transaction post‑processing to capture collateral‑return offsets.
  * Fail‑fast import when UTxO‑HD is enabled but required table path is missing.

* **Tests**
  * Added snapshot and transaction parsing unit tests for new edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->