### PR TITLE
fix(connmanager): log remote name when failing connection

### DIFF
--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -320,7 +320,8 @@ func (c *ConnectionManager) startListener(
 			if err != nil {
 				c.config.Logger.Error(
 					fmt.Sprintf(
-						"listener: failed to setup connection: %s",
+						"listener: failed to setup connection from %s: %s",
+						conn.RemoteAddr(),
 						err,
 					),
 				)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve listener error logging in `connmanager` by including the remote address when connection setup fails. This makes it clear which client failed and speeds up debugging.

<sup>Written for commit c009d8a3c6eb757b56684fe9ec20321a27f3f54b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2084?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diagnostic logging for N2N connection failures to include the remote address, improving troubleshooting capabilities when connections fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->