### PR TITLE
fix: mithril bootstrap seeds governance roots

### DIFF
--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -290,6 +290,29 @@ func ProcessEpoch(
 			root = rootsByPurpose[purpose]
 		}
 		if !validateParentChain(proposal, root) {
+			// A chained proposal that references a parent we
+			// don't have an enacted root for is the silent
+			// failure mode behind issue #2195: on a Mithril-
+			// bootstrapped node missing per-purpose seeded
+			// roots, every chained proposal hits this branch and
+			// silently expires. Log a warning so the next
+			// occurrence shows up in operator logs instead of
+			// only as a block-producer divergence at the next
+			// enactment boundary.
+			if in.Logger != nil &&
+				root == nil &&
+				proposal.ParentTxHash != nil &&
+				purpose != purposeNone {
+				in.Logger.Warn(
+					"skipping chained proposal: no enacted root for purpose; possible mithril bootstrap gap (#2195)",
+					"component", "governance",
+					"tx_hash", shortHash(proposal.TxHash),
+					"action_index", proposal.ActionIndex,
+					"action_type", proposal.ActionType,
+					"parent_tx_hash", hex.EncodeToString(proposal.ParentTxHash),
+					"epoch", in.NewEpoch,
+				)
+			}
 			continue
 		}
 

--- a/ledger/governance/mithril_root_test.go
+++ b/ledger/governance/mithril_root_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"testing"
+)
+
+// TestMithrilSeededRootUnblocksChainedProposal mirrors the failure
+// shape of issue #2195: a chained HardForkInitiation arriving on a
+// node whose only enacted-root visibility comes from a Mithril
+// snapshot must be accepted by validateParentChain when the per-
+// purpose root has been seeded as a synthetic enacted row.
+func TestMithrilSeededRootUnblocksChainedProposal(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	rootHash := testBytes(32, 0xA1)
+	parentIdx := uint32(0)
+
+	// Synthetic seeded root, equivalent to what
+	// ledgerstate.seedPrevGovActionIds writes.
+	enactedEpoch := uint64(500)
+	enactedSlot := uint64(123_456)
+	require.NoError(t, store.DB().Create(&models.GovernanceProposal{
+		TxHash:        rootHash,
+		ActionIndex:   parentIdx,
+		ActionType:    uint8(lcommon.GovActionTypeHardForkInitiation),
+		ProposedEpoch: 0,
+		ExpiresEpoch:  0,
+		EnactedEpoch:  &enactedEpoch,
+		EnactedSlot:   &enactedSlot,
+		Deposit:       0,
+		ReturnAddress: make([]byte, 29),
+		AnchorURL:     "",
+		AnchorHash:    make([]byte, 32),
+		AddedSlot:     0,
+	}).Error)
+
+	root, err := db.GetLastEnactedGovernanceProposal(
+		[]uint8{uint8(lcommon.GovActionTypeHardForkInitiation)},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, root, "synthetic root should be visible to ratification")
+
+	// Chained child whose parent points at the seeded root. Without
+	// the synthetic row this would be rejected by validateParentChain
+	// (currentRoot=nil, parent set) and silently expire — the bug.
+	child := &models.GovernanceProposal{
+		ActionType:      uint8(lcommon.GovActionTypeHardForkInitiation),
+		ParentTxHash:    rootHash,
+		ParentActionIdx: &parentIdx,
+	}
+	assert.True(
+		t, validateParentChain(child, root),
+		"chained child must validate against the seeded root",
+	)
+
+	// And without the root, the child still fails — we want the
+	// regression to come back if seeding ever silently no-ops.
+	assert.False(
+		t, validateParentChain(child, nil),
+		"sanity: chained child still fails without a root",
+	)
+}
+
+// TestValidateParentChain_NoConfidenceRootAllowsCommitteeUpdate
+// proves that when committee NoConfidence is the seeded root,
+// a subsequent UpdateCommittee whose parent matches the root is
+// accepted (purposeCommittee groups both action types).
+func TestValidateParentChain_NoConfidenceRootAllowsCommitteeUpdate(t *testing.T) {
+	rootHash := testBytes(32, 0xC1)
+	parentIdx := uint32(2)
+
+	root := &models.GovernanceProposal{
+		TxHash:      rootHash,
+		ActionIndex: parentIdx,
+		ActionType:  uint8(lcommon.GovActionTypeNoConfidence),
+	}
+	child := &models.GovernanceProposal{
+		ActionType:      uint8(lcommon.GovActionTypeUpdateCommittee),
+		ParentTxHash:    rootHash,
+		ParentActionIdx: &parentIdx,
+	}
+	assert.True(
+		t, validateParentChain(child, root),
+		"UpdateCommittee chained off NoConfidence root must validate",
+	)
+}

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1414,12 +1414,31 @@ type ParsedGovProposal struct {
 	ExpiresAfter uint64
 }
 
+// ParsedGovActionId holds a decoded GovActionId (txHash + index).
+type ParsedGovActionId struct {
+	TxHash      []byte // 32 bytes
+	ActionIndex uint32
+}
+
+// ParsedPrevGovActionIds holds the per-purpose chain roots from
+// cgsProposals's GovRelation (the first element of the proposals
+// container). Each pointer is non-nil when the corresponding
+// purpose has an enacted predecessor (SJust); nil means SNothing
+// (no enacted predecessor for that purpose).
+type ParsedPrevGovActionIds struct {
+	PParamUpdate *ParsedGovActionId
+	HardFork     *ParsedGovActionId
+	Committee    *ParsedGovActionId
+	Constitution *ParsedGovActionId
+}
+
 // ParsedGovState holds all decoded governance state components.
 type ParsedGovState struct {
-	Constitution    *ParsedConstitution
-	Committee       []ParsedCommitteeMember
-	CommitteeQuorum *cbor.Rat
-	Proposals       []ParsedGovProposal
+	Constitution     *ParsedConstitution
+	Committee        []ParsedCommitteeMember
+	CommitteeQuorum  *cbor.Rat
+	Proposals        []ParsedGovProposal
+	PrevGovActionIds *ParsedPrevGovActionIds
 }
 
 // ParseGovState decodes governance state from raw CBOR.
@@ -1487,13 +1506,14 @@ func ParseGovState(
 	result.CommitteeQuorum = quorum
 
 	// Parse proposals (field 0) — best-effort
-	proposals, err := parseProposals(fields[0])
+	proposals, prevIds, err := parseProposals(fields[0])
 	if err != nil {
 		warnings = append(warnings, fmt.Errorf(
 			"parsing proposals: %w", err,
 		))
 	}
 	result.Proposals = proposals
+	result.PrevGovActionIds = prevIds
 
 	return result, errors.Join(warnings...)
 }
@@ -1691,27 +1711,34 @@ func parseCommittee(data []byte) (
 //
 //	[roots, omap]
 //
-// where roots are previous governance action IDs and omap
-// is a flat array of GovActionState values (keys are derived
-// from the values via HasOKey during decoding).
+// where roots is a GovRelation StrictMaybe — a 4-element array of
+// per-purpose previous governance action IDs in the order
+// [PParamUpdate, HardFork, Committee, Constitution] — and omap is
+// a flat array of GovActionState values (keys are derived from the
+// values via HasOKey during decoding).
 //
 // Each GovActionState = [govActionId, committeeVotes,
 // drepVotes, spoVotes, proposalProcedure, proposedIn,
 // expiresAfter].
+//
+// Returns the proposals slice and the parsed per-purpose roots
+// (nil when all SNothing). Errors decoding the roots are surfaced
+// as warnings on the joined error so callers can still consume the
+// proposal list.
 func parseProposals(data []byte) (
-	[]ParsedGovProposal, error,
+	[]ParsedGovProposal, *ParsedPrevGovActionIds, error,
 ) {
 	container, err := decodeRawArray(data)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"decoding proposals container: %w", err,
 		)
 	}
 	if len(container) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if len(container) < 2 {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"proposals container has %d elements, "+
 				"expected 0 or at least 2",
 			len(container),
@@ -1724,7 +1751,7 @@ func parseProposals(data []byte) (
 
 	items, err := decodeRawArray(proposalSeq)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"decoding proposals OMap: %w", err,
 		)
 	}
@@ -1742,8 +1769,171 @@ func parseProposals(data []byte) (
 		}
 	}
 
-	// Return parsed proposals even if some failed
-	return proposals, errors.Join(propErrs...)
+	// Parse per-purpose roots (the GovRelation). A failure to
+	// decode roots is independently fatal to the chained-proposal
+	// ratification path on a Mithril-bootstrapped node, but we
+	// still want the proposals list to be returned so the rest of
+	// the import can complete. Surface the error as a warning.
+	prevIds, rootsErr := parseProposalsRoots(container[0])
+	if rootsErr != nil {
+		propErrs = append(propErrs, fmt.Errorf(
+			"decoding proposals roots: %w", rootsErr,
+		))
+	}
+
+	return proposals, prevIds, errors.Join(propErrs...)
+}
+
+// parseProposalsRoots decodes the GovRelation StrictMaybe at the
+// head of a Proposals CBOR container. The canonical encoding is a
+// 4-element array of StrictMaybe (GovPurposeId p era) values, in
+// the order [PParamUpdate, HardFork, Committee, Constitution].
+// StrictMaybe encodes as a 0- or 1-element array; SJust wraps a
+// GovActionId = [txHash, actionIndex].
+//
+// A 0-element top-level array (degenerate "no roots" form some
+// historical encoders emit) is accepted as all SNothing. Returns
+// nil when every purpose is SNothing.
+func parseProposalsRoots(data []byte) (
+	*ParsedPrevGovActionIds, error,
+) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	fields, err := decodeRawArray(data)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding GovRelation: %w", err,
+		)
+	}
+	if len(fields) == 0 {
+		// Degenerate "all SNothing" encoding: nothing to seed.
+		return nil, nil
+	}
+	if len(fields) != 4 {
+		return nil, fmt.Errorf(
+			"GovRelation has %d elements, expected 4",
+			len(fields),
+		)
+	}
+
+	pp, err := parseStrictMaybeGovActionId(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding pparam-update root: %w", err,
+		)
+	}
+	hf, err := parseStrictMaybeGovActionId(fields[1])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding hard-fork root: %w", err,
+		)
+	}
+	cm, err := parseStrictMaybeGovActionId(fields[2])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding committee root: %w", err,
+		)
+	}
+	cn, err := parseStrictMaybeGovActionId(fields[3])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding constitution root: %w", err,
+		)
+	}
+
+	if pp == nil && hf == nil && cm == nil && cn == nil {
+		return nil, nil
+	}
+	return &ParsedPrevGovActionIds{
+		PParamUpdate: pp,
+		HardFork:     hf,
+		Committee:    cm,
+		Constitution: cn,
+	}, nil
+}
+
+// parseStrictMaybeGovActionId decodes a StrictMaybe (GovPurposeId p
+// era) field. SNothing is the empty array; SJust wraps the inner
+// GovActionId = [txHash, actionIndex]. Returns nil for SNothing.
+//
+// Tolerates a CBOR null (0xf6) emitted by some historical encoders
+// in lieu of an empty array, and tolerates a directly-encoded
+// GovActionId (without the 1-element wrapper) so a non-canonical
+// encoder cannot silently drop a root.
+func parseStrictMaybeGovActionId(data []byte) (
+	*ParsedGovActionId, error,
+) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if len(data) == 1 && data[0] == 0xf6 {
+		return nil, nil
+	}
+	fields, err := decodeRawArray(data)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding StrictMaybe: %w", err,
+		)
+	}
+	switch len(fields) {
+	case 0:
+		return nil, nil
+	case 1:
+		// SJust [GovActionId]
+		return parseGovActionId(fields[0])
+	case 2:
+		// Directly-encoded GovActionId = [txHash, actionIndex].
+		// Some encoders skip the SJust wrapper; accept this shape
+		// rather than dropping the root.
+		return parseGovActionIdFromFields(fields)
+	default:
+		return nil, fmt.Errorf(
+			"StrictMaybe has %d elements, expected 0, 1, or 2",
+			len(fields),
+		)
+	}
+}
+
+// parseGovActionId decodes a CBOR-encoded GovActionId =
+// [txHash, actionIndex].
+func parseGovActionId(data []byte) (*ParsedGovActionId, error) {
+	fields, err := decodeRawArray(data)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding GovActionId: %w", err,
+		)
+	}
+	return parseGovActionIdFromFields(fields)
+}
+
+func parseGovActionIdFromFields(fields [][]byte) (
+	*ParsedGovActionId, error,
+) {
+	if len(fields) < 2 {
+		return nil, fmt.Errorf(
+			"GovActionId has %d elements, expected 2",
+			len(fields),
+		)
+	}
+	id := &ParsedGovActionId{}
+	if _, err := cbor.Decode(fields[0], &id.TxHash); err != nil {
+		return nil, fmt.Errorf(
+			"decoding GovActionId txHash: %w", err,
+		)
+	}
+	if len(id.TxHash) != 32 {
+		return nil, fmt.Errorf(
+			"GovActionId txHash has %d bytes, expected 32",
+			len(id.TxHash),
+		)
+	}
+	if _, err := cbor.Decode(fields[1], &id.ActionIndex); err != nil {
+		return nil, fmt.Errorf(
+			"decoding GovActionId index: %w", err,
+		)
+	}
+	return id, nil
 }
 
 // parseGovActionState decodes a single GovActionState.

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -1998,6 +1999,35 @@ func importGovState(
 		)
 	}
 
+	// Seed per-purpose chain roots from cgsPrevGovActionIds. Without
+	// these synthetic enacted rows, the next chained proposal that
+	// references a parent enacted before the snapshot would be
+	// rejected by validateParentChain (currentRoot is nil) and
+	// silently expire — see issue #2195. Genesis-synced nodes get
+	// these rows from the normal enactment path; Mithril snapshots
+	// don't surface them otherwise.
+	if govState.PrevGovActionIds != nil {
+		seeded, err := seedPrevGovActionIds(
+			cfg,
+			store,
+			govState,
+			currentEpochSlot,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"seeding per-purpose governance roots: %w",
+				err,
+			)
+		}
+		if seeded > 0 {
+			cfg.Logger.Info(
+				"seeded per-purpose governance chain roots",
+				"component", "ledgerstate",
+				"count", seeded,
+			)
+		}
+	}
+
 	progress(ImportProgress{
 		Stage:       "governance",
 		Percent:     100,
@@ -2006,6 +2036,162 @@ func importGovState(
 
 	return nil
 }
+
+// seedPrevGovActionIds writes synthetic enacted GovernanceProposal
+// rows for each per-purpose root recorded in the snapshot's
+// cgsPrevGovActionIds. These rows do not represent the full
+// proposal payload (anchor, deposit, return address are placeholders)
+// — they exist solely so GetLastEnactedGovernanceProposal returns a
+// non-nil root for the purpose, allowing chained children whose
+// parent is the on-chain enacted action to pass validateParentChain.
+//
+// AddedSlot is set to 0 so a normal rollback (which deletes rows
+// with added_slot > slot) cannot remove the seeded root. The
+// Mithril trust boundary blocks rollbacks past the snapshot anyway,
+// but slot 0 is a defense-in-depth choice.
+//
+// EnactedSlot/EnactedEpoch are set to the snapshot's current epoch
+// anchor so a later real enactment (which writes its own row with
+// a higher enacted slot/epoch) sorts above this synthetic row in
+// GetLastEnactedGovernanceProposal's ORDER BY.
+func seedPrevGovActionIds(
+	cfg ImportConfig,
+	store metadata.MetadataStore,
+	govState *ParsedGovState,
+	currentEpochSlot uint64,
+) (int, error) {
+	prev := govState.PrevGovActionIds
+	if prev == nil {
+		return 0, nil
+	}
+
+	// Committee root action_type heuristic: when the committee is
+	// absent (no members and no quorum), the most recent enacted
+	// committee-purpose action was a NoConfidence; otherwise an
+	// UpdateCommittee. The action_type matters because epoch.go
+	// reads committeeNoConfidenceState off the committee root to
+	// pick CommitteeNoConfidence vs CommitteeNormal thresholds.
+	committeeNoConfidence := len(govState.Committee) == 0 &&
+		govState.CommitteeQuorum == nil
+
+	type seed struct {
+		id         *ParsedGovActionId
+		actionType uint8
+	}
+	seeds := []seed{
+		{
+			id:         prev.PParamUpdate,
+			actionType: govActionTypeParameterChange,
+		},
+		{
+			id:         prev.HardFork,
+			actionType: govActionTypeHardForkInitiation,
+		},
+		{
+			id:         prev.Committee,
+			actionType: committeeRootActionType(committeeNoConfidence),
+		},
+		{
+			id:         prev.Constitution,
+			actionType: govActionTypeNewConstitution,
+		},
+	}
+
+	txn := cfg.Database.MetadataTxn(true)
+	defer txn.Release()
+	metaTxn := txn.Metadata()
+
+	count := 0
+	for _, s := range seeds {
+		if s.id == nil {
+			continue
+		}
+		// Defense-in-depth: an active proposal with the same
+		// (txHash, actionIndex) would collide with the unique
+		// index. Active proposals are pre-enactment, so a row
+		// matching a root cannot exist; skip if it does to avoid
+		// clobbering the live row's anchor/deposit data.
+		existing, err := store.GetGovernanceProposal(
+			s.id.TxHash, s.id.ActionIndex, metaTxn,
+		)
+		if err != nil && !errors.Is(
+			err, models.ErrGovernanceProposalNotFound,
+		) {
+			return count, fmt.Errorf(
+				"checking existing proposal for root %s#%d: %w",
+				hex.EncodeToString(s.id.TxHash),
+				s.id.ActionIndex,
+				err,
+			)
+		}
+		if existing != nil {
+			cfg.Logger.Warn(
+				"per-purpose root already exists in proposals; skipping seed",
+				"component", "ledgerstate",
+				"tx_hash", hex.EncodeToString(s.id.TxHash),
+				"action_index", s.id.ActionIndex,
+				"existing_action_type", existing.ActionType,
+			)
+			continue
+		}
+
+		enactedEpoch := cfg.State.Epoch
+		enactedSlot := currentEpochSlot
+		row := &models.GovernanceProposal{
+			TxHash:        s.id.TxHash,
+			ActionIndex:   s.id.ActionIndex,
+			ActionType:    s.actionType,
+			ProposedEpoch: 0,
+			ExpiresEpoch:  0,
+			EnactedEpoch:  &enactedEpoch,
+			EnactedSlot:   &enactedSlot,
+			Deposit:       0,
+			ReturnAddress: make([]byte, 29),
+			AnchorURL:     "",
+			AnchorHash:    make([]byte, 32),
+			AddedSlot:     0,
+		}
+		if err := store.SetGovernanceProposal(row, metaTxn); err != nil {
+			return count, fmt.Errorf(
+				"seeding root %s#%d (action_type %d): %w",
+				hex.EncodeToString(s.id.TxHash),
+				s.id.ActionIndex,
+				s.actionType,
+				err,
+			)
+		}
+		count++
+	}
+
+	if count == 0 {
+		return 0, nil
+	}
+	if err := txn.Commit(); err != nil {
+		return count, fmt.Errorf(
+			"committing seeded roots: %w", err,
+		)
+	}
+	return count, nil
+}
+
+func committeeRootActionType(noConfidence bool) uint8 {
+	if noConfidence {
+		return govActionTypeNoConfidence
+	}
+	return govActionTypeUpdateCommittee
+}
+
+// Action type discriminators used when seeding synthetic per-purpose
+// chain roots. Kept as untyped uint8 constants so this file does not
+// need to depend on the gouroboros lcommon package — these match the
+// CIP-1694 GovActionType wire values.
+const (
+	govActionTypeParameterChange    uint8 = 0
+	govActionTypeHardForkInitiation uint8 = 1
+	govActionTypeNoConfidence       uint8 = 3
+	govActionTypeUpdateCommittee    uint8 = 4
+	govActionTypeNewConstitution    uint8 = 5
+)
 
 func snapshotEpochAnchorSlot(
 	cfg ImportConfig,

--- a/ledgerstate/prev_gov_action_ids_test.go
+++ b/ledgerstate/prev_gov_action_ids_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeRoots encodes a 4-element GovRelation array of StrictMaybe
+// (GovPurposeId p era), in the order [PParamUpdate, HardFork,
+// Committee, Constitution]. ids[i] of nil encodes as SNothing ([]).
+func encodeRoots(t *testing.T, ids [4]*ParsedGovActionId) []byte {
+	t.Helper()
+	encoded := make([]any, 4)
+	for i, id := range ids {
+		if id == nil {
+			encoded[i] = []any{}
+			continue
+		}
+		encoded[i] = []any{
+			[]any{id.TxHash, uint64(id.ActionIndex)},
+		}
+	}
+	data, err := cbor.Encode(encoded)
+	require.NoError(t, err)
+	return data
+}
+
+func TestParseProposalsRootsEmpty(t *testing.T) {
+	got, err := parseProposalsRoots(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	emptyArr, err := cbor.Encode([]any{})
+	require.NoError(t, err)
+	got, err = parseProposalsRoots(emptyArr)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestParseProposalsRootsAllSNothing(t *testing.T) {
+	data := encodeRoots(t, [4]*ParsedGovActionId{nil, nil, nil, nil})
+	got, err := parseProposalsRoots(data)
+	require.NoError(t, err)
+	require.Nil(t, got, "all SNothing should map to nil result")
+}
+
+func TestParseProposalsRootsAllSet(t *testing.T) {
+	pp := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x11}, 32),
+		ActionIndex: 0,
+	}
+	hf := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x22}, 32),
+		ActionIndex: 1,
+	}
+	cm := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x33}, 32),
+		ActionIndex: 2,
+	}
+	cn := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x44}, 32),
+		ActionIndex: 3,
+	}
+
+	data := encodeRoots(t, [4]*ParsedGovActionId{pp, hf, cm, cn})
+	got, err := parseProposalsRoots(data)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.NotNil(t, got.PParamUpdate)
+	assert.Equal(t, pp.TxHash, got.PParamUpdate.TxHash)
+	assert.Equal(t, pp.ActionIndex, got.PParamUpdate.ActionIndex)
+
+	require.NotNil(t, got.HardFork)
+	assert.Equal(t, hf.TxHash, got.HardFork.TxHash)
+	assert.Equal(t, hf.ActionIndex, got.HardFork.ActionIndex)
+
+	require.NotNil(t, got.Committee)
+	assert.Equal(t, cm.TxHash, got.Committee.TxHash)
+	assert.Equal(t, cm.ActionIndex, got.Committee.ActionIndex)
+
+	require.NotNil(t, got.Constitution)
+	assert.Equal(t, cn.TxHash, got.Constitution.TxHash)
+	assert.Equal(t, cn.ActionIndex, got.Constitution.ActionIndex)
+}
+
+func TestParseProposalsRootsPartial(t *testing.T) {
+	hf := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0xAA}, 32),
+		ActionIndex: 7,
+	}
+	data := encodeRoots(t, [4]*ParsedGovActionId{nil, hf, nil, nil})
+	got, err := parseProposalsRoots(data)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.PParamUpdate)
+	require.NotNil(t, got.HardFork)
+	assert.Equal(t, hf.TxHash, got.HardFork.TxHash)
+	assert.Equal(t, hf.ActionIndex, got.HardFork.ActionIndex)
+	assert.Nil(t, got.Committee)
+	assert.Nil(t, got.Constitution)
+}
+
+func TestParseProposalsRootsBadShape(t *testing.T) {
+	// 3-element array is not a valid GovRelation.
+	data, err := cbor.Encode([]any{[]any{}, []any{}, []any{}})
+	require.NoError(t, err)
+	got, err := parseProposalsRoots(data)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "GovRelation has 3 elements")
+}
+
+func TestParseStrictMaybeGovActionIdNullSentinel(t *testing.T) {
+	// CBOR null (0xf6) is treated as SNothing.
+	got, err := parseStrictMaybeGovActionId([]byte{0xf6})
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestParseStrictMaybeGovActionIdDirectGovActionId(t *testing.T) {
+	// Tolerate a non-canonical encoder that emits the GovActionId
+	// directly without the SJust 1-element wrapper.
+	txHash := bytes.Repeat([]byte{0x55}, 32)
+	data, err := cbor.Encode([]any{txHash, uint64(9)})
+	require.NoError(t, err)
+	got, err := parseStrictMaybeGovActionId(data)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, txHash, got.TxHash)
+	assert.Equal(t, uint32(9), got.ActionIndex)
+}
+
+func TestParseStrictMaybeGovActionIdShortTxHash(t *testing.T) {
+	short := bytes.Repeat([]byte{0x77}, 16)
+	data, err := cbor.Encode([]any{[]any{short, uint64(0)}})
+	require.NoError(t, err)
+	got, err := parseStrictMaybeGovActionId(data)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "txHash has 16 bytes")
+}
+
+func TestParseProposalsIncludesRoots(t *testing.T) {
+	// End-to-end: parseProposals returns both the OMap proposals
+	// and the per-purpose roots.
+	pp := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0xBC}, 32),
+		ActionIndex: 4,
+	}
+	roots := encodeRootsAsAny(t, [4]*ParsedGovActionId{pp, nil, nil, nil})
+
+	// One Info proposal so the OMap is non-empty.
+	infoProp := []any{
+		[]any{bytes.Repeat([]byte{0x01}, 32), uint64(0)},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		[]any{
+			uint64(0),
+			bytes.Repeat([]byte{0x02}, 29),
+			[]any{uint8(6)}, // GovActionType Info = 6
+			[]any{
+				"https://example.com/info",
+				bytes.Repeat([]byte{0x03}, 32),
+			},
+		},
+		uint64(10),
+		uint64(20),
+	}
+	container, err := cbor.Encode([]any{roots, []any{infoProp}})
+	require.NoError(t, err)
+
+	props, prevIds, err := parseProposals(container)
+	require.NoError(t, err)
+	require.Len(t, props, 1)
+	require.NotNil(t, prevIds)
+	require.NotNil(t, prevIds.PParamUpdate)
+	assert.Equal(t, pp.TxHash, prevIds.PParamUpdate.TxHash)
+	assert.Equal(t, pp.ActionIndex, prevIds.PParamUpdate.ActionIndex)
+}
+
+// encodeRootsAsAny returns the GovRelation as []any so it can be
+// embedded in a larger container before CBOR-encoding.
+func encodeRootsAsAny(t *testing.T, ids [4]*ParsedGovActionId) []any {
+	t.Helper()
+	out := make([]any, 4)
+	for i, id := range ids {
+		if id == nil {
+			out[i] = []any{}
+			continue
+		}
+		out[i] = []any{
+			[]any{id.TxHash, uint64(id.ActionIndex)},
+		}
+	}
+	return out
+}

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// govStateWithRoots builds a Conway GovState CBOR payload whose
+// proposals container has the given per-purpose roots set and an
+// empty OMap. The committee field is encoded based on
+// committeePresent: true for a 1-element StrictMaybe Committee
+// wrapper with a 2/3 quorum and empty members; false for SNothing.
+//
+// The shape mirrors testGovStateData but exposes the roots so
+// tests can assert seeding behavior end to end.
+func govStateWithRoots(
+	t *testing.T,
+	roots [4]*ParsedGovActionId,
+	committeePresent bool,
+) []byte {
+	t.Helper()
+
+	rootsAny := encodeRootsAsAny(t, roots)
+	proposalsContainer := []any{rootsAny, []any{}}
+
+	var committee any
+	if committeePresent {
+		// committee field is StrictMaybe (Committee era), encoded
+		// as [ committee_body ] for SJust where committee_body =
+		// [members_map, quorum]. Empty members + 2/3 quorum is
+		// enough for parseCommittee to set CommitteeQuorum non-nil
+		// — the seeding heuristic checks for CommitteeQuorum != nil
+		// to distinguish UpdateCommittee from NoConfidence roots.
+		committee = []any{
+			[]any{
+				map[any]uint64{},
+				cbor.Rat{Rat: big.NewRat(2, 3)},
+			},
+		}
+	} else {
+		committee = []any{}
+	}
+
+	govState := []any{
+		proposalsContainer,
+		committee,
+		// Constitution: [anchor, scriptHash], anchor=[url,hash].
+		[]any{
+			[]any{
+				"https://example.com/constitution",
+				bytes.Repeat([]byte{0xAA}, 32),
+			},
+			nil,
+		},
+	}
+	data, err := cbor.Encode(govState)
+	require.NoError(t, err)
+	return data
+}
+
+func TestImportGovStateSeedsPrevGovActionIds(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	pp := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x11}, 32),
+		ActionIndex: 0,
+	}
+	hf := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x22}, 32),
+		ActionIndex: 0,
+	}
+	cm := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x33}, 32),
+		ActionIndex: 0,
+	}
+	cn := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x44}, 32),
+		ActionIndex: 0,
+	}
+
+	// committeePresent=false makes the committee root resolve to
+	// NoConfidence (3); flipping it would make it UpdateCommittee
+	// (4). We assert the action_type below.
+	govStateData := govStateWithRoots(
+		t,
+		[4]*ParsedGovActionId{pp, hf, cm, cn},
+		false,
+	)
+
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			GovStateData:  govStateData,
+			Epoch:         500,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 100,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.NoError(t, importGovState(
+		context.Background(),
+		cfg,
+		func(ImportProgress) {},
+	))
+
+	cases := []struct {
+		name        string
+		txHash      []byte
+		actionIdx   uint32
+		actionType  uint8
+		queryGroup  []uint8
+	}{
+		{
+			name:        "param-update",
+			txHash:      pp.TxHash,
+			actionIdx:   pp.ActionIndex,
+			actionType:  govActionTypeParameterChange,
+			queryGroup:  []uint8{govActionTypeParameterChange},
+		},
+		{
+			name:        "hard-fork",
+			txHash:      hf.TxHash,
+			actionIdx:   hf.ActionIndex,
+			actionType:  govActionTypeHardForkInitiation,
+			queryGroup:  []uint8{govActionTypeHardForkInitiation},
+		},
+		{
+			name:       "committee-no-confidence",
+			txHash:     cm.TxHash,
+			actionIdx:  cm.ActionIndex,
+			actionType: govActionTypeNoConfidence,
+			queryGroup: []uint8{
+				govActionTypeNoConfidence,
+				govActionTypeUpdateCommittee,
+			},
+		},
+		{
+			name:        "constitution",
+			txHash:      cn.TxHash,
+			actionIdx:   cn.ActionIndex,
+			actionType:  govActionTypeNewConstitution,
+			queryGroup:  []uint8{govActionTypeNewConstitution},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			row, err := db.Metadata().GetGovernanceProposal(
+				c.txHash, c.actionIdx, nil,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, row, "synthetic row missing for %s", c.name)
+			assert.Equal(
+				t, c.actionType, row.ActionType,
+				"unexpected action_type for %s", c.name,
+			)
+			require.NotNil(t, row.EnactedEpoch, "EnactedEpoch unset for %s", c.name)
+			require.NotNil(t, row.EnactedSlot, "EnactedSlot unset for %s", c.name)
+			assert.Equal(
+				t, uint64(0), row.AddedSlot,
+				"AddedSlot must be 0 to survive rollback for %s", c.name,
+			)
+
+			// GetLastEnactedGovernanceProposal must surface the
+			// synthetic row for its purpose; that's the lookup
+			// epoch.go performs at every boundary tick.
+			root, err := db.GetLastEnactedGovernanceProposal(
+				c.queryGroup, nil,
+			)
+			require.NoError(t, err)
+			require.NotNil(
+				t, root, "no enacted root visible for %s", c.name,
+			)
+			assert.Equal(t, c.txHash, root.TxHash)
+			assert.Equal(t, c.actionIdx, root.ActionIndex)
+		})
+	}
+}
+
+func TestImportGovStateSeedsCommitteeUpdateWhenCommitteePresent(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	cm := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x55}, 32),
+		ActionIndex: 0,
+	}
+
+	govStateData := govStateWithRoots(
+		t,
+		[4]*ParsedGovActionId{nil, nil, cm, nil},
+		true, // committee present → root action_type = UpdateCommittee
+	)
+
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			GovStateData:  govStateData,
+			Epoch:         500,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 100,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.NoError(t, importGovState(
+		context.Background(),
+		cfg,
+		func(ImportProgress) {},
+	))
+
+	row, err := db.Metadata().GetGovernanceProposal(
+		cm.TxHash, cm.ActionIndex, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, govActionTypeUpdateCommittee, row.ActionType)
+}
+
+func TestImportGovStateNoSeedingWhenAllSNothing(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	govStateData := govStateWithRoots(
+		t,
+		[4]*ParsedGovActionId{nil, nil, nil, nil},
+		false,
+	)
+
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			GovStateData:  govStateData,
+			Epoch:         500,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 100,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.NoError(t, importGovState(
+		context.Background(),
+		cfg,
+		func(ImportProgress) {},
+	))
+
+	// Without prev gov action IDs there is nothing to seed.
+	for _, group := range [][]uint8{
+		{govActionTypeParameterChange},
+		{govActionTypeHardForkInitiation},
+		{govActionTypeNoConfidence, govActionTypeUpdateCommittee},
+		{govActionTypeNewConstitution},
+	} {
+		root, err := db.GetLastEnactedGovernanceProposal(group, nil)
+		require.NoError(t, err)
+		require.Nil(t, root, "unexpected synthetic root for %v", group)
+	}
+}


### PR DESCRIPTION
Closes #2195 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chained governance proposals silently expiring on Mithril-bootstrapped nodes by seeding per-purpose governance roots during `ledgerstate` import. Adds a warning log when a chained proposal has no enacted root so operators can see the issue.

- **Bug Fixes**
  - Parse `GovRelation` prev action IDs from Conway governance state and expose them as `PrevGovActionIds` in `ledgerstate/certstate.go`.
  - During `ledgerstate` import, seed synthetic enacted `GovernanceProposal` rows for each per-purpose root so ratification finds a root after a snapshot; infer committee root type (NoConfidence vs UpdateCommittee) from committee presence.
  - In `ledger/governance/epoch.go`, log a warning when a chained proposal references a parent without an enacted root (possible Mithril bootstrap gap) instead of silently expiring.
  - Make CBOR parsing tolerant of non-canonical encodings for prev action IDs and keep proposals import resilient.

<sup>Written for commit 809cf132ce834f231017c81135c3b350221a9eb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

