### PR TITLE
feat(bark): get security window size from ledger state

### DIFF
--- a/bark/blob.go
+++ b/bark/blob.go
@@ -34,11 +34,10 @@ import (
 )
 
 type BlobStoreBarkConfig struct {
-	BaseUrl        string
-	SecurityWindow uint64
-	HTTPClient     *http.Client
-	LedgerState    *ledger.LedgerState
-	Logger         *slog.Logger
+	BaseUrl     string
+	HTTPClient  *http.Client
+	LedgerState *ledger.LedgerState
+	Logger      *slog.Logger
 }
 
 type BlobStoreBark struct {
@@ -140,8 +139,9 @@ func (b *BlobStoreBark) GetBlock(
 
 	// if the requested slot is still within the security window, defer to the
 	// upstream blob storage to retrieve the block
-	if b.config.SecurityWindow > currentSlot ||
-		slot >= currentSlot-b.config.SecurityWindow {
+	securityWindow := b.config.LedgerState.StabilityWindow()
+	if securityWindow > currentSlot ||
+		slot >= currentSlot-securityWindow {
 		return b.upstream.GetBlock(txn, slot, hash)
 	}
 

--- a/bark/pruner.go
+++ b/bark/pruner.go
@@ -28,11 +28,10 @@ import (
 )
 
 type PrunerConfig struct {
-	LedgerState    *ledger.LedgerState
-	DB             *database.Database
-	Logger         *slog.Logger
-	SecurityWindow uint64
-	Frequency      time.Duration
+	LedgerState *ledger.LedgerState
+	DB          *database.Database
+	Logger      *slog.Logger
+	Frequency   time.Duration
 }
 
 type Pruner struct {
@@ -75,14 +74,15 @@ func (p *Pruner) prune(ctx context.Context) {
 		return
 	}
 
-	if currentSlot <= p.config.SecurityWindow {
+	securityWindow := p.ledgerState.StabilityWindow()
+	if currentSlot <= securityWindow {
 		p.logger.Debug(
 			"pruner: skipped because current slot is not high enough")
 		return
 	}
 	iter := p.db.BlocksInRange(
 		0,
-		currentSlot-p.config.SecurityWindow-1,
+		currentSlot-securityWindow-1,
 	)
 	defer iter.Close()
 

--- a/config.go
+++ b/config.go
@@ -93,7 +93,6 @@ type Config struct {
 	outboundSourcePort       uint
 	utxorpcPort              uint
 	barkBaseUrl              string
-	barkSecurityWindow       uint64
 	barkPort                 uint
 	networkMagic             uint32
 	intersectTip             bool
@@ -801,12 +800,6 @@ func WithBlockfrostPort(port uint) ConfigOptionFunc {
 func WithBarkBaseUrl(baseUrl string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.barkBaseUrl = baseUrl
-	}
-}
-
-func WithBarkSecurityWindow(window uint64) ConfigOptionFunc {
-	return func(c *Config) {
-		c.barkSecurityWindow = window
 	}
 }
 

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -186,10 +186,6 @@ meshPort: 8080
 # CLI: --bark-url
 barkBaseUrl: ""
 
-# number of slots from tip within which blocks
-# will not be found in the bark archive
-barkSecurityWindow: 10000
-
 # TCP port bind for listening for bark RPC calls
 # CLI: --bark-port
 barkPort: 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,9 +220,8 @@ type Config struct {
 	RejectionWatermark   float64 `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
 	PrivatePort          uint    `yaml:"privatePort"                                                      split_words:"true"`
 	RelayPort            uint    `yaml:"relayPort"          envconfig:"port"`
-	BarkBaseUrl          string  `yaml:"barkBaseUrl"        envconfig:"DINGO_BARK_BASE_URL"`
-	BarkSecurityWindow   uint64  `yaml:"barkSecurityWindow" envconfig:"DINGO_BARK_SECURITY_WINDOW"`
-	BarkPort             uint    `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
+	BarkBaseUrl          string  `yaml:"barkBaseUrl" envconfig:"DINGO_BARK_BASE_URL"`
+	BarkPort             uint    `yaml:"barkPort"    envconfig:"DINGO_BARK_PORT"`
 	UtxorpcPort          uint    `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
 	MetricsPort          uint    `yaml:"metricsPort"                                                      split_words:"true"`
 	DebugPort            uint    `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
@@ -406,7 +405,6 @@ var globalConfig = &Config{
 	PrivatePort:          3002,
 	RelayPort:            3001,
 	BarkBaseUrl:          "",
-	BarkSecurityWindow:   10000,
 	BarkPort:             0,
 	UtxorpcPort:          9090,
 	BlockfrostPort:       3000,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -78,7 +78,6 @@ var flagSpecs = []flagSpec{
 
 	// Bark
 	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive base URL"),
-	uint64Flag("BarkSecurityWindow", "bark-security-window", "slots near tip that are not expected in Bark archive"),
 	uintFlag("BarkPort", "bark-port", "Bark RPC port"),
 
 	// Mempool

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -288,7 +288,6 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithUtxorpcTlsCertFilePath(cfg.TlsCertFilePath),
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
 			dingo.WithBarkBaseUrl(cfg.BarkBaseUrl),
-			dingo.WithBarkSecurityWindow(cfg.BarkSecurityWindow),
 			dingo.WithBarkPort(cfg.BarkPort),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
 			dingo.WithRunMode(string(cfg.RunMode)),

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2063,6 +2063,15 @@ func (ls *LedgerState) SecurityParam() int {
 	return int(k)
 }
 
+// StabilityWindow returns the Ouroboros security stability window for the
+// current era in slots. For Byron the window is 2k; for Shelley+ it is 3k/f.
+// It is safe to call from multiple goroutines.
+func (ls *LedgerState) StabilityWindow() uint64 {
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.calculateStabilityWindow()
+}
+
 type readChainResult struct {
 	rollbackPoint ocommon.Point
 	blocks        []ledger.Block

--- a/node.go
+++ b/node.go
@@ -305,8 +305,7 @@ func (n *Node) Run(ctx context.Context) error {
 
 	if n.config.barkBaseUrl != "" {
 		n.db.SetBlobStore(bark.NewBarkBlobStore(bark.BlobStoreBarkConfig{
-			BaseUrl:        n.config.barkBaseUrl,
-			SecurityWindow: n.config.barkSecurityWindow,
+			BaseUrl: n.config.barkBaseUrl,
 			HTTPClient: &http.Client{
 				Timeout: 30 * time.Second,
 			},
@@ -315,11 +314,10 @@ func (n *Node) Run(ctx context.Context) error {
 		}, n.db.Blob()))
 
 		n.barkPruner = bark.NewPruner(bark.PrunerConfig{
-			LedgerState:    state,
-			DB:             n.db,
-			Logger:         n.config.logger,
-			SecurityWindow: n.config.barkSecurityWindow,
-			Frequency:      time.Hour,
+			LedgerState: state,
+			DB:          n.db,
+			Logger:      n.config.logger,
+			Frequency:   time.Hour,
 		})
 
 		if err := n.barkPruner.Start(n.ctx); err != nil {


### PR DESCRIPTION
closes #1536 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `barkSecurityWindow` configuration parameter from CLI flags, YAML configuration, and environment variables.
  * The system now automatically derives the security window from the ledger's stability window at runtime, eliminating the need for manual configuration of this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->