### PR TITLE
fix(vrf): fix vrf behavior at shelly->allegra boundary

### DIFF
--- a/ledger/candidate_nonce.go
+++ b/ledger/candidate_nonce.go
@@ -57,13 +57,16 @@ var errNoncesMissing = errors.New("block nonce rows missing for epoch")
 //
 // Parameters:
 //   - txn: optional database transaction (nil to create a new one)
+//   - eraId: the era of the source epoch. Selects the
+//     randomness-stabilisation formula (3k/f for TPraos eras,
+//     4k/f for Praos) that determines the candidate-freeze cutoff.
 //   - prevEvolvingNonce: evolving nonce at the end of the previous
 //     epoch (genesis hash for the first Shelley epoch)
 //   - prevCandidateNonce: candidate nonce at the end of the previous
 //     epoch (genesis hash for the first Shelley epoch). In Haskell,
 //     psCandidateNonce carries across epochs independently of the
-//     evolving nonce. When 4k/f >= epochLength, the candidate is
-//     never updated and this value is returned as-is.
+//     evolving nonce. When the stability window >= epochLength, the
+//     candidate is never updated and this value is returned as-is.
 //   - epochStartSlot: first slot of the epoch
 //   - epochLengthInSlots: total slots in the epoch
 //
@@ -73,12 +76,13 @@ var errNoncesMissing = errors.New("block nonce rows missing for epoch")
 //   - evolvingNonce: the evolving nonce after all blocks in the epoch
 func (ls *LedgerState) computeCandidateNonce(
 	txn *database.Txn,
+	eraId uint,
 	prevEvolvingNonce []byte,
 	prevCandidateNonce []byte,
 	epochStartSlot uint64,
 	epochLengthInSlots uint64,
 ) ([]byte, []byte, error) {
-	stabilityWindow := ls.nonceStabilityWindow()
+	stabilityWindow := ls.nonceStabilityWindow(eraId)
 	epochEndSlot := epochStartSlot + epochLengthInSlots
 
 	// Determine the cutoff slot. Blocks at or past this slot do NOT
@@ -327,16 +331,29 @@ func (ls *LedgerState) computeCandidateNonceSlow(
 }
 
 // nonceStabilityWindow returns the randomness stabilisation window
-// (in slots) for nonce computation. In Ouroboros Praos (Conway+),
-// this determines when the evolving nonce is frozen: blocks with
-// slot + window >= firstSlotNextEpoch do NOT contribute.
+// (in slots) for nonce computation in the given era. Blocks at or past
+// (firstSlotNextEpoch - window) do NOT update the candidate nonce; the
+// evolving nonce continues to update.
 //
-// The value is 4k/f where k is securityParam and f is
-// activeSlotsCoeff from Shelley genesis. Note: pre-Conway eras used
-// 3k/f (computeStabilityWindow), but Conway uses 4k/f
-// (computeRandomnessStabilisationWindow) as per the Praos protocol.
-// See cardano-ledger StabilityWindow.hs.
-func (ls *LedgerState) nonceStabilityWindow() uint64 {
+// The multiplier of k differs between Praos protocol families:
+//
+//   - TPraos (Shelley/Allegra/Mary/Alonzo): 3k/f, from
+//     cardano-ledger's computeStabilityWindow.
+//   - Praos (Babbage onwards, including Conway): 4k/f, from
+//     cardano-ledger's computeRandomnessStabilisationWindow.
+//
+// Using 4k/f universally — as this function did before #2125 — shifts
+// the candidate-freeze cutoff in the source epoch and produces an
+// epoch nonce that diverges from cardano-node, breaking VRF
+// verification on every block of the next epoch in TPraos eras. The
+// symptom is most visible at the Shelley→Allegra boundary, where
+// epoch 0's misframed candidate yields a wrong eta0 for epoch 1 and
+// every Allegra header VRF-fails.
+//
+// Era IDs follow gouroboros: Byron=0, Shelley=1, Allegra=2, Mary=3,
+// Alonzo=4, Babbage=5, Conway=6. Byron has no Praos randomness
+// window and returns 0.
+func (ls *LedgerState) nonceStabilityWindow(eraId uint) uint64 {
 	if ls.config.CardanoNodeConfig == nil {
 		return 0
 	}
@@ -353,9 +370,13 @@ func (ls *LedgerState) nonceStabilityWindow() uint64 {
 		activeSlotsCoeff.Num().Sign() <= 0 {
 		return 0
 	}
-	// 4k/f = 4 * k * denom / num
+	multiplier, ok := nonceStabilityWindowKMultiplier(eraId)
+	if !ok {
+		return 0
+	}
+	// (multiplier * k) / f = (multiplier * k * f.denom) / f.num
 	numerator := new(big.Int).SetInt64(int64(k))
-	numerator.Mul(numerator, big.NewInt(4))
+	numerator.Mul(numerator, big.NewInt(multiplier))
 	numerator.Mul(numerator, activeSlotsCoeff.Denom())
 	denominator := new(big.Int).Set(activeSlotsCoeff.Num())
 	result := new(big.Int).Div(numerator, denominator)
@@ -368,4 +389,20 @@ func (ls *LedgerState) nonceStabilityWindow() uint64 {
 		return 0
 	}
 	return result.Uint64()
+}
+
+// nonceStabilityWindowKMultiplier returns the k multiplier for the
+// given era's randomness-stabilisation formula. The multiplier
+// changes from 3 to 4 at the TPraos→Praos transition (Alonzo→Babbage).
+// Byron is unsupported (no Praos nonce protocol) and returns ok=false,
+// as do era IDs the table does not know.
+func nonceStabilityWindowKMultiplier(eraId uint) (int64, bool) {
+	switch eraId {
+	case 1, 2, 3, 4: // Shelley, Allegra, Mary, Alonzo (TPraos)
+		return 3, true
+	case 5, 6: // Babbage, Conway (Praos)
+		return 4, true
+	default:
+		return 0, false
+	}
 }

--- a/ledger/candidate_nonce_window_test.go
+++ b/ledger/candidate_nonce_window_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+// shelleyGenesisCfgForNonceWindow loads a Shelley genesis with concrete
+// k and f values so nonceStabilityWindow has real inputs to compute on.
+// k=10, f=1/2 chosen so 3k/f=60 and 4k/f=80 — distinct, small integers
+// that make divergent results obvious in test failures.
+func shelleyGenesisCfgForNonceWindow(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(
+		strings.NewReader(`{
+			"systemStart": "2022-10-25T00:00:00Z",
+			"securityParam": 10,
+			"activeSlotsCoeff": 0.5
+		}`),
+	))
+	return cfg
+}
+
+// TestNonceStabilityWindow_EraDispatch asserts the randomness-stabilisation
+// window is era-aware:
+//
+//   - TPraos eras (Shelley, Allegra, Mary, Alonzo): 3k/f
+//     (cardano-ledger's computeStabilityWindow)
+//   - Praos eras (Babbage, Conway): 4k/f
+//     (cardano-ledger's computeRandomnessStabilisationWindow)
+//
+// The bug in #2125 is that nonceStabilityWindow returns 4k/f universally,
+// shifting the candidate-nonce freeze cutoff in pre-Babbage epochs and
+// producing an epoch nonce that diverges from cardano-node. That makes
+// every TPraos block VRF-fail at the next epoch boundary — observed at
+// Shelley→Allegra in the internal/test/devnet/eras stack.
+//
+// Today this test fails for Shelley/Allegra/Mary/Alonzo. After the fix,
+// all six era cases pass.
+func TestNonceStabilityWindow_EraDispatch(t *testing.T) {
+	cases := []struct {
+		name         string
+		eraId        uint
+		expectedSlot uint64 // 3k/f=60 for TPraos, 4k/f=80 for Praos
+	}{
+		{name: "shelley", eraId: shelley.EraIdShelley, expectedSlot: 60},
+		{name: "allegra", eraId: allegra.EraIdAllegra, expectedSlot: 60},
+		{name: "mary", eraId: mary.EraIdMary, expectedSlot: 60},
+		{name: "alonzo", eraId: alonzo.EraIdAlonzo, expectedSlot: 60},
+		{name: "babbage", eraId: babbage.EraIdBabbage, expectedSlot: 80},
+		{name: "conway", eraId: conway.EraIdConway, expectedSlot: 80},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ls := &LedgerState{
+				config: LedgerStateConfig{
+					CardanoNodeConfig: shelleyGenesisCfgForNonceWindow(t),
+				},
+			}
+			got := ls.nonceStabilityWindow(tc.eraId)
+			require.Equalf(
+				t,
+				tc.expectedSlot,
+				got,
+				"era %s (id=%d): expected stability window %d (issue #2125)",
+				tc.name, tc.eraId, tc.expectedSlot,
+			)
+		})
+	}
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2605,8 +2605,12 @@ func (ls *LedgerState) calculateEpochNonce(
 	// and evolvingNonce (after all blocks) from the remaining
 	// current-epoch blocks. Each block's VRF output is accumulated
 	// via the Nonce semigroup (⭒) starting from prevEvolvingNonce.
+	// Pass currentEra.Id so the candidate-freeze cutoff uses the
+	// correct stability window for the source epoch's protocol family
+	// (3k/f for TPraos, 4k/f for Praos). See #2125.
 	candidateNonce, evolvingNonce, err := ls.computeCandidateNonce(
 		txn,
+		currentEra.Id,
 		prevEvolvingNonce,
 		prevCandidateNonce,
 		computeStartSlot,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4213,7 +4213,7 @@ func (ls *LedgerState) nextEpochNonceReadyCutoffSlot(
 	if epochLength == 0 {
 		return 0, false
 	}
-	stabilityWindow := ls.nonceStabilityWindow()
+	stabilityWindow := ls.nonceStabilityWindow(currentEpoch.EraId)
 	if stabilityWindow >= epochLength {
 		return currentEpoch.StartSlot, true
 	}

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -780,6 +780,7 @@ func newNonceReadyTestLedgerState(
 			EpochId:             10,
 			StartSlot:           1000,
 			LengthInSlots:       100,
+			EraId:               eras.ShelleyEraDesc.Id,
 			Nonce:               nil,
 			EvolvingNonce:       []byte{0x02},
 			CandidateNonce:      []byte{0x03},
@@ -829,13 +830,17 @@ func TestNextEpochNonceReadyCutoffSlot(t *testing.T) {
 		},
 	}
 
+	// Shelley → TPraos: stabilityWindow = 3k/f = 3*432/0.05 = 25920
+	// cutoff = epochStart + epochLength - 25920
+	//        = 106963200 + 86400 - 25920 = 107023680
 	cutoffSlot, ok := ls.nextEpochNonceReadyCutoffSlot(models.Epoch{
 		EpochId:       1238,
 		StartSlot:     106963200,
 		LengthInSlots: 86400,
+		EraId:         eras.ShelleyEraDesc.Id,
 	})
 	require.True(t, ok)
-	assert.Equal(t, uint64(107015040), cutoffSlot)
+	assert.Equal(t, uint64(107023680), cutoffSlot)
 }
 
 func TestNextEpochNonceReadyEpoch(t *testing.T) {
@@ -880,6 +885,7 @@ func TestNextEpochNonceReadyEpoch(t *testing.T) {
 			EpochId:             10,
 			StartSlot:           1000,
 			LengthInSlots:       100,
+			EraId:               eras.ShelleyEraDesc.Id,
 			Nonce:               nil,
 			EvolvingNonce:       []byte{0x02},
 			CandidateNonce:      []byte{0x03},
@@ -992,6 +998,7 @@ func TestNextEpochNonceReadyEpochNotReadyBeforeCutoff(t *testing.T) {
 			EpochId:             10,
 			StartSlot:           1000,
 			LengthInSlots:       100,
+			EraId:               eras.ShelleyEraDesc.Id,
 			Nonce:               nil,
 			EvolvingNonce:       []byte{0x02},
 			CandidateNonce:      []byte{0x03},
@@ -1098,10 +1105,13 @@ func TestNextEpochNonceReadyCutoffSlotShortEpoch(t *testing.T) {
 		},
 	}
 
+	// Shelley → 3k/f = 25920, which exceeds the 100-slot epoch, so the
+	// cutoff degenerates to the epoch start.
 	cutoffSlot, ok := ls.nextEpochNonceReadyCutoffSlot(models.Epoch{
 		EpochId:       42,
 		StartSlot:     1000,
 		LengthInSlots: 100,
+		EraId:         eras.ShelleyEraDesc.Id,
 	})
 	require.True(t, ok)
 	assert.Equal(t, uint64(1000), cutoffSlot)

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -487,8 +487,12 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		}
 	}
 
+	// Use prevEpoch.EraId so the candidate-freeze cutoff applies the
+	// correct stability window for the source epoch's protocol family
+	// (3k/f for TPraos, 4k/f for Praos). See #2125.
 	candidateNonce, evolvingNonce, err := ls.computeCandidateNonce(
 		nil, // non-transactional
+		prevEpoch.EraId,
 		prevEvolvingNonce,
 		prevCandidateNonce,
 		computeStartSlot,


### PR DESCRIPTION
closes #2125 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix VRF verification across the Shelley→Allegra boundary by making candidate nonce freezing era-aware (3k/f for TPraos, 4k/f for Praos). This aligns epoch nonce computation with `cardano-node` and restores header verification in TPraos eras.

- **Bug Fixes**
  - Made `computeCandidateNonce` era-aware by passing `eraId` and using `nonceStabilityWindow(eraId)` with 3k/f for `Shelley/Allegra/Mary/Alonzo` and 4k/f for `Babbage/Conway` (Byron returns 0).
  - Updated callers to pass the correct era: `calculateEpochNonce`, `computeEpochNonceForSlot`, and `nextEpochNonceReadyCutoffSlot`.
  - Added `candidate_nonce_window_test.go` to assert era-specific windows; updated `state_test.go` to set `EraId` and fix cutoff expectations.

<sup>Written for commit 78e8b59cacb9d22416fd1efaa3bcd32380ce2e03. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

