### PR TITLE
fix(devnet): raise default TEST_TIMEOUT to 20m for full suite (#2197)

### DIFF
--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -148,7 +148,7 @@ export DEVNET_RELAY_ADDR="localhost:${RELAY_PORT}"
 
 # Run tests with the devnet build tag
 # The -count=1 flag disables test caching
-TEST_TIMEOUT="${TEST_TIMEOUT:-5m}"
+TEST_TIMEOUT="${TEST_TIMEOUT:-20m}"
 set +e
 go test \
   -tags devnet \


### PR DESCRIPTION
Closes #2197.

The DevNet suite needs ~4m48s of cumulative time before `TestEpochBoundaryConsensus` even starts, and that test waits ~12 minutes of wall time for the slot-700 boundary. The current 5m default panics the suite-wide deadline before the boundary test can do real work; raising the floor to 20m fits the full set with comfortable headroom. The default is still env-overridable (`TEST_TIMEOUT=NNm ./run-tests.sh`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default `TEST_TIMEOUT` from 5m to 20m in the DevNet test runner to prevent suite timeouts and let long-running boundary tests complete. The timeout remains overridable via `TEST_TIMEOUT=NNm ./run-tests.sh`.

<sup>Written for commit 6adbd56c4fe67086506d0141ef161c812b89b221. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout for integration tests from 5 minutes to 20 minutes to allow longer-running test suites to complete successfully.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2223)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->