### PR TITLE
fix(peergov): DNS resolution failure silently falls back to hostname

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -727,14 +727,14 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 	normalized := p.resolveAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	// if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
-	// 	p.denyList[p.peers[idx].NormalizedAddress] = time.Now().Add(duration)
-	// 	p.denyList[p.normalizeAddress(p.peers[idx].Address)] = time.Now().
-	// 		Add(duration)
-	//} else {
-	p.denyList[normalized] = time.Now().Add(duration)
-	// 	p.denyList[p.normalizeAddress(address)] = time.Now().Add(duration)
-	// }
+	if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
+		p.denyList[p.peers[idx].NormalizedAddress] = time.Now().Add(duration)
+		p.denyList[p.normalizeAddress(p.peers[idx].Address)] = time.Now().
+			Add(duration)
+	} else {
+		p.denyList[normalized] = time.Now().Add(duration)
+		p.denyList[p.normalizeAddress(address)] = time.Now().Add(duration)
+	}
 	p.config.Logger.Debug(
 		"peer added to deny list",
 		"address", address,
@@ -748,18 +748,17 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 func (p *PeerGovernor) IsDenied(address string) bool {
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)
-	// hostnameNormalized := p.normalizeAddress(address)
+	hostnameNormalized := p.normalizeAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.isDeniedLocked(normalized)
-	// if p.isDeniedLocked(normalized) || p.isDeniedLocked(hostnameNormalized) {
-	// 	return true
-	// }
-	// if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
-	// 	return p.isDeniedLocked(p.peers[idx].NormalizedAddress) ||
-	// 		p.isDeniedLocked(p.normalizeAddress(p.peers[idx].Address))
-	// }
-	// return false
+	if p.isDeniedLocked(normalized) || p.isDeniedLocked(hostnameNormalized) {
+		return true
+	}
+	if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
+		return p.isDeniedLocked(p.peers[idx].NormalizedAddress) ||
+			p.isDeniedLocked(p.normalizeAddress(p.peers[idx].Address))
+	}
+	return false
 }
 
 // isDeniedLocked checks if a peer is on the deny list.

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -727,7 +727,14 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 	normalized := p.resolveAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
+	// 	p.denyList[p.peers[idx].NormalizedAddress] = time.Now().Add(duration)
+	// 	p.denyList[p.normalizeAddress(p.peers[idx].Address)] = time.Now().
+	// 		Add(duration)
+	//} else {
 	p.denyList[normalized] = time.Now().Add(duration)
+	// 	p.denyList[p.normalizeAddress(address)] = time.Now().Add(duration)
+	// }
 	p.config.Logger.Debug(
 		"peer added to deny list",
 		"address", address,
@@ -741,9 +748,18 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 func (p *PeerGovernor) IsDenied(address string) bool {
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)
+	// hostnameNormalized := p.normalizeAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.isDeniedLocked(normalized)
+	// if p.isDeniedLocked(normalized) || p.isDeniedLocked(hostnameNormalized) {
+	// 	return true
+	// }
+	// if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
+	// 	return p.isDeniedLocked(p.peers[idx].NormalizedAddress) ||
+	// 		p.isDeniedLocked(p.normalizeAddress(p.peers[idx].Address))
+	// }
+	// return false
 }
 
 // isDeniedLocked checks if a peer is on the deny list.

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -212,8 +212,7 @@ func (p *PeerGovernor) addLedgerPeer(address string) bool {
 	p.mu.Lock()
 
 	// Check deny list
-	//if p.isDeniedLocked(normalized) || p.isDeniedLocked(p.normalizeAddress(address)) {
-	if p.isDeniedLocked(normalized) {
+	if p.isDeniedLocked(normalized) || p.isDeniedLocked(p.normalizeAddress(address)) {
 		p.mu.Unlock()
 		return false
 	}

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -212,6 +212,7 @@ func (p *PeerGovernor) addLedgerPeer(address string) bool {
 	p.mu.Lock()
 
 	// Check deny list
+	//if p.isDeniedLocked(normalized) || p.isDeniedLocked(p.normalizeAddress(address)) {
 	if p.isDeniedLocked(normalized) {
 		p.mu.Unlock()
 		return false

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -15,11 +15,13 @@
 package peergov
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1235,6 +1237,75 @@ func TestPeerGovernor_AddPeer_Denied(t *testing.T) {
 	peers = pg.GetPeers()
 	assert.Len(t, peers, 1)
 	assert.Equal(t, "44.0.0.1:3002", peers[0].Address)
+}
+
+func TestPeerGovernor_AddPeer_DedupesHostnameAfterDNSFailure(t *testing.T) {
+	oldLookupIP := lookupIP
+	lookupIP = func(string) ([]net.IP, error) {
+		return nil, errors.New("lookup failed")
+	}
+	t.Cleanup(func() { lookupIP = oldLookupIP })
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "relay.example.com:3001",
+		NormalizedAddress: "44.0.0.1:3001",
+		Source:            PeerSourceP2PGossip,
+		State:             PeerStateCold,
+	})
+
+	err := pg.AddPeer("relay.example.com:3001", PeerSourceP2PGossip)
+
+	require.NoError(t, err)
+	assert.Len(t, pg.peers, 1)
+}
+
+func TestPeerGovernor_DenyPeer_BlocksHostnameAfterDNSFailure(t *testing.T) {
+	oldLookupIP := lookupIP
+	t.Cleanup(func() { lookupIP = oldLookupIP })
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DenyDuration: time.Hour,
+	})
+
+	lookupIP = func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("44.0.0.1")}, nil
+	}
+	pg.DenyPeer("relay.example.com:3001", 0)
+
+	lookupIP = func(string) ([]net.IP, error) {
+		return nil, errors.New("lookup failed")
+	}
+	err := pg.AddPeer("relay.example.com:3001", PeerSourceP2PGossip)
+
+	require.NoError(t, err)
+	assert.Empty(t, pg.peers)
+	assert.True(t, pg.IsDenied("relay.example.com:3001"))
+}
+
+func TestPeerGovernor_ResolveAddress_LogsDNSFailure(t *testing.T) {
+	oldLookupIP := lookupIP
+	lookupIP = func(string) ([]net.IP, error) {
+		return nil, errors.New("lookup failed")
+	}
+	t.Cleanup(func() { lookupIP = oldLookupIP })
+
+	var buf bytes.Buffer
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(&buf, nil)),
+	})
+
+	normalized := pg.resolveAddress("relay.example.com:3001")
+
+	assert.Equal(t, "relay.example.com:3001", normalized)
+	assert.True(
+		t,
+		strings.Contains(buf.String(), "failed to resolve peer hostname"),
+		"expected DNS resolution failure to be logged",
+	)
 }
 
 func TestPeerGovernor_TestPeer_DeniesOnFailure(t *testing.T) {

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -94,7 +94,7 @@ func (p *PeerGovernor) AddPeer(
 ) error {
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)
-	// hostnameNormalized := p.normalizeAddress(address)
+	hostnameNormalized := p.normalizeAddress(address)
 
 	// Reject non-routable IPs early — topology peers bypass this check
 	// so operators can use private addresses for local relays. Inbound
@@ -114,8 +114,7 @@ func (p *PeerGovernor) AddPeer(
 
 	p.mu.Lock()
 	// Check deny list before adding
-	// if p.isDeniedLocked(normalized) || p.isDeniedLocked(hostnameNormalized) {
-	if p.isDeniedLocked(normalized) {
+	if p.isDeniedLocked(normalized) || p.isDeniedLocked(hostnameNormalized) {
 		p.config.Logger.Debug(
 			"not adding denied peer",
 			"address", address,
@@ -125,16 +124,12 @@ func (p *PeerGovernor) AddPeer(
 	}
 	// Check if already exists (use normalized address for deduplication)
 	for _, peer := range p.peers {
-		// if peer == nil {
-		// 	continue
-		// }
-		// if peer.NormalizedAddress == normalized ||
-		// 	peer.NormalizedAddress == hostnameNormalized ||
-		// 	p.normalizeAddress(peer.Address) == hostnameNormalized {
-		// 	p.mu.Unlock()
-		// 	return nil
-		// }
-		if peer != nil && peer.NormalizedAddress == normalized {
+		if peer == nil {
+			continue
+		}
+		if peer.NormalizedAddress == normalized ||
+			peer.NormalizedAddress == hostnameNormalized ||
+			p.normalizeAddress(peer.Address) == hostnameNormalized {
 			p.mu.Unlock()
 			return nil
 		}
@@ -247,12 +242,12 @@ func (p *PeerGovernor) resolveAddress(address string) string {
 	// It's a hostname - try to resolve it
 	ips, err := lookupIP(host)
 	if err != nil || len(ips) == 0 {
-		// p.config.Logger.Warn(
-		// 	"failed to resolve peer hostname",
-		// 	"address", address,
-		// 	"host", host,
-		// 	"error", err,
-		// )
+		p.config.Logger.Warn(
+			"failed to resolve peer hostname",
+			"address", address,
+			"host", host,
+			"error", err,
+		)
 		// Can't resolve, just lowercase the hostname
 		return net.JoinHostPort(strings.ToLower(host), port)
 	}

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -32,6 +32,8 @@ const defaultMinPeerListCap = 200
 // the peer list has reached its hard capacity limit.
 var ErrPeerListFull = errors.New("peer list at capacity")
 
+var lookupIP = net.LookupIP
+
 // maxPeerListSize returns the hard cap for the total number of peers.
 // This prevents unbounded growth between reconciliation cycles.
 // The cap is max(2 * TargetNumberOfKnownPeers, defaultMinPeerListCap).
@@ -92,6 +94,7 @@ func (p *PeerGovernor) AddPeer(
 ) error {
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)
+	// hostnameNormalized := p.normalizeAddress(address)
 
 	// Reject non-routable IPs early — topology peers bypass this check
 	// so operators can use private addresses for local relays. Inbound
@@ -111,6 +114,7 @@ func (p *PeerGovernor) AddPeer(
 
 	p.mu.Lock()
 	// Check deny list before adding
+	// if p.isDeniedLocked(normalized) || p.isDeniedLocked(hostnameNormalized) {
 	if p.isDeniedLocked(normalized) {
 		p.config.Logger.Debug(
 			"not adding denied peer",
@@ -121,6 +125,15 @@ func (p *PeerGovernor) AddPeer(
 	}
 	// Check if already exists (use normalized address for deduplication)
 	for _, peer := range p.peers {
+		// if peer == nil {
+		// 	continue
+		// }
+		// if peer.NormalizedAddress == normalized ||
+		// 	peer.NormalizedAddress == hostnameNormalized ||
+		// 	p.normalizeAddress(peer.Address) == hostnameNormalized {
+		// 	p.mu.Unlock()
+		// 	return nil
+		// }
 		if peer != nil && peer.NormalizedAddress == normalized {
 			p.mu.Unlock()
 			return nil
@@ -232,8 +245,14 @@ func (p *PeerGovernor) resolveAddress(address string) string {
 	}
 
 	// It's a hostname - try to resolve it
-	ips, err := net.LookupIP(host)
+	ips, err := lookupIP(host)
 	if err != nil || len(ips) == 0 {
+		// p.config.Logger.Warn(
+		// 	"failed to resolve peer hostname",
+		// 	"address", address,
+		// 	"host", host,
+		// 	"error", err,
+		// )
 		// Can't resolve, just lowercase the hostname
 		return net.JoinHostPort(strings.ToLower(host), port)
 	}


### PR DESCRIPTION
1. Added a warning log message in resolveAddress when DNS lookup fails instead of silently falling back to the hostname.
2. Made changes in AddPeer where it checks both the resolved address and the hostname-normalized address before adding a peer.
3. Also, made changes in AddPeer where it dedupes peers across IP and hostname forms, so the same peer is not tracked twice when DNS works once and fails later.
4. Made changes in DenyPeer to store deny entries for both known forms of a peer like resolved/IP form and hostname form.
5. Made changes in IsDenied where it checks both forms, so a peer denied as an IP cannot be allowed back as a hostname and ledger_discovery now applies the same two-form deny check before adding ledger-discovered peers.
6. Added the tests to cover DNS failure logging, duplicate prevention, and deny-list behavior when DNS succeeds first and fails later.

Closes #1526 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests to verify `peergov` dedupes peers and enforces the deny list when DNS resolution fails, and that DNS failures are logged. Introduces an injectable `lookupIP` and updates `resolveAddress` to use it for reliable DNS stubbing in tests.

<sup>Written for commit 7ac6ee93d00998a04a8819a2a89451a567efd775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer denial checks to work consistently across different address variants
  * Enhanced DNS resolution error handling with better fallback mechanisms  
  * More reliable peer deduplication when address normalization is involved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->