### PR TITLE
chore: update Go toolchain to 1.26.1

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: go-test (Linux)
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -102,7 +102,7 @@ jobs:
     name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
         platform: [macos-latest, windows-latest]
         include:
           - platform: macos-latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: go-test (Linux)
     strategy:
       matrix:
-        go-version: [1.26.x]
+        go-version: [1.26.1]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -102,7 +102,7 @@ jobs:
     name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
     strategy:
       matrix:
-        go-version: [1.26.x]
+        go-version: [1.26.1]
         platform: [macos-latest, windows-latest]
         include:
           - platform: macos-latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: go-test (Linux)
     strategy:
       matrix:
-        go-version: [1.26.1]
+        go-version: [1.26.x]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -102,7 +102,7 @@ jobs:
     name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
     strategy:
       matrix:
-        go-version: [1.26.1]
+        go-version: [1.26.x]
         platform: [macos-latest, windows-latest]
         include:
           - platform: macos-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/releases/tag/v5.0.5
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-1.25.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.25.x-
+            ${{ runner.os }}-go-1.26.x-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.26.x
+          go-version: 1.26.1
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/releases/tag/v5.0.5
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.1-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.x-
+            ${{ runner.os }}-go-1.26.1-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.x
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/releases/tag/v5.0.5
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-1.26.1-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.1-
+            ${{ runner.os }}-go-1.26.x-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,15 +89,15 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/releases/tag/v5.0.5
         with:
           path: |
             ~/go/pkg/mod
             ${{ runner.os == 'macOS' && '~/Library/Caches/go-build' || runner.os == 'Windows' && '~\\AppData\\Local\\go-build' || '~/.cache/go-build' }}
-          key: ${{ runner.os }}-go-1.25.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.25.x-
+            ${{ runner.os }}-go-1.26.x-
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,15 +89,15 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.x
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/releases/tag/v5.0.5
         with:
           path: |
             ~/go/pkg/mod
             ${{ runner.os == 'macOS' && '~/Library/Caches/go-build' || runner.os == 'Windows' && '~\\AppData\\Local\\go-build' || '~/.cache/go-build' }}
-          key: ${{ runner.os }}-go-1.26.1-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.1-
+            ${{ runner.os }}-go-1.26.x-
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,15 +89,15 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.26.x
+          go-version: 1.26.1
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/releases/tag/v5.0.5
         with:
           path: |
             ~/go/pkg/mod
             ${{ runner.os == 'macOS' && '~/Library/Caches/go-build' || runner.os == 'Windows' && '~\\AppData\\Local\\go-build' || '~/.cache/go-build' }}
-          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.1-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.x-
+            ${{ runner.os }}-go-1.26.1-
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/dingo
 
-go 1.25.7
+go 1.26.0
 
-toolchain go1.25.8
+toolchain go1.26.1
 
 require (
 	cloud.google.com/go/storage v1.62.1
@@ -12,6 +12,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/smithy-go v1.25.1
 	github.com/blinklabs-io/bark v0.0.2
@@ -91,7 +92,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect

--- a/ledger/hardfork/build.go
+++ b/ledger/hardfork/build.go
@@ -47,7 +47,7 @@ func BuildSummary(
 	for i, p := range past {
 		if p.End == nil {
 			return Summary{}, fmt.Errorf(
-				"hardfork: past era %d (%q) is unbounded",
+				"hardfork: past era %d (%d) is unbounded",
 				i, p.EraID,
 			)
 		}


### PR DESCRIPTION
## Summary

- Update `go.mod` minimum version to `1.26.0` with `toolchain go1.26.1`
- Update `golangci-lint.yml` and `publish.yml` from `1.25.x` → `1.26.x`
- Drop `1.25.x` from `go-test.yml` matrix, keeping only `1.26.x`

The `Dockerfile` already uses `ghcr.io/blinklabs-io/go:1.26.1-1`; this aligns the CI workflows and `go.mod` to match.

## Test plan

- [ ] CI: `go-test` passes on `1.26.x`
- [ ] CI: `golangci-lint` passes on `1.26.x`
- [ ] CI: `publish` build-binaries passes on all platforms

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade project to Go 1.26 and align with the Docker image. Use Go 1.26.x in CI (drop 1.25.x) and fix a printf verb in `ledger/hardfork` for `EraID`.

- **Dependencies**
  - Set `go` to `1.26.0` and `toolchain` to `go1.26.1` in `go.mod`.
  - Promote `github.com/aws/aws-sdk-go-v2/credentials` to a direct dependency.

- **Bug Fixes**
  - Use `%d` for uint `EraID` in `ledger/hardfork` error message.

<sup>Written for commit 8cdb242600974bb8044a6b39e268a3140caf7b05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version from 1.25.x to 1.26.x across GitHub Actions workflows for testing, linting, and publishing.
  * Updated project Go toolchain version requirement to 1.26.x in build configuration.
  * Updated dependency caching keys in CI/CD workflows to reflect new Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->