### PR TITLE
fix(ledgerstate): extract nonces correctly from snapshot

### DIFF
--- a/internal/devnet/scenarios/epoch_boundary_test.go
+++ b/internal/devnet/scenarios/epoch_boundary_test.go
@@ -1,0 +1,107 @@
+//go:build devnet
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scenarios
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/devnet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEpochBoundaryConsensus verifies Dingo and cardano-node remain in
+// consensus across at least one full epoch transition. With
+// epochLength=500, this exercises the candidate-nonce freeze, lab nonce
+// roll, and VRF verification with the new epoch nonce — the same code
+// path that has been observed to wedge on preview after a Mithril
+// bootstrap.
+//
+// Failure mode this catches: Dingo's tip falls behind cardano-node's by
+// more than slotTolerance after the boundary because every header in
+// the new epoch fails VRF verification (chain stops advancing on Dingo
+// while cardano-node continues forging).
+func TestEpochBoundaryConsensus(t *testing.T) {
+	cfg, err := devnet.LoadDevNetConfig()
+	require.NoError(
+		t, err, "failed to load devnet config from testnet.yaml",
+	)
+	t.Logf(
+		"devnet config: epochLength=%d slotLength=%.1fs"+
+			" activeSlotsCoeff=%.2f securityParam=%d",
+		cfg.EpochLength, cfg.SlotLength,
+		cfg.ActiveSlotsCoeff, cfg.SecurityParam,
+	)
+
+	endpoints := devnet.DefaultEndpoints()
+	h := devnet.NewTestHarness(
+		t, endpoints,
+		devnet.WithNetworkMagic(cfg.NetworkMagic),
+	)
+
+	h.WaitForAllNodesReady(60 * time.Second)
+
+	// Target a slot well past the first epoch boundary so we have
+	// blocks on both sides of the rollover. 1.4 * epochLength puts
+	// us ~200 slots into epoch 1.
+	targetSlot := cfg.EpochLength + cfg.EpochLength*2/5
+	timeout := time.Duration(targetSlot)*cfg.SlotDuration() +
+		cfg.ExpectedBlockTime()*10
+	t.Logf(
+		"waiting for slot %d (past epoch boundary at slot %d), timeout %s",
+		targetSlot, cfg.EpochLength, timeout,
+	)
+
+	cardanoEndpoint := endpoints[1]
+	h.WaitForNodeSlot(cardanoEndpoint, targetSlot, timeout)
+
+	// Both producers must agree on the chain after crossing the
+	// boundary. K is the initial catch-up tolerance; anything larger
+	// means one side has stalled, which is what the bug looks like.
+	tolerance := cfg.SecurityParam
+	convergeTimeout := cfg.ExpectedBlockTime() * 60
+	h.VerifyChainConsensus(tolerance, convergeTimeout)
+
+	// Once the boundary has passed and the nodes have had one K window to
+	// catch up, require near-immediate convergence. This catches Dingo
+	// staying materially behind cardano-node after new-epoch VRF checks.
+	tightTolerance := uint64(1)
+	tightConvergeTimeout := cfg.ExpectedBlockTime() * 10
+	h.VerifyChainConsensus(tightTolerance, tightConvergeTimeout)
+
+	dingoEndpoint := endpoints[0]
+	dingoTip, err := h.GetChainTip(dingoEndpoint)
+	require.NoError(t, err, "failed to get dingo tip after boundary")
+	cardanoTip, err := h.GetChainTip(cardanoEndpoint)
+	require.NoError(t, err, "failed to get cardano tip after boundary")
+	t.Logf(
+		"post-boundary: dingo slot=%d block=%d, cardano slot=%d block=%d",
+		dingoTip.SlotNumber, dingoTip.BlockNumber,
+		cardanoTip.SlotNumber, cardanoTip.BlockNumber,
+	)
+
+	// Dingo's tip slot must be past the boundary. If VRF verification
+	// fails on every new-epoch header, Dingo's chain stalls a few
+	// slots before slot=epochLength.
+	require.Greater(
+		t, dingoTip.SlotNumber, cfg.EpochLength,
+		"dingo did not advance past first epoch boundary "+
+			"(stuck before slot %d) — likely VRF verification "+
+			"failure on epoch 1 headers",
+		cfg.EpochLength,
+	)
+}

--- a/ledgerstate/praos_nonces_test.go
+++ b/ledgerstate/praos_nonces_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeTestNonce builds a CBOR Nonce value: [0] for NeutralNonce or
+// [1, hash] for Nonce(hash). The shape matches `decodeNonce`.
+func encodeTestNonce(t *testing.T, hash []byte) []byte {
+	t.Helper()
+	if hash == nil {
+		out, err := cbor.Encode([]any{uint64(0)})
+		require.NoError(t, err)
+		return out
+	}
+	out, err := cbor.Encode([]any{uint64(1), hash})
+	require.NoError(t, err)
+	return out
+}
+
+// TestExtractPraosNonces_LastEpochBlockNonceIs8FieldShape locks in the
+// fix for the Mithril-bootstrap VRF wedge. The cardano-ledger PraosState
+// has 8 fields with `previousEpochNonce` at index 5, shifting `labNonce`
+// to 6 and `lastEpochBlockNonce` to 7. The epoch-rollover formula uses
+// `lastEpochBlockNonce` (index 7), so picking up `labNonce` (index 6)
+// yields the wrong eta0 and every header in the next epoch fails VRF.
+func TestExtractPraosNonces_LastEpochBlockNonceIs8FieldShape(t *testing.T) {
+	evolving := bytes.Repeat([]byte{0xee}, 32)
+	candidate := bytes.Repeat([]byte{0xcc}, 32)
+	epoch := bytes.Repeat([]byte{0xee, 0x09}, 16)
+	previous := bytes.Repeat([]byte{0xa0}, 32)
+	lab := bytes.Repeat([]byte{0xab}, 32)
+	lastEpochBlock := bytes.Repeat([]byte{0xfe}, 32)
+
+	lastSlot, err := cbor.Encode(uint64(123456))
+	require.NoError(t, err)
+	ocertCounters, err := cbor.Encode(map[uint64]uint64{})
+	require.NoError(t, err)
+
+	praosState := [][]byte{
+		lastSlot,
+		ocertCounters,
+		encodeTestNonce(t, evolving),
+		encodeTestNonce(t, candidate),
+		encodeTestNonce(t, epoch),
+		encodeTestNonce(t, previous),
+		encodeTestNonce(t, lab),
+		encodeTestNonce(t, lastEpochBlock),
+	}
+
+	got, err := extractPraosNonces(praosState)
+	require.NoError(t, err)
+
+	require.Equal(t, evolving, got.EvolvingNonce, "evolving nonce")
+	require.Equal(t, candidate, got.CandidateNonce, "candidate nonce")
+	require.Equal(t, epoch, got.EpochNonce, "epoch nonce")
+	require.Equal(
+		t, lastEpochBlock, got.LastEpochBlockNonce,
+		"lastEpochBlockNonce must come from the LAST element "+
+			"(index 7); reading index 6 picks up labNonce and "+
+			"breaks VRF on every header in the next epoch",
+	)
+	require.NotEqual(
+		t, lab, got.LastEpochBlockNonce,
+		"sanity: parser must not return labNonce as "+
+			"LastEpochBlockNonce",
+	)
+}
+
+// TestExtractPraosNonces_LastEpochBlockNonceIs7FieldShape covers the
+// older PraosState shape (no `previousEpochNonce`), where
+// `lastEpochBlockNonce` is at index 6.
+func TestExtractPraosNonces_LastEpochBlockNonceIs7FieldShape(t *testing.T) {
+	evolving := bytes.Repeat([]byte{0xee}, 32)
+	candidate := bytes.Repeat([]byte{0xcc}, 32)
+	epoch := bytes.Repeat([]byte{0xee, 0x09}, 16)
+	lab := bytes.Repeat([]byte{0xab}, 32)
+	lastEpochBlock := bytes.Repeat([]byte{0xfe}, 32)
+
+	lastSlot, err := cbor.Encode(uint64(123456))
+	require.NoError(t, err)
+	ocertCounters, err := cbor.Encode(map[uint64]uint64{})
+	require.NoError(t, err)
+
+	praosState := [][]byte{
+		lastSlot,
+		ocertCounters,
+		encodeTestNonce(t, evolving),
+		encodeTestNonce(t, candidate),
+		encodeTestNonce(t, epoch),
+		encodeTestNonce(t, lab),
+		encodeTestNonce(t, lastEpochBlock),
+	}
+
+	got, err := extractPraosNonces(praosState)
+	require.NoError(t, err)
+	require.Equal(t, evolving, got.EvolvingNonce)
+	require.Equal(t, candidate, got.CandidateNonce)
+	require.Equal(t, epoch, got.EpochNonce)
+	require.Equal(t, lastEpochBlock, got.LastEpochBlockNonce)
+}

--- a/ledgerstate/snapshot.go
+++ b/ledgerstate/snapshot.go
@@ -816,19 +816,60 @@ func parsePraosNonces(headerStateData []byte) (*praosNonces, error) {
 		praosState = inner
 	}
 
-	// PraosState = [lastSlot, ocertCounters, evolvingNonce,
-	//               candidateNonce, epochNonce, labNonce,
-	//               lastEpochBlockNonce]
-	if len(praosState) < 5 {
+	return extractPraosNonces(praosState)
+}
+
+// extractPraosNonces extracts the nonce fields from a decoded
+// PraosState array. Split out from parsePraosNonces so tests can
+// exercise field-index handling without constructing the full
+// HeaderState/ChainDepState/Telescope CBOR wrapping.
+//
+// PraosState (Conway/Babbage, ouroboros-consensus
+// Ouroboros.Consensus.Protocol.Praos):
+//
+//	[0] lastSlot
+//	[1] ocertCounters
+//	[2] evolvingNonce
+//	[3] candidateNonce
+//	[4] epochNonce
+//	[5] previousEpochNonce
+//	[6] labNonce
+//	[7] lastEpochBlockNonce
+//
+// The cardano-ledger epoch-boundary formula uses
+// `lastEpochBlockNonce` (index 7), not `labNonce`:
+//
+//	newEpochNonce = candidateNonce ⭒ lastEpochBlockNonce
+//
+// Reading the wrong index yields the wrong eta0 for the next
+// epoch, which manifests as VRF verification failure on every
+// header in the first post-bootstrap epoch.
+//
+// Older snapshots predating `previousEpochNonce` had a 7-element
+// PraosState; in that shape `lastEpochBlockNonce` was at index 6.
+// We dispatch on length so a Mithril snapshot from either shape
+// produces the right value in `result.LastEpochBlockNonce`.
+func extractPraosNonces(praosState [][]byte) (*praosNonces, error) {
+	// lastEpochBlockNonce is always the final element of PraosState —
+	// index 7 in the 8-field shape, index 6 in the older 7-field shape.
+	// Reject unknown lengths rather than guess: a future shape that
+	// extends the array would push the final element past index 7, and
+	// silently reading index 7 would yield the wrong nonce.
+	var lastEpochBlockNonceIdx int
+	switch len(praosState) {
+	case 8:
+		lastEpochBlockNonceIdx = 7
+	case 7:
+		lastEpochBlockNonceIdx = 6
+	default:
 		return nil, fmt.Errorf(
-			"PraosState has %d elements, expected at least 5",
+			"unsupported PraosState length %d, expected 7 or 8",
 			len(praosState),
 		)
 	}
 
 	result := &praosNonces{}
 
-	// Extract evolving nonce (index 2)
 	evolvingNonce, err := decodeNonce(praosState[2])
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -843,22 +884,6 @@ func parsePraosNonces(headerStateData []byte) (*praosNonces, error) {
 	}
 	result.EvolvingNonce = evolvingNonce
 
-	// Extract epoch nonce (index 4)
-	epochNonce, err := decodeNonce(praosState[4])
-	if err != nil {
-		return nil, fmt.Errorf(
-			"decoding epoch nonce: %w", err,
-		)
-	}
-	if epochNonce != nil && len(epochNonce) != 32 {
-		return nil, fmt.Errorf(
-			"invalid epoch nonce length %d, expected 32",
-			len(epochNonce),
-		)
-	}
-	result.EpochNonce = epochNonce
-
-	// Extract candidate nonce (index 3)
 	candidateNonce, err := decodeNonce(praosState[3])
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -873,23 +898,35 @@ func parsePraosNonces(headerStateData []byte) (*praosNonces, error) {
 	}
 	result.CandidateNonce = candidateNonce
 
-	// Extract lastEpochBlockNonce (index 6) when present.
-	// Older eras/encodings may not include this field.
-	if len(praosState) > 6 {
-		lastEpochBlockNonce, err := decodeNonce(praosState[6])
-		if err != nil {
-			return nil, fmt.Errorf(
-				"decoding last epoch block nonce: %w", err,
-			)
-		}
-		if lastEpochBlockNonce != nil && len(lastEpochBlockNonce) != 32 {
-			return nil, fmt.Errorf(
-				"invalid last epoch block nonce length %d, expected 32",
-				len(lastEpochBlockNonce),
-			)
-		}
-		result.LastEpochBlockNonce = lastEpochBlockNonce
+	epochNonce, err := decodeNonce(praosState[4])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding epoch nonce: %w", err,
+		)
 	}
+	if epochNonce != nil && len(epochNonce) != 32 {
+		return nil, fmt.Errorf(
+			"invalid epoch nonce length %d, expected 32",
+			len(epochNonce),
+		)
+	}
+	result.EpochNonce = epochNonce
+
+	lastEpochBlockNonce, err := decodeNonce(
+		praosState[lastEpochBlockNonceIdx],
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding last epoch block nonce: %w", err,
+		)
+	}
+	if lastEpochBlockNonce != nil && len(lastEpochBlockNonce) != 32 {
+		return nil, fmt.Errorf(
+			"invalid last epoch block nonce length %d, expected 32",
+			len(lastEpochBlockNonce),
+		)
+	}
+	result.LastEpochBlockNonce = lastEpochBlockNonce
 
 	return result, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected nonce extraction to handle multiple snapshot shapes and strengthened validation.
  * Improved epoch-boundary consensus checks to detect convergence/regression around epoch transitions.

* **Refactor**
  * Centralized nonce extraction into a dedicated implementation to clarify array-shape handling.

* **Tests**
  * Added integration test for epoch-boundary consensus behavior.
  * Added unit tests validating nonce extraction across snapshot variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->