### PR TITLE
fix: nonce calculations for VRF

### DIFF
--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -111,9 +111,14 @@ func CalculateEtaVAllegra(
 	if !ok {
 		return nil, errors.New("unexpected block type")
 	}
+	// See CalculateEtaVShelley for the rationale: TPraos folds bnonce ∈
+	// Seed into the rolling nonce, where bnonce is BLAKE2b-256 of the
+	// raw VRF certificate output. Folding the raw certificate bytes
+	// directly produces nonces that disagree with peers (#2125).
+	contribution := lcommon.Blake2b256Hash(h.Body.NonceVrf.Output).Bytes()
 	tmpNonce, err := lcommon.CalculateRollingNonce(
 		prevBlockNonce,
-		h.Body.NonceVrf.Output,
+		contribution,
 	)
 	if err != nil {
 		return nil, err

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -122,9 +122,14 @@ func CalculateEtaVAlonzo(
 	if !ok {
 		return nil, errors.New("unexpected block type")
 	}
+	// See CalculateEtaVShelley for the rationale: TPraos folds bnonce ∈
+	// Seed into the rolling nonce, where bnonce is BLAKE2b-256 of the
+	// raw VRF certificate output. Folding the raw certificate bytes
+	// directly produces nonces that disagree with peers (#2125).
+	contribution := lcommon.Blake2b256Hash(h.Body.NonceVrf.Output).Bytes()
 	tmpNonce, err := lcommon.CalculateRollingNonce(
 		prevBlockNonce,
-		h.Body.NonceVrf.Output,
+		contribution,
 	)
 	if err != nil {
 		return nil, err

--- a/ledger/eras/mary.go
+++ b/ledger/eras/mary.go
@@ -111,9 +111,14 @@ func CalculateEtaVMary(
 	if !ok {
 		return nil, errors.New("unexpected block type")
 	}
+	// See CalculateEtaVShelley for the rationale: TPraos folds bnonce ∈
+	// Seed into the rolling nonce, where bnonce is BLAKE2b-256 of the
+	// raw VRF certificate output. Folding the raw certificate bytes
+	// directly produces nonces that disagree with peers (#2125).
+	contribution := lcommon.Blake2b256Hash(h.Body.NonceVrf.Output).Bytes()
 	tmpNonce, err := lcommon.CalculateRollingNonce(
 		prevBlockNonce,
-		h.Body.NonceVrf.Output,
+		contribution,
 	)
 	if err != nil {
 		return nil, err

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -134,9 +134,16 @@ func CalculateEtaVShelley(
 	if !ok {
 		return nil, errors.New("unexpected block type")
 	}
+	// The Shelley formal spec defines bnonce(bhbody) ∈ Seed and the
+	// seed-combination operator over Seeds; the wider VRF certificate
+	// output is hashed down to a Seed before folding into the rolling
+	// nonce. Folding the raw certificate bytes directly diverges the
+	// epoch nonce from peers and breaks header VRF verification at the
+	// next epoch boundary (#2125).
+	contribution := lcommon.Blake2b256Hash(h.Body.NonceVrf.Output).Bytes()
 	tmpNonce, err := lcommon.CalculateRollingNonce(
 		prevBlockNonce,
-		h.Body.NonceVrf.Output,
+		contribution,
 	)
 	if err != nil {
 		return nil, err

--- a/ledger/eras/tpraos_etav_test.go
+++ b/ledger/eras/tpraos_etav_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expectedTPraosEtaV computes one step of the evolving-nonce update under
+// the Shelley protocol's rules.
+//
+// Per the Shelley formal spec (chain.tex / crypto-details.tex):
+//
+//   - the per-block nonce contribution is bnonce(bhbody) ∈ Seed, where Seed
+//     is the BLAKE2b-256 output type (32 bytes);
+//   - the seed combination operator x ⊕ y is implemented as
+//     BLAKE2b-256(x || y) where both inputs are Seeds (32 bytes each);
+//   - the Update Nonce rule replaces η_v by η_v ⊕ η, where η is the block's
+//     Seed contribution.
+//
+// The VRF certificate output for the curve used in Shelley is wider than a
+// Seed, so converting it to bnonce ∈ Seed requires hashing it down. The
+// expected per-block update is therefore:
+//
+//	η_v' = BLAKE2b-256( η_v || BLAKE2b-256(rawVrfCertOutput) )
+//
+// Concatenating the raw certificate bytes with η_v and hashing in one step
+// instead of pre-hashing produces a different result that does not match
+// what other nodes on the network compute, which manifests as VRF
+// verification failures on every header at the next epoch boundary
+// (issue #2125 Shelley→Allegra symptom).
+func expectedTPraosEtaV(prev, rawVrfOutput []byte) []byte {
+	contribution := lcommon.Blake2b256Hash(rawVrfOutput).Bytes()
+	concat := make([]byte, 0, len(prev)+len(contribution))
+	concat = append(concat, prev...)
+	concat = append(concat, contribution...)
+	return lcommon.Blake2b256Hash(concat).Bytes()
+}
+
+// tpraosTestVectors returns deterministic inputs the TPraos eras share.
+// Non-trivial fixed bytes (no all-zeros, no neutral-nonce path) so the
+// divergence between the buggy and correct formulas is unambiguous.
+func tpraosTestVectors(t *testing.T) (cfg *cardano.CardanoNodeConfig, prev, rawVrf []byte) {
+	t.Helper()
+	prev = bytes.Repeat([]byte{0x33}, 32)
+	rawVrf = bytes.Repeat([]byte{0x42}, 64)
+	cfg = &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: hex.EncodeToString(bytes.Repeat([]byte{0x11}, 32)),
+	}
+	return cfg, prev, rawVrf
+}
+
+// TestCalculateEtaV_TPraos_RawVrfMustBePreHashed asserts that every TPraos
+// era's CalculateEtaVFunc applies BLAKE2b-256 to the raw VRF certificate
+// output before folding it into the rolling nonce. Without that pre-hash,
+// the resulting evolving and candidate nonces diverge from peers, the
+// derived epoch nonce no longer matches, and VRF verification of every
+// post-fork-boundary header fails — the symptom of issue #2125 at the
+// Shelley→Allegra boundary in the eras DevNet.
+func TestCalculateEtaV_TPraos_RawVrfMustBePreHashed(t *testing.T) {
+	cfg, prev, rawVrf := tpraosTestVectors(t)
+	expected := expectedTPraosEtaV(prev, rawVrf)
+
+	cases := []struct {
+		name  string
+		block ledger.Block
+		fn    func(*cardano.CardanoNodeConfig, []byte, ledger.Block) ([]byte, error)
+	}{
+		{
+			name: "shelley",
+			block: &shelley.ShelleyBlock{
+				BlockHeader: &shelley.ShelleyBlockHeader{
+					Body: shelley.ShelleyBlockHeaderBody{
+						NonceVrf: lcommon.VrfResult{Output: rawVrf},
+					},
+				},
+			},
+			fn: eras.CalculateEtaVShelley,
+		},
+		{
+			name: "allegra",
+			block: &allegra.AllegraBlock{
+				BlockHeader: &allegra.AllegraBlockHeader{
+					ShelleyBlockHeader: shelley.ShelleyBlockHeader{
+						Body: shelley.ShelleyBlockHeaderBody{
+							NonceVrf: lcommon.VrfResult{Output: rawVrf},
+						},
+					},
+				},
+			},
+			fn: eras.CalculateEtaVAllegra,
+		},
+		{
+			name: "mary",
+			block: &mary.MaryBlock{
+				BlockHeader: &mary.MaryBlockHeader{
+					ShelleyBlockHeader: shelley.ShelleyBlockHeader{
+						Body: shelley.ShelleyBlockHeaderBody{
+							NonceVrf: lcommon.VrfResult{Output: rawVrf},
+						},
+					},
+				},
+			},
+			fn: eras.CalculateEtaVMary,
+		},
+		{
+			name: "alonzo",
+			block: &alonzo.AlonzoBlock{
+				BlockHeader: &alonzo.AlonzoBlockHeader{
+					ShelleyBlockHeader: shelley.ShelleyBlockHeader{
+						Body: shelley.ShelleyBlockHeaderBody{
+							NonceVrf: lcommon.VrfResult{Output: rawVrf},
+						},
+					},
+				},
+			},
+			fn: eras.CalculateEtaVAlonzo,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.fn(cfg, prev, tc.block)
+			require.NoError(t, err)
+			assert.Equal(t,
+				hex.EncodeToString(expected),
+				hex.EncodeToString(got),
+				"TPraos %s: per-block etaV must hash the raw VRF "+
+					"certificate output to a Seed before folding "+
+					"(issue #2125)",
+				tc.name,
+			)
+		})
+	}
+}
+
+// TestCalculateEtaV_TPraos_GenesisFallback exercises the path where the
+// previous block nonce is empty (chain start). The Shelley genesis hash
+// is substituted as the initial accumulator, after which the same
+// pre-hashed update applies. Guards against a regression where the
+// genesis fallback skips the pre-hash step.
+func TestCalculateEtaV_TPraos_GenesisFallback(t *testing.T) {
+	cfg, _, rawVrf := tpraosTestVectors(t)
+	genesis, err := hex.DecodeString(cfg.ShelleyGenesisHash)
+	require.NoError(t, err)
+	expected := expectedTPraosEtaV(genesis, rawVrf)
+
+	block := &shelley.ShelleyBlock{
+		BlockHeader: &shelley.ShelleyBlockHeader{
+			Body: shelley.ShelleyBlockHeaderBody{
+				NonceVrf: lcommon.VrfResult{Output: rawVrf},
+			},
+		},
+	}
+	got, err := eras.CalculateEtaVShelley(cfg, nil, block)
+	require.NoError(t, err)
+	assert.Equal(t,
+		hex.EncodeToString(expected),
+		hex.EncodeToString(got),
+		"empty prev nonce should fall back to genesis hash, then apply "+
+			"the TPraos pre-hash formula (issue #2125)",
+	)
+}
+
+// TestCalculateEtaV_Praos_NotAffected guards the Praos (Babbage+) path
+// against an over-broad fix. Praos applies a domain-separated double
+// hash of the VRF output (range-extension prefix "N" then a second
+// BLAKE2b-256), producing a 32-byte contribution that is then folded by
+// the same seed-combination operator. The result is therefore distinct
+// from the TPraos pre-hash formula, which serves as a sanity check that
+// the two era families remain on separate code paths after the issue
+// #2125 fix.
+func TestCalculateEtaV_Praos_NotAffected(t *testing.T) {
+	cfg, prev, rawVrf := tpraosTestVectors(t)
+
+	// Independent recomputation of the Praos contribution.
+	tagged := make([]byte, 0, 1+len(rawVrf))
+	tagged = append(tagged, 'N')
+	tagged = append(tagged, rawVrf...)
+	rangeExtended := lcommon.Blake2b256Hash(tagged).Bytes()
+	contribution := lcommon.Blake2b256Hash(rangeExtended).Bytes()
+	concat := make([]byte, 0, len(prev)+len(contribution))
+	concat = append(concat, prev...)
+	concat = append(concat, contribution...)
+	expected := lcommon.Blake2b256Hash(concat).Bytes()
+
+	block := &babbage.BabbageBlock{
+		BlockHeader: &babbage.BabbageBlockHeader{
+			Body: babbage.BabbageBlockHeaderBody{
+				VrfResult: lcommon.VrfResult{Output: rawVrf},
+			},
+		},
+	}
+	got, err := eras.CalculateEtaVBabbage(cfg, prev, block)
+	require.NoError(t, err)
+	assert.Equal(t,
+		hex.EncodeToString(expected),
+		hex.EncodeToString(got),
+		"Babbage etaV should follow the Praos domain-separated formula",
+	)
+	assert.NotEqual(t,
+		hex.EncodeToString(expectedTPraosEtaV(prev, rawVrf)),
+		hex.EncodeToString(got),
+		"Praos and TPraos formulas should not collapse to the same result",
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix TPraos nonce calculation by hashing the raw VRF certificate output with BLAKE2b-256 before folding. This matches the Shelley spec and prevents epoch-boundary VRF verification failures (Linear #2125).

- **Bug Fixes**
  - Use `Blake2b256Hash(h.Body.NonceVrf.Output)` in `CalculateEtaVShelley`, `CalculateEtaVAllegra`, `CalculateEtaVMary`, `CalculateEtaVAlonzo`.
  - Apply the same pre-hash when using the genesis hash as the initial nonce.
  - Keep Praos (`Babbage+`) logic unchanged; verified by new tests in `ledger/eras/tpraos_etav_test.go`.

<sup>Written for commit faa75b83d3cddc5c6b8b8a6411cf314b9ba59f91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected nonce calculation across multiple consensus eras to ensure proper cryptographic processing of verification outputs.

* **Tests**
  * Added comprehensive test suite verifying nonce calculation behavior and consensus consistency across different eras, including fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->