### PR TITLE
fix(ledger): epoch switch rollover safe nonce calc

### DIFF
--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -58,6 +58,8 @@ type ChainTipProvider interface {
 type EpochNonceProvider interface {
 	// CurrentEpoch returns the current epoch number.
 	CurrentEpoch() uint64
+	// EpochForSlot returns the epoch containing the given slot.
+	EpochForSlot(slot uint64) (uint64, error)
 	// EpochNonce returns the nonce for the given epoch.
 	EpochNonce(epoch uint64) []byte
 }
@@ -423,9 +425,19 @@ func (b *DefaultBlockBuilder) BuildBlock(
 		)
 	}
 
-	// Compute VRF proof for leader election
-	currentEpoch := b.epochNonce.CurrentEpoch()
-	epochNonce := b.epochNonce.EpochNonce(currentEpoch)
+	// Compute VRF proof for leader election. Use the block slot's
+	// epoch rather than the ledger's current epoch because the slot
+	// clock can reach a new epoch before block processing commits the
+	// epoch rollover.
+	blockEpoch, err := b.epochNonce.EpochForSlot(slot)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to resolve epoch for slot %d: %w",
+			slot,
+			err,
+		)
+	}
+	epochNonce := b.epochNonce.EpochNonce(blockEpoch)
 	if len(epochNonce) == 0 {
 		return nil, nil, errors.New("epoch nonce not available")
 	}

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -15,6 +15,7 @@
 package forging
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"log/slog"
@@ -61,15 +62,33 @@ func (m *mockChainTip) Tip() ochainsync.Tip {
 
 // mockEpochNonceProvider implements EpochNonceProvider for testing.
 type mockEpochNonceProvider struct {
-	epoch uint64
-	nonce []byte
+	epoch           uint64
+	nonce           []byte
+	nonces          map[uint64][]byte
+	slotsPerEpoch   uint64
+	epochForSlotErr error
+	requestedEpochs []uint64
 }
 
 func (m *mockEpochNonceProvider) CurrentEpoch() uint64 {
 	return m.epoch
 }
 
-func (m *mockEpochNonceProvider) EpochNonce(_ uint64) []byte {
+func (m *mockEpochNonceProvider) EpochForSlot(slot uint64) (uint64, error) {
+	if m.epochForSlotErr != nil {
+		return 0, m.epochForSlotErr
+	}
+	if m.slotsPerEpoch == 0 {
+		return m.epoch, nil
+	}
+	return slot / m.slotsPerEpoch, nil
+}
+
+func (m *mockEpochNonceProvider) EpochNonce(epoch uint64) []byte {
+	m.requestedEpochs = append(m.requestedEpochs, epoch)
+	if m.nonces != nil {
+		return m.nonces[epoch]
+	}
 	return m.nonce
 }
 
@@ -206,6 +225,89 @@ func TestBuildBlockEmptyMempool(t *testing.T) {
 	assert.Equal(t, uint64(1001), block.SlotNumber())
 	assert.Equal(t, uint64(101), block.BlockNumber())
 	assert.Equal(t, 0, len(block.Transactions()))
+}
+
+func TestBuildBlockUsesSlotEpochForVRFNonce(t *testing.T) {
+	creds := setupTestCredentials(t)
+
+	pparams := &conway.ConwayProtocolParameters{
+		MaxTxSize:        16384,
+		MaxBlockBodySize: 90112,
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  20000000000,
+		},
+	}
+	epochNonce := &mockEpochNonceProvider{
+		epoch:         10, // ledger state has not rolled over yet
+		slotsPerEpoch: 100,
+		nonces: map[uint64][]byte{
+			10: bytes.Repeat([]byte{0x10}, 32),
+			11: bytes.Repeat([]byte{0x11}, 32),
+		},
+	}
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool:         &mockMempool{transactions: []MempoolTransaction{}},
+		PParamsProvider: &mockPParamsProvider{pparams: pparams},
+		ChainTip: &mockChainTip{
+			tip: ochainsync.Tip{
+				Point: ocommon.Point{
+					Slot: 1099,
+					Hash: make([]byte, 32),
+				},
+				BlockNumber: 100,
+			},
+		},
+		EpochNonce:  epochNonce,
+		Credentials: creds,
+	})
+	require.NoError(t, err)
+
+	block, _, err := builder.BuildBlock(1100, 0)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	require.Equal(t, []uint64{11}, epochNonce.requestedEpochs)
+}
+
+func TestBuildBlockPropagatesEpochForSlotError(t *testing.T) {
+	creds := setupTestCredentials(t)
+
+	pparams := &conway.ConwayProtocolParameters{
+		MaxTxSize:        16384,
+		MaxBlockBodySize: 90112,
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  20000000000,
+		},
+	}
+	sentinelErr := errors.New("epoch resolution failed")
+	epochNonce := &mockEpochNonceProvider{
+		epoch:           10,
+		nonce:           make([]byte, 32),
+		epochForSlotErr: sentinelErr,
+	}
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool:         &mockMempool{transactions: []MempoolTransaction{}},
+		PParamsProvider: &mockPParamsProvider{pparams: pparams},
+		ChainTip: &mockChainTip{
+			tip: ochainsync.Tip{
+				Point: ocommon.Point{
+					Slot: 1000,
+					Hash: make([]byte, 32),
+				},
+				BlockNumber: 100,
+			},
+		},
+		EpochNonce:  epochNonce,
+		Credentials: creds,
+	})
+	require.NoError(t, err)
+
+	_, _, err = builder.BuildBlock(1001, 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinelErr)
+	require.Empty(t, epochNonce.requestedEpochs,
+		"EpochNonce must not be queried when EpochForSlot fails")
 }
 
 func TestBuildBlockUsesDingoProtocolMinor(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4032,68 +4032,19 @@ func (ls *LedgerState) computeNextEpochNonce(
 	if currentEra.Id == 0 {
 		return nil
 	}
-	if ls.config.CardanoNodeConfig == nil ||
-		ls.config.CardanoNodeConfig.ShelleyGenesisHash == "" {
-		return nil
-	}
-
-	genesisHashBytes, err := hex.DecodeString(
-		ls.config.CardanoNodeConfig.ShelleyGenesisHash,
-	)
-	if err != nil {
-		return nil
-	}
-
-	if len(currentEpoch.Nonce) == 0 {
-		return genesisHashBytes
-	}
-
-	prevEvolvingNonce := currentEpoch.EvolvingNonce
-	if len(prevEvolvingNonce) == 0 {
-		prevEvolvingNonce = genesisHashBytes
-	}
-
-	prevCandidateNonce := currentEpoch.CandidateNonce
-	if len(prevCandidateNonce) == 0 {
-		prevCandidateNonce = genesisHashBytes
-	}
-
-	candidateNonce, _, err := ls.computeCandidateNonce(
-		nil,
-		prevEvolvingNonce,
-		prevCandidateNonce,
-		currentEpoch.StartSlot,
-		uint64(currentEpoch.LengthInSlots),
+	nextEpochStartSlot := currentEpoch.StartSlot +
+		uint64(currentEpoch.LengthInSlots)
+	nonce, _, _, _, err := ls.computeEpochNonceForSlot(
+		nextEpochStartSlot,
+		currentEpoch,
 	)
 	if err != nil {
 		ls.config.Logger.Warn(
-			"failed to compute candidate nonce",
+			"failed to compute next epoch nonce",
 			"component", "ledger",
+			"current_epoch", currentEpoch.EpochId,
+			"next_epoch", currentEpoch.EpochId+1,
 			"error", err,
-		)
-		return nil
-	}
-
-	// Use the LAGGED lastEpochBlockNonce. When NeutralNonce
-	// (epoch 0→1), candidateNonce ⭒ NeutralNonce = candidateNonce.
-	lastEpochBlockNonce := currentEpoch.LastEpochBlockNonce
-	if len(lastEpochBlockNonce) == 0 {
-		return candidateNonce
-	}
-	if len(candidateNonce) < 32 ||
-		len(lastEpochBlockNonce) < 32 {
-		return nil
-	}
-	result, calcErr := lcommon.CalculateEpochNonce(
-		candidateNonce,
-		lastEpochBlockNonce,
-		nil,
-	)
-	if calcErr != nil {
-		ls.config.Logger.Warn(
-			"failed to calculate epoch nonce",
-			"component", "ledger",
-			"error", calcErr,
 		)
 		return nil
 	}
@@ -4101,12 +4052,9 @@ func (ls *LedgerState) computeNextEpochNonce(
 		"speculative epoch nonce computed for next epoch",
 		"component", "ledger",
 		"next_epoch", currentEpoch.EpochId+1,
-		"candidate_nonce", hex.EncodeToString(candidateNonce),
-		"last_epoch_block_nonce",
-		hex.EncodeToString(lastEpochBlockNonce),
-		"epoch_nonce", hex.EncodeToString(result.Bytes()),
+		"epoch_nonce", hex.EncodeToString(nonce),
 	)
-	return result.Bytes()
+	return nonce
 }
 
 // SlotsPerEpoch returns the number of slots in an epoch for the current era.

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -900,6 +901,53 @@ func TestNextEpochNonceReadyEpoch(t *testing.T) {
 	readyEpoch, ok := ls.NextEpochNonceReadyEpoch()
 	require.True(t, ok)
 	assert.Equal(t, uint64(11), readyEpoch)
+}
+
+func TestComputeNextEpochNonceUsesImportedTipAnchor(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	tipNonce := bytes.Repeat([]byte{0x22}, 32)
+	candidateNonce := bytes.Repeat([]byte{0x33}, 32)
+
+	require.NoError(t, db.SetBlockNonce(
+		bytes.Repeat([]byte{0x44}, 32),
+		1050,
+		tipNonce,
+		false,
+		nil,
+	))
+
+	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ShelleyEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId:        10,
+			StartSlot:      1000,
+			LengthInSlots:  100,
+			Nonce:          bytes.Repeat([]byte{0x11}, 32),
+			EvolvingNonce:  tipNonce,
+			CandidateNonce: candidateNonce,
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 1050,
+			},
+		},
+		// currentTipBlockNonce is intentionally unset to mimic a snapshot
+		// import where the in-memory tip-nonce cache hasn't been populated.
+		// This forces computeEpochNonceForSlot past its in-memory short-circuit
+		// and exercises the DB-resume anchor lookup against block_nonce rows.
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newNonceReadyTestConfig(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	got := ls.computeNextEpochNonce(ls.currentEpoch, ls.currentEra)
+	require.Equal(t, candidateNonce, got)
+	require.NotEqual(t, tipNonce, got)
 }
 
 func TestNextEpochNonceReadyEpochNotReadyBeforeCutoff(t *testing.T) {

--- a/node_forging.go
+++ b/node_forging.go
@@ -299,6 +299,14 @@ func (a *epochNonceAdapter) CurrentEpoch() uint64 {
 	return a.ledgerState.CurrentEpoch()
 }
 
+func (a *epochNonceAdapter) EpochForSlot(slot uint64) (uint64, error) {
+	epoch, err := a.ledgerState.SlotToEpoch(slot)
+	if err != nil {
+		return 0, err
+	}
+	return epoch.EpochId, nil
+}
+
 func (a *epochNonceAdapter) EpochNonce(epoch uint64) []byte {
 	return a.ledgerState.EpochNonce(epoch)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved epoch derivation in block forging to use slot-based calculation instead of current ledger epoch.
  * Enhanced error handling for epoch resolution failures during block creation.
  * Refined epoch nonce computation, particularly at epoch boundaries.

* **Tests**
  * Added comprehensive test coverage for slot-based epoch derivation and nonce selection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leader election at epoch switch by using the block slot’s epoch nonce and makes next-epoch nonce calculation rollover-safe. Prevents wrong VRF nonce usage and stabilizes forging across epoch boundaries.

- **Bug Fixes**
  - `DefaultBlockBuilder` resolves the block slot’s epoch via `EpochForSlot(slot)` and uses that epoch’s nonce for VRF; if epoch resolution fails, it now returns an error.
  - Ledger `computeNextEpochNonce` computes the next-epoch nonce at the next epoch’s start via `computeEpochNonceForSlot`, honoring the imported tip anchor and removing fragile manual mixing. Tests added for slot-epoch selection, tip-anchor handling, and error propagation.
  - `EpochNonceProvider` and the `node_forging` adapter updated to support `EpochForSlot` (adapter calls `SlotToEpoch`).

- **Migration**
  - Add `EpochForSlot(slot uint64) (uint64, error)` to any custom `EpochNonceProvider` implementations.

<sup>Written for commit 40351c856854523d8299b5f71aab2cf67c17a713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

