### PR TITLE
feat(blockfrost): Blockfrost API Governance endpoints

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -42,6 +42,7 @@ var (
 	ErrBlockNotFound  = errors.New("block not found")
 	ErrEpochNotFound  = errors.New("epoch not found")
 	ErrAssetNotFound  = errors.New("asset not found")
+	ErrDRepNotFound   = errors.New("drep not found")
 )
 
 // NodeAdapter wraps a real dingo Node's LedgerState to
@@ -631,6 +632,64 @@ func (a *NodeAdapter) Asset(
 		InitialMintTxHash: "",
 		MintOrBurnCount:   0,
 		OnchainMetadata:   nil,
+	}, nil
+}
+
+// DRep returns governance DRep information for the requested
+// credential.
+func (a *NodeAdapter) DRep(
+	credential DRepCredential,
+) (DRepInfo, error) {
+	db := a.ledgerState.Database()
+	drep, err := db.GetDrep(credential.Hash, true, nil)
+	if err != nil {
+		if errors.Is(err, models.ErrDrepNotFound) {
+			return DRepInfo{}, fmt.Errorf(
+				"drep %x: %w",
+				credential.Hash,
+				ErrDRepNotFound,
+			)
+		}
+		return DRepInfo{}, fmt.Errorf(
+			"get drep %x: %w",
+			credential.Hash,
+			err,
+		)
+	}
+	power, err := db.GetDRepVotingPower(credential.Hash, nil)
+	if err != nil {
+		return DRepInfo{}, fmt.Errorf(
+			"get drep voting power %x: %w",
+			credential.Hash,
+			err,
+		)
+	}
+
+	registrationEpoch, err := a.ledgerState.SlotToEpoch(drep.AddedSlot)
+	if err != nil {
+		return DRepInfo{}, fmt.Errorf(
+			"get DRep registration epoch for slot %d: %w",
+			drep.AddedSlot,
+			err,
+		)
+	}
+
+	currentEpoch := a.ledgerState.CurrentEpoch()
+	registered := drep.Active
+	active := registered &&
+		(drep.ExpiryEpoch == 0 || drep.ExpiryEpoch > currentEpoch)
+	amount := strconv.FormatUint(power, 10)
+
+	return DRepInfo{
+		DRepID:      credential.ID,
+		Hex:         hex.EncodeToString(credential.Hash),
+		HasScript:   credential.HasScript,
+		Registered:  registered,
+		Epoch:       registrationEpoch.EpochId,
+		Amount:      amount,
+		Active:      active,
+		ActiveEpoch: drep.LastActivityEpoch,
+		LiveStake:   amount,
 	}, nil
 }
 

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -115,6 +115,10 @@ func (b *Blockfrost) Start(
 		b.handlePoolsExtended,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/governance/dreps/{drep_id}",
+		b.handleDRep,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/addresses/{address}/utxos",
 		b.handleAddressUTXOs,
 	)

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -45,6 +45,7 @@ type mockNode struct {
 	genesis                GenesisInfo
 	pools                  []PoolExtendedInfo
 	asset                  AssetInfo
+	drep                   DRepInfo
 	addressUTXOs           []AddressUTXOInfo
 	addressTransactions    []AddressTransactionInfo
 	metadataJSON           []MetadataTransactionJSONInfo
@@ -65,6 +66,7 @@ type mockNode struct {
 	genesisErr             error
 	poolsErr               error
 	assetErr               error
+	drepErr                error
 	addressUTXOsErr        error
 	addressTransactionsErr error
 	metadataJSONErr        error
@@ -142,6 +144,12 @@ func (m *mockNode) Asset(
 	_ []byte,
 ) (AssetInfo, error) {
 	return m.asset, m.assetErr
+}
+
+func (m *mockNode) DRep(
+	_ DRepCredential,
+) (DRepInfo, error) {
+	return m.drep, m.drepErr
 }
 
 func (m *mockNode) AddressUTXOs(
@@ -468,6 +476,101 @@ func TestHandleAssetNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, "Not Found", resp.Error)
 	assert.Equal(t, "The requested asset could not be found.", resp.Message)
+}
+
+func TestHandleDRep(t *testing.T) {
+	const drepHex = "00000000000000000000000000000000000000000000000000000000"
+	const drepID = drepHex
+
+	mock := &mockNode{
+		drep: DRepInfo{
+			DRepID:      drepID,
+			Hex:         drepHex,
+			HasScript:   false,
+			Registered:  true,
+			Epoch:       12,
+			Amount:      "123456",
+			Active:      true,
+			ActiveEpoch: 14,
+			LiveStake:   "123456",
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/governance/dreps/"+drepID,
+		nil,
+	)
+	req.SetPathValue("drep_id", drepID)
+	w := httptest.NewRecorder()
+	b.handleDRep(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DRepResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, mock.drep.DRepID, resp.DRepID)
+	assert.Equal(t, mock.drep.Hex, resp.Hex)
+	assert.Equal(t, mock.drep.HasScript, resp.HasScript)
+	assert.Equal(t, mock.drep.Registered, resp.Registered)
+	assert.Equal(t, mock.drep.Epoch, resp.Epoch)
+	assert.Equal(t, mock.drep.Amount, resp.Amount)
+	assert.Equal(t, mock.drep.Active, resp.Active)
+	assert.Equal(t, mock.drep.ActiveEpoch, resp.ActiveEpoch)
+	assert.Equal(t, mock.drep.LiveStake, resp.LiveStake)
+}
+
+func TestHandleDRepInvalidIdentifier(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/governance/dreps/not-a-drep",
+		nil,
+	)
+	req.SetPathValue("drep_id", "not-a-drep")
+	w := httptest.NewRecorder()
+	b.handleDRep(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "Bad Request", resp.Error)
+	assert.Equal(t, "Invalid DRep identifier.", resp.Message)
+}
+
+func TestHandleDRepNotFound(t *testing.T) {
+	mock := &mockNode{
+		drepErr: ErrDRepNotFound,
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/governance/dreps/00000000000000000000000000000000000000000000000000000000",
+		nil,
+	)
+	req.SetPathValue(
+		"drep_id",
+		"00000000000000000000000000000000000000000000000000000000",
+	)
+	w := httptest.NewRecorder()
+	b.handleDRep(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "Not Found", resp.Error)
+	assert.Equal(t, "The requested DRep could not be found.", resp.Message)
 }
 
 func TestHandleLatestBlockError(t *testing.T) {

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -18,13 +18,25 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
-const apiVersion = "0.1.0"
+const (
+	apiVersion = "0.1.0"
+
+	// DRep credentials are Blake2b-224 hashes: 224 bits = 28 bytes.
+	drepCredentialHashLen = 28
+	// Hex encodes each byte as two characters, so a 28-byte credential
+	// hash is represented by 56 hex characters.
+	drepCredentialHexLen = drepCredentialHashLen * 2
+)
 
 // writeJSON writes a JSON response with the given status
 // code. If encoding fails, it logs the error for
@@ -542,6 +554,61 @@ func (b *Blockfrost) handlePoolsExtended(
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// handleDRep handles GET /api/v0/governance/dreps/{drep_id}
+// and returns DRep governance information.
+func (b *Blockfrost) handleDRep(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	credential, err := parseDRepIdentifier(r.PathValue("drep_id"))
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid DRep identifier.",
+		)
+		return
+	}
+
+	drep, err := b.node.DRep(credential)
+	if err != nil {
+		if errors.Is(err, ErrDRepNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested DRep could not be found.",
+			)
+			return
+		}
+		b.logger.Error(
+			"failed to get drep",
+			"drep_id", r.PathValue("drep_id"),
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve DRep",
+		)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, DRepResponse{
+		DRepID:      drep.DRepID,
+		Hex:         drep.Hex,
+		HasScript:   drep.HasScript,
+		Registered:  drep.Registered,
+		Epoch:       drep.Epoch,
+		Amount:      drep.Amount,
+		Active:      drep.Active,
+		ActiveEpoch: drep.ActiveEpoch,
+		LiveStake:   drep.LiveStake,
+	})
+}
+
 // handleAddressUTXOs handles GET /api/v0/addresses/{address}/utxos
 // and returns the current UTxOs for an address.
 func (b *Blockfrost) handleAddressUTXOs(
@@ -772,6 +839,55 @@ func parseAssetIdentifier(
 		return "", nil, err
 	}
 	return policyID, assetName, nil
+}
+
+func parseDRepIdentifier(
+	id string,
+) (DRepCredential, error) {
+	if id == "" {
+		return DRepCredential{}, errors.New("empty DRep identifier")
+	}
+	// Blockfrost accepts the raw credential hash as hex. Storage uses the
+	// raw 28-byte hash for lookup.
+	if len(id) == drepCredentialHexLen {
+		hash, err := hex.DecodeString(id)
+		if err == nil {
+			return DRepCredential{
+				ID:        id,
+				Hash:      hash,
+				HasScript: false,
+			}, nil
+		}
+	}
+
+	// Non-hex input must be bech32. The HRP is the readable prefix before
+	// the separator "1" (for example, "drep" in "drep1...").
+	hrp, data, err := bech32.Decode(id)
+	if err != nil {
+		return DRepCredential{}, fmt.Errorf("decode DRep bech32: %w", err)
+	}
+	hrp = strings.ToLower(hrp)
+	if hrp != "drep" {
+		return DRepCredential{}, fmt.Errorf("invalid DRep prefix %q", hrp)
+	}
+	// Bech32 stores payload data as 5-bit groups. Convert it back to
+	// normal 8-bit bytes before checking the credential payload.
+	payload, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return DRepCredential{}, fmt.Errorf("decode DRep payload: %w", err)
+	}
+
+	if len(payload) != drepCredentialHashLen {
+		return DRepCredential{}, fmt.Errorf(
+			"invalid DRep credential length %d",
+			len(payload),
+		)
+	}
+	return DRepCredential{
+		ID:        id,
+		Hash:      payload,
+		HasScript: false,
+	}, nil
 }
 
 func writeNodeQueryError(

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -596,17 +596,7 @@ func (b *Blockfrost) handleDRep(
 		return
 	}
 
-	writeJSON(w, http.StatusOK, DRepResponse{
-		DRepID:      drep.DRepID,
-		Hex:         drep.Hex,
-		HasScript:   drep.HasScript,
-		Registered:  drep.Registered,
-		Epoch:       drep.Epoch,
-		Amount:      drep.Amount,
-		Active:      drep.Active,
-		ActiveEpoch: drep.ActiveEpoch,
-		LiveStake:   drep.LiveStake,
-	})
+	writeJSON(w, http.StatusOK, DRepResponse(drep))
 }
 
 // handleAddressUTXOs handles GET /api/v0/addresses/{address}/utxos

--- a/blockfrost/node_interface.go
+++ b/blockfrost/node_interface.go
@@ -97,6 +97,10 @@ type BlockfrostNode interface {
 		policyID string,
 		assetName []byte,
 	) (AssetInfo, error)
+
+	// DRep returns governance DRep information for a parsed
+	// DRep credential.
+	DRep(DRepCredential) (DRepInfo, error)
 }
 
 // ChainTipInfo holds chain tip data needed by the API.
@@ -297,4 +301,24 @@ type AssetInfo struct {
 	InitialMintTxHash string
 	MintOrBurnCount   int
 	OnchainMetadata   *any
+}
+
+// DRepCredential holds a parsed governance DRep identifier.
+type DRepCredential struct {
+	ID        string
+	Hash      []byte
+	HasScript bool
+}
+
+// DRepInfo holds DRep data needed by the governance API.
+type DRepInfo struct {
+	DRepID      string
+	Hex         string
+	HasScript   bool
+	Registered  bool
+	Epoch       uint64
+	Amount      string
+	Active      bool
+	ActiveEpoch uint64
+	LiveStake   string
 }

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -204,6 +204,19 @@ type AssetResponse struct {
 	Metadata                *any    `json:"metadata"`
 }
 
+// DRepResponse represents a Blockfrost governance DRep object.
+type DRepResponse struct {
+	DRepID      string `json:"drep_id"`
+	Hex         string `json:"hex"`
+	HasScript   bool   `json:"has_script"`
+	Registered  bool   `json:"registered"`
+	Epoch       uint64 `json:"epoch"`
+	Amount      string `json:"amount"`
+	Active      bool   `json:"active"`
+	ActiveEpoch uint64 `json:"active_epoch"`
+	LiveStake   string `json:"live_stake"`
+}
+
 // ErrorResponse represents a Blockfrost error response.
 type ErrorResponse struct {
 	StatusCode int    `json:"status_code"`


### PR DESCRIPTION
1. Added GET /api/v0/governance/dreps/{drep_id} to the blockfrost compatible API.
2. Added a parser DRep identifiers from either raw hex credential hash or bech32 drep1... format.
3. It looks up DRep state from local ledger metadata and maps missing DReps to 404 not found.
4. Included delegated voting power via existing DRep voting power calculation.
5. Made changes in returning blockfrost-compatible DRep fields including drep_id, hex, registered, active, amount, and live_stake.
6. Added handler tests for successful lookup, invalid identifier, and not-found behavior.

Closes #1372

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /api/v0/governance/dreps/{drep_id}` to the `blockfrost` API to fetch DRep state and voting power. Delivers the governance DRep endpoint requested in #1372 with hex and bech32 (`drep1...`) ID support.

- **New Features**
  - Added route and handler plus node adapter to read DRep data from the local ledger; returns 404 when missing and 400 for invalid IDs (tests cover success/invalid/not found).
  - Parse DRep IDs from 56-char hex or bech32 with HRP `drep`; validate length and payload.
  - Returns Blockfrost fields: `drep_id`, `hex`, `has_script`, `registered`, `epoch`, `amount`, `active`, `active_epoch`, `live_stake`.

- **Bug Fixes**
  - Fixed a lint error in the handler response.

<sup>Written for commit 81fe3261576251324775345e255a7d0980d24414. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance DRep (Delegate Representative) support with a new HTTP endpoint for querying DRep information.
  * Enables retrieval of DRep voting power, registration status, and activity metrics.
  * Supports multiple DRep identifier formats (hex and bech32) for flexible lookups.
  * Includes proper error handling for invalid or missing DRep records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->