### PR TITLE
feat(database): batch get accounts

### DIFF
--- a/database/account.go
+++ b/database/account.go
@@ -141,6 +141,22 @@ func (d *Database) GetAccount(
 	return account, nil
 }
 
+// GetAccounts returns accounts for the given staking keys in a single
+// query, keyed by string(StakingKey). Stake keys with no matching row
+// are omitted (callers detect "not found" by absence). An empty input
+// returns an empty (non-nil) map and no error.
+func (d *Database) GetAccounts(
+	stakeKeys [][]byte,
+	includeInactive bool,
+	txn *Txn,
+) (map[string]*models.Account, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetAccounts(stakeKeys, includeInactive, txn.Metadata())
+}
+
 // AddAccountReward credits the reward balance for a registered account.
 func (d *Database) AddAccountReward(
 	stakeKey []byte,

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -49,6 +49,35 @@ func (d *MetadataStoreMysql) GetAccount(
 	return ret, nil
 }
 
+// GetAccounts fetches multiple accounts in one IN-list query, keyed by
+// string(StakingKey). Stake keys with no matching row are omitted.
+func (d *MetadataStoreMysql) GetAccounts(
+	stakeKeys [][]byte,
+	includeInactive bool,
+	txn types.Txn,
+) (map[string]*models.Account, error) {
+	ret := make(map[string]*models.Account, len(stakeKeys))
+	if len(stakeKeys) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where("staking_key IN ?", stakeKeys)
+	if !includeInactive {
+		query = query.Where("active = ?", true)
+	}
+	var rows []*models.Account
+	if result := query.Find(&rows); result.Error != nil {
+		return nil, result.Error
+	}
+	for _, row := range rows {
+		ret[string(row.StakingKey)] = row
+	}
+	return ret, nil
+}
+
 // AddAccountReward credits a registered reward account.
 func (d *MetadataStoreMysql) AddAccountReward(
 	stakeKey []byte,

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -49,6 +49,35 @@ func (d *MetadataStorePostgres) GetAccount(
 	return ret, nil
 }
 
+// GetAccounts fetches multiple accounts in one IN-list query, keyed by
+// string(StakingKey). Stake keys with no matching row are omitted.
+func (d *MetadataStorePostgres) GetAccounts(
+	stakeKeys [][]byte,
+	includeInactive bool,
+	txn types.Txn,
+) (map[string]*models.Account, error) {
+	ret := make(map[string]*models.Account, len(stakeKeys))
+	if len(stakeKeys) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where("staking_key IN ?", stakeKeys)
+	if !includeInactive {
+		query = query.Where("active = ?", true)
+	}
+	var rows []*models.Account
+	if result := query.Find(&rows); result.Error != nil {
+		return nil, result.Error
+	}
+	for _, row := range rows {
+		ret[string(row.StakingKey)] = row
+	}
+	return ret, nil
+}
+
 // AddAccountReward credits a registered reward account.
 func (d *MetadataStorePostgres) AddAccountReward(
 	stakeKey []byte,

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -632,6 +632,35 @@ func (d *MetadataStoreSqlite) GetAccount(
 	return ret, nil
 }
 
+// GetAccounts fetches multiple accounts in one IN-list query, keyed by
+// string(StakingKey). Stake keys with no matching row are omitted.
+func (d *MetadataStoreSqlite) GetAccounts(
+	stakeKeys [][]byte,
+	includeInactive bool,
+	txn types.Txn,
+) (map[string]*models.Account, error) {
+	ret := make(map[string]*models.Account, len(stakeKeys))
+	if len(stakeKeys) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where("staking_key IN ?", stakeKeys)
+	if !includeInactive {
+		query = query.Where("active = ?", true)
+	}
+	var rows []*models.Account
+	if result := query.Find(&rows); result.Error != nil {
+		return nil, result.Error
+	}
+	for _, row := range rows {
+		ret[string(row.StakingKey)] = row
+	}
+	return ret, nil
+}
+
 // AddAccountReward credits a registered reward account.
 func (d *MetadataStoreSqlite) AddAccountReward(
 	stakeKey []byte,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -213,6 +213,16 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Account, error)
 
+	// GetAccounts retrieves multiple accounts by stake key in a single query,
+	// optionally including inactive accounts. The returned map is keyed by
+	// string(StakingKey); stake keys with no matching row are omitted. An
+	// empty input returns an empty (non-nil) map and no error.
+	GetAccounts(
+		[][]byte, // stakeKeys
+		bool, // includeInactive
+		types.Txn,
+	) (map[string]*models.Account, error)
+
 	// AddAccountReward credits a reward account by stake credential.
 	AddAccountReward(
 		[]byte, // stakeKey

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -524,13 +524,27 @@ func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 ) (any, error) {
 	delegations := make(map[olocalstatequery.StakeCredential]ledger.Blake2b224)
 	rewards := make(map[olocalstatequery.StakeCredential]uint64)
+	if len(creds) == 0 {
+		return []any{[]any{delegations, rewards}}, nil
+	}
+	stakeKeys := make([][]byte, 0, len(creds))
+	seen := make(map[string]struct{}, len(creds))
 	for _, cred := range creds {
-		account, err := ls.db.GetAccount(cred.Bytes[:], false, nil)
-		if err != nil {
-			if errors.Is(err, models.ErrAccountNotFound) {
-				continue
-			}
-			return nil, err
+		key := string(cred.Bytes[:])
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		stakeKeys = append(stakeKeys, cred.Bytes[:])
+	}
+	accounts, err := ls.db.GetAccounts(stakeKeys, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, cred := range creds {
+		account, ok := accounts[string(cred.Bytes[:])]
+		if !ok {
+			continue
 		}
 		rewards[cred] = uint64(account.Reward)
 		if len(account.Pool) > 0 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a batch account lookup by staking keys and update the ledger query to use it. This removes N+1 database calls and speeds up delegation/reward lookups.

- New Features
  - Added GetAccounts to MetadataStore and implemented for MySQL, Postgres, and SQLite; returns a map keyed by string(staking_key), respects includeInactive, and handles empty input.
  - Added Database.GetAccounts wrapper with automatic transaction handling.

- Refactors
  - Updated queryShelleyFilteredDelegationAndRewardAccounts to batch fetch accounts, dedupe stake keys, short-circuit on empty input, and build rewards/delegations from the batched result.

<sup>Written for commit 1a98c289b9795f15dd15d962357de4abb5a18b1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

