### PR TITLE
fix(ledger): perform a protocol check on block header version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/smithy-go v1.25.1
 	github.com/blinklabs-io/bark v0.0.2
@@ -91,7 +92,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect

--- a/ledger/header_protocol_version.go
+++ b/ledger/header_protocol_version.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// shelleyGenesisMainnet/TestnetNetworkId are the two values cardano-
+// ledger's NetworkId enum serializes into shelley-genesis.json's
+// networkId field. BBODY's `netId == Mainnet` predicate reads the
+// same field. Anything else is a configuration error and we refuse to
+// guess in either direction.
+const (
+	shelleyGenesisMainnetNetworkId = "Mainnet"
+	shelleyGenesisTestnetNetworkId = "Testnet"
+)
+
+// errUnknownNetwork is returned when the network identity cannot be
+// determined — Cardano node config or Shelley genesis is missing, or
+// the genesis carries an unrecognized networkId. The header-version
+// validator surfaces this as a validation failure rather than picking
+// a silent default that could weaken or strengthen the rule.
+var errUnknownNetwork = errors.New(
+	"cannot determine network identity from Shelley genesis",
+)
+
+// dijkstraMajorVersion is the protocol major version at which the
+// header pvMajor "too high" check becomes mandatory on every network.
+// Until cardano-ledger publishes stable Dijkstra specs and a Dijkstra
+// era table lands here, this value matches the Haskell `natVersion @12`
+// in cardano-ledger's BBODY rule.
+const dijkstraMajorVersion uint = 12
+
+// HeaderProtocolVersionTooHighError is returned when a block header's
+// protocol major version is more than one ahead of the current pparams
+// protocol major version. Mirrors cardano-ledger's HeaderProtVerTooHigh
+// failure from the BBODY rule.
+type HeaderProtocolVersionTooHighError struct {
+	Supplied uint
+	Expected uint
+}
+
+func (e *HeaderProtocolVersionTooHighError) Error() string {
+	return fmt.Sprintf(
+		"header protocol major version %d exceeds expected maximum %d",
+		e.Supplied, e.Expected,
+	)
+}
+
+// HeaderProtocolMajor extracts the protocol major version stored in a
+// block header. Returns (0, false) for Byron-era headers, which use a
+// different consensus mechanism (PBFT) and do not carry a Praos-style
+// ProtVer field.
+func HeaderProtocolMajor(header lcommon.BlockHeader) (uint, bool) {
+	switch h := header.(type) {
+	case *conway.ConwayBlockHeader:
+		return uint(h.Body.ProtoVersion.Major), true
+	case *babbage.BabbageBlockHeader:
+		return uint(h.Body.ProtoVersion.Major), true
+	case *alonzo.AlonzoBlockHeader:
+		return uint(h.Body.ProtoMajorVersion), true
+	case *mary.MaryBlockHeader:
+		return uint(h.Body.ProtoMajorVersion), true
+	case *allegra.AllegraBlockHeader:
+		return uint(h.Body.ProtoMajorVersion), true
+	case *shelley.ShelleyBlockHeader:
+		return uint(h.Body.ProtoMajorVersion), true
+	default:
+		// Byron and any unknown header type — skip the check rather
+		// than fabricating a value.
+		return 0, false
+	}
+}
+
+// ValidateHeaderProtocolVersion enforces cardano-ledger's BBODY-rule
+// check that a block header's protocol major version is not more than
+// one ahead of the current pparams protocol major version. A header
+// equal to or one greater than current is accepted; anything beyond
+// that is rejected with HeaderProtocolVersionTooHighError.
+//
+// The check is skipped on testnets (isMainnet == false) while the
+// current pparams major version is below Dijkstra (12). This mirrors
+// the relaxation introduced in cardano-ledger PR 5785 to support
+// ephemeral testnets that enable experimental hard forks or rebuild
+// chains in much older eras.
+//
+// Byron-era headers are also skipped, as they have no ProtVer field.
+func ValidateHeaderProtocolVersion(
+	header lcommon.BlockHeader,
+	curPvMajor uint,
+	isMainnet bool,
+) error {
+	if !isMainnet && curPvMajor < dijkstraMajorVersion {
+		return nil
+	}
+	bhMajor, ok := HeaderProtocolMajor(header)
+	if !ok {
+		return nil
+	}
+	nextMajor := curPvMajor + 1
+	if bhMajor > nextMajor {
+		return &HeaderProtocolVersionTooHighError{
+			Supplied: bhMajor,
+			Expected: nextMajor,
+		}
+	}
+	return nil
+}
+
+// isMainnet reports whether this LedgerState is configured for Cardano
+// mainnet, derived from the Shelley genesis networkId field. This is
+// the literal port of cardano-ledger's `netId == Mainnet` predicate
+// used by the BBODY rule. Network magic alone is not a reliable
+// discriminator (devnet shares mainnet's RequiresNoMagic wire setting);
+// only the genesis-declared identity has the right semantics.
+//
+// Fails closed: when CardanoNodeConfig or Shelley genesis is missing,
+// or the networkId field carries an unrecognized value, returns
+// errUnknownNetwork rather than silently picking a default. Callers
+// must treat that as a validation failure — picking either branch of
+// `Mainnet || pre-Dijkstra` blindly would either bypass the rule on a
+// real testnet or weaken it on mainnet.
+func (ls *LedgerState) isMainnet() (bool, error) {
+	if ls.config.CardanoNodeConfig == nil {
+		return false, errUnknownNetwork
+	}
+	sg := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if sg == nil {
+		return false, errUnknownNetwork
+	}
+	switch sg.NetworkId {
+	case shelleyGenesisMainnetNetworkId:
+		return true, nil
+	case shelleyGenesisTestnetNetworkId:
+		return false, nil
+	default:
+		return false, fmt.Errorf(
+			"%w: unrecognized networkId %q",
+			errUnknownNetwork, sg.NetworkId,
+		)
+	}
+}
+
+// validateBlockHeaderProtocolVersion is the LedgerState-bound entry
+// point for ValidateHeaderProtocolVersion. It pulls the current
+// protocol major version from pparams and the network identity from
+// the Shelley genesis, then delegates the BBODY-rule check. If the
+// network cannot be identified, returns the underlying error so the
+// block is rejected rather than validated against a guessed network.
+func (ls *LedgerState) validateBlockHeaderProtocolVersion(
+	header lcommon.BlockHeader,
+	pparams lcommon.ProtocolParameters,
+) error {
+	pv, err := GetProtocolVersion(pparams)
+	if err != nil {
+		return fmt.Errorf(
+			"validate header protocol version: %w", err,
+		)
+	}
+	mainnet, err := ls.isMainnet()
+	if err != nil {
+		return fmt.Errorf(
+			"validate header protocol version: %w", err,
+		)
+	}
+	return ValidateHeaderProtocolVersion(header, pv.Major, mainnet)
+}

--- a/ledger/header_protocol_version_test.go
+++ b/ledger/header_protocol_version_test.go
@@ -1,0 +1,387 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shelleyGenesisJSON returns a minimal Shelley genesis JSON document
+// carrying the network identity fields used by tests. Both networkId
+// ("Mainnet" or "Testnet") and networkMagic are populated so tests can
+// independently exercise either selector.
+func shelleyGenesisJSON(networkId string, magic uint32) string {
+	return fmt.Sprintf(`{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"systemStart": "2022-10-25T00:00:00Z",
+		"networkId": %q,
+		"networkMagic": %d
+	}`, networkId, magic)
+}
+
+func newLedgerStateForNetwork(t *testing.T, networkId string, magic uint32) *LedgerState {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(
+		strings.NewReader(shelleyGenesisJSON(networkId, magic)),
+	))
+	return &LedgerState{
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+// shelleyHeaderWithMajor builds a Shelley-family header (covers Shelley,
+// Allegra, Mary, Alonzo) with the given protocol major version.
+func shelleyHeaderWithMajor(t *testing.T, major uint64) *shelley.ShelleyBlockHeader {
+	t.Helper()
+	return &shelley.ShelleyBlockHeader{
+		Body: shelley.ShelleyBlockHeaderBody{
+			ProtoMajorVersion: major,
+		},
+	}
+}
+
+// babbageHeaderWithMajor builds a Babbage-family header (covers Babbage,
+// Conway) with the given protocol major version.
+func babbageHeaderWithMajor(t *testing.T, major uint64) *babbage.BabbageBlockHeader {
+	t.Helper()
+	return &babbage.BabbageBlockHeader{
+		Body: babbage.BabbageBlockHeaderBody{
+			ProtoVersion: babbage.BabbageProtoVersion{
+				Major: major,
+			},
+		},
+	}
+}
+
+func TestHeaderProtocolMajor_Shelley(t *testing.T) {
+	got, ok := HeaderProtocolMajor(shelleyHeaderWithMajor(t, 2))
+	require.True(t, ok)
+	assert.Equal(t, uint(2), got)
+}
+
+func TestHeaderProtocolMajor_Allegra(t *testing.T) {
+	h := &allegra.AllegraBlockHeader{
+		ShelleyBlockHeader: *shelleyHeaderWithMajor(t, 3),
+	}
+	got, ok := HeaderProtocolMajor(h)
+	require.True(t, ok)
+	assert.Equal(t, uint(3), got)
+}
+
+func TestHeaderProtocolMajor_Mary(t *testing.T) {
+	h := &mary.MaryBlockHeader{
+		ShelleyBlockHeader: *shelleyHeaderWithMajor(t, 4),
+	}
+	got, ok := HeaderProtocolMajor(h)
+	require.True(t, ok)
+	assert.Equal(t, uint(4), got)
+}
+
+func TestHeaderProtocolMajor_Alonzo(t *testing.T) {
+	h := &alonzo.AlonzoBlockHeader{
+		ShelleyBlockHeader: *shelleyHeaderWithMajor(t, 6),
+	}
+	got, ok := HeaderProtocolMajor(h)
+	require.True(t, ok)
+	assert.Equal(t, uint(6), got)
+}
+
+func TestHeaderProtocolMajor_Babbage(t *testing.T) {
+	got, ok := HeaderProtocolMajor(babbageHeaderWithMajor(t, 8))
+	require.True(t, ok)
+	assert.Equal(t, uint(8), got)
+}
+
+func TestHeaderProtocolMajor_Conway(t *testing.T) {
+	h := &conway.ConwayBlockHeader{
+		BabbageBlockHeader: *babbageHeaderWithMajor(t, 10),
+	}
+	got, ok := HeaderProtocolMajor(h)
+	require.True(t, ok)
+	assert.Equal(t, uint(10), got)
+}
+
+func TestHeaderProtocolMajor_Byron(t *testing.T) {
+	// Byron headers do not carry a ProtVer in the Praos sense, so the
+	// extractor reports the absence rather than fabricating a value.
+	h := &byron.ByronMainBlockHeader{}
+	_, ok := HeaderProtocolMajor(h)
+	assert.False(t, ok)
+}
+
+func TestValidateHeaderProtocolVersion_MainnetEqual(t *testing.T) {
+	// Header pvMajor == current pvMajor is always accepted.
+	err := ValidateHeaderProtocolVersion(
+		babbageHeaderWithMajor(t, 10),
+		10,
+		true,
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateHeaderProtocolVersion_MainnetOneAhead(t *testing.T) {
+	// Header pvMajor == current pvMajor + 1 is accepted (block producer
+	// is one version ahead, ready to hard fork).
+	err := ValidateHeaderProtocolVersion(
+		babbageHeaderWithMajor(t, 11),
+		10,
+		true,
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateHeaderProtocolVersion_MainnetTooHigh(t *testing.T) {
+	// Header pvMajor more than one ahead of current is rejected on mainnet.
+	err := ValidateHeaderProtocolVersion(
+		babbageHeaderWithMajor(t, 12),
+		10,
+		true,
+	)
+	require.Error(t, err)
+	var typed *HeaderProtocolVersionTooHighError
+	require.True(t, errors.As(err, &typed))
+	assert.Equal(t, uint(12), typed.Supplied)
+	assert.Equal(t, uint(11), typed.Expected)
+}
+
+func TestValidateHeaderProtocolVersion_TestnetTooHighPreDijkstra(t *testing.T) {
+	// On testnets, while pre-Dijkstra (current major < 12), a header
+	// with arbitrarily high pvMajor is accepted. This is the relaxation
+	// from cardano-ledger PR 5785.
+	err := ValidateHeaderProtocolVersion(
+		babbageHeaderWithMajor(t, 99),
+		10,
+		false,
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateHeaderProtocolVersion_TestnetTooHighAtDijkstra(t *testing.T) {
+	// On testnets, once current pvMajor reaches Dijkstra (12), the check
+	// becomes mainnet-equivalent: header more than one ahead is rejected.
+	err := ValidateHeaderProtocolVersion(
+		babbageHeaderWithMajor(t, 14),
+		12,
+		false,
+	)
+	require.Error(t, err)
+	var typed *HeaderProtocolVersionTooHighError
+	require.True(t, errors.As(err, &typed))
+	assert.Equal(t, uint(14), typed.Supplied)
+	assert.Equal(t, uint(13), typed.Expected)
+}
+
+func TestValidateHeaderProtocolVersion_TestnetOneAheadAtDijkstra(t *testing.T) {
+	// At Dijkstra on a testnet, header == current+1 is still accepted.
+	err := ValidateHeaderProtocolVersion(
+		babbageHeaderWithMajor(t, 13),
+		12,
+		false,
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateHeaderProtocolVersion_Byron(t *testing.T) {
+	// Byron headers are skipped entirely - they do not carry a ProtVer
+	// in the Praos sense.
+	err := ValidateHeaderProtocolVersion(
+		&byron.ByronMainBlockHeader{},
+		10,
+		true,
+	)
+	require.NoError(t, err)
+}
+
+func TestHeaderProtocolVersionTooHighError_Message(t *testing.T) {
+	err := &HeaderProtocolVersionTooHighError{
+		Supplied: 12,
+		Expected: 11,
+	}
+	// Message should mention both values so operators can diagnose.
+	msg := err.Error()
+	assert.Contains(t, msg, "12")
+	assert.Contains(t, msg, "11")
+}
+
+// Sanity check: the Block interface accessor (Header()) round-trips
+// through HeaderProtocolMajor for the typical case where callers pass
+// a full block via block.Header().
+func TestHeaderProtocolMajor_ViaBlockHeader(t *testing.T) {
+	var h lcommon.BlockHeader = babbageHeaderWithMajor(t, 8)
+	got, ok := HeaderProtocolMajor(h)
+	require.True(t, ok)
+	assert.Equal(t, uint(8), got)
+}
+
+func TestLedgerStateIsMainnet_True(t *testing.T) {
+	ls := newLedgerStateForNetwork(t, "Mainnet", byron.MainnetProtocolMagic)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+func TestLedgerStateIsMainnet_FalseOnPreprod(t *testing.T) {
+	// Preprod genesis uses networkId=Testnet, magic=1.
+	ls := newLedgerStateForNetwork(t, "Testnet", 1)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestLedgerStateIsMainnet_FalseOnDevnet(t *testing.T) {
+	// Devnet genesis uses networkId=Testnet, magic=42.
+	ls := newLedgerStateForNetwork(t, "Testnet", 42)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+// TestLedgerStateIsMainnet_FailClosedWhenConfigMissing pins the
+// fail-closed contract: when CardanoNodeConfig is absent, isMainnet
+// must return an error rather than silently picking a default. The
+// caller is expected to surface this as a validation failure so blocks
+// don't slip past the header-version check on a partially initialized
+// state.
+func TestLedgerStateIsMainnet_FailClosedWhenConfigMissing(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	_, err := ls.isMainnet()
+	require.Error(t, err)
+}
+
+// TestLedgerStateIsMainnet_FailClosedWhenGenesisMissing is the same
+// fail-closed guarantee for the case where CardanoNodeConfig is
+// present but Shelley genesis has not been loaded.
+func TestLedgerStateIsMainnet_FailClosedWhenGenesisMissing(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			CardanoNodeConfig: &cardano.CardanoNodeConfig{},
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	_, err := ls.isMainnet()
+	require.Error(t, err)
+}
+
+// TestLedgerStateIsMainnet_FailClosedOnUnknownNetworkId guards against
+// a Shelley genesis with a networkId field that's neither "Mainnet"
+// nor "Testnet" (typo, future enum value, corrupted file). We refuse
+// to guess in either direction.
+func TestLedgerStateIsMainnet_FailClosedOnUnknownNetworkId(t *testing.T) {
+	ls := newLedgerStateForNetwork(t, "Bogus", 42)
+	_, err := ls.isMainnet()
+	require.Error(t, err)
+}
+
+// TestLedgerStateIsMainnet_NetworkIdNotMagic pins the discriminator to
+// shelley-genesis networkId rather than networkMagic. A configuration
+// claiming networkId=Testnet must be treated as testnet even if it
+// happens to share mainnet's magic value, and a Mainnet-tagged genesis
+// must be honored even with a non-canonical magic. This is the literal
+// port of cardano-ledger's `netId == Mainnet` predicate.
+func TestLedgerStateIsMainnet_NetworkIdNotMagic(t *testing.T) {
+	t.Run("Testnet wins over mainnet magic", func(t *testing.T) {
+		ls := newLedgerStateForNetwork(
+			t, "Testnet", byron.MainnetProtocolMagic,
+		)
+		got, err := ls.isMainnet()
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+	t.Run("Mainnet wins over non-canonical magic", func(t *testing.T) {
+		ls := newLedgerStateForNetwork(t, "Mainnet", 999)
+		got, err := ls.isMainnet()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+}
+
+// TestLedgerStateValidateBlockHeaderProtocolVersion_FailClosedOnMissingConfig
+// confirms the fail-closed contract reaches the wiring layer:
+// validateBlockHeaderProtocolVersion must return an error rather than
+// validating against an undeterminable network identity.
+func TestLedgerStateValidateBlockHeaderProtocolVersion_FailClosedOnMissingConfig(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	pp := &conway.ConwayProtocolParameters{
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 10,
+		},
+	}
+	header := &conway.ConwayBlockHeader{
+		BabbageBlockHeader: *babbageHeaderWithMajor(t, 10),
+	}
+	err := ls.validateBlockHeaderProtocolVersion(header, pp)
+	require.Error(t, err)
+}
+
+func TestLedgerStateValidateBlockHeaderProtocolVersion_MainnetRejects(t *testing.T) {
+	ls := newLedgerStateForNetwork(t, "Mainnet", byron.MainnetProtocolMagic)
+	pp := &conway.ConwayProtocolParameters{
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 10,
+			Minor: 0,
+		},
+	}
+	header := &conway.ConwayBlockHeader{
+		BabbageBlockHeader: *babbageHeaderWithMajor(t, 12),
+	}
+	err := ls.validateBlockHeaderProtocolVersion(header, pp)
+	require.Error(t, err)
+	var typed *HeaderProtocolVersionTooHighError
+	require.True(t, errors.As(err, &typed))
+}
+
+func TestLedgerStateValidateBlockHeaderProtocolVersion_TestnetAllows(t *testing.T) {
+	ls := newLedgerStateForNetwork(t, "Testnet", 42)
+	pp := &conway.ConwayProtocolParameters{
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 10,
+			Minor: 0,
+		},
+	}
+	header := &conway.ConwayBlockHeader{
+		BabbageBlockHeader: *babbageHeaderWithMajor(t, 99),
+	}
+	require.NoError(t, ls.validateBlockHeaderProtocolVersion(header, pp))
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3194,6 +3194,16 @@ func (ls *LedgerState) ledgerProcessBlock(
 			)
 		}
 	}
+	// Reject blocks whose header protocol major version runs more than
+	// one ahead of current pparams. Skipped on testnets pre-Dijkstra
+	// per cardano-ledger PR 5785.
+	if shouldValidate {
+		if err := ls.validateBlockHeaderProtocolVersion(
+			block.Header(), pparams,
+		); err != nil {
+			return nil, err
+		}
+	}
 	// Process transactions
 	var delta *LedgerDelta
 	// Track outputs from earlier transactions in this block for intra-block


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a protocol check to block headers to reject blocks whose protocol major version is more than one ahead of current protocol parameters. Mirrors the BBODY rule and skips on testnets before Dijkstra (major < 12).

- **Bug Fixes**
  - Extract header protocol major for Shelley→Conway; skip Byron.
  - Enforce pvMajor <= current+1; always on mainnet, and on testnets at/after Dijkstra (12).
  - Wire validation into `ledgerProcessBlock` behind `shouldValidate`; detect mainnet from Shelley genesis `networkId`; fail closed if network identity is unknown; add era/network tests.

- **Dependencies**
  - Promote `github.com/aws/aws-sdk-go-v2/credentials` to a direct dependency.

<sup>Written for commit 3aa28ebcb56be7aa5383ef25579907d105fe74ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol version checking for block headers during block validation to reject headers with incompatible protocol versions.

* **Tests**
  * Added comprehensive test suite for header protocol version extraction and validation across multiple blockchain eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->