### PR TITLE
fix(bark): get block proxy metadata

### DIFF
--- a/bark/blob.go
+++ b/bark/blob.go
@@ -203,31 +203,46 @@ func (b *BlobStoreBark) GetBlock(
 	slot uint64,
 	hash []byte,
 ) ([]byte, types.BlockMetadata, error) {
-	currentSlot, err := b.config.LedgerState.CurrentSlot()
-	if err != nil {
-		return nil, types.BlockMetadata{},
-			fmt.Errorf("failed to get current slot: %w", err)
+	// Always consult the upstream first so we can pick up the local
+	// BlockMetadata (most importantly the block ID, which the chain
+	// iterator's BlockByIndex path depends on). Upstream reports
+	// ErrBlockTombstoned for archive-only blocks while still returning
+	// the metadata it kept around for exactly this purpose. Fall through
+	// to the archive on ErrBlobKeyNotFound too: blocks pruned before the
+	// tombstone-on-prune fix (or never indexed locally, e.g. snapshot
+	// bootstrap) have no bp entry, but the archive can still serve them.
+	upstreamCbor, upstreamMeta, err := b.upstream.GetBlock(txn, slot, hash)
+	if err == nil {
+		return upstreamCbor, upstreamMeta, nil
 	}
-
-	// If the requested slot is within the security window, the block is
-	// expected to live locally. Defer to upstream — but if upstream reports
-	// the block was tombstoned (rare in-window case, e.g. after a rollback
-	// crosses a previously pruned slot back into the window) fall through
-	// to the archive proxy.
-	securityWindow := b.config.LedgerState.StabilityWindow()
-	if securityWindow > currentSlot ||
-		slot >= currentSlot-securityWindow {
-		cbor, meta, err := b.upstream.GetBlock(txn, slot, hash)
-		if !errors.Is(err, types.ErrBlockTombstoned) {
-			return cbor, meta, err
-		}
+	if !errors.Is(err, types.ErrBlockTombstoned) &&
+		!errors.Is(err, types.ErrBlobKeyNotFound) {
+		return nil, types.BlockMetadata{}, err
 	}
 
 	ctx, cancel := context.WithTimeout(
 		context.Background(), archiveFetchTimeout,
 	)
 	defer cancel()
-	return b.fetchBlockFromArchive(ctx, slot, hash)
+	archiveCbor, archiveMeta, archErr := b.fetchBlockFromArchive(ctx, slot, hash)
+	if archErr != nil {
+		return nil, types.BlockMetadata{}, archErr
+	}
+	// Prefer the local metadata for ID (the archive does not know our
+	// local block IDs), but trust the archive for Type/Height/PrevHash
+	// in case upstream returned a zero metadata struct alongside the
+	// tombstone error.
+	merged := upstreamMeta
+	if merged.Type == 0 {
+		merged.Type = archiveMeta.Type
+	}
+	if merged.Height == 0 {
+		merged.Height = archiveMeta.Height
+	}
+	if len(merged.PrevHash) == 0 {
+		merged.PrevHash = archiveMeta.PrevHash
+	}
+	return archiveCbor, merged, nil
 }
 
 // fetchBlockFromArchive resolves a (slot, hash) block via the bark archive

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -635,14 +635,18 @@ func (d *BlobStoreBadger) GetBlock(
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
-	if types.IsBlockTombstone(cborData) {
-		return nil, types.BlockMetadata{},
-			&types.BlockTombstonedError{Slot: slot, Hash: hash}
-	}
+	// Read the metadata key whether or not the bp value is a tombstone.
+	// Tombstoned blocks keep their metadata so a wrapping archive proxy
+	// can populate models.Block.ID from the local node's bi index when
+	// fetching the CBOR remotely.
 	metadataKey := types.BlockBlobMetadataKey(key)
 	metadataVal, err := badgerTxn.tx.Get(metadataKey)
 	if err != nil {
 		if errors.Is(err, badger.ErrKeyNotFound) {
+			if types.IsBlockTombstone(cborData) {
+				return nil, types.BlockMetadata{},
+					&types.BlockTombstonedError{Slot: slot, Hash: hash}
+			}
 			return nil, types.BlockMetadata{}, types.ErrBlobKeyNotFound
 		}
 		return nil, types.BlockMetadata{}, err
@@ -654,6 +658,10 @@ func (d *BlobStoreBadger) GetBlock(
 	tmpMetadata, err := unmarshalBlockMetadata(metadataBytes)
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
+	}
+	if types.IsBlockTombstone(cborData) {
+		return nil, tmpMetadata,
+			&types.BlockTombstonedError{Slot: slot, Hash: hash}
 	}
 	return cborData, tmpMetadata, nil
 }
@@ -695,16 +703,18 @@ func (d *BlobStoreBadger) DeleteBlock(
 // types.ErrBlockTombstoned for the proxy to intercept.
 //
 // What stays:
+//
 //   - bi<id>: required by BlockByIndex (the chain iterator translates
 //     id→key here; no equivalent index exists in metadata).
+//
 //   - bh<hash>: BlockByHash has a sequential-scan fallback over bp keys,
 //     but on a deep chain that scan is O(N) per call — keeping the index
 //     preserves the fast path.
 //
-// What goes:
-//   - bp_metadata: GetBlock short-circuits on the tombstone before reading
-//     metadata, and no other caller asks for metadata of a tombstoned
-//     block — bark's archive response carries its own.
+//   - bp_metadata: kept so bark can populate models.Block.ID (and the
+//     other small metadata fields) when surfacing a CBOR fetched from
+//     the archive. Without this the chain iterator's BlockByIndex path
+//     gets ID=0 and immediately returns ErrIteratorChainTip.
 func (d *BlobStoreBadger) TombstoneBlock(
 	txn types.Txn,
 	slot uint64,
@@ -715,11 +725,7 @@ func (d *BlobStoreBadger) TombstoneBlock(
 		return err
 	}
 	key := types.BlockBlobKey(slot, hash)
-	if err := badgerTxn.tx.Set(key, types.BlockTombstone()); err != nil {
-		return err
-	}
-	metadataKey := types.BlockBlobMetadataKey(key)
-	return badgerTxn.tx.Delete(metadataKey)
+	return badgerTxn.tx.Set(key, types.BlockTombstone())
 }
 
 // SetUtxo stores a UTxO's CBOR data


### PR DESCRIPTION
Closes #2144 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing block metadata when fetching tombstoned or pruned blocks via the archive proxy. Keeps the local block ID so BlockByIndex works again.

- **Bug Fixes**
  - `bark`: Always query upstream first; on `ErrBlockTombstoned` or `ErrBlobKeyNotFound` fetch CBOR from the archive and merge metadata (keep upstream ID; fill Type/Height/PrevHash from archive if zero).
  - `badger`: `GetBlock` returns metadata even for tombstoned blocks (error raised after reading); `TombstoneBlock` keeps `bp_metadata`.

<sup>Written for commit 1faa9d7b17c6780ab3eadd991157bb41932497ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block retrieval fallback so upstream fetches are tried first and clearer errors are returned for genuine upstream failures.
  * On fallback, archive data is used to backfill missing metadata fields when upstream data is incomplete, ensuring more consistent block results.
  * Preserved metadata for tombstoned (deleted) blocks so historical metadata is retained and returned where available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->