### PR TITLE
test: windows runners are slow, use ldflags + longer timeout

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -95,7 +95,7 @@ jobs:
       - name: go-build
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test -race ./...
+        run: go test -ldflags="-s -w" -race ./...
 
   # macOS and Windows jobs without Postgres service
   go-test-other:
@@ -126,4 +126,4 @@ jobs:
       - name: go-build
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test ./...
+        run: go test -ldflags="-s -w" ./...

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -266,7 +266,7 @@ func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	// Wait for the handler to process both events
 	require.Eventually(t, func() bool {
 		return received.Load() >= 2
-	}, 2*time.Second, 10*time.Millisecond,
+	}, 10*time.Second, 10*time.Millisecond,
 		"handler should continue processing events after a panic",
 	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speed up and stabilize CI on Windows by stripping symbols from test binaries and giving slow runners more time. Adds `-ldflags="-s -w"` to `go test` in GitHub Actions and increases the `require.Eventually` timeout in `TestSubscribeFuncPanicRecovery` from 2s to 10s.

<sup>Written for commit 5949acd8841a72855ad3d3bead50cf6ad320db9f. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2065?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

