### PR TITLE
fix: don't use request logging for s3 client

### DIFF
--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -779,7 +779,7 @@ func (d *BlobStoreS3) Start() error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
 	// Load AWS config
-	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithClientLogMode(aws.LogRequestWithBody))
+	awsCfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		cancel()
 		return fmt.Errorf("s3 blob: load default AWS config: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable AWS request logging for the S3 client by removing `config.WithClientLogMode(aws.LogRequestWithBody)`. This prevents request body logs and reduces noisy output.

<sup>Written for commit c13d135b2889dccbac89f798fcd17fe73ac86c75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

