### PR TITLE
fix(ledger): preserve gap UTxOs

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1505,18 +1505,38 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 				err,
 			)
 		}
-		// Delete rolled-back UTxOs (blob offsets and metadata)
-		err := ls.db.UtxosDeleteRolledback(point.Slot, txn)
+		// Delete rolled-back UTxOs (blob offsets and metadata).
+		//
+		// Floor the deletion slot at mithrilLedgerSlot. UTxOs produced
+		// by gap blocks during Mithril bootstrap are written via
+		// SetGapBlockTransaction without advancing the ledger tip, so
+		// their added_slot values are well above the persisted ledger
+		// tip. A rollback whose target is below the Mithril boundary
+		// would otherwise bulk-delete every gap-block-produced UTxO,
+		// leaving the chain unable to validate the first post-gap
+		// block that consumes one of them. The Mithril snapshot is
+		// the trust anchor — we never rewind below it — so the
+		// authoritative deletion slot is the rollback target or the
+		// Mithril boundary, whichever is later.
+		deleteSlot := point.Slot
+		if ls.mithrilLedgerSlot > deleteSlot {
+			deleteSlot = ls.mithrilLedgerSlot
+		}
+		err := ls.db.UtxosDeleteRolledback(deleteSlot, txn)
 		if err != nil {
 			return fmt.Errorf("remove rolled-back UTxOs: %w", err)
 		}
 		// Delete rolled-back transaction offsets and metadata
-		err = ls.db.TransactionsDeleteRolledback(point.Slot, txn)
+		err = ls.db.TransactionsDeleteRolledback(deleteSlot, txn)
 		if err != nil {
 			return fmt.Errorf("remove rolled-back transactions: %w", err)
 		}
-		// Restore spent UTxOs
-		err = ls.db.UtxosUnspend(point.Slot, txn)
+		// Restore spent UTxOs. Use the same floored slot as the
+		// delete calls above so gap-block transactions and the UTxOs
+		// they consumed stay in sync: preserving a tx at slot S while
+		// restoring its consumed UTxO at deleted_slot=S would leave
+		// the tx pointing at a live UTxO it claims to have spent.
+		err = ls.db.UtxosUnspend(deleteSlot, txn)
 		if err != nil {
 			return fmt.Errorf(
 				"restore spent UTxOs after rollback: %w",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger rollback to respect snapshot trust boundaries, preventing bulk deletion of valid UTxOs produced by gap blocks. Rollback now aligns deletion points with the trust boundary, keeping transaction and consumed-UTxO state consistent during recovery and bootstrap scenarios to preserve data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->