### PR TITLE
feat: added flushbatch method to MetadataStoreSqlite/postgres/mysql for bulk writes

### DIFF
--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sqlite
+package mysql
 
 import (
 	"fmt"
@@ -25,10 +25,10 @@ import (
 )
 
 const (
+	batchChunkSize = 499
 	batchChunkRows = 100
 )
 
-// utxoSpend captures the information needed to mark a UTxO as spent.
 type utxoSpend struct {
 	TxId          []byte
 	OutputIdx     uint32
@@ -37,9 +37,7 @@ type utxoSpend struct {
 }
 
 // BatchAccumulator collects metadata rows across multiple transactions
-// for bulk database insertion. It is the foundational data structure for
-// the backfill batching optimization that reduces per-block SQL statements
-// from 30-150 down to 2-5 by batching writes across 50-100 blocks.
+// for bulk database insertion.
 type BatchAccumulator struct {
 	KeyWitnesses   []models.KeyWitness
 	WitnessScripts []models.WitnessScripts
@@ -53,7 +51,6 @@ type BatchAccumulator struct {
 	DeleteTxIDs    []uint
 }
 
-// NewBatchAccumulator returns an empty BatchAccumulator ready for use.
 func NewBatchAccumulator() *BatchAccumulator {
 	return &BatchAccumulator{}
 }
@@ -125,7 +122,7 @@ func (b *BatchAccumulator) Reset() {
 }
 
 // FlushBatch writes all accumulated records in a deterministic order.
-func (d *MetadataStoreSqlite) FlushBatch(
+func (d *MetadataStoreMysql) FlushBatch(
 	batch *BatchAccumulator,
 	txn types.Txn,
 ) error {

--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -279,26 +279,42 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 		var deletedSlotCases []string
 		var spentAtCases []string
 		var whereConditions []string
-		args := make([]any, 0, len(chunk)*8)
+		var deletedSlotArgs []any
+		var spentAtArgs []any
+		var whereArgs []any
 		for _, spend := range chunk {
 			deletedSlotCases = append(
 				deletedSlotCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx, spend.Slot)
+			deletedSlotArgs = append(
+				deletedSlotArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.Slot,
+			)
 
 			spentAtCases = append(
 				spentAtCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx, spend.SpentByTxHash)
+			spentAtArgs = append(
+				spentAtArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.SpentByTxHash,
+			)
 
 			whereConditions = append(
 				whereConditions,
 				"(tx_id = ? AND output_idx = ?)",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx)
+			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
 		}
+		args := make([]any, 0, len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs))
+		args = append(args, deletedSlotArgs...)
+		args = append(args, spentAtArgs...)
+		args = append(args, whereArgs...)
 		sql := fmt.Sprintf(
 			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND (%s)",
 			strings.Join(deletedSlotCases, " "),

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sqlite
+package postgres
 
 import (
 	"fmt"
@@ -25,10 +25,10 @@ import (
 )
 
 const (
+	batchChunkSize = 499
 	batchChunkRows = 100
 )
 
-// utxoSpend captures the information needed to mark a UTxO as spent.
 type utxoSpend struct {
 	TxId          []byte
 	OutputIdx     uint32
@@ -37,9 +37,7 @@ type utxoSpend struct {
 }
 
 // BatchAccumulator collects metadata rows across multiple transactions
-// for bulk database insertion. It is the foundational data structure for
-// the backfill batching optimization that reduces per-block SQL statements
-// from 30-150 down to 2-5 by batching writes across 50-100 blocks.
+// for bulk database insertion.
 type BatchAccumulator struct {
 	KeyWitnesses   []models.KeyWitness
 	WitnessScripts []models.WitnessScripts
@@ -53,7 +51,6 @@ type BatchAccumulator struct {
 	DeleteTxIDs    []uint
 }
 
-// NewBatchAccumulator returns an empty BatchAccumulator ready for use.
 func NewBatchAccumulator() *BatchAccumulator {
 	return &BatchAccumulator{}
 }
@@ -125,7 +122,7 @@ func (b *BatchAccumulator) Reset() {
 }
 
 // FlushBatch writes all accumulated records in a deterministic order.
-func (d *MetadataStoreSqlite) FlushBatch(
+func (d *MetadataStorePostgres) FlushBatch(
 	batch *BatchAccumulator,
 	txn types.Txn,
 ) error {

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -279,26 +279,42 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 		var deletedSlotCases []string
 		var spentAtCases []string
 		var whereConditions []string
-		args := make([]any, 0, len(chunk)*8)
+		var deletedSlotArgs []any
+		var spentAtArgs []any
+		var whereArgs []any
 		for _, spend := range chunk {
 			deletedSlotCases = append(
 				deletedSlotCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx, spend.Slot)
+			deletedSlotArgs = append(
+				deletedSlotArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.Slot,
+			)
 
 			spentAtCases = append(
 				spentAtCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx, spend.SpentByTxHash)
+			spentAtArgs = append(
+				spentAtArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.SpentByTxHash,
+			)
 
 			whereConditions = append(
 				whereConditions,
 				"(tx_id = ? AND output_idx = ?)",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx)
+			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
 		}
+		args := make([]any, 0, len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs))
+		args = append(args, deletedSlotArgs...)
+		args = append(args, spentAtArgs...)
+		args = append(args, whereArgs...)
 		sql := fmt.Sprintf(
 			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND (%s)",
 			strings.Join(deletedSlotCases, " "),

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -282,26 +282,42 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 		var deletedSlotCases []string
 		var spentAtCases []string
 		var whereConditions []string
-		args := make([]any, 0, len(chunk)*8)
+		var deletedSlotArgs []any
+		var spentAtArgs []any
+		var whereArgs []any
 		for _, spend := range chunk {
 			deletedSlotCases = append(
 				deletedSlotCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx, spend.Slot)
+			deletedSlotArgs = append(
+				deletedSlotArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.Slot,
+			)
 
 			spentAtCases = append(
 				spentAtCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx, spend.SpentByTxHash)
+			spentAtArgs = append(
+				spentAtArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.SpentByTxHash,
+			)
 
 			whereConditions = append(
 				whereConditions,
 				"(tx_id = ? AND output_idx = ?)",
 			)
-			args = append(args, spend.TxId, spend.OutputIdx)
+			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
 		}
+		args := make([]any, 0, len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs))
+		args = append(args, deletedSlotArgs...)
+		args = append(args, spentAtArgs...)
+		args = append(args, whereArgs...)
 		sql := fmt.Sprintf(
 			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND (%s)",
 			strings.Join(deletedSlotCases, " "),

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -133,4 +134,138 @@ func TestBatchAccumulator_AddAndReset(t *testing.T) {
 	})
 	assert.Len(t, ba.KeyWitnesses, 1)
 	assert.Equal(t, []byte{0xff}, ba.KeyWitnesses[0].Vkey)
+}
+
+func TestFlushBatch_Witnesses(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	batch := NewBatchAccumulator()
+
+	for i := uint(1); i <= 5; i++ {
+		batch.AddKeyWitness(models.KeyWitness{
+			TransactionID: i,
+			Type:          models.KeyWitnessTypeVkey,
+			Vkey:          []byte{byte(i)},
+			Signature:     []byte{byte(i + 10)},
+		})
+	}
+
+	require.NoError(t, store.FlushBatch(batch, nil))
+
+	var count int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.KeyWitness{}).Count(&count).Error,
+	)
+	assert.Equal(t, int64(5), count)
+}
+
+func TestFlushBatch_UtxoOutputsAndSpends(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	batch := NewBatchAccumulator()
+
+	// Use exactly 32-byte hashes to match the column's size:32 annotation.
+	txID := bytes.Repeat([]byte{0xAA}, 32)
+	spentBy := bytes.Repeat([]byte{0xBB}, 32)
+
+	// spent_at_tx_id references transactions.hash (FK enforced in SQLite).
+	// Create the spending transaction first so the FK constraint is satisfied.
+	spenderTx := models.Transaction{Hash: spentBy, Slot: 120, Valid: true}
+	require.NoError(t, store.DB().Create(&spenderTx).Error)
+
+	batch.AddUtxoOutput(models.Utxo{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 100,
+		Amount:    10,
+	})
+	batch.AddUtxoOutput(models.Utxo{
+		TxId:      txID,
+		OutputIdx: 1,
+		AddedSlot: 100,
+		Amount:    20,
+	})
+	batch.AddUtxoSpend(utxoSpend{
+		TxId:          txID,
+		OutputIdx:     1,
+		Slot:          120,
+		SpentByTxHash: spentBy,
+	})
+
+	require.NoError(t, store.FlushBatch(batch, nil))
+
+	var outputs []models.Utxo
+	require.NoError(
+		t,
+		store.DB().Order("output_idx ASC").
+			Where("tx_id = ?", txID).
+			Find(&outputs).Error,
+	)
+	require.Len(t, outputs, 2)
+	assert.Equal(t, uint64(0), outputs[0].DeletedSlot)
+	assert.Empty(t, outputs[0].SpentAtTxId)
+	assert.Equal(t, uint64(120), outputs[1].DeletedSlot)
+	assert.Equal(t, spentBy, outputs[1].SpentAtTxId)
+}
+
+func TestFlushBatch_Idempotent(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	batch := NewBatchAccumulator()
+
+	txID := uint(77)
+	batch.AddDeleteTxID(txID)
+	batch.AddKeyWitness(models.KeyWitness{
+		TransactionID: txID,
+		Type:          models.KeyWitnessTypeVkey,
+		Vkey:          []byte{0xaa},
+		Signature:     []byte{0xbb},
+	})
+	batch.AddAddressTx(models.AddressTransaction{
+		TransactionID: txID,
+		PaymentKey:    []byte{0x01, 0x02},
+		Slot:          300,
+		TxIndex:       4,
+	})
+	batch.AddScript(models.Script{
+		Hash:        []byte("script-hash-000000000000000001"),
+		Content:     []byte{0x10, 0x11},
+		CreatedSlot: 300,
+		Type:        1,
+	})
+	batch.AddUtxoOutput(models.Utxo{
+		TxId:      []byte("utxo-hash-000000000000000000000001"),
+		OutputIdx: 0,
+		AddedSlot: 300,
+		Amount:    50,
+	})
+
+	require.NoError(t, store.FlushBatch(batch, nil))
+	require.NoError(t, store.FlushBatch(batch, nil))
+
+	var witnessCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.KeyWitness{}).Count(&witnessCount).Error,
+	)
+	assert.Equal(t, int64(1), witnessCount)
+
+	var addrCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.AddressTransaction{}).Count(&addrCount).Error,
+	)
+	assert.Equal(t, int64(1), addrCount)
+
+	var scriptCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Script{}).Count(&scriptCount).Error,
+	)
+	assert.Equal(t, int64(1), scriptCount)
+
+	var utxoCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Utxo{}).Count(&utxoCount).Error,
+	)
+	assert.Equal(t, int64(1), utxoCount)
 }

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -207,6 +207,73 @@ func TestFlushBatch_UtxoOutputsAndSpends(t *testing.T) {
 	assert.Equal(t, spentBy, outputs[1].SpentAtTxId)
 }
 
+func TestFlushBatch_MultipleSpends(t *testing.T) {
+	// This test specifically guards against the args-ordering bug in
+	// batchSpendUtxos: with N>1 spends the SQL has three separate CASE
+	// sections whose bindings must be grouped (all deletedSlot args, then
+	// all spentAt args, then all WHERE args), not interleaved per-spend.
+	store := setupTestDBWithMode(t, "api")
+	batch := NewBatchAccumulator()
+
+	txID1 := bytes.Repeat([]byte{0x11}, 32)
+	txID2 := bytes.Repeat([]byte{0x22}, 32)
+	spentBy1 := bytes.Repeat([]byte{0xA1}, 32)
+	spentBy2 := bytes.Repeat([]byte{0xA2}, 32)
+
+	// Pre-insert spending transactions to satisfy the FK constraint.
+	require.NoError(
+		t,
+		store.DB().Create(
+			&models.Transaction{Hash: spentBy1, Slot: 200, Valid: true},
+		).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Create(
+			&models.Transaction{Hash: spentBy2, Slot: 201, Valid: true},
+		).Error,
+	)
+
+	// Two outputs from two different tx hashes.
+	batch.AddUtxoOutput(
+		models.Utxo{TxId: txID1, OutputIdx: 0, AddedSlot: 100, Amount: 1},
+	)
+	batch.AddUtxoOutput(
+		models.Utxo{TxId: txID2, OutputIdx: 0, AddedSlot: 100, Amount: 2},
+	)
+	// Spend both, with deliberately different slots and spentBy hashes.
+	batch.AddUtxoSpend(utxoSpend{
+		TxId:          txID1,
+		OutputIdx:     0,
+		Slot:          200,
+		SpentByTxHash: spentBy1,
+	})
+	batch.AddUtxoSpend(utxoSpend{
+		TxId:          txID2,
+		OutputIdx:     0,
+		Slot:          201,
+		SpentByTxHash: spentBy2,
+	})
+
+	require.NoError(t, store.FlushBatch(batch, nil))
+
+	var u1, u2 models.Utxo
+	require.NoError(
+		t,
+		store.DB().Where("tx_id = ? AND output_idx = 0", txID1).First(&u1).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Where("tx_id = ? AND output_idx = 0", txID2).First(&u2).Error,
+	)
+
+	// Each UTxO must carry its own slot and spentBy — wrong if args were interleaved.
+	assert.Equal(t, uint64(200), u1.DeletedSlot)
+	assert.Equal(t, spentBy1, u1.SpentAtTxId)
+	assert.Equal(t, uint64(201), u2.DeletedSlot)
+	assert.Equal(t, spentBy2, u2.SpentAtTxId)
+}
+
 func TestFlushBatch_Idempotent(t *testing.T) {
 	store := setupTestDBWithMode(t, "api")
 	batch := NewBatchAccumulator()
@@ -226,13 +293,13 @@ func TestFlushBatch_Idempotent(t *testing.T) {
 		TxIndex:       4,
 	})
 	batch.AddScript(models.Script{
-		Hash:        []byte("script-hash-000000000000000001"),
+		Hash:        bytes.Repeat([]byte{0xCC}, 28),
 		Content:     []byte{0x10, 0x11},
 		CreatedSlot: 300,
 		Type:        1,
 	})
 	batch.AddUtxoOutput(models.Utxo{
-		TxId:      []byte("utxo-hash-000000000000000000000001"),
+		TxId:      bytes.Repeat([]byte{0xDD}, 32),
 		OutputIdx: 0,
 		AddedSlot: 300,
 		Amount:    50,


### PR DESCRIPTION
closes #1798 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced batch processing capability for transaction metadata across supported databases, enabling more efficient handling of multiple transactions simultaneously with conflict resolution and atomic operations.

* **Tests**
  * Added comprehensive test coverage for batch metadata operations, including persistence verification and idempotency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FlushBatch to the metadata stores for SQLite, Postgres, and MySQL to batch metadata writes and UTXO updates. This reduces DB round-trips and makes bulk ingestion faster and idempotent.

- New Features
  - Added `FlushBatch` with a `BatchAccumulator` for SQLite, Postgres, and MySQL to collect rows across transactions.
  - Deterministic write order: delete by `transaction_id` → insert UTXOs/collateral returns → mark UTXO spends → insert witnesses, scripts, Plutus data, redeemers, and address-tx links.
  - Uses `gorm` batch inserts (`CreateInBatches`) with conflict handling: DoNothing for UTXOs (`tx_id`,`output_idx`) and Scripts (`hash`).
  - UTXO spend updates use a single CASE-based UPDATE to set `deleted_slot` and `spent_at_tx_id` when not already deleted.
  - Supports optional external transaction via `types.Txn`, otherwise wraps in a DB transaction.
  - Idempotent retries via `DeleteTxIDs` cleanup before inserts.
  - Added SQLite tests for witnesses, UTXO outputs/spends (including multi-spend ordering), and idempotency.

- Performance
  - Fewer queries through chunked batch inserts and bulk UPDATEs.
  - Predictable sequencing minimizes lock contention and duplicate conflicts.

<sup>Written for commit 696f24332a05a9b401340c973728eea4dafcdc9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

