### PR TITLE
test: archive node demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 dingo
 Dockerfile
 README.md
+internal/test/archive-demo/tmp/

--- a/internal/test/archive-demo/Dockerfile.configurator
+++ b/internal/test/archive-demo/Dockerfile.configurator
@@ -1,0 +1,38 @@
+# Antithesis configurator for ARM64/AMD64.
+#
+# Builds from cardano-foundation/testnet-generation-tool to generate
+# unique pool keys and genesis files for DevNet testing.
+#
+# Based on: https://github.com/cardano-foundation/antithesis
+
+# Pin to same version used in docker-compose.yml
+FROM ghcr.io/blinklabs-io/cardano-node:10.5.4
+
+USER root
+
+RUN apt update && \
+    apt install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        tar \
+        tree \
+        python3 \
+        python3-pip \
+        jq
+
+RUN python3 -m pip install --break-system-packages uv
+
+RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-node
+
+WORKDIR /usr/local/src
+# Pin to v0.1.0 (abab0b3ce616928cae4ea5c36a41654ec068e2e4)
+RUN git clone --branch v0.1.0 --depth 1 https://github.com/cardano-foundation/testnet-generation-tool.git
+
+WORKDIR /usr/local/src/testnet-generation-tool
+RUN uv sync && mkdir -p cardano-node && ln -sf /usr/local/bin ./cardano-node/bin
+
+COPY configurator.sh /
+RUN chmod 0755 /configurator.sh
+
+ENTRYPOINT ["/configurator.sh"]

--- a/internal/test/archive-demo/README.md
+++ b/internal/test/archive-demo/README.md
@@ -1,0 +1,75 @@
+# Archive Node Demo
+
+Runnable demonstration of Dingo's archive-node + pruning-node + Bark
+proxy. Mirrors `internal/test/devnet/` in shape but adds Minio (S3) and
+shows the S3 blob plugin and Bark proxy working end to end.
+
+## Stack
+
+- `cardano-producer` - sole block producer (cardano-node 10.5.4)
+- `dingo-archive` - Dingo with `blobPlugin: s3`, Bark server on port 3003
+- `dingo-pruning` - Dingo with `blobPlugin: badger`,
+  `barkBaseUrl` pointing at `dingo-archive`,
+  `barkPrunerFrequency: 5s`. The security window is derived from the
+  ledger's stability window (3k/f = 300 slots for testnet.yaml).
+- `minio` - S3-compatible blob storage; bucket `dingo-archive`
+
+## Usage
+
+```
+./demo.sh          # operator-facing guided demo (~5 min, prints periodic stats)
+./start.sh         # just bring the stack up
+./run-tests.sh     # run integration tests (build tag archive_demo)
+./stop.sh          # tear down
+```
+
+`demo.sh` is the right entry point for showing this off. It builds the
+helper binary, brings the stack up, prints a stats line every 10 seconds
+(chain tip, Minio object count, local Badger size, pruner activity), and
+once the chain has crossed the security window it runs a scripted
+BlockFetch from outside the stack against a pre-window block on the
+pruning node and prints the byte count and timing.
+
+## What it shows
+
+The demo and the integration test exercise the same three claims about a
+block at slot ~50, well behind the 300-slot stability window:
+
+1. Returned successfully when BlockFetched from `dingo-pruning` (the
+   bark proxy fetches it from the archive on the fly).
+2. Absent from `dingo-pruning`'s local Badger blob store (the pruner
+   really did delete it).
+3. Present in the Minio `dingo-archive` bucket (the archive holds the
+   only copy).
+
+`demo.sh` makes claims 2 and 3 visible as a live stats stream, then runs
+a scripted BlockFetch and prints the byte count and timing for claim 1.
+`run-tests.sh` asserts all three programmatically and exits non-zero if
+any fail.
+
+
+## Ports
+
+| Component | Default host port | Env override |
+|---|---|---|
+| cardano-producer NtN | 3110 | `ARCHIVEDEMO_CARDANO_PORT` |
+| dingo-archive NtN    | 3111 | `ARCHIVEDEMO_DINGO_ARCHIVE_PORT` |
+| dingo-archive Bark   | 3112 | `ARCHIVEDEMO_BARK_PORT` |
+| dingo-pruning NtN    | 3113 | `ARCHIVEDEMO_DINGO_PRUNING_PORT` |
+| Minio API            | 9100 | `ARCHIVEDEMO_MINIO_PORT` |
+| Minio console        | 9101 | `ARCHIVEDEMO_MINIO_CONSOLE_PORT` |
+
+Minio credentials: `demo` / `demodemo`.
+
+## Implementation notes
+
+- `tmp/dingo-pruning-data` is a host bind mount. The integration test
+  stops the dingo-pruning container before opening that directory with
+  the `inspect-blob` helper (Badger is single-writer, so the container
+  must release the lockfile first).
+- `cmd/inspect-blob/` is a small Go binary that imports Dingo's blob
+  plugin and reports whether a (slot, hash) pair is present in a Badger
+  store. `run-tests.sh` builds it on demand.
+- The pruner's run frequency is configurable via `barkPrunerFrequency`
+  in `dingo.yaml` or the `DINGO_BARK_PRUNER_FREQUENCY` env var. Default
+  is 1 hour; the demo uses 5 seconds.

--- a/internal/test/archive-demo/cmd/demo-fetch/main.go
+++ b/internal/test/archive-demo/cmd/demo-fetch/main.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// demo-fetch is a small CLI used by the archive-demo's demo.sh to make
+// the BlockFetch step of the demo visible: it connects to a Dingo NtN
+// endpoint, ChainSync-walks from origin to find a block at or past a
+// requested slot, then BlockFetches that block and reports the byte
+// count and elapsed time.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/archive-demo/internal/archivedemo"
+)
+
+func main() {
+	addr := flag.String("addr", "localhost:3113", "Dingo NtN address (host:port)")
+	name := flag.String("name", "dingo-pruning", "endpoint name shown in log lines")
+	magic := flag.Uint("magic", uint(archivedemo.DefaultNetworkMagic), "network magic")
+	slot := flag.Uint64("slot", 50, "fetch the first block at or after this slot")
+	resolveAddr := flag.String("resolve-addr", "localhost:3111", "endpoint used to resolve the target block hash (typically the archive node)")
+	resolveName := flag.String("resolve-name", "dingo-archive", "name for the resolve endpoint")
+	timeout := flag.Duration("timeout", 60*time.Second, "per-step timeout")
+	flag.Parse()
+
+	logf := func(format string, args ...any) {
+		fmt.Fprintf(os.Stderr, "[demo-fetch] "+format+"\n", args...)
+	}
+
+	if *magic > math.MaxUint32 {
+		fmt.Fprintf(os.Stderr, "FAIL: network magic %d exceeds uint32 max\n", *magic)
+		os.Exit(1)
+	}
+	magic32 := uint32(*magic) // #nosec G115 -- bounds checked above
+
+	resolve := archivedemo.Endpoint{Name: *resolveName, Address: *resolveAddr}
+	target := archivedemo.Endpoint{Name: *name, Address: *addr}
+
+	logf("resolving block at/after slot %d via %s...", *slot, resolve.Name)
+	t0 := time.Now()
+	point, err := archivedemo.FindBlockAtOrAfterSlot(
+		resolve, magic32, *slot, *timeout, logf,
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
+		os.Exit(1)
+	}
+	logf("resolved: slot=%d hash=%x (took %s)", point.Slot, point.Hash, time.Since(t0).Round(time.Millisecond))
+
+	logf("BlockFetch from %s for slot %d...", target.Name, point.Slot)
+	t1 := time.Now()
+	cbor, err := archivedemo.FetchBlock(target, magic32, point, *timeout)
+	elapsed := time.Since(t1).Round(time.Millisecond)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL after %s: %v\n", elapsed, err)
+		os.Exit(2)
+	}
+
+	fmt.Printf("OK: fetched %d bytes from %s in %s (slot=%d)\n",
+		len(cbor), target.Name, elapsed, point.Slot)
+}

--- a/internal/test/archive-demo/cmd/inspect-blob/main.go
+++ b/internal/test/archive-demo/cmd/inspect-blob/main.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// inspect-blob is a CLI used by the archive-demo integration test to
+// verify whether a block (slot, hash) is present in a Dingo node's
+// local Badger blob store. It exits 0 if present, 1 if absent, 2 on
+// any other error.
+//
+// The Dingo container running the blob store must be stopped before
+// invoking this tool (Badger is a single-writer database).
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/plugin"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+)
+
+func main() {
+	dir := flag.String("dir", "", "path to badger blob data directory")
+	slot := flag.Uint64("slot", 0, "block slot")
+	hashHex := flag.String("hash", "", "block hash (hex)")
+	flag.Parse()
+
+	if *dir == "" || *hashHex == "" {
+		fmt.Fprintln(
+			os.Stderr,
+			"usage: inspect-blob -dir DIR -slot N -hash HEX",
+		)
+		os.Exit(2)
+	}
+	hash, err := hex.DecodeString(*hashHex)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bad hash: %v\n", err)
+		os.Exit(2)
+	}
+
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob, "badger", "data-dir", *dir,
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "set data-dir: %v\n", err)
+		os.Exit(2)
+	}
+	// Run badger in API storage mode so we don't trip over core-mode
+	// mmap defaults that assume the dingo node owns the process.
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob, "badger", "storage-mode", "api",
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "set storage-mode: %v\n", err)
+		os.Exit(2)
+	}
+
+	store, err := blob.New("badger")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open badger: %v\n", err)
+		os.Exit(2)
+	}
+	defer func() { _ = store.Close() }()
+
+	txn := store.NewTransaction(false)
+	defer func() { _ = txn.Rollback() }()
+
+	cbor, _, err := store.GetBlock(txn, *slot, hash)
+	switch {
+	case err == nil && len(cbor) > 0:
+		fmt.Printf("present: slot=%d hash=%s bytes=%d\n", *slot, *hashHex, len(cbor))
+		os.Exit(0)
+	case err == nil:
+		fmt.Println("absent: nil cbor")
+		os.Exit(1)
+	case isNotFound(err):
+		fmt.Printf("absent: %v\n", err)
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stderr, "lookup error: %v\n", err)
+		os.Exit(2)
+	}
+}
+
+// isNotFound treats both "not found" and "tombstoned" errors as the
+// locally-absent case. A tombstone means the bp value has been replaced
+// with a small marker so the bark proxy can resolve the block remotely;
+// from the perspective of "is the real CBOR stored locally?" the answer
+// is no, same as a hard delete.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "errkeynotfound") ||
+		strings.Contains(msg, "tombstoned")
+}

--- a/internal/test/archive-demo/configs/dingo-archive.yaml
+++ b/internal/test/archive-demo/configs/dingo-archive.yaml
@@ -1,0 +1,11 @@
+# Archive node config: store all blobs in Minio (S3-compatible),
+# serve historical blocks via Bark gRPC on port 3003.
+# Network parameters come from env vars (see docker-compose.yml).
+database:
+  blob:
+    plugin: s3
+    s3:
+      endpoint: http://minio:9000
+      bucket: dingo-archive
+      region: us-east-1
+barkPort: 3003

--- a/internal/test/archive-demo/configs/dingo-pruning.yaml
+++ b/internal/test/archive-demo/configs/dingo-pruning.yaml
@@ -1,0 +1,7 @@
+# Pruning node config: local Badger blob store. The pruner runs every 5s
+# and deletes blocks beyond the chain stability window (derived by Dingo
+# from genesis: 3k/f, which is 300 slots for testnet.yaml). When asked
+# for a pre-window block, the BarkBlobStore wrapper transparently fetches
+# it from the archive node.
+barkBaseUrl: http://dingo-archive:3003
+barkPrunerFrequency: 5s

--- a/internal/test/archive-demo/configurator.sh
+++ b/internal/test/archive-demo/configurator.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UTXO_HD_WITH="mem"
+
+# Log file
+
+# Implement sponge-like command without the need for binary nor TMPDIR environment variable
+write_file() {
+    local target="${1}"
+    local tmp_file
+    tmp_file="$(mktemp "${target}.XXXXXXXX")"
+
+    # Redirect the output to the temporary file
+    cat >"${tmp_file}"
+
+    # mktemp creates files at 0600. Preserve the target's original mode so
+    # consumers running as non-root (e.g., the dingo image's uid 100) can
+    # still read the rewritten file.
+    if [[ -e "${target}" ]]; then
+        chmod --reference="${target}" "${tmp_file}"
+    fi
+
+    # Replace the original file
+    mv --force "${tmp_file}" "${target}"
+}
+
+# Updates specific node's configuration depending on environment variables
+# Those environment variables can be set in the service definition in the
+# docker-compose file like:
+#
+# ```
+# p2:
+#   <<: *base
+#   container_name: p2
+#   hostname: p2.example
+#   volumes:
+#     - p2:/opt/cardano-node/data
+#   ports:
+#     - "3002:3001"
+#   environment:
+#     <<: *env
+#     POOL_ID: "2"
+#     PEER_SHARING: "false"
+# ```
+config_config_json() {
+    PEER_SHARING="${PEER_SHARING:-true}"
+    CONFIG_JSON=$1/configs/config.json
+    # .AlonzoGenesisHash, .ByronGenesisHash, .ConwayGenesisHash, .ShelleyGenesisHash
+    jq "del(.AlonzoGenesisHash, .ByronGenesisHash, .ConwayGenesisHash, .ShelleyGenesisHash)" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+
+    # .hasEKG
+    jq "del(.hasEKG)" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+
+    # .options.mapBackends
+    jq "del(.options.mapBackends)" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+
+    # .PeerSharing
+    if [ "${PEER_SHARING,,}" = "true" ]; then
+        jq ".PeerSharing = true" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+    else
+        jq ".PeerSharing = false" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+    fi
+
+    # configure UTxO-HD
+    # see https://ouroboros-consensus.cardano.intersectmbo.org/docs/for-developers/utxo-hd/migrating
+    # FIXME: /state needs to match the --database-path in the
+    # node's command
+    # FIXME: We want to be able to configure this for each node separately
+    # FIXME: Btw also think about how to have a nice abstraction for generating
+    # the configs
+    # One alternative is:
+    # UTXO_HD_WITH: "hd hd hd mem mem mem"
+    case "${UTXO_HD_WITH,,}" in
+        hd)
+            jq ".LedgerDB = { Backend: \"V1LMDB\", LiveTablesPath: \"/state/lmdb\"}" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+            ;;
+        *)
+            jq '.LedgerDB = { Backend: "V2InMemory"}' "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
+            ;;
+    esac
+}
+
+config_topology_json() {
+    # Generate a ring topology, where pool_n is connected to pool_{n-1} and pool_{n+1}
+
+    VALENCY=2
+
+    local num_pools=$1
+    local i prev next
+
+    for ((i=1; i<=num_pools; i++)); do
+        prev=$((i - 1))
+        if [ $prev -eq 0 ]; then
+            prev=$num_pools
+        fi
+
+        next=$((i + 1))
+        if [ $next -gt $num_pools ]; then
+            next=1
+        fi
+
+        cat <<EOF > "/configs/$i/configs/topology.json"
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "p${prev}.example", "port": 3001},
+        {"address": "p${next}.example", "port": 3001}
+      ],
+    "advertise": true,
+    "trustable": true,
+    "valency": ${VALENCY}
+    }
+  ],
+    "publicRoots": [],
+    "useLedgerAfterSlot": 0
+}
+EOF
+    done
+}
+
+compute_start_time() {
+    # Set system start to now + 30s to give Docker time to start node
+    # containers after the configurator exits.
+    # genesis-cli.py's systemStartDelay (5s) is too short because key
+    # generation takes 30+ seconds, so we override after generation.
+    SYSTEM_START_UNIX=$(( $(date +%s) + 30 ))
+    SYSTEM_START_ISO="$(date -d @${SYSTEM_START_UNIX} -u '+%Y-%m-%dT%H:%M:%SZ')"
+}
+
+set_start_time() {
+    # Apply the pre-computed start time to a pool's genesis files.
+    # Must call compute_start_time first.
+    SHELLEY_GENESIS_JSON="$1/configs/shelley-genesis.json"
+    BYRON_GENESIS_JSON="$1/configs/byron-genesis.json"
+
+    # .systemStart
+    jq ".systemStart = \"${SYSTEM_START_ISO}\"" "${SHELLEY_GENESIS_JSON}" | write_file "${SHELLEY_GENESIS_JSON}"
+
+    # .startTime
+    jq ".startTime = ${SYSTEM_START_UNIX}" "${BYRON_GENESIS_JSON}" | write_file "${BYRON_GENESIS_JSON}"
+}
+
+
+# # Copy testnet.yaml specification
+cp /testnet.yaml ./testnet.yaml
+
+# # Build testnet configuration files
+uv run python3 genesis-cli.py testnet.yaml -o /tmp/testnet -c generate
+
+# # Remove dynamic topology.json
+find /tmp/testnet -type f -name 'topology.json' -exec rm -f '{}' ';'
+
+mkdir -p /configs
+cp -r /tmp/testnet/pools/* /configs
+cp -r /tmp/testnet/utxos/* /configs
+
+echo "removing /configs/keys"; rm -rf /configs/keys
+
+pools=$(ls -d /configs/[0-9]* 2>/dev/null)
+number_of_pools=$(echo "$pools" | grep -c '^/' || true)
+echo "number_of_pools: $number_of_pools"
+
+# Generate ring topology for all pools (writes all files in one pass)
+config_topology_json "$number_of_pools"
+
+# Override system start time AFTER key generation completes.
+# genesis-cli.py's systemStartDelay (5s) is too short because key generation
+# takes 30+ seconds. Set genesis to now + 30s to give Docker time to start
+# the node containers after the configurator exits.
+compute_start_time
+echo "system start: ${SYSTEM_START_ISO} (unix: ${SYSTEM_START_UNIX})"
+
+for pool in $pools; do
+  echo "pool: $pool"
+  set_start_time "$pool"
+  config_config_json "$pool"
+done

--- a/internal/test/archive-demo/demo.sh
+++ b/internal/test/archive-demo/demo.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Operator-facing guided demo of the archive-node + pruning-node + bark
+# proxy story. Stands the stack up, narrates chain growth and pruner
+# activity, then shows a live BlockFetch from outside the stack against
+# a block that has already been pruned locally.
+#
+# Usage:
+#   ./demo.sh             # full guided demo
+#   ./demo.sh --keep-up   # leave stack running on success
+#
+# What you should see:
+#   1. Stack comes up (Minio + cardano-producer + dingo-archive + dingo-pruning).
+#   2. Chain advances; both Dingo nodes track it.
+#   3. Minio bucket fills with block CBOR objects as the archive node writes.
+#   4. Pruner kicks in once tip is past the stability window (3k/f = 300
+#      slots for testnet.yaml); local Badger blob count drops.
+#   5. demo-fetch BlockFetches a block at slot ~50 from the pruning node
+#      and prints "OK: fetched X bytes from dingo-pruning in Yms" once the
+#      bark proxy returns the block from the archive.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+PRUNING_DATA_DIR="${SCRIPT_DIR}/tmp/dingo-pruning-data"
+
+# Mirror Compose's .env handling so port overrides set there reach the bash
+# side (host-port references like demo-fetch's --addr). Without this, .env-only
+# overrides take effect for `docker compose up` but not for our localhost
+# clients, leaving them aimed at the default ports.
+if [[ -f "${SCRIPT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/.env"
+  set +a
+fi
+
+# LAN address used for the Minio console URL we print to the operator. We pick
+# the source IP for the default route so a viewer on another machine can open
+# the link; falls back to localhost if detection fails.
+ARCHIVEDEMO_HOST="${ARCHIVEDEMO_HOST:-$(ip route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}')}"
+ARCHIVEDEMO_HOST="${ARCHIVEDEMO_HOST:-localhost}"
+
+KEEP_UP=false
+for arg in "$@"; do
+  case "${arg}" in
+    --keep-up) KEEP_UP=true ;;
+    *)         echo "unknown arg: ${arg}" >&2; exit 2 ;;
+  esac
+done
+
+say()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+note() { printf '   %s\n' "$*"; }
+die()  { echo "[demo] ERROR: $*" >&2; exit 1; }
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "${DEMO_BIN_DIR:-}" ]] && [[ -d "${DEMO_BIN_DIR}" ]]; then
+    rm -rf "${DEMO_BIN_DIR}"
+  fi
+  if [[ "${KEEP_UP}" == "true" ]] && [[ ${exit_code} -eq 0 ]]; then
+    say "Demo finished. Stack left running (--keep-up)."
+    note "Minio console:  http://${ARCHIVEDEMO_HOST}:${ARCHIVEDEMO_MINIO_CONSOLE_PORT:-9101} (demo / demodemo)"
+    note "Stop:           ${SCRIPT_DIR}/stop.sh"
+    return
+  fi
+  say "Tearing down..."
+  docker compose -f "${COMPOSE_FILE}" down -v 2>/dev/null || true
+  # The pruning data dir is bind-mounted into a container that runs as uid
+  # 100, so files inside may be unreadable to the host user. Wipe via a
+  # one-shot container before letting the host rm finish the parent.
+  if [[ -d "${SCRIPT_DIR}/tmp" ]]; then
+    docker run --rm -v "${SCRIPT_DIR}/tmp":/cleanup alpine \
+      sh -c 'rm -rf /cleanup/* /cleanup/.[!.]* 2>/dev/null || true' \
+      >/dev/null 2>&1 || true
+    rm -rf "${SCRIPT_DIR}/tmp" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+command -v docker >/dev/null || die "docker is not installed"
+command -v go     >/dev/null || die "go is not installed"
+
+# ---------------------------------------------------------------------------
+# Build helpers (demo-fetch lives under cmd/, separate from the test).
+# ---------------------------------------------------------------------------
+say "Building demo-fetch helper..."
+DEMO_BIN_DIR="$(mktemp -d)"
+DEMO_FETCH="${DEMO_BIN_DIR}/demo-fetch"
+( cd "${PROJECT_ROOT}" && go build -o "${DEMO_FETCH}" ./internal/test/archive-demo/cmd/demo-fetch )
+note "built: ${DEMO_FETCH}"
+
+# ---------------------------------------------------------------------------
+# Bring the stack up.
+# ---------------------------------------------------------------------------
+say "Starting archive-demo stack..."
+mkdir -p "${PRUNING_DATA_DIR}"
+chmod 777 "${PRUNING_DATA_DIR}"
+docker compose -f "${COMPOSE_FILE}" up -d --build >/dev/null
+
+note "Waiting for dingo-pruning to become healthy..."
+deadline=$(( $(date +%s) + 240 ))
+while true; do
+  status="$(docker inspect -f '{{.State.Health.Status}}' archivedemo-dingo-pruning 2>/dev/null || echo missing)"
+  if [[ "${status}" == "healthy" ]]; then
+    break
+  fi
+  if [[ $(date +%s) -ge ${deadline} ]]; then
+    die "dingo-pruning did not become healthy (last status: ${status})"
+  fi
+  sleep 3
+done
+note "All four services healthy."
+note "Minio console: http://${ARCHIVEDEMO_HOST}:${ARCHIVEDEMO_MINIO_CONSOLE_PORT:-9101} (demo / demodemo)"
+
+# Configure mc once so subsequent ls calls work cheaply.
+docker exec archivedemo-minio mc alias set local http://localhost:9000 demo demodemo >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+# Helpers for periodic stats.
+# ---------------------------------------------------------------------------
+last_tip_slot() {
+  docker logs archivedemo-dingo-pruning 2>&1 \
+    | grep -o 'chain extended, new tip: [0-9a-f]\+ at slot [0-9]\+' \
+    | tail -1 \
+    | grep -o '[0-9]\+$'
+}
+
+minio_object_count() {
+  docker exec archivedemo-minio mc ls --recursive local/dingo-archive 2>/dev/null | wc -l
+}
+
+minio_block_objects() {
+  # Block CBOR keys begin with "bp" which is hex-encoded as "6270".
+  docker exec archivedemo-minio mc ls --recursive local/dingo-archive 2>/dev/null \
+    | awk '{print $NF}' | grep -c '^6270' || true
+}
+
+badger_blob_size() {
+  # Query inside the container; the bind-mounted host path contains files
+  # owned by the container's dingo uid (100), which the host user usually
+  # can't read.
+  docker exec archivedemo-dingo-pruning du -sh /data/db/blob 2>/dev/null \
+    | awk '{print $1}' || echo "?"
+}
+
+pruner_rounds() {
+  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'completed round of pruning' || true
+}
+
+pruner_skipped() {
+  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'skipped because current slot is not high enough' || true
+}
+
+# ---------------------------------------------------------------------------
+# Watch the system grow: print a stats line every 10s until tip clears the
+# security window and the pruner has had time to act on slot ~50.
+# ---------------------------------------------------------------------------
+say "Watching chain grow and pruner act..."
+note "Stability window: 300 slots (3k/f from testnet.yaml). Target: tip >= 400 (pruner will have removed slots 0..99)."
+TARGET_TIP=400
+deadline=$(( $(date +%s) + 600 ))
+prev_pruner=0
+while true; do
+  tip="$(last_tip_slot 2>/dev/null || true)"
+  tip="${tip:-0}"
+  obj_total=$(minio_object_count)
+  obj_bp=$(minio_block_objects)
+  badger=$(badger_blob_size)
+  rounds=$(pruner_rounds)
+  delta=$(( rounds - prev_pruner ))
+  prev_pruner=${rounds}
+
+  printf '   tip=%-4s  minio_objects=%-5s  minio_block_cbor=%-4s  pruning_node_blob=%-7s  pruner_rounds=%s (+%d)\n' \
+    "${tip}" "${obj_total}" "${obj_bp}" "${badger}" "${rounds}" "${delta}"
+
+  if [[ ${tip} -ge ${TARGET_TIP} ]]; then
+    break
+  fi
+  if [[ $(date +%s) -ge ${deadline} ]]; then
+    die "chain did not reach slot ${TARGET_TIP} within timeout"
+  fi
+  sleep 10
+done
+
+note "Tip is past the security window. Pruner has run $(pruner_rounds) rounds."
+
+# ---------------------------------------------------------------------------
+# BlockFetch a block well behind the security window. Show timing.
+# ---------------------------------------------------------------------------
+say "BlockFetch test: requesting a block at slot ~50 from dingo-pruning"
+note "  slot 50 is ~350 slots behind the current tip (well past the 300-slot window)"
+note "  it has been deleted from dingo-pruning's local Badger"
+note "  if the bark proxy is wired correctly, dingo-pruning fetches it from the archive"
+note ""
+note "Running demo-fetch (timeout 60s)..."
+echo
+set +e
+"${DEMO_FETCH}" \
+  --addr "localhost:${ARCHIVEDEMO_DINGO_PRUNING_PORT:-3113}" \
+  --name dingo-pruning \
+  --resolve-addr "localhost:${ARCHIVEDEMO_DINGO_ARCHIVE_PORT:-3111}" \
+  --resolve-name dingo-archive \
+  --slot 50 \
+  --timeout 60s
+fetch_exit=$?
+set -e
+echo
+
+case "${fetch_exit}" in
+  0)
+    say "Demo complete: transparent proxy via bark works end to end."
+    ;;
+  *)
+    die "demo-fetch failed (exit ${fetch_exit}); see logs above"
+    ;;
+esac

--- a/internal/test/archive-demo/docker-compose.yml
+++ b/internal/test/archive-demo/docker-compose.yml
@@ -1,0 +1,229 @@
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Archive node demo Docker Compose configuration.
+#
+# Mirrors internal/test/devnet/ in shape but exercises the S3 blob plugin,
+# Bark archive server, and Bark client + pruner together.
+#
+# Services:
+#   configurator     - one-shot, generates pool keys and genesis files
+#   minio            - S3-compatible blob storage
+#   minio-init       - one-shot, creates the "dingo-archive" bucket
+#   cardano-producer - sole block producer (cardano-node 10.5.4)
+#   dingo-archive    - non-producer; S3 blob plugin + Bark server :3002
+#   dingo-pruning    - non-producer; Badger blob plugin + Bark client
+#                      pointed at dingo-archive
+#
+# Usage:
+#   ./start.sh         # bring up
+#   ./run-tests.sh     # run integration tests (build tag archive_demo)
+#   ./stop.sh          # tear down
+#
+# Host port overrides (set in env or .env):
+#   ARCHIVEDEMO_CARDANO_PORT          (default: 3110)
+#   ARCHIVEDEMO_DINGO_ARCHIVE_PORT    (default: 3111)
+#   ARCHIVEDEMO_BARK_PORT             (default: 3112)
+#   ARCHIVEDEMO_DINGO_PRUNING_PORT    (default: 3113)
+#   ARCHIVEDEMO_MINIO_PORT            (default: 9100)
+#   ARCHIVEDEMO_MINIO_CONSOLE_PORT    (default: 9101)
+
+services:
+  configurator:
+    build:
+      context: .
+      dockerfile: Dockerfile.configurator
+    container_name: archivedemo-configurator
+    volumes:
+      - ./testnet.yaml:/testnet.yaml
+      - p1-configs:/configs/1
+      - utxo-keys:/configs/utxo-keys
+
+  minio:
+    image: minio/minio:latest
+    container_name: archivedemo-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: demo
+      MINIO_ROOT_PASSWORD: demodemo
+    volumes:
+      - minio-data:/data
+    networks:
+      devnet:
+        ipv4_address: 172.21.0.13
+    ports:
+      - "${ARCHIVEDEMO_MINIO_PORT:-9100}:9000"
+      - "${ARCHIVEDEMO_MINIO_CONSOLE_PORT:-9101}:9001"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/ready || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+  minio-init:
+    image: minio/mc:latest
+    container_name: archivedemo-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        mc alias set local http://minio:9000 demo demodemo && \
+        mc mb --ignore-existing local/dingo-archive && \
+        echo "bucket ready"
+    networks:
+      devnet:
+        ipv4_address: 172.21.0.14
+
+  cardano-producer:
+    image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+    container_name: archivedemo-cardano-producer
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    environment:
+      CARDANO_BLOCK_PRODUCER: "true"
+      RESTORE_SNAPSHOT: "false"
+    command:
+      - "run"
+      - "--config"
+      - "/configs/configs/config.json"
+      - "--topology"
+      - "/topology/topology.json"
+      - "--database-path"
+      - "/data/db"
+      - "--socket-path"
+      - "/ipc/node.socket"
+      - "--shelley-kes-key"
+      - "/configs/keys/kes.skey"
+      - "--shelley-vrf-key"
+      - "/configs/keys/vrf.skey"
+      - "--shelley-operational-certificate"
+      - "/configs/keys/opcert.cert"
+      - "--port"
+      - "3001"
+    volumes:
+      - p1-configs:/configs
+      - ./topology/cardano-producer.json:/topology/topology.json:ro
+      - cardano-producer-data:/data/db
+      - cardano-producer-ipc:/ipc
+    ports:
+      - "${ARCHIVEDEMO_CARDANO_PORT:-3110}:3001"
+    networks:
+      devnet:
+        ipv4_address: 172.21.0.10
+    healthcheck:
+      test: ["CMD-SHELL", "test -S /ipc/node.socket || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  dingo-archive:
+    build:
+      context: ../../..
+    container_name: archivedemo-dingo-archive
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+      minio-init:
+        condition: service_completed_successfully
+      cardano-producer:
+        condition: service_healthy
+    command:
+      - "--config"
+      - "/etc/dingo/dingo.yaml"
+    environment:
+      CARDANO_NETWORK: devnet
+      CARDANO_CONFIG: /configs/configs/config.json
+      CARDANO_TOPOLOGY: /topology/topology.json
+      CARDANO_DATABASE_PATH: /data/db
+      CARDANO_NODE_SOCKET_PATH: /ipc/dingo.socket
+      DINGO_DEBUG: "1"
+      AWS_ACCESS_KEY_ID: demo
+      AWS_SECRET_ACCESS_KEY: demodemo
+      AWS_REGION: us-east-1
+    volumes:
+      - p1-configs:/configs:ro
+      - ./topology/dingo-archive.json:/topology/topology.json:ro
+      - ./configs/dingo-archive.yaml:/etc/dingo/dingo.yaml:ro
+      - dingo-archive-data:/data/db
+      - dingo-archive-ipc:/ipc
+    ports:
+      - "${ARCHIVEDEMO_DINGO_ARCHIVE_PORT:-3111}:3001"
+      - "${ARCHIVEDEMO_BARK_PORT:-3112}:3003"
+    networks:
+      devnet:
+        ipv4_address: 172.21.0.11
+    healthcheck:
+      test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 15s
+
+  dingo-pruning:
+    build:
+      context: ../../..
+    container_name: archivedemo-dingo-pruning
+    depends_on:
+      dingo-archive:
+        condition: service_healthy
+    command:
+      - "--config"
+      - "/etc/dingo/dingo.yaml"
+    environment:
+      CARDANO_NETWORK: devnet
+      CARDANO_CONFIG: /configs/configs/config.json
+      CARDANO_TOPOLOGY: /topology/topology.json
+      CARDANO_DATABASE_PATH: /data/db
+      CARDANO_NODE_SOCKET_PATH: /ipc/dingo.socket
+      DINGO_DEBUG: "1"
+    volumes:
+      - p1-configs:/configs:ro
+      - ./topology/dingo-pruning.json:/topology/topology.json:ro
+      - ./configs/dingo-pruning.yaml:/etc/dingo/dingo.yaml:ro
+      - ./tmp/dingo-pruning-data:/data/db
+      - dingo-pruning-ipc:/ipc
+    ports:
+      - "${ARCHIVEDEMO_DINGO_PRUNING_PORT:-3113}:3001"
+    networks:
+      devnet:
+        ipv4_address: 172.21.0.12
+    healthcheck:
+      test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 15s
+
+networks:
+  devnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.21.0.0/24
+
+volumes:
+  p1-configs:
+  utxo-keys:
+  minio-data:
+  cardano-producer-data:
+  cardano-producer-ipc:
+  dingo-archive-data:
+  dingo-archive-ipc:
+  dingo-pruning-ipc:

--- a/internal/test/archive-demo/internal/archivedemo/harness.go
+++ b/internal/test/archive-demo/internal/archivedemo/harness.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package archivedemo provides shared helpers for the archive-node demo
+// at internal/test/archive-demo/. The integration test (under build tag
+// archive_demo) and the demo-fetch CLI both consume it.
+package archivedemo
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	gcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// DefaultNetworkMagic matches the value baked into testnet.yaml.
+const DefaultNetworkMagic uint32 = 42
+
+// Endpoint is a named TCP target speaking Ouroboros NtN.
+type Endpoint struct {
+	Name    string
+	Address string
+}
+
+// DefaultEndpoints returns the archive and pruning Dingo endpoints,
+// honoring env overrides for CI flexibility.
+func DefaultEndpoints() (archive, pruning Endpoint) {
+	arch := os.Getenv("ARCHIVEDEMO_DINGO_ARCHIVE_ADDR")
+	if arch == "" {
+		arch = "localhost:3111"
+	}
+	prn := os.Getenv("ARCHIVEDEMO_DINGO_PRUNING_ADDR")
+	if prn == "" {
+		prn = "localhost:3113"
+	}
+	return Endpoint{Name: "dingo-archive", Address: arch},
+		Endpoint{Name: "dingo-pruning", Address: prn}
+}
+
+// Tip is a small subset of gouroboros' chainsync.Tip used by the harness.
+type Tip struct {
+	Slot  uint64
+	Block uint64
+	Hash  []byte
+}
+
+// Logger is a minimal printf-style logger callers can plug in. Both
+// testing.T.Logf and a stdlib log helper satisfy this signature.
+type Logger func(format string, args ...any)
+
+// dial opens an Ouroboros NtN connection to ep with optional extra config.
+// The caller is responsible for Close().
+func dial(ep Endpoint, magic uint32, extra ...ouroboros.ConnectionOptionFunc) (*ouroboros.Connection, error) {
+	conn, err := net.DialTimeout("tcp", ep.Address, 10*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", ep.Name, err)
+	}
+	opts := append([]ouroboros.ConnectionOptionFunc{
+		ouroboros.WithConnection(conn),
+		ouroboros.WithNetworkMagic(magic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(true),
+	}, extra...)
+	oConn, err := ouroboros.NewConnection(opts...)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("ouroboros %s: %w", ep.Name, err)
+	}
+	return oConn, nil
+}
+
+// GetTip returns the current chain tip as reported by ep over a fresh
+// connection. cardano-node only updates the tip on a new connection, so
+// callers should not cache the connection.
+func GetTip(ep Endpoint, magic uint32) (Tip, error) {
+	oc, err := dial(ep, magic)
+	if err != nil {
+		return Tip{}, err
+	}
+	defer oc.Close()
+	tip, err := oc.ChainSync().Client.GetCurrentTip()
+	if err != nil {
+		return Tip{}, fmt.Errorf("tip from %s: %w", ep.Name, err)
+	}
+	return Tip{
+		Slot:  tip.Point.Slot,
+		Block: tip.BlockNumber,
+		Hash:  tip.Point.Hash,
+	}, nil
+}
+
+// WaitForSlot polls ep until its tip slot reaches target or timeout fires.
+// Returns the final observed tip and an error on timeout.
+func WaitForSlot(ep Endpoint, magic uint32, target uint64, timeout time.Duration, log Logger) (Tip, error) {
+	deadline := time.Now().Add(timeout)
+	var last Tip
+	for {
+		tip, err := GetTip(ep, magic)
+		if err == nil {
+			last = tip
+			if log != nil {
+				log("WaitForSlot %s: slot=%d block=%d", ep.Name, tip.Slot, tip.Block)
+			}
+			if tip.Slot >= target {
+				return tip, nil
+			}
+		} else if log != nil {
+			log("WaitForSlot %s: %v", ep.Name, err)
+		}
+		if time.Now().After(deadline) {
+			return last, fmt.Errorf("%s did not reach slot %d within %s", ep.Name, target, timeout)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// FindBlockAtOrAfterSlot ChainSync-walks ep from origin and returns the
+// first block point whose slot is >= targetSlot.
+func FindBlockAtOrAfterSlot(
+	ep Endpoint,
+	magic uint32,
+	targetSlot uint64,
+	timeout time.Duration,
+	log Logger,
+) (pcommon.Point, error) {
+	var (
+		mu        sync.Mutex
+		found     pcommon.Point
+		foundOnce sync.Once
+		done      = make(chan struct{})
+	)
+
+	rollForward := func(_ chainsync.CallbackContext, blockType uint, blockOrHeader any, _ chainsync.Tip) error {
+		hdr, ok := blockOrHeader.(gcommon.BlockHeader)
+		if !ok {
+			if log != nil {
+				log("FindBlockAtOrAfterSlot: roll-forward got %T (blockType=%d), expected BlockHeader", blockOrHeader, blockType)
+			}
+			return nil
+		}
+		if hdr.SlotNumber() < targetSlot {
+			return nil
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		foundOnce.Do(func() {
+			found = pcommon.Point{
+				Slot: hdr.SlotNumber(),
+				Hash: hdr.Hash().Bytes(),
+			}
+			close(done)
+		})
+		return errors.New("archivedemo: target reached")
+	}
+
+	rollBackward := func(_ chainsync.CallbackContext, _ pcommon.Point, _ chainsync.Tip) error {
+		// Server sends RollBackward to origin on Sync, before any
+		// RollForward. We don't care; just acknowledge.
+		return nil
+	}
+
+	cfg := chainsync.NewConfig(
+		chainsync.WithRollForwardFunc(rollForward),
+		chainsync.WithRollBackwardFunc(rollBackward),
+	)
+	oc, err := dial(ep, magic, ouroboros.WithChainSyncConfig(cfg))
+	if err != nil {
+		return pcommon.Point{}, fmt.Errorf("dial %s: %w", ep.Name, err)
+	}
+	defer oc.Close()
+
+	// Origin point tells the peer to start streaming from genesis on the
+	// first roll-forward.
+	syncErr := make(chan error, 1)
+	go func() {
+		if err := oc.ChainSync().Client.Sync([]pcommon.Point{pcommon.NewPointOrigin()}); err != nil {
+			syncErr <- err
+		}
+	}()
+
+	select {
+	case <-done:
+		return found, nil
+	case err := <-syncErr:
+		// rollForward returns a sentinel error to stop streaming once
+		// we have a match; treat that as success.
+		select {
+		case <-done:
+			return found, nil
+		default:
+		}
+		return pcommon.Point{}, fmt.Errorf("chainsync %s: %w", ep.Name, err)
+	case <-time.After(timeout):
+		return pcommon.Point{}, fmt.Errorf("FindBlockAtOrAfterSlot: did not find block at/after slot %d on %s within %s",
+			targetSlot, ep.Name, timeout)
+	}
+}
+
+// FetchBlock issues BlockFetch for the given point on ep and returns the
+// raw block CBOR. Returns an error if BlockFetch fails or no block is
+// delivered before the timeout.
+func FetchBlock(
+	ep Endpoint,
+	magic uint32,
+	point pcommon.Point,
+	timeout time.Duration,
+) ([]byte, error) {
+	var (
+		mu       sync.Mutex
+		gotCbor  []byte
+		gotBlock = make(chan struct{}, 1)
+		batch    = make(chan struct{}, 1)
+	)
+	blockFunc := func(_ blockfetch.CallbackContext, _ uint, b gledger.Block) error {
+		mu.Lock()
+		gotCbor = b.Cbor()
+		mu.Unlock()
+		select {
+		case gotBlock <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+	batchDone := func(_ blockfetch.CallbackContext) error {
+		select {
+		case batch <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	cfg := blockfetch.NewConfig(
+		blockfetch.WithBlockFunc(blockFunc),
+		blockfetch.WithBatchDoneFunc(batchDone),
+		blockfetch.WithBatchStartTimeout(timeout),
+		blockfetch.WithBlockTimeout(timeout),
+	)
+	oc, err := dial(ep, magic, ouroboros.WithBlockFetchConfig(cfg))
+	if err != nil {
+		return nil, err
+	}
+	defer oc.Close()
+
+	// Single-point fetch: start == end is inclusive on both ends.
+	if err := oc.BlockFetch().Client.GetBlockRange(point, point); err != nil {
+		return nil, fmt.Errorf("blockfetch %s: %w", ep.Name, err)
+	}
+
+	select {
+	case <-gotBlock:
+		mu.Lock()
+		defer mu.Unlock()
+		return gotCbor, nil
+	case <-batch:
+		// Prefer a delivered block if blockFunc and batchDone raced.
+		select {
+		case <-gotBlock:
+			mu.Lock()
+			defer mu.Unlock()
+			return gotCbor, nil
+		default:
+			return nil, fmt.Errorf("blockfetch %s: batch completed with no block delivered", ep.Name)
+		}
+	case err := <-oc.ErrorChan():
+		return nil, fmt.Errorf("blockfetch %s connection error: %w", ep.Name, err)
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("blockfetch %s timed out after %s", ep.Name, timeout)
+	}
+}

--- a/internal/test/archive-demo/internal/archivedemo/scenarios/archive_demo_test.go
+++ b/internal/test/archive-demo/internal/archivedemo/scenarios/archive_demo_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build archive_demo
+
+package scenarios
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/blinklabs-io/dingo/internal/test/archive-demo/internal/archivedemo"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestArchiveProxy exercises the full archive-node + pruning-node + bark
+// proxy story end to end:
+//
+//  1. wait for chain to advance well past the security window on both nodes
+//  2. pick a target block well behind the security window
+//  3. assertion 1: BlockFetch on dingo-pruning succeeds and CBOR is non-empty
+//  4. assertion 3: target object exists in Minio bucket "dingo-archive"
+//  5. stop dingo-pruning, run inspect-blob against the bind-mounted Badger
+//     dir, assert block is NOT present locally (assertion 2)
+func TestArchiveProxy(t *testing.T) {
+	archive, pruning := archivedemo.DefaultEndpoints()
+
+	// Step 1: wait for both nodes to advance past the stability window.
+	// Dingo derives the bark security window from LedgerState.StabilityWindow(),
+	// which is 3k/f. With testnet.yaml's k=40 and f=0.4 that's 300 slots.
+	// We wait for tip >= 400 to give the pruner some cycles past the window.
+	const stabilityWindow = uint64(300) // 3 * k(40) / f(0.4)
+	const targetTip = uint64(400)
+	_, err := archivedemo.WaitForSlot(archive, archivedemo.DefaultNetworkMagic, targetTip, 10*time.Minute, t.Logf)
+	require.NoError(t, err)
+	_, err = archivedemo.WaitForSlot(pruning, archivedemo.DefaultNetworkMagic, targetTip, 10*time.Minute, t.Logf)
+	require.NoError(t, err)
+
+	// Step 1b: poll until the pruner has had time to act on candidateSlot.
+	// inspect-blob can't run while the container holds the badger lockfile,
+	// so we wait until the pruner's tick frequency (5s) has had several
+	// cycles past candidateSlot+stabilityWindow.
+	const candidateSlot = uint64(50)
+	require.Eventually(t, func() bool {
+		tip, err := archivedemo.GetTip(pruning, archivedemo.DefaultNetworkMagic)
+		if err != nil {
+			return false
+		}
+		return tip.Slot >= candidateSlot+stabilityWindow+30
+	}, 3*time.Minute, 5*time.Second, "chain did not advance far enough for pruner to act")
+
+	// Step 2: resolve (slot, hash) of the first block at or after candidateSlot
+	// using dingo-archive, which has the full chain.
+	point, err := archivedemo.FindBlockAtOrAfterSlot(
+		archive, archivedemo.DefaultNetworkMagic, candidateSlot, 60*time.Second, t.Logf,
+	)
+	require.NoError(t, err)
+	t.Logf("target block: slot=%d hash=%x", point.Slot, point.Hash)
+	require.GreaterOrEqual(t, point.Slot, candidateSlot)
+
+	// Step 3 (assertion 1): BlockFetch the target on dingo-pruning succeeds.
+	cbor, err := archivedemo.FetchBlock(
+		pruning, archivedemo.DefaultNetworkMagic, point, 60*time.Second,
+	)
+	require.NoError(t, err, "BlockFetch on pruning node should transparently proxy via bark")
+	require.NotEmpty(t, cbor, "block CBOR should be non-empty")
+
+	// Step 4 (assertion 3): object present in Minio bucket.
+	s3Client := newMinioClient(t)
+	key := blobKeyForBlock(point.Slot, point.Hash)
+	_, err = s3Client.HeadObject(context.Background(), &s3.HeadObjectInput{
+		Bucket: aws.String("dingo-archive"),
+		Key:    aws.String(key),
+	})
+	require.NoError(t, err, "block %q should be present in Minio bucket", key)
+
+	// Step 5 (assertion 2): stop dingo-pruning, run inspect-blob.
+	// We deliberately do not restart it: dingo currently fails to
+	// re-initialize a persisted database (foreign-key error recreating
+	// genesis). The whole stack is torn down by run-tests.sh anyway.
+	stopPruning(t)
+
+	inspectBin := os.Getenv("ARCHIVEDEMO_INSPECT_BIN")
+	require.NotEmpty(t, inspectBin, "ARCHIVEDEMO_INSPECT_BIN must be set by run-tests.sh")
+	pruningDir := os.Getenv("ARCHIVEDEMO_PRUNING_DATA_DIR")
+	require.NotEmpty(t, pruningDir, "ARCHIVEDEMO_PRUNING_DATA_DIR must be set")
+
+	inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer inspectCancel()
+	cmd := exec.CommandContext(inspectCtx, inspectBin,
+		"-dir", pruningDir,
+		"-slot", fmt.Sprintf("%d", point.Slot),
+		"-hash", hex.EncodeToString(point.Hash),
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	t.Logf("inspect-blob output:\n%s", out.String())
+	if errors.Is(inspectCtx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("inspect-blob timed out: %s", out.String())
+	}
+
+	// Exit 0 = present, 1 = absent. We require absent.
+	var exitErr *exec.ExitError
+	require.Error(t, runErr, "block should be ABSENT from local Badger; inspect-blob exited 0 (present)")
+	require.True(t, errors.As(runErr, &exitErr), "expected ExitError, got %T", runErr)
+	require.Equal(t, 1, exitErr.ExitCode(),
+		"inspect-blob should return 1 (absent), got %d", exitErr.ExitCode())
+}
+
+func newMinioClient(t *testing.T) *s3.Client {
+	t.Helper()
+	endpoint := os.Getenv("ARCHIVEDEMO_MINIO_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:9100"
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(
+		context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("demo", "demodemo", ""),
+		),
+	)
+	require.NoError(t, err)
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+		o.UsePathStyle = true
+	})
+}
+
+func stopPruning(t *testing.T) {
+	t.Helper()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer stopCancel()
+	cmd := exec.CommandContext(stopCtx, "docker", "compose",
+		"-f", composeFile(t),
+		"stop", "dingo-pruning",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "docker compose stop dingo-pruning: %s", out)
+
+	// Wait for badger to release its lock file rather than sleeping a
+	// fixed interval.
+	pruningDir := os.Getenv("ARCHIVEDEMO_PRUNING_DATA_DIR")
+	require.NotEmpty(t, pruningDir, "ARCHIVEDEMO_PRUNING_DATA_DIR must be set")
+	lockFile := filepath.Join(pruningDir, "blob", "LOCK")
+	testutil.WaitForCondition(t, func() bool {
+		_, statErr := os.Stat(lockFile)
+		return os.IsNotExist(statErr)
+	}, 30*time.Second, "badger lock file was not released after stopping dingo-pruning")
+
+	// The dingo container runs as uid 100, so files it created in the
+	// bind-mounted data dir aren't readable to the host user that will
+	// run inspect-blob. Spin a one-shot busybox container as root to
+	// open the perms back up.
+	chmodCtx, chmodCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer chmodCancel()
+	chmod := exec.CommandContext(chmodCtx, "docker", "run", "--rm",
+		"-v", pruningDir+":/data",
+		"alpine:latest",
+		"sh", "-c", "chmod -R a+rwX /data",
+	)
+	chmodOut, err := chmod.CombinedOutput()
+	require.NoError(t, err, "chmod bind mount: %s", chmodOut)
+}
+
+func composeFile(t *testing.T) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Output()
+	require.NoError(t, err, "git rev-parse")
+	root := strings.TrimSpace(string(out))
+	return filepath.Join(root, "internal", "test", "archive-demo", "docker-compose.yml")
+}
+
+// blobKeyForBlock returns the S3 object key the AWS blob plugin uses for
+// (slot, hash). Matches database/types/keys.go BlockBlobKey + S3 plugin
+// fullKey hex-encoding (database/plugin/blob/aws/database.go fullKey).
+func blobKeyForBlock(slot uint64, hash []byte) string {
+	var slotBytes [8]byte
+	binary.BigEndian.PutUint64(slotBytes[:], slot)
+	raw := append([]byte("bp"), slotBytes[:]...)
+	raw = append(raw, hash...)
+	return hex.EncodeToString(raw)
+}

--- a/internal/test/archive-demo/run-tests.sh
+++ b/internal/test/archive-demo/run-tests.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bring up the archive-demo stack, run integration tests, tear down.
+#
+# Usage:
+#   ./run-tests.sh                     # run all archive-demo tests
+#   ./run-tests.sh -run TestArchive    # filter
+#   ./run-tests.sh --keep-up           # leave stack running on success
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+PRUNING_DATA_DIR="${SCRIPT_DIR}/tmp/dingo-pruning-data"
+
+KEEP_UP=false
+TEST_ARGS=()
+for arg in "$@"; do
+  case "${arg}" in
+    --keep-up) KEEP_UP=true ;;
+    *)         TEST_ARGS+=("${arg}") ;;
+  esac
+done
+
+log()  { echo "[archive-demo run-tests] $*"; }
+warn() { echo "[archive-demo run-tests] WARNING: $*" >&2; }
+die()  { echo "[archive-demo run-tests] ERROR: $*" >&2; exit 1; }
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "${INSPECT_DIR:-}" ]] && [[ -d "${INSPECT_DIR}" ]]; then
+    rm -rf "${INSPECT_DIR}"
+  fi
+  if [[ "${KEEP_UP}" == "true" ]] && [[ ${exit_code} -eq 0 ]]; then
+    log "Tests passed. Stack left running (--keep-up)."
+    log "To stop:  docker compose -f ${COMPOSE_FILE} down -v"
+    return
+  fi
+  if [[ ${exit_code} -ne 0 ]]; then
+    log "Collecting logs before teardown..."
+    docker compose -f "${COMPOSE_FILE}" logs --tail=200 2>/dev/null || true
+  fi
+  log "Tearing down..."
+  docker compose -f "${COMPOSE_FILE}" down -v 2>/dev/null || true
+  rm -rf "${SCRIPT_DIR}/tmp"
+}
+trap cleanup EXIT
+
+command -v docker >/dev/null || die "docker is not installed"
+command -v go     >/dev/null || die "go is not installed"
+
+log "Building inspect-blob helper..."
+INSPECT_DIR="$(mktemp -d)"
+INSPECT_BIN="${INSPECT_DIR}/inspect-blob"
+( cd "${PROJECT_ROOT}" && go build -o "${INSPECT_BIN}" ./internal/test/archive-demo/cmd/inspect-blob )
+
+log "Bringing up archive-demo stack..."
+mkdir -p "${PRUNING_DATA_DIR}"
+chmod 777 "${PRUNING_DATA_DIR}"
+docker compose -f "${COMPOSE_FILE}" up -d --build
+
+log "Waiting for dingo-pruning to become healthy..."
+deadline=$(( $(date +%s) + 240 ))
+while true; do
+  status="$(docker inspect -f '{{.State.Health.Status}}' archivedemo-dingo-pruning 2>/dev/null || echo missing)"
+  if [[ "${status}" == "healthy" ]]; then
+    break
+  fi
+  if [[ $(date +%s) -ge ${deadline} ]]; then
+    die "dingo-pruning did not become healthy (last status: ${status})"
+  fi
+  sleep 3
+done
+log "All services healthy."
+
+log "Running tests..."
+cd "${PROJECT_ROOT}"
+ARCHIVEDEMO_INSPECT_BIN="${INSPECT_BIN}" \
+ARCHIVEDEMO_PRUNING_DATA_DIR="${PRUNING_DATA_DIR}" \
+go test -tags archive_demo -count=1 -v -timeout 15m \
+  ./internal/test/archive-demo/internal/archivedemo/scenarios/ "${TEST_ARGS[@]}"

--- a/internal/test/archive-demo/start.sh
+++ b/internal/test/archive-demo/start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start the archive-node demo for manual exploration.
+# The bind-mount tmp/dingo-pruning-data is created up front so the
+# pruning node has a stable host path the integration test can later
+# open with Badger.
+#
+# Usage: ./start.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mkdir -p "${SCRIPT_DIR}/tmp/dingo-pruning-data"
+# The dingo container runs as uid 100. Loosen permissions so the container
+# can write to the bind-mounted directory regardless of host ownership.
+chmod 777 "${SCRIPT_DIR}/tmp/dingo-pruning-data"
+
+echo "Starting archive-demo containers..."
+docker compose -f "${SCRIPT_DIR}/docker-compose.yml" up -d
+
+echo ""
+echo "Archive demo started."
+echo "  Cardano producer: localhost:${ARCHIVEDEMO_CARDANO_PORT:-3110}"
+echo "  Dingo archive:    localhost:${ARCHIVEDEMO_DINGO_ARCHIVE_PORT:-3111}"
+echo "  Bark gRPC:        localhost:${ARCHIVEDEMO_BARK_PORT:-3112}"
+echo "  Dingo pruning:    localhost:${ARCHIVEDEMO_DINGO_PRUNING_PORT:-3113}"
+echo "  Minio S3:         localhost:${ARCHIVEDEMO_MINIO_PORT:-9100}"
+echo "  Minio console:    localhost:${ARCHIVEDEMO_MINIO_CONSOLE_PORT:-9101} (demo/demodemo)"
+echo ""
+echo "View logs:  docker compose -f ${SCRIPT_DIR}/docker-compose.yml logs -f"
+echo "Stop:       ${SCRIPT_DIR}/stop.sh"

--- a/internal/test/archive-demo/stop.sh
+++ b/internal/test/archive-demo/stop.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tear down the archive-node demo and remove its volumes and bind-mount.
+#
+# Usage: ./stop.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Stopping archive-demo..."
+docker compose -f "${SCRIPT_DIR}/docker-compose.yml" down -v
+rm -rf "${SCRIPT_DIR}/tmp"
+echo "Stopped."

--- a/internal/test/archive-demo/testnet.yaml
+++ b/internal/test/archive-demo/testnet.yaml
@@ -1,0 +1,63 @@
+# Antithesis configurator specification for DevNet.
+#
+# Generates unique key sets and genesis files for each pool.
+# Used by the configurator service in docker-compose.yml.
+#
+# Format: 6 YAML documents (see below)
+#   1. Required testnet parameters
+#   2. Byron genesis overrides
+#   3. Shelley genesis overrides
+#   4. Alonzo genesis overrides
+#   5. Conway genesis overrides
+#   6. Node config (config.json) overrides
+
+--- # Required Testnet Parameters
+poolCount: 2
+poolCost: 0
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 2000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: devnet
+
+--- # Byron Genesis Override
+protocolConsts:
+  k: 40
+
+--- # Shelley Genesis Override
+# 1s slots, ~8 min epochs, block every ~5s per pool (~2.5s total)
+# nonceStabilityWindow = 4k/f = 4*40/0.4 = 400 < 500 = epochLength ✓
+# blockfetchStabilityWindow = 3k/f = 3*40/0.4 = 300 < 500 = epochLength ✓
+# Candidate nonce freezes 400 slots before epoch end (at slot 100).
+# Partition tolerance: K / per-pool-rate where per-pool-rate = 1-(1-f)^(1/n)
+# With f=0.4, n=2: per-pool-rate ≈ 0.225, so K / per-pool-rate ≈ 40/0.225 ≈ 178s (~3 min)
+epochLength: 500
+slotLength: 1
+activeSlotsCoeff: 0.4
+securityParam: 40
+maxLovelaceSupply: 2000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Alonzo Genesis Override
+
+--- # Conway Genesis Override
+
+--- # Node Config Override
+TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+TraceForge: true
+TraceChainDb: true
+TraceMempool: true
+TurnOnLogging: true

--- a/internal/test/archive-demo/topology/cardano-producer.json
+++ b/internal/test/archive-demo/topology/cardano-producer.json
@@ -1,0 +1,19 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {
+          "address": "172.21.0.11",
+          "port": 3001
+        }
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 1,
+      "warmValency": 1
+    }
+  ],
+  "publicRoots": [],
+  "bootstrapPeers": [],
+  "useLedgerAfterSlot": -1
+}

--- a/internal/test/archive-demo/topology/dingo-archive.json
+++ b/internal/test/archive-demo/topology/dingo-archive.json
@@ -1,0 +1,19 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {
+          "address": "172.21.0.10",
+          "port": 3001
+        }
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 1,
+      "warmValency": 1
+    }
+  ],
+  "publicRoots": [],
+  "bootstrapPeers": [],
+  "useLedgerAfterSlot": -1
+}

--- a/internal/test/archive-demo/topology/dingo-pruning.json
+++ b/internal/test/archive-demo/topology/dingo-pruning.json
@@ -1,0 +1,19 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {
+          "address": "172.21.0.10",
+          "port": 3001
+        }
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 1,
+      "warmValency": 1
+    }
+  ],
+  "publicRoots": [],
+  "bootstrapPeers": [],
+  "useLedgerAfterSlot": -1
+}


### PR DESCRIPTION
Closes #2067 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable archive-node + pruning-node demo with Docker Compose and a full integration test. Demonstrates Bark proxying with S3-backed blobs end to end, including pruning and on-demand fetch of historical blocks. Addresses #2067.

- **New Features**
  - Configurator: one-shot container generates DevNet genesis/keys and topology via the testnet generation tool.
  - Docker stack: `minio` S3 (+ init), `cardano-producer`, `dingo-archive` (S3 blob, Bark on 3003), `dingo-pruning` (Badger blob, Bark client; pruner every 5s).
  - Scripts: `start.sh`, `stop.sh`, `demo.sh` (guided run with live stats and a timed BlockFetch), `run-tests.sh` (stands up stack and runs tests).
  - Helper CLIs: `demo-fetch` (ChainSync + BlockFetch timing), `inspect-blob` (checks `badger` for a block).
  - Go harness and test (tag `archive_demo`) verify: proxy fetch from pruning node succeeds, block is absent in local `badger`, and object exists in S3.
  - Docs: README with usage, ports, and notes.

<sup>Written for commit 05132f4ce5a48f76417d158921aa60f19bc56b63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive archive node demo: Docker Compose stack, configurator, testnet/node/topology configs, helper CLIs, and entrypoint scripts to run/start/stop the demo and build images.

* **Tests**
  * Added end-to-end integration tests that validate pruning, archive proxy fetches, and S3 archive presence.

* **Documentation**
  * Added a detailed README describing setup, usage, verification flow, ports, and overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->