### PR TITLE
feat(peergov): add inbound prune/cooldown policy with recycle reasons

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -510,8 +510,6 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			State:              PeerStateCold,
 			EMAAlpha:           p.config.EMAAlpha,
 			FirstSeen:          now,
-			InboundArrivals:    1,
-			LastInboundArrival: now,
 		}
 		// Add inbound peer
 		p.peers = append(
@@ -524,8 +522,6 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			p.mu.Unlock()
 			return
 		}
-		tmpPeer.InboundArrivals++
-		tmpPeer.LastInboundArrival = now
 		// Record the topology identity once on first rule-2 match and
 		// keep it across subsequent reconnects. Rule-1 matches yield
 		// topologyGroupID == "" and must not clear a prior match.
@@ -542,6 +538,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	if e.IsDuplex {
 		tmpPeer.InboundDuplex = true
 	}
+	tmpPeer.ConnectedAt = now
 	if p.config.ConnManager != nil {
 		conn := p.config.ConnManager.GetConnectionById(e.ConnectionId)
 		if conn != nil {
@@ -623,6 +620,27 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 		peer := p.peers[peerIdx]
 		oldSource := peer.Source
 		oldConn := clonePeerConnection(peer.Connection)
+		connClosedAt := time.Now()
+		if peer.Source == PeerSourceInboundConn {
+			connDur := time.Duration(0)
+			if !peer.ConnectedAt.IsZero() {
+				connDur = connClosedAt.Sub(peer.ConnectedAt)
+			}
+			peer.LastInboundSessionDuration = connDur
+			// Reset burst when reconnects are no longer clustered inside the
+			// inbound cooldown window.
+			if !peer.LastInboundDisconnect.IsZero() &&
+				connClosedAt.Sub(peer.LastInboundDisconnect) >= p.config.InboundCooldown {
+				peer.InboundShortLivedCount = 0
+			}
+			if !peer.ConnectedAt.IsZero() &&
+				connDur < minStableConnectionDuration {
+				peer.InboundShortLivedCount++
+			} else if !peer.ConnectedAt.IsZero() {
+				peer.InboundShortLivedCount = 0
+			}
+			peer.LastInboundDisconnect = connClosedAt
+		}
 		peer.Connection = nil
 		peer.State = PeerStateCold
 		selectionEvents = p.appendChainSelectionEventsLocked(
@@ -632,6 +650,7 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 			oldConn,
 			peer,
 		)
+		peer.ConnectedAt = time.Time{}
 		p.updatePeerMetrics()
 		// Only reconnect for outbound peers that are not on the deny list
 		if peer.Source != PeerSourceInboundConn &&

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -504,12 +504,12 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			return
 		}
 		tmpPeer = &Peer{
-			Address:            address,
-			NormalizedAddress:  normalized,
-			Source:             PeerSourceInboundConn,
-			State:              PeerStateCold,
-			EMAAlpha:           p.config.EMAAlpha,
-			FirstSeen:          now,
+			Address:           address,
+			NormalizedAddress: normalized,
+			Source:            PeerSourceInboundConn,
+			State:             PeerStateCold,
+			EMAAlpha:          p.config.EMAAlpha,
+			FirstSeen:         now,
 		}
 		// Add inbound peer
 		p.peers = append(
@@ -538,7 +538,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	if e.IsDuplex {
 		tmpPeer.InboundDuplex = true
 	}
-	tmpPeer.ConnectedAt = now
+	tmpPeer.InboundConnectedAt = now
 	if p.config.ConnManager != nil {
 		conn := p.config.ConnManager.GetConnectionById(e.ConnectionId)
 		if conn != nil {
@@ -623,8 +623,8 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 		connClosedAt := time.Now()
 		if peer.Source == PeerSourceInboundConn {
 			connDur := time.Duration(0)
-			if !peer.ConnectedAt.IsZero() {
-				connDur = connClosedAt.Sub(peer.ConnectedAt)
+			if !peer.InboundConnectedAt.IsZero() {
+				connDur = connClosedAt.Sub(peer.InboundConnectedAt)
 			}
 			peer.LastInboundSessionDuration = connDur
 			// Reset burst when reconnects are no longer clustered inside the
@@ -633,13 +633,14 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 				connClosedAt.Sub(peer.LastInboundDisconnect) >= p.config.InboundCooldown {
 				peer.InboundShortLivedCount = 0
 			}
-			if !peer.ConnectedAt.IsZero() &&
+			if !peer.InboundConnectedAt.IsZero() &&
 				connDur < minStableConnectionDuration {
 				peer.InboundShortLivedCount++
-			} else if !peer.ConnectedAt.IsZero() {
+			} else if !peer.InboundConnectedAt.IsZero() {
 				peer.InboundShortLivedCount = 0
 			}
 			peer.LastInboundDisconnect = connClosedAt
+			peer.InboundConnectedAt = time.Time{}
 		}
 		peer.Connection = nil
 		peer.State = PeerStateCold
@@ -650,7 +651,9 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 			oldConn,
 			peer,
 		)
-		peer.ConnectedAt = time.Time{}
+		if peer.Source != PeerSourceInboundConn {
+			peer.ConnectedAt = time.Time{}
+		}
 		p.updatePeerMetrics()
 		// Only reconnect for outbound peers that are not on the deny list
 		if peer.Source != PeerSourceInboundConn &&

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -54,6 +54,7 @@ type peerGovernorMetrics struct {
 	inboundArrivalsTotal   prometheus.Counter
 	inboundTopologyMatched prometheus.Gauge
 	inboundDuplexHeld      prometheus.Gauge
+	inboundPrunedByReason  *prometheus.CounterVec
 }
 
 func (p *PeerGovernor) initMetrics() {
@@ -204,6 +205,13 @@ func (p *PeerGovernor) initMetrics() {
 			Name: "cardano_node_metrics_peerSelection_InboundDuplexHeld",
 			Help: "current number of inbound peers on full-duplex connections",
 		},
+	)
+	p.metrics.inboundPrunedByReason = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_peerSelection_InboundPrunedByReason",
+			Help: "total inbound peers pruned by policy reason",
+		},
+		[]string{"reason"},
 	)
 }
 

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -97,6 +97,7 @@ type Peer struct {
 	ConnectionStability     float64 // Connection stability score 0..1
 	ReconnectDelay          time.Duration
 	ConnectedAt             time.Time // When current outbound connection was established
+	InboundConnectedAt      time.Time // When current inbound connection was established
 	PerformanceScore        float64   // Composite score from the above metrics
 	ReconnectCount          int
 	Reconnecting            bool // Whether a reconnect goroutine is active for this peer

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -136,14 +136,16 @@ type Peer struct {
 	// from Connection.IsClient because it is retained across brief
 	// reconnects within the provisional window.
 	InboundDuplex bool
-	// InboundArrivals is the number of distinct inbound connection
-	// events observed for this peer identity since the process started.
-	// A value > 1 indicates a repeat arrival (the peer was already
-	// known when the event fired).
-	InboundArrivals uint32
-	// LastInboundArrival is the wall-clock time of the most recent
-	// inbound connection event matched to this peer.
-	LastInboundArrival time.Time
+	// InboundShortLivedCount counts consecutive short-lived inbound
+	// sessions (duration < minStableConnectionDuration). This drives
+	// flapping cooldown decisions.
+	InboundShortLivedCount uint32
+	// LastInboundDisconnect is when the most recent inbound connection
+	// for this peer closed.
+	LastInboundDisconnect time.Time
+	// LastInboundSessionDuration is the duration of the most recently
+	// closed inbound session.
+	LastInboundSessionDuration time.Duration
 	// InboundTopologyMatch records the GroupID of the configured
 	// topology peer that an inbound arrival was identified as, via the
 	// safe host-match rule in resolveInboundIdentity. Empty when no

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4685,14 +4685,14 @@ func TestPeerGovernor_IsInboundEligibleForHot_RejectsFlappingPeer(t *testing.T) 
 	pg.mu.Lock()
 	defer pg.mu.Unlock()
 	peer := &Peer{
-		Source:              PeerSourceInboundConn,
-		State:               PeerStateWarm,
-		Connection:          &PeerConnection{IsClient: true},
-		PerformanceScore:    0.9,
-		FirstSeen:           time.Now().Add(-time.Hour),
-		ChainSyncLastUpdate: time.Now(),
-		TipSlotDeltaInit:    true,
-		TipSlotDelta:        0,
+		Source:                 PeerSourceInboundConn,
+		State:                  PeerStateWarm,
+		Connection:             &PeerConnection{IsClient: true},
+		PerformanceScore:       0.9,
+		FirstSeen:              time.Now().Add(-time.Hour),
+		ChainSyncLastUpdate:    time.Now(),
+		TipSlotDeltaInit:       true,
+		TipSlotDelta:           0,
 		InboundShortLivedCount: 3,
 		LastInboundDisconnect:  time.Now(),
 	}
@@ -4731,11 +4731,11 @@ func TestPeerGovernor_Reconcile_PrunesIdleInboundWarmPeer(t *testing.T) {
 	_, recycleCh := eventBus.Subscribe(connmanager.ConnectionRecycleRequestedEventType)
 	_, removedCh := eventBus.Subscribe(PeerRemovedEventType)
 	pg := NewPeerGovernor(PeerGovernorConfig{
-		Logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:                eventBus,
-		InboundPruneAfter:       time.Minute,
-		InboundCooldown:         5 * time.Minute,
-		TargetNumberOfKnownPeers: -1,
+		Logger:                         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                       eventBus,
+		InboundPruneAfter:              time.Minute,
+		InboundCooldown:                5 * time.Minute,
+		TargetNumberOfKnownPeers:       -1,
 		TargetNumberOfEstablishedPeers: -1,
 		TargetNumberOfActivePeers:      -1,
 	})
@@ -4747,13 +4747,13 @@ func TestPeerGovernor_Reconcile_PrunesIdleInboundWarmPeer(t *testing.T) {
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:            "192.168.50.2:3001",
-			NormalizedAddress:  "192.168.50.2:3001",
-			Source:             PeerSourceInboundConn,
-			State:              PeerStateWarm,
-			Connection:         &PeerConnection{Id: connID, IsClient: true},
-			FirstSeen:          now.Add(-2 * time.Hour),
-			LastActivity:       now.Add(-2 * time.Hour),
+			Address:           "192.168.50.2:3001",
+			NormalizedAddress: "192.168.50.2:3001",
+			Source:            PeerSourceInboundConn,
+			State:             PeerStateWarm,
+			Connection:        &PeerConnection{Id: connID, IsClient: true},
+			FirstSeen:         now.Add(-2 * time.Hour),
+			LastActivity:      now.Add(-2 * time.Hour),
 		},
 	}
 	pg.mu.Unlock()
@@ -4794,12 +4794,12 @@ func TestPeerGovernor_Reconcile_AppliesEscalatingInboundCooldownForFlappingPeer(
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:            addr,
-			NormalizedAddress:  addr,
-			Source:             PeerSourceInboundConn,
-			State:              PeerStateWarm,
-			FirstSeen:          now.Add(-time.Hour),
-			LastActivity:       now.Add(-time.Hour),
+			Address:                addr,
+			NormalizedAddress:      addr,
+			Source:                 PeerSourceInboundConn,
+			State:                  PeerStateWarm,
+			FirstSeen:              now.Add(-time.Hour),
+			LastActivity:           now.Add(-time.Hour),
 			LastInboundDisconnect:  now.Add(-30 * time.Second),
 			InboundShortLivedCount: 4,
 		},
@@ -4823,9 +4823,9 @@ func TestPeerGovernor_Reconcile_AppliesEscalatingInboundCooldownForFlappingPeer(
 
 func TestPeerGovernor_Reconcile_DoesNotPruneUsefulTopologyInboundDuplexPeer(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
-		Logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		InboundPruneAfter:       time.Minute,
-		TargetNumberOfKnownPeers: -1,
+		Logger:                         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter:              time.Minute,
+		TargetNumberOfKnownPeers:       -1,
 		TargetNumberOfEstablishedPeers: -1,
 		TargetNumberOfActivePeers:      -1,
 	})
@@ -4833,16 +4833,16 @@ func TestPeerGovernor_Reconcile_DoesNotPruneUsefulTopologyInboundDuplexPeer(t *t
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:             "44.0.0.2:3001",
-			NormalizedAddress:   "44.0.0.2:3001",
-			Source:              PeerSourceTopologyLocalRoot,
-			State:               PeerStateWarm,
-			Connection:          &PeerConnection{IsClient: true},
-			FirstSeen:           now.Add(-2 * time.Hour),
-			LastActivity:        now.Add(-2 * time.Hour),
-			InboundDuplex:       true,
+			Address:              "44.0.0.2:3001",
+			NormalizedAddress:    "44.0.0.2:3001",
+			Source:               PeerSourceTopologyLocalRoot,
+			State:                PeerStateWarm,
+			Connection:           &PeerConnection{IsClient: true},
+			FirstSeen:            now.Add(-2 * time.Hour),
+			LastActivity:         now.Add(-2 * time.Hour),
+			InboundDuplex:        true,
 			InboundTopologyMatch: "local-root-0",
-			GroupID:             "local-root-0",
+			GroupID:              "local-root-0",
 		},
 	}
 	pg.mu.Unlock()
@@ -4855,10 +4855,10 @@ func TestPeerGovernor_Reconcile_DoesNotPruneUsefulTopologyInboundDuplexPeer(t *t
 
 func TestPeerGovernor_Reconcile_IdleInboundPruneDoesNotApplyCooldownDeny(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
-		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		InboundPruneAfter:         time.Minute,
-		InboundCooldown:           5 * time.Minute,
-		TargetNumberOfKnownPeers:  -1,
+		Logger:                         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter:              time.Minute,
+		InboundCooldown:                5 * time.Minute,
+		TargetNumberOfKnownPeers:       -1,
 		TargetNumberOfEstablishedPeers: -1,
 		TargetNumberOfActivePeers:      -1,
 	})
@@ -4867,12 +4867,12 @@ func TestPeerGovernor_Reconcile_IdleInboundPruneDoesNotApplyCooldownDeny(t *test
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:            addr,
-			NormalizedAddress:  addr,
-			Source:             PeerSourceInboundConn,
-			State:              PeerStateWarm,
-			FirstSeen:          now.Add(-2 * time.Hour),
-			LastActivity:       now.Add(-2 * time.Hour),
+			Address:                addr,
+			NormalizedAddress:      addr,
+			Source:                 PeerSourceInboundConn,
+			State:                  PeerStateWarm,
+			FirstSeen:              now.Add(-2 * time.Hour),
+			LastActivity:           now.Add(-2 * time.Hour),
 			LastInboundDisconnect:  now.Add(-2 * time.Hour),
 			InboundShortLivedCount: 1, // Not flapping; should not trigger cooldown deny
 		},
@@ -4890,11 +4890,11 @@ func TestPeerGovernor_Reconcile_IdleInboundPruneDoesNotApplyCooldownDeny(t *test
 
 func TestPeerGovernor_Reconcile_KeepsUsefulInboundWarmPeerPastPruneAfter(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
-		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		InboundPruneAfter:        time.Minute,
-		InboundHotScoreThreshold: 0.6,
-		InboundMinTenure:         10 * time.Minute,
-		TargetNumberOfKnownPeers: -1,
+		Logger:                         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter:              time.Minute,
+		InboundHotScoreThreshold:       0.6,
+		InboundMinTenure:               10 * time.Minute,
+		TargetNumberOfKnownPeers:       -1,
 		TargetNumberOfEstablishedPeers: -1,
 		TargetNumberOfActivePeers:      -1,
 	})
@@ -4903,18 +4903,18 @@ func TestPeerGovernor_Reconcile_KeepsUsefulInboundWarmPeerPastPruneAfter(t *test
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:              addr,
-			NormalizedAddress:    addr,
-			Source:               PeerSourceInboundConn,
-			State:                PeerStateWarm,
-			Connection:           &PeerConnection{IsClient: true},
-			FirstSeen:            now.Add(-2 * time.Hour),
-			LastActivity:         now.Add(-2 * time.Hour),
-			LastInboundDisconnect: now.Add(-2 * time.Hour),
-			PerformanceScore:     0.95,
-			ChainSyncLastUpdate:  now, // Fresh usefulness signal
-			TipSlotDeltaInit:     true,
-			TipSlotDelta:         0,
+			Address:                addr,
+			NormalizedAddress:      addr,
+			Source:                 PeerSourceInboundConn,
+			State:                  PeerStateWarm,
+			Connection:             &PeerConnection{IsClient: true},
+			FirstSeen:              now.Add(-2 * time.Hour),
+			LastActivity:           now.Add(-2 * time.Hour),
+			LastInboundDisconnect:  now.Add(-2 * time.Hour),
+			PerformanceScore:       0.95,
+			ChainSyncLastUpdate:    now, // Fresh usefulness signal
+			TipSlotDeltaInit:       true,
+			TipSlotDelta:           0,
 			InboundShortLivedCount: 1,
 		},
 	}
@@ -4954,13 +4954,13 @@ func TestPeerGovernor_Reconcile_FlappingCooldownReasonMetricAndCap(t *testing.T)
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:            addr,
-			NormalizedAddress:  addr,
-			Source:             PeerSourceInboundConn,
-			State:              PeerStateWarm,
-			Connection:         &PeerConnection{Id: connID, IsClient: true},
-			FirstSeen:          now.Add(-2 * time.Hour),
-			LastActivity:       now.Add(-2 * time.Hour),
+			Address:                addr,
+			NormalizedAddress:      addr,
+			Source:                 PeerSourceInboundConn,
+			State:                  PeerStateWarm,
+			Connection:             &PeerConnection{Id: connID, IsClient: true},
+			FirstSeen:              now.Add(-2 * time.Hour),
+			LastActivity:           now.Add(-2 * time.Hour),
 			LastInboundDisconnect:  now.Add(-10 * time.Second),
 			InboundShortLivedCount: 10, // Should cap multiplier at 5
 		},
@@ -5010,12 +5010,12 @@ func TestPeerGovernor_Reconcile_DoesNotCooldownSecondInboundArrival(t *testing.T
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
-			Address:            addr,
-			NormalizedAddress:  addr,
-			Source:             PeerSourceInboundConn,
-			State:              PeerStateWarm,
-			FirstSeen:          now.Add(-time.Hour),
-			LastActivity:       now.Add(-time.Hour),
+			Address:                addr,
+			NormalizedAddress:      addr,
+			Source:                 PeerSourceInboundConn,
+			State:                  PeerStateWarm,
+			FirstSeen:              now.Add(-time.Hour),
+			LastActivity:           now.Add(-time.Hour),
 			LastInboundDisconnect:  now.Add(-10 * time.Second),
 			InboundShortLivedCount: 1, // single short-lived prior session should not trigger flapping
 		},
@@ -6839,7 +6839,7 @@ func TestHandleInboundConnection_TopologyHostMatch(t *testing.T) {
 		"source must remain topology; inbound does not downgrade identity")
 	assert.Equal(t, "local-root-0", peer.InboundTopologyMatch,
 		"matched topology GroupID must be recorded")
-	assert.False(t, peer.ConnectedAt.IsZero())
+	assert.False(t, peer.InboundConnectedAt.IsZero())
 	assert.True(t, peer.InboundDuplex,
 		"event-carried IsDuplex must be recorded when no connmanager is wired")
 }
@@ -6888,7 +6888,7 @@ func TestHandleInboundConnection_AmbiguousHostCreatesNewPeer(t *testing.T) {
 	assert.True(t, foundInbound, "new inbound peer must be created")
 }
 
-func TestHandleInboundConnection_ReArrivalKeepsFirstSeenAndRefreshesConnectedAt(t *testing.T) {
+func TestHandleInboundConnection_ReArrivalKeepsFirstSeenAndRefreshesInboundConnectedAt(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:     newMockEventBus(),
@@ -6912,17 +6912,17 @@ func TestHandleInboundConnection_ReArrivalKeepsFirstSeenAndRefreshesConnectedAt(
 	first := pg.GetPeers()
 	require.Len(t, first, 1)
 	firstSeen := first[0].FirstSeen
-	firstConnectedAt := first[0].ConnectedAt
+	firstConnectedAt := first[0].InboundConnectedAt
 	require.False(t, firstConnectedAt.IsZero())
 
-	// Re-arrival should refresh ConnectedAt while preserving identity fields.
+	// Re-arrival should refresh InboundConnectedAt while preserving identity fields.
 	pg.handleInboundConnectionEvent(evt)
 	second := pg.GetPeers()
 	require.Len(t, second, 1, "re-arrival must not spawn a second peer entry")
 	assert.Equal(t, firstSeen, second[0].FirstSeen,
 		"FirstSeen must not move on re-arrival")
-	assert.False(t, second[0].ConnectedAt.Before(firstConnectedAt),
-		"ConnectedAt must not go backwards on re-arrival")
+	assert.False(t, second[0].InboundConnectedAt.Before(firstConnectedAt),
+		"InboundConnectedAt must not go backwards on re-arrival")
 }
 
 func TestHandleInboundConnection_TopologyMatchPersistsOnReArrival(t *testing.T) {
@@ -7105,7 +7105,7 @@ func TestCensusInboundCounts_DuplexRequiresLiveConnection(t *testing.T) {
 		Source:            PeerSourceInboundConn,
 		State:             PeerStateWarm,
 		FirstSeen:         time.Now().Add(-time.Hour),
-		InboundDuplex: true,
+		InboundDuplex:     true,
 	})
 	census := pg.censusInboundCounts()
 	pg.mu.Unlock()

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4693,12 +4693,12 @@ func TestPeerGovernor_IsInboundEligibleForHot_RejectsFlappingPeer(t *testing.T) 
 		ChainSyncLastUpdate: time.Now(),
 		TipSlotDeltaInit:    true,
 		TipSlotDelta:        0,
-		InboundArrivals:     3,
-		LastInboundArrival:  time.Now(),
+		InboundShortLivedCount: 3,
+		LastInboundDisconnect:  time.Now(),
 	}
 	assert.False(t, pg.isInboundEligibleForHot(peer),
 		"recent re-arrivals within cooldown must be treated as unstable")
-	peer.LastInboundArrival = time.Now().Add(-10 * time.Minute)
+	peer.LastInboundDisconnect = time.Now().Add(-10 * time.Minute)
 	assert.True(t, pg.isInboundEligibleForHot(peer),
 		"once cooldown passes, peer can be promoted again")
 }
@@ -4753,7 +4753,6 @@ func TestPeerGovernor_Reconcile_PrunesIdleInboundWarmPeer(t *testing.T) {
 			State:              PeerStateWarm,
 			Connection:         &PeerConnection{Id: connID, IsClient: true},
 			FirstSeen:          now.Add(-2 * time.Hour),
-			LastInboundArrival: now.Add(-2 * time.Hour),
 			LastActivity:       now.Add(-2 * time.Hour),
 		},
 	}
@@ -4801,8 +4800,8 @@ func TestPeerGovernor_Reconcile_AppliesEscalatingInboundCooldownForFlappingPeer(
 			State:              PeerStateWarm,
 			FirstSeen:          now.Add(-time.Hour),
 			LastActivity:       now.Add(-time.Hour),
-			LastInboundArrival: now.Add(-30 * time.Second),
-			InboundArrivals:    4,
+			LastInboundDisconnect:  now.Add(-30 * time.Second),
+			InboundShortLivedCount: 4,
 		},
 	}
 	pg.mu.Unlock()
@@ -4841,7 +4840,6 @@ func TestPeerGovernor_Reconcile_DoesNotPruneUsefulTopologyInboundDuplexPeer(t *t
 			Connection:          &PeerConnection{IsClient: true},
 			FirstSeen:           now.Add(-2 * time.Hour),
 			LastActivity:        now.Add(-2 * time.Hour),
-			LastInboundArrival:  now.Add(-2 * time.Hour),
 			InboundDuplex:       true,
 			InboundTopologyMatch: "local-root-0",
 			GroupID:             "local-root-0",
@@ -4875,8 +4873,8 @@ func TestPeerGovernor_Reconcile_IdleInboundPruneDoesNotApplyCooldownDeny(t *test
 			State:              PeerStateWarm,
 			FirstSeen:          now.Add(-2 * time.Hour),
 			LastActivity:       now.Add(-2 * time.Hour),
-			LastInboundArrival: now.Add(-2 * time.Hour),
-			InboundArrivals:    1, // Not flapping; should not trigger cooldown deny
+			LastInboundDisconnect:  now.Add(-2 * time.Hour),
+			InboundShortLivedCount: 1, // Not flapping; should not trigger cooldown deny
 		},
 	}
 	pg.mu.Unlock()
@@ -4912,12 +4910,12 @@ func TestPeerGovernor_Reconcile_KeepsUsefulInboundWarmPeerPastPruneAfter(t *test
 			Connection:           &PeerConnection{IsClient: true},
 			FirstSeen:            now.Add(-2 * time.Hour),
 			LastActivity:         now.Add(-2 * time.Hour),
-			LastInboundArrival:   now.Add(-2 * time.Hour),
+			LastInboundDisconnect: now.Add(-2 * time.Hour),
 			PerformanceScore:     0.95,
 			ChainSyncLastUpdate:  now, // Fresh usefulness signal
 			TipSlotDeltaInit:     true,
 			TipSlotDelta:         0,
-			InboundArrivals:      1,
+			InboundShortLivedCount: 1,
 		},
 	}
 	pg.mu.Unlock()
@@ -4963,8 +4961,8 @@ func TestPeerGovernor_Reconcile_FlappingCooldownReasonMetricAndCap(t *testing.T)
 			Connection:         &PeerConnection{Id: connID, IsClient: true},
 			FirstSeen:          now.Add(-2 * time.Hour),
 			LastActivity:       now.Add(-2 * time.Hour),
-			LastInboundArrival: now.Add(-10 * time.Second),
-			InboundArrivals:    10, // Should cap multiplier at 5
+			LastInboundDisconnect:  now.Add(-10 * time.Second),
+			InboundShortLivedCount: 10, // Should cap multiplier at 5
 		},
 	}
 	pg.mu.Unlock()
@@ -4998,6 +4996,79 @@ func TestPeerGovernor_Reconcile_FlappingCooldownReasonMetricAndCap(t *testing.T)
 	maxExpected := end.Add(10*time.Minute + 2*time.Second)
 	assert.True(t, expiry.After(minExpected) || expiry.Equal(minExpected))
 	assert.True(t, expiry.Before(maxExpected) || expiry.Equal(maxExpected))
+}
+
+func TestPeerGovernor_Reconcile_DoesNotCooldownSecondInboundArrival(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter: time.Minute,
+		InboundCooldown:   2 * time.Minute,
+		DenyDuration:      30 * time.Second,
+	})
+	now := time.Now()
+	addr := "192.168.73.2:3001"
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:            addr,
+			NormalizedAddress:  addr,
+			Source:             PeerSourceInboundConn,
+			State:              PeerStateWarm,
+			FirstSeen:          now.Add(-time.Hour),
+			LastActivity:       now.Add(-time.Hour),
+			LastInboundDisconnect:  now.Add(-10 * time.Second),
+			InboundShortLivedCount: 1, // single short-lived prior session should not trigger flapping
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1, "single reconnect should not trigger flapping cooldown prune")
+	pg.mu.Lock()
+	_, denied := pg.denyList[addr]
+	pg.mu.Unlock()
+	assert.False(t, denied, "single reconnect should not apply cooldown deny")
+}
+
+func TestPeerGovernor_Reconcile_InboundLimitExceededReasonMetric(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:                   reg,
+		TargetNumberOfKnownPeers:       1,
+		TargetNumberOfEstablishedPeers: -1,
+		TargetNumberOfActivePeers:      -1,
+		InboundPruneAfter:              time.Hour, // Avoid prune path to isolate limit path
+	})
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:           "192.168.74.2:3001",
+			NormalizedAddress: "192.168.74.2:3001",
+			Source:            PeerSourceInboundConn,
+			State:             PeerStateCold,
+		},
+		{
+			Address:           "192.168.74.3:3001",
+			NormalizedAddress: "192.168.74.3:3001",
+			Source:            PeerSourceInboundConn,
+			State:             PeerStateCold,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.inboundPrunedByReason.WithLabelValues("limit_exceeded"),
+		),
+		"limit exceeded inbound prune should increment reason metric",
+	)
 }
 
 func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {
@@ -6768,8 +6839,7 @@ func TestHandleInboundConnection_TopologyHostMatch(t *testing.T) {
 		"source must remain topology; inbound does not downgrade identity")
 	assert.Equal(t, "local-root-0", peer.InboundTopologyMatch,
 		"matched topology GroupID must be recorded")
-	assert.Equal(t, uint32(1), peer.InboundArrivals)
-	assert.False(t, peer.LastInboundArrival.IsZero())
+	assert.False(t, peer.ConnectedAt.IsZero())
 	assert.True(t, peer.InboundDuplex,
 		"event-carried IsDuplex must be recorded when no connmanager is wired")
 }
@@ -6818,7 +6888,7 @@ func TestHandleInboundConnection_AmbiguousHostCreatesNewPeer(t *testing.T) {
 	assert.True(t, foundInbound, "new inbound peer must be created")
 }
 
-func TestHandleInboundConnection_ReArrivalIncrementsArrivals(t *testing.T) {
+func TestHandleInboundConnection_ReArrivalKeepsFirstSeenAndRefreshesConnectedAt(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:     newMockEventBus(),
@@ -6842,20 +6912,17 @@ func TestHandleInboundConnection_ReArrivalIncrementsArrivals(t *testing.T) {
 	first := pg.GetPeers()
 	require.Len(t, first, 1)
 	firstSeen := first[0].FirstSeen
-	firstArrival := first[0].LastInboundArrival
-	require.Equal(t, uint32(1), first[0].InboundArrivals)
+	firstConnectedAt := first[0].ConnectedAt
+	require.False(t, firstConnectedAt.IsZero())
 
-	// Small real delay so the monotonic component advances; we only
-	// need LastInboundArrival to strictly increase, which time.Now()
-	// guarantees on the next call under Go's monotonic clock.
+	// Re-arrival should refresh ConnectedAt while preserving identity fields.
 	pg.handleInboundConnectionEvent(evt)
 	second := pg.GetPeers()
 	require.Len(t, second, 1, "re-arrival must not spawn a second peer entry")
-	assert.Equal(t, uint32(2), second[0].InboundArrivals)
 	assert.Equal(t, firstSeen, second[0].FirstSeen,
 		"FirstSeen must not move on re-arrival")
-	assert.False(t, second[0].LastInboundArrival.Before(firstArrival),
-		"LastInboundArrival must not go backwards")
+	assert.False(t, second[0].ConnectedAt.Before(firstConnectedAt),
+		"ConnectedAt must not go backwards on re-arrival")
 }
 
 func TestHandleInboundConnection_TopologyMatchPersistsOnReArrival(t *testing.T) {
@@ -6902,7 +6969,6 @@ func TestHandleInboundConnection_TopologyMatchPersistsOnReArrival(t *testing.T) 
 	require.Len(t, peers, 1)
 	assert.Equal(t, "local-root-0", peers[0].InboundTopologyMatch,
 		"rule-1 re-arrival must not clobber the existing topology match")
-	assert.Equal(t, uint32(2), peers[0].InboundArrivals)
 }
 
 // TestHandleInboundConnection_TopologyMatchNotClearedByUnrelatedReArrival
@@ -6927,7 +6993,6 @@ func TestHandleInboundConnection_TopologyMatchNotClearedByUnrelatedReArrival(
 		Source:               PeerSourceInboundConn,
 		State:                PeerStateWarm,
 		FirstSeen:            time.Now().Add(-time.Hour),
-		InboundArrivals:      1,
 		InboundTopologyMatch: "local-root-0",
 	})
 	pg.mu.Unlock()
@@ -6948,7 +7013,6 @@ func TestHandleInboundConnection_TopologyMatchNotClearedByUnrelatedReArrival(
 	require.Len(t, peers, 1)
 	assert.Equal(t, "local-root-0", peers[0].InboundTopologyMatch,
 		"re-arrival against a non-topology existing entry must not clear match")
-	assert.Equal(t, uint32(2), peers[0].InboundArrivals)
 }
 
 func TestInboundProvisionalWindow_ExcludesFreshFromCounts(t *testing.T) {
@@ -7041,8 +7105,7 @@ func TestCensusInboundCounts_DuplexRequiresLiveConnection(t *testing.T) {
 		Source:            PeerSourceInboundConn,
 		State:             PeerStateWarm,
 		FirstSeen:         time.Now().Add(-time.Hour),
-		InboundDuplex:     true,
-		InboundArrivals:   1,
+		InboundDuplex: true,
 	})
 	census := pg.censusInboundCounts()
 	pg.mu.Unlock()
@@ -7080,8 +7143,7 @@ func TestHandleConnectionClosedEvent_DuplexCensusDropsOnClose(t *testing.T) {
 			Id:       connId,
 			IsClient: true,
 		},
-		InboundDuplex:   true,
-		InboundArrivals: 1,
+		InboundDuplex: true,
 	})
 	require.Equal(t, 1, pg.censusInboundCounts().Duplex)
 	pg.mu.Unlock()

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4725,6 +4725,281 @@ func TestPeerGovernor_IsInboundEligibleForHot_BlockFetchSignalAlone(t *testing.T
 		"fresh useful blockfetch signal should be sufficient")
 }
 
+func TestPeerGovernor_Reconcile_PrunesIdleInboundWarmPeer(t *testing.T) {
+	eventBus := newMockEventBus()
+	defer eventBus.Stop()
+	_, recycleCh := eventBus.Subscribe(connmanager.ConnectionRecycleRequestedEventType)
+	_, removedCh := eventBus.Subscribe(PeerRemovedEventType)
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:                eventBus,
+		InboundPruneAfter:       time.Minute,
+		InboundCooldown:         5 * time.Minute,
+		TargetNumberOfKnownPeers: -1,
+		TargetNumberOfEstablishedPeers: -1,
+		TargetNumberOfActivePeers:      -1,
+	})
+	now := time.Now()
+	connID := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.50.2"), Port: 3001},
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:            "192.168.50.2:3001",
+			NormalizedAddress:  "192.168.50.2:3001",
+			Source:             PeerSourceInboundConn,
+			State:              PeerStateWarm,
+			Connection:         &PeerConnection{Id: connID, IsClient: true},
+			FirstSeen:          now.Add(-2 * time.Hour),
+			LastInboundArrival: now.Add(-2 * time.Hour),
+			LastActivity:       now.Add(-2 * time.Hour),
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	require.Empty(t, pg.GetPeers(), "idle unhelpful inbound warm peer should be pruned")
+	select {
+	case evt := <-recycleCh:
+		recycleEvt, ok := evt.Data.(connmanager.ConnectionRecycleRequestedEvent)
+		require.True(t, ok)
+		assert.Equal(t, connID, recycleEvt.ConnectionId)
+		assert.Equal(t, "192.168.50.2:3001", recycleEvt.ConnKey)
+		assert.Equal(t, "inbound idle or unhelpful past prune threshold", recycleEvt.Reason)
+	case <-time.After(time.Second):
+		t.Fatal("expected connection recycle request for pruned inbound peer")
+	}
+	select {
+	case evt := <-removedCh:
+		removedEvt, ok := evt.Data.(PeerStateChangeEvent)
+		require.True(t, ok)
+		assert.Equal(t, "192.168.50.2:3001", removedEvt.Address)
+		assert.Equal(t, "inbound idle or unhelpful past prune threshold", removedEvt.Reason)
+	case <-time.After(time.Second):
+		t.Fatal("expected peer removed event for pruned inbound peer")
+	}
+}
+
+func TestPeerGovernor_Reconcile_AppliesEscalatingInboundCooldownForFlappingPeer(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter: time.Minute,
+		InboundCooldown:   2 * time.Minute,
+		DenyDuration:      30 * time.Second,
+	})
+	now := time.Now()
+	addr := "192.168.60.2:3001"
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:            addr,
+			NormalizedAddress:  addr,
+			Source:             PeerSourceInboundConn,
+			State:              PeerStateWarm,
+			FirstSeen:          now.Add(-time.Hour),
+			LastActivity:       now.Add(-time.Hour),
+			LastInboundArrival: now.Add(-30 * time.Second),
+			InboundArrivals:    4,
+		},
+	}
+	pg.mu.Unlock()
+
+	start := time.Now()
+	pg.reconcile(t.Context())
+	end := time.Now()
+
+	require.Empty(t, pg.GetPeers(), "flapping inbound peer should be removed")
+	pg.mu.Lock()
+	expiry, ok := pg.denyList[addr]
+	pg.mu.Unlock()
+	require.True(t, ok, "flapping inbound peer should be cooled down on deny list")
+	minExpected := start.Add(8 * time.Minute)
+	maxExpected := end.Add(8*time.Minute + 2*time.Second)
+	assert.True(t, expiry.After(minExpected) || expiry.Equal(minExpected))
+	assert.True(t, expiry.Before(maxExpected) || expiry.Equal(maxExpected))
+}
+
+func TestPeerGovernor_Reconcile_DoesNotPruneUsefulTopologyInboundDuplexPeer(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter:       time.Minute,
+		TargetNumberOfKnownPeers: -1,
+		TargetNumberOfEstablishedPeers: -1,
+		TargetNumberOfActivePeers:      -1,
+	})
+	now := time.Now()
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:             "44.0.0.2:3001",
+			NormalizedAddress:   "44.0.0.2:3001",
+			Source:              PeerSourceTopologyLocalRoot,
+			State:               PeerStateWarm,
+			Connection:          &PeerConnection{IsClient: true},
+			FirstSeen:           now.Add(-2 * time.Hour),
+			LastActivity:        now.Add(-2 * time.Hour),
+			LastInboundArrival:  now.Add(-2 * time.Hour),
+			InboundDuplex:       true,
+			InboundTopologyMatch: "local-root-0",
+			GroupID:             "local-root-0",
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1, "topology peer must not be pruned by inbound pruning")
+	assert.EqualValues(t, PeerSourceTopologyLocalRoot, peers[0].Source)
+}
+
+func TestPeerGovernor_Reconcile_IdleInboundPruneDoesNotApplyCooldownDeny(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter:         time.Minute,
+		InboundCooldown:           5 * time.Minute,
+		TargetNumberOfKnownPeers:  -1,
+		TargetNumberOfEstablishedPeers: -1,
+		TargetNumberOfActivePeers:      -1,
+	})
+	now := time.Now()
+	addr := "192.168.70.2:3001"
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:            addr,
+			NormalizedAddress:  addr,
+			Source:             PeerSourceInboundConn,
+			State:              PeerStateWarm,
+			FirstSeen:          now.Add(-2 * time.Hour),
+			LastActivity:       now.Add(-2 * time.Hour),
+			LastInboundArrival: now.Add(-2 * time.Hour),
+			InboundArrivals:    1, // Not flapping; should not trigger cooldown deny
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+	require.Empty(t, pg.GetPeers(), "idle inbound peer should be pruned")
+
+	pg.mu.Lock()
+	_, denied := pg.denyList[addr]
+	pg.mu.Unlock()
+	assert.False(t, denied, "idle/unhelpful prune should not add cooldown deny entry")
+}
+
+func TestPeerGovernor_Reconcile_KeepsUsefulInboundWarmPeerPastPruneAfter(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		InboundPruneAfter:        time.Minute,
+		InboundHotScoreThreshold: 0.6,
+		InboundMinTenure:         10 * time.Minute,
+		TargetNumberOfKnownPeers: -1,
+		TargetNumberOfEstablishedPeers: -1,
+		TargetNumberOfActivePeers:      -1,
+	})
+	now := time.Now()
+	addr := "192.168.71.2:3001"
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:              addr,
+			NormalizedAddress:    addr,
+			Source:               PeerSourceInboundConn,
+			State:                PeerStateWarm,
+			Connection:           &PeerConnection{IsClient: true},
+			FirstSeen:            now.Add(-2 * time.Hour),
+			LastActivity:         now.Add(-2 * time.Hour),
+			LastInboundArrival:   now.Add(-2 * time.Hour),
+			PerformanceScore:     0.95,
+			ChainSyncLastUpdate:  now, // Fresh usefulness signal
+			TipSlotDeltaInit:     true,
+			TipSlotDelta:         0,
+			InboundArrivals:      1,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	var kept bool
+	for _, peer := range pg.GetPeers() {
+		if peer.Address == addr {
+			kept = true
+			break
+		}
+	}
+	assert.True(t, kept, "useful inbound peer should not be pruned just for age")
+}
+
+func TestPeerGovernor_Reconcile_FlappingCooldownReasonMetricAndCap(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	eventBus := newMockEventBus()
+	defer eventBus.Stop()
+	_, removedCh := eventBus.Subscribe(PeerRemovedEventType)
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:      reg,
+		EventBus:          eventBus,
+		InboundPruneAfter: time.Minute,
+		InboundCooldown:   2 * time.Minute,
+		DenyDuration:      30 * time.Second,
+	})
+	now := time.Now()
+	addr := "192.168.72.2:3001"
+	connID := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.72.2"), Port: 3001},
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:            addr,
+			NormalizedAddress:  addr,
+			Source:             PeerSourceInboundConn,
+			State:              PeerStateWarm,
+			Connection:         &PeerConnection{Id: connID, IsClient: true},
+			FirstSeen:          now.Add(-2 * time.Hour),
+			LastActivity:       now.Add(-2 * time.Hour),
+			LastInboundArrival: now.Add(-10 * time.Second),
+			InboundArrivals:    10, // Should cap multiplier at 5
+		},
+	}
+	pg.mu.Unlock()
+
+	start := time.Now()
+	pg.reconcile(t.Context())
+	end := time.Now()
+
+	select {
+	case evt := <-removedCh:
+		removedEvt, ok := evt.Data.(PeerStateChangeEvent)
+		require.True(t, ok)
+		assert.Equal(t, "inbound flapping cooldown", removedEvt.Reason)
+	case <-time.After(time.Second):
+		t.Fatal("expected peer removed event for flapping inbound peer")
+	}
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.inboundPrunedByReason.WithLabelValues("flapping_cooldown"),
+		),
+		"flapping prune reason metric should increment",
+	)
+
+	pg.mu.Lock()
+	expiry, ok := pg.denyList[addr]
+	pg.mu.Unlock()
+	require.True(t, ok)
+	minExpected := start.Add(10 * time.Minute) // 2m * min(10,5)
+	maxExpected := end.Add(10*time.Minute + 2*time.Second)
+	assert.True(t, expiry.After(minExpected) || expiry.Equal(minExpected))
+	assert.True(t, expiry.Before(maxExpected) || expiry.Equal(maxExpected))
+}
+
 func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),

--- a/peergov/quotas.go
+++ b/peergov/quotas.go
@@ -529,7 +529,7 @@ func (p *PeerGovernor) inboundSatisfiesTopologyValencyLocked(peer *Peer) bool {
 		peer.GroupID == "" || peer.Valency == 0 {
 		return false
 	}
-	reusableInboundHot := 0
+	var reusableInboundHot uint
 	for _, candidate := range p.peers {
 		if candidate == nil ||
 			candidate.GroupID != peer.GroupID ||
@@ -540,7 +540,7 @@ func (p *PeerGovernor) inboundSatisfiesTopologyValencyLocked(peer *Peer) bool {
 			reusableInboundHot++
 		}
 	}
-	return uint(reusableInboundHot) >= peer.Valency
+	return reusableInboundHot >= peer.Valency
 }
 
 // redistributeUnusedSlots redistributes unused quota slots to other categories.

--- a/peergov/quotas.go
+++ b/peergov/quotas.go
@@ -472,10 +472,8 @@ func (p *PeerGovernor) isInboundEligibleForHot(peer *Peer) bool {
 	if p.config.InboundDuplexOnlyForHot && !peer.hasClientConnection() && !peer.InboundDuplex {
 		return false
 	}
-	// Penalize peers that are reconnect-flapping (multiple arrivals in cooldown).
-	if peer.InboundArrivals > 1 &&
-		!peer.LastInboundArrival.IsZero() &&
-		now.Sub(peer.LastInboundArrival) < p.config.InboundCooldown {
+	// Penalize peers that are reconnect-flapping (repeated short-lived sessions).
+	if flapping, _ := p.inboundFlappingStateLocked(peer, now); flapping {
 		return false
 	}
 	// When observed, connection stability must meet a baseline.
@@ -490,6 +488,24 @@ func (p *PeerGovernor) isInboundEligibleForHot(peer *Peer) bool {
 		peer.BlockFetchSuccessInit &&
 		peer.BlockFetchSuccessRate >= minInboundBlockfetchSuccess
 	return chainSyncUseful || blockFetchUseful
+}
+
+// inboundFlappingStateLocked reports whether an inbound peer is currently
+// reconnect-flapping, and returns a bounded escalation multiplier.
+func (p *PeerGovernor) inboundFlappingStateLocked(
+	peer *Peer,
+	now time.Time,
+) (flapping bool, multiplier int) {
+	if peer == nil || peer.Source != PeerSourceInboundConn {
+		return false, 0
+	}
+	if peer.InboundShortLivedCount < 2 || peer.LastInboundDisconnect.IsZero() {
+		return false, 0
+	}
+	if now.Sub(peer.LastInboundDisconnect) >= p.config.InboundCooldown {
+		return false, 0
+	}
+	return true, min(int(peer.InboundShortLivedCount), 5)
 }
 
 // isReusableInboundTopologyConnectionLocked reports whether this peer currently

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"slices"
 	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
 )
 
 func (p *PeerGovernor) reconcile(ctx context.Context) {
@@ -350,6 +352,10 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 	// This ensures no single source dominates the hot peer slots
 	events = append(events, p.enforcePerSourceQuotas()...)
 
+	// Prune idle/unhelpful inbound warm peers and apply cooldown for
+	// flapping identities before generic state-limit pruning.
+	events = append(events, p.pruneInboundWarmPeersLocked(now, &knownRemoved)...)
+
 	// Log valency status for topology groups
 	if debugEnabled {
 		p.logValencyStatus()
@@ -619,4 +625,121 @@ func (p *PeerGovernor) enforceStateLimit(
 	}
 
 	return events
+}
+
+func (p *PeerGovernor) pruneInboundWarmPeersLocked(
+	now time.Time,
+	removedCount *int,
+) []pendingEvent {
+	var events []pendingEvent
+	for i := len(p.peers) - 1; i >= 0; i-- {
+		peer := p.peers[i]
+		if peer == nil || peer.Source != PeerSourceInboundConn || peer.State != PeerStateWarm {
+			continue
+		}
+		shouldPrune, reason, reasonLabel, cooldownDuration, applyCooldown := p.inboundPruneDecisionLocked(peer, now)
+		if !shouldPrune {
+			continue
+		}
+		oldSource := peer.Source
+		oldConn := clonePeerConnection(peer.Connection)
+		if peer.Connection != nil {
+			events = p.appendChainSelectionEventsLocked(
+				events,
+				p.bootstrapExited,
+				oldSource,
+				oldConn,
+				nil,
+			)
+			events = append(events, pendingEvent{
+				eventType: connmanager.ConnectionRecycleRequestedEventType,
+				data: connmanager.ConnectionRecycleRequestedEvent{
+					ConnectionId: peer.Connection.Id,
+					ConnKey:      peer.NormalizedAddress,
+					Reason:       reason,
+				},
+			})
+		}
+		if applyCooldown {
+			p.denyList[peer.NormalizedAddress] = now.Add(cooldownDuration)
+		}
+		p.config.Logger.Info(
+			"pruned inbound warm peer",
+			"address", peer.Address,
+			"reason", reason,
+			"inbound_arrivals", peer.InboundArrivals,
+			"last_inbound_arrival", peer.LastInboundArrival,
+			"prune_after", p.config.InboundPruneAfter,
+			"cooldown_applied", applyCooldown,
+			"cooldown_duration", cooldownDuration,
+		)
+		events = append(events, pendingEvent{
+			eventType: PeerRemovedEventType,
+			data: PeerStateChangeEvent{
+				Address: peer.Address,
+				Reason:  reason,
+			},
+		})
+		p.peers = slices.Delete(p.peers, i, i+1)
+		p.inboundPruned++
+		*removedCount++
+		if p.metrics != nil {
+			p.metrics.inboundPruned.Inc()
+			p.metrics.inboundPrunedByReason.WithLabelValues(reasonLabel).Inc()
+		}
+	}
+	return events
+}
+
+func (p *PeerGovernor) inboundPruneDecisionLocked(
+	peer *Peer,
+	now time.Time,
+) (
+	shouldPrune bool,
+	reason, reasonLabel string,
+	cooldownDuration time.Duration,
+	applyCooldown bool,
+) {
+	reason = "inbound idle or unhelpful past prune threshold"
+	reasonLabel = "idle_unhelpful"
+	if peer == nil || peer.Source != PeerSourceInboundConn || peer.State != PeerStateWarm {
+		return false, "", "", 0, false
+	}
+	if peer.InboundArrivals > 1 &&
+		!peer.LastInboundArrival.IsZero() &&
+		now.Sub(peer.LastInboundArrival) <= p.config.InboundCooldown {
+		multiplier := min(int(peer.InboundArrivals), 5)
+		cooldownDuration = p.config.InboundCooldown * time.Duration(multiplier)
+		// Keep cooldown at least as long as the normal deny duration.
+		if cooldownDuration < p.config.DenyDuration {
+			cooldownDuration = p.config.DenyDuration
+		}
+		reason = "inbound flapping cooldown"
+		reasonLabel = "flapping_cooldown"
+		applyCooldown = true
+		return true, reason, reasonLabel, cooldownDuration, applyCooldown
+	}
+	lastSignal := peer.FirstSeen
+	if peer.LastActivity.After(lastSignal) {
+		lastSignal = peer.LastActivity
+	}
+	if peer.ChainSyncLastUpdate.After(lastSignal) {
+		lastSignal = peer.ChainSyncLastUpdate
+	}
+	if peer.LastBlockFetchTime.After(lastSignal) {
+		lastSignal = peer.LastBlockFetchTime
+	}
+	if peer.LastInboundArrival.After(lastSignal) {
+		lastSignal = peer.LastInboundArrival
+	}
+	if peer.ConnectedAt.After(lastSignal) {
+		lastSignal = peer.ConnectedAt
+	}
+	if lastSignal.IsZero() || now.Sub(lastSignal) < p.config.InboundPruneAfter {
+		return false, reason, reasonLabel, cooldownDuration, applyCooldown
+	}
+	if p.isInboundEligibleForHot(peer) {
+		return false, reason, reasonLabel, cooldownDuration, applyCooldown
+	}
+	return true, reason, reasonLabel, cooldownDuration, applyCooldown
 }

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -596,6 +596,7 @@ func (p *PeerGovernor) enforceStateLimit(
 			p.inboundPruned++
 			if p.metrics != nil {
 				p.metrics.inboundPruned.Inc()
+				p.metrics.inboundPrunedByReason.WithLabelValues("limit_exceeded").Inc()
 			}
 		}
 	}
@@ -667,8 +668,9 @@ func (p *PeerGovernor) pruneInboundWarmPeersLocked(
 			"pruned inbound warm peer",
 			"address", peer.Address,
 			"reason", reason,
-			"inbound_arrivals", peer.InboundArrivals,
-			"last_inbound_arrival", peer.LastInboundArrival,
+			"inbound_short_lived_count", peer.InboundShortLivedCount,
+			"last_inbound_disconnect", peer.LastInboundDisconnect,
+			"last_inbound_session_duration", peer.LastInboundSessionDuration,
 			"prune_after", p.config.InboundPruneAfter,
 			"cooldown_applied", applyCooldown,
 			"cooldown_duration", cooldownDuration,
@@ -705,10 +707,7 @@ func (p *PeerGovernor) inboundPruneDecisionLocked(
 	if peer == nil || peer.Source != PeerSourceInboundConn || peer.State != PeerStateWarm {
 		return false, "", "", 0, false
 	}
-	if peer.InboundArrivals > 1 &&
-		!peer.LastInboundArrival.IsZero() &&
-		now.Sub(peer.LastInboundArrival) <= p.config.InboundCooldown {
-		multiplier := min(int(peer.InboundArrivals), 5)
+	if flapping, multiplier := p.inboundFlappingStateLocked(peer, now); flapping {
 		cooldownDuration = p.config.InboundCooldown * time.Duration(multiplier)
 		// Keep cooldown at least as long as the normal deny duration.
 		if cooldownDuration < p.config.DenyDuration {
@@ -729,8 +728,8 @@ func (p *PeerGovernor) inboundPruneDecisionLocked(
 	if peer.LastBlockFetchTime.After(lastSignal) {
 		lastSignal = peer.LastBlockFetchTime
 	}
-	if peer.LastInboundArrival.After(lastSignal) {
-		lastSignal = peer.LastInboundArrival
+	if peer.LastInboundDisconnect.After(lastSignal) {
+		lastSignal = peer.LastInboundDisconnect
 	}
 	if peer.ConnectedAt.After(lastSignal) {
 		lastSignal = peer.ConnectedAt


### PR DESCRIPTION
Closes #1934 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbound peer pruning that removes idle or unhelpful inbound connections and requests connection recycle when applicable.
  * Reason-labeled metrics for inbound peers removed (e.g., flapping cooldown, limit exceeded).
  * Session-based flapping detection with automatic, bounded cooldown escalation for restless inbound peers.

* **Tests**
  * Expanded test coverage for pruning, flapping cooldowns, idle retention, reconnect handling, and limit-exceeded cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an inbound prune and cooldown policy in `peergov` to reduce churn and keep only useful inbound peers. Flapping is detected via consecutive short-lived inbound sessions, and prunes emit clear recycle reasons and reason-labeled metrics.

- **New Features**
  - Prune idle/unhelpful inbound warm peers after `InboundPruneAfter` (no cooldown deny).
  - Detect flapping via consecutive short-lived inbound sessions; reset burst after `InboundCooldown`; apply escalating cooldown capped at 5x and not less than `DenyDuration`.
  - Skip pruning for topology-matched inbound duplex peers and those with fresh usefulness signals.
  - Emit `connmanager.ConnectionRecycleRequestedEvent` and `PeerRemovedEvent` with reason strings.
  - Add `cardano_node_metrics_peerSelection_InboundPrunedByReason` counter (labels: `idle_unhelpful`, `flapping_cooldown`, `limit_exceeded`).

<sup>Written for commit 82fc5dbe5e3a00a7f293353a7225bab0c4685373. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

