### PR TITLE
fix(ledger): skip already-applied headers in local rollback recovery

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1305,8 +1305,20 @@ func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 		if ancestorPoint == nil || !pointMatches(*ancestorPoint, point) {
 			continue
 		}
+		// Anything at or below the chain's current header tip is already
+		// applied. Without this guard, a forkPath entry whose hash equals
+		// the header tip causes AddBlockHeader to fail the prev-hash
+		// check (header tip's prev != header tip), which aborts recovery
+		// and breaks the chainsync session permanently. Use the larger
+		// of the rollback point and the live header tip so concurrent
+		// progress past `point` does not regress recovery.
+		cutoffSlot := point.Slot
+		if tipSlot := ls.chain.HeaderTip().Point.Slot; tipSlot > cutoffSlot {
+			cutoffSlot = tipSlot
+		}
+		added := 0
 		for _, evt := range forkPath {
-			if evt.Point.Slot <= point.Slot {
+			if evt.Point.Slot <= cutoffSlot {
 				continue
 			}
 			if err := ls.chain.AddBlockHeader(evt.BlockHeader); err != nil {
@@ -1314,8 +1326,9 @@ func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 				ls.headerPipelineConnId = ouroboros.ConnectionId{}
 				return 0, err
 			}
+			added++
 		}
-		if ls.chain.HeaderCount() == 0 {
+		if added == 0 {
 			continue
 		}
 		ls.headerPipelineConnId = connId

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -786,6 +786,74 @@ func TestRecoverAfterLocalRollbackSkipsConnectionCloseWhenPrimaryChainTipPastRol
 	assert.Equal(t, 7, fixture.ls.headerMismatchCount)
 }
 
+// Reproduces a chainsync recovery hang seen during multi-pool DevNet
+// runs. After a slot battle the chain has already extended past `point`
+// with the very block that peer history hands back as the only forkPath
+// entry. The recovery loop must skip events whose slot is at or below
+// the chain's header tip; otherwise AddBlockHeader rejects the duplicate
+// with BlockNotFitChainTipError, clearQueuedHeaders fires, and the
+// chainsync session never re-converges with the peer.
+func TestRecoverPeerHeaderHistoryFromPointSkipsHeadersAlreadyAtChainTip(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	advancedHash := testHashBytes("recovery-already-at-tip")
+	advancedSlot := fixture.currentTip.Point.Slot + 1
+	advancedBlockNumber := fixture.currentTip.BlockNumber + 1
+	require.NoError(
+		t,
+		fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+			{
+				Slot:        advancedSlot,
+				Hash:        advancedHash,
+				BlockNumber: advancedBlockNumber,
+				Type:        1,
+				PrevHash:    fixture.currentTip.Point.Hash,
+				Cbor:        []byte{0x80},
+			},
+		}),
+	)
+	require.Equal(
+		t,
+		advancedSlot,
+		fixture.ls.chain.HeaderTip().Point.Slot,
+		"chain header tip must reflect the post-rollback advance",
+	)
+
+	advancedHeader := mockHeader{
+		hash:        lcommon.NewBlake2b256(advancedHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+		blockNumber: advancedBlockNumber,
+		slot:        advancedSlot,
+	}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			advancedHeader.slot,
+			advancedHeader.hash.Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				advancedHeader.slot,
+				advancedHeader.hash.Bytes(),
+			),
+			BlockNumber: advancedHeader.blockNumber,
+		},
+		BlockHeader: advancedHeader,
+	})
+
+	fixture.ls.chainsyncMutex.Lock()
+	headerCount, err := fixture.ls.recoverPeerHeaderHistoryFromPointLocked(
+		fixture.connId,
+		fixture.currentTip.Point,
+	)
+	fixture.ls.chainsyncMutex.Unlock()
+
+	require.NoError(t, err)
+	assert.Zero(t, headerCount)
+}
+
 func TestHandleEventChainsyncBlockHeaderIgnoresStaleRollForwardBehindTip(
 	t *testing.T,
 ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent chainsync recovery hangs after a local rollback by skipping headers that are already applied at or below the current header tip. This avoids duplicate header insertions that previously aborted recovery and broke the chainsync session.

- **Bug Fixes**
  - In `recoverPeerHeaderHistoryFromPointLocked`, skip `forkPath` events at or below `cutoffSlot = max(point.Slot, HeaderTip().Point.Slot)`.
  - Track how many headers are added and update `headerPipelineConnId` only when at least one header is applied.
  - Add `TestRecoverPeerHeaderHistoryFromPointSkipsHeadersAlreadyAtChainTip` to reproduce the issue and assert recovery proceeds without errors or re-adding headers.

<sup>Written for commit 9d53dbcfd5607c9521d7db9fd005daf2875461b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

