### PR TITLE
fix: make bark and utxorpc gRPC startup errors determi…

### DIFF
--- a/bark/bark.go
+++ b/bark/bark.go
@@ -16,10 +16,12 @@ package bark
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -175,48 +177,54 @@ func (b *Bark) Start(ctx context.Context) error {
 	return nil
 }
 
+// startServer starts the HTTP server with deterministic error
+// detection. It validates TLS configuration, binds the listening
+// socket and pre-loads any TLS keypair synchronously so port and
+// certificate errors surface before returning, then serves in a
+// background goroutine.
 func (b *Bark) startServer(server *http.Server) error {
-	startErr := make(chan error, 1)
+	if (b.config.TlsCertFilePath != "") != (b.config.TlsKeyFilePath != "") {
+		return errors.New(
+			"failed to start bark gRPC server: both tls cert and key must be specified",
+		)
+	}
+	useTLS := b.config.TlsCertFilePath != "" && b.config.TlsKeyFilePath != ""
+	serverType := "non-TLS"
+	if useTLS {
+		serverType = "TLS"
+		if _, err := tls.LoadX509KeyPair(
+			b.config.TlsCertFilePath,
+			b.config.TlsKeyFilePath,
+		); err != nil {
+			return fmt.Errorf(
+				"failed to load TLS keypair for bark gRPC %s server: %w",
+				serverType, err,
+			)
+		}
+	}
+	ln, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to start bark gRPC %s server: %w",
+			serverType, err)
+	}
 	go func() {
-		var err error
-
-		if b.config.TlsCertFilePath != "" && b.config.TlsKeyFilePath == "" ||
-			b.config.TlsCertFilePath == "" && b.config.TlsKeyFilePath != "" {
-			err = errors.New("both tls cert and key must be specified")
+		var serveErr error
+		if useTLS {
+			serveErr = server.ServeTLS(
+				ln,
+				b.config.TlsCertFilePath,
+				b.config.TlsKeyFilePath,
+			)
+		} else {
+			serveErr = server.Serve(ln)
 		}
-
-		if err == nil {
-			if b.config.TlsCertFilePath != "" && b.config.TlsKeyFilePath != "" {
-				err = server.ListenAndServeTLS(
-					b.config.TlsCertFilePath,
-					b.config.TlsKeyFilePath,
-				)
-			} else {
-				err = server.ListenAndServe()
-			}
-		}
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			select {
-			case startErr <- err:
-			default:
-				b.config.Logger.Error(
-					"bark gRPC server error",
-					"error", err)
-			}
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			b.config.Logger.Error(
+				"bark gRPC server error",
+				"error", serveErr,
+			)
 		}
 	}()
-
-	select {
-	case err := <-startErr:
-		serverType := "non-TLS"
-		if b.config.TlsCertFilePath != "" && b.config.TlsKeyFilePath != "" {
-			serverType = "TLS"
-		}
-		return fmt.Errorf("failed to start bark gRPC %s server: %w", serverType, err)
-	case <-time.After(100 * time.Millisecond):
-		// Assume startup succeeded if no error within 100ms
-	}
-
 	return nil
 }
 

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -16,10 +16,12 @@ package utxorpc
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -260,44 +262,52 @@ func (u *Utxorpc) Stop(ctx context.Context) error {
 	return nil
 }
 
-// startServer starts the HTTP server with error detection
+// startServer starts the HTTP server with deterministic error
+// detection. It binds the listening socket and pre-loads any TLS
+// keypair synchronously so port and certificate errors surface before
+// returning, then serves in a background goroutine.
 func (u *Utxorpc) startServer(server *http.Server) error {
-	startErr := make(chan error, 1)
+	if (u.config.TlsCertFilePath != "") != (u.config.TlsKeyFilePath != "") {
+		return errors.New(
+			"failed to start utxorpc gRPC server: both tls cert and key must be specified",
+		)
+	}
+	useTLS := u.config.TlsCertFilePath != "" && u.config.TlsKeyFilePath != ""
+	serverType := "non-TLS"
+	if useTLS {
+		serverType = "TLS"
+		if _, err := tls.LoadX509KeyPair(
+			u.config.TlsCertFilePath,
+			u.config.TlsKeyFilePath,
+		); err != nil {
+			return fmt.Errorf(
+				"failed to load TLS keypair for utxorpc gRPC %s server: %w",
+				serverType, err,
+			)
+		}
+	}
+	ln, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to start utxorpc gRPC %s server: %w",
+			serverType, err)
+	}
 	go func() {
-		var err error
-		if u.config.TlsCertFilePath != "" && u.config.TlsKeyFilePath != "" {
-			err = server.ListenAndServeTLS(
+		var serveErr error
+		if useTLS {
+			serveErr = server.ServeTLS(
+				ln,
 				u.config.TlsCertFilePath,
 				u.config.TlsKeyFilePath,
 			)
 		} else {
-			err = server.ListenAndServe()
+			serveErr = server.Serve(ln)
 		}
-		if err != nil && err != http.ErrServerClosed {
-			select {
-			case startErr <- err:
-			default:
-				u.config.Logger.Error(
-					"utxorpc gRPC server error",
-					"error", err,
-				)
-			}
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			u.config.Logger.Error(
+				"utxorpc gRPC server error",
+				"error", serveErr,
+			)
 		}
 	}()
-
-	// Wait briefly for startup to succeed or fail
-	// NOTE: 100ms timeout assumes startup errors occur quickly (e.g., port binding).
-	// Delayed failures (e.g., certificate loading issues) may not be detected.
-	select {
-	case err := <-startErr:
-		serverType := "non-TLS"
-		if u.config.TlsCertFilePath != "" && u.config.TlsKeyFilePath != "" {
-			serverType = "TLS"
-		}
-		return fmt.Errorf("failed to start utxorpc gRPC %s server: %w",
-			serverType, err)
-	case <-time.After(100 * time.Millisecond):
-		// Assume startup succeeded if no error within 100ms
-	}
 	return nil
 }


### PR DESCRIPTION
Closes #1512 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `bark` and `utxorpc` gRPC servers fail fast with deterministic startup errors by validating TLS, preloading keypairs, and binding sockets before serving. This surfaces port conflicts and certificate issues on startup with clearer errors.

- **Bug Fixes**
  - Require both TLS cert and key; fail early with server name and type (TLS/non-TLS).
  - Preload TLS keypair via `tls.LoadX509KeyPair` to catch bad certs before serving.
  - Bind address with `net.Listen`, then call `Serve`/`ServeTLS` on the listener for deterministic failures.
  - Remove the 100ms startup wait and channel-based detection.
  - Use `errors.Is` to ignore `http.ErrServerClosed` and log other serve errors.

<sup>Written for commit d84fe64f66b9515fabbb4e2c234335e2dd9ea304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved server startup reliability with deterministic error detection to surface startup failures immediately.
  * Enhanced TLS configuration validation to prevent invalid or partial TLS setups from starting.
  * Fixed timing-dependent startup failures by validating networking and certificate readiness before accepting requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->