### PR TITLE
fix(ledger): restart pipeline on stale chain iterator after rollback

### DIFF
--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -36,6 +36,14 @@ var errHaltLedgerPipeline = errors.New(
 	"halt ledger pipeline after persistent tx validation failure",
 )
 
+// errStaleChainIterator is returned by ledgerProcessBlock when a block's
+// prev-hash doesn't match the current ledger tip. This signals that the
+// chain iterator has been made stale by a concurrent rollback: the iterator's
+// nextBlockIndex skipped ahead past the first new fork block and is now
+// returning a block that extends a branch we are no longer on. The ledger
+// pipeline must restart so its iterator rewinds to the current tip.
+var errStaleChainIterator = errors.New("block does not fit chain tip: stale iterator after rollback")
+
 type txValidationError struct {
 	BlockPoint ocommon.Point
 	TxHash     []byte

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3154,6 +3154,22 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					completeReadResult()
 					return errRestartLedgerPipeline
 				}
+				// A stale chain iterator delivers a fork block whose prev-hash
+				// doesn't match our current tip. This happens when a concurrent
+				// rollback moved the chain behind the iterator's position: the
+				// iterator skips the first fork block and reads one that extends
+				// a branch we are no longer on. Restarting the pipeline creates
+				// a fresh iterator from the (already rolled-back) currentTip,
+				// which will walk all fork blocks in order.
+				if errors.Is(err, errStaleChainIterator) {
+					ls.config.Logger.Debug(
+						"stale chain iterator detected, restarting pipeline to resync",
+						"component", "ledger",
+						"error", err,
+					)
+					completeReadResult()
+					return errRestartLedgerPipeline
+				}
 				completeReadResult()
 				return fmt.Errorf("process block batch: %w", err)
 			}
@@ -3251,7 +3267,8 @@ func (ls *LedgerState) ledgerProcessBlock(
 			expectedPrevHash,
 		) {
 			return nil, fmt.Errorf(
-				"block %s (with prev hash %s) does not fit on current chain tip (%x)",
+				"%w: block %s (with prev hash %s) does not fit on current chain tip (%x)",
+				errStaleChainIterator,
 				block.Hash().String(),
 				block.PrevHash().String(),
 				expectedPrevHash,


### PR DESCRIPTION
## Root Cause

When the chain rolls back and re-extends with fork blocks, the ledger pipeline's chain iterator is left at its old `nextBlockIndex` position. It skips all intermediate fork blocks and jumps to a block extending a branch the ledger is no longer on, causing:

```
block processing failed, restarting pipeline: process block batch: block X (with prev hash Y) does not fit on current chain tip (Z)
```

The pipeline restart creates a new iterator from `ls.currentTip` — but `nextBlockIndex` resets to `currentTip.ID + 1`, which now points to the **second** fork block (since the first fork block reused the position of the rolled-back block). The second fork block extends the first (not the ledger tip), so the same error fires immediately. This loops thousands of times per second, growing the tip gap without bound until manual restart.

**Concrete scenario:**
1. Ledger tip: block N (hash Z), chain advanced to N+5
2. Chain rolls back to N, re-extends with fork blocks N+1', N+2', ..., N+5', N+6'
3. Fork block N+1' reuses ID=N+1 in the blob store
4. Iterator is stuck at `nextBlockIndex=N+2` — returns fork block N+2' (extends N+1', not Z)
5. "Block doesn't fit" → pipeline restart → iterator resets to N+2 again → infinite loop

## Fix

Introduce `errStaleChainIterator` and wrap the prev-hash mismatch error with it in `ledgerProcessBlock`. In `ledgerProcessBlocksFromSource`, detect this sentinel and return `errRestartLedgerPipeline`.

The pipeline restart calls `ledgerReadChain` which snapshots `ls.currentTip` (already rolled back by the chainsync handler before any fork blocks are added) and creates a fresh iterator starting at `currentTip.ID + 1` = N+1. The iterator then walks N+1', N+2', ... in order — each extends the previous — and the ledger processes all fork blocks correctly.

## Testing

All existing ledger tests pass. The GCS integration test failure (`TestStorageBackends/GCS`) is pre-existing infrastructure (requires a real GCS bucket) and unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite restart loop in the ledger pipeline after rollbacks by detecting a stale chain iterator and restarting cleanly from the rolled-back tip. Prevents unbounded tip gaps and ensures fork blocks are processed in order.

- **Bug Fixes**
  - Added `errStaleChainIterator` and wrap prev-hash mismatch in `ledgerProcessBlock`.
  - In `ledgerProcessBlocksFromSource`, detect the sentinel and return `errRestartLedgerPipeline` to rebuild the iterator from `currentTip`.
  - Added a debug log when a stale iterator is detected to aid diagnosis.

<sup>Written for commit 2bf20183a7b4cd1136cc254a79410729eec6d404. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger pipeline reliability by enhancing error detection and recovery during block processing. The system now automatically restarts the pipeline in scenarios where concurrent operations cause synchronization issues, preventing transaction processing failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->