### PR TITLE
feat(blockfrost): Block and network endpoints

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -127,6 +127,9 @@ func (a *NodeAdapter) BlockByHashOrNumber(
 			ErrInvalidBlockID,
 		)
 	}
+	// Blockfrost accepts Cardano block height here. Dingo's blob block index
+	// is 1-based while Cardano block heights are 0-based, so translate height
+	// to the internal index before lookup.
 	block, err = a.ledgerState.Database().BlockByIndex(
 		height+database.BlockInitialIndex,
 		nil,

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -412,13 +412,16 @@ func (a *NodeAdapter) Network() (NetworkInfo, error) {
 		treasury = uint64(state.Treasury)
 		reserves = uint64(state.Reserves)
 	}
+	// TODO: Wire locked supply from script-address UTxOs and ledger deposits,
+	// then subtract it from circulating supply.
+	locked := uint64(0)
 	total := uint64(0)
 	if reserves <= maxSupply {
 		total = maxSupply - reserves
 	}
 	circulating := uint64(0)
-	if treasury <= total {
-		circulating = total - treasury
+	if treasury+locked <= total {
+		circulating = total - treasury - locked
 	}
 
 	activeStakeEpoch := uint64(0)
@@ -452,7 +455,7 @@ func (a *NodeAdapter) Network() (NetworkInfo, error) {
 				circulating,
 				10,
 			),
-			Locked:   "0",
+			Locked:   strconv.FormatUint(locked, 10),
 			Treasury: strconv.FormatUint(treasury, 10),
 			Reserves: strconv.FormatUint(reserves, 10),
 		},
@@ -481,6 +484,17 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 		}
 		first := epochs[0]
 		last := epochs[len(epochs)-1]
+		params, err := eras.BuildEraParams(
+			a.ledgerState.CardanoNodeConfig(),
+			era,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build era params for %s: %w",
+				era.Name,
+				err,
+			)
+		}
 		startTime, err := a.ledgerState.SlotToTime(first.StartSlot)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -514,7 +528,7 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 			Params: NetworkEraParamsInfo{
 				EpochLength: uint64(last.LengthInSlots),
 				SlotLength:  slotLengthSeconds,
-				SafeZone:    nil,
+				SafeZone:    params.SafeZoneSlots,
 			},
 		})
 	}
@@ -529,9 +543,13 @@ func (a *NodeAdapter) Genesis() (GenesisInfo, error) {
 	}
 	genesis := nodeCfg.ShelleyGenesis()
 	slotLength, _ := genesis.SlotLength.Float64()
+	slotLengthSeconds := int(math.Round(slotLength))
+	if slotLength > 0 && slotLengthSeconds == 0 {
+		slotLengthSeconds = 1
+	}
 	return GenesisInfo{
 		ActiveSlotsCoefficient: float32(a.ledgerState.ActiveSlotCoeff()),
-		UpdateQuorum:           float32(genesis.UpdateQuorum),
+		UpdateQuorum:           genesis.UpdateQuorum,
 		MaxLovelaceSupply: strconv.FormatUint(
 			genesis.MaxLovelaceSupply,
 			10,
@@ -540,7 +558,7 @@ func (a *NodeAdapter) Genesis() (GenesisInfo, error) {
 		EpochLength:       genesis.EpochLength,
 		SystemStart:       int(genesis.SystemStart.Unix()),
 		SlotsPerKESPeriod: genesis.SlotsPerKESPeriod,
-		SlotLength:        int(slotLength),
+		SlotLength:        slotLengthSeconds,
 		MaxKESEvolutions:  genesis.MaxKESEvolutions,
 		SecurityParam:     genesis.SecurityParam,
 	}, nil

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -519,7 +519,11 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 				err,
 			)
 		}
-		slotLengthSeconds := uint64(last.SlotLength) / 1000
+		slotLengthMs := uint64(last.SlotLength)
+		slotLengthSeconds := (slotLengthMs + 500) / 1000
+		if slotLengthMs > 0 && slotLengthSeconds == 0 {
+			slotLengthSeconds = 1
+		}
 		ret = append(ret, NetworkEraInfo{
 			Era: era.Name,
 			Start: NetworkEraBoundInfo{

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -127,6 +127,13 @@ func (a *NodeAdapter) BlockByHashOrNumber(
 			ErrInvalidBlockID,
 		)
 	}
+	if height > math.MaxUint64-database.BlockInitialIndex {
+		return BlockInfo{}, fmt.Errorf(
+			"block height %q overflows internal index: %w",
+			id,
+			ErrInvalidBlockID,
+		)
+	}
 	// Blockfrost accepts Cardano block height here. Dingo's blob block index
 	// is 1-based while Cardano block heights are 0-based, so translate height
 	// to the internal index before lookup.

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -496,7 +495,7 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 				err,
 			)
 		}
-		slotLength := time.Duration(last.SlotLength) * time.Millisecond
+		slotLengthSeconds := uint64(last.SlotLength) / 1000
 		ret = append(ret, NetworkEraInfo{
 			Era: era.Name,
 			Start: NetworkEraBoundInfo{
@@ -511,7 +510,7 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 			},
 			Params: NetworkEraParamsInfo{
 				EpochLength: uint64(last.LengthInSlots),
-				SlotLength:  int64(slotLength / time.Second),
+				SlotLength:  slotLengthSeconds,
 				SafeZone:    nil,
 			},
 		})

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"time"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/ledger"
@@ -37,6 +39,8 @@ import (
 
 var (
 	ErrInvalidAddress = errors.New("invalid address")
+	ErrInvalidBlockID = errors.New("invalid block id")
+	ErrBlockNotFound  = errors.New("block not found")
 	ErrEpochNotFound  = errors.New("epoch not found")
 	ErrAssetNotFound  = errors.New("asset not found")
 )
@@ -80,36 +84,105 @@ func (a *NodeAdapter) LatestBlock() (
 	BlockInfo, error,
 ) {
 	tip := a.ledgerState.Tip()
-	block, decodedBlock, err := a.latestBlockData(
-		tip.Point.Hash,
-	)
+	block, err := a.ledgerState.BlockByHash(tip.Point.Hash)
 	if err != nil {
 		return BlockInfo{}, err
 	}
-	epoch, err := a.ledgerState.SlotToEpoch(tip.Point.Slot)
+	return a.blockInfoFromBlock(block)
+}
+
+// BlockByHashOrNumber returns block information by hash or height.
+func (a *NodeAdapter) BlockByHashOrNumber(
+	id string,
+) (BlockInfo, error) {
+	var block models.Block
+	if len(id) == 64 {
+		hash, err := hex.DecodeString(id)
+		if err != nil {
+			return BlockInfo{}, fmt.Errorf(
+				"decode block hash %q: %w",
+				id,
+				ErrInvalidBlockID,
+			)
+		}
+		var getErr error
+		block, getErr = a.ledgerState.BlockByHash(hash)
+		if getErr != nil {
+			if errors.Is(getErr, models.ErrBlockNotFound) {
+				return BlockInfo{}, fmt.Errorf(
+					"block %s: %w",
+					id,
+					ErrBlockNotFound,
+				)
+			}
+			return BlockInfo{}, getErr
+		}
+		return a.blockInfoFromBlock(block)
+	}
+
+	height, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
 		return BlockInfo{}, fmt.Errorf(
-			"get epoch for tip slot %d: %w",
-			tip.Point.Slot,
+			"parse block height %q: %w",
+			id,
+			ErrInvalidBlockID,
+		)
+	}
+	block, err = a.ledgerState.Database().BlockByIndex(
+		height+database.BlockInitialIndex,
+		nil,
+	)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return BlockInfo{}, fmt.Errorf(
+				"block %s: %w",
+				id,
+				ErrBlockNotFound,
+			)
+		}
+		return BlockInfo{}, err
+	}
+	return a.blockInfoFromBlock(block)
+}
+
+func (a *NodeAdapter) blockInfoFromBlock(
+	block models.Block,
+) (BlockInfo, error) {
+	decodedBlock, err := block.Decode()
+	if err != nil {
+		return BlockInfo{}, fmt.Errorf(
+			"decode block %x: %w",
+			block.Hash,
 			err,
 		)
 	}
-	slotTime, err := a.ledgerState.SlotToTime(tip.Point.Slot)
+	epoch, err := a.ledgerState.SlotToEpoch(block.Slot)
 	if err != nil {
 		return BlockInfo{}, fmt.Errorf(
-			"get time for tip slot %d: %w",
-			tip.Point.Slot,
+			"get epoch for block slot %d: %w",
+			block.Slot,
 			err,
 		)
+	}
+	slotTime, err := a.ledgerState.SlotToTime(block.Slot)
+	if err != nil {
+		return BlockInfo{}, fmt.Errorf(
+			"get time for block slot %d: %w",
+			block.Slot,
+			err,
+		)
+	}
+	tip := a.ledgerState.Tip()
+	confirmations := uint64(0)
+	if tip.BlockNumber >= block.Number {
+		confirmations = tip.BlockNumber - block.Number
 	}
 	return BlockInfo{
-		Hash: hex.EncodeToString(
-			tip.Point.Hash,
-		),
-		Slot:      tip.Point.Slot,
-		Height:    tip.BlockNumber,
+		Hash:      hex.EncodeToString(block.Hash),
+		Slot:      block.Slot,
+		Height:    block.Number,
 		Epoch:     epoch.EpochId,
-		EpochSlot: tip.Point.Slot - epoch.StartSlot,
+		EpochSlot: block.Slot - epoch.StartSlot,
 		Time:      slotTime.Unix(),
 		Size:      uint64(len(block.Cbor)),
 		TxCount:   len(decodedBlock.Transactions()),
@@ -119,7 +192,7 @@ func (a *NodeAdapter) LatestBlock() (
 		PreviousBlock: blockHashString(
 			block.PrevHash,
 		),
-		Confirmations: 0,
+		Confirmations: confirmations,
 	}, nil
 }
 
@@ -318,6 +391,159 @@ func (a *NodeAdapter) EpochProtocolParams(
 	return info, nil
 }
 
+// Network returns current network supply and stake information.
+func (a *NodeAdapter) Network() (NetworkInfo, error) {
+	nodeCfg := a.ledgerState.CardanoNodeConfig()
+	if nodeCfg == nil || nodeCfg.ShelleyGenesis() == nil {
+		return NetworkInfo{}, errors.New("shelley genesis not available")
+	}
+	genesis := nodeCfg.ShelleyGenesis()
+	maxSupply := genesis.MaxLovelaceSupply
+
+	state, err := a.ledgerState.Database().Metadata().GetNetworkState(nil)
+	if err != nil {
+		return NetworkInfo{}, fmt.Errorf("get network state: %w", err)
+	}
+	treasury := uint64(0)
+	reserves := uint64(0)
+	if state != nil {
+		treasury = uint64(state.Treasury)
+		reserves = uint64(state.Reserves)
+	}
+	total := uint64(0)
+	if reserves <= maxSupply {
+		total = maxSupply - reserves
+	}
+	circulating := uint64(0)
+	if treasury <= total {
+		circulating = total - treasury
+	}
+
+	activeStakeEpoch := uint64(0)
+	currentEpoch := a.ledgerState.CurrentEpoch()
+	if currentEpoch >= 2 {
+		activeStakeEpoch = currentEpoch - 2
+	}
+	activeStake, err := a.ledgerState.Database().Metadata().
+		GetTotalActiveStake(activeStakeEpoch, "mark", nil)
+	if err != nil {
+		return NetworkInfo{}, fmt.Errorf(
+			"get active stake for epoch %d: %w",
+			activeStakeEpoch,
+			err,
+		)
+	}
+
+	liveStake, err := a.liveStake()
+	if err != nil {
+		return NetworkInfo{}, err
+	}
+
+	return NetworkInfo{
+		Supply: NetworkSupplyInfo{
+			Max: strconv.FormatUint(maxSupply, 10),
+			Total: strconv.FormatUint(
+				total,
+				10,
+			),
+			Circulating: strconv.FormatUint(
+				circulating,
+				10,
+			),
+			Locked:   "0",
+			Treasury: strconv.FormatUint(treasury, 10),
+			Reserves: strconv.FormatUint(reserves, 10),
+		},
+		Stake: NetworkStakeInfo{
+			Live:   strconv.FormatUint(liveStake, 10),
+			Active: strconv.FormatUint(activeStake, 10),
+		},
+	}, nil
+}
+
+// NetworkEras returns hard-fork era summaries.
+func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
+	ret := make([]NetworkEraInfo, 0, len(eras.Eras))
+	for _, era := range eras.Eras {
+		epochs, err := a.ledgerState.Database().Metadata().
+			GetEpochsByEra(era.Id, nil)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"get epochs for era %s: %w",
+				era.Name,
+				err,
+			)
+		}
+		if len(epochs) == 0 {
+			continue
+		}
+		first := epochs[0]
+		last := epochs[len(epochs)-1]
+		startTime, err := a.ledgerState.SlotToTime(first.StartSlot)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"get era %s start time: %w",
+				era.Name,
+				err,
+			)
+		}
+		endSlot := last.StartSlot + uint64(last.LengthInSlots)
+		endTime, err := a.ledgerState.SlotToTime(endSlot)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"get era %s end time: %w",
+				era.Name,
+				err,
+			)
+		}
+		slotLength := time.Duration(last.SlotLength) * time.Millisecond
+		ret = append(ret, NetworkEraInfo{
+			Era: era.Name,
+			Start: NetworkEraBoundInfo{
+				Time:  startTime.Unix(),
+				Slot:  first.StartSlot,
+				Epoch: first.EpochId,
+			},
+			End: &NetworkEraBoundInfo{
+				Time:  endTime.Unix(),
+				Slot:  endSlot,
+				Epoch: last.EpochId + 1,
+			},
+			Params: NetworkEraParamsInfo{
+				EpochLength: uint64(last.LengthInSlots),
+				SlotLength:  int64(slotLength / time.Second),
+				SafeZone:    nil,
+			},
+		})
+	}
+	return ret, nil
+}
+
+// Genesis returns Shelley genesis configuration values.
+func (a *NodeAdapter) Genesis() (GenesisInfo, error) {
+	nodeCfg := a.ledgerState.CardanoNodeConfig()
+	if nodeCfg == nil || nodeCfg.ShelleyGenesis() == nil {
+		return GenesisInfo{}, errors.New("shelley genesis not available")
+	}
+	genesis := nodeCfg.ShelleyGenesis()
+	slotLength, _ := genesis.SlotLength.Float64()
+	return GenesisInfo{
+		ActiveSlotsCoefficient: float32(a.ledgerState.ActiveSlotCoeff()),
+		UpdateQuorum:           float32(genesis.UpdateQuorum),
+		MaxLovelaceSupply: strconv.FormatUint(
+			genesis.MaxLovelaceSupply,
+			10,
+		),
+		NetworkMagic:      int(genesis.NetworkMagic),
+		EpochLength:       genesis.EpochLength,
+		SystemStart:       int(genesis.SystemStart.Unix()),
+		SlotsPerKESPeriod: genesis.SlotsPerKESPeriod,
+		SlotLength:        int(slotLength),
+		MaxKESEvolutions:  genesis.MaxKESEvolutions,
+		SecurityParam:     genesis.SecurityParam,
+	}, nil
+}
+
 // Asset returns native asset information for a policy ID
 // and raw asset name bytes.
 func (a *NodeAdapter) Asset(
@@ -401,6 +627,30 @@ func (a *NodeAdapter) latestBlockData(
 		)
 	}
 	return block, decodedBlock, nil
+}
+
+func (a *NodeAdapter) liveStake() (uint64, error) {
+	poolKeyHashes, err := a.ledgerState.Database().Metadata().
+		GetActivePoolKeyHashes(nil)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"get active pool key hashes: %w",
+			err,
+		)
+	}
+	if len(poolKeyHashes) == 0 {
+		return 0, nil
+	}
+	stakeByPool, _, err := a.ledgerState.Database().Metadata().
+		GetStakeByPools(poolKeyHashes, nil)
+	if err != nil {
+		return 0, fmt.Errorf("get live stake by pools: %w", err)
+	}
+	total := uint64(0)
+	for _, stake := range stakeByPool {
+		total += stake
+	}
+	return total, nil
 }
 
 // PoolsExtended returns the current active pools with

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -79,6 +79,10 @@ func (b *Blockfrost) Start(
 		b.handleLatestBlockTxs,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/blocks/{hash_or_number}",
+		b.handleBlock,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/epochs/latest",
 		b.handleLatestEpoch,
 	)
@@ -93,6 +97,14 @@ func (b *Blockfrost) Start(
 	mux.HandleFunc(
 		"GET /api/v0/network",
 		b.handleNetwork,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/network/eras",
+		b.handleNetworkEras,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/genesis",
+		b.handleGenesis,
 	)
 	mux.HandleFunc(
 		"GET /api/v0/assets/{asset}",

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -35,10 +35,14 @@ func intPtr(v int) *int {
 type mockNode struct {
 	chainTip               ChainTipInfo
 	block                  BlockInfo
+	blockByID              BlockInfo
 	txHashes               []string
 	epoch                  EpochInfo
 	params                 ProtocolParamsInfo
 	epochParams            ProtocolParamsInfo
+	network                NetworkInfo
+	networkEras            []NetworkEraInfo
+	genesis                GenesisInfo
 	pools                  []PoolExtendedInfo
 	asset                  AssetInfo
 	addressUTXOs           []AddressUTXOInfo
@@ -51,10 +55,14 @@ type mockNode struct {
 	metadataCBORTotal      int
 	chainTipErr            error
 	blockErr               error
+	blockByIDErr           error
 	txHashesErr            error
 	epochErr               error
 	paramsErr              error
 	epochParamsErr         error
+	networkErr             error
+	networkErasErr         error
+	genesisErr             error
 	poolsErr               error
 	assetErr               error
 	addressUTXOsErr        error
@@ -73,6 +81,12 @@ func (m *mockNode) LatestBlock() (
 	BlockInfo, error,
 ) {
 	return m.block, m.blockErr
+}
+
+func (m *mockNode) BlockByHashOrNumber(
+	_ string,
+) (BlockInfo, error) {
+	return m.blockByID, m.blockByIDErr
 }
 
 func (m *mockNode) LatestBlockTxHashes() (
@@ -97,6 +111,24 @@ func (m *mockNode) EpochProtocolParams(
 	_ uint64,
 ) (ProtocolParamsInfo, error) {
 	return m.epochParams, m.epochParamsErr
+}
+
+func (m *mockNode) Network() (
+	NetworkInfo, error,
+) {
+	return m.network, m.networkErr
+}
+
+func (m *mockNode) NetworkEras() (
+	[]NetworkEraInfo, error,
+) {
+	return m.networkEras, m.networkErasErr
+}
+
+func (m *mockNode) Genesis() (
+	GenesisInfo, error,
+) {
+	return m.genesis, m.genesisErr
 }
 
 func (m *mockNode) PoolsExtended() (
@@ -289,6 +321,59 @@ func TestHandleLatestBlock(t *testing.T) {
 	assert.Equal(t, "pool1xyz", resp.SlotLeader)
 	assert.Equal(t, "prev123", resp.PreviousBlock)
 	assert.Equal(t, uint64(10), resp.Confirmations)
+}
+
+func TestHandleBlockByHashOrNumber(t *testing.T) {
+	mock := &mockNode{
+		blockByID: BlockInfo{
+			Hash:          "abc123",
+			Slot:          12345,
+			Epoch:         10,
+			EpochSlot:     345,
+			Height:        1000,
+			Time:          1700000000,
+			Size:          4096,
+			TxCount:       5,
+			SlotLeader:    "pool1...",
+			PreviousBlock: "prevhash",
+			Confirmations: 7,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/blocks/1000",
+		nil,
+	)
+	req.SetPathValue("hash_or_number", "1000")
+	w := httptest.NewRecorder()
+	b.handleBlock(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp BlockResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", resp.Hash)
+	assert.Equal(t, uint64(1000), resp.Height)
+	assert.Equal(t, uint64(7), resp.Confirmations)
+}
+
+func TestHandleBlockNotFound(t *testing.T) {
+	mock := &mockNode{blockByIDErr: ErrBlockNotFound}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/blocks/999999",
+		nil,
+	)
+	req.SetPathValue("hash_or_number", "999999")
+	w := httptest.NewRecorder()
+	b.handleBlock(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestHandleAsset(t *testing.T) {
@@ -805,7 +890,22 @@ func TestHandleEpochParamsNotFound(t *testing.T) {
 }
 
 func TestHandleNetwork(t *testing.T) {
-	mock := &mockNode{}
+	mock := &mockNode{
+		network: NetworkInfo{
+			Supply: NetworkSupplyInfo{
+				Max:         "45000000000000000",
+				Total:       "33000000000000000",
+				Circulating: "32000000000000000",
+				Locked:      "0",
+				Treasury:    "500000000000",
+				Reserves:    "12000000000000000",
+			},
+			Stake: NetworkStakeInfo{
+				Live:   "25000000000000000",
+				Active: "24000000000000000",
+			},
+		},
+	}
 	b := newTestBlockfrost(mock)
 
 	req := httptest.NewRequest(
@@ -828,6 +928,90 @@ func TestHandleNetwork(t *testing.T) {
 	)
 	assert.NotEmpty(t, resp.Stake.Live)
 	assert.NotEmpty(t, resp.Stake.Active)
+	assert.Equal(t, "500000000000", resp.Supply.Treasury)
+	assert.Equal(t, "12000000000000000", resp.Supply.Reserves)
+}
+
+func TestHandleNetworkEras(t *testing.T) {
+	safeZone := uint64(4320)
+	mock := &mockNode{
+		networkEras: []NetworkEraInfo{
+			{
+				Era: "Byron",
+				Start: NetworkEraBoundInfo{
+					Time:  1506203091,
+					Slot:  0,
+					Epoch: 0,
+				},
+				End: &NetworkEraBoundInfo{
+					Time:  1563999616,
+					Slot:  4492800,
+					Epoch: 208,
+				},
+				Params: NetworkEraParamsInfo{
+					EpochLength: 21600,
+					SlotLength:  20,
+					SafeZone:    &safeZone,
+				},
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/network/eras",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleNetworkEras(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []NetworkEraResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "Byron", resp[0].Era)
+	assert.Equal(t, uint64(0), resp[0].Start.Epoch)
+	require.NotNil(t, resp[0].End)
+	assert.Equal(t, uint64(208), resp[0].End.Epoch)
+	assert.Equal(t, uint64(21600), resp[0].Parameters.EpochLength)
+}
+
+func TestHandleGenesis(t *testing.T) {
+	mock := &mockNode{
+		genesis: GenesisInfo{
+			ActiveSlotsCoefficient: 0.05,
+			UpdateQuorum:           5,
+			MaxLovelaceSupply:      "45000000000000000",
+			NetworkMagic:           764824073,
+			EpochLength:            432000,
+			SystemStart:            1506203091,
+			SlotsPerKESPeriod:      129600,
+			SlotLength:             1,
+			MaxKESEvolutions:       62,
+			SecurityParam:          2160,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/genesis",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleGenesis(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GenesisResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "45000000000000000", resp.MaxLovelaceSupply)
+	assert.Equal(t, 764824073, resp.NetworkMagic)
+	assert.Equal(t, 432000, resp.EpochLength)
 }
 
 func TestStopIdempotent(t *testing.T) {

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -933,7 +933,6 @@ func TestHandleNetwork(t *testing.T) {
 }
 
 func TestHandleNetworkEras(t *testing.T) {
-	safeZone := uint64(4320)
 	mock := &mockNode{
 		networkEras: []NetworkEraInfo{
 			{
@@ -951,7 +950,7 @@ func TestHandleNetworkEras(t *testing.T) {
 				Params: NetworkEraParamsInfo{
 					EpochLength: 21600,
 					SlotLength:  20,
-					SafeZone:    &safeZone,
+					SafeZone:    4320,
 				},
 			},
 		},
@@ -977,6 +976,7 @@ func TestHandleNetworkEras(t *testing.T) {
 	require.NotNil(t, resp[0].End)
 	assert.Equal(t, uint64(208), resp[0].End.Epoch)
 	assert.Equal(t, uint64(21600), resp[0].Parameters.EpochLength)
+	assert.Equal(t, uint64(4320), resp[0].Parameters.SafeZone)
 }
 
 func TestHandleGenesis(t *testing.T) {

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -107,25 +107,50 @@ func (b *Blockfrost) handleLatestBlock(
 		)
 		return
 	}
-	output := "0"
-	fees := "0"
-	writeJSON(w, http.StatusOK, BlockResponse{
-		Hash:          info.Hash,
-		Slot:          info.Slot,
-		Epoch:         info.Epoch,
-		EpochSlot:     info.EpochSlot,
-		Height:        info.Height,
-		Time:          info.Time,
-		Size:          info.Size,
-		TxCount:       info.TxCount,
-		SlotLeader:    info.SlotLeader,
-		PreviousBlock: info.PreviousBlock,
-		Confirmations: info.Confirmations,
-		Output:        &output,
-		Fees:          &fees,
-		BlockVRF:      nil,
-		NextBlock:     nil,
-	})
+	writeJSON(w, http.StatusOK, blockResponse(info))
+}
+
+// handleBlock handles GET /api/v0/blocks/{hash_or_number}.
+func (b *Blockfrost) handleBlock(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	info, err := b.node.BlockByHashOrNumber(
+		r.PathValue("hash_or_number"),
+	)
+	if err != nil {
+		if errors.Is(err, ErrInvalidBlockID) {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"Invalid block hash or number.",
+			)
+			return
+		}
+		if errors.Is(err, ErrBlockNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested block could not be found.",
+			)
+			return
+		}
+		b.logger.Error(
+			"failed to get block",
+			"block", r.PathValue("hash_or_number"),
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve block",
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, blockResponse(info))
 }
 
 // handleLatestBlockTxs handles
@@ -267,20 +292,113 @@ func (b *Blockfrost) handleNetwork(
 	w http.ResponseWriter,
 	_ *http.Request,
 ) {
-	// TODO: Wire to real supply/stake data when available
+	info, err := b.node.Network()
+	if err != nil {
+		b.logger.Error(
+			"failed to get network info",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve network information",
+		)
+		return
+	}
 	writeJSON(w, http.StatusOK, NetworkResponse{
 		Supply: NetworkSupply{
-			Max:         "45000000000000000",
-			Total:       "0",
-			Circulating: "0",
-			Locked:      "0",
-			Treasury:    "0",
-			Reserves:    "0",
+			Max:         info.Supply.Max,
+			Total:       info.Supply.Total,
+			Circulating: info.Supply.Circulating,
+			Locked:      info.Supply.Locked,
+			Treasury:    info.Supply.Treasury,
+			Reserves:    info.Supply.Reserves,
 		},
 		Stake: NetworkStake{
-			Live:   "0",
-			Active: "0",
+			Live:   info.Stake.Live,
+			Active: info.Stake.Active,
 		},
+	})
+}
+
+// handleNetworkEras handles GET /api/v0/network/eras.
+func (b *Blockfrost) handleNetworkEras(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	eras, err := b.node.NetworkEras()
+	if err != nil {
+		b.logger.Error(
+			"failed to get network eras",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve network eras",
+		)
+		return
+	}
+	resp := make([]NetworkEraResponse, 0, len(eras))
+	for _, era := range eras {
+		var end *NetworkEraBound
+		if era.End != nil {
+			end = &NetworkEraBound{
+				Time:  era.End.Time,
+				Slot:  era.End.Slot,
+				Epoch: era.End.Epoch,
+			}
+		}
+		resp = append(resp, NetworkEraResponse{
+			Era: era.Era,
+			Start: NetworkEraBound{
+				Time:  era.Start.Time,
+				Slot:  era.Start.Slot,
+				Epoch: era.Start.Epoch,
+			},
+			End: end,
+			Parameters: NetworkEraParameters{
+				EpochLength: era.Params.EpochLength,
+				SlotLength:  era.Params.SlotLength,
+				SafeZone:    era.Params.SafeZone,
+			},
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleGenesis handles GET /api/v0/genesis.
+func (b *Blockfrost) handleGenesis(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	info, err := b.node.Genesis()
+	if err != nil {
+		b.logger.Error(
+			"failed to get genesis info",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve genesis information",
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, GenesisResponse{
+		ActiveSlotsCoefficient: info.ActiveSlotsCoefficient,
+		UpdateQuorum:           info.UpdateQuorum,
+		MaxLovelaceSupply:      info.MaxLovelaceSupply,
+		NetworkMagic:           info.NetworkMagic,
+		EpochLength:            info.EpochLength,
+		SystemStart:            info.SystemStart,
+		SlotsPerKESPeriod:      info.SlotsPerKESPeriod,
+		SlotLength:             info.SlotLength,
+		MaxKESEvolutions:       info.MaxKESEvolutions,
+		SecurityParam:          info.SecurityParam,
 	})
 }
 
@@ -710,6 +828,28 @@ func assetNameASCII(
 		ret = append(ret, b)
 	}
 	return string(ret)
+}
+
+func blockResponse(info BlockInfo) BlockResponse {
+	output := "0"
+	fees := "0"
+	return BlockResponse{
+		Hash:          info.Hash,
+		Slot:          info.Slot,
+		Epoch:         info.Epoch,
+		EpochSlot:     info.EpochSlot,
+		Height:        info.Height,
+		Time:          info.Time,
+		Size:          info.Size,
+		TxCount:       info.TxCount,
+		SlotLeader:    info.SlotLeader,
+		PreviousBlock: info.PreviousBlock,
+		Confirmations: info.Confirmations,
+		Output:        &output,
+		Fees:          &fees,
+		BlockVRF:      nil,
+		NextBlock:     nil,
+	}
 }
 
 func protocolParamsResponse(

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -388,18 +388,7 @@ func (b *Blockfrost) handleGenesis(
 		)
 		return
 	}
-	writeJSON(w, http.StatusOK, GenesisResponse{
-		ActiveSlotsCoefficient: info.ActiveSlotsCoefficient,
-		UpdateQuorum:           info.UpdateQuorum,
-		MaxLovelaceSupply:      info.MaxLovelaceSupply,
-		NetworkMagic:           info.NetworkMagic,
-		EpochLength:            info.EpochLength,
-		SystemStart:            info.SystemStart,
-		SlotsPerKESPeriod:      info.SlotsPerKESPeriod,
-		SlotLength:             info.SlotLength,
-		MaxKESEvolutions:       info.MaxKESEvolutions,
-		SecurityParam:          info.SecurityParam,
-	})
+	writeJSON(w, http.StatusOK, GenesisResponse(info))
 }
 
 // handleAsset handles GET /api/v0/assets/{asset} and

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -204,13 +204,13 @@ type NetworkEraBoundInfo struct {
 type NetworkEraParamsInfo struct {
 	EpochLength uint64
 	SlotLength  uint64
-	SafeZone    *uint64
+	SafeZone    uint64
 }
 
 // GenesisInfo holds Shelley genesis configuration values.
 type GenesisInfo struct {
 	ActiveSlotsCoefficient float32
-	UpdateQuorum           float32
+	UpdateQuorum           int
 	MaxLovelaceSupply      string
 	NetworkMagic           int
 	EpochLength            int

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -203,7 +203,7 @@ type NetworkEraBoundInfo struct {
 // NetworkEraParamsInfo holds era timing parameters.
 type NetworkEraParamsInfo struct {
 	EpochLength uint64
-	SlotLength  int64
+	SlotLength  uint64
 	SafeZone    *uint64
 }
 

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -28,6 +28,10 @@ type BlockfrostNode interface {
 	// block on the chain.
 	LatestBlock() (BlockInfo, error)
 
+	// BlockByHashOrNumber returns information about a block
+	// identified by a 64-character hex hash or decimal height.
+	BlockByHashOrNumber(id string) (BlockInfo, error)
+
 	// LatestBlockTxHashes returns the transaction hashes
 	// for the latest block.
 	LatestBlockTxHashes() ([]string, error)
@@ -43,6 +47,15 @@ type BlockfrostNode interface {
 	// EpochProtocolParams returns protocol parameters for a
 	// specific epoch.
 	EpochProtocolParams(epoch uint64) (ProtocolParamsInfo, error)
+
+	// Network returns current network supply and stake information.
+	Network() (NetworkInfo, error)
+
+	// NetworkEras returns hard-fork era summaries.
+	NetworkEras() ([]NetworkEraInfo, error)
+
+	// Genesis returns Shelley genesis configuration values.
+	Genesis() (GenesisInfo, error)
 
 	// PoolsExtended returns the current active pools with
 	// extended details.
@@ -148,6 +161,64 @@ type ProtocolParamsInfo struct {
 	MaxValSize          string
 	CollateralPercent   int
 	MaxCollateralInputs int
+}
+
+// NetworkInfo holds network supply and stake data needed by the API.
+type NetworkInfo struct {
+	Supply NetworkSupplyInfo
+	Stake  NetworkStakeInfo
+}
+
+// NetworkSupplyInfo holds network supply data needed by the API.
+type NetworkSupplyInfo struct {
+	Max         string
+	Total       string
+	Circulating string
+	Locked      string
+	Treasury    string
+	Reserves    string
+}
+
+// NetworkStakeInfo holds network stake data needed by the API.
+type NetworkStakeInfo struct {
+	Live   string
+	Active string
+}
+
+// NetworkEraInfo holds a Blockfrost hard-fork era summary.
+type NetworkEraInfo struct {
+	Era    string
+	Start  NetworkEraBoundInfo
+	End    *NetworkEraBoundInfo
+	Params NetworkEraParamsInfo
+}
+
+// NetworkEraBoundInfo holds an era boundary.
+type NetworkEraBoundInfo struct {
+	Time  int64
+	Slot  uint64
+	Epoch uint64
+}
+
+// NetworkEraParamsInfo holds era timing parameters.
+type NetworkEraParamsInfo struct {
+	EpochLength uint64
+	SlotLength  int64
+	SafeZone    *uint64
+}
+
+// GenesisInfo holds Shelley genesis configuration values.
+type GenesisInfo struct {
+	ActiveSlotsCoefficient float32
+	UpdateQuorum           float32
+	MaxLovelaceSupply      string
+	NetworkMagic           int
+	EpochLength            int
+	SystemStart            int
+	SlotsPerKESPeriod      int
+	SlotLength             int
+	MaxKESEvolutions       int
+	SecurityParam          int
 }
 
 // PoolExtendedInfo holds pool data needed by the

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -140,7 +140,7 @@ type NetworkEraBound struct {
 // NetworkEraParameters represents era timing parameters.
 type NetworkEraParameters struct {
 	EpochLength uint64  `json:"epoch_length"`
-	SlotLength  int64   `json:"slot_length"`
+	SlotLength  uint64  `json:"slot_length"`
 	SafeZone    *uint64 `json:"safe_zone"`
 }
 

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -122,6 +122,42 @@ type NetworkStake struct {
 	Active string `json:"active"`
 }
 
+// NetworkEraResponse represents a Blockfrost era summary.
+type NetworkEraResponse struct {
+	Era        string               `json:"era,omitempty"`
+	Start      NetworkEraBound      `json:"start"`
+	End        *NetworkEraBound     `json:"end"`
+	Parameters NetworkEraParameters `json:"parameters"`
+}
+
+// NetworkEraBound represents an era boundary.
+type NetworkEraBound struct {
+	Time  int64  `json:"time"`
+	Slot  uint64 `json:"slot"`
+	Epoch uint64 `json:"epoch"`
+}
+
+// NetworkEraParameters represents era timing parameters.
+type NetworkEraParameters struct {
+	EpochLength uint64  `json:"epoch_length"`
+	SlotLength  int64   `json:"slot_length"`
+	SafeZone    *uint64 `json:"safe_zone"`
+}
+
+// GenesisResponse represents Blockfrost genesis info.
+type GenesisResponse struct {
+	ActiveSlotsCoefficient float32 `json:"active_slots_coefficient"`
+	UpdateQuorum           float32 `json:"update_quorum"`
+	MaxLovelaceSupply      string  `json:"max_lovelace_supply"`
+	NetworkMagic           int     `json:"network_magic"`
+	EpochLength            int     `json:"epoch_length"`
+	SystemStart            int     `json:"system_start"`
+	SlotsPerKESPeriod      int     `json:"slots_per_kes_period"`
+	SlotLength             int     `json:"slot_length"`
+	MaxKESEvolutions       int     `json:"max_kes_evolutions"`
+	SecurityParam          int     `json:"security_param"`
+}
+
 // AddressAmountResponse represents a Blockfrost address
 // amount object.
 type AddressAmountResponse struct {

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -139,15 +139,15 @@ type NetworkEraBound struct {
 
 // NetworkEraParameters represents era timing parameters.
 type NetworkEraParameters struct {
-	EpochLength uint64  `json:"epoch_length"`
-	SlotLength  uint64  `json:"slot_length"`
-	SafeZone    *uint64 `json:"safe_zone"`
+	EpochLength uint64 `json:"epoch_length"`
+	SlotLength  uint64 `json:"slot_length"`
+	SafeZone    uint64 `json:"safe_zone"`
 }
 
 // GenesisResponse represents Blockfrost genesis info.
 type GenesisResponse struct {
 	ActiveSlotsCoefficient float32 `json:"active_slots_coefficient"`
-	UpdateQuorum           float32 `json:"update_quorum"`
+	UpdateQuorum           int     `json:"update_quorum"`
 	MaxLovelaceSupply      string  `json:"max_lovelace_supply"`
 	NetworkMagic           int     `json:"network_magic"`
 	EpochLength            int     `json:"epoch_length"`


### PR DESCRIPTION
1. Added GET `/api/v0/blocks/{hash_or_number}` for blockfrost compatible block lookup by hash or height.
2. Added GET `/api/v0/network/eras` to return era boundary summaries from stored epoch data.
3. Added GET `/api/v0/genesis` to expose Shelley genesis configuration values.
4. Added  GET `/api/v0/network` & wired to real ledger state backed supply and stake data.
5. Expands the BlockfrostNode interface with block lookup, network, era, and genesis methods.
6. Made some changes in for block response mapping so latest and explicit block lookups share consistent formatting.
7. Added handler unit-tests for the new endpoints and updated network response behavior.

Closes #1364 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blockfrost-compatible endpoints for block lookup by hash or height, network supply/stake, era summaries, and Shelley genesis, backed by real ledger/database data. Unifies block responses, adds strict ID validation (including height overflow), and extends the Blockfrost node API; closes #1364.

- **New Features**
  - GET /api/v0/blocks/{hash_or_number}: look up by 64-hex hash or decimal height; 400 for invalid id (bad hash, non-decimal, or height overflow), 404 if not found.
  - GET /api/v0/network: real supply (max/total/circulating/locked/treasury/reserves) and stake (live/active).
  - GET /api/v0/network/eras: era start/end with epoch/slot/time and timing params.
  - GET /api/v0/genesis: Shelley genesis values.
  - Added BlockByHashOrNumber, Network, NetworkEras, and Genesis to Blockfrost node interface/adapter.

- **Refactors**
  - Unified block response for latest and by-id; confirmations computed against chain tip.
  - Slot length now returned in seconds with proper rounding (min 1s) for era and genesis responses.

<sup>Written for commit f99737331ec1b0098bf4e88c0994d2f5c30d4f32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block lookup by hash or decimal height
  * Network endpoint exposing supply, treasury, reserves and stake totals
  * Hard-fork era summaries with timing/epoch bounds
  * Genesis configuration endpoint

* **Bug Fixes**
  * Block confirmations computed correctly from chain tip

* **Refactor**
  * Standardized latest-block response construction

* **Tests**
  * Added handler tests for block lookup, network eras, genesis and network responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->