### PR TITLE
test: tune mempool timeouts for slow windows runners

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -2165,7 +2165,10 @@ func TestMempool_TTL_NonExpiredTransactionsRetained(t *testing.T) {
 }
 
 func TestMempool_TTL_MixedExpiryRetainsNonExpired(t *testing.T) {
-	m := newTestMempoolWithTTL(t, 50*time.Millisecond, 20*time.Millisecond)
+	// TTL is deliberately long relative to the test window so fresh
+	// txs can't age past it before Eventually observes len==2, even
+	// under scheduler jitter on slow CI runners.
+	m := newTestMempoolWithTTL(t, 5*time.Second, 20*time.Millisecond)
 	defer m.Stop(context.Background())
 
 	// Add a mix of expired and fresh transactions
@@ -2177,7 +2180,7 @@ func TestMempool_TTL_MixedExpiryRetainsNonExpired(t *testing.T) {
 			Hash:     fmt.Sprintf("old-tx-%d", i),
 			Cbor:     fmt.Appendf(nil, "old-cbor-%d", i),
 			Type:     uint(conway.EraIdConway),
-			LastSeen: time.Now().Add(-200 * time.Millisecond),
+			LastSeen: time.Now().Add(-10 * time.Second),
 		}
 		m.transactions = append(m.transactions, tx)
 		m.txByHash[tx.Hash] = tx
@@ -2307,7 +2310,10 @@ func TestMempool_TTL_ExpiredMetricUpdated(t *testing.T) {
 }
 
 func TestMempool_TTL_ConsumerIndexAdjustedOnExpiry(t *testing.T) {
-	m := newTestMempoolWithTTL(t, 50*time.Millisecond, 20*time.Millisecond)
+	// TTL is deliberately long relative to the test window so fresh
+	// txs can't age past it before Eventually observes len==3, even
+	// under scheduler jitter on slow CI runners.
+	m := newTestMempoolWithTTL(t, 5*time.Second, 20*time.Millisecond)
 	defer m.Stop(context.Background())
 
 	// Add a mix of expired and fresh transactions
@@ -2319,7 +2325,7 @@ func TestMempool_TTL_ConsumerIndexAdjustedOnExpiry(t *testing.T) {
 			Hash:     fmt.Sprintf("expired-%d", i),
 			Cbor:     fmt.Appendf(nil, "expired-cbor-%d", i),
 			Type:     uint(conway.EraIdConway),
-			LastSeen: time.Now().Add(-200 * time.Millisecond),
+			LastSeen: time.Now().Add(-10 * time.Second),
 		}
 		m.transactions = append(m.transactions, tx)
 		m.txByHash[tx.Hash] = tx


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test reliability by adjusting timing parameters in TTL-related tests to account for CI scheduling variations. Tests now use longer transaction TTL durations with adjusted timestamp configurations to ensure consistent behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase TTL windows in mempool TTL tests to reduce flakiness on slow Windows CI. Expired txs are now clearly old so fresh txs don’t age out during assertions.

- **Bug Fixes**
  - Raised TTL from 50ms to 5s in `TestMempool_TTL_MixedExpiryRetainsNonExpired` and `TestMempool_TTL_ConsumerIndexAdjustedOnExpiry` (20ms sweep unchanged).
  - Set seeded expired tx `LastSeen` from −200ms to −10s to guarantee expiry and avoid races during Eventually checks.

<sup>Written for commit 2ed4a365e7fd3d48c73fbcd3371e7d2cbe52c571. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

