### PR TITLE
fix(database): create delegations and initial DReps from Conway genesis

### DIFF
--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -3661,6 +3662,16 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 	_ types.Txn,
 ) error {
 	return errors.New("genesis staking not implemented for mysql")
+}
+
+// SetGenesisGovernance is not implemented for the MySQL metadata plugin.
+func (d *MetadataStoreMysql) SetGenesisGovernance(
+	_ conway.ConwayGenesisInitialDReps,
+	_ conway.ConwayGenesisDelegs,
+	_ []byte,
+	_ types.Txn,
+) error {
+	return errors.New("genesis governance not implemented for mysql")
 }
 
 // DeleteAddressTransactionsAfterSlot removes address-transaction mapping records

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -3669,6 +3670,16 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 	_ types.Txn,
 ) error {
 	return errors.New("genesis staking not implemented for postgres")
+}
+
+// SetGenesisGovernance is not implemented for the PostgreSQL metadata plugin.
+func (d *MetadataStorePostgres) SetGenesisGovernance(
+	_ conway.ConwayGenesisInitialDReps,
+	_ conway.ConwayGenesisDelegs,
+	_ []byte,
+	_ types.Txn,
+) error {
+	return errors.New("genesis governance not implemented for postgres")
 }
 
 // DeleteAddressTransactionsAfterSlot removes address-transaction mapping records

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -380,16 +380,21 @@ func batchFetchRegistration(
 		CertIndex  uint32
 	}
 	var records []result
-	// Use ROW_NUMBER to fetch only the latest record per staking key
+	// Use ROW_NUMBER to fetch only the latest record per staking key.
+	// LEFT JOIN so synthetic genesis Registration rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which
+	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM registration t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -501,16 +506,21 @@ func batchFetchStakeDelegation(
 		CertIndex   uint32
 	}
 	var records []result
-	// Use ROW_NUMBER to fetch only the latest record per staking key
+	// Use ROW_NUMBER to fetch only the latest record per staking key.
+	// LEFT JOIN so genesis stake_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which
+	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -548,16 +558,21 @@ func batchFetchVoteDelegation(
 		CertIndex  uint32
 	}
 	var records []result
-	// Use ROW_NUMBER to fetch only the latest record per staking key
+	// Use ROW_NUMBER to fetch only the latest record per staking key.
+	// LEFT JOIN so genesis vote_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which
+	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM vote_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -597,16 +612,21 @@ func batchFetchStakeVoteDelegation(
 		CertIndex   uint32
 	}
 	var records []result
-	// Use ROW_NUMBER to fetch only the latest record per staking key
+	// Use ROW_NUMBER to fetch only the latest record per staking key.
+	// LEFT JOIN so genesis stake_vote_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which
+	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_vote_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -97,9 +97,12 @@ func batchFetchDrepCerts(
 			AnchorHash     []byte
 		}
 		var regRecords []regResult
+		// LEFT JOIN so genesis registration_drep rows (no certs row,
+		// certificate_id=0) still surface; cert_index defaults to 0,
+		// which is safe because slot 0 precedes every real cert.
 		if err := db.Table("registration_drep").
-			Select("registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, certs.cert_index").
-			Joins("INNER JOIN certs ON certs.id = registration_drep.certificate_id").
+			Select("registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, COALESCE(certs.cert_index, 0) AS cert_index").
+			Joins("LEFT JOIN certs ON certs.id = registration_drep.certificate_id").
 			Where("drep_credential IN ? AND registration_drep.added_slot <= ?", credChunk, slot).
 			Find(&regRecords).Error; err != nil {
 			return nil, err

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -25,24 +25,28 @@ import (
 )
 
 // drepCertRecord holds certificate data for batch processing during DRep restoration.
-// Includes cert_index for same-slot disambiguation.
+// On-chain ordering is (added_slot DESC, block_index DESC, cert_index DESC)
+// because cert_index resets per tx, so block_index is required to
+// disambiguate across txs in the same block.
 type drepCertRecord struct {
 	addedSlot  uint64
+	blockIndex uint32
 	certIndex  uint32
 	anchorURL  string
 	anchorHash []byte
 }
 
 // isMoreRecent checks if this certificate is more recent than the other.
-// When slots are equal, cert_index determines order (higher = later in transaction).
+// Ordering follows (added_slot, block_index, cert_index): block_index
+// orders txs within a block, cert_index orders certs within a tx.
 func (r drepCertRecord) isMoreRecent(other drepCertRecord) bool {
-	if r.addedSlot > other.addedSlot {
-		return true
+	if r.addedSlot != other.addedSlot {
+		return r.addedSlot > other.addedSlot
 	}
-	if r.addedSlot == other.addedSlot && r.certIndex > other.certIndex {
-		return true
+	if r.blockIndex != other.blockIndex {
+		return r.blockIndex > other.blockIndex
 	}
-	return false
+	return r.certIndex > other.certIndex
 }
 
 // drepCertCache holds batch-fetched certificate data for all DReps being restored.
@@ -88,21 +92,25 @@ func batchFetchDrepCerts(
 		end := min(start+sqliteBindVarLimit, len(credentials))
 		credChunk := credentials[start:end]
 
-		// Fetch registration certificates with cert_index
+		// Fetch registration certificates with block_index + cert_index.
+		// LEFT JOIN certs so genesis registration_drep rows (no certs
+		// row, certificate_id=0) still surface; cert_index/block_index
+		// default to 0, which is safe because slot 0 precedes every
+		// real cert. block_index orders txs within a block; cert_index
+		// orders certs within a tx.
 		type regResult struct {
 			DrepCredential []byte
 			AddedSlot      uint64
+			BlockIndex     uint32
 			CertIndex      uint32
 			AnchorURL      string `gorm:"column:anchor_url"`
 			AnchorHash     []byte
 		}
 		var regRecords []regResult
-		// LEFT JOIN so genesis registration_drep rows (no certs row,
-		// certificate_id=0) still surface; cert_index defaults to 0,
-		// which is safe because slot 0 precedes every real cert.
 		if err := db.Table("registration_drep").
-			Select("registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, COALESCE(certs.cert_index, 0) AS cert_index").
+			Select(`registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, COALESCE("transaction".block_index, 0) AS block_index, COALESCE(certs.cert_index, 0) AS cert_index`).
 			Joins("LEFT JOIN certs ON certs.id = registration_drep.certificate_id").
+			Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
 			Where("drep_credential IN ? AND registration_drep.added_slot <= ?", credChunk, slot).
 			Find(&regRecords).Error; err != nil {
 			return nil, err
@@ -111,6 +119,7 @@ func batchFetchDrepCerts(
 			key := string(r.DrepCredential)
 			rec := drepCertRecord{
 				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
 				certIndex:  r.CertIndex,
 				anchorURL:  r.AnchorURL,
 				anchorHash: r.AnchorHash,
@@ -121,16 +130,18 @@ func batchFetchDrepCerts(
 			}
 		}
 
-		// Fetch deregistration certificates with cert_index
+		// Fetch deregistration certificates with block_index + cert_index.
 		type deregResult struct {
 			DrepCredential []byte
 			AddedSlot      uint64
+			BlockIndex     uint32
 			CertIndex      uint32
 		}
 		var deregRecords []deregResult
 		if err := db.Table("deregistration_drep").
-			Select("deregistration_drep.drep_credential, deregistration_drep.added_slot, certs.cert_index").
+			Select(`deregistration_drep.drep_credential, deregistration_drep.added_slot, COALESCE("transaction".block_index, 0) AS block_index, certs.cert_index`).
 			Joins("INNER JOIN certs ON certs.id = deregistration_drep.certificate_id").
+			Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
 			Where("drep_credential IN ? AND deregistration_drep.added_slot <= ?", credChunk, slot).
 			Find(&deregRecords).Error; err != nil {
 			return nil, err
@@ -138,8 +149,9 @@ func batchFetchDrepCerts(
 		for _, r := range deregRecords {
 			key := string(r.DrepCredential)
 			rec := drepCertRecord{
-				addedSlot: r.AddedSlot,
-				certIndex: r.CertIndex,
+				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
+				certIndex:  r.CertIndex,
 			}
 			if !cache.hasDereg[key] ||
 				rec.isMoreRecent(cache.deregistration[key]) {
@@ -148,18 +160,20 @@ func batchFetchDrepCerts(
 			}
 		}
 
-		// Fetch update certificates with cert_index
+		// Fetch update certificates with block_index + cert_index.
 		type updateResult struct {
 			Credential []byte
 			AddedSlot  uint64
+			BlockIndex uint32
 			CertIndex  uint32
 			AnchorURL  string `gorm:"column:anchor_url"`
 			AnchorHash []byte
 		}
 		var updateRecords []updateResult
 		if err := db.Table("update_drep").
-			Select("update_drep.credential, update_drep.added_slot, update_drep.anchor_url, update_drep.anchor_hash, certs.cert_index").
+			Select(`update_drep.credential, update_drep.added_slot, update_drep.anchor_url, update_drep.anchor_hash, COALESCE("transaction".block_index, 0) AS block_index, certs.cert_index`).
 			Joins("INNER JOIN certs ON certs.id = update_drep.certificate_id").
+			Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
 			Where("credential IN ? AND update_drep.added_slot <= ?", credChunk, slot).
 			Find(&updateRecords).Error; err != nil {
 			return nil, err
@@ -168,6 +182,7 @@ func batchFetchDrepCerts(
 			key := string(r.Credential)
 			rec := drepCertRecord{
 				addedSlot:  r.AddedSlot,
+				blockIndex: r.BlockIndex,
 				certIndex:  r.CertIndex,
 				anchorURL:  r.AnchorURL,
 				anchorHash: r.AnchorHash,

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -311,24 +311,26 @@ func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
 		}
 
 		// Determine the correct state by processing certificates in order.
-		// Start with registration state (DRep is active with registration's anchor data)
+		// Start with registration state (DRep is active with registration's
+		// anchor data) and track the latest event as a drepCertRecord so
+		// cross-type comparisons go through isMoreRecent — i.e., use the
+		// full (added_slot, block_index, cert_index) ordering. Without
+		// block_index, a same-slot deregistration in a later tx could lose
+		// to a registration in an earlier tx (both with cert_index=0).
 		active := true
 		anchorURL := lastReg.anchorURL
 		anchorHash := lastReg.anchorHash
-		latestSlot := lastReg.addedSlot
-		latestCertIndex := lastReg.certIndex
+		latest := lastReg
 		latestWasDereg := false
 
-		// Apply deregistration if it's more recent than registration
+		// Apply deregistration if it's more recent than the current latest.
 		if cache.hasDereg[key] {
 			lastDereg := cache.deregistration[key]
-			if lastDereg.addedSlot > latestSlot ||
-				(lastDereg.addedSlot == latestSlot && lastDereg.certIndex > latestCertIndex) {
+			if lastDereg.isMoreRecent(latest) {
 				active = false
-				latestSlot = lastDereg.addedSlot
-				latestCertIndex = lastDereg.certIndex
 				anchorURL = ""
 				anchorHash = nil
+				latest = lastDereg
 				latestWasDereg = true
 			}
 		}
@@ -340,25 +342,37 @@ func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
 		// to become active again. Therefore, we skip updates when latestWasDereg is true.
 		if cache.hasUpdate[key] && !latestWasDereg {
 			lastUpdate := cache.update[key]
-			if lastUpdate.addedSlot > latestSlot ||
-				(lastUpdate.addedSlot == latestSlot && lastUpdate.certIndex > latestCertIndex) {
+			if lastUpdate.isMoreRecent(latest) {
 				anchorURL = lastUpdate.anchorURL
 				anchorHash = lastUpdate.anchorHash
-				latestSlot = lastUpdate.addedSlot
+				latest = lastUpdate
 			}
 		}
 
-		// Update the DRep record with the restored state.
-		// Reset LastActivityEpoch and ExpiryEpoch to 0 since we cannot
-		// reliably reconstruct these values from certificate data alone
-		// during rollback. They will be recalculated as new activity occurs.
+		// Activity/expiry can't be reliably reconstructed from cert
+		// history alone (voting activity is tracked elsewhere and bumps
+		// expiry_epoch). For on-chain registrations, reset to 0 so they
+		// are re-seeded by subsequent activity. For genesis-rooted
+		// DReps (most-recent registration at slot 0), preserve the
+		// existing values — they were set from the Conway genesis
+		// config at bootstrap, and zeroing them would silently turn
+		// the DRep into a "never-expiring" one (drepActiveAtEpoch
+		// treats expiry_epoch=0 as unbounded), inflating governance
+		// tallies.
+		expiryEpoch := uint64(0)
+		lastActivityEpoch := uint64(0)
+		if lastReg.addedSlot == 0 {
+			expiryEpoch = drep.ExpiryEpoch
+			lastActivityEpoch = drep.LastActivityEpoch
+		}
+
 		if result := db.Model(&drep).Updates(map[string]any{
 			"active":              active,
 			"anchor_url":          anchorURL,
 			"anchor_hash":         anchorHash,
-			"added_slot":          latestSlot,
-			"last_activity_epoch": 0,
-			"expiry_epoch":        0,
+			"added_slot":          latest.addedSlot,
+			"last_activity_epoch": lastActivityEpoch,
+			"expiry_epoch":        expiryEpoch,
 		}); result.Error != nil {
 			return result.Error
 		}

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeCred(b byte) *lcommon.Credential {
+	var h [28]byte
+	for i := range h {
+		h[i] = b
+	}
+	return &lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.CredentialHash(h),
+	}
+}
+
+func makePoolId(b byte) lcommon.PoolId {
+	var p [28]byte
+	for i := range p {
+		p[i] = b
+	}
+	return lcommon.PoolId(p)
+}
+
+func TestSqliteSetGenesisGovernance(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := makeCred(0x11)
+	anchor := &lcommon.GovAnchor{
+		Url:      "https://example.com/drep.json",
+		DataHash: [32]byte{0xab, 0xcd},
+	}
+	initialDReps := conway.ConwayGenesisInitialDReps{
+		drepCred: conway.ConwayGenesisDRepState{
+			Expiry:  100,
+			Deposit: 500_000_000,
+			Anchor:  anchor,
+		},
+	}
+
+	stakeCred := makeCred(0x22)
+	voteCred := makeCred(0x33)
+	stakeVoteCred := makeCred(0x44)
+	poolA := makePoolId(0xaa)
+	poolB := makePoolId(0xbb)
+
+	delegs := conway.ConwayGenesisDelegs{
+		stakeCred: conway.ConwayGenesisDelegatee{
+			Type:   conway.ConwayGenesisDelegateeTypeStake,
+			PoolId: poolA,
+		},
+		voteCred: conway.ConwayGenesisDelegatee{
+			Type: conway.ConwayGenesisDelegateeTypeVote,
+			DRep: lcommon.Drep{
+				Type:       lcommon.DrepTypeAddrKeyHash,
+				Credential: drepCred.Credential[:],
+			},
+		},
+		stakeVoteCred: conway.ConwayGenesisDelegatee{
+			Type:   conway.ConwayGenesisDelegateeTypeStakeVote,
+			PoolId: poolB,
+			DRep: lcommon.Drep{
+				Type: lcommon.DrepTypeAbstain,
+			},
+		},
+	}
+
+	require.NoError(t, store.SetGenesisGovernance(
+		initialDReps,
+		delegs,
+		[]byte("genesis-hash"),
+		nil,
+	))
+
+	// DRep row exists at slot 0 with anchor and expiry.
+	var drep models.Drep
+	require.NoError(
+		t,
+		store.DB().Where("credential = ?", drepCred.Credential[:]).
+			First(&drep).Error,
+	)
+	assert.Equal(t, uint64(0), drep.AddedSlot)
+	assert.Equal(t, uint64(100), drep.ExpiryEpoch)
+	assert.Equal(t, "https://example.com/drep.json", drep.AnchorURL)
+	assert.True(t, drep.Active)
+
+	// Registration row recorded the deposit.
+	var reg models.RegistrationDrep
+	require.NoError(
+		t,
+		store.DB().Where("drep_credential = ?", drepCred.Credential[:]).
+			First(&reg).Error,
+	)
+	assert.Equal(t, uint64(0), reg.AddedSlot)
+	assert.Equal(t, types.Uint64(500_000_000), reg.DepositAmount)
+
+	// Stake-only delegation: account.pool set, no DRep.
+	var stakeAcct models.Account
+	require.NoError(
+		t,
+		store.DB().Where("staking_key = ?", stakeCred.Credential[:]).
+			First(&stakeAcct).Error,
+	)
+	assert.Equal(t, poolA[:], stakeAcct.Pool)
+	assert.Nil(t, stakeAcct.Drep)
+	var stakeRow models.StakeDelegation
+	require.NoError(
+		t,
+		store.DB().Where("staking_key = ?", stakeCred.Credential[:]).
+			First(&stakeRow).Error,
+	)
+	assert.Equal(t, poolA[:], stakeRow.PoolKeyHash)
+	assert.Equal(t, uint64(0), stakeRow.AddedSlot)
+
+	// Vote-only delegation: account.drep set, no pool.
+	var voteAcct models.Account
+	require.NoError(
+		t,
+		store.DB().Where("staking_key = ?", voteCred.Credential[:]).
+			First(&voteAcct).Error,
+	)
+	assert.Nil(t, voteAcct.Pool)
+	assert.Equal(t, drepCred.Credential[:], voteAcct.Drep)
+	assert.Equal(t, models.DrepTypeAddrKeyHash, voteAcct.DrepType)
+	var voteRow models.VoteDelegation
+	require.NoError(
+		t,
+		store.DB().Where("staking_key = ?", voteCred.Credential[:]).
+			First(&voteRow).Error,
+	)
+	assert.Equal(t, drepCred.Credential[:], voteRow.Drep)
+	assert.Equal(t, uint64(0), voteRow.AddedSlot)
+
+	// Combined stake+vote delegation, with an AlwaysAbstain predefined DRep
+	// (no credential persisted).
+	var stakeVoteAcct models.Account
+	require.NoError(
+		t,
+		store.DB().Where("staking_key = ?", stakeVoteCred.Credential[:]).
+			First(&stakeVoteAcct).Error,
+	)
+	assert.Equal(t, poolB[:], stakeVoteAcct.Pool)
+	assert.Nil(t, stakeVoteAcct.Drep)
+	assert.Equal(t, models.DrepTypeAlwaysAbstain, stakeVoteAcct.DrepType)
+	var stakeVoteRow models.StakeVoteDelegation
+	require.NoError(
+		t,
+		store.DB().Where("staking_key = ?", stakeVoteCred.Credential[:]).
+			First(&stakeVoteRow).Error,
+	)
+	assert.Equal(t, poolB[:], stakeVoteRow.PoolKeyHash)
+	assert.Nil(t, stakeVoteRow.Drep)
+	assert.Equal(t, models.DrepTypeAlwaysAbstain, stakeVoteRow.DrepType)
+}
+
+func TestSqliteSetGenesisGovernanceEmpty(t *testing.T) {
+	store := setupTestStore(t)
+	require.NoError(t, store.SetGenesisGovernance(
+		conway.ConwayGenesisInitialDReps{},
+		conway.ConwayGenesisDelegs{},
+		nil,
+		nil,
+	))
+
+	var count int64
+	require.NoError(t, store.DB().Model(&models.Drep{}).Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+	require.NoError(t, store.DB().Model(&models.Account{}).Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+}

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -454,11 +454,15 @@ func TestSqliteRollbackDrepCrossTypeBlockIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, restored)
 	// Deregistration is in the tx with higher block_index, so it wins.
-	// DRep must be inactive with cleared anchor.
+	// DRep must be inactive with cleared anchor, and AddedSlot must
+	// reflect the winning cert's slot (pins down that latest.addedSlot
+	// is what gets persisted out of the cross-type comparison).
 	assert.False(t, restored.Active,
 		"deregistration in higher-block_index tx must beat registration in lower-block_index tx at same slot")
 	assert.Equal(t, "", restored.AnchorURL,
 		"anchor must be cleared because deregistration wins")
+	assert.Equal(t, uint64(100), restored.AddedSlot,
+		"AddedSlot must be set to the winning cert's slot")
 }
 
 // TestSqliteRollbackPreservesGenesisVoteOnlyAccount verifies that an

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -175,6 +175,53 @@ func TestSqliteSetGenesisGovernance(t *testing.T) {
 	assert.Equal(t, models.DrepTypeAlwaysAbstain, stakeVoteRow.DrepType)
 }
 
+func TestSqliteSetGenesisGovernanceIdempotent(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := makeCred(0x55)
+	stakeCred := makeCred(0x66)
+	poolA := makePoolId(0x77)
+
+	initialDReps := conway.ConwayGenesisInitialDReps{
+		drepCred: conway.ConwayGenesisDRepState{
+			Expiry:  100,
+			Deposit: 500_000_000,
+		},
+	}
+	delegs := conway.ConwayGenesisDelegs{
+		stakeCred: conway.ConwayGenesisDelegatee{
+			Type:   conway.ConwayGenesisDelegateeTypeStake,
+			PoolId: poolA,
+		},
+	}
+
+	// Run twice — simulates a retry after partial genesis bootstrap.
+	require.NoError(t,
+		store.SetGenesisGovernance(initialDReps, delegs, nil, nil),
+	)
+	require.NoError(t,
+		store.SetGenesisGovernance(initialDReps, delegs, nil, nil),
+	)
+
+	var drepCount, regCount, accountCount, delegCount int64
+	require.NoError(t,
+		store.DB().Model(&models.Drep{}).Count(&drepCount).Error,
+	)
+	require.NoError(t,
+		store.DB().Model(&models.RegistrationDrep{}).Count(&regCount).Error,
+	)
+	require.NoError(t,
+		store.DB().Model(&models.Account{}).Count(&accountCount).Error,
+	)
+	require.NoError(t,
+		store.DB().Model(&models.StakeDelegation{}).Count(&delegCount).Error,
+	)
+	assert.Equal(t, int64(1), drepCount)
+	assert.Equal(t, int64(1), regCount)
+	assert.Equal(t, int64(1), accountCount)
+	assert.Equal(t, int64(1), delegCount)
+}
+
 func TestSqliteSetGenesisGovernanceEmpty(t *testing.T) {
 	store := setupTestStore(t)
 	require.NoError(t, store.SetGenesisGovernance(

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -459,3 +459,147 @@ func TestSqliteRollbackPreservesGenesisStakeVoteAccount(t *testing.T) {
 		"DRep must be restored to genesis value")
 	assert.Equal(t, models.DrepTypeAddrKeyHash, restored.DrepType)
 }
+
+// TestCertRecordIsMoreRecentBlockIndex verifies that the in-memory
+// recency comparator on certRecord and drepCertRecord breaks same-slot
+// ties by block_index BEFORE cert_index. This matters because
+// cert_index resets per transaction: at the same slot, two certs from
+// different txs can both have cert_index=0; only block_index
+// distinguishes them. (See CLAUDE.md: "Order certificates using
+// added_slot DESC, block_index DESC, cert_index DESC".)
+func TestCertRecordIsMoreRecentBlockIndex(t *testing.T) {
+	// Same slot, different block_index, same cert_index — the higher
+	// block_index must win.
+	earlier := certRecord{addedSlot: 100, blockIndex: 0, certIndex: 0}
+	later := certRecord{addedSlot: 100, blockIndex: 1, certIndex: 0}
+	assert.True(t, later.isMoreRecent(earlier),
+		"higher block_index must beat lower at same slot")
+	assert.False(t, earlier.isMoreRecent(later),
+		"lower block_index must lose to higher at same slot")
+
+	// block_index ranks above cert_index: a row with lower block_index
+	// but higher cert_index is still older than one with higher
+	// block_index. This is the precise failure case the reviewer
+	// flagged.
+	loBlkHiCert := certRecord{addedSlot: 100, blockIndex: 0, certIndex: 99}
+	hiBlkLoCert := certRecord{addedSlot: 100, blockIndex: 1, certIndex: 0}
+	assert.True(t, hiBlkLoCert.isMoreRecent(loBlkHiCert),
+		"block_index outranks cert_index when slots match")
+
+	// Same slot AND same block_index: cert_index breaks the tie.
+	c0 := certRecord{addedSlot: 100, blockIndex: 5, certIndex: 0}
+	c1 := certRecord{addedSlot: 100, blockIndex: 5, certIndex: 1}
+	assert.True(t, c1.isMoreRecent(c0))
+
+	// Same exact key: not more recent than self.
+	assert.False(t, c0.isMoreRecent(c0))
+
+	// drepCertRecord uses the same ordering.
+	drepEarlier := drepCertRecord{addedSlot: 100, blockIndex: 0, certIndex: 0}
+	drepLater := drepCertRecord{addedSlot: 100, blockIndex: 1, certIndex: 0}
+	assert.True(t, drepLater.isMoreRecent(drepEarlier))
+	assert.False(t, drepEarlier.isMoreRecent(drepLater))
+}
+
+// TestRollbackPicksLatestByBlockIndexAtSameSlot is an end-to-end check
+// that RestoreAccountStateAtSlot picks the correct VoteDelegation when
+// two of them land at the same slot in different transactions. The
+// later transaction (higher block_index) must win; with the previous
+// ordering (slot, cert_index) both certs tied on cert_index=0 and the
+// outcome was non-deterministic.
+func TestRollbackPicksLatestByBlockIndexAtSameSlot(t *testing.T) {
+	store := setupTestStore(t)
+
+	stakeKey := bytes.Repeat([]byte{0x91}, 28)
+	drepEarly := bytes.Repeat([]byte{0x92}, 28)
+	drepLate := bytes.Repeat([]byte{0x93}, 28)
+	drepCurrent := bytes.Repeat([]byte{0x94}, 28)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeKey,
+		Drep:       drepCurrent,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		AddedSlot:  300,
+		Active:     true,
+	}).Error)
+
+	// Registration so the account survives Phase 1 of restore.
+	require.NoError(t, createTestTransaction(store.DB(), 200, 50))
+	regCert := models.Certificate{
+		TransactionID: 200,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+		Slot:          50,
+	}
+	require.NoError(t, store.DB().Create(&regCert).Error)
+	require.NoError(t, store.DB().Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		AddedSlot:     50,
+		CertificateID: regCert.ID,
+	}).Error)
+
+	// Two VoteDelegation certs at the SAME slot 100, different txs.
+	// tx 201 has block_index=0; tx 202 has block_index=1. Both certs
+	// are the first in their respective tx (cert_index=0). The cert
+	// from tx 202 must win because of the higher block_index. We
+	// insert tx 202's cert first (lower certs.id) so a buggy query
+	// that doesn't tiebreak by block_index would deterministically
+	// pick the wrong one (tx 201, inserted later, higher certs.id).
+	require.NoError(t,
+		store.DB().Exec(
+			`INSERT INTO "transaction" (id, hash, slot, valid, type, block_index)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			201, []byte("tx201"), 100, true, 0, 0,
+		).Error,
+	)
+	require.NoError(t,
+		store.DB().Exec(
+			`INSERT INTO "transaction" (id, hash, slot, valid, type, block_index)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			202, []byte("tx202"), 100, true, 0, 1,
+		).Error,
+	)
+	// tx 202's cert (later block_index, correct answer) — insert FIRST
+	// so it gets the LOWER certs.id, while the WRONG answer gets the
+	// higher certs.id (typical SQL "last wins" tiebreak).
+	certLate := models.Certificate{
+		TransactionID: 202,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeVoteDelegation),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&certLate).Error)
+	require.NoError(t, store.DB().Create(&models.VoteDelegation{
+		StakingKey:    stakeKey,
+		Drep:          drepLate,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		AddedSlot:     100,
+		CertificateID: certLate.ID,
+	}).Error)
+	certEarly := models.Certificate{
+		TransactionID: 201,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeVoteDelegation),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&certEarly).Error)
+	require.NoError(t, store.DB().Create(&models.VoteDelegation{
+		StakingKey:    stakeKey,
+		Drep:          drepEarly,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		AddedSlot:     100,
+		CertificateID: certEarly.ID,
+	}).Error)
+
+	// Roll back to slot 200 — both slot-100 certs are valid history,
+	// the slot-300 state is undone. Expected DRep: drepLate (higher
+	// block_index).
+	require.NoError(t, store.RestoreAccountStateAtSlot(200, nil))
+
+	restored, err := store.GetAccount(stakeKey, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	assert.Equal(t, drepLate, restored.Drep,
+		"latest VoteDelegation at slot 100 must be the one in the tx "+
+			"with higher block_index (tx 202), not tx 201")
+}

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -116,6 +117,24 @@ func TestSqliteSetGenesisGovernance(t *testing.T) {
 	assert.Equal(t, uint64(0), reg.AddedSlot)
 	assert.Equal(t, types.Uint64(500_000_000), reg.DepositAmount)
 
+	// Every genesis delegation account has a synthetic Registration
+	// row at slot 0 so the rollback path treats it as registered.
+	for _, cred := range [][]byte{
+		stakeCred.Credential[:],
+		voteCred.Credential[:],
+		stakeVoteCred.Credential[:],
+	} {
+		var genReg models.Registration
+		require.NoError(
+			t,
+			store.DB().Where(
+				"staking_key = ? AND added_slot = ?", cred, uint64(0),
+			).First(&genReg).Error,
+			"missing genesis Registration for %x", cred,
+		)
+		assert.Equal(t, uint64(0), genReg.AddedSlot)
+	}
+
 	// Stake-only delegation: account.pool set, no DRep.
 	var stakeAcct models.Account
 	require.NoError(
@@ -203,12 +222,12 @@ func TestSqliteSetGenesisGovernanceIdempotent(t *testing.T) {
 		store.SetGenesisGovernance(initialDReps, delegs, nil, nil),
 	)
 
-	var drepCount, regCount, accountCount, delegCount int64
+	var drepCount, regDrepCount, accountCount, delegCount, regCount int64
 	require.NoError(t,
 		store.DB().Model(&models.Drep{}).Count(&drepCount).Error,
 	)
 	require.NoError(t,
-		store.DB().Model(&models.RegistrationDrep{}).Count(&regCount).Error,
+		store.DB().Model(&models.RegistrationDrep{}).Count(&regDrepCount).Error,
 	)
 	require.NoError(t,
 		store.DB().Model(&models.Account{}).Count(&accountCount).Error,
@@ -216,10 +235,14 @@ func TestSqliteSetGenesisGovernanceIdempotent(t *testing.T) {
 	require.NoError(t,
 		store.DB().Model(&models.StakeDelegation{}).Count(&delegCount).Error,
 	)
+	require.NoError(t,
+		store.DB().Model(&models.Registration{}).Count(&regCount).Error,
+	)
 	assert.Equal(t, int64(1), drepCount)
-	assert.Equal(t, int64(1), regCount)
+	assert.Equal(t, int64(1), regDrepCount)
 	assert.Equal(t, int64(1), accountCount)
 	assert.Equal(t, int64(1), delegCount)
+	assert.Equal(t, int64(1), regCount)
 }
 
 func TestSqliteSetGenesisGovernanceEmpty(t *testing.T) {
@@ -236,4 +259,203 @@ func TestSqliteSetGenesisGovernanceEmpty(t *testing.T) {
 	assert.Equal(t, int64(0), count)
 	require.NoError(t, store.DB().Model(&models.Account{}).Count(&count).Error)
 	assert.Equal(t, int64(0), count)
+}
+
+// TestSqliteRollbackPreservesGenesisDrep verifies that rolling back past
+// an on-chain DRep update does not error out on a DRep that was created
+// from Conway genesis. Before the fix, batchFetchDrepCerts INNER-JOINed
+// the genesis registration_drep row (certificate_id=0) out of the cache,
+// causing "DRep ... has no registration cert at or before slot ..." in
+// Phase 2 of RestoreDrepStateAtSlot.
+func TestSqliteRollbackPreservesGenesisDrep(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := makeCred(0x81)
+
+	require.NoError(t, store.SetGenesisGovernance(
+		conway.ConwayGenesisInitialDReps{
+			drepCred: conway.ConwayGenesisDRepState{
+				Expiry:  500,
+				Deposit: 500_000_000,
+			},
+		},
+		conway.ConwayGenesisDelegs{},
+		nil,
+		nil,
+	))
+
+	// On-chain UpdateDrep at slot 300 mutates Drep.added_slot.
+	require.NoError(t, createTestTransaction(store.DB(), 100, 300))
+	updateCert := models.Certificate{
+		TransactionID: 100,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeUpdateDrep),
+		Slot:          300,
+	}
+	require.NoError(t, store.DB().Create(&updateCert).Error)
+	require.NoError(t, store.DB().Create(&models.UpdateDrep{
+		Credential:    drepCred.Credential[:],
+		AnchorURL:     "https://example.com/updated",
+		AnchorHash:    bytes.Repeat([]byte{0x99}, 32),
+		AddedSlot:     300,
+		CertificateID: updateCert.ID,
+	}).Error)
+	require.NoError(t,
+		store.DB().Model(&models.Drep{}).
+			Where("credential = ?", drepCred.Credential[:]).
+			Updates(map[string]any{
+				"anchor_url":  "https://example.com/updated",
+				"anchor_hash": bytes.Repeat([]byte{0x99}, 32),
+				"added_slot":  uint64(300),
+			}).Error,
+	)
+
+	// Rollback to slot 200 must NOT error, and must keep the DRep
+	// (with its genesis anchor restored, since the update is undone).
+	require.NoError(t, store.RestoreDrepStateAtSlot(200, nil))
+
+	restored, err := store.GetDrep(drepCred.Credential[:], true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, restored, "genesis DRep must survive rollback")
+	assert.True(t, restored.Active)
+}
+
+// TestSqliteRollbackPreservesGenesisVoteOnlyAccount verifies that an
+// account created from a Conway-genesis vote delegation is NOT deleted
+// when we roll back past a later on-chain VoteDelegation. Before the
+// fix, batchFetchCerts INNER-JOINed the synthetic Registration row out,
+// hasReg was false, and the account was deleted by Phase 1 of
+// RestoreAccountStateAtSlot.
+func TestSqliteRollbackPreservesGenesisVoteOnlyAccount(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := makeCred(0x82)
+	stakeCred := makeCred(0x83)
+
+	require.NoError(t, store.SetGenesisGovernance(
+		conway.ConwayGenesisInitialDReps{
+			drepCred: conway.ConwayGenesisDRepState{Expiry: 500},
+		},
+		conway.ConwayGenesisDelegs{
+			stakeCred: conway.ConwayGenesisDelegatee{
+				Type: conway.ConwayGenesisDelegateeTypeVote,
+				DRep: lcommon.Drep{
+					Type:       lcommon.DrepTypeAddrKeyHash,
+					Credential: drepCred.Credential[:],
+				},
+			},
+		},
+		nil,
+		nil,
+	))
+
+	// On-chain VoteDelegation at slot 300 changes the account's DRep
+	// to AlwaysAbstain and bumps Account.added_slot.
+	require.NoError(t, createTestTransaction(store.DB(), 101, 300))
+	delegCert := models.Certificate{
+		TransactionID: 101,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeVoteDelegation),
+		Slot:          300,
+	}
+	require.NoError(t, store.DB().Create(&delegCert).Error)
+	require.NoError(t, store.DB().Create(&models.VoteDelegation{
+		StakingKey:    stakeCred.Credential[:],
+		Drep:          nil,
+		DrepType:      models.DrepTypeAlwaysAbstain,
+		AddedSlot:     300,
+		CertificateID: delegCert.ID,
+	}).Error)
+	require.NoError(t,
+		store.DB().Model(&models.Account{}).
+			Where("staking_key = ?", stakeCred.Credential[:]).
+			Updates(map[string]any{
+				"drep":       nil,
+				"drep_type":  models.DrepTypeAlwaysAbstain,
+				"added_slot": uint64(300),
+			}).Error,
+	)
+
+	// Rollback to slot 200: the genesis-rooted account must remain.
+	require.NoError(t, store.RestoreAccountStateAtSlot(200, nil))
+
+	restored, err := store.GetAccount(stakeCred.Credential[:], true, nil)
+	require.NoError(t, err)
+	require.NotNil(t,
+		restored,
+		"genesis-rooted vote account must not be deleted by rollback",
+	)
+	assert.Equal(t, drepCred.Credential[:], restored.Drep,
+		"DRep must be restored to genesis state")
+	assert.Equal(t, models.DrepTypeAddrKeyHash, restored.DrepType)
+}
+
+// TestSqliteRollbackPreservesGenesisStakeVoteAccount verifies that an
+// account created from a Conway-genesis stake+vote delegation is NOT
+// deleted when we roll back past a later on-chain StakeDelegation.
+func TestSqliteRollbackPreservesGenesisStakeVoteAccount(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := makeCred(0x84)
+	stakeCred := makeCred(0x85)
+	poolGenesis := makePoolId(0x86)
+	poolLater := makePoolId(0x87)
+
+	require.NoError(t, store.SetGenesisGovernance(
+		conway.ConwayGenesisInitialDReps{
+			drepCred: conway.ConwayGenesisDRepState{Expiry: 500},
+		},
+		conway.ConwayGenesisDelegs{
+			stakeCred: conway.ConwayGenesisDelegatee{
+				Type:   conway.ConwayGenesisDelegateeTypeStakeVote,
+				PoolId: poolGenesis,
+				DRep: lcommon.Drep{
+					Type:       lcommon.DrepTypeAddrKeyHash,
+					Credential: drepCred.Credential[:],
+				},
+			},
+		},
+		nil,
+		nil,
+	))
+
+	// On-chain StakeDelegation at slot 300 changes the account's pool.
+	require.NoError(t, createTestTransaction(store.DB(), 102, 300))
+	delegCert := models.Certificate{
+		TransactionID: 102,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		Slot:          300,
+	}
+	require.NoError(t, store.DB().Create(&delegCert).Error)
+	require.NoError(t, store.DB().Create(&models.StakeDelegation{
+		StakingKey:    stakeCred.Credential[:],
+		PoolKeyHash:   poolLater[:],
+		AddedSlot:     300,
+		CertificateID: delegCert.ID,
+	}).Error)
+	require.NoError(t,
+		store.DB().Model(&models.Account{}).
+			Where("staking_key = ?", stakeCred.Credential[:]).
+			Updates(map[string]any{
+				"pool":       poolLater[:],
+				"added_slot": uint64(300),
+			}).Error,
+	)
+
+	// Rollback to slot 200: the genesis-rooted account must remain,
+	// with both pool and DRep restored to their genesis values.
+	require.NoError(t, store.RestoreAccountStateAtSlot(200, nil))
+
+	restored, err := store.GetAccount(stakeCred.Credential[:], true, nil)
+	require.NoError(t, err)
+	require.NotNil(t,
+		restored,
+		"genesis-rooted stake/vote account must not be deleted",
+	)
+	assert.Equal(t, poolGenesis[:], restored.Pool,
+		"pool must be restored to genesis value")
+	assert.Equal(t, drepCred.Credential[:], restored.Drep,
+		"DRep must be restored to genesis value")
+	assert.Equal(t, models.DrepTypeAddrKeyHash, restored.DrepType)
 }

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -284,7 +284,8 @@ func TestSqliteRollbackPreservesGenesisDrep(t *testing.T) {
 		nil,
 	))
 
-	// On-chain UpdateDrep at slot 300 mutates Drep.added_slot.
+	// On-chain UpdateDrep at slot 300 mutates Drep.added_slot, and
+	// simulated voting activity bumps last_activity_epoch.
 	require.NoError(t, createTestTransaction(store.DB(), 100, 300))
 	updateCert := models.Certificate{
 		TransactionID: 100,
@@ -304,9 +305,10 @@ func TestSqliteRollbackPreservesGenesisDrep(t *testing.T) {
 		store.DB().Model(&models.Drep{}).
 			Where("credential = ?", drepCred.Credential[:]).
 			Updates(map[string]any{
-				"anchor_url":  "https://example.com/updated",
-				"anchor_hash": bytes.Repeat([]byte{0x99}, 32),
-				"added_slot":  uint64(300),
+				"anchor_url":          "https://example.com/updated",
+				"anchor_hash":         bytes.Repeat([]byte{0x99}, 32),
+				"added_slot":          uint64(300),
+				"last_activity_epoch": uint64(10),
 			}).Error,
 	)
 
@@ -318,6 +320,145 @@ func TestSqliteRollbackPreservesGenesisDrep(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, restored, "genesis DRep must survive rollback")
 	assert.True(t, restored.Active)
+	// ExpiryEpoch came from the Conway genesis config and must NOT be
+	// reset to 0 by rollback. drepActiveAtEpoch treats expiry_epoch=0
+	// as "never expires" — zeroing the genesis value would silently
+	// turn the DRep into an immortal one and inflate governance
+	// tallies after recovery.
+	assert.Equal(t, uint64(500), restored.ExpiryEpoch,
+		"genesis-configured ExpiryEpoch must be preserved on rollback")
+	assert.Equal(t, uint64(10), restored.LastActivityEpoch,
+		"genesis-rooted LastActivityEpoch must be preserved on rollback")
+}
+
+// TestSqliteRollbackResetsExpiryForOnChainDrep verifies that the
+// rollback path still resets ExpiryEpoch to 0 for purely on-chain
+// DReps (no genesis row), preserving the existing behavior where
+// expiry/activity is re-seeded by subsequent governance events. Only
+// genesis-rooted DReps (slot-0 registration) get their values
+// preserved.
+func TestSqliteRollbackResetsExpiryForOnChainDrep(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := bytes.Repeat([]byte{0xa1}, 28)
+
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential:        drepCred,
+		AddedSlot:         300,
+		ExpiryEpoch:       100,
+		LastActivityEpoch: 50,
+		Active:            true,
+	}).Error)
+
+	// On-chain registration at slot 100.
+	require.NoError(t, createTestTransaction(store.DB(), 300, 100))
+	regCert := models.Certificate{
+		TransactionID: 300,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeRegistrationDrep),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&regCert).Error)
+	require.NoError(t, store.DB().Create(&models.RegistrationDrep{
+		DrepCredential: drepCred,
+		AddedSlot:      100,
+		CertificateID:  regCert.ID,
+	}).Error)
+
+	require.NoError(t, store.RestoreDrepStateAtSlot(200, nil))
+
+	restored, err := store.GetDrep(drepCred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	// Non-genesis DRep: expiry/activity reset as documented.
+	assert.Equal(t, uint64(0), restored.ExpiryEpoch)
+	assert.Equal(t, uint64(0), restored.LastActivityEpoch)
+}
+
+// TestSqliteRollbackDrepCrossTypeBlockIndex verifies that the
+// cross-type comparison inside RestoreDrepStateAtSlot uses the full
+// (added_slot, block_index, cert_index) ordering. Same-slot
+// registration and deregistration certs in different txs both have
+// cert_index=0; only block_index disambiguates which wins. Before the
+// fix, the cross-type comparison used (added_slot, cert_index) only:
+// a same-slot deregistration with higher block_index would tie on
+// cert_index, fail the strict-greater check, and lose to the
+// registration (which the loop starts with as the default winner) —
+// silently keeping the DRep active when it should have been
+// deregistered.
+func TestSqliteRollbackDrepCrossTypeBlockIndex(t *testing.T) {
+	store := setupTestStore(t)
+
+	drepCred := bytes.Repeat([]byte{0xb1}, 28)
+
+	// Current DRep state (post-rollback the rollback path will rewrite
+	// this).
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential: drepCred,
+		AnchorURL:  "to-be-replaced",
+		AddedSlot:  300,
+		Active:     true,
+	}).Error)
+
+	// Two txs in the same block at slot 100. tx 401 has block_index=0,
+	// tx 402 has block_index=1.
+	require.NoError(t,
+		store.DB().Exec(
+			`INSERT INTO "transaction" (id, hash, slot, valid, type, block_index)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			401, []byte("dtx401"), 100, true, 0, 0,
+		).Error,
+	)
+	require.NoError(t,
+		store.DB().Exec(
+			`INSERT INTO "transaction" (id, hash, slot, valid, type, block_index)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			402, []byte("dtx402"), 100, true, 0, 1,
+		).Error,
+	)
+	// Registration in tx 401 (block_index=0) — comes BEFORE the
+	// deregistration in block order. Deregistration in tx 402
+	// (block_index=1) is the correct winner. The buggy cross-type
+	// comparison ignores block_index and keeps the registration as
+	// "latest" because both certs have cert_index=0 and the comparator
+	// requires a STRICT > on cert_index to swap.
+	regCert := models.Certificate{
+		TransactionID: 401,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeRegistrationDrep),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&regCert).Error)
+	require.NoError(t, store.DB().Create(&models.RegistrationDrep{
+		DrepCredential: drepCred,
+		AnchorURL:      "https://example.com/reg",
+		AddedSlot:      100,
+		CertificateID:  regCert.ID,
+	}).Error)
+	deregCert := models.Certificate{
+		TransactionID: 402,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeDeregistrationDrep),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&deregCert).Error)
+	require.NoError(t, store.DB().Create(&models.DeregistrationDrep{
+		DrepCredential: drepCred,
+		AddedSlot:      100,
+		CertificateID:  deregCert.ID,
+	}).Error)
+
+	require.NoError(t, store.RestoreDrepStateAtSlot(200, nil))
+
+	restored, err := store.GetDrep(drepCred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	// Deregistration is in the tx with higher block_index, so it wins.
+	// DRep must be inactive with cleared anchor.
+	assert.False(t, restored.Active,
+		"deregistration in higher-block_index tx must beat registration in lower-block_index tx at same slot")
+	assert.Equal(t, "", restored.AnchorURL,
+		"anchor must be cleared because deregistration wins")
 }
 
 // TestSqliteRollbackPreservesGenesisVoteOnlyAccount verifies that an

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -3952,6 +3952,27 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 		}
 		account.AddedSlot = 0
 
+		// Conway genesis delegations implicitly register the staking
+		// credential at slot 0 (no on-chain certificate, no deposit).
+		// We materialize this as a synthetic Registration row so the
+		// rollback path (RestoreAccountStateAtSlot) recognizes the
+		// account as "existed at genesis" via its standard hasReg
+		// check; without it, rolling back past a later on-chain cert
+		// would delete a genesis-rooted account.
+		var existingReg models.Registration
+		regResult := db.Where(
+			"staking_key = ? AND added_slot = ?",
+			stakeKey, uint64(0),
+		).Attrs(models.Registration{
+			StakingKey: stakeKey,
+			AddedSlot:  0,
+		}).FirstOrCreate(&existingReg)
+		if regResult.Error != nil {
+			return fmt.Errorf(
+				"create genesis registration: %w", regResult.Error,
+			)
+		}
+
 		// Delegation history tables have no unique constraint that covers
 		// (staking_key, added_slot), so we use FirstOrCreate to keep the
 		// slot-0 row idempotent across retries (e.g., resumed Mithril

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -3952,6 +3952,12 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 		}
 		account.AddedSlot = 0
 
+		// Delegation history tables have no unique constraint that covers
+		// (staking_key, added_slot), so we use FirstOrCreate to keep the
+		// slot-0 row idempotent across retries (e.g., resumed Mithril
+		// bootstrap). Each staking key contributes at most one genesis
+		// delegation row of a given type, so matching on staking_key +
+		// added_slot is sufficient.
 		switch delegatee.Type {
 		case conway.ConwayGenesisDelegateeTypeStake:
 			account.Pool = delegatee.PoolId[:]
@@ -3960,13 +3966,18 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 					"save genesis stake delegatee account: %w", err,
 				)
 			}
-			if err := saveCertRecord(&models.StakeDelegation{
+			var existing models.StakeDelegation
+			result := db.Where(
+				"staking_key = ? AND added_slot = ?",
+				stakeKey, uint64(0),
+			).Attrs(models.StakeDelegation{
 				StakingKey:  stakeKey,
 				PoolKeyHash: delegatee.PoolId[:],
 				AddedSlot:   0,
-			}, db); err != nil {
+			}).FirstOrCreate(&existing)
+			if result.Error != nil {
 				return fmt.Errorf(
-					"create genesis stake delegation: %w", err,
+					"create genesis stake delegation: %w", result.Error,
 				)
 			}
 		case conway.ConwayGenesisDelegateeTypeVote:
@@ -3977,14 +3988,19 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 					"save genesis vote delegatee account: %w", err,
 				)
 			}
-			if err := saveCertRecord(&models.VoteDelegation{
+			var existing models.VoteDelegation
+			result := db.Where(
+				"staking_key = ? AND added_slot = ?",
+				stakeKey, uint64(0),
+			).Attrs(models.VoteDelegation{
 				StakingKey: stakeKey,
 				Drep:       drepCredential,
 				DrepType:   drepType,
 				AddedSlot:  0,
-			}, db); err != nil {
+			}).FirstOrCreate(&existing)
+			if result.Error != nil {
 				return fmt.Errorf(
-					"create genesis vote delegation: %w", err,
+					"create genesis vote delegation: %w", result.Error,
 				)
 			}
 		case conway.ConwayGenesisDelegateeTypeStakeVote:
@@ -3996,15 +4012,20 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 					"save genesis stake/vote delegatee account: %w", err,
 				)
 			}
-			if err := saveCertRecord(&models.StakeVoteDelegation{
+			var existing models.StakeVoteDelegation
+			result := db.Where(
+				"staking_key = ? AND added_slot = ?",
+				stakeKey, uint64(0),
+			).Attrs(models.StakeVoteDelegation{
 				StakingKey:  stakeKey,
 				PoolKeyHash: delegatee.PoolId[:],
 				Drep:        drepCredential,
 				DrepType:    drepType,
 				AddedSlot:   0,
-			}, db); err != nil {
+			}).FirstOrCreate(&existing)
+			if result.Error != nil {
 				return fmt.Errorf(
-					"create genesis stake/vote delegation: %w", err,
+					"create genesis stake/vote delegation: %w", result.Error,
 				)
 			}
 		default:

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -3849,6 +3850,167 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 			return fmt.Errorf(
 				"create genesis account: %w",
 				result.Error,
+			)
+		}
+	}
+
+	return nil
+}
+
+// SetGenesisGovernance stores the initial DReps and stake/vote
+// delegations described in the conway-genesis.json bootstrap section.
+// All records are stamped at slot 0 so they appear as part of the
+// initial ledger state.
+func (d *MetadataStoreSqlite) SetGenesisGovernance(
+	initialDReps conway.ConwayGenesisInitialDReps,
+	delegs conway.ConwayGenesisDelegs,
+	_ []byte,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+
+	for cred, state := range initialDReps {
+		if cred == nil {
+			continue
+		}
+		drepCred := cred.Credential[:]
+		drep := &models.Drep{
+			Credential:  drepCred,
+			AddedSlot:   0,
+			ExpiryEpoch: state.Expiry,
+			Active:      true,
+		}
+		if state.Anchor != nil {
+			drep.AnchorURL = state.Anchor.Url
+			drep.AnchorHash = state.Anchor.DataHash[:]
+		}
+		if result := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "credential"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"added_slot",
+				"anchor_url",
+				"anchor_hash",
+				"expiry_epoch",
+				"active",
+			}),
+		}).Create(drep); result.Error != nil {
+			return fmt.Errorf(
+				"create genesis drep: %w",
+				result.Error,
+			)
+		}
+
+		reg := &models.RegistrationDrep{
+			DrepCredential: drepCred,
+			AddedSlot:      0,
+			DepositAmount:  types.Uint64(state.Deposit),
+		}
+		if state.Anchor != nil {
+			reg.AnchorURL = state.Anchor.Url
+			reg.AnchorHash = state.Anchor.DataHash[:]
+		}
+		if result := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "drep_credential"},
+				{Name: "added_slot"},
+			},
+			DoNothing: true,
+		}).Create(reg); result.Error != nil {
+			return fmt.Errorf(
+				"create genesis drep registration: %w",
+				result.Error,
+			)
+		}
+	}
+
+	for cred, delegatee := range delegs {
+		if cred == nil {
+			continue
+		}
+		stakeKey := cred.Credential[:]
+
+		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
+		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {
+			return fmt.Errorf("genesis delegatee drep type: %w", err)
+		}
+		var drepCredential []byte
+		if delegatee.Type != conway.ConwayGenesisDelegateeTypeStake &&
+			drepType != models.DrepTypeAlwaysAbstain &&
+			drepType != models.DrepTypeAlwaysNoConfidence {
+			drepCredential = delegatee.DRep.Credential
+		}
+
+		account, err := d.getOrCreateAccount(stakeKey, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"get or create genesis delegatee account: %w",
+				err,
+			)
+		}
+		account.AddedSlot = 0
+
+		switch delegatee.Type {
+		case conway.ConwayGenesisDelegateeTypeStake:
+			account.Pool = delegatee.PoolId[:]
+			if err := saveAccount(account, db); err != nil {
+				return fmt.Errorf(
+					"save genesis stake delegatee account: %w", err,
+				)
+			}
+			if err := saveCertRecord(&models.StakeDelegation{
+				StakingKey:  stakeKey,
+				PoolKeyHash: delegatee.PoolId[:],
+				AddedSlot:   0,
+			}, db); err != nil {
+				return fmt.Errorf(
+					"create genesis stake delegation: %w", err,
+				)
+			}
+		case conway.ConwayGenesisDelegateeTypeVote:
+			account.Drep = drepCredential
+			account.DrepType = drepType
+			if err := saveAccount(account, db); err != nil {
+				return fmt.Errorf(
+					"save genesis vote delegatee account: %w", err,
+				)
+			}
+			if err := saveCertRecord(&models.VoteDelegation{
+				StakingKey: stakeKey,
+				Drep:       drepCredential,
+				DrepType:   drepType,
+				AddedSlot:  0,
+			}, db); err != nil {
+				return fmt.Errorf(
+					"create genesis vote delegation: %w", err,
+				)
+			}
+		case conway.ConwayGenesisDelegateeTypeStakeVote:
+			account.Pool = delegatee.PoolId[:]
+			account.Drep = drepCredential
+			account.DrepType = drepType
+			if err := saveAccount(account, db); err != nil {
+				return fmt.Errorf(
+					"save genesis stake/vote delegatee account: %w", err,
+				)
+			}
+			if err := saveCertRecord(&models.StakeVoteDelegation{
+				StakingKey:  stakeKey,
+				PoolKeyHash: delegatee.PoolId[:],
+				Drep:        drepCredential,
+				DrepType:    drepType,
+				AddedSlot:   0,
+			}, db); err != nil {
+				return fmt.Errorf(
+					"create genesis stake/vote delegation: %w", err,
+				)
+			}
+		default:
+			return fmt.Errorf(
+				"unknown genesis delegatee type: %d",
+				delegatee.Type,
 			)
 		}
 	}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -577,6 +578,17 @@ type MetadataStore interface {
 	SetGenesisStaking(
 		pools map[string]lcommon.PoolRegistrationCertificate,
 		stakeDelegations map[string]string,
+		blockHash []byte,
+		txn types.Txn,
+	) error
+
+	// SetGenesisGovernance stores the initial DReps and stake/vote
+	// delegations from the conway-genesis.json governance bootstrap
+	// section. Records are stamped with slot 0 so they appear in the
+	// ledger as having been present since genesis.
+	SetGenesisGovernance(
+		initialDReps conway.ConwayGenesisInitialDReps,
+		delegs conway.ConwayGenesisDelegs,
 		blockHash []byte,
 		txn types.Txn,
 	) error

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
@@ -716,6 +717,36 @@ func (d *Database) SetGenesisStaking(
 		txn.Metadata(),
 	); err != nil {
 		return fmt.Errorf("set genesis staking: %w", err)
+	}
+	return nil
+}
+
+// SetGenesisGovernance stores initial DReps and delegations from the
+// Conway genesis bootstrap section. This is metadata-only.
+func (d *Database) SetGenesisGovernance(
+	initialDReps conway.ConwayGenesisInitialDReps,
+	delegs conway.ConwayGenesisDelegs,
+	blockHash []byte,
+	txn *Txn,
+) error {
+	if txn == nil {
+		if err := d.metadata.SetGenesisGovernance(
+			initialDReps,
+			delegs,
+			blockHash,
+			nil,
+		); err != nil {
+			return fmt.Errorf("set genesis governance: %w", err)
+		}
+		return nil
+	}
+	if err := d.metadata.SetGenesisGovernance(
+		initialDReps,
+		delegs,
+		blockHash,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("set genesis governance: %w", err)
 	}
 	return nil
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2582,6 +2582,32 @@ func (ls *LedgerState) createGenesisBlock() error {
 			}
 		}
 
+		// Load Conway genesis bootstrap data (initial DReps and
+		// stake/vote delegations). The conway-genesis.json may declare
+		// pre-existing DReps and delegations for test networks; mainnet
+		// has none.
+		conwayGenesis := ls.config.CardanoNodeConfig.ConwayGenesis()
+		if conwayGenesis != nil &&
+			(len(conwayGenesis.InitialDReps) > 0 ||
+				len(conwayGenesis.Delegs) > 0) {
+			ls.config.Logger.Info(
+				fmt.Sprintf(
+					"loading genesis governance: %d initial dreps, %d delegations",
+					len(conwayGenesis.InitialDReps),
+					len(conwayGenesis.Delegs),
+				),
+				"component", "ledger",
+			)
+			if err := ls.db.SetGenesisGovernance(
+				conwayGenesis.InitialDReps,
+				conwayGenesis.Delegs,
+				genesisHash[:],
+				txn,
+			); err != nil {
+				return fmt.Errorf("set genesis governance: %w", err)
+			}
+		}
+
 		return nil
 	})
 	return err


### PR DESCRIPTION
Closes #1710 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads initial DReps and stake/vote delegations from Conway genesis at slot 0 so the ledger starts with the correct governance state. Implemented for SQLite with idempotent writes and wired into genesis block creation; `postgres`/`mysql` return "not implemented".

- New Features
  - Added `SetGenesisGovernance` to `MetadataStore`/`Database`; `ledger` loads Conway genesis governance at genesis and logs counts.
  - SQLite persists DReps (expiry, anchor, deposit) and stake/vote/stake+vote delegations at slot 0, creates synthetic `Registration` rows to root accounts, and uses conflict-safe upserts/`FirstOrCreate`.

- Bug Fixes
  - Restoration now orders by (added_slot DESC, block_index DESC, cert_index DESC) and LEFT JOINs `certs`/`transaction` so genesis rows (certificate_id=0) are included and same-slot, cross-transaction tie-breaks are correct.
  - DRep rollback uses the full ordering and preserves genesis-rooted `ExpiryEpoch` and `LastActivityEpoch` (non-genesis still reset to 0); cross-type comparisons (registration/deregistration/update) use consistent recency checks to avoid keeping inactive DReps active.

<sup>Written for commit 27eb5b9b3f578392345b9e5ce47078d5680e9dad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ledger now loads and persists Conway genesis governance (initial DReps and delegations) at genesis block creation for SQLite; database API added to invoke this and ledger reads it from node config.
* **Bug Fixes**
  * Certificate selection and restore logic refined so synthetic/genesis rows participate deterministically in latest-record resolution and rollbacks.
* **Tests**
  * Extensive SQLite tests for genesis persistence, idempotency, empty input, and rollback/regression scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2231)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->