### PR TITLE
ci(go): disable CGO on Windows/Mac

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -110,6 +110,12 @@ jobs:
           - platform: windows-latest
             cache_path: ~\AppData\Local\go-build
     runs-on: ${{ matrix.platform }}
+    env:
+      # Use Go's internal linker. Without this, Windows runners auto-enable CGO
+      # because gcc is in PATH, then MinGW's ld.exe runs out of memory linking
+      # the integration test binary. The project has no cgo code, and -race
+      # (the only consumer of CGO) only runs on the Linux job.
+      CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
@@ -126,4 +132,4 @@ jobs:
       - name: go-build
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test -ldflags="-s -w" ./...
+        run: go test ./...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test workflow to disable CGO for non-Linux test runners to ensure consistent build behavior across platforms.
  * Modified test command invocation to remove linker flags from test builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable CGO on Windows and macOS CI test runners to prevent linker OOMs and ensure consistent builds. Also remove `-ldflags` from `go test` so tests link with default settings.

<sup>Written for commit cf241e9c6f02582a20659563dd248d040d4c9da4. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2069">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

