### PR TITLE
feat: validate block producer credentials at startup (#1853)

### DIFF
--- a/ledger/forging/kes_period.go
+++ b/ledger/forging/kes_period.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// CurrentKESPeriod returns the KES period that wall-clock time `now` falls
+// in, given the chain's Shelley genesis. It is a pure function so callers
+// can drive it with synthetic genesis and timestamps in tests.
+//
+// Semantics:
+//   - Before SystemStart, period is 0 (the chain has not begun).
+//   - SlotLength is a rational number of seconds per slot; the math is
+//     done in big.Rat to avoid losing precision on chains where slot
+//     length is a fraction (e.g. 1/20s on devnets).
+//   - Returns an error if SlotsPerKESPeriod is non-positive, SlotLength
+//     is non-positive, or the computed period overflows uint64.
+func CurrentKESPeriod(genesis *shelley.ShelleyGenesis, now time.Time) (uint64, error) {
+	if genesis == nil {
+		return 0, errors.New("shelley genesis is nil")
+	}
+	if genesis.SlotsPerKESPeriod <= 0 {
+		return 0, fmt.Errorf(
+			"genesis slotsPerKESPeriod must be positive, got %d",
+			genesis.SlotsPerKESPeriod,
+		)
+	}
+	if genesis.SlotLength.Rat == nil {
+		return 0, errors.New("genesis slotLength is nil")
+	}
+	slotLengthSeconds := new(big.Rat).Set(genesis.SlotLength.Rat)
+	if slotLengthSeconds.Sign() <= 0 {
+		return 0, fmt.Errorf(
+			"genesis slotLength must be positive, got %s",
+			slotLengthSeconds.RatString(),
+		)
+	}
+	if now.Before(genesis.SystemStart) {
+		return 0, nil
+	}
+	// slot = elapsedSeconds / slotLengthSeconds, computed exactly in big.Rat.
+	// Convert through nanoseconds to keep both sides as integers.
+	elapsedNanos := now.Sub(genesis.SystemStart).Nanoseconds()
+	num := new(big.Int).Mul(
+		big.NewInt(elapsedNanos),
+		slotLengthSeconds.Denom(),
+	)
+	denom := new(big.Int).Mul(
+		slotLengthSeconds.Num(),
+		big.NewInt(1_000_000_000),
+	)
+	slot := new(big.Int).Quo(num, denom)
+	period := new(big.Int).Quo(
+		slot,
+		big.NewInt(int64(genesis.SlotsPerKESPeriod)),
+	)
+	if !period.IsUint64() {
+		return 0, fmt.Errorf(
+			"computed KES period %s overflows uint64",
+			period.String(),
+		)
+	}
+	return period.Uint64(), nil
+}

--- a/ledger/forging/kes_period_test.go
+++ b/ledger/forging/kes_period_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+func synthGenesis(slotsPerKES, maxKES int, slotLen time.Duration, systemStart time.Time) *shelley.ShelleyGenesis {
+	rat := big.NewRat(int64(slotLen), int64(time.Second))
+	return &shelley.ShelleyGenesis{
+		SystemStart:       systemStart,
+		SlotsPerKESPeriod: slotsPerKES,
+		MaxKESEvolutions:  maxKES,
+		SlotLength:        common.GenesisRat{Rat: rat},
+	}
+}
+
+func TestCurrentKESPeriod_BeforeSystemStart(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	got, err := CurrentKESPeriod(g, systemStart.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("CurrentKESPeriod: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got %d, want 0 (before SystemStart)", got)
+	}
+}
+
+func TestCurrentKESPeriod_HappyPath(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	// 250 slots elapsed at 1s/slot, 100 slots per period → period 2.
+	got, err := CurrentKESPeriod(g, systemStart.Add(250*time.Second))
+	if err != nil {
+		t.Fatalf("CurrentKESPeriod: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("got %d, want 2", got)
+	}
+}
+
+func TestCurrentKESPeriod_FractionalSlotLength(t *testing.T) {
+	// Devnet style: 50ms slots, 200 slots per period.
+	// At 50_000ms elapsed → 1000 slots → period 5.
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := &shelley.ShelleyGenesis{
+		SystemStart:       systemStart,
+		SlotsPerKESPeriod: 200,
+		SlotLength:        common.GenesisRat{Rat: big.NewRat(1, 20)},
+	}
+	got, err := CurrentKESPeriod(g, systemStart.Add(50*time.Second))
+	if err != nil {
+		t.Fatalf("CurrentKESPeriod: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("got %d, want 5", got)
+	}
+}
+
+func TestCurrentKESPeriod_PeriodBoundaryExclusive(t *testing.T) {
+	// At exactly 100 slots elapsed (the start of period 1) we should be in
+	// period 1, not 0 or 2.
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	got, err := CurrentKESPeriod(g, systemStart.Add(100*time.Second))
+	if err != nil {
+		t.Fatalf("CurrentKESPeriod: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("got %d, want 1 (exact boundary)", got)
+	}
+}
+
+func TestCurrentKESPeriod_NilGenesis(t *testing.T) {
+	_, err := CurrentKESPeriod(nil, time.Now())
+	if err == nil {
+		t.Fatal("expected error for nil genesis")
+	}
+}
+
+func TestCurrentKESPeriod_ZeroSlotsPerKES(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(0, 5, time.Second, systemStart)
+	_, err := CurrentKESPeriod(g, systemStart)
+	if err == nil {
+		t.Fatal("expected error for zero SlotsPerKESPeriod")
+	}
+	if !strings.Contains(err.Error(), "slotsPerKESPeriod") {
+		t.Errorf("error should mention slotsPerKESPeriod, got: %v", err)
+	}
+}
+
+func TestCurrentKESPeriod_ZeroSlotLength(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := &shelley.ShelleyGenesis{
+		SystemStart:       systemStart,
+		SlotsPerKESPeriod: 100,
+		SlotLength:        common.GenesisRat{Rat: big.NewRat(0, 1)},
+	}
+	_, err := CurrentKESPeriod(g, systemStart.Add(time.Hour))
+	if err == nil {
+		t.Fatal("expected error for zero SlotLength")
+	}
+	if !strings.Contains(err.Error(), "slotLength") {
+		t.Errorf("error should mention slotLength, got: %v", err)
+	}
+}
+
+func TestCurrentKESPeriod_NilSlotLengthRat(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := &shelley.ShelleyGenesis{
+		SystemStart:       systemStart,
+		SlotsPerKESPeriod: 100,
+		SlotLength:        common.GenesisRat{Rat: nil},
+	}
+	_, err := CurrentKESPeriod(g, systemStart.Add(time.Hour))
+	if err == nil {
+		t.Fatal("expected error for nil SlotLength.Rat")
+	}
+}
+

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -22,10 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/gouroboros/kes"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/gouroboros/vrf"
 )
 
@@ -391,4 +393,122 @@ func (pc *PoolCredentials) PeriodsRemaining(currentPeriod uint64) uint64 {
 		return 0
 	}
 	return expiryPeriod - currentPeriod
+}
+
+// ValidateKESPeriod checks that the loaded operational certificate's KES
+// period is plausible at wall-clock time `now`, given the chain's Shelley
+// genesis. A non-nil result means the node should refuse to start: either
+// the opcert claims a period that hasn't started yet (rotated key staged
+// too early, or wrong network) or the opcert has expired and needs to be
+// rotated.
+//
+// The protocol-level expiry uses MaxKESEvolutions from genesis rather
+// than the raw 2^depth ceiling, so this matches the chain's view of when
+// an opcert stops being valid.
+func (pc *PoolCredentials) ValidateKESPeriod(
+	genesis *shelley.ShelleyGenesis,
+	now time.Time,
+) error {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+
+	if pc.opCert == nil {
+		return errors.New("operational certificate not loaded")
+	}
+	if genesis == nil {
+		return errors.New("shelley genesis is required")
+	}
+	current, err := CurrentKESPeriod(genesis, now)
+	if err != nil {
+		return err
+	}
+	if pc.opCert.KESPeriod > current {
+		return fmt.Errorf(
+			"opcert KES period %d is in the future (current %d)",
+			pc.opCert.KESPeriod, current,
+		)
+	}
+	maxEvolutions := uint64(genesis.MaxKESEvolutions) // #nosec G115
+	if maxEvolutions > 0 &&
+		current >= pc.opCert.KESPeriod+maxEvolutions {
+		return fmt.Errorf(
+			"opcert KES period %d has expired (current %d, max evolutions %d); rotate the operational certificate",
+			pc.opCert.KESPeriod, current, maxEvolutions,
+		)
+	}
+	return nil
+}
+
+// LedgerView is the subset of ledger state the post-startup credential
+// cross-check needs. The forging package depends on it as a small
+// interface so the package itself stays free of a ledger dependency, and
+// tests can drive the logic with a fake.
+type LedgerView interface {
+	// PoolRegistrationVRFKeyHash returns the VRF key hash recorded on
+	// the most recent active pool registration certificate for poolID.
+	// found is false when the pool has no on-chain registration yet.
+	PoolRegistrationVRFKeyHash(poolID [28]byte) (vrfKeyHash [32]byte, found bool, err error)
+	// LatestOpCertSequence returns the highest opcert IssueNumber
+	// observed on chain for poolID. found is false when on-chain
+	// counter tracking is not implemented or this pool has never
+	// minted a block.
+	LatestOpCertSequence(poolID [28]byte) (sequence uint64, found bool, err error)
+}
+
+// ValidateAgainstLedger cross-checks the loaded credentials against
+// ledger state once it is available. It is best-effort: a missing pool
+// registration is not fatal because operators commonly stage their keys
+// before submitting the registration certificate.
+//
+// Three return values describe the outcome:
+//   - registered: true if the pool registration was found on chain.
+//   - vrfMatched: true if registered AND the on-chain VRF key hash
+//     matched our loaded VRF verification key. False otherwise (also
+//     false when registered is false or the VRF verification key is
+//     unavailable, e.g. for a seed-only VRF skey).
+//   - err: a non-nil error means the node should refuse to start. Used
+//     for VRF mismatch and stale opcert counter.
+func (pc *PoolCredentials) ValidateAgainstLedger(
+	view LedgerView,
+) (registered, vrfMatched bool, err error) {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+
+	if view == nil {
+		return false, false, errors.New("ledger view is nil")
+	}
+	if pc.opCert == nil {
+		return false, false, errors.New("operational certificate not loaded")
+	}
+	var poolID [28]byte
+	copy(poolID[:], pc.poolID[:])
+
+	regVRF, found, err := view.PoolRegistrationVRFKeyHash(poolID)
+	if err != nil {
+		return false, false, fmt.Errorf("pool registration lookup: %w", err)
+	}
+	if !found {
+		return false, false, nil
+	}
+	if pc.vrfVKey != nil {
+		ourVRF := lcommon.Blake2b256Hash(pc.vrfVKey)
+		if ourVRF != regVRF {
+			return true, false, fmt.Errorf(
+				"VRF key hash mismatch: pool registration has %x but loaded VRF key hashes to %x",
+				regVRF, ourVRF,
+			)
+		}
+		vrfMatched = true
+	}
+	latestSeq, seqFound, err := view.LatestOpCertSequence(poolID)
+	if err != nil {
+		return true, vrfMatched, fmt.Errorf("opcert sequence lookup: %w", err)
+	}
+	if seqFound && pc.opCert.IssueNumber < latestSeq {
+		return true, vrfMatched, fmt.Errorf(
+			"opcert sequence %d is stale: ledger has observed %d for this pool",
+			pc.opCert.IssueNumber, latestSeq,
+		)
+	}
+	return true, vrfMatched, nil
 }

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -21,10 +21,13 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/kes"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -563,4 +566,299 @@ func TestUpdateKESPeriodBeforeOpCertStart(t *testing.T) {
 	err := pc.UpdateKESPeriod(700)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "before opcert start period")
+}
+
+func TestValidateKESPeriod_HappyPath(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
+	// 250 slots elapsed → KES period 2; opcert period 1 is within
+	// [2, 1+5).
+	now := systemStart.Add(250 * time.Second)
+	if err := pc.ValidateKESPeriod(g, now); err != nil {
+		t.Errorf("ValidateKESPeriod: %v", err)
+	}
+}
+
+func TestValidateKESPeriod_AtStart(t *testing.T) {
+	// Edge case: opcert KESPeriod equals current period (just rotated
+	// into use). Should pass.
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 2}}
+	now := systemStart.Add(250 * time.Second)
+	if err := pc.ValidateKESPeriod(g, now); err != nil {
+		t.Errorf("ValidateKESPeriod: %v", err)
+	}
+}
+
+func TestValidateKESPeriod_InFuture(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 10}}
+	// 50 slots elapsed → current period 0; opcert period 10 is in the
+	// future.
+	now := systemStart.Add(50 * time.Second)
+	err := pc.ValidateKESPeriod(g, now)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "future") {
+		t.Errorf("expected 'future' in error, got: %v", err)
+	}
+}
+
+func TestValidateKESPeriod_Expired(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 3, time.Second, systemStart)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
+	// Period 1 + max evolutions 3 = expires once current >= 4. At slot
+	// 500 → current period 5, which is past expiry.
+	now := systemStart.Add(500 * time.Second)
+	err := pc.ValidateKESPeriod(g, now)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' in error, got: %v", err)
+	}
+}
+
+func TestValidateKESPeriod_ExpiryBoundaryExclusive(t *testing.T) {
+	// current == start + maxEvolutions counts as expired (the half-open
+	// interval [start, start+max)).
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 3, time.Second, systemStart)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
+	// 400 slots → current period 4. start (1) + max (3) = 4 → expired.
+	now := systemStart.Add(400 * time.Second)
+	err := pc.ValidateKESPeriod(g, now)
+	if err == nil {
+		t.Fatal("expected expired error at exact boundary")
+	}
+}
+
+func TestValidateKESPeriod_BeforeSystemStart(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 0}}
+	if err := pc.ValidateKESPeriod(g, systemStart.Add(-time.Hour)); err != nil {
+		t.Errorf("ValidateKESPeriod: %v", err)
+	}
+}
+
+func TestValidateKESPeriod_NoOpCert(t *testing.T) {
+	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := synthGenesis(100, 5, time.Second, systemStart)
+	pc := &PoolCredentials{}
+	err := pc.ValidateKESPeriod(g, systemStart)
+	if err == nil {
+		t.Fatal("expected error when opcert not loaded")
+	}
+}
+
+func TestValidateKESPeriod_NilGenesis(t *testing.T) {
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 0}}
+	err := pc.ValidateKESPeriod(nil, time.Now())
+	if err == nil {
+		t.Fatal("expected error for nil genesis")
+	}
+}
+
+// fakeLedgerView is a test stub for the LedgerView interface.
+type fakeLedgerView struct {
+	registered bool
+	regVRFHash [32]byte
+	regErr     error
+	seqFound   bool
+	latestSeq  uint64
+	seqErr     error
+	gotPoolID  [28]byte
+	calledPool bool
+	calledSeq  bool
+}
+
+func (f *fakeLedgerView) PoolRegistrationVRFKeyHash(p [28]byte) ([32]byte, bool, error) {
+	f.calledPool = true
+	f.gotPoolID = p
+	return f.regVRFHash, f.registered, f.regErr
+}
+
+func (f *fakeLedgerView) LatestOpCertSequence(p [28]byte) (uint64, bool, error) {
+	f.calledSeq = true
+	return f.latestSeq, f.seqFound, f.seqErr
+}
+
+func newCredsForLedger(t *testing.T) *PoolCredentials {
+	t.Helper()
+	pc := &PoolCredentials{
+		vrfVKey: bytes32(0xAA),
+		opCert:  &OpCert{IssueNumber: 0},
+	}
+	pc.poolID = lcommon.PoolId(lcommon.Blake2b224Hash([]byte("test-cold-vkey")))
+	return pc
+}
+
+func TestValidateAgainstLedger_PoolNotRegistered(t *testing.T) {
+	pc := newCredsForLedger(t)
+	view := &fakeLedgerView{registered: false}
+	registered, matched, err := pc.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("ValidateAgainstLedger: %v", err)
+	}
+	if registered || matched {
+		t.Errorf("expected registered=false, matched=false; got %v %v", registered, matched)
+	}
+	if !view.calledPool {
+		t.Error("expected PoolRegistrationVRFKeyHash to be called")
+	}
+	if view.calledSeq {
+		t.Error("opcert sequence lookup should be skipped when pool not registered")
+	}
+	var poolBytes [28]byte
+	copy(poolBytes[:], pc.poolID[:])
+	if view.gotPoolID != poolBytes {
+		t.Errorf("LedgerView received wrong pool id %x, want %x", view.gotPoolID, poolBytes)
+	}
+}
+
+func TestValidateAgainstLedger_VRFMatch(t *testing.T) {
+	pc := newCredsForLedger(t)
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
+	}
+	registered, matched, err := pc.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Fatalf("ValidateAgainstLedger: %v", err)
+	}
+	if !registered || !matched {
+		t.Errorf("expected registered=true, matched=true; got %v %v", registered, matched)
+	}
+}
+
+func TestValidateAgainstLedger_VRFMismatch(t *testing.T) {
+	pc := newCredsForLedger(t)
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(bytes32(0xDD)),
+	}
+	_, _, err := pc.ValidateAgainstLedger(view)
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	if !strings.Contains(err.Error(), "VRF key hash mismatch") {
+		t.Errorf("expected mismatch in error, got: %v", err)
+	}
+}
+
+func TestValidateAgainstLedger_SeedOnlySkipsCheck(t *testing.T) {
+	// seed-only VRF skey leaves vrfVKey nil — we cannot derive the hash
+	// to compare, so the VRF check must be skipped without erroring.
+	pc := newCredsForLedger(t)
+	pc.vrfVKey = nil
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash([]byte("anything")),
+	}
+	registered, matched, err := pc.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("ValidateAgainstLedger: %v", err)
+	}
+	if !registered {
+		t.Error("expected registered=true")
+	}
+	if matched {
+		t.Error("expected matched=false (no VRF pubkey)")
+	}
+}
+
+func TestValidateAgainstLedger_StaleOpCert(t *testing.T) {
+	pc := newCredsForLedger(t)
+	pc.opCert.IssueNumber = 3
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
+		seqFound:   true,
+		latestSeq:  5,
+	}
+	_, _, err := pc.ValidateAgainstLedger(view)
+	if err == nil {
+		t.Fatal("expected stale-counter error")
+	}
+	if !strings.Contains(err.Error(), "stale") {
+		t.Errorf("expected stale in error, got: %v", err)
+	}
+}
+
+func TestValidateAgainstLedger_OpCertEqualOrAhead(t *testing.T) {
+	// Equal counter is fine; ahead-of-ledger is fine (the ledger may
+	// just not have observed our latest opcert yet).
+	cases := []struct {
+		name       string
+		ourSeq     uint64
+		ledgerSeq  uint64
+	}{
+		{"equal", 5, 5},
+		{"ahead", 6, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := newCredsForLedger(t)
+			pc.opCert.IssueNumber = tc.ourSeq
+			view := &fakeLedgerView{
+				registered: true,
+				regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
+				seqFound:   true,
+				latestSeq:  tc.ledgerSeq,
+			}
+			if _, _, err := pc.ValidateAgainstLedger(view); err != nil {
+				t.Errorf("ValidateAgainstLedger: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAgainstLedger_CounterTrackingNotImplemented(t *testing.T) {
+	// LedgerView returning seqFound=false from LatestOpCertSequence
+	// represents the current state where on-chain opcert tracking is
+	// not yet wired up. Must not block startup.
+	pc := newCredsForLedger(t)
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
+		seqFound:   false,
+	}
+	registered, matched, err := pc.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("ValidateAgainstLedger: %v", err)
+	}
+	if !registered || !matched {
+		t.Errorf("expected registered=true, matched=true; got %v %v", registered, matched)
+	}
+}
+
+func TestValidateAgainstLedger_NilView(t *testing.T) {
+	pc := newCredsForLedger(t)
+	_, _, err := pc.ValidateAgainstLedger(nil)
+	if err == nil {
+		t.Fatal("expected nil-view error")
+	}
+}
+
+func TestValidateAgainstLedger_NoOpCert(t *testing.T) {
+	pc := &PoolCredentials{vrfVKey: bytes32(0xAA)}
+	view := &fakeLedgerView{}
+	_, _, err := pc.ValidateAgainstLedger(view)
+	if err == nil {
+		t.Fatal("expected error when opcert not loaded")
+	}
+}
+
+func bytes32(seed byte) []byte {
+	b := make([]byte, 32)
+	for i := range b {
+		b[i] = seed + byte(i)
+	}
+	return b
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -939,6 +939,46 @@ func (ls *LedgerState) Chain() *chain.Chain {
 	return ls.chain
 }
 
+// PoolRegistrationVRFKeyHash returns the VRF key hash recorded on the
+// most recent active pool registration certificate for the given pool.
+// found is false when the pool has no on-chain registration yet — that
+// is informational, not an error condition, since operators commonly
+// stage credentials before the registration certificate is on chain.
+//
+// Used by the block-producer credential check at startup to confirm the
+// loaded VRF key matches what the chain has on file.
+func (ls *LedgerState) PoolRegistrationVRFKeyHash(
+	poolID [28]byte,
+) (vrfHash [32]byte, found bool, err error) {
+	pkh := lcommon.PoolKeyHash(lcommon.NewBlake2b224(poolID[:]))
+	pool, err := ls.db.GetPool(pkh, false, nil)
+	if err != nil {
+		if errors.Is(err, models.ErrPoolNotFound) {
+			return [32]byte{}, false, nil
+		}
+		return [32]byte{}, false, err
+	}
+	if pool == nil || len(pool.VrfKeyHash) != 32 {
+		return [32]byte{}, false, nil
+	}
+	copy(vrfHash[:], pool.VrfKeyHash)
+	return vrfHash, true, nil
+}
+
+// LatestOpCertSequence returns the highest operational-certificate
+// IssueNumber observed on chain for the given pool. found is always
+// false today: the chain stores opcerts in block headers but Dingo does
+// not yet aggregate the highest sequence per pool. This method exists
+// so the credential cross-check at startup can call into it; once
+// counter tracking lands the implementation will fill in without any
+// caller change.
+func (ls *LedgerState) LatestOpCertSequence(
+	poolID [28]byte,
+) (sequence uint64, found bool, err error) {
+	_ = poolID
+	return 0, false, nil
+}
+
 // Datum looks up a datum by hash & adding this for implementing query.ReadData #741
 func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 	return ls.db.GetDatum(hash, nil)

--- a/node.go
+++ b/node.go
@@ -854,6 +854,13 @@ func (n *Node) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("block producer startup validation failed: %w", err)
 		}
+		// Cross-check loaded credentials against ledger state. Mismatch
+		// against on-chain pool registration is fatal; "not yet
+		// registered" is a warning so operators can stage credentials
+		// before submitting the registration cert.
+		if err := n.validateBlockProducerLedger(creds); err != nil {
+			return fmt.Errorf("block producer credentials failed ledger check: %w", err)
+		}
 		//nolint:contextcheck // n.ctx is the node's lifecycle context, correct parent for forger
 		if err := n.initBlockForger(n.ctx, creds); err != nil {
 			return fmt.Errorf("failed to initialize block forger: %w", err)

--- a/node_forging.go
+++ b/node_forging.go
@@ -44,12 +44,97 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 	if err := creds.ValidateOpCert(); err != nil {
 		return nil, fmt.Errorf("validate operational certificate: %w", err)
 	}
+	// KES-period plausibility requires a Shelley genesis. Block producer
+	// mode without one is unsafe — a node with no genesis cannot tell
+	// whether the opcert is current — so refuse to start.
+	if n.config.cardanoNodeConfig == nil {
+		return nil, errors.New(
+			"block producer mode requires Cardano node config with Shelley genesis",
+		)
+	}
+	genesis := n.config.cardanoNodeConfig.ShelleyGenesis()
+	if genesis == nil {
+		return nil, errors.New(
+			"block producer mode requires Shelley genesis information",
+		)
+	}
+	if err := creds.ValidateKESPeriod(genesis, time.Now()); err != nil {
+		return nil, fmt.Errorf("validate KES period: %w", err)
+	}
+	currentPeriod, err := forging.CurrentKESPeriod(genesis, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("compute current KES period: %w", err)
+	}
+	opCert := creds.GetOpCert()
 	n.config.logger.Info(
 		"block producer credentials validated",
+		"component", "node",
 		"pool_id", creds.GetPoolID().String(),
+		"current_kes_period", currentPeriod,
+		"opcert_kes_period", opCert.KESPeriod,
+		"opcert_counter", opCert.IssueNumber,
 		"opcert_expiry_period", creds.OpCertExpiryPeriod(),
 	)
 	return creds, nil
+}
+
+// blockProducerLedgerView adapts ledger.LedgerState to
+// forging.LedgerView. The interface lives in the forging package so the
+// credential check can stay free of a ledger import; the concrete
+// adapter belongs here in package dingo where both types are visible.
+type blockProducerLedgerView struct {
+	ls *ledger.LedgerState
+}
+
+func (v blockProducerLedgerView) PoolRegistrationVRFKeyHash(
+	poolID [28]byte,
+) ([32]byte, bool, error) {
+	return v.ls.PoolRegistrationVRFKeyHash(poolID)
+}
+
+func (v blockProducerLedgerView) LatestOpCertSequence(
+	poolID [28]byte,
+) (uint64, bool, error) {
+	return v.ls.LatestOpCertSequence(poolID)
+}
+
+// validateBlockProducerLedger runs the ledger-aware cross-check against
+// the loaded credentials. Must be called after the ledger has started so
+// pool registrations can be queried. A pool that is not yet registered
+// is logged as a warning and the node is allowed to continue.
+func (n *Node) validateBlockProducerLedger(
+	creds *forging.PoolCredentials,
+) error {
+	if creds == nil {
+		return errors.New("nil pool credentials")
+	}
+	view := blockProducerLedgerView{ls: n.ledgerState}
+	registered, vrfMatched, err := creds.ValidateAgainstLedger(view)
+	if err != nil {
+		return err
+	}
+	poolID := creds.GetPoolID().String()
+	switch {
+	case !registered:
+		n.config.logger.Warn(
+			"block producer pool not yet registered on chain; node will continue",
+			"component", "node",
+			"pool_id", poolID,
+		)
+	case vrfMatched:
+		n.config.logger.Info(
+			"block producer pool registration verified on chain",
+			"component", "node",
+			"pool_id", poolID,
+		)
+	default:
+		n.config.logger.Warn(
+			"block producer VRF cross-check skipped (seed-only VRF key)",
+			"component", "node",
+			"pool_id", poolID,
+		)
+	}
+	return nil
 }
 
 // initBlockForger initializes the block forger for production mode.

--- a/node_forging.go
+++ b/node_forging.go
@@ -58,10 +58,11 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 			"block producer mode requires Shelley genesis information",
 		)
 	}
-	if err := creds.ValidateKESPeriod(genesis, time.Now()); err != nil {
+	now := time.Now()
+	if err := creds.ValidateKESPeriod(genesis, now); err != nil {
 		return nil, fmt.Errorf("validate KES period: %w", err)
 	}
-	currentPeriod, err := forging.CurrentKESPeriod(genesis, time.Now())
+	currentPeriod, err := forging.CurrentKESPeriod(genesis, now)
 	if err != nil {
 		return nil, fmt.Errorf("compute current KES period: %w", err)
 	}

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -98,22 +98,13 @@ func TestValidateBlockProducerStartup_NoCardanoConfig(t *testing.T) {
 	}
 }
 
-func TestValidateBlockProducerStartup_FutureKESPeriod(t *testing.T) {
-	// SystemStart in the far future means the wall-clock-derived current
-	// KES period is 0, so the devnet opcert (KESPeriod=0) should still
-	// be fine — but if we artificially mark the opcert period as 5,
-	// validation should reject it as in the future.
-	//
-	// We can't directly mutate the opcert returned by LoadFromFiles
-	// from outside the forging package, so instead we use a SystemStart
-	// that puts current=0 and rely on a different scenario: we use the
-	// expired path by setting maxKESEvolutions=0 and pushing SystemStart
-	// far enough in the past that current >> opcert period.
+func TestValidateBlockProducerStartup_ExpiredKESPeriod(t *testing.T) {
+	// systemStart a year in the past with slotsPerKESPeriod=10 means
+	// many KES periods have elapsed; maxKESEvolutions=1 makes anything
+	// past period 1 expired, so the devnet opcert (KESPeriod=0) is well
+	// outside its validity window and validation must reject it.
 	vrf, kes, opcert := devnetCredPaths()
 	cfg := &cardano.CardanoNodeConfig{}
-	// systemStart far in the past, slotsPerKESPeriod=10, so after years
-	// many KES periods have elapsed; maxKESEvolutions=1 makes anything
-	// past period 1 expired. devnet opcert KESPeriod=0 → expired.
 	systemStart := time.Now().Add(-365 * 24 * time.Hour)
 	if err := cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
 		"systemStart": "` + systemStart.UTC().Format(time.RFC3339Nano) + `",

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+)
+
+// devnetKeysDir locates the credential fixtures shipped with the repo.
+// Path is relative to this file (top-level dingo package).
+const devnetKeysDir = "config/cardano/devnet/keys"
+
+func devnetCredPaths() (vrf, kes, opcert string) {
+	return filepath.Join(devnetKeysDir, "vrf.skey"),
+		filepath.Join(devnetKeysDir, "kes.skey"),
+		filepath.Join(devnetKeysDir, "opcert.cert")
+}
+
+// shelleyGenesisCfgForBP returns a CardanoNodeConfig with a Shelley
+// genesis that is plausible for the devnet opcert (KESPeriod=0,
+// IssueNumber=0). systemStart slightly in the past, slotsPerKESPeriod
+// generous so the opcert is current rather than expired.
+func shelleyGenesisCfgForBP(t *testing.T, systemStart time.Time) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{}
+	if err := cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"systemStart": "` + systemStart.UTC().Format(time.RFC3339Nano) + `",
+		"securityParam": 10,
+		"activeSlotsCoeff": 0.5,
+		"slotsPerKESPeriod": 129600,
+		"maxKESEvolutions": 62,
+		"slotLength": 1
+	}`)); err != nil {
+		t.Fatalf("LoadShelleyGenesisFromReader: %v", err)
+	}
+	return cfg
+}
+
+func newTestNodeForBP(
+	t *testing.T,
+	enabled bool,
+	vrf, kes, opcert string,
+	cardanoCfg *cardano.CardanoNodeConfig,
+) *Node {
+	t.Helper()
+	cfg := Config{
+		logger:                        slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		blockProducer:                 enabled,
+		shelleyVRFKey:                 vrf,
+		shelleyKESKey:                 kes,
+		shelleyOperationalCertificate: opcert,
+		cardanoNodeConfig:             cardanoCfg,
+	}
+	return &Node{config: cfg}
+}
+
+func TestValidateBlockProducerStartup_HappyPath(t *testing.T) {
+	vrf, kes, opcert := devnetCredPaths()
+	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
+	creds, err := n.validateBlockProducerStartup()
+	if err != nil {
+		t.Fatalf("validateBlockProducerStartup: %v", err)
+	}
+	if !creds.IsLoaded() {
+		t.Error("expected credentials to be loaded")
+	}
+}
+
+func TestValidateBlockProducerStartup_NoCardanoConfig(t *testing.T) {
+	vrf, kes, opcert := devnetCredPaths()
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, nil)
+	_, err := n.validateBlockProducerStartup()
+	if err == nil {
+		t.Fatal("expected error for missing cardano node config")
+	}
+	if !strings.Contains(err.Error(), "Cardano node config") {
+		t.Errorf("expected 'Cardano node config' in error, got: %v", err)
+	}
+}
+
+func TestValidateBlockProducerStartup_FutureKESPeriod(t *testing.T) {
+	// SystemStart in the far future means the wall-clock-derived current
+	// KES period is 0, so the devnet opcert (KESPeriod=0) should still
+	// be fine — but if we artificially mark the opcert period as 5,
+	// validation should reject it as in the future.
+	//
+	// We can't directly mutate the opcert returned by LoadFromFiles
+	// from outside the forging package, so instead we use a SystemStart
+	// that puts current=0 and rely on a different scenario: we use the
+	// expired path by setting maxKESEvolutions=0 and pushing SystemStart
+	// far enough in the past that current >> opcert period.
+	vrf, kes, opcert := devnetCredPaths()
+	cfg := &cardano.CardanoNodeConfig{}
+	// systemStart far in the past, slotsPerKESPeriod=10, so after years
+	// many KES periods have elapsed; maxKESEvolutions=1 makes anything
+	// past period 1 expired. devnet opcert KESPeriod=0 → expired.
+	systemStart := time.Now().Add(-365 * 24 * time.Hour)
+	if err := cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"systemStart": "` + systemStart.UTC().Format(time.RFC3339Nano) + `",
+		"securityParam": 10,
+		"activeSlotsCoeff": 0.5,
+		"slotsPerKESPeriod": 10,
+		"maxKESEvolutions": 1,
+		"slotLength": 1
+	}`)); err != nil {
+		t.Fatalf("LoadShelleyGenesisFromReader: %v", err)
+	}
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, cfg)
+	_, err := n.validateBlockProducerStartup()
+	if err == nil {
+		t.Fatal("expected error for expired opcert KES period")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' in error, got: %v", err)
+	}
+}
+
+func TestValidateBlockProducerStartup_MissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
+	n := newTestNodeForBP(
+		t, true,
+		filepath.Join(tmp, "missing-vrf.skey"),
+		filepath.Join(tmp, "missing-kes.skey"),
+		filepath.Join(tmp, "missing-opcert.cert"),
+		cardanoCfg,
+	)
+	_, err := n.validateBlockProducerStartup()
+	if err == nil {
+		t.Fatal("expected error for missing credential files")
+	}
+	if !strings.Contains(err.Error(), "load pool credentials") {
+		t.Errorf("expected 'load pool credentials' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
closes #1853 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds startup validation for block producer credentials to catch misconfigured, future, or expired keys early. The node checks KES period using Shelley genesis and cross-checks credentials with the ledger, failing fast on unsafe setups.

- **New Features**
  - Validate opcert KES period at startup using Shelley genesis (supports fractional slot lengths); future or expired periods stop the node.
  - Require Cardano node config with Shelley genesis in block producer mode.
  - Cross-check loaded VRF key hash with on-chain pool registration; mismatch is fatal, unregistered logs a warning and continues; seed-only VRF keys skip the VRF check.
  - Check opcert IssueNumber against the ledger’s latest when available; stale counters are fatal. Added minimal ledger queries and an adapter to wire this in.

<sup>Written for commit 759b136722dcf28ea2aef6bf75688222790316a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

