### PR TITLE
feat(peergov): admission metadata and identitiy

### DIFF
--- a/connmanager/benchmark_test.go
+++ b/connmanager/benchmark_test.go
@@ -79,7 +79,7 @@ func BenchmarkHasInboundPeerAddress(b *testing.B) {
 					conn:      &ouroboros.Connection{},
 				}
 				cm.inboundCount++
-				peerKey := normalizePeerAddr(addr)
+				peerKey := NormalizePeerAddr(addr)
 				cm.inboundPeerAddrs[peerKey]++
 			}
 			targetAddr := net.JoinHostPort("203.0.113.10", "4000")

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -301,7 +301,18 @@ func (c *ConnectionManager) hasFullDuplex(info *connectionInfo) bool {
 	if info == nil || !info.isInbound || info.isNtC || info.conn == nil {
 		return false
 	}
-	_, versionData := info.conn.ProtocolVersion()
+	return connectionIsDuplex(info.conn)
+}
+
+// connectionIsDuplex reports whether a connection negotiated
+// InitiatorAndResponder (full-duplex) mode. Returns false when the
+// handshake has not completed yet or the connection is nil, so it is
+// safe to call at any time after ouroboros.NewConnection returns.
+func connectionIsDuplex(conn *ouroboros.Connection) bool {
+	if conn == nil {
+		return false
+	}
+	_, versionData := conn.ProtocolVersion()
 	if versionData == nil {
 		return false
 	}
@@ -321,7 +332,7 @@ func (c *ConnectionManager) updatePeerConnectivityLocked(
 	if peerAddr == "" {
 		return
 	}
-	peerKey := normalizePeerAddr(peerAddr)
+	peerKey := NormalizePeerAddr(peerAddr)
 	before := c.peerConnectivity[peerKey]
 	after := before
 	if add {
@@ -594,7 +605,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			if existing.isInbound &&
 				!existing.isNtC &&
 				c.tracksInboundPeerAddresses() {
-				if peerKey := normalizePeerAddr(existing.peerAddr); peerKey != "" {
+				if peerKey := NormalizePeerAddr(existing.peerAddr); peerKey != "" {
 					c.inboundPeerAddrs[peerKey]--
 					if c.inboundPeerAddrs[peerKey] <= 0 {
 						delete(c.inboundPeerAddrs, peerKey)
@@ -627,7 +638,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			if existing.isInbound &&
 				!existing.isNtC &&
 				c.tracksInboundPeerAddresses() {
-				if peerKey := normalizePeerAddr(existing.peerAddr); peerKey != "" {
+				if peerKey := NormalizePeerAddr(existing.peerAddr); peerKey != "" {
 					c.inboundPeerAddrs[peerKey]--
 					if c.inboundPeerAddrs[peerKey] <= 0 {
 						delete(c.inboundPeerAddrs, peerKey)
@@ -656,7 +667,7 @@ func (c *ConnectionManager) addConnectionImpl(
 	}
 	info := c.connections[connId]
 	if isInbound && !isNtC && c.tracksInboundPeerAddresses() {
-		if peerKey := normalizePeerAddr(peerAddr); peerKey != "" {
+		if peerKey := NormalizePeerAddr(peerAddr); peerKey != "" {
 			c.inboundPeerAddrs[peerKey]++
 		}
 	}
@@ -709,7 +720,7 @@ func (c *ConnectionManager) RemoveConnection(
 		info.isInbound &&
 		!info.isNtC &&
 		c.tracksInboundPeerAddresses() {
-		if peerKey := normalizePeerAddr(info.peerAddr); peerKey != "" {
+		if peerKey := NormalizePeerAddr(info.peerAddr); peerKey != "" {
 			c.inboundPeerAddrs[peerKey]--
 			if c.inboundPeerAddrs[peerKey] <= 0 {
 				delete(c.inboundPeerAddrs, peerKey)
@@ -747,7 +758,7 @@ func (c *ConnectionManager) HasInboundPeerAddress(
 	if !c.tracksInboundPeerAddresses() {
 		return false
 	}
-	targetAddr := normalizePeerAddr(peerAddr)
+	targetAddr := NormalizePeerAddr(peerAddr)
 	if targetAddr == "" {
 		return false
 	}
@@ -756,7 +767,14 @@ func (c *ConnectionManager) HasInboundPeerAddress(
 	return c.inboundPeerAddrs[targetAddr] > 0
 }
 
-func normalizePeerAddr(peerAddr string) string {
+// NormalizePeerAddr canonicalizes a host:port string into the form used
+// as the connmanager's transport-layer peer key: IPs are normalized to
+// their canonical form, hostnames are lowercased, and DNS is never
+// consulted. Exposed so that subscribers of InboundConnectionEvent can
+// key on the same identity the connection manager does, and so the
+// inbound-arrival path in peergov does not drift from
+// inboundPeerAddrs / HasInboundPeerAddress.
+func NormalizePeerAddr(peerAddr string) string {
 	host, port, err := net.SplitHostPort(peerAddr)
 	if err != nil {
 		return strings.ToLower(peerAddr)

--- a/connmanager/event.go
+++ b/connmanager/event.go
@@ -31,6 +31,19 @@ type InboundConnectionEvent struct {
 	LocalAddr    net.Addr
 	RemoteAddr   net.Addr
 	IsNtC        bool // true for node-to-client (local) connections
+	// NormalizedRemoteAddr is RemoteAddr.String() passed through
+	// NormalizePeerAddr, so subscribers key on the same transport
+	// identity the connection manager uses internally (and exposes via
+	// HasInboundPeerAddress). Populated by the listener; empty on
+	// events synthesized without a listener, in which case subscribers
+	// must call NormalizePeerAddr themselves to preserve the contract.
+	NormalizedRemoteAddr string
+	// IsDuplex reports whether the handshake negotiated
+	// InitiatorAndResponder (full-duplex) mode. Populated by the listener
+	// after ouroboros.NewConnection completes. When false, subscribers
+	// should treat the value as best-effort and fall back to
+	// ConnectionManager.GetConnectionById for authoritative state.
+	IsDuplex bool
 }
 
 type ConnectionClosedEvent struct {

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -250,10 +250,11 @@ func (c *ConnectionManager) startListener(
 						event.NewEvent(
 							InboundConnectionEventType,
 							InboundConnectionEvent{
-								ConnectionId: oConn.Id(),
-								LocalAddr:    conn.LocalAddr(),
-								RemoteAddr:   conn.RemoteAddr(),
-								IsNtC:        true,
+								ConnectionId:         oConn.Id(),
+								LocalAddr:            conn.LocalAddr(),
+								RemoteAddr:           conn.RemoteAddr(),
+								NormalizedRemoteAddr: NormalizePeerAddr(peerAddr),
+								IsNtC:                true,
 							},
 						),
 					)
@@ -342,17 +343,23 @@ func (c *ConnectionManager) startListener(
 			) {
 				continue
 			}
-			// Generate event
+			// Generate event. IsDuplex is a best-effort snapshot of the
+			// negotiated diffusion mode at publish time; subscribers that
+			// need an authoritative answer should fall back to
+			// GetConnectionById, because on paths where the handshake has
+			// not yet completed the version data is still nil here.
 			if c.config.EventBus != nil {
 				c.config.EventBus.Publish(
 					InboundConnectionEventType,
 					event.NewEvent(
 						InboundConnectionEventType,
 						InboundConnectionEvent{
-							ConnectionId: oConn.Id(),
-							LocalAddr:    conn.LocalAddr(),
-							RemoteAddr:   conn.RemoteAddr(),
-							IsNtC:        l.UseNtC,
+							ConnectionId:         oConn.Id(),
+							LocalAddr:            conn.LocalAddr(),
+							RemoteAddr:           conn.RemoteAddr(),
+							NormalizedRemoteAddr: NormalizePeerAddr(peerAddr),
+							IsNtC:                l.UseNtC,
+							IsDuplex:             connectionIsDuplex(oConn),
 						},
 					),
 				)

--- a/connmanager/peeraddr_test.go
+++ b/connmanager/peeraddr_test.go
@@ -52,7 +52,7 @@ func TestNormalizePeerAddr(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, normalizePeerAddr(test.input))
+			assert.Equal(t, test.expected, NormalizePeerAddr(test.input))
 		})
 	}
 }
@@ -66,7 +66,7 @@ func TestHasInboundPeerAddress(t *testing.T) {
 		isInbound: true,
 		peerAddr:  "1.2.3.4:3001",
 	}
-	cm.inboundPeerAddrs[normalizePeerAddr("1.2.3.4:3001")]++
+	cm.inboundPeerAddrs[NormalizePeerAddr("1.2.3.4:3001")]++
 	cm.connections[ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
 		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3002},
@@ -75,7 +75,7 @@ func TestHasInboundPeerAddress(t *testing.T) {
 		isInbound: true,
 		peerAddr:  "1.2.3.4:3002",
 	}
-	cm.inboundPeerAddrs[normalizePeerAddr("1.2.3.4:3002")]++
+	cm.inboundPeerAddrs[NormalizePeerAddr("1.2.3.4:3002")]++
 	cm.connections[ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
 		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 3999},
@@ -106,7 +106,7 @@ func TestHasInboundPeerAddressDisabledWithoutPortReuse(t *testing.T) {
 		isInbound: true,
 		peerAddr:  "1.2.3.4:3001",
 	}
-	cm.inboundPeerAddrs[normalizePeerAddr("1.2.3.4:3001")]++
+	cm.inboundPeerAddrs[NormalizePeerAddr("1.2.3.4:3001")]++
 
 	assert.False(t, cm.HasInboundPeerAddress("1.2.3.4:3001"))
 }

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -525,9 +525,12 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	}
 	oldSource := tmpPeer.Source
 	oldConn := clonePeerConnection(tmpPeer.Connection)
-	// Accept the event-embedded duplex hint as a provisional value; the
-	// connmanager lookup below is authoritative when present.
-	tmpPeer.InboundDuplex = e.IsDuplex
+	// Accept an event-embedded duplex=true hint as a provisional upgrade;
+	// do not clear a previously known true value on best-effort false.
+	// The connmanager lookup below is authoritative when present.
+	if e.IsDuplex {
+		tmpPeer.InboundDuplex = true
+	}
 	if p.config.ConnManager != nil {
 		conn := p.config.ConnManager.GetConnectionById(e.ConnectionId)
 		if conn != nil {

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -464,23 +464,22 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 		return
 	}
 	address := e.RemoteAddr.String()
-	// Resolve address before acquiring lock to avoid blocking DNS
-	normalized := p.resolveAddress(address)
+	// Key on the connmanager's canonical transport identity so inbound
+	// peer entries share a key space with HasInboundPeerAddress and
+	// inboundPeerAddrs. Never DNS-resolve the inbound remote: the
+	// 4-tuple is an IP:port and calling resolveAddress would diverge
+	// from the connmanager's non-DNS normalization. When an event is
+	// synthesized in tests without a populated NormalizedRemoteAddr,
+	// fall back to NormalizePeerAddr to preserve the same contract.
+	normalized := e.NormalizedRemoteAddr
+	if normalized == "" {
+		normalized = connmanager.NormalizePeerAddr(address)
+	}
+	now := time.Now()
 
 	var selectionEvents []pendingEvent
 	p.mu.Lock()
-	peerIdx := -1
-	// Check if peer already exists (possibly as inbound)
-	for i, peer := range p.peers {
-		if peer == nil {
-			continue
-		}
-		// Match by exact address or normalized address
-		if peer.Address == address || peer.NormalizedAddress == normalized {
-			peerIdx = i
-			break
-		}
-	}
+	peerIdx, topologyGroupID := p.resolveInboundIdentity(address, normalized)
 	var tmpPeer *Peer
 	if peerIdx == -1 {
 		// Enforce hard cap on peer list size for inbound peers
@@ -495,12 +494,14 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			return
 		}
 		tmpPeer = &Peer{
-			Address:           address,
-			NormalizedAddress: normalized,
-			Source:            PeerSourceInboundConn,
-			State:             PeerStateCold,
-			EMAAlpha:          p.config.EMAAlpha,
-			FirstSeen:         time.Now(),
+			Address:            address,
+			NormalizedAddress:  normalized,
+			Source:             PeerSourceInboundConn,
+			State:              PeerStateCold,
+			EMAAlpha:           p.config.EMAAlpha,
+			FirstSeen:          now,
+			InboundArrivals:    1,
+			LastInboundArrival: now,
 		}
 		// Add inbound peer
 		p.peers = append(
@@ -509,13 +510,24 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 		)
 	} else {
 		tmpPeer = p.peers[peerIdx]
-	}
-	if tmpPeer == nil {
-		p.mu.Unlock()
-		return
+		if tmpPeer == nil {
+			p.mu.Unlock()
+			return
+		}
+		tmpPeer.InboundArrivals++
+		tmpPeer.LastInboundArrival = now
+		// Record the topology identity once on first rule-2 match and
+		// keep it across subsequent reconnects. Rule-1 matches yield
+		// topologyGroupID == "" and must not clear a prior match.
+		if topologyGroupID != "" && tmpPeer.InboundTopologyMatch == "" {
+			tmpPeer.InboundTopologyMatch = topologyGroupID
+		}
 	}
 	oldSource := tmpPeer.Source
 	oldConn := clonePeerConnection(tmpPeer.Connection)
+	// Accept the event-embedded duplex hint as a provisional value; the
+	// connmanager lookup below is authoritative when present.
+	tmpPeer.InboundDuplex = e.IsDuplex
 	if p.config.ConnManager != nil {
 		conn := p.config.ConnManager.GetConnectionById(e.ConnectionId)
 		if conn != nil {
@@ -523,6 +535,9 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			if tmpPeer.Connection != nil {
 				tmpPeer.Sharable = tmpPeer.Connection.VersionData.PeerSharing()
 				tmpPeer.State = PeerStateWarm
+				// setConnection derives IsClient from live handshake
+				// data; prefer it over the event hint when available.
+				tmpPeer.InboundDuplex = tmpPeer.Connection.IsClient
 			}
 		}
 	}
@@ -541,6 +556,9 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 		oldConn,
 		tmpPeer,
 	)
+	if p.metrics != nil {
+		p.metrics.inboundArrivalsTotal.Inc()
+	}
 	p.updatePeerMetrics()
 	p.mu.Unlock()
 

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -525,6 +525,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	}
 	oldSource := tmpPeer.Source
 	oldConn := clonePeerConnection(tmpPeer.Connection)
+	hadClientConnection := tmpPeer.hasClientConnection()
 	// Accept an event-embedded duplex=true hint as a provisional upgrade;
 	// do not clear a previously known true value on best-effort false.
 	// The connmanager lookup below is authoritative when present.
@@ -534,14 +535,21 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	if p.config.ConnManager != nil {
 		conn := p.config.ConnManager.GetConnectionById(e.ConnectionId)
 		if conn != nil {
-			tmpPeer.setConnection(conn, false)
-			if tmpPeer.Connection != nil {
-				tmpPeer.Sharable = tmpPeer.Connection.VersionData.PeerSharing()
-				tmpPeer.State = PeerStateWarm
-				// setConnection derives IsClient from live handshake
-				// data; prefer it over the event hint when available.
-				tmpPeer.InboundDuplex = tmpPeer.Connection.IsClient
+			inboundPeerConn := &Peer{}
+			inboundPeerConn.setConnection(conn, false)
+			inboundIsClient := inboundPeerConn.hasClientConnection()
+			if !hadClientConnection || inboundIsClient {
+				// Preserve duplex-reuse semantics: a responder-only inbound
+				// must not replace an authoritative client-capable connection.
+				tmpPeer.setConnection(conn, false)
+				if tmpPeer.Connection != nil {
+					tmpPeer.Sharable = tmpPeer.Connection.VersionData.PeerSharing()
+					tmpPeer.State = PeerStateWarm
+				}
 			}
+			// setConnection derives IsClient from live handshake data; when
+			// available, treat it as authoritative for inbound duplex metadata.
+			tmpPeer.InboundDuplex = inboundIsClient
 		}
 	}
 	// Reset outbound backoff when an inbound connection from a

--- a/peergov/event.go
+++ b/peergov/event.go
@@ -72,10 +72,19 @@ type QuotaStatusEvent struct {
 	// Configured inbound budgets (phase 1 control surface).
 	InboundWarmTarget int
 	InboundHotQuota   int
-	// Current inbound usage.
+	// Current inbound usage. InboundWarm/InboundHot exclude peers still
+	// inside the InboundProvisionalWindow so flash-connects cannot
+	// inflate reported budget usage.
 	InboundWarm   int
 	InboundHot    int
 	InboundPruned int // Cumulative count since process start
+	// Inbound admission metadata (phase 2).
+	// InboundTopologyMatched is the current number of peers whose
+	// inbound arrival was identified as a configured topology peer.
+	// InboundDuplex is the current number of inbound peers on
+	// full-duplex connections.
+	InboundTopologyMatched int
+	InboundDuplex          int
 	// Existing active-tier category view.
 	TopologyHot int // Hot peers from topology sources (local + public roots)
 	GossipHot   int // Hot peers from gossip

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -15,6 +15,8 @@
 package peergov
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -48,6 +50,10 @@ type peerGovernorMetrics struct {
 	inboundWarmHeld   prometheus.Gauge
 	inboundHotHeld    prometheus.Gauge
 	inboundPruned     prometheus.Counter
+	// Inbound admission metadata metrics (phase 2)
+	inboundArrivalsTotal   prometheus.Counter
+	inboundTopologyMatched prometheus.Gauge
+	inboundDuplexHeld      prometheus.Gauge
 }
 
 func (p *PeerGovernor) initMetrics() {
@@ -181,6 +187,80 @@ func (p *PeerGovernor) initMetrics() {
 		Name: "cardano_node_metrics_peerSelection_InboundPruned",
 		Help: "total inbound peers pruned from governed sets",
 	})
+	p.metrics.inboundArrivalsTotal = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_peerSelection_InboundArrivalsTotal",
+			Help: "total inbound connection events observed since startup (includes re-arrivals)",
+		},
+	)
+	p.metrics.inboundTopologyMatched = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_peerSelection_InboundTopologyMatched",
+			Help: "current number of peers whose inbound arrival was identified as a configured topology peer",
+		},
+	)
+	p.metrics.inboundDuplexHeld = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cardano_node_metrics_peerSelection_InboundDuplexHeld",
+			Help: "current number of inbound peers on full-duplex connections",
+		},
+	)
+}
+
+// inboundCounts is the phase-2 census of inbound peers used to populate
+// both Prometheus metrics and QuotaStatusEvent. Centralizing this avoids
+// drift between the two surfaces.
+type inboundCounts struct {
+	// Warm and Hot are provisional-window-filtered budget counts: peers
+	// younger than InboundProvisionalWindow are excluded.
+	Warm int
+	Hot  int
+	// TopologyMatched is the count of peers with a non-empty
+	// InboundTopologyMatch.
+	TopologyMatched int
+	// Duplex is the count of peers with InboundDuplex set.
+	Duplex int
+}
+
+// censusInboundCounts computes the phase-2 inbound census. Must be
+// called with p.mu held.
+func (p *PeerGovernor) censusInboundCounts() inboundCounts {
+	var c inboundCounts
+	now := time.Now()
+	window := p.config.InboundProvisionalWindow
+	for _, peer := range p.peers {
+		if peer == nil {
+			continue
+		}
+		if peer.InboundTopologyMatch != "" {
+			c.TopologyMatched++
+		}
+		if peer.Source != PeerSourceInboundConn {
+			// Topology peers that inbound-matched still govern through
+			// their configured source, so they are not charged against
+			// the inbound budget. They do count toward topology-match
+			// observability above.
+			continue
+		}
+		if peer.InboundDuplex {
+			c.Duplex++
+		}
+		// Provisional-window filter: a negative window disables the
+		// grace, zero is normalized to the default in NewPeerGovernor.
+		if window > 0 && !peer.FirstSeen.IsZero() &&
+			now.Sub(peer.FirstSeen) < window {
+			continue
+		}
+		switch peer.State {
+		case PeerStateCold:
+			// Cold inbound peers do not hold a slot in either budget.
+		case PeerStateWarm:
+			c.Warm++
+		case PeerStateHot:
+			c.Hot++
+		}
+	}
+	return c
 }
 
 // updatePeerMetrics updates the Prometheus metrics for peer counts.
@@ -264,11 +344,14 @@ func (p *PeerGovernor) updatePeerMetrics() {
 			float64(count),
 		)
 	}
-	// Explicit inbound budget/usage gauges
+	// Explicit inbound budget/usage gauges. Use the provisional-window
+	// filter so flash-connects cannot inflate reported usage; phase 3
+	// enforcement will read the same filtered view.
 	p.metrics.inboundWarmTarget.Set(float64(p.config.InboundWarmTarget))
 	p.metrics.inboundHotQuota.Set(float64(p.config.InboundHotQuota))
-	inboundWarm := sourceCounts[sourceStateKey{source: "inbound", state: "warm"}]
-	inboundHot := sourceCounts[sourceStateKey{source: "inbound", state: "hot"}]
-	p.metrics.inboundWarmHeld.Set(float64(inboundWarm))
-	p.metrics.inboundHotHeld.Set(float64(inboundHot))
+	census := p.censusInboundCounts()
+	p.metrics.inboundWarmHeld.Set(float64(census.Warm))
+	p.metrics.inboundHotHeld.Set(float64(census.Hot))
+	p.metrics.inboundTopologyMatched.Set(float64(census.TopologyMatched))
+	p.metrics.inboundDuplexHeld.Set(float64(census.Duplex))
 }

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -218,8 +218,8 @@ type inboundCounts struct {
 	// TopologyMatched is the count of peers with a non-empty
 	// InboundTopologyMatch.
 	TopologyMatched int
-	// Duplex is the count of peers with a currently-live client-capable
-	// connection and inbound-arrival metadata.
+	// Duplex is the count of peers with a currently-live inbound
+	// client-capable connection.
 	Duplex int
 }
 
@@ -236,10 +236,18 @@ func (p *PeerGovernor) censusInboundCounts() inboundCounts {
 		if peer.InboundTopologyMatch != "" {
 			c.TopologyMatched++
 		}
-		if peer.Connection != nil &&
-			peer.Connection.IsClient &&
-			(peer.InboundDuplex || peer.InboundArrivals > 0) {
-			c.Duplex++
+		if peer.Connection != nil && peer.Connection.IsClient {
+			// "Current inbound duplex" must be derived from live transport
+			// direction, not sticky arrival metadata.
+			isLiveInbound := peer.Source == PeerSourceInboundConn
+			if p.config.ConnManager != nil {
+				isLiveInbound = p.config.ConnManager.IsInboundConnection(
+					peer.Connection.Id,
+				)
+			}
+			if isLiveInbound {
+				c.Duplex++
+			}
 		}
 		if peer.Source != PeerSourceInboundConn {
 			// Topology peers that inbound-matched still govern through

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -235,15 +235,16 @@ func (p *PeerGovernor) censusInboundCounts() inboundCounts {
 		if peer.InboundTopologyMatch != "" {
 			c.TopologyMatched++
 		}
+		if peer.InboundDuplex {
+			c.Duplex++
+		}
 		if peer.Source != PeerSourceInboundConn {
 			// Topology peers that inbound-matched still govern through
 			// their configured source, so they are not charged against
 			// the inbound budget. They do count toward topology-match
-			// observability above.
+			// observability above. Duplex capability is still included in
+			// the shared census above.
 			continue
-		}
-		if peer.InboundDuplex {
-			c.Duplex++
 		}
 		// Provisional-window filter: a negative window disables the
 		// grace, zero is normalized to the default in NewPeerGovernor.

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -218,7 +218,8 @@ type inboundCounts struct {
 	// TopologyMatched is the count of peers with a non-empty
 	// InboundTopologyMatch.
 	TopologyMatched int
-	// Duplex is the count of peers with InboundDuplex set.
+	// Duplex is the count of peers with a currently-live client-capable
+	// connection and inbound-arrival metadata.
 	Duplex int
 }
 
@@ -235,7 +236,9 @@ func (p *PeerGovernor) censusInboundCounts() inboundCounts {
 		if peer.InboundTopologyMatch != "" {
 			c.TopologyMatched++
 		}
-		if peer.InboundDuplex {
+		if peer.Connection != nil &&
+			peer.Connection.IsClient &&
+			(peer.InboundDuplex || peer.InboundArrivals > 0) {
 			c.Duplex++
 		}
 		if peer.Source != PeerSourceInboundConn {

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -125,6 +125,31 @@ type Peer struct {
 	WarmValency uint
 	// GroupID identifies the topology group this peer belongs to (for valency tracking)
 	GroupID string
+
+	// Inbound admission metadata (phase 2). These fields are only
+	// populated on inbound arrivals, but they live on every Peer so that
+	// a configured topology peer that an inbound matched to can record
+	// duplex/arrival information without losing its topology identity.
+
+	// InboundDuplex reports whether the most recent inbound connection
+	// for this peer negotiated InitiatorAndResponder. It is distinct
+	// from Connection.IsClient because it is retained across brief
+	// reconnects within the provisional window.
+	InboundDuplex bool
+	// InboundArrivals is the number of distinct inbound connection
+	// events observed for this peer identity since the process started.
+	// A value > 1 indicates a repeat arrival (the peer was already
+	// known when the event fired).
+	InboundArrivals uint32
+	// LastInboundArrival is the wall-clock time of the most recent
+	// inbound connection event matched to this peer.
+	LastInboundArrival time.Time
+	// InboundTopologyMatch records the GroupID of the configured
+	// topology peer that an inbound arrival was identified as, via the
+	// safe host-match rule in resolveInboundIdentity. Empty when no
+	// topology match was made. Set once on arrival and not cleared on
+	// subsequent reconnects.
+	InboundTopologyMatch string
 }
 
 func (p *Peer) setConnection(conn *ouroboros.Connection, outbound bool) {

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -66,6 +66,13 @@ const (
 	defaultInboundPruneAfter        = 15 * time.Minute
 	defaultInboundDuplexOnlyForHot  = false
 	defaultInboundCooldown          = 5 * time.Minute
+	// defaultInboundProvisionalWindow is the grace period during which a
+	// freshly-arrived inbound peer is not counted toward the inbound
+	// warm/hot budgets. It filters half-opens and scanner traffic
+	// without hiding real peers. Chosen to sit above typical TCP RTT
+	// noise but well below the Prometheus scrape cadence, so short-lived
+	// connections do not cause visible metric oscillation.
+	defaultInboundProvisionalWindow = 3 * time.Second
 
 	// Default bootstrap exit configuration
 	defaultMinLedgerPeersForExit                = 5
@@ -176,6 +183,12 @@ type PeerGovernorConfig struct {
 	InboundPruneAfter        time.Duration // Future prune grace (0 = default 15min)
 	InboundDuplexOnlyForHot  bool          // Future duplex policy (default false)
 	InboundCooldown          time.Duration // Future cooldown between churn actions (0 = default 5min)
+	// InboundProvisionalWindow is the grace duration a fresh inbound
+	// peer is excluded from InboundWarm/InboundHot budget counts, so a
+	// burst of half-open connects cannot inflate observed usage.
+	// 0 selects defaultInboundProvisionalWindow; set to a negative
+	// value to disable the filter entirely.
+	InboundProvisionalWindow time.Duration
 
 	// Bootstrap peer exit configuration
 	// Bootstrap peers are used during initial sync but should be exited once
@@ -301,6 +314,11 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	}
 	if cfg.InboundCooldown <= 0 {
 		cfg.InboundCooldown = defaultInboundCooldown
+	}
+	// InboundProvisionalWindow: 0 means use default; negative means
+	// disabled (no grace period applied to budget counting).
+	if cfg.InboundProvisionalWindow == 0 {
+		cfg.InboundProvisionalWindow = defaultInboundProvisionalWindow
 	}
 	// Bootstrap exit configuration defaults
 	if cfg.MinLedgerPeersForExit == 0 {

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -6362,6 +6362,77 @@ func TestHandleInboundConnection_InboundDuplexFromEvent(t *testing.T) {
 		"event-derived duplex hint must be retained when connmanager is nil")
 }
 
+func TestCensusInboundCounts_DuplexRequiresLiveConnection(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "44.0.0.1:51432",
+		NormalizedAddress: "44.0.0.1:51432",
+		Source:            PeerSourceInboundConn,
+		State:             PeerStateWarm,
+		FirstSeen:         time.Now().Add(-time.Hour),
+		InboundDuplex:     true,
+		InboundArrivals:   1,
+	})
+	census := pg.censusInboundCounts()
+	pg.mu.Unlock()
+	assert.Equal(t, 0, census.Duplex,
+		"duplex count must not include peers without a live connection")
+
+	pg.mu.Lock()
+	pg.peers[0].Connection = &PeerConnection{IsClient: true}
+	census = pg.censusInboundCounts()
+	pg.mu.Unlock()
+	assert.Equal(t, 1, census.Duplex,
+		"duplex count must include live client-capable inbound peers")
+}
+
+func TestHandleConnectionClosedEvent_DuplexCensusDropsOnClose(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           remoteAddr.String(),
+		NormalizedAddress: connmanager.NormalizePeerAddr(remoteAddr.String()),
+		Source:            PeerSourceInboundConn,
+		State:             PeerStateWarm,
+		FirstSeen:         time.Now().Add(-time.Hour),
+		Connection: &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		},
+		InboundDuplex:   true,
+		InboundArrivals: 1,
+	})
+	require.Equal(t, 1, pg.censusInboundCounts().Duplex)
+	pg.mu.Unlock()
+
+	pg.handleConnectionClosedEvent(event.Event{
+		Type: connmanager.ConnectionClosedEventType,
+		Data: connmanager.ConnectionClosedEvent{
+			ConnectionId: connId,
+		},
+	})
+
+	pg.mu.Lock()
+	assert.Equal(t, 0, pg.censusInboundCounts().Duplex,
+		"duplex count must drop after the inbound connection closes")
+	pg.mu.Unlock()
+}
+
 // TestHandleInboundConnection_NormalizedRemoteAddrFallback exercises
 // the fallback path: when the event arrives without a populated
 // NormalizedRemoteAddr (e.g. from subscribers that predate the field),

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -5826,3 +5826,592 @@ func TestAddLedgerPeer_AcceptsRoutable(t *testing.T) {
 	assert.True(t, added)
 	assert.Len(t, pg.GetPeers(), 1)
 }
+
+// --- Phase 2: inbound admission metadata & identity ---------------------
+
+// seedTopologyPeer appends a topology-sourced peer directly to the
+// governor state. It avoids AddPeer's DNS path so the NormalizedAddress
+// field is deterministic in tests.
+func seedTopologyPeer(
+	pg *PeerGovernor,
+	addr, normalized, groupID string,
+	source PeerSource,
+) {
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           addr,
+		NormalizedAddress: normalized,
+		Source:            source,
+		State:             PeerStateCold,
+		GroupID:           groupID,
+		FirstSeen:         time.Now(),
+	})
+}
+
+func TestResolveInboundIdentity(t *testing.T) {
+	type seed struct {
+		addr       string
+		normalized string
+		source     PeerSource
+		groupID    string
+	}
+	tests := []struct {
+		name            string
+		seeds           []seed
+		inboundAddr     string
+		wantIdx         int
+		wantTopologyGID string
+	}{
+		{
+			name: "exact-address match returns existing peer",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceP2PGossip,
+				},
+			},
+			inboundAddr: "44.0.0.1:3001",
+			wantIdx:     0,
+		},
+		{
+			name: "normalized-address match returns existing peer",
+			seeds: []seed{
+				{
+					addr:       "relay.example.com:3001",
+					normalized: "44.0.0.1:3001",
+					source:     PeerSourceP2PLedger,
+				},
+			},
+			inboundAddr: "44.0.0.1:3001",
+			wantIdx:     0,
+		},
+		{
+			name: "operator pattern — topology peer, ephemeral source port",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceTopologyLocalRoot, groupID: "local-root-0",
+				},
+			},
+			inboundAddr:     "44.0.0.1:51432",
+			wantIdx:         0,
+			wantTopologyGID: "local-root-0",
+		},
+		{
+			name: "ambiguous host — two topology peers on same host → no match",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceTopologyLocalRoot, groupID: "local-root-0",
+				},
+				{
+					addr: "44.0.0.1:3002", normalized: "44.0.0.1:3002",
+					source: PeerSourceTopologyLocalRoot, groupID: "local-root-1",
+				},
+			},
+			inboundAddr: "44.0.0.1:51432",
+			wantIdx:     -1,
+		},
+		{
+			name: "gossip peer sharing host does not widen identity",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceP2PGossip,
+				},
+			},
+			inboundAddr: "44.0.0.1:51432",
+			wantIdx:     -1,
+		},
+		{
+			name: "ledger peer sharing host does not widen identity",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceP2PLedger,
+				},
+			},
+			inboundAddr: "44.0.0.1:51432",
+			wantIdx:     -1,
+		},
+		{
+			name:        "no peers — no match",
+			seeds:       nil,
+			inboundAddr: "44.0.0.1:51432",
+			wantIdx:     -1,
+		},
+		{
+			name: "topology peer with DNS-unresolved normalized address — no host match",
+			seeds: []seed{
+				// DNS failed during topology load, NormalizedAddress is
+				// still a hostname. The inbound arrives as an IP; we
+				// deliberately do not re-do DNS during admission, so
+				// no rule-2 match.
+				{
+					addr:       "relay.example.com:3001",
+					normalized: "relay.example.com:3001",
+					source:     PeerSourceTopologyPublicRoot,
+					groupID:    "public-root-0",
+				},
+			},
+			inboundAddr: "44.0.0.1:51432",
+			wantIdx:     -1,
+		},
+		{
+			name: "IPv6 topology host match",
+			seeds: []seed{
+				{
+					addr: "[2001:db8::1]:3001", normalized: "[2001:db8::1]:3001",
+					source: PeerSourceTopologyLocalRoot, groupID: "local-root-0",
+				},
+			},
+			inboundAddr:     "[2001:db8::1]:51432",
+			wantIdx:         0,
+			wantTopologyGID: "local-root-0",
+		},
+		{
+			name: "exact match takes priority over topology host",
+			seeds: []seed{
+				// Topology peer that could also match via rule 2.
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceTopologyLocalRoot, groupID: "local-root-0",
+				},
+				// Existing inbound at the exact source port.
+				{
+					addr: "44.0.0.1:51432", normalized: "44.0.0.1:51432",
+					source: PeerSourceInboundConn,
+				},
+			},
+			inboundAddr: "44.0.0.1:51432",
+			wantIdx:     1, // exact match wins; topology index is 0
+		},
+		{
+			// Regression: rule 1 against a topology peer must still
+			// classify as a topology match. Otherwise an operator-
+			// configured peer that connects from its listener port
+			// would be indistinguishable from a random inbound.
+			name: "rule-1 exact match against topology peer yields GroupID",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceTopologyLocalRoot, groupID: "local-root-0",
+				},
+			},
+			inboundAddr:     "44.0.0.1:3001",
+			wantIdx:         0,
+			wantTopologyGID: "local-root-0",
+		},
+		{
+			// Rule 1 against a non-topology peer must not fabricate a
+			// topology classification.
+			name: "rule-1 exact match against gossip peer yields no GroupID",
+			seeds: []seed{
+				{
+					addr: "44.0.0.1:3001", normalized: "44.0.0.1:3001",
+					source: PeerSourceP2PGossip,
+				},
+			},
+			inboundAddr: "44.0.0.1:3001",
+			wantIdx:     0,
+			// wantTopologyGID zero value ""
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pg := NewPeerGovernor(PeerGovernorConfig{
+				Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			})
+			for _, s := range tc.seeds {
+				seedTopologyPeer(pg, s.addr, s.normalized, s.groupID, s.source)
+			}
+			// Use the connmanager canonical normalizer, matching
+			// what handleInboundConnectionEvent does in production.
+			normalized := connmanager.NormalizePeerAddr(tc.inboundAddr)
+			pg.mu.Lock()
+			idx, gid := pg.resolveInboundIdentity(tc.inboundAddr, normalized)
+			pg.mu.Unlock()
+			assert.Equal(t, tc.wantIdx, idx, "peer index")
+			assert.Equal(t, tc.wantTopologyGID, gid, "topology group id")
+		})
+	}
+}
+
+// TestResolveInboundIdentity_CanonicalKeyParity pins the invariant that
+// peergov's inbound admission keys on the same canonical form the
+// connmanager publishes, so inbound-peer-address lookups remain
+// symmetric across both layers.
+func TestResolveInboundIdentity_CanonicalKeyParity(t *testing.T) {
+	cases := []string{
+		"44.0.0.1:3001",
+		"[2001:0db8::1]:3001",
+		"[::ffff:1.2.3.4]:3001",
+	}
+	for _, addr := range cases {
+		t.Run(addr, func(t *testing.T) {
+			// connmanager canonicalization must equal peergov's
+			// lock-safe address normalization for IP:port inputs; any
+			// drift would cause inbound-peer lookups to miss.
+			pg := NewPeerGovernor(PeerGovernorConfig{
+				Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			})
+			assert.Equal(t,
+				connmanager.NormalizePeerAddr(addr),
+				pg.normalizeAddress(addr),
+				"normalization must agree for IP:port transport identities",
+			)
+		})
+	}
+}
+
+func TestHandleInboundConnection_TopologyHostMatch(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	seedTopologyPeer(
+		pg,
+		"44.0.0.1:3001",
+		"44.0.0.1:3001",
+		"local-root-0",
+		PeerSourceTopologyLocalRoot,
+	)
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr:  localAddr,
+				RemoteAddr: remoteAddr,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+			IsDuplex:             true,
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1, "inbound must attach to topology peer, not spawn new")
+	peer := peers[0]
+	assert.Equal(t, "44.0.0.1:3001", peer.Address,
+		"topology address must be preserved — do not rewrite with ephemeral port")
+	assert.Equal(t, PeerSource(PeerSourceTopologyLocalRoot), peer.Source,
+		"source must remain topology; inbound does not downgrade identity")
+	assert.Equal(t, "local-root-0", peer.InboundTopologyMatch,
+		"matched topology GroupID must be recorded")
+	assert.Equal(t, uint32(1), peer.InboundArrivals)
+	assert.False(t, peer.LastInboundArrival.IsZero())
+	assert.True(t, peer.InboundDuplex,
+		"event-carried IsDuplex must be recorded when no connmanager is wired")
+}
+
+func TestHandleInboundConnection_AmbiguousHostCreatesNewPeer(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	seedTopologyPeer(
+		pg, "44.0.0.1:3001", "44.0.0.1:3001",
+		"local-root-0", PeerSourceTopologyLocalRoot,
+	)
+	seedTopologyPeer(
+		pg, "44.0.0.1:3002", "44.0.0.1:3002",
+		"local-root-1", PeerSourceTopologyLocalRoot,
+	)
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr:  localAddr,
+				RemoteAddr: remoteAddr,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 3,
+		"ambiguous host must not merge distinct configured peers")
+	// Find the new inbound peer; it must not have inherited either GroupID.
+	var foundInbound bool
+	for _, peer := range peers {
+		if peer.Source == PeerSourceInboundConn {
+			foundInbound = true
+			assert.Equal(t, "44.0.0.1:51432", peer.Address)
+			assert.Empty(t, peer.InboundTopologyMatch,
+				"ambiguous host must not produce a topology match")
+		}
+	}
+	assert.True(t, foundInbound, "new inbound peer must be created")
+}
+
+func TestHandleInboundConnection_ReArrivalIncrementsArrivals(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	evt := event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr:  localAddr,
+				RemoteAddr: remoteAddr,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+		},
+	}
+	pg.handleInboundConnectionEvent(evt)
+	first := pg.GetPeers()
+	require.Len(t, first, 1)
+	firstSeen := first[0].FirstSeen
+	firstArrival := first[0].LastInboundArrival
+	require.Equal(t, uint32(1), first[0].InboundArrivals)
+
+	// Small real delay so the monotonic component advances; we only
+	// need LastInboundArrival to strictly increase, which time.Now()
+	// guarantees on the next call under Go's monotonic clock.
+	pg.handleInboundConnectionEvent(evt)
+	second := pg.GetPeers()
+	require.Len(t, second, 1, "re-arrival must not spawn a second peer entry")
+	assert.Equal(t, uint32(2), second[0].InboundArrivals)
+	assert.Equal(t, firstSeen, second[0].FirstSeen,
+		"FirstSeen must not move on re-arrival")
+	assert.False(t, second[0].LastInboundArrival.Before(firstArrival),
+		"LastInboundArrival must not go backwards")
+}
+
+func TestHandleInboundConnection_TopologyMatchPersistsOnReArrival(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	seedTopologyPeer(
+		pg, "44.0.0.1:3001", "44.0.0.1:3001",
+		"local-root-0", PeerSourceTopologyLocalRoot,
+	)
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+
+	// First arrival via ephemeral port — rule 2 records the match.
+	ephemeralAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr: localAddr, RemoteAddr: ephemeralAddr,
+			},
+			LocalAddr: localAddr, RemoteAddr: ephemeralAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(ephemeralAddr.String()),
+		},
+	})
+	require.Equal(t, "local-root-0", pg.GetPeers()[0].InboundTopologyMatch)
+
+	// Second arrival at the configured port — rule 1 now classifies
+	// this as a topology match too (the matched peer is topology-
+	// sourced). The recorded match must remain the same GroupID.
+	configuredAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:3001")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr: localAddr, RemoteAddr: configuredAddr,
+			},
+			LocalAddr: localAddr, RemoteAddr: configuredAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(configuredAddr.String()),
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	assert.Equal(t, "local-root-0", peers[0].InboundTopologyMatch,
+		"rule-1 re-arrival must not clobber the existing topology match")
+	assert.Equal(t, uint32(2), peers[0].InboundArrivals)
+}
+
+// TestHandleInboundConnection_TopologyMatchNotClearedByUnrelatedReArrival
+// exercises the write guard in the caller: a non-topology rule-1
+// re-arrival (e.g. a pre-existing inbound entry the event later
+// attaches to) must not clear a previously-recorded topology match.
+// Synthetic: we directly mutate the peer list to simulate the state
+// that phase 3 pruning could produce.
+func TestHandleInboundConnection_TopologyMatchNotClearedByUnrelatedReArrival(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	// Seed an inbound peer that was previously topology-matched.
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:              "44.0.0.1:51432",
+		NormalizedAddress:    "44.0.0.1:51432",
+		Source:               PeerSourceInboundConn,
+		State:                PeerStateWarm,
+		FirstSeen:            time.Now().Add(-time.Hour),
+		InboundArrivals:      1,
+		InboundTopologyMatch: "local-root-0",
+	})
+	pg.mu.Unlock()
+
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			},
+			LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	assert.Equal(t, "local-root-0", peers[0].InboundTopologyMatch,
+		"re-arrival against a non-topology existing entry must not clear match")
+	assert.Equal(t, uint32(2), peers[0].InboundArrivals)
+}
+
+func TestInboundProvisionalWindow_ExcludesFreshFromCounts(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                 newMockEventBus(),
+		PromRegistry:             reg,
+		InboundProvisionalWindow: time.Hour, // effectively always provisional
+	})
+	// Seed a warm inbound peer that is younger than the window.
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "44.0.0.1:51432",
+		NormalizedAddress: "44.0.0.1:51432",
+		Source:            PeerSourceInboundConn,
+		State:             PeerStateWarm,
+		FirstSeen:         time.Now(),
+	})
+	census := pg.censusInboundCounts()
+	pg.mu.Unlock()
+	assert.Equal(t, 0, census.Warm, "fresh inbound must not count toward warm budget")
+	assert.Equal(t, 0, census.Hot)
+
+	// Disable the window and re-check.
+	pg.config.InboundProvisionalWindow = -1
+	pg.mu.Lock()
+	census = pg.censusInboundCounts()
+	pg.mu.Unlock()
+	assert.Equal(t, 1, census.Warm,
+		"disabling the window must include the peer in warm count")
+}
+
+func TestInboundProvisionalWindow_IncludesAfterWindow(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                 newMockEventBus(),
+		PromRegistry:             prometheus.NewRegistry(),
+		InboundProvisionalWindow: time.Millisecond,
+	})
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "44.0.0.1:51432",
+		NormalizedAddress: "44.0.0.1:51432",
+		Source:            PeerSourceInboundConn,
+		State:             PeerStateHot,
+		FirstSeen:         time.Now().Add(-time.Hour),
+	})
+	census := pg.censusInboundCounts()
+	pg.mu.Unlock()
+	assert.Equal(t, 1, census.Hot,
+		"peer older than window must be counted")
+}
+
+func TestHandleInboundConnection_InboundDuplexFromEvent(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			},
+			LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+			IsDuplex:             true,
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	assert.True(t, peers[0].InboundDuplex,
+		"event-derived duplex hint must be retained when connmanager is nil")
+}
+
+// TestHandleInboundConnection_NormalizedRemoteAddrFallback exercises
+// the fallback path: when the event arrives without a populated
+// NormalizedRemoteAddr (e.g. from subscribers that predate the field),
+// peergov still keys on the connmanager canonical form by calling
+// NormalizePeerAddr itself. The resulting peer must be identical to
+// the one produced when the event carries the field.
+func TestHandleInboundConnection_NormalizedRemoteAddrFallback(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	// RemoteAddr deliberately constructed so (*net.TCPAddr).String()
+	// differs case-only from its canonical form — an IPv6 address with
+	// extra leading zeros — to make sure the fallback actually
+	// normalizes rather than copying through verbatim.
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "[2001:0db8::1]:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			},
+			LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			// NormalizedRemoteAddr intentionally unset.
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	assert.Equal(t,
+		connmanager.NormalizePeerAddr(remoteAddr.String()),
+		peers[0].NormalizedAddress,
+		"fallback must produce the canonical connmanager key",
+	)
+}
+
+func TestAddressHost(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"44.0.0.1:3001", "44.0.0.1"},
+		{"[2001:db8::1]:3001", "2001:db8::1"},
+		{"[::ffff:1.2.3.4]:3001", "1.2.3.4"},
+		{"Relay.Example.COM:3001", "relay.example.com"},
+		{"bogus", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, addressHost(tc.in))
+		})
+	}
+}

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -282,6 +282,102 @@ func (p *PeerGovernor) peerIndexByAddress(address string) int {
 	return -1
 }
 
+// addressHost returns the host portion of a host:port string with IPv6
+// addresses normalized to canonical form. Empty on parse failure. Used
+// by the inbound topology-host match, which deliberately ignores the
+// port because inbound source ports are ephemeral.
+func addressHost(address string) string {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.String()
+	}
+	return strings.ToLower(host)
+}
+
+// resolveInboundIdentity selects an existing peer entry to attribute an
+// inbound arrival to. It must be called with p.mu held.
+//
+// Match rules, applied in order (first win):
+//
+//  1. Exact address match: peer.Address == remoteAddr OR
+//     peer.NormalizedAddress == normalizedRemoteAddr. Covers peers that
+//     connect from their listener port and prior inbound peers on the
+//     same 4-tuple. Preserves phase-1 behavior.
+//
+//  2. Topology host match, unambiguous only: exactly one topology-sourced
+//     peer has a NormalizedAddress whose host portion equals the
+//     inbound's host portion. Supports the operator pattern where a
+//     configured topology peer dials us from an ephemeral source port.
+//     When two or more topology peers share the host we refuse to
+//     guess, because merging distinct configured identities would
+//     silently violate operator intent.
+//
+//  3. No match: caller creates a fresh PeerSourceInboundConn entry.
+//
+// Rule 2 only consults topology peers; gossip/ledger/other inbound
+// entries never widen their identity, because the affordance granted
+// by a topology match (trust, valency) is specific to operator-declared
+// peers.
+//
+// The second return value is the GroupID of the matched peer when that
+// peer is topology-sourced — regardless of whether the match came from
+// rule 1 or rule 2. A topology peer connecting from its configured port
+// is just as much a "topology match" as one connecting from an
+// ephemeral port; the rule that found it does not change that
+// classification. Empty when the matched peer is not a topology peer.
+func (p *PeerGovernor) resolveInboundIdentity(
+	remoteAddr, normalizedRemoteAddr string,
+) (idx int, topologyGroupID string) {
+	// Rule 1: exact address or normalized match.
+	for i, peer := range p.peers {
+		if peer == nil {
+			continue
+		}
+		if peer.Address == remoteAddr ||
+			peer.NormalizedAddress == normalizedRemoteAddr {
+			return i, topologyGroupIDForPeer(peer, p.isTopologyPeer(peer.Source))
+		}
+	}
+	// Rule 2: unambiguous topology-host match.
+	inboundHost := addressHost(normalizedRemoteAddr)
+	if inboundHost == "" {
+		return -1, ""
+	}
+	candidateIdx := -1
+	for i, peer := range p.peers {
+		if peer == nil || !p.isTopologyPeer(peer.Source) {
+			continue
+		}
+		if addressHost(peer.NormalizedAddress) != inboundHost {
+			continue
+		}
+		if candidateIdx != -1 {
+			// More than one topology peer shares this host. Refuse to
+			// guess which configured identity the inbound is; the
+			// caller will create a new inbound entry.
+			return -1, ""
+		}
+		candidateIdx = i
+	}
+	if candidateIdx == -1 {
+		return -1, ""
+	}
+	return candidateIdx, p.peers[candidateIdx].GroupID
+}
+
+// topologyGroupIDForPeer returns the matched peer's GroupID when the
+// peer is topology-sourced. Factored out so the rule-1 and rule-2
+// branches of resolveInboundIdentity agree on classification.
+func topologyGroupIDForPeer(peer *Peer, isTopology bool) string {
+	if peer == nil || !isTopology {
+		return ""
+	}
+	return peer.GroupID
+}
+
 func (p *PeerGovernor) peerIndexByConnId(connId ouroboros.ConnectionId) int {
 	for i, peer := range p.peers {
 		if peer != nil && peer.Connection != nil &&

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -336,49 +336,42 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 	// This runs after enforcePeerLimits so InboundPruned and held counts
 	// reflect the final post-prune state for this reconcile cycle.
 	hotByCategory := p.getHotPeersByCategory()
-	inboundWarm := 0
-	inboundHot := 0
-	for _, peer := range p.peers {
-		if peer == nil || peer.Source != PeerSourceInboundConn {
-			continue
-		}
-		switch peer.State {
-		case PeerStateCold:
-			// Inbound cold peers are tracked via peersBySource metrics.
-		case PeerStateWarm:
-			inboundWarm++
-		case PeerStateHot:
-			inboundHot++
-		default:
-			// Unknown state should not happen; ignore for quota accounting.
-		}
-	}
-	otherHot := max(0, hotByCategory["other"]-inboundHot)
+	// censusInboundCounts applies the provisional-window filter so the
+	// event agrees with the Prometheus gauges.
+	census := p.censusInboundCounts()
+	// hotByCategory["other"] still includes inbound hot peers, so
+	// subtract the filtered inbound hot count rather than the raw one
+	// to keep TotalHot self-consistent with the event fields.
+	otherHot := max(0, hotByCategory["other"]-census.Hot)
 	totalHot := hotByCategory["topology"] + hotByCategory["gossip"] +
-		hotByCategory["ledger"] + inboundHot + otherHot
+		hotByCategory["ledger"] + census.Hot + otherHot
 	events = append(events, pendingEvent{
 		QuotaStatusEventType,
 		QuotaStatusEvent{
-			InboundWarmTarget: p.config.InboundWarmTarget,
-			InboundHotQuota:   p.config.InboundHotQuota,
-			InboundWarm:       inboundWarm,
-			InboundHot:        inboundHot,
-			InboundPruned:     p.inboundPruned,
-			TopologyHot:       hotByCategory["topology"],
-			GossipHot:         hotByCategory["gossip"],
-			LedgerHot:         hotByCategory["ledger"],
-			OtherHot:          otherHot,
-			TotalHot:          totalHot,
+			InboundWarmTarget:      p.config.InboundWarmTarget,
+			InboundHotQuota:        p.config.InboundHotQuota,
+			InboundWarm:            census.Warm,
+			InboundHot:             census.Hot,
+			InboundPruned:          p.inboundPruned,
+			InboundTopologyMatched: census.TopologyMatched,
+			InboundDuplex:          census.Duplex,
+			TopologyHot:            hotByCategory["topology"],
+			GossipHot:              hotByCategory["gossip"],
+			LedgerHot:              hotByCategory["ledger"],
+			OtherHot:               otherHot,
+			TotalHot:               totalHot,
 		},
 	})
 	// Log quota status for debugging
 	p.config.Logger.Debug(
 		"quota status",
-		"inbound_warm", inboundWarm,
-		"inbound_hot", inboundHot,
+		"inbound_warm", census.Warm,
+		"inbound_hot", census.Hot,
 		"inbound_warm_target", p.config.InboundWarmTarget,
 		"inbound_hot_quota", p.config.InboundHotQuota,
 		"inbound_pruned", p.inboundPruned,
+		"inbound_topology_matched", census.TopologyMatched,
+		"inbound_duplex", census.Duplex,
 		"topology_hot", hotByCategory["topology"],
 		"gossip_hot", hotByCategory["gossip"],
 		"ledger_hot", hotByCategory["ledger"],


### PR DESCRIPTION
Closes #1932 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported peer-address normalization and host-only identity resolution for consistent inbound identity.
  * Inbound connection events include normalized remote address and provisional duplex metadata.
  * Persisted peer fields for inbound arrivals, last-arrival timestamp, topology match, and duplex; new inbound provisional window config.
  * New metrics for inbound arrivals, topology-matched, and duplex-held counts.

* **Refactor**
  * Centralized duplex detection and consolidated provisional-window census for inbound quota/metrics.

* **Tests**
  * Extensive phase-2 tests for inbound identity, arrivals, provisional-window census, and duplex behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phase 2 inbound admission metadata and identity to `peergov`, and aligns `connmanager` so inbound peers use a shared, canonical transport key. Introduces a short provisional window to filter flash connects (per #1932) and expands metrics and event fields for better visibility.

- **New Features**
  - Canonical identity: export `NormalizePeerAddr`; `InboundConnectionEvent` adds `NormalizedRemoteAddr` and `IsDuplex`; listener populates both; `peergov` falls back to `NormalizePeerAddr` if missing.
  - Inbound identity: resolve to an existing peer by exact address, else by a safe, unambiguous topology host match; record the matched topology `GroupID`.
  - Per-peer admission metadata: track `InboundDuplex` (best-effort from event, authoritative from handshake), `InboundArrivals`, and `LastInboundArrival`; increment on re-arrivals.
  - Provisional window: `InboundProvisionalWindow` (default 3s; negative disables) excludes fresh inbound peers from Warm/Hot counts; applied to Prometheus gauges and `QuotaStatusEvent`.
  - Metrics/events: add `InboundArrivalsTotal`, `InboundTopologyMatched`, `InboundDuplexHeld`; `QuotaStatusEvent` now reports `InboundTopologyMatched` and `InboundDuplex` using the same filtered inbound census as Prometheus.

- **Refactors**
  - Central inbound census feeds both Prometheus gauges and `QuotaStatusEvent` (with provisional-window filtering) to keep views in sync.
  - Listener detects duplex via `connectionIsDuplex`; inbound normalization updated across `connmanager`; avoid replacing a client-capable connection with a responder-only inbound.

<sup>Written for commit 51a441e00877ff41fdca8b87db6e79a3af60d699. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

