### PR TITLE
feat(metrics): add peer temperature and protocol-level observability …

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -58,14 +58,20 @@ type blockfetchConnection interface {
 
 func (o *Ouroboros) blockfetchServerConnOpts() []blockfetch.BlockFetchOptionFunc {
 	return []blockfetch.BlockFetchOptionFunc{
-		blockfetch.WithRequestRangeFunc(o.blockfetchServerRequestRange),
+		blockfetch.WithRequestRangeFunc(
+			o.instrumentBlockfetchRequestRange(o.blockfetchServerRequestRange),
+		),
 	}
 }
 
 func (o *Ouroboros) blockfetchClientConnOpts() []blockfetch.BlockFetchOptionFunc {
 	return []blockfetch.BlockFetchOptionFunc{
-		blockfetch.WithBlockFunc(o.blockfetchClientBlock),
-		blockfetch.WithBatchDoneFunc(o.blockfetchClientBatchDone),
+		blockfetch.WithBlockFunc(
+			o.instrumentBlockfetchBlock(o.blockfetchClientBlock),
+		),
+		blockfetch.WithBatchDoneFunc(
+			o.instrumentBlockfetchBatchDone(o.blockfetchClientBatchDone),
+		),
 		blockfetch.WithBatchStartTimeout(60 * time.Second),
 		blockfetch.WithBlockTimeout(60 * time.Second),
 	}
@@ -227,8 +233,8 @@ Loop:
 				)
 				return fmt.Errorf("blockfetch Block failed: %w", err)
 			}
-			if o.metrics != nil {
-				o.metrics.servedBlockCount.Inc()
+			if o.blockfetchMetrics != nil {
+				o.blockfetchMetrics.servedBlockCount.Inc()
 			}
 			// Make sure we don't hang waiting for the next block if we've already hit the end
 			if next.Block.Slot == end.Slot {
@@ -358,7 +364,7 @@ func (o *Ouroboros) blockfetchClientBlock(
 		// During catch-up all blocks are naturally "late" relative to
 		// wall-clock time, which permanently poisons the CDF.
 		atTip := o.LedgerState != nil && o.LedgerState.IsAtTip()
-		if atTip && o.metrics != nil {
+		if atTip && o.blockfetchMetrics != nil {
 			// Calculate block delay as wallclock time minus block slot time (cardano-node compatible)
 			var delaySeconds float64
 			if blockSlotTime, err := o.LedgerState.SlotToTime(block.SlotNumber()); err == nil {
@@ -367,34 +373,34 @@ func (o *Ouroboros) blockfetchClientBlock(
 				delaySeconds = fetchDuration.Seconds()
 			}
 
-			o.metrics.blockDelay.Set(delaySeconds)
-			total := atomic.AddInt64(&o.metrics.totalBlocksFetched, 1)
+			o.blockfetchMetrics.blockDelay.Set(delaySeconds)
+			total := atomic.AddInt64(&o.blockfetchMetrics.totalBlocksFetched, 1)
 			// Cumulative CDF buckets: each counter includes all
 			// blocks at or below its threshold.
 			if delaySeconds < 1.0 {
-				atomic.AddInt64(&o.metrics.blocksUnder1s, 1)
+				atomic.AddInt64(&o.blockfetchMetrics.blocksUnder1s, 1)
 			}
 			if delaySeconds < 3.0 {
-				atomic.AddInt64(&o.metrics.blocksUnder3s, 1)
+				atomic.AddInt64(&o.blockfetchMetrics.blocksUnder3s, 1)
 			}
 			if delaySeconds < 5.0 {
-				atomic.AddInt64(&o.metrics.blocksUnder5s, 1)
+				atomic.AddInt64(&o.blockfetchMetrics.blocksUnder5s, 1)
 			} else {
-				o.metrics.lateBlocks.Inc()
+				o.blockfetchMetrics.lateBlocks.Inc()
 			}
 			if total == 1 ||
 				total%blockfetchMetricsCdfUpdateInterval == 0 ||
 				delaySeconds >= 5.0 {
-				under1 := atomic.LoadInt64(&o.metrics.blocksUnder1s)
-				under3 := atomic.LoadInt64(&o.metrics.blocksUnder3s)
-				under5 := atomic.LoadInt64(&o.metrics.blocksUnder5s)
-				o.metrics.blockDelayCdfOne.Set(
+				under1 := atomic.LoadInt64(&o.blockfetchMetrics.blocksUnder1s)
+				under3 := atomic.LoadInt64(&o.blockfetchMetrics.blocksUnder3s)
+				under5 := atomic.LoadInt64(&o.blockfetchMetrics.blocksUnder5s)
+				o.blockfetchMetrics.blockDelayCdfOne.Set(
 					float64(under1) / float64(total) * 100,
 				)
-				o.metrics.blockDelayCdfThree.Set(
+				o.blockfetchMetrics.blockDelayCdfThree.Set(
 					float64(under3) / float64(total) * 100,
 				)
-				o.metrics.blockDelayCdfFive.Set(
+				o.blockfetchMetrics.blockDelayCdfFive.Set(
 					float64(under5) / float64(total) * 100,
 				)
 			}
@@ -449,4 +455,51 @@ func (o *Ouroboros) blockfetchClientBatchDone(
 		)
 	}
 	return nil
+}
+
+// instrumentBlockfetchRequestRange wraps the RequestRange callback. Note
+// that blockfetchServerRequestRange validates the request synchronously
+// then launches block delivery in a goroutine. The metric outcome label
+// reflects only the synchronous validation result; failures during async
+// streaming (iterator errors, Block, BatchDone) close the connection via
+// reportBlockfetchServerAsyncError and are not visible here.
+func (o *Ouroboros) instrumentBlockfetchRequestRange(
+	fn func(blockfetch.CallbackContext, ocommon.Point, ocommon.Point) error,
+) func(blockfetch.CallbackContext, ocommon.Point, ocommon.Point) error {
+	return func(
+		ctx blockfetch.CallbackContext,
+		start ocommon.Point,
+		end ocommon.Point,
+	) error {
+		startTime := time.Now()
+		err := fn(ctx, start, end)
+		o.recordProtocolMessage("blockfetch", err, time.Since(startTime))
+		return err
+	}
+}
+
+func (o *Ouroboros) instrumentBlockfetchBlock(
+	fn func(blockfetch.CallbackContext, uint, gledger.Block) error,
+) func(blockfetch.CallbackContext, uint, gledger.Block) error {
+	return func(
+		ctx blockfetch.CallbackContext,
+		blockType uint,
+		block gledger.Block,
+	) error {
+		start := time.Now()
+		err := fn(ctx, blockType, block)
+		o.recordProtocolMessage("blockfetch", err, time.Since(start))
+		return err
+	}
+}
+
+func (o *Ouroboros) instrumentBlockfetchBatchDone(
+	fn func(blockfetch.CallbackContext) error,
+) func(blockfetch.CallbackContext) error {
+	return func(ctx blockfetch.CallbackContext) error {
+		start := time.Now()
+		err := fn(ctx)
+		o.recordProtocolMessage("blockfetch", err, time.Since(start))
+		return err
+	}
 }

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -44,8 +44,12 @@ const (
 
 func (o *Ouroboros) chainsyncServerConnOpts() []ochainsync.ChainSyncOptionFunc {
 	return []ochainsync.ChainSyncOptionFunc{
-		ochainsync.WithFindIntersectFunc(o.chainsyncServerFindIntersect),
-		ochainsync.WithRequestNextFunc(o.chainsyncServerRequestNext),
+		ochainsync.WithFindIntersectFunc(
+			o.instrumentChainsyncFindIntersect(o.chainsyncServerFindIntersect),
+		),
+		ochainsync.WithRequestNextFunc(
+			o.instrumentChainsyncRequestNext(o.chainsyncServerRequestNext),
+		),
 		// Increase intersect timeout from the 10s default. Downstream
 		// peers may send FindIntersect with many points during initial
 		// sync, and processing can be slow under load.
@@ -60,8 +64,12 @@ func (o *Ouroboros) chainsyncServerConnOpts() []ochainsync.ChainSyncOptionFunc {
 
 func (o *Ouroboros) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 	return []ochainsync.ChainSyncOptionFunc{
-		ochainsync.WithRollForwardFunc(o.chainsyncClientRollForward),
-		ochainsync.WithRollBackwardFunc(o.chainsyncClientRollBackward),
+		ochainsync.WithRollForwardFunc(
+			o.instrumentChainsyncRollForward(o.chainsyncClientRollForward),
+		),
+		ochainsync.WithRollBackwardFunc(
+			o.instrumentChainsyncRollBackward(o.chainsyncClientRollBackward),
+		),
 		// Pipeline enough headers to keep one blockfetch batch (500
 		// blocks) ready while the previous batch processes. A depth
 		// of 10 is sufficient; higher values flood the header queue
@@ -1091,4 +1099,65 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 			}
 		},
 	)
+}
+
+func (o *Ouroboros) instrumentChainsyncFindIntersect(
+	fn func(ochainsync.CallbackContext, []ocommon.Point) (ocommon.Point, ochainsync.Tip, error),
+) func(ochainsync.CallbackContext, []ocommon.Point) (ocommon.Point, ochainsync.Tip, error) {
+	return func(
+		ctx ochainsync.CallbackContext,
+		points []ocommon.Point,
+	) (ocommon.Point, ochainsync.Tip, error) {
+		start := time.Now()
+		p, t, err := fn(ctx, points)
+		o.recordProtocolMessage("chainsync", err, time.Since(start))
+		return p, t, err
+	}
+}
+
+// instrumentChainsyncRequestNext wraps the RequestNext callback. Note
+// that chainsyncServerRequestNext does some synchronous work (initial
+// rollback, AddClient bookkeeping) then dispatches the Next-block fetch
+// to a goroutine. The metric outcome reflects only the synchronous path;
+// errors during async block delivery are logged but not surfaced here.
+func (o *Ouroboros) instrumentChainsyncRequestNext(
+	fn func(ochainsync.CallbackContext) error,
+) func(ochainsync.CallbackContext) error {
+	return func(ctx ochainsync.CallbackContext) error {
+		start := time.Now()
+		err := fn(ctx)
+		o.recordProtocolMessage("chainsync", err, time.Since(start))
+		return err
+	}
+}
+
+func (o *Ouroboros) instrumentChainsyncRollBackward(
+	fn func(ochainsync.CallbackContext, ocommon.Point, ochainsync.Tip) error,
+) func(ochainsync.CallbackContext, ocommon.Point, ochainsync.Tip) error {
+	return func(
+		ctx ochainsync.CallbackContext,
+		point ocommon.Point,
+		tip ochainsync.Tip,
+	) error {
+		start := time.Now()
+		err := fn(ctx, point, tip)
+		o.recordProtocolMessage("chainsync", err, time.Since(start))
+		return err
+	}
+}
+
+func (o *Ouroboros) instrumentChainsyncRollForward(
+	fn func(ochainsync.CallbackContext, uint, any, ochainsync.Tip) error,
+) func(ochainsync.CallbackContext, uint, any, ochainsync.Tip) error {
+	return func(
+		ctx ochainsync.CallbackContext,
+		blockType uint,
+		blockData any,
+		tip ochainsync.Tip,
+	) error {
+		start := time.Now()
+		err := fn(ctx, blockType, blockData, tip)
+		o.recordProtocolMessage("chainsync", err, time.Since(start))
+		return err
+	}
 }

--- a/ouroboros/keepalive.go
+++ b/ouroboros/keepalive.go
@@ -15,6 +15,8 @@
 package ouroboros
 
 import (
+	"time"
+
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/event"
 	okeepalive "github.com/blinklabs-io/gouroboros/protocol/keepalive"
@@ -22,7 +24,20 @@ import (
 
 func (o *Ouroboros) keepaliveConnOpts() []okeepalive.KeepAliveOptionFunc {
 	return []okeepalive.KeepAliveOptionFunc{
-		okeepalive.WithKeepAliveResponseFunc(o.keepaliveClientResponse),
+		okeepalive.WithKeepAliveResponseFunc(
+			o.instrumentKeepaliveResponse(o.keepaliveClientResponse),
+		),
+	}
+}
+
+func (o *Ouroboros) instrumentKeepaliveResponse(
+	fn func(okeepalive.CallbackContext, uint16) error,
+) func(okeepalive.CallbackContext, uint16) error {
+	return func(ctx okeepalive.CallbackContext, cookie uint16) error {
+		start := time.Now()
+		err := fn(ctx, cookie)
+		o.recordProtocolMessage("keepalive", err, time.Since(start))
+		return err
 	}
 }
 

--- a/ouroboros/leiosfetch.go
+++ b/ouroboros/leiosfetch.go
@@ -15,6 +15,8 @@
 package ouroboros
 
 import (
+	"time"
+
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
@@ -22,16 +24,82 @@ import (
 
 func (o *Ouroboros) leiosfetchServerConnOpts() []oleiosfetch.LeiosFetchOptionFunc {
 	return []oleiosfetch.LeiosFetchOptionFunc{
-		oleiosfetch.WithBlockRequestFunc(o.leiosfetchServerBlockRequest),
-		oleiosfetch.WithBlockTxsRequestFunc(o.leiosfetchServerBlockTxsRequest),
-		oleiosfetch.WithVotesRequestFunc(o.leiosfetchServerVotesRequest),
-		oleiosfetch.WithBlockRangeRequestFunc(o.leiosfetchServerBlockRangeRequest),
+		oleiosfetch.WithBlockRequestFunc(
+			o.instrumentLeiosfetchBlockRequest(o.leiosfetchServerBlockRequest),
+		),
+		oleiosfetch.WithBlockTxsRequestFunc(
+			o.instrumentLeiosfetchBlockTxsRequest(o.leiosfetchServerBlockTxsRequest),
+		),
+		oleiosfetch.WithVotesRequestFunc(
+			o.instrumentLeiosfetchVotesRequest(o.leiosfetchServerVotesRequest),
+		),
+		oleiosfetch.WithBlockRangeRequestFunc(
+			o.instrumentLeiosfetchBlockRangeRequest(o.leiosfetchServerBlockRangeRequest),
+		),
 	}
 }
 
 func (o *Ouroboros) leiosfetchClientConnOpts() []oleiosfetch.LeiosFetchOptionFunc {
 	return []oleiosfetch.LeiosFetchOptionFunc{
 		// NOTE: this is purposely empty
+	}
+}
+
+func (o *Ouroboros) instrumentLeiosfetchBlockRequest(
+	fn func(oleiosfetch.CallbackContext, ocommon.Point) (protocol.Message, error),
+) func(oleiosfetch.CallbackContext, ocommon.Point) (protocol.Message, error) {
+	return func(
+		ctx oleiosfetch.CallbackContext,
+		point ocommon.Point,
+	) (protocol.Message, error) {
+		start := time.Now()
+		msg, err := fn(ctx, point)
+		o.recordProtocolMessage("leiosfetch", err, time.Since(start))
+		return msg, err
+	}
+}
+
+func (o *Ouroboros) instrumentLeiosfetchBlockTxsRequest(
+	fn func(oleiosfetch.CallbackContext, ocommon.Point, map[uint16]uint64) (protocol.Message, error),
+) func(oleiosfetch.CallbackContext, ocommon.Point, map[uint16]uint64) (protocol.Message, error) {
+	return func(
+		ctx oleiosfetch.CallbackContext,
+		point ocommon.Point,
+		txBitmap map[uint16]uint64,
+	) (protocol.Message, error) {
+		start := time.Now()
+		msg, err := fn(ctx, point, txBitmap)
+		o.recordProtocolMessage("leiosfetch", err, time.Since(start))
+		return msg, err
+	}
+}
+
+func (o *Ouroboros) instrumentLeiosfetchVotesRequest(
+	fn func(oleiosfetch.CallbackContext, []oleiosfetch.MsgVotesRequestVoteId) (protocol.Message, error),
+) func(oleiosfetch.CallbackContext, []oleiosfetch.MsgVotesRequestVoteId) (protocol.Message, error) {
+	return func(
+		ctx oleiosfetch.CallbackContext,
+		voteIds []oleiosfetch.MsgVotesRequestVoteId,
+	) (protocol.Message, error) {
+		start := time.Now()
+		msg, err := fn(ctx, voteIds)
+		o.recordProtocolMessage("leiosfetch", err, time.Since(start))
+		return msg, err
+	}
+}
+
+func (o *Ouroboros) instrumentLeiosfetchBlockRangeRequest(
+	fn func(oleiosfetch.CallbackContext, ocommon.Point, ocommon.Point) error,
+) func(oleiosfetch.CallbackContext, ocommon.Point, ocommon.Point) error {
+	return func(
+		ctx oleiosfetch.CallbackContext,
+		start ocommon.Point,
+		end ocommon.Point,
+	) error {
+		startTime := time.Now()
+		err := fn(ctx, start, end)
+		o.recordProtocolMessage("leiosfetch", err, time.Since(startTime))
+		return err
 	}
 }
 

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -26,13 +26,17 @@ import (
 
 func (o *Ouroboros) leiosnotifyServerConnOpts() []oleiosnotify.LeiosNotifyOptionFunc {
 	return []oleiosnotify.LeiosNotifyOptionFunc{
-		oleiosnotify.WithRequestNextFunc(o.leiosnotifyServerRequestNext),
+		oleiosnotify.WithRequestNextFunc(
+			o.instrumentLeiosnotifyRequestNext(o.leiosnotifyServerRequestNext),
+		),
 	}
 }
 
 func (o *Ouroboros) leiosnotifyClientConnOpts() []oleiosnotify.LeiosNotifyOptionFunc {
 	return []oleiosnotify.LeiosNotifyOptionFunc{
-		oleiosnotify.WithNotificationFunc(o.leiosnotifyClientNotification),
+		oleiosnotify.WithNotificationFunc(
+			o.instrumentLeiosnotifyNotification(o.leiosnotifyClientNotification),
+		),
 		// Disable the Busy-state timeout. LeiosNotify is a push-based
 		// notification protocol where the server only sends when it has
 		// something to announce. Idle waits of arbitrary length are
@@ -54,6 +58,28 @@ func (o *Ouroboros) leiosnotifyClientStart(connId ouroboros.ConnectionId) error 
 		return err
 	}
 	return nil
+}
+
+func (o *Ouroboros) instrumentLeiosnotifyNotification(
+	fn func(oleiosnotify.CallbackContext, protocol.Message) error,
+) func(oleiosnotify.CallbackContext, protocol.Message) error {
+	return func(ctx oleiosnotify.CallbackContext, msg protocol.Message) error {
+		start := time.Now()
+		err := fn(ctx, msg)
+		o.recordProtocolMessage("leiosnotify", err, time.Since(start))
+		return err
+	}
+}
+
+func (o *Ouroboros) instrumentLeiosnotifyRequestNext(
+	fn func(oleiosnotify.CallbackContext) (protocol.Message, error),
+) func(oleiosnotify.CallbackContext) (protocol.Message, error) {
+	return func(ctx oleiosnotify.CallbackContext) (protocol.Message, error) {
+		start := time.Now()
+		msg, err := fn(ctx)
+		o.recordProtocolMessage("leiosnotify", err, time.Since(start))
+		return msg, err
+	}
 }
 
 func (o *Ouroboros) leiosnotifyClientNotification(

--- a/ouroboros/localstatequery.go
+++ b/ouroboros/localstatequery.go
@@ -15,14 +15,62 @@
 package ouroboros
 
 import (
+	"time"
+
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
 func (o *Ouroboros) localstatequeryServerConnOpts() []olocalstatequery.LocalStateQueryOptionFunc {
 	return []olocalstatequery.LocalStateQueryOptionFunc{
-		olocalstatequery.WithAcquireFunc(o.localstatequeryServerAcquire),
-		olocalstatequery.WithQueryFunc(o.localstatequeryServerQuery),
-		olocalstatequery.WithReleaseFunc(o.localstatequeryServerRelease),
+		olocalstatequery.WithAcquireFunc(
+			o.instrumentLocalstatequeryAcquire(o.localstatequeryServerAcquire),
+		),
+		olocalstatequery.WithQueryFunc(
+			o.instrumentLocalstatequeryQuery(o.localstatequeryServerQuery),
+		),
+		olocalstatequery.WithReleaseFunc(
+			o.instrumentLocalstatequeryRelease(o.localstatequeryServerRelease),
+		),
+	}
+}
+
+func (o *Ouroboros) instrumentLocalstatequeryAcquire(
+	fn func(olocalstatequery.CallbackContext, olocalstatequery.AcquireTarget, bool) error,
+) func(olocalstatequery.CallbackContext, olocalstatequery.AcquireTarget, bool) error {
+	return func(
+		ctx olocalstatequery.CallbackContext,
+		acquireTarget olocalstatequery.AcquireTarget,
+		reAcquire bool,
+	) error {
+		start := time.Now()
+		err := fn(ctx, acquireTarget, reAcquire)
+		o.recordProtocolMessage("localstatequery", err, time.Since(start))
+		return err
+	}
+}
+
+func (o *Ouroboros) instrumentLocalstatequeryQuery(
+	fn func(olocalstatequery.CallbackContext, olocalstatequery.QueryWrapper) (any, error),
+) func(olocalstatequery.CallbackContext, olocalstatequery.QueryWrapper) (any, error) {
+	return func(
+		ctx olocalstatequery.CallbackContext,
+		query olocalstatequery.QueryWrapper,
+	) (any, error) {
+		start := time.Now()
+		result, err := fn(ctx, query)
+		o.recordProtocolMessage("localstatequery", err, time.Since(start))
+		return result, err
+	}
+}
+
+func (o *Ouroboros) instrumentLocalstatequeryRelease(
+	fn func(olocalstatequery.CallbackContext) error,
+) func(olocalstatequery.CallbackContext) error {
+	return func(ctx olocalstatequery.CallbackContext) error {
+		start := time.Now()
+		err := fn(ctx)
+		o.recordProtocolMessage("localstatequery", err, time.Since(start))
+		return err
 	}
 }
 

--- a/ouroboros/localtxmonitor.go
+++ b/ouroboros/localtxmonitor.go
@@ -15,6 +15,8 @@
 package ouroboros
 
 import (
+	"time"
+
 	olocaltxmonitor "github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
 )
 
@@ -24,7 +26,20 @@ const (
 
 func (o *Ouroboros) localtxmonitorServerConnOpts() []olocaltxmonitor.LocalTxMonitorOptionFunc {
 	return []olocaltxmonitor.LocalTxMonitorOptionFunc{
-		olocaltxmonitor.WithGetMempoolFunc(o.localtxmonitorServerGetMempool),
+		olocaltxmonitor.WithGetMempoolFunc(
+			o.instrumentLocaltxmonitorGetMempool(o.localtxmonitorServerGetMempool),
+		),
+	}
+}
+
+func (o *Ouroboros) instrumentLocaltxmonitorGetMempool(
+	fn func(olocaltxmonitor.CallbackContext) (uint64, uint32, []olocaltxmonitor.TxAndEraId, error),
+) func(olocaltxmonitor.CallbackContext) (uint64, uint32, []olocaltxmonitor.TxAndEraId, error) {
+	return func(ctx olocaltxmonitor.CallbackContext) (uint64, uint32, []olocaltxmonitor.TxAndEraId, error) {
+		start := time.Now()
+		slot, capacity, txs, err := fn(ctx)
+		o.recordProtocolMessage("localtxmonitor", err, time.Since(start))
+		return slot, capacity, txs, err
 	}
 }
 

--- a/ouroboros/localtxsubmission.go
+++ b/ouroboros/localtxsubmission.go
@@ -16,13 +16,30 @@ package ouroboros
 
 import (
 	"fmt"
+	"time"
 
 	olocaltxsubmission "github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
 )
 
 func (o *Ouroboros) localtxsubmissionServerConnOpts() []olocaltxsubmission.LocalTxSubmissionOptionFunc {
 	return []olocaltxsubmission.LocalTxSubmissionOptionFunc{
-		olocaltxsubmission.WithSubmitTxFunc(o.localtxsubmissionServerSubmitTx),
+		olocaltxsubmission.WithSubmitTxFunc(
+			o.instrumentLocaltxsubmissionSubmitTx(o.localtxsubmissionServerSubmitTx),
+		),
+	}
+}
+
+func (o *Ouroboros) instrumentLocaltxsubmissionSubmitTx(
+	fn func(olocaltxsubmission.CallbackContext, olocaltxsubmission.MsgSubmitTxTransaction) error,
+) func(olocaltxsubmission.CallbackContext, olocaltxsubmission.MsgSubmitTxTransaction) error {
+	return func(
+		ctx olocaltxsubmission.CallbackContext,
+		tx olocaltxsubmission.MsgSubmitTxTransaction,
+	) error {
+		start := time.Now()
+		err := fn(ctx, tx)
+		o.recordProtocolMessage("localtxsubmission", err, time.Since(start))
+		return err
 	}
 }
 

--- a/ouroboros/metrics_protocol.go
+++ b/ouroboros/metrics_protocol.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type protocolMetrics struct {
+	messagesReceived *prometheus.CounterVec
+	messageDuration  *prometheus.HistogramVec
+}
+
+func (o *Ouroboros) initProtocolMetrics() {
+	factory := promauto.With(o.config.PromRegistry)
+	o.protocolMetrics = &protocolMetrics{
+		messagesReceived: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dingo_protocol_messages_received_total",
+				Help: "total mini-protocol messages received, by protocol and callback outcome",
+			},
+			[]string{"protocol", "outcome"},
+		),
+		messageDuration: factory.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "dingo_protocol_message_duration_seconds",
+				Help: "duration of mini-protocol callback processing, by protocol and outcome",
+				// Default Prometheus buckets start at 5ms, but most
+				// callbacks here are sub-ms (event publish, counter Inc,
+				// map lookup). Use a sub-ms-to-second range so fast
+				// callbacks are distinguishable from slow ones.
+				Buckets: []float64{
+					0.0001, 0.0005, 0.001, 0.005, 0.01,
+					0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+				},
+			},
+			[]string{"protocol", "outcome"},
+		),
+	}
+}
+
+// recordProtocolMessage records one received message and the callback
+// duration for the named protocol, labelled with success or error based
+// on err. Called by the per-signature instrument helpers in each protocol
+// file. Safe to call when metrics are not initialized.
+func (o *Ouroboros) recordProtocolMessage(
+	protocol string,
+	err error,
+	dur time.Duration,
+) {
+	if o.protocolMetrics == nil {
+		return
+	}
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	o.protocolMetrics.messagesReceived.
+		WithLabelValues(protocol, outcome).
+		Inc()
+	o.protocolMetrics.messageDuration.
+		WithLabelValues(protocol, outcome).
+		Observe(dur.Seconds())
+}

--- a/ouroboros/metrics_protocol_test.go
+++ b/ouroboros/metrics_protocol_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordProtocolMessage_LabelsByOutcome(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	o := NewOuroboros(OuroborosConfig{PromRegistry: reg})
+
+	o.recordProtocolMessage("chainsync", nil, time.Millisecond)
+	o.recordProtocolMessage("chainsync", nil, time.Millisecond)
+	o.recordProtocolMessage("chainsync", errors.New("boom"), time.Millisecond)
+	o.recordProtocolMessage("blockfetch", nil, time.Millisecond)
+
+	assert.Equal(
+		t,
+		float64(2),
+		testutil.ToFloat64(
+			o.protocolMetrics.messagesReceived.WithLabelValues(
+				"chainsync", "success",
+			),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			o.protocolMetrics.messagesReceived.WithLabelValues(
+				"chainsync", "error",
+			),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			o.protocolMetrics.messagesReceived.WithLabelValues(
+				"blockfetch", "success",
+			),
+		),
+	)
+	// Histogram should have observed three series: chainsync/success,
+	// chainsync/error, blockfetch/success.
+	assert.Equal(
+		t,
+		3,
+		testutil.CollectAndCount(o.protocolMetrics.messageDuration),
+	)
+}
+
+func TestRecordProtocolMessage_NoopWhenMetricsDisabled(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{}) // no PromRegistry → no metrics
+	// Must not panic when metrics are uninitialized.
+	o.recordProtocolMessage("chainsync", nil, time.Millisecond)
+	o.recordProtocolMessage("chainsync", errors.New("x"), time.Millisecond)
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -52,16 +52,17 @@ import (
 const defaultMaxChainsyncClients = chainsync.DefaultMaxClients
 
 type Ouroboros struct {
-	ConnManager      *connmanager.ConnectionManager
-	PeerGov          *peergov.PeerGovernor
-	ChainsyncState   *chainsync.State
-	EventBus         *event.EventBus
-	Mempool          *mempool.Mempool
-	LedgerState      *ledger.LedgerState
-	config           OuroborosConfig
-	metrics          *blockfetchMetrics
-	blockFetchStarts map[ouroboros.ConnectionId]time.Time
-	blockFetchMutex  sync.Mutex
+	ConnManager       *connmanager.ConnectionManager
+	PeerGov           *peergov.PeerGovernor
+	ChainsyncState    *chainsync.State
+	EventBus          *event.EventBus
+	Mempool           *mempool.Mempool
+	LedgerState       *ledger.LedgerState
+	config            OuroborosConfig
+	blockfetchMetrics *blockfetchMetrics
+	protocolMetrics   *protocolMetrics
+	blockFetchStarts  map[ouroboros.ConnectionId]time.Time
+	blockFetchMutex   sync.Mutex
 	// ChainSync measurement tracking for peer scoring
 	chainsyncStats map[ouroboros.ConnectionId]*chainsyncPeerStats
 	chainsyncMutex sync.Mutex
@@ -138,39 +139,40 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		)
 	}
 	if cfg.PromRegistry != nil {
-		o.initMetrics()
+		o.initBlockfetchMetrics()
+		o.initProtocolMetrics()
 	}
 	return o
 }
 
-func (o *Ouroboros) initMetrics() {
+func (o *Ouroboros) initBlockfetchMetrics() {
 	promautoFactory := promauto.With(o.config.PromRegistry)
-	o.metrics = &blockfetchMetrics{}
-	o.metrics.servedBlockCount = promautoFactory.NewCounter(
+	o.blockfetchMetrics = &blockfetchMetrics{}
+	o.blockfetchMetrics.servedBlockCount = promautoFactory.NewCounter(
 		prometheus.CounterOpts{
 			Name: "cardano_node_metrics_served_block_count_int",
 			Help: "total blocks served to clients",
 		},
 	)
-	o.metrics.blockDelay = promautoFactory.NewGauge(prometheus.GaugeOpts{
+	o.blockfetchMetrics.blockDelay = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_blockfetchclient_blockdelay_s",
 		Help: "delay in seconds for the most recent block fetch",
 	})
-	o.metrics.lateBlocks = promautoFactory.NewCounter(prometheus.CounterOpts{
+	o.blockfetchMetrics.lateBlocks = promautoFactory.NewCounter(prometheus.CounterOpts{
 		Name: "cardano_node_metrics_blockfetchclient_lateblocks",
 		Help: "blocks that took more than 5 seconds to fetch",
 	})
-	o.metrics.blockDelayCdfOne = promautoFactory.NewGauge(prometheus.GaugeOpts{
+	o.blockfetchMetrics.blockDelayCdfOne = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_blockfetchclient_blockdelay_cdfOne",
 		Help: "percentage of blocks fetched in less than 1 second",
 	})
-	o.metrics.blockDelayCdfThree = promautoFactory.NewGauge(
+	o.blockfetchMetrics.blockDelayCdfThree = promautoFactory.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "cardano_node_metrics_blockfetchclient_blockdelay_cdfThree",
 			Help: "percentage of blocks fetched in less than 3 seconds",
 		},
 	)
-	o.metrics.blockDelayCdfFive = promautoFactory.NewGauge(prometheus.GaugeOpts{
+	o.blockfetchMetrics.blockDelayCdfFive = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: "cardano_node_metrics_blockfetchclient_blockdelay_cdfFive",
 		Help: "percentage of blocks fetched in less than 5 seconds",
 	})

--- a/ouroboros/peersharing.go
+++ b/ouroboros/peersharing.go
@@ -17,6 +17,7 @@ package ouroboros
 import (
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/blinklabs-io/dingo/peergov"
 	opeersharing "github.com/blinklabs-io/gouroboros/protocol/peersharing"
@@ -26,13 +27,31 @@ const defaultPeersToRequest = 5
 
 func (o *Ouroboros) peersharingServerConnOpts() []opeersharing.PeerSharingOptionFunc {
 	return []opeersharing.PeerSharingOptionFunc{
-		opeersharing.WithShareRequestFunc(o.peersharingShareRequest),
+		opeersharing.WithShareRequestFunc(
+			o.instrumentPeersharingShareRequest(o.peersharingShareRequest),
+		),
 	}
 }
 
 func (o *Ouroboros) peersharingClientConnOpts() []opeersharing.PeerSharingOptionFunc {
 	return []opeersharing.PeerSharingOptionFunc{
-		opeersharing.WithShareRequestFunc(o.peersharingClientRequest),
+		opeersharing.WithShareRequestFunc(
+			o.instrumentPeersharingShareRequest(o.peersharingClientRequest),
+		),
+	}
+}
+
+func (o *Ouroboros) instrumentPeersharingShareRequest(
+	fn func(opeersharing.CallbackContext, int) ([]opeersharing.PeerAddress, error),
+) func(opeersharing.CallbackContext, int) ([]opeersharing.PeerAddress, error) {
+	return func(
+		ctx opeersharing.CallbackContext,
+		amount int,
+	) ([]opeersharing.PeerAddress, error) {
+		start := time.Now()
+		addrs, err := fn(ctx, amount)
+		o.recordProtocolMessage("peersharing", err, time.Since(start))
+		return addrs, err
 	}
 }
 

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -54,14 +54,73 @@ func txsubmissionBackoffDuration(consecutiveHits int) time.Duration {
 
 func (o *Ouroboros) txsubmissionServerConnOpts() []txsubmission.TxSubmissionOptionFunc {
 	return []txsubmission.TxSubmissionOptionFunc{
-		txsubmission.WithInitFunc(o.txsubmissionServerInit),
+		txsubmission.WithInitFunc(
+			o.instrumentTxsubmissionInit(o.txsubmissionServerInit),
+		),
 	}
 }
 
 func (o *Ouroboros) txsubmissionClientConnOpts() []txsubmission.TxSubmissionOptionFunc {
 	return []txsubmission.TxSubmissionOptionFunc{
-		txsubmission.WithRequestTxIdsFunc(o.txsubmissionClientRequestTxIds),
-		txsubmission.WithRequestTxsFunc(o.txsubmissionClientRequestTxs),
+		txsubmission.WithRequestTxIdsFunc(
+			o.instrumentTxsubmissionRequestTxIds(o.txsubmissionClientRequestTxIds),
+		),
+		txsubmission.WithRequestTxsFunc(
+			o.instrumentTxsubmissionRequestTxs(o.txsubmissionClientRequestTxs),
+		),
+	}
+}
+
+// instrumentTxsubmissionInit wraps the Init callback. txsubmissionServerInit
+// returns immediately after launching the per-peer mempool-pump goroutine.
+// The metric outcome reflects only that synchronous handoff; errors from
+// the long-running goroutine (rate-limit failures, peer disconnects) are
+// not visible here.
+func (o *Ouroboros) instrumentTxsubmissionInit(
+	fn func(txsubmission.CallbackContext) error,
+) func(txsubmission.CallbackContext) error {
+	return func(ctx txsubmission.CallbackContext) error {
+		start := time.Now()
+		err := fn(ctx)
+		o.recordProtocolMessage("txsubmission", err, time.Since(start))
+		return err
+	}
+}
+
+// instrumentTxsubmissionRequestTxIds wraps the RequestTxIds callback. When
+// the peer requests blocking=true and the mempool is empty, the underlying
+// callback waits inside consumer.NextTx(true) until a tx arrives, which on
+// quiet networks can be seconds to minutes. Those waits land in the
+// duration histogram and dominate p95/p99 — operators reading the
+// histogram should treat long tails for txsubmission as expected idle
+// time, not callback work.
+func (o *Ouroboros) instrumentTxsubmissionRequestTxIds(
+	fn func(txsubmission.CallbackContext, bool, uint16, uint16) ([]txsubmission.TxIdAndSize, error),
+) func(txsubmission.CallbackContext, bool, uint16, uint16) ([]txsubmission.TxIdAndSize, error) {
+	return func(
+		ctx txsubmission.CallbackContext,
+		blocking bool,
+		ack uint16,
+		req uint16,
+	) ([]txsubmission.TxIdAndSize, error) {
+		start := time.Now()
+		ids, err := fn(ctx, blocking, ack, req)
+		o.recordProtocolMessage("txsubmission", err, time.Since(start))
+		return ids, err
+	}
+}
+
+func (o *Ouroboros) instrumentTxsubmissionRequestTxs(
+	fn func(txsubmission.CallbackContext, []txsubmission.TxId) ([]txsubmission.TxBody, error),
+) func(txsubmission.CallbackContext, []txsubmission.TxId) ([]txsubmission.TxBody, error) {
+	return func(
+		ctx txsubmission.CallbackContext,
+		txIds []txsubmission.TxId,
+	) ([]txsubmission.TxBody, error) {
+		start := time.Now()
+		bodies, err := fn(ctx, txIds)
+		o.recordProtocolMessage("txsubmission", err, time.Since(start))
+		return bodies, err
 	}
 }
 

--- a/peergov/churn.go
+++ b/peergov/churn.go
@@ -71,6 +71,7 @@ func (p *PeerGovernor) gossipChurn() {
 		}
 		oldSource := peer.Source
 		oldConn := clonePeerConnection(peer.Connection)
+		p.recordPeerStateChange(peer.State, targetState)
 		peer.State = targetState
 
 		// Close connection when demoting to cold
@@ -206,6 +207,7 @@ func (p *PeerGovernor) publicRootChurn() {
 	demoted := 0
 	for i := 0; i < len(hotPublicRoots) && demoted < churnCount; i++ {
 		peer := hotPublicRoots[i]
+		p.recordPeerStateChange(peer.State, PeerStateWarm)
 		peer.State = PeerStateWarm // Public roots demote to warm, not cold
 		demoted++
 		// Update group counts after demotion
@@ -306,6 +308,7 @@ func (p *PeerGovernor) promoteWarmNonRootPeersLocked(count int) []pendingEvent {
 			continue // Skip peers without active connections
 		}
 		if peer.PerformanceScore >= p.config.MinScoreThreshold {
+			p.recordPeerStateChange(peer.State, PeerStateHot)
 			peer.State = PeerStateHot
 			peer.LastActivity = time.Now()
 			promoted++
@@ -405,6 +408,7 @@ func (p *PeerGovernor) promoteFromWarmPublicRootsLocked(
 			continue // Skip peers without active connections
 		}
 		if peer.PerformanceScore >= p.config.MinScoreThreshold {
+			p.recordPeerStateChange(peer.State, PeerStateHot)
 			peer.State = PeerStateHot
 			peer.LastActivity = time.Now()
 			promoted++

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -275,6 +275,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			oldConn := clonePeerConnection(currentPeer.Connection)
 			currentPeer.ConnectedAt = time.Now()
 			currentPeer.setConnection(conn, true)
+			p.recordPeerStateChange(currentPeer.State, PeerStateWarm)
 			currentPeer.State = PeerStateWarm
 			selectionEvents := p.appendChainSelectionEventsLocked(
 				nil,
@@ -563,6 +564,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 				tmpPeer.setConnection(conn, false)
 				if tmpPeer.Connection != nil {
 					tmpPeer.Sharable = tmpPeer.Connection.VersionData.PeerSharing()
+					p.recordPeerStateChange(tmpPeer.State, PeerStateWarm)
 					tmpPeer.State = PeerStateWarm
 					p.recordInboundLifecycle("warmed")
 				}
@@ -656,6 +658,7 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 			peer.InboundConnectedAt = time.Time{}
 		}
 		peer.Connection = nil
+		p.recordPeerStateChange(peer.State, PeerStateCold)
 		peer.State = PeerStateCold
 		selectionEvents = p.appendChainSelectionEventsLocked(
 			selectionEvents,

--- a/peergov/metrics.go
+++ b/peergov/metrics.go
@@ -58,6 +58,9 @@ type peerGovernorMetrics struct {
 	inboundLifecycle       *prometheus.CounterVec
 	inboundHotQuotaUsage   prometheus.Gauge
 	inboundWarmOccupancy   prometheus.Gauge
+	// Temperature observability
+	peerPromotions *prometheus.CounterVec // transitions toward hot, labels: from, to
+	peerDemotions  *prometheus.CounterVec // transitions toward cold, labels: from, to
 }
 
 func (p *PeerGovernor) initMetrics() {
@@ -231,6 +234,62 @@ func (p *PeerGovernor) initMetrics() {
 		Name: "dingo_metrics_peerSelection_InboundWarmTargetOccupancy",
 		Help: "fraction of inbound warm target currently occupied (>=0; may exceed 1 when over target)",
 	})
+	p.metrics.peerPromotions = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dingo_peer_promotion_total",
+			Help: "total peer state transitions toward hot",
+		},
+		[]string{"from", "to"},
+	)
+	p.metrics.peerDemotions = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dingo_peer_demotion_total",
+			Help: "total peer state transitions toward cold",
+		},
+		[]string{"from", "to"},
+	)
+	// Pre-populate every reachable transition with zero so Prometheus
+	// exports the series from startup. Without this, rate()/increase()
+	// alerts would have no data until the first event of each kind.
+	p.metrics.peerPromotions.WithLabelValues("cold", "warm").Add(0)
+	p.metrics.peerPromotions.WithLabelValues("cold", "hot").Add(0)
+	p.metrics.peerPromotions.WithLabelValues("warm", "hot").Add(0)
+	p.metrics.peerDemotions.WithLabelValues("hot", "warm").Add(0)
+	p.metrics.peerDemotions.WithLabelValues("hot", "cold").Add(0)
+	p.metrics.peerDemotions.WithLabelValues("warm", "cold").Add(0)
+}
+
+// peerStateLabel maps a PeerState to its Prometheus temperature label.
+func peerStateLabel(state PeerState) string {
+	switch state {
+	case PeerStateCold:
+		return "cold"
+	case PeerStateWarm:
+		return "warm"
+	case PeerStateHot:
+		return "hot"
+	}
+	return "unknown"
+}
+
+// recordPeerStateChange increments the appropriate transition counter
+// when a peer moves between cold/warm/hot. No-op when from == to or
+// metrics aren't initialized.
+func (p *PeerGovernor) recordPeerStateChange(from, to PeerState) {
+	if p.metrics == nil || p.metrics.peerPromotions == nil || p.metrics.peerDemotions == nil {
+		return
+	}
+	if from == to {
+		return
+	}
+	fromLabel := peerStateLabel(from)
+	toLabel := peerStateLabel(to)
+	// Promotion = toward hot (Cold<Warm<Hot in PeerState ordering).
+	if to > from {
+		p.metrics.peerPromotions.WithLabelValues(fromLabel, toLabel).Inc()
+	} else {
+		p.metrics.peerDemotions.WithLabelValues(fromLabel, toLabel).Inc()
+	}
 }
 
 func (p *PeerGovernor) recordInboundLifecycle(stage string) {

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -508,6 +508,152 @@ func TestPeerGovernor_Metrics(t *testing.T) {
 	assert.Equal(t, float64(1), testutil.ToFloat64(pg.metrics.activePeers))
 }
 
+func TestPeerGovernor_RecordPeerStateChange(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry: reg,
+	})
+
+	// Cold -> Warm = promotion.
+	pg.recordPeerStateChange(PeerStateCold, PeerStateWarm)
+	// Warm -> Hot = promotion.
+	pg.recordPeerStateChange(PeerStateWarm, PeerStateHot)
+	// Hot -> Warm = demotion.
+	pg.recordPeerStateChange(PeerStateHot, PeerStateWarm)
+	// Warm -> Cold = demotion.
+	pg.recordPeerStateChange(PeerStateWarm, PeerStateCold)
+	// Same-state = no-op.
+	pg.recordPeerStateChange(PeerStateHot, PeerStateHot)
+
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerPromotions.WithLabelValues("cold", "warm"),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerPromotions.WithLabelValues("warm", "hot"),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerDemotions.WithLabelValues("hot", "warm"),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerDemotions.WithLabelValues("warm", "cold"),
+		),
+	)
+}
+
+func TestPeerGovernor_TransitionMetrics_ReconcilePromotion(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: reg,
+		MinHotPeers:  1,
+	})
+
+	pg.AddPeer("44.0.0.1:3001", PeerSourceP2PGossip)
+	pg.mu.Lock()
+	pg.peers[0].State = PeerStateWarm
+	pg.peers[0].Connection = &PeerConnection{IsClient: true}
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerPromotions.WithLabelValues("warm", "hot"),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(
+			pg.metrics.peerDemotions.WithLabelValues("hot", "warm"),
+		),
+	)
+}
+
+func TestPeerGovernor_TransitionMetrics_GossipChurnDemotion(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		PromRegistry:       reg,
+		GossipChurnPercent: 0.50,
+		MinScoreThreshold:  0.3,
+	})
+
+	pg.peers = []*Peer{
+		{
+			Address: "gossip1:3001", Source: PeerSourceP2PGossip,
+			State: PeerStateHot, PerformanceScore: 0.9,
+		},
+		{
+			Address: "gossip2:3001", Source: PeerSourceP2PGossip,
+			State: PeerStateHot, PerformanceScore: 0.2,
+		},
+	}
+
+	pg.gossipChurn()
+
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerDemotions.WithLabelValues("hot", "cold"),
+		),
+	)
+}
+
+func TestPeerGovernor_TransitionMetrics_ReconcileDemotion(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: reg,
+	})
+
+	pg.AddPeer("44.0.0.1:3001", PeerSourceP2PGossip)
+	pg.mu.Lock()
+	pg.peers[0].State = PeerStateHot
+	pg.peers[0].Connection = nil
+	pg.peers[0].LastActivity = time.Now().Add(-15 * time.Minute)
+	pg.mu.Unlock()
+
+	pg.reconcile(t.Context())
+
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			pg.metrics.peerDemotions.WithLabelValues("hot", "warm"),
+		),
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(
+			pg.metrics.peerPromotions.WithLabelValues("warm", "hot"),
+		),
+	)
+}
+
 func TestPeerGovernor_PeerSharing(t *testing.T) {
 	eventBus := newMockEventBus()
 	reg := prometheus.NewRegistry()

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -407,6 +407,7 @@ func (p *PeerGovernor) SetPeerHotByConnId(connId ouroboros.ConnectionId) {
 	defer p.mu.Unlock()
 	peerIdx := p.peerIndexByConnId(connId)
 	if peerIdx != -1 && p.peers[peerIdx] != nil {
+		p.recordPeerStateChange(p.peers[peerIdx].State, PeerStateHot)
 		p.peers[peerIdx].State = PeerStateHot
 		p.peers[peerIdx].LastActivity = time.Now()
 		p.updatePeerMetrics()

--- a/peergov/quotas.go
+++ b/peergov/quotas.go
@@ -203,6 +203,7 @@ func (p *PeerGovernor) enforceTopologyQuota(currentCount int) []pendingEvent {
 	demoted := 0
 	for i := 0; i < len(candidates) && demoted < excess; i++ {
 		peer := candidates[i]
+		p.recordPeerStateChange(peer.State, PeerStateWarm)
 		peer.State = PeerStateWarm // Demote to warm, not cold
 		demoted++
 		p.config.Logger.Debug(
@@ -295,6 +296,7 @@ func (p *PeerGovernor) enforceGroupValency() []pendingEvent {
 		demoted := 0
 		for i := 0; i < len(candidates) && demoted < excess; i++ {
 			peer := candidates[i]
+			p.recordPeerStateChange(peer.State, PeerStateWarm)
 			peer.State = PeerStateWarm
 			demoted++
 			p.config.Logger.Debug(
@@ -352,6 +354,7 @@ func (p *PeerGovernor) enforceSourceQuota(
 	demoted := 0
 	for i := 0; i < len(candidates) && demoted < excess; i++ {
 		peer := candidates[i]
+		p.recordPeerStateChange(peer.State, PeerStateWarm)
 		peer.State = PeerStateWarm
 		demoted++
 		p.config.Logger.Debug(

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -67,6 +67,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 				(peer.Source != PeerSourceTopologyLocalRoot &&
 					now.Sub(peer.LastActivity) > p.config.InactivityTimeout)
 			if demoteForInactivity {
+				p.recordPeerStateChange(p.peers[i].State, PeerStateWarm)
 				p.peers[i].State = PeerStateWarm
 				warmDemotions++
 				activeDecreased++
@@ -119,6 +120,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 						peer,
 					)
 				} else {
+					p.recordPeerStateChange(p.peers[i].State, PeerStateWarm)
 					p.peers[i].State = PeerStateWarm
 					if p.peers[i].Source == PeerSourceInboundConn {
 						p.recordInboundLifecycle("warmed")
@@ -312,6 +314,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 				)
 				continue
 			}
+			p.recordPeerStateChange(peer.State, PeerStateHot)
 			peer.State = PeerStateHot
 			peer.LastActivity = now
 			warmPromotions++


### PR DESCRIPTION
closes #1654


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus metrics for mini‑protocol callbacks (message count and duration) and peer temperature transitions to improve runtime visibility and alerting. Implements #1654.

- **New Features**
  - Protocol metrics: `dingo_protocol_messages_received_total` and `dingo_protocol_message_duration_seconds`, labeled by protocol and outcome; lightweight wrappers record `o.recordProtocolMessage("<protocol>")` across server/client callbacks for chainsync, blockfetch, txsubmission, keepalive, leiosfetch, leiosnotify, localstatequery, localtxmonitor, localtxsubmission, peersharing.
  - Peer temperature metrics: `dingo_peer_promotion_total` and `dingo_peer_demotion_total` counters (labels: `from`, `to`); transitions tracked across churn, reconcile, quotas, connection open/close, and `SetPeerHotByConnId`. Tests cover protocol timing labels and peer transition counters.

- **Refactors**
  - Renamed blockfetch metrics field to `blockfetchMetrics` and split init into `initBlockfetchMetrics`; added `initProtocolMetrics` and updated call sites.

<sup>Written for commit 2723a4ecec010d45b279ce85d9552cdb0ca04608. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol-level timing instrumentation across multiple network protocols and peer-state transition recording for richer observability.

* **Refactor**
  * Split metrics initialization into separate protocol and blockfetch metrics; recording is safe when metrics are disabled.

* **Tests**
  * Added unit tests validating protocol timing labels/outcomes and peer state-transition counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->