### PR TITLE
fix(database): panic during shutdown

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -527,6 +527,7 @@ func (d *BlobStoreBadger) NewIterator(
 	txn types.Txn,
 	opts types.BlobIteratorOptions,
 ) types.BlobIterator {
+	// ) (iter types.BlobIterator) {
 	badgerTxn, err := d.validateTxn(txn)
 	if err != nil {
 		return &errorIterator{err: err}
@@ -535,6 +536,18 @@ func (d *BlobStoreBadger) NewIterator(
 		Prefix:  opts.Prefix,
 		Reverse: opts.Reverse,
 	}
+	// defer func() {
+	// 	if r := recover(); r != nil {
+	// 		err, ok := r.(error)
+	// 		if ok && errors.Is(err, badger.ErrDBClosed) {
+	// 			iter = &errorIterator{
+	// 				err: fmt.Errorf("%w: %w", types.ErrBlobStoreUnavailable, err),
+	// 			}
+	// 			return
+	// 		}
+	// 		panic(r)
+	// 	}
+	// }()
 	return &badgerIterator{iter: badgerTxn.tx.NewIterator(iterOpts)}
 }
 

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -526,8 +526,7 @@ func (d *BlobStoreBadger) Delete(txn types.Txn, key []byte) error {
 func (d *BlobStoreBadger) NewIterator(
 	txn types.Txn,
 	opts types.BlobIteratorOptions,
-) types.BlobIterator {
-	// ) (iter types.BlobIterator) {
+) (iter types.BlobIterator) {
 	badgerTxn, err := d.validateTxn(txn)
 	if err != nil {
 		return &errorIterator{err: err}
@@ -536,18 +535,18 @@ func (d *BlobStoreBadger) NewIterator(
 		Prefix:  opts.Prefix,
 		Reverse: opts.Reverse,
 	}
-	// defer func() {
-	// 	if r := recover(); r != nil {
-	// 		err, ok := r.(error)
-	// 		if ok && errors.Is(err, badger.ErrDBClosed) {
-	// 			iter = &errorIterator{
-	// 				err: fmt.Errorf("%w: %w", types.ErrBlobStoreUnavailable, err),
-	// 			}
-	// 			return
-	// 		}
-	// 		panic(r)
-	// 	}
-	// }()
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			if ok && errors.Is(err, badger.ErrDBClosed) {
+				iter = &errorIterator{
+					err: fmt.Errorf("%w: %w", types.ErrBlobStoreUnavailable, err),
+				}
+				return
+			}
+			panic(r)
+		}
+	}()
 	return &badgerIterator{iter: badgerTxn.tx.NewIterator(iterOpts)}
 }
 

--- a/database/plugin/blob/badger/database_test.go
+++ b/database/plugin/blob/badger/database_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalBlockMetadataRoundTrip(t *testing.T) {
@@ -85,4 +86,31 @@ func TestUnmarshalBlockMetadataLegacyCbor(t *testing.T) {
 	if !bytes.Equal(decoded.PrevHash, expected.PrevHash) {
 		t.Fatalf("expected PrevHash %x, got %x", expected.PrevHash, decoded.PrevHash)
 	}
+}
+
+// It reproduces the shutdown race where a transaction created before BlobStoreBadger.Close()
+// is later used to create an iterator. Badger panics with "DB Closed" in
+// that case; the blob store should return an error iterator instead.
+func TestBlobStoreBadger_NewIteratorAfterCloseDoesNotPanic(t *testing.T) {
+	// Create a Badger blob store.
+	store, err := New()
+	require.NoError(t, err)
+
+	// Create a transaction from that store.
+	txn := store.NewTransaction(false)
+
+	// Close the store.
+	require.NoError(t, store.Close())
+
+	// Try to create an iterator using the old transaction and expect no panic.
+	var iter types.BlobIterator
+	require.NotPanics(t, func() {
+		iter = store.NewIterator(txn, types.BlobIteratorOptions{
+			Prefix: []byte("x"),
+		})
+	})
+
+	// Expect an iterator object and to contain an error.
+	require.NotNil(t, iter)
+	require.Error(t, iter.Err())
 }


### PR DESCRIPTION
1. Added a fix for shutdown-time panic in the Badger blob store when NewIterator is called after the underlying Badger DB has been closed.
2. I have recovered badger.ErrDBClosed from BlobStoreBadger.NewIterator and return an errorIterator with types.ErrBlobStoreUnavailable instead of panicking.
3. Added a test for creating an iterator from a transaction after store close.

Closes #1225 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a regression test for the `badger`-backed blob store that reproduces the shutdown race and asserts correct behavior: creating an iterator from a pre-close transaction after `Close()` must not panic and should return an error iterator.

<sup>Written for commit 966a5b3cb173aeb068fda3b0099dd15867a5a0d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for blob store operations under edge-case conditions, ensuring graceful behavior instead of unexpected terminations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->