### PR TITLE
feat(peergov): enforce intentional inbound hot promotion and suppress…

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -202,6 +202,16 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			)
 			return
 		}
+		if currentPeer := p.peers[peerIdx]; p.inboundSatisfiesTopologyValencyLocked(currentPeer) {
+			p.mu.Unlock()
+			p.config.Logger.Info(
+				"outbound: inbound reusable topology connections already satisfy valency, suppressing outbound attempts",
+				"address", peer.Address,
+				"group", currentPeer.GroupID,
+				"valency", currentPeer.Valency,
+			)
+			return
+		}
 		// Only a client-capable connection can replace the outbound dial.
 		// This matches ouroboros-network's duplex-connection reuse: an
 		// existing inbound responder-only connection is not enough to

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4184,6 +4184,8 @@ func TestPeerGovernor_InboundPeer_BothRequirementsMet(t *testing.T) {
 			HeaderArrivalRateInit:   true,
 			TipSlotDelta:            0, // At tip
 			TipSlotDeltaInit:        true,
+			ChainSyncLastUpdate:     time.Now(),
+			LastBlockFetchTime:      time.Now(),
 		},
 	}
 	pg.mu.Unlock()
@@ -4303,6 +4305,9 @@ func TestPeerGovernor_IsInboundEligibleForHot(t *testing.T) {
 				PerformanceScore: 0.7, // Above threshold
 				FirstSeen: time.Now().
 					Add(-15 * time.Minute),
+				ChainSyncLastUpdate: time.Now(),
+				TipSlotDeltaInit:    true,
+				TipSlotDelta:        0,
 				// More than 10 min
 			},
 			expected: true,
@@ -4310,9 +4315,12 @@ func TestPeerGovernor_IsInboundEligibleForHot(t *testing.T) {
 		{
 			name: "inbound peer with exact threshold score",
 			peer: &Peer{
-				Source:           PeerSourceInboundConn,
-				PerformanceScore: 0.6, // Exact threshold
-				FirstSeen:        time.Now().Add(-15 * time.Minute),
+				Source:              PeerSourceInboundConn,
+				PerformanceScore:    0.6, // Exact threshold
+				FirstSeen:           time.Now().Add(-15 * time.Minute),
+				ChainSyncLastUpdate: time.Now(),
+				TipSlotDeltaInit:    true,
+				TipSlotDelta:        0,
 			},
 			expected: true,
 		},
@@ -4323,9 +4331,21 @@ func TestPeerGovernor_IsInboundEligibleForHot(t *testing.T) {
 				PerformanceScore: 0.8,
 				FirstSeen: time.Now().
 					Add(-10 * time.Minute),
+				ChainSyncLastUpdate: time.Now(),
+				TipSlotDeltaInit:    true,
+				TipSlotDelta:        0,
 				// Exact 10 min
 			},
 			expected: true,
+		},
+		{
+			name: "inbound peer without useful signal",
+			peer: &Peer{
+				Source:           PeerSourceInboundConn,
+				PerformanceScore: 0.8,
+				FirstSeen:        time.Now().Add(-15 * time.Minute),
+			},
+			expected: false,
 		},
 		{
 			name: "topology local root always eligible",
@@ -4438,6 +4458,243 @@ func TestPeerGovernor_InboundPeer_MixedPeerPromotion(t *testing.T) {
 		"gossip peer should be promoted to hot")
 	assert.Equal(t, PeerStateHot, gossip2State,
 		"gossip peer should be promoted to hot")
+}
+
+func TestPeerGovernor_InboundPeer_DuplexOnlyForHot(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundHotScoreThreshold: 0.6,
+		InboundMinTenure:         10 * time.Minute,
+		InboundDuplexOnlyForHot:  true,
+	})
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	peer := &Peer{
+		Source:              PeerSourceInboundConn,
+		State:               PeerStateWarm,
+		PerformanceScore:    0.9,
+		FirstSeen:           time.Now().Add(-time.Hour),
+		ChainSyncLastUpdate: time.Now(),
+		TipSlotDeltaInit:    true,
+		TipSlotDelta:        0,
+	}
+	assert.False(t, pg.isInboundEligibleForHot(peer))
+	peer.Connection = &PeerConnection{IsClient: true}
+	assert.True(t, pg.isInboundEligibleForHot(peer))
+}
+
+func TestPeerGovernor_InboundHotQuota_PreventsOverPromotion(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               2,
+		TargetNumberOfActivePeers: 2,
+		InboundHotQuota:           1,
+		InboundHotScoreThreshold:  0.6,
+		InboundMinTenure:          5 * time.Minute,
+	})
+	now := time.Now()
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:                 "192.168.10.1:3001",
+			Source:                  PeerSourceInboundConn,
+			State:                   PeerStateWarm,
+			Connection:              &PeerConnection{IsClient: true},
+			FirstSeen:               now.Add(-time.Hour),
+			ChainSyncLastUpdate:     now,
+			TipSlotDeltaInit:        true,
+			TipSlotDelta:            0,
+			BlockFetchLatencyMs:     50,
+			BlockFetchLatencyInit:   true,
+			BlockFetchSuccessRate:   0.95,
+			BlockFetchSuccessInit:   true,
+			ConnectionStability:     0.9,
+			ConnectionStabilityInit: true,
+			HeaderArrivalRate:       100,
+			HeaderArrivalRateInit:   true,
+		},
+		{
+			Address:                 "192.168.10.2:3001",
+			Source:                  PeerSourceInboundConn,
+			State:                   PeerStateWarm,
+			Connection:              &PeerConnection{IsClient: true},
+			FirstSeen:               now.Add(-time.Hour),
+			ChainSyncLastUpdate:     now,
+			TipSlotDeltaInit:        true,
+			TipSlotDelta:            0,
+			BlockFetchLatencyMs:     50,
+			BlockFetchLatencyInit:   true,
+			BlockFetchSuccessRate:   0.95,
+			BlockFetchSuccessInit:   true,
+			ConnectionStability:     0.9,
+			ConnectionStabilityInit: true,
+			HeaderArrivalRate:       100,
+			HeaderArrivalRateInit:   true,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+	peers := pg.GetPeers()
+	hotInbound := 0
+	for _, peer := range peers {
+		if peer.Source == PeerSourceInboundConn && peer.State == PeerStateHot {
+			hotInbound++
+		}
+	}
+	assert.Equal(t, 1, hotInbound, "inbound hot promotions must respect inbound hot quota")
+}
+
+func TestPeerGovernor_InboundSatisfiesTopologyValency(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	pg.peers = []*Peer{
+		{
+			Address:              "44.0.0.1:3001",
+			Source:               PeerSourceTopologyLocalRoot,
+			GroupID:              "local-root-0",
+			Valency:              1,
+			State:                PeerStateHot,
+			Connection:           &PeerConnection{IsClient: true},
+			InboundDuplex:        true,
+			InboundTopologyMatch: "local-root-0",
+		},
+		{
+			Address: "44.0.0.2:3001",
+			Source:  PeerSourceTopologyLocalRoot,
+			GroupID: "local-root-0",
+			Valency: 1,
+			State:   PeerStateCold,
+		},
+	}
+	assert.True(t, pg.inboundSatisfiesTopologyValencyLocked(pg.peers[1]))
+	pg.peers[0].State = PeerStateWarm
+	assert.False(t, pg.inboundSatisfiesTopologyValencyLocked(pg.peers[1]))
+}
+
+func TestPeerGovernor_IsInboundEligibleForHot_RejectsStaleSignals(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundHotScoreThreshold: 0.6,
+		InboundMinTenure:         10 * time.Minute,
+	})
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	peer := &Peer{
+		Source:              PeerSourceInboundConn,
+		State:               PeerStateWarm,
+		Connection:          &PeerConnection{IsClient: true},
+		PerformanceScore:    0.9,
+		FirstSeen:           time.Now().Add(-time.Hour),
+		ChainSyncLastUpdate: time.Now().Add(-time.Hour),
+		TipSlotDeltaInit:    true,
+		TipSlotDelta:        0,
+	}
+	assert.False(t, pg.isInboundEligibleForHot(peer),
+		"stale chainsync usefulness signal must not allow hot promotion")
+}
+
+func TestPeerGovernor_IsInboundEligibleForHot_RejectsFlappingPeer(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundHotScoreThreshold: 0.6,
+		InboundMinTenure:         10 * time.Minute,
+		InboundCooldown:          5 * time.Minute,
+	})
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	peer := &Peer{
+		Source:              PeerSourceInboundConn,
+		State:               PeerStateWarm,
+		Connection:          &PeerConnection{IsClient: true},
+		PerformanceScore:    0.9,
+		FirstSeen:           time.Now().Add(-time.Hour),
+		ChainSyncLastUpdate: time.Now(),
+		TipSlotDeltaInit:    true,
+		TipSlotDelta:        0,
+		InboundArrivals:     3,
+		LastInboundArrival:  time.Now(),
+	}
+	assert.False(t, pg.isInboundEligibleForHot(peer),
+		"recent re-arrivals within cooldown must be treated as unstable")
+	peer.LastInboundArrival = time.Now().Add(-10 * time.Minute)
+	assert.True(t, pg.isInboundEligibleForHot(peer),
+		"once cooldown passes, peer can be promoted again")
+}
+
+func TestPeerGovernor_IsInboundEligibleForHot_BlockFetchSignalAlone(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundHotScoreThreshold: 0.6,
+		InboundMinTenure:         10 * time.Minute,
+	})
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	peer := &Peer{
+		Source:                PeerSourceInboundConn,
+		State:                 PeerStateWarm,
+		Connection:            &PeerConnection{IsClient: true},
+		PerformanceScore:      0.9,
+		FirstSeen:             time.Now().Add(-time.Hour),
+		LastBlockFetchTime:    time.Now(),
+		BlockFetchSuccessInit: true,
+		BlockFetchSuccessRate: 0.9,
+	}
+	assert.True(t, pg.isInboundEligibleForHot(peer),
+		"fresh useful blockfetch signal should be sufficient")
+}
+
+func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               1,
+		TargetNumberOfActivePeers: 1,
+		InboundHotScoreThreshold:  0.6,
+		InboundMinTenure:          5 * time.Minute,
+	})
+	now := time.Now()
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:          "44.0.0.1:3001",
+			Source:           PeerSourceTopologyPublicRoot,
+			State:            PeerStateWarm,
+			Connection:       &PeerConnection{IsClient: true},
+			PerformanceScore: 0.5,
+			GroupID:          "public-root-0",
+			Valency:          1,
+			FirstSeen:        now.Add(-time.Hour),
+		},
+		{
+			Address:             "44.0.0.2:3001",
+			Source:              PeerSourceInboundConn,
+			State:               PeerStateWarm,
+			Connection:          &PeerConnection{IsClient: true},
+			PerformanceScore:    0.95,
+			FirstSeen:           now.Add(-time.Hour),
+			ChainSyncLastUpdate: now,
+			TipSlotDeltaInit:    true,
+			TipSlotDelta:        0,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+	peers := pg.GetPeers()
+	stateByAddress := map[string]PeerState{}
+	for _, peer := range peers {
+		stateByAddress[peer.Address] = peer.State
+	}
+	assert.Equal(
+		t,
+		PeerStateHot,
+		stateByAddress["44.0.0.1:3001"],
+		"higher-priority topology source should be promoted before inbound",
+	)
+	assert.Equal(t, PeerStateWarm, stateByAddress["44.0.0.2:3001"])
 }
 
 // Phase 7: Enhanced Observability Tests

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4545,6 +4545,79 @@ func TestPeerGovernor_InboundHotQuota_PreventsOverPromotion(t *testing.T) {
 	assert.Equal(t, 1, hotInbound, "inbound hot promotions must respect inbound hot quota")
 }
 
+// TestPeerGovernor_InboundHotQuota_CountsProvisionalHotPeers ensures promotion
+// uses actual hot inbound count, not censusInboundCounts.Hot (which excludes
+// peers still inside InboundProvisionalWindow), so a second inbound cannot be
+// promoted past InboundHotQuota.
+func TestPeerGovernor_InboundHotQuota_CountsProvisionalHotPeers(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               2,
+		TargetNumberOfActivePeers: 2,
+		InboundHotQuota:           1,
+		InboundHotScoreThreshold:  0.6,
+		InboundMinTenure:          1 * time.Minute,
+	})
+	now := time.Now()
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:                 "192.168.11.1:3001",
+			Source:                  PeerSourceInboundConn,
+			State:                   PeerStateHot,
+			Connection:              &PeerConnection{IsClient: true},
+			FirstSeen:               now,
+			LastActivity:            now,
+			ChainSyncLastUpdate:     now,
+			TipSlotDeltaInit:        true,
+			TipSlotDelta:            0,
+			BlockFetchLatencyMs:     50,
+			BlockFetchLatencyInit:   true,
+			BlockFetchSuccessRate:   0.95,
+			BlockFetchSuccessInit:   true,
+			ConnectionStability:     0.9,
+			ConnectionStabilityInit: true,
+			HeaderArrivalRate:       100,
+			HeaderArrivalRateInit:   true,
+		},
+		{
+			Address:                 "192.168.11.2:3001",
+			Source:                  PeerSourceInboundConn,
+			State:                   PeerStateWarm,
+			Connection:              &PeerConnection{IsClient: true},
+			FirstSeen:               now.Add(-2 * time.Minute),
+			ChainSyncLastUpdate:     now,
+			TipSlotDeltaInit:        true,
+			TipSlotDelta:            0,
+			BlockFetchLatencyMs:     50,
+			BlockFetchLatencyInit:   true,
+			BlockFetchSuccessRate:   0.95,
+			BlockFetchSuccessInit:   true,
+			ConnectionStability:     0.9,
+			ConnectionStabilityInit: true,
+			HeaderArrivalRate:       100,
+			HeaderArrivalRateInit:   true,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+	hotInbound := 0
+	var secondState PeerState
+	for _, peer := range pg.GetPeers() {
+		if peer.Source == PeerSourceInboundConn && peer.State == PeerStateHot {
+			hotInbound++
+		}
+		if peer.Address == "192.168.11.2:3001" {
+			secondState = peer.State
+		}
+	}
+	assert.Equal(t, 1, hotInbound,
+		"provisional-window hot inbound must still count toward InboundHotQuota")
+	assert.Equal(t, PeerStateWarm, secondState,
+		"second inbound must not be promoted when quota already satisfied by actual hot inbound")
+}
+
 func TestPeerGovernor_InboundSatisfiesTopologyValency(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -4657,6 +4730,8 @@ func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {
 	})
 	now := time.Now()
 	pg.mu.Lock()
+	// No GroupID/Valency so neither candidate wins on under-valency alone;
+	// ordering must come from peerSourcePriority (topology > inbound).
 	pg.peers = []*Peer{
 		{
 			Address:          "44.0.0.1:3001",
@@ -4664,8 +4739,6 @@ func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {
 			State:            PeerStateWarm,
 			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.5,
-			GroupID:          "public-root-0",
-			Valency:          1,
 			FirstSeen:        now.Add(-time.Hour),
 		},
 		{
@@ -4695,6 +4768,62 @@ func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {
 		"higher-priority topology source should be promoted before inbound",
 	)
 	assert.Equal(t, PeerStateWarm, stateByAddress["44.0.0.2:3001"])
+}
+
+// TestPeerGovernor_PromotionEqualSourcePriorityUsesScore verifies that when two
+// candidates map to the same peerSourcePriority (e.g. different topology
+// kinds), ordering falls through to PerformanceScore instead of arbitrary 0.
+func TestPeerGovernor_PromotionEqualSourcePriorityUsesScore(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:               1,
+		TargetNumberOfActivePeers: 1,
+	})
+	now := time.Now()
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:    "44.0.0.10:3001",
+			Source:     PeerSourceTopologyPublicRoot,
+			State:      PeerStateWarm,
+			Connection: &PeerConnection{IsClient: true},
+			FirstSeen:  now.Add(-time.Hour),
+			// Poor composite score after UpdatePeerScore in reconcile
+			BlockFetchLatencyMs:     2000,
+			BlockFetchLatencyInit:   true,
+			BlockFetchSuccessRate:   0.1,
+			BlockFetchSuccessInit:   true,
+			ConnectionStability:     0.1,
+			ConnectionStabilityInit: true,
+		},
+		{
+			Address:                 "44.0.0.11:3001",
+			Source:                  PeerSourceTopologyLocalRoot,
+			State:                   PeerStateWarm,
+			Connection:              &PeerConnection{IsClient: true},
+			FirstSeen:               now.Add(-time.Hour),
+			BlockFetchLatencyMs:     50,
+			BlockFetchLatencyInit:   true,
+			BlockFetchSuccessRate:   0.95,
+			BlockFetchSuccessInit:   true,
+			ConnectionStability:     0.9,
+			ConnectionStabilityInit: true,
+			HeaderArrivalRate:       100,
+			HeaderArrivalRateInit:   true,
+			TipSlotDeltaInit:        true,
+			TipSlotDelta:            0,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+	stateByAddress := map[string]PeerState{}
+	for _, peer := range pg.GetPeers() {
+		stateByAddress[peer.Address] = peer.State
+	}
+	assert.Equal(t, PeerStateHot, stateByAddress["44.0.0.11:3001"],
+		"same topology priority bucket must break ties by score")
+	assert.Equal(t, PeerStateWarm, stateByAddress["44.0.0.10:3001"])
 }
 
 // Phase 7: Enhanced Observability Tests

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4603,17 +4603,22 @@ func TestPeerGovernor_InboundHotQuota_CountsProvisionalHotPeers(t *testing.T) {
 
 	pg.reconcile(t.Context())
 	hotInbound := 0
-	var secondState PeerState
+	var firstState, secondState PeerState
 	for _, peer := range pg.GetPeers() {
 		if peer.Source == PeerSourceInboundConn && peer.State == PeerStateHot {
 			hotInbound++
 		}
-		if peer.Address == "192.168.11.2:3001" {
+		switch peer.Address {
+		case "192.168.11.1:3001":
+			firstState = peer.State
+		case "192.168.11.2:3001":
 			secondState = peer.State
 		}
 	}
 	assert.Equal(t, 1, hotInbound,
 		"provisional-window hot inbound must still count toward InboundHotQuota")
+	require.Equal(t, PeerStateHot, firstState,
+		"provisional hot inbound must stay hot; demote-then-promote would mask the quota invariant")
 	assert.Equal(t, PeerStateWarm, secondState,
 		"second inbound must not be promoted when quota already satisfied by actual hot inbound")
 }

--- a/peergov/quotas.go
+++ b/peergov/quotas.go
@@ -20,6 +20,12 @@ import (
 	"time"
 )
 
+const (
+	inboundUsefulSignalFreshness  = 15 * time.Minute
+	minInboundBlockfetchSuccess   = 0.5
+	minInboundConnectionStability = 0.5
+)
+
 // PeerCounts holds peer counts by state for a given source or category.
 type PeerCounts struct {
 	Cold int
@@ -448,6 +454,9 @@ func (p *PeerGovernor) isInboundEligibleForHot(peer *Peer) bool {
 	if peer.Source != PeerSourceInboundConn {
 		return true
 	}
+	// Inbound peers are hot-promoted only when explicitly useful and stable.
+	// This keeps inbound hot slots rare and intentional.
+	now := time.Now()
 	// Inbound peers must meet higher score threshold
 	if peer.PerformanceScore < p.config.InboundHotScoreThreshold {
 		return false
@@ -457,7 +466,65 @@ func (p *PeerGovernor) isInboundEligibleForHot(peer *Peer) bool {
 		return false
 	}
 	tenure := time.Since(peer.FirstSeen)
-	return tenure >= p.config.InboundMinTenure
+	if tenure < p.config.InboundMinTenure {
+		return false
+	}
+	if p.config.InboundDuplexOnlyForHot && !peer.hasClientConnection() && !peer.InboundDuplex {
+		return false
+	}
+	// Penalize peers that are reconnect-flapping (multiple arrivals in cooldown).
+	if peer.InboundArrivals > 1 &&
+		!peer.LastInboundArrival.IsZero() &&
+		now.Sub(peer.LastInboundArrival) < p.config.InboundCooldown {
+		return false
+	}
+	// When observed, connection stability must meet a baseline.
+	if peer.ConnectionStabilityInit &&
+		peer.ConnectionStability < minInboundConnectionStability {
+		return false
+	}
+	chainSyncUseful := peer.ChainSyncLastUpdate.After(now.Add(-inboundUsefulSignalFreshness)) &&
+		((peer.TipSlotDeltaInit && peer.TipSlotDelta <= 0) ||
+			(peer.HeaderArrivalRateInit && peer.HeaderArrivalRate > 0))
+	blockFetchUseful := peer.LastBlockFetchTime.After(now.Add(-inboundUsefulSignalFreshness)) &&
+		peer.BlockFetchSuccessInit &&
+		peer.BlockFetchSuccessRate >= minInboundBlockfetchSuccess
+	return chainSyncUseful || blockFetchUseful
+}
+
+// isReusableInboundTopologyConnectionLocked reports whether this peer currently
+// has a client-capable inbound connection that can satisfy topology demand
+// without an extra outbound dial.
+func (p *PeerGovernor) isReusableInboundTopologyConnectionLocked(peer *Peer) bool {
+	if peer == nil || !p.isTopologyPeer(peer.Source) || !peer.hasClientConnection() {
+		return false
+	}
+	if p.config.ConnManager != nil {
+		return p.config.ConnManager.IsInboundConnection(peer.Connection.Id)
+	}
+	// Fallback for tests/no connmanager wiring.
+	return peer.InboundDuplex
+}
+
+// inboundSatisfiesTopologyValencyLocked returns true when reusable inbound
+// topology connections already satisfy this peer's group's hot valency.
+func (p *PeerGovernor) inboundSatisfiesTopologyValencyLocked(peer *Peer) bool {
+	if peer == nil || !p.isTopologyPeer(peer.Source) ||
+		peer.GroupID == "" || peer.Valency == 0 {
+		return false
+	}
+	reusableInboundHot := 0
+	for _, candidate := range p.peers {
+		if candidate == nil ||
+			candidate.GroupID != peer.GroupID ||
+			candidate.State != PeerStateHot {
+			continue
+		}
+		if p.isReusableInboundTopologyConnectionLocked(candidate) {
+			reusableInboundHot++
+		}
+	}
+	return uint(reusableInboundHot) >= peer.Valency
 }
 
 // redistributeUnusedSlots redistributes unused quota slots to other categories.

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -243,6 +243,12 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 				}
 				return 1
 			}
+			if a.peer.Source != b.peer.Source {
+				return cmp.Compare(
+					p.peerSourcePriority(b.peer.Source),
+					p.peerSourcePriority(a.peer.Source),
+				)
+			}
 			if a.peer.PerformanceScore != b.peer.PerformanceScore {
 				return cmp.Compare(
 					b.peer.PerformanceScore,
@@ -257,8 +263,13 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 
 		needed := refillTarget - hotCount
 		promoted := 0
+		inboundHotHeld := p.censusInboundCounts().Hot
 		for i := 0; i < len(candidates) && promoted < needed; i++ {
 			peer := candidates[i].peer
+			if peer.Source == PeerSourceInboundConn &&
+				inboundHotHeld >= p.config.InboundHotQuota {
+				continue
+			}
 			// Check inbound peer eligibility (score threshold and tenure)
 			if !p.isInboundEligibleForHot(peer) {
 				p.config.Logger.Debug(
@@ -281,6 +292,9 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 			warmPromotions++
 			activeIncreased++
 			promoted++
+			if peer.Source == PeerSourceInboundConn {
+				inboundHotHeld++
+			}
 			if bootstrapPromotion && candidates[i].diversityGroup != "" {
 				selectedGroups[candidates[i].diversityGroup] = struct{}{}
 			}

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -243,11 +243,14 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 				}
 				return 1
 			}
-			if a.peer.Source != b.peer.Source {
-				return cmp.Compare(
-					p.peerSourcePriority(b.peer.Source),
-					p.peerSourcePriority(a.peer.Source),
-				)
+			// Prefer higher-priority sources when priorities differ; when two
+			// sources share the same priority (e.g. two topology kinds), fall
+			// through to score tie-breaking instead of returning 0 early.
+			if c := cmp.Compare(
+				p.peerSourcePriority(b.peer.Source),
+				p.peerSourcePriority(a.peer.Source),
+			); c != 0 {
+				return c
 			}
 			if a.peer.PerformanceScore != b.peer.PerformanceScore {
 				return cmp.Compare(
@@ -263,7 +266,17 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 
 		needed := refillTarget - hotCount
 		promoted := 0
-		inboundHotHeld := p.censusInboundCounts().Hot
+		// Count actual hot inbound peers (not censusInboundCounts.Hot, which
+		// excludes peers inside InboundProvisionalWindow) so quota cannot be
+		// exceeded when tenure is shorter than that window.
+		inboundHotHeld := 0
+		for _, existing := range p.peers {
+			if existing != nil &&
+				existing.Source == PeerSourceInboundConn &&
+				existing.State == PeerStateHot {
+				inboundHotHeld++
+			}
+		}
 		for i := 0; i < len(candidates) && promoted < needed; i++ {
 			peer := candidates[i].peer
 			if peer.Source == PeerSourceInboundConn &&


### PR DESCRIPTION
Closes #1933 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make inbound hot promotions intentional and limited. Prefer topology sources and suppress redundant outbound reconnects when reusable inbound topology connections already satisfy group valency.

- **New Features**
  - Gate inbound hot promotion on fresh chainsync or blockfetch signals (<=15m), minimum tenure, optional duplex-only, cooldown for re-arrivals, and a stability baseline.
  - Enforce `InboundHotQuota` by counting current hot inbound peers (including those in the provisional window) so quota isn’t exceeded.
  - Prefer higher‑priority topology sources over inbound when promoting; break ties within the same priority by score.

<sup>Written for commit 9c89bca0b1b2f496e7e212510fae1f0fadec741f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Peer Governance Improvements

**Improvements**
- Tightened inbound eligibility: requires recent usefulness/stability signals, cooldown and duplex/client conditions, and enforces minimum stability.
- Enforced inbound hot quotas during reconciliation; promotions stop when quota reached.
- Added source-priority and performance tie-breaker to promotion ordering.
- Avoids unnecessary outbound dials when inbound topology already satisfies valency.

**Tests**
- Expanded tests covering inbound eligibility, promotion ordering, quota enforcement, and signal-driven hot promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->