### PR TITLE
fix(database): deadline on block by hash scan

### DIFF
--- a/database/block.go
+++ b/database/block.go
@@ -17,10 +17,13 @@ package database
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -30,6 +33,11 @@ import (
 
 const (
 	BlockInitialIndex uint64 = 1
+)
+
+var (
+	blockByHashScanDeadline               = 100 * time.Millisecond
+	blockByHashScanDeadlineExceededWarned atomic.Bool
 )
 
 func (d *Database) BlockCreate(block models.Block, txn *Txn) error {
@@ -308,7 +316,21 @@ func BlockByHashTxn(txn *Txn, hash []byte) (models.Block, error) {
 	if err == nil && len(blockKey) > 0 {
 		return blockByKey(txn, blockKey)
 	}
-	// Fallback to sequential scan for blocks written before the index existed
+	// Fallback to sequential scan for blocks written before the index
+	// existed. Time-bounded: a Mithril-bootstrapped node carries
+	// millions of blob entries and chainsync intersect-point lookups
+	// (buildDefaultChainsyncIntersectPoints → RecentChainPoints →
+	// BlockByHash) call this per peer connection. An unbounded scan
+	// can pin one CPU per ongoing inbound chainsync handshake; with
+	// peer-sharing or a busy listener the node wedges and stops both
+	// chain extension and block production. Treating the hash as not
+	// found after the deadline lets fork recovery and intersect-point
+	// callers fall back to alternative paths (PeerHeaderLookupFunc,
+	// chainsync resync), which is fast. The narrow correctness loss
+	// is for blocks present in the blob store but missing a hash
+	// index entry — those should be backfilled offline rather than
+	// served via per-lookup scan.
+	scanDeadline := time.Now().Add(blockByHashScanDeadline)
 	iterOpts := types.BlobIteratorOptions{
 		Prefix: []byte(types.BlockBlobKeyPrefix),
 	}
@@ -318,6 +340,16 @@ func BlockByHashTxn(txn *Txn, hash []byte) (models.Block, error) {
 	}
 	defer it.Close()
 	for it.Seek([]byte(types.BlockBlobKeyPrefix)); it.ValidForPrefix([]byte(types.BlockBlobKeyPrefix)); it.Next() {
+		if time.Now().After(scanDeadline) {
+			if blockByHashScanDeadlineExceededWarned.CompareAndSwap(false, true) {
+				txn.DB().logger.Warn(
+					"block hash fallback scan deadline exceeded; returning not found",
+					"deadline", blockByHashScanDeadline.String(),
+					"hash", hex.EncodeToString(hash),
+				)
+			}
+			return models.Block{}, models.ErrBlockNotFound
+		}
 		item := it.Item()
 		if item == nil {
 			continue

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -253,13 +253,7 @@ func batchCreateUtxos(db *gorm.DB, items []models.Utxo) error {
 	if len(items) == 0 {
 		return nil
 	}
-	if result := db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-		DoNothing: true,
-	}).CreateInBatches(items, batchChunkRows); result.Error != nil {
-		return result.Error
-	}
-	return nil
+	return importUtxosWithDB(db, items)
 }
 
 func batchCreateScripts(db *gorm.DB, items []models.Script) error {

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -49,7 +49,13 @@ func (d *MetadataStoreSqlite) ImportUtxos(
 			"ImportUtxos: resolve db: %w", err,
 		)
 	}
+	return importUtxosWithDB(db, utxos)
+}
 
+func importUtxosWithDB(
+	db *gorm.DB,
+	utxos []models.Utxo,
+) error {
 	// Collect assets from UTxOs before insert. We work on a
 	// local copy of each UTxO so the caller's slice is not
 	// mutated (Assets remains intact after this call).
@@ -74,7 +80,7 @@ func (d *MetadataStoreSqlite) ImportUtxos(
 	for i := 0; i < len(stripped); i += importUtxoBatchSize {
 		end := min(i+importUtxoBatchSize, len(stripped))
 		batch := stripped[i:end]
-		result := db.Clauses(clause.OnConflict{
+		result := db.Omit("Assets").Clauses(clause.OnConflict{
 			Columns: []clause.Column{
 				{Name: "tx_id"},
 				{Name: "output_idx"},
@@ -101,6 +107,14 @@ func (d *MetadataStoreSqlite) ImportUtxos(
 		assets := make([]models.Asset, 0, len(pending))
 		for _, p := range pending {
 			p.asset.UtxoID = stripped[p.utxoIdx].ID
+			p.asset.ID = 0
+			if p.asset.UtxoID == 0 {
+				return fmt.Errorf(
+					"missing UTxO ID for asset on %x#%d",
+					stripped[p.utxoIdx].TxId,
+					stripped[p.utxoIdx].OutputIdx,
+				)
+			}
 			assets = append(assets, p.asset)
 		}
 		for i := 0; i < len(assets); i += importAssetBatchSize {

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -61,6 +61,13 @@ type mockTransaction struct {
 	hash         lcommon.Blake2b256
 	isValid      bool
 	metadata     lcommon.TransactionMetadatum
+	produced     []lcommon.Utxo
+	inputs       []lcommon.TransactionInput
+	consumed     []lcommon.TransactionInput
+	collateral   []lcommon.TransactionInput
+	refInputs    []lcommon.TransactionInput
+	outputs      []lcommon.TransactionOutput
+	collReturn   lcommon.TransactionOutput
 }
 
 func (m *mockTransaction) Hash() lcommon.Blake2b256 {
@@ -100,23 +107,23 @@ func (m *mockTransaction) RawAuxiliaryData() []byte {
 }
 
 func (m *mockTransaction) CollateralReturn() lcommon.TransactionOutput {
-	return nil
+	return m.collReturn
 }
 
 func (m *mockTransaction) Produced() []lcommon.Utxo {
-	return nil
+	return m.produced
 }
 
 func (m *mockTransaction) Outputs() []lcommon.TransactionOutput {
-	return nil
+	return m.outputs
 }
 
 func (m *mockTransaction) Inputs() []lcommon.TransactionInput {
-	return nil
+	return m.inputs
 }
 
 func (m *mockTransaction) Collateral() []lcommon.TransactionInput {
-	return nil
+	return m.collateral
 }
 
 func (m *mockTransaction) Certificates() []lcommon.Certificate {
@@ -140,7 +147,7 @@ func (m *mockTransaction) Cbor() []byte {
 }
 
 func (m *mockTransaction) Consumed() []lcommon.TransactionInput {
-	return nil
+	return m.consumed
 }
 
 func (m *mockTransaction) Witnesses() lcommon.TransactionWitnessSet {
@@ -152,7 +159,7 @@ func (m *mockTransaction) ValidityIntervalStart() uint64 {
 }
 
 func (m *mockTransaction) ReferenceInputs() []lcommon.TransactionInput {
-	return nil
+	return m.refInputs
 }
 
 func (m *mockTransaction) TotalCollateral() *big.Int {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -846,23 +846,20 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
 	}
 	if len(tmpTx.Outputs) > 0 {
-		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-			DoNothing: true,
-		}).Create(&tmpTx.Outputs)
-		if result.Error != nil {
-			return fmt.Errorf("create utxo outputs for tx %x: %w", txHash, result.Error)
+		if err := d.ImportUtxos(tmpTx.Outputs, txn); err != nil {
+			return fmt.Errorf("create utxo outputs for tx %x: %w", txHash, err)
 		}
 	}
 	// Create CollateralReturn UTxO if present
 	// Uses CollateralReturnForTxID (not TransactionID) to distinguish from regular outputs
 	if tmpTx.CollateralReturn != nil {
+		tmpTx.CollateralReturn.ID = 0
 		tmpTx.CollateralReturn.CollateralReturnForTxID = &tmpTx.ID
-		if result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-			DoNothing: true,
-		}).Create(tmpTx.CollateralReturn); result.Error != nil {
-			return fmt.Errorf("create collateral return utxo: %w", result.Error)
+		if err := d.ImportUtxos(
+			[]models.Utxo{*tmpTx.CollateralReturn},
+			txn,
+		); err != nil {
+			return fmt.Errorf("create collateral return utxo: %w", err)
 		}
 	}
 

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -36,6 +38,7 @@ type mockBlobStore struct {
 	deleteTxErrs map[string]error
 	commitErrs   []error
 	deleteTxnIDs []int
+	iterator     types.BlobIterator
 	txns         []*mockBlobTxn
 	utxoData     map[string][]byte
 }
@@ -80,7 +83,7 @@ func (m *mockBlobStore) NewIterator(
 	types.Txn,
 	types.BlobIteratorOptions,
 ) types.BlobIterator {
-	return nil
+	return m.iterator
 }
 
 func (m *mockBlobStore) GetCommitTimestamp() (int64, error) {
@@ -173,6 +176,62 @@ func (m *mockBlobTxn) Commit() error {
 func (m *mockBlobTxn) Rollback() error {
 	m.rollbackCount++
 	return nil
+}
+
+type alwaysValidIterator struct{}
+
+func (it *alwaysValidIterator) Rewind()                    {}
+func (it *alwaysValidIterator) Seek([]byte)                {}
+func (it *alwaysValidIterator) Valid() bool                { return true }
+func (it *alwaysValidIterator) ValidForPrefix([]byte) bool { return true }
+func (it *alwaysValidIterator) Next()                      {}
+func (it *alwaysValidIterator) Item() types.BlobItem       { return nil }
+func (it *alwaysValidIterator) Close()                     {}
+func (it *alwaysValidIterator) Err() error                 { return nil }
+
+func TestBlockByHashScanDeadlineLogsWarningOnce(t *testing.T) {
+	prevDeadline := blockByHashScanDeadline
+	blockByHashScanDeadline = -time.Nanosecond
+	blockByHashScanDeadlineExceededWarned.Store(false)
+	t.Cleanup(func() {
+		blockByHashScanDeadline = prevDeadline
+		blockByHashScanDeadlineExceededWarned.Store(false)
+	})
+
+	var logs bytes.Buffer
+	store := &mockBlobStore{
+		iterator: &alwaysValidIterator{},
+	}
+	db := &Database{
+		blob: store,
+		logger: slog.New(
+			slog.NewJSONHandler(
+				&logs,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	}
+	txn := db.BlobTxn(false)
+	defer func() {
+		require.NoError(t, txn.Rollback())
+	}()
+
+	_, err := BlockByHashTxn(txn, bytes.Repeat([]byte{0x01}, 32))
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	_, err = BlockByHashTxn(txn, bytes.Repeat([]byte{0x02}, 32))
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	logText := logs.String()
+	require.Contains(t, logText, `"level":"WARN"`)
+	require.Equal(
+		t,
+		1,
+		strings.Count(
+			logText,
+			"block hash fallback scan deadline exceeded",
+		),
+	)
 }
 
 func TestDeleteTxBlobsUsesCallerBlobTxn(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4155,6 +4155,22 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 	for len(points) < count && len(nextHash) > 0 {
 		block, err := database.BlockByHash(ls.db, nextHash)
 		if err != nil {
+			// Tolerate missing blocks: a block lacking a hash
+			// index entry can be reported NotFound by the
+			// time-bounded BlockByHash scan fallback added in
+			// this PR. Returning the error here would leave us
+			// unable to send any intersect points to peers,
+			// which breaks both inbound chainsync (peers can't
+			// sync from us) and our own outbound chainsync setup
+			// (we ship MsgFindIntersect with these points).
+			// Stopping the walk returns whatever we collected
+			// so far — chainsync negotiation handles a short
+			// candidate list, and the next chain extension or
+			// rollback will refill the recent window with
+			// fully-indexed blocks.
+			if errors.Is(err, models.ErrBlockNotFound) {
+				break
+			}
 			return nil, err
 		}
 		points = append(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 100ms deadline to the fallback block-by-hash scan to prevent CPU spikes and node stalls when the hash index is missing. After the deadline, we return not found and the ledger tolerates it during recent chain point building, so chainsync stays fast and the node stays responsive.

- **Bug Fixes**
  - Time-bound the sequential scan in `BlockByHashTxn`; emit a single WARN the first time the deadline is exceeded.
  - On timeout, return `models.ErrBlockNotFound`; the recent chain point walk now stops on this and returns collected points so peers can still intersect.
  - Route all UTxO inserts (batch `batchCreateUtxos`, tx outputs, collateral return) through `ImportUtxos`; omit `Assets` on insert, reset asset IDs, and validate UTxO IDs to avoid duplicates and correctly attach assets.

<sup>Written for commit 89031c9a963a0ad9e8ea27f4243e7366490ecf39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents long-running block-hash fallback scans by enforcing a short time bound and emitting a single warning if exceeded.
  * Ledger lookup now tolerates missing block entries when building recent chain points, avoiding failures during chain sync.

* **Refactor**
  * UTxO import/persistence flow revised to improve bulk insert idempotency and enforce stricter asset linking.

* **Tests**
  * Added tests to assert the timed-scan warning behavior and to exercise iterator-based logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2215)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->