### PR TITLE
perf(ledger): async hfi stability

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -441,6 +441,9 @@ type LedgerState struct {
 	currentPParams                     lcommon.ProtocolParameters
 	prevEraPParams                     lcommon.ProtocolParameters // pparams from the immediately previous era (for era-1 TX validation)
 	transitionInfo                     hardfork.TransitionInfo    // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
+	hfiEvalDoneEpoch                   uint64                     // currentEpoch.EpochId for which the HFI tally has been kicked off (held under ls.RWMutex)
+	hfiEvalGeneration                  atomic.Uint64              // bumped on rollback to invalidate any in-flight HFI tally
+	hfiStabilityEvalInFlight           atomic.Bool                // guard against overlapping async HFI tallies
 	mempool                            MempoolProvider
 	timerCleanupConsumedUtxos          *time.Timer
 	Scheduler                          *Scheduler
@@ -1778,6 +1781,12 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	// state.
 	ls.transitionInfo = hardfork.NewTransitionUnknown()
 	ls.reconstructTransitionInfo()
+	// Reopen the once-per-epoch gate so rollback can re-derive
+	// transitionInfo immediately, and bump the generation counter so
+	// any in-flight tally from before the rollback drops its result
+	// instead of committing stale data.
+	ls.hfiEvalDoneEpoch = 0
+	ls.hfiEvalGeneration.Add(1)
 	ls.evaluateHardForkInitiationStability()
 	// If rolling back behind the Mithril trust boundary, clear it.
 	// A rollback inside the gap means replacement blocks on the new
@@ -3655,7 +3664,6 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 	if ls.transitionInfo.State == hardfork.TransitionKnown {
 		return
 	}
-	expectedTargetEpoch := ls.currentEpoch.EpochId + 1
 	epochEndSlot, addErr := checkedSlotAdd(
 		ls.currentEpoch.StartSlot,
 		uint64(ls.currentEpoch.LengthInSlots),
@@ -3676,47 +3684,102 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 	if ls.currentTip.Point.Slot < votingDeadline {
 		return
 	}
+	// Once-per-epoch gate: post-deadline, the inputs to ratification
+	// (DRep voting power, SPO voting power, CC votes) are frozen —
+	// the pre-epoch stake snapshot fixes voting weights and votes
+	// after the deadline don't count toward this epoch's outcome. So
+	// one tally per epoch is the entire correctness budget; running
+	// it more often only wastes CPU on the SQLite DRep cascade
+	// (~94% of total CPU during catchup on preview, where the
+	// post-deadline window can span many hours). hfiEvalDoneEpoch is
+	// reset to 0 in rollback() to reopen the gate when chain history
+	// changes.
+	if ls.hfiEvalDoneEpoch == ls.currentEpoch.EpochId {
+		return
+	}
+	if !ls.hfiStabilityEvalInFlight.CompareAndSwap(false, true) {
+		return
+	}
+	ls.hfiEvalDoneEpoch = ls.currentEpoch.EpochId
+	gen := ls.hfiEvalGeneration.Load()
+	// Snapshot inputs while we hold the caller's write lock, then run
+	// the heavy DB call without it. Reacquiring the lock only to write
+	// transitionInfo keeps the per-block path off the SQLite query —
+	// otherwise the tally would run inline under ls.Lock() and stall
+	// the chainsync pipeline (rollback / new-block apply / read-side
+	// chainsync server FindIntersect requests all wait on the same
+	// RWMutex), adding multi-second pauses to every block on the
+	// catchup path. The snapshot/apply pattern matches the rollback()
+	// comment that calls this out as the intended approach for this
+	// exact contention concern.
+	snapshotEpoch := ls.currentEpoch.EpochId
+	snapshotPParams := ls.currentPParams
 	conwayGenesis := ls.config.CardanoNodeConfig.ConwayGenesis()
-	result, err := governance.EvaluateRatifiableHardForkInitiation(
-		governance.StabilityCheckInputs{
-			DB:            ls.db,
-			Logger:        ls.config.Logger,
-			CurrentEpoch:  ls.currentEpoch.EpochId,
-			PParams:       ls.currentPParams,
-			ConwayGenesis: conwayGenesis,
-		},
-	)
-	if err != nil {
-		ls.config.Logger.Warn(
-			"hardfork-initiation stability check failed",
-			"error", err,
-			"component", "ledger",
+	db := ls.db
+	logger := ls.config.Logger
+	go func() {
+		defer ls.hfiStabilityEvalInFlight.Store(false)
+		result, err := governance.EvaluateRatifiableHardForkInitiation(
+			governance.StabilityCheckInputs{
+				DB:            db,
+				Logger:        logger,
+				CurrentEpoch:  snapshotEpoch,
+				PParams:       snapshotPParams,
+				ConwayGenesis: conwayGenesis,
+			},
 		)
-		return
-	}
-	if result == nil {
-		return
-	}
-	// A ratifiable HardForkInitiation is only an era transition if its
-	// target ProtocolVersion crosses an era boundary. An intra-era
-	// pparams bump (e.g. Plomin's pv9 → pv10, both Conway) ratifies
-	// through the same governance path but doesn't end the era;
-	// surfacing it as TransitionKnown would mislead clients into
-	// thinking the era ends at the next boundary. Filter using the
-	// same era-mapping rule the boundary-time IsHardForkTransition
-	// applies, so mid-epoch detection and boundary dispatch agree.
-	currentVer, err := GetProtocolVersion(ls.currentPParams)
-	if err != nil {
-		return
-	}
-	targetVer := ProtocolVersion{
-		Major: result.NewMajor,
-		Minor: result.NewMinor,
-	}
-	if !IsHardForkTransition(currentVer, targetVer) {
-		return
-	}
-	ls.transitionInfo = hardfork.NewTransitionKnown(expectedTargetEpoch)
+		if err != nil {
+			logger.Warn(
+				"hardfork-initiation stability check failed",
+				"error", err,
+				"component", "ledger",
+			)
+			return
+		}
+		if result == nil {
+			return
+		}
+		// A ratifiable HardForkInitiation is only an era transition
+		// if its target ProtocolVersion crosses an era boundary. An
+		// intra-era pparams bump (e.g. Plomin's pv9 → pv10, both
+		// Conway) ratifies through the same governance path but
+		// doesn't end the era; surfacing it as TransitionKnown would
+		// mislead clients. Use the snapshotted PParams so the
+		// version comparison reflects the state we computed against.
+		currentVer, verErr := GetProtocolVersion(snapshotPParams)
+		if verErr != nil {
+			return
+		}
+		targetVer := ProtocolVersion{
+			Major: result.NewMajor,
+			Minor: result.NewMinor,
+		}
+		if !IsHardForkTransition(currentVer, targetVer) {
+			return
+		}
+		ls.Lock()
+		defer ls.Unlock()
+		// Generation guard: a rollback that landed while the tally
+		// was running invalidated our snapshot. Drop the result
+		// rather than commit stale data — rollback's own call to
+		// evaluateHardForkInitiationStability will spawn a fresh
+		// tally against the post-rollback state.
+		if ls.hfiEvalGeneration.Load() != gen {
+			return
+		}
+		// A higher-priority source (TestX override or pparams-bump
+		// detection) may have set TransitionKnown while the tally
+		// was running; don't overwrite.
+		if ls.transitionInfo.State == hardfork.TransitionKnown {
+			return
+		}
+		// Re-derive the target epoch from the current state at
+		// commit time so an epoch rollover that landed during the
+		// tally doesn't pin TransitionKnown to a stale epoch id.
+		ls.transitionInfo = hardfork.NewTransitionKnown(
+			ls.currentEpoch.EpochId + 1,
+		)
+	}()
 }
 
 // computePParams loads protocol parameters for the given epoch/era

--- a/ledger/transition_stability_test.go
+++ b/ledger/transition_stability_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -32,6 +33,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// awaitTransitionInfo blocks until evaluateHardForkInitiationStability's
+// async tally goroutine commits a new transitionInfo, then returns it
+// under a read lock so the caller's assertions race-free against the
+// goroutine's write. Use this whenever a test expects the helper to
+// promote transitionInfo (Unknown/Impossible -> Known); paths that
+// short-circuit before spawning the goroutine don't need it.
+func awaitTransitionInfo(
+	t *testing.T,
+	ls *LedgerState,
+	want hardfork.TransitionState,
+) hardfork.TransitionInfo {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		ls.RLock()
+		defer ls.RUnlock()
+		return ls.transitionInfo.State == want
+	}, 2*time.Second, 5*time.Millisecond,
+		"transitionInfo.State did not reach %v", want)
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.transitionInfo
+}
 
 // stabilityFixtureEpoch parameters: Shelley-style 432_000-slot epoch,
 // safeZone = ceil(3*432/0.05) = 25_920, voting deadline distance from
@@ -190,9 +214,8 @@ func TestEvaluateHardForkInitiationStability_PostDeadline_Ratifiable_SetsKnown(t
 
 	ls.evaluateHardForkInitiationStability()
 
-	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State,
-		"post-deadline + ratifiable must set TransitionKnown")
-	assert.Equal(t, stabilityFixtureEpochID+1, ls.transitionInfo.KnownEpoch,
+	got := awaitTransitionInfo(t, ls, hardfork.TransitionKnown)
+	assert.Equal(t, stabilityFixtureEpochID+1, got.KnownEpoch,
 		"target epoch is the next epoch boundary")
 }
 
@@ -327,8 +350,7 @@ func TestEvaluateHardForkInitiationStability_UpgradesImpossibleToKnown(t *testin
 
 	ls.evaluateHardForkInitiationStability()
 
-	assert.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State,
-		"a ratifiable proposal must upgrade Impossible to Known")
-	assert.Equal(t, stabilityFixtureEpochID+1, ls.transitionInfo.KnownEpoch)
+	got := awaitTransitionInfo(t, ls, hardfork.TransitionKnown)
+	assert.Equal(t, stabilityFixtureEpochID+1, got.KnownEpoch)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the hard fork initiation (HFI) stability check run asynchronously and only once per epoch, with rollback-safe invalidation. This removes chainsync stalls and reduces CPU during catchup in `ledger`.

- **Refactors**
  - Run the `governance` HFI stability tally in a goroutine with input snapshots; apply results under lock only if generation matches.
  - Added `hfiEvalDoneEpoch`, `hfiEvalGeneration`, and `hfiStabilityEvalInFlight` to gate once-per-epoch runs, prevent overlap, and drop stale results after rollback.
  - On rollback, reset the epoch gate and bump generation; immediately re-evaluate against the new history.
  - Keep mid-era pparams bumps from surfacing as era transitions; don’t overwrite existing `TransitionKnown`; compute target epoch at commit time.
  - Tests: introduced `awaitTransitionInfo` helper and updated tests to wait for the async commit.

<sup>Written for commit d51b6215410bd24cda52d769baa1ffb0a9991563. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added async database operation processing with improved concurrency safety
* **Bug Fixes**
  * Enhanced database conflict recovery with automatic resolution capabilities
  * Improved hard fork evaluation consistency and reliability through epoch-based safeguards
* **Improvements**
  * Better resilience in transaction processing and distributed database operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->