### PR TITLE
feat(ledger): add evaluateTriggerAtEpoch to LedgerState

### DIFF
--- a/ledger/eras/shape.go
+++ b/ledger/eras/shape.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
@@ -187,6 +188,23 @@ func BuildShape(cfg *cardano.CardanoNodeConfig) (hardfork.Shape, error) {
 			MaxMajorVersion: r.max,
 			Params:          params,
 		})
+	}
+
+	// Resolve each entry's NextEraTrigger. Must happen after the entries are
+	// built because AtVersion defaults to the *next* entry's MinMajorVersion.
+	// TestXHardForkAtEpoch is keyed on the lowercase successor era name and
+	// only honoured when ExperimentalHardForksEnabled is set.
+	for i := range entries {
+		if i == len(entries)-1 {
+			entries[i].NextEraTrigger = hardfork.NewTriggerNotDuringThisExecution()
+			continue
+		}
+		nextEra := entries[i+1]
+		if epoch, ok := cfg.HardForkEpoch(strings.ToLower(nextEra.EraName)); ok {
+			entries[i].NextEraTrigger = hardfork.NewTriggerAtEpoch(epoch)
+			continue
+		}
+		entries[i].NextEraTrigger = hardfork.NewTriggerAtVersion(nextEra.MinMajorVersion)
 	}
 
 	return hardfork.Shape{

--- a/ledger/eras/shape_test.go
+++ b/ledger/eras/shape_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -182,4 +183,113 @@ func TestBuildShape_MissingShelleyGenesis(t *testing.T) {
 	cfg := &cardano.CardanoNodeConfig{}
 	_, err := eras.BuildShape(cfg)
 	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------- NextEraTrigger
+
+// Default (no TestXHardForkAtEpoch configured): each era's NextEraTrigger is
+// TriggerAtVersion keyed on the next era's MinMajorVersion; the final era
+// is NotDuringThisExecution.
+func TestBuildShape_NextEraTrigger_DefaultsToAtVersion(t *testing.T) {
+	cfg := newTestCfg(t)
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+
+	for i, e := range shape.Eras {
+		if i == len(shape.Eras)-1 {
+			assert.Equal(t,
+				hardfork.TriggerNotDuringThisExecution,
+				e.NextEraTrigger.Kind,
+				"final era %q should carry NotDuringThisExecution", e.EraName,
+			)
+			continue
+		}
+		next := shape.Eras[i+1]
+		assert.Equal(t, hardfork.TriggerAtVersion, e.NextEraTrigger.Kind,
+			"era %q → %q should default to AtVersion", e.EraName, next.EraName)
+		assert.Equal(t, next.MinMajorVersion, e.NextEraTrigger.Version,
+			"era %q → %q: Version should equal next era's MinMajorVersion",
+			e.EraName, next.EraName)
+	}
+}
+
+// With ExperimentalHardForksEnabled=true and TestShelleyHardForkAtEpoch set,
+// Byron's NextEraTrigger becomes AtEpoch; all other eras remain AtVersion.
+func TestBuildShape_NextEraTrigger_AtEpochOverride(t *testing.T) {
+	cfg := newTestCfg(t)
+	enabled := true
+	override := uint64(5)
+	cfg.ExperimentalHardForksEnabled = &enabled
+	cfg.TestShelleyHardForkAtEpoch = &override
+
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+
+	// Byron → Shelley should be AtEpoch(5).
+	byron := shape.Eras[0]
+	require.Equal(t, "Byron", byron.EraName)
+	assert.Equal(t, hardfork.TriggerAtEpoch, byron.NextEraTrigger.Kind)
+	assert.Equal(t, uint64(5), byron.NextEraTrigger.Epoch)
+
+	// Shelley → Allegra should still be AtVersion.
+	shelley := shape.Eras[1]
+	require.Equal(t, "Shelley", shelley.EraName)
+	assert.Equal(t, hardfork.TriggerAtVersion, shelley.NextEraTrigger.Kind)
+}
+
+// TestXHardForkAtEpoch is ignored when ExperimentalHardForksEnabled is not
+// set: HardForkEpoch returns false, so we fall through to AtVersion.
+func TestBuildShape_NextEraTrigger_NoOverrideWithoutExperimentalFlag(t *testing.T) {
+	cfg := newTestCfg(t)
+	override := uint64(5)
+	cfg.TestShelleyHardForkAtEpoch = &override
+	// ExperimentalHardForksEnabled left nil.
+
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+
+	byron := shape.Eras[0]
+	require.Equal(t, "Byron", byron.EraName)
+	assert.Equal(t, hardfork.TriggerAtVersion, byron.NextEraTrigger.Kind,
+		"without ExperimentalHardForksEnabled, override must be ignored")
+}
+
+// Multiple TestXHardForkAtEpoch overrides: each affects only the era
+// whose successor it names.
+func TestBuildShape_NextEraTrigger_MultipleOverrides(t *testing.T) {
+	cfg := newTestCfg(t)
+	enabled := true
+	shelleyEpoch := uint64(3)
+	conwayEpoch := uint64(20)
+	cfg.ExperimentalHardForksEnabled = &enabled
+	cfg.TestShelleyHardForkAtEpoch = &shelleyEpoch
+	cfg.TestConwayHardForkAtEpoch = &conwayEpoch
+
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+
+	byEra := map[string]hardfork.ShapeEntry{}
+	for _, e := range shape.Eras {
+		byEra[e.EraName] = e
+	}
+
+	assert.Equal(t, hardfork.TriggerAtEpoch, byEra["Byron"].NextEraTrigger.Kind)
+	assert.Equal(t, shelleyEpoch, byEra["Byron"].NextEraTrigger.Epoch)
+	assert.Equal(t, hardfork.TriggerAtEpoch, byEra["Babbage"].NextEraTrigger.Kind)
+	assert.Equal(t, conwayEpoch, byEra["Babbage"].NextEraTrigger.Epoch)
+	assert.Equal(t, hardfork.TriggerAtVersion, byEra["Shelley"].NextEraTrigger.Kind)
+}
+
+// The Shape produced by BuildShape always validates, including the
+// NextEraTrigger invariants.
+func TestBuildShape_ValidateIncludesTriggerInvariants(t *testing.T) {
+	cfg := newTestCfg(t)
+	enabled := true
+	e := uint64(1)
+	cfg.ExperimentalHardForksEnabled = &enabled
+	cfg.TestShelleyHardForkAtEpoch = &e
+
+	shape, err := eras.BuildShape(cfg)
+	require.NoError(t, err)
+	assert.NoError(t, shape.Validate())
 }

--- a/ledger/hardfork/shape.go
+++ b/ledger/hardfork/shape.go
@@ -21,16 +21,21 @@ import (
 )
 
 // ShapeEntry describes one era's static identity and parameters: the era ID,
-// the span of protocol major versions it covers, and its EraParams.
+// the span of protocol major versions it covers, its EraParams, and the
+// trigger that arms the transition OUT of this era into its successor.
 //
 // Protocol major version ranges must be contiguous and non-overlapping across
-// a valid Shape.
+// a valid Shape. NextEraTrigger mirrors Haskell's per-era TriggerHardFork:
+// the final entry must be TriggerNotDuringThisExecution; every other entry
+// should carry either TriggerAtVersion (the default, keyed on the next era's
+// MinMajorVersion) or TriggerAtEpoch (the TestXHardForkAtEpoch override).
 type ShapeEntry struct {
 	EraID           uint
 	EraName         string
 	MinMajorVersion uint
 	MaxMajorVersion uint
 	Params          EraParams
+	NextEraTrigger  TriggerHardFork
 }
 
 // Shape is the static, compile-time-known era table: the set of eras this node
@@ -47,6 +52,8 @@ type Shape struct {
 //   - Consecutive entries' version ranges meet without gap and without overlap
 //     (cur.Min == prev.Max + 1).
 //   - Each entry's EraParams validate.
+//   - The final entry carries TriggerNotDuringThisExecution; no other entry
+//     does.
 func (s Shape) Validate() error {
 	if len(s.Eras) == 0 {
 		return errors.New("hardfork: Shape must have at least one era")
@@ -60,6 +67,26 @@ func (s Shape) Validate() error {
 		}
 		if err := e.Params.Validate(); err != nil {
 			return fmt.Errorf("hardfork: era %q: %w", e.EraName, err)
+		}
+		isLast := i == len(s.Eras)-1
+		switch {
+		case e.NextEraTrigger.Kind != TriggerAtVersion &&
+			e.NextEraTrigger.Kind != TriggerAtEpoch &&
+			e.NextEraTrigger.Kind != TriggerNotDuringThisExecution:
+			return fmt.Errorf(
+				"hardfork: era %q: NextEraTrigger has unknown kind %d",
+				e.EraName, e.NextEraTrigger.Kind,
+			)
+		case isLast && e.NextEraTrigger.Kind != TriggerNotDuringThisExecution:
+			return fmt.Errorf(
+				"hardfork: era %q (final): NextEraTrigger must be NotDuringThisExecution, got %s",
+				e.EraName, e.NextEraTrigger,
+			)
+		case !isLast && e.NextEraTrigger.Kind == TriggerNotDuringThisExecution:
+			return fmt.Errorf(
+				"hardfork: era %q (non-final): NextEraTrigger must not be NotDuringThisExecution",
+				e.EraName,
+			)
 		}
 		if i == 0 {
 			continue

--- a/ledger/hardfork/shape_test.go
+++ b/ledger/hardfork/shape_test.go
@@ -26,13 +26,13 @@ func sampleShape() hardfork.Shape {
 	return hardfork.Shape{
 		SystemStart: testSysStart,
 		Eras: []hardfork.ShapeEntry{
-			{EraID: 0, EraName: "Byron", MinMajorVersion: 0, MaxMajorVersion: 1, Params: byronParams},
-			{EraID: 1, EraName: "Shelley", MinMajorVersion: 2, MaxMajorVersion: 2, Params: shelleyParams},
-			{EraID: 2, EraName: "Allegra", MinMajorVersion: 3, MaxMajorVersion: 3, Params: shelleyParams},
-			{EraID: 3, EraName: "Mary", MinMajorVersion: 4, MaxMajorVersion: 4, Params: shelleyParams},
-			{EraID: 4, EraName: "Alonzo", MinMajorVersion: 5, MaxMajorVersion: 6, Params: shelleyParams},
-			{EraID: 5, EraName: "Babbage", MinMajorVersion: 7, MaxMajorVersion: 8, Params: shelleyParams},
-			{EraID: 6, EraName: "Conway", MinMajorVersion: 9, MaxMajorVersion: 10, Params: shelleyParams},
+			{EraID: 0, EraName: "Byron", MinMajorVersion: 0, MaxMajorVersion: 1, Params: byronParams, NextEraTrigger: hardfork.NewTriggerAtVersion(2)},
+			{EraID: 1, EraName: "Shelley", MinMajorVersion: 2, MaxMajorVersion: 2, Params: shelleyParams, NextEraTrigger: hardfork.NewTriggerAtVersion(3)},
+			{EraID: 2, EraName: "Allegra", MinMajorVersion: 3, MaxMajorVersion: 3, Params: shelleyParams, NextEraTrigger: hardfork.NewTriggerAtVersion(4)},
+			{EraID: 3, EraName: "Mary", MinMajorVersion: 4, MaxMajorVersion: 4, Params: shelleyParams, NextEraTrigger: hardfork.NewTriggerAtVersion(5)},
+			{EraID: 4, EraName: "Alonzo", MinMajorVersion: 5, MaxMajorVersion: 6, Params: shelleyParams, NextEraTrigger: hardfork.NewTriggerAtVersion(7)},
+			{EraID: 5, EraName: "Babbage", MinMajorVersion: 7, MaxMajorVersion: 8, Params: shelleyParams, NextEraTrigger: hardfork.NewTriggerAtVersion(9)},
+			{EraID: 6, EraName: "Conway", MinMajorVersion: 9, MaxMajorVersion: 10, Params: shelleyParams, NextEraTrigger: hardfork.NewTriggerNotDuringThisExecution()},
 		},
 	}
 }
@@ -117,4 +117,41 @@ func TestShape_EraIndex(t *testing.T) {
 
 	_, ok = s.EraIndex(99)
 	assert.False(t, ok)
+}
+
+// Validate must reject a shape whose non-final era carries
+// TriggerNotDuringThisExecution — that variant is reserved for the final era.
+func TestShape_Validate_RejectsNonFinalNotDuringThisExecution(t *testing.T) {
+	s := sampleShape()
+	// Force Byron (non-final) to carry NotDuringThisExecution.
+	s.Eras[0].NextEraTrigger = hardfork.NewTriggerNotDuringThisExecution()
+	err := s.Validate()
+	assert.ErrorContains(t, err, "NotDuringThisExecution")
+}
+
+// Validate must reject a shape whose final era carries a trigger other than
+// NotDuringThisExecution.
+func TestShape_Validate_RejectsFinalWithSuccessorTrigger(t *testing.T) {
+	s := sampleShape()
+	// Force Conway (final) to carry AtEpoch.
+	s.Eras[len(s.Eras)-1].NextEraTrigger = hardfork.NewTriggerAtEpoch(100)
+	err := s.Validate()
+	assert.ErrorContains(t, err, "final")
+}
+
+// AtEpoch triggers on non-final eras are accepted.
+func TestShape_Validate_AcceptsAtEpochOnNonFinal(t *testing.T) {
+	s := sampleShape()
+	s.Eras[0].NextEraTrigger = hardfork.NewTriggerAtEpoch(5)
+	assert.NoError(t, s.Validate())
+}
+
+// Validate must reject a trigger whose Kind is not one of the three known
+// variants, so future refactors / external constructors can't quietly produce
+// a shape that passes the final/non-final checks with a bogus kind.
+func TestShape_Validate_RejectsUnknownTriggerKind(t *testing.T) {
+	s := sampleShape()
+	s.Eras[0].NextEraTrigger = hardfork.TriggerHardFork{Kind: 99}
+	err := s.Validate()
+	assert.ErrorContains(t, err, "unknown kind")
 }

--- a/ledger/hardfork/trigger.go
+++ b/ledger/hardfork/trigger.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork
+
+import "fmt"
+
+// TriggerKind identifies which of the three TriggerHardFork variants applies.
+// Mirrors Haskell's Ouroboros.Consensus.HardFork.Simple.TriggerHardFork.
+type TriggerKind uint8
+
+const (
+	// TriggerAtVersion means the transition fires when the on-chain pparams
+	// advertise the configured next-era major protocol version (and, in the
+	// full HFC, the vote has stabilised). Version holds that major version.
+	TriggerAtVersion TriggerKind = iota
+	// TriggerAtEpoch means the transition is administratively pinned to a
+	// specific epoch (the "TestXHardForkAtEpoch" override). Epoch holds
+	// that epoch ID. The pparams major-version bump is bypassed.
+	TriggerAtEpoch
+	// TriggerNotDuringThisExecution means no transition out of this era can
+	// occur under the currently-running binary — the node does not know
+	// about the successor era.
+	TriggerNotDuringThisExecution
+)
+
+// TriggerHardFork describes how a transition OUT of a given era is armed.
+// It is stored per-era on ShapeEntry and is the Go equivalent of Haskell's
+// TriggerHardFork sum type.
+type TriggerHardFork struct {
+	Kind    TriggerKind
+	Version uint   // valid when Kind == TriggerAtVersion
+	Epoch   uint64 // valid when Kind == TriggerAtEpoch
+}
+
+// NewTriggerAtVersion returns a TriggerAtVersion variant targeting the given
+// next-era major protocol version.
+func NewTriggerAtVersion(majorVersion uint) TriggerHardFork {
+	return TriggerHardFork{Kind: TriggerAtVersion, Version: majorVersion}
+}
+
+// NewTriggerAtEpoch returns a TriggerAtEpoch variant pinning the transition
+// to the given epoch. This corresponds to the TestXHardForkAtEpoch YAML
+// override.
+func NewTriggerAtEpoch(epoch uint64) TriggerHardFork {
+	return TriggerHardFork{Kind: TriggerAtEpoch, Epoch: epoch}
+}
+
+// NewTriggerNotDuringThisExecution returns the variant used by the last era
+// a binary knows about: no successor, so no in-execution transition.
+func NewTriggerNotDuringThisExecution() TriggerHardFork {
+	return TriggerHardFork{Kind: TriggerNotDuringThisExecution}
+}
+
+// String returns a human-readable form, e.g. "AtVersion(4)", "AtEpoch(500)",
+// "NotDuringThisExecution".
+func (t TriggerHardFork) String() string {
+	switch t.Kind {
+	case TriggerAtVersion:
+		return fmt.Sprintf("AtVersion(%d)", t.Version)
+	case TriggerAtEpoch:
+		return fmt.Sprintf("AtEpoch(%d)", t.Epoch)
+	case TriggerNotDuringThisExecution:
+		return "NotDuringThisExecution"
+	default:
+		return fmt.Sprintf("TriggerHardFork(?kind=%d)", t.Kind)
+	}
+}

--- a/ledger/hardfork/trigger_test.go
+++ b/ledger/hardfork/trigger_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hardfork_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+)
+
+func TestTriggerHardFork_Constructors(t *testing.T) {
+	v := hardfork.NewTriggerAtVersion(7)
+	assert.Equal(t, hardfork.TriggerAtVersion, v.Kind)
+	assert.Equal(t, uint(7), v.Version)
+	assert.Equal(t, uint64(0), v.Epoch)
+
+	e := hardfork.NewTriggerAtEpoch(500)
+	assert.Equal(t, hardfork.TriggerAtEpoch, e.Kind)
+	assert.Equal(t, uint64(500), e.Epoch)
+	assert.Equal(t, uint(0), e.Version)
+
+	n := hardfork.NewTriggerNotDuringThisExecution()
+	assert.Equal(t, hardfork.TriggerNotDuringThisExecution, n.Kind)
+	assert.Equal(t, uint(0), n.Version)
+	assert.Equal(t, uint64(0), n.Epoch)
+}
+
+func TestTriggerHardFork_String(t *testing.T) {
+	cases := []struct {
+		in   hardfork.TriggerHardFork
+		want string
+	}{
+		{hardfork.NewTriggerAtVersion(4), "AtVersion(4)"},
+		{hardfork.NewTriggerAtEpoch(123), "AtEpoch(123)"},
+		{hardfork.NewTriggerNotDuringThisExecution(), "NotDuringThisExecution"},
+		{hardfork.TriggerHardFork{Kind: 99}, "TriggerHardFork(?kind=99)"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.String())
+	}
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -167,10 +167,9 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 	transitionInfo := ls.transitionInfo
 	ls.RUnlock()
 
-	cfg := ls.config.CardanoNodeConfig
-	shape, err := eras.BuildShape(cfg)
-	if err != nil {
-		return nil, err
+	shape := ls.eraShape()
+	if len(shape.Eras) == 0 {
+		return nil, errors.New("era history: shape unavailable")
 	}
 	if len(shape.Eras) != len(eras.Eras) {
 		return nil, fmt.Errorf(

--- a/ledger/queries_hfc_test.go
+++ b/ledger/queries_hfc_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -147,6 +148,85 @@ func TestQueryHardForkEraHistory_TransitionUnknown_TipNearEpochEnd(t *testing.T)
 		"Unknown: tip+safeZone crossing into next epoch should extend EraEnd to that epoch's end")
 	assert.Equal(t, expectedEraEndEpoch, epoch,
 		"Unknown: EraEnd epoch should be the epoch *after* the one containing tip+safeZone")
+}
+
+// TestQueryHardForkEraHistory_AtEpochOverride_SurfacesKnownEnd pins that
+// TestShelleyHardForkAtEpoch + ExperimentalHardForksEnabled propagates through
+// to queryHardForkEraHistory as a TransitionKnown end: the open era's EraEnd
+// epoch is the override epoch, not the stale tipSlot + safeZone cap.
+//
+// Setup: a Byron-only DB with a single epoch 3 occupying slots
+// [epochStart, epochStart+length). TestShelleyHardForkAtEpoch is 5 and
+// ExperimentalHardForksEnabled is true, so Byron's NextEraTrigger resolves to
+// AtEpoch(5). With currentEpoch=3 < 5, evaluateTriggerAtEpoch will set
+// TransitionKnown(5) and the Byron era's End must snap to epoch 5's start.
+func TestQueryHardForkEraHistory_AtEpochOverride_SurfacesKnownEnd(t *testing.T) {
+	const (
+		epochId        = uint64(3)
+		epochLen       = uint(21_600)   // Byron epoch length (10k, k=2160)
+		slotLenMs      = uint(20_000)   // 20s Byron slot
+		epochStartSlot = uint64(64_800) // epoch 3 starts after 3 * 21_600
+		tipSlot        = uint64(70_000)
+	)
+
+	db := newTestDB(t)
+	require.NoError(t, db.SetEpoch(
+		epochStartSlot, epochId,
+		nil, nil, nil, nil,
+		eras.ByronEraDesc.Id, slotLenMs, epochLen,
+		nil,
+	))
+
+	cfg := newTestEraHistoryCfg(t)
+	enabled := true
+	override := uint64(5)
+	cfg.ExperimentalHardForksEnabled = &enabled
+	cfg.TestShelleyHardForkAtEpoch = &override
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ByronEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId:       epochId,
+			StartSlot:     epochStartSlot,
+			LengthInSlots: epochLen,
+			SlotLength:    slotLenMs,
+			EraId:         eras.ByronEraDesc.Id,
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
+		},
+		transitionInfo: hardfork.NewTransitionUnknown(),
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	// Apply the trigger so transitionInfo reflects TransitionKnown(5) as it
+	// would at runtime via Start() / the tip-update path.
+	ls.evaluateTriggerAtEpoch()
+	require.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	require.Equal(t, override, ls.transitionInfo.KnownEpoch)
+
+	result, err := ls.queryHardForkEraHistory()
+	require.NoError(t, err)
+	list, ok := result.(cbor.IndefLengthList)
+	require.True(t, ok)
+	require.NotEmpty(t, list)
+
+	// The currently-open era (Byron at index 0) should have EraEnd.Epoch == 5.
+	byronEra, ok := list[0].([]any)
+	require.True(t, ok)
+	require.Len(t, byronEra, 3)
+	byronEnd, ok := byronEra[1].([]any)
+	require.True(t, ok)
+	require.Len(t, byronEnd, 3, "EraEnd is [relTime, slot, epoch]")
+
+	endEpoch, ok := byronEnd[2].(uint64)
+	require.True(t, ok, "EraEnd epoch must be uint64, got %T", byronEnd[2])
+	assert.Equal(t, override, endEpoch,
+		"AtEpoch override must pin the open era's EraEnd.Epoch at the override value")
 }
 
 // TestQueryHardForkEraHistory_AdjacentErasContiguous pins that whenever two

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -423,6 +423,7 @@ type LedgerState struct {
 	slotsPerKESPeriod                  atomic.Uint64
 	forgedBlockChecker                 atomic.Pointer[forgedBlockCheckerHolder]
 	slotBattleRecorder                 atomic.Pointer[slotBattleRecorderHolder]
+	cachedShape                        atomic.Pointer[hardfork.Shape] // lazy-built from CardanoNodeConfig; immutable for the LedgerState's lifetime
 	reachedTip                         bool
 	currentTip                         ochainsync.Tip
 	currentEpoch                       models.Epoch
@@ -664,6 +665,10 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// already covers the epoch end (TransitionImpossible).  This handles the
 	// case where the node was shut down after the tip advanced past the
 	// stability window but before the next epoch rollover was processed.
+	// First honor any TestXHardForkAtEpoch override (TriggerAtEpoch): this
+	// short-circuits TransitionUnknown/Impossible with a known-in-advance
+	// transition epoch, matching the Haskell HFC semantics.
+	ls.evaluateTriggerAtEpoch()
 	ls.evaluateTransitionImpossible()
 	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
 		return fmt.Errorf("failed to reconcile primary chain tip: %w", err)
@@ -2362,6 +2367,12 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					rolloverResult.NewCurrentEpoch.EpochId,
 				)
 			}
+			// Re-apply any TestXHardForkAtEpoch override. This matters both
+			// when no eraTransitions/HardFork occurred (the rollover reset
+			// transitionInfo to Unknown above) and when an era transition
+			// advanced ls.currentEra to a new era whose own successor may
+			// carry its own AtEpoch override.
+			ls.evaluateTriggerAtEpoch()
 			ls.Unlock()
 
 			// Update scheduler (thread-safe, no lock needed)
@@ -2928,11 +2939,14 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					ls.reachedTip = true
 				}
 				ls.updateTipMetrics()
-				// After advancing the tip, check whether the stability window
-				// now reaches or exceeds the epoch end.  If so, a hard fork
-				// cannot happen within this epoch and TransitionImpossible
-				// should be recorded so queryHardForkEraHistory serves the
-				// confirmed epoch-end slot instead of a stale safeZone cap.
+				// After advancing the tip, first honor any TestXHardForkAtEpoch
+				// override so queries surface the pinned epoch ahead of time;
+				// then check whether the stability window reaches or exceeds
+				// the epoch end, in which case a hard fork cannot happen
+				// within this epoch and TransitionImpossible should be
+				// recorded so queryHardForkEraHistory serves the confirmed
+				// epoch-end slot instead of a stale safeZone cap.
+				ls.evaluateTriggerAtEpoch()
 				ls.evaluateTransitionImpossible()
 				// Capture tip for logging while holding the lock
 				tipForLog = ls.currentTip
@@ -3293,6 +3307,75 @@ func (ls *LedgerState) reconstructTransitionInfo() {
 	if pparamsEraId > ls.currentEra.Id {
 		ls.transitionInfo = hardfork.NewTransitionKnown(ls.currentEpoch.EpochId)
 	}
+}
+
+// eraShape returns the resolved hardfork.Shape for this LedgerState's
+// CardanoNodeConfig, building and caching it on first access. cfg is
+// immutable for the LedgerState's lifetime, so the cached shape is too.
+//
+// Returns an empty Shape (no error) when CardanoNodeConfig is unset or when
+// BuildShape fails; callers must treat an empty Shape as "shape unavailable"
+// and skip shape-derived work.
+func (ls *LedgerState) eraShape() hardfork.Shape {
+	if s := ls.cachedShape.Load(); s != nil {
+		return *s
+	}
+	cfg := ls.config.CardanoNodeConfig
+	if cfg == nil {
+		return hardfork.Shape{}
+	}
+	s, err := eras.BuildShape(cfg)
+	if err != nil {
+		return hardfork.Shape{}
+	}
+	ls.cachedShape.CompareAndSwap(nil, &s)
+	return *ls.cachedShape.Load()
+}
+
+// evaluateTriggerAtEpoch sets transitionInfo to TransitionKnown(e) when the
+// current era's NextEraTrigger is TriggerAtEpoch(e) and that epoch has not
+// yet arrived. The trigger is resolved once at Shape build time from
+// CardanoNodeConfig (TestXHardForkAtEpoch + ExperimentalHardForksEnabled);
+// this method only consumes that resolution.
+//
+// The AtEpoch override is authoritative: it supersedes a prior
+// TransitionUnknown / TransitionImpossible, and replaces any
+// TransitionKnown(other) that may have been set from an on-chain pparams
+// major-version bump, mirroring the Haskell semantics where
+// `shelleyTriggerHardFork` short-circuits to the configured epoch without
+// inspecting pparams at all.
+//
+// The call is a no-op when:
+//   - the shape is unavailable or the current era is unknown to it,
+//   - the current era's NextEraTrigger is not TriggerAtEpoch (i.e. final era,
+//     or default AtVersion),
+//   - the configured epoch has already been reached (EpochId >= e) — at that
+//     point either the rollover has already applied the transition, or
+//     queries should naturally fall through to the new era's own trigger.
+//
+// Call under ls.Lock() (runtime paths) or without a lock during
+// single-threaded startup.
+func (ls *LedgerState) evaluateTriggerAtEpoch() {
+	shape := ls.eraShape()
+	if len(shape.Eras) == 0 {
+		return
+	}
+	entry, ok := shape.EraForID(ls.currentEra.Id)
+	if !ok {
+		return
+	}
+	if entry.NextEraTrigger.Kind != hardfork.TriggerAtEpoch {
+		return
+	}
+	epoch := entry.NextEraTrigger.Epoch
+	if ls.currentEpoch.EpochId >= epoch {
+		return
+	}
+	if ls.transitionInfo.State == hardfork.TransitionKnown &&
+		ls.transitionInfo.KnownEpoch == epoch {
+		return
+	}
+	ls.transitionInfo = hardfork.NewTransitionKnown(epoch)
 }
 
 // evaluateTransitionImpossible sets transitionInfo to TransitionImpossible

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2602,6 +2602,173 @@ func TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero(t *testing.T) {
 		"zero-length epoch must not trigger TransitionImpossible")
 }
 
+// ---------------------------------------------------------------------------
+// evaluateTriggerAtEpoch tests
+// ---------------------------------------------------------------------------
+
+// newTestLedgerStateWithTrigger builds a minimal LedgerState with the given
+// currentEra / currentEpoch / initial transitionInfo, and the requested
+// TestXHardForkAtEpoch override wired into the config (keyed on the
+// successor era's lowercase name).
+func newTestLedgerStateWithTrigger(
+	t *testing.T,
+	currentEraId uint,
+	currentEpochId uint64,
+	initialTI hardfork.TransitionInfo,
+	nextEraLower string,
+	overrideEpoch *uint64,
+	experimentalEnabled bool,
+) *LedgerState {
+	t.Helper()
+	cfg := newTestEraHistoryCfg(t)
+	if experimentalEnabled {
+		enabled := true
+		cfg.ExperimentalHardForksEnabled = &enabled
+	}
+	switch nextEraLower {
+	case "shelley":
+		cfg.TestShelleyHardForkAtEpoch = overrideEpoch
+	case "allegra":
+		cfg.TestAllegraHardForkAtEpoch = overrideEpoch
+	case "mary":
+		cfg.TestMaryHardForkAtEpoch = overrideEpoch
+	case "alonzo":
+		cfg.TestAlonzoHardForkAtEpoch = overrideEpoch
+	case "babbage":
+		cfg.TestBabbageHardForkAtEpoch = overrideEpoch
+	case "conway":
+		cfg.TestConwayHardForkAtEpoch = overrideEpoch
+	}
+	return &LedgerState{
+		currentEra:     *eras.GetEraById(currentEraId),
+		currentEpoch:   newTestEpoch(currentEpochId, 0, 432_000, currentEraId),
+		transitionInfo: initialTI,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+// Happy path: in Byron, with ExperimentalHardForksEnabled and
+// TestShelleyHardForkAtEpoch=5, and the current epoch before 5, the
+// TransitionInfo is surfaced as TransitionKnown(5).
+func TestEvaluateTriggerAtEpoch_SetsTransitionKnown(t *testing.T) {
+	target := uint64(5)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 3,
+		hardfork.NewTransitionUnknown(),
+		"shelley", &target, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	assert.Equal(t, target, ls.transitionInfo.KnownEpoch)
+}
+
+// Without ExperimentalHardForksEnabled, the override is inert.
+func TestEvaluateTriggerAtEpoch_InertWithoutExperimentalFlag(t *testing.T) {
+	target := uint64(5)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 3,
+		hardfork.NewTransitionUnknown(),
+		"shelley", &target, false,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
+		"override must be ignored without ExperimentalHardForksEnabled")
+}
+
+// When currentEpoch.EpochId >= target epoch, the trigger is not applied
+// (the transition should have already occurred).
+func TestEvaluateTriggerAtEpoch_NotSetWhenEpochReached(t *testing.T) {
+	target := uint64(5)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 5,
+		hardfork.NewTransitionUnknown(),
+		"shelley", &target, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State)
+}
+
+// The last known era has no successor: the call is a no-op even if
+// Test<Next>HardForkAtEpoch happens to be set (not meaningful).
+func TestEvaluateTriggerAtEpoch_NoOpOnFinalEra(t *testing.T) {
+	target := uint64(100)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ConwayEraDesc.Id, 3,
+		hardfork.NewTransitionUnknown(),
+		// Conway is final today; there is no TestDijkstraHardForkAtEpoch
+		// field on the config, so no override can ever match.
+		"", &target, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State)
+}
+
+// AtEpoch override supersedes a prior TransitionImpossible: AtEpoch is
+// authoritative info about a known upcoming transition and must override the
+// safe-zone-derived "no transition in this epoch" verdict.
+func TestEvaluateTriggerAtEpoch_OverridesTransitionImpossible(t *testing.T) {
+	target := uint64(10)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 3,
+		hardfork.NewTransitionImpossible(),
+		"shelley", &target, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	assert.Equal(t, target, ls.transitionInfo.KnownEpoch)
+}
+
+// AtEpoch override replaces a TransitionKnown set for a different epoch.
+// Mirrors Haskell's shelleyTriggerHardFork short-circuit: the AtEpoch config
+// is the truth and bypasses pparams-vote inspection entirely.
+func TestEvaluateTriggerAtEpoch_ReplacesDifferentKnownEpoch(t *testing.T) {
+	target := uint64(10)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 3,
+		hardfork.NewTransitionKnown(4),
+		"shelley", &target, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	assert.Equal(t, target, ls.transitionInfo.KnownEpoch,
+		"AtEpoch override must replace a stale TransitionKnown(other)")
+}
+
+// Idempotent when already TransitionKnown at the same epoch.
+func TestEvaluateTriggerAtEpoch_IdempotentOnSameEpoch(t *testing.T) {
+	target := uint64(10)
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 3,
+		hardfork.NewTransitionKnown(target),
+		"shelley", &target, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	assert.Equal(t, target, ls.transitionInfo.KnownEpoch)
+}
+
+// No override configured at all: evaluateTriggerAtEpoch is a no-op.
+func TestEvaluateTriggerAtEpoch_NoOpWithoutOverride(t *testing.T) {
+	ls := newTestLedgerStateWithTrigger(
+		t,
+		eras.ByronEraDesc.Id, 3,
+		hardfork.NewTransitionUnknown(),
+		"", nil, true,
+	)
+	ls.evaluateTriggerAtEpoch()
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State)
+}
+
 // TestRolloverCommit_ResetsTransitionImpossible verifies that a plain epoch
 // rollover (no HardFork, no era transition) resets TransitionImpossible to
 // TransitionUnknown so the new epoch starts fresh.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `evaluateTriggerAtEpoch` to `LedgerState`, introduces per-era `NextEraTrigger` on `hardfork.ShapeEntry`, and updates era history to surface configured hard-fork epochs as known ends. Caches the era `Shape` for reuse across queries.

- **New Features**
  - Per-era `NextEraTrigger` on `hardfork.ShapeEntry`: defaults to `AtVersion(next.MinMajorVersion)`, final era uses `NotDuringThisExecution`, and `AtEpoch` when a `TestXHardForkAtEpoch` override is active with `ExperimentalHardForksEnabled` (keyed on the lowercase successor era name).
  - `LedgerState.evaluateTriggerAtEpoch()` sets `TransitionKnown(epoch)` for `AtEpoch` overrides; runs at startup, on tip updates, and on epoch rollovers; supersedes `TransitionUnknown/Impossible` and replaces mismatched `TransitionKnown`.
  - Cached `hardfork.Shape` in `LedgerState` via `eraShape()`; `queryHardForkEraHistory` now uses it and surfaces `AtEpoch` as a known era end.

- **Bug Fixes**
  - Era history no longer serves a stale safe-zone cap when an `AtEpoch` override is set; it pins the open era’s end to the configured epoch.
  - Shape validation enforces trigger rules: non-final eras cannot use `NotDuringThisExecution`, the final era must use it, and unknown trigger kinds are rejected.

<sup>Written for commit f1f450e8e5bd12bf3b72d0c95ed11b415a7b11ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for hard-fork era transition triggers with version-based and epoch-based configuration options
  * Introduced experimental hard-fork epoch override capability for controlled era transitions

* **Tests**
  * Added comprehensive test coverage for era trigger construction, validation, and epoch override behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->