### PR TITLE
test: add tests and comments verifying era rollover behavior

### DIFF
--- a/chainselection/vrf_test.go
+++ b/chainselection/vrf_test.go
@@ -17,6 +17,8 @@ package chainselection
 import (
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -326,6 +328,41 @@ func TestCompareVRFOutputs_InvalidLength(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// TestGetVRFOutput_ByronReturnsNil pins the cross-era no-tiebreaker
+// invariant for Byron↔Shelley boundaries. Byron blocks have no VRF
+// (PBFT, not Praos), so any chain-selection tie that includes a Byron
+// tip must NOT use a VRF-derived field. The defense in dingo lives in
+// two layers:
+//
+//  1. GetVRFOutput's default branch returns nil for any header type it
+//     does not recognise — Byron is intentionally absent from the type
+//     switch.
+//  2. CompareVRFOutputs treats nil/wrong-length as ChainEqual, falling
+//     through to the connection-id tiebreak in selector.go.
+//
+// Together these implement the same semantic as Haskell's
+// Cardano/CanHardFork.hs:hardForkChainSel, which is `NoTiebreakerAcrossEras`
+// for Byron↔Shelley and `SameTiebreakerAcrossEras` (PraosTiebreakerView)
+// for inter-Shelley boundaries. This test pins layer 1 explicitly via a
+// real Byron header value, so a future addition to GetVRFOutput's switch
+// (e.g. a "Byron returns h.something" case introduced by mistake) fails
+// loudly. The existing nil-VRF cases in TestCompareVRFOutputs cover
+// layer 2.
+func TestGetVRFOutput_ByronReturnsNil(t *testing.T) {
+	byronHeader := &byron.ByronMainBlockHeader{}
+	assert.Nil(t, GetVRFOutput(byronHeader),
+		"Byron headers must yield nil VRF output (no VRF in PBFT)")
+
+	shelleyHeader := &shelley.ShelleyBlockHeader{}
+	cmp := CompareHeaders(byronHeader, shelleyHeader)
+	assert.Equal(t, ChainEqual, cmp,
+		"a tie that includes a Byron tip must not be broken by VRF "+
+			"(NoTiebreakerAcrossEras at Byron↔Shelley)")
+	cmp = CompareHeaders(shelleyHeader, byronHeader)
+	assert.Equal(t, ChainEqual, cmp,
+		"NoTiebreakerAcrossEras must be symmetric")
 }
 
 // Helper function to create a 64-byte VRF output filled with a specific value

--- a/ledger/avvm_removal.go
+++ b/ledger/avvm_removal.go
@@ -37,6 +37,24 @@ import (
 // each output's address and checking for Byron + redeem — lives here
 // because that knowledge is ledger-domain.
 //
+// Divergence from cardano-ledger:
+//
+// Haskell's Shelley ledger stashes the AVVM UTxO set into a dedicated
+// `stashedAVVMAddresses` NewEpochState field at genesis-build time, and
+// Allegra translation consumes that stash via
+// `shelleyToAllegraAVVMsToDelete = stashedAVVMAddresses`, then discards
+// the field. The comment at
+// cardano-ledger/eras/allegra/.../Translation.hs:53-54 is explicit about
+// the reason: a full UTxO scan at the boundary would be prohibitive on a
+// disk-persisted state. Dingo scans the live UTxO instead, which is
+// mainnet-equivalent because no AVVM UTxOs were spent before the
+// Allegra boundary so the live AVVM set equals the stashed set there.
+// On a hypothetical chain where AVVM UTxOs ARE spent pre-Allegra, the
+// scan-based approach is still correct — the stash variant gives the
+// same answer because spent UTxOs are absent from both views — so the
+// divergence is purely an implementation choice driven by dingo's
+// SQLite-backed UTxO model, not a semantic difference.
+//
 // Returns the count and total lovelace of the rows marked deleted.
 func (ls *LedgerState) removeAvvmUtxos(
 	txn *database.Txn,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2710,9 +2710,33 @@ func (ls *LedgerState) processEpochRollover(
 		)
 		return result, nil
 	}
-	// Apply pending pparam updates using the non-mutating version
-	// Updates target the next epoch, so we pass currentEpoch.EpochId + 1
-	// The quorum threshold comes from shelley-genesis.json updateQuorum
+	// EPOCH→HARDFORK ordering invariant.
+	//
+	// The remainder of this function mirrors the sequencing of cardano-
+	// ledger's Conway/Rules/Epoch.hs:374-379 (EPOCH STS), which dispatches
+	// HARDFORK only after enactment + pparams write. The relative order
+	// matters because the HARDFORK rule branch is selected from the new
+	// pparams' major version — a HARDFORK rule that ran before enactment
+	// would observe stale pparams and pick the wrong branch.
+	//
+	// The order, asserted by TestProcessEpochRollover_OrderingInvariant in
+	// chainsync_ordering_test.go, is:
+	//
+	//   1. ComputeAndApplyPParamUpdates  — Shelley-style ppuProtocolVersion
+	//      voting path; produces newPParams from on-chain pparam-update
+	//      proposals.
+	//   2. governance.ProcessEpoch       — Conway-style HardForkInitiation /
+	//      ParameterChange enactment; may further mutate pparams.
+	//   3. SetPParams                    — persist the enacted pparams.
+	//   4. IsHardForkTransition check    — detect inter-era boundary from
+	//      the now-final pparams.
+	//   5. applyIntraEraHardForkRule     — dispatch the per-major-version
+	//      HARDFORK STS rule (e.g. pv3 AVVM removal, pv10 DRep clear).
+	//
+	// Steps 4 and 5 must observe the post-enactment major version. Step 5
+	// must observe the persisted pparams (not just the in-memory ones)
+	// because its body issues SQL within `txn` that may join against
+	// `pparams` rows.
 	updateQuorum := 0
 	if shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis(); shelleyGenesis != nil {
 		updateQuorum = shelleyGenesis.UpdateQuorum

--- a/ledger/chainsync_ordering_test.go
+++ b/ledger/chainsync_ordering_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessEpochRollover_OrderingInvariant pins the EPOCH→HARDFORK call
+// sequence inside processEpochRollover. The order matters for correctness
+// (see the long-form comment at the top of processEpochRollover's body)
+// but is otherwise hard to test through observable side effects without
+// substantial governance + pparams + cert fixture setup.
+//
+// This is a structural lock-in test: it parses chainsync.go's AST, locates
+// the body of processEpochRollover, and asserts that the named call
+// expressions appear in the expected source order. A future refactor that
+// reorders these calls — even if all unit tests pass — will fail this
+// test loudly. The error message points to the comment block that
+// documents the invariant.
+//
+// Markers are matched by suffix on the call's selector expression so that
+// receiver renames (`ls.db` → `ls.metadata`) don't churn the test.
+func TestProcessEpochRollover_OrderingInvariant(t *testing.T) {
+	const targetFunc = "processEpochRollover"
+
+	// In source order, the calls that must appear inside processEpochRollover.
+	// Each entry is the trailing identifier of a SelectorExpr (or a bare
+	// Ident for unqualified calls).
+	wantOrder := []string{
+		"ComputeAndApplyPParamUpdates", // (1) Shelley-style pparam updates
+		"ProcessEpoch",                 // (2) Conway-style governance enact
+		"SetPParams",                   // (3) persist enacted pparams
+		"IsHardForkTransition",         // (4) inter-era boundary detection
+		"applyIntraEraHardForkRule",    // (5) per-major-version HARDFORK rule
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "chainsync.go", nil, parser.SkipObjectResolution)
+	require.NoError(t, err, "parse chainsync.go")
+
+	var fnDecl *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name.Name == targetFunc {
+			fnDecl = fd
+			break
+		}
+	}
+	require.NotNil(t, fnDecl, "%s not found in chainsync.go", targetFunc)
+	require.NotNil(t, fnDecl.Body, "%s has no body", targetFunc)
+
+	// Walk the function body, recording the source position of each
+	// call whose final identifier is in our marker set.
+	wanted := make(map[string]struct{}, len(wantOrder))
+	for _, m := range wantOrder {
+		wanted[m] = struct{}{}
+	}
+	type hit struct {
+		marker string
+		pos    token.Pos
+	}
+	var hits []hit
+	ast.Inspect(fnDecl.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fn.Sel.Name
+		case *ast.Ident:
+			name = fn.Name
+		default:
+			return true
+		}
+		if _, ok := wanted[name]; ok {
+			hits = append(hits, hit{marker: name, pos: call.Pos()})
+		}
+		return true
+	})
+
+	// Build the observed order by first occurrence (a marker can appear
+	// in nested branches; we only care about its first appearance).
+	seen := make(map[string]bool, len(wantOrder))
+	var observed []string
+	for _, h := range hits {
+		if seen[h.marker] {
+			continue
+		}
+		seen[h.marker] = true
+		observed = append(observed, h.marker)
+	}
+
+	for _, m := range wantOrder {
+		require.True(t, seen[m],
+			"marker %q not found in %s body — was it renamed or removed? "+
+				"If renamed, update wantOrder. If removed, also revisit "+
+				"the EPOCH→HARDFORK ordering comment in chainsync.go.",
+			m, targetFunc)
+	}
+
+	// observedFiltered is observed restricted to the wanted markers, in
+	// observed order. (Equivalent to observed today since wanted gates
+	// inclusion above, but keeps the assertion intent explicit.)
+	observedFiltered := observed
+	require.Equal(t, wantOrder, observedFiltered,
+		"call sequence in %s drifted from the EPOCH→HARDFORK ordering "+
+			"invariant. Expected %v, observed %v. See the comment block "+
+			"at the top of the function body for the rationale; if the "+
+			"reorder is intentional, update both the comment and "+
+			"wantOrder in this test.",
+		targetFunc, wantOrder, observedFiltered)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests and comments to pin era rollover behavior and cross-era chain selection. This guards the EPOCH→HARDFORK call order and ensures no VRF tiebreaker across Byron↔Shelley.

- New Tests
  - AST-based test asserts processEpochRollover calls occur in order: ComputeAndApplyPParamUpdates → ProcessEpoch → SetPParams → IsHardForkTransition → applyIntraEraHardForkRule.
  - VRF test confirms GetVRFOutput returns nil for `byron` headers and CompareHeaders yields ChainEqual for Byron↔Shelley ties (no VRF tiebreaker across eras).

- Refactors
  - Added comments in chainsync.go documenting the ordering invariant, and in avvm_removal.go explaining scan-vs-stash AVVM handling and why it matches cardano-ledger semantics.

<sup>Written for commit b06853751e2d69bed3bc3b71cf35ac25e2953a28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

