### PR TITLE
fix: don't disconnect only peer over local tip plateau

### DIFF
--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -181,31 +181,53 @@ func (n *Node) processChainsyncRecyclerTick(
 					effectiveCooldown,
 					effectivePlateau,
 				) {
-					n.config.logger.Warn(
-						"local tip plateau detected, resyncing chainsync client",
-						"connection_id", connKey,
-						"local_tip_slot", localTipSlot,
-						"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
-						"plateau_duration", now.Sub(*lastProgressAt),
-					)
-					n.eventBus.Publish(
-						event.ChainsyncResyncEventType,
-						event.NewEvent(
+					// Never disconnect the only eligible peer over
+					// a plateau. Plateau is a local-progress signal,
+					// not a peer-health signal: closing the only
+					// upstream forces a reconnect to the same remote
+					// on a fresh source port, which cannot recover a
+					// locally-pinned tip and amplifies disruption
+					// when the remote RSTs the reconnect. Mirrors the
+					// stalled-recycle guard below.
+					if eligibleCount <= 1 {
+						n.config.logger.Warn(
+							"local tip plateau detected but no spare eligible peer, skipping resync",
+							"connection_id", connKey,
+							"local_tip_slot", localTipSlot,
+							"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+							"plateau_duration", now.Sub(*lastProgressAt),
+							"eligible_peer_count", eligibleCount,
+						)
+						// Throttle the warning to plateau cadence
+						// instead of every tick.
+						*lastProgressAt = now
+					} else {
+						n.config.logger.Warn(
+							"local tip plateau detected, resyncing chainsync client",
+							"connection_id", connKey,
+							"local_tip_slot", localTipSlot,
+							"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+							"plateau_duration", now.Sub(*lastProgressAt),
+						)
+						n.eventBus.Publish(
 							event.ChainsyncResyncEventType,
-							event.ChainsyncResyncEvent{
-								ConnectionId: *targetConn,
-								Reason:       "local_tip_plateau",
-							},
-						),
-					)
-					n.realignOtherPeersAfterPlateau(
-						*targetConn,
-						trackedClients,
-						localTipSlot,
-					)
-					delete(recycleAt, connKey)
-					lastRecycled[connKey] = now
-					*lastProgressAt = now
+							event.NewEvent(
+								event.ChainsyncResyncEventType,
+								event.ChainsyncResyncEvent{
+									ConnectionId: *targetConn,
+									Reason:       "local_tip_plateau",
+								},
+							),
+						)
+						n.realignOtherPeersAfterPlateau(
+							*targetConn,
+							trackedClients,
+							localTipSlot,
+						)
+						delete(recycleAt, connKey)
+						lastRecycled[connKey] = now
+						*lastProgressAt = now
+					}
 				}
 			}
 		}

--- a/node_test.go
+++ b/node_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -349,7 +350,80 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 		event.ChainsyncResyncEventType,
 	)
 
-	connId := newNodeTestConnId(2)
+	activeConn := newNodeTestConnId(2)
+	secondConn := newNodeTestConnId(2001)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   2,
+			StallTimeout: time.Hour,
+		},
+	)
+	require.True(t, state.AddClientConnId(activeConn))
+	require.True(t, state.AddClientConnId(secondConn))
+	state.SetClientConnId(activeConn)
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(activeConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("best")},
+		BlockNumber: 60,
+	}, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+	}
+
+	now := time.Now()
+	lastProgressSlot := uint64(100)
+	lastProgressAt := now.Add(-5 * time.Minute)
+	recycleAt := make(map[string]time.Time)
+	lastRecycled := make(map[string]time.Time)
+
+	n.processChainsyncRecyclerTick(
+		now,
+		100,
+		chainsync.Config{
+			MaxClients:   2,
+			StallTimeout: time.Hour,
+		},
+		recycleAt,
+		lastRecycled,
+		&lastProgressSlot,
+		&lastProgressAt,
+		4*time.Minute,
+		time.Second,
+		2*time.Minute,
+	)
+
+	select {
+	case evt := <-resyncCh:
+		resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
+		require.True(t, ok)
+		assert.Equal(t, activeConn, resyncEvt.ConnectionId)
+		assert.Equal(t, "local_tip_plateau", resyncEvt.Reason)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected plateau resync event")
+	}
+}
+
+func TestProcessChainsyncRecyclerTickSkipsPlateauOnlyPeer(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(
+		event.ChainsyncResyncEventType,
+	)
+
+	connId := newNodeTestConnId(3)
 	state := chainsync.NewStateWithConfig(
 		bus,
 		nil,
@@ -380,7 +454,8 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 
 	now := time.Now()
 	lastProgressSlot := uint64(100)
-	lastProgressAt := now.Add(-5 * time.Minute)
+	originalProgress := now.Add(-5 * time.Minute)
+	lastProgressAt := originalProgress
 	recycleAt := make(map[string]time.Time)
 	lastRecycled := make(map[string]time.Time)
 
@@ -400,15 +475,24 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 		2*time.Minute,
 	)
 
-	select {
-	case evt := <-resyncCh:
-		resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
-		require.True(t, ok)
-		assert.Equal(t, connId, resyncEvt.ConnectionId)
-		assert.Equal(t, "local_tip_plateau", resyncEvt.Reason)
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("expected plateau resync event")
-	}
+	// No plateau resync event should be emitted when the only
+	// eligible peer would be the disconnect target. Disconnecting
+	// a single-relay BP's only upstream over a plateau cannot
+	// recover a locally-pinned tip and amplifies disruption.
+	testutil.RequireNoReceive(
+		t,
+		resyncCh,
+		50*time.Millisecond,
+		"plateau action should be suppressed for only eligible peer",
+	)
+
+	// lastProgressAt should be reset so the suppression warning
+	// is throttled to plateau cadence rather than every tick.
+	assert.True(
+		t,
+		lastProgressAt.After(originalProgress),
+		"lastProgressAt should be reset after suppressed plateau",
+	)
 }
 
 func TestProcessChainsyncRecyclerTickRealignsOtherPeersOnPlateau(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid disconnecting the only eligible peer when a local tip plateau is detected, preventing unnecessary reconnects and downtime. Resync still occurs when multiple eligible peers are available.

- **Bug Fixes**
  - Skip plateau resync when only one eligible peer is present (guard on eligibleCount <= 1) and log the eligible count.
  - Reset lastProgressAt when skipping to throttle warnings to plateau cadence.
  - Update plateau resync test to use two clients and expect resync.
  - Add test to verify skip behavior with a single peer and lastProgressAt reset.

<sup>Written for commit 656211e638d63566c9e762cc3379e1e4d3962888. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Chainsync recycler to prevent unnecessary resync operations when only a single eligible peer is available, reducing disruptive network activity.

* **Tests**
  * Extended test coverage for Chainsync recycler logic across single-peer and multi-peer connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->