### PR TITLE
fix(ledger): allow slot clock drift up to 500ms

### DIFF
--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -44,14 +44,16 @@ type SlotClockConfig struct {
 	Logger *slog.Logger
 	// ClockTolerance is the maximum drift allowed when waking at slot boundaries.
 	// If we wake up more than this much after the slot boundary, we log a warning.
-	// Default: 100ms
+	// Set high enough to ride out normal Go scheduler / GC pause jitter on a busy
+	// node — only sustained or large drifts indicate a real timing problem.
+	// Default: 500ms.
 	ClockTolerance time.Duration
 }
 
 // DefaultSlotClockConfig returns the default configuration
 func DefaultSlotClockConfig() SlotClockConfig {
 	return SlotClockConfig{
-		ClockTolerance: 100 * time.Millisecond,
+		ClockTolerance: 500 * time.Millisecond,
 	}
 }
 

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -82,7 +82,7 @@ func TestSlotClockCreation(t *testing.T) {
 	clock := NewSlotClock(provider, DefaultSlotClockConfig())
 	require.NotNil(t, clock)
 	assert.NotNil(t, clock.provider)
-	assert.Equal(t, 100*time.Millisecond, clock.config.ClockTolerance)
+	assert.Equal(t, 500*time.Millisecond, clock.config.ClockTolerance)
 }
 
 func TestSlotClockCurrentSlot(t *testing.T) {


### PR DESCRIPTION
Loosening this for now as it can get very noisy during catch-up. However, I think the original tolerance is probably a better target longer-term. We can handle that next quarter. 😂 