### PR TITLE
test: verify Dingo crosses vanRossem/PV11

### DIFF
--- a/database/plugin/metadata/sqlite/import_test.go
+++ b/database/plugin/metadata/sqlite/import_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportUtxosAddsMissingAssetsForExistingUtxo(t *testing.T) {
+	store := setupTestDB(t)
+
+	txID := bytes.Repeat([]byte{0x31}, 32)
+	policyID := bytes.Repeat([]byte{0x42}, 28)
+	assetA := models.Asset{
+		PolicyId:    policyID,
+		Name:        []byte("asset-a"),
+		NameHex:     []byte("61737365742d61"),
+		Fingerprint: []byte("fingerprint-a"),
+		Amount:      1,
+	}
+	assetB := models.Asset{
+		PolicyId:    policyID,
+		Name:        []byte("asset-b"),
+		NameHex:     []byte("61737365742d62"),
+		Fingerprint: []byte("fingerprint-b"),
+		Amount:      2,
+	}
+
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 100,
+		Amount:    10,
+		Assets:    []models.Asset{assetA},
+	}}, nil))
+
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 100,
+		Amount:    10,
+		Assets:    []models.Asset{assetA, assetB},
+	}}, nil))
+
+	var utxo models.Utxo
+	require.NoError(
+		t,
+		store.DB().
+			Where("tx_id = ? AND output_idx = ?", txID, 0).
+			First(&utxo).Error,
+	)
+
+	var assets []models.Asset
+	require.NoError(
+		t,
+		store.DB().
+			Where("utxo_id = ?", utxo.ID).
+			Order("name ASC").
+			Find(&assets).Error,
+	)
+	require.Len(t, assets, 2)
+
+	assert.Equal(t, []byte("asset-a"), assets[0].Name)
+	assert.Equal(t, assetA.Amount, assets[0].Amount)
+	assert.Equal(t, policyID, assets[0].PolicyId)
+	assert.Equal(t, []byte("61737365742d61"), assets[0].NameHex)
+	assert.Equal(t, []byte("fingerprint-a"), assets[0].Fingerprint)
+	assert.Equal(t, []byte("asset-b"), assets[1].Name)
+	assert.Equal(t, assetB.Amount, assets[1].Amount)
+	assert.Equal(t, policyID, assets[1].PolicyId)
+	assert.Equal(t, []byte("61737365742d62"), assets[1].NameHex)
+	assert.Equal(t, []byte("fingerprint-b"), assets[1].Fingerprint)
+}

--- a/internal/test/erastest/configurator.sh
+++ b/internal/test/erastest/configurator.sh
@@ -87,6 +87,24 @@ config_config_json() {
     esac
 }
 
+config_conway_genesis() {
+    # Strip the configurator's default 7-member script-hash committee.
+    # testnet-generation-tool seeds conway-genesis.committee.members
+    # with seven scriptHash entries (minSize=7, threshold=2/3) for which
+    # we have no signing material, so any HFI gov-action ratification
+    # under that committee is unmeetable. Drop to a NoCommittee state
+    # (empty members, minSize=0, threshold 0/1) so cardano-ledger Conway
+    # gov rules grant CC approval automatically and the vanrossem test
+    # driver only has to clear the SPO + DRep thresholds. The eras
+    # testnet does not exercise governance, so this clearing has no
+    # observable effect on its assertions.
+    CONWAY_GENESIS_JSON=$1/configs/conway-genesis.json
+    jq '.committee.members = {} |
+        .committee.threshold = {numerator: 0, denominator: 1} |
+        .committeeMinSize = 0' \
+        "${CONWAY_GENESIS_JSON}" | write_file "${CONWAY_GENESIS_JSON}"
+}
+
 config_topology_json() {
     # Generate a ring topology, where pool_n is connected to pool_{n-1} and pool_{n+1}
 
@@ -164,7 +182,15 @@ find /tmp/testnet -type f -name 'topology.json' -exec rm -f '{}' ';'
 
 mkdir -p /configs
 cp -r /tmp/testnet/pools/* /configs
-cp -r /tmp/testnet/utxos/* /configs
+
+# testnet-generation-tool drops the genesis-utxo Shelley payment / stake /
+# genesis spending keys under /tmp/testnet/utxos/keys/. The docker-compose
+# definition mounts an "utxo-keys" volume at /configs/utxo-keys for these,
+# so route the keys there explicitly — a `cp -r /tmp/testnet/utxos/* /configs`
+# silently misses the mount because it lands the files at /configs/keys (a
+# local in-container path that vanishes with the configurator container).
+mkdir -p /configs/utxo-keys
+cp -r /tmp/testnet/utxos/keys/* /configs/utxo-keys/
 
 echo "removing /configs/keys"; rm -rf /configs/keys
 
@@ -186,6 +212,7 @@ for pool in $pools; do
   echo "pool: $pool"
   set_start_time "$pool"
   config_config_json "$pool"
+  config_conway_genesis "$pool"
 done
 
 # Test-only credentials: make config + genesis files world-readable so any

--- a/internal/test/erastest/docker-compose.vanrossem.yml
+++ b/internal/test/erastest/docker-compose.vanrossem.yml
@@ -1,0 +1,54 @@
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compose override that flips internal/test/erastest's DevNet from the
+# default Shelley→Conway era-traversal scenario into a Conway-vanRossem
+# (PV11) bootstrap scenario.
+#
+# Apply with run-tests-vanrossem.sh, or manually:
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.vanrossem.yml \
+#     up -d
+#
+# What it changes:
+#   - configurator mounts testnet-vanrossem.yaml at /testnet.yaml
+#     instead of testnet.yaml. docker compose merges volume entries by
+#     container path, so the override's source wins for /testnet.yaml.
+#   - cardano-producer additionally mounts the utxo-keys volume so the
+#     HFI driver running inside it (via docker exec + cardano-cli) can
+#     sign payment / stake / governance txs with the genesis-utxo
+#     spending keys. Read-only mount; the driver never mutates the
+#     keys.
+#
+# The base docker-compose.yml already uses cardano-node:11.0.1 for both
+# producer and relay (and Dockerfile.configurator's FROM matches), so no
+# image overrides are needed here — every service inherits the
+# vanRossem-aware binary from the base file.
+
+services:
+  configurator:
+    volumes:
+      - ./testnet-vanrossem.yaml:/testnet.yaml
+
+  cardano-producer:
+    volumes:
+      - utxo-keys:/utxo-keys:ro
+      # The HFI driver needs to sign a Yes-vote tx as SPO 1 (dingo's
+      # pool), which requires pool 1's cold.skey. cardano-producer
+      # already has pool 2's keys at /configs/keys; mount pool 1's
+      # configs read-only at a sibling path so cardano-cli can read
+      # the cold.skey without ever mutating the dingo-owned volume.
+      - p1-configs:/p1-configs:ro

--- a/internal/test/erastest/run-tests-vanrossem.sh
+++ b/internal/test/erastest/run-tests-vanrossem.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run the vanRossem (PV11) variant of the erastest DevNet. Brings up the
+# same dingo-producer + cardano-producer + cardano-relay topology as
+# run-tests.sh, but bootstraps the chain directly into Conway at PV10
+# and drives PV10 to PV11 rather than starting in Shelley and traversing every era.
+#
+# Usage:
+#   ./run-tests-vanrossem.sh                     # run the vanRossem suite
+#   ./run-tests-vanrossem.sh -run TestVanRossem  # forward -run to go test
+#   ./run-tests-vanrossem.sh --keep-up           # leave the DevNet running
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+COMPOSE_BASE="${SCRIPT_DIR}/docker-compose.yml"
+COMPOSE_OVERRIDE="${SCRIPT_DIR}/docker-compose.vanrossem.yml"
+TESTNET_YAML="${SCRIPT_DIR}/testnet-vanrossem.yaml"
+
+KEEP_UP=false
+TEST_ARGS=()
+for arg in "$@"; do
+  case "${arg}" in
+    --keep-up) KEEP_UP=true ;;
+    *)         TEST_ARGS+=("${arg}") ;;
+  esac
+done
+
+log()  { echo "[vanrossem-tests] $*"; }
+warn() { echo "[vanrossem-tests] WARNING: $*" >&2; }
+die()  { echo "[vanrossem-tests] ERROR: $*" >&2; exit 1; }
+
+compose() {
+  docker compose -f "${COMPOSE_BASE}" -f "${COMPOSE_OVERRIDE}" "$@"
+}
+
+cleanup() {
+  local exit_code=$?
+  if [[ "${KEEP_UP}" == "true" ]] && [[ ${exit_code} -eq 0 ]]; then
+    log "Tests passed. DevNet left running (--keep-up)."
+    log "To stop:  docker compose -f ${COMPOSE_BASE} -f ${COMPOSE_OVERRIDE} down -v"
+    return
+  fi
+  log "Collecting full per-service logs before teardown..."
+  if [[ ${exit_code} -ne 0 ]]; then
+    compose logs --tail=200 2>/dev/null || true
+  fi
+  local logs_dir="/tmp/erastest-vanrossem-logs"
+  mkdir -p "${logs_dir}" 2>/dev/null || true
+  for svc in eras-dingo-producer eras-cardano-producer eras-cardano-relay eras-configurator; do
+    docker logs "${svc}" >"${logs_dir}/${svc}.log" 2>&1 || true
+  done
+  log "Full per-service logs dumped to ${logs_dir}/"
+  log "Tearing down DevNet..."
+  compose down -v 2>/dev/null || true
+}
+trap cleanup EXIT
+
+if ! command -v docker &>/dev/null; then
+  die "docker is not installed"
+fi
+if ! docker compose version &>/dev/null; then
+  die "docker compose plugin is not installed"
+fi
+
+log "Building images..."
+compose build dingo-producer configurator
+
+log "Starting DevNet containers..."
+compose up -d
+
+log "Waiting for nodes to become healthy..."
+MAX_WAIT=180
+ELAPSED=0
+while [[ ${ELAPSED} -lt ${MAX_WAIT} ]]; do
+  HEALTHY=0
+  for svc in eras-dingo-producer eras-cardano-producer eras-cardano-relay; do
+    status=$(docker inspect --format='{{.State.Health.Status}}' "${svc}" 2>/dev/null || echo "missing")
+    if [[ "${status}" == "healthy" ]]; then
+      HEALTHY=$((HEALTHY + 1))
+    fi
+  done
+  if [[ ${HEALTHY} -ge 3 ]]; then
+    log "All 3 nodes are healthy"
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  log "  Waiting... (${ELAPSED}s, ${HEALTHY}/3 healthy)"
+done
+
+if [[ ${ELAPSED} -ge ${MAX_WAIT} ]]; then
+  warn "Not all nodes became healthy within ${MAX_WAIT}s"
+  compose ps
+  compose logs --tail=80
+  die "Node health check timeout"
+fi
+
+log "Running vanRossem tests..."
+cd "${PROJECT_ROOT}"
+
+DINGO_PORT="${ERASTEST_DINGO_PORT:-3020}"
+CARDANO_PORT="${ERASTEST_CARDANO_PORT:-3021}"
+RELAY_PORT="${ERASTEST_RELAY_PORT:-3022}"
+export ERASTEST_DINGO_ADDR="localhost:${DINGO_PORT}"
+export ERASTEST_CARDANO_ADDR="localhost:${CARDANO_PORT}"
+export ERASTEST_RELAY_ADDR="localhost:${RELAY_PORT}"
+export ERASTEST_TESTNET_YAML="${TESTNET_YAML}"
+
+# The vanRossem variant runs the HFI driver end-to-end:
+#   * 2 epoch boundaries for the stake snapshot to pick up DRep delegation
+#   * 1 epoch of pre-bump baseline observation
+#   * HFI proposal + 3 vote txs (a few seconds each)
+#   * 2 epoch boundaries for RATIFY then ENACT
+#   * 1 epoch boundary of post-bump validation
+# With 75-slot/75s epochs that's ~6 wall-clock epochs ≈ 7.5 min, plus
+# bootstrap warmup. Default to 15m so flaky block-rate variance doesn't
+# clip the run; override with TEST_TIMEOUT.
+TEST_TIMEOUT="${TEST_TIMEOUT:-15m}"
+set +e
+go test \
+  -tags erastest \
+  -count=1 \
+  -v \
+  -timeout "${TEST_TIMEOUT}" \
+  -run 'TestVanRossem|TestPV11Readiness' \
+  ${TEST_ARGS[@]+"${TEST_ARGS[@]}"} \
+  ./internal/test/erastest/...
+TEST_EXIT=$?
+set -e
+
+if [[ ${TEST_EXIT} -eq 0 ]]; then
+  log "All vanRossem tests PASSED"
+else
+  log "vanRossem tests FAILED (exit code: ${TEST_EXIT})"
+fi
+
+exit ${TEST_EXIT}

--- a/internal/test/erastest/testnet-vanrossem.yaml
+++ b/internal/test/erastest/testnet-vanrossem.yaml
@@ -1,0 +1,99 @@
+# Configurator specification for the vanRossem (PV11) DevNet variant.
+#
+# Differs from internal/test/erastest/testnet.yaml in two ways:
+#
+#   1. Bootstraps directly into Conway-Plomin (protocolVersion.major: 10)
+#      instead of starting in Shelley. The chain begins one PV step away
+#      from the vanRossem boundary so a HardForkInitiation gov-action
+#      driver can submit and ratify the PV10→PV11 bump on a real chain
+#      under test (see internal/test/erastest/vanrossem_test.go).
+#   2. All Test{Era}HardForkAtEpoch toggles fast-forward to epoch 0 so
+#      the chain crosses no inter-era boundary; the only PV change the
+#      test exercises is the intra-Conway PV10→PV11 governance bump,
+#      which cardano-node has no built-in toggle for (the test* knobs
+#      jump from Conway directly to Dijkstra/PV12 with no stop at 11).
+#
+# Used by internal/test/erastest/docker-compose.vanrossem.yml as an
+# override on top of docker-compose.yml.
+#
+# Format: 6 YAML documents (see below)
+#   1. Required testnet parameters
+#   2. Byron genesis overrides
+#   3. Shelley genesis overrides
+#   4. Alonzo genesis overrides
+#   5. Conway genesis overrides
+#   6. Node config (config.json) overrides
+
+--- # Required Testnet Parameters
+poolCount: 2
+poolCost: 0
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 2000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: devnet
+
+--- # Byron Genesis Override
+protocolConsts:
+  k: 6
+
+--- # Shelley Genesis Override
+# 1s slots, 75-slot (~75s) epochs, k=6.
+# Stability budgets:
+#   nonceStabilityWindow      = 4k/f = 4*6/0.4 = 60 < 75 = epochLength ✓
+#   blockfetchStabilityWindow = 3k/f = 3*6/0.4 = 45 < 75 = epochLength ✓
+# Per-pool block expectation per epoch (2 pools, equal stake, f=0.4):
+#   1 - (1-f)^(1/n) ≈ 0.225 → ~17 blocks per pool per 75-slot epoch.
+# So a "dingo produces in every era" check has effectively zero variance
+# even over a single epoch.
+epochLength: 75
+slotLength: 1
+activeSlotsCoeff: 0.4
+securityParam: 6
+maxLovelaceSupply: 2000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Alonzo Genesis Override
+
+--- # Conway Genesis Override
+# The default conway-genesis emitted by testnet-generation-tool seeds a
+# 7-member committee whose members are all script-hash entries with
+# minSize=7 and threshold 2/3. We do not have signing material for any
+# of those scripts, so HFI ratification under that committee is
+# impossible (all 7 members are unsignable, threshold is unmeetable).
+# Empty the committee and drop minSize to 0 so the chain runs in a
+# NoCommittee state — under cardano-ledger Conway gov rules CC approval
+# for HFI is automatically granted when no committee exists, leaving
+# only SPO + DRep thresholds for the test driver to clear.
+committee:
+  members: {}
+  threshold:
+    numerator: 0
+    denominator: 1
+committeeMinSize: 0
+
+--- # Node Config Override
+# Every era transition fires at epoch 0, and the Shelley genesis above
+# sets protocolVersion.major to 10 (Plomin), so the chain starts in
+# Conway-Plomin at slot 0. The test driver subsequently submits a
+# HardForkInitiation governance action that proposes PV11 and votes it
+# through to enactment, which is the only path that produces a
+# PV10→PV11 boundary on a multi-node DevNet.
+ExperimentalHardForksEnabled: true
+TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+ExperimentalProtocolsEnabled: true
+TraceForge: true
+TraceChainDb: true
+TraceMempool: true
+TurnOnLogging: true

--- a/internal/test/erastest/vanrossem_driver_test.go
+++ b/internal/test/erastest/vanrossem_driver_test.go
@@ -1,0 +1,625 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build erastest
+
+// HardForkInitiation driver for the vanrossem testnet variant.
+//
+// The driver bootstraps a single DRep, delegates pool-1's genesis-utxo
+// stake to it (so the DRep gets non-zero voting power once the next
+// stake snapshot lands), submits a HardForkInitiation gov action that
+// proposes protocol version 11.0, casts Yes votes from both SPOs and
+// the DRep, and waits for the chain to RATIFY+ENACT the bump. Every
+// cardano-cli call runs inside the eras-cardano-producer container via
+// `docker exec`; that container already has cardano-cli, the node
+// socket, pool-2 keys, the utxo-keys volume, and a read-only mount of
+// pool-1's configs (see docker-compose.vanrossem.yml).
+//
+// The CC vote is intentionally skipped — conway-genesis is patched at
+// configurator time to clear the committee (see configurator.sh's
+// config_conway_genesis), so the ledger treats CC approval as auto-yes
+// for HFI under Conway gov rules.
+
+package erastest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+)
+
+// Paths inside the eras-cardano-producer container. Kept as constants so
+// a layout change in docker-compose.vanrossem.yml or configurator.sh
+// surfaces as a single-point edit.
+const (
+	cliContainer   = "eras-cardano-producer"
+	nodeSocketPath = "/ipc/node.socket"
+	testnetMagic   = "42"
+
+	// Driver scratch dir inside the container (drep keys, action /
+	// vote files, signed tx files, etc.).
+	driverWorkDir = "/tmp/vanrossem-driver"
+
+	// Genesis-utxo keys (mounted from utxo-keys volume).
+	utxoPay1Skey  = "/utxo-keys/payment.1.skey"
+	utxoStake1Vk  = "/utxo-keys/stake.1.vkey"
+	utxoStake1Sk  = "/utxo-keys/stake.1.skey"
+	utxoDeleg1Adr = "/utxo-keys/delegated.1.addr.info"
+
+	// Pool cold keys (pool 1 mounted RO at /p1-configs, pool 2 at
+	// /configs via the base compose).
+	pool1ColdSkey = "/p1-configs/keys/cold.skey"
+	pool1ColdVkey = "/p1-configs/keys/cold.vkey"
+	pool2ColdSkey = "/configs/keys/cold.skey"
+	pool2ColdVkey = "/configs/keys/cold.vkey"
+
+	// HFI target.
+	targetMajor = "11"
+	targetMinor = "0"
+
+	// Anchor is required by cardano-cli but our gov action has no real
+	// off-chain metadata to point at. A deterministic dummy hash keeps
+	// the action well-formed; we never run with --check-anchor-data so
+	// the URL is not fetched.
+	anchorURL  = "https://example.invalid/vanrossem.json"
+	anchorHash = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+// driveHFIToPV11 runs the end-to-end PV10→PV11 hard fork via gov
+// action on the live DevNet. Returns once the chain has ENACTed PV11.
+//
+// Stage outline (each stage logs progress via t.Logf so a flaky run is
+// debuggable from the test log alone):
+//
+//  1. prepareWorkDir  — fresh scratch dir inside cliContainer
+//  2. registerDRep    — generate DRep keys, build tx containing DRep
+//     registration cert + stake-vote-delegation cert, sign, submit
+//  3. waitForEpoch    — wait two boundaries so the stake snapshot
+//     picks up the DRep delegation as active voting power
+//  4. submitHFI       — build the HFI proposal action, embed in a tx,
+//     submit
+//  5. castVotes       — three Yes votes (SPO 1, SPO 2, DRep), each its
+//     own tx
+//  6. waitForEpoch    — wait two boundaries so RATIFY (after the next
+//     boundary) and ENACT (boundary after that) both fire
+//  7. verifyPV11      — query pparams via cardano-cli, assert
+//     protocolVersion.major == 11 on both producers
+func driveHFIToPV11(t *testing.T) {
+	t.Helper()
+	t.Logf("HFI driver: starting")
+
+	prepareWorkDir(t)
+	deposits := readDeposits(t)
+	t.Logf(
+		"HFI driver: pparams deposits — dRepDeposit=%d, govActionDeposit=%d",
+		deposits.DRep, deposits.GovAction,
+	)
+	drep := registerDRep(t, deposits.DRep)
+	startEpoch := currentEpoch(t)
+	t.Logf(
+		"HFI driver: DRep registered (txid=%s); current epoch=%d, waiting two epoch boundaries for stake snapshot",
+		drep.regTxID, startEpoch,
+	)
+	waitForEpoch(t, startEpoch+2)
+
+	proposal := submitHFI(t, deposits.GovAction)
+	t.Logf(
+		"HFI driver: HFI proposal submitted (txid=%s, action=%d)",
+		proposal.txID, proposal.actionIdx,
+	)
+
+	castSPOVote(t, pool1ColdVkey, pool1ColdSkey, proposal, "spo1-dingo")
+	castSPOVote(t, pool2ColdVkey, pool2ColdSkey, proposal, "spo2-cardano")
+	castDRepVote(t, drep, proposal)
+
+	voteEpoch := currentEpoch(t)
+	t.Logf(
+		"HFI driver: all votes cast at epoch=%d, waiting two epoch boundaries for RATIFY + ENACT",
+		voteEpoch,
+	)
+	waitForEpoch(t, voteEpoch+2)
+
+	verifyPV11(t)
+	t.Logf("HFI driver: PV11 reached")
+}
+
+// drepKeys describes the freshly-generated DRep credential set the
+// driver uses for both the registration tx and subsequent vote tx.
+type drepKeys struct {
+	vkeyPath string // /tmp/.../drep.vkey
+	skeyPath string // /tmp/.../drep.skey
+	regTxID  string // txid that contained the registration cert
+}
+
+// pparamDeposits captures the two lovelace deposit amounts the driver
+// needs at tx-build time. Both are queried once at driver start so a
+// later mid-flow pparams update can't quietly mis-balance txs.
+type pparamDeposits struct {
+	DRep      uint64 `json:"drep"`
+	GovAction uint64 `json:"govAction"`
+}
+
+func readDeposits(t *testing.T) pparamDeposits {
+	t.Helper()
+	out := runCli(t, "querying deposit pparams",
+		"cardano-cli conway query protocol-parameters "+
+			"--socket-path "+nodeSocketPath+" "+
+			"--testnet-magic "+testnetMagic+
+			" | jq '{drep: .dRepDeposit, govAction: .govActionDeposit}'")
+	var d pparamDeposits
+	if err := json.Unmarshal(out, &d); err != nil {
+		t.Fatalf("decoding deposits: %v\n%s", err, string(out))
+	}
+	if d.DRep == 0 || d.GovAction == 0 {
+		t.Fatalf(
+			"deposit pparams unexpectedly zero: drep=%d govAction=%d\nraw: %s",
+			d.DRep, d.GovAction, string(out),
+		)
+	}
+	return d
+}
+
+// hfiProposal identifies the in-flight HFI gov action by the txid that
+// submitted it and its index within that tx's proposal-procedures list.
+// Conway gov actions are addressed by (txid, ix); ix is 0 because our
+// proposal tx contains exactly one proposal.
+type hfiProposal struct {
+	txID      string
+	actionIdx uint
+}
+
+func prepareWorkDir(t *testing.T) {
+	t.Helper()
+	runCli(t, "preparing work dir",
+		"rm -rf "+driverWorkDir+" && mkdir -p "+driverWorkDir)
+}
+
+// registerDRep generates a DRep key-pair, builds a tx that contains
+// both the DRep registration cert and a stake vote-delegation cert
+// pointing pool-1's genesis-utxo stake at the new DRep, signs with the
+// utxo payment, utxo stake, and drep signing keys, and submits.
+//
+// The DRep registration deposit (dRepDeposit, default 500 ADA on this
+// testnet) is paid from delegated.1's UTxO; cardano-cli's
+// `transaction build` selects fee and change automatically.
+func registerDRep(t *testing.T, drepDeposit uint64) drepKeys {
+	t.Helper()
+	keys := drepKeys{
+		vkeyPath: driverWorkDir + "/drep.vkey",
+		skeyPath: driverWorkDir + "/drep.skey",
+	}
+
+	runCli(t, "generating DRep keys",
+		"cardano-cli conway governance drep key-gen "+
+			"--verification-key-file "+keys.vkeyPath+" "+
+			"--signing-key-file "+keys.skeyPath)
+
+	runCli(t, "building DRep registration certificate",
+		fmt.Sprintf(
+			"cardano-cli conway governance drep registration-certificate "+
+				"--drep-verification-key-file %s "+
+				"--key-reg-deposit-amt %d "+
+				"--out-file %s/drep-reg.cert",
+			keys.vkeyPath, drepDeposit, driverWorkDir,
+		))
+
+	runCli(t, "building stake vote-delegation certificate",
+		"cardano-cli conway stake-address vote-delegation-certificate "+
+			"--stake-verification-key-file "+utxoStake1Vk+" "+
+			"--drep-verification-key-file "+keys.vkeyPath+" "+
+			"--out-file "+driverWorkDir+"/vote-deleg.cert")
+
+	// Build, sign, submit a tx that registers the DRep and delegates
+	// pool-1's genesis stake to it. The build command auto-selects a
+	// UTxO from delegated.1's address; we pass an explicit
+	// --change-address so all leftover lovelace lands back at the
+	// same address (keeping the funded UTxO recyclable for the HFI
+	// and vote txs that follow).
+	depositAddr := readJSONField(t, utxoDeleg1Adr, ".address")
+	buildSignSubmit(
+		t,
+		"DRep registration",
+		[]string{
+			"--certificate-file " + driverWorkDir + "/drep-reg.cert",
+			"--certificate-file " + driverWorkDir + "/vote-deleg.cert",
+		},
+		[]string{utxoPay1Skey, utxoStake1Sk, keys.skeyPath},
+		depositAddr,
+		drepDeposit,
+		driverWorkDir+"/drep-tx",
+	)
+
+	keys.regTxID = readFile(t, driverWorkDir+"/drep-tx.txid")
+	return keys
+}
+
+// submitHFI builds the HardForkInitiation gov action targeting PV11.0
+// and submits it as a proposal tx.
+func submitHFI(t *testing.T, govActionDeposit uint64) hfiProposal {
+	t.Helper()
+	depositAddr := readJSONField(t, utxoDeleg1Adr, ".address")
+	runCli(t, "building HFI gov action",
+		fmt.Sprintf(
+			"cardano-cli conway governance action create-hardfork "+
+				"--testnet "+
+				"--governance-action-deposit %d "+
+				"--deposit-return-stake-verification-key-file %s "+
+				"--anchor-url %s "+
+				"--anchor-data-hash %s "+
+				"--protocol-major-version %s "+
+				"--protocol-minor-version %s "+
+				"--out-file %s/hfi.action",
+			govActionDeposit, utxoStake1Vk, anchorURL, anchorHash,
+			targetMajor, targetMinor, driverWorkDir,
+		))
+
+	buildSignSubmit(
+		t,
+		"HFI proposal",
+		[]string{"--proposal-file " + driverWorkDir + "/hfi.action"},
+		[]string{utxoPay1Skey},
+		depositAddr,
+		govActionDeposit,
+		driverWorkDir+"/hfi-tx",
+	)
+
+	return hfiProposal{
+		txID:      readFile(t, driverWorkDir+"/hfi-tx.txid"),
+		actionIdx: 0,
+	}
+}
+
+// castSPOVote builds and submits a Yes vote tx signed with a stake
+// pool cold key. tag is a short label used in logs (spo1-dingo /
+// spo2-cardano).
+func castSPOVote(
+	t *testing.T,
+	coldVkey, coldSkey string,
+	p hfiProposal,
+	tag string,
+) {
+	t.Helper()
+	voteFile := fmt.Sprintf("%s/vote-%s.vote", driverWorkDir, tag)
+	runCli(t, "building "+tag+" Yes vote",
+		fmt.Sprintf(
+			"cardano-cli conway governance vote create --yes "+
+				"--governance-action-tx-id %s "+
+				"--governance-action-index %d "+
+				"--cold-verification-key-file %s "+
+				"--out-file %s",
+			p.txID, p.actionIdx, coldVkey, voteFile,
+		))
+
+	depositAddr := readJSONField(t, utxoDeleg1Adr, ".address")
+	buildSignSubmit(
+		t,
+		tag+" vote",
+		[]string{"--vote-file " + voteFile},
+		[]string{utxoPay1Skey, coldSkey},
+		depositAddr,
+		0,
+		fmt.Sprintf("%s/vote-%s-tx", driverWorkDir, tag),
+	)
+}
+
+// castDRepVote builds and submits a Yes vote tx signed with the DRep
+// signing key generated during registerDRep.
+func castDRepVote(t *testing.T, d drepKeys, p hfiProposal) {
+	t.Helper()
+	voteFile := driverWorkDir + "/vote-drep.vote"
+	runCli(t, "building DRep Yes vote",
+		fmt.Sprintf(
+			"cardano-cli conway governance vote create --yes "+
+				"--governance-action-tx-id %s "+
+				"--governance-action-index %d "+
+				"--drep-verification-key-file %s "+
+				"--out-file %s",
+			p.txID, p.actionIdx, d.vkeyPath, voteFile,
+		))
+
+	depositAddr := readJSONField(t, utxoDeleg1Adr, ".address")
+	buildSignSubmit(
+		t,
+		"DRep vote",
+		[]string{"--vote-file " + voteFile},
+		[]string{utxoPay1Skey, d.skeyPath},
+		depositAddr,
+		0,
+		driverWorkDir+"/vote-drep-tx",
+	)
+}
+
+// flatTxFee is a generous flat fee in lovelace that every driver tx
+// pays. cardano-node only validates that in >= out + fee + deposits,
+// so over-paying fees is harmless; we lose at most ~1 ADA per tx and
+// avoid the per-tx fee computation that `transaction build` would
+// normally do via LSQ. linearFee on this testnet is the default
+// 44 lovelace/byte + 155381 lovelace constant; with tx bodies that
+// top out around 2 KB even for proposals, real fees stay under 0.25
+// ADA, so 1 ADA is comfortable overhead.
+const flatTxFee uint64 = 1_000_000
+
+// buildSignSubmit builds a tx with `cardano-cli conway transaction
+// build-raw`, signs with each provided signing key, submits via the
+// node socket, and writes the resulting txid to <outBase>.txid.
+//
+// We use build-raw rather than `transaction build` to dodge a
+// cardano-cli 11.0.0 vs cardano-node 11.0.1 LSQ-decoder mismatch:
+// `transaction build` issues an LSQ block-query whose response
+// envelope now mentions DijkstraEra, and the cardano-cli compiled
+// into the 11.0.1 image deserialises that envelope with
+// `DeserialiseFailure 4 "expected word"`. build-raw skips that whole
+// query path because the caller provides --fee and --tx-out
+// (change) directly. Until cardano-cli ships a matching 11.x patch,
+// flat-fee + manual change is the only stable option.
+//
+// deposit is the lovelace amount the tx implicitly burns: dRepDeposit
+// for the DRep registration tx, govActionDeposit for the HFI proposal
+// tx, 0 for plain vote txs. cardano-node reads the deposit value off
+// the cert/proposal contents at validation time; we just need to
+// reduce the change output by the same amount so the tx balances.
+func buildSignSubmit(
+	t *testing.T,
+	tag string,
+	extraArgs []string,
+	signingKeys []string,
+	changeAddr string,
+	deposit uint64,
+	outBase string,
+) {
+	t.Helper()
+
+	// Pick the largest UTxO at the deposit address and learn its
+	// lovelace value. Re-querying every call (rather than caching)
+	// keeps the driver resilient to driver-tx chain interleaving:
+	// each successfully-submitted prior tx burns its input and
+	// creates the change UTxO we want to spend next.
+	txIn, lovelaceIn := selectLargestUtxo(t, changeAddr)
+
+	if lovelaceIn <= deposit+flatTxFee {
+		t.Fatalf(
+			"%s: UTxO at %s has %d lovelace, not enough for deposit %d + fee %d",
+			tag, changeAddr, lovelaceIn, deposit, flatTxFee,
+		)
+	}
+	change := lovelaceIn - deposit - flatTxFee
+
+	buildArgs := make([]string, 0, 6+len(extraArgs))
+	buildArgs = append(buildArgs,
+		"cardano-cli conway transaction build-raw",
+		"--tx-in "+txIn,
+		fmt.Sprintf("--tx-out %s+%d", changeAddr, change),
+		fmt.Sprintf("--fee %d", flatTxFee),
+		"--out-file "+outBase+".body",
+	)
+	buildArgs = append(buildArgs, extraArgs...)
+	runCli(t, "building "+tag+" tx", strings.Join(buildArgs, " "))
+
+	signArgs := make([]string, 0, 4+len(signingKeys))
+	signArgs = append(signArgs,
+		"cardano-cli conway transaction sign",
+		"--testnet-magic "+testnetMagic,
+		"--tx-body-file "+outBase+".body",
+		"--out-file "+outBase+".signed",
+	)
+	for _, sk := range signingKeys {
+		signArgs = append(signArgs, "--signing-key-file "+sk)
+	}
+	runCli(t, "signing "+tag+" tx", strings.Join(signArgs, " "))
+
+	// Capture the txid before submit so the caller can address the
+	// gov action by (txid, ix=0) before the submit acknowledgement
+	// returns. cardano-cli 11.x's transaction-txid command emits a
+	// JSON object `{"txhash":"..."}`, not a bare hex string, so pipe
+	// through jq to extract the raw hex.
+	runCli(t, "computing "+tag+" txid",
+		fmt.Sprintf(
+			"cardano-cli conway transaction txid --tx-file %s.signed | jq -r .txhash > %s.txid",
+			outBase, outBase,
+		))
+
+	runCli(t, "submitting "+tag+" tx",
+		"cardano-cli conway transaction submit "+
+			"--socket-path "+nodeSocketPath+" "+
+			"--testnet-magic "+testnetMagic+" "+
+			"--tx-file "+outBase+".signed")
+
+	// Wait for the tx to settle on-chain so the next call's
+	// selectLargestUtxo sees the new change UTxO rather than the
+	// just-consumed input. `transaction submit` only proves
+	// admission to the node's mempool; under our flat-fee build-raw
+	// flow we must verify the tx has actually been included before
+	// the next call selects an input.
+	awaitTxOnChain(t, changeAddr, readFile(t, outBase+".txid"))
+}
+
+// awaitTxOnChain blocks until txid appears in the UTxO set at addr.
+func awaitTxOnChain(t *testing.T, addr, txid string) {
+	t.Helper()
+	testutil.WaitForConditionWithInterval(t, func() bool {
+		out := runCli(t, "polling UTxO for "+txid,
+			"cardano-cli conway query utxo "+
+				"--socket-path "+nodeSocketPath+" "+
+				"--testnet-magic "+testnetMagic+" "+
+				"--address "+addr+" "+
+				"--output-json")
+		var utxos map[string]json.RawMessage
+		if err := json.Unmarshal(out, &utxos); err != nil {
+			t.Fatalf("decoding utxo set at %s: %v\n%s", addr, err, string(out))
+		}
+		for k := range utxos {
+			if strings.HasPrefix(k, txid+"#") {
+				return true
+			}
+		}
+		return false
+	}, 90*time.Second, 2*time.Second, fmt.Sprintf(
+		"tx %s did not appear at %s within 90s",
+		txid,
+		addr,
+	))
+}
+
+// selectLargestUtxo returns ("<txid>#<ix>", lovelace) for the
+// highest-lovelace UTxO at addr. Fails the test if the address has
+// no UTxOs.
+func selectLargestUtxo(t *testing.T, addr string) (string, uint64) {
+	t.Helper()
+	out := runCli(t, "querying UTxO at "+addr,
+		"cardano-cli conway query utxo "+
+			"--socket-path "+nodeSocketPath+" "+
+			"--testnet-magic "+testnetMagic+" "+
+			"--address "+addr+" "+
+			"--output-json")
+	var utxos map[string]struct {
+		Value struct {
+			Lovelace uint64 `json:"lovelace"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(out, &utxos); err != nil {
+		t.Fatalf("decoding utxo set at %s: %v\n%s", addr, err, string(out))
+	}
+	if len(utxos) == 0 {
+		t.Fatalf("no UTxO at %s — cardano-node may still be processing the previous driver tx", addr)
+	}
+	var bestKey string
+	var bestLovelace uint64
+	for k, v := range utxos {
+		if v.Value.Lovelace > bestLovelace {
+			bestKey = k
+			bestLovelace = v.Value.Lovelace
+		}
+	}
+	return bestKey, bestLovelace
+}
+
+// readJSONField returns the value of jqExpr applied to path inside
+// cliContainer, stripped of surrounding whitespace and quotes.
+func readJSONField(t *testing.T, path, jqExpr string) string {
+	t.Helper()
+	out := runCli(t, "reading "+path+jqExpr,
+		"jq -r '"+jqExpr+"' "+path)
+	return strings.TrimSpace(string(out))
+}
+
+// readFile cat's path inside cliContainer and returns trimmed
+// contents.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	out := runCli(t, "reading "+path, "cat "+path)
+	return strings.TrimSpace(string(out))
+}
+
+// currentEpoch returns the epoch the node's chain is currently in.
+func currentEpoch(t *testing.T) uint64 {
+	t.Helper()
+	out := runCli(t, "querying tip",
+		"cardano-cli conway query tip "+
+			"--socket-path "+nodeSocketPath+" "+
+			"--testnet-magic "+testnetMagic)
+	var tip struct {
+		Epoch uint64 `json:"epoch"`
+	}
+	if err := json.Unmarshal(out, &tip); err != nil {
+		t.Fatalf("decoding tip: %v\n%s", err, string(out))
+	}
+	return tip.Epoch
+}
+
+// waitForEpoch blocks until the chain reaches at least epoch target,
+// polling every 5 seconds. Fails the test if 6 epochs of wall-clock
+// time elapse without progress (sized to absorb the 2-epoch RATIFY+
+// ENACT wait plus margin against block-rate variance).
+func waitForEpoch(t *testing.T, target uint64) {
+	t.Helper()
+	var cur uint64
+	testutil.WaitForConditionWithInterval(t, func() bool {
+		cur = currentEpoch(t)
+		return cur >= target
+	}, 6*time.Duration(75)*time.Second, 5*time.Second, fmt.Sprintf(
+		"waitForEpoch(%d) gave up after deadline",
+		target,
+	))
+	t.Logf("HFI driver: reached epoch %d (target %d)", cur, target)
+}
+
+// verifyPV11 queries protocol-parameters on both producers and
+// asserts that protocolVersion.major == 11. Querying both sides
+// (dingo via cardano-producer's chain-sync view is implicit because
+// the relay is the shared canonical chain, but we also confirm
+// against cardano-producer's local pparams view) guards against the
+// case where only one node enacts the bump.
+func verifyPV11(t *testing.T) {
+	t.Helper()
+	out := runCli(t, "querying pparams on cardano-producer",
+		"cardano-cli conway query protocol-parameters "+
+			"--socket-path "+nodeSocketPath+" "+
+			"--testnet-magic "+testnetMagic)
+	var pp struct {
+		ProtocolVersion struct {
+			Major uint `json:"major"`
+			Minor uint `json:"minor"`
+		} `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(out, &pp); err != nil {
+		t.Fatalf("decoding pparams: %v\n%s", err, string(out))
+	}
+	if pp.ProtocolVersion.Major != 11 {
+		t.Fatalf(
+			"HFI did not enact: pparams.protocolVersion=%d.%d (want 11.0). "+
+				"Inspect the cardano-producer log for ratification/enactment failure; "+
+				"likely causes: SPO/DRep voting power below threshold, "+
+				"committee approval blocked, or proposal expired before votes landed.",
+			pp.ProtocolVersion.Major, pp.ProtocolVersion.Minor,
+		)
+	}
+	t.Logf(
+		"HFI driver: cardano-producer pparams.protocolVersion=%d.%d ✓",
+		pp.ProtocolVersion.Major, pp.ProtocolVersion.Minor,
+	)
+}
+
+// runCli executes "docker exec eras-cardano-producer sh -c <cmd>" and
+// returns stdout. Fails the test on non-zero exit, including stderr
+// in the failure message for diagnostics.
+func runCli(t *testing.T, what, cmd string) []byte {
+	t.Helper()
+	t.Logf("HFI driver: %s", what)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, "docker", "exec", cliContainer, "sh", "-c", cmd)
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf(
+				"docker exec timed out after 30s (%s)\n--- cmd ---\n%s\n--- stdout ---\n%s\n--- stderr ---\n%s",
+				what, cmd, stdout.String(), stderr.String(),
+			)
+		}
+		t.Fatalf(
+			"docker exec failed (%s): %v\n--- cmd ---\n%s\n--- stdout ---\n%s\n--- stderr ---\n%s",
+			what, err, cmd, stdout.String(), stderr.String(),
+		)
+	}
+	return stdout.Bytes()
+}

--- a/internal/test/erastest/vanrossem_test.go
+++ b/internal/test/erastest/vanrossem_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build erastest
+
+package erastest
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/stretchr/testify/require"
+)
+
+// vanRossemPreBumpTargetSlot is the slot the chain must reach before
+// the pre-bump assertions run. Picked to exceed two full 75-slot
+// epochs so the observation window covers steady-state PV10 block
+// production after bootstrap warmup. With f=0.4 and two equal-stake
+// pools, the probability of zero forges from a given pool over 100
+// slots is (1-0.225)^100 ≈ 9e-11 — slot count is not a realistic
+// source of flakes.
+const vanRossemPreBumpTargetSlot = uint64(100)
+
+// TestVanRossem exercises the PV10→PV11 (vanRossem) intra-Conway
+// hard fork on a multi-node DevNet. The chain bootstraps in
+// Conway-Plomin via testnet-vanrossem.yaml; a HardForkInitiation
+// governance-action driver subsequently submits, votes, ratifies,
+// and enacts the bump to PV11 on the live chain. The test asserts:
+//
+//  1. The DevNet harness was actually pointed at the vanRossem
+//     variant (testnet-vanrossem.yaml), not the default eras testnet.
+//  2. Pre-bump (PV10): every header is in Conway era, both pools
+//     forge accepted blocks on the relay's chain. Establishes a
+//     known-good baseline before the boundary.
+//  3. Post-bump (PV11): once the HFI driver enacts the protocol
+//     version bump, the chain continues advancing, dingo continues
+//     forging blocks accepted by the cardano-node relay, and PV11
+//     rule activation does not break header / block validation on
+//     either side.
+//
+// The driver itself lives in vanrossem_driver.go (TODO: not yet
+// implemented). Until then, the post-bump sub-tests are skipped
+// rather than wired against a non-existent boundary, so the test
+// validates the PV10 baseline cleanly today.
+func TestVanRossem(t *testing.T) {
+	cfg := loadConfig(t)
+
+	// Defensive: confirm we are running against the vanrossem variant
+	// rather than the default eras testnet. An empty-schedule check is
+	// not load-bearing here because Config.ScheduledTransitions()
+	// reports Conway when StartingMajorVersion lives inside Conway's
+	// [MinMajorVersion, MaxMajorVersion] range — at PV10 there is still
+	// PV11 of Conway ahead, so the schedule reports `conway@epoch=0`
+	// even though no inter-era boundary will actually be crossed. The
+	// StartingMajorVersion equality check below is what distinguishes
+	// the variant.
+	require.Equalf(
+		t, uint(10), cfg.StartingMajorVersion,
+		"vanrossem variant must bootstrap at PV10 (Plomin); got %d. "+
+			"The HFI driver expects to start one PV step below "+
+			"vanRossem so it can drive the PV10→PV11 transition. "+
+			"Check shelley genesis protocolVersion.major in "+
+			"testnet-vanrossem.yaml — and run via "+
+			"run-tests-vanrossem.sh, not run-tests.sh.",
+		cfg.StartingMajorVersion,
+	)
+
+	endpoints := DefaultEndpoints()
+	streams := make(map[string]*EraStream, len(endpoints))
+	for _, ep := range endpoints {
+		streams[ep.Name] = NewEraStream(
+			t, ep, cfg.NetworkMagic, cfg.EpochLength,
+		)
+	}
+	t.Cleanup(func() {
+		for _, s := range streams {
+			s.Close()
+		}
+	})
+
+	// Drive each node past the pre-bump target so every PV10-era
+	// assertion below observes a non-trivial chain. Reusing
+	// transitionTimeout keeps the budget consistent with the eras
+	// test harness; the vanrossem variant has no inter-era boundaries
+	// so the timeout only needs to absorb container warmup and block-
+	// rate variance, not fork-resolution churn.
+	timeout := transitionTimeout(cfg)
+	for name, s := range streams {
+		_, err := s.WaitForSlot(vanRossemPreBumpTargetSlot, timeout)
+		require.NoErrorf(
+			t, err,
+			"node %s did not reach slot %d within %s: %v",
+			name, vanRossemPreBumpTargetSlot, timeout, err,
+		)
+	}
+
+	// All assertions read the relay's view because the relay forges no
+	// blocks itself, so the issuer vkey of every block on its chain is
+	// the producer (dingo or cardano-producer) that the relay actually
+	// accepted. Same rationale as TestEraTransitions /
+	// DingoProducesInEachEra.
+	relay := endpoints[2]
+	relayStream := streams[relay.Name]
+	require.NotNilf(
+		t, relayStream,
+		"no stream for relay endpoint %q; check DefaultEndpoints ordering",
+		relay.Name,
+	)
+
+	t.Run("ChainStaysInConway", func(t *testing.T) {
+		headers := relayStream.HeadersSnapshot()
+		require.NotEmpty(t, headers, "no headers observed on relay")
+		for _, h := range headers {
+			require.Equalf(
+				t, eras.ConwayEraDesc.Id, h.EraID,
+				"non-Conway header at slot %d (era ID %d). "+
+					"vanRossem chain must stay in Conway era throughout; "+
+					"a different era ID indicates the configurator did "+
+					"not honor the testnet-vanrossem.yaml fork schedule "+
+					"or cardano-node ran an inter-era HFC translation "+
+					"despite no scheduled transitions.",
+				h.Slot, h.EraID,
+			)
+		}
+	})
+
+	t.Run("DingoProducesAtPV10", func(t *testing.T) {
+		dingoVkey := readDingoColdVKey(t)
+		t.Logf("dingo cold vkey: %s", hex.EncodeToString(dingoVkey))
+
+		headers := relayStream.HeadersSnapshot()
+		var dingoBlocks, cardanoBlocks int
+		for _, h := range headers {
+			if bytes.Equal(h.IssuerVkey, dingoVkey) {
+				dingoBlocks++
+				continue
+			}
+			cardanoBlocks++
+		}
+		t.Logf(
+			"relay observed %d total headers (dingo-issued=%d, cardano-issued=%d)",
+			len(headers), dingoBlocks, cardanoBlocks,
+		)
+
+		require.Greaterf(
+			t, dingoBlocks, 0,
+			"no dingo-issued blocks observed on relay across %d headers — "+
+				"dingo's PV10 forges are not being accepted by the "+
+				"cardano-node relay. With two equal-stake pools and f=%.2f "+
+				"over %d slots the probability of zero forges is ≈1e-10, "+
+				"so this is a chain-divergence regression at PV10: "+
+				"investigate the dingo log for VRF / nonce / pparams "+
+				"disagreements with the cardano-node relay before any "+
+				"PV11 bump is even attempted.",
+			len(headers), cfg.ActiveSlotsCoeff, vanRossemPreBumpTargetSlot,
+		)
+
+		require.Greaterf(
+			t, cardanoBlocks, 0,
+			"no cardano-issued blocks observed on relay across %d "+
+				"headers — cardano-producer is not contributing to the "+
+				"canonical chain. Check that cardano-node:11.0.1 "+
+				"actually started and is forging at PV10.",
+			len(headers),
+		)
+	})
+
+	t.Run("DriveHFIToPV11", func(t *testing.T) {
+		driveHFIToPV11(t)
+
+		// Re-observe the relay stream after the bump and confirm
+		// dingo continues to forge accepted blocks on the canonical
+		// chain post-boundary. This is the assertion that catches a
+		// vanRossem rule activation breaking dingo's block validity
+		// against the cardano-node relay even when the PV bump
+		// itself succeeded.
+		beforeCount := len(relayStream.HeadersSnapshot())
+		postBumpTimeout := transitionTimeout(cfg)
+		// Wait for the relay to advance by at least 1 epoch's worth
+		// of slots after the bump so we have a fair sample of
+		// post-bump headers to inspect.
+		latest, _ := relayStream.LatestHeader()
+		_, err := relayStream.WaitForSlot(
+			latest.Slot+cfg.EpochLength, postBumpTimeout,
+		)
+		require.NoErrorf(
+			t, err,
+			"chain did not advance one epoch past PV11 boundary within %s",
+			postBumpTimeout,
+		)
+
+		dingoVkey := readDingoColdVKey(t)
+		var postBumpDingo, postBumpCardano int
+		for _, h := range relayStream.HeadersSnapshot()[beforeCount:] {
+			if bytes.Equal(h.IssuerVkey, dingoVkey) {
+				postBumpDingo++
+				continue
+			}
+			postBumpCardano++
+		}
+		t.Logf(
+			"post-PV11 headers on relay: dingo-issued=%d, cardano-issued=%d",
+			postBumpDingo, postBumpCardano,
+		)
+		require.Greaterf(
+			t, postBumpDingo, 0,
+			"no dingo-issued blocks observed on relay after PV11 enactment. "+
+				"The bump itself ratified (pparams.major=11 confirmed by "+
+				"driveHFIToPV11) but dingo's post-boundary forges are not "+
+				"being accepted by the cardano-node relay — investigate the "+
+				"dingo log for VRF / pparams disagreements clustered "+
+				"immediately after the enactment epoch boundary.",
+		)
+		require.GreaterOrEqualf(
+			t, postBumpCardano, 0,
+			"cardano-issued blocks after PV11 enactment may be zero; cardano-producer contribution is informational",
+		)
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a vanRossem (PV11) DevNet variant that boots in Conway at PV10 and fully drives the PV10→PV11 governance bump. Verifies Dingo forges before and after the bump against a `cardano-node:11.0.1` relay.

- **New Features**
  - Compose override mounts `testnet-vanrossem.yaml` and adds `utxo-keys` and `p1-configs` volumes to `cardano-producer` so the HFI driver can sign governance and vote txs.
  - `testnet-vanrossem.yaml`: Conway/Plomin boot (PV10), era toggles at epoch 0, 1s slots, 75-slot epochs, 2 pools, `f=0.4`; committee set to NoCommittee to allow HFI without CC signatures.
  - `vanrossem_driver_test.go` + `vanrossem_test.go`: register a DRep, submit PV11 HFI, cast SPO + DRep Yes votes, wait RATIFY/ENACT, assert pparams.major=11, and confirm both pools keep forging after the bump.
  - `run-tests-vanrossem.sh`: spins up the DevNet with the PV11 variant, waits for health, exports endpoints, runs `go test -tags erastest -run 'TestVanRossem|TestPV11Readiness'`, supports `--keep-up`, and dumps per-service logs on exit.

- **Bug Fixes**
  - Configurator: clear the Conway committee in `conway-genesis.json`; route genesis UTxO keys to `/configs/utxo-keys` so the driver can sign txs from inside the container.
  - DB test: add SQLite test ensuring `ImportUtxos` adds missing assets to an existing UTxO.

<sup>Written for commit 4d12b839021012fd1cd7d3c2f5228aaf7a0aff5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive testing infrastructure for Conway protocol version 11 upgrade validation, including database import tests, multi-node DevNet configurations, and hard fork initiation governance flow verification.

* **Chores**
  * Added test automation scripts and configuration files for internal development and quality assurance workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2220)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->