### PR TITLE
fix(ouroboros): surface async blockfetch server errors via connection…

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -135,7 +135,7 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 			chainIter.Cancel()
 			return
 		}
-		o.blockfetchServerSendBatch(
+		err := o.blockfetchServerSendBatch(
 			ctx.ConnectionId.String(),
 			start,
 			end,
@@ -143,6 +143,15 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 			ctx.Server,
 			conn,
 		)
+		if err != nil {
+			o.reportBlockfetchServerAsyncError(
+				conn,
+				ctx.ConnectionId.String(),
+				start,
+				end,
+				err,
+			)
+		}
 	}()
 	return nil
 }
@@ -154,7 +163,7 @@ func (o *Ouroboros) blockfetchServerSendBatch(
 	chainIter blockfetchRangeIterator,
 	server blockfetchBatchServer,
 	conn blockfetchConnection,
-) {
+) error {
 	defer chainIter.Cancel()
 	if err := server.StartBatch(); err != nil {
 		o.config.Logger.Error(
@@ -162,13 +171,13 @@ func (o *Ouroboros) blockfetchServerSendBatch(
 			"connection_id", connectionID,
 			"error", err,
 		)
-		return
+		return fmt.Errorf("blockfetch StartBatch failed: %w", err)
 	}
 Loop:
 	for {
 		select {
 		case <-conn.ErrorChan():
-			return
+			return nil
 		default:
 			next, iterErr := chainIter.Next(false)
 			if iterErr != nil {
@@ -187,7 +196,7 @@ Loop:
 					connectionID,
 					"iterator error after StartBatch",
 				)
-				return
+				return fmt.Errorf("blockfetch iterator failed: %w", iterErr)
 			}
 			if next == nil {
 				break Loop
@@ -216,7 +225,7 @@ Loop:
 					connectionID,
 					"failed to stream block after StartBatch",
 				)
-				return
+				return fmt.Errorf("blockfetch Block failed: %w", err)
 			}
 			if o.metrics != nil {
 				o.metrics.servedBlockCount.Inc()
@@ -240,6 +249,32 @@ Loop:
 			conn,
 			connectionID,
 			"failed to send BatchDone after StartBatch",
+		)
+		return fmt.Errorf("blockfetch BatchDone failed: %w", err)
+	}
+	return nil
+}
+
+func (o *Ouroboros) reportBlockfetchServerAsyncError(
+	conn blockfetchConnection,
+	connectionID string,
+	start ocommon.Point,
+	end ocommon.Point,
+	err error,
+) {
+	o.config.Logger.Error(
+		"blockfetch: async range server failed",
+		"connection_id", connectionID,
+		"start_slot", start.Slot,
+		"end_slot", end.Slot,
+		"error", err,
+	)
+	select {
+	case conn.ErrorChan() <- err:
+	default:
+		o.config.Logger.Debug(
+			"blockfetch: failed to forward async server error to connection error channel",
+			"connection_id", connectionID,
 		)
 	}
 }

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -269,13 +269,25 @@ func (o *Ouroboros) reportBlockfetchServerAsyncError(
 		"end_slot", end.Slot,
 		"error", err,
 	)
-	select {
-	case conn.ErrorChan() <- err:
-	default:
+	if !sendBlockfetchConnError(conn.ErrorChan(), err) {
 		o.config.Logger.Debug(
 			"blockfetch: failed to forward async server error to connection error channel",
 			"connection_id", connectionID,
 		)
+	}
+}
+
+func sendBlockfetchConnError(errCh chan error, err error) (sent bool) {
+	defer func() {
+		if recover() != nil {
+			sent = false
+		}
+	}()
+	select {
+	case errCh <- err:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -274,7 +274,7 @@ func TestBlockfetchServerSendBatch_ClosesConnectionOnIteratorError(
 	start := ocommon.NewPoint(100, []byte{0x01})
 	end := ocommon.NewPoint(200, []byte{0x02})
 
-	o.blockfetchServerSendBatch(
+	err := o.blockfetchServerSendBatch(
 		testConnId().String(),
 		start,
 		end,
@@ -283,6 +283,7 @@ func TestBlockfetchServerSendBatch_ClosesConnectionOnIteratorError(
 		conn,
 	)
 
+	assert.Error(t, err)
 	assert.Equal(t, 1, server.startBatchCalls)
 	assert.Equal(t, 0, server.batchDoneCalls)
 	assert.Equal(t, 1, conn.closeCalls)
@@ -303,7 +304,7 @@ func TestBlockfetchServerSendBatch_BatchDoneAtChainTip(t *testing.T) {
 	start := ocommon.NewPoint(100, []byte{0x01})
 	end := ocommon.NewPoint(200, []byte{0x02})
 
-	o.blockfetchServerSendBatch(
+	err := o.blockfetchServerSendBatch(
 		testConnId().String(),
 		start,
 		end,
@@ -312,10 +313,42 @@ func TestBlockfetchServerSendBatch_BatchDoneAtChainTip(t *testing.T) {
 		conn,
 	)
 
+	assert.NoError(t, err)
 	assert.Equal(t, 1, server.startBatchCalls)
 	assert.Equal(t, 1, server.batchDoneCalls)
 	assert.Equal(t, 0, conn.closeCalls)
 	assert.Equal(t, 1, iter.cancelCalls)
+}
+
+func TestReportBlockfetchServerAsyncError_ForwardsToConnectionErrorChan(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error, 1),
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(200, []byte{0x02})
+	expectedErr := errors.New("async blockfetch failure")
+
+	o.reportBlockfetchServerAsyncError(
+		conn,
+		testConnId().String(),
+		start,
+		end,
+		expectedErr,
+	)
+
+	select {
+	case gotErr := <-conn.errChan:
+		assert.Equal(t, expectedErr, gotErr)
+	default:
+		t.Fatal("expected async error to be forwarded to connection error channel")
+	}
 }
 
 func BenchmarkBlockfetchClientBlockMetrics(b *testing.B) {

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -351,6 +351,32 @@ func TestReportBlockfetchServerAsyncError_ForwardsToConnectionErrorChan(
 	}
 }
 
+func TestReportBlockfetchServerAsyncError_ClosedErrorChan_NoPanic(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error),
+	}
+	close(conn.errChan)
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(200, []byte{0x02})
+
+	assert.NotPanics(t, func() {
+		o.reportBlockfetchServerAsyncError(
+			conn,
+			testConnId().String(),
+			start,
+			end,
+			errors.New("closed channel test"),
+		)
+	})
+}
+
 func BenchmarkBlockfetchClientBlockMetrics(b *testing.B) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	eventBus := event.NewEventBus(nil, logger)


### PR DESCRIPTION
Closes #398 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface async BlockFetch server errors through the connection error channel so clients don’t fail silently. `blockfetchServerSendBatch` now returns errors, which are logged and forwarded when serving ranges asynchronously.

- **Bug Fixes**
  - `blockfetchServerSendBatch` returns errors for `StartBatch`, iterator, `Block`, and `BatchDone`, and exits early on connection errors.
  - `blockfetchServerRequestRange` captures errors and calls `reportBlockfetchServerAsyncError` to log with start/end slots and forward via `conn.ErrorChan()`.
  - Non-blocking, panic-safe forwarding via `sendBlockfetchConnError`, with a debug log if the channel is full or closed.
  - Tests cover error returns, forwarding to the connection channel, and closed-channel no-panic behavior.

<sup>Written for commit ac98c9a9ec123325d9daf819ddd511ebc428a936. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2098?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling in block fetching operations to capture and asynchronously report errors that were previously unhandled, improving reliability.
  * Better error visibility for batch operations, iterator failures, and block streaming issues.

* **Tests**
  * Expanded test coverage to validate error handling and asynchronous error reporting mechanisms in block fetching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->