### PR TITLE
feat(bark): tunable block pruning frequency

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	utxorpcPort              uint
 	barkBaseUrl              string
 	barkPort                 uint
+	barkPrunerFrequency      time.Duration
 	networkMagic             uint32
 	intersectTip             bool
 	peerSharing              bool
@@ -806,6 +807,15 @@ func WithBarkBaseUrl(baseUrl string) ConfigOptionFunc {
 func WithBarkPort(port uint) ConfigOptionFunc {
 	return func(c *Config) {
 		c.barkPort = port
+	}
+}
+
+// WithBarkPrunerFrequency specifies how often the Bark pruner runs
+// (deleting blob entries older than the ledger stability window).
+// Default is 1 hour. Values <= 0 fall back to the default.
+func WithBarkPrunerFrequency(freq time.Duration) ConfigOptionFunc {
+	return func(c *Config) {
+		c.barkPrunerFrequency = freq
 	}
 }
 

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -794,7 +794,15 @@ func (d *BlobStoreS3) Start() error {
 		awsCfg.BaseEndpoint = &d.endpoint
 	}
 
-	client := s3.NewFromConfig(awsCfg)
+	// When pointing at a custom endpoint (typically Minio or another
+	// S3-compatible target), force path-style addressing. Virtual-hosted
+	// style requires DNS for "<bucket>.<endpoint>", which custom
+	// endpoints cannot satisfy.
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		if d.endpoint != "" {
+			o.UsePathStyle = true
+		}
+	})
 
 	d.client = client
 	d.startupCtx = ctx

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/aws/smithy-go v1.25.1
 	github.com/blinklabs-io/bark v0.0.2
@@ -91,7 +92,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -201,34 +201,35 @@ func DefaultCacheConfig() CacheConfig {
 }
 
 type Config struct {
-	MetadataPlugin       string  `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
-	TlsKeyFilePath       string  `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
-	Topology             string  `yaml:"topology"`
-	CardanoConfig        string  `yaml:"cardanoConfig"      envconfig:"config"`
-	DatabasePath         string  `yaml:"databasePath"                                                     split_words:"true"`
-	SocketPath           string  `yaml:"socketPath"                                                       split_words:"true"`
-	TlsCertFilePath      string  `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr             string  `yaml:"bindAddr"                                                         split_words:"true"`
-	BlobPlugin           string  `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
-	PrivateBindAddr      string  `yaml:"privateBindAddr"                                                  split_words:"true"`
-	ShutdownTimeout      string  `yaml:"shutdownTimeout"                                                  split_words:"true"`
-	LedgerCatchupTimeout string  `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
-	Network              string  `yaml:"network"`
-	NetworkMagic         uint32  `yaml:"networkMagic"                                                     split_words:"true"`
-	MempoolCapacity      int64   `yaml:"mempoolCapacity"                                                  split_words:"true"`
-	EvictionWatermark    float64 `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
-	RejectionWatermark   float64 `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
-	PrivatePort          uint    `yaml:"privatePort"                                                      split_words:"true"`
-	RelayPort            uint    `yaml:"relayPort"          envconfig:"port"`
-	BarkBaseUrl          string  `yaml:"barkBaseUrl" envconfig:"DINGO_BARK_BASE_URL"`
-	BarkPort             uint    `yaml:"barkPort"    envconfig:"DINGO_BARK_PORT"`
-	UtxorpcPort          uint    `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
-	MetricsPort          uint    `yaml:"metricsPort"                                                      split_words:"true"`
-	DebugPort            uint    `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
-	IntersectTip         bool    `yaml:"intersectTip"                                                     split_words:"true"`
-	ValidateHistorical   bool    `yaml:"validateHistorical"                                               split_words:"true"`
-	RunMode              RunMode `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
-	ImmutableDbPath      string  `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
+	MetadataPlugin       string        `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
+	TlsKeyFilePath       string        `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
+	Topology             string        `yaml:"topology"`
+	CardanoConfig        string        `yaml:"cardanoConfig"      envconfig:"config"`
+	DatabasePath         string        `yaml:"databasePath"                                                     split_words:"true"`
+	SocketPath           string        `yaml:"socketPath"                                                       split_words:"true"`
+	TlsCertFilePath      string        `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
+	BindAddr             string        `yaml:"bindAddr"                                                         split_words:"true"`
+	BlobPlugin           string        `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
+	PrivateBindAddr      string        `yaml:"privateBindAddr"                                                  split_words:"true"`
+	ShutdownTimeout      string        `yaml:"shutdownTimeout"                                                  split_words:"true"`
+	LedgerCatchupTimeout string        `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
+	Network              string        `yaml:"network"`
+	NetworkMagic         uint32        `yaml:"networkMagic"                                                     split_words:"true"`
+	MempoolCapacity      int64         `yaml:"mempoolCapacity"                                                  split_words:"true"`
+	EvictionWatermark    float64       `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
+	RejectionWatermark   float64       `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
+	PrivatePort          uint          `yaml:"privatePort"                                                      split_words:"true"`
+	RelayPort            uint          `yaml:"relayPort"          envconfig:"port"`
+	BarkBaseUrl          string        `yaml:"barkBaseUrl"        envconfig:"DINGO_BARK_BASE_URL"`
+	BarkPort             uint          `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
+	BarkPrunerFrequency  time.Duration `yaml:"barkPrunerFrequency" envconfig:"DINGO_BARK_PRUNER_FREQUENCY"`
+	UtxorpcPort          uint          `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
+	MetricsPort          uint          `yaml:"metricsPort"                                                      split_words:"true"`
+	DebugPort            uint          `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
+	IntersectTip         bool          `yaml:"intersectTip"                                                     split_words:"true"`
+	ValidateHistorical   bool          `yaml:"validateHistorical"                                               split_words:"true"`
+	RunMode              RunMode       `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
+	ImmutableDbPath      string        `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
 	// Database worker pool tuning (worker count and task queue size)
 	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
 	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
@@ -406,6 +407,7 @@ var globalConfig = &Config{
 	RelayPort:            3001,
 	BarkBaseUrl:          "",
 	BarkPort:             0,
+	BarkPrunerFrequency:  time.Hour,
 	UtxorpcPort:          9090,
 	BlockfrostPort:       3000,
 	MeshPort:             8080,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -79,6 +79,7 @@ var flagSpecs = []flagSpec{
 	// Bark
 	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive base URL"),
 	uintFlag("BarkPort", "bark-port", "Bark RPC port"),
+	durationFlag("BarkPrunerFrequency", "bark-pruner-frequency", "Bark pruner run frequency"),
 
 	// Mempool
 	int64Flag("MempoolCapacity", "mempool-capacity", "mempool max bytes"),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -289,6 +289,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
 			dingo.WithBarkBaseUrl(cfg.BarkBaseUrl),
 			dingo.WithBarkPort(cfg.BarkPort),
+			dingo.WithBarkPrunerFrequency(cfg.BarkPrunerFrequency),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
 			dingo.WithRunMode(string(cfg.RunMode)),
 			dingo.WithShutdownTimeout(shutdownTimeout),

--- a/node.go
+++ b/node.go
@@ -313,11 +313,15 @@ func (n *Node) Run(ctx context.Context) error {
 			Logger:      n.config.logger,
 		}, n.db.Blob()))
 
+		prunerFreq := n.config.barkPrunerFrequency
+		if prunerFreq <= 0 {
+			prunerFreq = time.Hour
+		}
 		n.barkPruner = bark.NewPruner(bark.PrunerConfig{
 			LedgerState: state,
 			DB:          n.db,
 			Logger:      n.config.logger,
-			Frequency:   time.Hour,
+			Frequency:   prunerFreq,
 		})
 
 		if err := n.barkPruner.Start(n.ctx); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bark pruner frequency is configurable via CLI flag (--bark-pruner-frequency), environment variable, or config file; defaults to hourly.

* **Bug Fixes**
  * S3 client now properly supports custom endpoints by using path-style addressing when needed.

* **Chores**
  * AWS credentials dependency moved to a direct requirement in module configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->