### PR TITLE
fix(test): avoid creating s3:/ in worktree

### DIFF
--- a/internal/integration/benchmark_test.go
+++ b/internal/integration/benchmark_test.go
@@ -147,19 +147,29 @@ func getTestBackends(b namer, diskDataDir string) []struct {
 		},
 	}
 
-	// Add cloud backends if credentials are available AND database can be created
+	// Add cloud backends if credentials are available AND database can be created.
+	// Cloud blob plugins read bucket/prefix from plugin options, not DataDir, so
+	// DataDir is only consumed by the sqlite metadata plugin and must be a local
+	// filesystem path — using a "gcs://"/"s3://" URL would create a literal
+	// "gcs:/"/"s3:/" directory in the working tree.
 	if hasGCSCredentials() {
 		testBucket := os.Getenv("DINGO_TEST_GCS_BUCKET")
 		if testBucket == "" {
 			testBucket = "dingo-test-bucket"
 		}
-		// Use path prefix for isolation instead of unique bucket names
-		testPrefix := strings.ReplaceAll(b.Name(), "/", "-")
 		gcsConfig := &database.Config{
 			BlobPlugin:     "gcs",
-			DataDir:        "gcs://" + testBucket + "/" + testPrefix,
+			DataDir:        filepath.Join(diskDataDir, "gcs-metadata"),
 			MetadataPlugin: "sqlite",
 		}
+
+		plugin.SetPluginOption(
+			plugin.PluginTypeBlob,
+			"gcs",
+			"bucket",
+			testBucket,
+		)
+
 		if canCreateDatabase(gcsConfig) {
 			backends = append(backends, struct {
 				config *database.Config
@@ -177,10 +187,10 @@ func getTestBackends(b namer, diskDataDir string) []struct {
 			testBucket = "dingo-test-bucket"
 		}
 		// Use path prefix for isolation instead of unique bucket names
-		testPrefix := strings.ReplaceAll(b.Name(), "/", "-")
+		testPrefix := strings.ReplaceAll(b.Name(), "/", "-") + "/"
 		s3Config := &database.Config{
 			BlobPlugin:     "s3",
-			DataDir:        "s3://" + testBucket + "/" + testPrefix,
+			DataDir:        filepath.Join(diskDataDir, "s3-metadata"),
 			MetadataPlugin: "sqlite",
 		}
 
@@ -189,6 +199,13 @@ func getTestBackends(b namer, diskDataDir string) []struct {
 			"s3",
 			"bucket",
 			testBucket,
+		)
+
+		plugin.SetPluginOption(
+			plugin.PluginTypeBlob,
+			"s3",
+			"prefix",
+			testPrefix,
 		)
 
 		region := os.Getenv("AWS_REGION")


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes integration tests by writing cloud backend metadata to a local tmp dir, preventing accidental `s3:/` and `gcs:/` folders in the worktree. Cloud blob settings are now passed via plugin options instead of encoding them in `DataDir`.

- **Bug Fixes**
  - Set `DataDir` to `diskDataDir/gcs-metadata` and `diskDataDir/s3-metadata` for sqlite metadata while keeping blobs on GCS/S3.
  - Configure cloud blobs via `plugin.SetPluginOption` (`gcs.bucket`, `s3.bucket`, `s3.prefix`) and add a trailing slash to `testPrefix`.
  - Retains region fallback to `us-east-1` and only adds backends when database creation succeeds.

<sup>Written for commit c73d0bed56ef32036ba26f94d70caeeece40ca66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined cloud storage backend configuration in benchmark tests to better separate metadata storage from blob storage handling for GCS and S3 providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->