### PR TITLE
chore: modernize -v --fix ./...

### DIFF
--- a/bark/pruner.go
+++ b/bark/pruner.go
@@ -161,11 +161,9 @@ func (p *Pruner) Start(ctx context.Context) error {
 
 	ctx, p.cancel = context.WithCancel(ctx) //nolint:gosec
 
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
+	p.wg.Go(func() {
 		p.run(ctx)
-	}()
+	})
 	return nil
 }
 

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1014,9 +1014,6 @@ func paginationRange(
 	if start >= total {
 		return total, total
 	}
-	end := start + params.Count
-	if end > total {
-		end = total
-	}
+	end := min(start+params.Count, total)
 	return start, end
 }

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -15,7 +15,6 @@
 package chainselection
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"net"
@@ -746,8 +745,7 @@ func TestChainSelectorSwitchesImmediatelyOnEligibilityEvent(t *testing.T) {
 		EventBus:           eventBus,
 		EvaluationInterval: time.Hour,
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	require.NoError(t, cs.Start(ctx))
 
 	incumbentConn := newTestConnectionId(1)
@@ -789,8 +787,7 @@ func TestChainSelectorDoesNotSwitchEqualTipIncumbentOnPriorityEvent(
 		EventBus:           eventBus,
 		EvaluationInterval: time.Hour,
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	require.NoError(t, cs.Start(ctx))
 
 	incumbentConn := newTestConnectionId(1)
@@ -1866,11 +1863,11 @@ func TestChainSelectorPeerEvictionAtCapacity(t *testing.T) {
 	// Fill to capacity with peers. Each peer gets a slightly higher slot
 	// to ensure different LastUpdated timestamps (they are added
 	// sequentially so time.Now() progresses).
-	for i := 0; i < maxPeers; i++ {
+	for i := range maxPeers {
 		tip := ochainsync.Tip{
 			Point: ocommon.Point{
 				Slot: uint64(100 + i),
-				Hash: []byte(fmt.Sprintf("tip%d", i)),
+				Hash: fmt.Appendf(nil, "tip%d", i),
 			},
 			BlockNumber: uint64(50 + i),
 		}
@@ -1953,11 +1950,11 @@ func TestChainSelectorUpdateExistingPeerDoesNotEvict(t *testing.T) {
 	}
 
 	// Fill to capacity
-	for i := 0; i < maxPeers; i++ {
+	for i := range maxPeers {
 		tip := ochainsync.Tip{
 			Point: ocommon.Point{
 				Slot: uint64(100 + i),
-				Hash: []byte(fmt.Sprintf("tip%d", i)),
+				Hash: fmt.Appendf(nil, "tip%d", i),
 			},
 			BlockNumber: uint64(50 + i),
 		}
@@ -1981,7 +1978,7 @@ func TestChainSelectorUpdateExistingPeerDoesNotEvict(t *testing.T) {
 	)
 
 	// All original peers should still be present
-	for i := 0; i < maxPeers; i++ {
+	for i := range maxPeers {
 		assert.NotNil(
 			t,
 			cs.GetPeerTip(connIds[i]),
@@ -2030,7 +2027,7 @@ func TestChainSelectorEvictionPreservesBestPeer(t *testing.T) {
 		tip := ochainsync.Tip{
 			Point: ocommon.Point{
 				Slot: uint64(100 + i),
-				Hash: []byte(fmt.Sprintf("tip%d", i)),
+				Hash: fmt.Appendf(nil, "tip%d", i),
 			},
 			BlockNumber: uint64(50 + i),
 		}
@@ -2104,11 +2101,11 @@ func TestChainSelectorEvictionEmitsPeerEvictedEvent(t *testing.T) {
 	}
 
 	// Fill to capacity
-	for i := 0; i < maxPeers; i++ {
+	for i := range maxPeers {
 		tip := ochainsync.Tip{
 			Point: ocommon.Point{
 				Slot: uint64(100 + i),
-				Hash: []byte(fmt.Sprintf("tip%d", i)),
+				Hash: fmt.Appendf(nil, "tip%d", i),
 			},
 			BlockNumber: uint64(50 + i),
 		}
@@ -2183,11 +2180,11 @@ func TestChainSelectorNormalOperationWithinLimit(t *testing.T) {
 	}
 
 	// Add fewer peers than the limit
-	for i := 0; i < expectedCount; i++ {
+	for i := range expectedCount {
 		tip := ochainsync.Tip{
 			Point: ocommon.Point{
 				Slot: uint64(100 + i),
-				Hash: []byte(fmt.Sprintf("tip%d", i)),
+				Hash: fmt.Appendf(nil, "tip%d", i),
 			},
 			BlockNumber: uint64(50 + i),
 		}
@@ -2202,7 +2199,7 @@ func TestChainSelectorNormalOperationWithinLimit(t *testing.T) {
 	)
 
 	// All peers should be present
-	for i := 0; i < expectedCount; i++ {
+	for i := range expectedCount {
 		assert.NotNil(
 			t,
 			cs.GetPeerTip(connIds[i]),

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -138,9 +138,7 @@ func (c *ConnectionManager) startListener(
 		defaultConnOpts,
 		l.ConnectionOpts...,
 	)
-	c.goroutineWg.Add(1)
-	go func() {
-		defer c.goroutineWg.Done()
+	c.goroutineWg.Go(func() {
 		var consecutiveErrors int
 		for {
 			// Accept connection
@@ -360,7 +358,7 @@ func (c *ConnectionManager) startListener(
 				)
 			}
 		}
-	}()
+	})
 	return nil
 }
 

--- a/database/block_indexer_test.go
+++ b/database/block_indexer_test.go
@@ -39,7 +39,7 @@ func TestBlockIndexerComputeOffsets(t *testing.T) {
 	blocksWithTx := 0
 	maxBlocksToTest := 500
 
-	for i := 0; i < maxBlocksToTest; i++ {
+	for i := range maxBlocksToTest {
 		immBlock, err := iter.Next()
 		if err != nil {
 			t.Fatalf("unexpected error reading block %d: %s", i, err)
@@ -163,7 +163,7 @@ func findCborInBytes(data, target []byte) int {
 
 	for i := 0; i <= len(data)-len(target); i++ {
 		match := true
-		for j := 0; j < len(target); j++ {
+		for j := range target {
 			if data[i+j] != target[j] {
 				match = false
 				break

--- a/database/block_offset_test.go
+++ b/database/block_offset_test.go
@@ -40,7 +40,7 @@ func TestExtractTransactionOffsets(t *testing.T) {
 	blocksWithTx := 0
 	maxBlocksToTest := 500
 
-	for i := 0; i < maxBlocksToTest; i++ {
+	for i := range maxBlocksToTest {
 		immBlock, err := iter.Next()
 		if err != nil {
 			t.Fatalf("unexpected error reading block %d: %s", i, err)

--- a/database/cbor_cache_bench_test.go
+++ b/database/cbor_cache_bench_test.go
@@ -79,7 +79,7 @@ func BenchmarkHotCacheParallelGet(b *testing.B) {
 	cache := NewHotCache(10000, 0)
 
 	// Pre-populate with many entries
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := make([]byte, 36)
 		key[0] = byte(i)
 		key[1] = byte(i >> 8)
@@ -257,7 +257,7 @@ func BenchmarkBatchResolutionHotHits(b *testing.B) {
 
 	// Pre-populate hot cache with 100 entries
 	refs := make([]UtxoRef, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		refs[i] = UtxoRef{OutputIdx: uint32(i)}
 		refs[i].TxId[0] = byte(i)
 		refs[i].TxId[1] = byte(i >> 8)
@@ -284,7 +284,7 @@ func BenchmarkTxBatchResolutionHotHits(b *testing.B) {
 
 	// Pre-populate hot cache with 100 TX entries
 	hashes := make([][32]byte, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		hashes[i][0] = byte(i)
 		hashes[i][1] = byte(i >> 8)
 

--- a/database/hot_cache_test.go
+++ b/database/hot_cache_test.go
@@ -50,15 +50,15 @@ func TestHotCacheGetPut(t *testing.T) {
 	assert.Equal(t, value2, got, "expected updated value")
 
 	// Test multiple keys
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		value := []byte(fmt.Sprintf("value%d", i))
+	for i := range 10 {
+		key := fmt.Appendf(nil, "key%d", i)
+		value := fmt.Appendf(nil, "value%d", i)
 		cache.Put(key, value)
 	}
 
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		expectedValue := []byte(fmt.Sprintf("value%d", i))
+	for i := range 10 {
+		key := fmt.Appendf(nil, "key%d", i)
+		expectedValue := fmt.Appendf(nil, "value%d", i)
 		got, ok := cache.Get(key)
 		require.True(t, ok, "expected key%d to be found", i)
 		assert.Equal(t, expectedValue, got, "expected value%d to match", i)
@@ -75,23 +75,23 @@ func TestHotCacheConcurrent(t *testing.T) {
 	wg.Add(numGoroutines * 2)
 
 	// Writers
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
-				key := []byte(fmt.Sprintf("key-%d-%d", id, j))
-				value := []byte(fmt.Sprintf("value-%d-%d", id, j))
+			for j := range numOperations {
+				key := fmt.Appendf(nil, "key-%d-%d", id, j)
+				value := fmt.Appendf(nil, "value-%d-%d", id, j)
 				cache.Put(key, value)
 			}
 		}(i)
 	}
 
 	// Readers
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
-				key := []byte(fmt.Sprintf("key-%d-%d", id, j))
+			for j := range numOperations {
+				key := fmt.Appendf(nil, "key-%d-%d", id, j)
 				cache.Get(key)
 			}
 		}(i)
@@ -100,11 +100,11 @@ func TestHotCacheConcurrent(t *testing.T) {
 	wg.Wait()
 
 	// Verify some entries are still accessible
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("key-%d-%d", i, numOperations-1))
+	for i := range 10 {
+		key := fmt.Appendf(nil, "key-%d-%d", i, numOperations-1)
 		got, ok := cache.Get(key)
 		if ok {
-			expected := []byte(fmt.Sprintf("value-%d-%d", i, numOperations-1))
+			expected := fmt.Appendf(nil, "value-%d-%d", i, numOperations-1)
 			assert.Equal(t, expected, got, "value mismatch for concurrent key")
 		}
 	}
@@ -115,9 +115,9 @@ func TestHotCacheEviction(t *testing.T) {
 	cache := NewHotCache(maxSize, 0)
 
 	// Add entries up to maxSize
-	for i := 0; i < maxSize; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		value := []byte(fmt.Sprintf("value%d", i))
+	for i := range maxSize {
+		key := fmt.Appendf(nil, "key%d", i)
+		value := fmt.Appendf(nil, "value%d", i)
 		cache.Put(key, value)
 	}
 
@@ -128,15 +128,15 @@ func TestHotCacheEviction(t *testing.T) {
 		[]byte("key2"),
 	}
 	for _, key := range frequentKeys {
-		for j := 0; j < 10; j++ {
+		for range 10 {
 			cache.Get(key)
 		}
 	}
 
 	// Add more entries to trigger eviction
 	for i := maxSize; i < maxSize+10; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		value := []byte(fmt.Sprintf("value%d", i))
+		key := fmt.Appendf(nil, "key%d", i)
+		value := fmt.Appendf(nil, "value%d", i)
 		cache.Put(key, value)
 	}
 
@@ -167,8 +167,8 @@ func TestHotCacheMemoryLimit(t *testing.T) {
 
 	// Add entries that together exceed maxBytes
 	valueSize := 100
-	for i := 0; i < 20; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
+	for i := range 20 {
+		key := fmt.Appendf(nil, "key%d", i)
 		value := make([]byte, valueSize)
 		for j := range value {
 			value[j] = byte(i)
@@ -199,19 +199,19 @@ func TestHotCacheLFUEviction(t *testing.T) {
 	cache := NewHotCache(maxSize, 0)
 
 	// Add initial entries
-	for i := 0; i < maxSize; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		value := []byte(fmt.Sprintf("value%d", i))
+	for i := range maxSize {
+		key := fmt.Appendf(nil, "key%d", i)
+		value := fmt.Appendf(nil, "value%d", i)
 		cache.Put(key, value)
 	}
 
 	// Access key0 many times to make it frequently used
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		cache.Get([]byte("key0"))
 	}
 
 	// Access key1 a moderate number of times
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		cache.Get([]byte("key1"))
 	}
 
@@ -219,8 +219,8 @@ func TestHotCacheLFUEviction(t *testing.T) {
 
 	// Add new entries to force eviction
 	for i := maxSize; i < maxSize+5; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		value := []byte(fmt.Sprintf("value%d", i))
+		key := fmt.Appendf(nil, "key%d", i)
+		value := fmt.Appendf(nil, "value%d", i)
 		cache.Put(key, value)
 	}
 
@@ -258,9 +258,9 @@ func TestHotCacheZeroMaxSize(t *testing.T) {
 	// Zero maxSize means unlimited by count
 	cache := NewHotCache(0, 1000)
 
-	for i := 0; i < 100; i++ {
-		key := []byte(fmt.Sprintf("key%d", i))
-		value := []byte(fmt.Sprintf("value%d", i))
+	for i := range 100 {
+		key := fmt.Appendf(nil, "key%d", i)
+		value := fmt.Appendf(nil, "value%d", i)
 		cache.Put(key, value)
 	}
 

--- a/database/plugin/metadata/labelcodec/labelcodec.go
+++ b/database/plugin/metadata/labelcodec/labelcodec.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -96,7 +97,7 @@ func extractFromCbor(
 	for label := range rawByLabel {
 		labels = append(labels, label)
 	}
-	sort.Slice(labels, func(i, j int) bool { return labels[i] < labels[j] })
+	slices.Sort(labels)
 
 	ret := make([]Entry, 0, len(labels))
 	for _, label := range labels {

--- a/database/plugin/metadata/sqlite/concurrency_test.go
+++ b/database/plugin/metadata/sqlite/concurrency_test.go
@@ -68,7 +68,7 @@ func TestConcurrentReadsDuringWrites(t *testing.T) {
 		snapshot := &models.PoolStakeSnapshot{
 			Epoch:          1,
 			SnapshotType:   "go",
-			PoolKeyHash:    []byte(fmt.Sprintf("pool_%028d", i)),
+			PoolKeyHash:    fmt.Appendf(nil, "pool_%028d", i),
 			TotalStake:     1000000,
 			DelegatorCount: 100,
 			CapturedSlot:   1000,
@@ -88,12 +88,10 @@ func TestConcurrentReadsDuringWrites(t *testing.T) {
 				snapshot := &models.PoolStakeSnapshot{
 					Epoch:        uint64(writerID*1000 + i + 2),
 					SnapshotType: "go",
-					PoolKeyHash: []byte(
-						fmt.Sprintf(
-							"pool_w%d_%023d",
-							writerID,
-							i,
-						),
+					PoolKeyHash: fmt.Appendf(nil,
+						"pool_w%d_%023d",
+						writerID,
+						i,
 					),
 					TotalStake:     1000000,
 					DelegatorCount: 100,
@@ -178,12 +176,10 @@ func TestConcurrentWriteTransactions(t *testing.T) {
 						writerID*1000 + i + 1,
 					),
 					SnapshotType: "go",
-					PoolKeyHash: []byte(
-						fmt.Sprintf(
-							"pool_tw%d_%022d",
-							writerID,
-							i,
-						),
+					PoolKeyHash: fmt.Appendf(nil,
+						"pool_tw%d_%022d",
+						writerID,
+						i,
 					),
 					TotalStake:     1000000,
 					DelegatorCount: 100,
@@ -413,7 +409,7 @@ func TestConcurrentReadsDontBlock(t *testing.T) {
 		snapshot := &models.PoolStakeSnapshot{
 			Epoch:          1,
 			SnapshotType:   "go",
-			PoolKeyHash:    []byte(fmt.Sprintf("pool_%028d", i)),
+			PoolKeyHash:    fmt.Appendf(nil, "pool_%028d", i),
 			TotalStake:     1000000,
 			DelegatorCount: 100,
 			CapturedSlot:   1000,
@@ -432,9 +428,7 @@ func TestConcurrentReadsDontBlock(t *testing.T) {
 	)
 
 	for range numReaders {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 20 {
 				_, err := store.GetPoolStakeSnapshotsByEpoch(
 					1, "go", nil,
@@ -443,7 +437,7 @@ func TestConcurrentReadsDontBlock(t *testing.T) {
 					errors.Add(1)
 				}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/database/pparams_test.go
+++ b/database/pparams_test.go
@@ -213,7 +213,7 @@ func TestComputeAndApplyPParamUpdates_FiltersEpoch(
 	// When querying for epoch 4, GetPParamUpdates returns
 	// both (epoch=4 OR epoch=3). The quorum check should only
 	// count epoch 4 records.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		err := db.SetPParamUpdate(
 			[]byte{byte(i)},
 			[]byte{0x80}, // minimal CBOR
@@ -223,7 +223,7 @@ func TestComputeAndApplyPParamUpdates_FiltersEpoch(
 		)
 		require.NoError(t, err)
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		innerMinFeeA := uint(100)
 		updateCbor, innerErr := cbor.Encode(
 			&shelley.ShelleyProtocolParameterUpdate{

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -692,10 +692,7 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 		deleteBatch(txn.Blob(), txHashes)
 	} else {
 		for start := 0; start < len(txHashes); start += batchSize {
-			end := start + batchSize
-			if end > len(txHashes) {
-				end = len(txHashes)
-			}
+			end := min(start+batchSize, len(txHashes))
 			batch := txHashes[start:end]
 			batchTxn := NewBlobOnlyTxn(d, true)
 			batchBlobTxn := batchTxn.Blob()

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -44,10 +44,7 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 
 	var deleteErrors int
 	for start := 0; start < len(utxos); start += batchSize {
-		end := start + batchSize
-		if end > len(utxos) {
-			end = len(utxos)
-		}
+		end := min(start+batchSize, len(utxos))
 		batchTxn := NewBlobOnlyTxn(d, true)
 		for _, utxo := range utxos[start:end] {
 			if err := blob.DeleteUtxo(batchTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -69,22 +69,18 @@ func TestSubscribeFuncStopRace(t *testing.T) {
 
 		// Spawn multiple SubscribeFunc goroutines concurrently
 		for range 5 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				subId := eb.SubscribeFunc(typ, func(Event) {})
 				if subId != 0 {
 					successfulSubscribes.Add(1)
 				}
-			}()
+			})
 		}
 
 		// Concurrently call Stop
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			eb.Stop()
-		}()
+		})
 
 		wg.Wait()
 		// If we get here without panic, the race is handled correctly.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -167,7 +167,7 @@ func ApplyFlags(cmd *cobra.Command, cfg *Config) error {
 
 // fieldByPath walks a dotted path (e.g. "Cache.HotUtxoEntries") on v.
 func fieldByPath(v reflect.Value, path string) reflect.Value {
-	for _, p := range strings.Split(path, ".") {
+	for p := range strings.SplitSeq(path, ".") {
 		v = v.FieldByName(p)
 	}
 	return v

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -49,7 +49,7 @@ func TestRegisterFlags_CoversAllExportedConfigFields(t *testing.T) {
 	}
 
 	leafFields := map[string]struct{}{}
-	collectExportedLeafFields(reflect.TypeOf(Config{}), "", leafFields)
+	collectExportedLeafFields(reflect.TypeFor[Config](), "", leafFields)
 
 	for fieldPath := range leafFields {
 		if _, ok := specFields[fieldPath]; !ok {

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -823,7 +823,7 @@ func TestHandleEventChainsyncBlockHeaderScalesBatchWhenFarBehind(t *testing.T) {
 
 	prevHash := lcommon.NewBlake2b256(nil)
 	for i := 1; i <= 20; i++ {
-		headerHash := lcommon.NewBlake2b256([]byte(fmt.Sprintf("hdr-%d", i)))
+		headerHash := lcommon.NewBlake2b256(fmt.Appendf(nil, "hdr-%d", i))
 		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
 			ConnectionId: connId,
 			Point:        ocommon.NewPoint(uint64(i), headerHash.Bytes()),
@@ -1177,7 +1177,7 @@ func TestHandleEventChainsyncBlockHeaderStartsBlockfetchForSmallBlockGap(
 
 	prevHash := lcommon.NewBlake2b256(nil)
 	for i := range 5 {
-		hash := lcommon.NewBlake2b256([]byte(fmt.Sprintf("hdr-%d", i)))
+		hash := lcommon.NewBlake2b256(fmt.Appendf(nil, "hdr-%d", i))
 		slot := uint64(1064 + i*4)
 		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
 			ConnectionId: connId,
@@ -1241,7 +1241,7 @@ func TestHandleEventChainsyncBlockHeaderStartsBlockfetchForSparseBlockGap(
 	var prevHash lcommon.Blake2b256
 	for i, slot := range headerSlots {
 		hash := lcommon.NewBlake2b256(
-			[]byte(fmt.Sprintf("sparse-hdr-%d", i)),
+			fmt.Appendf(nil, "sparse-hdr-%d", i),
 		)
 		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
 			ConnectionId: connId,
@@ -1277,7 +1277,7 @@ func TestHandleEventChainsyncAwaitReplyStartsBlockfetchForActiveConnection(
 	var prevHash lcommon.Blake2b256
 	for i, slot := range []uint64{1001, 1002, 1003, 1004} {
 		hash := lcommon.NewBlake2b256(
-			[]byte(fmt.Sprintf("await-reply-hdr-%d", i)),
+			fmt.Appendf(nil, "await-reply-hdr-%d", i),
 		)
 		err := testChain.AddBlockHeader(mockHeader{
 			hash:        hash,

--- a/ledger/hardfork/build.go
+++ b/ledger/hardfork/build.go
@@ -67,10 +67,7 @@ func BuildSummary(
 		end = &b
 	case TransitionUnknown:
 		// Measure safe zone from max(tipSlot+1, era start).
-		fromSlot := tipSlot + 1
-		if fromSlot < current.Start.Slot {
-			fromSlot = current.Start.Slot
-		}
+		fromSlot := max(tipSlot+1, current.Start.Slot)
 		end = applySafeZone(current.Params, current.Start, fromSlot)
 	case TransitionImpossible:
 		end = applySafeZone(current.Params, current.Start, current.Start.Slot)

--- a/ledger/read_chain_test.go
+++ b/ledger/read_chain_test.go
@@ -144,8 +144,7 @@ func TestTrimReadBatchForRollbackRequestsRollbackWhenPointMissing(
 }
 
 func TestLedgerReadChainIteratorWaitsForResultCompletion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	resultCh := make(chan readChainResult)
 	iter := &scriptedLedgerReadIterator{

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -129,9 +129,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			"component", "snapshot",
 		)
 	} else {
-		m.loopWg.Add(1)
-		go func() {
-			defer m.loopWg.Done()
+		m.loopWg.Go(func() {
 			m.epochTransitionLoop(childCtx, evtCh)
 			// If the goroutine exits because the parent
 			// context was cancelled (not via Stop), reset
@@ -154,7 +152,7 @@ func (m *Manager) Start(ctx context.Context) error {
 				}
 			}
 			m.mu.Unlock()
-		}()
+		})
 	}
 
 	m.logger.Info("snapshot manager started", "component", "snapshot")

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -1925,9 +1925,7 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 	rolloverErr := make(chan error, 1)
 
 	// Start the epoch rollover goroutine
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		// Capture snapshot
 		ls.RLock()
@@ -1969,13 +1967,11 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 		ls.Unlock()
 
 		close(txnDone)
-	}()
+	})
 
 	// Start multiple reader goroutines that try to read during the transaction
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			// Wait for transaction to start
 			<-txnStarted
@@ -1994,7 +1990,7 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				}
 			}
-		}()
+		})
 	}
 
 	// Wait for all goroutines with timeout

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"slices"
 	"sync"
 	"time"
@@ -177,9 +178,7 @@ func (o *utxoOverlay) rebuildAggregates() {
 		for _, key := range at.consumed {
 			o.consumed[key] = struct{}{}
 		}
-		for key, utxo := range at.created {
-			o.created[key] = utxo
-		}
+		maps.Copy(o.created, at.created)
 	}
 }
 
@@ -288,9 +287,7 @@ func (o *utxoOverlay) simulateRemoveBatch(
 		for _, key := range at.consumed {
 			consumed[key] = struct{}{}
 		}
-		for key, utxo := range at.created {
-			created[key] = utxo
-		}
+		maps.Copy(created, at.created)
 	}
 	return consumed, created
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -803,9 +803,7 @@ func TestMempool_ConcurrentAddRemove(t *testing.T) {
 
 	// Start remover goroutines
 	for range numRemovers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range opsPerGoroutine {
 				select {
 				case hash := <-addedHashes:
@@ -814,7 +812,7 @@ func TestMempool_ConcurrentAddRemove(t *testing.T) {
 					// No hash available, skip
 				}
 			}
-		}()
+		})
 	}
 
 	// Wait for all operations to complete
@@ -840,9 +838,7 @@ func TestMempool_ConcurrentConsumerOperations(t *testing.T) {
 	done := make(chan struct{})
 
 	// Goroutine adding transactions
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-done:
@@ -860,12 +856,10 @@ func TestMempool_ConcurrentConsumerOperations(t *testing.T) {
 				time.Sleep(time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Goroutine removing transactions
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		removeIdx := 0
 		for {
 			select {
@@ -880,12 +874,10 @@ func TestMempool_ConcurrentConsumerOperations(t *testing.T) {
 				time.Sleep(2 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Goroutine creating consumers
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-done:
@@ -902,14 +894,12 @@ func TestMempool_ConcurrentConsumerOperations(t *testing.T) {
 				time.Sleep(5 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Goroutine consuming transactions
 	connId := newTestConnectionId(0)
 	consumer := m.AddConsumer(connId)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-done:
@@ -919,7 +909,7 @@ func TestMempool_ConcurrentConsumerOperations(t *testing.T) {
 				time.Sleep(time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Run for a short duration
 	time.Sleep(200 * time.Millisecond)
@@ -979,9 +969,7 @@ func TestMempool_ConcurrentNextTx_MultipleConsumers(t *testing.T) {
 	}
 
 	// Adder goroutine
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-done:
@@ -999,12 +987,10 @@ func TestMempool_ConcurrentNextTx_MultipleConsumers(t *testing.T) {
 				time.Sleep(time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Remover goroutine
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-done:
@@ -1014,7 +1000,7 @@ func TestMempool_ConcurrentNextTx_MultipleConsumers(t *testing.T) {
 				time.Sleep(time.Millisecond * 2)
 			}
 		}
-	}()
+	})
 
 	// Run for short duration
 	time.Sleep(300 * time.Millisecond)
@@ -2519,9 +2505,7 @@ func TestMempool_TTL_ConcurrentExpiryAndAddition(t *testing.T) {
 	done := make(chan struct{})
 
 	// Goroutine continuously adding transactions
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-done:
@@ -2544,14 +2528,12 @@ func TestMempool_TTL_ConcurrentExpiryAndAddition(t *testing.T) {
 				time.Sleep(5 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Goroutine reading transactions via consumer
 	connId := newTestConnectionId(0)
 	consumer := m.AddConsumer(connId)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-done:
@@ -2561,7 +2543,7 @@ func TestMempool_TTL_ConcurrentExpiryAndAddition(t *testing.T) {
 				time.Sleep(2 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Let it run with concurrent adds, reads, and expiry
 	time.Sleep(200 * time.Millisecond)
@@ -2729,9 +2711,7 @@ func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(
 	var readsCompleted atomic.Int32
 
 	// Reader goroutine: continuously reads mempool
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-done:
@@ -2742,12 +2722,10 @@ func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(
 				readsCompleted.Add(1)
 			}
 		}
-	}()
+	})
 
 	// Writer goroutine: continuously adds/removes
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-done:
@@ -2766,7 +2744,7 @@ func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(
 				time.Sleep(time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Trigger chain update events to cause re-validation
 	for range 5 {

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -376,9 +376,7 @@ func Bootstrap(
 	defer ancWg.Wait()
 	defer ancCancel()
 	if len(snapshot.AncillaryLocations) > 0 {
-		ancWg.Add(1)
-		go func() {
-			defer ancWg.Done()
+		ancWg.Go(func() {
 			candidateDir := filepath.Join(
 				downloadDir, "ancillary",
 			)
@@ -423,7 +421,7 @@ func Bootstrap(
 			}
 			ancillaryDir = dir
 			ancillaryArchivePath = archPath
-		}()
+		})
 	}
 
 	// Step 4: Extract main archive (skip if already extracted)

--- a/mithril/stm_verifier.go
+++ b/mithril/stm_verifier.go
@@ -237,7 +237,7 @@ func parseSTMAggregateSignatureBytes(raw []byte) (*stmAggregateSignature, error)
 	ret := &stmAggregateSignature{
 		Signatures: make([]stmSingleSignatureWithRegisteredParty, 0, totalSigs),
 	}
-	for i := uint64(0); i < totalSigs; i++ {
+	for i := range totalSigs {
 		if offset+8 > len(raw) {
 			return nil, fmt.Errorf(
 				"truncated aggregate signature at sig %d offset %d",
@@ -353,7 +353,7 @@ func parseSTMSingleSignatureBytes(raw []byte) (*stmSingleSignature, error) {
 	}
 	offset := 8
 	indexes := make([]uint64, 0, nrIndexes)
-	for i := uint64(0); i < nrIndexes; i++ {
+	for range nrIndexes {
 		index, err := readUint64BE(raw[offset : offset+8])
 		if err != nil {
 			return nil, err
@@ -410,14 +410,14 @@ func parseSTMMerkleBatchPathBytes(raw []byte) (*stmMerkleBatchPath, error) {
 		Values:  make([][]byte, 0, lenValues),
 		Indices: make([]int, 0, lenIndices),
 	}
-	for i := uint64(0); i < lenValues; i++ {
+	for range lenValues {
 		if offset+32 > len(raw) {
 			return nil, errors.New("merkle batch path values overflow")
 		}
 		ret.Values = append(ret.Values, append([]byte(nil), raw[offset:offset+32]...))
 		offset += 32
 	}
-	for i := uint64(0); i < lenIndices; i++ {
+	for range lenIndices {
 		if offset+8 > len(raw) {
 			return nil, errors.New("merkle batch path indices overflow")
 		}

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -592,8 +592,7 @@ func TestSubscribeChainsyncResyncRewindsClientsWithoutRecycle(
 	_, recycleCh := bus.Subscribe(
 		connmanager.ConnectionRecycleRequestedEventType,
 	)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	o.SubscribeChainsyncResync(ctx)
 
 	bus.Publish(
@@ -649,8 +648,7 @@ func TestSubscribeChainsyncResyncDoesNotRecycleOnLocalRollbackWithoutPeerHistory
 	_, recycleCh := bus.Subscribe(
 		connmanager.ConnectionRecycleRequestedEventType,
 	)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	o.SubscribeChainsyncResync(ctx)
 
 	bus.Publish(
@@ -728,8 +726,7 @@ func TestSubscribeChainsyncResyncClosesConnectionOnPersistentFork(
 	o.EventBus = bus
 	o.ConnManager = connManager
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	o.SubscribeChainsyncResync(ctx)
 
 	connId := oConn.Id()

--- a/ouroboros/txsubmission_rate_limiter_test.go
+++ b/ouroboros/txsubmission_rate_limiter_test.go
@@ -268,14 +268,12 @@ func TestTxSubmissionRateLimiter_ConcurrentAccess(t *testing.T) {
 	peer := testConnIdWithPort(4001)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			// Just exercise the rate limiter concurrently;
 			// we don't assert results since timing varies
 			rl.Allow(peer, 1)
-		}()
+		})
 	}
 	wg.Wait()
 	// If the test reaches here without data races (with -race),
@@ -480,7 +478,7 @@ func TestTxSubmissionRateLimiter_SyncMapConcurrency(t *testing.T) {
 
 	var wg sync.WaitGroup
 	// Concurrent Allow, WaitDuration, and RemovePeer across many peers
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		wg.Add(1)
 		go func(port int) {
 			defer wg.Done()

--- a/peergov/bootstrap.go
+++ b/peergov/bootstrap.go
@@ -197,11 +197,8 @@ func (p *PeerGovernor) checkBootstrapRecoveryLocked() []pendingEvent {
 	// Avoid immediate exit/recovery flapping right after bootstrap exit.
 	if !p.lastBootstrapExit.IsZero() &&
 		time.Since(p.lastBootstrapExit) < p.config.BootstrapRecoveryCooldown {
-		remaining := p.config.BootstrapRecoveryCooldown -
-			time.Since(p.lastBootstrapExit)
-		if remaining < 0 {
-			remaining = 0
-		}
+		remaining := max(p.config.BootstrapRecoveryCooldown-
+			time.Since(p.lastBootstrapExit), 0)
 		p.config.Logger.Debug(
 			"bootstrap recovery skipped: cooldown active",
 			"remaining", remaining,

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -1711,7 +1711,7 @@ func TestPeerGovernor_QuotaSumExceedsTarget(t *testing.T) {
 	})
 
 	// Simulate 30 hot peers across 3 sources (10 each)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		pg.peers = append(pg.peers, &Peer{
 			Address: fmt.Sprintf("gossip-%d:3001", i),
 			Source:  PeerSourceP2PGossip,

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -540,7 +540,7 @@ func (p *PeerGovernor) enforceStateLimit(
 
 	removeIdx := make([]bool, len(p.peers))
 	removed := 0
-	for i := 0; i < removeCount; i++ {
+	for i := range removeCount {
 		candidate := candidates[i]
 		peer := candidate.peer
 		p.config.Logger.Debug(

--- a/utxorpc/query_test.go
+++ b/utxorpc/query_test.go
@@ -56,7 +56,6 @@ func TestCaip2FromNetworkMagic_KnownNetworks(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := caip2FromNetworkMagic(tc.magic)

--- a/utxorpc/tx_predicate_test.go
+++ b/utxorpc/tx_predicate_test.go
@@ -315,7 +315,7 @@ func TestWatchHandlers_nilProtobufPredicateSkipsEval(t *testing.T) {
 
 func TestEvalTxPredicate_MaxDepthExceeded(t *testing.T) {
 	pred := matchSubmit(&cardano.TxPattern{})
-	for i := 0; i < maxTxPredicateDepth; i++ {
+	for range maxTxPredicateDepth {
 		pred = &submit.TxPredicate{
 			Not: []*submit.TxPredicate{pred},
 		}

--- a/utxorpc/watch.go
+++ b/utxorpc/watch.go
@@ -124,7 +124,7 @@ func (s *watchServiceServer) watchTxFetchRollbackUndoFromBlocks(
 	hash := append([]byte(nil), startHash...)
 	out := make([]*watch.WatchTxResponse, 0, 64)
 	const maxWalkBlocks = 2160
-	for i := 0; i < maxWalkBlocks; i++ {
+	for range maxWalkBlocks {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Modernized loop constructs throughout the codebase using range-based iteration.
  * Simplified goroutine lifecycle management with consolidated WaitGroup handling.
  * Streamlined boundary calculations using standard utility functions.
  * Optimized byte-slice construction for improved efficiency.
  * Adopted standard library utilities for common operations (map copying, sorting, reflection, string parsing).
  * Cleaned up test context management for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Modernizes the codebase to Go 1.22 idioms for safer concurrency and cleaner code with no functional changes. Improves readability and reduces allocations in hot paths and tests.

- **Refactors**
  - Concurrency: replace wg.Add/go with `wg.Go` in `bark`, `connmanager`, `ledger/snapshot`, `mithril`, `event`, and tests; use `t.Context()` in tests.
  - Iteration & math: adopt “range N” loops; use built-in `min`/`max` for bounds (pagination, batch deletes, cooldowns, hardfork calculations).
  - Collections: use `maps.Copy` and `slices.Sort`; iterate with `strings.SplitSeq` in flag path parsing.
  - Formatting: switch `fmt.Sprintf`+conversions to `fmt.Appendf` to avoid string-to-byte copies in tests and helpers.
  - Batching: simplify end-index calculations in `blockfrost` pagination and database blob deletions.
  - Test cleanup: remove redundant shadows, tighten loops, and standardize goroutine patterns across `mempool`, `peergov`, `ouroboros`, and `utxorpc`.

<sup>Written for commit 07c6f65f75228e0e7a59671d310bca9eb897f637. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

