### PR TITLE
fix(ledger): return sentinel error so caller knows the rollback was skipped

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -95,8 +95,19 @@ const (
 	// Chainsync re-sync reasons
 	resyncReasonRollbackAhead    = "rollback point ahead of local tip"
 	resyncReasonRollbackNotFound = "rollback point not found"
+	resyncReasonRollbackLoop     = "rollback loop detected"
 
 	maxPeerHeaderHistoryPerConn = 256
+)
+
+var (
+	// ErrRollbackLoopDetected is returned by handleEventChainsyncRollback when
+	// the same peer repeatedly requests a rollback to the same slot within the
+	// rollback loop detection window. The rollback is skipped to break the loop,
+	// and the caller should trigger a chainsync re-sync to recover.
+	ErrRollbackLoopDetected = errors.New(
+		"rollback loop detected: same slot rolled back too many times within window",
+	)
 )
 
 type peerHeaderRecord struct {
@@ -133,6 +144,27 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 	}
 	if e.Rollback {
 		if err := ls.handleEventChainsyncRollback(e); err != nil {
+			if errors.Is(err, ErrRollbackLoopDetected) {
+				// The rollback was skipped to break a pathological
+				// loop. Trigger a chainsync re-sync so the peer
+				// can negotiate a fresh intersection rather than
+				// continuing to send the same rollback point.
+				ls.resetChainsyncResyncState()
+				ls.chainsyncState = SyncingChainsyncState
+				if ls.config.EventBus != nil {
+					ls.config.EventBus.Publish(
+						event.ChainsyncResyncEventType,
+						event.NewEvent(
+							event.ChainsyncResyncEventType,
+							event.ChainsyncResyncEvent{
+								ConnectionId: e.ConnectionId,
+								Reason:       resyncReasonRollbackLoop,
+							},
+						),
+					)
+				}
+				return
+			}
 			ls.config.Logger.Error(
 				"failed to handle rollback",
 				"component", "ledger",
@@ -1060,7 +1092,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				"count", slotCount,
 				"window", rollbackLoopWindow,
 			)
-			return nil
+			return ErrRollbackLoopDetected
 		}
 	}
 

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -224,7 +224,7 @@ func TestHandleEventChainsyncRollbackSkipsSamePeerLoop(
 			Point:        fixture.ancestorTip.Point,
 		},
 	)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrRollbackLoopDetected)
 
 	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
 	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)


### PR DESCRIPTION
closes #1524 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a sentinel error when a chainsync rollback loop is detected, and trigger a re-sync instead of silently skipping. Prevents infinite rollback loops and makes recovery explicit.

- **Bug Fixes**
  - Introduced `ErrRollbackLoopDetected` and return it from rollback handling when the same slot repeats within the window.
  - On this error, reset chainsync resync state, set state to syncing, and publish a `ChainsyncResyncEvent` with reason "rollback loop detected" via `EventBus`.
  - Updated the rollback loop test to expect the sentinel error.

<sup>Written for commit 94edd8a306a24d28d52b112116120930ae8b2451. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

