### PR TITLE
fix(ledger): Fix data race in LedgerState.ledgerProcessBlocks

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1972,7 +1972,10 @@ func (ls *LedgerState) IsAtTip() bool {
 // For Byron era, returns 2k. For Shelley+ eras, returns 3k/f.
 // Returns the default threshold if genesis data is unavailable or invalid.
 func (ls *LedgerState) calculateStabilityWindow() uint64 {
-	return ls.calculateStabilityWindowForEra(ls.currentEra.Id)
+	ls.RLock()
+	eraId := ls.currentEra.Id
+	ls.RUnlock()
+	return ls.calculateStabilityWindowForEra(eraId)
 }
 
 // calculateStabilityWindowForEra calculates the stability window for the given era.
@@ -2126,8 +2129,6 @@ func (ls *LedgerState) SecurityParam() int {
 // current era in slots. For Byron the window is 2k; for Shelley+ it is 3k/f.
 // It is safe to call from multiple goroutines.
 func (ls *LedgerState) StabilityWindow() uint64 {
-	ls.RLock()
-	defer ls.RUnlock()
 	return ls.calculateStabilityWindow()
 }
 

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -68,10 +68,8 @@ func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
 	require.NoError(t, err)
 }
 
-// It reproduces the race where block processing updates currentEra while
-// calculateStabilityWindow reads currentEra.Id without taking ls.RLock().
-// This test is expected to fail under go test -race until the reader is
-// synchronized with the writer.
+// It verifies that calculating the stability window is synchronized with
+// concurrent currentEra updates from block processing.
 func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 	ls := &LedgerState{
 		currentEra: eras.ShelleyEraDesc,

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -68,6 +68,10 @@ func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
 	require.NoError(t, err)
 }
 
+// It reproduces the race where block processing updates currentEra while
+// calculateStabilityWindow reads currentEra.Id without taking ls.RLock().
+// This test is expected to fail under go test -race until the reader is
+// synchronized with the writer.
 func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 	ls := &LedgerState{
 		currentEra: eras.ShelleyEraDesc,

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -68,6 +68,54 @@ func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
 	require.NoError(t, err)
 }
 
+func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
+	ls := &LedgerState{
+		currentEra: eras.ShelleyEraDesc,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	start := make(chan struct{})
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100; i++ {
+			ls.Lock()
+			if i%2 == 0 {
+				ls.currentEra = eras.BabbageEraDesc
+			} else {
+				ls.currentEra = eras.ConwayEraDesc
+			}
+			ls.Unlock()
+		}
+		close(done)
+	}()
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = ls.calculateStabilityWindow()
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
 // TestCalculateStabilityWindow_ByronEra tests the stability window calculation for Byron era
 func TestCalculateStabilityWindow_ByronEra(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
1. Added a race test for concurrent currentEra updates and stability window reads.
2. Modified calculateStabilityWindow() to read currentEra.Id under ls.RLock().
3. Removed the extra lock in StabilityWindow() since the calculateStabilityWindow() locks internally.

Closes #1260 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `currentEra` data race by RLocking the era read in `calculateStabilityWindow()` and having `StabilityWindow()` delegate to it without extra locking, and add a concurrency test that previously failed under `go test -race`, addressing #1260.

<sup>Written for commit 52401953fc3c325ab8d06b242369f93cca921121. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal concurrency handling for stability calculations.

* **Tests**
  * Added comprehensive concurrency tests for stability window behavior under concurrent access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->