### PR TITLE
fix: repair mithril snapshot bootstrap correctness and resume handling

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -367,6 +367,7 @@ type RawBlock struct {
 func (c *Chain) addRawBlockLocked(
 	rb RawBlock,
 	txn *database.Txn,
+	callback func(RawBlock, *database.Txn) error,
 ) (event.Event, error) {
 	// Validate hash fields before any comparisons
 	if len(rb.Hash) == 0 {
@@ -417,6 +418,11 @@ func (c *Chain) addRawBlockLocked(
 	if err := c.manager.addBlock(tmpBlock, txn, c.persistent); err != nil {
 		return event.Event{}, fmt.Errorf("persisting block: %w", err)
 	}
+	if callback != nil {
+		if err := callback(rb, txn); err != nil {
+			return event.Event{}, err
+		}
+	}
 	if !c.persistent {
 		c.blocks = append(c.blocks, tmpPoint)
 	}
@@ -444,6 +450,39 @@ func (c *Chain) addRawBlockLocked(
 
 // AddRawBlocks adds a batch of pre-extracted blocks to the chain.
 func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
+	return c.addRawBlocks(blocks, nil)
+}
+
+// AddRawBlocksWithCallback adds a batch of pre-extracted blocks to the chain
+// and runs the callback in the same transaction after each block is persisted.
+// Callers can use this to atomically attach additional blob-side state, such as
+// offset indexes, without reopening the immutable DB on resume.
+//
+// The callback executes with c.mutex and c.manager.mutex locked, inside the
+// active blob transaction, and BEFORE c.currentTip / c.tipBlockIndex are
+// updated for the just-persisted block. As a result:
+//   - The callback must not call back into Chain or ChainManager methods that
+//     acquire those same locks (e.g., c.Tip(), c.HeaderTip(),
+//     c.BlockByPoint()) — doing so will deadlock.
+//   - Tip-state observed via fields read under those locks reflects the
+//     pre-update tip, not the block being added.
+//
+// Error semantics: a callback error aborts the entire current batch, not just
+// the offending block. addRawBlocks drives the loop inside txn.Do, which rolls
+// back every block persisted by that transaction when the callback returns
+// non-nil. Callers should make per-batch decisions idempotent so a retry on a
+// later batch does not duplicate effects from a partial earlier attempt.
+func (c *Chain) AddRawBlocksWithCallback(
+	blocks []RawBlock,
+	callback func(RawBlock, *database.Txn) error,
+) error {
+	return c.addRawBlocks(blocks, callback)
+}
+
+func (c *Chain) addRawBlocks(
+	blocks []RawBlock,
+	callback func(RawBlock, *database.Txn) error,
+) error {
 	if c == nil {
 		return errors.New("chain is nil")
 	}
@@ -458,7 +497,23 @@ func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
 		// successfully.
 		pendingEvents := make([]event.Event, 0, batchSize)
 		txn := c.manager.db.BlobTxn(true)
+		// addRawBlockLocked mutates c.currentTip, c.tipBlockIndex,
+		// c.headers, and c.blocks before the txn commits. If a
+		// later block in the batch fails the closure restores the
+		// pre-batch state, but txn.Do also runs Commit *after* the
+		// closure returns and after the chain locks are released —
+		// a Commit failure rolls back the persistent state while
+		// leaving the in-memory chain advanced. Capture the
+		// snapshot here so we can also restore on Commit failure.
+		var (
+			snapshotTaken      bool
+			savedTip           ochainsync.Tip
+			savedTipBlockIndex uint64
+			savedHeaders       []queuedHeader
+			savedBlocks        []ocommon.Point
+		)
 		err := txn.Do(func(txn *database.Txn) error {
+			batch := blocks[batchOffset : batchOffset+batchSize]
 			c.mutex.Lock()
 			defer c.mutex.Unlock()
 			c.manager.mutex.Lock()
@@ -466,9 +521,26 @@ func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
 			if err := c.reconcile(); err != nil {
 				return fmt.Errorf("reconcile: %w", err)
 			}
-			for _, rb := range blocks[batchOffset : batchOffset+batchSize] {
-				evt, err := c.addRawBlockLocked(rb, txn)
+			savedTip = c.currentTip
+			savedTipBlockIndex = c.tipBlockIndex
+			savedHeaders = slices.Clone(c.headers)
+			if !c.persistent {
+				savedBlocks = slices.Clone(c.blocks)
+			}
+			snapshotTaken = true
+			for _, rb := range batch {
+				evt, err := c.addRawBlockLocked(
+					rb,
+					txn,
+					callback,
+				)
 				if err != nil {
+					c.currentTip = savedTip
+					c.tipBlockIndex = savedTipBlockIndex
+					c.headers = savedHeaders
+					if !c.persistent {
+						c.blocks = savedBlocks
+					}
 					return err
 				}
 				if evt.Type != "" {
@@ -480,6 +552,24 @@ func (c *Chain) AddRawBlocks(blocks []RawBlock) error {
 			return nil
 		})
 		if err != nil {
+			// Cover the Commit-failure path: closure returned nil
+			// but txn.Do's later Commit failed, so memory still
+			// reflects the post-batch tip while the DB rolled
+			// back. Re-acquire the locks and restore. Restoring
+			// after a closure-internal error path is a safe no-op
+			// because the closure already wrote the same values.
+			if snapshotTaken {
+				c.mutex.Lock()
+				c.manager.mutex.Lock()
+				c.currentTip = savedTip
+				c.tipBlockIndex = savedTipBlockIndex
+				c.headers = savedHeaders
+				if !c.persistent {
+					c.blocks = savedBlocks
+				}
+				c.manager.mutex.Unlock()
+				c.mutex.Unlock()
+			}
 			return fmt.Errorf("add raw block batch: %w", err)
 		}
 		c.notifyWaitingIterators()

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -31,17 +31,17 @@ import (
 	dingo "github.com/blinklabs-io/dingo"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
-	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/governance"
 	"github.com/blinklabs-io/dingo/ledgerstate"
 	"github.com/blinklabs-io/dingo/mithril"
 	ouroboros "github.com/blinklabs-io/gouroboros"
-	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -352,6 +352,28 @@ func runMithrilSync(
 	if err := db.SetSyncState("sync_status", "in_progress", nil); err != nil {
 		return fmt.Errorf("marking sync in-progress: %w", err)
 	}
+
+	// For API mode, mark an incomplete backfill checkpoint BEFORE any
+	// blob writes. If the process dies between writing blocks and
+	// node.Backfill.Run() creating its own initial checkpoint, the next
+	// startup would see blocks but no checkpoint and skip the backfill.
+	// Pre-seeding the checkpoint here ensures NeedsBackfill() returns
+	// the correct answer at any interruption point.
+	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
+		now := time.Now()
+		if err := db.Metadata().SetBackfillCheckpoint(
+			&models.BackfillCheckpoint{
+				Phase:     node.BackfillPhase,
+				StartedAt: now,
+				UpdatedAt: now,
+			},
+			nil,
+		); err != nil {
+			return fmt.Errorf(
+				"marking backfill in-progress: %w", err,
+			)
+		}
+	}
 	// On error, log a message guiding the user to re-run.
 	syncComplete := false
 	defer func() {
@@ -409,24 +431,6 @@ func runMithrilSync(
 		return err
 	}
 
-	// Post-process ImmutableDB blocks to compute UTxO byte
-	// offsets. The ImmutableDB load (copyBlocksRaw) only stores
-	// block CBOR and header metadata. This step re-reads the
-	// ImmutableDB files, extracts transaction output byte ranges,
-	// and stores offset references in the blob store so that
-	// UtxoByRef() can extract UTxO CBOR on-demand from blocks.
-	logger.Info(
-		"post-processing UTxO offsets from ImmutableDB",
-		"component", "mithril",
-	)
-	if err := postProcessUtxoOffsets(
-		ctx, db, logger, result.ImmutableDir,
-	); err != nil {
-		return fmt.Errorf(
-			"post-processing UTxO offsets: %w", err,
-		)
-	}
-
 	// Fetch volatile blocks between the ImmutableDB tip and the
 	// ledger state tip. The Mithril snapshot's UTxO set is at the
 	// ledger state tip, but the ImmutableDB only has blocks up to
@@ -435,6 +439,166 @@ func runMithrilSync(
 	recentBlocks, err := database.BlocksRecent(db, 1)
 	if err != nil {
 		return fmt.Errorf("reading chain tip: %w", err)
+	}
+	immutableTipSlot := uint64(0)
+	if loadResult != nil {
+		immutableTipSlot = loadResult.ImmutableTipSlot
+	}
+	// When the snapshot's ledger state lands exactly on an immutable
+	// boundary, there is no gap to fill — but stale volatile blocks
+	// from a prior run can still sit above it. Drop them now so the
+	// trust boundary below lands on ledgerStateSlot instead of the
+	// stale block slot.
+	if len(recentBlocks) > 0 &&
+		recentBlocks[0].Slot > immutableTipSlot &&
+		immutableTipSlot == ledgerStateSlot {
+		logger.Info(
+			"removing stale volatile blocks above ledger state tip",
+			"component", "mithril",
+			"stored_tip_slot", recentBlocks[0].Slot,
+			"ledger_state_slot", ledgerStateSlot,
+		)
+		if cleanupErr := deleteBlobBlocksAboveSlot(
+			db, immutableTipSlot,
+		); cleanupErr != nil {
+			return fmt.Errorf(
+				"removing stale volatile blocks above slot %d: %w",
+				immutableTipSlot, cleanupErr,
+			)
+		}
+		recentBlocks, err = database.BlocksRecent(db, 1)
+		if err != nil {
+			return fmt.Errorf(
+				"reading chain tip after stale volatile cleanup: %w",
+				err,
+			)
+		}
+	}
+	if len(recentBlocks) > 0 &&
+		recentBlocks[0].Slot > immutableTipSlot &&
+		immutableTipSlot < ledgerStateSlot {
+		resumeGapEnd := min(recentBlocks[0].Slot, ledgerStateSlot)
+		logger.Info(
+			"processing stored volatile gap blocks from blob store",
+			"component", "mithril",
+			"immutable_tip_slot", immutableTipSlot,
+			"stored_tip_slot", recentBlocks[0].Slot,
+			"resume_gap_end_slot", resumeGapEnd,
+		)
+		storedGapBlocks, err := loadGapBlocksFromBlob(
+			db,
+			immutableTipSlot+1,
+			resumeGapEnd,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"loading stored gap blocks from blob store: %w",
+				err,
+			)
+		}
+		immutableTip, err := database.BlockBeforeSlot(
+			db,
+			immutableTipSlot+1,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"reading immutable tip for stored gap validation: %w",
+				err,
+			)
+		}
+		if immutableTip.Slot != immutableTipSlot {
+			return fmt.Errorf(
+				"reading immutable tip for stored gap validation: expected slot %d, got slot %d",
+				immutableTipSlot,
+				immutableTip.Slot,
+			)
+		}
+		// Only enforce the terminal-hash check against ledgerStateHash
+		// when the stored gap reaches the ledger state tip. A partial
+		// stored gap is still useful: continuity-validate it and let
+		// the volatile fetch path below pull the remainder.
+		var validateErr error
+		if resumeGapEnd == ledgerStateSlot {
+			validateErr = validateStoredGapBlocks(
+				storedGapBlocks,
+				immutableTip,
+				ledgerStateHash,
+			)
+		} else {
+			validateErr = validateStoredGapContinuity(
+				storedGapBlocks,
+				immutableTip,
+			)
+		}
+		if validateErr != nil {
+			logger.Warn(
+				"stored volatile gap blocks failed continuity check, refetching from relay",
+				"component", "mithril",
+				"immutable_tip_slot", immutableTipSlot,
+				"resume_gap_end_slot", resumeGapEnd,
+				"ledger_state_slot", ledgerStateSlot,
+				"ledger_state_hash", hex.EncodeToString(ledgerStateHash),
+				"error", validateErr,
+			)
+			// Drop the rejected blob blocks so neither the upcoming
+			// BlocksRecent query nor any slot-ordered iterator can
+			// resurface them as the chain tip after the relay refetch.
+			if cleanupErr := deleteBlobBlocksAboveSlot(
+				db, immutableTipSlot,
+			); cleanupErr != nil {
+				return fmt.Errorf(
+					"removing rejected gap blocks above slot %d: %w",
+					immutableTipSlot, cleanupErr,
+				)
+			}
+			recentBlocks = []models.Block{immutableTip}
+		} else {
+			storedTipSlot := recentBlocks[0].Slot
+			if storedTipSlot > resumeGapEnd {
+				logger.Info(
+					"removing stored volatile blocks beyond ledger state tip",
+					"component", "mithril",
+					"stored_tip_slot", storedTipSlot,
+					"resume_gap_end_slot", resumeGapEnd,
+				)
+				if cleanupErr := deleteBlobBlocksAboveSlot(
+					db, resumeGapEnd,
+				); cleanupErr != nil {
+					return fmt.Errorf(
+						"removing stored gap blocks above slot %d: %w",
+						resumeGapEnd,
+						cleanupErr,
+					)
+				}
+			}
+			if resumeGapEnd < ledgerStateSlot {
+				logger.Info(
+					"accepted partial stored volatile gap; remainder will be fetched from relay",
+					"component", "mithril",
+					"immutable_tip_slot", immutableTipSlot,
+					"resume_gap_end_slot", resumeGapEnd,
+					"ledger_state_slot", ledgerStateSlot,
+				)
+			}
+			if err := processGapBlocks(
+				ctx,
+				db,
+				logger,
+				storedGapBlocks,
+			); err != nil {
+				return fmt.Errorf(
+					"processing stored gap block transactions: %w",
+					err,
+				)
+			}
+			recentBlocks, err = database.BlocksRecent(db, 1)
+			if err != nil {
+				return fmt.Errorf(
+					"reading chain tip after gap resume: %w",
+					err,
+				)
+			}
+		}
 	}
 	if len(recentBlocks) > 0 && ledgerStateSlot > recentBlocks[0].Slot {
 		immutableTip := recentBlocks[0]
@@ -958,6 +1122,201 @@ func fetchGapBlocksFromPeer(
 	return blocks, nil
 }
 
+// deleteBlobBlocksAboveSlot removes every block from the blob store
+// whose slot is greater than the given threshold AND drops any
+// metadata indexed for those blocks (transactions, UTxOs, governance
+// proposals/votes), and restores any UTxOs that the rejected gap
+// blocks had marked spent. Used to clean up rejected gap blocks from
+// a previous failed Mithril resume so the next BlocksRecent query and
+// any slot-ordered iterator (chainsync replay, etc.) cannot resurface
+// them, and so leftover metadata from the discarded fork cannot
+// shadow the refetched chain.
+func deleteBlobBlocksAboveSlot(
+	db *database.Database,
+	slot uint64,
+) error {
+	if slot == ^uint64(0) {
+		return nil
+	}
+	iter := db.BlocksInRange(slot+1, ^uint64(0))
+	var stale []ocommon.Point
+	for {
+		next, err := iter.NextRaw()
+		if err != nil {
+			iter.Close()
+			return fmt.Errorf(
+				"iterating stale gap blocks above slot %d: %w",
+				slot, err,
+			)
+		}
+		if next == nil {
+			break
+		}
+		stale = append(stale, ocommon.Point{
+			Slot: next.Slot,
+			Hash: append([]byte(nil), next.Hash...),
+		})
+	}
+	iter.Close()
+	if len(stale) == 0 {
+		return nil
+	}
+	txn := db.Transaction(true)
+	return txn.Do(func(txn *database.Txn) error {
+		for _, p := range stale {
+			block, err := database.BlockByPointTxn(txn, p)
+			if err != nil {
+				if errors.Is(err, models.ErrBlockNotFound) {
+					continue
+				}
+				return fmt.Errorf(
+					"lookup stale gap block at slot %d: %w",
+					p.Slot, err,
+				)
+			}
+			if err := database.BlockDeleteTxn(txn, block); err != nil {
+				return fmt.Errorf(
+					"delete stale gap block at slot %d: %w",
+					p.Slot, err,
+				)
+			}
+		}
+		// Drop metadata indexed for the rejected blocks. Without this
+		// the refetched chain would inherit stale UTxO consumption,
+		// duplicate tx records, and orphan governance proposals/votes
+		// from the previous run's gap-block processing.
+		if err := db.UtxosDeleteRolledback(slot, txn); err != nil {
+			return fmt.Errorf(
+				"delete rolled-back UTxOs above slot %d: %w",
+				slot, err,
+			)
+		}
+		if err := db.TransactionsDeleteRolledback(slot, txn); err != nil {
+			return fmt.Errorf(
+				"delete rolled-back transactions above slot %d: %w",
+				slot, err,
+			)
+		}
+		if err := db.UtxosUnspend(slot, txn); err != nil {
+			return fmt.Errorf(
+				"restore UTxOs spent above slot %d: %w",
+				slot, err,
+			)
+		}
+		if err := db.DeleteGovernanceVotesAfterSlot(
+			slot, txn,
+		); err != nil {
+			return fmt.Errorf(
+				"delete rolled-back governance votes above slot %d: %w",
+				slot, err,
+			)
+		}
+		if err := db.DeleteGovernanceProposalsAfterSlot(
+			slot, txn,
+		); err != nil {
+			return fmt.Errorf(
+				"delete rolled-back governance proposals above slot %d: %w",
+				slot, err,
+			)
+		}
+		return nil
+	})
+}
+
+func loadGapBlocksFromBlob(
+	db *database.Database,
+	startSlot uint64,
+	endSlot uint64,
+) ([]models.Block, error) {
+	if startSlot > endSlot {
+		return nil, nil
+	}
+	iter := db.BlocksInRange(startSlot, endSlot)
+	defer iter.Close()
+	var ret []models.Block
+	for {
+		next, err := iter.NextRaw()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"iterate blob blocks in range [%d,%d]: %w",
+				startSlot,
+				endSlot,
+				err,
+			)
+		}
+		if next == nil {
+			break
+		}
+		ret = append(ret, models.Block{
+			Slot:     next.Slot,
+			Hash:     append([]byte(nil), next.Hash...),
+			PrevHash: append([]byte(nil), next.PrevHash...),
+			Cbor:     append([]byte(nil), next.Cbor...),
+			Number:   next.Height,
+			Type:     next.BlockType,
+		})
+	}
+	return ret, nil
+}
+
+// validateStoredGapContinuity verifies the stored gap is non-empty,
+// chains from immutableTip, and is internally hash-linked. It does not
+// check the terminal block hash, so it is safe to use for partial gaps
+// that don't yet reach the ledger state tip.
+func validateStoredGapContinuity(
+	blocks []models.Block,
+	immutableTip models.Block,
+) error {
+	if len(blocks) == 0 {
+		return fmt.Errorf(
+			"stored volatile gap is empty after immutable tip slot %d",
+			immutableTip.Slot,
+		)
+	}
+	if !bytes.Equal(blocks[0].PrevHash, immutableTip.Hash) {
+		return fmt.Errorf(
+			"stored gap first block at slot %d prev hash %x does not match immutable tip slot %d hash %x",
+			blocks[0].Slot,
+			blocks[0].PrevHash,
+			immutableTip.Slot,
+			immutableTip.Hash,
+		)
+	}
+	for i := 1; i < len(blocks); i++ {
+		if bytes.Equal(blocks[i].PrevHash, blocks[i-1].Hash) {
+			continue
+		}
+		return fmt.Errorf(
+			"stored gap block at slot %d prev hash %x does not match previous block slot %d hash %x",
+			blocks[i].Slot,
+			blocks[i].PrevHash,
+			blocks[i-1].Slot,
+			blocks[i-1].Hash,
+		)
+	}
+	return nil
+}
+
+func validateStoredGapBlocks(
+	blocks []models.Block,
+	immutableTip models.Block,
+	ledgerStateHash []byte,
+) error {
+	if err := validateStoredGapContinuity(blocks, immutableTip); err != nil {
+		return err
+	}
+	last := blocks[len(blocks)-1]
+	if !bytes.Equal(last.Hash, ledgerStateHash) {
+		return fmt.Errorf(
+			"stored gap terminal block at slot %d hash %x does not match ledger state hash %x",
+			last.Slot,
+			last.Hash,
+			ledgerStateHash,
+		)
+	}
+	return nil
+}
+
 // processGapBlocks computes byte offsets and stores transaction
 // metadata for gap blocks that were fetched from a relay peer.
 // BlockCreate only writes raw CBOR to the blob store; this function
@@ -969,6 +1328,14 @@ func processGapBlocks(
 	logger *slog.Logger,
 	blocks []models.Block,
 ) error {
+	if len(blocks) == 0 {
+		return nil
+	}
+	epochs, err := db.GetEpochs(nil)
+	if err != nil {
+		return fmt.Errorf("loading epochs for gap blocks: %w", err)
+	}
+	conwayPParamsCache := make(map[uint64]*conway.ConwayProtocolParameters)
 	for _, block := range blocks {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("cancelled: %w", err)
@@ -1004,31 +1371,54 @@ func processGapBlocks(
 			)
 		}
 		point := ocommon.NewPoint(block.Slot, block.Hash)
-		if err := func() error {
-			txn := db.Transaction(true)
-			defer txn.Release()
-			// Gap blocks are already reflected in the Mithril
-			// snapshot's UTxO set, so input UTxOs are already
-			// consumed. Use SetGapBlockTransaction which stores
-			// only blob offsets and the TX record without
-			// attempting to look up or consume inputs.
-			for i, tx := range txs {
-				if err := db.SetGapBlockTransaction(
-					tx, point, uint32(i), // #nosec G115 -- tx index within a block
-					offsets, txn,
-				); err != nil {
+		epoch, err := gapBlockEpoch(epochs, block.Slot)
+		if err != nil {
+			return fmt.Errorf(
+				"resolving epoch for gap block at slot %d: %w",
+				block.Slot,
+				err,
+			)
+		}
+		blockConwayPParams := (*conway.ConwayProtocolParameters)(nil)
+		if epoch.EraId == conway.EraIdConway {
+			cached, ok := conwayPParamsCache[epoch.EpochId]
+			if !ok {
+				pparams, err := db.GetPParams(
+					epoch.EpochId,
+					eras.ConwayEraDesc.DecodePParamsFunc,
+					nil,
+				)
+				if err != nil {
 					return fmt.Errorf(
-						"storing TX: %w", err,
+						"loading protocol parameters for gap block at slot %d (epoch %d): %w",
+						block.Slot,
+						epoch.EpochId,
+						err,
 					)
 				}
+				if pparams != nil {
+					cached, ok = pparams.(*conway.ConwayProtocolParameters)
+					if !ok {
+						return fmt.Errorf(
+							"unexpected protocol params %T for gap block at slot %d (epoch %d)",
+							pparams,
+							block.Slot,
+							epoch.EpochId,
+						)
+					}
+				}
+				conwayPParamsCache[epoch.EpochId] = cached
 			}
-			if err := txn.Commit(); err != nil {
-				return fmt.Errorf(
-					"commit transaction: %w", err,
-				)
-			}
-			return nil
-		}(); err != nil {
+			blockConwayPParams = cached
+		}
+		if err := processGapBlockTransactions(
+			db,
+			point,
+			txs,
+			offsets,
+			epoch.EpochId,
+			blockConwayPParams,
+		); err != nil {
 			return fmt.Errorf(
 				"processing gap block at slot %d: %w",
 				block.Slot, err,
@@ -1044,506 +1434,101 @@ func processGapBlocks(
 	return nil
 }
 
-const txBodyKeyCollateralReturn uint64 = 16
-
-// extractInvalidTxIndices returns the set of transaction indices flagged as
-// script-invalid in the block (blockArray[4] for Alonzo+ blocks). The
-// collateral-return UTxO is produced only for invalid transactions — see
-// gouroboros ConwayTransaction.Produced(). Eras without invalid_transactions
-// (Byron/Shelley/Allegra/Mary) return an empty set.
-func extractInvalidTxIndices(blockCbor []byte) (map[int]struct{}, error) {
-	var blockArray []cbor.RawMessage
-	if _, err := cbor.Decode(blockCbor, &blockArray); err != nil {
-		return nil, err
-	}
-	if len(blockArray) < 5 {
-		return nil, nil
-	}
-	var invalidTxs []uint
-	if _, err := cbor.Decode([]byte(blockArray[4]), &invalidTxs); err != nil {
-		return nil, err
-	}
-	if len(invalidTxs) == 0 {
-		return nil, nil
-	}
-	set := make(map[int]struct{}, len(invalidTxs))
-	for _, idx := range invalidTxs {
-		set[int(idx)] = struct{}{} // #nosec G115 -- gouroboros bounds to 1M
-	}
-	return set, nil
-}
-
-func txBodyMapValueRange(
-	bodyCbor []byte,
-	bodyOffset uint32,
-	key uint64,
-) (uint32, uint32, bool, error) {
-	decoder, err := cbor.NewStreamDecoder(bodyCbor)
-	if err != nil {
-		return 0, 0, false, err
-	}
-	count, _, _, err := decoder.DecodeMapHeader()
-	if err != nil {
-		return 0, 0, false, err
-	}
-	for range count {
-		var currentKey uint64
-		if _, _, err := decoder.Decode(&currentKey); err != nil {
-			return 0, 0, false, err
-		}
-		valueOffset, valueLen, err := decoder.Skip()
-		if err != nil {
-			return 0, 0, false, err
-		}
-		if currentKey != key {
-			continue
-		}
-		valueOffset32, err := checkedUint32(valueOffset)
-		if err != nil {
-			return 0, 0, false, err
-		}
-		valueLen32, err := checkedUint32(valueLen)
-		if err != nil {
-			return 0, 0, false, err
-		}
-		if valueOffset32 > ^uint32(0)-bodyOffset {
-			return 0, 0, false, fmt.Errorf(
-				"value offset %d overflows body offset %d",
-				valueOffset32,
-				bodyOffset,
-			)
-		}
-		return bodyOffset + valueOffset32, valueLen32, true, nil
-	}
-	return 0, 0, false, nil
-}
-
-func checkedUint32(v int) (uint32, error) {
-	if v < 0 {
-		return 0, fmt.Errorf("negative value %d", v)
-	}
-	if uint64(v) > uint64(^uint32(0)) {
-		return 0, fmt.Errorf("value %d overflows uint32", v)
-	}
-	return uint32(v), nil // #nosec G115 -- checked above
-}
-
-// postProcessUtxoOffsets iterates all ImmutableDB blocks and
-// computes byte offset references for every transaction output.
-// This enables UtxoByRef() to extract UTxO CBOR on-demand from
-// the source block stored in the blob store.
-//
-// Fast path (Shelley+): uses ExtractTransactionOffsets for
-// structural CBOR parsing without full block decode, then
-// computes tx hashes via blake2b-256 on body CBOR.
-//
-// Fallback (Byron and other eras): parses the full block via
-// NewBlockFromCbor and locates output CBOR via byte search.
-func postProcessUtxoOffsets(
-	ctx context.Context,
+func processGapBlockTransactions(
 	db *database.Database,
-	logger *slog.Logger,
-	immutableDir string,
+	point ocommon.Point,
+	txs []lcommon.Transaction,
+	offsets *database.BlockIngestionResult,
+	epochId uint64,
+	conwayPParams *conway.ConwayProtocolParameters,
 ) error {
-	blob := db.Blob()
-	if blob == nil {
-		return errors.New("blob store not available")
-	}
-
-	imm, err := immutable.New(immutableDir)
-	if err != nil {
-		return fmt.Errorf(
-			"opening immutable DB: %w", err,
-		)
-	}
-	immutableTip, err := imm.GetTip()
-	if err != nil {
-		return fmt.Errorf(
-			"getting immutable DB tip: %w", err,
-		)
-	}
-	if immutableTip == nil {
-		return errors.New("immutable DB tip is nil")
-	}
-
-	iter, err := imm.BlocksFromPoint(ocommon.Point{})
-	if err != nil {
-		return fmt.Errorf(
-			"getting block iterator: %w", err,
-		)
-	}
-	defer iter.Close()
-
-	const batchBlocks = 50
-	const batchUtxoOffsets = 10000
-	var processedBlocks, totalUtxos int
-	startTime := time.Now()
-	lastProgressLog := time.Time{}
-	lastProgressSlot := uint64(0)
-	txn := db.BlobTxn(true)
-	blocksInBatch := 0
-	utxosInBatch := 0
-	// Deferred rollback ensures the active transaction is cleaned
-	// up if the loop body panics. Rollback after Commit is a no-op
-	// in Badger, so this is safe on the normal path.
-	defer func() { txn.Rollback() }() //nolint:errcheck
-
-	flushTxn := func() error {
-		if err := txn.Commit(); err != nil {
-			return fmt.Errorf(
-				"committing UTxO offsets: %w",
-				err,
-			)
+	txn := db.Transaction(true)
+	defer txn.Release()
+	for i, tx := range txs {
+		// Gap blocks are already reflected in the Mithril snapshot's
+		// UTxO set, so input UTxOs are already consumed. Store the TX
+		// record and blob offsets without re-consuming inputs.
+		if err := db.SetGapBlockTransaction(
+			tx,
+			point,
+			uint32(i), // #nosec G115 -- tx index within a block
+			offsets,
+			txn,
+		); err != nil {
+			return fmt.Errorf("storing TX: %w", err)
 		}
-		blocksInBatch = 0
-		utxosInBatch = 0
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("cancelled: %w", err)
-		}
-		txn = db.BlobTxn(true)
-		return nil
-	}
-
-	for {
-		if err := ctx.Err(); err != nil {
-			txn.Rollback() //nolint:errcheck
-			return fmt.Errorf("cancelled: %w", err)
-		}
-		next, err := iter.Next()
-		if err != nil {
-			txn.Rollback() //nolint:errcheck
-			return fmt.Errorf("reading block: %w", err)
-		}
-		if next == nil {
-			break
-		}
-
-		// Skip EBBs (epoch boundary blocks have no
-		// transactions).
-		if next.IsEbb {
-			processedBlocks++
+		if !tx.IsValid() {
 			continue
 		}
-
-		var blockHash [32]byte
-		copy(blockHash[:], next.Hash)
-		blobTxn := txn.Blob()
-
-		// Try fast path: structural CBOR parsing without
-		// full block decode (works for Shelley+ eras).
-		offsets, extractErr := lcommon.ExtractTransactionOffsets(
-			next.Cbor,
-		)
-		if extractErr == nil {
-			invalidTxs, invErr := extractInvalidTxIndices(next.Cbor)
-			if invErr != nil {
-				txn.Rollback() //nolint:errcheck
-				return fmt.Errorf(
-					"block at slot %d: decoding invalid tx indices: %w",
-					next.Slot, invErr,
-				)
-			}
-			for txIdx, txLoc := range offsets.Transactions {
-				bodyEnd := txLoc.Body.Offset +
-					txLoc.Body.Length
-				if int(bodyEnd) > len(next.Cbor) {
-					txn.Rollback() //nolint:errcheck
-					return fmt.Errorf(
-						"block at slot %d: body "+
-							"range [%d:%d] exceeds "+
-							"block size %d",
-						next.Slot,
-						txLoc.Body.Offset,
-						bodyEnd,
-						len(next.Cbor),
-					)
-				}
-				bodyBytes := next.Cbor[txLoc.Body.Offset:bodyEnd]
-				txHash := lcommon.Blake2b256Hash(bodyBytes)
-				_, txIsInvalid := invalidTxs[txIdx]
-
-				if !txIsInvalid {
-					for i, outLoc := range txLoc.Outputs {
-						if outLoc.Length == 0 {
-							continue
-						}
-						offset := database.CborOffset{
-							BlockSlot:  next.Slot,
-							BlockHash:  blockHash,
-							ByteOffset: outLoc.Offset,
-							ByteLength: outLoc.Length,
-						}
-						offsetData := database.EncodeUtxoOffset(
-							&offset,
-						)
-						// #nosec G115
-						if err := blob.SetUtxo(
-							blobTxn,
-							txHash[:],
-							uint32(i),
-							offsetData,
-						); err != nil {
-							txn.Rollback() //nolint:errcheck
-							return fmt.Errorf(
-								"storing UTxO offset: %w",
-								err,
-							)
-						}
-						totalUtxos++
-						utxosInBatch++
-						if utxosInBatch >= batchUtxoOffsets {
-							if err := flushTxn(); err != nil {
-								return err
-							}
-							blobTxn = txn.Blob()
-						}
-					}
-					continue
-				}
-				collReturnOffset, collReturnLen, found, err := txBodyMapValueRange(
-					next.Cbor[txLoc.Body.Offset:bodyEnd],
-					txLoc.Body.Offset,
-					txBodyKeyCollateralReturn,
-				)
-				if err != nil {
-					txn.Rollback() //nolint:errcheck
-					return fmt.Errorf(
-						"block at slot %d: transaction %x collateral return offset: %w",
-						next.Slot,
-						txHash[:8],
-						err,
-					)
-				}
-				if found {
-					offset := database.CborOffset{
-						BlockSlot:  next.Slot,
-						BlockHash:  blockHash,
-						ByteOffset: collReturnOffset,
-						ByteLength: collReturnLen,
-					}
-					offsetData := database.EncodeUtxoOffset(
-						&offset,
-					)
-					outputIdx := uint32(len(txLoc.Outputs)) // #nosec G115
-					if err := blob.SetUtxo(
-						blobTxn,
-						txHash[:],
-						outputIdx,
-						offsetData,
-					); err != nil {
-						txn.Rollback() //nolint:errcheck
-						return fmt.Errorf(
-							"storing collateral return UTxO offset: %w",
-							err,
-						)
-					}
-					totalUtxos++
-					utxosInBatch++
-					if utxosInBatch >= batchUtxoOffsets {
-						if err := flushTxn(); err != nil {
-							return err
-						}
-						blobTxn = txn.Blob()
-					}
-				}
-			}
-		} else {
-			// Fallback: full block parsing for Byron
-			// and other eras where structural extraction
-			// fails.
-			parsedBlock, parseErr := gledger.NewBlockFromCbor(
-				next.Type, next.Cbor,
+		hasGovernance := len(tx.ProposalProcedures()) > 0 ||
+			len(tx.VotingProcedures()) > 0
+		if !hasGovernance {
+			continue
+		}
+		if conwayPParams == nil {
+			return errors.New(
+				"missing Conway protocol parameters for governance gap block processing",
 			)
-			if parseErr != nil {
-				txn.Rollback() //nolint:errcheck
-				return fmt.Errorf(
-					"parsing block at slot %d: %w",
-					next.Slot, parseErr,
-				)
-			}
-			seenCbor := make(map[string]int)
-			for _, tx := range parsedBlock.Transactions() {
-				txHash := tx.Hash()
-				var txHashArr [32]byte
-				copy(txHashArr[:], txHash.Bytes())
-				produced := tx.Produced()
-				for _, utxo := range produced {
-					outCbor := utxo.Output.Cbor()
-					if len(outCbor) == 0 {
-						txn.Rollback() //nolint:errcheck
-						return fmt.Errorf(
-							"block at slot %d: "+
-								"output %d has "+
-								"no CBOR",
-							next.Slot,
-							utxo.Id.Index(),
-						)
-					}
-					// Search the raw block for the nth
-					// occurrence of this output's CBOR.
-					// NOTE: this searches all block
-					// sections (header, witnesses, etc.),
-					// not just outputs. A false match in
-					// a non-output section would produce
-					// a wrong offset. In practice this is
-					// safe for Byron blocks because output
-					// CBOR (unique base58 addresses +
-					// amounts) is extremely unlikely to
-					// appear verbatim elsewhere. Shelley+
-					// blocks use the structural fast path.
-					key := string(outCbor)
-					nth := seenCbor[key]
-					seenCbor[key]++
-					pos := findNthOccurrence(
-						next.Cbor, outCbor, nth,
-					)
-					if pos < 0 {
-						txn.Rollback() //nolint:errcheck
-						return fmt.Errorf(
-							"block at slot %d: "+
-								"output %d CBOR "+
-								"not found",
-							next.Slot,
-							utxo.Id.Index(),
-						)
-					}
-					offset := database.CborOffset{
-						BlockSlot: next.Slot,
-						BlockHash: blockHash,
-						// #nosec G115
-						ByteOffset: uint32(pos),
-						// #nosec G115
-						ByteLength: uint32(
-							len(outCbor),
-						),
-					}
-					offsetData := database.EncodeUtxoOffset(
-						&offset,
-					)
-					if err := blob.SetUtxo(
-						blobTxn,
-						txHashArr[:],
-						utxo.Id.Index(),
-						offsetData,
-					); err != nil {
-						txn.Rollback() //nolint:errcheck
-						return fmt.Errorf(
-							"storing UTxO offset: %w",
-							err,
-						)
-					}
-					totalUtxos++
-					utxosInBatch++
-					if utxosInBatch >= batchUtxoOffsets {
-						if err := flushTxn(); err != nil {
-							return err
-						}
-						blobTxn = txn.Blob()
-					}
-				}
-			}
 		}
-
-		processedBlocks++
-		lastProgressSlot = next.Slot
-		blocksInBatch++
-
-		if blocksInBatch >= batchBlocks {
-			if err := flushTxn(); err != nil {
-				return err
-			}
-		}
-
-		maybeLogUtxoOffsetProgress(
-			logger,
-			processedBlocks,
-			totalUtxos,
-			lastProgressSlot,
-			immutableTip.Slot,
-			startTime,
-			&lastProgressLog,
-		)
-	}
-
-	// Commit remaining batch; the deferred rollback handles
-	// cleanup when there is nothing to commit.
-	if blocksInBatch > 0 || utxosInBatch > 0 {
-		if err := txn.Commit(); err != nil {
+		if err := governance.ProcessProposals(
+			tx,
+			point,
+			epochId,
+			conwayPParams.GovActionValidityPeriod,
+			db,
+			txn,
+		); err != nil {
 			return fmt.Errorf(
-				"committing final UTxO offsets: %w",
+				"processing governance proposals: %w",
+				err,
+			)
+		}
+		if err := governance.ProcessVotes(
+			tx,
+			point,
+			epochId,
+			conwayPParams.DRepInactivityPeriod,
+			db,
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"processing governance votes: %w",
 				err,
 			)
 		}
 	}
-
-	logger.Info(
-		"UTxO offset post-processing complete",
-		"component", "mithril",
-		"blocks_processed", processedBlocks,
-		"utxo_offsets_stored", totalUtxos,
-	)
-
+	if err := txn.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
 	return nil
 }
 
-func maybeLogUtxoOffsetProgress(
-	logger *slog.Logger,
-	processedBlocks int,
-	totalUtxos int,
-	currentSlot uint64,
-	tipSlot uint64,
-	startTime time.Time,
-	lastLogTime *time.Time,
-) {
-	now := time.Now()
-	if !lastLogTime.IsZero() && now.Sub(*lastLogTime) < 10*time.Second {
-		return
-	}
-	*lastLogTime = now
-
-	elapsed := now.Sub(startTime)
-	attrs := []any{
-		"component", "mithril",
-		"blocks", processedBlocks,
-		"utxos", totalUtxos,
-		"slot", currentSlot,
-	}
-	if elapsed > 0 {
-		attrs = append(
-			attrs,
-			"blocks_per_sec",
-			fmt.Sprintf("%.0f", float64(processedBlocks)/elapsed.Seconds()),
-		)
-	}
-	if tipSlot > 0 {
-		attrs = append(
-			attrs,
-			"progress",
-			fmt.Sprintf("%.1f%%", float64(currentSlot)/float64(tipSlot)*100),
-		)
-	}
-	logger.Info("UTxO offset progress", attrs...)
-}
-
-// findNthOccurrence returns the byte offset of the nth (0-indexed)
-// occurrence of target within data, or -1 if not found.
-func findNthOccurrence(data, target []byte, n int) int {
-	if len(target) == 0 || n < 0 {
-		return -1
-	}
-	off := 0
-	for range n {
-		idx := bytes.Index(data[off:], target)
-		if idx < 0 {
-			return -1
+// gapBlockEpoch resolves the epoch containing slot from a slice of
+// epochs ordered by ascending StartSlot (as returned by db.GetEpochs).
+// It enforces the upper bound StartSlot + LengthInSlots so a slot past
+// the last known epoch surfaces an error rather than silently binding
+// to the final entry.
+func gapBlockEpoch(
+	epochs []models.Epoch,
+	slot uint64,
+) (models.Epoch, error) {
+	for i := len(epochs) - 1; i >= 0; i-- {
+		if slot < epochs[i].StartSlot {
+			continue
 		}
-		off += idx + len(target)
+		end := epochs[i].StartSlot + uint64(epochs[i].LengthInSlots)
+		if epochs[i].LengthInSlots > 0 && slot >= end {
+			return models.Epoch{}, fmt.Errorf(
+				"slot %d is past the end of the last known epoch %d (slots %d..%d)",
+				slot,
+				epochs[i].EpochId,
+				epochs[i].StartSlot,
+				end,
+			)
+		}
+		return epochs[i], nil
 	}
-	idx := bytes.Index(data[off:], target)
-	if idx < 0 {
-		return -1
-	}
-	return off + idx
+	return models.Epoch{}, fmt.Errorf("no epoch found for slot %d", slot)
 }
 
 // epochLengthFromConfig returns an EpochLengthFunc that resolves

--- a/cmd/dingo/mithril_gap_governance_test.go
+++ b/cmd/dingo/mithril_gap_governance_test.go
@@ -1,0 +1,638 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+type mockGapGovernanceTransaction struct {
+	hash               lcommon.Blake2b256
+	votingProcedures   lcommon.VotingProcedures
+	proposalProcedures []lcommon.ProposalProcedure
+	isValid            bool
+}
+
+func (m *mockGapGovernanceTransaction) Hash() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m *mockGapGovernanceTransaction) Id() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m *mockGapGovernanceTransaction) Type() int {
+	return gledger.TxTypeConway
+}
+
+func (m *mockGapGovernanceTransaction) Fee() *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *mockGapGovernanceTransaction) TTL() uint64 {
+	return 0
+}
+
+func (m *mockGapGovernanceTransaction) IsValid() bool {
+	return m.isValid
+}
+
+func (m *mockGapGovernanceTransaction) Metadata() lcommon.TransactionMetadatum {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) AuxiliaryData() lcommon.AuxiliaryData {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) RawAuxiliaryData() []byte {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) CollateralReturn() lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Produced() []lcommon.Utxo {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Outputs() []lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Inputs() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Collateral() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Certificates() []lcommon.Certificate {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) ProtocolParameterUpdates() (
+	uint64,
+	map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate,
+) {
+	return 0, nil
+}
+
+func (m *mockGapGovernanceTransaction) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) AuxDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Cbor() []byte {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Consumed() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Witnesses() lcommon.TransactionWitnessSet {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) ValidityIntervalStart() uint64 {
+	return 0
+}
+
+func (m *mockGapGovernanceTransaction) ReferenceInputs() []lcommon.TransactionInput {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) TotalCollateral() *big.Int {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Withdrawals() map[*lcommon.Address]*big.Int {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) RequiredSigners() []lcommon.Blake2b224 {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) ScriptDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) VotingProcedures() lcommon.VotingProcedures {
+	return m.votingProcedures
+}
+
+func (m *mockGapGovernanceTransaction) ProposalProcedures() []lcommon.ProposalProcedure {
+	return m.proposalProcedures
+}
+
+func (m *mockGapGovernanceTransaction) CurrentTreasuryValue() *big.Int {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Donation() *big.Int {
+	return nil
+}
+
+func (m *mockGapGovernanceTransaction) Utxorpc() (*cardano.Tx, error) {
+	return nil, nil
+}
+
+func (m *mockGapGovernanceTransaction) LeiosHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func testGapHash32(seed string) []byte {
+	hash := make([]byte, 32)
+	copy(hash, []byte(seed))
+	return hash
+}
+
+func testGapHash28(seed string) []byte {
+	hash := make([]byte, 28)
+	copy(hash, []byte(seed))
+	return hash
+}
+
+func TestValidateStoredGapBlocks(t *testing.T) {
+	immutableTip := models.Block{
+		Slot: 10,
+		Hash: testGapHash32("immutable-tip"),
+	}
+	first := models.Block{
+		Slot:     11,
+		Hash:     testGapHash32("first-gap"),
+		PrevHash: immutableTip.Hash,
+	}
+	second := models.Block{
+		Slot:     12,
+		Hash:     testGapHash32("second-gap"),
+		PrevHash: first.Hash,
+	}
+
+	require.NoError(
+		t,
+		validateStoredGapBlocks(
+			[]models.Block{first, second},
+			immutableTip,
+			second.Hash,
+		),
+	)
+
+	brokenFirst := first
+	brokenFirst.PrevHash = testGapHash32("wrong-prev")
+	require.ErrorContains(
+		t,
+		validateStoredGapBlocks(
+			[]models.Block{brokenFirst, second},
+			immutableTip,
+			second.Hash,
+		),
+		"does not match immutable tip",
+	)
+
+	brokenSecond := second
+	brokenSecond.PrevHash = testGapHash32("wrong-link")
+	require.ErrorContains(
+		t,
+		validateStoredGapBlocks(
+			[]models.Block{first, brokenSecond},
+			immutableTip,
+			second.Hash,
+		),
+		"does not match previous block",
+	)
+
+	require.ErrorContains(
+		t,
+		validateStoredGapBlocks(
+			[]models.Block{first, second},
+			immutableTip,
+			testGapHash32("ledger-hash"),
+		),
+		"does not match ledger state hash",
+	)
+}
+
+func testGapConwayProtocolParameters() *conway.ConwayProtocolParameters {
+	return &conway.ConwayProtocolParameters{
+		GovActionValidityPeriod: 20,
+		DRepInactivityPeriod:    20,
+	}
+}
+
+func TestProcessGapBlockTransactionsProcessesGovernance(
+	t *testing.T,
+) {
+	tmpDir := t.TempDir()
+
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	rewardAddress, err := lcommon.NewAddressFromBytes(
+		append([]byte{0xE1}, testGapHash28("proposal-reward")...),
+	)
+	require.NoError(t, err)
+	proposalProcedure := conway.ConwayProposalProcedure{
+		PPDeposit:       42,
+		PPRewardAccount: rewardAddress,
+		PPGovAction: conway.ConwayGovAction{
+			Type: uint(lcommon.GovActionTypeInfo),
+			Action: &lcommon.InfoGovAction{
+				Type: uint(lcommon.GovActionTypeInfo),
+			},
+		},
+		PPAnchor: lcommon.GovAnchor{
+			Url:      "https://example.com/proposal",
+			DataHash: [32]byte(testGapHash32("proposal-anchor")),
+		},
+	}
+	proposalBodyCbor, err := cbor.Encode(
+		&conway.ConwayTransactionBody{
+			TxProposalProcedures: []conway.ConwayProposalProcedure{
+				proposalProcedure,
+			},
+		},
+	)
+	require.NoError(t, err)
+	proposalTxHash := lcommon.Blake2b256Hash(proposalBodyCbor)
+	proposalTx := &mockGapGovernanceTransaction{
+		hash:               proposalTxHash,
+		proposalProcedures: []lcommon.ProposalProcedure{proposalProcedure},
+		isValid:            true,
+	}
+
+	ccCred := testGapHash28("committee-voter")
+	var voterHash [28]byte
+	copy(voterHash[:], ccCred)
+	var actionTxHash [32]byte
+	copy(actionTxHash[:], proposalTxHash.Bytes())
+	voter := &lcommon.Voter{
+		Type: lcommon.VoterTypeConstitutionalCommitteeHotKeyHash,
+		Hash: voterHash,
+	}
+	actionID := &lcommon.GovActionId{
+		TransactionId: actionTxHash,
+		GovActionIdx:  0,
+	}
+	var voteTxHash lcommon.Blake2b256
+	copy(voteTxHash[:], testGapHash32("vote-tx"))
+	voteTx := &mockGapGovernanceTransaction{
+		hash:    voteTxHash,
+		isValid: true,
+		votingProcedures: lcommon.VotingProcedures{
+			voter: {
+				actionID: {Vote: models.VoteYes},
+			},
+		},
+	}
+
+	point := ocommon.Point{
+		Slot: 1000,
+		Hash: testGapHash32("gap-block"),
+	}
+	var blockHash [32]byte
+	copy(blockHash[:], point.Hash)
+	var proposalTxHashArray [32]byte
+	copy(proposalTxHashArray[:], proposalTxHash.Bytes())
+	var voteTxHashArray [32]byte
+	copy(voteTxHashArray[:], voteTxHash.Bytes())
+	// The TxOffsets entries below are placeholders, not real offsets
+	// into a stored block: the test builds proposalTxHash from the
+	// in-memory proposalBodyCbor and never persists that CBOR to the
+	// blob store. SetGapBlockTransaction (invoked via
+	// processGapBlockTransactions) only requires that the tx hash has
+	// an entry in BlockIngestionResult.TxOffsets, and
+	// mockGapGovernanceTransaction.Consumed() returns nil so no input
+	// recovery / block lookup is triggered. As a result this test does
+	// not exercise CBOR blob round-trip or offset validation, and
+	// future eager validation in processGapBlockTransactions must not
+	// rely on these offsets pointing at usable bytes.
+	offsets := &database.BlockIngestionResult{
+		TxOffsets: map[[32]byte]database.CborOffset{
+			proposalTxHashArray: {
+				BlockSlot:  point.Slot,
+				BlockHash:  blockHash,
+				ByteOffset: 0,
+				ByteLength: 1,
+			},
+			voteTxHashArray: {
+				BlockSlot:  point.Slot,
+				BlockHash:  blockHash,
+				ByteOffset: 1,
+				ByteLength: 1,
+			},
+		},
+		UtxoOffsets: make(map[database.UtxoRef]database.CborOffset),
+	}
+
+	err = processGapBlockTransactions(
+		db,
+		point,
+		[]lcommon.Transaction{proposalTx, voteTx},
+		offsets,
+		100,
+		testGapConwayProtocolParameters(),
+	)
+	require.NoError(t, err)
+
+	proposal, err := db.GetGovernanceProposal(
+		proposalTxHash.Bytes(),
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, proposal)
+	assert.Equal(t, proposalTxHash.Bytes(), proposal.TxHash)
+	assert.Equal(t, uint32(0), proposal.ActionIndex)
+	assert.Equal(t, uint8(lcommon.GovActionTypeInfo), proposal.ActionType)
+	assert.Equal(t, uint64(100), proposal.ProposedEpoch)
+	assert.Equal(t, uint64(120), proposal.ExpiresEpoch)
+	assert.Equal(t, proposalProcedure.PPAnchor.Url, proposal.AnchorURL)
+	assert.Equal(t, proposalProcedure.PPAnchor.DataHash[:], proposal.AnchorHash)
+
+	votes, err := db.GetGovernanceVotes(proposal.ID, nil)
+	require.NoError(t, err)
+	require.Len(t, votes, 1)
+	assert.Equal(t, uint8(models.VoterTypeCC), votes[0].VoterType)
+	assert.Equal(t, ccCred, votes[0].VoterCredential)
+	assert.Equal(t, uint8(models.VoteYes), votes[0].Vote)
+	assert.Equal(t, point.Slot, votes[0].AddedSlot)
+}
+
+func TestProcessGapBlocksNoOpWithoutUint64Overflow(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Empty input returns immediately without touching the epoch
+	// table; verify no arithmetic is attempted on an empty epochs
+	// slice (where len(epochs)-1 would wrap to a huge uint).
+	require.NoError(t, processGapBlocks(t.Context(), db, logger, nil))
+	require.NoError(
+		t,
+		processGapBlocks(t.Context(), db, logger, []models.Block{}),
+	)
+
+	// With at least one gap block and no epoch records,
+	// processGapBlocks must surface an error rather than panic
+	// on epochs[len(epochs)-1] or wrap the negative index into a
+	// large uint64. Use a real block from immutable/testdata so
+	// gledger.NewBlockFromCbor succeeds and execution actually
+	// reaches gapBlockEpoch with an empty epochs slice — that is
+	// the path the underflow regression would land on.
+	immutableDir := filepath.Join(
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+	imm, err := immutable.New(immutableDir)
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var block models.Block
+	const maxIterations = 1_000
+	for i := range maxIterations {
+		next, err := iter.Next()
+		require.NoError(t, err)
+		if next == nil {
+			require.Failf(
+				t,
+				"immutable testdata exhausted",
+				"no non-EBB block with transactions found after %d iterations",
+				i+1,
+			)
+		}
+		if next.IsEbb {
+			continue
+		}
+		parsed, err := gledger.NewBlockFromCbor(
+			next.Type,
+			next.Cbor,
+			lcommon.VerifyConfig{SkipBodyHashValidation: true},
+		)
+		require.NoError(t, err)
+		if len(parsed.Transactions()) == 0 {
+			continue
+		}
+		block = models.Block{
+			Slot: next.Slot,
+			Hash: append([]byte(nil), next.Hash...),
+			Cbor: append([]byte(nil), next.Cbor...),
+			Type: next.Type,
+		}
+		break
+	}
+	require.NotZero(
+		t,
+		block.Slot,
+		"no non-EBB block with transactions found within scan bound",
+	)
+
+	var processErr error
+	require.NotPanics(t, func() {
+		processErr = processGapBlocks(
+			t.Context(),
+			db,
+			logger,
+			[]models.Block{block},
+		)
+	})
+	require.Error(t, processErr)
+	require.ErrorContains(t, processErr, "no epoch found for slot")
+}
+
+func TestDeleteBlobBlocksAboveSlot(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Three synthetic blocks at well-separated slots so the deletion
+	// boundary is unambiguous. CBOR/type don't need to parse — the
+	// blob store treats them as opaque bytes.
+	blocks := []models.Block{
+		{Slot: 100, Hash: testGapHash32("blk-100"), Cbor: []byte{0x82, 0x01}, Type: 1},
+		{Slot: 200, Hash: testGapHash32("blk-200"), Cbor: []byte{0x82, 0x02}, Type: 1},
+		{Slot: 300, Hash: testGapHash32("blk-300"), Cbor: []byte{0x82, 0x03}, Type: 1},
+	}
+	for _, b := range blocks {
+		require.NoError(t, db.BlockCreate(b, nil))
+	}
+
+	require.NoError(t, deleteBlobBlocksAboveSlot(db, 150))
+
+	remaining, err := loadGapBlocksFromBlob(db, 0, 1000)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, uint64(100), remaining[0].Slot)
+
+	// Idempotent re-run is a no-op.
+	require.NoError(t, deleteBlobBlocksAboveSlot(db, 150))
+	remaining, err = loadGapBlocksFromBlob(db, 0, 1000)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, uint64(100), remaining[0].Slot)
+}
+
+func TestDeleteBlobBlocksAboveSlotKeepsBoundaryTip(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := []models.Block{
+		{Slot: 100, Hash: testGapHash32("blk-100"), Cbor: []byte{0x82, 0x01}, Type: 1},
+		{Slot: 200, Hash: testGapHash32("blk-200"), Cbor: []byte{0x82, 0x02}, Type: 1},
+		{Slot: 300, Hash: testGapHash32("blk-300"), Cbor: []byte{0x82, 0x03}, Type: 1},
+	}
+	for _, b := range blocks {
+		require.NoError(t, db.BlockCreate(b, nil))
+	}
+
+	require.NoError(t, deleteBlobBlocksAboveSlot(db, 200))
+
+	remaining, err := loadGapBlocksFromBlob(db, 0, 1000)
+	require.NoError(t, err)
+	require.Len(t, remaining, 2)
+	assert.Equal(t, uint64(100), remaining[0].Slot)
+	assert.Equal(t, uint64(200), remaining[1].Slot)
+
+	recent, err := database.BlocksRecent(db, 1)
+	require.NoError(t, err)
+	require.Len(t, recent, 1)
+	assert.Equal(t, uint64(200), recent[0].Slot)
+}
+
+func TestLoadGapBlocksFromBlob(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	immutableDir := filepath.Join(
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+	imm, err := immutable.New(immutableDir)
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var expected models.Block
+	const maxIterations = 1_000
+	for i := range maxIterations {
+		next, err := iter.Next()
+		require.NoError(t, err)
+		if next == nil {
+			require.Failf(
+				t,
+				"immutable testdata exhausted",
+				"iterator returned nil before a non-EBB block was found (after %d iterations)",
+				i+1,
+			)
+		}
+		if next.IsEbb {
+			continue
+		}
+		expected = models.Block{
+			Slot: next.Slot,
+			Hash: append([]byte(nil), next.Hash...),
+			Cbor: append([]byte(nil), next.Cbor...),
+			Type: next.Type,
+		}
+		break
+	}
+	require.NotZero(
+		t,
+		expected.Slot,
+		"no non-EBB block found within the %d-iteration scan bound",
+		maxIterations,
+	)
+	require.NoError(t, db.BlockCreate(expected, nil))
+
+	loaded, err := loadGapBlocksFromBlob(
+		db,
+		expected.Slot,
+		expected.Slot,
+	)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, expected.Slot, loaded[0].Slot)
+	assert.Equal(t, expected.Hash, loaded[0].Hash)
+	assert.Equal(t, expected.Cbor, loaded[0].Cbor)
+	assert.Equal(t, expected.Type, loaded[0].Type)
+}

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -42,7 +42,7 @@ func serveRun(
 		os.Exit(1)
 	}
 
-	// Resume incomplete metadata backfill if interrupted
+	// Historical metadata backfill is only needed for API mode.
 	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
 		if err := resumeBackfill(
 			cmd.Context(), cfg, logger,
@@ -95,7 +95,7 @@ func checkSyncState(
 	)
 }
 
-// resumeBackfill checks for an incomplete metadata backfill and
+// resumeBackfill checks whether metadata backfill is needed and
 // runs it to completion before the node starts serving.
 func resumeBackfill(
 	ctx context.Context,
@@ -155,7 +155,7 @@ func resumeBackfill(
 	defer cleanup()
 
 	logger.Info(
-		"resuming incomplete metadata backfill",
+		"running metadata backfill",
 		"component", "backfill",
 	)
 	if err := bf.Run(ctx); err != nil {

--- a/database/block_indexer.go
+++ b/database/block_indexer.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -277,34 +278,18 @@ func (bi *BlockIndexer) extractOutputOffsets(
 		// Fall through to byte searching for missing outputs
 	}
 
-	// Fallback: search for output CBOR within the body (slower but always works)
-	// Returns error if offset cannot be computed for any output.
-	// We need to track how many times we've seen each unique CBOR pattern
-	// to handle duplicate outputs (which are valid in Cardano).
-	seenCborCounts := make(map[string]int)
-
+	// Fallback: structurally walk the transaction body and locate
+	// the exact produced output value. Do not use raw substring
+	// search; identical bytes can appear in non-output fields.
 	for _, utxo := range produced {
 		ref := UtxoRef{
 			TxId:      txHashArray,
 			OutputIdx: utxo.Id.Index(),
 		}
 
-		outputCbor := utxo.Output.Cbor()
-
-		// Skip if we already have an offset for this output, but still
-		// increment seenCborCounts so subsequent duplicate outputs resolve
-		// to the correct occurrence
+		// Skip if we already have an offset for this output.
 		if _, ok := result.UtxoOffsets[ref]; ok {
-			if len(outputCbor) > 0 {
-				seenCborCounts[string(outputCbor)]++
-			}
 			continue
-		}
-		if len(outputCbor) == 0 {
-			return fmt.Errorf(
-				"output %d has no CBOR data - cannot compute offset",
-				utxo.Id.Index(),
-			)
 		}
 
 		bodyStart := txLoc.Body.Offset
@@ -319,58 +304,57 @@ func (bi *BlockIndexer) extractOutputOffsets(
 		}
 
 		bodyBytes := blockCbor[bodyStart:bodyEnd]
-
-		// Track which occurrence of this CBOR pattern we need
-		cborKey := string(outputCbor)
-		targetOccurrence := seenCborCounts[cborKey]
-		seenCborCounts[cborKey]++
-
-		// Find the nth occurrence of this CBOR pattern
-		offset := findNthCborOccurrence(bodyBytes, outputCbor, targetOccurrence)
-		if offset < 0 {
+		offset, length, found, err := txBodyProducedOutputRange(
+			bodyBytes,
+			bodyStart,
+			utxo.Id.Index(),
+		)
+		if err != nil {
 			return fmt.Errorf(
-				"output %d: CBOR occurrence %d not found in transaction body",
+				"output %d: locate structural CBOR range: %w",
 				utxo.Id.Index(),
-				targetOccurrence,
+				err,
+			)
+		}
+		if !found {
+			return fmt.Errorf(
+				"output %d: structural CBOR range not found in transaction body",
+				utxo.Id.Index(),
+			)
+		}
+		end := uint64(offset) + uint64(length)
+		if end > uint64(len(blockCbor)) {
+			return fmt.Errorf(
+				"output %d: structural range [%d:%d] exceeds block size %d",
+				utxo.Id.Index(),
+				offset,
+				end,
+				len(blockCbor),
+			)
+		}
+		outputCbor := utxo.Output.Cbor()
+		if len(outputCbor) == 0 {
+			return fmt.Errorf(
+				"output %d has no CBOR data - cannot verify offset",
+				utxo.Id.Index(),
+			)
+		}
+		start := int(offset) // #nosec G115 -- bounds checked above
+		stop := int(end)     // #nosec G115 -- bounds checked above
+		if !bytes.Equal(blockCbor[start:stop], outputCbor) {
+			return fmt.Errorf(
+				"output %d: structural CBOR range does not match produced output",
+				utxo.Id.Index(),
 			)
 		}
 
 		result.UtxoOffsets[ref] = CborOffset{
 			BlockSlot:  bi.blockSlot,
 			BlockHash:  bi.blockHash,
-			ByteOffset: bodyStart + safeIntToUint32(offset),
-			ByteLength: safeIntToUint32(len(outputCbor)),
+			ByteOffset: offset,
+			ByteLength: length,
 		}
 	}
 
 	return nil
-}
-
-// findNthCborOccurrence finds the nth (0-indexed) occurrence of a CBOR byte
-// sequence within a larger byte slice. Returns the offset if found, -1 otherwise.
-// This handles transactions with duplicate outputs (identical CBOR).
-func findNthCborOccurrence(data, target []byte, n int) int {
-	if len(target) == 0 || len(data) < len(target) || n < 0 {
-		return -1
-	}
-
-	count := 0
-	for i := 0; i <= len(data)-len(target); i++ {
-		match := true
-		for j := range len(target) {
-			if data[i+j] != target[j] {
-				match = false
-				break
-			}
-		}
-		if match {
-			if count == n {
-				return i
-			}
-			count++
-			// Skip past this match to find non-overlapping occurrences
-			i += len(target) - 1
-		}
-	}
-	return -1
 }

--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -310,7 +310,7 @@ func (c *TieredCborCache) ResolveUtxoCbor(
 // so reconstructing a complete transaction ([body, witness, is_valid, aux_data])
 // would require fetching multiple components. Use tx.Cbor() from the parsed
 // block if you need complete transaction CBOR for decoding.
-func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
+func (c *TieredCborCache) ResolveTxCbor(txn *Txn, txHash []byte) ([]byte, error) {
 	// Tier 1: Hot cache check
 	if cbor, ok := c.hotTx.Get(txHash); ok {
 		c.metrics.IncTxHotHit()
@@ -330,11 +330,22 @@ func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
 		return nil, types.ErrBlobStoreUnavailable
 	}
 
-	// Get TX offset data from blob store
-	txn := blob.NewTransaction(false)
-	defer txn.Rollback() //nolint:errcheck
+	// Get TX offset data from blob store. Use the caller's active
+	// blob transaction when provided so uncommitted writes are visible.
+	blobTxn := types.Txn(nil)
+	cacheResolved := true
+	if txn != nil {
+		blobTxn = txn.Blob()
+		if blobTxn != nil && txn.IsReadWrite() {
+			cacheResolved = false
+		}
+	}
+	if blobTxn == nil {
+		blobTxn = blob.NewTransaction(false)
+		defer blobTxn.Rollback() //nolint:errcheck
+	}
 
-	txData, err := blob.GetTx(txn, txHash)
+	txData, err := blob.GetTx(blobTxn, txHash)
 	if err != nil {
 		return nil, fmt.Errorf("get tx from blob: %w", err)
 	}
@@ -342,7 +353,9 @@ func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
 	// Check if this is offset-based storage
 	if !IsTxOffsetStorage(txData) {
 		// Legacy format: raw CBOR data - populate hot cache and return
-		c.hotTx.Put(txHash, txData)
+		if cacheResolved {
+			c.hotTx.Put(txHash, txData)
+		}
 		return txData, nil
 	}
 
@@ -358,7 +371,9 @@ func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
 		cbor := cachedBlock.Extract(offset.ByteOffset, offset.ByteLength)
 		if cbor != nil {
 			// Populate hot cache
-			c.hotTx.Put(txHash, cbor)
+			if cacheResolved {
+				c.hotTx.Put(txHash, cbor)
+			}
 			return cbor, nil
 		}
 	}
@@ -367,7 +382,11 @@ func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
 	c.metrics.IncBlockLRUMiss()
 
 	// Fetch block from blob store
-	blockCbor, _, err := blob.GetBlock(txn, offset.BlockSlot, offset.BlockHash[:])
+	blockCbor, _, err := blob.GetBlock(
+		blobTxn,
+		offset.BlockSlot,
+		offset.BlockHash[:],
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get block for tx extraction: %w", err)
 	}
@@ -390,7 +409,9 @@ func (c *TieredCborCache) ResolveTxCbor(txHash []byte) ([]byte, error) {
 	}
 
 	// Populate hot cache
-	c.hotTx.Put(txHash, cbor)
+	if cacheResolved {
+		c.hotTx.Put(txHash, cbor)
+	}
 	return cbor, nil
 }
 

--- a/database/cbor_cache_test.go
+++ b/database/cbor_cache_test.go
@@ -15,6 +15,8 @@
 package database
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -92,7 +94,7 @@ func TestTieredCborCacheHotHitTx(t *testing.T) {
 	cache.hotTx.Put(txHash[:], testCbor)
 
 	// Resolve should hit the hot cache
-	result, err := cache.ResolveTxCbor(txHash[:])
+	result, err := cache.ResolveTxCbor(nil, txHash[:])
 
 	require.NoError(t, err)
 	assert.Equal(t, testCbor, result)
@@ -147,7 +149,7 @@ func TestTieredCborCacheHotMissTx(t *testing.T) {
 
 	// Resolve should miss the hot cache and return ErrBlobStoreUnavailable
 	// (since db is nil)
-	result, err := cache.ResolveTxCbor(txHash[:])
+	result, err := cache.ResolveTxCbor(nil, txHash[:])
 
 	assert.ErrorIs(t, err, types.ErrBlobStoreUnavailable)
 	assert.Nil(t, result)
@@ -156,6 +158,55 @@ func TestTieredCborCacheHotMissTx(t *testing.T) {
 	metrics := cache.Metrics()
 	assert.Equal(t, uint64(0), metrics.TxHotHits.Load())
 	assert.Equal(t, uint64(1), metrics.TxHotMisses.Load())
+}
+
+func TestResolveTxCborUsesCallerTxn(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	var txHash [32]byte
+	copy(txHash[:], []byte("active-txn-visible-tx"))
+	var blockHash [32]byte
+	copy(blockHash[:], []byte("active-txn-visible-block"))
+	txBodyCbor := []byte{0x82, 0x01, 0x02}
+	blockCbor := append([]byte("prefix-"), txBodyCbor...)
+	offset := CborOffset{
+		BlockSlot:  42,
+		BlockHash:  blockHash,
+		ByteOffset: uint32(len(blockCbor) - len(txBodyCbor)),
+		ByteLength: uint32(len(txBodyCbor)),
+	}
+
+	txn := db.BlobTxn(true)
+	defer txn.Release()
+	require.NoError(t, db.Blob().SetBlock(
+		txn.Blob(),
+		offset.BlockSlot,
+		blockHash[:],
+		blockCbor,
+		1,
+		0,
+		0,
+		nil,
+	))
+	require.NoError(t, db.Blob().SetTx(
+		txn.Blob(),
+		txHash[:],
+		EncodeTxOffset(&offset),
+	))
+
+	result, err := db.CborCache().ResolveTxCbor(txn, txHash[:])
+
+	require.NoError(t, err)
+	assert.Equal(t, txBodyCbor, result)
 }
 
 func TestTieredCborCacheMetrics(t *testing.T) {
@@ -206,9 +257,9 @@ func TestTieredCborCacheMetrics(t *testing.T) {
 	// txHash2 is NOT in cache
 
 	// Perform some hits and misses
-	_, _ = cache.ResolveTxCbor(txHash1[:]) // hit
-	_, _ = cache.ResolveTxCbor(txHash2[:]) // miss
-	_, _ = cache.ResolveTxCbor(txHash2[:]) // miss
+	_, _ = cache.ResolveTxCbor(nil, txHash1[:]) // hit
+	_, _ = cache.ResolveTxCbor(nil, txHash2[:]) // miss
+	_, _ = cache.ResolveTxCbor(nil, txHash2[:]) // miss
 
 	// Verify counts
 	assert.Equal(t, uint64(1), metrics.TxHotHits.Load())
@@ -410,10 +461,10 @@ func TestCacheMetricsPrometheus(t *testing.T) {
 	cache.hotTx.Put(txHash[:], []byte{0x02})
 
 	// Generate some hits
-	_, _ = cache.ResolveUtxoCbor(txId[:], 0)      // UTxO hot hit
-	_, _ = cache.ResolveTxCbor(txHash[:])         // TX hot hit
-	_, _ = cache.ResolveUtxoCbor(txId[:], 99)     // UTxO hot miss (no db)
-	_, _ = cache.ResolveTxCbor([]byte("missing")) // TX hot miss (not impl)
+	_, _ = cache.ResolveUtxoCbor(txId[:], 0)           // UTxO hot hit
+	_, _ = cache.ResolveTxCbor(nil, txHash[:])         // TX hot hit
+	_, _ = cache.ResolveUtxoCbor(txId[:], 99)          // UTxO hot miss (no db)
+	_, _ = cache.ResolveTxCbor(nil, []byte("missing")) // TX hot miss (not impl)
 
 	// Verify atomic counters
 	metrics := cache.Metrics()

--- a/database/epoch.go
+++ b/database/epoch.go
@@ -45,6 +45,16 @@ func (d *Database) GetEpochs(txn *Txn) ([]models.Epoch, error) {
 	return txn.db.metadata.GetEpochs(txn.Metadata())
 }
 
+func (d *Database) GetEpochBySlot(
+	slot uint64,
+	txn *Txn,
+) (*models.Epoch, error) {
+	if txn == nil {
+		return d.metadata.GetEpochBySlot(slot, nil)
+	}
+	return txn.db.metadata.GetEpochBySlot(slot, txn.Metadata())
+}
+
 func (d *Database) DeleteEpochsAfterSlot(
 	slot uint64,
 	txn *Txn,

--- a/database/mithril_gap_test.go
+++ b/database/mithril_gap_test.go
@@ -1,0 +1,781 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+type gapRollbackCandidate struct {
+	consumerBlock  models.Block
+	consumerPoint  ocommon.Point
+	consumerTx     lcommon.Transaction
+	producerBlocks []models.Block
+}
+
+// gapProducerTx identifies one of the transactions that produced an
+// input consumed by a gap-block test candidate. It keeps the producer
+// tx and its block point so the test can feed both halves of the
+// produce→consume pair through SetGapBlockTransaction.
+type gapProducerTx struct {
+	block models.Block
+	point ocommon.Point
+	tx    lcommon.Transaction
+}
+
+type gapConsumeCandidate struct {
+	consumerBlock models.Block
+	consumerPoint ocommon.Point
+	consumerTx    lcommon.Transaction
+	producers     []gapProducerTx
+}
+
+func TestSetGapBlockTransactionRestoresConsumedInputsOnRollback(
+	t *testing.T,
+) {
+	// Intentionally not t.Parallel(): database.New() writes to
+	// plugin option destination pointers via SetPluginOption, which
+	// the race detector flags when two tests build a Database
+	// concurrently.
+
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findGapRollbackCandidate(t)
+	for _, block := range candidate.producerBlocks {
+		storeBlockOffsetsOnly(t, db, block)
+	}
+	storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+
+	require.NoError(
+		t,
+		db.SetGapBlockTransaction(
+			candidate.consumerTx,
+			candidate.consumerPoint,
+			0,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			nil,
+		),
+	)
+
+	for _, input := range candidate.consumerTx.Consumed() {
+		utxo, err := db.Metadata().GetUtxoIncludingSpent(
+			input.Id().Bytes(),
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			utxo,
+			"expected gap-consumed input %s to be present for rollback",
+			input.String(),
+		)
+		require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
+		require.Equal(
+			t,
+			candidate.consumerTx.Hash().Bytes(),
+			utxo.SpentAtTxId,
+		)
+	}
+
+	txn := db.MetadataTxn(true)
+	require.NoError(
+		t,
+		txn.Do(func(txn *Txn) error {
+			return db.Metadata().DeleteTransactionsAfterSlot(
+				candidate.consumerPoint.Slot-1,
+				txn.Metadata(),
+			)
+		}),
+	)
+	txn.Release()
+
+	for _, input := range candidate.consumerTx.Consumed() {
+		utxo, err := db.Metadata().GetUtxo(
+			input.Id().Bytes(),
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			utxo,
+			"expected rollback to restore gap-consumed input %s",
+			input.String(),
+		)
+		require.Zero(t, utxo.DeletedSlot)
+		require.Nil(t, utxo.SpentAtTxId)
+	}
+}
+
+func TestSetTransactionRecoversMissingConsumedInputsFromBlob(
+	t *testing.T,
+) {
+	// Intentionally not t.Parallel(): database.New() writes to
+	// plugin option destination pointers via SetPluginOption, which
+	// the race detector flags when two tests build a Database
+	// concurrently. Running serially matches other Database tests
+	// in this package.
+
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findGapRollbackCandidateWithoutCertificates(t)
+	for _, block := range candidate.producerBlocks {
+		storeBlockOffsetsOnly(t, db, block)
+	}
+	storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+
+	require.NoError(
+		t,
+		db.SetTransaction(
+			candidate.consumerTx,
+			candidate.consumerPoint,
+			0,
+			0,
+			nil,
+			nil,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			nil,
+		),
+	)
+
+	for _, input := range candidate.consumerTx.Consumed() {
+		utxo, err := db.Metadata().GetUtxoIncludingSpent(
+			input.Id().Bytes(),
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			utxo,
+			"expected SetTransaction to recover consumed input %s",
+			input.String(),
+		)
+		require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
+		require.Equal(
+			t,
+			candidate.consumerTx.Hash().Bytes(),
+			utxo.SpentAtTxId,
+		)
+	}
+}
+
+func findGapRollbackCandidate(t *testing.T) gapRollbackCandidate {
+	return findGapRollbackCandidateMatching(t, false)
+}
+
+func findGapRollbackCandidateWithoutCertificates(
+	t *testing.T,
+) gapRollbackCandidate {
+	return findGapRollbackCandidateMatching(t, true)
+}
+
+func findGapRollbackCandidateMatching(
+	t *testing.T,
+	requireNoCertificates bool,
+) gapRollbackCandidate {
+	t.Helper()
+
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err)
+
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	seenOutputs := make(map[string]models.Block)
+	for {
+		immBlock, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+		if immBlock == nil {
+			break
+		}
+		block, err := gledger.NewBlockFromCbor(
+			immBlock.Type,
+			immBlock.Cbor,
+		)
+		require.NoError(t, err)
+		blockModel := models.Block{
+			Slot:     block.SlotNumber(),
+			Hash:     block.Hash().Bytes(),
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     block.Cbor(),
+		}
+		for _, tx := range block.Transactions() {
+			if requireNoCertificates && len(tx.Certificates()) > 0 {
+				for _, utxo := range tx.Produced() {
+					seenOutputs[inputRefKey(
+						utxo.Id.Id().Bytes(),
+						utxo.Id.Index(),
+					)] = blockModel
+				}
+				continue
+			}
+			consumed := tx.Consumed()
+			if len(consumed) > 0 {
+				producerByPoint := make(map[string]models.Block)
+				allEarlier := true
+				for _, input := range consumed {
+					producerBlock, ok := seenOutputs[inputRefKey(
+						input.Id().Bytes(),
+						input.Index(),
+					)]
+					if !ok || producerBlock.Slot >= blockModel.Slot {
+						allEarlier = false
+						break
+					}
+					pointKey := fmt.Sprintf(
+						"%d:%x",
+						producerBlock.Slot,
+						producerBlock.Hash,
+					)
+					producerByPoint[pointKey] = producerBlock
+				}
+				if allEarlier {
+					producerBlocks := make(
+						[]models.Block,
+						0,
+						len(producerByPoint),
+					)
+					for _, producerBlock := range producerByPoint {
+						producerBlocks = append(
+							producerBlocks,
+							producerBlock,
+						)
+					}
+					return gapRollbackCandidate{
+						consumerBlock: blockModel,
+						consumerPoint: ocommon.Point{
+							Slot: blockModel.Slot,
+							Hash: blockModel.Hash,
+						},
+						consumerTx:     tx,
+						producerBlocks: producerBlocks,
+					}
+				}
+			}
+			for _, utxo := range tx.Produced() {
+				seenOutputs[inputRefKey(
+					utxo.Id.Id().Bytes(),
+					utxo.Id.Index(),
+				)] = blockModel
+			}
+		}
+	}
+
+	t.Fatal("failed to find rollback candidate in immutable testdata")
+	return gapRollbackCandidate{}
+}
+
+func storeBlockOffsetsOnly(t *testing.T, db *Database, block models.Block) {
+	t.Helper()
+
+	offsets := mustBlockOffsets(t, block)
+	txn := db.Transaction(true)
+	require.NoError(
+		t,
+		txn.Do(func(txn *Txn) error {
+			if err := db.BlockCreate(block, txn); err != nil {
+				return err
+			}
+			blob := txn.DB().Blob()
+			for txHash, offset := range offsets.TxOffsets {
+				if err := blob.SetTx(
+					txn.Blob(),
+					txHash[:],
+					EncodeTxOffset(&offset),
+				); err != nil {
+					return err
+				}
+			}
+			for ref, offset := range offsets.UtxoOffsets {
+				if err := blob.SetUtxo(
+					txn.Blob(),
+					ref.TxId[:],
+					ref.OutputIdx,
+					EncodeUtxoOffset(&offset),
+				); err != nil {
+					return err
+				}
+			}
+			return nil
+		}),
+	)
+	txn.Release()
+}
+
+func mustBlockOffsets(
+	t *testing.T,
+	block models.Block,
+) *BlockIngestionResult {
+	t.Helper()
+
+	decodedBlock, err := gledger.NewBlockFromCbor(
+		block.Type,
+		block.Cbor,
+	)
+	require.NoError(t, err)
+	indexer := NewBlockIndexer(block.Slot, block.Hash)
+	offsets, err := indexer.ComputeOffsets(block.Cbor, decodedBlock)
+	require.NoError(t, err)
+	return &BlockIngestionResult{
+		TxOffsets:   offsets.TxOffsets,
+		UtxoOffsets: offsets.UtxoOffsets,
+	}
+}
+
+func inputRefKey(txId []byte, outputIdx uint32) string {
+	return fmt.Sprintf("%x:%d", txId, outputIdx)
+}
+
+// findGapConsumeCandidate walks the immutable testdata and returns a
+// produce-then-consume pair where both halves are separately
+// addressable transactions: the producer tx(s) that created the
+// consumed outputs plus the consumer tx that later spent them in a
+// different (later) block. Useful for exercising the full gap-block
+// ingestion path through two SetGapBlockTransaction calls.
+func findGapConsumeCandidate(t *testing.T) gapConsumeCandidate {
+	t.Helper()
+
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err)
+
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	type producedEntry struct {
+		block models.Block
+		point ocommon.Point
+		tx    lcommon.Transaction
+	}
+	produced := make(map[string]producedEntry)
+
+	for {
+		immBlock, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+		if immBlock == nil {
+			break
+		}
+		block, err := gledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		blockModel := models.Block{
+			Slot:     block.SlotNumber(),
+			Hash:     block.Hash().Bytes(),
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     block.Cbor(),
+		}
+		blockPoint := ocommon.Point{
+			Slot: blockModel.Slot,
+			Hash: blockModel.Hash,
+		}
+		for _, tx := range block.Transactions() {
+			consumed := tx.Consumed()
+			if len(consumed) > 0 {
+				producerByKey := make(
+					map[string]gapProducerTx,
+				)
+				allFound := true
+				for _, input := range consumed {
+					key := inputRefKey(
+						input.Id().Bytes(),
+						input.Index(),
+					)
+					entry, ok := produced[key]
+					if !ok || entry.block.Slot >= blockModel.Slot {
+						allFound = false
+						break
+					}
+					pKey := fmt.Sprintf(
+						"%d:%x:%x",
+						entry.block.Slot,
+						entry.block.Hash,
+						entry.tx.Hash().Bytes(),
+					)
+					producerByKey[pKey] = gapProducerTx{
+						block: entry.block,
+						point: entry.point,
+						tx:    entry.tx,
+					}
+				}
+				if allFound {
+					producers := make(
+						[]gapProducerTx,
+						0,
+						len(producerByKey),
+					)
+					for _, p := range producerByKey {
+						producers = append(producers, p)
+					}
+					return gapConsumeCandidate{
+						consumerBlock: blockModel,
+						consumerPoint: blockPoint,
+						consumerTx:    tx,
+						producers:     producers,
+					}
+				}
+			}
+			for _, utxo := range tx.Produced() {
+				produced[inputRefKey(
+					utxo.Id.Id().Bytes(),
+					utxo.Id.Index(),
+				)] = producedEntry{
+					block: blockModel,
+					point: blockPoint,
+					tx:    tx,
+				}
+			}
+		}
+	}
+
+	t.Fatal("failed to find gap consume candidate in immutable testdata")
+	return gapConsumeCandidate{}
+}
+
+// findGapConsumeCandidateWithoutCertificates is the cert-free variant
+// of findGapConsumeCandidate. It walks the immutable testdata for the
+// same produce-then-consume pair, but skips any transaction (in either
+// position) that carries certificates so callers can drive the pair
+// through SetTransaction with no certDeposits map.
+func findGapConsumeCandidateWithoutCertificates(
+	t *testing.T,
+) gapConsumeCandidate {
+	t.Helper()
+
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err)
+
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	type producedEntry struct {
+		block models.Block
+		point ocommon.Point
+		tx    lcommon.Transaction
+	}
+	produced := make(map[string]producedEntry)
+
+	for {
+		immBlock, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+		if immBlock == nil {
+			break
+		}
+		block, err := gledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		blockModel := models.Block{
+			Slot:     block.SlotNumber(),
+			Hash:     block.Hash().Bytes(),
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     block.Cbor(),
+		}
+		blockPoint := ocommon.Point{
+			Slot: blockModel.Slot,
+			Hash: blockModel.Hash,
+		}
+		for _, tx := range block.Transactions() {
+			if len(tx.Certificates()) > 0 {
+				// A producer with certs would carry deposit-bearing
+				// state we don't want to fixture-up; drop it from
+				// both sides by not tracking its outputs and not
+				// matching it as a consumer.
+				continue
+			}
+			consumed := tx.Consumed()
+			if len(consumed) > 0 {
+				producerByKey := make(map[string]gapProducerTx)
+				allFound := true
+				for _, input := range consumed {
+					key := inputRefKey(
+						input.Id().Bytes(),
+						input.Index(),
+					)
+					entry, ok := produced[key]
+					if !ok || entry.block.Slot >= blockModel.Slot {
+						allFound = false
+						break
+					}
+					pKey := fmt.Sprintf(
+						"%d:%x:%x",
+						entry.block.Slot,
+						entry.block.Hash,
+						entry.tx.Hash().Bytes(),
+					)
+					producerByKey[pKey] = gapProducerTx{
+						block: entry.block,
+						point: entry.point,
+						tx:    entry.tx,
+					}
+				}
+				if allFound {
+					producers := make(
+						[]gapProducerTx,
+						0,
+						len(producerByKey),
+					)
+					for _, p := range producerByKey {
+						producers = append(producers, p)
+					}
+					return gapConsumeCandidate{
+						consumerBlock: blockModel,
+						consumerPoint: blockPoint,
+						consumerTx:    tx,
+						producers:     producers,
+					}
+				}
+			}
+			for _, utxo := range tx.Produced() {
+				produced[inputRefKey(
+					utxo.Id.Id().Bytes(),
+					utxo.Id.Index(),
+				)] = producedEntry{
+					block: blockModel,
+					point: blockPoint,
+					tx:    tx,
+				}
+			}
+		}
+	}
+
+	t.Fatal(
+		"failed to find cert-free gap consume candidate in immutable testdata",
+	)
+	return gapConsumeCandidate{}
+}
+
+// TestSetGapBlockTransactionSpendsLiveProducedInputs verifies that when
+// a gap-block transaction consumes a UTxO produced by an earlier
+// gap-block transaction (both ingested through SetGapBlockTransaction),
+// the produced UTxO row is marked as spent with both deleted_slot and
+// spent_at_tx_id populated — matching the normal SetTransaction path.
+//
+// Regression test for a bug where ensureGapConsumedUtxos unconditionally
+// skipped existing UTxO rows, leaving outputs produced by earlier gap
+// blocks live forever even after a later gap block consumed them.
+func TestSetGapBlockTransactionSpendsLiveProducedInputs(t *testing.T) {
+	// Intentionally not t.Parallel(): database.New() writes to
+	// plugin option destination pointers via SetPluginOption, which
+	// the race detector flags when two tests build a Database
+	// concurrently. Running serially matches other Database tests
+	// in this package.
+
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findGapConsumeCandidate(t)
+
+	// Store blob offsets for all producer blocks plus the consumer
+	// block so SetGapBlockTransaction can look up and persist
+	// produced UTxO offset references.
+	storedBlocks := make(map[string]struct{})
+	for _, producer := range candidate.producers {
+		key := fmt.Sprintf("%d:%x", producer.block.Slot, producer.block.Hash)
+		if _, ok := storedBlocks[key]; ok {
+			continue
+		}
+		storedBlocks[key] = struct{}{}
+		storeBlockOffsetsOnly(t, db, producer.block)
+	}
+	consumerKey := fmt.Sprintf(
+		"%d:%x",
+		candidate.consumerBlock.Slot,
+		candidate.consumerBlock.Hash,
+	)
+	if _, ok := storedBlocks[consumerKey]; !ok {
+		storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+	}
+
+	// Seed each producer tx's own consumed inputs as already-spent
+	// rows (without a SpentAtTxId, to avoid needing a parent
+	// transaction row for the Inputs FK) so the producer's
+	// gap-block ingestion does not try to recover them from a blob
+	// store that lacks the predecessor blocks. This mimics the
+	// Mithril snapshot state where inputs from before the gap
+	// window are already recorded as spent.
+	//
+	// Contract for the gap path: AddedSlot = DeletedSlot = seedSlot
+	// with seedSlot != point.Slot drives ensureGapConsumedUtxos into
+	// its "already spent by a different tx" branch (SpentAtTxId == nil
+	// AND DeletedSlot != 0 AND DeletedSlot != point.Slot), so the
+	// existing row is left untouched. Future changes to the gap-path
+	// branch conditions must keep this skip path reachable or update
+	// this seed accordingly.
+	seedSlot := uint64(1)
+	for _, producer := range candidate.producers {
+		seeded := make([]models.Utxo, 0, len(producer.tx.Consumed()))
+		for _, in := range producer.tx.Consumed() {
+			seeded = append(seeded, models.Utxo{
+				TxId:        in.Id().Bytes(),
+				OutputIdx:   in.Index(),
+				AddedSlot:   seedSlot,
+				DeletedSlot: seedSlot,
+			})
+		}
+		if len(seeded) > 0 {
+			txn := db.MetadataTxn(true)
+			require.NoError(
+				t,
+				txn.Do(func(txn *Txn) error {
+					return db.Metadata().ImportUtxos(
+						seeded,
+						txn.Metadata(),
+					)
+				}),
+			)
+			txn.Release()
+		}
+	}
+
+	// Ingest every producer tx through the gap path first, so the
+	// consumed inputs exist as live UTxO rows when the consumer tx
+	// arrives.
+	for _, producer := range candidate.producers {
+		require.NoError(
+			t,
+			db.SetGapBlockTransaction(
+				producer.tx,
+				producer.point,
+				0,
+				mustBlockOffsets(t, producer.block),
+				nil,
+			),
+		)
+	}
+
+	// Sanity: every consumed input is live before the consumer runs.
+	for _, input := range candidate.consumerTx.Consumed() {
+		utxo, err := db.Metadata().GetUtxoIncludingSpent(
+			input.Id().Bytes(),
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			utxo,
+			"producer gap tx did not persist input %s",
+			input.String(),
+		)
+		require.Zero(
+			t,
+			utxo.DeletedSlot,
+			"input %s should be live before consumer gap tx runs",
+			input.String(),
+		)
+		require.Nil(
+			t,
+			utxo.SpentAtTxId,
+			"input %s should be unspent before consumer gap tx runs",
+			input.String(),
+		)
+	}
+
+	// Now ingest the consumer gap tx. This must mark the produced
+	// UTxOs as spent rather than silently skipping them.
+	require.NoError(
+		t,
+		db.SetGapBlockTransaction(
+			candidate.consumerTx,
+			candidate.consumerPoint,
+			0,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			nil,
+		),
+	)
+
+	spenderTxHash := candidate.consumerTx.Hash().Bytes()
+	for _, input := range candidate.consumerTx.Consumed() {
+		utxo, err := db.Metadata().GetUtxoIncludingSpent(
+			input.Id().Bytes(),
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			utxo,
+			"expected consumed input %s to remain in metadata",
+			input.String(),
+		)
+		require.Equal(
+			t,
+			candidate.consumerPoint.Slot,
+			utxo.DeletedSlot,
+			"input %s deleted_slot not set to consumer slot",
+			input.String(),
+		)
+		require.Equal(
+			t,
+			spenderTxHash,
+			utxo.SpentAtTxId,
+			"input %s spent_at_tx_id not set to consumer tx hash",
+			input.String(),
+		)
+	}
+}

--- a/database/models/block_nonce.go
+++ b/database/models/block_nonce.go
@@ -14,15 +14,123 @@
 
 package models
 
+import (
+	"fmt"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
 type BlockNonce struct {
-	Hash         []byte `gorm:"index:hash_slot;size:32"`
+	Hash         []byte `gorm:"uniqueIndex:hash_slot;size:32"`
 	Nonce        []byte
 	ID           uint   `gorm:"primarykey"`
-	Slot         uint64 `gorm:"index:hash_slot"`
+	Slot         uint64 `gorm:"uniqueIndex:hash_slot"`
 	IsCheckpoint bool
 }
 
 // TableName overrides default table name
 func (BlockNonce) TableName() string {
 	return "block_nonce"
+}
+
+// MigrateBlockNonceUniqueIndex prepares the block_nonce table for the
+// uniqueIndex:hash_slot tag introduced after the original non-unique
+// index. AutoMigrate will not promote an existing non-unique index to
+// unique, so an upgrading database keeps the legacy index and the new
+// SetBlockNonce upsert (clause.OnConflict on hash+slot) fails because
+// no matching unique constraint exists.
+//
+// This helper deduplicates any (hash, slot) collisions, then drops the
+// legacy non-unique index so AutoMigrate can recreate it as unique.
+// It is a no-op when the table does not exist or the existing index
+// is already unique.
+func MigrateBlockNonceUniqueIndex(db *gorm.DB, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&BlockNonce{}) {
+		return nil
+	}
+
+	indexes, err := db.Migrator().GetIndexes(&BlockNonce{})
+	if err != nil {
+		return fmt.Errorf("getting block_nonce indexes: %w", err)
+	}
+	legacyIndex := false
+	for _, idx := range indexes {
+		if idx.Name() != "hash_slot" {
+			continue
+		}
+		unique, ok := idx.Unique()
+		if !ok || !unique {
+			legacyIndex = true
+		}
+		break
+	}
+	if !legacyIndex {
+		return nil
+	}
+
+	type dupGroup struct {
+		Hash []byte
+		Slot uint64
+	}
+	var dups []dupGroup
+	err = db.Raw(`
+		SELECT hash, slot
+		FROM block_nonce
+		GROUP BY hash, slot
+		HAVING COUNT(*) > 1
+	`).Scan(&dups).Error
+	if err != nil {
+		return fmt.Errorf(
+			"query duplicate block_nonce groups: %w", err,
+		)
+	}
+	if len(dups) > 0 {
+		logger.Info(
+			"deduplicating block_nonce rows before creating unique index",
+			"duplicate_groups", len(dups),
+		)
+		for _, d := range dups {
+			// Prefer a checkpoint row when one exists so the
+			// is_checkpoint flag is not silently dropped during
+			// dedup; fall back to MAX(id) otherwise.
+			var keepID uint
+			err := db.Raw(`
+				SELECT id FROM block_nonce
+				WHERE hash = ? AND slot = ?
+				ORDER BY is_checkpoint DESC, id DESC
+				LIMIT 1
+			`, d.Hash, d.Slot).Scan(&keepID).Error
+			if err != nil {
+				return fmt.Errorf(
+					"select keep id for block_nonce (slot=%d): %w",
+					d.Slot, err,
+				)
+			}
+			err = db.Exec(`
+				DELETE FROM block_nonce
+				WHERE hash = ? AND slot = ? AND id != ?
+			`, d.Hash, d.Slot, keepID).Error
+			if err != nil {
+				return fmt.Errorf(
+					"delete duplicate block_nonce (slot=%d): %w",
+					d.Slot, err,
+				)
+			}
+		}
+		logger.Info("block_nonce deduplication complete")
+	}
+
+	if err := db.Migrator().DropIndex(
+		&BlockNonce{}, "hash_slot",
+	); err != nil {
+		return fmt.Errorf(
+			"dropping legacy non-unique block_nonce hash_slot index: %w",
+			err,
+		)
+	}
+	return nil
 }

--- a/database/models/block_nonce_test.go
+++ b/database/models/block_nonce_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// legacyBlockNonce mirrors the original BlockNonce schema where the
+// hash_slot index was non-unique. The TableName override matches the
+// production model so the migration helper sees the same table.
+type legacyBlockNonce struct {
+	Hash         []byte `gorm:"index:hash_slot;size:32"`
+	Nonce        []byte
+	ID           uint   `gorm:"primarykey"`
+	Slot         uint64 `gorm:"index:hash_slot"`
+	IsCheckpoint bool
+}
+
+func (legacyBlockNonce) TableName() string {
+	return "block_nonce"
+}
+
+func openMemoryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	// A unique DSN per test prevents state leaking between sibling
+	// tests through the SQLite shared-cache in-memory database.
+	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	dsn := fmt.Sprintf("file:mem_%s?mode=memory&cache=shared", name)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	return db
+}
+
+func TestMigrateBlockNonceUniqueIndex_NoTable(t *testing.T) {
+	db := openMemoryDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	require.NoError(t, MigrateBlockNonceUniqueIndex(db, logger))
+}
+
+func TestMigrateBlockNonceUniqueIndex_PromotesLegacyIndex(t *testing.T) {
+	db := openMemoryDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	require.NoError(t, db.AutoMigrate(&legacyBlockNonce{}))
+
+	hashA := make([]byte, 32)
+	hashA[0] = 0xAA
+	hashB := make([]byte, 32)
+	hashB[0] = 0xBB
+	require.NoError(t, db.Create(&legacyBlockNonce{
+		Hash: hashA, Slot: 1, Nonce: []byte{0x01},
+	}).Error)
+	require.NoError(t, db.Create(&legacyBlockNonce{
+		Hash: hashA, Slot: 1, Nonce: []byte{0x02}, IsCheckpoint: true,
+	}).Error)
+	require.NoError(t, db.Create(&legacyBlockNonce{
+		Hash: hashB, Slot: 2, Nonce: []byte{0x03},
+	}).Error)
+
+	require.NoError(t, MigrateBlockNonceUniqueIndex(db, logger))
+
+	// Dedup prefers an IsCheckpoint row first, falling back to the
+	// highest-id row when no checkpoint flag is set on any duplicate.
+	var rows []BlockNonce
+	require.NoError(t, db.Order("id ASC").Find(&rows).Error)
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		switch r.Slot {
+		case 1:
+			assert.Equal(t, hashA, r.Hash)
+			assert.Equal(t, []byte{0x02}, r.Nonce)
+			assert.True(t, r.IsCheckpoint)
+		case 2:
+			assert.Equal(t, hashB, r.Hash)
+		default:
+			t.Fatalf("unexpected slot in remaining rows: %d", r.Slot)
+		}
+	}
+
+	// The migration helper drops the legacy index. AutoMigrate then
+	// recreates it as the unique index declared on BlockNonce, which
+	// is the contract SetBlockNonce's clause.OnConflict relies on.
+	require.NoError(t, db.AutoMigrate(&BlockNonce{}))
+	indexes, err := db.Migrator().GetIndexes(&BlockNonce{})
+	require.NoError(t, err)
+	var found bool
+	for _, idx := range indexes {
+		if idx.Name() != "hash_slot" {
+			continue
+		}
+		found = true
+		unique, ok := idx.Unique()
+		require.True(t, ok, "driver did not report uniqueness")
+		assert.True(t, unique, "hash_slot must be unique after migration")
+	}
+	require.True(t, found, "hash_slot index missing after AutoMigrate")
+}
+
+func TestMigrateBlockNonceUniqueIndex_AlreadyUnique(t *testing.T) {
+	db := openMemoryDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	require.NoError(t, db.AutoMigrate(&BlockNonce{}))
+	// Second invocation must be a no-op when the index is already unique.
+	require.NoError(t, MigrateBlockNonceUniqueIndex(db, logger))
+	indexes, err := db.Migrator().GetIndexes(&BlockNonce{})
+	require.NoError(t, err)
+	var found bool
+	for _, idx := range indexes {
+		if idx.Name() != "hash_slot" {
+			continue
+		}
+		found = true
+		unique, ok := idx.Unique()
+		require.True(t, ok)
+		assert.True(t, unique)
+	}
+	require.True(t, found, "hash_slot index should still be present")
+}

--- a/database/plugin/metadata/mysql/block_nonce.go
+++ b/database/plugin/metadata/mysql/block_nonce.go
@@ -22,9 +22,13 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
-// SetBlockNonce inserts a block nonce into the block_nonce table
+// SetBlockNonce inserts or updates a block nonce. The (hash, slot)
+// uniqueIndex makes this safe to call repeatedly for the same block,
+// which happens when the metadata backfill resumes from a checkpoint
+// that pre-dates a previously-written nonce row.
 func (d *MetadataStoreMysql) SetBlockNonce(
 	blockHash []byte,
 	slotNumber uint64,
@@ -43,7 +47,26 @@ func (d *MetadataStoreMysql) SetBlockNonce(
 	if err != nil {
 		return err
 	}
-	result := db.Create(&item)
+	// is_checkpoint is updated with an OR so a later upsert with
+	// false cannot demote a previously-promoted checkpoint row.
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "hash"},
+			{Name: "slot"},
+		},
+		DoUpdates: clause.Set{
+			{
+				Column: clause.Column{Name: "nonce"},
+				Value:  gorm.Expr("VALUES(nonce)"),
+			},
+			{
+				Column: clause.Column{Name: "is_checkpoint"},
+				Value: gorm.Expr(
+					"is_checkpoint OR VALUES(is_checkpoint)",
+				),
+			},
+		},
+	}).Create(&item)
 
 	if result.Error != nil {
 		return result.Error

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -308,6 +308,16 @@ func (d *MetadataStoreMysql) Start() error {
 			"pool_stake_snapshot dedup failed: %w", err,
 		)
 	}
+	// Promote the legacy non-unique block_nonce hash_slot index to a
+	// unique one before AutoMigrate; AutoMigrate will not change index
+	// uniqueness on its own and SetBlockNonce's upsert depends on it.
+	if err := models.MigrateBlockNonceUniqueIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"block_nonce unique index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/mysql/epoch.go
+++ b/database/plugin/metadata/mysql/epoch.go
@@ -76,6 +76,33 @@ func (d *MetadataStoreMysql) GetEpochs(
 	return ret, nil
 }
 
+// GetEpochBySlot returns the epoch containing the given slot, or nil if not found.
+func (d *MetadataStoreMysql) GetEpochBySlot(
+	slot uint64,
+	txn types.Txn,
+) (*models.Epoch, error) {
+	var ret models.Epoch
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where(
+			"start_slot <= ? AND ? < start_slot + length_in_slots",
+			slot,
+			slot,
+		).
+		Order("start_slot DESC").
+		First(&ret)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &ret, nil
+}
+
 // DeleteEpochsAfterSlot removes all epoch entries whose start slot
 // is after the given slot.
 func (d *MetadataStoreMysql) DeleteEpochsAfterSlot(

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -100,6 +100,56 @@ func (d *MetadataStoreMysql) GetTransactionByHash(
 	return ret, nil
 }
 
+// GetTransactionSlotByHash returns the slot of the transaction with the
+// given hash without preloading any related rows. Returns (0, false, nil)
+// when no such transaction exists.
+func (d *MetadataStoreMysql) GetTransactionSlotByHash(
+	hash []byte,
+	txn types.Txn,
+) (uint64, bool, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, false, err
+	}
+	var row struct{ Slot uint64 }
+	result := db.Model(&models.Transaction{}).
+		Select("slot").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, result.Error
+	}
+	return row.Slot, true, nil
+}
+
+// GetTransactionIDByHash returns the primary-key ID of the transaction
+// with the given hash without preloading any related rows. Returns
+// (0, false, nil) when no such transaction exists.
+func (d *MetadataStoreMysql) GetTransactionIDByHash(
+	hash []byte,
+	txn types.Txn,
+) (uint, bool, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, false, err
+	}
+	var row struct{ ID uint }
+	result := db.Model(&models.Transaction{}).
+		Select("id").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, result.Error
+	}
+	return row.ID, true, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *MetadataStoreMysql) GetTransactionsByHashes(
 	hashes [][]byte,
@@ -628,30 +678,12 @@ func (d *MetadataStoreMysql) SetTransaction(
 		metadataLabels = tmpLabels
 	}
 	collateralReturn := tx.CollateralReturn()
-	// For invalid transactions with collateral returns, fix indices via CBOR matching
-	// since Produced() uses enumerated indices rather than real transaction indices
-	var realIndexMap map[lcommon.Blake2b256]uint32
-	if !tx.IsValid() && collateralReturn != nil {
-		realIndexMap = make(map[lcommon.Blake2b256]uint32)
-		for idx, out := range tx.Outputs() {
-			if out != nil && idx <= int(^uint32(0)) {
-				// Hash CBOR for efficient map key
-				outputHash := lcommon.NewBlake2b256(out.Cbor())
-				//nolint:gosec // G115: idx bounds already checked above
-				realIndexMap[outputHash] = uint32(idx)
-			}
-		}
-	}
+	// tx.Produced() already returns correct indices for both
+	// valid transactions (regular outputs at 0, 1, ...) and
+	// invalid transactions (collateral return at len(Outputs())).
 	for _, utxo := range tx.Produced() {
 		if collateralReturn != nil && utxo.Output == collateralReturn {
 			m := models.UtxoLedgerToModel(utxo, point.Slot)
-			// Fix collateral return index for invalid transactions
-			if realIndexMap != nil && m.Cbor != nil {
-				outputHash := lcommon.NewBlake2b256(m.Cbor)
-				if realIdx, ok := realIndexMap[outputHash]; ok {
-					m.OutputIdx = realIdx
-				}
-			}
 			tmpTx.CollateralReturn = &m
 			continue
 		}

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -489,26 +489,76 @@ func (d *MetadataStoreMysql) AddUtxos(
 	return nil
 }
 
-// SetUtxoDeletedAtSlot marks a UTxO as deleted at a given slot
+// SetUtxoDeletedAtSlot marks a UTxO as deleted at a given slot and
+// records the hash of the transaction that consumed it. The update uses
+// the same optimistic-locking predicate as the normal consume path and
+// also repairs same-slot rows that are still missing spent_at_tx_id.
 func (d *MetadataStoreMysql) SetUtxoDeletedAtSlot(
 	utxoId ledger.TransactionInput,
 	slot uint64,
+	spenderTxHash []byte,
 	txn types.Txn,
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return err
 	}
-	result := db.Model(models.Utxo{}).
-		Where("tx_id = ? AND output_idx = ?", utxoId.Id().Bytes(), utxoId.Index()).
-		Update("deleted_slot", slot)
+	result := db.Model(&models.Utxo{}).
+		Where(
+			"tx_id = ? AND output_idx = ? AND spent_at_tx_id IS NULL AND (deleted_slot = 0 OR deleted_slot = ?)",
+			utxoId.Id().Bytes(),
+			utxoId.Index(),
+			slot,
+		).
+		Updates(map[string]any{
+			"deleted_slot":   slot,
+			"spent_at_tx_id": spenderTxHash,
+		})
 	if result.Error != nil {
 		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		var count int64
+		existsResult := db.Model(&models.Utxo{}).
+			Where(
+				"tx_id = ? AND output_idx = ?",
+				utxoId.Id().Bytes(),
+				utxoId.Index(),
+			).
+			Count(&count)
+		if existsResult.Error != nil {
+			return existsResult.Error
+		}
+		if count == 0 {
+			return fmt.Errorf(
+				"%w: %x:%d",
+				types.ErrUtxoNotFound,
+				utxoId.Id().Bytes(),
+				utxoId.Index(),
+			)
+		}
+		return fmt.Errorf(
+			"%w: %x:%d",
+			types.ErrUtxoConflict,
+			utxoId.Id().Bytes(),
+			utxoId.Index(),
+		)
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf(
+			"%w: %x:%d",
+			types.ErrUtxoConflict,
+			utxoId.Id().Bytes(),
+			utxoId.Index(),
+		)
 	}
 	return nil
 }
 
-// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot
+// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot.
+// Both deleted_slot and spent_at_tx_id must be cleared so the restored row
+// satisfies the spend predicate (deleted_slot = 0 AND spent_at_tx_id IS NULL);
+// otherwise the UTxO appears live but cannot be re-spent.
 func (d *MetadataStoreMysql) SetUtxosNotDeletedAfterSlot(
 	slot uint64,
 	txn types.Txn,
@@ -519,7 +569,10 @@ func (d *MetadataStoreMysql) SetUtxosNotDeletedAfterSlot(
 	}
 	result := db.Model(models.Utxo{}).
 		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", 0)
+		Updates(map[string]any{
+			"deleted_slot":   0,
+			"spent_at_tx_id": nil,
+		})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/database/plugin/metadata/postgres/block_nonce.go
+++ b/database/plugin/metadata/postgres/block_nonce.go
@@ -22,9 +22,13 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
-// SetBlockNonce inserts a block nonce into the block_nonce table
+// SetBlockNonce inserts or updates a block nonce. The (hash, slot)
+// uniqueIndex makes this safe to call repeatedly for the same block,
+// which happens when the metadata backfill resumes from a checkpoint
+// that pre-dates a previously-written nonce row.
 func (d *MetadataStorePostgres) SetBlockNonce(
 	blockHash []byte,
 	slotNumber uint64,
@@ -43,7 +47,26 @@ func (d *MetadataStorePostgres) SetBlockNonce(
 	if err != nil {
 		return err
 	}
-	result := db.Create(&item)
+	// is_checkpoint is updated with an OR so a later upsert with
+	// false cannot demote a previously-promoted checkpoint row.
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "hash"},
+			{Name: "slot"},
+		},
+		DoUpdates: clause.Set{
+			{
+				Column: clause.Column{Name: "nonce"},
+				Value:  gorm.Expr("excluded.nonce"),
+			},
+			{
+				Column: clause.Column{Name: "is_checkpoint"},
+				Value: gorm.Expr(
+					"block_nonce.is_checkpoint OR excluded.is_checkpoint",
+				),
+			},
+		},
+	}).Create(&item)
 
 	if result.Error != nil {
 		return result.Error

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -268,6 +268,16 @@ func (d *MetadataStorePostgres) Start() error {
 			"pool_stake_snapshot dedup failed: %w", err,
 		)
 	}
+	// Promote the legacy non-unique block_nonce hash_slot index to a
+	// unique one before AutoMigrate; AutoMigrate will not change index
+	// uniqueness on its own and SetBlockNonce's upsert depends on it.
+	if err := models.MigrateBlockNonceUniqueIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"block_nonce unique index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/postgres/epoch.go
+++ b/database/plugin/metadata/postgres/epoch.go
@@ -76,6 +76,33 @@ func (d *MetadataStorePostgres) GetEpochs(
 	return ret, nil
 }
 
+// GetEpochBySlot returns the epoch containing the given slot, or nil if not found.
+func (d *MetadataStorePostgres) GetEpochBySlot(
+	slot uint64,
+	txn types.Txn,
+) (*models.Epoch, error) {
+	var ret models.Epoch
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	result := db.
+		Where(
+			"start_slot <= ? AND ? < start_slot + length_in_slots",
+			slot,
+			slot,
+		).
+		Order("start_slot DESC").
+		First(&ret)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &ret, nil
+}
+
 // DeleteEpochsAfterSlot removes all epoch entries whose start slot
 // is after the given slot.
 func (d *MetadataStorePostgres) DeleteEpochsAfterSlot(

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -100,6 +100,56 @@ func (d *MetadataStorePostgres) GetTransactionByHash(
 	return ret, nil
 }
 
+// GetTransactionSlotByHash returns the slot of the transaction with the
+// given hash without preloading any related rows. Returns (0, false, nil)
+// when no such transaction exists.
+func (d *MetadataStorePostgres) GetTransactionSlotByHash(
+	hash []byte,
+	txn types.Txn,
+) (uint64, bool, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, false, err
+	}
+	var row struct{ Slot uint64 }
+	result := db.Model(&models.Transaction{}).
+		Select("slot").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, result.Error
+	}
+	return row.Slot, true, nil
+}
+
+// GetTransactionIDByHash returns the primary-key ID of the transaction
+// with the given hash without preloading any related rows. Returns
+// (0, false, nil) when no such transaction exists.
+func (d *MetadataStorePostgres) GetTransactionIDByHash(
+	hash []byte,
+	txn types.Txn,
+) (uint, bool, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, false, err
+	}
+	var row struct{ ID uint }
+	result := db.Model(&models.Transaction{}).
+		Select("id").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, result.Error
+	}
+	return row.ID, true, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *MetadataStorePostgres) GetTransactionsByHashes(
 	hashes [][]byte,

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -490,26 +490,76 @@ func (d *MetadataStorePostgres) AddUtxos(
 	return nil
 }
 
-// SetUtxoDeletedAtSlot marks a UTxO as deleted at a given slot
+// SetUtxoDeletedAtSlot marks a UTxO as deleted at a given slot and
+// records the hash of the transaction that consumed it. The update uses
+// the same optimistic-locking predicate as the normal consume path and
+// also repairs same-slot rows that are still missing spent_at_tx_id.
 func (d *MetadataStorePostgres) SetUtxoDeletedAtSlot(
 	utxoId ledger.TransactionInput,
 	slot uint64,
+	spenderTxHash []byte,
 	txn types.Txn,
 ) error {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return err
 	}
-	result := db.Model(models.Utxo{}).
-		Where("tx_id = ? AND output_idx = ?", utxoId.Id().Bytes(), utxoId.Index()).
-		Update("deleted_slot", slot)
+	result := db.Model(&models.Utxo{}).
+		Where(
+			"tx_id = ? AND output_idx = ? AND spent_at_tx_id IS NULL AND (deleted_slot = 0 OR deleted_slot = ?)",
+			utxoId.Id().Bytes(),
+			utxoId.Index(),
+			slot,
+		).
+		Updates(map[string]any{
+			"deleted_slot":   slot,
+			"spent_at_tx_id": spenderTxHash,
+		})
 	if result.Error != nil {
 		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		var count int64
+		existsResult := db.Model(&models.Utxo{}).
+			Where(
+				"tx_id = ? AND output_idx = ?",
+				utxoId.Id().Bytes(),
+				utxoId.Index(),
+			).
+			Count(&count)
+		if existsResult.Error != nil {
+			return existsResult.Error
+		}
+		if count == 0 {
+			return fmt.Errorf(
+				"%w: %x:%d",
+				types.ErrUtxoNotFound,
+				utxoId.Id().Bytes(),
+				utxoId.Index(),
+			)
+		}
+		return fmt.Errorf(
+			"%w: %x:%d",
+			types.ErrUtxoConflict,
+			utxoId.Id().Bytes(),
+			utxoId.Index(),
+		)
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf(
+			"%w: %x:%d",
+			types.ErrUtxoConflict,
+			utxoId.Id().Bytes(),
+			utxoId.Index(),
+		)
 	}
 	return nil
 }
 
-// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot
+// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot.
+// Both deleted_slot and spent_at_tx_id must be cleared so the restored row
+// satisfies the spend predicate (deleted_slot = 0 AND spent_at_tx_id IS NULL);
+// otherwise the UTxO appears live but cannot be re-spent.
 func (d *MetadataStorePostgres) SetUtxosNotDeletedAfterSlot(
 	slot uint64,
 	txn types.Txn,
@@ -520,7 +570,10 @@ func (d *MetadataStorePostgres) SetUtxosNotDeletedAfterSlot(
 	}
 	result := db.Model(models.Utxo{}).
 		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", 0)
+		Updates(map[string]any{
+			"deleted_slot":   0,
+			"spent_at_tx_id": nil,
+		})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/database/plugin/metadata/sqlite/block_nonce.go
+++ b/database/plugin/metadata/sqlite/block_nonce.go
@@ -21,9 +21,13 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
-// SetBlockNonce inserts a block nonce into the block_nonce table
+// SetBlockNonce inserts or updates a block nonce. The (hash, slot)
+// uniqueIndex makes this safe to call repeatedly for the same block,
+// which happens when the metadata backfill resumes from a checkpoint
+// that pre-dates a previously-written nonce row.
 func (d *MetadataStoreSqlite) SetBlockNonce(
 	blockHash []byte,
 	slotNumber uint64,
@@ -42,7 +46,26 @@ func (d *MetadataStoreSqlite) SetBlockNonce(
 	if err != nil {
 		return err
 	}
-	result := db.Create(&item)
+	// is_checkpoint is updated with an OR so a later upsert with
+	// false cannot demote a previously-promoted checkpoint row.
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "hash"},
+			{Name: "slot"},
+		},
+		DoUpdates: clause.Set{
+			{
+				Column: clause.Column{Name: "nonce"},
+				Value:  gorm.Expr("excluded.nonce"),
+			},
+			{
+				Column: clause.Column{Name: "is_checkpoint"},
+				Value: gorm.Expr(
+					"block_nonce.is_checkpoint OR excluded.is_checkpoint",
+				),
+			},
+		},
+	}).Create(&item)
 
 	if result.Error != nil {
 		return result.Error

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -437,6 +437,16 @@ func (d *MetadataStoreSqlite) Start() error {
 			"pool_stake_snapshot dedup failed: %w", err,
 		)
 	}
+	// Promote the legacy non-unique block_nonce hash_slot index to a
+	// unique one before AutoMigrate; AutoMigrate will not change index
+	// uniqueness on its own and SetBlockNonce's upsert depends on it.
+	if err := models.MigrateBlockNonceUniqueIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"block_nonce unique index migration failed: %w", err,
+		)
+	}
 	// Create table schemas (uses write connection)
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/sqlite/epoch.go
+++ b/database/plugin/metadata/sqlite/epoch.go
@@ -90,6 +90,37 @@ func (d *MetadataStoreSqlite) GetEpochs(
 	return ret, nil
 }
 
+// GetEpochBySlot returns the epoch containing the given slot, or nil if not found.
+func (d *MetadataStoreSqlite) GetEpochBySlot(
+	slot uint64,
+	txn types.Txn,
+) (*models.Epoch, error) {
+	var ret models.Epoch
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetEpochBySlot: resolve db: %w", err,
+		)
+	}
+	result := db.
+		Where(
+			"start_slot <= ? AND ? < start_slot + length_in_slots",
+			slot,
+			slot,
+		).
+		Order("start_slot DESC").
+		First(&ret)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"GetEpochBySlot: query: %w", result.Error,
+		)
+	}
+	return &ret, nil
+}
+
 // DeleteEpochsAfterSlot removes all epoch entries whose start slot
 // is after the given slot.
 func (d *MetadataStoreSqlite) DeleteEpochsAfterSlot(

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -17,51 +17,22 @@ package sqlite
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
-	pdata "github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
-	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
-
-// --- Mock transaction input with consumed support ---
-
-type mockInput struct {
-	txId  []byte
-	index uint32
-}
-
-func (m *mockInput) Id() lcommon.Blake2b256 {
-	return lcommon.NewBlake2b256(m.txId)
-}
-
-func (m *mockInput) Index() uint32 {
-	return m.index
-}
-
-func (m *mockInput) String() string {
-	return fmt.Sprintf("%x#%d", m.txId, m.index)
-}
-
-func (m *mockInput) Utxorpc() (*cardano.TxInput, error) {
-	return nil, nil
-}
-
-func (m *mockInput) ToPlutusData() pdata.PlutusData {
-	return nil
-}
 
 // mockTransactionWithInputs extends mockTransaction with consumed
 // inputs for testing the optimistic locking UTxO spend path.
 type mockTransactionWithInputs struct {
 	mockTransaction
-	consumed []mockInput
+	consumed []dbtestutil.MockInput
 }
 
 func (m *mockTransactionWithInputs) Consumed() []lcommon.TransactionInput {
@@ -77,6 +48,103 @@ func (m *mockTransactionWithInputs) Inputs() []lcommon.TransactionInput {
 }
 
 // --- Optimistic UTxO locking tests ---
+
+func TestSetUtxoDeletedAtSlotBackfillsSameSlotMissingSpender(t *testing.T) {
+	store := setupTestDB(t)
+
+	utxoTxId := bytes.Repeat([]byte{0xAB}, 32)
+	utxo := models.Utxo{
+		TxId:        utxoTxId,
+		OutputIdx:   0,
+		AddedSlot:   100,
+		DeletedSlot: 200,
+		Amount:      types.Uint64(5000000),
+	}
+	require.NoError(t, store.DB().Create(&utxo).Error)
+
+	input := dbtestutil.NewMockInput(utxoTxId, 0)
+	spenderTxHash := bytes.Repeat([]byte{0xCD}, 32)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Transaction{
+			Hash:  spenderTxHash,
+			Valid: true,
+		}).Error,
+	)
+	require.NoError(
+		t,
+		store.SetUtxoDeletedAtSlot(
+			input,
+			200,
+			spenderTxHash,
+			nil,
+		),
+	)
+
+	var updated models.Utxo
+	require.NoError(
+		t,
+		store.DB().Where(
+			"tx_id = ? AND output_idx = ?",
+			utxoTxId,
+			0,
+		).First(&updated).Error,
+	)
+	require.Equal(t, uint64(200), updated.DeletedSlot)
+	require.Equal(t, spenderTxHash, updated.SpentAtTxId)
+}
+
+func TestSetUtxoDeletedAtSlotReturnsNotFoundWhenRowMissing(
+	t *testing.T,
+) {
+	store := setupTestDB(t)
+
+	input := dbtestutil.NewMockInput(bytes.Repeat([]byte{0xEF}, 32), 0)
+	err := store.SetUtxoDeletedAtSlot(
+		input,
+		200,
+		bytes.Repeat([]byte{0x12}, 32),
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrUtxoNotFound)
+}
+
+func TestSetUtxoDeletedAtSlotReturnsConflictWhenRowAlreadySpent(
+	t *testing.T,
+) {
+	store := setupTestDB(t)
+
+	utxoTxId := bytes.Repeat([]byte{0xEF}, 32)
+	spentTxHash := bytes.Repeat([]byte{0x34}, 32)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Transaction{
+			Hash:  spentTxHash,
+			Valid: true,
+		}).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Utxo{
+			TxId:        utxoTxId,
+			OutputIdx:   0,
+			AddedSlot:   100,
+			DeletedSlot: 150,
+			SpentAtTxId: spentTxHash,
+			Amount:      types.Uint64(5000000),
+		}).Error,
+	)
+
+	err := store.SetUtxoDeletedAtSlot(
+		dbtestutil.NewMockInput(utxoTxId, 0),
+		200,
+		bytes.Repeat([]byte{0x12}, 32),
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrUtxoConflict)
+}
 
 // TestOptimisticLockingConflictDetection verifies that the optimistic
 // locking mechanism in SetTransaction correctly detects when a UTxO
@@ -101,8 +169,8 @@ func TestOptimisticLockingConflictDetection(t *testing.T) {
 			hash:    tx1Hash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: utxoTxId, index: 0},
+		consumed: []dbtestutil.MockInput{
+			{TxId: utxoTxId, IndexValue: 0},
 		},
 	}
 
@@ -141,8 +209,8 @@ func TestOptimisticLockingConflictDetection(t *testing.T) {
 			hash:    tx2Hash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: utxoTxId, index: 0},
+		consumed: []dbtestutil.MockInput{
+			{TxId: utxoTxId, IndexValue: 0},
 		},
 	}
 
@@ -184,8 +252,8 @@ func TestOptimisticLockingIdempotentRetry(t *testing.T) {
 			hash:    txHash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: utxoTxId, index: 0},
+		consumed: []dbtestutil.MockInput{
+			{TxId: utxoTxId, IndexValue: 0},
 		},
 	}
 
@@ -215,8 +283,8 @@ func TestOptimisticLockingMissingUtxo(t *testing.T) {
 			hash:    txHash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: missingTxId, index: 0},
+		consumed: []dbtestutil.MockInput{
+			{TxId: missingTxId, IndexValue: 0},
 		},
 	}
 
@@ -258,9 +326,9 @@ func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
 			hash:    txHash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: utxoTxId, index: 0},
-			{txId: utxoTxId, index: 0}, // duplicate input reference
+		consumed: []dbtestutil.MockInput{
+			{TxId: utxoTxId, IndexValue: 0},
+			{TxId: utxoTxId, IndexValue: 0}, // duplicate input reference
 		},
 	}
 	point := ocommon.Point{
@@ -1098,8 +1166,8 @@ func TestRollbackConcurrentUtxoSpend(t *testing.T) {
 			hash:    tx1Hash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: utxoTxId, index: 0},
+		consumed: []dbtestutil.MockInput{
+			{TxId: utxoTxId, IndexValue: 0},
 		},
 	}
 	point1 := ocommon.Point{
@@ -1153,8 +1221,8 @@ func TestRollbackConcurrentUtxoSpend(t *testing.T) {
 			hash:    tx2Hash,
 			isValid: true,
 		},
-		consumed: []mockInput{
-			{txId: utxoTxId, index: 0},
+		consumed: []dbtestutil.MockInput{
+			{TxId: utxoTxId, IndexValue: 0},
 		},
 	}
 	point2 := ocommon.Point{

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -122,6 +122,56 @@ func (d *MetadataStoreSqlite) GetTransactionByHash(
 	return ret, nil
 }
 
+// GetTransactionSlotByHash returns the slot of the transaction with the
+// given hash without preloading any related rows. Returns (0, false, nil)
+// when no such transaction exists.
+func (d *MetadataStoreSqlite) GetTransactionSlotByHash(
+	hash []byte,
+	txn types.Txn,
+) (uint64, bool, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, false, err
+	}
+	var row struct{ Slot uint64 }
+	result := db.Model(&models.Transaction{}).
+		Select("slot").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, result.Error
+	}
+	return row.Slot, true, nil
+}
+
+// GetTransactionIDByHash returns the primary-key ID of the transaction
+// with the given hash without preloading any related rows. Returns
+// (0, false, nil) when no such transaction exists.
+func (d *MetadataStoreSqlite) GetTransactionIDByHash(
+	hash []byte,
+	txn types.Txn,
+) (uint, bool, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, false, err
+	}
+	var row struct{ ID uint }
+	result := db.Model(&models.Transaction{}).
+		Select("id").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, result.Error
+	}
+	return row.ID, true, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *MetadataStoreSqlite) GetTransactionsByHashes(
 	hashes [][]byte,

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -552,10 +552,14 @@ func (d *MetadataStoreSqlite) AddUtxos(
 	return result.Error
 }
 
-// SetUtxoDeletedAtSlot marks a UTxO as deleted at the given slot
+// SetUtxoDeletedAtSlot marks a UTxO as deleted at the given slot and
+// records the hash of the transaction that consumed it. The update uses
+// the same optimistic-locking predicate as the normal consume path and
+// also repairs same-slot rows that are still missing spent_at_tx_id.
 func (d *MetadataStoreSqlite) SetUtxoDeletedAtSlot(
 	input ledger.TransactionInput,
 	slot uint64,
+	spenderTxHash []byte,
 	txn types.Txn,
 ) error {
 	db, err := d.resolveDB(txn)
@@ -563,15 +567,61 @@ func (d *MetadataStoreSqlite) SetUtxoDeletedAtSlot(
 		return err
 	}
 	result := db.Model(&models.Utxo{}).
-		Where("tx_id = ? AND output_idx = ?", input.Id().Bytes(), input.Index()).
-		Update("deleted_slot", slot)
+		Where(
+			"tx_id = ? AND output_idx = ? AND spent_at_tx_id IS NULL AND (deleted_slot = 0 OR deleted_slot = ?)",
+			input.Id().Bytes(),
+			input.Index(),
+			slot,
+		).
+		Updates(map[string]any{
+			"deleted_slot":   slot,
+			"spent_at_tx_id": spenderTxHash,
+		})
 	if result.Error != nil {
 		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		var count int64
+		existsResult := db.Model(&models.Utxo{}).
+			Where(
+				"tx_id = ? AND output_idx = ?",
+				input.Id().Bytes(),
+				input.Index(),
+			).
+			Count(&count)
+		if existsResult.Error != nil {
+			return existsResult.Error
+		}
+		if count == 0 {
+			return fmt.Errorf(
+				"%w: %x:%d",
+				types.ErrUtxoNotFound,
+				input.Id().Bytes(),
+				input.Index(),
+			)
+		}
+		return fmt.Errorf(
+			"%w: %x:%d",
+			types.ErrUtxoConflict,
+			input.Id().Bytes(),
+			input.Index(),
+		)
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf(
+			"%w: %x:%d",
+			types.ErrUtxoConflict,
+			input.Id().Bytes(),
+			input.Index(),
+		)
 	}
 	return nil
 }
 
-// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot
+// SetUtxosNotDeletedAfterSlot marks a list of Utxos as not deleted after a given slot.
+// Both deleted_slot and spent_at_tx_id must be cleared so the restored row
+// satisfies the spend predicate (deleted_slot = 0 AND spent_at_tx_id IS NULL);
+// otherwise the UTxO appears live but cannot be re-spent.
 func (d *MetadataStoreSqlite) SetUtxosNotDeletedAfterSlot(
 	slot uint64,
 	txn types.Txn,
@@ -582,7 +632,10 @@ func (d *MetadataStoreSqlite) SetUtxosNotDeletedAfterSlot(
 	}
 	result := db.Model(models.Utxo{}).
 		Where("deleted_slot > ?", slot).
-		Update("deleted_slot", 0)
+		Updates(map[string]any{
+			"deleted_slot":   0,
+			"spent_at_tx_id": nil,
+		})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -295,6 +295,25 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Transaction, error)
 
+	// GetTransactionSlotByHash returns the slot of the block that
+	// contains the given tx hash. The bool result is false when no
+	// such transaction is recorded. Lighter than GetTransactionByHash
+	// because it skips loading inputs/outputs/witnesses.
+	GetTransactionSlotByHash(
+		[]byte, // hash
+		types.Txn,
+	) (uint64, bool, error)
+
+	// GetTransactionIDByHash returns the primary-key ID of the
+	// transaction with the given hash. The bool result is false when
+	// no such transaction is recorded. Used by UTxO recovery paths
+	// that need to populate the producer transaction FK on rows they
+	// re-import without paying the cost of loading every association.
+	GetTransactionIDByHash(
+		[]byte, // hash
+		types.Txn,
+	) (uint, bool, error)
+
 	// GetTransactionsByHashes retrieves transactions by their hashes.
 	GetTransactionsByHashes(
 		[][]byte, // hashes
@@ -502,6 +521,10 @@ type MetadataStore interface {
 	// GetEpochs retrieves all epochs.
 	GetEpochs(types.Txn) ([]models.Epoch, error)
 
+	// GetEpochBySlot retrieves the epoch containing the given slot.
+	// Returns nil if no matching epoch exists.
+	GetEpochBySlot(uint64, types.Txn) (*models.Epoch, error)
+
 	// DeleteEpochsAfterSlot removes all epoch entries whose start slot
 	// is after the given slot. Used during chain rollback to discard
 	// epoch nonces that were computed from rolled-back blocks.
@@ -548,11 +571,13 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.Utxo, error)
 
-	// SetUtxoDeletedAtSlot marks a UTxO as deleted at the given slot.
+	// SetUtxoDeletedAtSlot marks a UTxO as deleted at the given slot
+	// and records the hash of the transaction that consumed it.
 	SetUtxoDeletedAtSlot(
-		ledger.TransactionInput,
-		uint64,
-		types.Txn,
+		input ledger.TransactionInput,
+		deletedAtSlot uint64,
+		spenderHash []byte,
+		txn types.Txn,
 	) error
 
 	// SetUtxosNotDeletedAfterSlot marks all UTxOs created after the given slot as not deleted.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -15,11 +15,14 @@
 package database
 
 import (
+	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -117,6 +120,9 @@ func (d *Database) SetTransaction(
 		}
 	}
 
+	if err := d.ensureTransactionConsumedUtxos(tx, point, txn); err != nil {
+		return err
+	}
 	if err := d.metadata.SetTransaction(tx, point, idx, certDeposits, txn.Metadata()); err != nil {
 		return fmt.Errorf("set transaction metadata: %w", err)
 	}
@@ -223,6 +229,13 @@ func (d *Database) SetGapBlockTransaction(
 			"set gap block transaction metadata: %w", err,
 		)
 	}
+	if err := d.ensureGapConsumedUtxos(
+		tx,
+		point,
+		txn,
+	); err != nil {
+		return err
+	}
 
 	if owned {
 		if err := txn.Commit(); err != nil {
@@ -231,6 +244,367 @@ func (d *Database) SetGapBlockTransaction(
 	}
 
 	return nil
+}
+
+func (d *Database) ensureTransactionConsumedUtxos(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	txn *Txn,
+) error {
+	consumed := tx.Consumed()
+	if len(consumed) == 0 {
+		return nil
+	}
+	spenderTxHash := tx.Hash().Bytes()
+	recoveredUtxos := make([]models.Utxo, 0, len(consumed))
+	seen := make(map[string]struct{}, len(consumed))
+	for _, input := range consumed {
+		inputTxId := input.Id().Bytes()
+		inputKey := fmt.Sprintf("%x:%d", inputTxId, input.Index())
+		if _, ok := seen[inputKey]; ok {
+			continue
+		}
+		seen[inputKey] = struct{}{}
+		existingUtxo, err := d.metadata.GetUtxoIncludingSpent(
+			inputTxId,
+			input.Index(),
+			txn.Metadata(),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"check transaction input utxo %s: %w",
+				input.String(),
+				err,
+			)
+		}
+		if existingUtxo != nil {
+			// Backfill the spender link on a same-slot row that was
+			// marked deleted by an earlier code path (e.g., a previous
+			// partial run) without recording the consumer tx hash.
+			// Without this, metadata.SetTransaction's batch consume
+			// would fail with ErrUtxoConflict and rollback cleanup
+			// could not restore the row.
+			if existingUtxo.SpentAtTxId == nil &&
+				existingUtxo.DeletedSlot == point.Slot {
+				if err := d.metadata.SetUtxoDeletedAtSlot(
+					input,
+					point.Slot,
+					spenderTxHash,
+					txn.Metadata(),
+				); err != nil &&
+					!errors.Is(err, types.ErrUtxoNotFound) &&
+					!errors.Is(err, types.ErrUtxoConflict) {
+					return fmt.Errorf(
+						"backfill spender for input utxo %s at slot %d: %w",
+						input.String(),
+						point.Slot,
+						err,
+					)
+				}
+			}
+			continue
+		}
+		recoveredUtxo, err := d.recoverConsumedUtxo(
+			input,
+			txn,
+		)
+		if err != nil {
+			d.logger.Debug(
+				"skipping unrecoverable transaction input utxo repair",
+				"input",
+				input.String(),
+				"error",
+				err,
+			)
+			continue
+		}
+		recoveredUtxos = append(recoveredUtxos, *recoveredUtxo)
+	}
+	if len(recoveredUtxos) == 0 {
+		return nil
+	}
+	if err := d.metadata.ImportUtxos(
+		recoveredUtxos,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"import recovered transaction input utxos: %w",
+			err,
+		)
+	}
+	return nil
+}
+
+func (d *Database) ensureGapConsumedUtxos(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	txn *Txn,
+) error {
+	consumed := tx.Consumed()
+	if len(consumed) == 0 {
+		return nil
+	}
+	spenderTxHash := tx.Hash().Bytes()
+	recoveredUtxos := make([]models.Utxo, 0, len(consumed))
+	seen := make(map[string]struct{}, len(consumed))
+	for _, input := range consumed {
+		inputTxId := input.Id().Bytes()
+		inputKey := fmt.Sprintf("%x:%d", inputTxId, input.Index())
+		if _, ok := seen[inputKey]; ok {
+			continue
+		}
+		seen[inputKey] = struct{}{}
+		existingUtxo, err := d.metadata.GetUtxoIncludingSpent(
+			inputTxId,
+			input.Index(),
+			txn.Metadata(),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"check gap input utxo %s at slot %d: %w",
+				input.String(),
+				point.Slot,
+				err,
+			)
+		}
+		if existingUtxo != nil {
+			// Already spent by this same transaction: idempotent
+			// re-processing of the same gap block is a no-op.
+			if existingUtxo.SpentAtTxId != nil &&
+				bytes.Equal(existingUtxo.SpentAtTxId, spenderTxHash) {
+				continue
+			}
+			// Live rows from an earlier gap block or snapshot need to
+			// be consumed now. Same-slot deleted rows with a missing
+			// SpentAtTxId need their consumer link backfilled.
+			if existingUtxo.SpentAtTxId == nil &&
+				(existingUtxo.DeletedSlot == 0 ||
+					existingUtxo.DeletedSlot == point.Slot) {
+				if err := d.metadata.SetUtxoDeletedAtSlot(
+					input,
+					point.Slot,
+					spenderTxHash,
+					txn.Metadata(),
+				); err != nil {
+					// ErrUtxoConflict can occur if another path raced
+					// the row into a different state between our read
+					// and the update; treat it like NotFound so the
+					// recover-from-blob path runs (which is a no-op for
+					// any row that actually still exists thanks to
+					// ImportUtxos' ON CONFLICT DO NOTHING).
+					switch {
+					case errors.Is(err, types.ErrUtxoNotFound),
+						errors.Is(err, types.ErrUtxoConflict):
+						existingUtxo = nil
+					default:
+						return fmt.Errorf(
+							"mark gap input utxo %s spent at slot %d: %w",
+							input.String(),
+							point.Slot,
+							err,
+						)
+					}
+				}
+				if existingUtxo != nil {
+					continue
+				}
+			} else {
+				// Already spent by a different tx (e.g. the Mithril
+				// snapshot import already recorded this spend): leave the
+				// existing row alone.
+				continue
+			}
+		}
+		recoveredUtxo, err := d.recoverConsumedUtxo(input, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"recover gap input utxo %s at slot %d: %w",
+				input.String(),
+				point.Slot,
+				err,
+			)
+		}
+		recoveredUtxo.DeletedSlot = point.Slot
+		recoveredUtxo.SpentAtTxId = append(
+			[]byte(nil),
+			spenderTxHash...,
+		)
+		recoveredUtxos = append(recoveredUtxos, *recoveredUtxo)
+	}
+	if len(recoveredUtxos) == 0 {
+		return nil
+	}
+	if err := d.metadata.ImportUtxos(
+		recoveredUtxos,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"import recovered gap input utxos at slot %d: %w",
+			point.Slot,
+			err,
+		)
+	}
+	return nil
+}
+
+func (d *Database) recoverConsumedUtxo(
+	input lcommon.TransactionInput,
+	txn *Txn,
+) (*models.Utxo, error) {
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return nil, types.ErrNilTxn
+	}
+	utxoData, err := blob.GetUtxo(
+		blobTxn,
+		input.Id().Bytes(),
+		input.Index(),
+	)
+	if err != nil && !errors.Is(err, types.ErrBlobKeyNotFound) {
+		return nil, fmt.Errorf("lookup blob data: %w", err)
+	}
+	addedSlot := uint64(0)
+	outputCbor := utxoData
+	switch {
+	case err == nil && IsUtxoOffsetStorage(utxoData):
+		offset, err := DecodeUtxoOffset(utxoData)
+		if err != nil {
+			return nil, fmt.Errorf("decode utxo offset: %w", err)
+		}
+		blockCbor, _, err := blob.GetBlock(
+			blobTxn,
+			offset.BlockSlot,
+			offset.BlockHash[:],
+		)
+		if err != nil {
+			return nil, fmt.Errorf("load producer block: %w", err)
+		}
+		end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
+		if end > uint64(len(blockCbor)) {
+			return nil, fmt.Errorf(
+				"utxo offset out of bounds: offset=%d, length=%d, block_size=%d",
+				offset.ByteOffset,
+				offset.ByteLength,
+				len(blockCbor),
+			)
+		}
+		outputCbor = blockCbor[offset.ByteOffset:end]
+		addedSlot = offset.BlockSlot
+	case err == nil:
+		// Legacy format: raw output CBOR is already present in utxoData.
+		// Resolve the producer slot so addedSlot reflects when the UTxO
+		// was actually created; otherwise recovered legacy rows would look
+		// like genesis entries (added_slot = 0) and be invisible to
+		// slot-bounded queries and rollback cleanup. We only need the slot
+		// here, so the metadata-driven slot lookup avoids a full block
+		// fetch.
+		slot, found, slotErr := utxoRecoverySlotForTx(
+			txn.DB(),
+			txn,
+			input.Id().Bytes(),
+		)
+		if slotErr != nil {
+			return nil, fmt.Errorf(
+				"lookup producer slot for legacy utxo recovery: %w",
+				slotErr,
+			)
+		}
+		if !found {
+			return nil, ErrUtxoNotFound
+		}
+		addedSlot = slot
+	default:
+		block, err := utxoRecoveryBlockForTx(
+			txn.DB(),
+			txn,
+			input.Id().Bytes(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("lookup producer block: %w", err)
+		}
+		if block == nil {
+			return nil, ErrUtxoNotFound
+		}
+		decodedBlock, err := block.Decode()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"decode producer block for input recovery at slot %d: %w",
+				block.Slot,
+				err,
+			)
+		}
+		outputCbor, err = utxoCborFromDecodedBlock(
+			decodedBlock,
+			input.Id().Bytes(),
+			input.Index(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		addedSlot = block.Slot
+		indexer := NewBlockIndexer(block.Slot, block.Hash)
+		offsets, indexErr := indexer.ComputeOffsets(block.Cbor, decodedBlock)
+		if indexErr == nil {
+			var txHashArray [32]byte
+			copy(txHashArray[:], input.Id().Bytes())
+			ref := UtxoRef{TxId: txHashArray, OutputIdx: input.Index()}
+			if offset, ok := offsets.UtxoOffsets[ref]; ok {
+				if repairErr := repairUtxoBlob(
+					txn.DB(),
+					txn,
+					input.Id().Bytes(),
+					input.Index(),
+					&offset,
+				); repairErr != nil {
+					d.logger.Debug(
+						"failed to repair missing consumed input utxo blob",
+						"input",
+						input.String(),
+						"error",
+						repairErr,
+					)
+				}
+			}
+		}
+	}
+	output, err := gledger.NewTransactionOutputFromCbor(outputCbor)
+	if err != nil {
+		return nil, fmt.Errorf("decode transaction output: %w", err)
+	}
+	ret := models.UtxoLedgerToModel(
+		lcommon.Utxo{
+			Id:     input,
+			Output: output,
+		},
+		addedSlot,
+	)
+	// Populate the producer transaction FK so that joins on
+	// utxo.transaction_id and Preload("Outputs") from the producer
+	// Transaction see this row after a rollback reanimates it. The
+	// producer tx record may genuinely be absent (the very condition
+	// that drove recovery in some branches); in that case we leave
+	// the FK nil and the row stays unjoinable until backfilled by a
+	// later path that has the producer.
+	producerID, found, lookupErr := d.metadata.GetTransactionIDByHash(
+		input.Id().Bytes(),
+		txn.Metadata(),
+	)
+	if lookupErr != nil {
+		d.logger.Debug(
+			"failed to resolve producer transaction id for recovered utxo",
+			"input",
+			input.String(),
+			"error",
+			lookupErr,
+		)
+	} else if found {
+		ret.TransactionID = &producerID
+	}
+	return &ret, nil
 }
 
 // SetGenesisTransaction stores a genesis transaction with its UTxO outputs.

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -18,12 +18,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +37,7 @@ type mockBlobStore struct {
 	commitErrs   []error
 	deleteTxnIDs []int
 	txns         []*mockBlobTxn
+	utxoData     map[string][]byte
 }
 
 type mockBlobTxn struct {
@@ -59,7 +65,7 @@ func (m *mockBlobStore) NewTransaction(bool) types.Txn {
 }
 
 func (m *mockBlobStore) Get(types.Txn, []byte) ([]byte, error) {
-	return nil, nil
+	return nil, types.ErrBlobKeyNotFound
 }
 
 func (m *mockBlobStore) Set(types.Txn, []byte, []byte) error {
@@ -103,7 +109,7 @@ func (m *mockBlobStore) GetBlock(
 	uint64,
 	[]byte,
 ) ([]byte, types.BlockMetadata, error) {
-	return nil, types.BlockMetadata{}, nil
+	return nil, types.BlockMetadata{}, types.ErrBlobKeyNotFound
 }
 
 func (m *mockBlobStore) DeleteBlock(types.Txn, uint64, []byte, uint64) error {
@@ -115,15 +121,20 @@ func (m *mockBlobStore) GetBlockURL(
 	types.Txn,
 	ocommon.Point,
 ) (types.SignedURL, types.BlockMetadata, error) {
-	return types.SignedURL{}, types.BlockMetadata{}, nil
+	return types.SignedURL{}, types.BlockMetadata{}, types.ErrBlobKeyNotFound
 }
 
 func (m *mockBlobStore) SetUtxo(types.Txn, []byte, uint32, []byte) error {
 	return nil
 }
 
-func (m *mockBlobStore) GetUtxo(types.Txn, []byte, uint32) ([]byte, error) {
-	return nil, nil
+func (m *mockBlobStore) GetUtxo(txn types.Txn, txId []byte, outputIdx uint32) ([]byte, error) {
+	if m.utxoData != nil {
+		if data, ok := m.utxoData[fmt.Sprintf("%x:%d", txId, outputIdx)]; ok {
+			return data, nil
+		}
+	}
+	return nil, types.ErrBlobKeyNotFound
 }
 
 func (m *mockBlobStore) DeleteUtxo(types.Txn, []byte, uint32) error {
@@ -135,7 +146,7 @@ func (m *mockBlobStore) SetTx(types.Txn, []byte, []byte) error {
 }
 
 func (m *mockBlobStore) GetTx(types.Txn, []byte) ([]byte, error) {
-	return nil, nil
+	return nil, types.ErrBlobKeyNotFound
 }
 
 func (m *mockBlobStore) DeleteTx(txn types.Txn, txHash []byte) error {
@@ -206,4 +217,233 @@ func TestDeleteTxBlobsCountsFailedBatchCommit(t *testing.T) {
 	require.Equal(t, 1, store.txns[0].commitCount)
 	require.Contains(t, logs.String(), "\"failed\":3")
 	require.Contains(t, logs.String(), "\"total\":3")
+}
+
+func TestRecoverConsumedUtxoLegacyRawCborWithoutProducerBlockFails(t *testing.T) {
+	db, err := New(&Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+	origBlob := db.Blob()
+	store := &mockBlobStore{utxoData: make(map[string][]byte)}
+	db.SetBlobStore(store)
+	if origBlob != nil {
+		require.NoError(t, origBlob.Close())
+	}
+
+	txId := bytes.Repeat([]byte{0xAB}, 32)
+	output, err := mockledger.NewTransactionOutputBuilder().
+		WithAddress("addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd").
+		WithLovelace(1_000_000).
+		Build()
+	require.NoError(t, err)
+	rawOutput, err := cbor.Encode(output)
+	require.NoError(t, err)
+	store.utxoData[fmt.Sprintf("%x:%d", txId, 0)] = rawOutput
+
+	txn := db.Transaction(true)
+	defer txn.Release()
+
+	_, err = db.recoverConsumedUtxo(dbtestutil.NewMockInput(txId, 0), txn)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrUtxoNotFound)
+}
+
+// TestSetTransactionRecoveryPopulatesProducerFK verifies that when
+// ensureTransactionConsumedUtxos has to recover a missing UTxO row for
+// a consumed input, the recovered row carries the producer transaction
+// FK. Without this FK, SetUtxosNotDeletedAfterSlot would reanimate the
+// row during a rollback but joins on utxo.transaction_id and GORM
+// Preload("Outputs") through the producer Transaction would silently
+// drop it.
+func TestSetTransactionRecoveryPopulatesProducerFK(t *testing.T) {
+	// Intentionally not t.Parallel(): database.New() writes to plugin
+	// option destination pointers via SetPluginOption, which the race
+	// detector flags when two tests build a Database concurrently.
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	candidate := findGapConsumeCandidateWithoutCertificates(t)
+
+	// Persist each producer half: the block + blob offsets, plus a
+	// metadata Transaction row with its produced UTxOs. We bypass the
+	// db.SetTransaction wrapper because the producer's own inputs are
+	// not part of this fixture and would force a recovery cascade. We
+	// only need the producer's Transaction row and its produced UTxO
+	// rows to exist so the consumer's recovery has a real FK target.
+	for _, p := range candidate.producers {
+		storeBlockOffsetsOnly(t, db, p.block)
+		metaTxn := db.MetadataTxn(true)
+		producer := p
+		require.NoError(
+			t,
+			metaTxn.Do(func(txn *Txn) error {
+				return db.Metadata().SetGapBlockTransaction(
+					producer.tx,
+					producer.point,
+					0,
+					txn.Metadata(),
+				)
+			}),
+		)
+		metaTxn.Release()
+	}
+
+	// Snapshot each producer transaction's primary key so we can
+	// later assert the recovered UTxOs' FK matches.
+	producerIDByHash := make(map[string]uint, len(candidate.producers))
+	for _, p := range candidate.producers {
+		producerHash := p.tx.Hash().Bytes()
+		got, err := db.Metadata().GetTransactionByHash(producerHash, nil)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			got,
+			"producer transaction row must be persisted",
+		)
+		require.NotZero(t, got.ID)
+		producerIDByHash[fmt.Sprintf("%x", producerHash)] = got.ID
+	}
+
+	storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+
+	// Force the recovery path by deleting the metadata Utxo rows for
+	// the inputs the consumer is about to spend. The blob store still
+	// has their offset references, and the metadata Transaction row
+	// for each producer remains intact.
+	refs := make([]models.UtxoId, 0, len(candidate.consumerTx.Consumed()))
+	for _, input := range candidate.consumerTx.Consumed() {
+		refs = append(refs, models.UtxoId{
+			Hash: input.Id().Bytes(),
+			Idx:  input.Index(),
+		})
+	}
+	metaTxn := db.MetadataTxn(true)
+	require.NoError(
+		t,
+		metaTxn.Do(func(txn *Txn) error {
+			return db.Metadata().DeleteUtxos(refs, txn.Metadata())
+		}),
+	)
+	metaTxn.Release()
+	for _, input := range candidate.consumerTx.Consumed() {
+		utxo, err := db.Metadata().GetUtxoIncludingSpent(
+			input.Id().Bytes(),
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.Nil(
+			t,
+			utxo,
+			"setup: utxo %s must be deleted to exercise recovery",
+			input.String(),
+		)
+	}
+
+	// SetTransaction on the consumer triggers
+	// ensureTransactionConsumedUtxos -> recoverConsumedUtxo for each
+	// missing input.
+	require.NoError(
+		t,
+		db.SetTransaction(
+			candidate.consumerTx,
+			candidate.consumerPoint,
+			0,
+			0,
+			nil,
+			nil,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			nil,
+		),
+	)
+
+	// Each recovered UTxO row must carry the producer transaction FK
+	// pointing at the right Transaction.ID.
+	for _, input := range candidate.consumerTx.Consumed() {
+		producerHash := input.Id().Bytes()
+		expectedID, ok := producerIDByHash[fmt.Sprintf("%x", producerHash)]
+		require.True(
+			t,
+			ok,
+			"setup: producer hash %x missing from snapshot",
+			producerHash,
+		)
+		utxo, err := db.Metadata().GetUtxoIncludingSpent(
+			producerHash,
+			input.Index(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			utxo,
+			"recovered UTxO for %s must be present",
+			input.String(),
+		)
+		require.NotNil(
+			t,
+			utxo.TransactionID,
+			"recovered UTxO for %s must carry producer FK so that "+
+				"rollback reanimation keeps it visible to joins on "+
+				"utxo.transaction_id and Preload(\"Outputs\")",
+			input.String(),
+		)
+		require.Equal(t, expectedID, *utxo.TransactionID)
+	}
+
+	// Stronger end-to-end check: rollback past the consumer slot and
+	// confirm the producer Transaction's preloaded Outputs include
+	// each reanimated row.
+	rollbackTxn := db.MetadataTxn(true)
+	require.NoError(
+		t,
+		rollbackTxn.Do(func(txn *Txn) error {
+			return db.Metadata().DeleteTransactionsAfterSlot(
+				candidate.consumerPoint.Slot-1,
+				txn.Metadata(),
+			)
+		}),
+	)
+	rollbackTxn.Release()
+	rollbackTxn = db.MetadataTxn(true)
+	require.NoError(
+		t,
+		rollbackTxn.Do(func(txn *Txn) error {
+			return db.Metadata().SetUtxosNotDeletedAfterSlot(
+				candidate.consumerPoint.Slot-1,
+				txn.Metadata(),
+			)
+		}),
+	)
+	rollbackTxn.Release()
+	for _, input := range candidate.consumerTx.Consumed() {
+		producer, err := db.Metadata().GetTransactionByHash(
+			input.Id().Bytes(),
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, producer)
+		found := false
+		for _, out := range producer.Outputs {
+			if out.OutputIdx == input.Index() {
+				found = true
+				break
+			}
+		}
+		require.True(
+			t,
+			found,
+			"after rollback, recovered UTxO for %s must be "+
+				"reachable from producer Transaction.Outputs preload",
+			input.String(),
+		)
+	}
 }

--- a/database/tx_body_offsets.go
+++ b/database/tx_body_offsets.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+const (
+	txBodyKeyOutputs uint64 = 1
+	// TxBodyKeyCollateralReturn is the CBOR map key for the
+	// collateral_return entry in a transaction body. Exported so the
+	// node loader can reuse it without redeclaring the constant.
+	TxBodyKeyCollateralReturn uint64 = 16
+)
+
+func checkedIntToUint32(v int) (uint32, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("negative value %d", v)
+	}
+	if uint64(v) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("value %d overflows uint32", v)
+	}
+	return uint32(v), nil // #nosec G115 -- checked above
+}
+
+func absoluteBodyRange(
+	bodyOffset uint32,
+	valueOffset int,
+	valueLen int,
+) (uint32, uint32, error) {
+	valueOffset32, err := checkedIntToUint32(valueOffset)
+	if err != nil {
+		return 0, 0, err
+	}
+	valueLen32, err := checkedIntToUint32(valueLen)
+	if err != nil {
+		return 0, 0, err
+	}
+	if valueOffset32 > ^uint32(0)-bodyOffset {
+		return 0, 0, fmt.Errorf(
+			"value offset %d overflows body offset %d",
+			valueOffset32,
+			bodyOffset,
+		)
+	}
+	return bodyOffset + valueOffset32, valueLen32, nil
+}
+
+func txBodyProducedOutputRange(
+	bodyCbor []byte,
+	bodyOffset uint32,
+	outputIndex uint32,
+) (uint32, uint32, bool, error) {
+	decoder, err := cbor.NewStreamDecoder(bodyCbor)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	count, _, _, err := decoder.DecodeMapHeader()
+	if err != nil {
+		return 0, 0, false, err
+	}
+	if count < 0 {
+		return 0, 0, false, errors.New("indefinite tx body map")
+	}
+
+	var outputCount uint32
+	var haveOutputs bool
+	var collateralOffset uint32
+	var collateralLen uint32
+	var haveCollateral bool
+
+	for range count {
+		var currentKey uint64
+		if _, _, err := decoder.Decode(&currentKey); err != nil {
+			return 0, 0, false, err
+		}
+
+		switch currentKey {
+		case txBodyKeyOutputs:
+			arrCount, _, _, err := decoder.DecodeArrayHeader()
+			if err != nil {
+				return 0, 0, false, err
+			}
+			if arrCount < 0 {
+				return 0, 0, false, errors.New("indefinite output array")
+			}
+			outputCount64 := uint64(arrCount)
+			if outputCount64 > uint64(^uint32(0)) {
+				return 0, 0, false, fmt.Errorf(
+					"output count %d overflows uint32",
+					outputCount64,
+				)
+			}
+			outputCount = uint32(outputCount64) // #nosec G115 -- checked above
+			haveOutputs = true
+			for i := range arrCount {
+				valueOffset, valueLen, err := decoder.Skip()
+				if err != nil {
+					return 0, 0, false, err
+				}
+				if uint32(i) != outputIndex { // #nosec G115 -- i < outputCount
+					continue
+				}
+				offset, length, err := absoluteBodyRange(
+					bodyOffset,
+					valueOffset,
+					valueLen,
+				)
+				if err != nil {
+					return 0, 0, false, err
+				}
+				return offset, length, true, nil
+			}
+		case TxBodyKeyCollateralReturn:
+			valueOffset, valueLen, err := decoder.Skip()
+			if err != nil {
+				return 0, 0, false, err
+			}
+			offset, length, err := absoluteBodyRange(
+				bodyOffset,
+				valueOffset,
+				valueLen,
+			)
+			if err != nil {
+				return 0, 0, false, err
+			}
+			collateralOffset = offset
+			collateralLen = length
+			haveCollateral = true
+		default:
+			if _, _, err := decoder.Skip(); err != nil {
+				return 0, 0, false, err
+			}
+		}
+	}
+
+	// collateral_return is the pseudo-output at index len(outputs),
+	// matching lcommon.Transaction.Produced() for invalid Babbage+ txs.
+	if haveOutputs &&
+		haveCollateral &&
+		outputIndex == outputCount {
+		return collateralOffset, collateralLen, true, nil
+	}
+	return 0, 0, false, nil
+}

--- a/database/tx_body_offsets_test.go
+++ b/database/tx_body_offsets_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxBodyProducedOutputRangeIgnoresNonOutputMatch(t *testing.T) {
+	bodyCbor := []byte{
+		0xa2,
+		0x00, 0x43, 0x82, 0x01, 0x02,
+		0x01, 0x82,
+		0x82, 0x01, 0x02,
+		0x82, 0x03, 0x04,
+	}
+
+	offset, length, found, err := txBodyProducedOutputRange(
+		bodyCbor,
+		0,
+		0,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint32(8), offset)
+	require.Equal(t, uint32(3), length)
+	require.Equal(t, []byte{0x82, 0x01, 0x02}, bodyCbor[offset:offset+length])
+}
+
+func TestTxBodyProducedOutputRangeDuplicateOutputs(t *testing.T) {
+	bodyCbor := []byte{
+		0xa1,
+		0x01, 0x82,
+		0x82, 0x01, 0x02,
+		0x82, 0x01, 0x02,
+	}
+
+	offset0, length0, found0, err := txBodyProducedOutputRange(
+		bodyCbor,
+		0,
+		0,
+	)
+	require.NoError(t, err)
+	require.True(t, found0)
+	require.Equal(t, uint32(3), offset0)
+	require.Equal(t, uint32(3), length0)
+	require.Equal(
+		t,
+		[]byte{0x82, 0x01, 0x02},
+		bodyCbor[offset0:offset0+length0],
+	)
+
+	offset1, length1, found1, err := txBodyProducedOutputRange(
+		bodyCbor,
+		0,
+		1,
+	)
+	require.NoError(t, err)
+	require.True(t, found1)
+	require.Equal(t, uint32(6), offset1)
+	require.Equal(t, uint32(3), length1)
+	require.Equal(
+		t,
+		[]byte{0x82, 0x01, 0x02},
+		bodyCbor[offset1:offset1+length1],
+	)
+}
+
+func TestTxBodyProducedOutputRangeCollateralReturn(t *testing.T) {
+	bodyCbor := []byte{
+		0xa2,
+		0x01, 0x81,
+		0x82, 0x01, 0x02,
+		0x10,
+		0x82, 0x03, 0x04,
+	}
+
+	// 42 is an arbitrary base offset of bodyCbor inside an enclosing
+	// block envelope; the returned offset is base + position-within-body.
+	offset, length, found, err := txBodyProducedOutputRange(
+		bodyCbor,
+		42,
+		1,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint32(49), offset)
+	require.Equal(t, uint32(3), length)
+	relativeOffset := offset - 42
+	require.Equal(
+		t,
+		[]byte{0x82, 0x03, 0x04},
+		bodyCbor[relativeOffset:relativeOffset+length],
+	)
+}

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -172,6 +172,9 @@ var ErrPartialCommit = errors.New(
 // conflicts from other errors and retry or reject accordingly.
 var ErrUtxoConflict = errors.New("UTxO already spent")
 
+// ErrUtxoNotFound is returned when a requested UTxO row does not exist.
+var ErrUtxoNotFound = errors.New("utxo not found")
+
 // UtxoKey identifies a UTxO row by its transaction id and output
 // index. Used as a parameter type for batch UTxO operations across
 // the metadata-store interface (e.g. MarkUtxosDeletedAtSlot). The

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -30,7 +30,7 @@ import (
 // ErrUtxoNotFound signals that the metadata row for a UTxO does not
 // exist (or was filtered out, e.g. by deleted_slot != 0 in the live
 // view). Callers may use errors.Is to detect a genuinely-absent row.
-var ErrUtxoNotFound = errors.New("utxo not found")
+var ErrUtxoNotFound = types.ErrUtxoNotFound
 
 // ErrUtxoCborUnavailable signals that the metadata row for a UTxO
 // exists but its CBOR could not be loaded from the blob store and
@@ -242,6 +242,88 @@ func recoverUtxoCbor(
 	return recoveredCbor, nil
 }
 
+// utxoRecoverySlotForTx returns the producer block slot for txId without
+// fetching the block itself. Returns (0, false, nil) when the producer tx
+// cannot be located so callers can decide whether that is fatal.
+func utxoRecoverySlotForTx(
+	db *Database,
+	txn *Txn,
+	txId []byte,
+) (uint64, bool, error) {
+	slot, _, found, err := fetchTxBlobSlotAndHash(db, txn, txId)
+	if err != nil {
+		return 0, false, err
+	}
+	if found {
+		return slot, true, nil
+	}
+	slot, found, err = db.metadata.GetTransactionSlotByHash(
+		txId, txn.Metadata(),
+	)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			"lookup producer tx metadata for utxo recovery %x: %w",
+			txId[:8],
+			err,
+		)
+	}
+	if !found {
+		return 0, false, nil
+	}
+	return slot, true, nil
+}
+
+func fetchTxBlobSlotAndHash(
+	db *Database,
+	txn *Txn,
+	txId []byte,
+) (uint64, [32]byte, bool, error) {
+	var blockHash [32]byte
+	if db == nil || txn == nil {
+		return 0, blockHash, false, nil
+	}
+	blob := db.Blob()
+	blobTxn := txn.Blob()
+	if blob == nil || blobTxn == nil {
+		return 0, blockHash, false, nil
+	}
+	txData, err := blob.GetTx(blobTxn, txId)
+	if err != nil {
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return 0, blockHash, false, nil
+		}
+		return 0, blockHash, false, fmt.Errorf(
+			"lookup tx blob for utxo recovery %x: %w",
+			txId[:8],
+			err,
+		)
+	}
+	switch {
+	case IsTxOffsetStorage(txData):
+		offset, err := DecodeTxOffset(txData)
+		if err != nil {
+			return 0, blockHash, false, fmt.Errorf(
+				"decode tx offset for utxo recovery %x: %w",
+				txId[:8],
+				err,
+			)
+		}
+		return offset.BlockSlot, offset.BlockHash, true, nil
+	case IsTxCborPartsStorage(txData):
+		parts, err := DecodeTxCborParts(txData)
+		if err != nil {
+			return 0, blockHash, false, fmt.Errorf(
+				"decode tx parts for utxo recovery %x: %w",
+				txId[:8],
+				err,
+			)
+		}
+		return parts.BlockSlot, parts.BlockHash, true, nil
+	default:
+		return 0, blockHash, false, nil
+	}
+}
+
 func utxoRecoveryBlockForTx(
 	db *Database,
 	txn *Txn,
@@ -250,61 +332,23 @@ func utxoRecoveryBlockForTx(
 	// Try the blob-based path when both the blob store and a blob
 	// transaction handle are available; otherwise skip straight to the
 	// metadata-based lookup below.
-	blob := db.Blob()
-	blobTxn := txn.Blob()
-	if blob != nil && blobTxn != nil {
-		if txData, err := blob.GetTx(blobTxn, txId); err == nil {
-			switch {
-			case IsTxOffsetStorage(txData):
-				offset, err := DecodeTxOffset(txData)
-				if err != nil {
-					return nil, fmt.Errorf(
-						"decode tx offset for utxo recovery %x: %w",
-						txId[:8],
-						err,
-					)
-				}
-				block, err := BlockByPointTxn(
-					txn,
-					ocommon.NewPoint(offset.BlockSlot, offset.BlockHash[:]),
-				)
-				if err != nil {
-					return nil, fmt.Errorf(
-						"lookup producer block from tx offset %x: %w",
-						txId[:8],
-						err,
-					)
-				}
-				return &block, nil
-			case IsTxCborPartsStorage(txData):
-				parts, err := DecodeTxCborParts(txData)
-				if err != nil {
-					return nil, fmt.Errorf(
-						"decode tx parts for utxo recovery %x: %w",
-						txId[:8],
-						err,
-					)
-				}
-				block, err := BlockByPointTxn(
-					txn,
-					ocommon.NewPoint(parts.BlockSlot, parts.BlockHash[:]),
-				)
-				if err != nil {
-					return nil, fmt.Errorf(
-						"lookup producer block from tx parts %x: %w",
-						txId[:8],
-						err,
-					)
-				}
-				return &block, nil
-			}
-		} else if !errors.Is(err, types.ErrBlobKeyNotFound) {
+	slot, blockHash, found, err := fetchTxBlobSlotAndHash(db, txn, txId)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		block, err := BlockByPointTxn(
+			txn,
+			ocommon.NewPoint(slot, blockHash[:]),
+		)
+		if err != nil {
 			return nil, fmt.Errorf(
-				"lookup tx blob for utxo recovery %x: %w",
+				"lookup producer block from tx blob %x: %w",
 				txId[:8],
 				err,
 			)
 		}
+		return &block, nil
 	}
 	producerTx, err := db.metadata.GetTransactionByHash(txId, txn.Metadata())
 	if err != nil {

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -33,7 +33,9 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
-const backfillPhase = "metadata"
+// BackfillPhase is the phase name used for the historical metadata
+// backfill checkpoint.
+const BackfillPhase = "metadata"
 
 // Backfill replays stored blocks to populate historical metadata.
 // It is triggered automatically during Mithril sync when
@@ -69,10 +71,9 @@ func NewBackfill(
 }
 
 // NeedsBackfill checks if there's an incomplete backfill checkpoint.
-// Returns true only when a checkpoint exists and is not yet completed.
 func (b *Backfill) NeedsBackfill() (bool, error) {
 	cp, err := b.db.Metadata().GetBackfillCheckpoint(
-		backfillPhase, nil,
+		BackfillPhase, nil,
 	)
 	if err != nil {
 		return false, fmt.Errorf(
@@ -91,6 +92,18 @@ func (b *Backfill) loadEpochs() error {
 	b.epochs = epochs
 	b.pparamsCache = make(map[uint64]lcommon.ProtocolParameters)
 	return nil
+}
+
+func (b *Backfill) initializeFromFirstEpoch() {
+	if len(b.epochs) == 0 {
+		return
+	}
+	b.lastEpochId = b.epochs[0].EpochId
+	b.currentEraId = b.epochs[0].EraId
+	pp := b.getPParams(b.epochs[0].EpochId)
+	if pp != nil {
+		b.currentPParams = pp
+	}
 }
 
 // slotToEpoch finds the epoch containing the given slot.
@@ -509,7 +522,7 @@ func (b *Backfill) processBlockGovernance(
 // resume.
 func (b *Backfill) Run(ctx context.Context) error {
 	cp, err := b.db.Metadata().GetBackfillCheckpoint(
-		backfillPhase, nil,
+		BackfillPhase, nil,
 	)
 	if err != nil {
 		return fmt.Errorf("reading backfill checkpoint: %w", err)
@@ -531,6 +544,24 @@ func (b *Backfill) Run(ctx context.Context) error {
 			"no blocks in blob store, nothing to backfill",
 			"component", "backfill",
 		)
+		// A pre-seeded checkpoint (e.g. from `dingo mithril sync`
+		// marking the backfill in-progress before any blocks are
+		// written) would otherwise persist forever, leaving
+		// NeedsBackfill() perpetually true on every subsequent
+		// startup. Mark it complete so the empty-store case is
+		// truly a no-op for resume purposes.
+		if cp != nil && !cp.Completed {
+			cp.Completed = true
+			cp.UpdatedAt = time.Now()
+			if err := b.db.Metadata().SetBackfillCheckpoint(
+				cp, nil,
+			); err != nil {
+				return fmt.Errorf(
+					"completing empty backfill checkpoint: %w",
+					err,
+				)
+			}
+		}
 		return nil
 	}
 	tipSlot := tipBlocks[0].Slot
@@ -554,7 +585,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 	now := time.Now()
 	if cp == nil {
 		cp = &models.BackfillCheckpoint{
-			Phase:      backfillPhase,
+			Phase:      BackfillPhase,
 			LastSlot:   0,
 			TotalSlots: tipSlot,
 			StartedAt:  now,
@@ -575,33 +606,42 @@ func (b *Backfill) Run(ctx context.Context) error {
 		// Fresh start: reset epoch/era tracking to the
 		// first epoch so processEpochBoundary doesn't
 		// misinterpret the first block as an era change.
-		if len(b.epochs) > 0 {
-			b.lastEpochId = b.epochs[0].EpochId
-			b.currentEraId = b.epochs[0].EraId
-			pp := b.getPParams(b.epochs[0].EpochId)
+		b.initializeFromFirstEpoch()
+	} else {
+		startSlot = cp.LastSlot + 1
+		if cp.LastSlot == 0 {
+			// LastSlot 0 is ambiguous: it can mean either
+			// slot 0 was processed or an initial checkpoint
+			// was written before any block completed. Resume
+			// from 0 so a pre-seeded checkpoint cannot skip
+			// the first real block.
+			startSlot = 0
+			b.logger.Info(
+				"reinitializing metadata backfill from first block",
+				"component", "backfill",
+				"tip_slot", tipSlot,
+				"restart_from_first_block", true,
+			)
+			b.initializeFromFirstEpoch()
+		} else {
+			b.logger.Info(
+				"resuming metadata backfill",
+				"component", "backfill",
+				"resume_from_slot", cp.LastSlot,
+				"tip_slot", tipSlot,
+			)
+			// Recover running nonce from the last processed
+			// block so nonce computation can continue.
+			b.recoverNonce(cp.LastSlot)
+
+			// Set epoch tracking to resume point.
+			epochId, eraId := b.slotToEpoch(cp.LastSlot)
+			b.lastEpochId = epochId
+			b.currentEraId = eraId
+			pp := b.getPParams(epochId)
 			if pp != nil {
 				b.currentPParams = pp
 			}
-		}
-	} else {
-		startSlot = cp.LastSlot + 1
-		b.logger.Info(
-			"resuming metadata backfill",
-			"component", "backfill",
-			"resume_from_slot", cp.LastSlot,
-			"tip_slot", tipSlot,
-		)
-		// Recover running nonce from the last processed
-		// block so nonce computation can continue.
-		b.recoverNonce(cp.LastSlot)
-
-		// Set epoch tracking to resume point
-		epochId, eraId := b.slotToEpoch(cp.LastSlot)
-		b.lastEpochId = epochId
-		b.currentEraId = eraId
-		pp := b.getPParams(epochId)
-		if pp != nil {
-			b.currentPParams = pp
 		}
 	}
 

--- a/internal/node/backfill_test.go
+++ b/internal/node/backfill_test.go
@@ -15,7 +15,9 @@
 package node
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"testing"
@@ -46,7 +48,32 @@ func TestNeedsBackfill_NoCheckpoint(t *testing.T) {
 	db := newTestDB(t)
 	bf := NewBackfill(db, nil, slog.Default())
 
-	// No checkpoint exists => NeedsBackfill should return false
+	// No checkpoint and no blocks => nothing to backfill
+	needed, err := bf.NeedsBackfill()
+	require.NoError(t, err)
+	assert.False(t, needed)
+}
+
+func TestNeedsBackfill_NoCheckpointWithBlocks(t *testing.T) {
+	db := newTestDB(t)
+	bf := NewBackfill(db, nil, slog.Default())
+
+	// Blocks present but no checkpoint => backfill is NOT needed.
+	// Backfill is driven by the checkpoint alone. Normal-sync API
+	// nodes have blocks but never run backfill, so the absence of
+	// a checkpoint must mean "don't backfill".
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i)
+	}
+	err := db.BlockCreate(models.Block{
+		Slot: 100,
+		Hash: hash,
+		Cbor: []byte{0x82, 0x01},
+		Type: 1,
+	}, nil)
+	require.NoError(t, err)
+
 	needed, err := bf.NeedsBackfill()
 	require.NoError(t, err)
 	assert.False(t, needed)
@@ -59,7 +86,7 @@ func TestNeedsBackfill_IncompleteCheckpoint(t *testing.T) {
 	// Create an incomplete checkpoint
 	now := time.Now()
 	cp := &models.BackfillCheckpoint{
-		Phase:      backfillPhase,
+		Phase:      BackfillPhase,
 		LastSlot:   5000,
 		TotalSlots: 100000,
 		StartedAt:  now,
@@ -82,7 +109,7 @@ func TestNeedsBackfill_CompletedCheckpoint(t *testing.T) {
 	// Create a completed checkpoint
 	now := time.Now()
 	cp := &models.BackfillCheckpoint{
-		Phase:      backfillPhase,
+		Phase:      BackfillPhase,
 		LastSlot:   100000,
 		TotalSlots: 100000,
 		StartedAt:  now,
@@ -119,7 +146,7 @@ func TestRun_AlreadyCompleted(t *testing.T) {
 	// Pre-create a completed checkpoint
 	now := time.Now()
 	cp := &models.BackfillCheckpoint{
-		Phase:      backfillPhase,
+		Phase:      BackfillPhase,
 		LastSlot:   100000,
 		TotalSlots: 100000,
 		StartedAt:  now,
@@ -141,7 +168,7 @@ func TestRun_CancelledContext_EmptyBlobStore(t *testing.T) {
 	// Create an incomplete checkpoint so Run will attempt work
 	now := time.Now()
 	cp := &models.BackfillCheckpoint{
-		Phase:      backfillPhase,
+		Phase:      BackfillPhase,
 		LastSlot:   0,
 		TotalSlots: 100000,
 		StartedAt:  now,
@@ -159,6 +186,94 @@ func TestRun_CancelledContext_EmptyBlobStore(t *testing.T) {
 	// context.
 	err = bf.Run(ctx)
 	require.NoError(t, err)
+}
+
+func TestRun_IncompleteCheckpointAtZeroStartsAtSlotZero(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now()
+	cp := &models.BackfillCheckpoint{
+		Phase:      BackfillPhase,
+		LastSlot:   0,
+		TotalSlots: 1,
+		StartedAt:  now,
+		UpdatedAt:  now,
+		Completed:  false,
+	}
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(cp, nil))
+
+	for _, slot := range []uint64{0, 1} {
+		hash := make([]byte, 32)
+		hash[0] = byte(slot + 1)
+		require.NoError(t, db.BlockCreate(models.Block{
+			Slot: slot,
+			Hash: hash,
+			Cbor: []byte{0x82, 0x01},
+			Type: 1,
+		}, nil))
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bf := NewBackfill(db, nil, logger)
+
+	require.NoError(t, bf.Run(context.Background()))
+	got, err := db.Metadata().GetBackfillCheckpoint(BackfillPhase, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(1), got.LastSlot)
+}
+
+// TestRun_IncompleteCheckpointAtZeroVisitsSlotZero proves the iterator
+// actually starts at slot 0 (rather than LastSlot+1 = 1). Asserting only
+// the final cp.LastSlot is too weak: it's left at 1 in both the correct
+// resume-from-zero case and the buggy skip-slot-zero case. We verify
+// directly by feeding intentionally-unparseable CBOR for both blocks and
+// observing the per-block "skipping unparseable block" log line for
+// slot 0 — that log fires from inside the iteration loop and so only
+// emits when the iterator visits that slot.
+func TestRun_IncompleteCheckpointAtZeroVisitsSlotZero(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now()
+	cp := &models.BackfillCheckpoint{
+		Phase:      BackfillPhase,
+		LastSlot:   0,
+		TotalSlots: 1,
+		StartedAt:  now,
+		UpdatedAt:  now,
+		Completed:  false,
+	}
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(cp, nil))
+
+	for _, slot := range []uint64{0, 1} {
+		hash := make([]byte, 32)
+		hash[0] = byte(slot + 1)
+		require.NoError(t, db.BlockCreate(models.Block{
+			Slot: slot,
+			Hash: hash,
+			Cbor: []byte{0x82, 0x01},
+			Type: 1,
+		}, nil))
+	}
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	bf := NewBackfill(db, nil, logger)
+
+	require.NoError(t, bf.Run(context.Background()))
+
+	// One unparseable-block warning per visited slot proves the
+	// iterator's slot boundary directly. Both must appear; missing
+	// slot 0 means resume started at 1 and silently skipped the
+	// first block.
+	output := logs.String()
+	assert.Contains(t, output, `"msg":"skipping unparseable block"`)
+	assert.Contains(t, output, `"slot":0`,
+		"iterator must visit slot 0 when resuming from a checkpoint with LastSlot=0")
+	assert.Contains(t, output, `"slot":1`,
+		"iterator must also visit slot 1")
 }
 
 func TestRun_CancelledContext_WithBlocks(t *testing.T) {

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -32,6 +32,7 @@ import (
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	fxcbor "github.com/fxamacker/cbor/v2"
 )
 
@@ -262,12 +263,26 @@ func LoadBlobsWithDB(
 		return nil, errors.New("primary chain not available")
 	}
 
-	blocksCopied, immutableTipSlot, err := copyBlocksRaw(
-		ctx, logger, immutableDir, c,
+	var utxoOffsetsStored int
+	blocksCopied, immutableTipSlot, err := copyBlocksRawWithCallback(
+		ctx, logger, immutableDir, db, c,
+		func(rb chain.RawBlock, txn *database.Txn) error {
+			stored, err := storeRawBlockUtxoOffsets(txn, rb)
+			if err != nil {
+				return err
+			}
+			utxoOffsetsStored += stored
+			return nil
+		},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("loading blocks: %w", err)
 	}
+	logger.Info(
+		"finished storing immutable UTxO offsets during copy",
+		"blocks_copied", blocksCopied,
+		"utxo_offsets_stored", utxoOffsetsStored,
+	)
 
 	return &LoadBlobsResult{
 		BlocksCopied:     blocksCopied,
@@ -297,6 +312,14 @@ func copyBlocksDirect(
 	}
 	logger.Info("copying blocks from immutable DB")
 	chainTip := c.Tip()
+	if chainTip.Point.Slot > immutableTip.Slot {
+		logger.Info(
+			"chain tip already beyond immutable DB tip; skipping immutable copy",
+			"chain_tip_slot", chainTip.Point.Slot,
+			"immutable_tip_slot", immutableTip.Slot,
+		)
+		return 0, immutableTip.Slot, nil
+	}
 	iter, err := immutable.BlocksFromPoint(chainTip.Point)
 	if err != nil {
 		return 0, 0, fmt.Errorf(
@@ -385,16 +408,20 @@ func copyBlocksDirect(
 	return blocksCopied, immutableTip.Slot, nil
 }
 
-// copyBlocksRaw is a lightweight variant of copyBlocks that decodes only
-// block headers instead of full blocks. This is significantly faster for
-// bulk loading since it skips decoding transaction bodies and witnesses
-// (which can be 50-90KB per block) while extracting just the ~200-500
-// byte header needed for chain indexing.
-func copyBlocksRaw(
+// copyBlocksRawWithCallback is a lightweight variant of copyBlocks that
+// decodes only block headers instead of full blocks. This is significantly
+// faster for bulk loading since it skips decoding transaction bodies and
+// witnesses (which can be 50-90KB per block) while extracting just the
+// ~200-500 byte header needed for chain indexing. The optional callback
+// runs in the same transaction after each block is persisted, giving
+// callers a hook to attach derived blob-side state such as UTxO offsets.
+func copyBlocksRawWithCallback(
 	ctx context.Context,
 	logger *slog.Logger,
 	immutableDir string,
+	db *database.Database,
 	c *chain.Chain,
+	callback func(chain.RawBlock, *database.Txn) error,
 ) (int, uint64, error) {
 	imm, err := immutable.New(immutableDir)
 	if err != nil {
@@ -409,6 +436,32 @@ func copyBlocksRaw(
 	}
 	logger.Info("copying blocks from immutable DB (header-only decode)")
 	chainTip := c.Tip()
+	if chainTip.Point.Slot > immutableTip.Slot {
+		logger.Info(
+			"chain tip already beyond immutable DB tip; skipping immutable copy",
+			"chain_tip_slot", chainTip.Point.Slot,
+			"immutable_tip_slot", immutableTip.Slot,
+		)
+		if callback != nil && db != nil {
+			blocksBackfilled, err := backfillRawBlockCallbacks(
+				ctx,
+				imm,
+				db,
+				callback,
+			)
+			if err != nil {
+				return 0, immutableTip.Slot, fmt.Errorf(
+					"backfill immutable raw block callback state: %w",
+					err,
+				)
+			}
+			logger.Info(
+				"backfilled immutable raw block callback state",
+				"blocks_backfilled", blocksBackfilled,
+			)
+		}
+		return 0, immutableTip.Slot, nil
+	}
 	iter, err := imm.BlocksFromPoint(chainTip.Point)
 	if err != nil {
 		return 0, 0, fmt.Errorf(
@@ -442,32 +495,14 @@ func copyBlocksRaw(
 				bytes.Equal(next.Hash, chainTip.Point.Hash) {
 				continue
 			}
-			// Extract header CBOR from the block's outer array
-			// (first element for all eras), then decode just the
-			// header — skipping transaction bodies and witnesses.
-			headerCbor, err := extractHeaderCbor(next.Cbor)
+			rawBlock, err := rawBlockFromImmutableBlock(next)
 			if err != nil {
 				return blocksCopied, immutableTip.Slot, fmt.Errorf(
-					"extracting block header CBOR: %w", err,
+					"building raw block: %w",
+					err,
 				)
 			}
-			header, err := gledger.NewBlockHeaderFromCbor(
-				next.Type,
-				headerCbor,
-			)
-			if err != nil {
-				return blocksCopied, immutableTip.Slot, fmt.Errorf(
-					"decoding block header: %w", err,
-				)
-			}
-			blockBatch = append(blockBatch, chain.RawBlock{
-				Slot:        header.SlotNumber(),
-				Hash:        header.Hash().Bytes(),
-				BlockNumber: header.BlockNumber(),
-				Type:        next.Type,
-				PrevHash:    header.PrevHash().Bytes(),
-				Cbor:        next.Cbor,
-			})
+			blockBatch = append(blockBatch, rawBlock)
 			if len(blockBatch) == cap(blockBatch) {
 				break
 			}
@@ -475,7 +510,7 @@ func copyBlocksRaw(
 		if len(blockBatch) == 0 {
 			break
 		}
-		if err := c.AddRawBlocks(blockBatch); err != nil {
+		if err := c.AddRawBlocksWithCallback(blockBatch, callback); err != nil {
 			return blocksCopied, immutableTip.Slot, fmt.Errorf(
 				"failed to import block: %w",
 				err,
@@ -506,6 +541,286 @@ func copyBlocksRaw(
 		"blocks_copied", blocksCopied,
 	)
 	return blocksCopied, immutableTip.Slot, nil
+}
+
+func backfillRawBlockCallbacks(
+	ctx context.Context,
+	imm *immutable.ImmutableDb,
+	db *database.Database,
+	callback func(chain.RawBlock, *database.Txn) error,
+) (int, error) {
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get immutable DB iterator: %w", err)
+	}
+	defer iter.Close()
+
+	var blocksBackfilled int
+	blockBatch := make([]chain.RawBlock, 0, loadBlockBatchSize)
+	flush := func() error {
+		if len(blockBatch) == 0 {
+			return nil
+		}
+		txn := db.BlobTxn(true)
+		defer txn.Release()
+		if err := txn.Do(func(txn *database.Txn) error {
+			for _, rb := range blockBatch {
+				if err := callback(rb, txn); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		blocksBackfilled += len(blockBatch)
+		blockBatch = blockBatch[:0]
+		return nil
+	}
+
+	for {
+		next, err := iter.Next()
+		if err != nil {
+			return blocksBackfilled, fmt.Errorf("reading next block: %w", err)
+		}
+		if next == nil {
+			break
+		}
+		rawBlock, err := rawBlockFromImmutableBlock(next)
+		if err != nil {
+			return blocksBackfilled, fmt.Errorf("building raw block: %w", err)
+		}
+		blockBatch = append(blockBatch, rawBlock)
+		if len(blockBatch) == cap(blockBatch) {
+			if err := flush(); err != nil {
+				return blocksBackfilled, err
+			}
+			if err := ctx.Err(); err != nil {
+				return blocksBackfilled, fmt.Errorf("loading blocks: %w", err)
+			}
+		}
+	}
+	if err := flush(); err != nil {
+		return blocksBackfilled, err
+	}
+	if err := ctx.Err(); err != nil {
+		return blocksBackfilled, fmt.Errorf("loading blocks: %w", err)
+	}
+	return blocksBackfilled, nil
+}
+
+func rawBlockFromImmutableBlock(block *immutable.Block) (chain.RawBlock, error) {
+	// Extract header CBOR from the block's outer array (first element for all
+	// eras), then decode just the header without decoding transaction bodies.
+	headerCbor, err := extractHeaderCbor(block.Cbor)
+	if err != nil {
+		return chain.RawBlock{}, fmt.Errorf(
+			"extracting block header CBOR: %w",
+			err,
+		)
+	}
+	header, err := gledger.NewBlockHeaderFromCbor(block.Type, headerCbor)
+	if err != nil {
+		return chain.RawBlock{}, fmt.Errorf("decoding block header: %w", err)
+	}
+	return chain.RawBlock{
+		Slot:        header.SlotNumber(),
+		Hash:        header.Hash().Bytes(),
+		BlockNumber: header.BlockNumber(),
+		Type:        block.Type,
+		PrevHash:    header.PrevHash().Bytes(),
+		Cbor:        block.Cbor,
+	}, nil
+}
+
+func storeRawBlockUtxoOffsets(
+	txn *database.Txn,
+	block chain.RawBlock,
+) (int, error) {
+	if txn == nil || txn.Blob() == nil {
+		return 0, errors.New("blob transaction not available")
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return 0, errors.New("blob store not available")
+	}
+	var blockHash [32]byte
+	copy(blockHash[:], block.Hash)
+	totalUtxos := 0
+
+	offsets, extractErr := lcommon.ExtractTransactionOffsets(block.Cbor)
+	if extractErr != nil {
+		return 0, fmt.Errorf(
+			"block at slot %d: extract transaction offsets: %w",
+			block.Slot,
+			extractErr,
+		)
+	}
+	if offsets == nil || len(offsets.Transactions) == 0 {
+		return 0, nil
+	}
+	invalidTxs, err := extractInvalidTxIndices(block.Cbor)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"block at slot %d: decode invalid tx indices: %w",
+			block.Slot,
+			err,
+		)
+	}
+	for txIdx, txLoc := range offsets.Transactions {
+		bodyEnd := txLoc.Body.Offset + txLoc.Body.Length
+		if int(bodyEnd) > len(block.Cbor) {
+			return 0, fmt.Errorf(
+				"block at slot %d: body range [%d:%d] exceeds block size %d",
+				block.Slot,
+				txLoc.Body.Offset,
+				bodyEnd,
+				len(block.Cbor),
+			)
+		}
+		bodyBytes := block.Cbor[txLoc.Body.Offset:bodyEnd]
+		txHash := lcommon.Blake2b256Hash(bodyBytes)
+		_, txIsInvalid := invalidTxs[txIdx]
+		if !txIsInvalid {
+			for i, outLoc := range txLoc.Outputs {
+				if outLoc.Length == 0 {
+					continue
+				}
+				offset := database.CborOffset{
+					BlockSlot:  block.Slot,
+					BlockHash:  blockHash,
+					ByteOffset: outLoc.Offset,
+					ByteLength: outLoc.Length,
+				}
+				if err := blob.SetUtxo(
+					txn.Blob(),
+					txHash[:],
+					uint32(i), // #nosec G115
+					database.EncodeUtxoOffset(&offset),
+				); err != nil {
+					return 0, fmt.Errorf("storing UTxO offset: %w", err)
+				}
+				totalUtxos++
+			}
+			continue
+		}
+		collReturnOffset, collReturnLen, found, err := txBodyMapValueRange(
+			block.Cbor[txLoc.Body.Offset:bodyEnd],
+			txLoc.Body.Offset,
+			database.TxBodyKeyCollateralReturn,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"block at slot %d: transaction %x collateral return offset: %w",
+				block.Slot,
+				txHash[:8],
+				err,
+			)
+		}
+		if !found {
+			continue
+		}
+		offset := database.CborOffset{
+			BlockSlot:  block.Slot,
+			BlockHash:  blockHash,
+			ByteOffset: collReturnOffset,
+			ByteLength: collReturnLen,
+		}
+		outputIdx := uint32(len(txLoc.Outputs)) // #nosec G115
+		if err := blob.SetUtxo(
+			txn.Blob(),
+			txHash[:],
+			outputIdx,
+			database.EncodeUtxoOffset(&offset),
+		); err != nil {
+			return 0, fmt.Errorf(
+				"storing collateral return UTxO offset: %w",
+				err,
+			)
+		}
+		totalUtxos++
+	}
+	return totalUtxos, nil
+}
+
+func extractInvalidTxIndices(blockCbor []byte) (map[int]struct{}, error) {
+	var blockArray []gcbor.RawMessage
+	if _, err := gcbor.Decode(blockCbor, &blockArray); err != nil {
+		return nil, err
+	}
+	if len(blockArray) < 5 {
+		return nil, nil
+	}
+	var invalidTxs []uint
+	if _, err := gcbor.Decode([]byte(blockArray[4]), &invalidTxs); err != nil {
+		return nil, err
+	}
+	if len(invalidTxs) == 0 {
+		return nil, nil
+	}
+	set := make(map[int]struct{}, len(invalidTxs))
+	for _, idx := range invalidTxs {
+		set[int(idx)] = struct{}{} // #nosec G115
+	}
+	return set, nil
+}
+
+func txBodyMapValueRange(
+	bodyCbor []byte,
+	bodyOffset uint32,
+	key uint64,
+) (uint32, uint32, bool, error) {
+	decoder, err := gcbor.NewStreamDecoder(bodyCbor)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	count, _, _, err := decoder.DecodeMapHeader()
+	if err != nil {
+		return 0, 0, false, err
+	}
+	if count < 0 {
+		return 0, 0, false, errors.New("indefinite tx body map")
+	}
+	for range count {
+		var currentKey uint64
+		if _, _, err := decoder.Decode(&currentKey); err != nil {
+			return 0, 0, false, err
+		}
+		valueOffset, valueLen, err := decoder.Skip()
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if currentKey != key {
+			continue
+		}
+		valueOffset32, err := checkedUint32(valueOffset)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		valueLen32, err := checkedUint32(valueLen)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if valueOffset32 > ^uint32(0)-bodyOffset {
+			return 0, 0, false, fmt.Errorf(
+				"value offset %d overflows body offset %d",
+				valueOffset32,
+				bodyOffset,
+			)
+		}
+		return bodyOffset + valueOffset32, valueLen32, true, nil
+	}
+	return 0, 0, false, nil
+}
+
+func checkedUint32(v int) (uint32, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("negative value %d", v)
+	}
+	if uint64(v) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("value %d overflows uint32", v)
+	}
+	return uint32(v), nil // #nosec G115
 }
 
 func maybeLogBlockCopyProgress(

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	fxcbor "github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
@@ -169,11 +171,13 @@ func TestCopyBlocksRaw_PreservesByronEbbLinkageAtOrigin(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	blocksCopied, _, err := copyBlocksRaw(
+	blocksCopied, _, err := copyBlocksRawWithCallback(
 		context.Background(),
 		logger,
 		immutableDir,
+		db,
 		cm.PrimaryChain(),
+		nil,
 	)
 	require.NoError(t, err)
 	require.Greater(t, blocksCopied, 1)
@@ -195,6 +199,200 @@ func TestCopyBlocksRaw_PreservesByronEbbLinkageAtOrigin(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, importedNext)
 	assert.Equal(t, ebbPoint.Hash, importedNext.PrevHash)
+}
+
+func TestCopyBlocksRawWithCallback_StoresUtxoOffsets(t *testing.T) {
+	// No t.Parallel(): newTestDB shares process-wide plugin state
+	// (see database.go:164), so concurrent test runs race on
+	// SetPluginOption and the in-memory schema migration.
+	immutableDir := filepath.Join(
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+	imm, err := immutable.New(immutableDir)
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var (
+		expectedPoint      ocommon.Point
+		expectedTxHash     []byte
+		expectedOutputIdx  uint32
+		expectedOutputCbor []byte
+	)
+	const maxIterations = 10_000
+	for i := range maxIterations {
+		next, err := iter.Next()
+		require.NoError(t, err)
+		if next == nil {
+			require.Failf(
+				t,
+				"no non-EBB block with produced outputs found",
+				"iterator ended after %d iterations",
+				i+1,
+			)
+		}
+		if next.IsEbb {
+			continue
+		}
+		block, err := gledger.NewBlockFromCbor(
+			next.Type,
+			next.Cbor,
+			lcommon.VerifyConfig{SkipBodyHashValidation: true},
+		)
+		require.NoError(t, err)
+		for _, tx := range block.Transactions() {
+			produced := tx.Produced()
+			if len(produced) == 0 {
+				continue
+			}
+			expectedPoint = ocommon.NewPoint(next.Slot, next.Hash)
+			expectedTxHash = bytes.Clone(tx.Hash().Bytes())
+			expectedOutputIdx = produced[0].Id.Index()
+			expectedOutputCbor = bytes.Clone(produced[0].Output.Cbor())
+			break
+		}
+		if len(expectedTxHash) > 0 {
+			break
+		}
+	}
+	require.NotEmptyf(
+		t,
+		expectedTxHash,
+		"no non-EBB block with produced outputs found after %d iterations",
+		maxIterations,
+	)
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	blocksCopied, _, err := copyBlocksRawWithCallback(
+		context.Background(),
+		logger,
+		immutableDir,
+		db,
+		cm.PrimaryChain(),
+		func(rb chain.RawBlock, txn *database.Txn) error {
+			_, err := storeRawBlockUtxoOffsets(txn, rb)
+			return err
+		},
+	)
+	require.NoError(t, err)
+	require.Greater(t, blocksCopied, 1)
+
+	blobTxn := db.BlobTxn(false)
+	defer blobTxn.Rollback() //nolint:errcheck
+	offsetData, err := db.Blob().GetUtxo(
+		blobTxn.Blob(),
+		expectedTxHash,
+		expectedOutputIdx,
+	)
+	require.NoError(t, err)
+	require.True(t, database.IsUtxoOffsetStorage(offsetData))
+
+	offset, err := database.DecodeUtxoOffset(offsetData)
+	require.NoError(t, err)
+	assert.Equal(t, expectedPoint.Slot, offset.BlockSlot)
+	assert.Equal(t, expectedPoint.Hash, offset.BlockHash[:])
+
+	storedBlock, err := database.BlockByPoint(db, expectedPoint)
+	require.NoError(t, err)
+	end := uint64(offset.ByteOffset) + uint64(offset.ByteLength)
+	require.LessOrEqual(t, end, uint64(len(storedBlock.Cbor)))
+	assert.Equal(
+		t,
+		expectedOutputCbor,
+		storedBlock.Cbor[offset.ByteOffset:end],
+	)
+}
+
+func TestStoreRawBlockUtxoOffsetsPropagatesExtractError(t *testing.T) {
+	db := newTestDB(t)
+	txn := db.BlobTxn(true)
+	defer txn.Rollback() //nolint:errcheck
+
+	_, err := storeRawBlockUtxoOffsets(txn, chain.RawBlock{
+		Slot: 42,
+		Hash: bytes.Repeat([]byte{0x42}, 32),
+		Cbor: []byte{0x82, 0x01},
+		Type: 1,
+	})
+	require.ErrorContains(
+		t,
+		err,
+		"block at slot 42: extract transaction offsets",
+	)
+}
+
+func TestCopyBlocksRawWithCallback_BackfillsWhenChainTipPastImmutableTip(
+	t *testing.T,
+) {
+	// No t.Parallel(): newTestDB shares process-wide plugin state
+	// (see database.go:164), so concurrent test runs race on
+	// SetPluginOption and the in-memory schema migration.
+	immutableDir := filepath.Join(
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, immutableTipSlot, err := copyBlocksRawWithCallback(
+		context.Background(),
+		logger,
+		immutableDir,
+		db,
+		cm.PrimaryChain(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	currentTip := cm.PrimaryChain().Tip()
+	// AddRawBlocks treats Cbor as opaque — a stub byte string is
+	// sufficient to advance the chain tip past immutableTipSlot
+	// for the resume check exercised below. If a future change
+	// makes AddRawBlocks decode the body, swap this for a real
+	// raw block from the immutable testdata directory.
+	err = cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        immutableTipSlot + 5,
+			Hash:        bytes.Repeat([]byte{0x42}, 32),
+			BlockNumber: currentTip.BlockNumber + 1,
+			Type:        0,
+			PrevHash:    currentTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	})
+	require.NoError(t, err)
+
+	var offsetsStored int
+	blocksCopied, resumedImmutableTipSlot, err := copyBlocksRawWithCallback(
+		context.Background(),
+		logger,
+		immutableDir,
+		db,
+		cm.PrimaryChain(),
+		func(rb chain.RawBlock, txn *database.Txn) error {
+			stored, err := storeRawBlockUtxoOffsets(txn, rb)
+			offsetsStored += stored
+			return err
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, blocksCopied)
+	assert.Equal(t, immutableTipSlot, resumedImmutableTipSlot)
+	assert.Greater(t, offsetsStored, 0)
 }
 
 func decodeImmutableBlockHeader(

--- a/internal/node/load_utxo_offsets_test.go
+++ b/internal/node/load_utxo_offsets_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package node
 
 import (
 	"bytes"
 	"encoding/hex"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
@@ -55,7 +56,7 @@ func TestTxBodyMapValueRangeFindsCollateralReturn(t *testing.T) {
 	offset, length, found, err := txBodyMapValueRange(
 		bodyCbor,
 		0,
-		txBodyKeyCollateralReturn,
+		database.TxBodyKeyCollateralReturn,
 	)
 	require.NoError(t, err)
 	require.True(t, found)
@@ -97,7 +98,7 @@ func TestTxBodyMapValueRangeHonorsBaseOffset(t *testing.T) {
 	offset, length, found, err := txBodyMapValueRange(
 		bodyCbor,
 		bodyOffset,
-		txBodyKeyCollateralReturn,
+		database.TxBodyKeyCollateralReturn,
 	)
 	require.NoError(t, err)
 	require.True(t, found)
@@ -119,7 +120,7 @@ func TestTxBodyMapValueRangeMissingKey(t *testing.T) {
 	_, _, found, err := txBodyMapValueRange(
 		bodyCbor,
 		0,
-		txBodyKeyCollateralReturn,
+		database.TxBodyKeyCollateralReturn,
 	)
 	require.NoError(t, err)
 	require.False(t, found)

--- a/internal/test/testutil/mock_input.go
+++ b/internal/test/testutil/mock_input.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"errors"
+	"fmt"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	pdata "github.com/blinklabs-io/plutigo/data"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// MockInput is a reusable transaction input for database tests.
+type MockInput struct {
+	TxId       []byte
+	IndexValue uint32
+}
+
+func NewMockInput(txId []byte, index uint32) *MockInput {
+	return &MockInput{
+		TxId:       txId,
+		IndexValue: index,
+	}
+}
+
+func (m *MockInput) Id() lcommon.Blake2b256 {
+	return lcommon.NewBlake2b256(m.TxId)
+}
+
+func (m *MockInput) Index() uint32 {
+	return m.IndexValue
+}
+
+func (m *MockInput) String() string {
+	return fmt.Sprintf("%x#%d", m.TxId, m.IndexValue)
+}
+
+func (m *MockInput) Utxorpc() (*cardano.TxInput, error) {
+	return nil, errors.New("MockInput.Utxorpc: not implemented")
+}
+
+func (m *MockInput) ToPlutusData() pdata.PlutusData {
+	return nil
+}

--- a/ledger/governance/processing.go
+++ b/ledger/governance/processing.go
@@ -15,17 +15,25 @@
 package governance
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
+
+type proposalSource interface {
+	Id() lcommon.Blake2b256
+	ProposalProcedures() []lcommon.ProposalProcedure
+}
 
 // ProcessProposals extracts governance proposals from a Conway-era
 // transaction and persists them to the database. Each proposal procedure in the
@@ -42,12 +50,30 @@ func ProcessProposals(
 	db *database.Database,
 	txn *database.Txn,
 ) error {
+	return persistGovernanceProposals(
+		tx,
+		point,
+		currentEpoch,
+		govActionLifetime,
+		db,
+		txn,
+	)
+}
+
+func persistGovernanceProposals(
+	tx proposalSource,
+	point ocommon.Point,
+	currentEpoch uint64,
+	govActionLifetime uint64,
+	db *database.Database,
+	txn *database.Txn,
+) error {
 	proposals := tx.ProposalProcedures()
 	if len(proposals) == 0 {
 		return nil
 	}
 
-	txHash := tx.Hash().Bytes()
+	txHash := tx.Id().Bytes()
 	if len(txHash) != 32 {
 		return fmt.Errorf("invalid tx hash length: got %d", len(txHash))
 	}
@@ -157,6 +183,7 @@ func ProcessVotes(
 		actionIdx uint32
 	}
 	proposalCache := make(map[proposalKey]*models.GovernanceProposal)
+	repairCache := newProposalRepairCache()
 
 	// Track DRep credentials that have already had their activity updated
 	// in this transaction to avoid redundant DB writes.
@@ -254,11 +281,40 @@ func ProcessVotes(
 					txn,
 				)
 				if err != nil {
-					return fmt.Errorf(
-						"lookup governance proposal for vote in tx %s: %w",
-						txHashForLog,
-						err,
+					if !errors.Is(err, models.ErrGovernanceProposalNotFound) {
+						return fmt.Errorf(
+							"lookup governance proposal for vote in tx %s: %w",
+							txHashForLog,
+							err,
+						)
+					}
+					var repairErr error
+					proposal, repairErr = repairMissingGovernanceProposal(
+						actionId.TransactionId[:],
+						actionId.GovActionIdx,
+						db,
+						txn,
+						repairCache,
 					)
+					if repairErr != nil {
+						if errors.Is(
+							repairErr,
+							models.ErrGovernanceProposalNotFound,
+						) {
+							return fmt.Errorf(
+								"repair missing governance proposal for vote in tx %s failed to find tx/proposal %s#%d: %w",
+								txHashForLog,
+								shortHash(actionId.TransactionId[:]),
+								actionId.GovActionIdx,
+								repairErr,
+							)
+						}
+						return fmt.Errorf(
+							"repair missing governance proposal for vote in tx %s: %w",
+							txHashForLog,
+							repairErr,
+						)
+					}
 				}
 				proposalCache[cacheKey] = proposal
 			}
@@ -294,6 +350,191 @@ func ProcessVotes(
 	}
 
 	return nil
+}
+
+type proposalRepairCache struct {
+	epochsByID                 map[uint64]models.Epoch
+	govActionValidityByEpochID map[uint64]uint64
+}
+
+func newProposalRepairCache() *proposalRepairCache {
+	return &proposalRepairCache{
+		epochsByID:                 make(map[uint64]models.Epoch),
+		govActionValidityByEpochID: make(map[uint64]uint64),
+	}
+}
+
+func (c *proposalRepairCache) epochForSlot(
+	slot uint64,
+	db *database.Database,
+	txn *database.Txn,
+) (models.Epoch, error) {
+	if c == nil {
+		epoch, err := db.GetEpochBySlot(slot, txn)
+		if err != nil {
+			return models.Epoch{}, err
+		}
+		if epoch == nil {
+			return models.Epoch{}, fmt.Errorf(
+				"no epoch found for slot %d",
+				slot,
+			)
+		}
+		return *epoch, nil
+	}
+	for _, epoch := range c.epochsByID {
+		if epochContainsSlot(epoch, slot) {
+			return epoch, nil
+		}
+	}
+	epoch, err := db.GetEpochBySlot(slot, txn)
+	if err != nil {
+		return models.Epoch{}, err
+	}
+	if epoch == nil {
+		return models.Epoch{}, fmt.Errorf("no epoch found for slot %d", slot)
+	}
+	c.epochsByID[epoch.EpochId] = *epoch
+	return *epoch, nil
+}
+
+func (c *proposalRepairCache) govActionValidityPeriod(
+	epoch models.Epoch,
+	proposalTxHash []byte,
+	db *database.Database,
+	txn *database.Txn,
+) (uint64, error) {
+	if c != nil {
+		if validity, ok := c.govActionValidityByEpochID[epoch.EpochId]; ok {
+			return validity, nil
+		}
+	}
+	if epoch.EraId != conway.EraIdConway {
+		return 0, fmt.Errorf(
+			"unexpected era %d for governance proposal tx %s, expected Conway era %d",
+			epoch.EraId,
+			shortHash(proposalTxHash),
+			conway.EraIdConway,
+		)
+	}
+	era := eras.GetEraById(epoch.EraId)
+	if era == nil {
+		return 0, fmt.Errorf(
+			"unknown era %d for governance proposal tx %s",
+			epoch.EraId,
+			shortHash(proposalTxHash),
+		)
+	}
+	pparams, err := db.GetPParams(epoch.EpochId, era.DecodePParamsFunc, txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"load protocol params for governance proposal tx %s: %w",
+			shortHash(proposalTxHash),
+			err,
+		)
+	}
+	conwayPParams, ok := pparams.(*conway.ConwayProtocolParameters)
+	if !ok {
+		return 0, fmt.Errorf(
+			"unexpected protocol params %T for governance proposal tx %s in era %d",
+			pparams,
+			shortHash(proposalTxHash),
+			epoch.EraId,
+		)
+	}
+	validity := conwayPParams.GovActionValidityPeriod
+	if c != nil {
+		c.govActionValidityByEpochID[epoch.EpochId] = validity
+	}
+	return validity, nil
+}
+
+func repairMissingGovernanceProposal(
+	proposalTxHash []byte,
+	actionIndex uint32,
+	db *database.Database,
+	txn *database.Txn,
+	repairCache *proposalRepairCache,
+) (*models.GovernanceProposal, error) {
+	txRecord, err := db.GetTransactionByHash(proposalTxHash, txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"lookup governance proposal tx %s: %w",
+			shortHash(proposalTxHash),
+			err,
+		)
+	}
+	if txRecord == nil {
+		return nil, models.ErrGovernanceProposalNotFound
+	}
+	txBodyCbor, err := db.CborCache().ResolveTxCbor(txn, proposalTxHash)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve governance proposal tx body %s: %w",
+			shortHash(proposalTxHash),
+			err,
+		)
+	}
+	txBody, err := gledger.NewTransactionBodyFromCbor(
+		uint(txRecord.Type), //nolint:gosec // era ID fits in uint
+		txBodyCbor,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode governance proposal tx body %s: %w",
+			shortHash(proposalTxHash),
+			err,
+		)
+	}
+	if !bytes.Equal(txBody.Id().Bytes(), proposalTxHash) {
+		return nil, fmt.Errorf(
+			"decoded governance proposal tx body hash mismatch for %s",
+			shortHash(proposalTxHash),
+		)
+	}
+	epoch, err := repairCache.epochForSlot(txRecord.Slot, db, txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"lookup proposal epoch for tx %s: %w",
+			shortHash(proposalTxHash),
+			err,
+		)
+	}
+	govActionValidityPeriod, err := repairCache.govActionValidityPeriod(
+		epoch,
+		proposalTxHash,
+		db,
+		txn,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := persistGovernanceProposals(
+		txBody,
+		ocommon.Point{
+			Slot: txRecord.Slot,
+			Hash: txRecord.BlockHash,
+		},
+		epoch.EpochId,
+		govActionValidityPeriod,
+		db,
+		txn,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"rebuild governance proposal from tx %s: %w",
+			shortHash(proposalTxHash),
+			err,
+		)
+	}
+	return db.GetGovernanceProposal(proposalTxHash, actionIndex, txn)
+}
+
+func epochContainsSlot(epoch models.Epoch, slot uint64) bool {
+	if slot < epoch.StartSlot || epoch.LengthInSlots == 0 {
+		return false
+	}
+	endSlot := epoch.StartSlot + uint64(epoch.LengthInSlots)
+	return endSlot < epoch.StartSlot || slot < endSlot
 }
 
 // extractGovActionInfo extracts the action type, parent action ID, and policy

--- a/ledger/governance/processing_test.go
+++ b/ledger/governance/processing_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -40,6 +42,27 @@ func testHash28(seed string) []byte {
 	hash := make([]byte, 28)
 	copy(hash, []byte(seed))
 	return hash
+}
+
+func testConwayProtocolParameters() *conway.ConwayProtocolParameters {
+	pparams := mockledger.NewMockConwayProtocolParams()
+	pparams.GovActionValidityPeriod = 20
+	pparams.DRepInactivityPeriod = 20
+	return &pparams
+}
+
+func TestEpochContainsSlot(t *testing.T) {
+	epoch := models.Epoch{EpochId: 1, StartSlot: 100, LengthInSlots: 100}
+	require.False(t, epochContainsSlot(epoch, 99))
+	require.True(t, epochContainsSlot(epoch, 100))
+	require.True(t, epochContainsSlot(epoch, 199))
+	require.False(t, epochContainsSlot(epoch, 200))
+}
+
+func TestEpochContainsSlotZeroLengthRejectsAll(t *testing.T) {
+	epoch := models.Epoch{EpochId: 1, StartSlot: 100, LengthInSlots: 0}
+	require.False(t, epochContainsSlot(epoch, 100))
+	require.False(t, epochContainsSlot(epoch, 200))
 }
 
 func TestMapVoterType(t *testing.T) {
@@ -331,4 +354,203 @@ func TestProcessVotesRepairsMissingDRepRow(t *testing.T) {
 	assert.Equal(t, drepCred, votes[0].VoterCredential)
 	assert.Equal(t, uint8(models.VoteYes), votes[0].Vote)
 	assert.Equal(t, point.Slot, votes[0].AddedSlot)
+}
+
+func TestProcessVotesRepairsMissingGovernanceProposal(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	db, err := database.New(&database.Config{
+		DataDir:        tmpDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	const (
+		proposalEpoch     = uint64(100)
+		proposalSlot      = uint64(1000)
+		voteEpoch         = uint64(101)
+		govActionLifetime = uint64(20)
+	)
+	require.NoError(
+		t,
+		db.SetEpoch(
+			proposalSlot,
+			proposalEpoch,
+			nil,
+			nil,
+			nil,
+			nil,
+			conway.EraIdConway,
+			1,
+			432000,
+			nil,
+		),
+	)
+	pparams := testConwayProtocolParameters()
+	pparamsCbor, err := cbor.Encode(pparams)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		db.SetPParams(
+			pparamsCbor,
+			proposalSlot,
+			proposalEpoch,
+			conway.EraIdConway,
+			nil,
+		),
+	)
+
+	rewardAddress, err := lcommon.NewAddressFromBytes(
+		append([]byte{0xE1}, testHash28("proposal-reward")...),
+	)
+	require.NoError(t, err)
+	proposalProcedure := conway.ConwayProposalProcedure{
+		PPDeposit:       42,
+		PPRewardAccount: rewardAddress,
+		PPGovAction: conway.ConwayGovAction{
+			Type: uint(lcommon.GovActionTypeInfo),
+			Action: &lcommon.InfoGovAction{
+				Type: uint(lcommon.GovActionTypeInfo),
+			},
+		},
+		PPAnchor: lcommon.GovAnchor{
+			Url:      "https://example.com/proposal",
+			DataHash: [32]byte(testHash32("proposal-anchor")),
+		},
+	}
+	proposalBodyCbor, err := cbor.Encode(
+		&conway.ConwayTransactionBody{
+			TxProposalProcedures: []conway.ConwayProposalProcedure{
+				proposalProcedure,
+			},
+		},
+	)
+	require.NoError(t, err)
+	proposalTxHash := lcommon.Blake2b256Hash(proposalBodyCbor)
+	proposalTx := mockledger.NewTransactionBuilder()
+	proposalTx.WithId(proposalTxHash.Bytes())
+	proposalTx.WithType(gledger.TxTypeConway)
+	proposalTx.WithProposalProcedures(proposalProcedure)
+	proposalTx.WithValid(true)
+	proposalPoint := ocommon.Point{
+		Slot: proposalSlot,
+		Hash: testHash32("proposal-block"),
+	}
+	// Mirror the production gap-block storage path: store the proposal
+	// body inside a synthetic block in the blob store and register it
+	// through SetGapBlockTransaction with offsets, so the repair path
+	// must traverse ResolveTxCbor's offset-decode + block-extract branch
+	// instead of the legacy raw-CBOR fallback.
+	blockBytes := append(
+		[]byte("gap-block-prefix-"),
+		proposalBodyCbor...,
+	)
+	bodyByteOffset := uint32(len(blockBytes) - len(proposalBodyCbor))
+	var blockHashArr [32]byte
+	copy(blockHashArr[:], proposalPoint.Hash)
+	var proposalTxHashArr [32]byte
+	copy(proposalTxHashArr[:], proposalTxHash.Bytes())
+	offsets := &database.BlockIngestionResult{
+		TxOffsets: map[[32]byte]database.CborOffset{
+			proposalTxHashArr: {
+				BlockSlot:  proposalSlot,
+				BlockHash:  blockHashArr,
+				ByteOffset: bodyByteOffset,
+				ByteLength: uint32(len(proposalBodyCbor)),
+			},
+		},
+		UtxoOffsets: make(map[database.UtxoRef]database.CborOffset),
+	}
+	ccCred := testHash28("committee-voter")
+	var voterHash [28]byte
+	copy(voterHash[:], ccCred)
+	var actionTxHash [32]byte
+	copy(actionTxHash[:], proposalTxHash.Bytes())
+	voter := &lcommon.Voter{
+		Type: lcommon.VoterTypeConstitutionalCommitteeHotKeyHash,
+		Hash: voterHash,
+	}
+	actionID := &lcommon.GovActionId{
+		TransactionId: actionTxHash,
+		GovActionIdx:  0,
+	}
+	var voteTxHash lcommon.Blake2b256
+	copy(voteTxHash[:], testHash32("vote-tx"))
+	voteTx := mockledger.NewTransactionBuilder()
+	voteTx.WithId(voteTxHash.Bytes())
+	voteTx.WithType(gledger.TxTypeConway)
+	voteTx.WithValid(true)
+	voteTx.WithVotingProcedures(lcommon.VotingProcedures{
+		voter: {
+			actionID: {Vote: models.VoteYes},
+		},
+	})
+	votePoint := ocommon.Point{
+		Slot: proposalSlot + 50,
+		Hash: testHash32("vote-block"),
+	}
+
+	_, err = db.GetGovernanceProposal(proposalTxHash.Bytes(), 0, nil)
+	require.ErrorIs(t, err, models.ErrGovernanceProposalNotFound)
+
+	// Mirror the production gap-block + vote processing path, where the
+	// blob write and ProcessVotes happen inside the same write txn so
+	// ResolveTxCbor must see the uncommitted blob to repair the proposal.
+	txn := db.Transaction(true)
+	defer txn.Release()
+	require.NoError(
+		t,
+		txn.Do(func(txn *database.Txn) error {
+			if err := db.Blob().SetBlock(
+				txn.Blob(),
+				proposalSlot,
+				proposalPoint.Hash,
+				blockBytes,
+				0,
+				0,
+				0,
+				nil,
+			); err != nil {
+				return err
+			}
+			if err := db.SetGapBlockTransaction(
+				proposalTx,
+				proposalPoint,
+				0,
+				offsets,
+				txn,
+			); err != nil {
+				return err
+			}
+			return ProcessVotes(voteTx, votePoint, voteEpoch, 20, db, txn)
+		}),
+	)
+
+	proposal, err := db.GetGovernanceProposal(proposalTxHash.Bytes(), 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, proposal)
+	assert.Equal(t, proposalTxHash.Bytes(), proposal.TxHash)
+	assert.Equal(t, uint32(0), proposal.ActionIndex)
+	assert.Equal(t, uint8(lcommon.GovActionTypeInfo), proposal.ActionType)
+	assert.Equal(t, proposalEpoch, proposal.ProposedEpoch)
+	assert.Equal(t, proposalEpoch+govActionLifetime, proposal.ExpiresEpoch)
+	assert.Equal(t, proposalProcedure.PPAnchor.Url, proposal.AnchorURL)
+	assert.Equal(t, proposalProcedure.PPAnchor.DataHash[:], proposal.AnchorHash)
+	assert.Equal(t, proposalProcedure.PPDeposit, proposal.Deposit)
+	returnAddress, err := rewardAddress.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, returnAddress, proposal.ReturnAddress)
+	assert.Equal(t, proposalSlot, proposal.AddedSlot)
+	assert.NotEmpty(t, proposal.GovActionCbor)
+
+	votes, err := db.GetGovernanceVotes(proposal.ID, nil)
+	require.NoError(t, err)
+	require.Len(t, votes, 1)
+	assert.Equal(t, uint8(models.VoterTypeCC), votes[0].VoterType)
+	assert.Equal(t, ccCred, votes[0].VoterCredential)
+	assert.Equal(t, uint8(models.VoteYes), votes[0].Vote)
+	assert.Equal(t, votePoint.Slot, votes[0].AddedSlot)
 }

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -457,7 +457,7 @@ func ImportLedgerState(
 		if cfg.State.GovStateData != nil &&
 			cfg.State.EraIndex >= EraConway {
 			if err := importGovState(
-				ctx, cfg, slot, progress,
+				ctx, cfg, progress,
 			); err != nil {
 				return fmt.Errorf(
 					"importing governance state: %w",
@@ -1772,11 +1772,15 @@ func importPParams(
 	store := cfg.Database.Metadata()
 	txn := cfg.Database.MetadataTxn(true)
 	defer txn.Release()
+	pparamsSlot := snapshotEpochAnchorSlot(
+		cfg,
+		cfg.State.Epoch,
+	)
 
 	// #nosec G115
 	if err := store.SetPParams(
 		pparamsCbor,
-		cfg.State.Tip.Slot,
+		pparamsSlot,
 		cfg.State.Epoch,
 		uint(cfg.State.EraIndex),
 		txn.Metadata(),
@@ -1801,7 +1805,6 @@ func importPParams(
 func importGovState(
 	ctx context.Context,
 	cfg ImportConfig,
-	slot uint64,
 	progress func(ImportProgress),
 ) error {
 	cfg.Logger.Info(
@@ -1830,6 +1833,10 @@ func importGovState(
 	}
 
 	store := cfg.Database.Metadata()
+	currentEpochSlot := snapshotEpochAnchorSlot(
+		cfg,
+		cfg.State.Epoch,
+	)
 
 	// Import constitution
 	if govState.Constitution != nil {
@@ -1841,7 +1848,7 @@ func importGovState(
 					AnchorURL:  govState.Constitution.AnchorURL,
 					AnchorHash: govState.Constitution.AnchorHash,
 					PolicyHash: govState.Constitution.PolicyHash,
-					AddedSlot:  slot,
+					AddedSlot:  currentEpochSlot,
 				},
 				txn.Metadata(),
 			); err != nil {
@@ -1886,7 +1893,7 @@ func importGovState(
 					members[i] = &models.CommitteeMember{
 						ColdCredHash: cm.ColdCredential.Hash,
 						ExpiresEpoch: cm.ExpiresEpoch,
-						AddedSlot:    slot,
+						AddedSlot:    currentEpochSlot,
 					}
 				}
 				if err := store.SetCommitteeMembers(
@@ -1905,7 +1912,7 @@ func importGovState(
 					Rat: new(big.Rat).Set(govState.CommitteeQuorum.Rat),
 				}
 				if err := store.SetCommitteeQuorum(
-					quorum, slot, txn.Metadata(),
+					quorum, currentEpochSlot, txn.Metadata(),
 				); err != nil {
 					return fmt.Errorf(
 						"importing committee quorum: %w", err,
@@ -1947,6 +1954,10 @@ func importGovState(
 					)
 				default:
 				}
+				proposedSlot := snapshotEpochAnchorSlot(
+					cfg,
+					prop.ProposedIn,
+				)
 				if err := store.SetGovernanceProposal(
 					&models.GovernanceProposal{
 						TxHash:        prop.TxHash,
@@ -1958,7 +1969,7 @@ func importGovState(
 						ReturnAddress: prop.ReturnAddr,
 						AnchorURL:     prop.AnchorURL,
 						AnchorHash:    prop.AnchorHash,
-						AddedSlot:     slot,
+						AddedSlot:     proposedSlot,
 					},
 					metaTxn,
 				); err != nil {
@@ -1994,4 +2005,116 @@ func importGovState(
 	})
 
 	return nil
+}
+
+func snapshotEpochAnchorSlot(
+	cfg ImportConfig,
+	epoch uint64,
+) uint64 {
+	if cfg.State == nil {
+		return 0
+	}
+	if len(cfg.State.EraBounds) > 0 &&
+		epoch < cfg.State.EraBounds[0].Epoch {
+		logSnapshotEpochAnchorFallback(
+			cfg,
+			epoch,
+			"epoch precedes first era bound",
+			nil,
+		)
+		return 0
+	}
+	for eraIndex := len(cfg.State.EraBounds) - 1; eraIndex >= 0; eraIndex-- {
+		bound := cfg.State.EraBounds[eraIndex]
+		if epoch < bound.Epoch {
+			continue
+		}
+		return snapshotEpochAnchorSlotFromBound(
+			cfg,
+			epoch,
+			uint(eraIndex), //nolint:gosec // era index fits in uint
+			bound.Epoch,
+			bound.Slot,
+		)
+	}
+	if epoch < cfg.State.EraBoundEpoch {
+		logSnapshotEpochAnchorFallback(
+			cfg,
+			epoch,
+			"era bounds unavailable; using single-bound fallback",
+			nil,
+		)
+	}
+	return snapshotEpochAnchorSlotFromBound(
+		cfg,
+		epoch,
+		uint(cfg.State.EraIndex), //nolint:gosec // era ID fits in uint
+		cfg.State.EraBoundEpoch,
+		cfg.State.EraBoundSlot,
+	)
+}
+
+func snapshotEpochAnchorSlotFromBound(
+	cfg ImportConfig,
+	epoch uint64,
+	eraIndex uint,
+	boundEpoch uint64,
+	boundSlot uint64,
+) uint64 {
+	if epoch < boundEpoch {
+		return boundSlot
+	}
+	if cfg.EpochLength == nil {
+		logSnapshotEpochAnchorFallback(
+			cfg,
+			epoch,
+			"epoch length unavailable (EpochLength is nil)",
+			nil,
+		)
+		return boundSlot
+	}
+	_, epochLength, err := cfg.EpochLength(eraIndex)
+	if err != nil {
+		logSnapshotEpochAnchorFallback(
+			cfg,
+			epoch,
+			"failed to resolve epoch length",
+			err,
+		)
+		return boundSlot
+	}
+	if epochLength == 0 {
+		logSnapshotEpochAnchorFallback(
+			cfg,
+			epoch,
+			"epoch length is zero",
+			nil,
+		)
+		return boundSlot
+	}
+	return boundSlot + (epoch-boundEpoch)*uint64(epochLength)
+}
+
+func logSnapshotEpochAnchorFallback(
+	cfg ImportConfig,
+	epoch uint64,
+	msg string,
+	err error,
+) {
+	if cfg.State == nil {
+		return
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	args := []any{
+		"component", "ledgerstate",
+		"epoch", epoch,
+		"era_bound_epoch", cfg.State.EraBoundEpoch,
+	}
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	logger.Warn("snapshotEpochAnchorSlot: "+msg, args...)
 }

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -16,10 +16,15 @@ package ledgerstate
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/stretchr/testify/require"
 )
 
@@ -230,7 +235,9 @@ func TestImportedEpochSummaryKeepsCurrentEpochMetadataWhenExisting(
 func TestPersistImportedSnapshotClearsEpochWhenEmpty(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	store := db.Metadata()
 	targetEpoch := uint64(100)
@@ -296,4 +303,233 @@ func TestPersistImportedSnapshotClearsEpochWhenEmpty(t *testing.T) {
 	require.True(t, summary.SnapshotReady)
 	require.Equal(t, existingSummary.BoundarySlot, summary.BoundarySlot)
 	require.True(t, bytes.Equal(existingSummary.EpochNonce, summary.EpochNonce))
+}
+
+func TestImportPParamsAnchorsAddedSlotToCurrentEpochStart(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	pparamsCbor, err := cbor.Encode(testConwayPParams())
+	require.NoError(t, err)
+
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			PParamsData:   pparamsCbor,
+			Epoch:         1277,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 1200,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.NoError(t, importPParams(context.Background(), cfg))
+
+	pparams, err := db.Metadata().GetPParams(1277, nil)
+	require.NoError(t, err)
+	require.Len(t, pparams, 1)
+	require.Equal(t, uint64(17_700), pparams[0].AddedSlot)
+}
+
+func TestImportGovStateAnchorsProposalAndConstitutionSlots(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	txHash := bytes.Repeat([]byte{0x91}, 32)
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			GovStateData:  testGovStateData(t, txHash, 1275),
+			Epoch:         1277,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 1200,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.NoError(t, importGovState(
+		context.Background(),
+		cfg,
+		func(ImportProgress) {},
+	))
+
+	proposal, err := db.Metadata().GetGovernanceProposal(
+		txHash,
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, proposal)
+	// Proposal AddedSlot is anchored to the proposal's original epoch
+	// (ProposedIn=1275 → 10_000 + (1275-1200)*100 = 17_500), not the
+	// snapshot's current epoch, so older proposals retain their original
+	// slot for rollback/pruning purposes.
+	require.Equal(t, uint64(17_500), proposal.AddedSlot)
+
+	constitution, err := db.Metadata().GetConstitution(nil)
+	require.NoError(t, err)
+	require.NotNil(t, constitution)
+	require.Equal(t, uint64(17_700), constitution.AddedSlot)
+}
+
+func TestSnapshotEpochAnchorSlotUsesMatchingEraBound(t *testing.T) {
+	cfg := ImportConfig{
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			EraBounds: []EraBound{
+				{Slot: 0, Epoch: 0},
+				{Slot: 1_000, Epoch: 10},
+				{Slot: 2_000, Epoch: 20},
+			},
+			EraIndex:      EraConway,
+			EraBoundEpoch: 20,
+			EraBoundSlot:  2_000,
+		},
+		EpochLength: func(eraId uint) (uint, uint, error) {
+			switch eraId {
+			case 0:
+				return 1, 50, nil
+			case 1:
+				return 1, 100, nil
+			default:
+				return 1, 200, nil
+			}
+		},
+	}
+
+	require.Equal(t, uint64(1_500), snapshotEpochAnchorSlot(cfg, 15))
+}
+
+func TestSnapshotEpochAnchorSlotWarnsOnFallback(t *testing.T) {
+	var logBuf bytes.Buffer
+	cfg := ImportConfig{
+		Logger: slog.New(
+			slog.NewTextHandler(&logBuf, nil),
+		),
+		State: &RawLedgerState{
+			EraBounds: []EraBound{
+				{Slot: 1_000, Epoch: 10},
+				{Slot: 2_000, Epoch: 20},
+			},
+			EraIndex:      EraConway,
+			EraBoundEpoch: 20,
+			EraBoundSlot:  2_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.Zero(t, snapshotEpochAnchorSlot(cfg, 5))
+	require.Contains(t, logBuf.String(), "snapshotEpochAnchorSlot")
+	require.Contains(t, logBuf.String(), "epoch precedes first era bound")
+	require.Contains(t, logBuf.String(), "epoch=5")
+	require.Contains(t, logBuf.String(), "era_bound_epoch=20")
+}
+
+func TestSnapshotEpochAnchorSlotWarnsOnMissingEpochLength(t *testing.T) {
+	var logBuf bytes.Buffer
+	cfg := ImportConfig{
+		Logger: slog.New(
+			slog.NewTextHandler(&logBuf, nil),
+		),
+		State: &RawLedgerState{
+			EraBounds: []EraBound{
+				{Slot: 1_000, Epoch: 10},
+			},
+			EraIndex:      EraConway,
+			EraBoundEpoch: 10,
+			EraBoundSlot:  1_000,
+		},
+	}
+
+	require.Equal(t, uint64(1_000), snapshotEpochAnchorSlot(cfg, 12))
+	require.Contains(t, logBuf.String(), "snapshotEpochAnchorSlot")
+	require.Contains(t, logBuf.String(), "epoch length unavailable")
+	require.Contains(t, logBuf.String(), "epoch=12")
+}
+
+func TestSnapshotEpochAnchorSlotWarnsOnEpochLengthError(t *testing.T) {
+	var logBuf bytes.Buffer
+	cfg := ImportConfig{
+		Logger: slog.New(
+			slog.NewTextHandler(&logBuf, nil),
+		),
+		State: &RawLedgerState{
+			EraBounds: []EraBound{
+				{Slot: 0, Epoch: 0},
+			},
+			EraIndex:      EraConway,
+			EraBoundEpoch: 0,
+			EraBoundSlot:  0,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 0, 0, errors.New("boom")
+		},
+	}
+
+	require.Zero(t, snapshotEpochAnchorSlot(cfg, 3))
+	require.Contains(t, logBuf.String(), "snapshotEpochAnchorSlot")
+	require.Contains(t, logBuf.String(), "failed to resolve epoch length")
+	require.Contains(t, logBuf.String(), "boom")
+}
+
+func testGovStateData(
+	t *testing.T,
+	txHash []byte,
+	proposedEpoch uint64,
+) []byte {
+	t.Helper()
+
+	proposal := []any{
+		[]any{txHash, uint64(0)},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		[]any{
+			uint64(100_000_000),
+			bytes.Repeat([]byte{0xa1}, 29),
+			[]any{uint8(2)},
+			[]any{
+				"https://example.com/proposal",
+				bytes.Repeat([]byte{0xb2}, 32),
+			},
+		},
+		proposedEpoch,
+		proposedEpoch + 5,
+	}
+	govState := []any{
+		[]any{[]any{}, []any{proposal}},
+		[]any{},
+		[]any{
+			[]any{
+				"https://example.com/constitution",
+				bytes.Repeat([]byte{0xc3}, 32),
+			},
+			nil,
+		},
+	}
+	data, err := cbor.Encode(govState)
+	require.NoError(t, err)
+	return data
 }

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -16,6 +16,7 @@ package ledgerstate
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,14 +38,14 @@ var zeroBlake2b224 ledger.Blake2b224
 //   - CBOR array: [hash, index]
 //   - CBOR tag 24 (WrappedCbor): bstr wrapping CBOR or binary TxIn
 //   - Plain byte string: CBOR or binary TxIn inside
-//   - Binary: 32-byte hash + 2-byte little-endian index
+//   - Binary: 32-byte hash + 2-byte big-endian index
 func decodeTxIn(
 	raw cbor.RawMessage,
 ) (txHash []byte, outputIndex uint32, err error) {
 	// Try 1: Plain byte string (MemPack TxIn in UTxO-HD tvar)
 	// This is the most common case for MemPack files where each
 	// key is a CBOR byte string wrapping 34 bytes of MemPack
-	// TxIn (32-byte hash + 2-byte LE index).
+	// TxIn (32-byte hash + 2-byte BE index).
 	// decodeTxInFromBytes handles both the exact 34-byte binary
 	// path and CBOR-array-inside-byte-string fallback.
 	var keyBytes []byte
@@ -103,18 +104,20 @@ func decodeTxInFromArray(
 }
 
 // decodeTxInFromBytes decodes TxIn from inner bytes that may be
-// raw binary (32-byte hash + 2-byte LE index) or a CBOR array.
+// raw binary (32-byte hash + 2-byte BE index) or a CBOR array.
 // Binary format is tried first since it's the standard MemPack
 // encoding used in UTxO-HD tvar files.
 func decodeTxInFromBytes(
 	data []byte,
 ) ([]byte, uint32, error) {
-	// Binary format: 32-byte hash + 2-byte little-endian index
-	// This is the MemPack TxIn encoding (PackedBytes32 + Word16)
+	// Binary format: 32-byte hash + 2-byte big-endian index.
+	// Preview UTxO-HD snapshots encode the trailing Word16 in
+	// network order; decoding it as little-endian inflates #1 to
+	// #256 and corrupts imported UTxO keys.
 	if len(data) == 34 {
 		txHash := make([]byte, 32)
 		copy(txHash, data[:32])
-		idx := uint32(data[32]) | uint32(data[33])<<8
+		idx := uint32(binary.BigEndian.Uint16(data[32:34]))
 		return txHash, idx, nil
 	}
 
@@ -348,7 +351,7 @@ func parseUTxOsStreamingWithProgress(
 //   - Legacy CBOR: TxOut is a CBOR array or map
 //   - UTxO-HD MemPack: TxOut is MemPack binary (tags 0-5)
 //   - TxIn: CBOR array, tag-24-wrapped, or plain byte string
-//     with 32-byte hash + 2-byte LE index
+//     with 32-byte hash + 2-byte BE index
 func parseUTxOEntry(
 	keyRaw cbor.RawMessage,
 	valRaw cbor.RawMessage,

--- a/ledgerstate/utxo_test.go
+++ b/ledgerstate/utxo_test.go
@@ -1,0 +1,23 @@
+package ledgerstate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeTxIn_BinaryKeyUsesBigEndianOutputIndex(t *testing.T) {
+	t.Parallel()
+
+	txHash := bytes.Repeat([]byte{0x5a}, 32)
+	keyBytes := append(append([]byte{}, txHash...), 0x00, 0x01)
+	keyRaw, err := cbor.Encode(keyBytes)
+	require.NoError(t, err)
+
+	decodedHash, outputIndex, err := decodeTxIn(cbor.RawMessage(keyRaw))
+	require.NoError(t, err)
+	require.Equal(t, txHash, decodedHash)
+	require.Equal(t, uint32(1), outputIndex)
+}


### PR DESCRIPTION
Closes #2019 
Closes #2027 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs Mithril snapshot bootstrap and resume so restarts are safe and fast. Persists per-output UTxO offsets during `ImmutableDB` copy in the same transaction, replays gap blocks with epoch anchoring for Conway governance, and only runs historical backfill in API mode when a checkpoint exists.

- **Bug Fixes**
  - Recover missing consumed UTxOs for normal and gap txs; record spender `spent_at_tx_id`; repair same-slot rows via updated `SetUtxoDeletedAtSlot`; restore using UTxO blob offsets or producer tx slots via `GetTransactionSlotByHash`.
  - Process Conway governance in gap blocks; handle votes-before-proposal; anchor proposals, PParams, constitution, and committee to epoch-start slots via `GetEpochBySlot`.
  - Compute produced-output offsets by structurally walking the CBOR tx body (incl. `collateral_return`) to avoid false byte matches.
  - `TieredCborCache.ResolveTxCbor` now reads via the caller’s blob transaction so uncommitted writes (e.g., during immutable copy) are visible.
  - Skip immutable copy when chain tip is past the `ImmutableDB` tip; decode binary TxIn indices as big-endian.
  - Make block-nonce writes idempotent with upsert on unique `(hash, slot)`, migrate the legacy non-unique index, and preserve `is_checkpoint=true` on upsert.

- **New Features**
  - Add `Chain.AddRawBlocksWithCallback` to run per-block callbacks in the same transaction during raw import; used to persist UTxO offset indexes during `ImmutableDB` copy.
  - Add `GetEpochBySlot`, `GetTransactionSlotByHash`, and `GetTransactionIDByHash`; clearer serve/backfill logs; metadata backfill runs only in API mode when a checkpoint exists.

<sup>Written for commit 54741bd8791935d22202f3768cb3631f92d27284. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2032?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-block callbacks during atomic block ingestion for immediate UTxO-offset persistence and safer header-only imports
  * Epoch-aware gap-block processing with governance indexing and automatic proposal repair
  * UTxO records now include spender transaction hashes and a slot→epoch lookup

* **Bug Fixes**
  * Fixed transaction-input index endianness
  * More robust produced-output/offset extraction, optimistic-locking to prevent spend races, and safer rollback/restore semantics

* **Tests**
  * Expanded coverage for gap governance, UTxO recovery/rollback, ledger import anchoring, and callback paths

* **Documentation**
  * Clarified historical metadata backfill messaging and resume semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->