### PR TITLE
fix: update txpump context directory so docker compose can build from…

### DIFF
--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -126,8 +126,8 @@ services:
 
   txpump:
     build:
-      context: ../../..
-      dockerfile: internal/test/antithesis/Dockerfile.txpump
+      context: ../antithesis
+      dockerfile: Dockerfile.txpump
     container_name: devnet-txpump
     depends_on:
       dingo-producer:


### PR DESCRIPTION
… the top level

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `txpump` image build by pointing the build context to `internal/test/antithesis` and using `Dockerfile.txpump`, so `docker compose` works when run from the repo root. Updates `internal/test/devnet/docker-compose.yml` to remove the incorrect top-level context references.

<sup>Written for commit bb5b8acb4f967b8229ff2f379e9db9be309557c6. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development environment configuration to optimize build processes.

---

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->