### PR TITLE
feat: add SetTransactionBatched to sqlite/mysql/postgres

### DIFF
--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -121,6 +121,20 @@ func (b *BatchAccumulator) Reset() {
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
 }
 
+// MergeFrom appends all records from other into b.
+func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
+	b.KeyWitnesses = append(b.KeyWitnesses, other.KeyWitnesses...)
+	b.WitnessScripts = append(b.WitnessScripts, other.WitnessScripts...)
+	b.Scripts = append(b.Scripts, other.Scripts...)
+	b.PlutusData = append(b.PlutusData, other.PlutusData...)
+	b.Redeemers = append(b.Redeemers, other.Redeemers...)
+	b.AddressTxs = append(b.AddressTxs, other.AddressTxs...)
+	b.UtxoOutputs = append(b.UtxoOutputs, other.UtxoOutputs...)
+	b.UtxoSpends = append(b.UtxoSpends, other.UtxoSpends...)
+	b.CollateralRets = append(b.CollateralRets, other.CollateralRets...)
+	b.DeleteTxIDs = append(b.DeleteTxIDs, other.DeleteTxIDs...)
+}
+
 // FlushBatch writes all accumulated records in a deterministic order.
 func (d *MetadataStoreMysql) FlushBatch(
 	batch *BatchAccumulator,

--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -122,7 +122,11 @@ func (b *BatchAccumulator) Reset() {
 }
 
 // MergeFrom appends all records from other into b.
+// It is a no-op when other is nil or other == b.
 func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
+	if other == nil || other == b {
+		return
+	}
 	b.KeyWitnesses = append(b.KeyWitnesses, other.KeyWitnesses...)
 	b.WitnessScripts = append(b.WitnessScripts, other.WitnessScripts...)
 	b.Scripts = append(b.Scripts, other.Scripts...)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -3255,7 +3255,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				}
 				caseStmt := strings.Join(whenClauses, " ")
 				query := fmt.Sprintf(
-					"UPDATE certs SET certificate_id = CASE %s END WHERE id IN (?)",
+					"UPDATE certs SET certificate_id = CASE %s END WHERE id IN ?",
 					caseStmt,
 				)
 				values = append(values, ids)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2075,13 +2075,21 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	// ------------------------------------------------------------------ //
 	// 1. Write transaction record immediately (needed for FK IDs)         //
 	// ------------------------------------------------------------------ //
+	var feeUint uint64
+	if txFee := tx.Fee(); txFee != nil {
+		if txFee.BitLen() > 64 {
+			feeUint = math.MaxUint64
+		} else {
+			feeUint = txFee.Uint64()
+		}
+	}
 	tmpTx := &models.Transaction{
 		Hash:       txHash,
 		Type:       tx.Type(),
 		BlockHash:  point.Hash,
 		BlockIndex: idx,
 		Slot:       point.Slot,
-		Fee:        types.Uint64(tx.Fee().Uint64()),
+		Fee:        types.Uint64(feeUint),
 		TTL:        types.Uint64(tx.TTL()),
 		Valid:      tx.IsValid(),
 	}
@@ -2103,12 +2111,34 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	collateralReturn := tx.CollateralReturn()
 	produced := tx.Produced()
 
+	// For invalid transactions with collateral returns, fix indices via CBOR matching
+	// since Produced() uses enumerated indices rather than real transaction indices
+	var realIndexMap map[lcommon.Blake2b256]uint32
+	if !tx.IsValid() && collateralReturn != nil {
+		realIndexMap = make(map[lcommon.Blake2b256]uint32)
+		for idx, out := range tx.Outputs() {
+			if out != nil && idx <= int(^uint32(0)) {
+				// Hash CBOR for efficient map key
+				outputHash := lcommon.NewBlake2b256(out.Cbor())
+				//nolint:gosec // G115: idx bounds already checked above
+				realIndexMap[outputHash] = uint32(idx)
+			}
+		}
+	}
+
 	// Separate collateral return from regular outputs.
 	var colRetUtxo *models.Utxo
 	outputModels := make([]models.Utxo, 0, len(produced))
 	for _, utxo := range produced {
 		m := models.UtxoLedgerToModel(utxo, point.Slot)
 		if collateralReturn != nil && utxo.Output == collateralReturn {
+			// Fix collateral return index for invalid transactions
+			if realIndexMap != nil && m.Cbor != nil {
+				outputHash := lcommon.NewBlake2b256(m.Cbor)
+				if realIdx, ok := realIndexMap[outputHash]; ok {
+					m.OutputIdx = realIdx
+				}
+			}
 			colRetUtxo = &m
 			continue
 		}
@@ -2200,116 +2230,97 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
 	//    These update UTxOs that already exist from prior blocks.        //
 	// ------------------------------------------------------------------ //
-	if d.storageMode == types.StorageModeAPI {
-		// Fetch input UTxOs for address-indexing below.
-		for _, input := range tx.Inputs() {
+	if len(tx.Collateral()) > 0 {
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
 			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
 			if err != nil {
 				return fmt.Errorf(
-					"failed to fetch input UTxO (batched): %w",
+					"failed to fetch collateral UTxO (batched): %w",
 					err,
 				)
 			}
 			if utxo == nil {
 				continue
 			}
-			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
 		}
-
-		if len(tx.Collateral()) > 0 {
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
-			for _, input := range tx.Collateral() {
-				inTxId := input.Id().Bytes()
-				inIdx := input.Index()
-				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to fetch collateral UTxO (batched): %w",
-						err,
-					)
-				}
-				if utxo == nil {
-					continue
-				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			if r := db.Exec(sql, args...); r.Error != nil {
+				return fmt.Errorf(
+					"batch update collateral (batched): %w",
+					r.Error,
 				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
-				tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
-			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
-				)
-				if r := db.Exec(sql, args...); r.Error != nil {
-					return fmt.Errorf(
-						"batch update collateral (batched): %w",
-						r.Error,
-					)
-				}
 			}
 		}
+	}
 
-		if len(tx.ReferenceInputs()) > 0 {
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
-			for _, input := range tx.ReferenceInputs() {
-				inTxId := input.Id().Bytes()
-				inIdx := input.Index()
-				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to fetch reference input UTxO (batched): %w",
-						err,
-					)
-				}
-				if utxo == nil {
-					continue
-				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
-				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
-				tmpTx.ReferenceInputs = append(
-					tmpTx.ReferenceInputs,
-					*utxo,
+	if len(tx.ReferenceInputs()) > 0 {
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+		for _, input := range tx.ReferenceInputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch reference input UTxO (batched): %w",
+					err,
 				)
 			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
+			if utxo == nil {
+				continue
+			}
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			tmpTx.ReferenceInputs = append(
+				tmpTx.ReferenceInputs,
+				*utxo,
+			)
+		}
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			if r := db.Exec(sql, args...); r.Error != nil {
+				return fmt.Errorf(
+					"batch update reference inputs (batched): %w",
+					r.Error,
 				)
-				if r := db.Exec(sql, args...); r.Error != nil {
-					return fmt.Errorf(
-						"batch update reference inputs (batched): %w",
-						r.Error,
-					)
-				}
 			}
 		}
 	}
@@ -2343,6 +2354,23 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 		// On retry: schedule deletion of previously flushed rows for this tx.
 		if needsIdFetch {
 			acc.AddDeleteTxID(tmpTx.ID)
+		}
+
+		// Fetch input UTxOs for address-indexing below.
+		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch input UTxO (batched): %w",
+					err,
+				)
+			}
+			if utxo == nil {
+				continue
+			}
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
 		}
 
 		// Address-transaction index.
@@ -2486,6 +2514,9 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 			}
 			if len(unifiedIDs) > 0 {
 				tables := []string{
+					// Child tables must be deleted before parent tables (FK constraints).
+					"pool_registration_owner",
+					"pool_registration_relay",
 					"stake_registration", "pool_registration", "pool_retirement",
 					"auth_committee_hot", "resign_committee_cold",
 					"deregistration", "stake_delegation",
@@ -2770,6 +2801,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					}
 					if tmpAccount.ID == 0 {
 						tmpAccount.AddedSlot = point.Slot
+						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -2960,6 +2992,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					}
 					if tmpAccount.ID == 0 {
 						tmpAccount.AddedSlot = point.Slot
+						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2067,7 +2067,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	txn types.Txn,
 ) error {
 	if acc == nil {
-		return fmt.Errorf("SetTransactionBatched: acc must not be nil")
+		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2042,6 +2042,1224 @@ func (d *MetadataStoreMysql) SetTransaction(
 	return nil
 }
 
+// SetTransactionBatched performs the same logical work as SetTransaction but
+// accumulates all per-item metadata rows into acc for later bulk flushing via
+// FlushBatch.  The transaction record itself is still written immediately so
+// that downstream foreign-key dependencies (witness, script, etc.) can
+// reference its auto-increment ID.
+//
+// Items written immediately (FK or ordering dependency):
+//   - Transaction record (upsert)
+//   - Collateral / reference-input UTXO marker UPDATEs
+//   - Certificates and governance records
+//   - storeTransactionDatums hash index
+//
+// Items deferred to acc:
+//   - UTxO outputs, collateral return, UTxO spends
+//   - Key witnesses, witness scripts, scripts, plutus data, redeemers
+//   - Address-transaction index rows
+func (d *MetadataStoreMysql) SetTransactionBatched(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	acc *BatchAccumulator,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// ------------------------------------------------------------------ //
+	// 1. Write transaction record immediately (needed for FK IDs)         //
+	// ------------------------------------------------------------------ //
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Slot:       point.Slot,
+		Fee:        types.Uint64(tx.Fee().Uint64()),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	var metadataLabels []labelcodec.Entry
+	if tx.Metadata() != nil && d.storageMode == types.StorageModeAPI {
+		tmpMetadata, tmpLabels, err := labelcodec.EncodeAndExtract(
+			tx.Metadata(),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to extract metadata labels: %w",
+				err,
+			)
+		}
+		tmpTx.Metadata = tmpMetadata
+		metadataLabels = tmpLabels
+	}
+
+	collateralReturn := tx.CollateralReturn()
+	produced := tx.Produced()
+
+	// Separate collateral return from regular outputs.
+	var colRetUtxo *models.Utxo
+	outputModels := make([]models.Utxo, 0, len(produced))
+	for _, utxo := range produced {
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			colRetUtxo = &m
+			continue
+		}
+		outputModels = append(outputModels, m)
+	}
+
+	// Clear Outputs on tmpTx so the upsert doesn't try to create them.
+	tmpTx.Outputs = nil
+
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index", "slot"},
+		),
+	}).Create(tmpTx)
+	needsIdFetch := tmpTx.ID == 0
+
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create transaction (batched) at slot %d, block %x, txHash %x, txIndex %d: %w",
+			point.Slot,
+			point.Hash,
+			txHash,
+			idx,
+			result.Error,
+		)
+	}
+	if needsIdFetch {
+		var existing struct{ ID uint }
+		if err := db.Model(&models.Transaction{}).
+			Select("id").
+			Where("hash = ?", txHash).
+			Take(&existing).Error; err != nil {
+			return fmt.Errorf(
+				"failed to fetch transaction ID after upsert (batched): %w",
+				err,
+			)
+		}
+		tmpTx.ID = existing.ID
+	}
+
+	// metadata labels – small, write immediately just like SetTransaction.
+	if len(metadataLabels) > 0 {
+		labelRecords := make(
+			[]models.TransactionMetadataLabel,
+			0,
+			len(metadataLabels),
+		)
+		for _, tmpLabel := range metadataLabels {
+			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
+				TransactionID: tmpTx.ID,
+				Label:         tmpLabel.Label,
+				Slot:          point.Slot,
+				CborValue:     tmpLabel.CborValue,
+				JsonValue:     tmpLabel.JsonValue,
+			})
+		}
+		if result := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "transaction_id"},
+				{Name: "label"},
+			},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"slot", "cbor_value", "json_value"},
+			),
+		}).Create(&labelRecords); result.Error != nil {
+			return fmt.Errorf(
+				"create metadata labels for tx %x (batched): %w",
+				txHash,
+				result.Error,
+			)
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 2. Accumulate UTxO outputs                                          //
+	// ------------------------------------------------------------------ //
+	for i := range outputModels {
+		outputModels[i].ID = 0
+		outputModels[i].TransactionID = &tmpTx.ID
+		acc.AddUtxoOutput(outputModels[i])
+	}
+	if colRetUtxo != nil {
+		colRetUtxo.CollateralReturnForTxID = &tmpTx.ID
+		acc.AddCollateralReturn(*colRetUtxo)
+	}
+
+	// ------------------------------------------------------------------ //
+	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
+	//    These update UTxOs that already exist from prior blocks.        //
+	// ------------------------------------------------------------------ //
+	if d.storageMode == types.StorageModeAPI {
+		// Fetch input UTxOs for address-indexing below.
+		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch input UTxO (batched): %w",
+					err,
+				)
+			}
+			if utxo == nil {
+				continue
+			}
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
+		}
+
+		if len(tx.Collateral()) > 0 {
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.Collateral() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+				if err != nil {
+					return fmt.Errorf(
+						"failed to fetch collateral UTxO (batched): %w",
+						err,
+					)
+				}
+				if utxo == nil {
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				if r := db.Exec(sql, args...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update collateral (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+
+		if len(tx.ReferenceInputs()) > 0 {
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.ReferenceInputs() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+				if err != nil {
+					return fmt.Errorf(
+						"failed to fetch reference input UTxO (batched): %w",
+						err,
+					)
+				}
+				if utxo == nil {
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.ReferenceInputs = append(
+					tmpTx.ReferenceInputs,
+					*utxo,
+				)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				if r := db.Exec(sql, args...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update reference inputs (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 4. Accumulate UTxO spends (consumed inputs)                        //
+	// ------------------------------------------------------------------ //
+	if len(tx.Consumed()) > 0 {
+		seen := make(map[string]bool, len(tx.Consumed()))
+		for _, input := range tx.Consumed() {
+			inTxID := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxID, inIdx)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			acc.AddUtxoSpend(utxoSpend{
+				TxId:          inTxID,
+				OutputIdx:     inIdx,
+				Slot:          point.Slot,
+				SpentByTxHash: txHash,
+			})
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 5. Accumulate API-mode metadata (witnesses, scripts, address txs)  //
+	// ------------------------------------------------------------------ //
+	if d.storageMode == types.StorageModeAPI {
+		// On retry: schedule deletion of previously flushed rows for this tx.
+		if needsIdFetch {
+			acc.AddDeleteTxID(tmpTx.ID)
+		}
+
+		// Address-transaction index.
+		addressUtxos := make(
+			[]models.Utxo,
+			0,
+			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(outputModels)+1,
+		)
+		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
+		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
+		addressUtxos = append(addressUtxos, outputModels...)
+		if colRetUtxo != nil {
+			addressUtxos = append(addressUtxos, *colRetUtxo)
+		}
+		for _, atx := range collectAddressTransactions(
+			tmpTx.ID,
+			point.Slot,
+			idx,
+			addressUtxos,
+		) {
+			acc.AddAddressTx(atx)
+		}
+
+		// Witnesses.
+		ws := tx.Witnesses()
+		if ws != nil {
+			for _, vkey := range ws.Vkey() {
+				acc.AddKeyWitness(models.KeyWitness{
+					TransactionID: tmpTx.ID,
+					Type:          models.KeyWitnessTypeVkey,
+					Vkey:          vkey.Vkey,
+					Signature:     vkey.Signature,
+				})
+			}
+			for _, bootstrap := range ws.Bootstrap() {
+				acc.AddKeyWitness(models.KeyWitness{
+					TransactionID: tmpTx.ID,
+					Type:          models.KeyWitnessTypeBootstrap,
+					PublicKey:     bootstrap.PublicKey,
+					Signature:     bootstrap.Signature,
+					ChainCode:     bootstrap.ChainCode,
+					Attributes:    bootstrap.Attributes,
+				})
+			}
+
+			// Scripts – collect into accumulator instead of writing to DB.
+			for _, s := range ws.NativeScripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypeNativeScript),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypeNativeScript),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV1Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV1),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV1),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV2Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV2),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV2),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV3Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV3),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV3),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+
+			// PlutusData (datums).
+			if tx.IsValid() {
+				for _, datum := range ws.PlutusData() {
+					acc.AddPlutusData(models.PlutusData{
+						TransactionID: tmpTx.ID,
+						Data:          datum.Cbor(),
+					})
+				}
+			}
+
+			// Redeemers.
+			if ws.Redeemers() != nil {
+				for key, value := range ws.Redeemers().Iter() {
+					//nolint:gosec
+					acc.AddRedeemer(models.Redeemer{
+						TransactionID: tmpTx.ID,
+						Tag:           uint8(key.Tag),
+						Index:         key.Index,
+						Data:          value.Data.Cbor(),
+						ExUnitsMemory: uint64(max(0, value.ExUnits.Memory)),
+						ExUnitsCPU:    uint64(max(0, value.ExUnits.Steps)),
+					})
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 6. Certificates and governance – immediate, same as SetTransaction //
+	// ------------------------------------------------------------------ //
+	if tx.IsValid() {
+		certs := tx.Certificates()
+		if len(certs) > 0 {
+			unifiedIDs := []uint{}
+			if result := db.Model(&models.Certificate{}).
+				Where("transaction_id = ?", tmpTx.ID).
+				Pluck("id", &unifiedIDs); result.Error != nil {
+				return fmt.Errorf(
+					"query existing unified certificates (batched): %w",
+					result.Error,
+				)
+			}
+			if len(unifiedIDs) > 0 {
+				tables := []string{
+					"stake_registration", "pool_registration", "pool_retirement",
+					"auth_committee_hot", "resign_committee_cold",
+					"deregistration", "stake_delegation",
+					"stake_registration_delegation", "stake_vote_delegation",
+					"stake_vote_registration_delegation", "registration",
+					"registration_drep", "deregistration_drep", "update_drep",
+					"vote_delegation", "vote_registration_delegation",
+					"move_instantaneous_rewards",
+				}
+				for _, table := range tables {
+					if result := db.Table(table).
+						Where("certificate_id IN ?", unifiedIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing %s records (batched): %w",
+							table,
+							result.Error,
+						)
+					}
+				}
+			}
+			certIDMap := make(map[int]uint)
+			certIDUpdates := make(map[uint]uint)
+			for i, cert := range certs {
+				var certType uint
+				switch cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypePoolRegistration)
+				case *lcommon.StakeRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistration)
+				case *lcommon.PoolRetirementCertificate:
+					certType = uint(lcommon.CertificateTypePoolRetirement)
+				case *lcommon.StakeDeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDeregistration)
+				case *lcommon.DeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistration)
+				case *lcommon.StakeDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDelegation)
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistrationDelegation)
+				case *lcommon.StakeVoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteDelegation)
+				case *lcommon.RegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeRegistration)
+				case *lcommon.RegistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeRegistrationDrep)
+				case *lcommon.DeregistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistrationDrep)
+				case *lcommon.UpdateDrepCertificate:
+					certType = uint(lcommon.CertificateTypeUpdateDrep)
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation)
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteRegistrationDelegation)
+				case *lcommon.VoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteDelegation)
+				case *lcommon.AuthCommitteeHotCertificate:
+					certType = uint(lcommon.CertificateTypeAuthCommitteeHot)
+				case *lcommon.ResignCommitteeColdCertificate:
+					certType = uint(lcommon.CertificateTypeResignCommitteeCold)
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					certType = uint(lcommon.CertificateTypeMoveInstantaneousRewards)
+				default:
+					d.logger.Warn(
+						"unknown certificate type (batched)",
+						"type",
+						fmt.Sprintf("%T", cert),
+					)
+					continue
+				}
+				unifiedCert := models.Certificate{
+					TransactionID: tmpTx.ID,
+					CertIndex:     uint(i), //nolint:gosec
+					CertType:      certType,
+					Slot:          point.Slot,
+					BlockHash:     point.Hash,
+				}
+				if result := db.Clauses(clause.OnConflict{
+					Columns: []clause.Column{
+						{Name: "transaction_id"},
+						{Name: "cert_index"},
+					},
+					DoNothing: true,
+				}).Create(&unifiedCert); result.Error != nil {
+					return fmt.Errorf(
+						"create unified certificate (batched): %w",
+						result.Error,
+					)
+				}
+				if unifiedCert.ID == 0 {
+					if result := db.Where(
+						"transaction_id = ? AND cert_index = ?",
+						tmpTx.ID,
+						uint(i), //nolint:gosec
+					).First(&unifiedCert); result.Error != nil {
+						return fmt.Errorf(
+							"fetch existing unified certificate (batched): %w",
+							result.Error,
+						)
+					}
+				}
+				certIDMap[i] = unifiedCert.ID
+			}
+			for i, cert := range certs {
+				deposit := uint64(0)
+				if certDeposits != nil {
+					if depositVal, ok := certDeposits[i]; ok {
+						deposit = depositVal
+					} else if certRequiresDeposit(cert) {
+						d.logger.Warn(
+							"missing deposit for deposit-bearing certificate (batched)",
+							"index", i, "type", fmt.Sprintf("%T", cert),
+						)
+					}
+				}
+				if certDeposits == nil && certRequiresDeposit(cert) {
+					return fmt.Errorf(
+						"missing certDeposits for deposit-bearing certificate at index %d (batched)",
+						i,
+					)
+				}
+				switch c := cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					tmpPool, err := d.GetPool(
+						lcommon.PoolKeyHash(c.Operator[:]),
+						true,
+						txn,
+					)
+					if err != nil && !errors.Is(err, models.ErrPoolNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{
+							PoolKeyHash: c.Operator[:],
+							VrfKeyHash:  c.VrfKeyHash[:],
+						}
+					}
+					tmpPool.Pledge = types.Uint64(c.Pledge)
+					tmpPool.Cost = types.Uint64(c.Cost)
+					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
+					tmpPool.RewardAccount = c.RewardAccount[:]
+					tmpReg := models.PoolRegistration{
+						PoolKeyHash:   c.Operator[:],
+						VrfKeyHash:    c.VrfKeyHash[:],
+						Pledge:        types.Uint64(c.Pledge),
+						Cost:          types.Uint64(c.Cost),
+						Margin:        &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount: c.RewardAccount[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if c.PoolMetadata != nil {
+						tmpReg.MetadataUrl = c.PoolMetadata.Url
+						tmpReg.MetadataHash = c.PoolMetadata.Hash[:]
+					}
+					for _, owner := range c.PoolOwners {
+						tmpReg.Owners = append(
+							tmpReg.Owners,
+							models.PoolRegistrationOwner{KeyHash: owner[:]},
+						)
+					}
+					tmpPool.Owners = tmpReg.Owners
+					for _, relay := range c.Relays {
+						r := models.PoolRegistrationRelay{
+							Ipv4: relay.Ipv4,
+							Ipv6: relay.Ipv6,
+						}
+						if relay.Port != nil {
+							r.Port = uint(*relay.Port)
+						}
+						if relay.Hostname != nil {
+							r.Hostname = *relay.Hostname
+						}
+						tmpReg.Relays = append(tmpReg.Relays, r)
+					}
+					tmpPool.Relays = tmpReg.Relays
+					if tmpPool.ID == 0 {
+						if r := db.Omit(clause.Associations).Create(tmpPool); r.Error != nil {
+							return fmt.Errorf(
+								"process certificate (batched): %w",
+								r.Error,
+							)
+						}
+					} else {
+						if r := db.Omit(clause.Associations).Save(tmpPool); r.Error != nil {
+							return fmt.Errorf(
+								"process certificate (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					tmpReg.PoolID = tmpPool.ID
+					for j := range tmpReg.Owners {
+						tmpReg.Owners[j].PoolID = tmpPool.ID
+					}
+					for j := range tmpReg.Relays {
+						tmpReg.Relays[j].PoolID = tmpPool.ID
+					}
+					r2 := db.Clauses(clause.OnConflict{
+						Columns: []clause.Column{
+							{Name: "pool_id"},
+							{Name: "added_slot"},
+						},
+						DoUpdates: clause.AssignmentColumns([]string{
+							"vrf_key_hash", "pledge", "cost", "margin",
+							"reward_account", "certificate_id",
+							"metadata_url", "metadata_hash", "deposit_amount",
+						}),
+					}).Omit("Owners", "Relays").Create(&tmpReg)
+					if r2.Error != nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							r2.Error,
+						)
+					}
+					if tmpReg.ID == 0 {
+						var existing models.PoolRegistration
+						if err := db.Where(
+							"pool_id = ? AND added_slot = ?",
+							tmpReg.PoolID, tmpReg.AddedSlot,
+						).First(&existing).Error; err != nil {
+							return fmt.Errorf(
+								"fetching pool registration ID after upsert (batched): %w",
+								err,
+							)
+						}
+						tmpReg.ID = existing.ID
+					}
+					if r := db.Where(
+						"pool_registration_id = ?", tmpReg.ID,
+					).Delete(&models.PoolRegistrationOwner{}); r.Error != nil {
+						return fmt.Errorf(
+							"delete pool registration owners (batched): %w",
+							r.Error,
+						)
+					}
+					if r := db.Where(
+						"pool_registration_id = ?", tmpReg.ID,
+					).Delete(&models.PoolRegistrationRelay{}); r.Error != nil {
+						return fmt.Errorf(
+							"delete pool registration relays (batched): %w",
+							r.Error,
+						)
+					}
+					if len(tmpReg.Owners) > 0 {
+						for j := range tmpReg.Owners {
+							tmpReg.Owners[j].PoolRegistrationID = tmpReg.ID
+							tmpReg.Owners[j].PoolID = tmpPool.ID
+						}
+						if r := db.Create(&tmpReg.Owners); r.Error != nil {
+							return fmt.Errorf(
+								"create pool registration owners (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					if len(tmpReg.Relays) > 0 {
+						for j := range tmpReg.Relays {
+							tmpReg.Relays[j].PoolRegistrationID = tmpReg.ID
+							tmpReg.Relays[j].PoolID = tmpPool.ID
+						}
+						if r := db.Create(&tmpReg.Relays); r.Error != nil {
+							return fmt.Errorf(
+								"create pool registration relays (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeRegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpReg := models.StakeRegistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.PoolRetirementCertificate:
+					tmpPool, err := d.GetPool(
+						lcommon.PoolKeyHash(c.PoolKeyHash[:]),
+						true,
+						txn,
+					)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{PoolKeyHash: c.PoolKeyHash[:]}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "pool_key_hash"}},
+							UpdateAll: true,
+						}).Create(&tmpPool)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpItem := models.PoolRetirement{
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Epoch:         c.Epoch,
+						AddedSlot:     point.Slot,
+						PoolID:        tmpPool.ID,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpAccount == nil {
+						tmpAccount = &models.Account{StakingKey: stakeKey}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeDeregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.DeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpAccount == nil {
+						tmpAccount = &models.Account{StakingKey: stakeKey}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.Deregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+						Amount:        types.Uint64(deposit),
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.StakeRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeVoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeVoteDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.RegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpReg := models.Registration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.RegistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpReg := models.RegistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpReg.AnchorURL = c.Anchor.Url
+						tmpReg.AnchorHash = c.Anchor.DataHash[:]
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot,
+						tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					r2 := db.Clauses(clause.OnConflict{
+						Columns: []clause.Column{
+							{Name: "drep_credential"},
+							{Name: "added_slot"},
+						},
+						DoUpdates: clause.AssignmentColumns([]string{
+							"anchor_url", "anchor_hash", "certificate_id",
+						}),
+					}).Create(&tmpReg)
+					if r2.Error != nil {
+						return fmt.Errorf("process certificate (batched): %w", r2.Error)
+					}
+					if tmpReg.ID == 0 {
+						var existing models.RegistrationDrep
+						if err := db.Where(
+							"drep_credential = ? AND added_slot = ?",
+							tmpReg.DrepCredential, tmpReg.AddedSlot,
+						).First(&existing).Error; err != nil {
+							return fmt.Errorf(
+								"fetching drep registration ID after upsert (batched): %w",
+								err,
+							)
+						}
+						tmpReg.ID = existing.ID
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.DeregistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpDereg := models.DeregistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if existingDrep == nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							models.ErrDrepNotFound,
+						)
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot, "", nil, false, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpDereg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpDereg.ID
+				case *lcommon.UpdateDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpUpdate := models.UpdateDrep{
+						Credential:    drepCredential,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpUpdate.AnchorURL = c.Anchor.Url
+						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
+					}
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if existingDrep == nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							models.ErrDrepNotFound,
+						)
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot,
+						tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpUpdate, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.StakeVoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.VoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.VoteDelegation{
+						StakingKey:    stakeKey,
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.AuthCommitteeHotCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					hotCredential := c.HotCredential.Credential[:]
+					tmpAuth := models.AuthCommitteeHot{
+						ColdCredential: coldCredential,
+						HotCredential:  hotCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if err := saveCertRecord(&tmpAuth, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpAuth.ID
+				case *lcommon.ResignCommitteeColdCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					tmpResign := models.ResignCommitteeCold{
+						ColdCredential: coldCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if c.Anchor != nil {
+						tmpResign.AnchorURL = c.Anchor.Url
+						tmpResign.AnchorHash = c.Anchor.DataHash[:]
+					}
+					if err := saveCertRecord(&tmpResign, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpResign.ID
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					tmpMIR := models.MoveInstantaneousRewards{
+						Pot:           c.Reward.Source,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if r := db.Create(&tmpMIR); r.Error != nil {
+						return fmt.Errorf("process certificate (batched): %w", r.Error)
+					}
+					certIDUpdates[certIDMap[i]] = tmpMIR.ID
+					for credential, amount := range c.Reward.Rewards {
+						tmpReward := models.MoveInstantaneousRewardsReward{
+							Credential: credential.Credential[:],
+							Amount:     types.Uint64(amount),
+							MIRID:      tmpMIR.ID,
+						}
+						if r := db.Create(&tmpReward); r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+				default:
+					return fmt.Errorf(
+						"unsupported certificate type (batched) %T",
+						cert,
+					)
+				}
+			}
+
+			if len(certIDUpdates) > 0 {
+				var ids []uint
+				var whenClauses []string
+				var values []any
+				for unifiedID, specializedID := range certIDUpdates {
+					ids = append(ids, unifiedID)
+					whenClauses = append(whenClauses, "WHEN id = ? THEN ?")
+					values = append(values, unifiedID, specializedID)
+				}
+				caseStmt := strings.Join(whenClauses, " ")
+				query := fmt.Sprintf(
+					"UPDATE certs SET certificate_id = CASE %s END WHERE id IN (?)",
+					caseStmt,
+				)
+				values = append(values, ids)
+				if r := db.Exec(query, values...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update unified certificates (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+
+		if d.storageMode == types.StorageModeAPI {
+			if err := d.storeTransactionDatums(tx, point.Slot, txn); err != nil {
+				return fmt.Errorf("store datums failed (batched): %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // SetGenesisTransaction stores a genesis transaction record.
 // Genesis transactions have no inputs, witnesses, or fees - just outputs.
 func (d *MetadataStoreMysql) SetGenesisTransaction(

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2114,34 +2114,15 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	collateralReturn := tx.CollateralReturn()
 	produced := tx.Produced()
 
-	// For invalid transactions with collateral returns, fix indices via CBOR matching
-	// since Produced() uses enumerated indices rather than real transaction indices
-	var realIndexMap map[lcommon.Blake2b256]uint32
-	if !tx.IsValid() && collateralReturn != nil {
-		realIndexMap = make(map[lcommon.Blake2b256]uint32)
-		for idx, out := range tx.Outputs() {
-			if out != nil && idx <= int(^uint32(0)) {
-				// Hash CBOR for efficient map key
-				outputHash := lcommon.NewBlake2b256(out.Cbor())
-				//nolint:gosec // G115: idx bounds already checked above
-				realIndexMap[outputHash] = uint32(idx)
-			}
-		}
-	}
-
 	// Separate collateral return from regular outputs.
+	// tx.Produced() already returns correct indices for both valid transactions
+	// (regular outputs at 0, 1, ...) and invalid transactions (collateral return
+	// at len(Outputs())), so no index rewriting is needed.
 	var colRetUtxo *models.Utxo
 	outputModels := make([]models.Utxo, 0, len(produced))
 	for _, utxo := range produced {
 		m := models.UtxoLedgerToModel(utxo, point.Slot)
 		if collateralReturn != nil && utxo.Output == collateralReturn {
-			// Fix collateral return index for invalid transactions
-			if realIndexMap != nil && m.Cbor != nil {
-				outputHash := lcommon.NewBlake2b256(m.Cbor)
-				if realIdx, ok := realIndexMap[outputHash]; ok {
-					m.OutputIdx = realIdx
-				}
-			}
 			colRetUtxo = &m
 			continue
 		}

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2066,6 +2066,9 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	acc *BatchAccumulator,
 	txn types.Txn,
 ) error {
+	if acc == nil {
+		return fmt.Errorf("SetTransactionBatched: acc must not be nil")
+	}
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2069,6 +2069,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	if acc == nil {
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
+	local := NewBatchAccumulator()
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -2203,11 +2204,11 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	for i := range outputModels {
 		outputModels[i].ID = 0
 		outputModels[i].TransactionID = &tmpTx.ID
-		acc.AddUtxoOutput(outputModels[i])
+		local.AddUtxoOutput(outputModels[i])
 	}
 	if colRetUtxo != nil {
 		colRetUtxo.CollateralReturnForTxID = &tmpTx.ID
-		acc.AddCollateralReturn(*colRetUtxo)
+		local.AddCollateralReturn(*colRetUtxo)
 	}
 
 	// ------------------------------------------------------------------ //
@@ -2322,7 +2323,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				continue
 			}
 			seen[key] = true
-			acc.AddUtxoSpend(utxoSpend{
+			local.AddUtxoSpend(utxoSpend{
 				TxId:          inTxID,
 				OutputIdx:     inIdx,
 				Slot:          point.Slot,
@@ -2337,7 +2338,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	if d.storageMode == types.StorageModeAPI {
 		// On retry: schedule deletion of previously flushed rows for this tx.
 		if needsIdFetch {
-			acc.AddDeleteTxID(tmpTx.ID)
+			local.AddDeleteTxID(tmpTx.ID)
 		}
 
 		// Fetch input UTxOs for address-indexing below.
@@ -2375,14 +2376,14 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 			idx,
 			addressUtxos,
 		) {
-			acc.AddAddressTx(atx)
+			local.AddAddressTx(atx)
 		}
 
 		// Witnesses.
 		ws := tx.Witnesses()
 		if ws != nil {
 			for _, vkey := range ws.Vkey() {
-				acc.AddKeyWitness(models.KeyWitness{
+				local.AddKeyWitness(models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeVkey,
 					Vkey:          vkey.Vkey,
@@ -2390,7 +2391,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				})
 			}
 			for _, bootstrap := range ws.Bootstrap() {
-				acc.AddKeyWitness(models.KeyWitness{
+				local.AddKeyWitness(models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeBootstrap,
 					PublicKey:     bootstrap.PublicKey,
@@ -2402,12 +2403,12 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 
 			// Scripts – collect into accumulator instead of writing to DB.
 			for _, s := range ws.NativeScripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypeNativeScript),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypeNativeScript),
 					Content:     s.RawScriptBytes(),
@@ -2415,12 +2416,12 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV1Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV1),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV1),
 					Content:     s.RawScriptBytes(),
@@ -2428,12 +2429,12 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV2Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV2),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV2),
 					Content:     s.RawScriptBytes(),
@@ -2441,12 +2442,12 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV3Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV3),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV3),
 					Content:     s.RawScriptBytes(),
@@ -2457,7 +2458,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 			// PlutusData (datums).
 			if tx.IsValid() {
 				for _, datum := range ws.PlutusData() {
-					acc.AddPlutusData(models.PlutusData{
+					local.AddPlutusData(models.PlutusData{
 						TransactionID: tmpTx.ID,
 						Data:          datum.Cbor(),
 					})
@@ -2468,7 +2469,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 			if ws.Redeemers() != nil {
 				for key, value := range ws.Redeemers().Iter() {
 					//nolint:gosec
-					acc.AddRedeemer(models.Redeemer{
+					local.AddRedeemer(models.Redeemer{
 						TransactionID: tmpTx.ID,
 						Tag:           uint8(key.Tag),
 						Index:         key.Index,
@@ -2783,8 +2784,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
 					}
+					tmpAccount.AddedSlot = point.Slot
 					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
 						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
@@ -2974,8 +2975,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
 					}
+					tmpAccount.AddedSlot = point.Slot
 					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
 						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
@@ -3274,6 +3275,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 		}
 	}
 
+	acc.MergeFrom(local)
 	return nil
 }
 

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -122,7 +122,11 @@ func (b *BatchAccumulator) Reset() {
 }
 
 // MergeFrom appends all records from other into b.
+// It is a no-op when other is nil or other == b.
 func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
+	if other == nil || other == b {
+		return
+	}
 	b.KeyWitnesses = append(b.KeyWitnesses, other.KeyWitnesses...)
 	b.WitnessScripts = append(b.WitnessScripts, other.WitnessScripts...)
 	b.Scripts = append(b.Scripts, other.Scripts...)

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -121,6 +121,20 @@ func (b *BatchAccumulator) Reset() {
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
 }
 
+// MergeFrom appends all records from other into b.
+func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
+	b.KeyWitnesses = append(b.KeyWitnesses, other.KeyWitnesses...)
+	b.WitnessScripts = append(b.WitnessScripts, other.WitnessScripts...)
+	b.Scripts = append(b.Scripts, other.Scripts...)
+	b.PlutusData = append(b.PlutusData, other.PlutusData...)
+	b.Redeemers = append(b.Redeemers, other.Redeemers...)
+	b.AddressTxs = append(b.AddressTxs, other.AddressTxs...)
+	b.UtxoOutputs = append(b.UtxoOutputs, other.UtxoOutputs...)
+	b.UtxoSpends = append(b.UtxoSpends, other.UtxoSpends...)
+	b.CollateralRets = append(b.CollateralRets, other.CollateralRets...)
+	b.DeleteTxIDs = append(b.DeleteTxIDs, other.DeleteTxIDs...)
+}
+
 // FlushBatch writes all accumulated records in a deterministic order.
 func (d *MetadataStorePostgres) FlushBatch(
 	batch *BatchAccumulator,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2131,6 +2131,16 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	// Clear Outputs on tmpTx so the upsert doesn't try to create them.
 	tmpTx.Outputs = nil
 
+	// Explicitly track whether the transaction already existed before this call.
+	// GORM v1.31.1 always populates tmpTx.ID via PostgreSQL RETURNING even on
+	// the conflict path, so needsIdFetch cannot reliably detect retries here.
+	var txExistedBefore bool
+	{
+		var cnt int64
+		db.Model(&models.Transaction{}).Where("hash = ?", txHash).Count(&cnt)
+		txExistedBefore = cnt > 0
+	}
+
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}},
 		DoUpdates: clause.AssignmentColumns(
@@ -2335,7 +2345,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	// ------------------------------------------------------------------ //
 	if d.storageMode == types.StorageModeAPI {
 		// On retry: schedule deletion of previously flushed rows for this tx.
-		if needsIdFetch {
+		if txExistedBefore {
 			local.AddDeleteTxID(tmpTx.ID)
 		}
 

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2043,6 +2043,1224 @@ func (d *MetadataStorePostgres) SetTransaction(
 	return nil
 }
 
+// SetTransactionBatched performs the same logical work as SetTransaction but
+// accumulates all per-item metadata rows into acc for later bulk flushing via
+// FlushBatch.  The transaction record itself is still written immediately so
+// that downstream foreign-key dependencies (witness, script, etc.) can
+// reference its auto-increment ID.
+//
+// Items written immediately (FK or ordering dependency):
+//   - Transaction record (upsert)
+//   - Collateral / reference-input UTXO marker UPDATEs
+//   - Certificates and governance records
+//   - storeTransactionDatums hash index
+//
+// Items deferred to acc:
+//   - UTxO outputs, collateral return, UTxO spends
+//   - Key witnesses, witness scripts, scripts, plutus data, redeemers
+//   - Address-transaction index rows
+func (d *MetadataStorePostgres) SetTransactionBatched(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	acc *BatchAccumulator,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// ------------------------------------------------------------------ //
+	// 1. Write transaction record immediately (needed for FK IDs)         //
+	// ------------------------------------------------------------------ //
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Slot:       point.Slot,
+		Fee:        types.Uint64(tx.Fee().Uint64()),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	var metadataLabels []labelcodec.Entry
+	if tx.Metadata() != nil && d.storageMode == types.StorageModeAPI {
+		tmpMetadata, tmpLabels, err := labelcodec.EncodeAndExtract(
+			tx.Metadata(),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to extract metadata labels: %w",
+				err,
+			)
+		}
+		tmpTx.Metadata = tmpMetadata
+		metadataLabels = tmpLabels
+	}
+
+	collateralReturn := tx.CollateralReturn()
+	produced := tx.Produced()
+
+	// Separate collateral return from regular outputs.
+	var colRetUtxo *models.Utxo
+	outputModels := make([]models.Utxo, 0, len(produced))
+	for _, utxo := range produced {
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			colRetUtxo = &m
+			continue
+		}
+		outputModels = append(outputModels, m)
+	}
+
+	// Clear Outputs on tmpTx so the upsert doesn't try to create them.
+	tmpTx.Outputs = nil
+
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index", "slot"},
+		),
+	}).Create(tmpTx)
+	needsIdFetch := tmpTx.ID == 0
+
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create transaction (batched) at slot %d, block %x, txHash %x, txIndex %d: %w",
+			point.Slot,
+			point.Hash,
+			txHash,
+			idx,
+			result.Error,
+		)
+	}
+	if needsIdFetch {
+		var existing struct{ ID uint }
+		if err := db.Model(&models.Transaction{}).
+			Select("id").
+			Where("hash = ?", txHash).
+			Take(&existing).Error; err != nil {
+			return fmt.Errorf(
+				"failed to fetch transaction ID after upsert (batched): %w",
+				err,
+			)
+		}
+		tmpTx.ID = existing.ID
+	}
+
+	// metadata labels – small, write immediately just like SetTransaction.
+	if len(metadataLabels) > 0 {
+		labelRecords := make(
+			[]models.TransactionMetadataLabel,
+			0,
+			len(metadataLabels),
+		)
+		for _, tmpLabel := range metadataLabels {
+			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
+				TransactionID: tmpTx.ID,
+				Label:         tmpLabel.Label,
+				Slot:          point.Slot,
+				CborValue:     tmpLabel.CborValue,
+				JsonValue:     tmpLabel.JsonValue,
+			})
+		}
+		if result := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "transaction_id"},
+				{Name: "label"},
+			},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"slot", "cbor_value", "json_value"},
+			),
+		}).Create(&labelRecords); result.Error != nil {
+			return fmt.Errorf(
+				"create metadata labels for tx %x (batched): %w",
+				txHash,
+				result.Error,
+			)
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 2. Accumulate UTxO outputs                                          //
+	// ------------------------------------------------------------------ //
+	for i := range outputModels {
+		outputModels[i].ID = 0
+		outputModels[i].TransactionID = &tmpTx.ID
+		acc.AddUtxoOutput(outputModels[i])
+	}
+	if colRetUtxo != nil {
+		colRetUtxo.CollateralReturnForTxID = &tmpTx.ID
+		acc.AddCollateralReturn(*colRetUtxo)
+	}
+
+	// ------------------------------------------------------------------ //
+	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
+	//    These update UTxOs that already exist from prior blocks.        //
+	// ------------------------------------------------------------------ //
+	if d.storageMode == types.StorageModeAPI {
+		// Fetch input UTxOs for address-indexing below.
+		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch input UTxO (batched): %w",
+					err,
+				)
+			}
+			if utxo == nil {
+				continue
+			}
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
+		}
+
+		if len(tx.Collateral()) > 0 {
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.Collateral() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+				if err != nil {
+					return fmt.Errorf(
+						"failed to fetch collateral UTxO (batched): %w",
+						err,
+					)
+				}
+				if utxo == nil {
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				if r := db.Exec(sql, args...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update collateral (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+
+		if len(tx.ReferenceInputs()) > 0 {
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.ReferenceInputs() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+				if err != nil {
+					return fmt.Errorf(
+						"failed to fetch reference input UTxO (batched): %w",
+						err,
+					)
+				}
+				if utxo == nil {
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.ReferenceInputs = append(
+					tmpTx.ReferenceInputs,
+					*utxo,
+				)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				if r := db.Exec(sql, args...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update reference inputs (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 4. Accumulate UTxO spends (consumed inputs)                        //
+	// ------------------------------------------------------------------ //
+	if len(tx.Consumed()) > 0 {
+		seen := make(map[string]bool, len(tx.Consumed()))
+		for _, input := range tx.Consumed() {
+			inTxID := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxID, inIdx)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			acc.AddUtxoSpend(utxoSpend{
+				TxId:          inTxID,
+				OutputIdx:     inIdx,
+				Slot:          point.Slot,
+				SpentByTxHash: txHash,
+			})
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 5. Accumulate API-mode metadata (witnesses, scripts, address txs)  //
+	// ------------------------------------------------------------------ //
+	if d.storageMode == types.StorageModeAPI {
+		// On retry: schedule deletion of previously flushed rows for this tx.
+		if needsIdFetch {
+			acc.AddDeleteTxID(tmpTx.ID)
+		}
+
+		// Address-transaction index.
+		addressUtxos := make(
+			[]models.Utxo,
+			0,
+			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(outputModels)+1,
+		)
+		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
+		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
+		addressUtxos = append(addressUtxos, outputModels...)
+		if colRetUtxo != nil {
+			addressUtxos = append(addressUtxos, *colRetUtxo)
+		}
+		for _, atx := range collectAddressTransactions(
+			tmpTx.ID,
+			point.Slot,
+			idx,
+			addressUtxos,
+		) {
+			acc.AddAddressTx(atx)
+		}
+
+		// Witnesses.
+		ws := tx.Witnesses()
+		if ws != nil {
+			for _, vkey := range ws.Vkey() {
+				acc.AddKeyWitness(models.KeyWitness{
+					TransactionID: tmpTx.ID,
+					Type:          models.KeyWitnessTypeVkey,
+					Vkey:          vkey.Vkey,
+					Signature:     vkey.Signature,
+				})
+			}
+			for _, bootstrap := range ws.Bootstrap() {
+				acc.AddKeyWitness(models.KeyWitness{
+					TransactionID: tmpTx.ID,
+					Type:          models.KeyWitnessTypeBootstrap,
+					PublicKey:     bootstrap.PublicKey,
+					Signature:     bootstrap.Signature,
+					ChainCode:     bootstrap.ChainCode,
+					Attributes:    bootstrap.Attributes,
+				})
+			}
+
+			// Scripts – collect into accumulator instead of writing to DB.
+			for _, s := range ws.NativeScripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypeNativeScript),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypeNativeScript),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV1Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV1),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV1),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV2Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV2),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV2),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV3Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV3),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV3),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+
+			// PlutusData (datums).
+			if tx.IsValid() {
+				for _, datum := range ws.PlutusData() {
+					acc.AddPlutusData(models.PlutusData{
+						TransactionID: tmpTx.ID,
+						Data:          datum.Cbor(),
+					})
+				}
+			}
+
+			// Redeemers.
+			if ws.Redeemers() != nil {
+				for key, value := range ws.Redeemers().Iter() {
+					//nolint:gosec
+					acc.AddRedeemer(models.Redeemer{
+						TransactionID: tmpTx.ID,
+						Tag:           uint8(key.Tag),
+						Index:         key.Index,
+						Data:          value.Data.Cbor(),
+						ExUnitsMemory: uint64(max(0, value.ExUnits.Memory)),
+						ExUnitsCPU:    uint64(max(0, value.ExUnits.Steps)),
+					})
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 6. Certificates and governance – immediate, same as SetTransaction //
+	// ------------------------------------------------------------------ //
+	if tx.IsValid() {
+		certs := tx.Certificates()
+		if len(certs) > 0 {
+			unifiedIDs := []uint{}
+			if result := db.Model(&models.Certificate{}).
+				Where("transaction_id = ?", tmpTx.ID).
+				Pluck("id", &unifiedIDs); result.Error != nil {
+				return fmt.Errorf(
+					"query existing unified certificates (batched): %w",
+					result.Error,
+				)
+			}
+			if len(unifiedIDs) > 0 {
+				tables := []string{
+					"stake_registration", "pool_registration", "pool_retirement",
+					"auth_committee_hot", "resign_committee_cold",
+					"deregistration", "stake_delegation",
+					"stake_registration_delegation", "stake_vote_delegation",
+					"stake_vote_registration_delegation", "registration",
+					"registration_drep", "deregistration_drep", "update_drep",
+					"vote_delegation", "vote_registration_delegation",
+					"move_instantaneous_rewards",
+				}
+				for _, table := range tables {
+					if result := db.Table(table).
+						Where("certificate_id IN ?", unifiedIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing %s records (batched): %w",
+							table,
+							result.Error,
+						)
+					}
+				}
+			}
+			certIDMap := make(map[int]uint)
+			certIDUpdates := make(map[uint]uint)
+			for i, cert := range certs {
+				var certType uint
+				switch cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypePoolRegistration)
+				case *lcommon.StakeRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistration)
+				case *lcommon.PoolRetirementCertificate:
+					certType = uint(lcommon.CertificateTypePoolRetirement)
+				case *lcommon.StakeDeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDeregistration)
+				case *lcommon.DeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistration)
+				case *lcommon.StakeDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDelegation)
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistrationDelegation)
+				case *lcommon.StakeVoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteDelegation)
+				case *lcommon.RegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeRegistration)
+				case *lcommon.RegistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeRegistrationDrep)
+				case *lcommon.DeregistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistrationDrep)
+				case *lcommon.UpdateDrepCertificate:
+					certType = uint(lcommon.CertificateTypeUpdateDrep)
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation)
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteRegistrationDelegation)
+				case *lcommon.VoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteDelegation)
+				case *lcommon.AuthCommitteeHotCertificate:
+					certType = uint(lcommon.CertificateTypeAuthCommitteeHot)
+				case *lcommon.ResignCommitteeColdCertificate:
+					certType = uint(lcommon.CertificateTypeResignCommitteeCold)
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					certType = uint(lcommon.CertificateTypeMoveInstantaneousRewards)
+				default:
+					d.logger.Warn(
+						"unknown certificate type (batched)",
+						"type",
+						fmt.Sprintf("%T", cert),
+					)
+					continue
+				}
+				unifiedCert := models.Certificate{
+					TransactionID: tmpTx.ID,
+					CertIndex:     uint(i), //nolint:gosec
+					CertType:      certType,
+					Slot:          point.Slot,
+					BlockHash:     point.Hash,
+				}
+				if result := db.Clauses(clause.OnConflict{
+					Columns: []clause.Column{
+						{Name: "transaction_id"},
+						{Name: "cert_index"},
+					},
+					DoNothing: true,
+				}).Create(&unifiedCert); result.Error != nil {
+					return fmt.Errorf(
+						"create unified certificate (batched): %w",
+						result.Error,
+					)
+				}
+				if unifiedCert.ID == 0 {
+					if result := db.Where(
+						"transaction_id = ? AND cert_index = ?",
+						tmpTx.ID,
+						uint(i), //nolint:gosec
+					).First(&unifiedCert); result.Error != nil {
+						return fmt.Errorf(
+							"fetch existing unified certificate (batched): %w",
+							result.Error,
+						)
+					}
+				}
+				certIDMap[i] = unifiedCert.ID
+			}
+			for i, cert := range certs {
+				deposit := uint64(0)
+				if certDeposits != nil {
+					if depositVal, ok := certDeposits[i]; ok {
+						deposit = depositVal
+					} else if certRequiresDeposit(cert) {
+						d.logger.Warn(
+							"missing deposit for deposit-bearing certificate (batched)",
+							"index", i, "type", fmt.Sprintf("%T", cert),
+						)
+					}
+				}
+				if certDeposits == nil && certRequiresDeposit(cert) {
+					return fmt.Errorf(
+						"missing certDeposits for deposit-bearing certificate at index %d (batched)",
+						i,
+					)
+				}
+				switch c := cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					tmpPool, err := d.GetPool(
+						lcommon.PoolKeyHash(c.Operator[:]),
+						true,
+						txn,
+					)
+					if err != nil && !errors.Is(err, models.ErrPoolNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{
+							PoolKeyHash: c.Operator[:],
+							VrfKeyHash:  c.VrfKeyHash[:],
+						}
+					}
+					tmpPool.Pledge = types.Uint64(c.Pledge)
+					tmpPool.Cost = types.Uint64(c.Cost)
+					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
+					tmpPool.RewardAccount = c.RewardAccount[:]
+					tmpReg := models.PoolRegistration{
+						PoolKeyHash:   c.Operator[:],
+						VrfKeyHash:    c.VrfKeyHash[:],
+						Pledge:        types.Uint64(c.Pledge),
+						Cost:          types.Uint64(c.Cost),
+						Margin:        &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount: c.RewardAccount[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if c.PoolMetadata != nil {
+						tmpReg.MetadataUrl = c.PoolMetadata.Url
+						tmpReg.MetadataHash = c.PoolMetadata.Hash[:]
+					}
+					for _, owner := range c.PoolOwners {
+						tmpReg.Owners = append(
+							tmpReg.Owners,
+							models.PoolRegistrationOwner{KeyHash: owner[:]},
+						)
+					}
+					tmpPool.Owners = tmpReg.Owners
+					for _, relay := range c.Relays {
+						r := models.PoolRegistrationRelay{
+							Ipv4: relay.Ipv4,
+							Ipv6: relay.Ipv6,
+						}
+						if relay.Port != nil {
+							r.Port = uint(*relay.Port)
+						}
+						if relay.Hostname != nil {
+							r.Hostname = *relay.Hostname
+						}
+						tmpReg.Relays = append(tmpReg.Relays, r)
+					}
+					tmpPool.Relays = tmpReg.Relays
+					if tmpPool.ID == 0 {
+						if r := db.Omit(clause.Associations).Create(tmpPool); r.Error != nil {
+							return fmt.Errorf(
+								"process certificate (batched): %w",
+								r.Error,
+							)
+						}
+					} else {
+						if r := db.Omit(clause.Associations).Save(tmpPool); r.Error != nil {
+							return fmt.Errorf(
+								"process certificate (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					tmpReg.PoolID = tmpPool.ID
+					for j := range tmpReg.Owners {
+						tmpReg.Owners[j].PoolID = tmpPool.ID
+					}
+					for j := range tmpReg.Relays {
+						tmpReg.Relays[j].PoolID = tmpPool.ID
+					}
+					r2 := db.Clauses(clause.OnConflict{
+						Columns: []clause.Column{
+							{Name: "pool_id"},
+							{Name: "added_slot"},
+						},
+						DoUpdates: clause.AssignmentColumns([]string{
+							"vrf_key_hash", "pledge", "cost", "margin",
+							"reward_account", "certificate_id",
+							"metadata_url", "metadata_hash", "deposit_amount",
+						}),
+					}).Omit("Owners", "Relays").Create(&tmpReg)
+					if r2.Error != nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							r2.Error,
+						)
+					}
+					if tmpReg.ID == 0 {
+						var existing models.PoolRegistration
+						if err := db.Where(
+							"pool_id = ? AND added_slot = ?",
+							tmpReg.PoolID, tmpReg.AddedSlot,
+						).First(&existing).Error; err != nil {
+							return fmt.Errorf(
+								"fetching pool registration ID after upsert (batched): %w",
+								err,
+							)
+						}
+						tmpReg.ID = existing.ID
+					}
+					if r := db.Where(
+						"pool_registration_id = ?", tmpReg.ID,
+					).Delete(&models.PoolRegistrationOwner{}); r.Error != nil {
+						return fmt.Errorf(
+							"delete pool registration owners (batched): %w",
+							r.Error,
+						)
+					}
+					if r := db.Where(
+						"pool_registration_id = ?", tmpReg.ID,
+					).Delete(&models.PoolRegistrationRelay{}); r.Error != nil {
+						return fmt.Errorf(
+							"delete pool registration relays (batched): %w",
+							r.Error,
+						)
+					}
+					if len(tmpReg.Owners) > 0 {
+						for j := range tmpReg.Owners {
+							tmpReg.Owners[j].PoolRegistrationID = tmpReg.ID
+							tmpReg.Owners[j].PoolID = tmpPool.ID
+						}
+						if r := db.Create(&tmpReg.Owners); r.Error != nil {
+							return fmt.Errorf(
+								"create pool registration owners (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					if len(tmpReg.Relays) > 0 {
+						for j := range tmpReg.Relays {
+							tmpReg.Relays[j].PoolRegistrationID = tmpReg.ID
+							tmpReg.Relays[j].PoolID = tmpPool.ID
+						}
+						if r := db.Create(&tmpReg.Relays); r.Error != nil {
+							return fmt.Errorf(
+								"create pool registration relays (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeRegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpReg := models.StakeRegistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.PoolRetirementCertificate:
+					tmpPool, err := d.GetPool(
+						lcommon.PoolKeyHash(c.PoolKeyHash[:]),
+						true,
+						txn,
+					)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{PoolKeyHash: c.PoolKeyHash[:]}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "pool_key_hash"}},
+							UpdateAll: true,
+						}).Create(&tmpPool)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpItem := models.PoolRetirement{
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Epoch:         c.Epoch,
+						AddedSlot:     point.Slot,
+						PoolID:        tmpPool.ID,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpAccount == nil {
+						tmpAccount = &models.Account{StakingKey: stakeKey}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeDeregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.DeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpAccount == nil {
+						tmpAccount = &models.Account{StakingKey: stakeKey}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.Deregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+						Amount:        types.Uint64(deposit),
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.StakeRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeVoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeVoteDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.RegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpReg := models.Registration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.RegistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpReg := models.RegistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpReg.AnchorURL = c.Anchor.Url
+						tmpReg.AnchorHash = c.Anchor.DataHash[:]
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot,
+						tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					r2 := db.Clauses(clause.OnConflict{
+						Columns: []clause.Column{
+							{Name: "drep_credential"},
+							{Name: "added_slot"},
+						},
+						DoUpdates: clause.AssignmentColumns([]string{
+							"anchor_url", "anchor_hash", "certificate_id",
+						}),
+					}).Create(&tmpReg)
+					if r2.Error != nil {
+						return fmt.Errorf("process certificate (batched): %w", r2.Error)
+					}
+					if tmpReg.ID == 0 {
+						var existing models.RegistrationDrep
+						if err := db.Where(
+							"drep_credential = ? AND added_slot = ?",
+							tmpReg.DrepCredential, tmpReg.AddedSlot,
+						).First(&existing).Error; err != nil {
+							return fmt.Errorf(
+								"fetching drep registration ID after upsert (batched): %w",
+								err,
+							)
+						}
+						tmpReg.ID = existing.ID
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.DeregistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpDereg := models.DeregistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if existingDrep == nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							models.ErrDrepNotFound,
+						)
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot, "", nil, false, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpDereg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpDereg.ID
+				case *lcommon.UpdateDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpUpdate := models.UpdateDrep{
+						Credential:    drepCredential,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpUpdate.AnchorURL = c.Anchor.Url
+						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
+					}
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if existingDrep == nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							models.ErrDrepNotFound,
+						)
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot,
+						tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpUpdate, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.StakeVoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.VoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.VoteDelegation{
+						StakingKey:    stakeKey,
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.AuthCommitteeHotCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					hotCredential := c.HotCredential.Credential[:]
+					tmpAuth := models.AuthCommitteeHot{
+						ColdCredential: coldCredential,
+						HotCredential:  hotCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if err := saveCertRecord(&tmpAuth, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpAuth.ID
+				case *lcommon.ResignCommitteeColdCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					tmpResign := models.ResignCommitteeCold{
+						ColdCredential: coldCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if c.Anchor != nil {
+						tmpResign.AnchorURL = c.Anchor.Url
+						tmpResign.AnchorHash = c.Anchor.DataHash[:]
+					}
+					if err := saveCertRecord(&tmpResign, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpResign.ID
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					tmpMIR := models.MoveInstantaneousRewards{
+						Pot:           c.Reward.Source,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if r := db.Create(&tmpMIR); r.Error != nil {
+						return fmt.Errorf("process certificate (batched): %w", r.Error)
+					}
+					certIDUpdates[certIDMap[i]] = tmpMIR.ID
+					for credential, amount := range c.Reward.Rewards {
+						tmpReward := models.MoveInstantaneousRewardsReward{
+							Credential: credential.Credential[:],
+							Amount:     types.Uint64(amount),
+							MIRID:      tmpMIR.ID,
+						}
+						if r := db.Create(&tmpReward); r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+				default:
+					return fmt.Errorf(
+						"unsupported certificate type (batched) %T",
+						cert,
+					)
+				}
+			}
+
+			if len(certIDUpdates) > 0 {
+				var ids []uint
+				var whenClauses []string
+				var values []any
+				for unifiedID, specializedID := range certIDUpdates {
+					ids = append(ids, unifiedID)
+					whenClauses = append(whenClauses, "WHEN id = ? THEN ?")
+					values = append(values, unifiedID, specializedID)
+				}
+				caseStmt := strings.Join(whenClauses, " ")
+				query := fmt.Sprintf(
+					"UPDATE certs SET certificate_id = CASE %s END WHERE id IN (?)",
+					caseStmt,
+				)
+				values = append(values, ids)
+				if r := db.Exec(query, values...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update unified certificates (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+
+		if d.storageMode == types.StorageModeAPI {
+			if err := d.storeTransactionDatums(tx, point.Slot, txn); err != nil {
+				return fmt.Errorf("store datums failed (batched): %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // SetGenesisTransaction stores a genesis transaction record.
 // Genesis transactions have no inputs, witnesses, or fees - just outputs.
 func (d *MetadataStorePostgres) SetGenesisTransaction(

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2068,7 +2068,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	txn types.Txn,
 ) error {
 	if acc == nil {
-		return fmt.Errorf("SetTransactionBatched: acc must not be nil")
+		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1449,8 +1449,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 						CertificateID: certIDMap[i],
 					}
 
+					tmpAccount.AddedSlot = point.Slot
 					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
 						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
@@ -1683,8 +1683,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 						CertificateID: certIDMap[i],
 					}
 
+					tmpAccount.AddedSlot = point.Slot
 					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
 						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
@@ -2070,6 +2070,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	if acc == nil {
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
+	local := NewBatchAccumulator()
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -2201,11 +2202,11 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	for i := range outputModels {
 		outputModels[i].ID = 0
 		outputModels[i].TransactionID = &tmpTx.ID
-		acc.AddUtxoOutput(outputModels[i])
+		local.AddUtxoOutput(outputModels[i])
 	}
 	if colRetUtxo != nil {
 		colRetUtxo.CollateralReturnForTxID = &tmpTx.ID
-		acc.AddCollateralReturn(*colRetUtxo)
+		local.AddCollateralReturn(*colRetUtxo)
 	}
 
 	// ------------------------------------------------------------------ //
@@ -2320,7 +2321,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				continue
 			}
 			seen[key] = true
-			acc.AddUtxoSpend(utxoSpend{
+			local.AddUtxoSpend(utxoSpend{
 				TxId:          inTxID,
 				OutputIdx:     inIdx,
 				Slot:          point.Slot,
@@ -2335,7 +2336,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	if d.storageMode == types.StorageModeAPI {
 		// On retry: schedule deletion of previously flushed rows for this tx.
 		if needsIdFetch {
-			acc.AddDeleteTxID(tmpTx.ID)
+			local.AddDeleteTxID(tmpTx.ID)
 		}
 
 		// Fetch input UTxOs for address-indexing below.
@@ -2373,14 +2374,14 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 			idx,
 			addressUtxos,
 		) {
-			acc.AddAddressTx(atx)
+			local.AddAddressTx(atx)
 		}
 
 		// Witnesses.
 		ws := tx.Witnesses()
 		if ws != nil {
 			for _, vkey := range ws.Vkey() {
-				acc.AddKeyWitness(models.KeyWitness{
+				local.AddKeyWitness(models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeVkey,
 					Vkey:          vkey.Vkey,
@@ -2388,7 +2389,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				})
 			}
 			for _, bootstrap := range ws.Bootstrap() {
-				acc.AddKeyWitness(models.KeyWitness{
+				local.AddKeyWitness(models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeBootstrap,
 					PublicKey:     bootstrap.PublicKey,
@@ -2400,12 +2401,12 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 
 			// Scripts – collect into accumulator instead of writing to DB.
 			for _, s := range ws.NativeScripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypeNativeScript),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypeNativeScript),
 					Content:     s.RawScriptBytes(),
@@ -2413,12 +2414,12 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV1Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV1),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV1),
 					Content:     s.RawScriptBytes(),
@@ -2426,12 +2427,12 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV2Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV2),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV2),
 					Content:     s.RawScriptBytes(),
@@ -2439,12 +2440,12 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV3Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV3),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV3),
 					Content:     s.RawScriptBytes(),
@@ -2455,7 +2456,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 			// PlutusData (datums).
 			if tx.IsValid() {
 				for _, datum := range ws.PlutusData() {
-					acc.AddPlutusData(models.PlutusData{
+					local.AddPlutusData(models.PlutusData{
 						TransactionID: tmpTx.ID,
 						Data:          datum.Cbor(),
 					})
@@ -2466,7 +2467,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 			if ws.Redeemers() != nil {
 				for key, value := range ws.Redeemers().Iter() {
 					//nolint:gosec
-					acc.AddRedeemer(models.Redeemer{
+					local.AddRedeemer(models.Redeemer{
 						TransactionID: tmpTx.ID,
 						Tag:           uint8(key.Tag),
 						Index:         key.Index,
@@ -2781,8 +2782,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
 					}
+					tmpAccount.AddedSlot = point.Slot
 					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
 						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
@@ -2972,8 +2973,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
 					}
+					tmpAccount.AddedSlot = point.Slot
 					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
 						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
@@ -3272,6 +3273,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 		}
 	}
 
+	acc.MergeFrom(local)
 	return nil
 }
 

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2076,13 +2076,21 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	// ------------------------------------------------------------------ //
 	// 1. Write transaction record immediately (needed for FK IDs)         //
 	// ------------------------------------------------------------------ //
+	var feeUint uint64
+	if txFee := tx.Fee(); txFee != nil {
+		if txFee.BitLen() > 64 {
+			feeUint = math.MaxUint64
+		} else {
+			feeUint = txFee.Uint64()
+		}
+	}
 	tmpTx := &models.Transaction{
 		Hash:       txHash,
 		Type:       tx.Type(),
 		BlockHash:  point.Hash,
 		BlockIndex: idx,
 		Slot:       point.Slot,
-		Fee:        types.Uint64(tx.Fee().Uint64()),
+		Fee:        types.Uint64(feeUint),
 		TTL:        types.Uint64(tx.TTL()),
 		Valid:      tx.IsValid(),
 	}
@@ -2201,116 +2209,97 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
 	//    These update UTxOs that already exist from prior blocks.        //
 	// ------------------------------------------------------------------ //
-	if d.storageMode == types.StorageModeAPI {
-		// Fetch input UTxOs for address-indexing below.
-		for _, input := range tx.Inputs() {
+	if len(tx.Collateral()) > 0 {
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
 			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
 			if err != nil {
 				return fmt.Errorf(
-					"failed to fetch input UTxO (batched): %w",
+					"failed to fetch collateral UTxO (batched): %w",
 					err,
 				)
 			}
 			if utxo == nil {
 				continue
 			}
-			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
 		}
-
-		if len(tx.Collateral()) > 0 {
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
-			for _, input := range tx.Collateral() {
-				inTxId := input.Id().Bytes()
-				inIdx := input.Index()
-				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to fetch collateral UTxO (batched): %w",
-						err,
-					)
-				}
-				if utxo == nil {
-					continue
-				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			if r := db.Exec(sql, args...); r.Error != nil {
+				return fmt.Errorf(
+					"batch update collateral (batched): %w",
+					r.Error,
 				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
-				tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
-			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
-				)
-				if r := db.Exec(sql, args...); r.Error != nil {
-					return fmt.Errorf(
-						"batch update collateral (batched): %w",
-						r.Error,
-					)
-				}
 			}
 		}
+	}
 
-		if len(tx.ReferenceInputs()) > 0 {
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
-			for _, input := range tx.ReferenceInputs() {
-				inTxId := input.Id().Bytes()
-				inIdx := input.Index()
-				utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to fetch reference input UTxO (batched): %w",
-						err,
-					)
-				}
-				if utxo == nil {
-					continue
-				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
-				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
-				tmpTx.ReferenceInputs = append(
-					tmpTx.ReferenceInputs,
-					*utxo,
+	if len(tx.ReferenceInputs()) > 0 {
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+		for _, input := range tx.ReferenceInputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch reference input UTxO (batched): %w",
+					err,
 				)
 			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
+			if utxo == nil {
+				continue
+			}
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			tmpTx.ReferenceInputs = append(
+				tmpTx.ReferenceInputs,
+				*utxo,
+			)
+		}
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			if r := db.Exec(sql, args...); r.Error != nil {
+				return fmt.Errorf(
+					"batch update reference inputs (batched): %w",
+					r.Error,
 				)
-				if r := db.Exec(sql, args...); r.Error != nil {
-					return fmt.Errorf(
-						"batch update reference inputs (batched): %w",
-						r.Error,
-					)
-				}
 			}
 		}
 	}
@@ -2344,6 +2333,23 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 		// On retry: schedule deletion of previously flushed rows for this tx.
 		if needsIdFetch {
 			acc.AddDeleteTxID(tmpTx.ID)
+		}
+
+		// Fetch input UTxOs for address-indexing below.
+		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch input UTxO (batched): %w",
+					err,
+				)
+			}
+			if utxo == nil {
+				continue
+			}
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
 		}
 
 		// Address-transaction index.
@@ -2487,6 +2493,9 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 			}
 			if len(unifiedIDs) > 0 {
 				tables := []string{
+					// Child tables must be deleted before parent tables (FK constraints).
+					"pool_registration_owner",
+					"pool_registration_relay",
 					"stake_registration", "pool_registration", "pool_retirement",
 					"auth_committee_hot", "resign_committee_cold",
 					"deregistration", "stake_delegation",
@@ -2771,6 +2780,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					}
 					if tmpAccount.ID == 0 {
 						tmpAccount.AddedSlot = point.Slot
+						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -2961,6 +2971,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					}
 					if tmpAccount.ID == 0 {
 						tmpAccount.AddedSlot = point.Slot
+						tmpAccount.CertificateID = certIDMap[i]
 					}
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3233,7 +3244,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				var values []any
 				for unifiedID, specializedID := range certIDUpdates {
 					ids = append(ids, unifiedID)
-					whenClauses = append(whenClauses, "WHEN id = ? THEN ?")
+					whenClauses = append(whenClauses, "WHEN id = ? THEN CAST(? AS bigint)")
 					values = append(values, unifiedID, specializedID)
 				}
 				caseStmt := strings.Join(whenClauses, " ")

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2067,6 +2067,9 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	acc *BatchAccumulator,
 	txn types.Txn,
 ) error {
+	if acc == nil {
+		return fmt.Errorf("SetTransactionBatched: acc must not be nil")
+	}
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -125,7 +125,11 @@ func (b *BatchAccumulator) Reset() {
 }
 
 // MergeFrom appends all records from other into b.
+// It is a no-op when other is nil or other == b.
 func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
+	if other == nil || other == b {
+		return
+	}
 	b.KeyWitnesses = append(b.KeyWitnesses, other.KeyWitnesses...)
 	b.WitnessScripts = append(b.WitnessScripts, other.WitnessScripts...)
 	b.Scripts = append(b.Scripts, other.Scripts...)

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -124,6 +124,20 @@ func (b *BatchAccumulator) Reset() {
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
 }
 
+// MergeFrom appends all records from other into b.
+func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
+	b.KeyWitnesses = append(b.KeyWitnesses, other.KeyWitnesses...)
+	b.WitnessScripts = append(b.WitnessScripts, other.WitnessScripts...)
+	b.Scripts = append(b.Scripts, other.Scripts...)
+	b.PlutusData = append(b.PlutusData, other.PlutusData...)
+	b.Redeemers = append(b.Redeemers, other.Redeemers...)
+	b.AddressTxs = append(b.AddressTxs, other.AddressTxs...)
+	b.UtxoOutputs = append(b.UtxoOutputs, other.UtxoOutputs...)
+	b.UtxoSpends = append(b.UtxoSpends, other.UtxoSpends...)
+	b.CollateralRets = append(b.CollateralRets, other.CollateralRets...)
+	b.DeleteTxIDs = append(b.DeleteTxIDs, other.DeleteTxIDs...)
+}
+
 // FlushBatch writes all accumulated records in a deterministic order.
 func (d *MetadataStoreSqlite) FlushBatch(
 	batch *BatchAccumulator,

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -335,4 +336,65 @@ func TestFlushBatch_Idempotent(t *testing.T) {
 		store.DB().Model(&models.Utxo{}).Count(&utxoCount).Error,
 	)
 	assert.Equal(t, int64(1), utxoCount)
+}
+
+// TestSetTransactionBatched_AccumulatesCorrectly verifies that
+// SetTransactionBatched writes the transaction record to the DB immediately
+// (so it can be queried) and routes key witnesses and address-transaction rows
+// to the accumulator rather than the database.
+// A subsequent FlushBatch call must materialise those rows correctly.
+func TestSetTransactionBatched_AccumulatesCorrectly(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+
+	// ------------------------------------------------------------------ //
+	// Build a mock transaction with one VKey witness.                    //
+	// (uses the same helper pattern as TestStorageMode_APIStoresWitnesses)//
+	// ------------------------------------------------------------------ //
+	tx := newTestWitnessTransaction(
+		"batched_test_hash_1234567890123456789012345678901234567890",
+	)
+	point := ocommon.Point{
+		Hash: []byte("block_hash_batched_12345678901234"),
+		Slot: 999,
+	}
+	acc := NewBatchAccumulator()
+
+	require.NoError(
+		t,
+		store.SetTransactionBatched(tx, point, 0, nil, acc, nil),
+	)
+
+	// ------------------------------------------------------------------ //
+	// 1. Transaction record must exist in the DB immediately.             //
+	// ------------------------------------------------------------------ //
+	var txCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Transaction{}).Count(&txCount).Error,
+	)
+	assert.Equal(t, int64(1), txCount, "transaction record must be written immediately")
+
+	// ------------------------------------------------------------------ //
+	// 2. Key witness must be in the accumulator, NOT yet in the DB.      //
+	// ------------------------------------------------------------------ //
+	assert.Len(t, acc.KeyWitnesses, 1, "one vkey witness expected in accumulator")
+	assert.Equal(t, models.KeyWitnessTypeVkey, acc.KeyWitnesses[0].Type)
+
+	var witnessCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.KeyWitness{}).Count(&witnessCount).Error,
+	)
+	assert.Equal(t, int64(0), witnessCount, "witness must not yet be flushed to DB")
+
+	// ------------------------------------------------------------------ //
+	// 3. FlushBatch must write the deferred rows to the DB.              //
+	// ------------------------------------------------------------------ //
+	require.NoError(t, store.FlushBatch(acc, nil))
+
+	require.NoError(
+		t,
+		store.DB().Model(&models.KeyWitness{}).Count(&witnessCount).Error,
+	)
+	assert.Equal(t, int64(1), witnessCount, "witness must be present after flush")
 }

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -2241,13 +2242,21 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	// ------------------------------------------------------------------ //
 	// 1. Write transaction record immediately (needed for FK IDs)         //
 	// ------------------------------------------------------------------ //
+	var feeUint uint64
+	if txFee := tx.Fee(); txFee != nil {
+		if txFee.BitLen() > 64 {
+			feeUint = math.MaxUint64
+		} else {
+			feeUint = txFee.Uint64()
+		}
+	}
 	tmpTx := &models.Transaction{
 		Hash:       txHash,
 		Type:       tx.Type(),
 		BlockHash:  point.Hash,
 		BlockIndex: idx,
 		Slot:       point.Slot,
-		Fee:        types.Uint64(tx.Fee().Uint64()),
+		Fee:        types.Uint64(feeUint),
 		TTL:        types.Uint64(tx.TTL()),
 		Valid:      tx.IsValid(),
 	}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2233,6 +2233,9 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	acc *BatchAccumulator,
 	txn types.Txn,
 ) error {
+	if acc == nil {
+		return fmt.Errorf("SetTransactionBatched: acc must not be nil")
+	}
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1617,9 +1617,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 						CertificateID: certIDMap[i],
 					}
 
-					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
-					}
+					tmpAccount.AddedSlot = point.Slot
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1850,9 +1848,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 						CertificateID: certIDMap[i],
 					}
 
-					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
-					}
+					tmpAccount.AddedSlot = point.Slot
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2236,6 +2232,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	if acc == nil {
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
+	local := NewBatchAccumulator()
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -2367,11 +2364,11 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	for i := range outputModels {
 		outputModels[i].ID = 0
 		outputModels[i].TransactionID = &tmpTx.ID
-		acc.AddUtxoOutput(outputModels[i])
+		local.AddUtxoOutput(outputModels[i])
 	}
 	if colRetUtxo != nil {
 		colRetUtxo.CollateralReturnForTxID = &tmpTx.ID
-		acc.AddCollateralReturn(*colRetUtxo)
+		local.AddCollateralReturn(*colRetUtxo)
 	}
 
 	// ------------------------------------------------------------------ //
@@ -2526,7 +2523,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				continue
 			}
 			seen[key] = true
-			acc.AddUtxoSpend(utxoSpend{
+			local.AddUtxoSpend(utxoSpend{
 				TxId:          inTxID,
 				OutputIdx:     inIdx,
 				Slot:          point.Slot,
@@ -2541,7 +2538,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	if d.storageMode == types.StorageModeAPI {
 		// On retry: schedule deletion of previously flushed rows for this tx.
 		if needsIdFetch {
-			acc.AddDeleteTxID(tmpTx.ID)
+			local.AddDeleteTxID(tmpTx.ID)
 		}
 
 		// Address-transaction index.
@@ -2562,14 +2559,14 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			idx,
 			addressUtxos,
 		) {
-			acc.AddAddressTx(atx)
+			local.AddAddressTx(atx)
 		}
 
 		// Witnesses.
 		ws := tx.Witnesses()
 		if ws != nil {
 			for _, vkey := range ws.Vkey() {
-				acc.AddKeyWitness(models.KeyWitness{
+				local.AddKeyWitness(models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeVkey,
 					Vkey:          vkey.Vkey,
@@ -2577,7 +2574,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				})
 			}
 			for _, bootstrap := range ws.Bootstrap() {
-				acc.AddKeyWitness(models.KeyWitness{
+				local.AddKeyWitness(models.KeyWitness{
 					TransactionID: tmpTx.ID,
 					Type:          models.KeyWitnessTypeBootstrap,
 					PublicKey:     bootstrap.PublicKey,
@@ -2589,12 +2586,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 
 			// Scripts – collect into accumulator instead of writing to DB.
 			for _, s := range ws.NativeScripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypeNativeScript),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypeNativeScript),
 					Content:     s.RawScriptBytes(),
@@ -2602,12 +2599,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV1Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV1),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV1),
 					Content:     s.RawScriptBytes(),
@@ -2615,12 +2612,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV2Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV2),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV2),
 					Content:     s.RawScriptBytes(),
@@ -2628,12 +2625,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				})
 			}
 			for _, s := range ws.PlutusV3Scripts() {
-				acc.AddWitnessScript(models.WitnessScripts{
+				local.AddWitnessScript(models.WitnessScripts{
 					TransactionID: tmpTx.ID,
 					Type:          uint8(lcommon.ScriptRefTypePlutusV3),
 					ScriptHash:    s.Hash().Bytes(),
 				})
-				acc.AddScript(models.Script{
+				local.AddScript(models.Script{
 					Hash:        s.Hash().Bytes(),
 					Type:        uint8(lcommon.ScriptRefTypePlutusV3),
 					Content:     s.RawScriptBytes(),
@@ -2644,7 +2641,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			// PlutusData (datums).
 			if tx.IsValid() {
 				for _, datum := range ws.PlutusData() {
-					acc.AddPlutusData(models.PlutusData{
+					local.AddPlutusData(models.PlutusData{
 						TransactionID: tmpTx.ID,
 						Data:          datum.Cbor(),
 					})
@@ -2655,7 +2652,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			if ws.Redeemers() != nil {
 				for key, value := range ws.Redeemers().Iter() {
 					//nolint:gosec
-					acc.AddRedeemer(models.Redeemer{
+					local.AddRedeemer(models.Redeemer{
 						TransactionID: tmpTx.ID,
 						Tag:           uint8(key.Tag),
 						Index:         key.Index,
@@ -2970,9 +2967,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
 					}
-					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
-					}
+					tmpAccount.AddedSlot = point.Slot
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3160,9 +3155,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
 					}
-					if tmpAccount.ID == 0 {
-						tmpAccount.AddedSlot = point.Slot
-					}
+					tmpAccount.AddedSlot = point.Slot
 					if err := saveAccount(tmpAccount, db); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3459,6 +3452,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		}
 	}
 
+	acc.MergeFrom(local)
 	return nil
 }
 

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2208,6 +2208,1245 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	return nil
 }
 
+// SetTransactionBatched performs the same logical work as SetTransaction but
+// accumulates all per-item metadata rows into acc for later bulk flushing via
+// FlushBatch.  The transaction record itself is still written immediately so
+// that downstream foreign-key dependencies (witness, script, etc.) can
+// reference its auto-increment ID.
+//
+// Items written immediately (FK or ordering dependency):
+//   - Transaction record (upsert)
+//   - Collateral / reference-input UTXO marker UPDATEs
+//   - Certificates and governance records
+//   - storeTransactionDatums hash index
+//
+// Items deferred to acc:
+//   - UTxO outputs, collateral return, UTxO spends
+//   - Key witnesses, witness scripts, scripts, plutus data, redeemers
+//   - Address-transaction index rows
+func (d *MetadataStoreSqlite) SetTransactionBatched(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	acc *BatchAccumulator,
+	txn types.Txn,
+) error {
+	txHash := tx.Hash().Bytes()
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	// ------------------------------------------------------------------ //
+	// 1. Write transaction record immediately (needed for FK IDs)         //
+	// ------------------------------------------------------------------ //
+	tmpTx := &models.Transaction{
+		Hash:       txHash,
+		Type:       tx.Type(),
+		BlockHash:  point.Hash,
+		BlockIndex: idx,
+		Slot:       point.Slot,
+		Fee:        types.Uint64(tx.Fee().Uint64()),
+		TTL:        types.Uint64(tx.TTL()),
+		Valid:      tx.IsValid(),
+	}
+	var metadataLabels []labelcodec.Entry
+	if tx.Metadata() != nil && d.storageMode == types.StorageModeAPI {
+		tmpMetadata, tmpLabels, err := labelcodec.EncodeAndExtract(
+			tx.Metadata(),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to extract metadata labels: %w",
+				err,
+			)
+		}
+		tmpTx.Metadata = tmpMetadata
+		metadataLabels = tmpLabels
+	}
+
+	collateralReturn := tx.CollateralReturn()
+	produced := tx.Produced()
+
+	// Separate collateral return from regular outputs.
+	var colRetUtxo *models.Utxo
+	outputModels := make([]models.Utxo, 0, len(produced))
+	for _, utxo := range produced {
+		m := models.UtxoLedgerToModel(utxo, point.Slot)
+		if collateralReturn != nil && utxo.Output == collateralReturn {
+			colRetUtxo = &m
+			continue
+		}
+		outputModels = append(outputModels, m)
+	}
+
+	// Clear Outputs on tmpTx so the upsert doesn't try to create them.
+	tmpTx.Outputs = nil
+
+	result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "hash"}},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"block_hash", "block_index", "slot"},
+		),
+	}).Create(tmpTx)
+	needsIdFetch := tmpTx.ID == 0
+
+	if result.Error != nil {
+		return fmt.Errorf(
+			"create transaction (batched) at slot %d, block %x, txHash %x, txIndex %d: %w",
+			point.Slot,
+			point.Hash,
+			txHash,
+			idx,
+			result.Error,
+		)
+	}
+	if needsIdFetch {
+		var existing struct{ ID uint }
+		if err := db.Model(&models.Transaction{}).
+			Select("id").
+			Where("hash = ?", txHash).
+			Take(&existing).Error; err != nil {
+			return fmt.Errorf(
+				"failed to fetch transaction ID after upsert (batched): %w",
+				err,
+			)
+		}
+		tmpTx.ID = existing.ID
+	}
+
+	// metadata labels – small, write immediately just like SetTransaction.
+	if len(metadataLabels) > 0 {
+		labelRecords := make(
+			[]models.TransactionMetadataLabel,
+			0,
+			len(metadataLabels),
+		)
+		for _, tmpLabel := range metadataLabels {
+			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
+				TransactionID: tmpTx.ID,
+				Label:         tmpLabel.Label,
+				Slot:          point.Slot,
+				CborValue:     tmpLabel.CborValue,
+				JsonValue:     tmpLabel.JsonValue,
+			})
+		}
+		if result := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "transaction_id"},
+				{Name: "label"},
+			},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"slot", "cbor_value", "json_value"},
+			),
+		}).Create(&labelRecords); result.Error != nil {
+			return fmt.Errorf(
+				"create metadata labels for tx %x (batched): %w",
+				txHash,
+				result.Error,
+			)
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 2. Accumulate UTxO outputs                                          //
+	// ------------------------------------------------------------------ //
+	for i := range outputModels {
+		outputModels[i].ID = 0
+		outputModels[i].TransactionID = &tmpTx.ID
+		acc.AddUtxoOutput(outputModels[i])
+	}
+	if colRetUtxo != nil {
+		colRetUtxo.CollateralReturnForTxID = &tmpTx.ID
+		acc.AddCollateralReturn(*colRetUtxo)
+	}
+
+	// ------------------------------------------------------------------ //
+	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
+	//    These update UTxOs that already exist from prior blocks.        //
+	// ------------------------------------------------------------------ //
+	if d.storageMode == types.StorageModeAPI {
+		// Fetch input UTxOs for address-indexing below.
+		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
+		for _, input := range tx.Inputs() {
+			inputRefs = append(inputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to batch fetch input UTXOs (batched): %w",
+				err,
+			)
+		}
+		for _, input := range tx.Inputs() {
+			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
+			if u := inputUtxos[key]; u != nil {
+				tmpTx.Inputs = append(tmpTx.Inputs, *u)
+			}
+		}
+
+		if len(tx.Collateral()) > 0 {
+			collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
+			for _, input := range tx.Collateral() {
+				collateralRefs = append(collateralRefs, UtxoRef{
+					TxId:      input.Id().Bytes(),
+					OutputIdx: input.Index(),
+				})
+			}
+			collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to batch fetch collateral UTXOs (batched): %w",
+					err,
+				)
+			}
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.Collateral() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+				if collateralUtxos[key] == nil {
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.Collateral = append(tmpTx.Collateral, *collateralUtxos[key])
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				if r := db.Exec(sql, args...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update collateral (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+
+		if len(tx.ReferenceInputs()) > 0 {
+			var refInputRefs []UtxoRef
+			for _, input := range tx.ReferenceInputs() {
+				refInputRefs = append(refInputRefs, UtxoRef{
+					TxId:      input.Id().Bytes(),
+					OutputIdx: input.Index(),
+				})
+			}
+			refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to batch fetch reference input UTXOs (batched): %w",
+					err,
+				)
+			}
+			var caseClauses []string
+			var whereConditions []string
+			var caseArgs []any
+			var whereArgs []any
+			for _, input := range tx.ReferenceInputs() {
+				inTxId := input.Id().Bytes()
+				inIdx := input.Index()
+				key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+				if refInputUtxos[key] == nil {
+					continue
+				}
+				caseClauses = append(
+					caseClauses,
+					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				)
+				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				whereArgs = append(whereArgs, inTxId, inIdx)
+				tmpTx.ReferenceInputs = append(
+					tmpTx.ReferenceInputs,
+					*refInputUtxos[key],
+				)
+			}
+			if len(caseClauses) > 0 {
+				args := append(caseArgs, whereArgs...)
+				sql := fmt.Sprintf(
+					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+					strings.Join(caseClauses, " "),
+					strings.Join(whereConditions, " OR "),
+				)
+				if r := db.Exec(sql, args...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update reference inputs (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 4. Accumulate UTxO spends (consumed inputs)                        //
+	// ------------------------------------------------------------------ //
+	if len(tx.Consumed()) > 0 {
+		seen := make(map[string]bool, len(tx.Consumed()))
+		for _, input := range tx.Consumed() {
+			inTxID := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxID, inIdx)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			acc.AddUtxoSpend(utxoSpend{
+				TxId:          inTxID,
+				OutputIdx:     inIdx,
+				Slot:          point.Slot,
+				SpentByTxHash: txHash,
+			})
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 5. Accumulate API-mode metadata (witnesses, scripts, address txs)  //
+	// ------------------------------------------------------------------ //
+	if d.storageMode == types.StorageModeAPI {
+		// On retry: schedule deletion of previously flushed rows for this tx.
+		if needsIdFetch {
+			acc.AddDeleteTxID(tmpTx.ID)
+		}
+
+		// Address-transaction index.
+		addressUtxos := make(
+			[]models.Utxo,
+			0,
+			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(outputModels)+1,
+		)
+		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
+		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
+		addressUtxos = append(addressUtxos, outputModels...)
+		if colRetUtxo != nil {
+			addressUtxos = append(addressUtxos, *colRetUtxo)
+		}
+		for _, atx := range collectAddressTransactions(
+			tmpTx.ID,
+			point.Slot,
+			idx,
+			addressUtxos,
+		) {
+			acc.AddAddressTx(atx)
+		}
+
+		// Witnesses.
+		ws := tx.Witnesses()
+		if ws != nil {
+			for _, vkey := range ws.Vkey() {
+				acc.AddKeyWitness(models.KeyWitness{
+					TransactionID: tmpTx.ID,
+					Type:          models.KeyWitnessTypeVkey,
+					Vkey:          vkey.Vkey,
+					Signature:     vkey.Signature,
+				})
+			}
+			for _, bootstrap := range ws.Bootstrap() {
+				acc.AddKeyWitness(models.KeyWitness{
+					TransactionID: tmpTx.ID,
+					Type:          models.KeyWitnessTypeBootstrap,
+					PublicKey:     bootstrap.PublicKey,
+					Signature:     bootstrap.Signature,
+					ChainCode:     bootstrap.ChainCode,
+					Attributes:    bootstrap.Attributes,
+				})
+			}
+
+			// Scripts – collect into accumulator instead of writing to DB.
+			for _, s := range ws.NativeScripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypeNativeScript),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypeNativeScript),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV1Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV1),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV1),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV2Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV2),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV2),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+			for _, s := range ws.PlutusV3Scripts() {
+				acc.AddWitnessScript(models.WitnessScripts{
+					TransactionID: tmpTx.ID,
+					Type:          uint8(lcommon.ScriptRefTypePlutusV3),
+					ScriptHash:    s.Hash().Bytes(),
+				})
+				acc.AddScript(models.Script{
+					Hash:        s.Hash().Bytes(),
+					Type:        uint8(lcommon.ScriptRefTypePlutusV3),
+					Content:     s.RawScriptBytes(),
+					CreatedSlot: point.Slot,
+				})
+			}
+
+			// PlutusData (datums).
+			if tx.IsValid() {
+				for _, datum := range ws.PlutusData() {
+					acc.AddPlutusData(models.PlutusData{
+						TransactionID: tmpTx.ID,
+						Data:          datum.Cbor(),
+					})
+				}
+			}
+
+			// Redeemers.
+			if ws.Redeemers() != nil {
+				for key, value := range ws.Redeemers().Iter() {
+					//nolint:gosec
+					acc.AddRedeemer(models.Redeemer{
+						TransactionID: tmpTx.ID,
+						Tag:           uint8(key.Tag),
+						Index:         key.Index,
+						Data:          value.Data.Cbor(),
+						ExUnitsMemory: uint64(max(0, value.ExUnits.Memory)),
+						ExUnitsCPU:    uint64(max(0, value.ExUnits.Steps)),
+					})
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ //
+	// 6. Certificates and governance – immediate, same as SetTransaction //
+	// ------------------------------------------------------------------ //
+	if tx.IsValid() {
+		certs := tx.Certificates()
+		if len(certs) > 0 {
+			unifiedIDs := []uint{}
+			if result := db.Model(&models.Certificate{}).
+				Where("transaction_id = ?", tmpTx.ID).
+				Pluck("id", &unifiedIDs); result.Error != nil {
+				return fmt.Errorf(
+					"query existing unified certificates (batched): %w",
+					result.Error,
+				)
+			}
+			if len(unifiedIDs) > 0 {
+				tables := []string{
+					"stake_registration", "pool_registration", "pool_retirement",
+					"auth_committee_hot", "resign_committee_cold",
+					"deregistration", "stake_delegation",
+					"stake_registration_delegation", "stake_vote_delegation",
+					"stake_vote_registration_delegation", "registration",
+					"registration_drep", "deregistration_drep", "update_drep",
+					"vote_delegation", "vote_registration_delegation",
+					"move_instantaneous_rewards",
+				}
+				for _, table := range tables {
+					if result := db.Table(table).
+						Where("certificate_id IN ?", unifiedIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing %s records (batched): %w",
+							table,
+							result.Error,
+						)
+					}
+				}
+			}
+			certIDMap := make(map[int]uint)
+			certIDUpdates := make(map[uint]uint)
+			for i, cert := range certs {
+				var certType uint
+				switch cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypePoolRegistration)
+				case *lcommon.StakeRegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistration)
+				case *lcommon.PoolRetirementCertificate:
+					certType = uint(lcommon.CertificateTypePoolRetirement)
+				case *lcommon.StakeDeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDeregistration)
+				case *lcommon.DeregistrationCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistration)
+				case *lcommon.StakeDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeDelegation)
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeRegistrationDelegation)
+				case *lcommon.StakeVoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteDelegation)
+				case *lcommon.RegistrationCertificate:
+					certType = uint(lcommon.CertificateTypeRegistration)
+				case *lcommon.RegistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeRegistrationDrep)
+				case *lcommon.DeregistrationDrepCertificate:
+					certType = uint(lcommon.CertificateTypeDeregistrationDrep)
+				case *lcommon.UpdateDrepCertificate:
+					certType = uint(lcommon.CertificateTypeUpdateDrep)
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation)
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteRegistrationDelegation)
+				case *lcommon.VoteDelegationCertificate:
+					certType = uint(lcommon.CertificateTypeVoteDelegation)
+				case *lcommon.AuthCommitteeHotCertificate:
+					certType = uint(lcommon.CertificateTypeAuthCommitteeHot)
+				case *lcommon.ResignCommitteeColdCertificate:
+					certType = uint(lcommon.CertificateTypeResignCommitteeCold)
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					certType = uint(lcommon.CertificateTypeMoveInstantaneousRewards)
+				default:
+					d.logger.Warn(
+						"unknown certificate type (batched)",
+						"type",
+						fmt.Sprintf("%T", cert),
+					)
+					continue
+				}
+				unifiedCert := models.Certificate{
+					TransactionID: tmpTx.ID,
+					CertIndex:     uint(i), //nolint:gosec
+					CertType:      certType,
+					Slot:          point.Slot,
+					BlockHash:     point.Hash,
+				}
+				if result := db.Clauses(clause.OnConflict{
+					Columns: []clause.Column{
+						{Name: "transaction_id"},
+						{Name: "cert_index"},
+					},
+					DoNothing: true,
+				}).Create(&unifiedCert); result.Error != nil {
+					return fmt.Errorf(
+						"create unified certificate (batched): %w",
+						result.Error,
+					)
+				}
+				if unifiedCert.ID == 0 {
+					if result := db.Where(
+						"transaction_id = ? AND cert_index = ?",
+						tmpTx.ID,
+						uint(i), //nolint:gosec
+					).First(&unifiedCert); result.Error != nil {
+						return fmt.Errorf(
+							"fetch existing unified certificate (batched): %w",
+							result.Error,
+						)
+					}
+				}
+				certIDMap[i] = unifiedCert.ID
+			}
+			for i, cert := range certs {
+				deposit := uint64(0)
+				if certDeposits != nil {
+					if depositVal, ok := certDeposits[i]; ok {
+						deposit = depositVal
+					} else if certRequiresDeposit(cert) {
+						d.logger.Warn(
+							"missing deposit for deposit-bearing certificate (batched)",
+							"index", i, "type", fmt.Sprintf("%T", cert),
+						)
+					}
+				}
+				if certDeposits == nil && certRequiresDeposit(cert) {
+					return fmt.Errorf(
+						"missing certDeposits for deposit-bearing certificate at index %d (batched)",
+						i,
+					)
+				}
+				switch c := cert.(type) {
+				case *lcommon.PoolRegistrationCertificate:
+					tmpPool, err := d.GetPool(
+						lcommon.PoolKeyHash(c.Operator[:]),
+						true,
+						txn,
+					)
+					if err != nil && !errors.Is(err, models.ErrPoolNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{
+							PoolKeyHash: c.Operator[:],
+							VrfKeyHash:  c.VrfKeyHash[:],
+						}
+					}
+					tmpPool.Pledge = types.Uint64(c.Pledge)
+					tmpPool.Cost = types.Uint64(c.Cost)
+					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
+					tmpPool.RewardAccount = c.RewardAccount[:]
+					tmpReg := models.PoolRegistration{
+						PoolKeyHash:   c.Operator[:],
+						VrfKeyHash:    c.VrfKeyHash[:],
+						Pledge:        types.Uint64(c.Pledge),
+						Cost:          types.Uint64(c.Cost),
+						Margin:        &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount: c.RewardAccount[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if c.PoolMetadata != nil {
+						tmpReg.MetadataUrl = c.PoolMetadata.Url
+						tmpReg.MetadataHash = c.PoolMetadata.Hash[:]
+					}
+					for _, owner := range c.PoolOwners {
+						tmpReg.Owners = append(
+							tmpReg.Owners,
+							models.PoolRegistrationOwner{KeyHash: owner[:]},
+						)
+					}
+					tmpPool.Owners = tmpReg.Owners
+					for _, relay := range c.Relays {
+						r := models.PoolRegistrationRelay{
+							Ipv4: relay.Ipv4,
+							Ipv6: relay.Ipv6,
+						}
+						if relay.Port != nil {
+							r.Port = uint(*relay.Port)
+						}
+						if relay.Hostname != nil {
+							r.Hostname = *relay.Hostname
+						}
+						tmpReg.Relays = append(tmpReg.Relays, r)
+					}
+					tmpPool.Relays = tmpReg.Relays
+					if tmpPool.ID == 0 {
+						if r := db.Omit(clause.Associations).Create(tmpPool); r.Error != nil {
+							return fmt.Errorf(
+								"process certificate (batched): %w",
+								r.Error,
+							)
+						}
+					} else {
+						if r := db.Omit(clause.Associations).Save(tmpPool); r.Error != nil {
+							return fmt.Errorf(
+								"process certificate (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					tmpReg.PoolID = tmpPool.ID
+					for j := range tmpReg.Owners {
+						tmpReg.Owners[j].PoolID = tmpPool.ID
+					}
+					for j := range tmpReg.Relays {
+						tmpReg.Relays[j].PoolID = tmpPool.ID
+					}
+					r2 := db.Clauses(clause.OnConflict{
+						Columns: []clause.Column{
+							{Name: "pool_id"},
+							{Name: "added_slot"},
+						},
+						DoUpdates: clause.AssignmentColumns([]string{
+							"vrf_key_hash", "pledge", "cost", "margin",
+							"reward_account", "certificate_id",
+							"metadata_url", "metadata_hash", "deposit_amount",
+						}),
+					}).Omit("Owners", "Relays").Create(&tmpReg)
+					if r2.Error != nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							r2.Error,
+						)
+					}
+					if tmpReg.ID == 0 {
+						var existing models.PoolRegistration
+						if err := db.Where(
+							"pool_id = ? AND added_slot = ?",
+							tmpReg.PoolID, tmpReg.AddedSlot,
+						).First(&existing).Error; err != nil {
+							return fmt.Errorf(
+								"fetching pool registration ID after upsert (batched): %w",
+								err,
+							)
+						}
+						tmpReg.ID = existing.ID
+					}
+					if r := db.Where(
+						"pool_registration_id = ?", tmpReg.ID,
+					).Delete(&models.PoolRegistrationOwner{}); r.Error != nil {
+						return fmt.Errorf(
+							"delete pool registration owners (batched): %w",
+							r.Error,
+						)
+					}
+					if r := db.Where(
+						"pool_registration_id = ?", tmpReg.ID,
+					).Delete(&models.PoolRegistrationRelay{}); r.Error != nil {
+						return fmt.Errorf(
+							"delete pool registration relays (batched): %w",
+							r.Error,
+						)
+					}
+					if len(tmpReg.Owners) > 0 {
+						for j := range tmpReg.Owners {
+							tmpReg.Owners[j].PoolRegistrationID = tmpReg.ID
+							tmpReg.Owners[j].PoolID = tmpPool.ID
+						}
+						if r := db.Create(&tmpReg.Owners); r.Error != nil {
+							return fmt.Errorf(
+								"create pool registration owners (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					if len(tmpReg.Relays) > 0 {
+						for j := range tmpReg.Relays {
+							tmpReg.Relays[j].PoolRegistrationID = tmpReg.ID
+							tmpReg.Relays[j].PoolID = tmpPool.ID
+						}
+						if r := db.Create(&tmpReg.Relays); r.Error != nil {
+							return fmt.Errorf(
+								"create pool registration relays (batched): %w",
+								r.Error,
+							)
+						}
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeRegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpReg := models.StakeRegistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.PoolRetirementCertificate:
+					tmpPool, err := d.GetPool(
+						lcommon.PoolKeyHash(c.PoolKeyHash[:]),
+						true,
+						txn,
+					)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpPool == nil {
+						tmpPool = &models.Pool{PoolKeyHash: c.PoolKeyHash[:]}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "pool_key_hash"}},
+							UpdateAll: true,
+						}).Create(&tmpPool)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpItem := models.PoolRetirement{
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Epoch:         c.Epoch,
+						AddedSlot:     point.Slot,
+						PoolID:        tmpPool.ID,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpAccount == nil {
+						tmpAccount = &models.Account{StakingKey: stakeKey}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeDeregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.DeregistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if tmpAccount == nil {
+						tmpAccount = &models.Account{StakingKey: stakeKey}
+						r := db.Clauses(clause.OnConflict{
+							Columns:   []clause.Column{{Name: "staking_key"}},
+							UpdateAll: true,
+						}).Create(tmpAccount)
+						if r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+					tmpAccount.Active = false
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.Deregistration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+						Amount:        types.Uint64(deposit),
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.StakeRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.StakeRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.StakeVoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.StakeVoteDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.RegistrationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					tmpReg := models.Registration{
+						StakingKey:    stakeKey,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if tmpAccount.ID == 0 {
+						tmpAccount.AddedSlot = point.Slot
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.RegistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpReg := models.RegistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpReg.AnchorURL = c.Anchor.Url
+						tmpReg.AnchorHash = c.Anchor.DataHash[:]
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot,
+						tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					r2 := db.Clauses(clause.OnConflict{
+						Columns: []clause.Column{
+							{Name: "drep_credential"},
+							{Name: "added_slot"},
+						},
+						DoUpdates: clause.AssignmentColumns([]string{
+							"anchor_url", "anchor_hash", "certificate_id",
+						}),
+					}).Create(&tmpReg)
+					if r2.Error != nil {
+						return fmt.Errorf("process certificate (batched): %w", r2.Error)
+					}
+					if tmpReg.ID == 0 {
+						var existing models.RegistrationDrep
+						if err := db.Where(
+							"drep_credential = ? AND added_slot = ?",
+							tmpReg.DrepCredential, tmpReg.AddedSlot,
+						).First(&existing).Error; err != nil {
+							return fmt.Errorf(
+								"fetching drep registration ID after upsert (batched): %w",
+								err,
+							)
+						}
+						tmpReg.ID = existing.ID
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.DeregistrationDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpDereg := models.DeregistrationDrep{
+						DrepCredential: drepCredential,
+						AddedSlot:      point.Slot,
+						DepositAmount:  types.Uint64(deposit),
+						CertificateID:  certIDMap[i],
+					}
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if existingDrep == nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							models.ErrDrepNotFound,
+						)
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot, "", nil, false, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpDereg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpDereg.ID
+				case *lcommon.UpdateDrepCertificate:
+					drepCredential := c.DrepCredential.Credential[:]
+					tmpUpdate := models.UpdateDrep{
+						Credential:    drepCredential,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if c.Anchor != nil {
+						tmpUpdate.AnchorURL = c.Anchor.Url
+						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
+					}
+					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if existingDrep == nil {
+						return fmt.Errorf(
+							"process certificate (batched): %w",
+							models.ErrDrepNotFound,
+						)
+					}
+					if err := d.SetDrep(
+						drepCredential, point.Slot,
+						tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn,
+					); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpUpdate, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
+				case *lcommon.StakeVoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Pool = c.PoolKeyHash[:]
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.StakeVoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						PoolKeyHash:   c.PoolKeyHash[:],
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteRegistrationDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpReg := models.VoteRegistrationDelegation{
+						StakingKey:    stakeKey,
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						DepositAmount: types.Uint64(deposit),
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpReg, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpReg.ID
+				case *lcommon.VoteDelegationCertificate:
+					stakeKey := c.StakeCredential.Credential[:]
+					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					drepType, err := models.DrepTypeFromInt(c.Drep.Type)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					var drepCredential []byte
+					if drepType != models.DrepTypeAlwaysAbstain &&
+						drepType != models.DrepTypeAlwaysNoConfidence {
+						drepCredential = c.Drep.Credential[:]
+					}
+					tmpAccount.Drep = drepCredential
+					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
+					tmpItem := models.VoteDelegation{
+						StakingKey:    stakeKey,
+						Drep:          drepCredential,
+						DrepType:      drepType,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if err := saveAccount(tmpAccount, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					if err := saveCertRecord(&tmpItem, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpItem.ID
+				case *lcommon.AuthCommitteeHotCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					hotCredential := c.HotCredential.Credential[:]
+					tmpAuth := models.AuthCommitteeHot{
+						ColdCredential: coldCredential,
+						HotCredential:  hotCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if err := saveCertRecord(&tmpAuth, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpAuth.ID
+				case *lcommon.ResignCommitteeColdCertificate:
+					coldCredential := c.ColdCredential.Credential[:]
+					tmpResign := models.ResignCommitteeCold{
+						ColdCredential: coldCredential,
+						CertificateID:  certIDMap[i],
+						AddedSlot:      point.Slot,
+					}
+					if c.Anchor != nil {
+						tmpResign.AnchorURL = c.Anchor.Url
+						tmpResign.AnchorHash = c.Anchor.DataHash[:]
+					}
+					if err := saveCertRecord(&tmpResign, db); err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
+					certIDUpdates[certIDMap[i]] = tmpResign.ID
+				case *lcommon.MoveInstantaneousRewardsCertificate:
+					tmpMIR := models.MoveInstantaneousRewards{
+						Pot:           c.Reward.Source,
+						AddedSlot:     point.Slot,
+						CertificateID: certIDMap[i],
+					}
+					if r := db.Create(&tmpMIR); r.Error != nil {
+						return fmt.Errorf("process certificate (batched): %w", r.Error)
+					}
+					certIDUpdates[certIDMap[i]] = tmpMIR.ID
+					for credential, amount := range c.Reward.Rewards {
+						tmpReward := models.MoveInstantaneousRewardsReward{
+							Credential: credential.Credential[:],
+							Amount:     types.Uint64(amount),
+							MIRID:      tmpMIR.ID,
+						}
+						if r := db.Create(&tmpReward); r.Error != nil {
+							return fmt.Errorf("process certificate (batched): %w", r.Error)
+						}
+					}
+				default:
+					return fmt.Errorf(
+						"unsupported certificate type (batched) %T",
+						cert,
+					)
+				}
+			}
+
+			if len(certIDUpdates) > 0 {
+				var ids []uint
+				var whenClauses []string
+				var values []any
+				for unifiedID, specializedID := range certIDUpdates {
+					ids = append(ids, unifiedID)
+					whenClauses = append(whenClauses, "WHEN id = ? THEN ?")
+					values = append(values, unifiedID, specializedID)
+				}
+				caseStmt := strings.Join(whenClauses, " ")
+				query := fmt.Sprintf(
+					"UPDATE certs SET certificate_id = CASE %s END WHERE id IN (?)",
+					caseStmt,
+				)
+				values = append(values, ids)
+				if r := db.Exec(query, values...); r.Error != nil {
+					return fmt.Errorf(
+						"batch update unified certificates (batched): %w",
+						r.Error,
+					)
+				}
+			}
+		}
+
+		if d.storageMode == types.StorageModeAPI {
+			if err := d.storeTransactionDatums(tx, point.Slot, txn); err != nil {
+				return fmt.Errorf("store datums failed (batched): %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // SetGenesisTransaction stores a genesis transaction record.
 // Genesis transactions have no inputs, witnesses, or fees - just outputs.
 func (d *MetadataStoreSqlite) SetGenesisTransaction(

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2685,6 +2685,9 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			}
 			if len(unifiedIDs) > 0 {
 				tables := []string{
+					// Child tables must be deleted before parent tables (FK constraints).
+					"pool_registration_owner",
+					"pool_registration_relay",
 					"stake_registration", "pool_registration", "pool_retirement",
 					"auth_committee_hot", "resign_committee_cold",
 					"deregistration", "stake_delegation",

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2234,7 +2234,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	txn types.Txn,
 ) error {
 	if acc == nil {
-		return fmt.Errorf("SetTransactionBatched: acc must not be nil")
+		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2375,137 +2375,113 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
 	//    These update UTxOs that already exist from prior blocks.        //
 	// ------------------------------------------------------------------ //
-	if d.storageMode == types.StorageModeAPI {
-		// Fetch input UTxOs for address-indexing below.
-		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
-		for _, input := range tx.Inputs() {
-			inputRefs = append(inputRefs, UtxoRef{
+	if len(tx.Collateral()) > 0 {
+		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
+		for _, input := range tx.Collateral() {
+			collateralRefs = append(collateralRefs, UtxoRef{
 				TxId:      input.Id().Bytes(),
 				OutputIdx: input.Index(),
 			})
 		}
-		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
+		collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to batch fetch input UTXOs (batched): %w",
+				"failed to batch fetch collateral UTXOs (batched): %w",
 				err,
 			)
 		}
-		for _, input := range tx.Inputs() {
-			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
-			if u := inputUtxos[key]; u != nil {
-				tmpTx.Inputs = append(tmpTx.Inputs, *u)
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+		for _, input := range tx.Collateral() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			if collateralUtxos[key] == nil {
+				continue
+			}
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			tmpTx.Collateral = append(tmpTx.Collateral, *collateralUtxos[key])
+		}
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			if r := db.Exec(sql, args...); r.Error != nil {
+				return fmt.Errorf(
+					"batch update collateral (batched): %w",
+					r.Error,
+				)
 			}
 		}
+	}
 
-		if len(tx.Collateral()) > 0 {
-			collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
-			for _, input := range tx.Collateral() {
-				collateralRefs = append(collateralRefs, UtxoRef{
-					TxId:      input.Id().Bytes(),
-					OutputIdx: input.Index(),
-				})
-			}
-			collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
-			if err != nil {
-				return fmt.Errorf(
-					"failed to batch fetch collateral UTXOs (batched): %w",
-					err,
-				)
-			}
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
-			for _, input := range tx.Collateral() {
-				inTxId := input.Id().Bytes()
-				inIdx := input.Index()
-				key := fmt.Sprintf("%x:%d", inTxId, inIdx)
-				if collateralUtxos[key] == nil {
-					continue
-				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
-				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
-				tmpTx.Collateral = append(tmpTx.Collateral, *collateralUtxos[key])
-			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
-				)
-				if r := db.Exec(sql, args...); r.Error != nil {
-					return fmt.Errorf(
-						"batch update collateral (batched): %w",
-						r.Error,
-					)
-				}
-			}
+	if len(tx.ReferenceInputs()) > 0 {
+		var refInputRefs []UtxoRef
+		for _, input := range tx.ReferenceInputs() {
+			refInputRefs = append(refInputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
 		}
-
-		if len(tx.ReferenceInputs()) > 0 {
-			var refInputRefs []UtxoRef
-			for _, input := range tx.ReferenceInputs() {
-				refInputRefs = append(refInputRefs, UtxoRef{
-					TxId:      input.Id().Bytes(),
-					OutputIdx: input.Index(),
-				})
+		refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to batch fetch reference input UTXOs (batched): %w",
+				err,
+			)
+		}
+		var caseClauses []string
+		var whereConditions []string
+		var caseArgs []any
+		var whereArgs []any
+		for _, input := range tx.ReferenceInputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			if refInputUtxos[key] == nil {
+				continue
 			}
-			refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
-			if err != nil {
+			caseClauses = append(
+				caseClauses,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, inTxId, inIdx)
+			tmpTx.ReferenceInputs = append(
+				tmpTx.ReferenceInputs,
+				*refInputUtxos[key],
+			)
+		}
+		if len(caseClauses) > 0 {
+			args := append(caseArgs, whereArgs...)
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+				strings.Join(caseClauses, " "),
+				strings.Join(whereConditions, " OR "),
+			)
+			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
-					"failed to batch fetch reference input UTXOs (batched): %w",
-					err,
+					"batch update reference inputs (batched): %w",
+					r.Error,
 				)
-			}
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
-			for _, input := range tx.ReferenceInputs() {
-				inTxId := input.Id().Bytes()
-				inIdx := input.Index()
-				key := fmt.Sprintf("%x:%d", inTxId, inIdx)
-				if refInputUtxos[key] == nil {
-					continue
-				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
-				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
-				tmpTx.ReferenceInputs = append(
-					tmpTx.ReferenceInputs,
-					*refInputUtxos[key],
-				)
-			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
-				)
-				if r := db.Exec(sql, args...); r.Error != nil {
-					return fmt.Errorf(
-						"batch update reference inputs (batched): %w",
-						r.Error,
-					)
-				}
 			}
 		}
 	}
@@ -2539,6 +2515,28 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		// On retry: schedule deletion of previously flushed rows for this tx.
 		if needsIdFetch {
 			local.AddDeleteTxID(tmpTx.ID)
+		}
+
+		// Fetch input UTxOs for address-indexing below.
+		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
+		for _, input := range tx.Inputs() {
+			inputRefs = append(inputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to batch fetch input UTXOs (batched): %w",
+				err,
+			)
+		}
+		for _, input := range tx.Inputs() {
+			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
+			if u := inputUtxos[key]; u != nil {
+				tmpTx.Inputs = append(tmpTx.Inputs, *u)
+			}
 		}
 
 		// Address-transaction index.


### PR DESCRIPTION
closes #1799 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SetTransactionBatched` to `sqlite`, `mysql`, and `postgres` to batch per-item metadata writes while still upserting the transaction row immediately for FK safety. Also adds `MergeFrom` to combine accumulators before a `FlushBatch`.

- **New Features**
  - `SetTransactionBatched` + accumulator/`FlushBatch` API across all backends.
  - Immediate writes: transaction upsert; collateral/reference-input markers; certificates/governance; datum-hash index.
  - Deferred writes: UTxO outputs/collateral return/spends; witnesses/scripts/plutus data/redeemers; address-transaction index.
  - `MergeFrom` to combine accumulators before flushing.

- **Bug Fixes**
  - Set `AddedSlot` consistently for accounts during certificate processing in `sqlite`/`postgres` to avoid stale slot timestamps on updates.

<sup>Written for commit e6fb662e4d5ed94074f7a76740434494f5e6bc9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Batched transaction persistence added across backends to defer per-item metadata writes, queue UTxO outputs/spends and witness-related rows for bulk flush, and separate collateral-return handling.
  * Added ability to merge deferred batches before flush.

* **Bug Fixes**
  * Improved idempotency and retry handling when a transaction ID is discovered after initial upsert to avoid duplicate/orphaned rows.

* **Tests**
  * Added test verifying immediate transaction row persistence with deferred metadata accumulation and flush.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->