### PR TITLE
feat(ledger): remove AVVMs on shelly<->allegra transition

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -20,6 +20,20 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 )
 
+// CreateAccount inserts an Account row directly. See the MetadataStore
+// interface for the difference between this and ImportAccount. When txn
+// is nil a write transaction is opened, committed on success and rolled
+// back on error via Txn.Do; pass an existing write txn to participate
+// in a wider unit of work.
+func (d *Database) CreateAccount(txn *Txn, account *models.Account) error {
+	if txn != nil {
+		return d.metadata.CreateAccount(txn.Metadata(), account)
+	}
+	return d.MetadataTxn(true).Do(func(t *Txn) error {
+		return d.metadata.CreateAccount(t.Metadata(), account)
+	})
+}
+
 // ClearDanglingDRepDelegations applies the cardano-ledger Conway HARDFORK
 // STS rule for protocol major version 10 (Plomin, mainnet January 2025): any
 // account with a credential-backed DRep delegation (DrepType 0 or 1) whose

--- a/database/drep.go
+++ b/database/drep.go
@@ -20,6 +20,20 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 )
 
+// CreateDrep inserts a Drep row directly. See the MetadataStore
+// interface for the difference between this and ImportDrep. When txn
+// is nil a write transaction is opened, committed on success and
+// rolled back on error via Txn.Do; pass an existing write txn to
+// participate in a wider unit of work.
+func (d *Database) CreateDrep(txn *Txn, drep *models.Drep) error {
+	if txn != nil {
+		return d.metadata.CreateDrep(txn.Metadata(), drep)
+	}
+	return d.MetadataTxn(true).Do(func(t *Txn) error {
+		return d.metadata.CreateDrep(t.Metadata(), drep)
+	})
+}
+
 // RestoreDrepStateAtSlot reverts DRep state to the given slot. DReps
 // registered only after the slot are deleted; remaining DReps have their
 // anchor and active status restored.

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -79,6 +79,14 @@ type Utxo struct {
 	DeletedSlot             uint64       `gorm:"index"`
 	Amount                  types.Uint64 `gorm:"index"`
 	OutputIdx               uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
+	// ByronAddressType records the inner Byron address type (pubkey=0,
+	// script=1, redeem=2) for UTxOs at Byron-format addresses. Non-Byron
+	// UTxOs and Byron pubkey UTxOs both store 0; to distinguish them use
+	// the 1/2 values directly or check the payment address separately.
+	// Used by the Shelley→Allegra HARDFORK rule to identify AVVM redeem
+	// UTxOs for removal (cardano-ledger Allegra/Translation.hs
+	// returnRedeemAddrsToReserves).
+	ByronAddressType uint8 `gorm:"default:0;index"`
 }
 
 // UtxoWithOrdering includes UTxO with transaction ordering metadata
@@ -144,6 +152,19 @@ func UtxoLedgerToModel(
 		AddedSlot: slot,
 		Amount:    types.Uint64(utxo.Output.Amount().Uint64()),
 		OutputIdx: utxo.Id.Index(),
+	}
+	if outAddr.Type() == lcommon.AddressTypeByron {
+		// Narrow the decoded uint64 to the known inner-type values so a
+		// malformed address with an out-of-range type cannot overflow
+		// the uint8 column (gosec G115).
+		switch outAddr.ByronType() {
+		case lcommon.ByronAddressTypePubkey:
+			ret.ByronAddressType = uint8(lcommon.ByronAddressTypePubkey)
+		case lcommon.ByronAddressTypeScript:
+			ret.ByronAddressType = uint8(lcommon.ByronAddressTypeScript)
+		case lcommon.ByronAddressTypeRedeem:
+			ret.ByronAddressType = uint8(lcommon.ByronAddressTypeRedeem)
+		}
 	}
 	var zeroHash ledger.Blake2b224
 	pkh := outAddr.PaymentKeyHash()

--- a/database/plugin/metadata/mysql/create.go
+++ b/database/plugin/metadata/mysql/create.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// CreateDrep inserts a Drep row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStoreMysql) CreateDrep(
+	txn types.Txn,
+	drep *models.Drep,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(drep).Error
+}
+
+// CreateAccount inserts an Account row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStoreMysql) CreateAccount(
+	txn types.Txn,
+	account *models.Account,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(account).Error
+}
+
+// CreateUtxo inserts a Utxo row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStoreMysql) CreateUtxo(
+	txn types.Txn,
+	utxo *models.Utxo,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(utxo).Error
+}

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -496,3 +496,46 @@ func (d *MetadataStoreMysql) SetUtxosNotDeletedAfterSlot(
 	}
 	return nil
 }
+
+// RemoveByronAvvmUtxos implements the Shelley→Allegra HARDFORK rule
+// (cardano-ledger Allegra/Translation.hs, returnRedeemAddrsToReserves):
+// marks all live UTxOs at Byron redeem (AVVM) addresses as deleted at
+// atSlot and returns the count and total lovelace amount that was
+// reclaimed. DeletedSlot is set to atSlot so rollback across the
+// boundary (via SetUtxosNotDeletedAfterSlot) correctly un-deletes them.
+// See the MetadataStore interface for semantics.
+func (d *MetadataStoreMysql) RemoveByronAvvmUtxos(
+	atSlot uint64,
+	txn types.Txn,
+) (int, uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, 0, err
+	}
+	var stats struct {
+		Count int64
+		Sum   uint64
+	}
+	if err := db.Model(&models.Utxo{}).
+		Select("COUNT(*) AS count, COALESCE(SUM(amount), 0) AS sum").
+		Where(
+			"byron_address_type = ? AND deleted_slot = 0",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Scan(&stats).Error; err != nil {
+		return 0, 0, err
+	}
+	if stats.Count == 0 {
+		return 0, 0, nil
+	}
+	result := db.Model(&models.Utxo{}).
+		Where(
+			"byron_address_type = ? AND deleted_slot = 0",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Update("deleted_slot", atSlot)
+	if result.Error != nil {
+		return 0, 0, result.Error
+	}
+	return int(stats.Count), stats.Sum, nil
+}

--- a/database/plugin/metadata/postgres/create.go
+++ b/database/plugin/metadata/postgres/create.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// CreateDrep inserts a Drep row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStorePostgres) CreateDrep(
+	txn types.Txn,
+	drep *models.Drep,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(drep).Error
+}
+
+// CreateAccount inserts an Account row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStorePostgres) CreateAccount(
+	txn types.Txn,
+	account *models.Account,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(account).Error
+}
+
+// CreateUtxo inserts a Utxo row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStorePostgres) CreateUtxo(
+	txn types.Txn,
+	utxo *models.Utxo,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(utxo).Error
+}

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -497,3 +497,46 @@ func (d *MetadataStorePostgres) SetUtxosNotDeletedAfterSlot(
 	}
 	return nil
 }
+
+// RemoveByronAvvmUtxos implements the Shelley→Allegra HARDFORK rule
+// (cardano-ledger Allegra/Translation.hs, returnRedeemAddrsToReserves):
+// marks all live UTxOs at Byron redeem (AVVM) addresses as deleted at
+// atSlot and returns the count and total lovelace amount that was
+// reclaimed. DeletedSlot is set to atSlot so rollback across the
+// boundary (via SetUtxosNotDeletedAfterSlot) correctly un-deletes them.
+// See the MetadataStore interface for semantics.
+func (d *MetadataStorePostgres) RemoveByronAvvmUtxos(
+	atSlot uint64,
+	txn types.Txn,
+) (int, uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, 0, err
+	}
+	var stats struct {
+		Count int64
+		Sum   uint64
+	}
+	if err := db.Model(&models.Utxo{}).
+		Select("COUNT(*) AS count, COALESCE(SUM(amount), 0) AS sum").
+		Where(
+			"byron_address_type = ? AND deleted_slot = 0",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Scan(&stats).Error; err != nil {
+		return 0, 0, err
+	}
+	if stats.Count == 0 {
+		return 0, 0, nil
+	}
+	result := db.Model(&models.Utxo{}).
+		Where(
+			"byron_address_type = ? AND deleted_slot = 0",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Update("deleted_slot", atSlot)
+	if result.Error != nil {
+		return 0, 0, result.Error
+	}
+	return int(stats.Count), stats.Sum, nil
+}

--- a/database/plugin/metadata/sqlite/allegra_avvm_test.go
+++ b/database/plugin/metadata/sqlite/allegra_avvm_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Shelley→Allegra HARDFORK rule (pv3): cardano-ledger
+// Allegra/Translation.hs returnRedeemAddrsToReserves. See
+// database/plugin/metadata/store.go for the interface contract.
+
+// seedAvvmFixtures inserts one UTxO of each Byron inner-address type
+// (pubkey, script, redeem), one modern/non-Byron UTxO, and one
+// already-spent redeem UTxO. Only the live redeem UTxO should be
+// removed by RemoveByronAvvmUtxos.
+func seedAvvmFixtures(t *testing.T, store *MetadataStoreSqlite) {
+	t.Helper()
+	rows := []models.Utxo{
+		{
+			TxId:             bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx:        0,
+			PaymentKey:       bytes.Repeat([]byte{0xA1}, 28),
+			Amount:           types.Uint64(1_000_000),
+			AddedSlot:        100,
+			ByronAddressType: uint8(lcommon.ByronAddressTypeRedeem),
+		},
+		{
+			TxId:             bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:        0,
+			PaymentKey:       bytes.Repeat([]byte{0xA2}, 28),
+			Amount:           types.Uint64(2_500_000),
+			AddedSlot:        110,
+			ByronAddressType: uint8(lcommon.ByronAddressTypeRedeem),
+		},
+		{
+			TxId:             bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:        0,
+			PaymentKey:       bytes.Repeat([]byte{0xB1}, 28),
+			Amount:           types.Uint64(9_999_999),
+			AddedSlot:        120,
+			ByronAddressType: uint8(lcommon.ByronAddressTypePubkey),
+		},
+		{
+			TxId:             bytes.Repeat([]byte{0x04}, 32),
+			OutputIdx:        0,
+			PaymentKey:       bytes.Repeat([]byte{0xB2}, 28),
+			Amount:           types.Uint64(8_888_888),
+			AddedSlot:        130,
+			ByronAddressType: uint8(lcommon.ByronAddressTypeScript),
+		},
+		{
+			TxId:       bytes.Repeat([]byte{0x05}, 32),
+			OutputIdx:  0,
+			PaymentKey: bytes.Repeat([]byte{0xC1}, 28),
+			StakingKey: bytes.Repeat([]byte{0xC2}, 28),
+			Amount:     types.Uint64(7_777_777),
+			AddedSlot:  140,
+			// ByronAddressType == 0 (non-Byron; or Byron pubkey — both
+			// are excluded from the redeem filter anyway).
+		},
+		{
+			// Already-spent redeem: must not be touched.
+			TxId:             bytes.Repeat([]byte{0x06}, 32),
+			OutputIdx:        0,
+			PaymentKey:       bytes.Repeat([]byte{0xD1}, 28),
+			Amount:           types.Uint64(100),
+			AddedSlot:        50,
+			DeletedSlot:      200,
+			ByronAddressType: uint8(lcommon.ByronAddressTypeRedeem),
+		},
+	}
+	for i := range rows {
+		require.NoError(t, store.DB().Create(&rows[i]).Error)
+	}
+}
+
+// Exactly the two live redeem UTxOs get cleared; their value is summed;
+// everything else is untouched.
+func TestRemoveByronAvvmUtxos_ClearsLiveRedeemersOnly(t *testing.T) {
+	store := setupTestDB(t)
+	seedAvvmFixtures(t, store)
+
+	const boundarySlot uint64 = 500_000
+	count, total, err := store.RemoveByronAvvmUtxos(boundarySlot, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.Equal(t, uint64(3_500_000), total)
+
+	// The two live redeem UTxOs (tx_id 0x01, 0x02) are now deleted at the
+	// boundary slot.
+	for _, id := range [][]byte{
+		bytes.Repeat([]byte{0x01}, 32),
+		bytes.Repeat([]byte{0x02}, 32),
+	} {
+		var r models.Utxo
+		require.NoError(t, store.DB().
+			Where("tx_id = ?", id).First(&r).Error)
+		assert.Equal(t, boundarySlot, r.DeletedSlot,
+			"live redeem UTxO must be deleted at the boundary slot")
+	}
+
+	// Non-redeem UTxOs stay live (anything with byron_address_type != 2).
+	var live int64
+	require.NoError(t, store.DB().
+		Model(&models.Utxo{}).
+		Where("byron_address_type != ?",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Where("deleted_slot = 0").
+		Count(&live).Error)
+	assert.Equal(t, int64(3), live,
+		"pubkey/script/non-Byron UTxOs must remain live")
+
+	// The pre-existing spent redeem row stays at its original DeletedSlot.
+	var preSpent models.Utxo
+	require.NoError(t, store.DB().
+		Where("tx_id = ?", bytes.Repeat([]byte{0x06}, 32)).
+		First(&preSpent).Error)
+	assert.Equal(t, uint64(200), preSpent.DeletedSlot,
+		"already-spent UTxO must keep its prior DeletedSlot")
+}
+
+// Running the rule on a chain with no AVVM UTxOs is a no-op.
+func TestRemoveByronAvvmUtxos_EmptyIsNoOp(t *testing.T) {
+	store := setupTestDB(t)
+	// One non-redeem UTxO only.
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:             bytes.Repeat([]byte{0xE1}, 32),
+		OutputIdx:        0,
+		PaymentKey:       bytes.Repeat([]byte{0xE2}, 28),
+		Amount:           types.Uint64(1_234_567),
+		AddedSlot:        100,
+		ByronAddressType: uint8(lcommon.ByronAddressTypePubkey),
+	}).Error)
+
+	count, total, err := store.RemoveByronAvvmUtxos(999_999, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, uint64(0), total)
+
+	var live int64
+	require.NoError(t, store.DB().
+		Model(&models.Utxo{}).
+		Where("deleted_slot = 0").
+		Count(&live).Error)
+	assert.Equal(t, int64(1), live)
+}
+
+// A second call after the boundary must find nothing to do.
+func TestRemoveByronAvvmUtxos_Idempotent(t *testing.T) {
+	store := setupTestDB(t)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:             bytes.Repeat([]byte{0xF1}, 32),
+		OutputIdx:        0,
+		PaymentKey:       bytes.Repeat([]byte{0xF2}, 28),
+		Amount:           types.Uint64(42),
+		AddedSlot:        100,
+		ByronAddressType: uint8(lcommon.ByronAddressTypeRedeem),
+	}).Error)
+
+	count, total, err := store.RemoveByronAvvmUtxos(500_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, uint64(42), total)
+
+	count, total, err = store.RemoveByronAvvmUtxos(600_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, uint64(0), total,
+		"re-running after the boundary must be a no-op")
+}

--- a/database/plugin/metadata/sqlite/create.go
+++ b/database/plugin/metadata/sqlite/create.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// CreateDrep inserts a Drep row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStoreSqlite) CreateDrep(
+	txn types.Txn,
+	drep *models.Drep,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(drep).Error
+}
+
+// CreateAccount inserts an Account row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStoreSqlite) CreateAccount(
+	txn types.Txn,
+	account *models.Account,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(account).Error
+}
+
+// CreateUtxo inserts a Utxo row directly. See the MetadataStore
+// interface for semantics.
+func (d *MetadataStoreSqlite) CreateUtxo(
+	txn types.Txn,
+	utxo *models.Utxo,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Create(utxo).Error
+}

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -559,3 +559,46 @@ func (d *MetadataStoreSqlite) SetUtxosNotDeletedAfterSlot(
 	}
 	return nil
 }
+
+// RemoveByronAvvmUtxos implements the Shelley→Allegra HARDFORK rule
+// (cardano-ledger Allegra/Translation.hs, returnRedeemAddrsToReserves):
+// marks all live UTxOs at Byron redeem (AVVM) addresses as deleted at
+// atSlot and returns the count and total lovelace amount that was
+// reclaimed. DeletedSlot is set to atSlot so rollback across the
+// boundary (via SetUtxosNotDeletedAfterSlot) correctly un-deletes them.
+// See the MetadataStore interface for semantics.
+func (d *MetadataStoreSqlite) RemoveByronAvvmUtxos(
+	atSlot uint64,
+	txn types.Txn,
+) (int, uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, 0, err
+	}
+	var stats struct {
+		Count int64
+		Sum   uint64
+	}
+	if err := db.Model(&models.Utxo{}).
+		Select("COUNT(*) AS count, COALESCE(SUM(amount), 0) AS sum").
+		Where(
+			"byron_address_type = ? AND deleted_slot = 0",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Scan(&stats).Error; err != nil {
+		return 0, 0, err
+	}
+	if stats.Count == 0 {
+		return 0, 0, nil
+	}
+	result := db.Model(&models.Utxo{}).
+		Where(
+			"byron_address_type = ? AND deleted_slot = 0",
+			uint8(lcommon.ByronAddressTypeRedeem),
+		).
+		Update("deleted_slot", atSlot)
+	if result.Error != nil {
+		return 0, 0, result.Error
+	}
+	return int(stats.Count), stats.Sum, nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -94,6 +94,23 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// CreateDrep inserts a Drep row directly. Used by callers (e.g.
+	// fixture seeding from outside the plugin packages) that already
+	// have a fully-populated model and want a single-row insert without
+	// the registration-record side effects of ImportDrep.
+	CreateDrep(types.Txn, *models.Drep) error
+
+	// CreateAccount inserts an Account row directly. See CreateDrep
+	// for the rationale; this is the simple-insert sibling of
+	// ImportAccount.
+	CreateAccount(types.Txn, *models.Account) error
+
+	// CreateUtxo inserts a Utxo row directly. The normal block-
+	// application path uses AddUtxos with UtxoSlot inputs; this is
+	// the simple-insert variant for callers that already have a
+	// populated model.
+	CreateUtxo(types.Txn, *models.Utxo) error
+
 	// GetImportCheckpoint retrieves the checkpoint for a given
 	// import key (e.g., "{digest}:{slot}"). Returns nil if no
 	// checkpoint exists.

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -535,6 +535,19 @@ type MetadataStore interface {
 	// SetUtxosNotDeletedAfterSlot marks all UTxOs created after the given slot as not deleted.
 	SetUtxosNotDeletedAfterSlot(uint64, types.Txn) error
 
+	// RemoveByronAvvmUtxos implements the Shelley→Allegra HARDFORK rule
+	// (cardano-ledger Allegra/Translation.hs, returnRedeemAddrsToReserves).
+	// At the Shelley→Allegra boundary, every live UTxO at a Byron redeem
+	// (AVVM, ByronAddressType == 2) address is removed from the active
+	// UTxO set and its lovelace is reclaimed into reserves. Implementations
+	// mark matching rows as deleted at atSlot and return (count, total
+	// lovelace) reclaimed; callers handle the reserves accounting and
+	// rollback un-deletion (via SetUtxosNotDeletedAfterSlot).
+	RemoveByronAvvmUtxos(
+		atSlot uint64,
+		txn types.Txn,
+	) (count int, totalLovelace uint64, err error)
+
 	// Stake snapshot methods
 
 	// SavePoolStakeSnapshot saves a single pool stake snapshot.

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -27,7 +27,20 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
+// ErrUtxoNotFound signals that the metadata row for a UTxO does not
+// exist (or was filtered out, e.g. by deleted_slot != 0 in the live
+// view). Callers may use errors.Is to detect a genuinely-absent row.
 var ErrUtxoNotFound = errors.New("utxo not found")
+
+// ErrUtxoCborUnavailable signals that the metadata row for a UTxO
+// exists but its CBOR could not be loaded from the blob store and
+// could not be recovered from any indexed block — typically because
+// the row was inserted directly (e.g. fixture seeding) without a
+// corresponding blob, or because the producing block is missing.
+// This is distinct from ErrUtxoNotFound: the row IS present in the
+// live UTxO set; only the on-the-wire bytes are unrecoverable. Callers
+// that only need indexed metadata fields can ignore this error.
+var ErrUtxoCborUnavailable = errors.New("utxo cbor unavailable")
 
 // deleteUtxoBlobs performs best-effort deletion of blob data for the given
 // [models.Utxo] entries. Metadata remains the authoritative source of truth;
@@ -180,7 +193,11 @@ func recoverUtxoCbor(
 		return nil, err
 	}
 	if block == nil {
-		return nil, ErrUtxoNotFound
+		// The producer block could not be located. This is a CBOR-
+		// recovery failure (the metadata row may still be present);
+		// use the dedicated sentinel so callers can distinguish it
+		// from a missing metadata row.
+		return nil, ErrUtxoCborUnavailable
 	}
 
 	// Decode the block once for both CBOR extraction and offset computation
@@ -319,6 +336,11 @@ func utxoCborFromDecodedBlock(
 	txId []byte,
 	outputIdx uint32,
 ) ([]byte, error) {
+	// These returns signal "the producing block was located but the
+	// requested output's CBOR cannot be reconstructed from it" — a
+	// CBOR-recovery failure, not a missing metadata row. Use the
+	// dedicated sentinel so callers can distinguish the two via
+	// errors.Is.
 	for _, tx := range decodedBlock.Transactions() {
 		if !bytes.Equal(tx.Hash().Bytes(), txId) {
 			continue
@@ -328,9 +350,9 @@ func utxoCborFromDecodedBlock(
 				return produced.Output.Cbor(), nil
 			}
 		}
-		return nil, ErrUtxoNotFound
+		return nil, ErrUtxoCborUnavailable
 	}
-	return nil, ErrUtxoNotFound
+	return nil, ErrUtxoCborUnavailable
 }
 
 func repairUtxoBlob(
@@ -388,6 +410,20 @@ func (d *Database) UtxoByRef(
 		return nil, err
 	}
 	return utxo, nil
+}
+
+// CreateUtxo inserts a Utxo row directly. The normal block-application
+// path uses AddUtxos with UtxoSlot inputs; this is the simple-insert
+// variant for callers that already have a populated model. When txn
+// is nil a write transaction is opened, committed on success and
+// rolled back on error via Txn.Do.
+func (d *Database) CreateUtxo(txn *Txn, utxo *models.Utxo) error {
+	if txn != nil {
+		return d.metadata.CreateUtxo(txn.Metadata(), utxo)
+	}
+	return d.MetadataTxn(true).Do(func(t *Txn) error {
+		return d.metadata.CreateUtxo(t.Metadata(), utxo)
+	})
 }
 
 // UtxoByRefIncludingSpent returns a Utxo by reference,

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -629,3 +629,46 @@ func (d *Database) UtxosUnspend(
 	}
 	return nil
 }
+
+// RemoveByronAvvmUtxos applies the Shelley→Allegra HARDFORK rule
+// (cardano-ledger Allegra/Translation.hs, returnRedeemAddrsToReserves):
+// marks every live UTxO at a Byron redeem (AVVM) address as deleted at
+// atSlot and returns the count and total lovelace reclaimed. The
+// DeletedSlot bookkeeping lets a rollback past atSlot un-delete the rows
+// via the existing SetUtxosNotDeletedAfterSlot path. Callers are
+// responsible for adding totalLovelace to reserves; this wrapper does
+// not touch NetworkState because reserves tracking is broader than the
+// AVVM rule.
+func (d *Database) RemoveByronAvvmUtxos(
+	atSlot uint64,
+	txn *Txn,
+) (int, uint64, error) {
+	owned := false
+	if txn == nil {
+		txn = NewMetadataOnlyTxn(d, true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	count, total, err := d.metadata.RemoveByronAvvmUtxos(
+		atSlot,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf(
+			"remove Byron AVVM UTxOs at slot %d: %w",
+			atSlot,
+			err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return 0, 0, fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return count, total, nil
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2834,6 +2834,19 @@ func (ls *LedgerState) processEpochRollover(
 				"component", "ledger",
 			)
 		}
+		// Apply cardano-ledger's per-major-version HARDFORK rule. This
+		// runs on ANY major-version bump, including intra-era ones like
+		// Conway pv9→pv10 (Plomin, mainnet January 2025) that do not
+		// trigger an era change, and inter-era ones like Shelley→Allegra
+		// (pv2→pv3) that carry a state rewrite. See cardano-ledger
+		// Conway/Rules/HardFork.hs and Allegra/Translation.hs.
+		if oldVer.Major != newVer.Major {
+			if err := ls.applyIntraEraHardForkRule(
+				txn, newVer.Major, epochStartSlot, currentEpoch.EpochId+1,
+			); err != nil {
+				return nil, fmt.Errorf("apply major-version HARDFORK: %w", err)
+			}
+		}
 	}
 
 	// Create next epoch record

--- a/ledger/hardfork_rule.go
+++ b/ledger/hardfork_rule.go
@@ -36,6 +36,10 @@ import (
 //     live UTxO at a Byron redeem (AVVM) address and return its lovelace
 //     to reserves. Ports cardano-ledger
 //     Allegra/Translation.hs:returnRedeemAddrsToReserves.
+//   - major == 10 (Plomin, mainnet January 2025): clear any dangling
+//     credential-backed DRep delegation whose target DRep credential is
+//     not currently registered as an active DRep. Pseudo-DRep
+//     delegations (AlwaysAbstain, AlwaysNoConfidence) are preserved.
 //
 // Cases known but not yet required (no era defined in dingo yet):
 //

--- a/ledger/hardfork_rule.go
+++ b/ledger/hardfork_rule.go
@@ -58,7 +58,10 @@ func (ls *LedgerState) applyIntraEraHardForkRule(
 	case 3:
 		count, total, err := ls.db.RemoveByronAvvmUtxos(boundarySlot, txn)
 		if err != nil {
-			return fmt.Errorf("pv3 remove Byron AVVM UTxOs: %w", err)
+			return fmt.Errorf(
+				"pv3 remove Byron AVVM UTxOs at slot %d: %w",
+				boundarySlot, err,
+			)
 		}
 		// Reserves are not maintained on every epoch-rollover in dingo
 		// today — governance enactment is the only caller that writes
@@ -76,7 +79,10 @@ func (ls *LedgerState) applyIntraEraHardForkRule(
 	case 10:
 		n, err := ls.db.ClearDanglingDRepDelegations(boundarySlot, txn)
 		if err != nil {
-			return fmt.Errorf("pv10 clear dangling DRep delegations: %w", err)
+			return fmt.Errorf(
+				"pv10 clear dangling DRep delegations at slot %d: %w",
+				boundarySlot, err,
+			)
 		}
 		ls.config.Logger.Info(
 			"applied Conway HARDFORK rule (pv10 Plomin)",

--- a/ledger/hardfork_rule.go
+++ b/ledger/hardfork_rule.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+)
+
+// applyIntraEraHardForkRule dispatches cardano-ledger's per-major-version
+// HARDFORK rule. Unlike the inter-era HFC detection that fires when the
+// era ID changes, this runs on any bump of the protocol *major* version
+// — including intra-era ones that do not cross an era boundary, and
+// inter-era ones whose translation carries a state rewrite.
+//
+// The rule is called at the epoch-rollover boundary, in the same
+// database transaction as the pparams write, so the state rewrite
+// commits atomically with the major-version bump that triggers it.
+//
+// Currently implemented cases:
+//
+//   - major == 3 (Shelley→Allegra, mainnet December 2020): remove every
+//     live UTxO at a Byron redeem (AVVM) address and return its lovelace
+//     to reserves. Ports cardano-ledger
+//     Allegra/Translation.hs:returnRedeemAddrsToReserves.
+//
+// Cases known but not yet required (no era defined in dingo yet):
+//
+//   - major == 11 (Dijkstra): populate per-pool VRF key hashes. Stubbed
+//     until the Dijkstra era lands in gouroboros + dingo's era table.
+//
+// Any future major-version bump that lands without a case here is a
+// no-op, matching the Haskell rule's `otherwise = id` branch.
+func (ls *LedgerState) applyIntraEraHardForkRule(
+	txn *database.Txn,
+	newMajor uint,
+	boundarySlot uint64,
+	newEpoch uint64,
+) error {
+	switch newMajor {
+	case 3:
+		count, total, err := ls.db.RemoveByronAvvmUtxos(boundarySlot, txn)
+		if err != nil {
+			return fmt.Errorf("pv3 remove Byron AVVM UTxOs: %w", err)
+		}
+		// Reserves are not maintained on every epoch-rollover in dingo
+		// today — governance enactment is the only caller that writes
+		// NetworkState — so we log the reclaimed total rather than
+		// writing a partial, likely-misleading reserves value. When
+		// full reserves tracking lands, consume totalLovelace here.
+		ls.config.Logger.Info(
+			"applied Allegra HARDFORK rule (pv3 AVVM return)",
+			"removed_avvm_utxos", count,
+			"reclaimed_lovelace", total,
+			"epoch", newEpoch,
+			"boundary_slot", boundarySlot,
+			"component", "ledger",
+		)
+	}
+	return nil
+}

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -225,6 +225,15 @@ func TestApplyIntraEraHardForkRule_Pv3_RemovesAvvm(t *testing.T) {
 		require.ErrorIs(t, err, database.ErrUtxoNotFound,
 			"AVVM UTxO must be removed from the live UTxO set")
 	}
+
+	// Non-redeem Byron (pubkey) UTxO must survive the pv3 rule: the
+	// only thing standing between the dispatcher and over-deletion of
+	// every Byron UTxO is the ByronAddressType == Redeem filter in the
+	// metadata layer, so check it directly here.
+	_, err := db.UtxoByRef(keys.Pubkey, 0, nil)
+	require.ErrorIs(t, err, database.ErrUtxoCborUnavailable,
+		"non-redeem Byron UTxO must survive the pv3 AVVM return rule")
+	require.NotErrorIs(t, err, database.ErrUtxoNotFound)
 }
 
 // Only pv3 may touch AVVM UTxOs. Verifies that other majors — both the
@@ -251,4 +260,13 @@ func TestApplyIntraEraHardForkRule_OtherMajors_DoNotTouchAvvm(t *testing.T) {
 		require.NotErrorIs(t, err, database.ErrUtxoNotFound,
 			"non-pv3 dispatch must not remove AVVM UTxOs")
 	}
+
+	// Pubkey (non-AVVM) Byron UTxO must also remain untouched: a
+	// regression that incorrectly broadens the metadata filter beyond
+	// ByronAddressType == Redeem on a non-pv3 major would otherwise
+	// slip through.
+	_, err := db.UtxoByRef(keys.Pubkey, 0, nil)
+	require.ErrorIs(t, err, database.ErrUtxoCborUnavailable,
+		"non-pv3 dispatch must not touch AVVM pubkey UTxOs")
+	require.NotErrorIs(t, err, database.ErrUtxoNotFound)
 }

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// allegraAvvmFixtureKeys holds the TxIds seeded by seedAllegraAvvmFixtures
+// so tests can look them up after the rule runs.
+type allegraAvvmFixtureKeys struct {
+	Redeem [][]byte
+	Pubkey []byte
+}
+
+// seedAllegraAvvmFixtures plants two live Byron redeem UTxOs (AVVM) and
+// one Byron pubkey UTxO that must survive the pv3 rule.
+func seedAllegraAvvmFixtures(
+	t *testing.T,
+	db *database.Database,
+) allegraAvvmFixtureKeys {
+	t.Helper()
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test DB must be backed by sqlite")
+
+	keys := allegraAvvmFixtureKeys{
+		Redeem: [][]byte{
+			bytes.Repeat([]byte{0x01}, 32),
+			bytes.Repeat([]byte{0x02}, 32),
+		},
+		Pubkey: bytes.Repeat([]byte{0x03}, 32),
+	}
+
+	for i, id := range keys.Redeem {
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TxId:             id,
+			OutputIdx:        0,
+			PaymentKey:       bytes.Repeat([]byte{0xA0 + byte(i)}, 28),
+			Amount:           types.Uint64(uint64(1_000_000 * (i + 1))),
+			AddedSlot:        100,
+			ByronAddressType: uint8(lcommon.ByronAddressTypeRedeem),
+		}).Error)
+	}
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:             keys.Pubkey,
+		OutputIdx:        0,
+		PaymentKey:       bytes.Repeat([]byte{0xB1}, 28),
+		Amount:           types.Uint64(5_555_555),
+		AddedSlot:        150,
+		ByronAddressType: uint8(lcommon.ByronAddressTypePubkey),
+	}).Error)
+	return keys
+}
+
+// newTestLSForHardForkRule wires just enough of a LedgerState to call
+// applyIntraEraHardForkRule against the given test DB.
+func newTestLSForHardForkRule(
+	t *testing.T,
+	db *database.Database,
+) *LedgerState {
+	t.Helper()
+	return &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+// pv3 (Shelley→Allegra): every live AVVM UTxO is marked deleted at the
+// boundary slot; non-redeem UTxOs are preserved.
+func TestApplyIntraEraHardForkRule_Pv3_RemovesAvvm(t *testing.T) {
+	db := newTestDB(t)
+	keys := seedAllegraAvvmFixtures(t, db)
+
+	ls := newTestLSForHardForkRule(t, db)
+	const boundarySlot uint64 = 4_492_800 // approx mainnet Allegra start
+	require.NoError(t, ls.applyIntraEraHardForkRule(
+		nil,          // nil txn → owned metadata txn inside the Database wrapper
+		3,            // newMajor (Allegra)
+		boundarySlot, // boundarySlot
+		208,          // newEpoch (log-only)
+	))
+
+	store := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	for _, id := range keys.Redeem {
+		var u models.Utxo
+		require.NoError(t, store.DB().
+			Where("tx_id = ?", id).First(&u).Error)
+		assert.Equal(t, boundarySlot, u.DeletedSlot,
+			"AVVM UTxO must be deleted at the Allegra boundary slot")
+	}
+
+	var pubkey models.Utxo
+	require.NoError(t, store.DB().
+		Where("tx_id = ?", keys.Pubkey).First(&pubkey).Error)
+	assert.Equal(t, uint64(0), pubkey.DeletedSlot,
+		"Byron pubkey UTxO must survive the pv3 rule")
+}
+
+// Unknown major versions are a no-op — matches the Haskell rule's
+// `otherwise = id` branch. Explicitly verifies that pv2 (pre-Allegra),
+// pv4 (Allegra→Mary), and pv10 (Plomin, handled elsewhere) do not touch
+// AVVM UTxOs through this dispatch.
+func TestApplyIntraEraHardForkRule_OtherMajors_DoNotTouchAvvm(t *testing.T) {
+	db := newTestDB(t)
+	keys := seedAllegraAvvmFixtures(t, db)
+
+	ls := newTestLSForHardForkRule(t, db)
+	for _, major := range []uint{2, 4, 10, 99} {
+		require.NoError(t, ls.applyIntraEraHardForkRule(
+			nil, major, 1_234_567, 42,
+		))
+	}
+
+	store := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	for _, id := range keys.Redeem {
+		var u models.Utxo
+		require.NoError(t, store.DB().
+			Where("tx_id = ?", id).First(&u).Error)
+		assert.Equal(t, uint64(0), u.DeletedSlot,
+			"non-pv3 dispatch must not touch AVVM UTxOs")
+	}
+}

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
-	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -53,28 +52,25 @@ func seedPlominFixtures(t *testing.T, db *database.Database) plominFixtureKeys {
 		Dead: bytes.Repeat([]byte{0xA2}, 28),
 	}
 
-	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
-	require.True(t, ok, "test DB must be backed by sqlite")
-
-	require.NoError(t, store.DB().Create(&models.Drep{
+	require.NoError(t, db.CreateDrep(nil, &models.Drep{
 		Credential: liveCred,
 		Active:     true,
 		AddedSlot:  10,
-	}).Error)
-	require.NoError(t, store.DB().Create(&models.Account{
+	}))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
 		StakingKey: keys.Live,
 		Drep:       liveCred,
 		DrepType:   models.DrepTypeAddrKeyHash,
 		Active:     true,
 		AddedSlot:  100,
-	}).Error)
-	require.NoError(t, store.DB().Create(&models.Account{
+	}))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
 		StakingKey: keys.Dead,
 		Drep:       deadCred,
 		DrepType:   models.DrepTypeAddrKeyHash,
 		Active:     true,
 		AddedSlot:  100,
-	}).Error)
+	}))
 	return keys
 }
 
@@ -150,9 +146,6 @@ func seedAllegraAvvmFixtures(
 	db *database.Database,
 ) allegraAvvmFixtureKeys {
 	t.Helper()
-	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
-	require.True(t, ok, "test DB must be backed by sqlite")
-
 	keys := allegraAvvmFixtureKeys{
 		Redeem: [][]byte{
 			bytes.Repeat([]byte{0x01}, 32),
@@ -162,23 +155,23 @@ func seedAllegraAvvmFixtures(
 	}
 
 	for i, id := range keys.Redeem {
-		require.NoError(t, store.DB().Create(&models.Utxo{
+		require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
 			TxId:             id,
 			OutputIdx:        0,
 			PaymentKey:       bytes.Repeat([]byte{0xA0 + byte(i)}, 28),
 			Amount:           types.Uint64(uint64(1_000_000 * (i + 1))),
 			AddedSlot:        100,
 			ByronAddressType: uint8(lcommon.ByronAddressTypeRedeem),
-		}).Error)
+		}))
 	}
-	require.NoError(t, store.DB().Create(&models.Utxo{
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
 		TxId:             keys.Pubkey,
 		OutputIdx:        0,
 		PaymentKey:       bytes.Repeat([]byte{0xB1}, 28),
 		Amount:           types.Uint64(5_555_555),
 		AddedSlot:        150,
 		ByronAddressType: uint8(lcommon.ByronAddressTypePubkey),
-	}).Error)
+	}))
 	return keys
 }
 
@@ -197,11 +190,25 @@ func newTestLSForHardForkRule(
 	}
 }
 
-// pv3 (Shelley→Allegra): every live AVVM UTxO is marked deleted at the
-// boundary slot; non-redeem UTxOs are preserved.
+// pv3 (Shelley→Allegra): every live AVVM UTxO is removed from the live
+// UTxO set. The dispatcher's contract with the database layer (exact
+// DeletedSlot bookkeeping, idempotency) is covered in the sqlite
+// plugin's allegra_avvm_test.go. Here we only verify that the dispatch
+// reached the rule, distinguishing "metadata row gone" (ErrUtxoNotFound)
+// from "metadata row present but CBOR unavailable"
+// (ErrUtxoCborUnavailable, which is what fixture rows return before the
+// rule runs because no blob backs them).
 func TestApplyIntraEraHardForkRule_Pv3_RemovesAvvm(t *testing.T) {
 	db := newTestDB(t)
 	keys := seedAllegraAvvmFixtures(t, db)
+
+	// Sanity-check the seed: pre-rule, fixture rows are present in
+	// metadata but have no CBOR backing.
+	for _, id := range keys.Redeem {
+		_, err := db.UtxoByRef(id, 0, nil)
+		require.ErrorIs(t, err, database.ErrUtxoCborUnavailable,
+			"pre-rule fixture row should be in live set with no CBOR")
+	}
 
 	ls := newTestLSForHardForkRule(t, db)
 	const boundarySlot uint64 = 4_492_800 // approx mainnet Allegra start
@@ -212,26 +219,20 @@ func TestApplyIntraEraHardForkRule_Pv3_RemovesAvvm(t *testing.T) {
 		208,          // newEpoch (log-only)
 	))
 
-	store := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	// Post-rule, the metadata rows are gone from the live set.
 	for _, id := range keys.Redeem {
-		var u models.Utxo
-		require.NoError(t, store.DB().
-			Where("tx_id = ?", id).First(&u).Error)
-		assert.Equal(t, boundarySlot, u.DeletedSlot,
-			"AVVM UTxO must be deleted at the Allegra boundary slot")
+		_, err := db.UtxoByRef(id, 0, nil)
+		require.ErrorIs(t, err, database.ErrUtxoNotFound,
+			"AVVM UTxO must be removed from the live UTxO set")
 	}
-
-	var pubkey models.Utxo
-	require.NoError(t, store.DB().
-		Where("tx_id = ?", keys.Pubkey).First(&pubkey).Error)
-	assert.Equal(t, uint64(0), pubkey.DeletedSlot,
-		"Byron pubkey UTxO must survive the pv3 rule")
 }
 
 // Only pv3 may touch AVVM UTxOs. Verifies that other majors — both the
 // no-op branches matching the Haskell rule's `otherwise = id` (pv2, pv99)
 // and majors with their own non-AVVM handlers (pv10/Plomin) — leave
-// redeem UTxOs untouched through this dispatch.
+// redeem UTxOs in the live set. The rows still exist in metadata so
+// UtxoByRef returns ErrUtxoCborUnavailable (not ErrUtxoNotFound)
+// because the fixture has no blob backing.
 func TestApplyIntraEraHardForkRule_OtherMajors_DoNotTouchAvvm(t *testing.T) {
 	db := newTestDB(t)
 	keys := seedAllegraAvvmFixtures(t, db)
@@ -243,12 +244,11 @@ func TestApplyIntraEraHardForkRule_OtherMajors_DoNotTouchAvvm(t *testing.T) {
 		))
 	}
 
-	store := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
 	for _, id := range keys.Redeem {
-		var u models.Utxo
-		require.NoError(t, store.DB().
-			Where("tx_id = ?", id).First(&u).Error)
-		assert.Equal(t, uint64(0), u.DeletedSlot,
-			"non-pv3 dispatch must not touch AVVM UTxOs")
+		_, err := db.UtxoByRef(id, 0, nil)
+		require.ErrorIs(t, err, database.ErrUtxoCborUnavailable,
+			"non-pv3 dispatch must leave AVVM rows in the live set")
+		require.NotErrorIs(t, err, database.ErrUtxoNotFound,
+			"non-pv3 dispatch must not remove AVVM UTxOs")
 	}
 }

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -78,21 +78,6 @@ func seedPlominFixtures(t *testing.T, db *database.Database) plominFixtureKeys {
 	return keys
 }
 
-// newTestLSForPlomin wires just enough of a LedgerState to call
-// applyIntraEraHardForkRule against the given test DB.
-func newTestLSForPlomin(
-	t *testing.T,
-	db *database.Database,
-) *LedgerState {
-	t.Helper()
-	return &LedgerState{
-		db: db,
-		config: LedgerStateConfig{
-			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		},
-	}
-}
-
 // pv10 is the major-version bump that currently has a non-no-op handler:
 // accounts with credential-backed delegations to unregistered DReps are
 // cleared; accounts delegating to registered DReps are preserved.
@@ -100,7 +85,7 @@ func TestApplyIntraEraHardForkRule_Pv10_ClearsDangling(t *testing.T) {
 	db := newTestDB(t)
 	keys := seedPlominFixtures(t, db)
 
-	ls := newTestLSForPlomin(t, db)
+	ls := newTestLSForHardForkRule(t, db)
 	require.NoError(t, ls.applyIntraEraHardForkRule(
 		nil,  // nil txn → owned metadata txn inside the Database wrapper
 		10,   // newMajor
@@ -130,7 +115,7 @@ func TestApplyIntraEraHardForkRule_UnknownMajor_NoOp(t *testing.T) {
 	db := newTestDB(t)
 	keys := seedPlominFixtures(t, db)
 
-	ls := newTestLSForPlomin(t, db)
+	ls := newTestLSForHardForkRule(t, db)
 
 	for _, major := range []uint{9, 11, 12, 99} {
 		require.NoError(t, ls.applyIntraEraHardForkRule(
@@ -243,10 +228,10 @@ func TestApplyIntraEraHardForkRule_Pv3_RemovesAvvm(t *testing.T) {
 		"Byron pubkey UTxO must survive the pv3 rule")
 }
 
-// Unknown major versions are a no-op — matches the Haskell rule's
-// `otherwise = id` branch. Explicitly verifies that pv2 (pre-Allegra),
-// pv4 (Allegra→Mary), and pv10 (Plomin, handled elsewhere) do not touch
-// AVVM UTxOs through this dispatch.
+// Only pv3 may touch AVVM UTxOs. Verifies that other majors — both the
+// no-op branches matching the Haskell rule's `otherwise = id` (pv2, pv99)
+// and majors with their own non-AVVM handlers (pv10/Plomin) — leave
+// redeem UTxOs untouched through this dispatch.
 func TestApplyIntraEraHardForkRule_OtherMajors_DoNotTouchAvvm(t *testing.T) {
 	db := newTestDB(t)
 	keys := seedAllegraAvvmFixtures(t, db)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shelley→Allegra hard-fork: removes live Byron AVVM redeem UTxOs at the era boundary and reclaims their lovelace to reserves.
  * UTxO records now track Byron address subtype to distinguish redeem/pubkey outputs.
  * Metadata layer extended with direct create/remove operations across MySQL/Postgres/SQLite to support these behaviors.

* **Tests**
  * New tests validate AVVM removal semantics, idempotence, and non-removal for non-redeem outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the Shelley→Allegra rule (pv3): at the boundary slot, remove all live Byron AVVM UTxOs and return the reclaimed lovelace. Adds direct create helpers in the database layer to keep tests and callers within boundaries.

- **New Features**
  - Track `ByronAddressType` on `Utxo`; add `RemoveByronAvvmUtxos(atSlot, txn)` to `MetadataStore` with `mysql`, `postgres`, and `sqlite` implementations, plus `Database.RemoveByronAvvmUtxos`. Wired into `applyIntraEraHardForkRule` for pv3; rollback uses `deleted_slot`. Logged reclaimed lovelace.
  - Added `CreateDrep`, `CreateAccount`, and `CreateUtxo` to `MetadataStore` and `Database` for single-row inserts without side effects.
  - Introduced `ErrUtxoCborUnavailable` to distinguish missing CBOR from a missing UTxO row.

- **Migration**
  - Add the indexed `byron_address_type` column on `utxo` (auto-migration or run your migrations).

<sup>Written for commit 3fd01bd0d4e8a979733130cca01c0e9b65ec1c2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

