### PR TITLE
fix(mithril): preserve more data on backfill

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -49,6 +49,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	syncStatusInProgress = "in_progress"
+	syncStatusBackfill   = "backfill"
+)
+
 func mithrilCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mithril",
@@ -365,7 +370,7 @@ func runMithrilSync(
 
 	// Mark sync as in-progress so `dingo serve` can detect an
 	// incomplete sync and refuse to start.
-	if err := db.SetSyncState("sync_status", "in_progress", nil); err != nil {
+	if err := db.SetSyncState("sync_status", syncStatusInProgress, nil); err != nil {
 		return fmt.Errorf("marking sync in-progress: %w", err)
 	}
 
@@ -376,15 +381,7 @@ func runMithrilSync(
 	// Pre-seeding the checkpoint here ensures NeedsBackfill() returns
 	// the correct answer at any interruption point.
 	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
-		now := time.Now()
-		if err := db.Metadata().SetBackfillCheckpoint(
-			&models.BackfillCheckpoint{
-				Phase:     node.BackfillPhase,
-				StartedAt: now,
-				UpdatedAt: now,
-			},
-			nil,
-		); err != nil {
+		if err := ensureMithrilBackfillCheckpoint(db); err != nil {
 			return fmt.Errorf(
 				"marking backfill in-progress: %w", err,
 			)
@@ -653,6 +650,15 @@ func runMithrilSync(
 		)
 	}
 
+	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
+		if err := updateMithrilReadyState(
+			db, logger, loadResult, ledgerStateSlot,
+			syncStatusBackfill, false,
+		); err != nil {
+			return err
+		}
+	}
+
 	// Backfill historical metadata if storage mode is API.
 	// This replays all stored blocks to populate transaction
 	// records needed for API queries (Blockfrost, UTxO RPC).
@@ -662,15 +668,44 @@ func runMithrilSync(
 			"component", "mithril",
 		)
 		bf := node.NewBackfill(db, nodeCfg, logger)
+		bf.DisableNonceComputation()
 		if err := bf.Run(ctx); err != nil {
 			return fmt.Errorf("backfill: %w", err)
 		}
 	}
 
-	// Set the metadata tip to the latest block in the blob store.
-	// After gap blocks are stored, this should match the ledger
-	// state tip, giving the node a consistent starting point.
-	recentBlocks, err = database.BlocksRecent(db, 1)
+	if err := updateMithrilReadyState(
+		db, logger, loadResult, ledgerStateSlot,
+		"", true,
+	); err != nil {
+		return err
+	}
+	syncComplete = true
+
+	// Clean up temporary files after a successful complete load.
+	if cfg.Mithril.CleanupAfterLoad {
+		result.Cleanup(logger)
+	}
+
+	logger.Info(
+		"Mithril bootstrap complete",
+		"component", "mithril",
+		"epoch", result.Snapshot.Beacon.Epoch,
+		"immutable_file_number", result.Snapshot.Beacon.ImmutableFileNumber,
+	)
+
+	return nil
+}
+
+func updateMithrilReadyState(
+	db *database.Database,
+	logger *slog.Logger,
+	loadResult *node.LoadBlobsResult,
+	ledgerStateSlot uint64,
+	syncStatus string,
+	clearSyncState bool,
+) error {
+	recentBlocks, err := database.BlocksRecent(db, 1)
 	if err != nil {
 		return fmt.Errorf("reading final chain tip: %w", err)
 	}
@@ -710,14 +745,20 @@ func runMithrilSync(
 		trustBoundarySlot = recentBlocks[0].Slot
 	}
 
-	// Clean up ephemeral sync state and record the Mithril trust
-	// boundary atomically. Both must succeed together: if cleanup
-	// succeeds but the boundary write fails, dingo serve would
-	// start without the trust boundary and hit the replay bug.
 	txn := db.MetadataTxn(true)
 	if err := txn.Do(func(txn *database.Txn) error {
-		if err := db.ClearSyncState(txn); err != nil {
-			return fmt.Errorf("cleaning up sync state: %w", err)
+		if clearSyncState {
+			if err := db.ClearSyncState(txn); err != nil {
+				return fmt.Errorf("cleaning up sync state: %w", err)
+			}
+		} else if syncStatus != "" {
+			if err := db.SetSyncState(
+				"sync_status", syncStatus, txn,
+			); err != nil {
+				return fmt.Errorf(
+					"recording sync status: %w", err,
+				)
+			}
 		}
 		if err := db.SetSyncState(
 			"mithril_ledger_slot",
@@ -732,20 +773,38 @@ func runMithrilSync(
 	}); err != nil {
 		return err
 	}
-	syncComplete = true
+	return nil
+}
 
-	// Clean up temporary files after a successful complete load.
-	if cfg.Mithril.CleanupAfterLoad {
-		result.Cleanup(logger)
+func ensureMithrilBackfillCheckpoint(db *database.Database) error {
+	cp, err := db.Metadata().GetBackfillCheckpoint(
+		node.BackfillPhase, nil,
+	)
+	if err != nil {
+		return fmt.Errorf("reading backfill checkpoint: %w", err)
 	}
 
-	logger.Info(
-		"Mithril bootstrap complete",
-		"component", "mithril",
-		"epoch", result.Snapshot.Beacon.Epoch,
-		"immutable_file_number", result.Snapshot.Beacon.ImmutableFileNumber,
-	)
+	if cp != nil && !cp.Completed {
+		return nil
+	}
 
+	now := time.Now()
+	if cp == nil {
+		cp = &models.BackfillCheckpoint{
+			Phase:     node.BackfillPhase,
+			LastSlot:  0,
+			StartedAt: now,
+			UpdatedAt: now,
+			Completed: false,
+		}
+	} else {
+		cp.Completed = false
+		cp.UpdatedAt = now
+	}
+
+	if err := db.Metadata().SetBackfillCheckpoint(cp, nil); err != nil {
+		return fmt.Errorf("setting backfill checkpoint: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/dingo/mithril_test.go
+++ b/cmd/dingo/mithril_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/internal/node"
+	"github.com/stretchr/testify/require"
+)
+
+func newMithrilTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db
+}
+
+func TestEnsureMithrilBackfillCheckpointCreatesMissing(t *testing.T) {
+	db := newMithrilTestDB(t)
+
+	require.NoError(t, ensureMithrilBackfillCheckpoint(db))
+
+	cp, err := db.Metadata().GetBackfillCheckpoint(
+		node.BackfillPhase, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	require.Equal(t, uint64(0), cp.LastSlot)
+	require.False(t, cp.Completed)
+	require.False(t, cp.StartedAt.IsZero())
+	require.False(t, cp.UpdatedAt.IsZero())
+}
+
+func TestEnsureMithrilBackfillCheckpointPreservesIncomplete(t *testing.T) {
+	db := newMithrilTestDB(t)
+	startedAt := time.Now().Add(-time.Hour)
+	updatedAt := time.Now().Add(-time.Minute)
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(
+		&models.BackfillCheckpoint{
+			Phase:      node.BackfillPhase,
+			LastSlot:   1042527,
+			TotalSlots: 2000000,
+			StartedAt:  startedAt,
+			UpdatedAt:  updatedAt,
+			Completed:  false,
+		},
+		nil,
+	))
+
+	require.NoError(t, ensureMithrilBackfillCheckpoint(db))
+
+	cp, err := db.Metadata().GetBackfillCheckpoint(
+		node.BackfillPhase, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	require.Equal(t, uint64(1042527), cp.LastSlot)
+	require.Equal(t, uint64(2000000), cp.TotalSlots)
+	require.False(t, cp.Completed)
+	require.Equal(t, startedAt.UnixNano(), cp.StartedAt.UnixNano())
+	require.Equal(t, updatedAt.UnixNano(), cp.UpdatedAt.UnixNano())
+}
+
+func TestEnsureMithrilBackfillCheckpointReopensCompleted(t *testing.T) {
+	db := newMithrilTestDB(t)
+	startedAt := time.Now().Add(-time.Hour)
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(
+		&models.BackfillCheckpoint{
+			Phase:      node.BackfillPhase,
+			LastSlot:   5000,
+			TotalSlots: 5000,
+			StartedAt:  startedAt,
+			UpdatedAt:  startedAt,
+			Completed:  true,
+		},
+		nil,
+	))
+
+	require.NoError(t, ensureMithrilBackfillCheckpoint(db))
+
+	cp, err := db.Metadata().GetBackfillCheckpoint(
+		node.BackfillPhase, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	require.Equal(t, uint64(5000), cp.LastSlot)
+	require.Equal(t, uint64(5000), cp.TotalSlots)
+	require.False(t, cp.Completed)
+	require.Equal(t, startedAt.UnixNano(), cp.StartedAt.UnixNano())
+	require.True(t, cp.UpdatedAt.After(startedAt))
+}

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -98,7 +98,7 @@ func checkSyncState(
 	if err != nil {
 		return fmt.Errorf("checking sync state: %w", err)
 	}
-	if val == "" {
+	if val == "" || val == syncStatusBackfill {
 		return nil
 	}
 	return fmt.Errorf(
@@ -170,12 +170,13 @@ func resumeBackfill(
 	defer db.Close()
 
 	bf := node.NewBackfill(db, nodeCfg, logger)
+	bf.DisableNonceComputation()
 	needed, err := bf.NeedsBackfill()
 	if err != nil {
 		return fmt.Errorf("checking backfill state: %w", err)
 	}
 	if !needed {
-		return nil
+		return clearBackfillSyncStatus(db)
 	}
 
 	// Enable bulk-load optimizations for the backfill
@@ -188,6 +189,23 @@ func resumeBackfill(
 	)
 	if err := bf.Run(ctx); err != nil {
 		return fmt.Errorf("backfill: %w", err)
+	}
+	if err := clearBackfillSyncStatus(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func clearBackfillSyncStatus(db *database.Database) error {
+	status, err := db.GetSyncState("sync_status", nil)
+	if err != nil {
+		return fmt.Errorf("reading sync status: %w", err)
+	}
+	if status != syncStatusBackfill {
+		return nil
+	}
+	if err := db.DeleteSyncState("sync_status", nil); err != nil {
+		return fmt.Errorf("clearing backfill sync status: %w", err)
 	}
 	return nil
 }

--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -250,13 +250,7 @@ func batchCreateUtxos(db *gorm.DB, items []models.Utxo) error {
 	if len(items) == 0 {
 		return nil
 	}
-	if result := db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-		DoNothing: true,
-	}).CreateInBatches(items, batchChunkRows); result.Error != nil {
-		return result.Error
-	}
-	return nil
+	return importUtxosWithDB(db, items)
 }
 
 func batchCreateScripts(db *gorm.DB, items []models.Script) error {

--- a/database/plugin/metadata/mysql/import.go
+++ b/database/plugin/metadata/mysql/import.go
@@ -46,7 +46,13 @@ func (d *MetadataStoreMysql) ImportUtxos(
 	if err != nil {
 		return fmt.Errorf("resolve db for import utxos: %w", err)
 	}
+	return importUtxosWithDB(db, utxos)
+}
 
+func importUtxosWithDB(
+	db *gorm.DB,
+	utxos []models.Utxo,
+) error {
 	// Collect assets from UTxOs before insert. We work on a
 	// local copy of each UTxO so the caller's slice is not
 	// mutated (Assets remains intact after this call).
@@ -98,6 +104,14 @@ func (d *MetadataStoreMysql) ImportUtxos(
 		assets := make([]models.Asset, 0, len(pending))
 		for _, p := range pending {
 			p.asset.UtxoID = stripped[p.utxoIdx].ID
+			p.asset.ID = 0
+			if p.asset.UtxoID == 0 {
+				return fmt.Errorf(
+					"missing UTxO ID for asset on %x#%d",
+					stripped[p.utxoIdx].TxId,
+					stripped[p.utxoIdx].OutputIdx,
+				)
+			}
 			assets = append(assets, p.asset)
 		}
 		for i := 0; i < len(assets); i += importAssetBatchSize {

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -250,13 +250,7 @@ func batchCreateUtxos(db *gorm.DB, items []models.Utxo) error {
 	if len(items) == 0 {
 		return nil
 	}
-	if result := db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "tx_id"}, {Name: "output_idx"}},
-		DoNothing: true,
-	}).CreateInBatches(items, batchChunkRows); result.Error != nil {
-		return result.Error
-	}
-	return nil
+	return importUtxosWithDB(db, items)
 }
 
 func batchCreateScripts(db *gorm.DB, items []models.Script) error {

--- a/database/plugin/metadata/postgres/import.go
+++ b/database/plugin/metadata/postgres/import.go
@@ -46,7 +46,13 @@ func (d *MetadataStorePostgres) ImportUtxos(
 	if err != nil {
 		return fmt.Errorf("import utxos: %w", err)
 	}
+	return importUtxosWithDB(db, utxos)
+}
 
+func importUtxosWithDB(
+	db *gorm.DB,
+	utxos []models.Utxo,
+) error {
 	// Collect assets from UTxOs before insert. We work on a
 	// local copy of each UTxO so the caller's slice is not
 	// mutated (Assets remains intact after this call).
@@ -98,6 +104,14 @@ func (d *MetadataStorePostgres) ImportUtxos(
 		assets := make([]models.Asset, 0, len(pending))
 		for _, p := range pending {
 			p.asset.UtxoID = stripped[p.utxoIdx].ID
+			p.asset.ID = 0
+			if p.asset.UtxoID == 0 {
+				return fmt.Errorf(
+					"missing UTxO ID for asset on %x#%d",
+					stripped[p.utxoIdx].TxId,
+					stripped[p.utxoIdx].OutputIdx,
+				)
+			}
 			assets = append(assets, p.asset)
 		}
 		for i := 0; i < len(assets); i += importAssetBatchSize {

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -117,6 +117,9 @@ func importUtxosWithDB(
 			}
 			assets = append(assets, p.asset)
 		}
+		if len(assets) == 0 {
+			return nil
+		}
 		for i := 0; i < len(assets); i += importAssetBatchSize {
 			end := min(i+importAssetBatchSize, len(assets))
 			batch := assets[i:end]

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
 
@@ -200,6 +201,123 @@ func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
 
 func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
 	return lcommon.Blake2b256{}
+}
+
+type mockTransactionInput struct {
+	hash  lcommon.Blake2b256
+	index uint32
+}
+
+func (m mockTransactionInput) Id() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m mockTransactionInput) Index() uint32 {
+	return m.index
+}
+
+func (m mockTransactionInput) String() string {
+	return m.hash.String()
+}
+
+func (m mockTransactionInput) Utxorpc() (*cardano.TxInput, error) {
+	return nil, nil
+}
+
+func (m mockTransactionInput) ToPlutusData() data.PlutusData {
+	return nil
+}
+
+type mockTransactionOutput struct {
+	amount *big.Int
+}
+
+func (m *mockTransactionOutput) Address() lcommon.Address {
+	return lcommon.Address{}
+}
+
+func (m *mockTransactionOutput) Amount() *big.Int {
+	return m.amount
+}
+
+func (m *mockTransactionOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return nil
+}
+
+func (m *mockTransactionOutput) Datum() *lcommon.Datum {
+	return nil
+}
+
+func (m *mockTransactionOutput) DatumHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockTransactionOutput) Cbor() []byte {
+	return nil
+}
+
+func (m *mockTransactionOutput) Utxorpc() (*cardano.TxOutput, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionOutput) ScriptRef() lcommon.Script {
+	return nil
+}
+
+func (m *mockTransactionOutput) ToPlutusData() data.PlutusData {
+	return nil
+}
+
+func (m *mockTransactionOutput) String() string {
+	return ""
+}
+
+func TestSetTransactionIdempotentlyStoresCollateralReturn(t *testing.T) {
+	sqliteStore := setupTestDB(t)
+
+	var txHash lcommon.Blake2b256
+	txHash[0] = 0x4f
+	var blockHash []byte = bytes.Repeat([]byte{0xf8}, 32)
+	collateralReturn := &mockTransactionOutput{
+		amount: big.NewInt(7_000_000),
+	}
+	tx := &mockTransaction{
+		hash:    txHash,
+		isValid: false,
+		produced: []lcommon.Utxo{
+			{
+				Id: mockTransactionInput{
+					hash:  txHash,
+					index: 1,
+				},
+				Output: collateralReturn,
+			},
+		},
+		collReturn: collateralReturn,
+	}
+	point := ocommon.NewPoint(1556770, blockHash)
+
+	requireNoError := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	requireNoError(sqliteStore.SetTransaction(tx, point, 0, nil, nil))
+	requireNoError(sqliteStore.SetTransaction(tx, point, 0, nil, nil))
+
+	var txModel models.Transaction
+	requireNoError(sqliteStore.DB().
+		Where("hash = ?", txHash.Bytes()).
+		Take(&txModel).Error)
+	var count int64
+	requireNoError(sqliteStore.DB().
+		Model(&models.Utxo{}).
+		Where("collateral_return_for_tx_id = ?", txModel.ID).
+		Count(&count).Error)
+	if count != 1 {
+		t.Fatalf("expected one collateral return UTxO, got %d", count)
+	}
 }
 
 func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -656,7 +656,9 @@ func (d *MetadataStoreSqlite) SetGapBlockTransaction(
 		tmpTx.Outputs = append(tmpTx.Outputs, m)
 	}
 	outputsToCreate := tmpTx.Outputs
+	collateralReturnToCreate := tmpTx.CollateralReturn
 	tmpTx.Outputs = nil
+	tmpTx.CollateralReturn = nil
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}},
 		DoUpdates: clause.AssignmentColumns(
@@ -664,6 +666,7 @@ func (d *MetadataStoreSqlite) SetGapBlockTransaction(
 		),
 	}).Create(tmpTx)
 	tmpTx.Outputs = outputsToCreate
+	tmpTx.CollateralReturn = collateralReturnToCreate
 	if result.Error != nil {
 		return fmt.Errorf(
 			"create gap block transaction at slot %d: %w",
@@ -766,7 +769,9 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	// Store outputs in a separate slice for explicit creation later
 	// GORM's Create with OnConflict doesn't properly handle associations
 	outputsToCreate := tmpTx.Outputs
+	collateralReturnToCreate := tmpTx.CollateralReturn
 	tmpTx.Outputs = nil
+	tmpTx.CollateralReturn = nil
 
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}}, // unique txn hash
@@ -778,6 +783,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 	// Restore outputs for later explicit creation
 	tmpTx.Outputs = outputsToCreate
+	tmpTx.CollateralReturn = collateralReturnToCreate
 
 	if result.Error != nil {
 		return fmt.Errorf(

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -120,7 +120,6 @@ func (d *MetadataStoreSqlite) GetUtxosBatch(
 		// Without parens, SQL operator precedence (AND > OR) causes deleted_slot=0
 		// to only apply to the first condition.
 		query := db.Where("deleted_slot = 0").
-			Preload("Assets").
 			Where("("+strings.Join(conditions, " OR ")+")", args...)
 		if queryResult := query.Find(&utxos); queryResult.Error != nil {
 			return nil, queryResult.Error

--- a/database/pparams.go
+++ b/database/pparams.go
@@ -84,11 +84,19 @@ func (d *Database) ApplyPParamUpdates(
 	updateFunc func(lcommon.ProtocolParameters, any) (lcommon.ProtocolParameters, error),
 	txn *Txn,
 ) error {
-	// Handle nil transaction by creating a read-only transaction
 	if txn == nil {
-		tmpTxn := d.Transaction(false)
+		tmpTxn := d.MetadataTxn(true)
 		defer tmpTxn.Release()
-		txn = tmpTxn
+		if err := d.ApplyPParamUpdates(
+			slot, epoch, era, quorum, currentPParams,
+			decodeFunc, updateFunc, tmpTxn,
+		); err != nil {
+			return err
+		}
+		if err := tmpTxn.Commit(); err != nil {
+			return fmt.Errorf("commit pparams update: %w", err)
+		}
+		return nil
 	}
 	// Check for pparam updates that apply at the end of the epoch
 	pparamUpdates, err := d.metadata.GetPParamUpdates(epoch, txn.Metadata())
@@ -189,11 +197,20 @@ func (d *Database) ComputeAndApplyPParamUpdates(
 	) (lcommon.ProtocolParameters, error),
 	txn *Txn,
 ) (lcommon.ProtocolParameters, error) {
-	// Handle nil transaction by creating a read-only transaction
 	if txn == nil {
-		tmpTxn := d.Transaction(false)
+		tmpTxn := d.MetadataTxn(true)
 		defer tmpTxn.Release()
-		txn = tmpTxn
+		result, err := d.ComputeAndApplyPParamUpdates(
+			slot, epoch, era, quorum, currentPParams,
+			decodeFunc, updateFunc, tmpTxn,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := tmpTxn.Commit(); err != nil {
+			return nil, fmt.Errorf("commit pparams update: %w", err)
+		}
+		return result, nil
 	}
 	// Check for pparam updates that apply at the end of the epoch
 	pparamUpdates, err := d.metadata.GetPParamUpdates(epoch, txn.Metadata())

--- a/database/pparams_test.go
+++ b/database/pparams_test.go
@@ -199,6 +199,132 @@ func TestComputeAndApplyPParamUpdates_QuorumMet(
 	require.NotNil(t, stored)
 }
 
+func TestComputeAndApplyPParamUpdates_NilTxnCommitsWrite(
+	t *testing.T,
+) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	minFeeA := uint(100)
+	updateCbor, err := cbor.Encode(
+		&shelley.ShelleyProtocolParameterUpdate{
+			MinFeeA: &minFeeA,
+		},
+	)
+	require.NoError(t, err)
+	for i := range 5 {
+		require.NoError(t, db.SetPParamUpdate(
+			[]byte{byte(i)}, updateCbor, uint64(300+i), 4, nil,
+		))
+	}
+
+	currentPParams := &shelley.ShelleyProtocolParameters{
+		MinFeeA: 44,
+	}
+	decodeFunc := func(data []byte) (any, error) {
+		var update shelley.ShelleyProtocolParameterUpdate
+		_, err := cbor.Decode(data, &update)
+		return update, err
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		tmp := *current.(*shelley.ShelleyProtocolParameters)
+		tmp.MinFeeA = *update.(shelley.ShelleyProtocolParameterUpdate).MinFeeA
+		return &tmp, nil
+	}
+
+	result, err := db.ComputeAndApplyPParamUpdates(
+		400, 4, 2, 5,
+		currentPParams,
+		decodeFunc, updateFunc,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint(100), result.(*shelley.ShelleyProtocolParameters).MinFeeA)
+
+	stored, err := db.GetPParams(
+		4,
+		2,
+		func(data []byte) (lcommon.ProtocolParameters, error) {
+			var params shelley.ShelleyProtocolParameters
+			_, err := cbor.Decode(data, &params)
+			return &params, err
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, uint(100), stored.(*shelley.ShelleyProtocolParameters).MinFeeA)
+}
+
+func TestApplyPParamUpdates_NilTxnCommitsWrite(t *testing.T) {
+	config := &Config{DataDir: ""}
+	db, err := New(config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	minFeeA := uint(100)
+	updateCbor, err := cbor.Encode(
+		&shelley.ShelleyProtocolParameterUpdate{
+			MinFeeA: &minFeeA,
+		},
+	)
+	require.NoError(t, err)
+	for i := range 5 {
+		require.NoError(t, db.SetPParamUpdate(
+			[]byte{byte(i)}, updateCbor, uint64(300+i), 4, nil,
+		))
+	}
+
+	currentPParams := lcommon.ProtocolParameters(
+		&shelley.ShelleyProtocolParameters{
+			MinFeeA: 44,
+		},
+	)
+	decodeFunc := func(data []byte) (any, error) {
+		var update shelley.ShelleyProtocolParameterUpdate
+		_, err := cbor.Decode(data, &update)
+		return update, err
+	}
+	updateFunc := func(
+		current lcommon.ProtocolParameters,
+		update any,
+	) (lcommon.ProtocolParameters, error) {
+		tmp := *current.(*shelley.ShelleyProtocolParameters)
+		tmp.MinFeeA = *update.(shelley.ShelleyProtocolParameterUpdate).MinFeeA
+		return &tmp, nil
+	}
+
+	require.NoError(t, db.ApplyPParamUpdates(
+		400, 4, 2, 5,
+		&currentPParams,
+		decodeFunc, updateFunc,
+		nil,
+	))
+	require.Equal(
+		t, uint(100),
+		currentPParams.(*shelley.ShelleyProtocolParameters).MinFeeA,
+	)
+
+	stored, err := db.GetPParams(
+		4,
+		2,
+		func(data []byte) (lcommon.ProtocolParameters, error) {
+			var params shelley.ShelleyProtocolParameters
+			_, err := cbor.Decode(data, &params)
+			return &params, err
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, uint(100), stored.(*shelley.ShelleyProtocolParameters).MinFeeA)
+}
+
 func TestComputeAndApplyPParamUpdates_FiltersEpoch(
 	t *testing.T,
 ) {

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -70,6 +70,14 @@ func NewBackfill(
 	}
 }
 
+// DisableNonceComputation skips historical block nonce reconstruction.
+// Mithril imports already seed the ledger-state tip nonce needed for
+// live sync; API metadata backfill does not need per-block historical
+// nonce rows.
+func (b *Backfill) DisableNonceComputation() {
+	b.computeNonces = false
+}
+
 // NeedsBackfill checks if there's an incomplete backfill checkpoint.
 func (b *Backfill) NeedsBackfill() (bool, error) {
 	cp, err := b.db.Metadata().GetBackfillCheckpoint(

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -42,6 +43,8 @@ import (
 const (
 	loadBlockBatchSize  = 50
 	progressLogInterval = 10 * time.Second
+
+	immutableUtxoOffsetsSyncStateKey = "immutable_utxo_offsets_tip"
 )
 
 func Load(ctx context.Context, cfg *config.Config, logger *slog.Logger, immutableDir string) error {
@@ -459,22 +462,42 @@ func copyBlocksRawWithCallback(
 			"immutable_tip_slot", immutableTip.Slot,
 		)
 		if callback != nil && db != nil {
-			blocksBackfilled, err := backfillRawBlockCallbacks(
-				ctx,
-				imm,
+			complete, err := immutableUtxoOffsetsComplete(
 				db,
-				callback,
+				immutableTip.Slot,
 			)
 			if err != nil {
-				return 0, immutableTip.Slot, fmt.Errorf(
-					"backfill immutable raw block callback state: %w",
-					err,
+				return 0, immutableTip.Slot, err
+			}
+			if complete {
+				logger.Info(
+					"immutable raw block callback state already backfilled",
+					"immutable_tip_slot", immutableTip.Slot,
+				)
+			} else {
+				blocksBackfilled, err := backfillRawBlockCallbacks(
+					ctx,
+					imm,
+					db,
+					callback,
+				)
+				if err != nil {
+					return 0, immutableTip.Slot, fmt.Errorf(
+						"backfill immutable raw block callback state: %w",
+						err,
+					)
+				}
+				if err := markImmutableUtxoOffsetsComplete(
+					db,
+					immutableTip.Slot,
+				); err != nil {
+					return 0, immutableTip.Slot, err
+				}
+				logger.Info(
+					"backfilled immutable raw block callback state",
+					"blocks_backfilled", blocksBackfilled,
 				)
 			}
-			logger.Info(
-				"backfilled immutable raw block callback state",
-				"blocks_backfilled", blocksBackfilled,
-			)
 		}
 		return 0, immutableTip.Slot, nil
 	}
@@ -556,7 +579,60 @@ func copyBlocksRawWithCallback(
 		"finished copying blocks from immutable DB",
 		"blocks_copied", blocksCopied,
 	)
+	if callback != nil && db != nil && blocksCopied > 0 {
+		if err := markImmutableUtxoOffsetsComplete(
+			db,
+			immutableTip.Slot,
+		); err != nil {
+			return blocksCopied, immutableTip.Slot, err
+		}
+	}
 	return blocksCopied, immutableTip.Slot, nil
+}
+
+func immutableUtxoOffsetsComplete(
+	db *database.Database,
+	immutableTipSlot uint64,
+) (bool, error) {
+	val, err := db.GetSyncState(
+		immutableUtxoOffsetsSyncStateKey,
+		nil,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"checking immutable UTxO offset state: %w",
+			err,
+		)
+	}
+	if val == "" {
+		return false, nil
+	}
+	slot, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf(
+			"parsing immutable UTxO offset state %q: %w",
+			val,
+			err,
+		)
+	}
+	return slot >= immutableTipSlot, nil
+}
+
+func markImmutableUtxoOffsetsComplete(
+	db *database.Database,
+	immutableTipSlot uint64,
+) error {
+	if err := db.SetSyncState(
+		immutableUtxoOffsetsSyncStateKey,
+		strconv.FormatUint(immutableTipSlot, 10),
+		nil,
+	); err != nil {
+		return fmt.Errorf(
+			"marking immutable UTxO offset state complete: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 func backfillRawBlockCallbacks(

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -317,6 +317,7 @@ func Bootstrap(
 		truncateDigest(snapshot.Digest),
 	)
 	archivePath := filepath.Join(downloadDir, archiveFilename)
+	snapshotCacheKey := snapshot.Digest
 
 	if isFileComplete(archivePath, snapshot.Size) {
 		cfg.Logger.Info(
@@ -360,7 +361,10 @@ func Bootstrap(
 	// Steps 4+5: Extract main archive and download ancillary in
 	// parallel. These write to separate directories (immutable/
 	// vs ancillary/) so they are independent.
-	extractDir := filepath.Join(downloadDir, "immutable")
+	extractDir := filepath.Join(
+		downloadDir,
+		"immutable-"+snapshotCacheKey,
+	)
 	var ancillaryDir string
 	var ancillaryArchivePath string
 
@@ -378,7 +382,8 @@ func Bootstrap(
 	if len(snapshot.AncillaryLocations) > 0 {
 		ancWg.Go(func() {
 			candidateDir := filepath.Join(
-				downloadDir, "ancillary",
+				downloadDir,
+				"ancillary-"+snapshotCacheKey,
 			)
 			if hasLedgerFiles(candidateDir) {
 				cfg.Logger.Info(
@@ -538,7 +543,10 @@ func downloadAncillary(
 		)
 	}
 
-	ancillaryDir := filepath.Join(downloadDir, "ancillary")
+	ancillaryDir := filepath.Join(
+		downloadDir,
+		"ancillary-"+snapshot.Digest,
+	)
 	if _, extractErr := ExtractArchive(
 		ctx, ancillaryPath, ancillaryDir, cfg.Logger,
 	); extractErr != nil {

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -175,6 +175,70 @@ func TestBootstrap(t *testing.T) {
 	require.True(t, hasChunkFiles(result.ImmutableDir))
 }
 
+func TestBootstrapUsesDigestSpecificExtractDir(t *testing.T) {
+	archiveData := createChunkArchive(t)
+	digest := "newdigest1234567890abcdef"
+	snapshots := []SnapshotListItem{
+		{
+			SnapshotBase: SnapshotBase{
+				Digest:    digest,
+				Network:   "preprod",
+				Size:      int64(len(archiveData)),
+				Locations: []string{},
+			},
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/artifact/snapshots",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(snapshots))
+		},
+	)
+	mux.HandleFunc(
+		"/download/snapshot.tar.zst",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archiveData)
+		},
+	)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	snapshots[0].Locations = []string{
+		server.URL + "/download/snapshot.tar.zst",
+	}
+	downloadDir := t.TempDir()
+	staleImmutableDir := filepath.Join(
+		downloadDir,
+		"immutable",
+		"immutable",
+	)
+	require.NoError(t, os.MkdirAll(staleImmutableDir, 0o750))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(staleImmutableDir, "00000.chunk"),
+			[]byte("stale chunk"),
+			0o640,
+		),
+	)
+
+	result, err := Bootstrap(context.Background(), BootstrapConfig{
+		Network:       "preprod",
+		AggregatorURL: server.URL,
+		DownloadDir:   downloadDir,
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		filepath.Join(downloadDir, "immutable-"+digest),
+		result.ExtractDir,
+	)
+	require.NotEqual(t, staleImmutableDir, result.ImmutableDir)
+	require.True(t, hasChunkFiles(result.ImmutableDir))
+}
+
 func TestBootstrapCertVerifyNoCertHash(t *testing.T) {
 	snapshots := []SnapshotListItem{
 		{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve Mithril bootstrap/backfill to preserve metadata and resume safely after interruptions. Fixes UTxO asset/collateral handling, avoids repeated offset backfills, and ensures pparam updates commit when no txn is passed.

- **Bug Fixes**
  - Record `in_progress`/`backfill` sync states, allow `dingo serve` during backfill, and clear status after completion or when not needed.
  - Create or reopen the Mithril backfill checkpoint and keep progress on retries.
  - Disable nonce computation during API backfill.
  - Make UTxO asset import idempotent by skipping existing assets after ID refetch.
  - Store a single collateral-return UTxO per tx; avoid duplicate associations.
  - Track immutable UTxO-offset backfill in sync state to skip reruns.
  - Use digest-specific extract directories to avoid stale snapshot files.
  - Commit protocol parameter updates when invoked without a transaction.

- **Refactors**
  - Add helpers for sync-state updates and backfill checkpoint management.
  - Expand tests for backfill checkpoints, collateral return idempotency, pparam writes, and snapshot extract paths.

<sup>Written for commit 33bc67a59d56e63b9e58fca462f49e6b7697cd11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

