### PR TITLE
fix(event): Stop() race condition can panic during shutdown

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -407,6 +407,13 @@ func (e *EventBus) deliverWithTimeout(
 
 // Publish allows a producer to send an event of a particular type to all subscribers
 func (e *EventBus) Publish(eventType EventType, evt Event) {
+	e.stopMu.RLock()
+	if e.stopped || e.closed {
+		e.stopMu.RUnlock()
+		return
+	}
+	defer e.stopMu.RUnlock()
+
 	e.mu.RLock()
 	subList := e.subscriberSnapshots[eventType]
 	e.mu.RUnlock()
@@ -459,14 +466,13 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 // Use this for non-critical events where immediate delivery is not required.
 // Returns false if the EventBus is stopped, closed, or the async queue is full.
 func (e *EventBus) PublishAsync(eventType EventType, evt Event) bool {
-	// Capture asyncQueue under lock to protect against concurrent reassignment in Stop()
 	e.stopMu.RLock()
 	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return false
 	}
 	q := e.asyncQueue
-	e.stopMu.RUnlock()
+	defer e.stopMu.RUnlock()
 
 	select {
 	case q <- asyncEvent{eventType: eventType, event: evt}:

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -93,6 +93,92 @@ func TestSubscribeFuncStopRace(t *testing.T) {
 	}
 }
 
+type blockingSubscriber struct {
+	deliverStarted chan struct{}
+	releaseDeliver chan struct{}
+	deliverDone    chan struct{}
+	closeCalled    atomic.Bool
+	startOnce      sync.Once
+	doneOnce       sync.Once
+}
+
+func newBlockingSubscriber() *blockingSubscriber {
+	return &blockingSubscriber{
+		deliverStarted: make(chan struct{}),
+		releaseDeliver: make(chan struct{}),
+		deliverDone:    make(chan struct{}),
+	}
+}
+
+func (s *blockingSubscriber) Deliver(Event) error {
+	s.startOnce.Do(func() {
+		close(s.deliverStarted)
+	})
+	<-s.releaseDeliver
+	s.doneOnce.Do(func() {
+		close(s.deliverDone)
+	})
+	return nil
+}
+
+func (s *blockingSubscriber) Close() {
+	s.closeCalled.Store(true)
+}
+
+// TestStopWaitsForInFlightPublish verifies that Stop cannot close subscribers
+// and return while a Publish call is still delivering to a subscriber.
+func TestStopWaitsForInFlightPublish(t *testing.T) {
+	eb := NewEventBus(nil, nil)
+	typ := EventType("race.publish.stop.wait")
+	sub := newBlockingSubscriber()
+	require.NotZero(t, eb.RegisterSubscriber(typ, sub))
+
+	publishDone := make(chan struct{})
+	go func() {
+		defer close(publishDone)
+		eb.Publish(typ, NewEvent(typ, "blocked"))
+	}()
+
+	select {
+	case <-sub.deliverStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish did not enter subscriber Deliver")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		eb.Stop()
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while Publish was still in flight")
+	case <-time.After(25 * time.Millisecond):
+		// Expected: Stop is blocked behind the in-flight Publish.
+	}
+
+	close(sub.releaseDeliver)
+
+	select {
+	case <-publishDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish did not complete after subscriber was released")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not complete after in-flight Publish completed")
+	}
+
+	require.True(t, sub.closeCalled.Load(), "Stop should close subscriber")
+	select {
+	case <-sub.deliverDone:
+	default:
+		t.Fatal("subscriber Close happened before Deliver completed")
+	}
+}
+
 // TestPublishDoesNotBlockOnFullChannel verifies that Publish returns
 // promptly even when a subscriber's channel buffer is completely full.
 // Before the non-blocking send fix, this scenario would deadlock:

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -146,10 +146,13 @@ func TestStopWaitsForInFlightPublish(t *testing.T) {
 	}
 
 	stopDone := make(chan struct{})
+	stopStarted := make(chan struct{})
 	go func() {
+		close(stopStarted)
 		defer close(stopDone)
 		eb.Stop()
 	}()
+	<-stopStarted
 
 	select {
 	case <-stopDone:


### PR DESCRIPTION
1. Made changes to an event bus shutdown race where Stop() could return while Publish() was still delivering to subscribers.
2. Publish() now holds the event bus stop lock for the full delivery path, so shutdown waits for in-flight publishes before closing subscriber channels.
3. Added a unit test to verify the Stop() blocks until an active publish completes.


Closes #1852

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shutdown race in the `event` bus (fixes #1852): `Stop()` now blocks until any in‑flight `Publish`/`PublishAsync` completes, holding the stop lock through delivery/enqueue so subscribers and the async queue aren’t closed mid‑flight. Adds a regression test with a blocking subscriber and synchronized assertions to verify `Stop()` waits for delivery to finish and only closes after `Deliver` completes.

<sup>Written for commit 5114202e8a0e2753ef6b2c21b32461321ef5da08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hard fork era shape configuration and automatic protocol version-based era selection.
  * Implemented automatic Byron AVVM UTxO cleanup and DRep delegation clearing during protocol upgrades.
  * Enhanced committee quorum management with clearing support.
  * Added batch metadata flushing for improved database operations.
  * Improved inbound peer governance with topology matching and duplex mode detection.

* **Bug Fixes**
  * Fixed rollback-loop suppression to correctly distinguish rollbacks from different peer connections.
  * Corrected VRF nonce computation to use the block slot's epoch instead of current epoch.
  * Enhanced Mithril snapshot recovery detection for incomplete syncs.

* **Improvements**
  * Refined error handling for CBOR reconstruction with new sentinel error type.
  * Streamlined loop structures and goroutine lifecycle management.
  * Optimized era selection and transition logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->