### PR TITLE
fix: rename dingo only cardano node metrics to dingo metrics

### DIFF
--- a/docs/dashboards/README.md
+++ b/docs/dashboards/README.md
@@ -151,7 +151,7 @@ Some metrics only emit when their feature is active. Panels display "No data" un
 |--------|---------------|
 | `cardano_node_metrics_Forge_node_is_leader_int` | Forging is enabled |
 | `cardano_node_metrics_Forge_adopted_int` | Block is forged and adopted |
-| `cardano_node_metrics_blockForgingLatency_seconds_bucket` | Block is forged |
+| `dingo_metrics_blockForgingLatency_seconds_bucket` | Block is forged |
 | `cardano_node_metrics_remainingKESPeriods_int` | KES key is configured |
 | `dingo_forge_tip_gap_slots` | Forging is enabled |
 | `dingo_database_size_bytes` | Database stores are initialized |

--- a/docs/dashboards/block-production.json
+++ b/docs/dashboards/block-production.json
@@ -478,7 +478,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -582,7 +582,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -1123,7 +1123,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "{{alias}}",
           "refId": "A"
@@ -1718,7 +1718,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.5, rate(cardano_node_metrics_blockForgingLatency_seconds_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.5, rate(dingo_metrics_blockForgingLatency_seconds_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p50",
           "range": true,
           "refId": "A"
@@ -1728,7 +1728,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, rate(cardano_node_metrics_blockForgingLatency_seconds_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.95, rate(dingo_metrics_blockForgingLatency_seconds_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p95",
           "range": true,
           "refId": "B"
@@ -1738,7 +1738,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, rate(cardano_node_metrics_blockForgingLatency_seconds_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.99, rate(dingo_metrics_blockForgingLatency_seconds_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p99",
           "range": true,
           "refId": "C"
@@ -2336,7 +2336,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.5, rate(cardano_node_metrics_forgedBlockSize_bytes_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.5, rate(dingo_metrics_forgedBlockSize_bytes_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p50 bytes",
           "range": true,
           "refId": "A"
@@ -2346,7 +2346,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, rate(cardano_node_metrics_forgedBlockSize_bytes_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.95, rate(dingo_metrics_forgedBlockSize_bytes_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p95 bytes",
           "range": true,
           "refId": "B"
@@ -2436,7 +2436,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.5, rate(cardano_node_metrics_forgedBlockTxCount_int_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.5, rate(dingo_metrics_forgedBlockTxCount_int_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p50 tx",
           "range": true,
           "refId": "A"
@@ -2446,7 +2446,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, rate(cardano_node_metrics_forgedBlockTxCount_int_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
+          "expr": "histogram_quantile(0.95, rate(dingo_metrics_forgedBlockTxCount_int_bucket{network=\"$network\",instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{alias}} p95 tx",
           "range": true,
           "refId": "B"

--- a/docs/dashboards/full-panel.json
+++ b/docs/dashboards/full-panel.json
@@ -338,7 +338,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "expr": "increase(cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}[1h])",
+      "expr": "increase(dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}[1h])",
       "instant": true,
       "legendFormat": "",
       "range": false,
@@ -442,7 +442,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+      "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
       "instant": true,
       "legendFormat": "",
       "range": false,

--- a/docs/dashboards/mempool.json
+++ b/docs/dashboards/mempool.json
@@ -478,7 +478,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -582,7 +582,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -956,7 +956,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "{{alias}}",
           "refId": "A"
@@ -1010,7 +1010,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_txsExpiredNum_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_txsExpiredNum_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "{{alias}}",
           "refId": "A"
@@ -1329,7 +1329,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}[5m]) * 60",
+          "expr": "rate(dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}[5m]) * 60",
           "legendFormat": "{{alias}} evict/min",
           "range": true,
           "refId": "C"
@@ -1339,7 +1339,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(cardano_node_metrics_txsExpiredNum_int{network=\"$network\",instance=~\"$instance\"}[5m]) * 60",
+          "expr": "rate(dingo_metrics_txsExpiredNum_int{network=\"$network\",instance=~\"$instance\"}[5m]) * 60",
           "legendFormat": "{{alias}} expire/min",
           "range": true,
           "refId": "D"
@@ -2068,7 +2068,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(cardano_node_metrics_txsEvictedNum_int{network=~\"$network\"}[$__rate_interval])",
+          "expr": "rate(dingo_metrics_txsEvictedNum_int{network=~\"$network\"}[$__rate_interval])",
           "format": "time_series",
           "instant": false,
           "legendFormat": "evicted",
@@ -2081,7 +2081,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(cardano_node_metrics_txsExpiredNum_int{network=~\"$network\"}[$__rate_interval])",
+          "expr": "rate(dingo_metrics_txsExpiredNum_int{network=~\"$network\"}[$__rate_interval])",
           "format": "time_series",
           "instant": false,
           "legendFormat": "expired",

--- a/docs/dashboards/node-overview.json
+++ b/docs/dashboards/node-overview.json
@@ -478,7 +478,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "increase(cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}[1h])",
+          "expr": "increase(dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}[1h])",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -582,7 +582,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,

--- a/docs/dashboards/peer-health.json
+++ b/docs/dashboards/peer-health.json
@@ -478,7 +478,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -582,7 +582,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -2150,7 +2150,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_peerSelection_peers_by_source{state=\"hot\",network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_peerSelection_peers_by_source{state=\"hot\",network=\"$network\",instance=~\"$instance\"}",
           "legendFormat": "{{alias}} {{source}} hot",
           "range": true,
           "refId": "A"
@@ -2160,7 +2160,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_peerSelection_peers_by_source{state=\"warm\",network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_peerSelection_peers_by_source{state=\"warm\",network=\"$network\",instance=~\"$instance\"}",
           "legendFormat": "{{alias}} {{source}} warm",
           "range": true,
           "refId": "B"
@@ -2170,7 +2170,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_peerSelection_peers_by_source{state=\"cold\",network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_peerSelection_peers_by_source{state=\"cold\",network=\"$network\",instance=~\"$instance\"}",
           "legendFormat": "{{alias}} {{source}} cold",
           "range": true,
           "refId": "C"

--- a/docs/dashboards/resources.json
+++ b/docs/dashboards/resources.json
@@ -500,7 +500,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_txsEvictedNum_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,
@@ -604,7 +604,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "cardano_node_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
+          "expr": "dingo_metrics_slotBattlesTotal_int{network=\"$network\",instance=~\"$instance\"}",
           "instant": true,
           "legendFormat": "",
           "range": false,

--- a/ledger/forging/metrics.go
+++ b/ledger/forging/metrics.go
@@ -122,13 +122,13 @@ func initForgingMetrics(
 	// Dingo-specific metrics
 	m.slotBattlesTotal = factory.NewCounter(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_slotBattlesTotal_int",
+			Name: "dingo_metrics_slotBattlesTotal_int",
 			Help: "slot battles detected (competing blocks at same slot)",
 		},
 	)
 	m.blockSizeBytes = factory.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "cardano_node_metrics_forgedBlockSize_bytes",
+			Name: "dingo_metrics_forgedBlockSize_bytes",
 			Help: "size of forged block bodies in bytes",
 			Buckets: prometheus.ExponentialBuckets(
 				256, 2, 14,
@@ -137,7 +137,7 @@ func initForgingMetrics(
 	)
 	m.blockTxCount = factory.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "cardano_node_metrics_forgedBlockTxCount_int",
+			Name: "dingo_metrics_forgedBlockTxCount_int",
 			Help: "number of transactions in forged blocks",
 			Buckets: prometheus.LinearBuckets(
 				0, 10, 20,

--- a/ledger/leader/metrics.go
+++ b/ledger/leader/metrics.go
@@ -35,45 +35,45 @@ func initElectionMetrics(reg prometheus.Registerer) *electionMetrics {
 	factory := promauto.With(reg)
 	return &electionMetrics{
 		slotChecksTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "cardano_node_metrics_leader_slot_checks_total",
+			Name: "dingo_metrics_leader_slot_checks_total",
 			Help: "number of leader slot checks executed",
 		}),
 		slotWonTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "cardano_node_metrics_leader_slot_won_total",
+			Name: "dingo_metrics_leader_slot_won_total",
 			Help: "number of leader checks that won a slot",
 		}),
 		slotNotWonTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "cardano_node_metrics_leader_slot_not_won_total",
+			Name: "dingo_metrics_leader_slot_not_won_total",
 			Help: "number of leader checks that did not win a slot",
 		}),
 		vrfEvalDurationSeconds: factory.NewHistogram(prometheus.HistogramOpts{
-			Name: "cardano_node_metrics_leader_vrf_eval_duration_seconds",
+			Name: "dingo_metrics_leader_vrf_eval_duration_seconds",
 			Help: "duration spent evaluating VRF over an epoch schedule",
 			Buckets: prometheus.ExponentialBuckets(
 				0.001, 2, 16,
 			), // 1ms to ~32s
 		}),
 		stakeLookupDuration: factory.NewHistogram(prometheus.HistogramOpts{
-			Name: "cardano_node_metrics_leader_stake_lookup_duration_seconds",
+			Name: "dingo_metrics_leader_stake_lookup_duration_seconds",
 			Help: "duration spent loading stake data for leader schedule computation",
 			Buckets: prometheus.ExponentialBuckets(
 				0.0001, 2, 16,
 			), // 100us to ~3.2s
 		}),
 		lastEpochSlotsChecked: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_leader_last_epoch_slots_checked_int",
+			Name: "dingo_metrics_leader_last_epoch_slots_checked_int",
 			Help: "slots evaluated in the most recently computed epoch schedule",
 		}),
 		lastEpochSlotsWon: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_leader_last_epoch_slots_won_int",
+			Name: "dingo_metrics_leader_last_epoch_slots_won_int",
 			Help: "winning slots in the most recently computed epoch schedule",
 		}),
 		lastEpochSlotsNotWon: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_leader_last_epoch_slots_not_won_int",
+			Name: "dingo_metrics_leader_last_epoch_slots_not_won_int",
 			Help: "non-winning slots in the most recently computed epoch schedule",
 		}),
 		lastEvaluatedEpochNumber: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_leader_last_evaluated_epoch_int",
+			Name: "dingo_metrics_leader_last_evaluated_epoch_int",
 			Help: "most recent epoch for which leader schedule was evaluated",
 		}),
 	}

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -73,7 +73,7 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	})
 	m.blockForgingLatency = promautoFactory.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "cardano_node_metrics_blockForgingLatency_seconds",
+			Name:    "dingo_metrics_blockForgingLatency_seconds",
 			Help:    "latency of block forging from slot start to block completion",
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 15), // 1ms to ~16s
 		},

--- a/ledger/snapshot/metrics.go
+++ b/ledger/snapshot/metrics.go
@@ -32,30 +32,30 @@ func initManagerMetrics(reg prometheus.Registerer) *managerMetrics {
 	factory := promauto.With(reg)
 	return &managerMetrics{
 		captureDurationSeconds: factory.NewHistogram(prometheus.HistogramOpts{
-			Name: "cardano_node_metrics_stake_snapshot_capture_duration_seconds",
+			Name: "dingo_metrics_stake_snapshot_capture_duration_seconds",
 			Help: "duration of stake snapshot capture runs",
 			Buckets: prometheus.ExponentialBuckets(
 				0.001, 2, 16,
 			), // 1ms to ~32s
 		}),
 		captureSuccessTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "cardano_node_metrics_stake_snapshot_capture_success_total",
+			Name: "dingo_metrics_stake_snapshot_capture_success_total",
 			Help: "successful stake snapshot captures",
 		}),
 		captureFailureTotal: factory.NewCounter(prometheus.CounterOpts{
-			Name: "cardano_node_metrics_stake_snapshot_capture_failure_total",
+			Name: "dingo_metrics_stake_snapshot_capture_failure_total",
 			Help: "failed stake snapshot captures",
 		}),
 		capturePoolsTotal: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_stake_snapshot_pool_count_int",
+			Name: "dingo_metrics_stake_snapshot_pool_count_int",
 			Help: "number of pools in the latest captured snapshot",
 		}),
 		captureTotalStakeLovelace: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_stake_snapshot_total_active_stake_lovelace",
+			Name: "dingo_metrics_stake_snapshot_total_active_stake_lovelace",
 			Help: "total active stake in the latest captured snapshot",
 		}),
 		lastSuccessfulEpoch: factory.NewGauge(prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_stake_snapshot_last_successful_epoch_int",
+			Name: "dingo_metrics_stake_snapshot_last_successful_epoch_int",
 			Help: "epoch of the latest successful snapshot capture",
 		}),
 	}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -379,13 +379,13 @@ func NewMempool(config MempoolConfig) *Mempool {
 	)
 	m.metrics.txsEvicted = promautoFactory.NewCounter(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_txsEvictedNum_int",
+			Name: "dingo_metrics_txsEvictedNum_int",
 			Help: "total transactions evicted from mempool",
 		},
 	)
 	m.metrics.txsExpired = promautoFactory.NewCounter(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_txsExpiredNum_int",
+			Name: "dingo_metrics_txsExpiredNum_int",
 			Help: "total transactions expired from mempool by TTL",
 		},
 	)

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -152,83 +152,83 @@ func (p *PeerGovernor) initMetrics() {
 	// Per-source metrics (Phase 7: Enhanced Observability)
 	p.metrics.peersBySource = promautoFactory.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_peerSelection_peers_by_source",
+			Name: "dingo_metrics_peerSelection_peers_by_source",
 			Help: "number of peers by source and state",
 		},
 		[]string{"source", "state"},
 	)
 	p.metrics.churnDemotionsBySource = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_peerSelection_churn_demotions_by_source",
+			Name: "dingo_metrics_peerSelection_churn_demotions_by_source",
 			Help: "number of churn demotions by source",
 		},
 		[]string{"source"},
 	)
 	p.metrics.churnPromotionsBySource = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_peerSelection_churn_promotions_by_source",
+			Name: "dingo_metrics_peerSelection_churn_promotions_by_source",
 			Help: "number of churn promotions by source",
 		},
 		[]string{"source"},
 	)
 	p.metrics.inboundWarmTarget = promautoFactory.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundWarmTarget",
+		Name: "dingo_metrics_peerSelection_InboundWarmTarget",
 		Help: "configured inbound warm peer target",
 	})
 	p.metrics.inboundHotQuota = promautoFactory.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundHotQuota",
+		Name: "dingo_metrics_peerSelection_InboundHotQuota",
 		Help: "configured inbound hot peer quota",
 	})
 	p.metrics.inboundWarmHeld = promautoFactory.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundWarmHeld",
+		Name: "dingo_metrics_peerSelection_InboundWarmHeld",
 		Help: "current number of inbound peers held warm",
 	})
 	p.metrics.inboundHotHeld = promautoFactory.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundHotHeld",
+		Name: "dingo_metrics_peerSelection_InboundHotHeld",
 		Help: "current number of inbound peers held hot",
 	})
 	p.metrics.inboundPruned = promautoFactory.NewCounter(prometheus.CounterOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundPruned",
+		Name: "dingo_metrics_peerSelection_InboundPruned",
 		Help: "total inbound peers pruned from governed sets",
 	})
 	p.metrics.inboundArrivalsTotal = promautoFactory.NewCounter(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_peerSelection_InboundArrivalsTotal",
+			Name: "dingo_metrics_peerSelection_InboundArrivalsTotal",
 			Help: "total inbound connection events observed since startup (includes re-arrivals)",
 		},
 	)
 	p.metrics.inboundTopologyMatched = promautoFactory.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_peerSelection_InboundTopologyMatched",
+			Name: "dingo_metrics_peerSelection_InboundTopologyMatched",
 			Help: "current number of peers whose inbound arrival was identified as a configured topology peer",
 		},
 	)
 	p.metrics.inboundDuplexHeld = promautoFactory.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "cardano_node_metrics_peerSelection_InboundDuplexHeld",
+			Name: "dingo_metrics_peerSelection_InboundDuplexHeld",
 			Help: "current number of inbound peers on full-duplex connections",
 		},
 	)
 	p.metrics.inboundPrunedByReason = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_peerSelection_InboundPrunedByReason",
+			Name: "dingo_metrics_peerSelection_InboundPrunedByReason",
 			Help: "total inbound peers pruned by policy reason",
 		},
 		[]string{"reason"},
 	)
 	p.metrics.inboundLifecycle = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cardano_node_metrics_peerSelection_InboundLifecycleTotal",
+			Name: "dingo_metrics_peerSelection_InboundLifecycleTotal",
 			Help: "total inbound lifecycle transitions by stage",
 		},
 		[]string{"stage"},
 	)
 	p.metrics.inboundHotQuotaUsage = promautoFactory.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundHotQuotaUsage",
+		Name: "dingo_metrics_peerSelection_InboundHotQuotaUsage",
 		Help: "fraction of inbound hot quota currently occupied (>=0; may exceed 1 when over quota)",
 	})
 	p.metrics.inboundWarmOccupancy = promautoFactory.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_peerSelection_InboundWarmTargetOccupancy",
+		Name: "dingo_metrics_peerSelection_InboundWarmTargetOccupancy",
 		Help: "fraction of inbound warm target currently occupied (>=0; may exceed 1 when over target)",
 	})
 }


### PR DESCRIPTION
Closes #2068 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed Dingo‑only Prometheus metrics from `cardano_node_metrics_*` to `dingo_metrics_*` and updated all Grafana dashboards to use the new names. This fixes mislabeling that implied these were upstream Cardano node metrics (closes #2068).

- **Bug Fixes**
  - Switched metric prefixes to `dingo_metrics_*` across ledger, forging, leader election, mempool, snapshot, and `peergov` (e.g., `blockForgingLatency`, mempool evicted/expired, slot battles, forged block size/tx count, leader schedule, stake snapshots, peer selection).
  - Updated dashboards (`block-production`, `mempool`, `node-overview`, `peer-health`, `resources`, `full-panel`) and docs to reference the new metric names.

- **Migration**
  - Update any custom Prometheus alerts/recording rules to use `dingo_metrics_*`; bundled dashboards are already updated.
  - No functional changes; only metric name prefixes changed.

<sup>Written for commit 9a7d1fdcb9bb5f0ea5f39d2324269cb0d546c726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple Grafana dashboards including node overview, peer health, mempool analysis, block production monitoring, and resources to reflect new metric naming conventions
  * Updated metric documentation and reference tables for monitoring configuration
* **Refactor**
  * Updated Prometheus metric identifiers across the monitoring infrastructure with new standardized naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->