### PR TITLE
chore: remove stale rate limit constant

### DIFF
--- a/ouroboros/txsubmission_rate_limiter.go
+++ b/ouroboros/txsubmission_rate_limiter.go
@@ -27,10 +27,6 @@ func connIdKey(c ouroboros.ConnectionId) string {
 	return c.String()
 }
 
-// DefaultMaxTxSubmissionsPerSecond is the default maximum number of
-// transaction submissions accepted per peer per second.
-const DefaultMaxTxSubmissionsPerSecond = 30
-
 // tokenBucket implements a simple token bucket rate limiter.
 // Tokens are replenished at a fixed rate up to a maximum burst.
 type tokenBucket struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed stale rate limit constant `DefaultMaxTxSubmissionsPerSecond` from the transaction submission rate limiter. No functional changes; limiter continues to use existing token bucket configuration.

<sup>Written for commit 3687aafdab0b7ed30100933f3b9fb4bd7acf49c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

