### PR TITLE
test: cardano-node 11.0.1

### DIFF
--- a/internal/test/antithesis/Dockerfile.configurator
+++ b/internal/test/antithesis/Dockerfile.configurator
@@ -4,7 +4,7 @@
 # unique pool keys and genesis files for Antithesis testing.
 
 # Pin to same version used in docker-compose.yaml
-FROM ghcr.io/blinklabs-io/cardano-node:10.5.4
+FROM ghcr.io/blinklabs-io/cardano-node:11.0.1
 
 ARG UV_VERSION=0.11.2
 ARG TESTNET_GENERATION_TOOL_VERSION=v0.1.0

--- a/internal/test/antithesis/docker-compose.yaml
+++ b/internal/test/antithesis/docker-compose.yaml
@@ -29,7 +29,7 @@
 #   ./scripts/test-local.sh    # Build, start, wait for health, tail logs
 
 x-cardano-node-base: &cardano-node-base
-  image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+  image: ghcr.io/blinklabs-io/cardano-node:11.0.1
   init: true
   environment: &cardano-node-env
     CARDANO_BLOCK_PRODUCER: "true"

--- a/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
+++ b/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
@@ -25,7 +25,7 @@
 #
 # Variables (set via environment or .env file):
 #   IMAGE_TAG              — dingo image tag        (default: main)
-#   CARDANO_NODE_VERSION   — cardano-node image tag  (default: 10.5.4)
+#   CARDANO_NODE_VERSION   — cardano-node image tag  (default: 11.0.1)
 #   INTERNAL_NETWORK       — isolate network from host (default: false)
 
 # ---------------------------------------------------------------------------
@@ -51,7 +51,7 @@ x-cardano-node-command: &cardano-node-command
   - "3001"
 
 x-cardano-node: &cardano-node
-  image: ghcr.io/blinklabs-io/cardano-node:${CARDANO_NODE_VERSION:-10.5.4}
+  image: ghcr.io/blinklabs-io/cardano-node:${CARDANO_NODE_VERSION:-11.0.1}
   init: true
   command: *cardano-node-command
   environment: &cn-env

--- a/internal/test/archive-demo/Dockerfile.configurator
+++ b/internal/test/archive-demo/Dockerfile.configurator
@@ -6,7 +6,7 @@
 # Based on: https://github.com/cardano-foundation/antithesis
 
 # Pin to same version used in docker-compose.yml
-FROM ghcr.io/blinklabs-io/cardano-node:10.5.4
+FROM ghcr.io/blinklabs-io/cardano-node:11.0.1
 
 USER root
 

--- a/internal/test/archive-demo/README.md
+++ b/internal/test/archive-demo/README.md
@@ -6,7 +6,7 @@ shows the S3 blob plugin and Bark proxy working end to end.
 
 ## Stack
 
-- `cardano-producer` - sole block producer (cardano-node 10.5.4)
+- `cardano-producer` - sole block producer (cardano-node 11.0.1)
 - `dingo-archive` - Dingo with `blobPlugin: s3`, Bark server on port 3003
 - `dingo-pruning` - Dingo with `blobPlugin: badger`,
   `barkBaseUrl` pointing at `dingo-archive`,

--- a/internal/test/archive-demo/docker-compose.yml
+++ b/internal/test/archive-demo/docker-compose.yml
@@ -21,7 +21,7 @@
 #   configurator     - one-shot, generates pool keys and genesis files
 #   minio            - S3-compatible blob storage
 #   minio-init       - one-shot, creates the "dingo-archive" bucket
-#   cardano-producer - sole block producer (cardano-node 10.5.4)
+#   cardano-producer - sole block producer (cardano-node 11.0.1)
 #   dingo-archive    - non-producer; S3 blob plugin + Bark server :3002
 #   dingo-pruning    - non-producer; Badger blob plugin + Bark client
 #                      pointed at dingo-archive
@@ -90,7 +90,7 @@ services:
         ipv4_address: 172.21.0.14
 
   cardano-producer:
-    image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+    image: ghcr.io/blinklabs-io/cardano-node:11.0.1
     container_name: archivedemo-cardano-producer
     depends_on:
       configurator:

--- a/internal/test/devnet/Dockerfile.configurator
+++ b/internal/test/devnet/Dockerfile.configurator
@@ -6,7 +6,7 @@
 # Based on: https://github.com/cardano-foundation/antithesis
 
 # Pin to same version used in docker-compose.yml
-FROM ghcr.io/blinklabs-io/cardano-node:10.5.4
+FROM ghcr.io/blinklabs-io/cardano-node:11.0.1
 
 USER root
 

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -52,7 +52,7 @@ Driven by `testnet.yaml`. Notable values:
 - Docker with the Compose plugin (`docker compose version` must work).
 - Go 1.25+ on the host (matching `go.mod`) to run the integration tests.
 - Outbound network access on first run to pull
-  `ghcr.io/blinklabs-io/cardano-node:10.5.4` and to clone
+  `ghcr.io/blinklabs-io/cardano-node:11.0.1` and to clone
   `cardano-foundation/testnet-generation-tool` inside the configurator image.
 - Local build of Dingo via the repo root `Dockerfile` — Compose builds it
   automatically on `up` / `run-tests.sh`.

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       start_period: 10s
 
   cardano-producer:
-    image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+    image: ghcr.io/blinklabs-io/cardano-node:11.0.1
     container_name: cardano-producer
     depends_on:
       configurator:
@@ -151,7 +151,7 @@ services:
         ipv4_address: 172.20.0.20
 
   cardano-relay:
-    image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+    image: ghcr.io/blinklabs-io/cardano-node:11.0.1
     container_name: cardano-relay
     depends_on:
       configurator:

--- a/internal/test/erastest/Dockerfile.configurator
+++ b/internal/test/erastest/Dockerfile.configurator
@@ -6,7 +6,7 @@
 # Based on: https://github.com/cardano-foundation/antithesis
 
 # Pin to same version used in docker-compose.yml
-FROM ghcr.io/blinklabs-io/cardano-node:10.5.4
+FROM ghcr.io/blinklabs-io/cardano-node:11.0.1
 
 USER root
 

--- a/internal/test/erastest/docker-compose.yml
+++ b/internal/test/erastest/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       start_period: 10s
 
   cardano-producer:
-    image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+    image: ghcr.io/blinklabs-io/cardano-node:11.0.1
     container_name: eras-cardano-producer
     depends_on:
       configurator:
@@ -143,7 +143,7 @@ services:
       start_period: 10s
 
   cardano-relay:
-    image: ghcr.io/blinklabs-io/cardano-node:10.5.4
+    image: ghcr.io/blinklabs-io/cardano-node:11.0.1
     container_name: eras-cardano-relay
     depends_on:
       configurator:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade test environments to `ghcr.io/blinklabs-io/cardano-node:11.0.1`, updating Dockerfiles, Compose configs, and docs across Antithesis, Archive Demo, Devnet, and ErasTest. Also sets the dingo-praos default `CARDANO_NODE_VERSION` to `11.0.1`.

- **Dependencies**
  - Bump `ghcr.io/blinklabs-io/cardano-node` from `10.5.4` to `11.0.1` in all relevant Dockerfiles and `docker-compose` files.
  - Update READMEs and comments to reference `11.0.1`.

<sup>Written for commit 11494ab9028b7a423a3043a81d116389d7f5f9b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configurations to use a newer cardano-node container image version across multiple testing setups, including Antithesis, Archive Demo, Development, and Era testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->