### PR TITLE
refactor: use single era table rather than maintaining two

### DIFF
--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -30,6 +30,8 @@ import (
 var AllegraEraDesc = EraDesc{
 	Id:                      allegra.EraIdAllegra,
 	Name:                    allegra.EraNameAllegra,
+	MinMajorVersion:         3,
+	MaxMajorVersion:         3,
 	DecodePParamsFunc:       DecodePParamsAllegra,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateAllegra,
 	PParamsUpdateFunc:       PParamsUpdateAllegra,

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -36,6 +36,8 @@ import (
 var AlonzoEraDesc = EraDesc{
 	Id:                      alonzo.EraIdAlonzo,
 	Name:                    alonzo.EraNameAlonzo,
+	MinMajorVersion:         5,
+	MaxMajorVersion:         6,
 	DecodePParamsFunc:       DecodePParamsAlonzo,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateAlonzo,
 	PParamsUpdateFunc:       PParamsUpdateAlonzo,

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -36,6 +36,8 @@ import (
 var BabbageEraDesc = EraDesc{
 	Id:                      babbage.EraIdBabbage,
 	Name:                    babbage.EraNameBabbage,
+	MinMajorVersion:         7,
+	MaxMajorVersion:         8,
 	DecodePParamsFunc:       DecodePParamsBabbage,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateBabbage,
 	PParamsUpdateFunc:       PParamsUpdateBabbage,

--- a/ledger/eras/byron.go
+++ b/ledger/eras/byron.go
@@ -27,6 +27,8 @@ import (
 var ByronEraDesc = EraDesc{
 	Id:              byron.EraIdByron,
 	Name:            byron.EraNameByron,
+	MinMajorVersion: 0,
+	MaxMajorVersion: 1,
 	EpochLengthFunc: EpochLengthByron,
 	ValidateTxFunc:  ValidateTxByron,
 }

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -36,6 +36,8 @@ import (
 var ConwayEraDesc = EraDesc{
 	Id:                      conway.EraIdConway,
 	Name:                    conway.EraNameConway,
+	MinMajorVersion:         9,
+	MaxMajorVersion:         10,
 	DecodePParamsFunc:       DecodePParamsConway,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateConway,
 	PParamsUpdateFunc:       PParamsUpdateConway,

--- a/ledger/eras/eras.go
+++ b/ledger/eras/eras.go
@@ -59,6 +59,11 @@ type EraDesc struct {
 	EvaluateTxFunc          func(lcommon.Transaction, lcommon.LedgerState, lcommon.ProtocolParameters) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error)
 	Name                    string
 	Id                      uint
+	// MinMajorVersion and MaxMajorVersion are the inclusive protocol-major
+	// version range covered by this era. Adjacent eras must meet without
+	// gap or overlap (cur.MinMajorVersion == prev.MaxMajorVersion + 1).
+	MinMajorVersion uint
+	MaxMajorVersion uint
 }
 
 var Eras = []EraDesc{
@@ -71,18 +76,17 @@ var Eras = []EraDesc{
 	ConwayEraDesc,
 }
 
-var ProtocolMajorVersionToEra = map[uint]EraDesc{
-	0:  ByronEraDesc,
-	1:  ByronEraDesc,
-	2:  ShelleyEraDesc,
-	3:  AllegraEraDesc,
-	4:  MaryEraDesc,
-	5:  AlonzoEraDesc,
-	6:  AlonzoEraDesc,
-	7:  BabbageEraDesc,
-	8:  BabbageEraDesc,
-	9:  ConwayEraDesc,
-	10: ConwayEraDesc,
+// EraForVersion returns the era descriptor whose [MinMajorVersion,
+// MaxMajorVersion] range contains majorVersion. Returns (nil, false) if
+// no era covers the given version.
+func EraForVersion(majorVersion uint) (*EraDesc, bool) {
+	for i := range Eras {
+		if majorVersion >= Eras[i].MinMajorVersion &&
+			majorVersion <= Eras[i].MaxMajorVersion {
+			return &Eras[i], true
+		}
+	}
+	return nil, false
 }
 
 // GetEraById returns the era descriptor for the given era ID.

--- a/ledger/eras/mary.go
+++ b/ledger/eras/mary.go
@@ -30,6 +30,8 @@ import (
 var MaryEraDesc = EraDesc{
 	Id:                      mary.EraIdMary,
 	Name:                    mary.EraNameMary,
+	MinMajorVersion:         4,
+	MaxMajorVersion:         4,
 	DecodePParamsFunc:       DecodePParamsMary,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateMary,
 	PParamsUpdateFunc:       PParamsUpdateMary,

--- a/ledger/eras/shape.go
+++ b/ledger/eras/shape.go
@@ -136,8 +136,7 @@ func BuildEraParams(cfg *cardano.CardanoNodeConfig, era EraDesc) (hardfork.EraPa
 // BuildShape constructs a hardfork.Shape from dingo's static era table.
 // The shape's SystemStart comes from the Shelley genesis; each entry's
 // EraParams are built via BuildEraParams; the protocol-version range
-// (MinMajorVersion/MaxMajorVersion) is derived by inverting
-// ProtocolMajorVersionToEra.
+// is read directly from EraDesc.MinMajorVersion / MaxMajorVersion.
 func BuildShape(cfg *cardano.CardanoNodeConfig) (hardfork.Shape, error) {
 	if cfg == nil {
 		return hardfork.Shape{}, errors.New("eras: nil CardanoNodeConfig")
@@ -147,45 +146,17 @@ func BuildShape(cfg *cardano.CardanoNodeConfig) (hardfork.Shape, error) {
 		return hardfork.Shape{}, errors.New("eras: Shelley genesis unavailable (required for SystemStart)")
 	}
 
-	// Invert ProtocolMajorVersionToEra to compute {min,max} per era ID.
-	type versionRange struct {
-		min, max uint
-		hasAny   bool
-	}
-	ranges := map[uint]*versionRange{}
-	for v, e := range ProtocolMajorVersionToEra {
-		r, ok := ranges[e.Id]
-		if !ok {
-			r = &versionRange{min: v, max: v, hasAny: true}
-			ranges[e.Id] = r
-			continue
-		}
-		if v < r.min {
-			r.min = v
-		}
-		if v > r.max {
-			r.max = v
-		}
-	}
-
 	entries := make([]hardfork.ShapeEntry, 0, len(Eras))
 	for _, era := range Eras {
 		params, err := BuildEraParams(cfg, era)
 		if err != nil {
 			return hardfork.Shape{}, err
 		}
-		r, ok := ranges[era.Id]
-		if !ok {
-			return hardfork.Shape{}, fmt.Errorf(
-				"eras: era %q (id=%d) has no entry in ProtocolMajorVersionToEra",
-				era.Name, era.Id,
-			)
-		}
 		entries = append(entries, hardfork.ShapeEntry{
 			EraID:           era.Id,
 			EraName:         era.Name,
-			MinMajorVersion: r.min,
-			MaxMajorVersion: r.max,
+			MinMajorVersion: era.MinMajorVersion,
+			MaxMajorVersion: era.MaxMajorVersion,
 			Params:          params,
 		})
 	}

--- a/ledger/eras/shape_test.go
+++ b/ledger/eras/shape_test.go
@@ -141,7 +141,7 @@ func TestBuildShape_OK(t *testing.T) {
 	assert.Equal(t, "Shelley", shape.Eras[1].EraName)
 	assert.Equal(t, "Conway", shape.Eras[6].EraName)
 
-	// Version ranges derived from ProtocolMajorVersionToEra.
+	// Version ranges read directly from each EraDesc.
 	type vr struct{ min, max uint }
 	want := map[string]vr{
 		"Byron":   {0, 1},
@@ -162,21 +162,25 @@ func TestBuildShape_OK(t *testing.T) {
 	assert.NoError(t, shape.Validate(), "BuildShape must produce a valid Shape")
 }
 
-// EraForVersion from the resulting Shape matches the legacy EraForVersion lookup.
-func TestBuildShape_EraForVersionMatchesLegacy(t *testing.T) {
+// Shape.EraForVersion and the package-level eras.EraForVersion agree on
+// every covered major-version, and both reject unknown versions.
+func TestBuildShape_EraForVersionAgreesWithEraTable(t *testing.T) {
 	cfg := newTestCfg(t)
 	shape, err := eras.BuildShape(cfg)
 	require.NoError(t, err)
 
 	for v := uint(0); v <= 10; v++ {
-		got, found := shape.EraForVersion(v)
-		require.True(t, found, "version %d should resolve", v)
-		legacy := eras.ProtocolMajorVersionToEra[v]
-		assert.Equal(t, legacy.Id, got.EraID, "version %d EraID", v)
+		gotShape, found := shape.EraForVersion(v)
+		require.True(t, found, "version %d should resolve via Shape", v)
+		gotEra, found := eras.EraForVersion(v)
+		require.True(t, found, "version %d should resolve via era table", v)
+		assert.Equal(t, gotEra.Id, gotShape.EraID, "version %d EraID", v)
 	}
 
 	_, found := shape.EraForVersion(99)
-	assert.False(t, found)
+	assert.False(t, found, "Shape should reject unknown version")
+	_, found = eras.EraForVersion(99)
+	assert.False(t, found, "era table should reject unknown version")
 }
 
 func TestBuildShape_MissingShelleyGenesis(t *testing.T) {

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -30,6 +30,8 @@ import (
 var ShelleyEraDesc = EraDesc{
 	Id:                      shelley.EraIdShelley,
 	Name:                    shelley.EraNameShelley,
+	MinMajorVersion:         2,
+	MaxMajorVersion:         2,
 	DecodePParamsFunc:       DecodePParamsShelley,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateShelley,
 	PParamsUpdateFunc:       PParamsUpdateShelley,

--- a/ledger/protocol_version.go
+++ b/ledger/protocol_version.go
@@ -96,11 +96,11 @@ func GetProtocolVersion(
 	}
 }
 
-// EraForVersion returns the era ID for a given protocol
-// major version using the ProtocolMajorVersionToEra map in
-// ledger/eras/. Returns false if the version is not mapped.
+// EraForVersion returns the era ID for a given protocol major version,
+// resolved against the static era table in ledger/eras/. Returns false
+// if no era covers the given version.
 func EraForVersion(majorVersion uint) (uint, bool) {
-	eraDesc, ok := eras.ProtocolMajorVersionToEra[majorVersion]
+	eraDesc, ok := eras.EraForVersion(majorVersion)
 	if !ok {
 		return 0, false
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3577,13 +3577,20 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 		return errors.New("failed to load Shelley genesis")
 	}
 	startProtoVersion := shelleyGenesis.ProtocolParameters.ProtocolVersion.Major
-	startEra := eras.ProtocolMajorVersionToEra[startProtoVersion]
+	startEra, startEraOk := eras.EraForVersion(startProtoVersion)
 	// Initialize current era to Byron when starting from genesis
 	ls.currentEra = eras.Eras[0] // Byron era
-	// Transition through every era between the current and the target era
+	// Transition through every era between the current and the target era.
+	// If the configured version is unknown, the loop is skipped and the
+	// node starts at Byron — same fallback behavior as the previous map
+	// lookup, which returned the zero-value EraDesc for unmapped versions.
 	// During startup, it's safe to apply results immediately since there's
 	// no concurrent access.
-	for nextEraId := ls.currentEra.Id + 1; nextEraId <= startEra.Id; nextEraId++ {
+	startEraId := uint(0)
+	if startEraOk {
+		startEraId = startEra.Id
+	}
+	for nextEraId := ls.currentEra.Id + 1; nextEraId <= startEraId; nextEraId++ {
 		result, err := ls.transitionToEra(
 			txn,
 			nextEraId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors era version resolution to use a single static era table with per-era protocol-major version ranges, removing the duplicate version→era map. This reduces duplication and keeps `Shape.EraForVersion` and the era table in sync.

- **Refactors**
  - Added `MinMajorVersion` and `MaxMajorVersion` to `EraDesc`; populated for all eras (Byron→Conway).
  - Removed `ProtocolMajorVersionToEra`; introduced `EraForVersion(uint)` that resolves via the `Eras` table.
  - `BuildShape` now reads version ranges directly from each `EraDesc` (deleted inversion logic).
  - Updated `protocol_version.EraForVersion` and ledger startup to use the new resolver; preserve Byron fallback for unknown versions.
  - Tests updated to validate version-range coverage and agreement between `Shape.EraForVersion` and `eras.EraForVersion`.

- **Migration**
  - Replace any use of `eras.ProtocolMajorVersionToEra` with `eras.EraForVersion`.

<sup>Written for commit 0f56c3675b758f62f04a3a01b4f069fd5f3e4cd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced protocol version compatibility by establishing explicit boundaries for era support.
  * Improved era resolution logic with more accurate version-to-era mapping.
  * Refined startup initialization for better protocol version handling during node startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->