### PR TITLE
fix(event): right-size per-subscriber channel buffer

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -24,10 +24,22 @@ import (
 )
 
 const (
-	EventQueueSize       = 100000
-	AsyncQueueSize       = 1000
-	AsyncWorkerPoolSize  = 4
-	RemoteDeliverTimeout = 5 * time.Second
+	// EventQueueSize is the high-burst buffer used by subscribers that may
+	// receive bulk-sync bursts (e.g. chainsync/blockfetch ingest in the
+	// ledger). Subscribers opt in to this size via the *WithBuffer
+	// variants. Sized to absorb the worst case from #1556 / #1914.
+	EventQueueSize = 100000
+	// DefaultSubscriberBuffer is the per-subscriber channel buffer used by
+	// Subscribe/SubscribeFunc when no explicit size is requested. Most
+	// subscribers (peergov, governance, async housekeeping, etc.) only
+	// receive sparse traffic and do not need 100k slots; sizing the
+	// default down keeps idle steady-state heap small while leaving the
+	// burst headroom available to opt-in callers via SubscribeWithBuffer
+	// / SubscribeFuncWithBuffer. See blinklabs-io/dingo#2106.
+	DefaultSubscriberBuffer = 1024
+	AsyncQueueSize          = 1000
+	AsyncWorkerPoolSize     = 4
+	RemoteDeliverTimeout    = 5 * time.Second
 )
 
 type EventType string
@@ -230,11 +242,15 @@ func (c *channelSubscriber) Close() {
 // Callers must hold stopMu.RLock or have otherwise ensured the EventBus is not stopped.
 func (e *EventBus) subscribeInternal(
 	eventType EventType,
+	buffer int,
 ) (EventSubscriberId, *channelSubscriber) {
+	if buffer <= 0 {
+		buffer = DefaultSubscriberBuffer
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	// Create channel-backed subscriber
-	chSub := newChannelSubscriber(EventQueueSize, e.Logger)
+	chSub := newChannelSubscriber(buffer, e.Logger)
 	// Increment subscriber ID
 	subId := e.lastSubId + 1
 	e.lastSubId = subId
@@ -257,12 +273,24 @@ func (e *EventBus) subscribeInternal(
 func (e *EventBus) Subscribe(
 	eventType EventType,
 ) (EventSubscriberId, <-chan Event) {
+	return e.SubscribeWithBuffer(eventType, DefaultSubscriberBuffer)
+}
+
+// SubscribeWithBuffer is like Subscribe but lets the caller pick the
+// per-subscriber channel buffer. Use this for subscribers that need to
+// tolerate bursts larger than DefaultSubscriberBuffer (e.g. chainsync
+// or blockfetch ingest during bulk catch-up). A non-positive buffer
+// falls back to DefaultSubscriberBuffer.
+func (e *EventBus) SubscribeWithBuffer(
+	eventType EventType,
+	buffer int,
+) (EventSubscriberId, <-chan Event) {
 	e.stopMu.RLock()
 	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return 0, nil
 	}
-	subId, chSub := e.subscribeInternal(eventType)
+	subId, chSub := e.subscribeInternal(eventType, buffer)
 	e.stopMu.RUnlock()
 	return subId, chSub.ch
 }
@@ -271,6 +299,20 @@ func (e *EventBus) Subscribe(
 // Returns 0 if the EventBus is stopped or closed.
 func (e *EventBus) SubscribeFunc(
 	eventType EventType,
+	handlerFunc EventHandlerFunc,
+) EventSubscriberId {
+	return e.SubscribeFuncWithBuffer(
+		eventType,
+		DefaultSubscriberBuffer,
+		handlerFunc,
+	)
+}
+
+// SubscribeFuncWithBuffer is like SubscribeFunc but lets the caller pick
+// the per-subscriber channel buffer. See SubscribeWithBuffer for details.
+func (e *EventBus) SubscribeFuncWithBuffer(
+	eventType EventType,
+	buffer int,
 	handlerFunc EventHandlerFunc,
 ) EventSubscriberId {
 	// Hold stopMu.RLock through Add(1) to prevent Stop() from calling Wait()
@@ -283,7 +325,7 @@ func (e *EventBus) SubscribeFunc(
 		e.stopMu.RUnlock()
 		return 0
 	}
-	subId, chSub := e.subscribeInternal(eventType)
+	subId, chSub := e.subscribeInternal(eventType, buffer)
 	e.subscriberWg.Add(1)
 	e.stopMu.RUnlock()
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -381,10 +381,10 @@ func TestPublishDropsEventsOnFullBuffer(t *testing.T) {
 	eb := event.NewEventBus(nil, nil)
 	defer eb.Stop()
 
-	// Subscribe but never consume events.
-	_, subCh := eb.Subscribe(testEvtType)
+	// Subscribe with the high-burst buffer; never consume events.
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, event.EventQueueSize)
 
-	// Fill the buffer (EventQueueSize = 1000)
+	// Fill the buffer (EventQueueSize)
 	for i := range event.EventQueueSize {
 		eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
 	}
@@ -418,4 +418,46 @@ func TestPublishDropsEventsOnFullBuffer(t *testing.T) {
 			t.Fatal("expected buffered event not received")
 		}
 	}
+}
+
+// TestSubscribeUsesSmallDefaultBuffer is the regression test for #2106.
+// Subscribe / SubscribeFunc must allocate the small default buffer; only
+// callers that explicitly opt in via the *WithBuffer variants should pay
+// the EventQueueSize allocation. Verified by capacity, since cap on a
+// receive-only channel reports the underlying buffer size.
+func TestSubscribeUsesSmallDefaultBuffer(t *testing.T) {
+	const testEvtType event.EventType = "test.default.buffer"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	_, defaultCh := eb.Subscribe(testEvtType)
+	require.Equal(
+		t,
+		event.DefaultSubscriberBuffer,
+		cap(defaultCh),
+		"Subscribe must default to the small per-subscriber buffer",
+	)
+	require.Less(
+		t,
+		event.DefaultSubscriberBuffer,
+		event.EventQueueSize,
+		"DefaultSubscriberBuffer must stay below EventQueueSize",
+	)
+
+	_, burstCh := eb.SubscribeWithBuffer(testEvtType, event.EventQueueSize)
+	require.Equal(
+		t,
+		event.EventQueueSize,
+		cap(burstCh),
+		"SubscribeWithBuffer must honor the requested buffer size",
+	)
+
+	// Non-positive buffer falls back to the default.
+	_, fallbackCh := eb.SubscribeWithBuffer(testEvtType, 0)
+	require.Equal(
+		t,
+		event.DefaultSubscriberBuffer,
+		cap(fallbackCh),
+		"non-positive buffer must fall back to DefaultSubscriberBuffer",
+	)
 }

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -187,7 +187,7 @@ func TestPublishDoesNotBlockOnFullChannel(t *testing.T) {
 	eb := NewEventBus(nil, nil)
 	typ := EventType("deadlock.test")
 
-	_, ch := eb.Subscribe(typ)
+	_, ch := eb.SubscribeWithBuffer(typ, EventQueueSize)
 
 	// Fill the subscriber's channel buffer completely.
 	for range EventQueueSize {
@@ -248,7 +248,7 @@ func TestCloseDoesNotDeadlockWithFullChannel(t *testing.T) {
 	for range iters {
 		eb := NewEventBus(nil, nil)
 		typ := EventType("close.deadlock.test")
-		subId, ch := eb.Subscribe(typ)
+		subId, ch := eb.SubscribeWithBuffer(typ, EventQueueSize)
 
 		// Fill the buffer.
 		for range EventQueueSize {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -643,22 +643,27 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		ls.config.Logger.Info("database worker pool disabled")
 	}
 
-	// Setup event handlers
+	// Setup event handlers. The chainsync/blockfetch/chain-update streams
+	// can burst at bulk-sync rates (#1556 / #1914), so they opt into the
+	// large EventQueueSize buffer. Sparser streams use the default.
 	if ls.config.EventBus != nil {
-		ls.chainsyncSubID = ls.config.EventBus.SubscribeFunc(
+		ls.chainsyncSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			ChainsyncEventType,
+			event.EventQueueSize,
 			ls.handleEventChainsync,
 		)
 		ls.chainsyncAwaitReplySubID = ls.config.EventBus.SubscribeFunc(
 			ChainsyncAwaitReplyEventType,
 			ls.handleEventChainsyncAwaitReply,
 		)
-		ls.blockfetchSubID = ls.config.EventBus.SubscribeFunc(
+		ls.blockfetchSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			BlockfetchEventType,
+			event.EventQueueSize,
 			ls.handleEventBlockfetch,
 		)
-		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFunc(
+		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			chain.ChainUpdateEventType,
+			event.EventQueueSize,
 			ls.handleEventChainUpdate,
 		)
 		ls.chainSwitchSubID = ls.config.EventBus.SubscribeFunc(

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -453,8 +453,10 @@ func (m *Mempool) processChainEvents() {
 	if m.eventBus == nil {
 		return
 	}
-	chainUpdateSubId, chainUpdateChan := m.eventBus.Subscribe(
+	// Sized for catch-up bursts (one event per block). See #2106.
+	chainUpdateSubId, chainUpdateChan := m.eventBus.SubscribeWithBuffer(
 		chain.ChainUpdateEventType,
+		event.EventQueueSize,
 	)
 	defer func() {
 		m.eventBus.Unsubscribe(chain.ChainUpdateEventType, chainUpdateSubId)


### PR DESCRIPTION
Fixes #2106.

`event.newChannelSubscriber` allocated `EventQueueSize` (100k slots) per subscriber, so a serving node with ~190 subscribers paid ~192 MB / 45% of the in-use heap on it alone (steady-state preview catch-up profile from the issue). The 100k buffer was sized for the worst-case bulk-sync burst from #1556 / #1914 but stayed allocated for the lifetime of every subscription, including quiescent peergov, governance, and housekeeping callbacks.

`Subscribe` / `SubscribeFunc` now default to `DefaultSubscriberBuffer` (1024). New `SubscribeWithBuffer` / `SubscribeFuncWithBuffer` variants let callers opt into a larger size; the bursty consumers in `ledger/state.go` (chainsync, blockfetch, chain-update) and the mempool's chain-update consumer opt into `EventQueueSize` so the catch-up burst headroom that motivated #1914 is preserved exactly where it is needed.

Net effect: ~190 subscribers \* (100000 - 1024) slots \* sizeof(Event) of idle heap freed, while the four streams that actually catch bulk-sync bursts retain the 100k buffer.

Tests:
- `event.TestSubscribeUsesSmallDefaultBuffer` (new) asserts `Subscribe` cap is `DefaultSubscriberBuffer`, `SubscribeWithBuffer` honors the requested size, and a non-positive buffer falls back.
- Existing fill-the-buffer tests in `event_test.go` and `race_test.go` switched to `SubscribeWithBuffer(EventQueueSize)` to keep their semantics.
- `go test -race ./event/... -timeout 90s` and `go test -race ./mempool/... -timeout 120s` pass.

Public API stays back-compat: existing `Subscribe` / `SubscribeFunc` callers keep their signatures, just with a smaller default allocation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce idle heap by right-sizing per-subscriber event channel buffers while preserving bulk-sync burst capacity. Default buffer is now 1024; bursty consumers explicitly opt into the 100k buffer.

- **Bug Fixes**
  - In `event`: `Subscribe`/`SubscribeFunc` now use `DefaultSubscriberBuffer` (1024); added `SubscribeWithBuffer`/`SubscribeFuncWithBuffer` (non‑positive size falls back).
  - Opt-in 100k buffers only where needed: `ledger/state.go` (chainsync, blockfetch, chain-update) and `mempool` chain-update.
  - Resolves #2106 and keeps burst headroom from #1914; adds a regression test for defaults, updates buffer-fill/race tests; API remains backward-compatible.

<sup>Written for commit 394371075c9ba2d0f81e452c80552624b84fe9e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable buffer sizes for event subscriptions with new APIs for fine-tuned queue management.

* **Improvements**
  * Updated high-burst event streams (chain sync, block fetch, chain updates) to use explicit buffering for improved handling of event bursts.
  * Reduced default subscriber buffer size for more efficient memory usage while maintaining reliability for critical operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->