### PR TITLE
fix: rollback block nonces

### DIFF
--- a/database/block_nonce.go
+++ b/database/block_nonce.go
@@ -99,6 +99,19 @@ func (d *Database) DeleteBlockNoncesBeforeSlotWithoutCheckpoints(
 	)
 }
 
+// DeleteBlockNoncesAfterPoint removes nonces that cannot belong to the
+// active chain after rolling back to point. It keeps the exact point row and
+// removes competing rows at the same slot.
+func (d *Database) DeleteBlockNoncesAfterPoint(
+	point ocommon.Point,
+	txn *Txn,
+) error {
+	if txn == nil {
+		return d.metadata.DeleteBlockNoncesAfterPoint(point, nil)
+	}
+	return d.metadata.DeleteBlockNoncesAfterPoint(point, txn.Metadata())
+}
+
 func (d *Database) SetBlockNonce(
 	blockHash []byte,
 	slotNumber uint64,

--- a/database/plugin/metadata/mysql/block_nonce.go
+++ b/database/plugin/metadata/mysql/block_nonce.go
@@ -184,3 +184,31 @@ func (d *MetadataStoreMysql) DeleteBlockNoncesBeforeSlotWithoutCheckpoints(
 
 	return result.Error
 }
+
+// DeleteBlockNoncesAfterPoint deletes block_nonce rows that are no longer on
+// the active chain after a rollback. The rollback point's exact row is kept;
+// same-slot rows with a different hash are removed.
+func (d *MetadataStoreMysql) DeleteBlockNoncesAfterPoint(
+	point ocommon.Point,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if len(point.Hash) == 0 {
+		return db.
+			Where("slot >= ?", point.Slot).
+			Delete(&models.BlockNonce{}).
+			Error
+	}
+	return db.
+		Where(
+			"slot > ? OR (slot = ? AND hash <> ?)",
+			point.Slot,
+			point.Slot,
+			point.Hash,
+		).
+		Delete(&models.BlockNonce{}).
+		Error
+}

--- a/database/plugin/metadata/postgres/block_nonce.go
+++ b/database/plugin/metadata/postgres/block_nonce.go
@@ -184,3 +184,31 @@ func (d *MetadataStorePostgres) DeleteBlockNoncesBeforeSlotWithoutCheckpoints(
 
 	return result.Error
 }
+
+// DeleteBlockNoncesAfterPoint deletes block_nonce rows that are no longer on
+// the active chain after a rollback. The rollback point's exact row is kept;
+// same-slot rows with a different hash are removed.
+func (d *MetadataStorePostgres) DeleteBlockNoncesAfterPoint(
+	point ocommon.Point,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if len(point.Hash) == 0 {
+		return db.
+			Where("slot >= ?", point.Slot).
+			Delete(&models.BlockNonce{}).
+			Error
+	}
+	return db.
+		Where(
+			"slot > ? OR (slot = ? AND hash <> ?)",
+			point.Slot,
+			point.Slot,
+			point.Hash,
+		).
+		Delete(&models.BlockNonce{}).
+		Error
+}

--- a/database/plugin/metadata/sqlite/block_nonce.go
+++ b/database/plugin/metadata/sqlite/block_nonce.go
@@ -177,3 +177,31 @@ func (d *MetadataStoreSqlite) DeleteBlockNoncesBeforeSlotWithoutCheckpoints(
 
 	return result.Error
 }
+
+// DeleteBlockNoncesAfterPoint deletes block_nonce rows that are no longer on
+// the active chain after a rollback. The rollback point's exact row is kept;
+// same-slot rows with a different hash are removed.
+func (d *MetadataStoreSqlite) DeleteBlockNoncesAfterPoint(
+	point ocommon.Point,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if len(point.Hash) == 0 {
+		return db.
+			Where("slot >= ?", point.Slot).
+			Delete(&models.BlockNonce{}).
+			Error
+	}
+	return db.
+		Where(
+			"slot > ? OR (slot = ? AND hash <> ?)",
+			point.Slot,
+			point.Slot,
+			point.Hash,
+		).
+		Delete(&models.BlockNonce{}).
+		Error
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -502,6 +502,10 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// DeleteBlockNoncesAfterPoint removes block nonces after a rollback
+	// point and competing nonces at the same slot.
+	DeleteBlockNoncesAfterPoint(ocommon.Point, types.Txn) error
+
 	// DeleteUtxo removes a single unspent transaction output.
 	DeleteUtxo(models.UtxoId, types.Txn) error
 

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -76,6 +76,96 @@ func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestHandleEventChainsyncRollbackPrunesStaleBlockNonces(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	competingHash := testHashBytes("competing-ancestor-slot")
+	require.NoError(
+		t,
+		fixture.ls.db.SetBlockNonce(
+			competingHash,
+			fixture.ancestorTip.Point.Slot,
+			[]byte("stale-same-slot"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		fixture.ls.db.SetBlockNonce(
+			testHashBytes("future-fork-block"),
+			fixture.currentTip.Point.Slot+10,
+			[]byte("stale-future"),
+			false,
+			nil,
+		),
+	)
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+		},
+	)
+	require.NoError(t, err)
+
+	rows, err := fixture.ls.db.GetBlockNoncesInSlotRange(
+		fixture.ancestorTip.Point.Slot,
+		fixture.currentTip.Point.Slot+11,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, fixture.ancestorTip.Point.Hash, rows[0].Hash)
+	assert.Equal(t, fixture.ancestorTip.Point.Slot, rows[0].Slot)
+	assert.Equal(t, fixture.ancestorNonce, rows[0].Nonce)
+}
+
+func TestLoadTipPrunesStaleBlockNonces(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	competingHash := testHashBytes("competing-tip-slot")
+	require.NoError(
+		t,
+		fixture.ls.db.SetBlockNonce(
+			competingHash,
+			fixture.currentTip.Point.Slot,
+			[]byte("stale-same-slot"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		fixture.ls.db.SetBlockNonce(
+			testHashBytes("future-fork-block"),
+			fixture.currentTip.Point.Slot+10,
+			[]byte("stale-future"),
+			false,
+			nil,
+		),
+	)
+
+	require.NoError(t, fixture.ls.loadTip())
+
+	rows, err := fixture.ls.db.GetBlockNoncesInSlotRange(
+		fixture.ancestorTip.Point.Slot,
+		fixture.currentTip.Point.Slot+11,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, fixture.ancestorTip.Point.Hash, rows[0].Hash)
+	assert.Equal(t, fixture.currentTip.Point.Hash, rows[1].Hash)
+	assert.True(
+		t,
+		bytes.Equal(
+			fixture.ls.currentTipBlockNonce,
+			rows[1].Nonce,
+		),
+	)
+}
+
 func TestHandleEventChainsyncRollbackDoesNotSkipDifferentPeerHistory(
 	t *testing.T,
 ) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1462,6 +1462,19 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 				err,
 			)
 		}
+		// Delete block nonce rows from the abandoned fork. Epoch
+		// nonces are derived from slot-range block_nonce lookups, so
+		// same-slot competitors and later fork rows must not survive
+		// rollback.
+		if err := ls.db.DeleteBlockNoncesAfterPoint(
+			point,
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"delete block nonces after rollback: %w",
+				err,
+			)
+		}
 		// Delete rolled-back network state records
 		if err := ls.db.DeleteNetworkStateAfterSlot(
 			point.Slot,
@@ -3632,6 +3645,9 @@ func (ls *LedgerState) loadTip() error {
 	tmpTip, err := ls.db.GetTip(nil)
 	if err != nil {
 		return err
+	}
+	if err := ls.db.DeleteBlockNoncesAfterPoint(tmpTip.Point, nil); err != nil {
+		return fmt.Errorf("prune block nonces beyond tip: %w", err)
 	}
 	// Load tip block nonce before acquiring lock
 	var tipNonce []byte


### PR DESCRIPTION
Closes #2028

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes stale block nonces on rollback and tip load so epoch nonce derivation uses only the active chain. Removes future nonces and same-slot competitors from abandoned forks.

- **Bug Fixes**
  - Added DeleteBlockNoncesAfterPoint to the `MetadataStore` and implemented it for MySQL, Postgres, and SQLite.
  - Called during rollback (with txn) and `loadTip` to delete rows with slot > point, and same-slot rows with a different hash (keeps the exact point row).
  - Added tests to confirm pruning of same-slot competitors and future fork rows.

<sup>Written for commit 2dd587b592c8706100782229b53b1b0b4391fc5a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2066?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale block nonce data during chain rollbacks to maintain data consistency.
  * Added pruning of orphaned block nonces during ledger startup to ensure accurate chain state.

* **Tests**
  * Added test coverage for block nonce pruning behavior during chain rollback and tip loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->