### PR TITLE
fix: update configuration permissions and glob patterns

### DIFF
--- a/internal/test/devnet/configurator.sh
+++ b/internal/test/devnet/configurator.sh
@@ -150,8 +150,8 @@ cp -r /tmp/testnet/utxos/* /configs
 
 echo "removing /configs/keys"; rm -rf /configs/keys
 
-pools=$(ls -d /configs/*)
-number_of_pools=$(ls -d /configs/* | wc -l)
+pools=$(ls -d /configs/[0-9]*)
+number_of_pools=$(ls -d /configs/[0-9]* | wc -l)
 echo "number_of_pools: $number_of_pools"
 
 # Generate ring topology for all pools (writes all files in one pass)
@@ -169,3 +169,8 @@ for pool in $pools; do
   set_start_time "$pool"
   config_config_json "$pool"
 done
+
+# Test-only credentials: relax permissions so consuming containers running as
+# non-root (e.g. the dingo image runs as uid 100) can read pool keys and
+# genesis/config files.
+chmod -R a+rX /configs


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened pool directory matching to numeric folders and relaxed config permissions so non-root containers can read test keys and configs. Fixes incorrect pool detection and read errors in devnet tests.

- **Bug Fixes**
  - Match pools with `/configs/[0-9]*` to avoid non-pool directories and ensure correct counts/topology.
  - Apply `chmod -R a+rX /configs` so non-root containers (e.g., uid 100) can read genesis, configs, and pool keys (test-only).

<sup>Written for commit f96018ec0b716975cc3c5e440b08a8b24e7c661a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2110?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

