### PR TITLE
fix(dashboard): add wall-clock reference line to epoch slot progress panel

### DIFF
--- a/docs/dashboards/node-overview.json
+++ b/docs/dashboards/node-overview.json
@@ -1414,6 +1414,32 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9900",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [10, 10]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
           }
         ]
       },
@@ -1437,10 +1463,20 @@
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "floor((time() - max(dingo_shelley_start_time{network=\"$network\"})) % max(dingo_epoch_length_slots{network=\"$network\"}))",
+          "legendFormat": "Reference (wall clock)",
+          "range": true,
+          "refId": "B"
         }
       ],
       "transparent": true,
-      "description": "Progress through the current epoch expressed as slot number."
+      "description": "Progress through the current epoch expressed as slot number. The orange dashed line shows the expected slot based on wall-clock time — if node slots fall below the reference, the node is stalling."
     },
     {
       "type": "stat",


### PR DESCRIPTION
## Summary

Adds a second series to the **Slot In Epoch** timeseries panel showing where the node *should* be based on wall-clock time.

**Formula:**
```promql
floor((time() - max(dingo_shelley_start_time{network="$network"})) % max(dingo_epoch_length_slots{network="$network"}))
```

Both metrics are already exported by dingo (`ledger/metrics.go`). Using `max()` (not `scalar(max())`) keeps the result as a vector so `floor()` is valid PromQL.

## Visual

- **Blue solid**: node's actual `slotInEpoch` from chain tip  
- **Orange dashed** (`#FF9900`): expected slot from wall clock

Nodes falling below the reference line are stalling. Works across all networks via `$network` variable.

## Testing

Verified on live preview nodes — formula returns correct slot-in-epoch with no parse errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a wall-clock reference line to the “Slot In Epoch” panel to show where the node should be in the current epoch. This makes it easy to spot stalls when the actual slot falls below the reference.

- **New Features**
  - Added second series (refId `B`) labeled “Reference (wall clock)” using: `floor((time() - max(dingo_shelley_start_time{network="$network"})) % max(dingo_epoch_length_slots{network="$network"}))`
  - Styled as an orange dashed line (`#FF9900`, width 2)
  - Works across networks via the `$network` variable
  - Updated panel description to explain the reference line

<sup>Written for commit 45c0f5bd6b5c00b6106d1980fe57c0ffa890583b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the node overview dashboard with an expected slot progression reference line. The reference series is displayed as an orange dashed line to help detect stalling conditions.

* **Documentation**
  * Updated panel description documenting the new expected slot reference and its use for identifying nodes where reported slots lag behind expected progression.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->