### PR TITLE
fix(database): treat blob key not found as empty for mithril

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -343,7 +343,23 @@ func runMithrilSync(
 		StorageMode:    cfg.StorageMode,
 	})
 	if err != nil {
-		return fmt.Errorf("opening database: %w", err)
+		// Tolerate a recoverable commit-timestamp mismatch carried
+		// over from a previously interrupted run. The mithril import
+		// writes blocks and ledger state through full transactions
+		// that update both stores' timestamps in lockstep, so the
+		// mismatch heals as soon as we make forward progress.
+		var cte database.CommitTimestampError
+		if errors.As(err, &cte) && db != nil {
+			logger.Warn(
+				"opened database with commit timestamp mismatch; "+
+					"continuing mithril sync — import will heal it",
+				"component", "mithril",
+				"metadata_timestamp", cte.MetadataTimestamp,
+				"blob_timestamp", cte.BlobTimestamp,
+			)
+		} else {
+			return fmt.Errorf("opening database: %w", err)
+		}
 	}
 	defer db.Close()
 

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -76,7 +77,20 @@ func checkSyncState(
 		StorageMode:    cfg.StorageMode,
 	})
 	if err != nil {
-		return fmt.Errorf("opening database: %w", err)
+		// A commit-timestamp mismatch is recoverable downstream in
+		// node.Run. We only need to read sync_status here, which
+		// works on the partially-initialised db handle returned with
+		// the error.
+		var cte database.CommitTimestampError
+		if !errors.As(err, &cte) || db == nil {
+			return fmt.Errorf("opening database: %w", err)
+		}
+		logger.Warn(
+			"sync state check observed commit timestamp mismatch; "+
+				"deferring recovery to node startup",
+			"metadata_timestamp", cte.MetadataTimestamp,
+			"blob_timestamp", cte.BlobTimestamp,
+		)
 	}
 	defer db.Close()
 
@@ -137,7 +151,21 @@ func resumeBackfill(
 		StorageMode:    cfg.StorageMode,
 	})
 	if err != nil {
-		return fmt.Errorf("opening database: %w", err)
+		// Backfill writes through full transactions which heal a
+		// commit-timestamp mismatch as it makes progress, and
+		// node.Run will run a full recovery pass afterwards. So a
+		// recoverable mismatch should not block the resume.
+		var cte database.CommitTimestampError
+		if !errors.As(err, &cte) || db == nil {
+			return fmt.Errorf("opening database: %w", err)
+		}
+		logger.Warn(
+			"backfill observed commit timestamp mismatch; "+
+				"continuing — backfill writes will heal it",
+			"component", "backfill",
+			"metadata_timestamp", cte.MetadataTimestamp,
+			"blob_timestamp", cte.BlobTimestamp,
+		)
 	}
 	defer db.Close()
 

--- a/database/commit_timestamp_repro_test.go
+++ b/database/commit_timestamp_repro_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckCommitTimestamp_FreshBlobAndMetadata verifies that a brand-new
+// database opens cleanly: a missing blob commit-timestamp key must be
+// treated like a missing metadata row (return 0), not as a fatal error.
+func TestCheckCommitTimestamp_FreshBlobAndMetadata(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	bts, bErr := db.Blob().GetCommitTimestamp()
+	require.NoError(t, bErr, "blob.GetCommitTimestamp on fresh blob must not error")
+	require.Equal(t, int64(0), bts, "fresh blob should report timestamp 0")
+}
+
+// TestCheckCommitTimestamp_MetadataOnly reproduces the user-reported failure
+// path: metadata has a commit timestamp but the blob does not. After the
+// fix, opening must surface this as a recoverable CommitTimestampError
+// (so the existing recovery path in node.Run can run), not as the raw
+// "blob key not found" plumbing leak.
+func TestCheckCommitTimestamp_MetadataOnly(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	dataDir := db.config.DataDir
+
+	metaTxn := db.Metadata().Transaction()
+	require.NoError(t, db.Metadata().SetCommitTimestamp(123456789, metaTxn))
+	require.NoError(t, metaTxn.Commit())
+	require.NoError(t, db.Close())
+
+	db2, err := New(&Config{
+		DataDir:        dataDir,
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	if db2 != nil {
+		defer db2.Close()
+	}
+	require.Error(t, err)
+	var cte CommitTimestampError
+	require.ErrorAs(t, err, &cte, "expected recoverable CommitTimestampError, got: %v", err)
+	require.Equal(t, int64(123456789), cte.MetadataTimestamp)
+	require.Equal(t, int64(0), cte.BlobTimestamp)
+	require.False(
+		t,
+		errors.Is(err, types.ErrBlobKeyNotFound),
+		"missing blob timestamp must not surface as raw ErrBlobKeyNotFound",
+	)
+}

--- a/database/plugin/blob/aws/commit_timestamp.go
+++ b/database/plugin/blob/aws/commit_timestamp.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
 	"time"
 
@@ -34,6 +35,12 @@ func (b *BlobStoreS3) GetCommitTimestamp() (int64, error) {
 
 	data, err := b.Get(txn, []byte(commitTimestampBlobKey))
 	if err != nil {
+		// A missing key means no timestamp has been written yet —
+		// return 0 to mirror the metadata stores' missing-row
+		// behavior so a fresh blob does not look like a corrupt one.
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return 0, nil
+		}
 		return 0, err
 	}
 

--- a/database/plugin/blob/badger/commit_timestamp.go
+++ b/database/plugin/blob/badger/commit_timestamp.go
@@ -16,6 +16,7 @@ package badger
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -32,6 +33,13 @@ func (b *BlobStoreBadger) GetCommitTimestamp() (int64, error) {
 
 	val, err := b.Get(txn, []byte(commitTimestampBlobKey))
 	if err != nil {
+		// Treat a missing key the same as the metadata stores treat a
+		// missing row: no timestamp written yet, return 0. Returning
+		// an error here turned a fresh blob into a fatal open failure
+		// whenever metadata had any non-zero timestamp.
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return 0, nil
+		}
 		return 0, fmt.Errorf("failed to read commit timestamp: %w", err)
 	}
 	if len(val) == 8 {

--- a/database/plugin/blob/gcs/commit_timestamp.go
+++ b/database/plugin/blob/gcs/commit_timestamp.go
@@ -16,6 +16,7 @@ package gcs
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
 	"time"
 
@@ -34,6 +35,12 @@ func (b *BlobStoreGCS) GetCommitTimestamp() (int64, error) {
 
 	r, err := b.Get(txn, []byte(commitTimestampBlobKey))
 	if err != nil {
+		// A missing key means no timestamp has been written yet —
+		// return 0 to mirror the metadata stores' missing-row
+		// behavior so a fresh blob does not look like a corrupt one.
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return 0, nil
+		}
 		return 0, err
 	}
 

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -70,6 +70,22 @@ func ensureDB(
 	}
 	newDB, err := database.New(dbConfig)
 	if err != nil {
+		// Bootstrap paths (load / mithril sync) tolerate a recoverable
+		// commit-timestamp mismatch: the import work that follows
+		// writes through full transactions which heal the timestamps.
+		// Returning the error here would leave the user unable to
+		// re-run a load / re-bootstrap from a previous interrupted
+		// import.
+		var cte database.CommitTimestampError
+		if errors.As(err, &cte) && newDB != nil {
+			logger.Warn(
+				"opened database with commit timestamp mismatch; "+
+					"continuing — import will heal it",
+				"metadata_timestamp", cte.MetadataTimestamp,
+				"blob_timestamp", cte.BlobTimestamp,
+			)
+			return newDB, func() { newDB.Close() }, nil
+		}
 		return nil, nil, fmt.Errorf("creating database: %w", err)
 	}
 	return newDB, func() { newDB.Close() }, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Treats a missing blob commit-timestamp as zero and lets mithril import, backfill, and node startup proceed when a recoverable timestamp mismatch is detected. This prevents fatal "blob key not found" errors after interrupted runs and allows the import to self-heal.

- **Bug Fixes**
  - `badger`, `gcs`, and `aws` blob plugins now return 0 (not an error) when the commit-timestamp key is missing.
  - `mithril` sync, `checkSyncState`, `resumeBackfill`, and node bootstrap paths log a warning and continue on `CommitTimestampError` so normal writes heal the mismatch.
  - Added tests to confirm fresh blob stores open cleanly and that a metadata-only timestamp surfaces as a recoverable `CommitTimestampError`, not `ErrBlobKeyNotFound`.

<sup>Written for commit edd844756d373bbc2a7a242c5e58b3addba7bad4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

