### PR TITLE
build(deps): gouroboros 0.168.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.25.1
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.167.0
+	github.com/blinklabs-io/gouroboros v0.168.0
 	github.com/blinklabs-io/ouroboros-mock v0.10.0
 	github.com/blinklabs-io/plutigo v0.1.9
 	github.com/blockfrost/blockfrost-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.167.0 h1:wlNY/WDCueR3dXY93O/kB1FA+5VuQrcbNdoF9t8eblk=
-github.com/blinklabs-io/gouroboros v0.167.0/go.mod h1:pzkbnDL0xlJPY5vCvApLR/R2zEbyBuOPZCv6SX2ugvc=
+github.com/blinklabs-io/gouroboros v0.168.0 h1:BA8bWKth+VlnpAqXlRvZuMDvTKhKWqQA6VEOMxlytss=
+github.com/blinklabs-io/gouroboros v0.168.0/go.mod h1:pzkbnDL0xlJPY5vCvApLR/R2zEbyBuOPZCv6SX2ugvc=
 github.com/blinklabs-io/ouroboros-mock v0.10.0 h1:8fhKaaTm3pDHSr8Yx91zEthooQH+o+NQhGfN2FKxwMI=
 github.com/blinklabs-io/ouroboros-mock v0.10.0/go.mod h1:1vWKSGxMtUfF3gkrVjUsjPTXdA+A665bQZjbVWpG5lg=
 github.com/blinklabs-io/plutigo v0.1.9 h1:J3kAB5jrKPGhU9elTuFx9oz/cWTQobwFLfVuQ64jf7I=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `github.com/blinklabs-io/gouroboros` from 0.167.0 to 0.168.0 to stay current with upstream and maintain compatibility. Only `go.mod` and `go.sum` were updated.

<sup>Written for commit c678f948189250928b9526486f776ac9e09cf897. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

