### PR TITLE
fix(database): sqlite batch accumulator utxo upsert

### DIFF
--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -250,16 +250,126 @@ func batchCreate[T any](db *gorm.DB, items []T) error {
 }
 
 func batchCreateUtxos(db *gorm.DB, items []models.Utxo) error {
+	return createUtxosWithAssets(db, items)
+}
+
+func createUtxosWithAssets(db *gorm.DB, items []models.Utxo) error {
 	if len(items) == 0 {
 		return nil
+	}
+	utxos := make([]models.Utxo, len(items))
+	assetsByUtxo := make(map[string][]models.Asset, len(items))
+	hasAssets := false
+	for i := range items {
+		utxos[i] = items[i]
+		utxos[i].Assets = nil
+		if len(items[i].Assets) == 0 {
+			continue
+		}
+		hasAssets = true
+		key := utxoUniqueKey(items[i].TxId, items[i].OutputIdx)
+		assetsByUtxo[key] = append(assetsByUtxo[key], items[i].Assets...)
 	}
 	if result := db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
 		DoNothing: true,
-	}).CreateInBatches(items, batchChunkRows); result.Error != nil {
+	}).CreateInBatches(utxos, batchChunkRows); result.Error != nil {
+		return result.Error
+	}
+	if !hasAssets {
+		return nil
+	}
+	utxoIDs, err := fetchUtxoIDs(db, items)
+	if err != nil {
+		return err
+	}
+	assetByKey := make(map[string]models.Asset)
+	assetKeys := make([]string, 0)
+	for i := range items {
+		utxoKey := utxoUniqueKey(items[i].TxId, items[i].OutputIdx)
+		utxoID, ok := utxoIDs[utxoKey]
+		if !ok {
+			return fmt.Errorf(
+				"missing utxo id for tx_id %x output_idx %d",
+				items[i].TxId,
+				items[i].OutputIdx,
+			)
+		}
+		for _, asset := range assetsByUtxo[utxoKey] {
+			asset.ID = 0
+			asset.UtxoID = utxoID
+			assetKey := utxoAssetUniqueKey(asset)
+			if _, ok := assetByKey[assetKey]; !ok {
+				assetKeys = append(assetKeys, assetKey)
+			}
+			assetByKey[assetKey] = asset
+		}
+	}
+	assets := make([]models.Asset, 0, len(assetKeys))
+	for _, key := range assetKeys {
+		assets = append(assets, assetByKey[key])
+	}
+	if len(assets) == 0 {
+		return nil
+	}
+	if result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "name"},
+			{Name: "policy_id"},
+			{Name: "utxo_id"},
+		},
+		DoUpdates: clause.AssignmentColumns(
+			[]string{"name_hex", "fingerprint", "amount"},
+		),
+	}).CreateInBatches(assets, batchChunkRows); result.Error != nil {
 		return result.Error
 	}
 	return nil
+}
+
+type utxoIDRow struct {
+	TxId      []byte `gorm:"column:tx_id"`
+	ID        uint   `gorm:"column:id"`
+	OutputIdx uint32 `gorm:"column:output_idx"`
+}
+
+func fetchUtxoIDs(
+	db *gorm.DB,
+	items []models.Utxo,
+) (map[string]uint, error) {
+	ids := make(map[string]uint, len(items))
+	for i := 0; i < len(items); i += batchChunkRows {
+		end := min(i+batchChunkRows, len(items))
+		chunk := items[i:end]
+		whereConditions := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for _, item := range chunk {
+			whereConditions = append(
+				whereConditions,
+				"(tx_id = ? AND output_idx = ?)",
+			)
+			args = append(args, item.TxId, item.OutputIdx)
+		}
+		var rows []utxoIDRow
+		if result := db.Model(&models.Utxo{}).
+			Select("id, tx_id, output_idx").
+			Where(strings.Join(whereConditions, " OR "), args...).
+			Find(&rows); result.Error != nil {
+			return nil, result.Error
+		}
+		for _, row := range rows {
+			ids[utxoUniqueKey(row.TxId, row.OutputIdx)] = row.ID
+		}
+	}
+	return ids, nil
+}
+
+func utxoUniqueKey(txID []byte, outputIdx uint32) string {
+	return fmt.Sprintf("%x:%d", txID, outputIdx)
+}
+
+func utxoAssetUniqueKey(asset models.Asset) string {
+	return fmt.Sprintf("%d:%x:%x", asset.UtxoID, asset.PolicyId, asset.Name)
 }
 
 func batchCreateScripts(db *gorm.DB, items []models.Script) error {

--- a/database/plugin/metadata/sqlite/import_utxo_test.go
+++ b/database/plugin/metadata/sqlite/import_utxo_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+const testAddress = "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp"
+
+func TestSetTransactionIdempotentlyStoresMultiAssetOutputs(t *testing.T) {
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+	txID := bytes.Repeat([]byte{0x35}, 32)
+	policyID := bytes.Repeat([]byte{0xcd}, 28)
+	assetName := []byte("INDY")
+	output0 := mustTestOutput(t, policyID, assetName, 1)
+	output1 := mustTestOutput(t, policyID, assetName, 2)
+	tx := &mockTransaction{
+		hash:    lcommon.NewBlake2b256(txID),
+		isValid: true,
+		produced: []lcommon.Utxo{
+			{Id: mustTestInput(t, txID, 0), Output: output0},
+			{Id: mustTestInput(t, txID, 1), Output: output1},
+		},
+		outputs: []lcommon.TransactionOutput{output0, output1},
+	}
+	point := ocommon.Point{
+		Hash: bytes.Repeat([]byte{0x77}, 32),
+		Slot: 12345,
+	}
+
+	require.NoError(t, store.SetTransaction(tx, point, 0, nil, nil))
+	require.NoError(t, store.SetTransaction(tx, point, 0, nil, nil))
+
+	requireUtxoAssetCounts(t, store, 2, 2)
+}
+
+func TestFlushBatchIdempotentlyStoresMultiAssetOutputs(t *testing.T) {
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+	txID := bytes.Repeat([]byte{0x46}, 32)
+	policyID := bytes.Repeat([]byte{0xef}, 28)
+	assetName := []byte("DAO")
+	batch := NewBatchAccumulator()
+	batch.AddUtxoOutput(models.Utxo{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 100,
+		Amount:    10,
+		Assets: []models.Asset{
+			testAsset(policyID, assetName, 1),
+		},
+	})
+	batch.AddUtxoOutput(models.Utxo{
+		TxId:      txID,
+		OutputIdx: 1,
+		AddedSlot: 100,
+		Amount:    20,
+		Assets: []models.Asset{
+			testAsset(policyID, assetName, 2),
+		},
+	})
+
+	require.NoError(t, store.FlushBatch(batch, nil))
+	require.NoError(t, store.FlushBatch(batch, nil))
+
+	requireUtxoAssetCounts(t, store, 2, 2)
+}
+
+func mustTestInput(
+	t *testing.T,
+	txID []byte,
+	idx uint32,
+) lcommon.TransactionInput {
+	t.Helper()
+	input, err := mockledger.NewTransactionInputBuilder().
+		WithTxId(txID).
+		WithIndex(idx).
+		Build()
+	require.NoError(t, err)
+	return input
+}
+
+func mustTestOutput(
+	t *testing.T,
+	policyID []byte,
+	assetName []byte,
+	amount uint64,
+) lcommon.TransactionOutput {
+	t.Helper()
+	output, err := mockledger.NewTransactionOutputBuilder().
+		WithAddress(testAddress).
+		WithLovelace(2_000_000).
+		WithAssets(mockledger.Asset{
+			PolicyId:  policyID,
+			AssetName: assetName,
+			Amount:    amount,
+		}).
+		Build()
+	require.NoError(t, err)
+	return output
+}
+
+func testAsset(
+	policyID []byte,
+	name []byte,
+	amount uint64,
+) models.Asset {
+	fingerprint := lcommon.NewAssetFingerprint(policyID, name)
+	return models.Asset{
+		Name:        name,
+		NameHex:     []byte(hex.EncodeToString(name)),
+		PolicyId:    policyID,
+		Fingerprint: []byte(fingerprint.String()),
+		Amount:      types.Uint64(amount),
+	}
+}
+
+func requireUtxoAssetCounts(
+	t *testing.T,
+	store *MetadataStoreSqlite,
+	wantUtxos int64,
+	wantAssets int64,
+) {
+	t.Helper()
+	var utxoCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Utxo{}).Count(&utxoCount).Error,
+	)
+	require.Equal(t, wantUtxos, utxoCount)
+	var assetCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Asset{}).Count(&assetCount).Error,
+	)
+	require.Equal(t, wantAssets, assetCount)
+	var zeroUtxoAssets int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Asset{}).
+			Where("utxo_id = 0").
+			Count(&zeroUtxoAssets).Error,
+	)
+	require.Zero(t, zeroUtxoAssets)
+}

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -61,6 +61,8 @@ type mockTransaction struct {
 	hash         lcommon.Blake2b256
 	isValid      bool
 	metadata     lcommon.TransactionMetadatum
+	outputs      []lcommon.TransactionOutput
+	produced     []lcommon.Utxo
 }
 
 func (m *mockTransaction) Hash() lcommon.Blake2b256 {
@@ -104,11 +106,11 @@ func (m *mockTransaction) CollateralReturn() lcommon.TransactionOutput {
 }
 
 func (m *mockTransaction) Produced() []lcommon.Utxo {
-	return nil
+	return m.produced
 }
 
 func (m *mockTransaction) Outputs() []lcommon.TransactionOutput {
-	return nil
+	return m.outputs
 }
 
 func (m *mockTransaction) Inputs() []lcommon.TransactionInput {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -846,23 +846,19 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
 	}
 	if len(tmpTx.Outputs) > 0 {
-		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-			DoNothing: true,
-		}).Create(&tmpTx.Outputs)
-		if result.Error != nil {
-			return fmt.Errorf("create utxo outputs for tx %x: %w", txHash, result.Error)
+		if err := createUtxosWithAssets(db, tmpTx.Outputs); err != nil {
+			return fmt.Errorf("create utxo outputs for tx %x: %w", txHash, err)
 		}
 	}
 	// Create CollateralReturn UTxO if present
 	// Uses CollateralReturnForTxID (not TransactionID) to distinguish from regular outputs
 	if tmpTx.CollateralReturn != nil {
 		tmpTx.CollateralReturn.CollateralReturnForTxID = &tmpTx.ID
-		if result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-			DoNothing: true,
-		}).Create(tmpTx.CollateralReturn); result.Error != nil {
-			return fmt.Errorf("create collateral return utxo: %w", result.Error)
+		if err := createUtxosWithAssets(
+			db,
+			[]models.Utxo{*tmpTx.CollateralReturn},
+		); err != nil {
+			return fmt.Errorf("create collateral return utxo: %w", err)
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes SQLite UTxO batch upsert to correctly and idempotently store multi-asset outputs. Assets are now linked to their UTxOs and deduplicated, preventing duplicates and rows with utxo_id = 0.

- Bug Fixes
  - Added createUtxosWithAssets: inserts UTxOs, fetches their IDs, then upserts related assets on (name, policy_id, utxo_id) with updates to name_hex, fingerprint, amount.
  - Deduplicates assets per UTxO using stable keys to avoid duplicate rows.
  - Updated SetTransaction and CollateralReturn paths to use the new helper; `FlushBatch` benefits as well.
  - Added tests for idempotent multi-asset outputs via SetTransaction and `FlushBatch`, asserting correct UTxO/asset counts and non-zero utxo_id.

<sup>Written for commit 949b7fc1eb665f690f86dd39dbea8064c9c2103d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

