### PR TITLE
fix: automatic peer sharing management

### DIFF
--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -75,6 +75,12 @@ type CardanoNodeConfig struct {
 	TargetNumberOfEstablishedPeers int  `yaml:"TargetNumberOfEstablishedPeers"`
 	TargetNumberOfActivePeers      int  `yaml:"TargetNumberOfActivePeers"`
 	EnableP2P                      bool `yaml:"EnableP2P"`
+
+	// PeerSharing in cardano-node config.json. Pointer distinguishes
+	// "field absent" (nil) from "explicitly false". Only consulted as
+	// a fallback default for non-block-producing nodes when the
+	// Dingo-native peerSharing value is unset.
+	PeerSharing *bool `yaml:"PeerSharing"`
 }
 
 const (

--- a/config/cardano/node_test.go
+++ b/config/cardano/node_test.go
@@ -258,6 +258,32 @@ func TestValidateGenesisHashEmpty(t *testing.T) {
 	assert.Equal(t, expectedHash, hash)
 }
 
+func TestCardanoNodeConfigPeerSharing(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want *bool
+	}{
+		{name: "absent", body: `{}`, want: nil},
+		{name: "true", body: `{"PeerSharing": true}`, want: ptrBool(true)},
+		{name: "false", body: `{"PeerSharing": false}`, want: ptrBool(false)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := NewCardanoNodeConfigFromReader(
+				bytes.NewReader([]byte(tc.body)),
+			)
+			require.NoError(t, err)
+			if tc.want == nil {
+				assert.Nil(t, cfg.PeerSharing)
+				return
+			}
+			require.NotNil(t, cfg.PeerSharing)
+			assert.Equal(t, *tc.want, *cfg.PeerSharing)
+		})
+	}
+}
+
 func TestGenesisHashMismatchFromFile(t *testing.T) {
 	// Config with wrong Byron genesis hash should fail to load
 	cfgBytes := []byte(`{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -294,10 +294,11 @@ type Config struct {
 	MeshPort uint `yaml:"meshPort" envconfig:"DINGO_MESH_PORT"`
 
 	// PeerSharing enables the peer sharing protocol, allowing this node
-	// to advertise known peers to other nodes on request. Defaults to
-	// false; should remain disabled on block producers to avoid leaking
-	// topology information.
-	PeerSharing bool `yaml:"peerSharing" envconfig:"DINGO_PEER_SHARING"`
+	// to advertise known peers to other nodes on request. Pointer
+	// distinguishes "operator did not set this" (nil) from "explicitly
+	// false". On a block producer the resolved default is false unless
+	// this field is explicitly set to true.
+	PeerSharing *bool `yaml:"peerSharing" envconfig:"DINGO_PEER_SHARING"`
 
 	// Storage mode: "core" (default) or "api".
 	// "core" stores only consensus data

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -69,7 +69,7 @@ var flagSpecs = []flagSpec{
 	uintFlag("PrivatePort", "private-port", "private/NtC port"),
 	uintFlag("MetricsPort", "metrics-port", "metrics port"),
 	uintFlag("DebugPort", "debug-port", "debug pprof port (0 = disabled)"),
-	boolFlag("PeerSharing", "peer-sharing", "enable peer sharing protocol"),
+	boolPtrFlag("PeerSharing", "peer-sharing", "enable peer sharing protocol (default: cardano-node config.json fallback for non-block-producers; false for block producers)"),
 
 	// APIs
 	uintFlag("UtxorpcPort", "utxorpc-port", "UTxO RPC API port"),
@@ -272,6 +272,31 @@ func boolFlag(field, name, help string) flagSpec {
 				return err
 			}
 			targetValue(cfg, field).SetBool(v)
+			return nil
+		},
+	}
+}
+
+// boolPtrFlag binds a CLI flag to a *bool field. The pointer distinguishes
+// "operator did not set this" (nil) from "explicitly false", which the flag
+// alone cannot express. The default the user sees in --help is false; we
+// only write to the field when the flag was explicitly passed.
+func boolPtrFlag(field, name, help string) flagSpec {
+	return flagSpec{
+		field: field,
+		name:  name,
+		register: func(f *pflag.FlagSet) {
+			f.Bool(name, false, help)
+		},
+		apply: func(f *pflag.FlagSet, cfg *Config) error {
+			if !f.Changed(name) {
+				return nil
+			}
+			v, err := f.GetBool(name)
+			if err != nil {
+				return err
+			}
+			targetValue(cfg, field).Set(reflect.ValueOf(&v))
 			return nil
 		},
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -172,6 +172,16 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		}
 		_ = rp // TargetNumberOfRootPeers not yet wired to peergov
 	}
+	var cardanoNodePeerSharing *bool
+	if nodeCfg != nil {
+		cardanoNodePeerSharing = nodeCfg.PeerSharing
+	}
+	peerSharing := resolvePeerSharing(
+		cfg.PeerSharing,
+		cfg.BlockProducer,
+		cardanoNodePeerSharing,
+		logger,
+	)
 
 	listeners := []dingo.ListenerConfig{}
 	if cfg.RelayPort > 0 {
@@ -283,7 +293,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithCardanoNodeConfig(nodeCfg),
 			dingo.WithListeners(listeners...),
 			dingo.WithOutboundSourcePort(cfg.RelayPort),
-			dingo.WithPeerSharing(cfg.PeerSharing),
+			dingo.WithPeerSharing(peerSharing),
 			dingo.WithUtxorpcPort(cfg.UtxorpcPort),
 			dingo.WithUtxorpcTlsCertFilePath(cfg.TlsCertFilePath),
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),

--- a/internal/node/peersharing.go
+++ b/internal/node/peersharing.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import "log/slog"
+
+// resolvePeerSharing decides the effective PeerSharing setting from the
+// Dingo-native value (CLI/env/YAML, may be nil), the BlockProducer flag,
+// and the cardano-node config.json value (may be nil). On a block producer
+// PeerSharing defaults to off and only the Dingo-native flag can turn it
+// on; cardano-node config.json is ignored. Off block-producers, the
+// cardano-node value acts as a fallback default when the Dingo-native
+// value is unconfigured.
+//
+// The reason this lives at the node-startup boundary rather than inside the
+// ouroboros wrapper or the gouroboros library: PeerSharing leaks topology
+// from a forging node and is incompatible with relays that do not speak
+// NtN >= 13 (they reset connections with UnknownMiniProtocol on
+// MiniProtocolNum 10). The decision must be made before any outbound NtN
+// VersionData is constructed.
+func resolvePeerSharing(
+	dingoNative *bool,
+	blockProducer bool,
+	cardanoNode *bool,
+	logger *slog.Logger,
+) bool {
+	if dingoNative != nil {
+		if *dingoNative && blockProducer && logger != nil {
+			logger.Warn(
+				"PeerSharing enabled on a block producer; this leaks topology and is incompatible with relays running NtN < 13. Disable unless you know what you're doing.",
+				"component", "node",
+			)
+		}
+		return *dingoNative
+	}
+	if blockProducer {
+		if logger != nil {
+			logger.Info(
+				"PeerSharing disabled by default on block producer; set --peer-sharing=true to override",
+				"component", "node",
+			)
+		}
+		return false
+	}
+	if cardanoNode != nil {
+		if logger != nil {
+			logger.Info(
+				"using cardano-node config.json PeerSharing as fallback default",
+				"component", "node",
+				"value", *cardanoNode,
+			)
+		}
+		return *cardanoNode
+	}
+	return false
+}

--- a/internal/node/peersharing_test.go
+++ b/internal/node/peersharing_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestResolvePeerSharing(t *testing.T) {
+	tests := []struct {
+		name            string
+		dingoNative     *bool
+		blockProducer   bool
+		cardanoNode     *bool
+		want            bool
+		wantLogContains string
+	}{
+		{
+			name:            "explicit true on BP warns and stays true",
+			dingoNative:     boolPtr(true),
+			blockProducer:   true,
+			cardanoNode:     nil,
+			want:            true,
+			wantLogContains: "leaks topology",
+		},
+		{
+			name:          "explicit true off BP stays true",
+			dingoNative:   boolPtr(true),
+			blockProducer: false,
+			cardanoNode:   nil,
+			want:          true,
+		},
+		{
+			name:          "explicit false on BP stays false",
+			dingoNative:   boolPtr(false),
+			blockProducer: true,
+			cardanoNode:   boolPtr(true),
+			want:          false,
+		},
+		{
+			name:          "explicit false off BP stays false",
+			dingoNative:   boolPtr(false),
+			blockProducer: false,
+			cardanoNode:   boolPtr(true),
+			want:          false,
+		},
+		{
+			name:            "unset on BP defaults off, ignores cardano-node",
+			dingoNative:     nil,
+			blockProducer:   true,
+			cardanoNode:     boolPtr(true),
+			want:            false,
+			wantLogContains: "disabled by default on block producer",
+		},
+		{
+			name:            "unset off BP, cardano-node true falls through",
+			dingoNative:     nil,
+			blockProducer:   false,
+			cardanoNode:     boolPtr(true),
+			want:            true,
+			wantLogContains: "cardano-node config.json PeerSharing",
+		},
+		{
+			name:          "unset off BP, cardano-node false falls through",
+			dingoNative:   nil,
+			blockProducer: false,
+			cardanoNode:   boolPtr(false),
+			want:          false,
+		},
+		{
+			name:          "unset off BP, cardano-node nil defaults off",
+			dingoNative:   nil,
+			blockProducer: false,
+			cardanoNode:   nil,
+			want:          false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+			got := resolvePeerSharing(
+				tc.dingoNative,
+				tc.blockProducer,
+				tc.cardanoNode,
+				logger,
+			)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			if tc.wantLogContains != "" &&
+				!strings.Contains(buf.String(), tc.wantLogContains) {
+				t.Fatalf(
+					"log %q missing %q",
+					buf.String(),
+					tc.wantLogContains,
+				)
+			}
+		})
+	}
+}
+
+func TestResolvePeerSharingNilLogger(t *testing.T) {
+	// Must not panic with nil logger on any branch.
+	cases := []struct {
+		dingoNative   *bool
+		blockProducer bool
+		cardanoNode   *bool
+	}{
+		{boolPtr(true), true, nil},
+		{nil, true, nil},
+		{nil, false, boolPtr(true)},
+		{nil, false, nil},
+	}
+	for _, tc := range cases {
+		_ = resolvePeerSharing(
+			tc.dingoNative,
+			tc.blockProducer,
+			tc.cardanoNode,
+			nil,
+		)
+	}
+}


### PR DESCRIPTION
Closes #2191 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically determine peer sharing with safe defaults: off for block producers unless explicitly enabled; relays fall back to `cardano-node` config when unset. This reduces accidental topology leaks and avoids issues with nodes running older NtN versions.

- **Bug Fixes**
  - Added startup resolver to pick peer sharing from the Dingo flag, block-producer mode, and `cardano-node` `config.json` fallback.
  - Updated config and CLI to use a `*bool` for `peerSharing`; `--peer-sharing` only applies when explicitly passed.
  - Parse optional `PeerSharing` from `cardano-node` `config.json`; ignore it on block producers.
  - Wired the resolved value into node initialization and added tests for config parsing and resolver logic.

<sup>Written for commit 05ceab18c4fbac32c6ea285eedbded3188dce95e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added peer sharing configuration option with improved three-state support (unset, enabled, disabled)
  * Supports configuration via YAML files, environment variables, and CLI flags
  * Implements configuration precedence to intelligently resolve peer sharing settings from multiple sources

* **Tests**
  * Added comprehensive test coverage for peer sharing configuration parsing and resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->