### PR TITLE
feat(ledger): add guard to only advance a single era

### DIFF
--- a/ledger/eras/advancement.go
+++ b/ledger/eras/advancement.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+// IsValidEraAdvancement reports whether a block tagged with nextEraId
+// can legitimately advance the ledger from currentEraId. Valid cases:
+//
+//   - Same era (in-era epoch rollover): nextEraId == currentEraId.
+//   - One step forward: nextEraId is the era immediately following
+//     currentEraId in the ordered Eras slice.
+//
+// All other cases — multi-step forward, any backwards step, and
+// advancement to or from an era that is not present in the Eras slice
+// — are rejected. Each era boundary on a healthy chain is crossed by a
+// specific block from that era, so multi-step advancement implies a
+// non-conforming block, a malformed snapshot, or a chain-selection bug;
+// silently catching up by iterating each era's HardForkFunc would skip
+// per-era epoch-based events that should have fired during the omitted
+// span.
+//
+// Era IDs are not assumed to be contiguous integers; the check resolves
+// each ID to its position in Eras and compares positions.
+func IsValidEraAdvancement(currentEraId, nextEraId uint) bool {
+	currentIdx := indexOfEra(currentEraId)
+	if currentIdx < 0 {
+		return false
+	}
+	if nextEraId == currentEraId {
+		return true
+	}
+	nextIdx := indexOfEra(nextEraId)
+	if nextIdx < 0 {
+		return false
+	}
+	return nextIdx == currentIdx+1
+}
+
+// indexOfEra returns the position of an era ID in the Eras slice, or
+// -1 if the era is not present.
+func indexOfEra(eraId uint) int {
+	for i := range Eras {
+		if Eras[i].Id == eraId {
+			return i
+		}
+	}
+	return -1
+}

--- a/ledger/eras/advancement_test.go
+++ b/ledger/eras/advancement_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+)
+
+// TestIsValidEraAdvancement_SameEra: a block claiming the same era as
+// the ledger is valid (in-era epoch rollover).
+func TestIsValidEraAdvancement_SameEra(t *testing.T) {
+	for _, era := range eras.Eras {
+		if !eras.IsValidEraAdvancement(era.Id, era.Id) {
+			t.Errorf("same era %d (%s) must be a valid advancement",
+				era.Id, era.Name)
+		}
+	}
+}
+
+// TestIsValidEraAdvancement_OneStepForward: a block claiming the era
+// immediately after the ledger's era is valid (normal era boundary).
+func TestIsValidEraAdvancement_OneStepForward(t *testing.T) {
+	for i := 0; i < len(eras.Eras)-1; i++ {
+		current := eras.Eras[i]
+		next := eras.Eras[i+1]
+		if !eras.IsValidEraAdvancement(current.Id, next.Id) {
+			t.Errorf("one-step %d (%s) → %d (%s) must be valid",
+				current.Id, current.Name, next.Id, next.Name)
+		}
+	}
+}
+
+// TestIsValidEraAdvancement_MultiStepForward_Rejected: a block claiming
+// an era ≥2 ahead of the ledger is rejected. Each era boundary must be
+// crossed by a block from that era; multi-step advancement would skip
+// per-era epoch-based events that should have fired during the omitted
+// span.
+func TestIsValidEraAdvancement_MultiStepForward_Rejected(t *testing.T) {
+	for i := 0; i < len(eras.Eras); i++ {
+		for j := i + 2; j < len(eras.Eras); j++ {
+			current := eras.Eras[i]
+			next := eras.Eras[j]
+			if eras.IsValidEraAdvancement(current.Id, next.Id) {
+				t.Errorf("multi-step %d (%s) → %d (%s) must be rejected",
+					current.Id, current.Name, next.Id, next.Name)
+			}
+		}
+	}
+}
+
+// TestIsValidEraAdvancement_Backwards_Rejected: a block claiming an
+// earlier era than the ledger's current era is rejected. The chain
+// only advances forward through the era list.
+func TestIsValidEraAdvancement_Backwards_Rejected(t *testing.T) {
+	for i := 1; i < len(eras.Eras); i++ {
+		for j := 0; j < i; j++ {
+			current := eras.Eras[i]
+			next := eras.Eras[j]
+			if eras.IsValidEraAdvancement(current.Id, next.Id) {
+				t.Errorf("backwards %d (%s) → %d (%s) must be rejected",
+					current.Id, current.Name, next.Id, next.Name)
+			}
+		}
+	}
+}
+
+// TestIsValidEraAdvancement_UnknownNextEra_Rejected: a next era ID
+// outside the known era set (e.g. a block from a future era dingo
+// hasn't been updated for) is rejected. Accepting it would be silently
+// wrong: dingo cannot apply a HardForkFunc for an unknown era, so
+// pparams translation would be skipped.
+func TestIsValidEraAdvancement_UnknownNextEra_Rejected(t *testing.T) {
+	currentEraId := eras.Eras[len(eras.Eras)-1].Id
+	if eras.IsValidEraAdvancement(currentEraId, currentEraId+5) {
+		t.Errorf("advancement to unknown era %d must be rejected",
+			currentEraId+5)
+	}
+}
+
+// TestIsValidEraAdvancement_UnknownCurrentEra_Rejected: a current era
+// ID outside the known era set has no defined "next era" so any
+// advancement is rejected. This guards against caller bugs where the
+// snapshot era was zero or otherwise corrupt.
+func TestIsValidEraAdvancement_UnknownCurrentEra_Rejected(t *testing.T) {
+	unknownEraId := uint(99)
+	if eras.IsValidEraAdvancement(unknownEraId, unknownEraId) {
+		t.Errorf("advancement from unknown era %d must be rejected",
+			unknownEraId)
+	}
+	if eras.IsValidEraAdvancement(unknownEraId, eras.ConwayEraDesc.Id) {
+		t.Errorf("advancement from unknown era %d to known era must be rejected",
+			unknownEraId)
+	}
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2344,26 +2344,41 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				workingPParams := snapshotPParams
 				workingEraId := snapshotEra.Id
 
-				// Check for era change
+				// Check for era change. The guard rejects multi-step
+				// forward, backwards, and to/from-unknown-era cases:
+				// each era boundary on a healthy chain is crossed by
+				// a block from that era, so anything else implies a
+				// non-conforming block, a malformed snapshot, or a
+				// chain-selection bug. Allowing a multi-step jump
+				// would silently apply each intermediate era's
+				// HardForkFunc but skip per-era epoch-based events
+				// that should have fired during the omitted span.
 				if nextEpochEraId != snapshotEra.Id {
-					// Transition through every era between the current and the target era
-					for nextEraId := snapshotEra.Id + 1; nextEraId <= nextEpochEraId; nextEraId++ {
-						result, err := ls.transitionToEra(
-							txn,
-							nextEraId,
-							snapshotEpoch.EpochId,
-							snapshotEpoch.StartSlot+uint64(
-								snapshotEpoch.LengthInSlots,
-							),
-							workingPParams,
+					if !eras.IsValidEraAdvancement(
+						snapshotEra.Id, nextEpochEraId,
+					) {
+						return fmt.Errorf(
+							"refusing era advancement from %d to %d: "+
+								"only single-step forward advancement to "+
+								"a known era is permitted",
+							snapshotEra.Id, nextEpochEraId,
 						)
-						if err != nil {
-							return err
-						}
-						workingPParams = result.NewPParams
-						workingEraId = result.NewEra.Id
-						eraTransitions = append(eraTransitions, result)
 					}
+					result, err := ls.transitionToEra(
+						txn,
+						nextEpochEraId,
+						snapshotEpoch.EpochId,
+						snapshotEpoch.StartSlot+uint64(
+							snapshotEpoch.LengthInSlots,
+						),
+						workingPParams,
+					)
+					if err != nil {
+						return err
+					}
+					workingPParams = result.NewPParams
+					workingEraId = result.NewEra.Id
+					eraTransitions = append(eraTransitions, result)
 				}
 
 				// Process epoch rollover


### PR DESCRIPTION
part of #1857 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a guard that only allows single-step era advancement during block processing. This prevents skipping era-specific logic by rejecting multi-step, backward, or unknown era transitions.

- **New Features**
  - Added `ledger/eras.IsValidEraAdvancement(currentEraId, nextEraId)` to allow same-era or next-era only, based on positions in `eras.Eras`.
  - Enforced the guard in `ledger/state.go` during epoch rollover; perform one `transitionToEra` and error on invalid jumps.
  - Added tests for same-era, one-step forward, multi-step forward rejection, backward rejection, and unknown-era rejection.

<sup>Written for commit c8cf668f20a4f1020ad96b8c5ba541e2b6134d11. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2082?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

