### PR TITLE
fix(connmanager): reduce listener failure logs

### DIFF
--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -271,7 +271,7 @@ func (c *ConnectionManager) startListener(
 				if lingerErr := enableTCPLingerZero(conn); lingerErr != nil {
 					c.config.Logger.Warn(
 						fmt.Sprintf(
-							"listener: failed to enable SO_LINGER 0 on accepted connection from %s: %s",
+							"listener: failed to enable SO_LINGER 0 on inbound connection from %s: %s",
 							conn.RemoteAddr(),
 							lingerErr,
 						),
@@ -322,12 +322,6 @@ func (c *ConnectionManager) startListener(
 				c.releaseInboundSlot()
 				continue
 			}
-			c.config.Logger.Info(
-				fmt.Sprintf(
-					"listener: accepted connection from %s",
-					conn.RemoteAddr(),
-				),
-			)
 			// Setup Ouroboros connection
 			connOpts := append(
 				defaultConnOpts,
@@ -335,9 +329,9 @@ func (c *ConnectionManager) startListener(
 			)
 			oConn, err := ouroboros.NewConnection(connOpts...)
 			if err != nil {
-				c.config.Logger.Error(
+				c.config.Logger.Info(
 					fmt.Sprintf(
-						"listener: failed to setup connection from %s: %s",
+						"listener: inbound connection from %s failed: %s",
 						conn.RemoteAddr(),
 						err,
 					),
@@ -348,6 +342,12 @@ func (c *ConnectionManager) startListener(
 				c.releaseInboundSlot()
 				continue
 			}
+			c.config.Logger.Info(
+				fmt.Sprintf(
+					"listener: inbound connection from %s",
+					conn.RemoteAddr(),
+				),
+			)
 			// Consume the reserved slot and add to connection manager.
 			// The reservation is released because AddConnection will
 			// add the actual connection entry to the map.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce noisy listener logs by consolidating connection messages and downgrading expected setup failures from error to info. Avoids double logs on inbound connections and makes transient failures less alarming.

- **Bug Fixes**
  - Log connection success once after `ouroboros.NewConnection`; removed early "accepted connection" info.
  - Downgraded setup failures to info with clearer "inbound connection ... failed" message.
  - Updated linger warning wording to "inbound connection" for consistency.

<sup>Written for commit b3cd7649e093463d5c7a02ede0de2f625e02261f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging clarity for inbound connection handling, with updated error messages and corrected severity levels to better reflect actual connection states and diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->