### PR TITLE
perf: blockfetch batch scaling

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -49,12 +49,17 @@ const (
 	// This prevents us exceeding the configured recv queue size in the block-fetch protocol
 	blockfetchBatchSize = 500
 
-	// When we're still meaningfully behind tip, wait for a small header runway
-	// before starting blockfetch. This avoids repeated one-block fetch loops
-	// near a fork boundary where peers may not yet serve the first announced
-	// block body.
+	// When we're still meaningfully behind tip, wait for a header runway
+	// before starting blockfetch so each batch amortises peer round-trip
+	// and protocol overhead over many blocks instead of trickling 1-8
+	// blocks per request. The cap was 64 historically (a fork-boundary
+	// safety value) — too small for catchup, where the chain can fall
+	// thousands of blocks behind and we want to fetch hundreds-per-batch.
+	// `desiredBlockfetchBatchHeaders` scales up to this cap based on the
+	// observed block-gap; near tip it falls back to small batches for
+	// low latency.
 	blockfetchMinBatchHeadersWhenBehind = 8
-	blockfetchMaxBatchHeadersWhenBehind = 64
+	blockfetchMaxBatchHeadersWhenBehind = 500
 	blockfetchMinBatchGapSlots          = 64
 
 	// Number of received blockfetch blocks to buffer before committing them.
@@ -796,12 +801,24 @@ func desiredBlockfetchBatchHeaders(
 		}
 		return min(1, maxHeaders)
 	}
+	// Scale the header runway with the size of the catchup gap. A node
+	// that's hundreds of blocks behind benefits from batching close to
+	// the blockfetch protocol limit (500), while near-tip cases keep
+	// small batches for low latency. The previous values (max 8 when
+	// gapBlocks > 64) starved the blockfetch pipeline during catchup —
+	// every blockfetch round-trip carried only a handful of blocks even
+	// though `chain.HeaderRange(blockfetchBatchSize)` is willing to span
+	// up to 500.
 	var minHeaders int
 	switch {
+	case gapBlocks > 1000:
+		minHeaders = 256
+	case gapBlocks > 256:
+		minHeaders = 128
 	case gapBlocks > 64:
-		minHeaders = 8
+		minHeaders = 32
 	case gapBlocks > 16:
-		minHeaders = 4
+		minHeaders = 8
 	case gapBlocks > 4:
 		minHeaders = 2
 	default:

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -823,8 +823,16 @@ func TestHandleEventChainsyncBlockHeaderScalesBatchWhenFarBehind(t *testing.T) {
 		},
 	}
 
+	// gapBlocks > 1000 puts the runway in the deepest catchup bucket
+	// (minHeaders = 256), so we send enough headers to cross that
+	// threshold and trigger exactly one batch. Headers added past the
+	// trigger queue against the in-flight batch (the test's
+	// BlockfetchRequestRangeFunc mock never completes), so requestCount
+	// stays at 1 — that's the "scales up but doesn't re-fire while
+	// in-flight" guarantee this test pins.
+	const totalHeaders = 260
 	prevHash := lcommon.NewBlake2b256(nil)
-	for i := 1; i <= 20; i++ {
+	for i := 1; i <= totalHeaders; i++ {
 		headerHash := lcommon.NewBlake2b256(fmt.Appendf(nil, "hdr-%d", i))
 		err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
 			ConnectionId: connId,
@@ -843,12 +851,13 @@ func TestHandleEventChainsyncBlockHeaderScalesBatchWhenFarBehind(t *testing.T) {
 		require.NoError(t, err)
 		prevHash = headerHash
 		if i == 7 {
-			assert.Equal(t, 0, requestCount)
+			assert.Equal(t, 0, requestCount,
+				"no batch before runway accumulates")
 		}
 	}
 
 	assert.Equal(t, 1, requestCount)
-	assert.Equal(t, 20, ls.chain.HeaderCount())
+	assert.Equal(t, totalHeaders, ls.chain.HeaderCount())
 }
 
 func TestHandleEventChainsyncBlockHeaderAcceptsEquivalentOwnerConnectionId(

--- a/ledger/chainsync_test.go
+++ b/ledger/chainsync_test.go
@@ -69,14 +69,28 @@ func TestDesiredBlockfetchBatchHeaders(t *testing.T) {
 			gapSlots:   128,
 			gapBlocks:  32,
 			maxHeaders: 16,
-			want:       4,
+			want:       8,
+		},
+		{
+			name:       "very large block gap scales up",
+			gapSlots:   2048,
+			gapBlocks:  512,
+			maxHeaders: 256,
+			want:       128,
+		},
+		{
+			name:       "deep catchup uses large batch",
+			gapSlots:   8192,
+			gapBlocks:  2048,
+			maxHeaders: 500,
+			want:       256,
 		},
 		{
 			name:       "overflow-sized block gap stays bounded",
 			gapSlots:   128,
 			gapBlocks:  math.MaxUint64,
 			maxHeaders: 16,
-			want:       8,
+			want:       16,
 		},
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scaled blockfetch batching to speed up catchup when far from tip. The header runway now scales with the gap and can grow to 500; near tip it stays small for low latency.

- Performance
  - Increased `blockfetchMaxBatchHeadersWhenBehind` from 64 to 500.
  - Updated `desiredBlockfetchBatchHeaders` thresholds: gap >1000→256, >256→128, >64→32, >16→8, >4→2.
  - Expanded tests to assert larger batches in deep catchup and that only one request fires while in-flight.

<sup>Written for commit 88ab6e853ba0d445fe610595c729962c7cbe848f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Optimizations**
  * Enhanced header batching efficiency for chain synchronization when far behind the network tip
  * Increased batch capacity limits to improve responsiveness during large catch-up scenarios
  * Improved batching strategy that scales more aggressively with larger synchronization gaps
  * Optimized request behavior to handle significant blockchain synchronization distances more efficiently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->