### PR TITLE
fix(ledger): per-peer loop detection

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -482,10 +482,10 @@ func (ls *LedgerState) detectConnectionSwitch() (
 		}
 		ls.lastActiveConnId = activeConnId
 		// Preserve rollbackHistory across connection switches so the
-		// rollback loop detector can fire when multiple peers all send
-		// RollBackward to the same slot during rapid chain selection
-		// changes (e.g., post-Mithril startup). Clearing it here
-		// previously allowed unbounded oscillation.
+		// loop detector can still catch repeated rollbacks from the
+		// same peer/session. The detector keys on exact rollback
+		// point + connection, so peer switches do not poison healthy
+		// fork convergence.
 	}
 	return activeConnId, true
 }
@@ -1002,10 +1002,16 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 	}
 
 	// Rollback loop detection: track recent rollbacks and skip if
-	// the same slot appears too frequently within the detection window.
+	// the same peer repeats the same rollback point too frequently
+	// within the detection window.
 	now := time.Now()
+	connKey := connIdKey(e.ConnectionId)
 	ls.rollbackHistory = append(ls.rollbackHistory, rollbackRecord{
-		slot:      e.Point.Slot,
+		point: ocommon.Point{
+			Slot: e.Point.Slot,
+			Hash: append([]byte(nil), e.Point.Hash...),
+		},
+		connKey:   connKey,
 		timestamp: now,
 	})
 	// Prune entries older than the detection window
@@ -1017,10 +1023,13 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		}
 	}
 	ls.rollbackHistory = pruned
-	// Count rollbacks to this specific slot
+	// Count repeated rollbacks to this exact point from the same
+	// connection. Different peers can legitimately converge on the
+	// same rollback point during chain selection, and those rollbacks
+	// must not be suppressed.
 	var slotCount int
 	for _, r := range ls.rollbackHistory {
-		if r.slot == e.Point.Slot {
+		if r.connKey == connKey && pointMatches(r.point, e.Point) {
 			slotCount++
 		}
 	}

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -76,6 +76,70 @@ func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestHandleEventChainsyncRollbackDoesNotSkipDifferentPeerHistory(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	otherConnId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	fixture.ls.rollbackHistory = []rollbackRecord{
+		{
+			point: ocommon.Point{
+				Slot: fixture.ancestorTip.Point.Slot,
+				Hash: append([]byte(nil), fixture.ancestorTip.Point.Hash...),
+			},
+			connKey:   connIdKey(otherConnId),
+			timestamp: time.Now(),
+		},
+	}
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+}
+
+func TestHandleEventChainsyncRollbackSkipsSamePeerLoop(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	fixture.ls.rollbackHistory = []rollbackRecord{
+		{
+			point: ocommon.Point{
+				Slot: fixture.ancestorTip.Point.Slot,
+				Hash: append([]byte(nil), fixture.ancestorTip.Point.Hash...),
+			},
+			connKey:   connIdKey(fixture.connId),
+			timestamp: time.Now(),
+		},
+	}
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
+}
+
 func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 
@@ -518,7 +582,11 @@ func TestRecoverAfterLocalRollbackResetsStateWithoutTrackedClients(t *testing.T)
 	fixture.ls.headerMismatchCount = 3
 	fixture.ls.rollbackHistory = []rollbackRecord{
 		{
-			slot:      fixture.currentTip.Point.Slot,
+			point: ocommon.Point{
+				Slot: fixture.currentTip.Point.Slot,
+				Hash: append([]byte(nil), fixture.currentTip.Point.Hash...),
+			},
+			connKey:   connIdKey(fixture.connId),
 			timestamp: time.Now(),
 		},
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -389,7 +389,8 @@ type MempoolProvider interface {
 	Transactions() []mempool.MempoolTransaction
 }
 type rollbackRecord struct {
-	slot      uint64
+	point     ocommon.Point
+	connKey   string
 	timestamp time.Time
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make rollback loop detection per-peer and per-point to avoid suppressing valid rollbacks from other peers and to stop repeat loops from the same peer. This improves chain selection stability and prevents oscillation during sync.

- **Bug Fixes**
  - Track rollback history by exact point (slot + hash) and connection key; skip only when the same peer repeats the same point within the window.
  - Preserve history across connection switches without poisoning other peers.
  - Added tests for cross-peer vs same-peer behavior and updated the rollback record structure.

<sup>Written for commit a0a557fad6b61bf0b9b293fd12e19ec2aaadf334. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

