### PR TITLE
feat: clear dangling dreps

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -20,6 +20,52 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 )
 
+// ClearDanglingDRepDelegations applies the cardano-ledger Conway HARDFORK
+// STS rule for protocol major version 10 (Plomin, mainnet January 2025): any
+// account with a credential-backed DRep delegation (DrepType 0 or 1) whose
+// target DRep credential is not currently registered as an active DRep has
+// its delegation cleared. Account.AddedSlot is updated to atSlot so the
+// rewritten row is excluded from a rollback restore targeting any slot
+// before atSlot (the restore filters on `added_slot <= targetSlot` and picks
+// up the prior certificate history instead). Pseudo-DRep delegations
+// (AlwaysAbstain, AlwaysNoConfidence) are preserved. Returns the number of
+// accounts updated.
+//
+// See cardano-ledger Conway/Rules/HardFork.hs (updateDRepDelegations).
+func (d *Database) ClearDanglingDRepDelegations(
+	atSlot uint64,
+	txn *Txn,
+) (int, error) {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	n, err := d.metadata.ClearDanglingDRepDelegations(
+		atSlot,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"clear dangling drep delegations at slot %d: %w",
+			atSlot,
+			err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return 0, fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return n, nil
+}
+
 // RestoreAccountStateAtSlot reverts account delegation state to the given
 // slot. For accounts modified after the slot, this restores their Pool and
 // Drep delegations to the state they had at the given slot, or deletes them

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -886,3 +886,40 @@ func (d *MetadataStoreMysql) RestoreAccountStateAtSlot(
 
 	return nil
 }
+
+// ClearDanglingDRepDelegations implements the Conway HARDFORK rule for
+// protocol major version 10 (Plomin). See the MetadataStore interface
+// documentation for semantics.
+func (d *MetadataStoreMysql) ClearDanglingDRepDelegations(
+	atSlot uint64,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	// NOT EXISTS is used rather than NOT IN because NOT IN has
+	// surprising semantics around NULL values in the subquery result.
+	liveDrepExists := db.Model(&models.Drep{}).
+		Select("1").
+		Where("drep.credential = account.drep AND drep.active = ?", true)
+	result := db.Model(&models.Account{}).
+		Where("drep IS NOT NULL").
+		Where(
+			"drep_type IN ?",
+			[]uint64{
+				models.DrepTypeAddrKeyHash,
+				models.DrepTypeScriptHash,
+			},
+		).
+		Where("NOT EXISTS (?)", liveDrepExists).
+		Updates(map[string]any{
+			"drep":       gorm.Expr("NULL"),
+			"drep_type":  uint64(0),
+			"added_slot": atSlot,
+		})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return int(result.RowsAffected), nil
+}

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -886,3 +886,40 @@ func (d *MetadataStorePostgres) RestoreAccountStateAtSlot(
 
 	return nil
 }
+
+// ClearDanglingDRepDelegations implements the Conway HARDFORK rule for
+// protocol major version 10 (Plomin). See the MetadataStore interface
+// documentation for semantics.
+func (d *MetadataStorePostgres) ClearDanglingDRepDelegations(
+	atSlot uint64,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	// NOT EXISTS is used rather than NOT IN because NOT IN has
+	// surprising semantics around NULL values in the subquery result.
+	liveDrepExists := db.Model(&models.Drep{}).
+		Select("1").
+		Where("drep.credential = account.drep AND drep.active = ?", true)
+	result := db.Model(&models.Account{}).
+		Where("drep IS NOT NULL").
+		Where(
+			"drep_type IN ?",
+			[]uint64{
+				models.DrepTypeAddrKeyHash,
+				models.DrepTypeScriptHash,
+			},
+		).
+		Where("NOT EXISTS (?)", liveDrepExists).
+		Updates(map[string]any{
+			"drep":       gorm.Expr("NULL"),
+			"drep_type":  uint64(0),
+			"added_slot": atSlot,
+		})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return int(result.RowsAffected), nil
+}

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -902,3 +902,40 @@ func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
 
 	return nil
 }
+
+// ClearDanglingDRepDelegations implements the Conway HARDFORK rule for
+// protocol major version 10 (Plomin). See the MetadataStore interface
+// documentation for semantics.
+func (d *MetadataStoreSqlite) ClearDanglingDRepDelegations(
+	atSlot uint64,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	// NOT EXISTS is used rather than NOT IN because NOT IN has
+	// surprising semantics around NULL values in the subquery result.
+	liveDrepExists := db.Model(&models.Drep{}).
+		Select("1").
+		Where("drep.credential = account.drep AND drep.active = ?", true)
+	result := db.Model(&models.Account{}).
+		Where("drep IS NOT NULL").
+		Where(
+			"drep_type IN ?",
+			[]uint64{
+				models.DrepTypeAddrKeyHash,
+				models.DrepTypeScriptHash,
+			},
+		).
+		Where("NOT EXISTS (?)", liveDrepExists).
+		Updates(map[string]any{
+			"drep":       gorm.Expr("NULL"),
+			"drep_type":  uint64(0),
+			"added_slot": atSlot,
+		})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return int(result.RowsAffected), nil
+}

--- a/database/plugin/metadata/sqlite/plomin_test.go
+++ b/database/plugin/metadata/sqlite/plomin_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// Plomin (pv10) HARDFORK rule: cardano-ledger's
+// Conway/Rules/HardFork.hs updateDRepDelegations.
+
+// Account delegating to an active DRep has its delegation preserved; an
+// account delegating to a credential that is not present in the drep
+// table is cleared.
+func TestClearDanglingDRepDelegations_ClearsUnregisteredCredBackedDelegation(t *testing.T) {
+	store := setupTestDB(t)
+
+	liveCred := bytes.Repeat([]byte{0x11}, 28)
+	deadCred := bytes.Repeat([]byte{0x22}, 28)
+
+	stakeKeyLive := bytes.Repeat([]byte{0xA1}, 28)
+	stakeKeyDead := bytes.Repeat([]byte{0xA2}, 28)
+
+	// Live DRep registered as active
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential: liveCred,
+		Active:     true,
+		AddedSlot:  50,
+	}).Error)
+
+	// One account delegating to the live DRep (key cred = DrepType 0).
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKeyLive,
+		Drep:       liveCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	// One account delegating to a credential with NO drep row at all.
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKeyDead,
+		Drep:       deadCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n, err := store.ClearDanglingDRepDelegations(1_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n,
+		"exactly one account has a dangling delegation and should be cleared")
+
+	liveAcct, err := store.GetAccount(stakeKeyLive, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, liveAcct)
+	assert.True(t, bytes.Equal(liveAcct.Drep, liveCred),
+		"delegation to an active DRep must survive the rule")
+	assert.Equal(t, models.DrepTypeAddrKeyHash, liveAcct.DrepType)
+	assert.Equal(t, uint64(100), liveAcct.AddedSlot,
+		"unchanged accounts keep their original AddedSlot")
+
+	deadAcct, err := store.GetAccount(stakeKeyDead, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, deadAcct)
+	assert.Nil(t, deadAcct.Drep,
+		"dangling delegation credential must be cleared")
+	assert.Equal(t, uint64(0), deadAcct.DrepType,
+		"DrepType must be reset to the zero value")
+	assert.Equal(t, uint64(1_000), deadAcct.AddedSlot,
+		"AddedSlot must be bumped so rollback past the boundary re-derives the cert state")
+}
+
+// Inactive DReps (deregistered) are also not "live" and their delegators
+// must have their delegations cleared.
+func TestClearDanglingDRepDelegations_InactiveDRepCountsAsDangling(t *testing.T) {
+	store := setupTestDB(t)
+
+	inactiveCred := bytes.Repeat([]byte{0x33}, 28)
+	stakeKey := bytes.Repeat([]byte{0xB1}, 28)
+
+	// Note: models.Drep carries `gorm:"default:true"` on Active so a zero
+	// value ("false") at Create time is silently rewritten to true by GORM.
+	// Flip the column explicitly with a post-Create UPDATE.
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential: inactiveCred,
+		Active:     true,
+		AddedSlot:  50,
+	}).Error)
+	require.NoError(t, store.DB().Model(&models.Drep{}).
+		Where("credential = ?", inactiveCred).
+		Update("active", false).Error)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKey,
+		Drep:       inactiveCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n, err := store.ClearDanglingDRepDelegations(2_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	acct, err := store.GetAccount(stakeKey, true, nil)
+	require.NoError(t, err)
+	assert.Nil(t, acct.Drep)
+	assert.Equal(t, uint64(2_000), acct.AddedSlot)
+}
+
+// Script-credential delegations (DrepType 1) are treated the same way
+// as key credentials.
+func TestClearDanglingDRepDelegations_ScriptCredentialAlsoCleared(t *testing.T) {
+	store := setupTestDB(t)
+
+	deadScriptCred := bytes.Repeat([]byte{0x44}, 28)
+	stakeKey := bytes.Repeat([]byte{0xC1}, 28)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKey,
+		Drep:       deadScriptCred,
+		DrepType:   models.DrepTypeScriptHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n, err := store.ClearDanglingDRepDelegations(1_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	acct, err := store.GetAccount(stakeKey, true, nil)
+	require.NoError(t, err)
+	assert.Nil(t, acct.Drep)
+}
+
+// AlwaysAbstain / AlwaysNoConfidence delegations are pseudo-DReps with no
+// credential and must not be touched by the rule.
+func TestClearDanglingDRepDelegations_PseudoDRepDelegationsPreserved(t *testing.T) {
+	store := setupTestDB(t)
+
+	stakeKeyA := bytes.Repeat([]byte{0xD1}, 28)
+	stakeKeyB := bytes.Repeat([]byte{0xD2}, 28)
+
+	// Pseudo-DRep delegations are stored with Drep = nil.
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKeyA,
+		Drep:       nil,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKeyB,
+		Drep:       nil,
+		DrepType:   models.DrepTypeAlwaysNoConfidence,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n, err := store.ClearDanglingDRepDelegations(1_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n,
+		"pseudo-DRep delegations must never be counted as dangling")
+
+	a, err := store.GetAccount(stakeKeyA, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.DrepTypeAlwaysAbstain, a.DrepType)
+	assert.Equal(t, uint64(100), a.AddedSlot, "AddedSlot untouched")
+
+	b, err := store.GetAccount(stakeKeyB, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.DrepTypeAlwaysNoConfidence, b.DrepType)
+	assert.Equal(t, uint64(100), b.AddedSlot)
+}
+
+// Accounts with no DRep delegation at all are not touched.
+func TestClearDanglingDRepDelegations_NoDelegationUntouched(t *testing.T) {
+	store := setupTestDB(t)
+
+	stakeKey := bytes.Repeat([]byte{0xE1}, 28)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKey,
+		Pool:       bytes.Repeat([]byte{0xFA}, 28),
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n, err := store.ClearDanglingDRepDelegations(1_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	acct, err := store.GetAccount(stakeKey, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), acct.AddedSlot)
+}
+
+// Idempotent: once dangling delegations have been cleared, a second call
+// finds nothing to do.
+func TestClearDanglingDRepDelegations_Idempotent(t *testing.T) {
+	store := setupTestDB(t)
+
+	dead := bytes.Repeat([]byte{0x55}, 28)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: bytes.Repeat([]byte{0xF1}, 28),
+		Drep:       dead,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n1, err := store.ClearDanglingDRepDelegations(1_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n1)
+
+	n2, err := store.ClearDanglingDRepDelegations(2_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n2, "re-running after a clean rule-application is a no-op")
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -881,6 +881,20 @@ type MetadataStore interface {
 	// anchor and active status restored.
 	RestoreDrepStateAtSlot(uint64, types.Txn) error
 
+	// ClearDanglingDRepDelegations implements the cardano-ledger Conway
+	// HARDFORK STS rule for protocol major version 10 (Plomin, mainnet
+	// January 2025, Cardano/Conway/Rules/HardFork.hs updateDRepDelegations).
+	// For each account with a credential-backed DRep delegation
+	// (DrepType 0 or 1), if the target DRep credential is not currently
+	// registered as an active DRep, clear the delegation. Pseudo-DRep
+	// delegations (AlwaysAbstain, AlwaysNoConfidence) are preserved.
+	// Updates Account.AddedSlot to atSlot on every row it modifies so the
+	// rewritten row is excluded from a subsequent rollback restore
+	// targeting any slot before atSlot (the restore filters on
+	// `added_slot <= targetSlot` and falls back to prior certificate
+	// history). Returns the number of accounts updated.
+	ClearDanglingDRepDelegations(atSlot uint64, txn types.Txn) (int, error)
+
 	// DeletePParamsAfterSlot removes protocol parameter records added after
 	// the given slot.
 	DeletePParamsAfterSlot(uint64, types.Txn) error

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2834,6 +2834,18 @@ func (ls *LedgerState) processEpochRollover(
 				"component", "ledger",
 			)
 		}
+		// Apply cardano-ledger's per-major-version HARDFORK STS rule. This
+		// runs on ANY major-version bump, including intra-era ones like
+		// Conway pv9→pv10 (Plomin, mainnet January 2025) that do not
+		// trigger an era change. See cardano-ledger
+		// Conway/Rules/HardFork.hs.
+		if oldVer.Major != newVer.Major {
+			if err := ls.applyIntraEraHardForkRule(
+				txn, newVer.Major, epochStartSlot, currentEpoch.EpochId+1,
+			); err != nil {
+				return nil, fmt.Errorf("apply major-version HARDFORK: %w", err)
+			}
+		}
 	}
 
 	// Create next epoch record

--- a/ledger/hardfork_rule.go
+++ b/ledger/hardfork_rule.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+)
+
+// applyIntraEraHardForkRule dispatches cardano-ledger's per-major-version
+// HARDFORK STS rule (Conway/Rules/HardFork.hs). Unlike the inter-era HFC
+// detection that fires when the era ID changes, this runs on any bump of
+// the protocol *major* version — including intra-era ones that do not
+// cross an era boundary.
+//
+// The rule is called at the epoch-rollover boundary, in the same
+// database transaction as the pparams write, so the state rewrite
+// commits atomically with the major-version bump that triggers it.
+//
+// Currently implemented cases:
+//
+//   - major == 10 (Plomin, mainnet January 2025): clear any dangling
+//     credential-backed DRep delegation whose target DRep credential is
+//     not currently registered as an active DRep. Pseudo-DRep
+//     delegations (AlwaysAbstain, AlwaysNoConfidence) are preserved.
+//
+// Cases known but not yet required (no era defined in dingo yet):
+//
+//   - major == 11 (Dijkstra): populate per-pool VRF key hashes. Stubbed
+//     until the Dijkstra era lands in gouroboros + dingo's era table.
+//
+// Any future major-version bump that lands without a case here is a
+// no-op, matching the Haskell rule's `otherwise = id` branch.
+func (ls *LedgerState) applyIntraEraHardForkRule(
+	txn *database.Txn,
+	newMajor uint,
+	boundarySlot uint64,
+	newEpoch uint64,
+) error {
+	switch newMajor {
+	case 10:
+		n, err := ls.db.ClearDanglingDRepDelegations(boundarySlot, txn)
+		if err != nil {
+			return fmt.Errorf("pv10 clear dangling DRep delegations: %w", err)
+		}
+		ls.config.Logger.Info(
+			"applied Conway HARDFORK rule (pv10 Plomin)",
+			"cleared_dangling_drep_delegations", n,
+			"epoch", newEpoch,
+			"boundary_slot", boundarySlot,
+			"component", "ledger",
+		)
+	}
+	return nil
+}

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+)
+
+// plominFixtureKeys holds the staking keys seeded by
+// seedPlominFixtures, used by the assertions below.
+type plominFixtureKeys struct {
+	Live, Dead []byte
+}
+
+// seedPlominFixtures writes:
+//   - an active DRep (liveCred)
+//   - an Account (stakeKeyLive) delegating to liveCred  → should survive
+//     the pv10 rule.
+//   - an Account (stakeKeyDead) delegating to a credential with NO DRep row
+//     → should be cleared by the pv10 rule.
+//
+// Returns the two staking keys for later lookups.
+func seedPlominFixtures(t *testing.T, db *database.Database) plominFixtureKeys {
+	t.Helper()
+	liveCred := bytes.Repeat([]byte{0x11}, 28)
+	deadCred := bytes.Repeat([]byte{0x22}, 28)
+	keys := plominFixtureKeys{
+		Live: bytes.Repeat([]byte{0xA1}, 28),
+		Dead: bytes.Repeat([]byte{0xA2}, 28),
+	}
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test DB must be backed by sqlite")
+
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential: liveCred,
+		Active:     true,
+		AddedSlot:  10,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: keys.Live,
+		Drep:       liveCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: keys.Dead,
+		Drep:       deadCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+	return keys
+}
+
+// newTestLSForPlomin wires just enough of a LedgerState to call
+// applyIntraEraHardForkRule against the given test DB.
+func newTestLSForPlomin(
+	t *testing.T,
+	db *database.Database,
+) *LedgerState {
+	t.Helper()
+	return &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+// pv10 is the major-version bump that currently has a non-no-op handler:
+// accounts with credential-backed delegations to unregistered DReps are
+// cleared; accounts delegating to registered DReps are preserved.
+func TestApplyIntraEraHardForkRule_Pv10_ClearsDangling(t *testing.T) {
+	db := newTestDB(t)
+	keys := seedPlominFixtures(t, db)
+
+	ls := newTestLSForPlomin(t, db)
+	require.NoError(t, ls.applyIntraEraHardForkRule(
+		nil,  // nil txn → owned metadata txn inside the Database wrapper
+		10,   // newMajor
+		7777, // boundarySlot
+		500,  // newEpoch (log-only)
+	))
+
+	live, err := db.GetAccount(keys.Live, true, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, live.Drep,
+		"delegation to registered DRep must survive the rule")
+
+	dead, err := db.GetAccount(keys.Dead, true, nil)
+	require.NoError(t, err)
+	assert.Nil(t, dead.Drep,
+		"dangling delegation must be cleared at pv10")
+	assert.Equal(t, uint64(7777), dead.AddedSlot,
+		"AddedSlot must be bumped to the boundary slot so a later "+
+			"rollback past boundarySlot re-derives from cert history")
+}
+
+// Every major-version bump other than the ones with an explicit case
+// falls through to a no-op (matching the Haskell rule's `otherwise = id`).
+// Verified against a representative sample of values below and above the
+// handled pv10 case.
+func TestApplyIntraEraHardForkRule_UnknownMajor_NoOp(t *testing.T) {
+	db := newTestDB(t)
+	keys := seedPlominFixtures(t, db)
+
+	ls := newTestLSForPlomin(t, db)
+
+	for _, major := range []uint{9, 11, 12, 99} {
+		require.NoError(t, ls.applyIntraEraHardForkRule(
+			nil, major, 1234, 100,
+		))
+	}
+
+	live, err := db.GetAccount(keys.Live, true, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, live.Drep)
+	assert.Equal(t, uint64(100), live.AddedSlot,
+		"unknown-major dispatch must not touch unrelated accounts")
+
+	dead, err := db.GetAccount(keys.Dead, true, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, dead.Drep,
+		"unknown-major dispatch must not touch even the dangling account")
+	assert.Equal(t, uint64(100), dead.AddedSlot)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the Conway pv10 hardfork rule to clear dangling DRep delegations on any protocol major-version bump during epoch rollover. Preserves pseudo-DReps and bumps `added_slot` to the boundary slot for safe rollback.

- **New Features**
  - Executes at epoch rollover when the major version changes via `ledger.applyIntraEraHardForkRule`.
  - Adds `database.ClearDanglingDRepDelegations` (MySQL/Postgres/SQLite) to clear credential-backed delegations to non-active/unregistered DReps, reset `drep_type`, and set `added_slot` to the boundary slot.
  - Adds focused tests in `ledger/hardfork_rule_test.go` and `database/plugin/metadata/sqlite/plomin_test.go`.

<sup>Written for commit af2cc96729fcef7d4e98d795e89e0aff93d690bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented protocol hard-fork support (major version 10) featuring automatic cleanup of stake delegations to unregistered or inactive delegates during epoch transitions, while preserving all active delegations and ensuring ledger consistency for chain state rollbacks.

* **Tests**
  * Added test coverage validating hard-fork cleanup behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->