### PR TITLE
feat: mid-epoch transition stability

### DIFF
--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -185,6 +185,16 @@ func ProcessEpoch(
 	}
 
 	// --- RATIFICATION -------------------------------------------------
+	//
+	// The inputs assembled below (TallyContext, activeDRepCount,
+	// rootsByPurpose, committeeState, ccQuorum, conwayPParams,
+	// majorVersion, ccInNoConfidence) feed ShouldRatify. A parallel
+	// build for HardForkInitiation specifically exists in
+	// EvaluateRatifiableHardForkInitiation (governance/stability.go),
+	// which runs the same check mid-epoch to surface upcoming
+	// transitions before the boundary tick fires. Adding a new
+	// ratification input here without updating the mid-epoch path
+	// will silently make the two answers diverge — keep them in sync.
 	tallyCtx := &TallyContext{
 		DB:           in.DB,
 		Txn:          in.Txn,
@@ -385,6 +395,10 @@ func stakeEpochFor(newEpoch uint64) uint64 {
 // countActiveDReps returns the number of DReps eligible to vote in the
 // current tick. AlwaysAbstain / AlwaysNoConfidence virtual DReps are
 // not included.
+//
+// countActiveDRepsAtEpoch in stability.go is the parallel for the
+// mid-epoch ratifiability check — it takes plain inputs instead of
+// EpochInput. Behaviour changes here must mirror there.
 func countActiveDReps(in *EpochInput) (int, error) {
 	dreps, err := in.DB.GetActiveDreps(in.Txn)
 	if err != nil {

--- a/ledger/governance/stability.go
+++ b/ledger/governance/stability.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+)
+
+// StabilityCheckInputs collects the state needed to determine whether
+// any active HardForkInitiation proposal would ratify if the boundary
+// tick fired now. Inputs mirror those consumed by ProcessEpoch's
+// RATIFY phase. The mid-epoch path duplicates the build instead of
+// sharing because ProcessEpoch is the boundary path used on every
+// mainnet rollover; refactoring it just to support mid-epoch evaluation
+// would risk regressions for marginal benefit.
+type StabilityCheckInputs struct {
+	DB            *database.Database
+	Txn           *database.Txn
+	Logger        *slog.Logger
+	CurrentEpoch  uint64
+	PParams       lcommon.ProtocolParameters
+	ConwayGenesis *conway.ConwayGenesis
+}
+
+// RatifiableHardForkInitiation describes a HardForkInitiation proposal
+// whose tally currently meets ratification thresholds. NewMajor and
+// NewMinor are the protocol version the action would enact at the next
+// epoch boundary.
+type RatifiableHardForkInitiation struct {
+	Proposal *models.GovernanceProposal
+	NewMajor uint
+	NewMinor uint
+}
+
+// EvaluateRatifiableHardForkInitiation searches the active proposal set
+// for a HardForkInitiation that would be marked Ratified by the
+// boundary tick if it ran right now, and returns the first such
+// proposal along with the protocol version it would enact.
+//
+// "Would ratify now" means: tally + ShouldRatify against the live vote
+// state, current pparams, and the current snapshots of active DReps
+// and committee membership.
+//
+// The result is intended for mid-epoch surfacing of upcoming era
+// transitions to clients via TransitionInfo. Callers should gate use
+// on the voting deadline (currentSlot >= epochEnd - 2*stabilityWindow);
+// before that point, the answer can flip when new votes arrive.
+//
+// Returns nil with no error when no HardForkInitiation is currently
+// ratifiable, or when the chain is pre-Conway.
+func EvaluateRatifiableHardForkInitiation(
+	in StabilityCheckInputs,
+) (*RatifiableHardForkInitiation, error) {
+	if in.DB == nil {
+		return nil, errors.New("nil database")
+	}
+	conwayPParams, ok := in.PParams.(*conway.ConwayProtocolParameters)
+	if !ok {
+		// Pre-Conway: no governance state machine exists, so no
+		// HardForkInitiation can be in flight.
+		return nil, nil
+	}
+
+	proposals, err := in.DB.GetActiveGovernanceProposals(
+		in.CurrentEpoch, in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get active proposals: %w", err)
+	}
+
+	hardForkProposals := make([]*models.GovernanceProposal, 0)
+	for _, p := range proposals {
+		if lcommon.GovActionType(p.ActionType) ==
+			lcommon.GovActionTypeHardForkInitiation {
+			hardForkProposals = append(hardForkProposals, p)
+		}
+	}
+	if len(hardForkProposals) == 0 {
+		return nil, nil
+	}
+
+	// Build the inputs ShouldRatify needs. The active-DRep, committee
+	// state, parent-chain root, and quorum reads are the same the
+	// boundary path performs; doing them again here is the cost of not
+	// sharing with ProcessEpoch.
+	tallyCtx := &TallyContext{
+		DB:           in.DB,
+		Txn:          in.Txn,
+		StakeEpoch:   stakeEpochFor(in.CurrentEpoch),
+		CurrentEpoch: in.CurrentEpoch,
+	}
+
+	activeDRepCount, err := countActiveDRepsAtEpoch(
+		in.DB, in.Txn, in.CurrentEpoch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("count active dreps: %w", err)
+	}
+
+	committeeState, err := LoadCommitteeVotingState(
+		in.DB, in.Txn, in.CurrentEpoch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load committee voting state: %w", err)
+	}
+	tallyCtx.CommitteeState = committeeState
+
+	committeeRoot, err := in.DB.GetLastEnactedGovernanceProposal(
+		purposeActionTypes(purposeCommittee), in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get committee root: %w", err)
+	}
+	committeeNoConfidence := committeeNoConfidenceState(committeeRoot)
+
+	ccQuorum, err := conwayRatifyQuorum(
+		in.Logger, in.DB, in.Txn, in.ConwayGenesis,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compute committee quorum: %w", err)
+	}
+
+	// Parent-chain root for HardForkInitiation lineage: a HardForkInitiation
+	// must descend from the most recently enacted HardForkInitiation, or
+	// from genesis if none has enacted yet.
+	hardForkRoot, err := in.DB.GetLastEnactedGovernanceProposal(
+		purposeActionTypes(purposeHardFork), in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get hardfork root: %w", err)
+	}
+
+	for _, proposal := range hardForkProposals {
+		if !validateParentChain(proposal, hardForkRoot) {
+			continue
+		}
+		tally, err := TallyProposal(tallyCtx, proposal)
+		if err != nil {
+			return nil, fmt.Errorf("tally proposal: %w", err)
+		}
+		decision := ShouldRatify(RatifyInputs{
+			Tally:                 tally,
+			PParams:               conwayPParams,
+			ParamUpdate:           nil, // not used for HardForkInitiation
+			ActiveDRepCount:       activeDRepCount,
+			ActiveCCCount:         committeeState.ActiveMemberCount,
+			CCQuorum:              ccQuorum,
+			MajorVersion:          conwayPParams.ProtocolVersion.Major,
+			CommitteeNoConfidence: committeeNoConfidence,
+		})
+		if !decision.Ratified {
+			continue
+		}
+		// Decode to extract the target protocol version; an active
+		// HardForkInitiation that fails to decode here is a
+		// data-integrity bug, but the conservative behaviour is to
+		// skip it rather than abort the whole check.
+		action, err := decodeGovAction(
+			proposal.GovActionCbor, proposal.ActionType,
+		)
+		if err != nil {
+			if in.Logger != nil {
+				in.Logger.Warn(
+					"skipping ratifiable HardForkInitiation: decode failed",
+					"proposal_id", proposal.ID,
+					"error", err,
+				)
+			}
+			continue
+		}
+		hf, ok := action.(*lcommon.HardForkInitiationGovAction)
+		if !ok {
+			continue
+		}
+		return &RatifiableHardForkInitiation{
+			Proposal: proposal,
+			NewMajor: hf.ProtocolVersion.Major,
+			NewMinor: hf.ProtocolVersion.Minor,
+		}, nil
+	}
+	return nil, nil
+}
+
+// countActiveDRepsAtEpoch returns the number of credential-backed DReps
+// eligible to vote in the given epoch (active and not aged out by
+// inactivity). AlwaysAbstain / AlwaysNoConfidence virtual DReps are not
+// counted. Equivalent to countActiveDReps but takes plain inputs so it
+// can be called outside the EpochInput-driven boundary path.
+func countActiveDRepsAtEpoch(
+	db *database.Database,
+	txn *database.Txn,
+	currentEpoch uint64,
+) (int, error) {
+	dreps, err := db.GetActiveDreps(txn)
+	if err != nil {
+		return 0, err
+	}
+	active := 0
+	for _, drep := range dreps {
+		if drepActiveAtEpoch(drep, currentEpoch) {
+			active++
+		}
+	}
+	return active, nil
+}

--- a/ledger/governance/stability_test.go
+++ b/ledger/governance/stability_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	stabilityTestEpoch  uint64 = 50
+	stabilityProposalTx byte   = 0xAA
+	stabilityDRepCred   byte   = 0xBB
+	stabilityStakeCred  byte   = 0xCC
+)
+
+// stabilityConwayPParams returns Conway pparams configured for the
+// requested protocol major version. Threshold values are realistic so
+// post-bootstrap tests exercise the same code path as production. The
+// bootstrap branch in ShouldRatify (major <= 9) ignores thresholds
+// entirely; only one yes vote of any kind is required.
+func stabilityConwayPParams(major uint) *conway.ConwayProtocolParameters {
+	p := mockledger.NewMockConwayProtocolParams()
+	p.ProtocolVersion.Major = major
+	p.MinCommitteeSize = 0
+	p.DRepVotingThresholds.HardForkInitiation = newRat(60, 100)
+	p.PoolVotingThresholds.HardForkInitiation = newRat(51, 100)
+	return &p
+}
+
+// seedHardForkInitiationProposal inserts an active HardForkInitiation
+// proposal whose enacted state would bump the protocol major version to
+// targetMajor. The proposal is configured to be returned by
+// GetActiveGovernanceProposals(currentEpoch): proposed in the past, not
+// yet expired, not enacted/expired/deleted.
+func seedHardForkInitiationProposal(
+	t *testing.T,
+	db *database.Database,
+	currentEpoch uint64,
+	targetMajor uint,
+) *models.GovernanceProposal {
+	t.Helper()
+	action := &lcommon.HardForkInitiationGovAction{Type: 1}
+	action.ProtocolVersion.Major = targetMajor
+	action.ProtocolVersion.Minor = 0
+	cborBytes, err := cbor.Encode(action)
+	require.NoError(t, err)
+
+	proposal := &models.GovernanceProposal{
+		TxHash:        testBytes(32, stabilityProposalTx),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeHardForkInitiation),
+		ProposedEpoch: currentEpoch - 1,
+		ExpiresEpoch:  currentEpoch + 10,
+		Deposit:       1_000,
+		ReturnAddress: testBytes(29, 0),
+		AnchorURL:     "https://example.invalid/anchor",
+		AnchorHash:    testBytes(32, 0xEE),
+		GovActionCbor: cborBytes,
+		AddedSlot:     1,
+	}
+	require.NoError(t, db.SetGovernanceProposal(proposal, nil))
+	loaded, err := db.GetGovernanceProposal(proposal.TxHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	return loaded
+}
+
+// seedDRepWithStake creates an active DRep, an account delegating to
+// it, and a UTxO funding that account's stake. The DRep ends up with
+// stakeAmount of voting power. Returns the DRep's credential so the
+// caller can attach a vote.
+func seedDRepWithStake(
+	t *testing.T,
+	db *database.Database,
+	stakeAmount uint64,
+) []byte {
+	t.Helper()
+	drepCred := testBytes(28, stabilityDRepCred)
+	stakeCred := testBytes(28, stabilityStakeCred)
+
+	require.NoError(t, db.CreateDrep(nil, &models.Drep{
+		Credential: drepCred,
+		Active:     true,
+		AddedSlot:  1,
+	}))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: stakeCred,
+		Drep:       drepCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		AddedSlot:  1,
+		Active:     true,
+	}))
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+		TxId:       testBytes(32, 1),
+		OutputIdx:  0,
+		StakingKey: stakeCred,
+		AddedSlot:  1,
+		Amount:     types.Uint64(stakeAmount),
+	}))
+	return drepCred
+}
+
+// seedDRepYesVote attaches a Yes vote from drepCred to the given
+// proposal.
+func seedDRepYesVote(
+	t *testing.T,
+	db *database.Database,
+	proposalID uint,
+	drepCred []byte,
+) {
+	t.Helper()
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      proposalID,
+		VoterType:       models.VoterTypeDRep,
+		VoterCredential: drepCred,
+		Vote:            models.VoteYes,
+		AddedSlot:       2,
+	}, nil))
+}
+
+func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+	in := StabilityCheckInputs{
+		DB:           db,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CurrentEpoch: stabilityTestEpoch,
+		PParams:      nil, // pre-Conway: no governance state machine yet
+	}
+	got, err := EvaluateRatifiableHardForkInitiation(in)
+	require.NoError(t, err)
+	assert.Nil(t, got, "pre-Conway pparams must short-circuit to nil")
+}
+
+func TestEvaluateRatifiableHardForkInitiation_NoActiveProposals_ReturnsNil(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+	in := StabilityCheckInputs{
+		DB:           db,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CurrentEpoch: stabilityTestEpoch,
+		PParams:      stabilityConwayPParams(9),
+	}
+	got, err := EvaluateRatifiableHardForkInitiation(in)
+	require.NoError(t, err)
+	assert.Nil(t, got, "empty active proposal set must yield nil")
+}
+
+func TestEvaluateRatifiableHardForkInitiation_OnlyOtherActionType_ReturnsNil(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+
+	// A TreasuryWithdrawal — active but not a HardForkInitiation, so
+	// the helper must skip it even if it would otherwise ratify.
+	otherAction := &lcommon.TreasuryWithdrawalGovAction{}
+	cborBytes, err := cbor.Encode(otherAction)
+	require.NoError(t, err)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        testBytes(32, 0xDD),
+		ActionType:    uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		ProposedEpoch: stabilityTestEpoch - 1,
+		ExpiresEpoch:  stabilityTestEpoch + 10,
+		Deposit:       1_000,
+		ReturnAddress: testBytes(29, 0),
+		AnchorURL:     "https://example.invalid/anchor",
+		AnchorHash:    testBytes(32, 0xEE),
+		GovActionCbor: cborBytes,
+		AddedSlot:     1,
+	}, nil))
+
+	in := StabilityCheckInputs{
+		DB:           db,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CurrentEpoch: stabilityTestEpoch,
+		PParams:      stabilityConwayPParams(9),
+	}
+	got, err := EvaluateRatifiableHardForkInitiation(in)
+	require.NoError(t, err)
+	assert.Nil(t, got, "non-HardForkInitiation actions must be ignored")
+}
+
+// TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote pins
+// the bootstrap ratification semantic: in pparams with major <= 9 a
+// single yes vote of any non-zero magnitude suffices to make a proposal
+// ratifiable, regardless of thresholds. The mid-epoch helper must
+// surface this as an upcoming transition with the correct target major
+// version (extracted from the proposal's encoded action).
+func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+
+	const targetMajor uint = 11
+	proposal := seedHardForkInitiationProposal(t, db, stabilityTestEpoch, targetMajor)
+	drepCred := seedDRepWithStake(t, db, 1_000)
+	seedDRepYesVote(t, db, proposal.ID, drepCred)
+
+	in := StabilityCheckInputs{
+		DB:           db,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CurrentEpoch: stabilityTestEpoch,
+		PParams:      stabilityConwayPParams(9),
+	}
+	got, err := EvaluateRatifiableHardForkInitiation(in)
+	require.NoError(t, err)
+	require.NotNil(t, got, "bootstrap + yes vote must be ratifiable")
+	assert.Equal(t, targetMajor, got.NewMajor,
+		"target major must come from the proposal's encoded action")
+	assert.Equal(t, proposal.ID, got.Proposal.ID,
+		"the helper must return the proposal that ratifies")
+}
+
+// TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable
+// pins the negative side of bootstrap: even though thresholds are zero,
+// at least ONE yes vote (DRep, SPO, or CC) is required. With zero votes
+// of any kind, the proposal does not ratify.
+func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+	seedHardForkInitiationProposal(t, db, stabilityTestEpoch, 11)
+
+	in := StabilityCheckInputs{
+		DB:           db,
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		CurrentEpoch: stabilityTestEpoch,
+		PParams:      stabilityConwayPParams(9),
+	}
+	got, err := EvaluateRatifiableHardForkInitiation(in)
+	require.NoError(t, err)
+	assert.Nil(t, got, "no votes means no ratification, even in bootstrap")
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -41,6 +41,7 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/governance"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/dingo/mempool"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -689,6 +690,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// transition epoch, matching the Haskell HFC semantics.
 	ls.evaluateTriggerAtEpoch()
 	ls.evaluateTransitionImpossible()
+	ls.evaluateHardForkInitiationStability()
 	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
 		return fmt.Errorf("failed to reconcile primary chain tip: %w", err)
 	}
@@ -1681,7 +1683,23 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.currentTip = newTip
 	// A rollback invalidates any pending TransitionKnown because the
 	// epoch-rollover block that set it may no longer be on the chain.
+	// After the reset, re-derive what the rolled-back state implies:
+	//
+	//   - reconstructTransitionInfo restores Known(currentEpoch) when
+	//     the post-rollback pparams already carry a major-version
+	//     bump that the rollback didn't undo (the rolled-back chain
+	//     still has the bump committed at an earlier point).
+	//   - evaluateHardForkInitiationStability restores Known(N+1) if
+	//     a HardForkInitiation governance action survived the
+	//     rollback and is still ratifiable past the voting deadline.
+	//
+	// Without these re-derivations a client querying era history
+	// between rollback completion and the next block-apply would see
+	// a transient Unknown that doesn't reflect the actual chain
+	// state.
 	ls.transitionInfo = hardfork.NewTransitionUnknown()
+	ls.reconstructTransitionInfo()
+	ls.evaluateHardForkInitiationStability()
 	// If rolling back behind the Mithril trust boundary, clear it.
 	// A rollback inside the gap means replacement blocks on the new
 	// fork were NOT processed by SetGapBlockTransaction and must go
@@ -2980,6 +2998,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// epoch-end slot instead of a stale safeZone cap.
 				ls.evaluateTriggerAtEpoch()
 				ls.evaluateTransitionImpossible()
+				ls.evaluateHardForkInitiationStability()
 				// Capture tip for logging while holding the lock
 				tipForLog = ls.currentTip
 				checker = ls.config.ForgedBlockChecker
@@ -3448,6 +3467,122 @@ func (ls *LedgerState) evaluateTransitionImpossible() {
 	if safeEndSlot >= epochEndSlot {
 		ls.transitionInfo = hardfork.NewTransitionImpossible()
 	}
+}
+
+// evaluateHardForkInitiationStability surfaces an upcoming era boundary
+// to clients while the current epoch is still being applied, by
+// checking whether any in-flight HardForkInitiation governance action
+// would be ratified if the boundary tick fired now.
+//
+// Why this is correct mid-epoch: governance votes stop being accepted
+// at slot epochEnd - 2*stabilityWindow (the voting deadline). After
+// that point the inputs to the ratification computation are frozen —
+// no new vote, registration, or pool change can flip the outcome — so
+// "would ratify now" equals "will ratify at the next boundary tick".
+// Before the deadline the answer is volatile and surfacing it would
+// give clients a stale view, so the function returns early.
+//
+// Priority order on a successful detection: TransitionKnown supersedes
+// both TransitionUnknown and TransitionImpossible because it carries
+// strictly more information (the exact target epoch). The function is
+// idempotent when transitionInfo is already TransitionKnown for the
+// same target.
+//
+// The DB-driven assembly is delegated to
+// governance.EvaluateRatifiableHardForkInitiation, which runs the same
+// tally + threshold check the boundary path would run.
+//
+// Performance: in steady state the function returns from one of two
+// short-circuits (transitionInfo already Known, or tip is pre-deadline)
+// before any database access, so per-block invocation cost is a few
+// pointer dereferences. The full DB-driven check fires only in the
+// post-voting-deadline window before the boundary, which on mainnet
+// is at most a few minutes per epoch and at most one HardForkInitiation
+// proposal at a time. If contention with concurrent readers becomes a
+// concern in that window, the assembly can be moved out of the
+// caller's lock-held section using the snapshot/apply pattern
+// rollback() uses for newPParams.
+//
+// Lock semantics: call under ls.Lock() at the per-block tip-update and
+// rollback sites (both already hold the write lock when invoking the
+// sibling evaluators). Safe to call without a lock during the
+// single-threaded startup path before the chainsync goroutine starts.
+func (ls *LedgerState) evaluateHardForkInitiationStability() {
+	if ls.currentEpoch.LengthInSlots == 0 {
+		return
+	}
+	// Defer to any TransitionKnown already set by a higher-priority
+	// source (TestXHardForkAtEpoch override or pparams-bump
+	// detection). Only promote from Unknown / Impossible, matching
+	// the pattern of the sibling evaluators on this code path. This
+	// also gives idempotency: once we've published the upcoming
+	// boundary, subsequent block-apply invocations short-circuit
+	// without a DB lookup.
+	if ls.transitionInfo.State == hardfork.TransitionKnown {
+		return
+	}
+	expectedTargetEpoch := ls.currentEpoch.EpochId + 1
+	epochEndSlot, addErr := checkedSlotAdd(
+		ls.currentEpoch.StartSlot,
+		uint64(ls.currentEpoch.LengthInSlots),
+	)
+	if addErr != nil {
+		return
+	}
+	stabilityWindow := ls.calculateStabilityWindowForEra(ls.currentEra.Id)
+	// votingDeadline = epochEndSlot - 2*stabilityWindow. Guard the
+	// subtraction; on a small synthetic epoch the deadline could land
+	// before the epoch start, in which case any tip in-epoch is
+	// post-deadline.
+	deadlineGap := 2 * stabilityWindow
+	var votingDeadline uint64
+	if epochEndSlot > deadlineGap {
+		votingDeadline = epochEndSlot - deadlineGap
+	}
+	if ls.currentTip.Point.Slot < votingDeadline {
+		return
+	}
+	conwayGenesis := ls.config.CardanoNodeConfig.ConwayGenesis()
+	result, err := governance.EvaluateRatifiableHardForkInitiation(
+		governance.StabilityCheckInputs{
+			DB:            ls.db,
+			Logger:        ls.config.Logger,
+			CurrentEpoch:  ls.currentEpoch.EpochId,
+			PParams:       ls.currentPParams,
+			ConwayGenesis: conwayGenesis,
+		},
+	)
+	if err != nil {
+		ls.config.Logger.Warn(
+			"hardfork-initiation stability check failed",
+			"error", err,
+			"component", "ledger",
+		)
+		return
+	}
+	if result == nil {
+		return
+	}
+	// A ratifiable HardForkInitiation is only an era transition if its
+	// target ProtocolVersion crosses an era boundary. An intra-era
+	// pparams bump (e.g. Plomin's pv9 → pv10, both Conway) ratifies
+	// through the same governance path but doesn't end the era;
+	// surfacing it as TransitionKnown would mislead clients into
+	// thinking the era ends at the next boundary. Filter using the
+	// same era-mapping rule the boundary-time IsHardForkTransition
+	// applies, so mid-epoch detection and boundary dispatch agree.
+	currentVer, err := GetProtocolVersion(ls.currentPParams)
+	if err != nil {
+		return
+	}
+	targetVer := ProtocolVersion{
+		Major: result.NewMajor,
+		Minor: result.NewMinor,
+	}
+	if !IsHardForkTransition(currentVer, targetVer) {
+		return
+	}
+	ls.transitionInfo = hardfork.NewTransitionKnown(expectedTargetEpoch)
 }
 
 // computePParams loads protocol parameters for the given epoch/era

--- a/ledger/transition_stability_test.go
+++ b/ledger/transition_stability_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stabilityFixtureEpoch parameters: Shelley-style 432_000-slot epoch,
+// safeZone = ceil(3*432/0.05) = 25_920, voting deadline distance from
+// epoch end is 2 * safeZone = 51_840. So an epoch ending at slot
+// 532_000 has its voting deadline at slot 480_160.
+const (
+	stabilityFixtureEpochID    uint64 = 500
+	stabilityFixtureEpochStart uint64 = 100_000
+	stabilityFixtureEpochLen   uint   = 432_000
+	stabilityFixtureEpochEnd   uint64 = stabilityFixtureEpochStart +
+		uint64(stabilityFixtureEpochLen)
+	stabilityFixtureVotingDeadline uint64 = stabilityFixtureEpochEnd - 2*25_920
+)
+
+// stabilityFixtureLedgerState assembles a LedgerState wired with
+// real-shaped Shelley genesis (so calculateStabilityWindowForEra returns
+// the expected 25_920) and an in-memory DB. The caller seeds proposal /
+// vote rows on db, sets currentTip and transitionInfo, and invokes
+// evaluateHardForkInitiationStability.
+//
+// Setting currentPParams to Conway pparams with the supplied major
+// version exercises the post-Conway code path inside the helper.
+// Bootstrap (major <= 9) uses the simplest ratification semantics
+// (single yes vote suffices) so a typical test only needs one DRep
+// fixture.
+func stabilityFixtureLedgerState(
+	t *testing.T,
+	major uint,
+) (*LedgerState, *database.Database) {
+	t.Helper()
+	db := newTestDB(t)
+	pparams := mockledger.NewMockConwayProtocolParams()
+	pparams.ProtocolVersion.Major = major
+	ls := &LedgerState{
+		db:             db,
+		currentEra:     eras.ConwayEraDesc,
+		currentEpoch:   newTestEpoch(stabilityFixtureEpochID, stabilityFixtureEpochStart, stabilityFixtureEpochLen, eras.ConwayEraDesc.Id),
+		currentPParams: &pparams,
+		transitionInfo: hardfork.NewTransitionUnknown(),
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	return ls, db
+}
+
+// seedRatifiableBootstrapHardForkInitiation primes the DB so that the
+// governance ratifiability helper returns a non-nil result when the
+// bootstrap (major<=9) ratification rule is in effect — a HardForkInitiation
+// proposal in the active set plus a single DRep yes vote.
+func seedRatifiableBootstrapHardForkInitiation(
+	t *testing.T,
+	db *database.Database,
+	currentEpoch uint64,
+	targetMajor uint,
+) *models.GovernanceProposal {
+	t.Helper()
+	action := &lcommon.HardForkInitiationGovAction{Type: 1}
+	action.ProtocolVersion.Major = targetMajor
+	action.ProtocolVersion.Minor = 0
+	cborBytes, err := cbor.Encode(action)
+	require.NoError(t, err)
+
+	proposal := &models.GovernanceProposal{
+		TxHash:        repeatByte(32, 0xAA),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeHardForkInitiation),
+		ProposedEpoch: currentEpoch - 1,
+		ExpiresEpoch:  currentEpoch + 10,
+		Deposit:       1_000,
+		ReturnAddress: repeatByte(29, 0),
+		AnchorURL:     "https://example.invalid/anchor",
+		AnchorHash:    repeatByte(32, 0xEE),
+		GovActionCbor: cborBytes,
+		AddedSlot:     1,
+	}
+	require.NoError(t, db.SetGovernanceProposal(proposal, nil))
+	loaded, err := db.GetGovernanceProposal(proposal.TxHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	drepCred := repeatByte(28, 0xBB)
+	stakeCred := repeatByte(28, 0xCC)
+	require.NoError(t, db.CreateDrep(nil, &models.Drep{
+		Credential: drepCred,
+		Active:     true,
+		AddedSlot:  1,
+	}))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: stakeCred,
+		Drep:       drepCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		AddedSlot:  1,
+		Active:     true,
+	}))
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+		TxId:       repeatByte(32, 0x01),
+		OutputIdx:  0,
+		StakingKey: stakeCred,
+		AddedSlot:  1,
+		Amount:     types.Uint64(1_000),
+	}))
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      loaded.ID,
+		VoterType:       models.VoterTypeDRep,
+		VoterCredential: drepCred,
+		Vote:            models.VoteYes,
+		AddedSlot:       2,
+	}, nil))
+	return loaded
+}
+
+func repeatByte(length int, b byte) []byte {
+	out := make([]byte, length)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+// TestEvaluateHardForkInitiationStability_PreDeadline_NoChange pins the
+// "votes can still flip the outcome" guard: while the current tip is
+// before the voting deadline (epochEnd - 2*stabilityWindow), the helper
+// must not surface the upcoming transition even if the in-flight
+// proposal currently meets thresholds — a yet-to-arrive No vote could
+// still defeat it.
+func TestEvaluateHardForkInitiationStability_PreDeadline_NoChange(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9 /* bootstrap */)
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 7,
+	)
+	// Tip one slot before the voting deadline.
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline-1, []byte("tip")),
+	}
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
+		"pre-deadline must not promote to TransitionKnown")
+}
+
+// TestEvaluateHardForkInitiationStability_PostDeadline_Ratifiable_SetsKnown
+// is the core happy-path: after the voting deadline, with a ratifiable
+// HardForkInitiation in flight, the helper must set TransitionKnown for
+// the epoch the boundary will fire (currentEpoch + 1).
+func TestEvaluateHardForkInitiationStability_PostDeadline_Ratifiable_SetsKnown(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9 /* bootstrap */)
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 7,
+	)
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline, []byte("tip")),
+	}
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State,
+		"post-deadline + ratifiable must set TransitionKnown")
+	assert.Equal(t, stabilityFixtureEpochID+1, ls.transitionInfo.KnownEpoch,
+		"target epoch is the next epoch boundary")
+}
+
+// TestEvaluateHardForkInitiationStability_PostDeadline_NotRatifiable_NoChange
+// pins the negative side: post-deadline without a ratifiable proposal,
+// transitionInfo stays Unknown. (No proposal seeded; helper returns nil.)
+func TestEvaluateHardForkInitiationStability_PostDeadline_NotRatifiable_NoChange(t *testing.T) {
+	ls, _ := stabilityFixtureLedgerState(t, 9)
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline+5_000, []byte("tip")),
+	}
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
+		"no ratifiable proposal means transitionInfo stays Unknown")
+}
+
+// TestEvaluateHardForkInitiationStability_PreConwayPParams_NoOp pins the
+// short-circuit when the chain is pre-Conway: no governance state
+// machine exists, so the helper must not even attempt the DB lookup
+// (and certainly must not promote transitionInfo).
+func TestEvaluateHardForkInitiationStability_PreConwayPParams_NoOp(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9)
+	// Even with a "ratifiable" proposal seeded, swapping pparams to nil
+	// (or any non-Conway type) makes the helper short-circuit before
+	// it hits the proposal store.
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 7,
+	)
+	ls.currentPParams = nil
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline+5_000, []byte("tip")),
+	}
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
+		"pre-Conway pparams must short-circuit without promotion")
+}
+
+// TestEvaluateHardForkInitiationStability_AlreadyKnownForSameEpoch_Idempotent
+// pins the short-circuit when transitionInfo already reports the same
+// upcoming boundary. The function must not redundantly mutate state
+// (a redundant mutation is harmless to behaviour but makes per-block
+// invocations noisier than necessary).
+func TestEvaluateHardForkInitiationStability_AlreadyKnownForSameEpoch_Idempotent(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9)
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 7,
+	)
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline+5_000, []byte("tip")),
+	}
+	ls.transitionInfo = hardfork.NewTransitionKnown(stabilityFixtureEpochID + 1)
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	assert.Equal(t, stabilityFixtureEpochID+1, ls.transitionInfo.KnownEpoch)
+}
+
+// TestEvaluateHardForkInitiationStability_PreservesKnownFromOtherSource
+// pins the deference to higher-priority sources of TransitionKnown.
+// Both evaluateTriggerAtEpoch (test override) and reconstructTransitionInfo
+// (pparams-bump detection) may set Known for a specific epoch. The
+// mid-epoch governance detector must not clobber that decision even if
+// it would otherwise fire, so on-chain HFI ratifiability cannot
+// override an operator-configured TestXHardForkAtEpoch boundary.
+func TestEvaluateHardForkInitiationStability_PreservesKnownFromOtherSource(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9)
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 7,
+	)
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline+5_000, []byte("tip")),
+	}
+	const externalTargetEpoch = stabilityFixtureEpochID + 7
+	ls.transitionInfo = hardfork.NewTransitionKnown(externalTargetEpoch)
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
+	assert.Equal(t, uint64(externalTargetEpoch), ls.transitionInfo.KnownEpoch,
+		"a Known target set elsewhere must not be overwritten by mid-epoch detection")
+}
+
+// TestEvaluateHardForkInitiationStability_IntraEraHFI_DoesNotSetKnown
+// pins the era-boundary gate: TransitionKnown signals an upcoming era
+// transition, not just any pparams bump. A HardForkInitiation that
+// proposes a new ProtocolVersion still inside the current era's
+// version range (e.g. Plomin's pv9 → pv10, both Conway) is an
+// intra-era bump and must not be surfaced as TransitionKnown — clients
+// would otherwise see era-history responses claiming the era ends at
+// epoch+1 when in fact the era continues.
+//
+// The check matches the era-filter the boundary path's
+// IsHardForkTransition applies, so mid-epoch detection and the
+// boundary's enactment dispatch agree on what counts as a transition.
+func TestEvaluateHardForkInitiationStability_IntraEraHFI_DoesNotSetKnown(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9 /* Conway, bootstrap */)
+	// Target major 10 — still in Conway (Conway covers pv9-pv10).
+	// A ratifiable proposal here represents an intra-era pparams
+	// bump, not an era transition.
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 10,
+	)
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline+5_000, []byte("tip")),
+	}
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
+		"intra-era HardForkInitiation must not be surfaced as TransitionKnown")
+}
+
+// TestEvaluateHardForkInitiationStability_UpgradesImpossibleToKnown pins
+// the priority order: TransitionKnown is strictly more informative than
+// TransitionImpossible (the latter only says "no transition this epoch
+// before safe-zone end", the former says "transition will happen at
+// epoch+1"). When both could apply, Known wins.
+func TestEvaluateHardForkInitiationStability_UpgradesImpossibleToKnown(t *testing.T) {
+	ls, db := stabilityFixtureLedgerState(t, 9)
+	seedRatifiableBootstrapHardForkInitiation(
+		t, db, stabilityFixtureEpochID, 7,
+	)
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.NewPoint(stabilityFixtureVotingDeadline+5_000, []byte("tip")),
+	}
+	ls.transitionInfo = hardfork.NewTransitionImpossible()
+
+	ls.evaluateHardForkInitiationStability()
+
+	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State,
+		"a ratifiable proposal must upgrade Impossible to Known")
+	assert.Equal(t, stabilityFixtureEpochID+1, ls.transitionInfo.KnownEpoch)
+}
+


### PR DESCRIPTION
contributes to #1857 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Surfaces upcoming era transitions mid-epoch by detecting ratifiable HardForkInitiation proposals after the voting deadline. Sets TransitionKnown for the next epoch so clients see the transition earlier and avoid transient Unknown after rollbacks.

- New Features
  - Added `ledger/governance/stability.go` with StabilityCheckInputs and EvaluateRatifiableHardForkInitiation. Uses live tallies, active DReps, committee quorum, and parent-chain lineage; pre-Conway pparams return nil.
  - Integrated `evaluateHardForkInitiationStability` in `ledger/state.go` (startup, post-epoch checks, and after rollback). Runs only after the voting deadline (epochEnd - 2*stabilityWindow), upgrades Unknown/Impossible to Known, and never overrides an existing Known.
  - Added tests for bootstrap semantics, non-HFI filtering, pre-/post-deadline behavior, pre-Conway short-circuit, idempotency, and priority over Impossible or external Known.

<sup>Written for commit 721936b1f6ab9d7aa64cf83a16cb4d90c50f779d. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2079?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Proactive hard fork stability detection that evaluates active hard fork proposals during in-epoch processing and determines their ratification likelihood based on current governance voting state.
  * Early notification of upcoming protocol upgrades before epoch boundaries.

* **Tests**
  * Comprehensive test coverage for hard fork stability detection, including edge cases and protocol version-dependent governance logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->