### PR TITLE
feat(node): validate block producer credentials at startup (#1853)

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -217,6 +217,14 @@ func main() {
 		Int("db-workers", 5, "database worker pool worker count")
 	rootCmd.PersistentFlags().
 		Int("db-queue-size", 50, "database worker pool task queue size")
+	rootCmd.PersistentFlags().
+		Bool("block-producer", false, "run as a block producer; requires --vrf-key-file, --kes-key-file, and --op-cert-file")
+	rootCmd.PersistentFlags().
+		String("vrf-key-file", "", "path to VRF signing key file (block producer mode)")
+	rootCmd.PersistentFlags().
+		String("kes-key-file", "", "path to KES signing key file (block producer mode)")
+	rootCmd.PersistentFlags().
+		String("op-cert-file", "", "path to operational certificate file (block producer mode)")
 
 	// Add plugin-specific flags
 	if err := plugin.PopulateCmdlineOptions(rootCmd.PersistentFlags()); err != nil {
@@ -257,6 +265,28 @@ func main() {
 		if cmd.Root().PersistentFlags().Changed("db-queue-size") {
 			if queueSize, err := cmd.Root().PersistentFlags().GetInt("db-queue-size"); err == nil {
 				cfg.DatabaseQueueSize = queueSize
+			}
+		}
+
+		// Override block producer config if flags are provided
+		if cmd.Root().PersistentFlags().Changed("block-producer") {
+			if v, err := cmd.Root().PersistentFlags().GetBool("block-producer"); err == nil {
+				cfg.BlockProducer = v
+			}
+		}
+		if cmd.Root().PersistentFlags().Changed("vrf-key-file") {
+			if v, err := cmd.Root().PersistentFlags().GetString("vrf-key-file"); err == nil {
+				cfg.VrfKeyFilePath = v
+			}
+		}
+		if cmd.Root().PersistentFlags().Changed("kes-key-file") {
+			if v, err := cmd.Root().PersistentFlags().GetString("kes-key-file"); err == nil {
+				cfg.KesKeyFilePath = v
+			}
+		}
+		if cmd.Root().PersistentFlags().Changed("op-cert-file") {
+			if v, err := cmd.Root().PersistentFlags().GetString("op-cert-file"); err == nil {
+				cfg.OpCertFilePath = v
 			}
 		}
 

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@
 package dingo
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/internal/blockproducer"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -41,6 +43,9 @@ type Config struct {
 	network                  string
 	tlsCertFilePath          string
 	tlsKeyFilePath           string
+	vrfKeyFilePath           string
+	kesKeyFilePath           string
+	opCertFilePath           string
 	intersectPoints          []ocommon.Point
 	listeners                []ListenerConfig
 	mempoolCapacity          int64
@@ -53,6 +58,7 @@ type Config struct {
 	tracing                  bool
 	tracingStdout            bool
 	devMode                  bool
+	blockProducer            bool
 	shutdownTimeout          time.Duration
 	DatabaseWorkerPoolConfig ledger.DatabaseWorkerPoolConfig
 }
@@ -105,6 +111,56 @@ func (n *Node) configValidate() error {
 			)
 		}
 	}
+	if err := n.loadBlockProducerCredentials(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadBlockProducerCredentials parses and validates the operator credential
+// files when block producer mode is enabled. This runs at startup so that a
+// misconfigured node fails before it can attempt to forge.
+func (n *Node) loadBlockProducerCredentials() error {
+	if !n.config.blockProducer {
+		return nil
+	}
+	if n.config.vrfKeyFilePath == "" ||
+		n.config.kesKeyFilePath == "" ||
+		n.config.opCertFilePath == "" {
+		return errors.New(
+			"block producer mode requires vrfKeyFile, kesKeyFile, and opCertFile",
+		)
+	}
+	if n.config.cardanoNodeConfig == nil {
+		return errors.New(
+			"block producer mode requires Cardano node config with Shelley genesis",
+		)
+	}
+	genesis := n.config.cardanoNodeConfig.ShelleyGenesis()
+	if genesis == nil {
+		return errors.New(
+			"block producer mode requires Shelley genesis information",
+		)
+	}
+	creds, err := blockproducer.Load(
+		n.config.vrfKeyFilePath,
+		n.config.kesKeyFilePath,
+		n.config.opCertFilePath,
+	)
+	if err != nil {
+		return fmt.Errorf("invalid block producer credentials: %w", err)
+	}
+	if err := creds.Validate(genesis, time.Now()); err != nil {
+		return fmt.Errorf("block producer credentials failed validation: %w", err)
+	}
+	n.blockProducerCreds = creds
+	n.config.logger.Info(
+		"block producer credentials loaded",
+		"component", "node",
+		"pool_id", hex.EncodeToString(creds.PoolID[:]),
+		"kes_period", creds.OpCert.KESPeriod,
+		"opcert_counter", creds.OpCert.SequenceNumber,
+	)
 	return nil
 }
 
@@ -285,5 +341,20 @@ func WithDatabaseWorkerPoolConfig(
 ) ConfigOptionFunc {
 	return func(c *Config) {
 		c.DatabaseWorkerPoolConfig = cfg
+	}
+}
+
+// WithBlockProducer enables block producer mode and sets the operator
+// credential file paths. The files are loaded and validated by Node.New;
+// invalid or missing credentials cause Node.New to fail.
+func WithBlockProducer(
+	enabled bool,
+	vrfKeyFilePath, kesKeyFilePath, opCertFilePath string,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.blockProducer = enabled
+		c.vrfKeyFilePath = vrfKeyFilePath
+		c.kesKeyFilePath = kesKeyFilePath
+		c.opCertFilePath = opCertFilePath
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func baseTestConfigOpts() []ConfigOptionFunc {
+	return []ConfigOptionFunc{
+		WithLogger(slog.New(slog.NewJSONHandler(io.Discard, nil))),
+		WithNetworkMagic(764824073),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+	}
+}
+
+func TestConfigValidate_BlockProducerDisabled(t *testing.T) {
+	cfg := NewConfig(baseTestConfigOpts()...)
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+
+func TestConfigValidate_BlockProducerNoCardanoConfig(t *testing.T) {
+	// Block producer mode without a cardanoNodeConfig must be rejected
+	// because we need the Shelley genesis for KES period math.
+	opts := append(baseTestConfigOpts(), WithBlockProducer(
+		true, "vrf.skey", "kes.skey", "op.cert",
+	))
+	_, err := New(NewConfig(opts...))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Cardano node config") {
+		t.Errorf("expected error to mention Cardano node config, got: %v", err)
+	}
+}
+
+func TestConfigValidate_BlockProducerEmptyPaths(t *testing.T) {
+	opts := append(baseTestConfigOpts(), WithBlockProducer(true, "", "", ""))
+	_, err := New(NewConfig(opts...))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "vrfKeyFile") {
+		t.Errorf("expected error to name missing fields, got: %v", err)
+	}
+}
+
+func TestConfigValidate_BlockProducerMissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	opts := append(baseTestConfigOpts(), WithBlockProducer(
+		true,
+		filepath.Join(tmp, "missing.skey"),
+		filepath.Join(tmp, "missing.skey"),
+		filepath.Join(tmp, "missing.cert"),
+	))
+	_, err := New(NewConfig(opts...))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "block producer") {
+		t.Errorf("expected error to mention block producer, got: %v", err)
+	}
+}

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -104,3 +104,29 @@ devMode: false
 
 # Validate historical blocks during ledger processing (default: false)
 validateHistorical: false
+
+# Enable block producer mode (default: false). When enabled, the operator
+# credential paths below must be set; the node loads and validates them at
+# startup and will refuse to start if they are missing or malformed.
+#
+# Can be overridden with the BLOCK_PRODUCER environment variable or the
+# --block-producer command-line flag.
+blockProducer: false
+
+# Path to the VRF signing key file (cardano-cli TextEnvelope format).
+#
+# Can be overridden with the VRF_KEY_FILE_PATH environment variable or the
+# --vrf-key-file command-line flag.
+vrfKeyFilePath: ""
+
+# Path to the KES signing key file (cardano-cli TextEnvelope format).
+#
+# Can be overridden with the KES_KEY_FILE_PATH environment variable or the
+# --kes-key-file command-line flag.
+kesKeyFilePath: ""
+
+# Path to the operational certificate file (cardano-cli TextEnvelope format).
+#
+# Can be overridden with the OP_CERT_FILE_PATH environment variable or the
+# --op-cert-file command-line flag.
+opCertFilePath: ""

--- a/internal/blockproducer/credentials.go
+++ b/internal/blockproducer/credentials.go
@@ -1,0 +1,376 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package blockproducer parses and validates the credentials a Cardano stake
+// pool operator supplies to a node running in block producer mode: the VRF
+// signing key, the KES signing key, and the operational certificate. Loading
+// happens at startup so misconfiguration fails fast rather than surfacing on
+// the first leader check.
+package blockproducer
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// Sizes (in bytes) of the byte-string payloads we expect after CBOR decoding.
+const (
+	vrfSeedSize         = 32
+	vrfSeedAndPubSize   = 64
+	kesSecretKeySize    = 608 // sum6 KES used by Cardano
+	verificationKeySize = 32
+	signatureSize       = 64
+	coldVKeySize        = 32
+	poolIDSize          = 28
+)
+
+// Accepted envelope type tags. Cardano-cli and bursa use slightly different
+// spellings for the same key formats; both are supported.
+var (
+	vrfTypes    = []string{"VrfSigningKey_PraosVRF", "VRFSigningKey_PraosVRF"}
+	kesTypes    = []string{"KesSigningKey_ed25519_kes_2^6", "KESSigningKey_PraosV2"}
+	opCertTypes = []string{"NodeOperationalCertificate"}
+)
+
+// OperationalCertificate is the parsed contents of a node operational
+// certificate. The cold key signs the (hot KES vkey, sequence number, KES
+// period) tuple with its long-lived signing key; the node uses the hot KES
+// vkey to verify forge signatures during the active KES period.
+type OperationalCertificate struct {
+	HotKESVKey     []byte
+	SequenceNumber uint64
+	KESPeriod      uint64
+	ColdSignature  []byte
+	ColdVKey       []byte
+}
+
+// Credentials are the operator-supplied keys and certificate required to
+// produce blocks. Construct via Load.
+type Credentials struct {
+	VRFSigningKey      []byte // 32 (seed) or 64 (seed+pub)
+	VRFVerificationKey []byte // 32; populated only when VRFSigningKey is 64 bytes
+	KESSigningKey      []byte // 608
+	OpCert             OperationalCertificate
+	PoolID             [poolIDSize]byte // Blake2b-224(OpCert.ColdVKey)
+}
+
+// Load reads VRF signing key, KES signing key, and operational certificate
+// files from disk and decodes them. It validates encoding and sizes only;
+// semantic checks (KES period plausibility, ledger consistency) are performed
+// by Validate and ValidateAgainstLedger.
+func Load(vrfPath, kesPath, opCertPath string) (*Credentials, error) {
+	vrfSk, vrfVk, err := loadVRFSigningKey(vrfPath)
+	if err != nil {
+		return nil, fmt.Errorf("vrf signing key: %w", err)
+	}
+	kesSk, err := loadKESSigningKey(kesPath)
+	if err != nil {
+		return nil, fmt.Errorf("kes signing key: %w", err)
+	}
+	opCert, err := loadOperationalCertificate(opCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("operational certificate: %w", err)
+	}
+	c := &Credentials{
+		VRFSigningKey:      vrfSk,
+		VRFVerificationKey: vrfVk,
+		KESSigningKey:      kesSk,
+		OpCert:             opCert,
+	}
+	c.PoolID = lcommon.Blake2b224Hash(opCert.ColdVKey)
+	return c, nil
+}
+
+func loadVRFSigningKey(path string) ([]byte, []byte, error) {
+	env, err := readEnvelope(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	raw, err := envelopeBytes(env, vrfTypes...)
+	if err != nil {
+		return nil, nil, err
+	}
+	var skBytes []byte
+	if _, err := cbor.Decode(raw, &skBytes); err != nil {
+		return nil, nil, fmt.Errorf("decode cbor: %w", err)
+	}
+	switch len(skBytes) {
+	case vrfSeedAndPubSize:
+		// cardano-cli format: seed (32) || pubkey (32)
+		return skBytes, skBytes[vrfSeedSize:], nil
+	case vrfSeedSize:
+		// Seed-only format. We retain the seed but cannot derive the public
+		// key without a VRF KeyGen helper, which gouroboros does not provide
+		// at this version. The ledger cross-check (VRF hash match) requires
+		// the public key, so callers should be aware that it will be skipped.
+		return skBytes, nil, nil
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid length: expected %d or %d bytes, got %d",
+			vrfSeedSize, vrfSeedAndPubSize, len(skBytes),
+		)
+	}
+}
+
+func loadKESSigningKey(path string) ([]byte, error) {
+	env, err := readEnvelope(path)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := envelopeBytes(env, kesTypes...)
+	if err != nil {
+		return nil, err
+	}
+	var skBytes []byte
+	if _, err := cbor.Decode(raw, &skBytes); err != nil {
+		return nil, fmt.Errorf("decode cbor: %w", err)
+	}
+	if len(skBytes) != kesSecretKeySize {
+		return nil, fmt.Errorf(
+			"invalid length: expected %d bytes, got %d",
+			kesSecretKeySize, len(skBytes),
+		)
+	}
+	return skBytes, nil
+}
+
+func loadOperationalCertificate(path string) (OperationalCertificate, error) {
+	env, err := readEnvelope(path)
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	raw, err := envelopeBytes(env, opCertTypes...)
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	// CBOR shape: [[hot_kes_vkey, sequence_number, kes_period, signature], cold_vkey]
+	var outer []any
+	if _, err := cbor.Decode(raw, &outer); err != nil {
+		return OperationalCertificate{}, fmt.Errorf("decode cbor: %w", err)
+	}
+	if len(outer) != 2 {
+		return OperationalCertificate{}, fmt.Errorf(
+			"expected 2-element outer array, got %d",
+			len(outer),
+		)
+	}
+	inner, ok := outer[0].([]any)
+	if !ok {
+		return OperationalCertificate{}, errors.New(
+			"first element is not an array",
+		)
+	}
+	if len(inner) != 4 {
+		return OperationalCertificate{}, fmt.Errorf(
+			"expected 4-element cert array, got %d",
+			len(inner),
+		)
+	}
+	hotKES, err := bytesField(inner[0], "hot_kes_vkey", verificationKeySize)
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	seqNum, err := uintField(inner[1], "sequence_number")
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	kesPeriod, err := uintField(inner[2], "kes_period")
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	sig, err := bytesField(inner[3], "signature", signatureSize)
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	coldVKey, err := bytesField(outer[1], "cold_vkey", coldVKeySize)
+	if err != nil {
+		return OperationalCertificate{}, err
+	}
+	return OperationalCertificate{
+		HotKESVKey:     hotKES,
+		SequenceNumber: seqNum,
+		KESPeriod:      kesPeriod,
+		ColdSignature:  sig,
+		ColdVKey:       coldVKey,
+	}, nil
+}
+
+func bytesField(v any, name string, expected int) ([]byte, error) {
+	b, ok := v.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("%s is not bytes (got %T)", name, v)
+	}
+	if len(b) != expected {
+		return nil, fmt.Errorf(
+			"%s has wrong length: expected %d, got %d",
+			name, expected, len(b),
+		)
+	}
+	return b, nil
+}
+
+// uintField extracts a non-negative integer from a CBOR value. The decoder
+// uses uint64 for small unsigned ints; very large values may surface as
+// a *big.Int so we accept that too.
+func uintField(v any, name string) (uint64, error) {
+	switch n := v.(type) {
+	case uint64:
+		return n, nil
+	case int64:
+		if n < 0 {
+			return 0, fmt.Errorf("%s is negative", name)
+		}
+		return uint64(n), nil
+	case uint:
+		return uint64(n), nil
+	case int:
+		if n < 0 {
+			return 0, fmt.Errorf("%s is negative", name)
+		}
+		return uint64(n), nil
+	default:
+		return 0, fmt.Errorf("%s is not an integer (got %T)", name, v)
+	}
+}
+
+// Validate runs offline checks against the operational certificate that do
+// not require ledger state: KES period plausibility relative to the genesis
+// SystemStart and the wall clock. A non-nil result means the node should
+// refuse to start.
+func (c *Credentials) Validate(genesis *shelley.ShelleyGenesis, now time.Time) error {
+	if genesis == nil {
+		return errors.New("shelley genesis is required")
+	}
+	if genesis.SlotsPerKESPeriod <= 0 {
+		return fmt.Errorf(
+			"genesis slotsPerKESPeriod must be positive, got %d",
+			genesis.SlotsPerKESPeriod,
+		)
+	}
+	current, err := currentKESPeriod(genesis, now)
+	if err != nil {
+		return err
+	}
+	if c.OpCert.KESPeriod > current {
+		return fmt.Errorf(
+			"opcert KES period %d is in the future (current %d)",
+			c.OpCert.KESPeriod, current,
+		)
+	}
+	maxEvolutions := uint64(genesis.MaxKESEvolutions) // #nosec G115
+	if maxEvolutions > 0 && current >= c.OpCert.KESPeriod+maxEvolutions {
+		return fmt.Errorf(
+			"opcert KES period %d has expired (current %d, max evolutions %d); rotate the operational certificate",
+			c.OpCert.KESPeriod, current, maxEvolutions,
+		)
+	}
+	return nil
+}
+
+// currentKESPeriod returns the KES period the node should consider current
+// based on wall-clock time and the Shelley genesis slot timing.
+func currentKESPeriod(genesis *shelley.ShelleyGenesis, now time.Time) (uint64, error) {
+	if now.Before(genesis.SystemStart) {
+		// Before the chain has started, treat the current period as 0.
+		return 0, nil
+	}
+	// SlotLength is a rational number of seconds per slot.
+	slotLengthSeconds := new(big.Rat).Set(genesis.SlotLength.Rat)
+	if slotLengthSeconds.Sign() <= 0 {
+		return 0, fmt.Errorf(
+			"genesis slotLength must be positive, got %s",
+			slotLengthSeconds.RatString(),
+		)
+	}
+	elapsedNanos := now.Sub(genesis.SystemStart).Nanoseconds()
+	// slot = elapsed_nanos / (slotLengthSeconds * 1e9)
+	num := new(big.Int).Mul(
+		big.NewInt(elapsedNanos),
+		slotLengthSeconds.Denom(),
+	)
+	denom := new(big.Int).Mul(
+		slotLengthSeconds.Num(),
+		big.NewInt(1_000_000_000),
+	)
+	slot := new(big.Int).Quo(num, denom)
+	period := new(big.Int).Quo(slot, big.NewInt(int64(genesis.SlotsPerKESPeriod)))
+	if !period.IsUint64() {
+		return 0, fmt.Errorf("computed KES period %s overflows uint64", period.String())
+	}
+	return period.Uint64(), nil
+}
+
+// LedgerView is the subset of dingo's LedgerView the credential check needs.
+// Defined here so this package does not depend on the ledger package and
+// callers can pass an adapter.
+type LedgerView interface {
+	// PoolRegistrationVRFKeyHash returns the VRF key hash recorded in the
+	// most recent active pool registration certificate for the given pool.
+	// The found return is false when the pool is not (yet) registered.
+	PoolRegistrationVRFKeyHash(poolID [poolIDSize]byte) (vrfKeyHash [32]byte, found bool, err error)
+	// LatestOpCertSequence returns the highest operational certificate
+	// sequence number observed for the given pool. When tracking is not
+	// implemented or the pool has never minted, found is false.
+	LatestOpCertSequence(poolID [poolIDSize]byte) (sequence uint64, found bool, err error)
+}
+
+// ValidateAgainstLedger cross-checks the loaded credentials against ledger
+// state. Best-effort: missing pool registrations are not fatal because a pool
+// can be configured before its registration certificate is on chain.
+//
+// It returns three results:
+//   - registered: true if the pool registration was found.
+//   - vrfMatched: true if registered and the registration's VRF key hash
+//     matched our VRF verification key. False when registered=false or when
+//     the VRF verification key is unavailable (32-byte seed-only VRF skey).
+//   - err: a non-nil error means the node should refuse to start.
+func (c *Credentials) ValidateAgainstLedger(view LedgerView) (registered, vrfMatched bool, err error) {
+	if view == nil {
+		return false, false, errors.New("ledger view is nil")
+	}
+	regVRF, found, err := view.PoolRegistrationVRFKeyHash(c.PoolID)
+	if err != nil {
+		return false, false, fmt.Errorf("pool registration lookup: %w", err)
+	}
+	if !found {
+		return false, false, nil
+	}
+	if c.VRFVerificationKey != nil {
+		ourVRF := lcommon.Blake2b256Hash(c.VRFVerificationKey)
+		if ourVRF != regVRF {
+			return true, false, fmt.Errorf(
+				"VRF key hash mismatch: opcert pool registers %x but loaded VRF key hashes to %x",
+				regVRF, ourVRF,
+			)
+		}
+		vrfMatched = true
+	}
+	latestSeq, seqFound, err := view.LatestOpCertSequence(c.PoolID)
+	if err != nil {
+		return true, vrfMatched, fmt.Errorf("opcert sequence lookup: %w", err)
+	}
+	if seqFound && c.OpCert.SequenceNumber < latestSeq {
+		return true, vrfMatched, fmt.Errorf(
+			"opcert sequence %d is stale: ledger has observed %d for this pool",
+			c.OpCert.SequenceNumber, latestSeq,
+		)
+	}
+	return true, vrfMatched, nil
+}

--- a/internal/blockproducer/credentials_test.go
+++ b/internal/blockproducer/credentials_test.go
@@ -1,0 +1,533 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockproducer
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// devnetKeysDir locates the devnet credential fixtures shipped with the
+// repository. Tests rely on these being well-formed real keys.
+const devnetKeysDir = "../../config/cardano/devnet/keys"
+
+func devnetPaths() (vrf, kes, opcert string) {
+	return filepath.Join(devnetKeysDir, "vrf.skey"),
+		filepath.Join(devnetKeysDir, "kes.skey"),
+		filepath.Join(devnetKeysDir, "opcert.cert")
+}
+
+// writeEnvelope writes a TextEnvelope JSON file to a temp path and returns
+// the path. Callers can pass arbitrary type/cborHex to construct malformed
+// inputs.
+func writeEnvelope(t *testing.T, name, envType, cborHex string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	body := fmt.Sprintf(
+		`{"type":%q,"description":"test","cborHex":%q}`,
+		envType, cborHex,
+	)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write envelope: %v", err)
+	}
+	return path
+}
+
+// cborByteString returns the CBOR encoding of a byte string of the given
+// length, with bytes filled by repeating the supplied seed.
+func cborByteString(t *testing.T, length int, seed byte) string {
+	t.Helper()
+	buf := make([]byte, length)
+	for i := range buf {
+		buf[i] = seed + byte(i)
+	}
+	enc, err := cbor.Encode(buf)
+	if err != nil {
+		t.Fatalf("cbor encode: %v", err)
+	}
+	return hex.EncodeToString(enc)
+}
+
+func TestLoad_DevnetFixtures(t *testing.T) {
+	vrf, kes, opcert := devnetPaths()
+	creds, err := Load(vrf, kes, opcert)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(creds.VRFSigningKey); got != vrfSeedAndPubSize {
+		t.Errorf("VRFSigningKey length = %d, want %d", got, vrfSeedAndPubSize)
+	}
+	if got := len(creds.VRFVerificationKey); got != verificationKeySize {
+		t.Errorf(
+			"VRFVerificationKey length = %d, want %d",
+			got, verificationKeySize,
+		)
+	}
+	if got := len(creds.KESSigningKey); got != kesSecretKeySize {
+		t.Errorf("KESSigningKey length = %d, want %d", got, kesSecretKeySize)
+	}
+	if got := len(creds.OpCert.HotKESVKey); got != verificationKeySize {
+		t.Errorf("OpCert.HotKESVKey length = %d, want %d", got, verificationKeySize)
+	}
+	if got := len(creds.OpCert.ColdSignature); got != signatureSize {
+		t.Errorf("OpCert.ColdSignature length = %d, want %d", got, signatureSize)
+	}
+	if got := len(creds.OpCert.ColdVKey); got != coldVKeySize {
+		t.Errorf("OpCert.ColdVKey length = %d, want %d", got, coldVKeySize)
+	}
+	zero := [poolIDSize]byte{}
+	if creds.PoolID == zero {
+		t.Error("PoolID is all zeros, expected derived hash")
+	}
+}
+
+func TestLoad_PoolIDDerivation(t *testing.T) {
+	vrf, kes, opcert := devnetPaths()
+	creds, err := Load(vrf, kes, opcert)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	expected := lcommon.Blake2b224Hash(creds.OpCert.ColdVKey)
+	if creds.PoolID != expected {
+		t.Errorf(
+			"PoolID = %x, want %x",
+			creds.PoolID, expected,
+		)
+	}
+}
+
+func TestLoad_MissingFiles(t *testing.T) {
+	_, kes, opcert := devnetPaths()
+	missing := filepath.Join(t.TempDir(), "nope.skey")
+
+	cases := []struct {
+		name  string
+		paths [3]string // vrf, kes, opcert
+	}{
+		{"vrf", [3]string{missing, kes, opcert}},
+		{"kes", [3]string{filepath.Join(devnetKeysDir, "vrf.skey"), missing, opcert}},
+		{"opcert", [3]string{filepath.Join(devnetKeysDir, "vrf.skey"), kes, missing}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(tc.paths[0], tc.paths[1], tc.paths[2])
+			if err == nil {
+				t.Fatal("expected error for missing file")
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("expected os.ErrNotExist, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_VRFWrongType(t *testing.T) {
+	// Pass a KES envelope at the VRF path.
+	wrongVRF := writeEnvelope(t, "vrf.skey",
+		"KesSigningKey_ed25519_kes_2^6",
+		cborByteString(t, kesSecretKeySize, 0x01),
+	)
+	_, kes, opcert := devnetPaths()
+	_, err := Load(wrongVRF, kes, opcert)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unexpected envelope type") {
+		t.Errorf("error should mention envelope type, got: %v", err)
+	}
+}
+
+func TestLoad_VRFInvalidHex(t *testing.T) {
+	bad := writeEnvelope(t, "vrf.skey", vrfTypes[0], "not-hex-data")
+	_, kes, opcert := devnetPaths()
+	_, err := Load(bad, kes, opcert)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "decode cborHex") {
+		t.Errorf("error should mention hex decode, got: %v", err)
+	}
+}
+
+func TestLoad_VRFInvalidLength(t *testing.T) {
+	bad := writeEnvelope(t, "vrf.skey", vrfTypes[0], cborByteString(t, 16, 0x02))
+	_, kes, opcert := devnetPaths()
+	_, err := Load(bad, kes, opcert)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid length") {
+		t.Errorf("error should mention invalid length, got: %v", err)
+	}
+}
+
+func TestLoad_VRFSeedOnly(t *testing.T) {
+	// 32-byte seed-only form is accepted but VRFVerificationKey is unset.
+	good := writeEnvelope(t, "vrf.skey", vrfTypes[0], cborByteString(t, vrfSeedSize, 0x03))
+	_, kes, opcert := devnetPaths()
+	creds, err := Load(good, kes, opcert)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(creds.VRFSigningKey) != vrfSeedSize {
+		t.Errorf(
+			"VRFSigningKey length = %d, want %d",
+			len(creds.VRFSigningKey), vrfSeedSize,
+		)
+	}
+	if creds.VRFVerificationKey != nil {
+		t.Errorf("VRFVerificationKey should be nil for seed-only key, got %d bytes",
+			len(creds.VRFVerificationKey))
+	}
+}
+
+func TestLoad_KESWrongLength(t *testing.T) {
+	bad := writeEnvelope(t, "kes.skey", kesTypes[0],
+		cborByteString(t, kesSecretKeySize-1, 0x04),
+	)
+	vrf, _, opcert := devnetPaths()
+	_, err := Load(vrf, bad, opcert)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid length") {
+		t.Errorf("error should mention invalid length, got: %v", err)
+	}
+}
+
+func TestLoad_OpCertOuterArrayWrongSize(t *testing.T) {
+	// CBOR for a 3-element array of empty byte strings.
+	enc, err := cbor.Encode([]any{[]byte{}, []byte{}, []byte{}})
+	if err != nil {
+		t.Fatalf("cbor encode: %v", err)
+	}
+	bad := writeEnvelope(t, "opcert.cert", opCertTypes[0], hex.EncodeToString(enc))
+	vrf, kes, _ := devnetPaths()
+	_, err = Load(vrf, kes, bad)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "outer array") {
+		t.Errorf("error should mention outer array, got: %v", err)
+	}
+}
+
+func TestLoad_OpCertColdVKeyWrongLength(t *testing.T) {
+	hotKES := bytes32(0x10)
+	sig := bytes64(0x20)
+	wrongCold := make([]byte, coldVKeySize-1)
+	enc, err := cbor.Encode([]any{
+		[]any{hotKES, uint64(0), uint64(0), sig},
+		wrongCold,
+	})
+	if err != nil {
+		t.Fatalf("cbor encode: %v", err)
+	}
+	bad := writeEnvelope(t, "opcert.cert", opCertTypes[0], hex.EncodeToString(enc))
+	vrf, kes, _ := devnetPaths()
+	_, err = Load(vrf, kes, bad)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cold_vkey") {
+		t.Errorf("error should mention cold_vkey, got: %v", err)
+	}
+}
+
+func TestLoad_OpCertHotKESWrongLength(t *testing.T) {
+	wrongHot := make([]byte, verificationKeySize-1)
+	sig := bytes64(0x20)
+	cold := bytes32(0x30)
+	enc, err := cbor.Encode([]any{
+		[]any{wrongHot, uint64(0), uint64(0), sig},
+		cold,
+	})
+	if err != nil {
+		t.Fatalf("cbor encode: %v", err)
+	}
+	bad := writeEnvelope(t, "opcert.cert", opCertTypes[0], hex.EncodeToString(enc))
+	vrf, kes, _ := devnetPaths()
+	_, err = Load(vrf, kes, bad)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "hot_kes_vkey") {
+		t.Errorf("error should mention hot_kes_vkey, got: %v", err)
+	}
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(t, 100, 5, time.Second, systemStart)
+	creds := &Credentials{
+		OpCert: OperationalCertificate{KESPeriod: 1, SequenceNumber: 0},
+	}
+	// 250 slots elapsed → KES period 2.
+	now := systemStart.Add(250 * time.Second)
+	if err := creds.Validate(g, now); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+}
+
+func TestValidate_KESPeriodInFuture(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(t, 100, 5, time.Second, systemStart)
+	creds := &Credentials{
+		OpCert: OperationalCertificate{KESPeriod: 10},
+	}
+	// 50 slots elapsed → current period 0; opcert period 10 is in the future.
+	now := systemStart.Add(50 * time.Second)
+	err := creds.Validate(g, now)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "future") {
+		t.Errorf("expected 'future' in error, got: %v", err)
+	}
+}
+
+func TestValidate_KESPeriodExpired(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(t, 100, 3, time.Second, systemStart)
+	creds := &Credentials{
+		OpCert: OperationalCertificate{KESPeriod: 1},
+	}
+	// Period 1 + max evolutions 3 = expires at period 4. At slot 500 →
+	// current period 5, which is past expiry.
+	now := systemStart.Add(500 * time.Second)
+	err := creds.Validate(g, now)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' in error, got: %v", err)
+	}
+}
+
+func TestValidate_BeforeSystemStart(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(t, 100, 5, time.Second, systemStart)
+	creds := &Credentials{
+		OpCert: OperationalCertificate{KESPeriod: 0},
+	}
+	// One hour before system start; current period is 0; opcert period 0 is fine.
+	now := systemStart.Add(-time.Hour)
+	if err := creds.Validate(g, now); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+}
+
+func TestValidate_ZeroSlotsPerKESPeriod(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(t, 0, 5, time.Second, systemStart)
+	creds := &Credentials{}
+	err := creds.Validate(g, systemStart)
+	if err == nil {
+		t.Fatal("expected error for zero SlotsPerKESPeriod")
+	}
+}
+
+type fakeView struct {
+	registered  bool
+	regVRFHash  [32]byte
+	regErr      error
+	seqFound    bool
+	latestSeq   uint64
+	seqErr      error
+	gotPoolID   [poolIDSize]byte
+	seqPoolID   [poolIDSize]byte
+	calledPool  bool
+	calledSeq   bool
+}
+
+func (f *fakeView) PoolRegistrationVRFKeyHash(p [poolIDSize]byte) ([32]byte, bool, error) {
+	f.calledPool = true
+	f.gotPoolID = p
+	return f.regVRFHash, f.registered, f.regErr
+}
+
+func (f *fakeView) LatestOpCertSequence(p [poolIDSize]byte) (uint64, bool, error) {
+	f.calledSeq = true
+	f.seqPoolID = p
+	return f.latestSeq, f.seqFound, f.seqErr
+}
+
+func TestValidateAgainstLedger_PoolNotRegistered(t *testing.T) {
+	creds := &Credentials{
+		VRFVerificationKey: bytes32(0xAA),
+	}
+	creds.PoolID = lcommon.Blake2b224Hash([]byte("cold-vkey"))
+	view := &fakeView{registered: false}
+	registered, matched, err := creds.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+	if registered || matched {
+		t.Errorf("expected registered=false, matched=false; got %v %v", registered, matched)
+	}
+	if !view.calledPool {
+		t.Error("expected PoolRegistrationVRFKeyHash to be called")
+	}
+}
+
+func TestValidateAgainstLedger_VRFMatch(t *testing.T) {
+	vrfPub := bytes32(0xBB)
+	creds := &Credentials{VRFVerificationKey: vrfPub}
+	creds.PoolID = lcommon.Blake2b224Hash([]byte("cold-vkey"))
+	view := &fakeView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(vrfPub),
+	}
+	registered, matched, err := creds.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !registered || !matched {
+		t.Errorf("expected registered=true, matched=true; got %v %v", registered, matched)
+	}
+}
+
+func TestValidateAgainstLedger_VRFMismatch(t *testing.T) {
+	creds := &Credentials{VRFVerificationKey: bytes32(0xCC)}
+	creds.PoolID = lcommon.Blake2b224Hash([]byte("cold-vkey"))
+	view := &fakeView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(bytes32(0xDD)),
+	}
+	_, _, err := creds.ValidateAgainstLedger(view)
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	if !strings.Contains(err.Error(), "VRF key hash mismatch") {
+		t.Errorf("expected mismatch in error, got: %v", err)
+	}
+}
+
+func TestValidateAgainstLedger_SeedOnlySkipsCheck(t *testing.T) {
+	creds := &Credentials{VRFVerificationKey: nil}
+	creds.PoolID = lcommon.Blake2b224Hash([]byte("cold-vkey"))
+	view := &fakeView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash([]byte("anything")),
+	}
+	registered, matched, err := creds.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+	if !registered {
+		t.Error("expected registered=true")
+	}
+	if matched {
+		t.Error("expected matched=false (no VRF pubkey)")
+	}
+}
+
+func TestValidateAgainstLedger_StaleOpCert(t *testing.T) {
+	vrfPub := bytes32(0xEE)
+	creds := &Credentials{
+		VRFVerificationKey: vrfPub,
+		OpCert:             OperationalCertificate{SequenceNumber: 3},
+	}
+	creds.PoolID = lcommon.Blake2b224Hash([]byte("cold-vkey"))
+	view := &fakeView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(vrfPub),
+		seqFound:   true,
+		latestSeq:  5,
+	}
+	_, _, err := creds.ValidateAgainstLedger(view)
+	if err == nil {
+		t.Fatal("expected stale-counter error")
+	}
+	if !strings.Contains(err.Error(), "stale") {
+		t.Errorf("expected stale in error, got: %v", err)
+	}
+}
+
+func TestValidateAgainstLedger_CounterTrackingNotImplemented(t *testing.T) {
+	// When the ledger does not track opcert counters, the check must not
+	// produce false positives or block startup.
+	vrfPub := bytes32(0xFE)
+	creds := &Credentials{
+		VRFVerificationKey: vrfPub,
+		OpCert:             OperationalCertificate{SequenceNumber: 0},
+	}
+	creds.PoolID = lcommon.Blake2b224Hash([]byte("cold-vkey"))
+	view := &fakeView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(vrfPub),
+		seqFound:   false, // tracking returns "not found"
+	}
+	registered, matched, err := creds.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+	if !registered || !matched {
+		t.Errorf("expected registered=true, matched=true; got %v %v", registered, matched)
+	}
+}
+
+func TestValidateAgainstLedger_NilView(t *testing.T) {
+	creds := &Credentials{}
+	_, _, err := creds.ValidateAgainstLedger(nil)
+	if err == nil {
+		t.Fatal("expected nil-view error")
+	}
+}
+
+// synthGenesis builds a minimal Shelley genesis for KES timing math.
+func synthGenesis(
+	t *testing.T,
+	slotsPerKES, maxKES int,
+	slotLen time.Duration,
+	systemStart time.Time,
+) *shelley.ShelleyGenesis {
+	t.Helper()
+	// SlotLength is in seconds as a rational.
+	rat := big.NewRat(int64(slotLen), int64(time.Second))
+	return &shelley.ShelleyGenesis{
+		SystemStart:       systemStart,
+		SlotsPerKESPeriod: slotsPerKES,
+		MaxKESEvolutions:  maxKES,
+		SlotLength:        cbor.Rat{Rat: rat},
+	}
+}
+
+func bytes32(seed byte) []byte {
+	b := make([]byte, 32)
+	for i := range b {
+		b[i] = seed + byte(i)
+	}
+	return b
+}
+
+func bytes64(seed byte) []byte {
+	b := make([]byte, 64)
+	for i := range b {
+		b[i] = seed + byte(i)
+	}
+	return b
+}

--- a/internal/blockproducer/textenvelope.go
+++ b/internal/blockproducer/textenvelope.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockproducer
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+)
+
+// textEnvelope is the cardano-cli on-disk format for serialized keys and
+// certificates. The CBOR payload is hex-encoded and wrapped in a JSON object
+// with a type tag that identifies what it contains.
+type textEnvelope struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	CborHex     string `json:"cborHex"`
+}
+
+func readEnvelope(path string) (*textEnvelope, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+	var env textEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse %q: %w", path, err)
+	}
+	if env.Type == "" {
+		return nil, fmt.Errorf("parse %q: missing type field", path)
+	}
+	if env.CborHex == "" {
+		return nil, fmt.Errorf("parse %q: missing cborHex field", path)
+	}
+	return &env, nil
+}
+
+// envelopeBytes returns the raw CBOR payload of a TextEnvelope after
+// validating that the type matches one of the accepted values.
+func envelopeBytes(env *textEnvelope, accepted ...string) ([]byte, error) {
+	if !slices.Contains(accepted, env.Type) {
+		return nil, fmt.Errorf(
+			"unexpected envelope type %q (want one of %v)",
+			env.Type,
+			accepted,
+		)
+	}
+	raw, err := hex.DecodeString(env.CborHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode cborHex: %w", err)
+	}
+	return raw, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,12 @@ type Config struct {
 	// Database worker pool tuning (worker count and task queue size)
 	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
 	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
+	// Block producer credentials. When BlockProducer is true the node loads
+	// and validates these files at startup; otherwise they are ignored.
+	BlockProducer  bool   `yaml:"blockProducer"   envconfig:"BLOCK_PRODUCER"`
+	VrfKeyFilePath string `yaml:"vrfKeyFilePath"  envconfig:"VRF_KEY_FILE_PATH"`
+	KesKeyFilePath string `yaml:"kesKeyFilePath"  envconfig:"KES_KEY_FILE_PATH"`
+	OpCertFilePath string `yaml:"opCertFilePath"  envconfig:"OP_CERT_FILE_PATH"`
 }
 
 func (c *Config) ParseCmdlineArgs(programName string, args []string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -275,6 +275,64 @@ func TestLoadConfig_UnsupportedNetworkWithUserConfig(t *testing.T) {
 	}
 }
 
+func TestLoad_BlockProducerYAML(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+network: "preview"
+blockProducer: true
+vrfKeyFilePath: "/etc/dingo/vrf.skey"
+kesKeyFilePath: "/etc/dingo/kes.skey"
+opCertFilePath: "/etc/dingo/op.cert"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-bp.yaml")
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.BlockProducer {
+		t.Error("expected BlockProducer to be true")
+	}
+	if cfg.VrfKeyFilePath != "/etc/dingo/vrf.skey" {
+		t.Errorf("VrfKeyFilePath = %q", cfg.VrfKeyFilePath)
+	}
+	if cfg.KesKeyFilePath != "/etc/dingo/kes.skey" {
+		t.Errorf("KesKeyFilePath = %q", cfg.KesKeyFilePath)
+	}
+	if cfg.OpCertFilePath != "/etc/dingo/op.cert" {
+		t.Errorf("OpCertFilePath = %q", cfg.OpCertFilePath)
+	}
+}
+
+func TestLoad_BlockProducerEnv(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("CARDANO_BLOCK_PRODUCER", "true")
+	t.Setenv("CARDANO_VRF_KEY_FILE_PATH", "/env/vrf.skey")
+	t.Setenv("CARDANO_KES_KEY_FILE_PATH", "/env/kes.skey")
+	t.Setenv("CARDANO_OP_CERT_FILE_PATH", "/env/op.cert")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.BlockProducer {
+		t.Error("expected BlockProducer to be true from env")
+	}
+	if cfg.VrfKeyFilePath != "/env/vrf.skey" {
+		t.Errorf("VrfKeyFilePath = %q", cfg.VrfKeyFilePath)
+	}
+	if cfg.KesKeyFilePath != "/env/kes.skey" {
+		t.Errorf("KesKeyFilePath = %q", cfg.KesKeyFilePath)
+	}
+	if cfg.OpCertFilePath != "/env/op.cert" {
+		t.Errorf("OpCertFilePath = %q", cfg.OpCertFilePath)
+	}
+}
+
 func TestLoad_DatabaseSection(t *testing.T) {
 	resetGlobalConfig()
 	yamlContent := `

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -133,6 +133,12 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
 			dingo.WithDevMode(cfg.DevMode),
+			dingo.WithBlockProducer(
+				cfg.BlockProducer,
+				cfg.VrfKeyFilePath,
+				cfg.KesKeyFilePath,
+				cfg.OpCertFilePath,
+			),
 			dingo.WithShutdownTimeout(shutdownTimeout),
 			// Enable metrics with default prometheus registry
 			dingo.WithPrometheusRegistry(prometheus.DefaultRegisterer),

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -425,6 +425,50 @@ func (ls *LedgerState) Chain() *chain.Chain {
 	return ls.chain
 }
 
+// PoolRegistrationVRFKeyHash returns the VRF key hash recorded in the most
+// recent active pool registration certificate for the given pool. found is
+// false when the pool has no active registration on this chain.
+func (ls *LedgerState) PoolRegistrationVRFKeyHash(
+	poolID [28]byte,
+) (vrfHash [32]byte, found bool, err error) {
+	pkh := lcommon.PoolKeyHash(lcommon.NewBlake2b224(poolID[:]))
+	pool, err := ls.db.GetPool(pkh, false, nil)
+	if err != nil {
+		if errors.Is(err, models.ErrPoolNotFound) {
+			return [32]byte{}, false, nil
+		}
+		return [32]byte{}, false, err
+	}
+	if len(pool.Registration) == 0 {
+		return [32]byte{}, false, nil
+	}
+	var latest *models.PoolRegistration
+	var latestSlot uint64
+	for i := range pool.Registration {
+		reg := &pool.Registration[i]
+		if latest == nil || reg.AddedSlot >= latestSlot {
+			latestSlot = reg.AddedSlot
+			latest = reg
+		}
+	}
+	if latest == nil || len(latest.VrfKeyHash) != 32 {
+		return [32]byte{}, false, nil
+	}
+	copy(vrfHash[:], latest.VrfKeyHash)
+	return vrfHash, true, nil
+}
+
+// LatestOpCertSequence returns the highest operational-certificate sequence
+// number observed on chain for the given pool. Tracking is not yet
+// implemented, so found is always false; the call site is in place so that
+// when counter tracking lands the credential check picks it up automatically.
+func (ls *LedgerState) LatestOpCertSequence(
+	poolID [28]byte,
+) (sequence uint64, found bool, err error) {
+	_ = poolID
+	return 0, false, nil
+}
+
 // Datum looks up a datum by hash & adding this for implementing query.ReadData #741
 func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 	return ls.db.GetDatum(hash, nil)

--- a/node.go
+++ b/node.go
@@ -16,6 +16,7 @@ package dingo
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -26,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/blockproducer"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/mempool"
 	ouroborosPkg "github.com/blinklabs-io/dingo/ouroboros"
@@ -34,21 +36,22 @@ import (
 )
 
 type Node struct {
-	connManager    *connmanager.ConnectionManager
-	peerGov        *peergov.PeerGovernor
-	chainsyncState *chainsync.State
-	eventBus       *event.EventBus
-	mempool        *mempool.Mempool
-	chainManager   *chain.ChainManager
-	db             *database.Database
-	ledgerState    *ledger.LedgerState
-	utxorpc        *utxorpc.Utxorpc
-	ouroboros      *ouroborosPkg.Ouroboros
-	shutdownFuncs  []func(context.Context) error
-	config         Config
-	ctx            context.Context
-	cancel         context.CancelFunc
-	shutdownOnce   sync.Once
+	connManager        *connmanager.ConnectionManager
+	peerGov            *peergov.PeerGovernor
+	chainsyncState     *chainsync.State
+	eventBus           *event.EventBus
+	mempool            *mempool.Mempool
+	chainManager       *chain.ChainManager
+	db                 *database.Database
+	ledgerState        *ledger.LedgerState
+	utxorpc            *utxorpc.Utxorpc
+	ouroboros          *ouroborosPkg.Ouroboros
+	blockProducerCreds *blockproducer.Credentials
+	shutdownFuncs      []func(context.Context) error
+	config             Config
+	ctx                context.Context
+	cancel             context.CancelFunc
+	shutdownOnce       sync.Once
 }
 
 func New(cfg Config) (*Node, error) {
@@ -154,6 +157,12 @@ func (n *Node) Run(ctx context.Context) error {
 	if err := n.ledgerState.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("failed to start ledger: %w", err)
 	}
+	// Cross-check block producer credentials against ledger state once it's
+	// available. A pool that isn't yet registered on chain is acceptable; a
+	// VRF or sequence-number mismatch is fatal.
+	if err := n.validateBlockProducerLedger(); err != nil {
+		return fmt.Errorf("block producer credentials failed ledger check: %w", err)
+	}
 	// Initialize mempool
 	n.mempool = mempool.NewMempool(mempool.MempoolConfig{
 		MempoolCapacity: n.config.mempoolCapacity,
@@ -232,6 +241,57 @@ func (n *Node) Run(ctx context.Context) error {
 
 	// Wait for shutdown signal
 	<-n.ctx.Done()
+	return nil
+}
+
+// blockProducerLedgerView adapts LedgerState to the LedgerView interface
+// expected by the blockproducer credential check.
+type blockProducerLedgerView struct {
+	ls *ledger.LedgerState
+}
+
+func (v blockProducerLedgerView) PoolRegistrationVRFKeyHash(
+	poolID [28]byte,
+) ([32]byte, bool, error) {
+	return v.ls.PoolRegistrationVRFKeyHash(poolID)
+}
+
+func (v blockProducerLedgerView) LatestOpCertSequence(
+	poolID [28]byte,
+) (uint64, bool, error) {
+	return v.ls.LatestOpCertSequence(poolID)
+}
+
+func (n *Node) validateBlockProducerLedger() error {
+	if n.blockProducerCreds == nil {
+		return nil
+	}
+	view := blockProducerLedgerView{ls: n.ledgerState}
+	registered, vrfMatched, err := n.blockProducerCreds.ValidateAgainstLedger(view)
+	if err != nil {
+		return err
+	}
+	if !registered {
+		n.config.logger.Warn(
+			"block producer pool not yet registered on ledger; will continue starting",
+			"component", "node",
+			"pool_id", hex.EncodeToString(n.blockProducerCreds.PoolID[:]),
+		)
+		return nil
+	}
+	if vrfMatched {
+		n.config.logger.Info(
+			"block producer pool registration verified",
+			"component", "node",
+			"pool_id", hex.EncodeToString(n.blockProducerCreds.PoolID[:]),
+		)
+	} else {
+		n.config.logger.Warn(
+			"block producer VRF verification skipped (seed-only key)",
+			"component", "node",
+			"pool_id", hex.EncodeToString(n.blockProducerCreds.PoolID[:]),
+		)
+	}
 	return nil
 }
 


### PR DESCRIPTION
closes #1853 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate block producer credentials at startup and cross-check them against the ledger to fail fast on misconfiguration. Adds CLI/config to enable block producer mode and provide VRF/KES/opcert paths.

- **New Features**
  - Added `internal/blockproducer` to load and validate VRF skey, KES skey, and opcert at node start; rejects missing/malformed files, future/expired KES periods, and ledger VRF mismatches.
  - New flags: `--block-producer`, `--vrf-key-file`, `--kes-key-file`, `--op-cert-file`. YAML keys: `blockProducer`, `vrfKeyFilePath`, `kesKeyFilePath`, `opCertFilePath` (env var overrides supported). Example updated in `dingo.yaml.example`.
  - Logs pool ID, KES period, and opcert counter after successful load; warns if pool not yet registered or VRF check is skipped (seed-only VRF key).
  - Ledger support: added `PoolRegistrationVRFKeyHash` and a placeholder `LatestOpCertSequence` in `ledger.State` for on-chain checks.

- **Migration**
  - No action if not producing blocks.
  - To run as a block producer: enable `blockProducer` (or `--block-producer`), set `vrfKeyFilePath`, `kesKeyFilePath`, and `opCertFilePath`, and ensure the Cardano Shelley genesis is available in node config. Files must be cardano-cli TextEnvelope format.

<sup>Written for commit cc2d13fd152071df0b693318b79c68f127f6b91a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added block producer mode with `--block-producer` CLI flag
  * New CLI flags for block producer credentials: `--vrf-key-file`, `--kes-key-file`, `--op-cert-file`
  * Block producer configuration via YAML and environment variables
  * Automatic credential validation during startup

* **Tests**
  * Added configuration and credential validation test coverage

* **Documentation**
  * Updated configuration example with block producer settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->