### PR TITLE
fix: realign peers after plateau

### DIFF
--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -198,6 +198,11 @@ func (n *Node) processChainsyncRecyclerTick(
 							},
 						),
 					)
+					n.realignOtherPeersAfterPlateau(
+						*targetConn,
+						trackedClients,
+						localTipSlot,
+					)
 					delete(recycleAt, connKey)
 					lastRecycled[connKey] = now
 					*lastProgressAt = now
@@ -317,6 +322,53 @@ func (n *Node) processChainsyncRecyclerTick(
 		)
 		delete(recycleAt, connKey)
 		lastRecycled[connKey] = now
+	}
+}
+
+// realignOtherPeersAfterPlateau requests a chainsync resync via the
+// default Stop+Start+Sync path for every ingress-eligible tracked peer
+// other than the one being closed for plateau. Without realignment, a
+// peer that has been streaming RollForwards while the active peer was
+// stuck holds a server-side cursor far past our local tip; the chain
+// selector will promote one of these peers as the next active, and its
+// next RollForward delivers a header beyond the local block tip with
+// no in-memory ancestor history to bridge the gap. The local fork
+// resolver then fails and closes that peer too, cycling through peers
+// until process restart. Realigning candidate peers' cursors to the
+// current local tip lets whichever peer is promoted next deliver
+// headers from local-tip+1 onward.
+func (n *Node) realignOtherPeersAfterPlateau(
+	closedConnId ouroboros.ConnectionId,
+	trackedClients []chainsync.TrackedClient,
+	localTipSlot uint64,
+) {
+	closedKey := closedConnId.String()
+	for _, conn := range trackedClients {
+		if conn.ObservabilityOnly {
+			continue
+		}
+		if conn.ConnId.String() == closedKey {
+			continue
+		}
+		if conn.Cursor.Slot <= localTipSlot {
+			continue
+		}
+		n.config.logger.Info(
+			"realigning peer chainsync cursor after plateau",
+			"connection_id", conn.ConnId.String(),
+			"cursor_slot", conn.Cursor.Slot,
+			"local_tip_slot", localTipSlot,
+		)
+		n.eventBus.Publish(
+			event.ChainsyncResyncEventType,
+			event.NewEvent(
+				event.ChainsyncResyncEventType,
+				event.ChainsyncResyncEvent{
+					ConnectionId: conn.ConnId,
+					Reason:       "post_plateau_realign",
+				},
+			),
+		)
 	}
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -411,6 +411,114 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 	}
 }
 
+func TestProcessChainsyncRecyclerTickRealignsOtherPeersOnPlateau(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(
+		event.ChainsyncResyncEventType,
+	)
+
+	stalledConn := newNodeTestConnId(4001)
+	candidateConn := newNodeTestConnId(4002)
+	farBehindConn := newNodeTestConnId(4003)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   3,
+			StallTimeout: time.Hour,
+		},
+	)
+	require.True(t, state.AddClientConnId(stalledConn))
+	require.True(t, state.AddClientConnId(candidateConn))
+	require.True(t, state.AddClientConnId(farBehindConn))
+	state.SetClientConnId(stalledConn)
+	// Stalled active peer reported a tip past local tip.
+	stalledPoint := ocommon.NewPoint(120, []byte("stalled"))
+	stalledTip := ochainsync.Tip{Point: stalledPoint, BlockNumber: 60}
+	state.UpdateClientTip(stalledConn, stalledPoint, stalledTip)
+	// Candidate peer's chainsync cursor has advanced past local tip
+	// (we only marked it deduped while the active peer was the sole
+	// publisher); without realignment its next RollForward delivers a
+	// header beyond the local block tip and the fork resolver fails.
+	candidatePoint := ocommon.NewPoint(150, []byte("candidate"))
+	candidateTip := ochainsync.Tip{Point: candidatePoint, BlockNumber: 75}
+	state.UpdateClientTip(candidateConn, candidatePoint, candidateTip)
+	// A peer whose cursor sits at-or-below local tip does not need
+	// realigning; it can deliver headers from local-tip+1 directly.
+	farBehindPoint := ocommon.NewPoint(80, []byte("behind"))
+	farBehindTip := ochainsync.Tip{Point: farBehindPoint, BlockNumber: 40}
+	state.UpdateClientTip(farBehindConn, farBehindPoint, farBehindTip)
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(stalledConn, stalledTip, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+	}
+
+	now := time.Now()
+	lastProgressSlot := uint64(100)
+	lastProgressAt := now.Add(-5 * time.Minute)
+	recycleAt := make(map[string]time.Time)
+	lastRecycled := make(map[string]time.Time)
+
+	n.processChainsyncRecyclerTick(
+		now,
+		100,
+		chainsync.Config{
+			MaxClients:   3,
+			StallTimeout: time.Hour,
+		},
+		recycleAt,
+		lastRecycled,
+		&lastProgressSlot,
+		&lastProgressAt,
+		4*time.Minute,
+		time.Second,
+		2*time.Minute,
+	)
+
+	gotPlateauForStalled := false
+	gotRealignForCandidate := false
+	timeout := time.After(200 * time.Millisecond)
+	for !gotPlateauForStalled || !gotRealignForCandidate {
+		select {
+		case evt := <-resyncCh:
+			resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
+			require.True(t, ok)
+			switch {
+			case resyncEvt.Reason == "local_tip_plateau" &&
+				resyncEvt.ConnectionId == stalledConn:
+				gotPlateauForStalled = true
+			case resyncEvt.Reason == "post_plateau_realign" &&
+				resyncEvt.ConnectionId == candidateConn:
+				gotRealignForCandidate = true
+			case resyncEvt.Reason == "post_plateau_realign" &&
+				resyncEvt.ConnectionId == farBehindConn:
+				t.Fatalf(
+					"unexpected realign for peer at-or-below local tip: %+v",
+					resyncEvt,
+				)
+			default:
+				t.Fatalf("unexpected resync event: %+v", resyncEvt)
+			}
+		case <-timeout:
+			t.Fatalf(
+				"missing resync events: plateau=%v realign=%v",
+				gotPlateauForStalled, gotRealignForCandidate,
+			)
+		}
+	}
+}
+
 func TestRunStallCheckerTickRecoversAndAllowsFutureTicks(t *testing.T) {
 	n := &Node{
 		config: Config{


### PR DESCRIPTION
Closes #2150 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Realigns non-active peers after a local tip plateau so the next active peer streams from local-tip+1 and avoids fork resolver failures. When recycling the stalled peer, we resync other ingress peers whose cursors are ahead of the local tip.

- **Bug Fixes**
  - Trigger resync for peers (excluding the stalled one) with cursors > local tip; skip observability-only and at/below-tip peers.
  - Added test to verify resync events: plateau for the stalled peer and post-plateau realign for the ahead peer; none for behind peers.

<sup>Written for commit 4d808fbba3fc06df0a63ca3a57a22f0606d8f004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

