### PR TITLE
fix(ledgerstate): extract gov action parents from cert state at import

### DIFF
--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1412,6 +1412,25 @@ type ParsedGovProposal struct {
 	AnchorHash   []byte
 	ProposedIn   uint64
 	ExpiresAfter uint64
+	// ParentTxHash is the parent gov-action's tx hash for chained action
+	// types (ParameterChange, HardForkInitiation, NoConfidence,
+	// UpdateCommittee, NewConstitution). Nil for unchained actions
+	// (TreasuryWithdrawals, InfoAction) and for chained actions with no
+	// prior enacted predecessor (SNothing in cardano-ledger terms).
+	ParentTxHash []byte
+	// ParentActionIdx is the action index that pairs with ParentTxHash.
+	// nil iff ParentTxHash is nil; otherwise points to the parent's
+	// uint32 index.
+	ParentActionIdx *uint32
+	// GovActionCbor is the raw CBOR bytes of the gov action body (the
+	// govAction element inside the ProposalProcedure). Persisted on
+	// import so the enactment path (ledger/governance/enact.go) can
+	// decode the action's payload (e.g. HardForkInitiation's protocol
+	// version, ParameterChange's pparam delta) at the boundary tick
+	// that enacts a previously-ratified proposal. Without it, ENACT
+	// fails to decode and aborts the entire boundary tick, halting
+	// the chain at the first enactment after a Mithril boot.
+	GovActionCbor []byte
 }
 
 // ParsedGovActionId holds a decoded GovActionId (txHash + index).
@@ -2029,6 +2048,14 @@ func parseGovActionState(
 		)
 	}
 
+	// Persist the raw gov action CBOR. EnactProposal decodes this
+	// payload at the enactment tick to read action-specific fields
+	// (HardForkInitiation's protocol version, ParameterChange's
+	// pparam delta, etc). Snapshot-imported proposals must carry it
+	// or the first enactment after a Mithril bootstrap aborts the
+	// whole boundary txn with "decode gov action: ...".
+	prop.GovActionCbor = append([]byte(nil), procedure[2]...)
+
 	// govAction = [actionType, ...] - extract actionType
 	govAction, err := decodeRawArray(procedure[2])
 	if err != nil {
@@ -2047,6 +2074,42 @@ func parseGovActionState(
 		return nil, fmt.Errorf(
 			"decoding govAction type: %w", err,
 		)
+	}
+
+	// Parent gov-action ID. Chained actions (ParameterChange=0,
+	// HardForkInitiation=1, NoConfidence=3, UpdateCommittee=4,
+	// NewConstitution=5) carry the parent at govAction[1] as
+	// StrictMaybe(GovActionId); SNothing means no prior enacted
+	// predecessor. TreasuryWithdrawals=2 and InfoAction=6 have no
+	// parent. Without this, validateParentChain rejects every
+	// chained child of a pre-snapshot enactment as if the parent
+	// were missing, and chained proposals silently expire instead of
+	// ratifying. See issue #2195.
+	switch prop.ActionType {
+	case 0, 1, 3, 4, 5:
+		if len(govAction) < 2 {
+			return nil, fmt.Errorf(
+				"decoding parent gov action id "+
+					"for action type %d: missing parent field",
+				prop.ActionType,
+			)
+		}
+		parentId, parentErr := parseStrictMaybeGovActionId(
+			govAction[1],
+		)
+		if parentErr != nil {
+			return nil, fmt.Errorf(
+				"decoding parent gov action id "+
+					"for action type %d: %w",
+				prop.ActionType,
+				parentErr,
+			)
+		}
+		if parentId != nil {
+			prop.ParentTxHash = parentId.TxHash
+			idx := parentId.ActionIndex
+			prop.ParentActionIdx = &idx
+		}
 	}
 
 	// anchor = [url, hash] — best-effort: proposals are still

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -15,6 +15,7 @@
 package ledgerstate
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -1942,6 +1943,34 @@ func importGovState(
 
 	// Import governance proposals
 	if len(govState.Proposals) > 0 {
+		// Snapshot bootstrap close-the-1-epoch-lag heuristic. Canon
+		// nodes mark a HFI ratified at boundary N-1 -> N and enact at
+		// boundary N -> N+1. The snapshot at epoch N reflects the
+		// ratification (in cgsDRepPulsingState's DRComplete result)
+		// but we don't parse that field, so without intervention our
+		// local node would re-ratify at boundary N -> N+1 and only
+		// enact at N+1 -> N+2 — putting us one epoch behind canon
+		// for the protocol-version bump. As a block producer that is
+		// the difference between forging vN+ blocks alongside canon
+		// and forging vN- blocks that risk rejection on TX-validation
+		// rule mismatches gated by the new version.
+		//
+		// Heuristic: when there is exactly one active HFI whose
+		// parent equals the snapshot's per-purpose HardFork root,
+		// mark it ratified at the snapshot's epoch so ENACT picks
+		// it up at the next boundary tick. Skips silently when the
+		// match is ambiguous (0 or >1 candidates) — the lag returns
+		// in those cases but correctness is preserved.
+		ratifiedHFI := findRatifiedHFICandidate(govState)
+		if ratifiedHFI != nil {
+			cfg.Logger.Info(
+				"marking active HFI as ratified at snapshot epoch (close 1-epoch lag)",
+				"component", "ledgerstate",
+				"tx_hash", hex.EncodeToString(ratifiedHFI.TxHash),
+				"action_index", ratifiedHFI.ActionIndex,
+				"ratified_epoch", cfg.State.Epoch,
+			)
+		}
 		if err := func() error {
 			txn := cfg.Database.MetadataTxn(true)
 			defer txn.Release()
@@ -1959,18 +1988,33 @@ func importGovState(
 					cfg,
 					prop.ProposedIn,
 				)
+				var ratifiedEpoch *uint64
+				var ratifiedSlot *uint64
+				if ratifiedHFI != nil &&
+					bytes.Equal(prop.TxHash, ratifiedHFI.TxHash) &&
+					prop.ActionIndex == ratifiedHFI.ActionIndex {
+					re := cfg.State.Epoch
+					rs := currentEpochSlot
+					ratifiedEpoch = &re
+					ratifiedSlot = &rs
+				}
 				if err := store.SetGovernanceProposal(
 					&models.GovernanceProposal{
-						TxHash:        prop.TxHash,
-						ActionIndex:   prop.ActionIndex,
-						ActionType:    prop.ActionType,
-						ProposedEpoch: prop.ProposedIn,
-						ExpiresEpoch:  prop.ExpiresAfter,
-						Deposit:       prop.Deposit,
-						ReturnAddress: prop.ReturnAddr,
-						AnchorURL:     prop.AnchorURL,
-						AnchorHash:    prop.AnchorHash,
-						AddedSlot:     proposedSlot,
+						TxHash:          prop.TxHash,
+						ActionIndex:     prop.ActionIndex,
+						ActionType:      prop.ActionType,
+						ProposedEpoch:   prop.ProposedIn,
+						ExpiresEpoch:    prop.ExpiresAfter,
+						Deposit:         prop.Deposit,
+						ReturnAddress:   prop.ReturnAddr,
+						AnchorURL:       prop.AnchorURL,
+						AnchorHash:      prop.AnchorHash,
+						ParentTxHash:    prop.ParentTxHash,
+						ParentActionIdx: prop.ParentActionIdx,
+						GovActionCbor:   prop.GovActionCbor,
+						RatifiedEpoch:   ratifiedEpoch,
+						RatifiedSlot:    ratifiedSlot,
+						AddedSlot:       proposedSlot,
 					},
 					metaTxn,
 				); err != nil {
@@ -2172,6 +2216,52 @@ func seedPrevGovActionIds(
 		)
 	}
 	return count, nil
+}
+
+// findRatifiedHFICandidate returns the unique active HFI proposal whose
+// parent equals the snapshot's per-purpose HardFork root, or nil if no
+// such proposal exists or more than one matches.
+//
+// The snapshot's PrevGovActionIds.HardFork is the action ID of the most
+// recently enacted HFI before the snapshot. An active proposal whose
+// parent equals that root is the next link in the chain — by canon's
+// ratify ordering, when more than one such candidate exists at most one
+// can be canonically ratified per epoch boundary (priority ties broken
+// by submission order/IDs), and we cannot tell which without parsing
+// cgsDRepPulsingState. Returning nil in the ambiguous case preserves
+// correctness at the cost of a 1-epoch enactment lag for that boundary.
+func findRatifiedHFICandidate(
+	govState *ParsedGovState,
+) *ParsedGovProposal {
+	if govState == nil ||
+		govState.PrevGovActionIds == nil ||
+		govState.PrevGovActionIds.HardFork == nil {
+		return nil
+	}
+	root := govState.PrevGovActionIds.HardFork
+	var candidate *ParsedGovProposal
+	matches := 0
+	for i := range govState.Proposals {
+		p := &govState.Proposals[i]
+		if p.ActionType != govActionTypeHardForkInitiation {
+			continue
+		}
+		if p.ParentTxHash == nil || p.ParentActionIdx == nil {
+			continue
+		}
+		if !bytes.Equal(p.ParentTxHash, root.TxHash) {
+			continue
+		}
+		if *p.ParentActionIdx != root.ActionIndex {
+			continue
+		}
+		matches++
+		candidate = p
+	}
+	if matches != 1 {
+		return nil
+	}
+	return candidate
 }
 
 func committeeRootActionType(noConfidence bool) uint8 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extract and persist parent governance action IDs and raw action CBOR during cert-state import in `ledgerstate` so chained proposals validate and enactments decode correctly after snapshots. Also mark the uniquely matching Hard Fork Initiation as ratified at the snapshot to avoid a 1‑epoch enactment lag.

- **Bug Fixes**
  - Extract parent `GovActionId` for chained types (0, 1, 3, 4, 5); skip unchained types.
  - Persist `ParentTxHash`, `ParentActionIdx`, and `GovActionCbor` on proposals during import.
  - When exactly one active HFI’s parent equals the snapshot HardFork root, set its ratified epoch/slot to the snapshot values to align enactment timing.

<sup>Written for commit 0d40cc5884924b9e5cb5b025f41965262363663b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track parent governance-action predecessors for proposals and persist raw action payloads; store richer proposal metadata and apply snapshot-time ratification for matching hard-fork candidates.
* **Chores / Performance**
  * Throttle expensive hard-fork stability evaluations and avoid redundant work after rollbacks.
* **Bug Fixes**
  * Scale blockfetch batching to avoid pipeline starvation when far behind the tip.
* **Tests**
  * Adjust blockfetch batch-size tests to reflect new scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->