### PR TITLE
database: include block_index in cert ordering for account restore

### DIFF
--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -211,25 +211,30 @@ func (d *MetadataStoreMysql) SetAccount(
 
 // certRecord holds common fields extracted from certificate records for
 // batch processing during account state restoration.
-// Includes certIndex for same-slot disambiguation.
+// Includes blockIndex and certIndex for same-slot disambiguation across
+// transactions and within a transaction respectively.
 type certRecord struct {
-	pool      []byte
-	drep      []byte
-	drepType  uint64
-	addedSlot uint64
-	certIndex uint32
+	pool       []byte
+	drep       []byte
+	drepType   uint64
+	addedSlot  uint64
+	blockIndex uint64
+	certIndex  uint32
 }
 
 // isMoreRecent checks if this certificate is more recent than the other.
-// When slots are equal, certIndex determines order (higher = later in transaction).
+// Order matches the SQL ORDER BY clause used in batchFetch helpers:
+// added_slot DESC, block_index DESC, cert_index DESC. block_index is
+// required to disambiguate same-slot certs across different transactions
+// because cert_index resets per transaction.
 func (r certRecord) isMoreRecent(other certRecord) bool {
-	if r.addedSlot > other.addedSlot {
-		return true
+	if r.addedSlot != other.addedSlot {
+		return r.addedSlot > other.addedSlot
 	}
-	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
-		return true
+	if r.blockIndex != other.blockIndex {
+		return r.blockIndex > other.blockIndex
 	}
-	return false
+	return r.certIndex > other.certIndex
 }
 
 // accountCertCache holds batch-fetched certificate data for all accounts
@@ -355,22 +360,24 @@ func batchFetchStakeRegistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -378,7 +385,7 @@ func batchFetchStakeRegistration(
 	for _, r := range records {
 		cache.updateReg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -394,21 +401,23 @@ func batchFetchStakeRegistrationDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -416,9 +425,10 @@ func batchFetchStakeRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			pool:      r.PoolKeyHash,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			pool:       r.PoolKeyHash,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updatePoolDelegation(key, rec)
@@ -438,21 +448,23 @@ func batchFetchStakeVoteRegistrationDelegation(
 		Drep        []byte
 		DrepType    uint64
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -460,21 +472,23 @@ func batchFetchStakeVoteRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			pool:      r.PoolKeyHash,
-			drep:      r.Drep,
-			drepType:  r.DrepType,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			pool:       r.PoolKeyHash,
+			drep:       r.Drep,
+			drepType:   r.DrepType,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updatePoolDelegation(key, rec)
 		cache.updateDrepDelegation(
 			key,
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -492,21 +506,23 @@ func batchFetchVoteRegistrationDelegation(
 		Drep       []byte
 		DrepType   uint64
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -514,10 +530,11 @@ func batchFetchVoteRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			drep:      r.Drep,
-			drepType:  r.DrepType,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			drep:       r.Drep,
+			drepType:   r.DrepType,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updateDrepDelegation(key, rec)
@@ -534,21 +551,23 @@ func batchFetchRegistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM registration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -556,7 +575,7 @@ func batchFetchRegistration(
 	for _, r := range records {
 		cache.updateReg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -571,21 +590,23 @@ func batchFetchStakeDeregistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_deregistration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -593,7 +614,7 @@ func batchFetchStakeDeregistration(
 	for _, r := range records {
 		cache.updateDereg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -608,21 +629,23 @@ func batchFetchDeregistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM deregistration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -630,7 +653,7 @@ func batchFetchDeregistration(
 	for _, r := range records {
 		cache.updateDereg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -646,21 +669,23 @@ func batchFetchStakeDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -669,9 +694,10 @@ func batchFetchStakeDelegation(
 		cache.updatePoolDelegation(
 			string(r.StakingKey),
 			certRecord{
-				pool:      r.PoolKeyHash,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				pool:       r.PoolKeyHash,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -690,21 +716,23 @@ func batchFetchStakeVoteDelegation(
 		Drep        []byte
 		DrepType    uint64
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -714,18 +742,20 @@ func batchFetchStakeVoteDelegation(
 		cache.updatePoolDelegation(
 			key,
 			certRecord{
-				pool:      r.PoolKeyHash,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				pool:       r.PoolKeyHash,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 		cache.updateDrepDelegation(
 			key,
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -743,21 +773,23 @@ func batchFetchVoteDelegation(
 		Drep       []byte
 		DrepType   uint64
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -766,10 +798,11 @@ func batchFetchVoteDelegation(
 		cache.updateDrepDelegation(
 			string(r.StakingKey),
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -211,25 +211,30 @@ func (d *MetadataStorePostgres) SetAccount(
 
 // certRecord holds common fields extracted from certificate records for
 // batch processing during account state restoration.
-// Includes certIndex for same-slot disambiguation.
+// Includes blockIndex and certIndex for same-slot disambiguation across
+// transactions and within a transaction respectively.
 type certRecord struct {
-	pool      []byte
-	drep      []byte
-	drepType  uint64
-	addedSlot uint64
-	certIndex uint32
+	pool       []byte
+	drep       []byte
+	drepType   uint64
+	addedSlot  uint64
+	blockIndex uint64
+	certIndex  uint32
 }
 
 // isMoreRecent checks if this certificate is more recent than the other.
-// When slots are equal, certIndex determines order (higher = later in transaction).
+// Order matches the SQL ORDER BY clause used in batchFetch helpers:
+// added_slot DESC, block_index DESC, cert_index DESC. block_index is
+// required to disambiguate same-slot certs across different transactions
+// because cert_index resets per transaction.
 func (r certRecord) isMoreRecent(other certRecord) bool {
-	if r.addedSlot > other.addedSlot {
-		return true
+	if r.addedSlot != other.addedSlot {
+		return r.addedSlot > other.addedSlot
 	}
-	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
-		return true
+	if r.blockIndex != other.blockIndex {
+		return r.blockIndex > other.blockIndex
 	}
-	return false
+	return r.certIndex > other.certIndex
 }
 
 // accountCertCache holds batch-fetched certificate data for all accounts
@@ -355,22 +360,24 @@ func batchFetchStakeRegistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -378,7 +385,7 @@ func batchFetchStakeRegistration(
 	for _, r := range records {
 		cache.updateReg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -394,21 +401,23 @@ func batchFetchStakeRegistrationDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -416,9 +425,10 @@ func batchFetchStakeRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			pool:      r.PoolKeyHash,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			pool:       r.PoolKeyHash,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updatePoolDelegation(key, rec)
@@ -438,21 +448,23 @@ func batchFetchStakeVoteRegistrationDelegation(
 		Drep        []byte
 		DrepType    uint64
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -460,21 +472,23 @@ func batchFetchStakeVoteRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			pool:      r.PoolKeyHash,
-			drep:      r.Drep,
-			drepType:  r.DrepType,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			pool:       r.PoolKeyHash,
+			drep:       r.Drep,
+			drepType:   r.DrepType,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updatePoolDelegation(key, rec)
 		cache.updateDrepDelegation(
 			key,
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -492,21 +506,23 @@ func batchFetchVoteRegistrationDelegation(
 		Drep       []byte
 		DrepType   uint64
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -514,10 +530,11 @@ func batchFetchVoteRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			drep:      r.Drep,
-			drepType:  r.DrepType,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			drep:       r.Drep,
+			drepType:   r.DrepType,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updateDrepDelegation(key, rec)
@@ -534,21 +551,23 @@ func batchFetchRegistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM registration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -556,7 +575,7 @@ func batchFetchRegistration(
 	for _, r := range records {
 		cache.updateReg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -571,21 +590,23 @@ func batchFetchStakeDeregistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_deregistration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -593,7 +614,7 @@ func batchFetchStakeDeregistration(
 	for _, r := range records {
 		cache.updateDereg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -608,21 +629,23 @@ func batchFetchDeregistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM deregistration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -630,7 +653,7 @@ func batchFetchDeregistration(
 	for _, r := range records {
 		cache.updateDereg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -646,21 +669,23 @@ func batchFetchStakeDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -669,9 +694,10 @@ func batchFetchStakeDelegation(
 		cache.updatePoolDelegation(
 			string(r.StakingKey),
 			certRecord{
-				pool:      r.PoolKeyHash,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				pool:       r.PoolKeyHash,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -690,21 +716,23 @@ func batchFetchStakeVoteDelegation(
 		Drep        []byte
 		DrepType    uint64
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -714,18 +742,20 @@ func batchFetchStakeVoteDelegation(
 		cache.updatePoolDelegation(
 			key,
 			certRecord{
-				pool:      r.PoolKeyHash,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				pool:       r.PoolKeyHash,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 		cache.updateDrepDelegation(
 			key,
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -743,21 +773,23 @@ func batchFetchVoteDelegation(
 		Drep       []byte
 		DrepType   uint64
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -766,10 +798,11 @@ func batchFetchVoteDelegation(
 		cache.updateDrepDelegation(
 			string(r.StakingKey),
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -26,25 +26,30 @@ import (
 
 // certRecord holds common fields extracted from certificate records for
 // batch processing during account state restoration.
-// Includes certIndex for same-slot disambiguation.
+// Includes blockIndex and certIndex for same-slot disambiguation across
+// transactions and within a transaction respectively.
 type certRecord struct {
-	pool      []byte
-	drep      []byte
-	drepType  uint64
-	addedSlot uint64
-	certIndex uint32
+	pool       []byte
+	drep       []byte
+	drepType   uint64
+	addedSlot  uint64
+	blockIndex uint64
+	certIndex  uint32
 }
 
 // isMoreRecent checks if this certificate is more recent than the other.
-// When slots are equal, certIndex determines order (higher = later in transaction).
+// Order matches the SQL ORDER BY clause used in batchFetch helpers:
+// added_slot DESC, block_index DESC, cert_index DESC. block_index is
+// required to disambiguate same-slot certs across different transactions
+// because cert_index resets per transaction.
 func (r certRecord) isMoreRecent(other certRecord) bool {
-	if r.addedSlot > other.addedSlot {
-		return true
+	if r.addedSlot != other.addedSlot {
+		return r.addedSlot > other.addedSlot
 	}
-	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
-		return true
+	if r.blockIndex != other.blockIndex {
+		return r.blockIndex > other.blockIndex
 	}
-	return false
+	return r.certIndex > other.certIndex
 }
 
 // accountCertCache holds batch-fetched certificate data for all accounts
@@ -177,22 +182,24 @@ func batchFetchStakeRegistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -200,7 +207,7 @@ func batchFetchStakeRegistration(
 	for _, r := range records {
 		cache.updateReg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -216,22 +223,24 @@ func batchFetchStakeRegistrationDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -239,9 +248,10 @@ func batchFetchStakeRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			pool:      r.PoolKeyHash,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			pool:       r.PoolKeyHash,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updatePoolDelegation(key, rec)
@@ -261,22 +271,24 @@ func batchFetchStakeVoteRegistrationDelegation(
 		Drep        []byte
 		DrepType    uint64
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -284,21 +296,23 @@ func batchFetchStakeVoteRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			pool:      r.PoolKeyHash,
-			drep:      r.Drep,
-			drepType:  r.DrepType,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			pool:       r.PoolKeyHash,
+			drep:       r.Drep,
+			drepType:   r.DrepType,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updatePoolDelegation(key, rec)
 		cache.updateDrepDelegation(
 			key,
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -316,22 +330,24 @@ func batchFetchVoteRegistrationDelegation(
 		Drep       []byte
 		DrepType   uint64
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_registration_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -339,10 +355,11 @@ func batchFetchVoteRegistrationDelegation(
 	for _, r := range records {
 		key := string(r.StakingKey)
 		rec := certRecord{
-			drep:      r.Drep,
-			drepType:  r.DrepType,
-			addedSlot: r.AddedSlot,
-			certIndex: r.CertIndex,
+			drep:       r.Drep,
+			drepType:   r.DrepType,
+			addedSlot:  r.AddedSlot,
+			blockIndex: r.BlockIndex,
+			certIndex:  r.CertIndex,
 		}
 		cache.updateReg(key, rec)
 		cache.updateDrepDelegation(key, rec)
@@ -359,22 +376,24 @@ func batchFetchRegistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM registration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -382,7 +401,7 @@ func batchFetchRegistration(
 	for _, r := range records {
 		cache.updateReg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -397,22 +416,24 @@ func batchFetchStakeDeregistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_deregistration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -420,7 +441,7 @@ func batchFetchStakeDeregistration(
 	for _, r := range records {
 		cache.updateDereg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -435,22 +456,24 @@ func batchFetchDeregistration(
 	type result struct {
 		StakingKey []byte
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM deregistration t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index
+		SELECT staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -458,7 +481,7 @@ func batchFetchDeregistration(
 	for _, r := range records {
 		cache.updateDereg(
 			string(r.StakingKey),
-			certRecord{addedSlot: r.AddedSlot, certIndex: r.CertIndex},
+			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
 	return nil
@@ -474,22 +497,24 @@ func batchFetchStakeDelegation(
 		StakingKey  []byte
 		PoolKeyHash []byte
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -498,9 +523,10 @@ func batchFetchStakeDelegation(
 		cache.updatePoolDelegation(
 			string(r.StakingKey),
 			certRecord{
-				pool:      r.PoolKeyHash,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				pool:       r.PoolKeyHash,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -518,22 +544,24 @@ func batchFetchVoteDelegation(
 		Drep       []byte
 		DrepType   uint64
 		AddedSlot  uint64
+		BlockIndex uint64
 		CertIndex  uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -542,10 +570,11 @@ func batchFetchVoteDelegation(
 		cache.updateDrepDelegation(
 			string(r.StakingKey),
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}
@@ -564,22 +593,24 @@ func batchFetchStakeVoteDelegation(
 		Drep        []byte
 		DrepType    uint64
 		AddedSlot   uint64
+		BlockIndex  uint64
 		CertIndex   uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_delegation t
 			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index
+		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
@@ -589,18 +620,20 @@ func batchFetchStakeVoteDelegation(
 		cache.updatePoolDelegation(
 			key,
 			certRecord{
-				pool:      r.PoolKeyHash,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				pool:       r.PoolKeyHash,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 		cache.updateDrepDelegation(
 			key,
 			certRecord{
-				drep:      r.Drep,
-				drepType:  r.DrepType,
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				drep:       r.Drep,
+				drepType:   r.DrepType,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			},
 		)
 	}

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -63,3 +63,187 @@ func TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse(t *testing.T) {
 	require.NotNil(t, got, "inactive account must be returned when includeInactive=true")
 	assert.False(t, got.Active, "returned account should have Active=false")
 }
+
+// TestBatchFetchCerts_SameSlotTiebreakByBlockIndex pins the cert ordering
+// invariant documented in CLAUDE.md: when two certs for the same staking
+// key live in the same slot but in different transactions of the same
+// block, batchFetchCerts must pick the one with the higher block_index.
+//
+// cert_index resets per transaction, so without block_index the SQL
+// ORDER BY is ambiguous and the DB is free to return either row, breaking
+// RestoreAccountStateAtSlot's determinism. Pool queries already follow
+// "added_slot DESC, block_index DESC, cert_index DESC"; the account-side
+// queries must too.
+func TestBatchFetchCerts_SameSlotTiebreakByBlockIndex(t *testing.T) {
+	store := setupTestStore(t)
+	db := store.DB()
+	const slot = uint64(1000)
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xCD
+	}
+	earlyPool := make([]byte, 28)
+	for i := range earlyPool {
+		earlyPool[i] = 0x01
+	}
+	latePool := make([]byte, 28)
+	for i := range latePool {
+		latePool[i] = 0x02
+	}
+
+	// Two transactions in the same slot; tx1 is earlier in the block
+	// (block_index=0), tx2 is later (block_index=1). Both contain a
+	// stake_delegation cert at cert_index=0 (cert_index resets per tx),
+	// pointing to different pools.
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         1,
+		Hash:       []byte("tx_block_index_0_hash_xxxxxxxxxx"),
+		Slot:       slot,
+		BlockIndex: 0,
+	}).Error)
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         2,
+		Hash:       []byte("tx_block_index_1_hash_xxxxxxxxxx"),
+		Slot:       slot,
+		BlockIndex: 1,
+	}).Error)
+
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            10,
+		TransactionID: 1,
+		CertIndex:     0,
+		Slot:          slot,
+		CertType:      2, // StakeDelegation
+	}).Error)
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            11,
+		TransactionID: 2,
+		CertIndex:     0,
+		Slot:          slot,
+		CertType:      2,
+	}).Error)
+
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		ID:            100,
+		StakingKey:    stakeKey,
+		PoolKeyHash:   earlyPool,
+		CertificateID: 10,
+		AddedSlot:     slot,
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		ID:            101,
+		StakingKey:    stakeKey,
+		PoolKeyHash:   latePool,
+		CertificateID: 11,
+		AddedSlot:     slot,
+	}).Error)
+
+	cache, err := batchFetchCerts(db, [][]byte{stakeKey}, slot)
+	require.NoError(t, err)
+
+	rec, ok := cache.poolDelegation[string(stakeKey)]
+	require.True(t, ok, "expected pool delegation for staking key")
+	assert.Equal(
+		t,
+		latePool,
+		rec.pool,
+		"pool delegation must come from the cert in the higher-block_index transaction; "+
+			"without block_index in the ORDER BY this picks an ambiguous row",
+	)
+}
+
+// TestBatchFetchCerts_CrossTableTiebreakByBlockIndex pins the cross-table
+// merge contract behind certRecord.isMoreRecent: when same-slot pool
+// delegations exist in two different certificate tables (here
+// stake_delegation vs stake_vote_delegation), the in-memory cache merge
+// must use block_index, not the iteration order of batchFetch* helpers,
+// to pick the winner. Without block_index in certRecord/isMoreRecent the
+// chosen pool depends purely on which batchFetch* runs last, which is
+// non-deterministic across refactors and makes the restore path silently
+// drift from the on-chain ordering.
+func TestBatchFetchCerts_CrossTableTiebreakByBlockIndex(t *testing.T) {
+	store := setupTestStore(t)
+	db := store.DB()
+	const slot = uint64(2000)
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xEF
+	}
+	earlyPool := make([]byte, 28)
+	for i := range earlyPool {
+		earlyPool[i] = 0x03
+	}
+	latePool := make([]byte, 28)
+	for i := range latePool {
+		latePool[i] = 0x04
+	}
+	drep := make([]byte, 28)
+	for i := range drep {
+		drep[i] = 0x05
+	}
+
+	// tx1 (block_index=0) carries a stake_delegation pointing at earlyPool;
+	// tx2 (block_index=1) carries a stake_vote_delegation pointing at
+	// latePool. Both share the same slot. The on-chain ordering is tx2,
+	// so latePool must win the cross-table cache merge.
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         3,
+		Hash:       []byte("tx_cross_table_block0_xxxxxxxxxx"),
+		Slot:       slot,
+		BlockIndex: 0,
+	}).Error)
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         4,
+		Hash:       []byte("tx_cross_table_block1_xxxxxxxxxx"),
+		Slot:       slot,
+		BlockIndex: 1,
+	}).Error)
+
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            20,
+		TransactionID: 3,
+		CertIndex:     0,
+		Slot:          slot,
+		CertType:      2, // StakeDelegation
+	}).Error)
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            21,
+		TransactionID: 4,
+		CertIndex:     0,
+		Slot:          slot,
+		CertType:      9, // StakeVoteDelegation
+	}).Error)
+
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		ID:            200,
+		StakingKey:    stakeKey,
+		PoolKeyHash:   earlyPool,
+		CertificateID: 20,
+		AddedSlot:     slot,
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeVoteDelegation{
+		ID:            201,
+		StakingKey:    stakeKey,
+		PoolKeyHash:   latePool,
+		Drep:          drep,
+		DrepType:      0,
+		CertificateID: 21,
+		AddedSlot:     slot,
+	}).Error)
+
+	cache, err := batchFetchCerts(db, [][]byte{stakeKey}, slot)
+	require.NoError(t, err)
+
+	rec, ok := cache.poolDelegation[string(stakeKey)]
+	require.True(t, ok, "expected pool delegation for staking key")
+	assert.Equal(
+		t,
+		latePool,
+		rec.pool,
+		"cross-table cache merge must pick the cert from the higher-block_index "+
+			"transaction; without block_index in certRecord/isMoreRecent this "+
+			"falls through to batchFetch* iteration order",
+	)
+}


### PR DESCRIPTION
Fixes #2036.

The 10 `batchFetch*` helpers in `database/plugin/metadata/{sqlite,mysql,postgres}/account.go` ranked per-stake-key cert rows with `ORDER BY added_slot DESC, cert_index DESC`, which is ambiguous across transactions in the same block (`cert_index` resets per tx). Each query now joins `transaction` and orders by `added_slot DESC, block_index DESC, cert_index DESC`, matching the pool-side queries and the invariant in CLAUDE.md. New regression test `TestBatchFetchCerts_SameSlotTiebreakByBlockIndex` constructs two stake_delegation certs in the same slot but different block_index, asserts the higher-block_index pool wins, and fails on `main` (non-deterministic) before this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make account restore deterministic by ranking certs with added_slot, block_index, then cert_index to break same-slot ties across transactions and tables.

- **Bug Fixes**
  - LEFT JOIN `transaction` and order by added_slot DESC, COALESCE(tx.block_index, 0) DESC, cert_index DESC in all account batch fetch queries for `sqlite`, `mysql`, and `postgres`.
  - Thread `block_index` through `certRecord` and use it in the cache merge comparator to resolve cross-transaction and cross-table ties.
  - Add regression tests: `TestBatchFetchCerts_SameSlotTiebreakByBlockIndex` and `TestBatchFetchCerts_CrossTableTiebreakByBlockIndex`.

<sup>Written for commit e9b37c60947a7bace589a61e610272a3ef2fa26f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic selection of the “latest” certificate/ stake record when multiple events share the same slot by adding an additional tie-breaker, reducing inconsistent restoration results.

* **Tests**
  * Added tests covering same-slot and cross-table tie-break scenarios to ensure consistent certificate selection and cache behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->