### PR TITLE
fix(ledger): drain replayBufferedHeadersAsync on Close to avoid DB Closed panic

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -935,9 +935,23 @@ func (ls *LedgerState) nextBufferedHeaderConnId() (
 func (ls *LedgerState) replayBufferedHeadersAsync(
 	connId ouroboros.ConnectionId,
 ) {
+	// Bail out if Close has already started so we never spawn a worker
+	// that issues DB reads after phase 3 closes the database (#2107).
+	if ls.closed.Load() {
+		return
+	}
+	ls.replayWG.Add(1)
 	go func() {
+		defer ls.replayWG.Done()
 		ls.chainsyncMutex.Lock()
 		defer ls.chainsyncMutex.Unlock()
+		// Re-check after acquiring the mutex in case Close started
+		// while we were waiting for the lock; the DB reads inside
+		// handleEventChainsyncBlockHeader (BlockByHash etc.) will
+		// panic with "DB Closed" once the owner closes the DB.
+		if ls.closed.Load() {
+			return
+		}
 		if ls.headerPipelineConnId != (ouroboros.ConnectionId{}) ||
 			ls.chain.HeaderCount() > 0 {
 			return

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -935,12 +935,17 @@ func (ls *LedgerState) nextBufferedHeaderConnId() (
 func (ls *LedgerState) replayBufferedHeadersAsync(
 	connId ouroboros.ConnectionId,
 ) {
-	// Bail out if Close has already started so we never spawn a worker
-	// that issues DB reads after phase 3 closes the database (#2107).
+	// Hold replayMu so Close cannot start Wait between our closed check
+	// and Add(1); otherwise Wait could observe a zero counter and the
+	// subsequent Add(1) would panic with "WaitGroup misuse: Add called
+	// concurrently with Wait" (#2107).
+	ls.replayMu.Lock()
 	if ls.closed.Load() {
+		ls.replayMu.Unlock()
 		return
 	}
 	ls.replayWG.Add(1)
+	ls.replayMu.Unlock()
 	go func() {
 		defer ls.replayWG.Done()
 		ls.chainsyncMutex.Lock()

--- a/ledger/chainsync_replay_shutdown_test.go
+++ b/ledger/chainsync_replay_shutdown_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression for #2107: replayBufferedHeadersAsync must be a no-op once
+// Close has been observed, so its goroutine can never reach DB reads
+// after the database is closed.
+func TestReplayBufferedHeadersAsyncSkippedAfterClose(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	// Simulate that Close has begun (closed=true) before the replay
+	// is scheduled. The async helper must not spawn a worker.
+	ls.closed.Store(true)
+
+	ls.replayBufferedHeadersAsync(fixture.connId)
+
+	done := make(chan struct{})
+	go func() {
+		ls.replayWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replayWG did not complete: a worker was spawned despite ls.closed=true")
+	}
+}
+
+// Regression for #2107: Close must drain in-flight replay goroutines
+// before returning, so callers (Node.shutdown phase 3) can safely close
+// the database without racing the replay's DB reads.
+func TestCloseWaitsForInFlightReplay(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	// Hold the chainsync mutex so the goroutine spawned by
+	// replayBufferedHeadersAsync blocks before touching the DB.
+	ls.chainsyncMutex.Lock()
+	ls.replayBufferedHeadersAsync(fixture.connId)
+
+	// Confirm a worker really did start and is now waiting on the lock.
+	// (The goroutine ran replayWG.Add(1) synchronously before launching.)
+	closeReturned := make(chan error, 1)
+	go func() {
+		closeReturned <- ls.Close()
+	}()
+
+	// Close must not return while the worker is still in flight.
+	select {
+	case err := <-closeReturned:
+		ls.chainsyncMutex.Unlock()
+		t.Fatalf("Close returned (err=%v) before replay drained", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Releasing the mutex lets the worker observe ls.closed=true and exit
+	// without issuing any DB reads.
+	ls.chainsyncMutex.Unlock()
+
+	select {
+	case err := <-closeReturned:
+		if err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Close did not return after replay worker exited")
+	}
+}

--- a/ledger/chainsync_replay_shutdown_test.go
+++ b/ledger/chainsync_replay_shutdown_test.go
@@ -56,23 +56,36 @@ func TestCloseWaitsForInFlightReplay(t *testing.T) {
 	ls.chainsyncMutex.Lock()
 	ls.replayBufferedHeadersAsync(fixture.connId)
 
-	// Confirm a worker really did start and is now waiting on the lock.
-	// (The goroutine ran replayWG.Add(1) synchronously before launching.)
+	// (The goroutine ran replayWG.Add(1) synchronously before launching,
+	// so the wait group counter is non-zero from this point.)
 	closeReturned := make(chan error, 1)
 	go func() {
 		closeReturned <- ls.Close()
 	}()
 
-	// Close must not return while the worker is still in flight.
+	// Wait until Close has set closed=true and is therefore committed
+	// to draining the replay worker before it can return.
+	deadline := time.Now().Add(2 * time.Second)
+	for !ls.closed.Load() {
+		if time.Now().After(deadline) {
+			ls.chainsyncMutex.Unlock()
+			t.Fatal("Close did not set ls.closed within 2s")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// With closed=true and the worker blocked on chainsyncMutex, Close
+	// must not return: doing so would close the DB while the worker is
+	// still alive (the original #2107 panic).
 	select {
 	case err := <-closeReturned:
 		ls.chainsyncMutex.Unlock()
 		t.Fatalf("Close returned (err=%v) before replay drained", err)
-	case <-time.After(200 * time.Millisecond):
+	default:
 	}
 
 	// Releasing the mutex lets the worker observe ls.closed=true and exit
-	// without issuing any DB reads.
+	// without issuing any DB reads; Close can then finish draining.
 	ls.chainsyncMutex.Unlock()
 
 	select {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -496,7 +496,10 @@ type LedgerState struct {
 	// closed.Load() and Add(1) in handleEventChainUpdate.
 	rollbackMu sync.Mutex
 	// rollbackWG tracks in-flight rollback event emission goroutines
-	rollbackWG        sync.WaitGroup
+	rollbackWG sync.WaitGroup
+	// replayWG tracks in-flight replayBufferedHeadersAsync goroutines so
+	// Close can drain them before the database is closed (issue #2107).
+	replayWG          sync.WaitGroup
 	validationEnabled bool
 	// Sync progress reporting (Fix 4)
 	syncProgressLastLog  time.Time     // last time we logged sync progress
@@ -985,6 +988,30 @@ func (ls *LedgerState) Close() error {
 		)
 	}
 	ls.rollbackMu.Unlock()
+
+	// Drain in-flight replayBufferedHeadersAsync goroutines so they
+	// finish issuing DB reads before the owner closes the database
+	// (#2107). The closed flag set above prevents new goroutines from
+	// being spawned, so this Wait is bounded.
+	ls.config.Logger.Info("waiting for in-flight header replay goroutines")
+	replayStart := time.Now()
+	replayDone := make(chan struct{})
+	go func() {
+		ls.replayWG.Wait()
+		close(replayDone)
+	}()
+	select {
+	case <-replayDone:
+		ls.config.Logger.Info(
+			"header replay goroutines finished",
+			"elapsed", time.Since(replayStart).Round(time.Millisecond),
+		)
+	case <-time.After(10 * time.Second):
+		ls.config.Logger.Warn(
+			"timed out waiting for header replay goroutines",
+			"elapsed", time.Since(replayStart).Round(time.Millisecond),
+		)
+	}
 
 	// Stop slot clock
 	if ls.slotClock != nil {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -497,6 +497,10 @@ type LedgerState struct {
 	rollbackMu sync.Mutex
 	// rollbackWG tracks in-flight rollback event emission goroutines
 	rollbackWG sync.WaitGroup
+	// replayMu serializes replayWG.Add with Close's replayWG.Wait to
+	// prevent Add-after-Wait panics from the TOCTOU race between
+	// closed.Load() and Add(1) in replayBufferedHeadersAsync (#2107).
+	replayMu sync.Mutex
 	// replayWG tracks in-flight replayBufferedHeadersAsync goroutines so
 	// Close can drain them before the database is closed (issue #2107).
 	replayWG          sync.WaitGroup
@@ -991,27 +995,21 @@ func (ls *LedgerState) Close() error {
 
 	// Drain in-flight replayBufferedHeadersAsync goroutines so they
 	// finish issuing DB reads before the owner closes the database
-	// (#2107). The closed flag set above prevents new goroutines from
-	// being spawned, so this Wait is bounded.
+	// (#2107). Hold replayMu so no new goroutine can Add(1) between our
+	// closed flag and this Wait. The closed flag set above prevents
+	// new goroutines from being spawned, so the Wait is bounded by the
+	// in-flight workers; we wait unconditionally because returning
+	// while replay goroutines are still issuing DB reads would
+	// reintroduce the panic this fix is meant to prevent.
 	ls.config.Logger.Info("waiting for in-flight header replay goroutines")
 	replayStart := time.Now()
-	replayDone := make(chan struct{})
-	go func() {
-		ls.replayWG.Wait()
-		close(replayDone)
-	}()
-	select {
-	case <-replayDone:
-		ls.config.Logger.Info(
-			"header replay goroutines finished",
-			"elapsed", time.Since(replayStart).Round(time.Millisecond),
-		)
-	case <-time.After(10 * time.Second):
-		ls.config.Logger.Warn(
-			"timed out waiting for header replay goroutines",
-			"elapsed", time.Since(replayStart).Round(time.Millisecond),
-		)
-	}
+	ls.replayMu.Lock()
+	ls.replayWG.Wait()
+	ls.replayMu.Unlock()
+	ls.config.Logger.Info(
+		"header replay goroutines finished",
+		"elapsed", time.Since(replayStart).Round(time.Millisecond),
+	)
 
 	// Stop slot clock
 	if ls.slotClock != nil {


### PR DESCRIPTION
Fixes #2107.

`replayBufferedHeadersAsync` spawned a goroutine that took `chainsyncMutex` and then called into `BlockByHash` (Badger `NewIterator`) for fork resolution. A SIGTERM during catch-up could let the DB owner close the database in shutdown phase 3 while that goroutine was mid-iteration, panicking with `DB Closed` and skipping deferred `--cpuprofile` cleanup.

Two small changes pin the lifetime to `LedgerState.Close`:

- `replayBufferedHeadersAsync` checks `ls.closed` before spawning, and again after acquiring `chainsyncMutex`, so it never reaches DB reads once Close has started. In-flight workers track themselves with a new `replayWG`.
- `Close` waits on `replayWG` (with the same 10s timeout pattern as the rollback drain) before returning, so the database owner can safely close the DB after `Close` returns.

Regression tests in `ledger/chainsync_replay_shutdown_test.go` cover both: the no-op-after-closed case and that `Close` blocks until an in-flight worker exits.

`go test -race -timeout 90s ./ledger/...` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a shutdown race that caused a "DB Closed" panic by skipping header replay workers once closing starts, serializing Add/Wait, and draining in-flight replays during `Close` before DB teardown. Fixes #2107 and makes shutdown safe during catch-up.

- **Bug Fixes**
  - `replayBufferedHeadersAsync` holds `replayMu`, checks `ls.closed` before spawn and after `chainsyncMutex`, and tracks workers via `replayWG`.
  - `Close` unconditionally waits for `replayWG` under `replayMu` before DB shutdown, preventing Add-after-Wait and "DB Closed" panics.
  - Added regression tests for no-op after close and that `Close` blocks until a running replay exits.

<sup>Written for commit 4dabe43345f66b951e8f72bc80df666cafaa2c68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced shutdown handling to ensure graceful termination of in-flight operations and prevent potential errors during ledger shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->