### PR TITLE
chore: appease golangci-lint

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -119,14 +119,12 @@ const (
 	maxPeerHeaderHistoryPerConn = 256
 )
 
-var (
-	// ErrRollbackLoopDetected is returned by handleEventChainsyncRollback when
-	// the same peer repeatedly requests a rollback to the same slot within the
-	// rollback loop detection window. The rollback is skipped to break the loop,
-	// and the caller should trigger a chainsync re-sync to recover.
-	ErrRollbackLoopDetected = errors.New(
-		"rollback loop detected: same slot rolled back too many times within window",
-	)
+// ErrRollbackLoopDetected is returned by handleEventChainsyncRollback when
+// the same peer repeatedly requests a rollback to the same slot within the
+// rollback loop detection window. The rollback is skipped to break the loop,
+// and the caller should trigger a chainsync re-sync to recover.
+var ErrRollbackLoopDetected = errors.New(
+	"rollback loop detected: same slot rolled back too many times within window",
 )
 
 type peerHeaderRecord struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix golangci-lint warning by moving ErrRollbackLoopDetected out of a var block and attaching the doc comment to the symbol. No functional changes.

<sup>Written for commit 58554e9701356c45302a42373862322dc19d4e9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->