### PR TITLE
fix(ledger): rewind ledger state on rollback

### DIFF
--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -270,6 +270,22 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 			err,
 		)
 	}
+	// Roll back the ledger metadata state to the rewind point. Without
+	// this, the chain is pruned to rewindPoint but the UTxO database
+	// still reflects the failing block's post-apply state — consumed
+	// inputs stay consumed, created outputs stay created. When peers
+	// re-deliver the block we just rewound past, ledger validation
+	// looks up its inputs, finds them already marked consumed, and
+	// returns "rule 22 bad input(s) ... rule 24 value not conserved
+	// (consumed 0)" again, looping the recovery indefinitely until
+	// process restart. RewindPrimaryChainToPoint by design only touches
+	// the chain blob — the matching ledger rollback must be explicit.
+	if err := ls.rollback(rewindPoint); err != nil {
+		return false, fmt.Errorf(
+			"rollback ledger state after validation failure: %w",
+			err,
+		)
+	}
 	if ls.config.EventBus != nil {
 		ls.config.EventBus.Publish(
 			event.ChainsyncResyncEventType,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Roll back the ledger UTxO state when recovering from a tx validation error so it matches the chain rewind and avoids infinite resync loops.

- **Bug Fixes**
  - After `RewindPrimaryChainToPoint`, explicitly call `ls.rollback(rewindPoint)` to revert UTxO metadata.
  - Stops repeat validation failures ("bad input(s)" / "value not conserved") when the rewound block is re-delivered.

<sup>Written for commit 9be20b02a46828e5d44421d9fa9b4c5e6e010e13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

