### PR TITLE
fix: pprof listener debug port

### DIFF
--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -136,6 +136,12 @@ topology: ""
 # CLI: --metrics-port
 metricsPort: 12798
 
+# TCP port to bind for pprof debug endpoints (heap, profile, goroutine, etc).
+# 0 disables. Operators opt in; never enable in production by default — debug
+# endpoints expose internal state and run on a separate listener from metrics.
+# CLI: --debug-port  Env: DINGO_DEBUG_PORT
+debugPort: 0
+
 # Internal/private address to bind for listening for Ouroboros NtC
 privateBindAddr: "127.0.0.1"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,7 @@ type Config struct {
 	BarkPort             uint    `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
 	UtxorpcPort          uint    `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
 	MetricsPort          uint    `yaml:"metricsPort"                                                      split_words:"true"`
+	DebugPort            uint    `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
 	IntersectTip         bool    `yaml:"intersectTip"                                                     split_words:"true"`
 	ValidateHistorical   bool    `yaml:"validateHistorical"                                               split_words:"true"`
 	RunMode              RunMode `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
@@ -400,6 +401,7 @@ var globalConfig = &Config{
 	Network:              "preview",
 	NetworkMagic:         0,
 	MetricsPort:          12798,
+	DebugPort:            0,
 	PrivateBindAddr:      "127.0.0.1",
 	PrivatePort:          3002,
 	RelayPort:            3001,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -68,6 +68,7 @@ var flagSpecs = []flagSpec{
 	stringFlag("PrivateBindAddr", "private-bind-addr", "", "private bind address"),
 	uintFlag("PrivatePort", "private-port", "private/NtC port"),
 	uintFlag("MetricsPort", "metrics-port", "metrics port"),
+	uintFlag("DebugPort", "debug-port", "debug pprof port (0 = disabled)"),
 	boolFlag("PeerSharing", "peer-sharing", "enable peer sharing protocol"),
 
 	// APIs

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -57,11 +58,17 @@ func waitForSignalOrError(
 func gracefulShutdown(
 	logger *slog.Logger,
 	metricsServer *http.Server,
+	debugServer *http.Server,
 	d *dingo.Node,
 	timeout time.Duration,
 ) error {
+	var debugShutdown func(context.Context) error
+	if debugServer != nil {
+		debugShutdown = debugServer.Shutdown
+	}
 	shutdownErr := shutdownNodeResources(
 		metricsServer.Shutdown,
+		debugShutdown,
 		d.Stop,
 		timeout,
 	)
@@ -77,6 +84,7 @@ func gracefulShutdown(
 
 func shutdownNodeResources(
 	metricsServerShutdown func(context.Context) error,
+	debugServerShutdown func(context.Context) error,
 	nodeStop func() error,
 	timeout time.Duration,
 ) error {
@@ -91,6 +99,14 @@ func shutdownNodeResources(
 			err,
 			fmt.Errorf("metrics server shutdown: %w", shutdownErr),
 		)
+	}
+	if debugServerShutdown != nil {
+		if shutdownErr := debugServerShutdown(shutdownCtx); shutdownErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("debug server shutdown: %w", shutdownErr),
+			)
+		}
 	}
 	if stopErr := nodeStop(); stopErr != nil {
 		err = errors.Join(
@@ -371,6 +387,27 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+	// Optional debug listener with pprof handlers, on a separate port from
+	// metrics so monitoring scrapers never see profiling endpoints.
+	var debugServer *http.Server
+	if cfg.DebugPort != 0 {
+		debugMux := http.NewServeMux()
+		debugMux.HandleFunc("/debug/pprof/", pprof.Index)
+		debugMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		debugMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		debugMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		debugMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		debugAddr := fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.DebugPort)
+		logger.Info(
+			"serving pprof debug endpoints on "+debugAddr,
+			"component", "node",
+		)
+		debugServer = &http.Server{
+			Addr:              debugAddr,
+			Handler:           debugMux,
+			ReadHeaderTimeout: 60 * time.Second,
+		}
+	}
 	// Wait for interrupt/termination signal
 	signalCtx, signalCtxStop := signal.NotifyContext(
 		context.Background(),
@@ -379,8 +416,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	)
 	defer signalCtxStop()
 
-	// Error channel for both node and metrics goroutines
-	errChan := make(chan error, 2)
+	// Error channel for node, metrics, and optional debug goroutines
+	errChan := make(chan error, 3)
 	go func() {
 		if err := metricsServer.ListenAndServe(); err != nil &&
 			err != http.ErrServerClosed {
@@ -391,6 +428,18 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			errChan <- fmt.Errorf("metrics server: %w", err)
 		}
 	}()
+	if debugServer != nil {
+		go func() {
+			if err := debugServer.ListenAndServe(); err != nil &&
+				err != http.ErrServerClosed {
+				logger.Error(
+					fmt.Sprintf("failed to start debug listener: %s", err),
+					"component", "node",
+				)
+				errChan <- fmt.Errorf("debug server: %w", err)
+			}
+		}()
+	}
 	go func() {
 		//nolint:contextcheck
 		err := d.Run(signalCtx)
@@ -411,6 +460,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		if err := gracefulShutdown(
 			logger,
 			metricsServer,
+			debugServer,
 			d,
 			shutdownTimeout,
 		); err != nil {
@@ -425,6 +475,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		if err := gracefulShutdown(
 			logger,
 			metricsServer,
+			debugServer,
 			d,
 			shutdownTimeout,
 		); err != nil {
@@ -436,8 +487,13 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	logger.Error("node error", "error", err)
 	signalCtxStop()
 
+	var debugShutdown func(context.Context) error
+	if debugServer != nil {
+		debugShutdown = debugServer.Shutdown
+	}
 	cleanupErr := shutdownNodeResources(
 		metricsServer.Shutdown,
+		debugShutdown,
 		d.Stop,
 		shutdownTimeout,
 	)

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -68,6 +68,7 @@ func TestShutdownNodeResourcesAggregatesErrors(t *testing.T) {
 		func(context.Context) error {
 			return metricsErr
 		},
+		nil,
 		func() error {
 			return nodeErr
 		},
@@ -97,6 +98,7 @@ func TestShutdownNodeResourcesReturnsNilWithoutErrors(t *testing.T) {
 		func(context.Context) error {
 			return nil
 		},
+		nil,
 		func() error {
 			return nil
 		},


### PR DESCRIPTION
Closes #1557 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated pprof debug listener behind a new debug port. Keeps profiling endpoints off the metrics port and shuts them down cleanly.

- **Bug Fixes**
  - Added `DebugPort` config with `--debug-port` and `DINGO_DEBUG_PORT` (0 disables; default 0).
  - Served `net/http/pprof` handlers on a separate listener at `BindAddr:DebugPort`.
  - Integrated graceful shutdown for the debug server and updated tests.

<sup>Written for commit e77b3c78419a6a68fb8ecafdad4904c2d5645fa4. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2109?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional debug port configuration to enable debug endpoints on a separate HTTP listener. Debug endpoints are disabled by default and can be enabled by setting the debug port via configuration file, environment variable, or command-line flag.

* **Documentation**
  * Updated example configuration with new debug port setting and available configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->