### PR TITLE
fix: ensure era transitions bump protocol versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,11 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/aws/smithy-go v1.25.1
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.166.0
+	github.com/blinklabs-io/gouroboros v0.166.1
 	github.com/blinklabs-io/ouroboros-mock v0.10.0
 	github.com/blinklabs-io/plutigo v0.1.9
 	github.com/blockfrost/blockfrost-go v0.3.0
@@ -92,6 +91,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.166.0 h1:c/5ERPmvlpRWMTItGNYK+uFB62qGBkcf0wg74qT4jtk=
-github.com/blinklabs-io/gouroboros v0.166.0/go.mod h1:cWQCEPvrlZmTr1Z02az0e7XJtn7nLxuv4pMnubyI94s=
+github.com/blinklabs-io/gouroboros v0.166.1 h1:byCLvCOiN5E4qC/v3nGo9Her+4fSa459eQ0XhjN83+s=
+github.com/blinklabs-io/gouroboros v0.166.1/go.mod h1:cWQCEPvrlZmTr1Z02az0e7XJtn7nLxuv4pMnubyI94s=
 github.com/blinklabs-io/ouroboros-mock v0.10.0 h1:8fhKaaTm3pDHSr8Yx91zEthooQH+o+NQhGfN2FKxwMI=
 github.com/blinklabs-io/ouroboros-mock v0.10.0/go.mod h1:1vWKSGxMtUfF3gkrVjUsjPTXdA+A665bQZjbVWpG5lg=
 github.com/blinklabs-io/plutigo v0.1.9 h1:J3kAB5jrKPGhU9elTuFx9oz/cWTQobwFLfVuQ64jf7I=

--- a/internal/erastest/era.go
+++ b/internal/erastest/era.go
@@ -49,6 +49,11 @@ type EraTransition struct {
 	ToEraID   uint
 	// Slot of the first block in the new era.
 	Slot uint64
+	// PrevSlot is the slot of the last block in the prior era. Zero
+	// when no prior header was observed on this stream (genesis
+	// case). Slot - PrevSlot gives the inter-block gap that crossed
+	// the era boundary.
+	PrevSlot uint64
 	// Approximate epoch the transition crossed at, computed against the
 	// configured EpochLength. Zero if no Config was supplied.
 	Epoch uint64
@@ -189,8 +194,10 @@ func (s *EraStream) onRollForward(
 	// chain that begins in Shelley still records that as a transition
 	// (FromEraID=0, ToEraID=1).
 	prevEra := uint(0)
+	prevSlot := uint64(0)
 	if n := len(s.headers); n > 0 {
 		prevEra = s.headers[n-1].EraID
+		prevSlot = s.headers[n-1].Slot
 	}
 	if info.EraID != prevEra {
 		epoch := uint64(0)
@@ -201,6 +208,7 @@ func (s *EraStream) onRollForward(
 			FromEraID: prevEra,
 			ToEraID:   info.EraID,
 			Slot:      info.Slot,
+			PrevSlot:  prevSlot,
 			Epoch:     epoch,
 		})
 	}

--- a/internal/erastest/era_transitions_test.go
+++ b/internal/erastest/era_transitions_test.go
@@ -123,11 +123,13 @@ func transitionTimeout(cfg *Config) time.Duration {
 	return d
 }
 
-// TestEraSchedule asserts that every era transition configured in the
-// testnet.yaml is observed on dingo's chain at the expected epoch. The
-// final observed era must be the last successor in the schedule
-// (Conway, for the eras testnet.yaml).
-func TestEraSchedule(t *testing.T) {
+// TestEraTransitions drives the live DevNet through every scheduled
+// hard fork once and runs the per-scenario assertions as subtests
+// against the shared observation state. Sharing one EraStream per
+// endpoint avoids both redundant from-origin replays and the
+// retroactive-history pitfalls that arise when each test reads the
+// chain after it has already traversed.
+func TestEraTransitions(t *testing.T) {
 	cfg := loadConfig(t)
 	schedule := cfg.ScheduledTransitions()
 	require.NotEmpty(
@@ -140,155 +142,66 @@ func TestEraSchedule(t *testing.T) {
 	)
 
 	endpoints := DefaultEndpoints()
-	dingoEndpoint := endpoints[0]
-	stream := NewEraStream(
-		t, dingoEndpoint, cfg.NetworkMagic, cfg.EpochLength,
-	)
-	defer stream.Close()
-
-	timeout := transitionTimeout(cfg)
-	for _, want := range schedule {
-		hdr, err := stream.WaitForEra(&want.Era, timeout)
-		require.NoErrorf(
-			t, err,
-			"WaitForEra(%s) within %s: %v",
-			want.Era.Name, timeout, err,
-		)
-		observedEpoch := hdr.Slot / cfg.EpochLength
-		t.Logf(
-			"observed %s at slot=%d (epoch=%d, configured epoch=%d)",
-			want.Era.Name, hdr.Slot, observedEpoch, want.Epoch,
-		)
-		// A scheduled fork takes effect at the rollover into the
-		// configured epoch. The first header in the new era is in that
-		// epoch (within ±1 to absorb genesis-time skew + the "first
-		// post-fork header may be a slot or two late" case).
-		require.LessOrEqualf(
-			t, absDelta(observedEpoch, want.Epoch), uint64(1),
-			"%s observed at epoch %d but configured for %d",
-			want.Era.Name, observedEpoch, want.Epoch,
-		)
-	}
-
-	last, ok := stream.LatestHeader()
-	require.True(t, ok, "no headers observed")
-	finalWanted := schedule[len(schedule)-1].Era
-	require.Equalf(
-		t, finalWanted.Id, last.EraID,
-		"final observed era ID %d != configured terminal era %s (%d)",
-		last.EraID, finalWanted.Name, finalWanted.Id,
-	)
-}
-
-// TestNoStallAcrossForks asserts that no era transition stalls forging
-// for an unreasonable number of slots. Each gap between consecutive
-// observed headers must stay under maxGapSlots; if a fork transition
-// pauses the chain, the gap covering that boundary blows past the
-// bound.
-func TestNoStallAcrossForks(t *testing.T) {
-	cfg := loadConfig(t)
-	schedule := cfg.ScheduledTransitions()
-	require.NotEmpty(t, schedule, "eras testnet.yaml must configure forks")
-
-	endpoints := DefaultEndpoints()
-	stream := NewEraStream(
-		t, endpoints[0], cfg.NetworkMagic, cfg.EpochLength,
-	)
-	defer stream.Close()
-
-	// Wait until the chain has reached the terminal era. Tests #2-#4
-	// run after TestEraSchedule has already either traversed every
-	// fork or failed; we only need enough budget for a fresh
-	// EraStream to catch up from origin to the current tip, not to
-	// pace through the schedule again. transitionTimeout (single
-	// fork's worth) is sufficient and keeps cascade failures fast.
-	terminal := schedule[len(schedule)-1].Era
-	_, err := stream.WaitForEra(&terminal, transitionTimeout(cfg))
-	require.NoErrorf(
-		t, err,
-		"WaitForEra(%s): %v", terminal.Name, err,
-	)
-	// Give the chain one extra epoch in the terminal era so we have
-	// post-final-fork data points for the stall analysis.
-	finalSlot := schedule[len(schedule)-1].Slot + cfg.EpochLength
-	_, err = stream.WaitForSlot(finalSlot, transitionTimeout(cfg))
-	require.NoErrorf(
-		t, err, "WaitForSlot(%d): %v", finalSlot, err,
-	)
-
-	headers := stream.HeadersSnapshot()
-	require.GreaterOrEqual(
-		t, len(headers), 2,
-		"need ≥2 headers to measure gaps",
-	)
-
-	// Allowed gap: 4*expectedBlockTime (i.e. 4*slot/f). With f=0.4
-	// and 1s slots that's 10 slots — comfortable for normal VRF
-	// variance without masking a multi-epoch stall. We scale by k as
-	// well so smaller-k testnets (which run shorter forks) still see
-	// reasonable bounds.
-	maxGapSlots := uint64(10) + cfg.SecurityParam
-	var (
-		biggestGap         uint64
-		biggestGapPrevSlot uint64
-		biggestGapNextSlot uint64
-	)
-	for i := 1; i < len(headers); i++ {
-		// Skip pairs that aren't strictly forward in time. With
-		// onRollBackward trimming we shouldn't see this on a healthy
-		// stream, but defending against it avoids unsigned underflow
-		// from masquerading as a multi-million-slot stall.
-		if headers[i].Slot < headers[i-1].Slot {
-			continue
-		}
-		gap := headers[i].Slot - headers[i-1].Slot
-		if gap > biggestGap {
-			biggestGap = gap
-			biggestGapPrevSlot = headers[i-1].Slot
-			biggestGapNextSlot = headers[i].Slot
-		}
-	}
-	t.Logf(
-		"largest inter-block gap: %d slots (between slot %d and slot %d) "+
-			"— max allowed %d",
-		biggestGap, biggestGapPrevSlot, biggestGapNextSlot, maxGapSlots,
-	)
-	require.LessOrEqualf(
-		t, biggestGap, maxGapSlots,
-		"chain stalled across at least one boundary: gap of %d slots "+
-			"between %d and %d (allowed %d)",
-		biggestGap, biggestGapPrevSlot, biggestGapNextSlot, maxGapSlots,
-	)
-}
-
-// TestConsensusAtEachFork opens an EraStream against every endpoint
-// and asserts that, by the time each node has reached the terminal
-// era, all nodes agree on the slot at which each scheduled fork
-// occurred.
-func TestConsensusAtEachFork(t *testing.T) {
-	cfg := loadConfig(t)
-	schedule := cfg.ScheduledTransitions()
-	require.NotEmpty(t, schedule, "eras testnet.yaml must configure forks")
-
-	endpoints := DefaultEndpoints()
 	streams := make(map[string]*EraStream, len(endpoints))
 	for _, ep := range endpoints {
 		streams[ep.Name] = NewEraStream(
 			t, ep, cfg.NetworkMagic, cfg.EpochLength,
 		)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		for _, s := range streams {
 			s.Close()
 		}
-	}()
+	})
 
-	// Each EraStream syncs from origin in parallel; one
-	// transitionTimeout is enough to either catch up to a healthy
-	// chain (fast on a local devnet) or fail fast on a stuck chain.
-	terminal := schedule[len(schedule)-1].Era
+	dingoStream := streams[endpoints[0].Name]
+	require.NotNil(t, dingoStream, "dingo-producer stream missing")
+
+	// Drive the chain through every scheduled fork on dingo's chain
+	// before any subtest reads observations. This is also where
+	// "Schedule" is verified: WaitForEra returns the first header in
+	// each successor era, and we assert it lands at the configured
+	// epoch.
 	timeout := transitionTimeout(cfg)
+	t.Run("Schedule", func(t *testing.T) {
+		for _, want := range schedule {
+			hdr, err := dingoStream.WaitForEra(&want.Era, timeout)
+			require.NoErrorf(
+				t, err,
+				"WaitForEra(%s) within %s: %v",
+				want.Era.Name, timeout, err,
+			)
+			observedEpoch := hdr.Slot / cfg.EpochLength
+			t.Logf(
+				"observed %s at slot=%d (epoch=%d, configured epoch=%d)",
+				want.Era.Name, hdr.Slot, observedEpoch, want.Epoch,
+			)
+			require.LessOrEqualf(
+				t, absDelta(observedEpoch, want.Epoch), uint64(1),
+				"%s observed at epoch %d but configured for %d",
+				want.Era.Name, observedEpoch, want.Epoch,
+			)
+		}
+
+		last, ok := dingoStream.LatestHeader()
+		require.True(t, ok, "no headers observed")
+		finalWanted := schedule[len(schedule)-1].Era
+		require.Equalf(
+			t, finalWanted.Id, last.EraID,
+			"final observed era ID %d != configured terminal era %s (%d)",
+			last.EraID, finalWanted.Name, finalWanted.Id,
+		)
+	})
+
+	// At this point dingo's stream has observed every scheduled
+	// fork. Drain the other endpoints' streams up to the same
+	// terminal era so that ConsensusAtEachFork sees a comparable
+	// view from each.
+	terminal := schedule[len(schedule)-1].Era
 	for name, s := range streams {
+		if name == endpoints[0].Name {
+			continue
+		}
 		_, err := s.WaitForEra(&terminal, timeout)
 		require.NoErrorf(
 			t, err,
@@ -297,141 +210,170 @@ func TestConsensusAtEachFork(t *testing.T) {
 		)
 	}
 
-	// For each scheduled era, every node should report the same
-	// transition slot (i.e. the same first-block-in-new-era slot).
-	for _, want := range schedule {
-		slotByNode := make(map[string]uint64, len(streams))
-		for name, s := range streams {
-			// Take the most recent matching transition. Earlier
-			// matches can be stale pre-rollback observations even
-			// after onRollBackward trims state, since the trim
-			// happens at the rollback point and a re-applied
-			// branch can reintroduce a same-target transition at
-			// a new slot.
-			trs := s.Transitions()
-			for i := len(trs) - 1; i >= 0; i-- {
-				if trs[i].ToEraID == want.Era.Id {
-					slotByNode[name] = trs[i].Slot
-					break
-				}
-			}
+	t.Run("NoStallAcrossForks", func(t *testing.T) {
+		// Use the per-transition slot delta recorded by the stream
+		// (Slot - PrevSlot), not a scan over the full header buffer.
+		// That way completed bootstrap warmup and intra-era leader
+		// pauses can't blow past the threshold; we only assess the
+		// gap that actually crossed each scheduled fork boundary.
+		//
+		// Allowed gap: SecurityParam (=k) + 10 slots. With k=6 and
+		// 1s slots that's 16 slots — comfortable for the
+		// stability-window-crossing pause that fires the rollover,
+		// without masking a multi-epoch stall.
+		maxGapSlots := cfg.SecurityParam + 10
+		transitions := dingoStream.Transitions()
+		// Index transitions by ToEraID so we can look up the
+		// boundary observation for each scheduled fork.
+		byEra := make(map[uint]EraTransition, len(transitions))
+		for _, tr := range transitions {
+			byEra[tr.ToEraID] = tr
 		}
-		require.Equalf(
-			t, len(streams), len(slotByNode),
-			"%s: not every node observed the transition: %+v",
-			want.Era.Name, slotByNode,
-		)
-		// All values must be identical.
-		var canonical uint64
-		var canonicalNode string
-		for name, slot := range slotByNode {
-			if canonicalNode == "" {
-				canonical = slot
-				canonicalNode = name
-				continue
-			}
-			require.Equalf(
-				t, canonical, slot,
-				"era %s: %s observed transition at slot %d but %s saw it at %d",
-				want.Era.Name, canonicalNode, canonical, name, slot,
+		for _, want := range schedule {
+			tr, ok := byEra[want.Era.Id]
+			require.Truef(
+				t, ok,
+				"no transition into %s observed on dingo's stream",
+				want.Era.Name,
+			)
+			require.NotZerof(
+				t, tr.PrevSlot,
+				"%s transition has no recorded predecessor slot — "+
+					"chain started after the fork point?",
+				want.Era.Name,
+			)
+			gap := tr.Slot - tr.PrevSlot
+			t.Logf(
+				"%s boundary: prev_slot=%d new_slot=%d gap=%d "+
+					"(max allowed %d)",
+				want.Era.Name, tr.PrevSlot, tr.Slot, gap, maxGapSlots,
+			)
+			require.LessOrEqualf(
+				t, gap, maxGapSlots,
+				"chain stalled crossing into %s: %d-slot gap "+
+					"between %d and %d (allowed %d)",
+				want.Era.Name, gap, tr.PrevSlot, tr.Slot, maxGapSlots,
 			)
 		}
-		t.Logf(
-			"all nodes agree: %s transition observed at slot %d",
-			want.Era.Name, canonical,
-		)
-	}
-}
+	})
 
-// TestDingoProducesInEachEra asserts that pool 1 (the dingo producer)
-// successfully forges at least one block in every era the chain
-// enters, proving dingo's forging code path correctly handles each
-// era.
-//
-// Pool selection is VRF-driven, but with two equal-stake pools and
-// f=0.4 over a 75-slot epoch the probability that dingo wins zero
-// slots in any given epoch is ≈ (1-0.225)^75 ≈ 1e-8, so VRF variance
-// is not a realistic source of flakes here.
-func TestDingoProducesInEachEra(t *testing.T) {
-	cfg := loadConfig(t)
-	schedule := cfg.ScheduledTransitions()
-	require.NotEmpty(t, schedule, "eras testnet.yaml must configure forks")
-
-	dingoVkey := readDingoColdVKey(t)
-	t.Logf("dingo cold vkey: %s", hex.EncodeToString(dingoVkey))
-
-	// Observe via the relay because it sees blocks from both producers
-	// without contributing its own. Issuer vkeys on its chain therefore
-	// reflect the actual producer of each block.
-	endpoints := DefaultEndpoints()
-	relay := endpoints[2]
-	stream := NewEraStream(
-		t, relay, cfg.NetworkMagic, cfg.EpochLength,
-	)
-	defer stream.Close()
-
-	// One transition's budget is enough to catch up from origin on a
-	// healthy chain or fail fast on a stuck one.
-	terminal := schedule[len(schedule)-1].Era
-	timeout := transitionTimeout(cfg)
-	_, err := stream.WaitForEra(&terminal, timeout)
-	require.NoErrorf(
-		t, err, "relay did not reach %s within %s",
-		terminal.Name, timeout,
-	)
-	// Wait one more epoch in the terminal era to give dingo a chance
-	// to forge a block there.
-	finalSlot := schedule[len(schedule)-1].Slot + cfg.EpochLength
-	_, err = stream.WaitForSlot(finalSlot, transitionTimeout(cfg))
-	require.NoErrorf(
-		t, err, "relay did not advance past slot %d", finalSlot,
-	)
-
-	headers := stream.HeadersSnapshot()
-	dingoBlocksByEra := make(map[uint]int)
-	totalByEra := make(map[uint]int)
-	for _, h := range headers {
-		totalByEra[h.EraID]++
-		if bytes.Equal(h.IssuerVkey, dingoVkey) {
-			dingoBlocksByEra[h.EraID]++
+	t.Run("ConsensusAtEachFork", func(t *testing.T) {
+		// For each scheduled era, every node should report the same
+		// transition slot (i.e. the same first-block-in-new-era
+		// slot). Use the most recent matching transition: a rollback
+		// followed by re-application can leave a stale earlier
+		// match in the stream.
+		for _, want := range schedule {
+			slotByNode := make(map[string]uint64, len(streams))
+			for name, s := range streams {
+				trs := s.Transitions()
+				for i := len(trs) - 1; i >= 0; i-- {
+					if trs[i].ToEraID == want.Era.Id {
+						slotByNode[name] = trs[i].Slot
+						break
+					}
+				}
+			}
+			require.Equalf(
+				t, len(streams), len(slotByNode),
+				"%s: not every node observed the transition: %+v",
+				want.Era.Name, slotByNode,
+			)
+			var canonical uint64
+			var canonicalNode string
+			for name, slot := range slotByNode {
+				if canonicalNode == "" {
+					canonical = slot
+					canonicalNode = name
+					continue
+				}
+				require.Equalf(
+					t, canonical, slot,
+					"era %s: %s observed transition at slot %d "+
+						"but %s saw it at %d",
+					want.Era.Name, canonicalNode, canonical, name, slot,
+				)
+			}
+			t.Logf(
+				"all nodes agree: %s transition observed at slot %d",
+				want.Era.Name, canonical,
+			)
 		}
-	}
+	})
 
-	// Build the era set to check: the genesis era (the era already
-	// active at slot 0, which ScheduledTransitions excludes) plus
-	// every successor era the schedule transitions into. Without
-	// the explicit genesis check, a node that never forges in the
-	// starting era would still pass.
-	type eraCheck struct {
-		id   uint
-		name string
-	}
-	var erasToCheck []eraCheck
-	if start, ok := cfg.StartingEra(); ok {
-		erasToCheck = append(erasToCheck, eraCheck{id: start.Id, name: start.Name})
-	}
-	for _, want := range schedule {
-		erasToCheck = append(erasToCheck, eraCheck{id: want.Era.Id, name: want.Era.Name})
-	}
+	t.Run("DingoProducesInEachEra", func(t *testing.T) {
+		// Pool selection is VRF-driven, but with two equal-stake
+		// pools and f=0.4 over a 75-slot epoch the probability
+		// dingo wins zero slots in any given epoch is ≈
+		// (1-0.225)^75 ≈ 1e-8, so VRF variance is not a realistic
+		// source of flakes here.
+		dingoVkey := readDingoColdVKey(t)
+		t.Logf("dingo cold vkey: %s", hex.EncodeToString(dingoVkey))
 
-	for _, era := range erasToCheck {
-		total := totalByEra[era.id]
-		dingo := dingoBlocksByEra[era.id]
-		t.Logf(
-			"%s: total blocks=%d, dingo-issued=%d",
-			era.name, total, dingo,
+		// Observe via the relay because it sees blocks from both
+		// producers without contributing its own. Issuer vkeys on
+		// its chain therefore reflect the actual producer of each
+		// block.
+		relay := endpoints[2]
+		relayStream := streams[relay.Name]
+		require.NotNil(t, relayStream, "cardano-relay stream missing")
+
+		// Wait one extra epoch in the terminal era so dingo has had
+		// a chance to forge a Conway block.
+		finalSlot := schedule[len(schedule)-1].Slot + cfg.EpochLength
+		_, err := relayStream.WaitForSlot(finalSlot, transitionTimeout(cfg))
+		require.NoErrorf(
+			t, err, "relay did not advance past slot %d", finalSlot,
 		)
-		require.Greaterf(
-			t, total, 0,
-			"no blocks at all observed in era %s — chain stalled?",
-			era.name,
-		)
-		require.Greaterf(
-			t, dingo, 0,
-			"dingo did not issue any blocks in era %s",
-			era.name,
-		)
-	}
+
+		headers := relayStream.HeadersSnapshot()
+		dingoBlocksByEra := make(map[uint]int)
+		totalByEra := make(map[uint]int)
+		for _, h := range headers {
+			totalByEra[h.EraID]++
+			if bytes.Equal(h.IssuerVkey, dingoVkey) {
+				dingoBlocksByEra[h.EraID]++
+			}
+		}
+
+		// The era set to check: the genesis era (the era already
+		// active at slot 0, which ScheduledTransitions excludes)
+		// plus every successor era the schedule transitions into.
+		type eraCheck struct {
+			id   uint
+			name string
+		}
+		var erasToCheck []eraCheck
+		if start, ok := cfg.StartingEra(); ok {
+			erasToCheck = append(erasToCheck, eraCheck{
+				id: start.Id, name: start.Name,
+			})
+		}
+		for _, want := range schedule {
+			erasToCheck = append(erasToCheck, eraCheck{
+				id: want.Era.Id, name: want.Era.Name,
+			})
+		}
+
+		for _, era := range erasToCheck {
+			total := totalByEra[era.id]
+			dingo := dingoBlocksByEra[era.id]
+			t.Logf(
+				"%s: total blocks=%d, dingo-issued=%d",
+				era.name, total, dingo,
+			)
+			require.Greaterf(
+				t, total, 0,
+				"no blocks at all observed in era %s — chain stalled?",
+				era.name,
+			)
+			require.Greaterf(
+				t, dingo, 0,
+				"dingo did not issue any blocks in era %s",
+				era.name,
+			)
+		}
+	})
 }
 
 // absDelta returns |a-b| for unsigned values without underflow.

--- a/internal/erastest/era_transitions_test.go
+++ b/internal/erastest/era_transitions_test.go
@@ -37,7 +37,12 @@ import (
 // counts. The chain advances ~ActiveSlotsCoeff blocks per slot, so
 // observing "the first header in era N+1" needs at least one full
 // epoch after the configured fork epoch plus a margin for VRF variance.
-const transitionTimeoutSlots = 200
+//
+// Sized as one epoch (75 slots in the eras testnet) plus a 25-slot
+// margin: large enough that VRF variance won't flake a healthy chain,
+// small enough that a stuck chain fails fast for short test/debug
+// cycles.
+const transitionTimeoutSlots = 100
 
 // dingoColdKeyContainer is the running container we read the dingo
 // pool's cold verification key from. The eras-stack docker-compose
@@ -108,12 +113,12 @@ func readDingoColdVKey(t *testing.T) []byte {
 }
 
 // transitionTimeout converts transitionTimeoutSlots into a wall-clock
-// timeout for the configured slot length, with a floor of 60s so very
+// timeout for the configured slot length, with a floor of 30s so very
 // short slot lengths still leave room for bootstrap variance.
 func transitionTimeout(cfg *Config) time.Duration {
 	d := time.Duration(transitionTimeoutSlots) * cfg.SlotDuration()
-	if d < 60*time.Second {
-		d = 60 * time.Second
+	if d < 30*time.Second {
+		d = 30 * time.Second
 	}
 	return d
 }
@@ -191,12 +196,14 @@ func TestNoStallAcrossForks(t *testing.T) {
 	)
 	defer stream.Close()
 
-	// Wait until the chain has reached the terminal era.
+	// Wait until the chain has reached the terminal era. Tests #2-#4
+	// run after TestEraSchedule has already either traversed every
+	// fork or failed; we only need enough budget for a fresh
+	// EraStream to catch up from origin to the current tip, not to
+	// pace through the schedule again. transitionTimeout (single
+	// fork's worth) is sufficient and keeps cascade failures fast.
 	terminal := schedule[len(schedule)-1].Era
-	_, err := stream.WaitForEra(
-		&terminal,
-		transitionTimeout(cfg)*time.Duration(len(schedule)),
-	)
+	_, err := stream.WaitForEra(&terminal, transitionTimeout(cfg))
 	require.NoErrorf(
 		t, err,
 		"WaitForEra(%s): %v", terminal.Name, err,
@@ -276,8 +283,11 @@ func TestConsensusAtEachFork(t *testing.T) {
 		}
 	}()
 
+	// Each EraStream syncs from origin in parallel; one
+	// transitionTimeout is enough to either catch up to a healthy
+	// chain (fast on a local devnet) or fail fast on a stuck chain.
 	terminal := schedule[len(schedule)-1].Era
-	timeout := transitionTimeout(cfg) * time.Duration(len(schedule))
+	timeout := transitionTimeout(cfg)
 	for name, s := range streams {
 		_, err := s.WaitForEra(&terminal, timeout)
 		require.NoErrorf(
@@ -360,8 +370,10 @@ func TestDingoProducesInEachEra(t *testing.T) {
 	)
 	defer stream.Close()
 
+	// One transition's budget is enough to catch up from origin on a
+	// healthy chain or fail fast on a stuck one.
 	terminal := schedule[len(schedule)-1].Era
-	timeout := transitionTimeout(cfg) * time.Duration(len(schedule))
+	timeout := transitionTimeout(cfg)
 	_, err := stream.WaitForEra(&terminal, timeout)
 	require.NoErrorf(
 		t, err, "relay did not reach %s within %s",

--- a/internal/test/erastest/run-tests.sh
+++ b/internal/test/erastest/run-tests.sh
@@ -110,8 +110,11 @@ export ERASTEST_CARDANO_ADDR="localhost:${CARDANO_PORT}"
 export ERASTEST_RELAY_ADDR="localhost:${RELAY_PORT}"
 export ERASTEST_TESTNET_YAML="${TESTNET_YAML}"
 
-# Default timeout: ~6 epochs * 75s + bootstrap + margin.
-TEST_TIMEOUT="${TEST_TIMEOUT:-15m}"
+# Default timeout: ~6 epochs * 75s ≈ 7.5 min for a healthy traversal
+# plus margin for bootstrap and the test cascade. Set TEST_TIMEOUT in
+# the environment to override (e.g. for slow CI runners or extended
+# debugging).
+TEST_TIMEOUT="${TEST_TIMEOUT:-8m}"
 set +e
 go test \
   -tags erastest \

--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -30,8 +30,8 @@ import (
 var AllegraEraDesc = EraDesc{
 	Id:                      allegra.EraIdAllegra,
 	Name:                    allegra.EraNameAllegra,
-	MinMajorVersion:         3,
-	MaxMajorVersion:         3,
+	MinMajorVersion:         allegra.MinProtocolVersionAllegra,
+	MaxMajorVersion:         allegra.MaxProtocolVersionAllegra,
 	DecodePParamsFunc:       DecodePParamsAllegra,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateAllegra,
 	PParamsUpdateFunc:       PParamsUpdateAllegra,
@@ -92,6 +92,14 @@ func HardForkAllegra(
 		)
 	}
 	ret := allegra.UpgradePParams(*shelleyPParams)
+	// Bump ProtocolMajor to Allegra's range when entering the era.
+	// gouroboros's UpgradePParams is a type-cast that preserves the
+	// caller's major value; without this bump, schedule-driven
+	// transitions land in Allegra with major still at Shelley's
+	// value, and downstream era disambiguation reads as Shelley.
+	if ret.ProtocolMajor < allegra.MinProtocolVersionAllegra {
+		ret.ProtocolMajor = allegra.MinProtocolVersionAllegra
+	}
 	return &ret, nil
 }
 

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -36,8 +36,8 @@ import (
 var AlonzoEraDesc = EraDesc{
 	Id:                      alonzo.EraIdAlonzo,
 	Name:                    alonzo.EraNameAlonzo,
-	MinMajorVersion:         5,
-	MaxMajorVersion:         6,
+	MinMajorVersion:         alonzo.MinProtocolVersionAlonzo,
+	MaxMajorVersion:         alonzo.MaxProtocolVersionAlonzo,
 	DecodePParamsFunc:       DecodePParamsAlonzo,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateAlonzo,
 	PParamsUpdateFunc:       PParamsUpdateAlonzo,
@@ -102,6 +102,13 @@ func HardForkAlonzo(
 	alonzoGenesis := nodeConfig.AlonzoGenesis()
 	if err := ret.UpdateFromGenesis(alonzoGenesis); err != nil {
 		return nil, err
+	}
+	// Bump ProtocolMajor to Alonzo's range when entering the era.
+	// gouroboros's UpgradePParams carries the prior major forward
+	// unchanged; schedule-driven transitions would otherwise reach
+	// Alonzo with major still at Mary's value.
+	if ret.ProtocolMajor < alonzo.MinProtocolVersionAlonzo {
+		ret.ProtocolMajor = alonzo.MinProtocolVersionAlonzo
 	}
 	return &ret, nil
 }

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -36,8 +36,8 @@ import (
 var BabbageEraDesc = EraDesc{
 	Id:                      babbage.EraIdBabbage,
 	Name:                    babbage.EraNameBabbage,
-	MinMajorVersion:         7,
-	MaxMajorVersion:         8,
+	MinMajorVersion:         babbage.MinProtocolVersionBabbage,
+	MaxMajorVersion:         babbage.MaxProtocolVersionBabbage,
 	DecodePParamsFunc:       DecodePParamsBabbage,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateBabbage,
 	PParamsUpdateFunc:       PParamsUpdateBabbage,
@@ -135,6 +135,13 @@ func HardForkBabbage(
 	}
 	if _, hasV2 := ret.CostModels[1]; !hasV2 {
 		ret.CostModels[1] = DefaultPlutusV2CostModel
+	}
+	// Bump ProtocolMajor to Babbage's range when entering the era.
+	// gouroboros's UpgradePParams carries the prior major forward
+	// unchanged; schedule-driven transitions would otherwise reach
+	// Babbage with major still at Alonzo's value.
+	if ret.ProtocolMajor < babbage.MinProtocolVersionBabbage {
+		ret.ProtocolMajor = babbage.MinProtocolVersionBabbage
 	}
 	return &ret, nil
 }

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -36,8 +36,8 @@ import (
 var ConwayEraDesc = EraDesc{
 	Id:                      conway.EraIdConway,
 	Name:                    conway.EraNameConway,
-	MinMajorVersion:         9,
-	MaxMajorVersion:         10,
+	MinMajorVersion:         conway.MinProtocolVersionConway,
+	MaxMajorVersion:         conway.MaxProtocolVersionConway,
 	DecodePParamsFunc:       DecodePParamsConway,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateConway,
 	PParamsUpdateFunc:       PParamsUpdateConway,
@@ -102,6 +102,13 @@ func HardForkConway(
 	conwayGenesis := nodeConfig.ConwayGenesis()
 	if err := ret.UpdateFromGenesis(conwayGenesis); err != nil {
 		return nil, err
+	}
+	// Bump ProtocolVersion.Major to Conway's range when entering the
+	// era. gouroboros's UpgradePParams carries the prior major
+	// forward unchanged; schedule-driven transitions would otherwise
+	// reach Conway with major still at Babbage's value.
+	if ret.ProtocolVersion.Major < conway.MinProtocolVersionConway {
+		ret.ProtocolVersion.Major = conway.MinProtocolVersionConway
 	}
 	return &ret, nil
 }

--- a/ledger/eras/hardfork_test.go
+++ b/ledger/eras/hardfork_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+// HardForkFunc is invoked when the chain crosses an era boundary. Its
+// postcondition must be: the returned pparams reflect the new era,
+// including ProtocolMajor at or above the new era's MinMajorVersion.
+//
+// Without this guarantee, schedule-driven era transitions
+// (Test*HardForkAtEpoch overrides, HardForkInitiation gov actions)
+// leave the major version stale at the prior era's value, and
+// downstream consumers that disambiguate eras by ProtocolMajor (e.g.
+// ledger/forging/eras.go extractPParamsLimits) treat the post-fork
+// pparams as belonging to the prior era. The chain then never
+// advances.
+//
+// The tests below cover the era transitions whose HardForkFunc takes
+// no genesis configuration. Shelley, Alonzo, and Conway are excluded
+// because they require ShelleyGenesis / AlonzoGenesis / ConwayGenesis
+// respectively to produce a valid result; their version-bump
+// postcondition is identical and is verified end-to-end by the eras
+// integration test.
+
+func TestHardForkAllegraBumpsProtocolMajor(t *testing.T) {
+	prev := &shelley.ShelleyProtocolParameters{
+		ProtocolMajor: 2,
+		ProtocolMinor: 0,
+	}
+	got, err := eras.HardForkAllegra(nil, prev)
+	require.NoError(t, err)
+	pp, ok := got.(*shelley.ShelleyProtocolParameters)
+	require.Truef(t, ok, "expected *shelley.ShelleyProtocolParameters, got %T", got)
+	require.Equalf(
+		t, eras.AllegraEraDesc.MinMajorVersion, pp.ProtocolMajor,
+		"HardForkAllegra must bump ProtocolMajor to AllegraEraDesc.MinMajorVersion (%d), got %d",
+		eras.AllegraEraDesc.MinMajorVersion, pp.ProtocolMajor,
+	)
+}
+
+func TestHardForkMaryBumpsProtocolMajor(t *testing.T) {
+	// Allegra pparams are a type alias of Shelley pparams; pass the
+	// underlying type directly. ProtocolMajor=3 reflects an in-Allegra
+	// chain about to transition to Mary.
+	prev := &shelley.ShelleyProtocolParameters{
+		ProtocolMajor: 3,
+		ProtocolMinor: 0,
+	}
+	got, err := eras.HardForkMary(nil, prev)
+	require.NoError(t, err)
+	pp, ok := got.(*mary.MaryProtocolParameters)
+	require.Truef(t, ok, "expected *mary.MaryProtocolParameters, got %T", got)
+	require.Equalf(
+		t, eras.MaryEraDesc.MinMajorVersion, pp.ProtocolMajor,
+		"HardForkMary must bump ProtocolMajor to MaryEraDesc.MinMajorVersion (%d), got %d",
+		eras.MaryEraDesc.MinMajorVersion, pp.ProtocolMajor,
+	)
+}
+
+func TestHardForkBabbageBumpsProtocolMajor(t *testing.T) {
+	// Alonzo pparams with ProtocolMajor=6 (top of Alonzo's range)
+	// transitioning to Babbage's MinMajorVersion (7).
+	prev := &alonzo.AlonzoProtocolParameters{
+		ProtocolMajor: 6,
+		ProtocolMinor: 0,
+	}
+	got, err := eras.HardForkBabbage(nil, prev)
+	require.NoError(t, err)
+	pp, ok := got.(*babbage.BabbageProtocolParameters)
+	require.Truef(t, ok, "expected *babbage.BabbageProtocolParameters, got %T", got)
+	require.Equalf(
+		t, eras.BabbageEraDesc.MinMajorVersion, pp.ProtocolMajor,
+		"HardForkBabbage must bump ProtocolMajor to BabbageEraDesc.MinMajorVersion (%d), got %d",
+		eras.BabbageEraDesc.MinMajorVersion, pp.ProtocolMajor,
+	)
+}

--- a/ledger/eras/mary.go
+++ b/ledger/eras/mary.go
@@ -30,8 +30,8 @@ import (
 var MaryEraDesc = EraDesc{
 	Id:                      mary.EraIdMary,
 	Name:                    mary.EraNameMary,
-	MinMajorVersion:         4,
-	MaxMajorVersion:         4,
+	MinMajorVersion:         mary.MinProtocolVersionMary,
+	MaxMajorVersion:         mary.MaxProtocolVersionMary,
 	DecodePParamsFunc:       DecodePParamsMary,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateMary,
 	PParamsUpdateFunc:       PParamsUpdateMary,
@@ -92,6 +92,13 @@ func HardForkMary(
 		)
 	}
 	ret := mary.UpgradePParams(*allegraPParams)
+	// Bump ProtocolMajor to Mary's range when entering the era.
+	// gouroboros's UpgradePParams carries the prior major forward
+	// unchanged; without this bump, schedule-driven transitions
+	// reach Mary with major still at Allegra's value.
+	if ret.ProtocolMajor < mary.MinProtocolVersionMary {
+		ret.ProtocolMajor = mary.MinProtocolVersionMary
+	}
 	return &ret, nil
 }
 

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -30,8 +30,8 @@ import (
 var ShelleyEraDesc = EraDesc{
 	Id:                      shelley.EraIdShelley,
 	Name:                    shelley.EraNameShelley,
-	MinMajorVersion:         2,
-	MaxMajorVersion:         2,
+	MinMajorVersion:         shelley.MinProtocolVersionShelley,
+	MaxMajorVersion:         shelley.MaxProtocolVersionShelley,
 	DecodePParamsFunc:       DecodePParamsShelley,
 	DecodePParamsUpdateFunc: DecodePParamsUpdateShelley,
 	PParamsUpdateFunc:       PParamsUpdateShelley,
@@ -90,6 +90,15 @@ func HardForkShelley(
 	shelleyGenesis := nodeConfig.ShelleyGenesis()
 	if err := ret.UpdateFromGenesis(shelleyGenesis); err != nil {
 		return nil, err
+	}
+	// Ensure ProtocolMajor reflects the Shelley era. Schedule-driven
+	// transitions reach this code path with no on-chain pparams
+	// update having bumped the major version; the postcondition that
+	// pparams identify the new era would otherwise be violated.
+	// Idempotent on a governance-driven transition because the
+	// quorum already lands on this era's minimum major.
+	if ret.ProtocolMajor < shelley.MinProtocolVersionShelley {
+		ret.ProtocolMajor = shelley.MinProtocolVersionShelley
 	}
 	return &ret, nil
 }

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -46,6 +46,13 @@ type MempoolProvider interface {
 // ProtocolParamsProvider provides access to protocol parameters.
 type ProtocolParamsProvider interface {
 	GetCurrentPParams() lcommon.ProtocolParameters
+	// ProtocolParamsForSlot returns the pparams that should govern a
+	// block forged at the given slot. When the slot is in an epoch
+	// beyond a scheduled fork that has not yet been applied to the
+	// in-memory ledger state, the returned pparams are the
+	// post-fork pparams. The forger uses this to produce
+	// era-correct blocks at fork boundaries.
+	ProtocolParamsForSlot(slot uint64) lcommon.ProtocolParameters
 }
 
 // ChainTipProvider provides access to the current chain tip.
@@ -154,15 +161,20 @@ func (b *DefaultBlockBuilder) BuildBlock(
 		nextBlockNumber = currentTip.BlockNumber + 1
 	}
 
-	// Get current protocol parameters for limits
-	pparams := b.pparamsProvider.GetCurrentPParams()
+	// Get protocol parameters for the slot being forged. This
+	// projects forward through any scheduled fork (TriggerAtEpoch)
+	// whose epoch lies at or before the slot, so the forger
+	// produces an era-correct block at a fork boundary even when
+	// the in-memory rollover has not yet seen a post-fork peer
+	// block.
+	pparams := b.pparamsProvider.ProtocolParamsForSlot(slot)
 	if pparams == nil {
 		return nil, nil, errors.New("failed to get protocol parameters")
 	}
 
-	// Read pparams limits via per-era dispatch. TPraos eras
-	// (Shelley/Allegra/Mary/Alonzo) return errTPraosForgingUnsupported;
-	// Babbage and Conway both produce Praos-shape blocks.
+	// Read pparams limits via per-era dispatch. The pparams type
+	// drives the block layout (Shelley/Allegra/Mary/Alonzo run
+	// TPraos; Babbage/Conway run Praos).
 	limits, err := extractPParamsLimits(pparams)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build block: %w", err)

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -51,6 +51,10 @@ func (m *mockPParamsProvider) GetCurrentPParams() lcommon.ProtocolParameters {
 	return m.pparams
 }
 
+func (m *mockPParamsProvider) ProtocolParamsForSlot(_ uint64) lcommon.ProtocolParameters {
+	return m.pparams
+}
+
 // mockChainTip implements ChainTipProvider for testing.
 type mockChainTip struct {
 	tip ochainsync.Tip

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2397,6 +2397,25 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				workingPParams := snapshotPParams
 				workingEraId := snapshotEra.Id
 
+				// Honor the era schedule when the boundary-crossing
+				// block did not bump the era itself. The current
+				// era's NextEraTrigger may pin the next transition
+				// to a specific epoch; if we are crossing into (or
+				// past) that epoch and the block we observed is
+				// still in the prior era, transition anyway.
+				// Without this, a sole producer that builds in the
+				// prior era at the boundary would never advance,
+				// since nextEpochEraId would equal snapshotEra.Id.
+				newEpochId := snapshotEpoch.EpochId + 1
+				if entry, ok := ls.eraShape().EraForID(snapshotEra.Id); ok &&
+					entry.NextEraTrigger.Kind == hardfork.TriggerAtEpoch &&
+					entry.NextEraTrigger.Epoch <= newEpochId &&
+					nextEpochEraId == snapshotEra.Id {
+					if int(snapshotEra.Id+1) < len(eras.Eras) {
+						nextEpochEraId = snapshotEra.Id + 1
+					}
+				}
+
 				// Check for era change. The guard rejects multi-step
 				// forward, backwards, and to/from-unknown-era cases:
 				// each era boundary on a healthy chain is crossed by
@@ -4121,6 +4140,89 @@ func (ls *LedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
 	ls.RLock()
 	defer ls.RUnlock()
 	return ls.currentPParams
+}
+
+// ProtocolParamsForSlot returns the protocol parameters that should
+// govern a block forged at the given slot. When the slot lies in an
+// epoch beyond a scheduled fork (the active era's NextEraTrigger is
+// TriggerAtEpoch and the slot's epoch is at or past the trigger),
+// the returned pparams are the post-fork pparams computed by walking
+// each successor era's HardForkFunc up to the slot's era.
+//
+// The forger uses this when picking an era to build a block in.
+// Reading currentPParams alone would lock a sole producer to the
+// pre-fork era forever: the boundary-crossing block would be encoded
+// in the old era, the rollover (which trusts the observed block's
+// era) would not advance, and the chain would never traverse the
+// fork. Forecasting from the schedule lets the forger produce a
+// block in the era the schedule requires, regardless of how the
+// schedule was produced — administrative overrides, on-chain update
+// proposals, or HardForkInitiation gov actions all surface as
+// TriggerAtEpoch entries on the shape.
+func (ls *LedgerState) ProtocolParamsForSlot(
+	slot uint64,
+) lcommon.ProtocolParameters {
+	ls.RLock()
+	currentEpoch := ls.currentEpoch
+	currentEra := ls.currentEra
+	currentPParams := ls.currentPParams
+	ls.RUnlock()
+
+	if currentPParams == nil || currentEpoch.LengthInSlots == 0 {
+		return currentPParams
+	}
+	slotEpoch := slot / uint64(currentEpoch.LengthInSlots)
+	if slotEpoch <= currentEpoch.EpochId {
+		return currentPParams
+	}
+	shape := ls.eraShape()
+	if len(shape.Eras) == 0 {
+		return currentPParams
+	}
+	// Walk forward from the current era, applying each successor's
+	// HardForkFunc whose triggerEpoch <= slotEpoch. The single-step
+	// case (one fork between currentEpoch and slotEpoch) is the
+	// nominal path; the loop also tolerates multi-step jumps so the
+	// helper stays sound if a caller skips ahead.
+	pparams := currentPParams
+	eraID := currentEra.Id
+	for {
+		entry, ok := shape.EraForID(eraID)
+		if !ok ||
+			entry.NextEraTrigger.Kind != hardfork.TriggerAtEpoch {
+			break
+		}
+		if entry.NextEraTrigger.Epoch > slotEpoch {
+			break
+		}
+		nextID := eraID + 1
+		if int(nextID) >= len(eras.Eras) {
+			break
+		}
+		nextEra := eras.Eras[nextID]
+		if nextEra.HardForkFunc == nil {
+			eraID = nextID
+			continue
+		}
+		newPParams, err := nextEra.HardForkFunc(
+			ls.config.CardanoNodeConfig,
+			pparams,
+		)
+		if err != nil {
+			ls.config.Logger.Warn(
+				"ProtocolParamsForSlot: HardForkFunc failed",
+				"slot", slot,
+				"slot_epoch", slotEpoch,
+				"from_era", eraID,
+				"to_era", nextID,
+				"error", err,
+			)
+			return currentPParams
+		}
+		pparams = newPParams
+		eraID = nextID
+	}
+	return pparams
 }
 
 // CurrentEpoch returns the current epoch number.


### PR DESCRIPTION
closes #2147 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stalled era transitions by bumping protocol majors on every hard fork and teaching the forger to use post-fork parameters so blocks at boundaries are built in the correct era.

- **Bug Fixes**
  - All `HardFork*` functions now bump `ProtocolMajor` to the new era’s minimum, ensuring downstream era detection switches eras.
  - Added `ProtocolParamsForSlot` to forecast pparams across scheduled forks; `DefaultBlockBuilder` now uses it to forge era-correct blocks at boundaries.
  - Ledger now advances when crossing a `TriggerAtEpoch` even if the observed block is still encoded in the prior era.
  - Tests: added unit tests for Allegra/Mary/Babbage version bumps; reworked eras tests into subtests that share streams across nodes, added `PrevSlot` to measure boundary gaps, reduced timeouts, and set `internal/test/erastest/run-tests.sh` default to 8m.
  - Era descriptors now use canonical min/max protocol version constants from `gouroboros`.
  - Updated `github.com/blinklabs-io/gouroboros` to `v0.166.1`.

- **Migration**
  - The `ProtocolParamsProvider` interface adds `ProtocolParamsForSlot(slot uint64)`. Implementations must provide this method.

<sup>Written for commit c228c6f90adc1a65b94c6ba1b3e7563ff126b984. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed protocol version enforcement during era transitions (Allegra, Mary, Alonzo, Babbage, Conway, Shelley) to ensure correct minimum versions are applied at fork boundaries.
  * Improved block construction to use appropriate protocol parameters for specific slots, maintaining era compliance at fork transitions.

* **Tests**
  * Optimized test execution timeouts for faster feedback.
  * Added validation tests for hard fork protocol version handling.

* **Chores**
  * Updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->