### PR TITLE
fix(connmanager): enable linger zero for port reuse

### DIFF
--- a/connmanager/linger.go
+++ b/connmanager/linger.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import "net"
+
+// enableTCPLingerZero sets SO_LINGER to 0 on a TCP connection so
+// Close sends RST instead of FIN and the kernel skips TIME_WAIT.
+// This is required when OutboundSourcePort source-port reuse is
+// active: both inbound and outbound connections share the local
+// listen port, so a closed connection's 4-tuple stays in TIME_WAIT
+// and the next dial to the same peer fails with EADDRNOTAVAIL until
+// the kernel releases it (typically tcp_fin_timeout, default 60s on
+// Linux). With many peers and any churn (handshake failure, intersect
+// lookup failure, plateau recovery), the source port saturates with
+// TIME_WAIT 4-tuples and outbound dials fail consistently.
+//
+// Safe for Cardano N2N protocols: chainsync, blockfetch, and
+// txsubmission state is reconstructed from peer history on reconnect,
+// and ouroboros multiplexer shutdowns already drop in-flight messages
+// when a connection is closed for stall recovery. Unix-socket NtC
+// connections are unaffected because the type assertion fails for
+// non-TCP connections and the call is a no-op.
+func enableTCPLingerZero(conn net.Conn) error {
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return nil
+	}
+	return tc.SetLinger(0)
+}

--- a/connmanager/linger_test.go
+++ b/connmanager/linger_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnableTCPLingerZeroOnTCP verifies that enableTCPLingerZero
+// sets SO_LINGER on a real TCP connection. We can't directly read
+// the linger value back through Go's net API, so we drive it through
+// a paired listen/dial and assert the helper does not return an error.
+// The semantic effect (RST on close) is exercised by integration paths.
+func TestEnableTCPLingerZeroOnTCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	dialDone := make(chan net.Conn, 1)
+	go func() {
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			dialDone <- nil
+			return
+		}
+		dialDone <- c
+	}()
+
+	srv, err := ln.Accept()
+	require.NoError(t, err)
+	defer srv.Close()
+
+	cli := <-dialDone
+	require.NotNil(t, cli)
+	defer cli.Close()
+
+	assert.NoError(t, enableTCPLingerZero(srv))
+	assert.NoError(t, enableTCPLingerZero(cli))
+}
+
+// TestEnableTCPLingerZeroOnNonTCPIsNoop verifies that calling the
+// helper on a non-TCP connection (e.g. unix-socket NtC) is a no-op
+// and never returns an error. The listener wires the helper before
+// the unix-socket wrapping, so this guard prevents NtC paths from
+// erroring on accept. net.Pipe gives us a non-TCP net.Conn pair
+// without a filesystem path — important on macOS where t.TempDir
+// paths exceed the unix-socket sun_path length limit.
+func TestEnableTCPLingerZeroOnNonTCPIsNoop(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer srv.Close()
+	defer cli.Close()
+
+	assert.NoError(t, enableTCPLingerZero(srv))
+	assert.NoError(t, enableTCPLingerZero(cli))
+}
+
+// TestEnableTCPLingerZeroOnNilIsNoop covers the defensive path where
+// a caller passes a nil connection (e.g. dial error path).
+func TestEnableTCPLingerZeroOnNilIsNoop(t *testing.T) {
+	assert.NoError(t, enableTCPLingerZero(nil))
+}

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -262,6 +262,23 @@ func (c *ConnectionManager) startListener(
 				continue
 			}
 
+			// N2N path: when source-port reuse is in use, force RST
+			// on close so the 4-tuple does not get stuck in TIME_WAIT
+			// and block a subsequent outbound dial to the same peer
+			// with EADDRNOTAVAIL on the matching local-listen-port
+			// 4-tuple.
+			if c.config.OutboundSourcePort > 0 {
+				if lingerErr := enableTCPLingerZero(conn); lingerErr != nil {
+					c.config.Logger.Warn(
+						fmt.Sprintf(
+							"listener: failed to enable SO_LINGER 0 on accepted connection from %s: %s",
+							conn.RemoteAddr(),
+							lingerErr,
+						),
+					)
+				}
+			}
+
 			// N2N path: reserve an inbound slot before further processing
 			if !c.tryReserveInboundSlot() {
 				c.config.Logger.Warn(

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -60,6 +60,19 @@ func (c *ConnectionManager) CreateOutboundConn(
 	if err != nil {
 		return nil, err
 	}
+	// When source-port reuse is in use, force RST on close so the
+	// 4-tuple does not get stuck in TIME_WAIT and block a subsequent
+	// dial to the same peer with EADDRNOTAVAIL.
+	if c.config.OutboundSourcePort > 0 {
+		if lingerErr := enableTCPLingerZero(tmpConn); lingerErr != nil {
+			c.config.Logger.Warn(
+				"outbound: failed to enable SO_LINGER 0 on dialed connection",
+				"role", "client",
+				"address", address,
+				"error", lingerErr,
+			)
+		}
+	}
 	// Build connection options
 	connOpts := make(
 		[]ouroboros.ConnectionOptionFunc,


### PR DESCRIPTION
Closes #2165 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EADDRNOTAVAIL when reusing a source port by setting SO_LINGER(0) so TCP closes send RST and skip TIME_WAIT. Applies to inbound and outbound TCP when `OutboundSourcePort` is set; non-TCP is a no-op.

- **Bug Fixes**
  - Set SO_LINGER(0) on accepted TCP connections when `OutboundSourcePort > 0`.
  - Set SO_LINGER(0) on dialed TCP connections when `OutboundSourcePort > 0`.
  - No-op on non-TCP and nil connections; added unit tests.
  - Warn if enabling SO_LINGER(0) fails.

<sup>Written for commit 136521211039b424e0cf18edf40670d0a2778ec3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TCP socket linger is now set to zero for connections when outbound source ports are configured.

* **Tests**
  * Added test coverage for TCP socket linger behavior across various connection types, including nil connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->