### PR TITLE
fix(database): release prune lock immediately

### DIFF
--- a/database/prune.go
+++ b/database/prune.go
@@ -48,10 +48,12 @@ func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
 	// transaction so the blob write txn below has a single, simple commit
 	// scope. A UTxO consumed between this read and the blob write is
 	// handled below: GetUtxo will return ErrBlobKeyNotFound and the entry
-	// is skipped.
+	// is skipped. Release the read txn as soon as liveUtxos is
+	// materialized so the connection is freed before the blob write txn
+	// and block operations run.
 	mdTxn := d.MetadataTxn(false)
-	defer mdTxn.Release()
 	liveUtxos, err := d.metadata.GetLiveUtxosBySlot(slot, mdTxn.Metadata())
+	mdTxn.Release()
 	if err != nil {
 		return 0, fmt.Errorf(
 			"prune block (slot=%d): list live utxos: %w",
@@ -137,7 +139,7 @@ func (d *Database) materializeUtxo(
 	// offset is the authoritative source. If they disagree, the UTxO
 	// is backed by a different block — leave it alone.
 	if offset.BlockSlot != slot || !bytes.Equal(offset.BlockHash[:], hash) {
-		d.logger.Warn(
+		d.logger.Error(
 			"prune block: utxo offset references unexpected block; skipping",
 			"slot", slot,
 			"hash", hex.EncodeToString(hash),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release the metadata read transaction in `database` pruning as soon as live UTxOs are materialized to free the connection and reduce contention during blob writes and block operations. Also upgrade the log when a UTxO offset references an unexpected block from warn to error for better visibility.

<sup>Written for commit c9d4da67f715daa8a6f87fd3a57e26ef204d0a0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diagnostic reporting for database conditions by adjusting notification levels.

* **Improvements**
  * Refined metadata transaction lifecycle management in database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->