### PR TITLE
fix: repair missing drep rows during vote replay

### DIFF
--- a/database/drep.go
+++ b/database/drep.go
@@ -87,6 +87,47 @@ func (d *Database) GetActiveDreps(
 	return d.metadata.GetActiveDreps(txn.Metadata())
 }
 
+// InsertDrepIfAbsent inserts a minimal DRep row when no record exists
+// for the given credential. Existing rows are left untouched so real
+// registration metadata (added_slot, anchor_url, anchor_hash, active)
+// is never overwritten by the vote-replay recovery path.
+func (d *Database) InsertDrepIfAbsent(
+	cred []byte,
+	slot uint64,
+	url string,
+	hash []byte,
+	active bool,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.InsertDrepIfAbsent(
+		cred,
+		slot,
+		url,
+		hash,
+		active,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("failed to insert DRep if absent: %w", err)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return nil
+}
+
 // GetDRepVotingPower calculates the voting power for a DRep by summing
 // the current stake of all delegated accounts, approximated from live
 // UTxO balance plus reward-account balance.

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -97,6 +97,35 @@ func (d *MetadataStoreMysql) SetDrep(
 	return nil
 }
 
+// InsertDrepIfAbsent inserts a DRep row only when no record exists for
+// the given credential. Existing rows are left untouched so the repair
+// path cannot clobber real registration metadata.
+func (d *MetadataStoreMysql) InsertDrepIfAbsent(
+	cred []byte,
+	slot uint64,
+	url string,
+	hash []byte,
+	active bool,
+	txn types.Txn,
+) error {
+	tmpItem := models.Drep{
+		Credential: cred,
+		AddedSlot:  slot,
+		AnchorURL:  url,
+		AnchorHash: hash,
+		Active:     active,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
 // GetDRepVotingPower calculates the voting power for a DRep by summing the
 // current stake of all accounts delegated to it, including live UTxO balance
 // plus reward-account balance.

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -97,6 +97,35 @@ func (d *MetadataStorePostgres) SetDrep(
 	return nil
 }
 
+// InsertDrepIfAbsent inserts a DRep row only when no record exists for
+// the given credential. Existing rows are left untouched so the repair
+// path cannot clobber real registration metadata.
+func (d *MetadataStorePostgres) InsertDrepIfAbsent(
+	cred []byte,
+	slot uint64,
+	url string,
+	hash []byte,
+	active bool,
+	txn types.Txn,
+) error {
+	tmpItem := models.Drep{
+		Credential: cred,
+		AddedSlot:  slot,
+		AnchorURL:  url,
+		AnchorHash: hash,
+		Active:     active,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
 // GetDRepVotingPower calculates the voting power for a DRep by summing the
 // current stake of all accounts delegated to it, including live UTxO balance
 // plus reward-account balance.

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -399,6 +399,35 @@ func (d *MetadataStoreSqlite) SetDrep(
 	return nil
 }
 
+// InsertDrepIfAbsent inserts a DRep row only when no record exists for
+// the given credential. Existing rows are left untouched so the repair
+// path cannot clobber real registration metadata.
+func (d *MetadataStoreSqlite) InsertDrepIfAbsent(
+	cred []byte,
+	slot uint64,
+	url string,
+	hash []byte,
+	active bool,
+	txn types.Txn,
+) error {
+	tmpItem := models.Drep{
+		Credential: cred,
+		AddedSlot:  slot,
+		AnchorURL:  url,
+		AnchorHash: hash,
+		Active:     active,
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&tmpItem); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
 // GetDRepVotingPower calculates the voting power for a DRep by summing the
 // current stake of all accounts delegated to it, including live UTxO balance
 // plus reward-account balance.

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -145,3 +145,48 @@ func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1200), powers[string(drepCred)])
 }
+
+func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {
+	store := setupTestStore(t)
+
+	cred := []byte("drep_insert_absent_1234567890123456789012")
+	require.NoError(
+		t,
+		store.InsertDrepIfAbsent(cred, 1500, "", nil, true, nil),
+	)
+
+	drep, err := store.GetDrep(cred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, drep)
+	assert.True(t, drep.Active)
+	assert.Equal(t, uint64(1500), drep.AddedSlot)
+	assert.Equal(t, "", drep.AnchorURL)
+	assert.Nil(t, drep.AnchorHash)
+}
+
+func TestSqliteInsertDrepIfAbsentLeavesExistingRowUntouched(t *testing.T) {
+	store := setupTestStore(t)
+
+	cred := []byte("drep_insert_absent_2234567890123456789012")
+	anchorURL := "https://drep.example.com/metadata"
+	anchorHash := []byte("anchor_hash_1234567890123456789012345678")
+	require.NoError(
+		t,
+		store.SetDrep(cred, 1000, anchorURL, anchorHash, true, nil),
+	)
+
+	// Attempt repair with placeholder values at a later slot — must be a no-op.
+	require.NoError(
+		t,
+		store.InsertDrepIfAbsent(cred, 9999, "", nil, true, nil),
+	)
+
+	drep, err := store.GetDrep(cred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, drep)
+	assert.Equal(t, uint64(1000), drep.AddedSlot)
+	assert.Equal(t, anchorURL, drep.AnchorURL)
+	assert.Equal(t, anchorHash, drep.AnchorHash)
+	assert.True(t, drep.Active)
+}
+

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -772,6 +772,21 @@ type MetadataStore interface {
 
 	// DRep voting power and activity methods
 
+	// InsertDrepIfAbsent inserts a minimal DRep row when no record
+	// exists for the given credential. If a row already exists, it is
+	// left untouched: added_slot, anchor_url, anchor_hash, and active
+	// are never overwritten. Used on the vote-replay recovery path to
+	// recreate rows lost during recovery/bootstrap without clobbering
+	// real registration metadata.
+	InsertDrepIfAbsent(
+		cred []byte,
+		slot uint64,
+		url string,
+		hash []byte,
+		active bool,
+		txn types.Txn,
+	) error
+
 	// GetDRepVotingPower calculates the voting power for a DRep by summing
 	// the current stake of all delegated accounts, approximated from live
 	// UTxO balance plus reward-account balance.

--- a/ledger/governance/processing.go
+++ b/ledger/governance/processing.go
@@ -15,6 +15,8 @@
 package governance
 
 import (
+	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -178,12 +180,51 @@ func ProcessVotes(
 		if voterType == models.VoterTypeDRep {
 			credKey := string(voter.Hash[:])
 			if !drepActivityUpdated[credKey] {
-				if err := db.UpdateDRepActivity(
+				err := db.UpdateDRepActivity(
 					voter.Hash[:],
 					currentEpoch,
 					drepInactivityPeriod,
 					txn,
-				); err != nil {
+				)
+				if errors.Is(err, models.ErrDrepActivityNotUpdated) {
+					// A valid DRep vote proves the credential exists on-chain.
+					// If metadata lost the DRep row during recovery/bootstrap,
+					// recreate a minimal active record so replay can continue.
+					// InsertDrepIfAbsent never overwrites an existing row, so
+					// any real registration metadata (added_slot, anchor_url,
+					// anchor_hash, active) is preserved and rollback semantics
+					// in RestoreDrepStateAtSlot remain intact.
+					if setErr := db.InsertDrepIfAbsent(
+						voter.Hash[:],
+						point.Slot,
+						"",
+						nil,
+						true,
+						txn,
+					); setErr != nil {
+						return fmt.Errorf(
+							"repair missing drep in tx %s: %w",
+							txHashForLog,
+							setErr,
+						)
+					}
+					if logger := db.Logger(); logger != nil {
+						logger.Warn(
+							"recreated missing drep record during vote replay",
+							"tx_hash", txHashForLog,
+							"drep_hash", hex.EncodeToString(voter.Hash[:]),
+							"slot", point.Slot,
+							"component", "governance",
+						)
+					}
+					err = db.UpdateDRepActivity(
+						voter.Hash[:],
+						currentEpoch,
+						drepInactivityPeriod,
+						txn,
+					)
+				}
+				if err != nil {
 					return fmt.Errorf(
 						"update drep activity in tx %s: %w",
 						txHashForLog,

--- a/ledger/governance/processing_test.go
+++ b/ledger/governance/processing_test.go
@@ -15,14 +15,32 @@
 package governance
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/database/models"
 )
+
+func testHash32(seed string) []byte {
+	hash := make([]byte, 32)
+	copy(hash, []byte(seed))
+	return hash
+}
+
+func testHash28(seed string) []byte {
+	hash := make([]byte, 28)
+	copy(hash, []byte(seed))
+	return hash
+}
 
 func TestMapVoterType(t *testing.T) {
 	tests := []struct {
@@ -232,4 +250,85 @@ func TestExtractGovActionInfo_Info(t *testing.T) {
 	assert.Nil(t, parentTxHash)
 	assert.Nil(t, parentActionIdx)
 	assert.Nil(t, policyHash)
+}
+
+func TestProcessVotesRepairsMissingDRepRow(t *testing.T) {
+	db, err := database.New(&database.Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	proposalTxHash := testHash32("proposal")
+	returnAddress := append([]byte{0xE1}, testHash28("reward-account")...)
+	require.NoError(
+		t,
+		db.SetGovernanceProposal(&models.GovernanceProposal{
+			TxHash:        proposalTxHash,
+			ActionIndex:   0,
+			ActionType:    uint8(lcommon.GovActionTypeInfo),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  120,
+			AnchorURL:     "https://example.com/proposal",
+			AnchorHash:    testHash32("proposal-anchor"),
+			Deposit:       1,
+			ReturnAddress: returnAddress,
+			AddedSlot:     1000,
+		}, nil),
+	)
+	proposal, err := db.GetGovernanceProposal(proposalTxHash, 0, nil)
+	require.NoError(t, err)
+
+	drepCred := testHash28("drep-voter")
+	var voterHash [28]byte
+	copy(voterHash[:], drepCred)
+	var actionTxHash [32]byte
+	copy(actionTxHash[:], proposalTxHash)
+	voter := &lcommon.Voter{
+		Type: lcommon.VoterTypeDRepKeyHash,
+		Hash: voterHash,
+	}
+	actionID := &lcommon.GovActionId{
+		TransactionId: actionTxHash,
+		GovActionIdx:  0,
+	}
+	tx := mockledger.NewTransactionBuilder().
+		WithVotingProcedures(lcommon.VotingProcedures{
+			voter: {
+				actionID: {Vote: models.VoteYes},
+			},
+		})
+	tx.WithId(testHash32("vote-tx"))
+	point := ocommon.Point{
+		Slot: 2000,
+		Hash: testHash32("vote-block"),
+	}
+
+	txn := db.Transaction(true)
+	defer txn.Release()
+	require.NoError(
+		t,
+		txn.Do(func(txn *database.Txn) error {
+			return ProcessVotes(tx, point, 100, 20, db, txn)
+		}),
+	)
+
+	drep, err := db.GetDrep(drepCred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, drep)
+	assert.True(t, drep.Active)
+	assert.Equal(t, point.Slot, drep.AddedSlot)
+	assert.Equal(t, uint64(100), drep.LastActivityEpoch)
+	assert.Equal(t, uint64(120), drep.ExpiryEpoch)
+
+	votes, err := db.GetGovernanceVotes(proposal.ID, nil)
+	require.NoError(t, err)
+	require.Len(t, votes, 1)
+	assert.Equal(t, uint8(models.VoterTypeDRep), votes[0].VoterType)
+	assert.Equal(t, drepCred, votes[0].VoterCredential)
+	assert.Equal(t, uint8(models.VoteYes), votes[0].Vote)
+	assert.Equal(t, point.Slot, votes[0].AddedSlot)
 }


### PR DESCRIPTION
Closes #2026 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically repairs missing DRep rows during vote replay by inserting a minimal record only if absent and then updating activity, so replay continues and DRep activity/expiry remain correct.

- **Bug Fixes**
  - On `models.ErrDrepActivityNotUpdated`, call `database.InsertDrepIfAbsent` with the vote slot, retry `UpdateDRepActivity`, and log a warning with `tx_hash`, `drep_hash`, and `slot`.
  - Added `InsertDrepIfAbsent` to `database` and the `MetadataStore` (MySQL/Postgres/SQLite) with conflict-safe inserts; added tests for no-op on existing rows and end-to-end replay repair.

<sup>Written for commit 72de23230c1e76ec035f637701e2c4e65a3dcc14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DRep records can now be created if missing and will not overwrite existing entries, improving metadata resilience.
  * Vote processing automatically repairs and activates missing DRep records during processing to avoid failures.

* **Tests**
  * Added end-to-end and unit tests validating DRep recovery during governance vote processing and ensuring correct vote persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->