### PR TITLE
fix: noctx to appease golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,6 @@ linters:
     - zerologlint
   disable:
     - depguard
-    - noctx
   exclusions:
     generated: lax
     presets:

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -183,7 +183,7 @@ func (b *BlobStoreBark) GetBlock(
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("failed creating request for bark supplied url: %w", err)
 	}
-	blockResp, err := b.httpClient.Do(blockReq) //nolint:gosec // URL is from trusted bark archive service
+	blockResp, err := b.httpClient.Do(blockReq) //nolint:gosec
 	if err != nil {
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("failed downloading block from bark supplied url: %w", err)

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -173,7 +173,17 @@ func (b *BlobStoreBark) GetBlock(
 
 	block := blocks[0]
 
-	blockResp, err := b.httpClient.Get(block.GetUrl())
+	blockReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		block.GetUrl(),
+		nil,
+	)
+	if err != nil {
+		return nil, types.BlockMetadata{},
+			fmt.Errorf("failed creating request for bark supplied url: %w", err)
+	}
+	blockResp, err := b.httpClient.Do(blockReq) //nolint:gosec // URL is from trusted bark archive service
 	if err != nil {
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("failed downloading block from bark supplied url: %w", err)


### PR DESCRIPTION
closes #802 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagate context to the block download HTTP request in the Bark blob store and re-enable the `noctx` linter (closes #802). This enables request cancellation/timeouts and removes the `noctx` disable from `.golangci.yml`.

<sup>Written for commit 612166e466605c880e8acfb6b3ed9fe6cea8721b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2088?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

