### PR TITLE
feat(backfill):  Wire batch accumulator into backfill pipeline

### DIFF
--- a/database/batch.go
+++ b/database/batch.go
@@ -70,12 +70,14 @@ func (d *Database) SetTransactionBatched(
 		return errors.New("batch accumulator must not be nil")
 	}
 	owned := false
-	accDirty := false
 	if txn == nil {
 		txn = d.Transaction(true)
 		owned = true
 		defer func() {
-			if retErr != nil && accDirty {
+			if txn == nil {
+				return
+			}
+			if retErr != nil {
 				acc.Reset()
 			}
 			_ = txn.Rollback()
@@ -149,7 +151,6 @@ func (d *Database) SetTransactionBatched(
 	if metadataTxn == nil {
 		return types.ErrNilTxn
 	}
-	accDirty = owned
 	if err := d.metadata.SetTransactionBatched(
 		tx, point, idx, certDeposits, acc, metadataTxn,
 	); err != nil {
@@ -177,6 +178,7 @@ func (d *Database) SetTransactionBatched(
 		if err := txn.Commit(); err != nil {
 			return err
 		}
+		txn = nil
 		acc.Reset()
 	}
 

--- a/database/batch.go
+++ b/database/batch.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/mysql"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/postgres"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// BatchAccumulator wraps the concrete accumulator used by the active
+// metadata plugin.
+type BatchAccumulator struct {
+	sqlite   *sqlite.BatchAccumulator
+	postgres *postgres.BatchAccumulator
+	mysql    *mysql.BatchAccumulator
+}
+
+// NewBatchAccumulator creates an accumulator for the configured metadata
+// plugin.
+func (d *Database) NewBatchAccumulator() (*BatchAccumulator, error) {
+	switch d.metadata.(type) {
+	case *sqlite.MetadataStoreSqlite:
+		return &BatchAccumulator{sqlite: sqlite.NewBatchAccumulator()}, nil
+	case *postgres.MetadataStorePostgres:
+		return &BatchAccumulator{postgres: postgres.NewBatchAccumulator()}, nil
+	case *mysql.MetadataStoreMysql:
+		return &BatchAccumulator{mysql: mysql.NewBatchAccumulator()}, nil
+	default:
+		return nil, fmt.Errorf(
+			"batch accumulator unsupported for metadata store %T",
+			d.metadata,
+		)
+	}
+}
+
+// Reset clears all accumulated rows while reusing backing storage.
+func (b *BatchAccumulator) Reset() {
+	if b == nil {
+		return
+	}
+	switch {
+	case b.sqlite != nil:
+		b.sqlite.Reset()
+	case b.postgres != nil:
+		b.postgres.Reset()
+	case b.mysql != nil:
+		b.mysql.Reset()
+	}
+}
+
+// FlushBatch writes accumulated metadata rows for the active metadata plugin.
+func (d *Database) FlushBatch(
+	acc *BatchAccumulator,
+	txn *Txn,
+) error {
+	if acc == nil {
+		return nil
+	}
+	var metadataTxn types.Txn
+	if txn != nil {
+		metadataTxn = txn.Metadata()
+	}
+	switch store := d.metadata.(type) {
+	case *sqlite.MetadataStoreSqlite:
+		return store.FlushBatch(acc.sqlite, metadataTxn)
+	case *postgres.MetadataStorePostgres:
+		return store.FlushBatch(acc.postgres, metadataTxn)
+	case *mysql.MetadataStoreMysql:
+		return store.FlushBatch(acc.mysql, metadataTxn)
+	default:
+		return fmt.Errorf(
+			"flush batch unsupported for metadata store %T",
+			d.metadata,
+		)
+	}
+}
+
+// SetTransactionBatched stores transaction blob offsets and immediate
+// metadata, while accumulating bulk metadata rows into acc for a later
+// FlushBatch.
+func (d *Database) SetTransactionBatched(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	updateEpoch uint64,
+	pparamUpdates map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate,
+	certDeposits map[int]uint64,
+	offsets *BlockIngestionResult,
+	acc *BatchAccumulator,
+	txn *Txn,
+) error {
+	if acc == nil {
+		return fmt.Errorf("batch accumulator must not be nil")
+	}
+	owned := false
+	if txn == nil {
+		txn = d.Transaction(true)
+		owned = true
+		defer txn.Rollback() //nolint:errcheck
+	}
+
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return types.ErrBlobStoreUnavailable
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return types.ErrNilTxn
+	}
+
+	txHash := tx.Hash()
+	var txHashArray [32]byte
+	copy(txHashArray[:], txHash.Bytes())
+
+	if offsets == nil {
+		return fmt.Errorf(
+			"missing offsets for transaction %s at slot %d: offsets must be computed",
+			hex.EncodeToString(txHash.Bytes()[:8]),
+			point.Slot,
+		)
+	}
+	txOffset, ok := offsets.TxOffsets[txHashArray]
+	if !ok {
+		return fmt.Errorf(
+			"missing TX offset for %s at slot %d: offset must be computed by block indexer",
+			hex.EncodeToString(txHash.Bytes()[:8]),
+			point.Slot,
+		)
+	}
+	offsetData := EncodeTxOffset(&txOffset)
+	if err := blob.SetTx(blobTxn, txHash.Bytes(), offsetData); err != nil {
+		return fmt.Errorf("set tx offset: %w", err)
+	}
+
+	for _, utxo := range tx.Produced() {
+		txID := utxo.Id.Id().Bytes()
+		outputIdx := utxo.Id.Index()
+		ref := UtxoRef{
+			TxId:      txHashArray,
+			OutputIdx: outputIdx,
+		}
+		offset, ok := offsets.UtxoOffsets[ref]
+		if !ok {
+			return fmt.Errorf(
+				"missing UTxO offset for %s#%d at slot %d: offset must be computed by block indexer",
+				hex.EncodeToString(txID[:8]),
+				outputIdx,
+				point.Slot,
+			)
+		}
+		offsetData := EncodeUtxoOffset(&offset)
+		if err := blob.SetUtxo(blobTxn, txID, outputIdx, offsetData); err != nil {
+			return fmt.Errorf(
+				"set utxo offset %x#%d: %w",
+				txID[:8],
+				outputIdx,
+				err,
+			)
+		}
+	}
+
+	if err := d.ensureTransactionConsumedUtxos(tx, point, txn); err != nil {
+		return err
+	}
+	if err := d.setTransactionMetadataBatched(
+		tx, point, idx, certDeposits, acc, txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("set transaction metadata: %w", err)
+	}
+
+	if updateEpoch > 0 && tx.IsValid() {
+		for genesisHash, update := range pparamUpdates {
+			if err := d.SetPParamUpdate(
+				genesisHash.Bytes(),
+				update.Cbor(),
+				point.Slot,
+				updateEpoch,
+				txn,
+			); err != nil {
+				return fmt.Errorf("set pparam update: %w", err)
+			}
+		}
+	}
+
+	if owned {
+		if err := d.FlushBatch(acc, txn); err != nil {
+			return err
+		}
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Database) setTransactionMetadataBatched(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	acc *BatchAccumulator,
+	txn types.Txn,
+) error {
+	switch store := d.metadata.(type) {
+	case *sqlite.MetadataStoreSqlite:
+		return store.SetTransactionBatched(
+			tx, point, idx, certDeposits, acc.sqlite, txn,
+		)
+	case *postgres.MetadataStorePostgres:
+		return store.SetTransactionBatched(
+			tx, point, idx, certDeposits, acc.postgres, txn,
+		)
+	case *mysql.MetadataStoreMysql:
+		return store.SetTransactionBatched(
+			tx, point, idx, certDeposits, acc.mysql, txn,
+		)
+	default:
+		return fmt.Errorf(
+			"batched transaction unsupported for metadata store %T",
+			d.metadata,
+		)
+	}
+}

--- a/database/batch.go
+++ b/database/batch.go
@@ -79,6 +79,9 @@ func (d *Database) FlushBatch(
 	var metadataTxn types.Txn
 	if txn != nil {
 		metadataTxn = txn.Metadata()
+		if metadataTxn == nil {
+			return types.ErrNilTxn
+		}
 	}
 	switch store := d.metadata.(type) {
 	case *sqlite.MetadataStoreSqlite:
@@ -182,8 +185,12 @@ func (d *Database) SetTransactionBatched(
 	if err := d.ensureTransactionConsumedUtxos(tx, point, txn); err != nil {
 		return err
 	}
+	metadataTxn := txn.Metadata()
+	if metadataTxn == nil {
+		return types.ErrNilTxn
+	}
 	if err := d.setTransactionMetadataBatched(
-		tx, point, idx, certDeposits, acc, txn.Metadata(),
+		tx, point, idx, certDeposits, acc, metadataTxn,
 	); err != nil {
 		return fmt.Errorf("set transaction metadata: %w", err)
 	}

--- a/database/batch.go
+++ b/database/batch.go
@@ -65,15 +65,21 @@ func (d *Database) SetTransactionBatched(
 	offsets *BlockIngestionResult,
 	acc BatchAccumulator,
 	txn *Txn,
-) error {
+) (retErr error) {
 	if acc == nil {
 		return errors.New("batch accumulator must not be nil")
 	}
 	owned := false
+	accDirty := false
 	if txn == nil {
 		txn = d.Transaction(true)
 		owned = true
-		defer txn.Rollback() //nolint:errcheck
+		defer func() {
+			if retErr != nil && accDirty {
+				acc.Reset()
+			}
+			_ = txn.Rollback()
+		}()
 	}
 
 	blob := txn.DB().Blob()
@@ -143,6 +149,7 @@ func (d *Database) SetTransactionBatched(
 	if metadataTxn == nil {
 		return types.ErrNilTxn
 	}
+	accDirty = owned
 	if err := d.metadata.SetTransactionBatched(
 		tx, point, idx, certDeposits, acc, metadataTxn,
 	); err != nil {

--- a/database/batch.go
+++ b/database/batch.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/mysql"
@@ -109,7 +110,7 @@ func (d *Database) SetTransactionBatched(
 	txn *Txn,
 ) error {
 	if acc == nil {
-		return fmt.Errorf("batch accumulator must not be nil")
+		return errors.New("batch accumulator must not be nil")
 	}
 	owned := false
 	if txn == nil {

--- a/database/batch.go
+++ b/database/batch.go
@@ -209,6 +209,7 @@ func (d *Database) SetTransactionBatched(
 		if err := txn.Commit(); err != nil {
 			return err
 		}
+		acc.Reset()
 	}
 
 	return nil

--- a/database/batch.go
+++ b/database/batch.go
@@ -19,58 +19,24 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/blinklabs-io/dingo/database/plugin/metadata/mysql"
-	"github.com/blinklabs-io/dingo/database/plugin/metadata/postgres"
-	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
-// BatchAccumulator wraps the concrete accumulator used by the active
-// metadata plugin.
-type BatchAccumulator struct {
-	sqlite   *sqlite.BatchAccumulator
-	postgres *postgres.BatchAccumulator
-	mysql    *mysql.BatchAccumulator
-}
+// BatchAccumulator is an opaque accumulator owned by the active metadata
+// plugin.
+type BatchAccumulator = types.MetadataBatchAccumulator
 
 // NewBatchAccumulator creates an accumulator for the configured metadata
 // plugin.
-func (d *Database) NewBatchAccumulator() (*BatchAccumulator, error) {
-	switch d.metadata.(type) {
-	case *sqlite.MetadataStoreSqlite:
-		return &BatchAccumulator{sqlite: sqlite.NewBatchAccumulator()}, nil
-	case *postgres.MetadataStorePostgres:
-		return &BatchAccumulator{postgres: postgres.NewBatchAccumulator()}, nil
-	case *mysql.MetadataStoreMysql:
-		return &BatchAccumulator{mysql: mysql.NewBatchAccumulator()}, nil
-	default:
-		return nil, fmt.Errorf(
-			"batch accumulator unsupported for metadata store %T",
-			d.metadata,
-		)
-	}
-}
-
-// Reset clears all accumulated rows while reusing backing storage.
-func (b *BatchAccumulator) Reset() {
-	if b == nil {
-		return
-	}
-	switch {
-	case b.sqlite != nil:
-		b.sqlite.Reset()
-	case b.postgres != nil:
-		b.postgres.Reset()
-	case b.mysql != nil:
-		b.mysql.Reset()
-	}
+func (d *Database) NewBatchAccumulator() BatchAccumulator {
+	return d.metadata.NewBatchAccumulator()
 }
 
 // FlushBatch writes accumulated metadata rows for the active metadata plugin.
 func (d *Database) FlushBatch(
-	acc *BatchAccumulator,
+	acc BatchAccumulator,
 	txn *Txn,
 ) error {
 	if acc == nil {
@@ -83,19 +49,7 @@ func (d *Database) FlushBatch(
 			return types.ErrNilTxn
 		}
 	}
-	switch store := d.metadata.(type) {
-	case *sqlite.MetadataStoreSqlite:
-		return store.FlushBatch(acc.sqlite, metadataTxn)
-	case *postgres.MetadataStorePostgres:
-		return store.FlushBatch(acc.postgres, metadataTxn)
-	case *mysql.MetadataStoreMysql:
-		return store.FlushBatch(acc.mysql, metadataTxn)
-	default:
-		return fmt.Errorf(
-			"flush batch unsupported for metadata store %T",
-			d.metadata,
-		)
-	}
+	return d.metadata.FlushBatch(acc, metadataTxn)
 }
 
 // SetTransactionBatched stores transaction blob offsets and immediate
@@ -109,7 +63,7 @@ func (d *Database) SetTransactionBatched(
 	pparamUpdates map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate,
 	certDeposits map[int]uint64,
 	offsets *BlockIngestionResult,
-	acc *BatchAccumulator,
+	acc BatchAccumulator,
 	txn *Txn,
 ) error {
 	if acc == nil {
@@ -189,7 +143,7 @@ func (d *Database) SetTransactionBatched(
 	if metadataTxn == nil {
 		return types.ErrNilTxn
 	}
-	if err := d.setTransactionMetadataBatched(
+	if err := d.metadata.SetTransactionBatched(
 		tx, point, idx, certDeposits, acc, metadataTxn,
 	); err != nil {
 		return fmt.Errorf("set transaction metadata: %w", err)
@@ -220,33 +174,4 @@ func (d *Database) SetTransactionBatched(
 	}
 
 	return nil
-}
-
-func (d *Database) setTransactionMetadataBatched(
-	tx lcommon.Transaction,
-	point ocommon.Point,
-	idx uint32,
-	certDeposits map[int]uint64,
-	acc *BatchAccumulator,
-	txn types.Txn,
-) error {
-	switch store := d.metadata.(type) {
-	case *sqlite.MetadataStoreSqlite:
-		return store.SetTransactionBatched(
-			tx, point, idx, certDeposits, acc.sqlite, txn,
-		)
-	case *postgres.MetadataStorePostgres:
-		return store.SetTransactionBatched(
-			tx, point, idx, certDeposits, acc.postgres, txn,
-		)
-	case *mysql.MetadataStoreMysql:
-		return store.SetTransactionBatched(
-			tx, point, idx, certDeposits, acc.mysql, txn,
-		)
-	default:
-		return fmt.Errorf(
-			"batched transaction unsupported for metadata store %T",
-			d.metadata,
-		)
-	}
 }

--- a/database/mithril_gap_test.go
+++ b/database/mithril_gap_test.go
@@ -53,6 +53,18 @@ type gapConsumeCandidate struct {
 	producers     []gapProducerTx
 }
 
+type batchedCrossBlockSpendCandidate struct {
+	producerBlock models.Block
+	producerPoint ocommon.Point
+	producerTx    lcommon.Transaction
+	producerIdx   uint32
+	consumerBlock models.Block
+	consumerPoint ocommon.Point
+	consumerTx    lcommon.Transaction
+	consumerIdx   uint32
+	input         lcommon.TransactionInput
+}
+
 func TestSetGapBlockTransactionRestoresConsumedInputsOnRollback(
 	t *testing.T,
 ) {
@@ -196,6 +208,73 @@ func TestSetTransactionRecoversMissingConsumedInputsFromBlob(
 			utxo.SpentAtTxId,
 		)
 	}
+}
+
+func TestSetTransactionBatchedSpendsPreviousBlockOutputInSameBatch(
+	t *testing.T,
+) {
+	// Intentionally not t.Parallel(): database.New() writes to
+	// plugin option destination pointers via SetPluginOption, which
+	// the race detector flags when two tests build a Database
+	// concurrently.
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+	storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	require.NoError(
+		t,
+		db.SetTransactionBatched(
+			candidate.producerTx,
+			candidate.producerPoint,
+			candidate.producerIdx,
+			0,
+			nil,
+			nil,
+			mustBlockOffsets(t, candidate.producerBlock),
+			acc,
+			txn,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetTransactionBatched(
+			candidate.consumerTx,
+			candidate.consumerPoint,
+			candidate.consumerIdx,
+			0,
+			nil,
+			nil,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			acc,
+			txn,
+		),
+	)
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+
+	utxo, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(),
+		candidate.input.Index(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, utxo)
+	require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
+	require.Equal(t, candidate.consumerTx.Hash().Bytes(), utxo.SpentAtTxId)
 }
 
 func findGapRollbackCandidate(t *testing.T) gapRollbackCandidate {
@@ -601,6 +680,103 @@ func findGapConsumeCandidateWithoutCertificates(
 		"failed to find cert-free gap consume candidate in immutable testdata",
 	)
 	return gapConsumeCandidate{}
+}
+
+func findBatchedCrossBlockSpendCandidate(
+	t *testing.T,
+) batchedCrossBlockSpendCandidate {
+	t.Helper()
+
+	imm, err := immutable.New("immutable/testdata")
+	require.NoError(t, err)
+
+	iter, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	type producedEntry struct {
+		block models.Block
+		point ocommon.Point
+		tx    lcommon.Transaction
+		idx   uint32
+	}
+	prevProduced := make(map[string]producedEntry)
+
+	for {
+		immBlock, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+		if immBlock == nil {
+			break
+		}
+		block, err := gledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		blockModel := models.Block{
+			Slot:     block.SlotNumber(),
+			Hash:     block.Hash().Bytes(),
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     block.Cbor(),
+		}
+		blockPoint := ocommon.Point{
+			Slot: blockModel.Slot,
+			Hash: blockModel.Hash,
+		}
+
+		for idx, tx := range block.Transactions() {
+			if len(tx.Certificates()) > 0 {
+				continue
+			}
+			for _, input := range tx.Consumed() {
+				entry, ok := prevProduced[inputRefKey(
+					input.Id().Bytes(),
+					input.Index(),
+				)]
+				if !ok {
+					continue
+				}
+				return batchedCrossBlockSpendCandidate{
+					producerBlock: entry.block,
+					producerPoint: entry.point,
+					producerTx:    entry.tx,
+					producerIdx:   entry.idx,
+					consumerBlock: blockModel,
+					consumerPoint: blockPoint,
+					consumerTx:    tx,
+					consumerIdx:   uint32(idx),
+					input:         input,
+				}
+			}
+		}
+
+		prevProduced = make(map[string]producedEntry)
+		for idx, tx := range block.Transactions() {
+			if len(tx.Certificates()) > 0 {
+				continue
+			}
+			for _, utxo := range tx.Produced() {
+				prevProduced[inputRefKey(
+					utxo.Id.Id().Bytes(),
+					utxo.Id.Index(),
+				)] = producedEntry{
+					block: blockModel,
+					point: blockPoint,
+					tx:    tx,
+					idx:   uint32(idx),
+				}
+			}
+		}
+	}
+
+	t.Fatal(
+		"failed to find previous-block spend candidate in immutable testdata",
+	)
+	return batchedCrossBlockSpendCandidate{}
 }
 
 // TestSetGapBlockTransactionSpendsLiveProducedInputs verifies that when

--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -55,6 +55,11 @@ func NewBatchAccumulator() *BatchAccumulator {
 	return &BatchAccumulator{}
 }
 
+// NewBatchAccumulator creates an accumulator for this metadata store.
+func (d *MetadataStoreMysql) NewBatchAccumulator() types.MetadataBatchAccumulator {
+	return NewBatchAccumulator()
+}
+
 // AddKeyWitness appends a key witness record to the batch.
 func (b *BatchAccumulator) AddKeyWitness(kw models.KeyWitness) {
 	b.KeyWitnesses = append(b.KeyWitnesses, kw)
@@ -141,9 +146,13 @@ func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
 
 // FlushBatch writes all accumulated records in a deterministic order.
 func (d *MetadataStoreMysql) FlushBatch(
-	batch *BatchAccumulator,
+	acc types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
+	batch, ok := acc.(*BatchAccumulator)
+	if !ok {
+		return fmt.Errorf("mysql FlushBatch: wrong accumulator type %T", acc)
+	}
 	if batch == nil {
 		return nil
 	}

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2063,10 +2063,17 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	point ocommon.Point,
 	idx uint32,
 	certDeposits map[int]uint64,
-	acc *BatchAccumulator,
+	acc types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
-	if acc == nil {
+	batch, ok := acc.(*BatchAccumulator)
+	if !ok {
+		return fmt.Errorf(
+			"SetTransactionBatched: wrong accumulator type %T",
+			acc,
+		)
+	}
+	if batch == nil {
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	local := NewBatchAccumulator()
@@ -2498,10 +2505,34 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				)
 			}
 			if len(unifiedIDs) > 0 {
+				poolRegistrationIDs := []uint{}
+				if result := db.Model(&models.PoolRegistration{}).
+					Where("certificate_id IN ?", unifiedIDs).
+					Pluck("id", &poolRegistrationIDs); result.Error != nil {
+					return fmt.Errorf(
+						"query existing pool registrations (batched): %w",
+						result.Error,
+					)
+				}
+				if len(poolRegistrationIDs) > 0 {
+					if result := db.Table("pool_registration_owner").
+						Where("pool_registration_id IN ?", poolRegistrationIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing pool_registration_owner records (batched): %w",
+							result.Error,
+						)
+					}
+					if result := db.Table("pool_registration_relay").
+						Where("pool_registration_id IN ?", poolRegistrationIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing pool_registration_relay records (batched): %w",
+							result.Error,
+						)
+					}
+				}
 				tables := []string{
-					// Child tables must be deleted before parent tables (FK constraints).
-					"pool_registration_owner",
-					"pool_registration_relay",
 					"stake_registration", "pool_registration", "pool_retirement",
 					"auth_committee_hot", "resign_committee_cold",
 					"deregistration", "stake_delegation",
@@ -3275,7 +3306,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 		}
 	}
 
-	acc.MergeFrom(local)
+	batch.MergeFrom(local)
 	return nil
 }
 

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -55,6 +55,11 @@ func NewBatchAccumulator() *BatchAccumulator {
 	return &BatchAccumulator{}
 }
 
+// NewBatchAccumulator creates an accumulator for this metadata store.
+func (d *MetadataStorePostgres) NewBatchAccumulator() types.MetadataBatchAccumulator {
+	return NewBatchAccumulator()
+}
+
 // AddKeyWitness appends a key witness record to the batch.
 func (b *BatchAccumulator) AddKeyWitness(kw models.KeyWitness) {
 	b.KeyWitnesses = append(b.KeyWitnesses, kw)
@@ -141,9 +146,13 @@ func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
 
 // FlushBatch writes all accumulated records in a deterministic order.
 func (d *MetadataStorePostgres) FlushBatch(
-	batch *BatchAccumulator,
+	acc types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
+	batch, ok := acc.(*BatchAccumulator)
+	if !ok {
+		return fmt.Errorf("postgres FlushBatch: wrong accumulator type %T", acc)
+	}
 	if batch == nil {
 		return nil
 	}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2064,10 +2064,17 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	point ocommon.Point,
 	idx uint32,
 	certDeposits map[int]uint64,
-	acc *BatchAccumulator,
+	acc types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
-	if acc == nil {
+	batch, ok := acc.(*BatchAccumulator)
+	if !ok {
+		return fmt.Errorf(
+			"SetTransactionBatched: wrong accumulator type %T",
+			acc,
+		)
+	}
+	if batch == nil {
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	local := NewBatchAccumulator()
@@ -2506,10 +2513,34 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				)
 			}
 			if len(unifiedIDs) > 0 {
+				poolRegistrationIDs := []uint{}
+				if result := db.Model(&models.PoolRegistration{}).
+					Where("certificate_id IN ?", unifiedIDs).
+					Pluck("id", &poolRegistrationIDs); result.Error != nil {
+					return fmt.Errorf(
+						"query existing pool registrations (batched): %w",
+						result.Error,
+					)
+				}
+				if len(poolRegistrationIDs) > 0 {
+					if result := db.Table("pool_registration_owner").
+						Where("pool_registration_id IN ?", poolRegistrationIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing pool_registration_owner records (batched): %w",
+							result.Error,
+						)
+					}
+					if result := db.Table("pool_registration_relay").
+						Where("pool_registration_id IN ?", poolRegistrationIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing pool_registration_relay records (batched): %w",
+							result.Error,
+						)
+					}
+				}
 				tables := []string{
-					// Child tables must be deleted before parent tables (FK constraints).
-					"pool_registration_owner",
-					"pool_registration_relay",
 					"stake_registration", "pool_registration", "pool_retirement",
 					"auth_committee_hot", "resign_committee_cold",
 					"deregistration", "stake_delegation",
@@ -3283,7 +3314,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 		}
 	}
 
-	acc.MergeFrom(local)
+	batch.MergeFrom(local)
 	return nil
 }
 

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -15,6 +15,8 @@
 package sqlite
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -213,7 +215,7 @@ func (d *MetadataStoreSqlite) FlushBatch(
 				err,
 			)
 		}
-		if err := batchSpendUtxos(db, batch.UtxoSpends); err != nil {
+		if err := d.batchSpendUtxos(db, batch.UtxoSpends); err != nil {
 			return fmt.Errorf("flush batch: spend utxos: %w", err)
 		}
 
@@ -294,7 +296,7 @@ func batchDeleteByTxIDs(db *gorm.DB, table string, ids []uint) error {
 	return nil
 }
 
-func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
+func (d *MetadataStoreSqlite) batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 	if len(spends) == 0 {
 		return nil
 	}
@@ -312,8 +314,64 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 				spend.OutputIdx,
 			); result.Error != nil {
 				return result.Error
+			} else if result.RowsAffected == 0 {
+				if err := d.checkUnmatchedUtxoSpend(
+					db,
+					spend,
+				); err != nil {
+					return err
+				}
 			}
 		}
 	}
 	return nil
+}
+
+func (d *MetadataStoreSqlite) checkUnmatchedUtxoSpend(
+	db *gorm.DB,
+	spend utxoSpend,
+) error {
+	var existingUtxo models.Utxo
+	checkResult := db.Where(
+		"tx_id = ? AND output_idx = ?",
+		spend.TxId,
+		spend.OutputIdx,
+	).First(&existingUtxo)
+	if checkResult.Error != nil {
+		if errors.Is(checkResult.Error, gorm.ErrRecordNotFound) {
+			d.warnLimiter.warn(
+				d.logger,
+				"input-utxo-not-found",
+				"input UTxO not found",
+				"hash",
+				fmt.Sprintf("%x", spend.TxId),
+				"index",
+				spend.OutputIdx,
+			)
+			return nil
+		}
+		return fmt.Errorf(
+			"failed to check UTXO %x#%d: %w",
+			spend.TxId,
+			spend.OutputIdx,
+			checkResult.Error,
+		)
+	}
+	if existingUtxo.SpentAtTxId != nil &&
+		bytes.Equal(existingUtxo.SpentAtTxId, spend.SpentByTxHash) {
+		return nil
+	}
+	if existingUtxo.DeletedSlot == 0 && existingUtxo.SpentAtTxId == nil {
+		return fmt.Errorf(
+			"batch spend did not update UTXO %x#%d",
+			spend.TxId,
+			spend.OutputIdx,
+		)
+	}
+	return fmt.Errorf(
+		"%w: %x:%d",
+		types.ErrUtxoConflict,
+		spend.TxId,
+		spend.OutputIdx,
+	)
 }

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -344,7 +345,7 @@ func (d *MetadataStoreSqlite) checkUnmatchedUtxoSpend(
 				"input-utxo-not-found",
 				"input UTxO not found",
 				"hash",
-				fmt.Sprintf("%x", spend.TxId),
+				hex.EncodeToString(spend.TxId),
 				"index",
 				spend.OutputIdx,
 			)

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -317,6 +317,7 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 				spend.OutputIdx,
 				spend.Slot,
 			)
+
 			spentAtCases = append(
 				spentAtCases,
 				"WHEN tx_id = ? AND output_idx = ? THEN ?",
@@ -327,6 +328,7 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 				spend.OutputIdx,
 				spend.SpentByTxHash,
 			)
+
 			whereConditions = append(
 				whereConditions,
 				"(tx_id = ? AND output_idx = ?)",
@@ -334,23 +336,17 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
 		}
 
-		args := make(
-			[]any,
-			0,
-			len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs),
-		)
+		args := make([]any, 0, len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs))
 		args = append(args, deletedSlotArgs...)
 		args = append(args, spentAtArgs...)
 		args = append(args, whereArgs...)
-
 		sql := fmt.Sprintf(
-			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
+			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND (%s)",
 			strings.Join(deletedSlotCases, " "),
 			strings.Join(spentAtCases, " "),
 			strings.Join(whereConditions, " OR "),
 		)
-		result := db.Exec(sql, args...)
-		if result.Error != nil {
+		if result := db.Exec(sql, args...); result.Error != nil {
 			return result.Error
 		}
 	}

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -16,7 +16,6 @@ package sqlite
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -25,7 +24,9 @@ import (
 )
 
 const (
-	batchChunkRows = 100
+	// Keep generic bulk inserts well below SQLite's variable limit while
+	// avoiding excessive statement counts for address/witness rows.
+	batchChunkRows = 500
 )
 
 // utxoSpend captures the information needed to mark a UTxO as spent.
@@ -56,6 +57,11 @@ type BatchAccumulator struct {
 // NewBatchAccumulator returns an empty BatchAccumulator ready for use.
 func NewBatchAccumulator() *BatchAccumulator {
 	return &BatchAccumulator{}
+}
+
+// NewBatchAccumulator creates an accumulator for this metadata store.
+func (d *MetadataStoreSqlite) NewBatchAccumulator() types.MetadataBatchAccumulator {
+	return NewBatchAccumulator()
 }
 
 // AddKeyWitness appends a key witness record to the batch.
@@ -144,9 +150,13 @@ func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
 
 // FlushBatch writes all accumulated records in a deterministic order.
 func (d *MetadataStoreSqlite) FlushBatch(
-	batch *BatchAccumulator,
+	acc types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
+	batch, ok := acc.(*BatchAccumulator)
+	if !ok {
+		return fmt.Errorf("sqlite FlushBatch: wrong accumulator type %T", acc)
+	}
 	if batch == nil {
 		return nil
 	}
@@ -291,53 +301,18 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 	for i := 0; i < len(spends); i += batchChunkRows {
 		end := min(i+batchChunkRows, len(spends))
 		chunk := spends[i:end]
-		var deletedSlotCases []string
-		var spentAtCases []string
-		var whereConditions []string
-		var deletedSlotArgs []any
-		var spentAtArgs []any
-		var whereArgs []any
 		for _, spend := range chunk {
-			deletedSlotCases = append(
-				deletedSlotCases,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
-			)
-			deletedSlotArgs = append(
-				deletedSlotArgs,
-				spend.TxId,
-				spend.OutputIdx,
+			if result := db.Exec(
+				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL "+
+					"AND tx_id = ? AND output_idx = ?",
 				spend.Slot,
-			)
-
-			spentAtCases = append(
-				spentAtCases,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
-			)
-			spentAtArgs = append(
-				spentAtArgs,
+				spend.SpentByTxHash,
 				spend.TxId,
 				spend.OutputIdx,
-				spend.SpentByTxHash,
-			)
-
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
-		}
-		args := make([]any, 0, len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs))
-		args = append(args, deletedSlotArgs...)
-		args = append(args, spentAtArgs...)
-		args = append(args, whereArgs...)
-		sql := fmt.Sprintf(
-			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND (%s)",
-			strings.Join(deletedSlotCases, " "),
-			strings.Join(spentAtCases, " "),
-			strings.Join(whereConditions, " OR "),
-		)
-		if result := db.Exec(sql, args...); result.Error != nil {
-			return result.Error
+			); result.Error != nil {
+				return result.Error
+			}
 		}
 	}
 	return nil

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -15,10 +15,8 @@
 package sqlite
 
 import (
-	"bytes"
-	"encoding/hex"
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -27,9 +25,7 @@ import (
 )
 
 const (
-	// Keep generic bulk inserts well below SQLite's variable limit while
-	// avoiding excessive statement counts for address/witness rows.
-	batchChunkRows = 500
+	batchChunkRows = 100
 )
 
 // utxoSpend captures the information needed to mark a UTxO as spent.
@@ -216,7 +212,7 @@ func (d *MetadataStoreSqlite) FlushBatch(
 				err,
 			)
 		}
-		if err := d.batchSpendUtxos(db, batch.UtxoSpends); err != nil {
+		if err := batchSpendUtxos(db, batch.UtxoSpends); err != nil {
 			return fmt.Errorf("flush batch: spend utxos: %w", err)
 		}
 
@@ -297,82 +293,66 @@ func batchDeleteByTxIDs(db *gorm.DB, table string, ids []uint) error {
 	return nil
 }
 
-func (d *MetadataStoreSqlite) batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
+func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 	if len(spends) == 0 {
 		return nil
 	}
 	for i := 0; i < len(spends); i += batchChunkRows {
 		end := min(i+batchChunkRows, len(spends))
 		chunk := spends[i:end]
+		var deletedSlotCases []string
+		var spentAtCases []string
+		var whereConditions []string
+		var deletedSlotArgs []any
+		var spentAtArgs []any
+		var whereArgs []any
 		for _, spend := range chunk {
-			if result := db.Exec(
-				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
-					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL "+
-					"AND tx_id = ? AND output_idx = ?",
-				spend.Slot,
-				spend.SpentByTxHash,
+			deletedSlotCases = append(
+				deletedSlotCases,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			deletedSlotArgs = append(
+				deletedSlotArgs,
 				spend.TxId,
 				spend.OutputIdx,
-			); result.Error != nil {
-				return result.Error
-			} else if result.RowsAffected == 0 {
-				if err := d.checkUnmatchedUtxoSpend(
-					db,
-					spend,
-				); err != nil {
-					return err
-				}
-			}
+				spend.Slot,
+			)
+			spentAtCases = append(
+				spentAtCases,
+				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			)
+			spentAtArgs = append(
+				spentAtArgs,
+				spend.TxId,
+				spend.OutputIdx,
+				spend.SpentByTxHash,
+			)
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
+		}
+
+		args := make(
+			[]any,
+			0,
+			len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs),
+		)
+		args = append(args, deletedSlotArgs...)
+		args = append(args, spentAtArgs...)
+		args = append(args, whereArgs...)
+
+		sql := fmt.Sprintf(
+			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
+			strings.Join(deletedSlotCases, " "),
+			strings.Join(spentAtCases, " "),
+			strings.Join(whereConditions, " OR "),
+		)
+		result := db.Exec(sql, args...)
+		if result.Error != nil {
+			return result.Error
 		}
 	}
 	return nil
-}
-
-func (d *MetadataStoreSqlite) checkUnmatchedUtxoSpend(
-	db *gorm.DB,
-	spend utxoSpend,
-) error {
-	var existingUtxo models.Utxo
-	checkResult := db.Where(
-		"tx_id = ? AND output_idx = ?",
-		spend.TxId,
-		spend.OutputIdx,
-	).First(&existingUtxo)
-	if checkResult.Error != nil {
-		if errors.Is(checkResult.Error, gorm.ErrRecordNotFound) {
-			d.warnLimiter.warn(
-				d.logger,
-				"input-utxo-not-found",
-				"input UTxO not found",
-				"hash",
-				hex.EncodeToString(spend.TxId),
-				"index",
-				spend.OutputIdx,
-			)
-			return nil
-		}
-		return fmt.Errorf(
-			"failed to check UTXO %x#%d: %w",
-			spend.TxId,
-			spend.OutputIdx,
-			checkResult.Error,
-		)
-	}
-	if existingUtxo.SpentAtTxId != nil &&
-		bytes.Equal(existingUtxo.SpentAtTxId, spend.SpentByTxHash) {
-		return nil
-	}
-	if existingUtxo.DeletedSlot == 0 && existingUtxo.SpentAtTxId == nil {
-		return fmt.Errorf(
-			"batch spend did not update UTXO %x#%d",
-			spend.TxId,
-			spend.OutputIdx,
-		)
-	}
-	return fmt.Errorf(
-		"%w: %x:%d",
-		types.ErrUtxoConflict,
-		spend.TxId,
-		spend.OutputIdx,
-	)
 }

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -16,11 +16,9 @@ package sqlite
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -275,106 +273,6 @@ func TestFlushBatch_MultipleSpends(t *testing.T) {
 	assert.Equal(t, spentBy1, u1.SpentAtTxId)
 	assert.Equal(t, uint64(201), u2.DeletedSlot)
 	assert.Equal(t, spentBy2, u2.SpentAtTxId)
-}
-
-func TestFlushBatch_SpendConflictReturnsError(t *testing.T) {
-	store := setupTestDBWithMode(t, "api")
-	batch := NewBatchAccumulator()
-
-	txID := bytes.Repeat([]byte{0x33}, 32)
-	originalSpender := bytes.Repeat([]byte{0xB1}, 32)
-	conflictingSpender := bytes.Repeat([]byte{0xB2}, 32)
-
-	require.NoError(
-		t,
-		store.DB().Create(
-			&models.Transaction{Hash: originalSpender, Slot: 200, Valid: true},
-		).Error,
-	)
-	require.NoError(
-		t,
-		store.DB().Create(
-			&models.Transaction{Hash: conflictingSpender, Slot: 201, Valid: true},
-		).Error,
-	)
-	require.NoError(
-		t,
-		store.DB().Create(&models.Utxo{
-			TxId:        txID,
-			OutputIdx:   0,
-			AddedSlot:   100,
-			DeletedSlot: 200,
-			SpentAtTxId: originalSpender,
-			Amount:      1,
-		}).Error,
-	)
-
-	batch.AddUtxoSpend(utxoSpend{
-		TxId:          txID,
-		OutputIdx:     0,
-		Slot:          201,
-		SpentByTxHash: conflictingSpender,
-	})
-
-	err := store.FlushBatch(batch, nil)
-	require.Error(t, err)
-	assert.True(
-		t,
-		errors.Is(err, types.ErrUtxoConflict),
-		"expected ErrUtxoConflict, got %v",
-		err,
-	)
-
-	var existing models.Utxo
-	require.NoError(
-		t,
-		store.DB().Where("tx_id = ? AND output_idx = 0", txID).First(&existing).Error,
-	)
-	assert.Equal(t, uint64(200), existing.DeletedSlot)
-	assert.Equal(t, originalSpender, existing.SpentAtTxId)
-}
-
-func TestFlushBatch_SameSpendIsIdempotent(t *testing.T) {
-	store := setupTestDBWithMode(t, "api")
-	batch := NewBatchAccumulator()
-
-	txID := bytes.Repeat([]byte{0x44}, 32)
-	spender := bytes.Repeat([]byte{0xC1}, 32)
-
-	require.NoError(
-		t,
-		store.DB().Create(
-			&models.Transaction{Hash: spender, Slot: 200, Valid: true},
-		).Error,
-	)
-	require.NoError(
-		t,
-		store.DB().Create(&models.Utxo{
-			TxId:        txID,
-			OutputIdx:   0,
-			AddedSlot:   100,
-			DeletedSlot: 200,
-			SpentAtTxId: spender,
-			Amount:      1,
-		}).Error,
-	)
-
-	batch.AddUtxoSpend(utxoSpend{
-		TxId:          txID,
-		OutputIdx:     0,
-		Slot:          200,
-		SpentByTxHash: spender,
-	})
-
-	require.NoError(t, store.FlushBatch(batch, nil))
-
-	var existing models.Utxo
-	require.NoError(
-		t,
-		store.DB().Where("tx_id = ? AND output_idx = 0", txID).First(&existing).Error,
-	)
-	assert.Equal(t, uint64(200), existing.DeletedSlot)
-	assert.Equal(t, spender, existing.SpentAtTxId)
 }
 
 func TestFlushBatch_Idempotent(t *testing.T) {

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -16,9 +16,11 @@ package sqlite
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -273,6 +275,106 @@ func TestFlushBatch_MultipleSpends(t *testing.T) {
 	assert.Equal(t, spentBy1, u1.SpentAtTxId)
 	assert.Equal(t, uint64(201), u2.DeletedSlot)
 	assert.Equal(t, spentBy2, u2.SpentAtTxId)
+}
+
+func TestFlushBatch_SpendConflictReturnsError(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	batch := NewBatchAccumulator()
+
+	txID := bytes.Repeat([]byte{0x33}, 32)
+	originalSpender := bytes.Repeat([]byte{0xB1}, 32)
+	conflictingSpender := bytes.Repeat([]byte{0xB2}, 32)
+
+	require.NoError(
+		t,
+		store.DB().Create(
+			&models.Transaction{Hash: originalSpender, Slot: 200, Valid: true},
+		).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Create(
+			&models.Transaction{Hash: conflictingSpender, Slot: 201, Valid: true},
+		).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Utxo{
+			TxId:        txID,
+			OutputIdx:   0,
+			AddedSlot:   100,
+			DeletedSlot: 200,
+			SpentAtTxId: originalSpender,
+			Amount:      1,
+		}).Error,
+	)
+
+	batch.AddUtxoSpend(utxoSpend{
+		TxId:          txID,
+		OutputIdx:     0,
+		Slot:          201,
+		SpentByTxHash: conflictingSpender,
+	})
+
+	err := store.FlushBatch(batch, nil)
+	require.Error(t, err)
+	assert.True(
+		t,
+		errors.Is(err, types.ErrUtxoConflict),
+		"expected ErrUtxoConflict, got %v",
+		err,
+	)
+
+	var existing models.Utxo
+	require.NoError(
+		t,
+		store.DB().Where("tx_id = ? AND output_idx = 0", txID).First(&existing).Error,
+	)
+	assert.Equal(t, uint64(200), existing.DeletedSlot)
+	assert.Equal(t, originalSpender, existing.SpentAtTxId)
+}
+
+func TestFlushBatch_SameSpendIsIdempotent(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	batch := NewBatchAccumulator()
+
+	txID := bytes.Repeat([]byte{0x44}, 32)
+	spender := bytes.Repeat([]byte{0xC1}, 32)
+
+	require.NoError(
+		t,
+		store.DB().Create(
+			&models.Transaction{Hash: spender, Slot: 200, Valid: true},
+		).Error,
+	)
+	require.NoError(
+		t,
+		store.DB().Create(&models.Utxo{
+			TxId:        txID,
+			OutputIdx:   0,
+			AddedSlot:   100,
+			DeletedSlot: 200,
+			SpentAtTxId: spender,
+			Amount:      1,
+		}).Error,
+	)
+
+	batch.AddUtxoSpend(utxoSpend{
+		TxId:          txID,
+		OutputIdx:     0,
+		Slot:          200,
+		SpentByTxHash: spender,
+	})
+
+	require.NoError(t, store.FlushBatch(batch, nil))
+
+	var existing models.Utxo
+	require.NoError(
+		t,
+		store.DB().Where("tx_id = ? AND output_idx = 0", txID).First(&existing).Error,
+	)
+	assert.Equal(t, uint64(200), existing.DeletedSlot)
+	assert.Equal(t, spender, existing.SpentAtTxId)
 }
 
 func TestFlushBatch_Idempotent(t *testing.T) {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2229,10 +2229,17 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	point ocommon.Point,
 	idx uint32,
 	certDeposits map[int]uint64,
-	acc *BatchAccumulator,
+	acc types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
-	if acc == nil {
+	batch, ok := acc.(*BatchAccumulator)
+	if !ok {
+		return fmt.Errorf(
+			"SetTransactionBatched: wrong accumulator type %T",
+			acc,
+		)
+	}
+	if batch == nil {
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	local := NewBatchAccumulator()
@@ -2682,10 +2689,34 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				)
 			}
 			if len(unifiedIDs) > 0 {
+				poolRegistrationIDs := []uint{}
+				if result := db.Model(&models.PoolRegistration{}).
+					Where("certificate_id IN ?", unifiedIDs).
+					Pluck("id", &poolRegistrationIDs); result.Error != nil {
+					return fmt.Errorf(
+						"query existing pool registrations (batched): %w",
+						result.Error,
+					)
+				}
+				if len(poolRegistrationIDs) > 0 {
+					if result := db.Table("pool_registration_owner").
+						Where("pool_registration_id IN ?", poolRegistrationIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing pool_registration_owner records (batched): %w",
+							result.Error,
+						)
+					}
+					if result := db.Table("pool_registration_relay").
+						Where("pool_registration_id IN ?", poolRegistrationIDs).
+						Delete(nil); result.Error != nil {
+						return fmt.Errorf(
+							"delete existing pool_registration_relay records (batched): %w",
+							result.Error,
+						)
+					}
+				}
 				tables := []string{
-					// Child tables must be deleted before parent tables (FK constraints).
-					"pool_registration_owner",
-					"pool_registration_relay",
 					"stake_registration", "pool_registration", "pool_retirement",
 					"auth_committee_hot", "resign_committee_cold",
 					"deregistration", "stake_delegation",
@@ -3453,7 +3484,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		}
 	}
 
-	acc.MergeFrom(local)
+	batch.MergeFrom(local)
 	return nil
 }
 

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -478,6 +478,27 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// NewBatchAccumulator creates a metadata-plugin-specific accumulator
+	// for batched transaction ingestion.
+	NewBatchAccumulator() types.MetadataBatchAccumulator
+
+	// FlushBatch writes accumulated batched metadata rows.
+	FlushBatch(
+		types.MetadataBatchAccumulator,
+		types.Txn,
+	) error
+
+	// SetTransactionBatched stores transaction metadata while accumulating
+	// batchable rows into the provided accumulator for a later FlushBatch.
+	SetTransactionBatched(
+		lcommon.Transaction,
+		ocommon.Point,
+		uint32, // idx
+		map[int]uint64, // certDeposits
+		types.MetadataBatchAccumulator,
+		types.Txn,
+	) error
+
 	// SetGapBlockTransaction stores a transaction record and its
 	// produced outputs without looking up or consuming input UTxOs.
 	// This is used for mithril gap blocks where the snapshot's UTxO

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -260,6 +260,12 @@ type Txn interface {
 	Rollback() error
 }
 
+// MetadataBatchAccumulator is an opaque plugin-owned accumulator used by
+// metadata stores that support batched transaction ingestion.
+type MetadataBatchAccumulator interface {
+	Reset()
+}
+
 // BlockMetadata contains metadata for a block stored in blob.
 // IMPORTANT: Field order must remain [ID, Type, Height, PrevHash] because
 // cbor.StructAsArray encodes/decodes by position. Changing the order would

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -676,7 +676,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 	var (
 		processedBlocks int
 		processedTxs    int
-		// batchBlockCount tracks blocks accumulated since the last flush.
+		// It tracks blocks accumulated since the last flush
 		batchBlockCount int
 		// committedSlot is the latest slot durably committed by a batch.
 		committedSlot = cp.LastSlot
@@ -690,12 +690,14 @@ func (b *Backfill) Run(ctx context.Context) error {
 		if batchBlockCount == 0 {
 			return nil
 		}
-		if err := b.db.FlushBatch(acc, batchTxn); err != nil {
+		oldTxn := batchTxn
+		if err := b.db.FlushBatch(acc, oldTxn); err != nil {
 			return err
 		}
-		if err := batchTxn.Commit(); err != nil {
+		if err := oldTxn.Commit(); err != nil {
 			return err
 		}
+		oldTxn.Release()
 		committedSlot = cp.LastSlot
 		acc.Reset()
 		batchTxn = b.db.Transaction(true)

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -37,6 +37,10 @@ import (
 // backfill checkpoint.
 const BackfillPhase = "metadata"
 
+// backfillBatchSize controls how many processed blocks are accumulated
+// before deferred metadata rows are flushed.
+const backfillBatchSize = 100
+
 // Backfill replays stored blocks to populate historical metadata.
 // It is triggered automatically during Mithril sync when
 // storageMode is "api".
@@ -656,22 +660,75 @@ func (b *Backfill) Run(ctx context.Context) error {
 	it := b.db.BlocksFromSlot(startSlot)
 	defer it.Close()
 
+	// Keep one batch accumulator and transaction open across multiple
+	// blocks so metadata writes can be flushed in bulk.
+	acc, err := b.db.NewBatchAccumulator()
+	if err != nil {
+		return fmt.Errorf("creating backfill batch accumulator: %w", err)
+	}
+	batchTxn := b.db.Transaction(true)
+	defer func() {
+		if batchTxn != nil {
+			batchTxn.Release()
+		}
+	}()
+
 	var (
 		processedBlocks int
 		processedTxs    int
-		lastLogTime     = time.Now()
-		startTime       = time.Now()
+		// batchBlockCount tracks blocks accumulated since the last flush.
+		batchBlockCount int
+		// committedSlot is the latest slot durably committed by a batch.
+		committedSlot = cp.LastSlot
+		lastLogTime   = time.Now()
+		startTime     = time.Now()
 	)
+
+	// flushBatch writes deferred rows, commits the active transaction,
+	// and starts the next batch window.
+	flushBatch := func() error {
+		if batchBlockCount == 0 {
+			return nil
+		}
+		if err := b.db.FlushBatch(acc, batchTxn); err != nil {
+			return err
+		}
+		if err := batchTxn.Commit(); err != nil {
+			return err
+		}
+		committedSlot = cp.LastSlot
+		acc.Reset()
+		batchTxn = b.db.Transaction(true)
+		batchBlockCount = 0
+		return nil
+	}
+	// saveCommittedCheckpoint avoids advancing resume state past rows
+	// that are still buffered in the current uncommitted batch.
+	saveCommittedCheckpoint := func() {
+		currentSlot := cp.LastSlot
+		cp.LastSlot = committedSlot
+		b.saveCheckpoint(cp)
+		cp.LastSlot = currentSlot
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {
+			// On cancellation, flush the current batch before recording
+			// progress so resume does not skip buffered rows.
+			if fErr := flushBatch(); fErr != nil {
+				saveCommittedCheckpoint()
+				return fmt.Errorf(
+					"flushing backfill batch before cancellation: %w",
+					fErr,
+				)
+			}
 			b.saveCheckpoint(cp)
 			return fmt.Errorf("cancelled: %w", err)
 		}
 
 		blk, err := it.NextRaw()
 		if err != nil {
-			b.saveCheckpoint(cp)
+			saveCommittedCheckpoint()
 			return fmt.Errorf("iterating blocks: %w", err)
 		}
 		if blk == nil {
@@ -718,7 +775,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 				parsedBlock, point, eraId,
 				isNewEpoch, nil,
 			); nErr != nil {
-				b.saveCheckpoint(cp)
+				saveCommittedCheckpoint()
 				return fmt.Errorf(
 					"block nonce at slot %d: %w",
 					blk.Slot, nErr,
@@ -741,11 +798,13 @@ func (b *Backfill) Run(ctx context.Context) error {
 						"error", oErr,
 					)
 				} else {
-					if pErr := b.processBlockTxs(
+					// Store transaction metadata into the shared batch
+					// instead of committing once per block.
+					if pErr := b.processBlockTxsBatched(
 						txs, point, epochId, eraId,
-						pp, offsets,
+						pp, offsets, acc, batchTxn,
 					); pErr != nil {
-						b.saveCheckpoint(cp)
+						saveCommittedCheckpoint()
 						return fmt.Errorf(
 							"processing block at slot %d: %w",
 							blk.Slot, pErr,
@@ -760,14 +819,33 @@ func (b *Backfill) Run(ctx context.Context) error {
 		processedTxs += blockTxCount
 		cp.LastSlot = blk.Slot
 		processedBlocks++
+		batchBlockCount++
+
+		// Flush once the current batch reaches the configured block
+		// window.
+		if batchBlockCount >= backfillBatchSize {
+			if err := flushBatch(); err != nil {
+				saveCommittedCheckpoint()
+				return fmt.Errorf(
+					"flushing backfill batch: %w", err,
+				)
+			}
+		}
 
 		if processedBlocks%1000 == 0 {
-			b.saveCheckpoint(cp)
+			// Periodic checkpoints must not pass the last committed
+			// batch boundary.
+			saveCommittedCheckpoint()
 		}
 		b.maybeLogProgress(
 			cp, processedBlocks, processedTxs,
 			tipSlot, startSlot, startTime, &lastLogTime,
 		)
+	}
+
+	// Flushes the last batch and may be fewer than 100 blocks.
+	if err := flushBatch(); err != nil {
+		return fmt.Errorf("flushing final backfill batch: %w", err)
 	}
 
 	cp.Completed = true
@@ -791,27 +869,27 @@ func (b *Backfill) Run(ctx context.Context) error {
 	return nil
 }
 
-// processBlockTxs stores transactions and processes governance
-// within a single database transaction.
-func (b *Backfill) processBlockTxs(
+// processBlockTxsBatched stores transactions into an existing database
+// transaction and accumulates batchable metadata rows for a later flush.
+func (b *Backfill) processBlockTxsBatched(
 	txs []lcommon.Transaction,
 	point ocommon.Point,
 	epochId uint64,
 	eraId uint,
 	pp lcommon.ProtocolParameters,
 	offsets *database.BlockIngestionResult,
+	acc *database.BatchAccumulator,
+	txn *database.Txn,
 ) error {
-	txn := b.db.Transaction(true)
-	defer txn.Release()
 	for i, tx := range txs {
 		updateEpoch, paramUpdates := tx.ProtocolParameterUpdates()
 		certDeposits := b.calculateCertDeposits(
 			tx, eraId, pp,
 		)
-		if err := b.db.SetTransaction(
+		if err := b.db.SetTransactionBatched(
 			tx, point, uint32(i), // #nosec G115
 			updateEpoch, paramUpdates,
-			certDeposits, offsets, txn,
+			certDeposits, offsets, acc, txn,
 		); err != nil {
 			return fmt.Errorf("storing TX: %w", err)
 		}
@@ -823,11 +901,6 @@ func (b *Backfill) processBlockTxs(
 				point.Slot, i, err,
 			)
 		}
-	}
-	if err := txn.Commit(); err != nil {
-		return fmt.Errorf(
-			"commit at slot %d: %w", point.Slot, err,
-		)
 	}
 	return nil
 }

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -873,6 +873,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 
 	// Flush the final partial batch (may be < backfillBatchSize blocks).
 	if err := flushBatch(); err != nil {
+		saveCommittedCheckpoint()
 		return fmt.Errorf("flushing final backfill batch: %w", err)
 	}
 

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -660,13 +660,12 @@ func (b *Backfill) Run(ctx context.Context) error {
 	it := b.db.BlocksFromSlot(startSlot)
 	defer it.Close()
 
-	// Keep one batch accumulator and transaction open across multiple
-	// blocks so metadata writes can be flushed in bulk.
-	acc, err := b.db.NewBatchAccumulator()
-	if err != nil {
-		return fmt.Errorf("creating backfill batch accumulator: %w", err)
-	}
-	batchTxn := b.db.Transaction(true)
+	// Keep one batch accumulator across multiple blocks so metadata
+	// writes can be flushed in bulk. The DB transaction is opened
+	// lazily after a block is read and released after each flush so
+	// checkpoint/final writes can use the base DB connection.
+	acc := b.db.NewBatchAccumulator()
+	var batchTxn *database.Txn
 	defer func() {
 		if batchTxn != nil {
 			batchTxn.Release()
@@ -684,11 +683,28 @@ func (b *Backfill) Run(ctx context.Context) error {
 		startTime     = time.Now()
 	)
 
+	ensureBatchTxn := func() {
+		if batchTxn == nil {
+			batchTxn = b.db.Transaction(true)
+		}
+	}
+	rollbackBatch := func() {
+		if batchTxn != nil {
+			_ = batchTxn.Rollback()
+			batchTxn.Release()
+			batchTxn = nil
+		}
+		acc.Reset()
+		batchBlockCount = 0
+	}
 	// flushBatch writes deferred rows, commits the active transaction,
-	// and starts the next batch window.
+	// and releases the current batch window.
 	flushBatch := func() error {
 		if batchBlockCount == 0 {
 			return nil
+		}
+		if batchTxn == nil {
+			return errors.New("missing backfill batch transaction")
 		}
 		oldTxn := batchTxn
 		if err := b.db.FlushBatch(acc, oldTxn); err != nil {
@@ -700,13 +716,14 @@ func (b *Backfill) Run(ctx context.Context) error {
 		oldTxn.Release()
 		committedSlot = cp.LastSlot
 		acc.Reset()
-		batchTxn = b.db.Transaction(true)
+		batchTxn = nil
 		batchBlockCount = 0
 		return nil
 	}
 	// saveCommittedCheckpoint avoids advancing resume state past rows
 	// that are still buffered in the current uncommitted batch.
 	saveCommittedCheckpoint := func() {
+		rollbackBatch()
 		currentSlot := cp.LastSlot
 		cp.LastSlot = committedSlot
 		b.saveCheckpoint(cp)
@@ -736,6 +753,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 		if blk == nil {
 			break // iteration complete
 		}
+		ensureBatchTxn()
 
 		epochId, eraId := b.slotToEpoch(blk.Slot)
 
@@ -775,7 +793,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 			// Compute and store block nonce
 			if nErr := b.computeBlockNonce(
 				parsedBlock, point, eraId,
-				isNewEpoch, nil,
+				isNewEpoch, batchTxn,
 			); nErr != nil {
 				saveCommittedCheckpoint()
 				return fmt.Errorf(
@@ -880,7 +898,7 @@ func (b *Backfill) processBlockTxsBatched(
 	eraId uint,
 	pp lcommon.ProtocolParameters,
 	offsets *database.BlockIngestionResult,
-	acc *database.BatchAccumulator,
+	acc database.BatchAccumulator,
 	txn *database.Txn,
 ) error {
 	for i, tx := range txs {

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -675,7 +675,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 	var (
 		processedBlocks int
 		processedTxs    int
-		// It tracks blocks accumulated since the last flush
+		// batchBlockCount tracks blocks accumulated since the last flush.
 		batchBlockCount int
 		// committedSlot is the latest slot durably committed by a batch.
 		committedSlot = cp.LastSlot
@@ -853,9 +853,17 @@ func (b *Backfill) Run(ctx context.Context) error {
 		}
 
 		if processedBlocks%1000 == 0 {
-			// Periodic checkpoints must not pass the last committed
-			// batch boundary.
-			saveCommittedCheckpoint()
+			// Periodic checkpoints must only record durable progress.
+			// Flush any partial batch first so checkpoint safety does
+			// not depend on backfillBatchSize dividing 1000.
+			if err := flushBatch(); err != nil {
+				saveCommittedCheckpoint()
+				return fmt.Errorf(
+					"flushing backfill batch before checkpoint: %w",
+					err,
+				)
+			}
+			b.saveCheckpoint(cp)
 		}
 		b.maybeLogProgress(
 			cp, processedBlocks, processedTxs,
@@ -863,7 +871,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 		)
 	}
 
-	// Flushes the last batch and may be fewer than 100 blocks.
+	// Flush the final partial batch (may be < backfillBatchSize blocks).
 	if err := flushBatch(); err != nil {
 		return fmt.Errorf("flushing final backfill batch: %w", err)
 	}


### PR DESCRIPTION
1. Added backfillBatchSize = 100 to control how many blocks are accumulated before flushing.
2. Made changes in backfill.Run() to create a batch accumulator before iterating blocks, opens one DB transaction for the active batch  and added a tracker how many blocks are accumulated with batchBlockCount.
3. Flushes the batch for every backfillBatchSize blocks, resets the accumulator and starts a new transaction after each flush.
4. Made changes to saves checkpoints only up to the last committed batch slot and flushes the final partial batch before marking backfill complete.
5. Added a database-level BatchAccumulator wrapper for creating the correct metadata plugin accumulator for sqlite, postgres and mysql.
6. Added database level methods NewBatchAccumulator(), FlushBatch(), SetTransactionBatched(), SetTransactionBatched() mirrors the existing SetTransaction() flow, but calls the metadata plugin’s SetTransactionBatched() instead of SetTransaction().

Closes #1801


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch backfill now buffers metadata across 100 blocks with a shared accumulator and commits once per batch to cut DB commits and speed up historical replay. Checkpoints advance only to committed batches; we flush on cancel, before periodic checkpoints, and at completion, and on errors we save the last committed checkpoint for safe resume.

- **New Features**
  - Shared backfill accumulator: one transaction per batch, flush every 100 blocks, then reset.
  - Database batching API: `NewBatchAccumulator()`, `FlushBatch()`, `SetTransactionBatched()` on `Database`/`MetadataStore`; opaque `types.MetadataBatchAccumulator` with plugin type checks.
  - Offsets are written to blob immediately; batched path via `processBlockTxsBatched`.

- **Bug Fixes**
  - Checkpointing records only durable slots; we flush current batches on cancel, before checkpoints, and at final flush; on errors (including final flush) we save the last committed checkpoint and reset the owned accumulator.
  - Fixed pool registration cleanup by deleting `pool_registration_owner`/`pool_registration_relay` before parent rows across all stores.
  - Batched ingestion handles cross-block UTxO spends within the same batch; added a test.
  - SQLite: preserve UTxO spend conflict checks in batches, skip already-spent rows when updating batch spends, warn when inputs are missing, and increase bulk-insert chunk to 500.

<sup>Written for commit f77d133d4d4cc71a7df387748deba59ea36ddcb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for batched metadata ingestion during block backfilling to improve performance and reliability.

* **Refactor**
  * Transformed transaction metadata persistence from individual per-block commits to batch-based buffering. Metadata is now accumulated and written together, reducing database write overhead and improving checkpoint consistency.

* **Tests**
  * Added regression test verifying correct handling of cross-block transaction spending within batched operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2203)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->