### PR TITLE
feat(peergov): add inbound governance observability and operator cont…

### DIFF
--- a/connmanager/ip_rate_limit_test.go
+++ b/connmanager/ip_rate_limit_test.go
@@ -650,6 +650,33 @@ func TestIPRateLimitRejectLogMessage(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestIPRateLimitFairnessUnderConnectionChurn verifies that per-IP limits
+// remain fair under repeated acquire/release churn: saturation on one IP must
+// not block another IP from making progress.
+func TestIPRateLimitFairnessUnderConnectionChurn(t *testing.T) {
+	const maxPerIP = 2
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		MaxConnectionsPerIP: maxPerIP,
+	})
+	ipA := "203.0.113.10"
+	ipB := "203.0.113.11"
+
+	// Repeatedly churn IP A between full and empty.
+	for range 20 {
+		require.True(t, cm.acquireIPSlot(ipA))
+		require.True(t, cm.acquireIPSlot(ipA))
+		require.False(t, cm.acquireIPSlot(ipA), "IP A should hit its own cap")
+		// IP B must still be able to acquire while A is saturated.
+		require.True(t, cm.acquireIPSlot(ipB), "IP B progress must be independent of IP A saturation")
+		cm.releaseIPSlot(ipB)
+		cm.releaseIPSlot(ipA)
+		cm.releaseIPSlot(ipA)
+	}
+
+	assert.Equal(t, 0, cm.IPConnCount(ipA))
+	assert.Equal(t, 0, cm.IPConnCount(ipB))
+}
+
 // safeBuffer is a thread-safe buffer for capturing log output in tests.
 type safeBuffer struct {
 	buf  []byte

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -489,11 +489,21 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 
 	var selectionEvents []pendingEvent
 	p.mu.Lock()
+	if p.isDeniedLocked(normalized) {
+		p.recordInboundLifecycle("denied")
+		p.config.Logger.Info(
+			"denied inbound peer during cooldown",
+			"address", address,
+		)
+		p.mu.Unlock()
+		return
+	}
 	peerIdx, topologyGroupID := p.resolveInboundIdentity(address, normalized)
 	var tmpPeer *Peer
 	if peerIdx == -1 {
 		// Enforce hard cap on peer list size for inbound peers
 		if p.isAtPeerCapLocked() {
+			p.recordInboundLifecycle("rejected")
 			p.config.Logger.Debug(
 				"rejecting inbound peer: peer list at capacity",
 				"address", address,
@@ -516,12 +526,14 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			p.peers,
 			tmpPeer,
 		)
+		p.recordInboundLifecycle("accepted")
 	} else {
 		tmpPeer = p.peers[peerIdx]
 		if tmpPeer == nil {
 			p.mu.Unlock()
 			return
 		}
+		p.recordInboundLifecycle("accepted")
 		// Record the topology identity once on first rule-2 match and
 		// keep it across subsequent reconnects. Rule-1 matches yield
 		// topologyGroupID == "" and must not clear a prior match.
@@ -552,6 +564,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 				if tmpPeer.Connection != nil {
 					tmpPeer.Sharable = tmpPeer.Connection.VersionData.PeerSharing()
 					tmpPeer.State = PeerStateWarm
+					p.recordInboundLifecycle("warmed")
 				}
 			}
 			// setConnection derives IsClient from live handshake data; when

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -22,6 +22,9 @@ import (
 	"net"
 	"syscall"
 	"testing"
+	"time"
+
+	"log/slog"
 )
 
 func TestIsExpectedConnectionCloseError(t *testing.T) {
@@ -216,5 +219,89 @@ func TestIsExpectedNetworkDialError(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsAddrInUseError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "eaddrnotavail",
+			err:  syscall.EADDRNOTAVAIL,
+			want: true,
+		},
+		{
+			name: "wrapped eaddrinuse",
+			err:  fmt.Errorf("dial failed: %w", syscall.EADDRINUSE),
+			want: true,
+		},
+		{
+			name: "string cannot assign requested address",
+			err:  errors.New("dial tcp: cannot assign requested address"),
+			want: true,
+		},
+		{
+			name: "different dial error",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isAddrInUseError(tc.err)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateOutboundConnection_SuppressesRetryWhenReusableInboundSatisfiesValency(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	pg.stopCh = make(chan struct{})
+	topologyPeer := &Peer{
+		Address:           "44.0.0.10:3001",
+		NormalizedAddress: "44.0.0.10:3001",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateCold,
+		GroupID:           "local-root-0",
+		Valency:           1,
+	}
+	reusableInbound := &Peer{
+		Address:           "44.0.0.11:3001",
+		NormalizedAddress: "44.0.0.11:3001",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateHot,
+		GroupID:           "local-root-0",
+		Valency:           1,
+		Connection:        &PeerConnection{IsClient: true},
+		InboundDuplex:     true,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{topologyPeer, reusableInbound}
+	pg.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		pg.createOutboundConnection(topologyPeer)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("createOutboundConnection should return when inbound valency is satisfied")
+	}
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	if topologyPeer.Reconnecting {
+		t.Fatal("reconnecting flag should be cleared after early suppression")
+	}
+	if topologyPeer.ReconnectCount != 0 {
+		t.Fatalf("reconnect count changed unexpectedly: %d", topologyPeer.ReconnectCount)
 	}
 }

--- a/peergov/doc.go
+++ b/peergov/doc.go
@@ -47,4 +47,28 @@
 // connections are allowed to provide header/block data, preventing
 // low-quality peers from backpressuring the primary chainsync
 // stream.
+//
+// # Inbound vs outbound governance
+//
+// Outbound governance is proactive: the governor selects candidates from
+// topology/gossip/ledger and opens connections to satisfy active-tier targets.
+//
+// Inbound governance is reactive: peers arrive unsolicited and must earn
+// promotion through stricter policy gates. Inbound peers have a separate warm
+// target and hot quota (InboundWarmTarget/InboundHotQuota), can be denied by
+// cooldown policy, and are pruned when idle/unhelpful past InboundPruneAfter.
+// This keeps unsolicited traffic from displacing curated outbound sources while
+// still allowing high-quality inbound duplex peers to be promoted.
+//
+// # Operator tuning guidance
+//
+// Public relays usually run with larger inbound budgets and stricter promotion
+// gates so they can absorb more unsolicited traffic without over-promoting:
+// increase InboundWarmTarget/InboundHotQuota and raise
+// InboundHotScoreThreshold/InboundMinTenure.
+//
+// More private or producer-adjacent deployments typically prefer tighter
+// admission and faster shedding of low-value inbound traffic:
+// reduce InboundWarmTarget/InboundHotQuota, lower InboundPruneAfter, and keep
+// InboundCooldown non-zero to suppress reconnect flapping.
 package peergov

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -225,11 +225,11 @@ func (p *PeerGovernor) initMetrics() {
 	)
 	p.metrics.inboundHotQuotaUsage = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_peerSelection_InboundHotQuotaUsage",
-		Help: "fraction of inbound hot quota currently occupied (0..1)",
+		Help: "fraction of inbound hot quota currently occupied (>=0; may exceed 1 when over quota)",
 	})
 	p.metrics.inboundWarmOccupancy = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_peerSelection_InboundWarmTargetOccupancy",
-		Help: "fraction of inbound warm target currently occupied (0..1)",
+		Help: "fraction of inbound warm target currently occupied (>=0; may exceed 1 when over target)",
 	})
 }
 

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -55,6 +55,9 @@ type peerGovernorMetrics struct {
 	inboundTopologyMatched prometheus.Gauge
 	inboundDuplexHeld      prometheus.Gauge
 	inboundPrunedByReason  *prometheus.CounterVec
+	inboundLifecycle       *prometheus.CounterVec
+	inboundHotQuotaUsage   prometheus.Gauge
+	inboundWarmOccupancy   prometheus.Gauge
 }
 
 func (p *PeerGovernor) initMetrics() {
@@ -213,6 +216,28 @@ func (p *PeerGovernor) initMetrics() {
 		},
 		[]string{"reason"},
 	)
+	p.metrics.inboundLifecycle = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cardano_node_metrics_peerSelection_InboundLifecycleTotal",
+			Help: "total inbound lifecycle transitions by stage",
+		},
+		[]string{"stage"},
+	)
+	p.metrics.inboundHotQuotaUsage = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_peerSelection_InboundHotQuotaUsage",
+		Help: "fraction of inbound hot quota currently occupied (0..1)",
+	})
+	p.metrics.inboundWarmOccupancy = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_peerSelection_InboundWarmTargetOccupancy",
+		Help: "fraction of inbound warm target currently occupied (0..1)",
+	})
+}
+
+func (p *PeerGovernor) recordInboundLifecycle(stage string) {
+	if p.metrics == nil || p.metrics.inboundLifecycle == nil {
+		return
+	}
+	p.metrics.inboundLifecycle.WithLabelValues(stage).Inc()
 }
 
 // inboundCounts is the phase-2 census of inbound peers used to populate
@@ -372,6 +397,16 @@ func (p *PeerGovernor) updatePeerMetrics() {
 	census := p.censusInboundCounts()
 	p.metrics.inboundWarmHeld.Set(float64(census.Warm))
 	p.metrics.inboundHotHeld.Set(float64(census.Hot))
+	if p.config.InboundHotQuota > 0 {
+		p.metrics.inboundHotQuotaUsage.Set(float64(census.Hot) / float64(p.config.InboundHotQuota))
+	} else {
+		p.metrics.inboundHotQuotaUsage.Set(0)
+	}
+	if p.config.InboundWarmTarget > 0 {
+		p.metrics.inboundWarmOccupancy.Set(float64(census.Warm) / float64(p.config.InboundWarmTarget))
+	} else {
+		p.metrics.inboundWarmOccupancy.Set(0)
+	}
 	p.metrics.inboundTopologyMatched.Set(float64(census.TopologyMatched))
 	p.metrics.inboundDuplexHeld.Set(float64(census.Duplex))
 }

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -4198,6 +4198,12 @@ func TestPeerGovernor_InboundPeer_BothRequirementsMet(t *testing.T) {
 	// header rate ~0.67, tip delta 1.0 => weighted average should be >0.6
 	assert.Equal(t, PeerStateHot, peers[0].State,
 		"inbound peer meeting both requirements should be promoted to hot")
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(pg.metrics.inboundLifecycle.WithLabelValues("promoted")),
+		"inbound lifecycle promoted metric should increment on hot promotion",
+	)
 }
 
 // TestPeerGovernor_NonInboundPeer_UsesNormalThreshold tests that non-inbound
@@ -5069,6 +5075,132 @@ func TestPeerGovernor_Reconcile_InboundLimitExceededReasonMetric(t *testing.T) {
 		),
 		"limit exceeded inbound prune should increment reason metric",
 	)
+}
+
+func TestPeerGovernor_InboundLifecycleMetrics_RejectedAndDenied(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:             reg,
+		TargetNumberOfKnownPeers: 1, // forces maxPeerListSize=200 via hard-cap floor
+	})
+	// Fill to hard cap, then one more inbound must be rejected.
+	pg.mu.Lock()
+	for i := range pg.maxPeerListSize() {
+		addr := fmt.Sprintf("44.1.0.%d:3001", i+1)
+		pg.peers = append(pg.peers, &Peer{
+			Address:           addr,
+			NormalizedAddress: addr,
+			Source:            PeerSourceP2PGossip,
+			State:             PeerStateCold,
+			FirstSeen:         time.Now(),
+		})
+	}
+	pg.mu.Unlock()
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteRejected, _ := net.ResolveTCPAddr("tcp", "44.2.0.1:40001")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr:  localAddr,
+				RemoteAddr: remoteRejected,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteRejected,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteRejected.String()),
+		},
+	})
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(pg.metrics.inboundLifecycle.WithLabelValues("rejected")),
+	)
+
+	// Free one slot and deny an inbound explicitly.
+	pg.mu.Lock()
+	pg.peers = pg.peers[:len(pg.peers)-1]
+	remoteDenied, _ := net.ResolveTCPAddr("tcp", "44.2.0.2:40002")
+	normalizedDenied := connmanager.NormalizePeerAddr(remoteDenied.String())
+	pg.denyList[normalizedDenied] = time.Now().Add(time.Minute)
+	pg.mu.Unlock()
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr:  localAddr,
+				RemoteAddr: remoteDenied,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteDenied,
+			NormalizedRemoteAddr: normalizedDenied,
+		},
+	})
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(pg.metrics.inboundLifecycle.WithLabelValues("denied")),
+	)
+}
+
+func TestPeerGovernor_InboundLifecycleMetrics_CooldownAndOccupancy(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:              reg,
+		TargetNumberOfActivePeers: -1,
+		InboundWarmTarget:         10,
+		InboundHotQuota:           2,
+		InboundHotScoreThreshold:  0.6,
+		InboundMinTenure:          5 * time.Minute,
+		InboundPruneAfter:         time.Minute,
+		InboundCooldown:           2 * time.Minute,
+		DenyDuration:              30 * time.Second,
+	})
+	now := time.Now()
+	pg.mu.Lock()
+	pg.peers = []*Peer{
+		{
+			Address:             "44.3.0.1:3001",
+			NormalizedAddress:   "44.3.0.1:3001",
+			Source:              PeerSourceInboundConn,
+			State:               PeerStateHot,
+			Connection:          &PeerConnection{IsClient: true},
+			InboundDuplex:       true,
+			PerformanceScore:    0.95,
+			FirstSeen:           now.Add(-time.Hour),
+			LastActivity:        now,
+			ChainSyncLastUpdate: now,
+			TipSlotDeltaInit:    true,
+			TipSlotDelta:        0,
+		},
+		{
+			Address:                "44.3.0.2:3001",
+			NormalizedAddress:      "44.3.0.2:3001",
+			Source:                 PeerSourceInboundConn,
+			State:                  PeerStateWarm,
+			FirstSeen:              now.Add(-2 * time.Hour),
+			LastActivity:           now.Add(-2 * time.Hour),
+			LastInboundDisconnect:  now.Add(-10 * time.Second),
+			InboundShortLivedCount: 3,
+		},
+	}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		pg.metrics.inboundLifecycle.WithLabelValues("pruned"),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		pg.metrics.inboundLifecycle.WithLabelValues("cooled-down"),
+	))
+	assert.Equal(t, float64(0.5), testutil.ToFloat64(
+		pg.metrics.inboundHotQuotaUsage,
+	), "1 hot inbound / quota 2 should report 0.5 occupancy")
+	assert.Equal(t, float64(0), testutil.ToFloat64(
+		pg.metrics.inboundWarmOccupancy,
+	), "all inbound warm peers were either promoted or pruned")
 }
 
 func TestPeerGovernor_PromotionPrefersHigherPrioritySources(t *testing.T) {

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -120,6 +120,9 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 					)
 				} else {
 					p.peers[i].State = PeerStateWarm
+					if p.peers[i].Source == PeerSourceInboundConn {
+						p.recordInboundLifecycle("warmed")
+					}
 					coldPromotions++
 					p.config.Logger.Debug(
 						"promoted peer to warm",
@@ -309,6 +312,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 			promoted++
 			if peer.Source == PeerSourceInboundConn {
 				inboundHotHeld++
+				p.recordInboundLifecycle("promoted")
 			}
 			if bootstrapPromotion && candidates[i].diversityGroup != "" {
 				selectedGroups[candidates[i].diversityGroup] = struct{}{}
@@ -331,12 +335,29 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 				}
 				slices.SortFunc(candidates[i+1:], rankCandidates)
 			}
-			p.config.Logger.Debug(
-				"promoted peer to hot (score-based)",
+			logMsg := "promoted peer to hot (score-based)"
+			logArgs := []any{
 				"address", peer.Address,
 				"score", peer.PerformanceScore,
 				"group", peer.GroupID,
-			)
+			}
+			if peer.Source == PeerSourceInboundConn {
+				logMsg = "promoted inbound peer"
+				tenure := time.Duration(0)
+				if !peer.FirstSeen.IsZero() {
+					tenure = now.Sub(peer.FirstSeen)
+				}
+				logArgs = append(
+					logArgs,
+					"tenure", tenure,
+					"min_tenure", p.config.InboundMinTenure,
+					"score_threshold", p.config.InboundHotScoreThreshold,
+					"full_duplex", peer.hasClientConnection() || peer.InboundDuplex,
+					"topology_slot", peer.InboundTopologyMatch,
+					"satisfies_topology_slot", candidates[i].underValency && peer.InboundTopologyMatch != "",
+				)
+			}
+			p.config.Logger.Info(logMsg, logArgs...)
 			events = append(events, pendingEvent{
 				PeerPromotedEventType,
 				PeerStateChangeEvent{
@@ -593,6 +614,7 @@ func (p *PeerGovernor) enforceStateLimit(
 		removed++
 		*removedCount++
 		if peer.Source == PeerSourceInboundConn {
+			p.recordInboundLifecycle("pruned")
 			p.inboundPruned++
 			if p.metrics != nil {
 				p.metrics.inboundPruned.Inc()
@@ -663,6 +685,7 @@ func (p *PeerGovernor) pruneInboundWarmPeersLocked(
 		}
 		if applyCooldown {
 			p.denyList[peer.NormalizedAddress] = now.Add(cooldownDuration)
+			p.recordInboundLifecycle("cooled-down")
 		}
 		p.config.Logger.Info(
 			"pruned inbound warm peer",
@@ -672,6 +695,10 @@ func (p *PeerGovernor) pruneInboundWarmPeersLocked(
 			"last_inbound_disconnect", peer.LastInboundDisconnect,
 			"last_inbound_session_duration", peer.LastInboundSessionDuration,
 			"prune_after", p.config.InboundPruneAfter,
+			"score", peer.PerformanceScore,
+			"tenure", now.Sub(peer.FirstSeen),
+			"topology_slot", peer.InboundTopologyMatch,
+			"full_duplex", peer.hasClientConnection() || peer.InboundDuplex,
 			"cooldown_applied", applyCooldown,
 			"cooldown_duration", cooldownDuration,
 		)
@@ -683,6 +710,7 @@ func (p *PeerGovernor) pruneInboundWarmPeersLocked(
 			},
 		})
 		p.peers = slices.Delete(p.peers, i, i+1)
+		p.recordInboundLifecycle("pruned")
 		p.inboundPruned++
 		*removedCount++
 		if p.metrics != nil {

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -284,6 +284,13 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 		}
 		for i := 0; i < len(candidates) && promoted < needed; i++ {
 			peer := candidates[i].peer
+			satisfiesTopologySlot := false
+			if peer.InboundTopologyMatch != "" {
+				if gc, ok := groups[peer.InboundTopologyMatch]; ok &&
+					gc.Valency > 0 && uint(gc.Hot) < gc.Valency { //nolint:gosec // Hot counts are always >= 0
+					satisfiesTopologySlot = true
+				}
+			}
 			if peer.Source == PeerSourceInboundConn &&
 				inboundHotHeld >= p.config.InboundHotQuota {
 				continue
@@ -354,7 +361,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 					"score_threshold", p.config.InboundHotScoreThreshold,
 					"full_duplex", peer.hasClientConnection() || peer.InboundDuplex,
 					"topology_slot", peer.InboundTopologyMatch,
-					"satisfies_topology_slot", candidates[i].underValency && peer.InboundTopologyMatch != "",
+					"satisfies_topology_slot", satisfiesTopologySlot,
 				)
 			}
 			p.config.Logger.Info(logMsg, logArgs...)


### PR DESCRIPTION
Closes #1935 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inbound governance observability to `peergov` with lifecycle metrics, hot-quota/warm-occupancy gauges, and clearer promotion/pruning logs. Also adds docs and tests to help operators tune inbound policies and validate behavior.

- **New Features**
  - Prometheus: `cardano_node_metrics_peerSelection_InboundLifecycleTotal` (increments on denied/rejected/accepted/warmed/promoted/pruned/cooled-down), `...InboundHotQuotaUsage`, `...InboundWarmTargetOccupancy`.
  - Logs: info-level promotion/pruning entries now include score, tenure, min_tenure, score_threshold, full_duplex, topology_slot, satisfies_topology_slot, and cooldown details; warmed transitions are logged.
  - Docs & tests: inbound vs outbound overview and operator tuning guidance; metric assertions (rejected/denied/promoted/pruned/cooled-down, occupancy), cooldown/prune paths, suppression of outbound retries when inbound satisfies valency, per-IP rate-limit fairness under churn, and addr-in-use detection.

<sup>Written for commit 9d07c51c2f8fff3828975f441a58a76b1eb9008b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2062?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbound peer lifecycle tracking with detailed state transitions (accepted, denied, rejected, warmed, promoted, pruned, cooled-down)
  * New metrics for monitoring inbound hot quota usage and warm occupancy percentages

* **Documentation**
  * Added operator guidance for configuring inbound peer budgets and promotion thresholds across different deployment types

* **Tests**
  * Enhanced test coverage for per-IP rate limiting fairness and connection handling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->