### PR TITLE
fix(chain): add multi-chain reconcile tests (#752)

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1257,13 +1257,17 @@ func (c *Chain) reconcile() error {
 		if err != nil {
 			return err
 		}
-		// Lookup same block index on primary chain
+		// Lookup same block index on primary chain. When the primary
+		// has rolled back past tmpBlock's old index the lookup misses;
+		// treat tmpBlock as non-common and keep walking back via its
+		// PrevHash rather than aborting reconcile.
 		primaryBlock, err := primaryChain.blockByIndex(tmpBlock.ID)
-		if err != nil {
+		if err != nil && !errors.Is(err, models.ErrBlockNotFound) {
 			return err
 		}
 		// Update last common block index and return when we find a matching block on the primary chain
-		if tmpBlock.Slot == primaryBlock.Slot &&
+		if err == nil &&
+			tmpBlock.Slot == primaryBlock.Slot &&
 			bytes.Equal(tmpBlock.Hash, primaryBlock.Hash) {
 			c.lastCommonBlockIndex = tmpBlock.ID
 			break

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1232,8 +1232,18 @@ func (c *Chain) reconcile() error {
 	}
 	// Determine prev-hash from earliest known good block
 	knownPoint := c.currentTip.Point
+	// Iterate backward through chain based on prev-hash until we find a matching block on the primary chain
+	// Accumulate blocks locally to avoid O(K²) prepending
+	newBlocks := make([]ocommon.Point, 0, securityParam)
 	if len(c.blocks) > 0 {
 		knownPoint = c.blocks[0]
+	} else {
+		// No in-memory blocks: the chain's current tip is itself the
+		// earliest known good block. Seed newBlocks so the tip is
+		// preserved after we re-anchor lastCommonBlockIndex against
+		// the primary; otherwise iteration past the new common point
+		// would silently truncate at it.
+		newBlocks = append(newBlocks, knownPoint)
 	}
 	knownBlock, err := c.manager.blockByPoint(knownPoint, nil)
 	if err != nil {
@@ -1244,9 +1254,6 @@ func (c *Chain) reconcile() error {
 		return err
 	}
 	lastPrevHash := decodedKnownBlock.PrevHash().Bytes()
-	// Iterate backward through chain based on prev-hash until we find a matching block on the primary chain
-	// Accumulate blocks locally to avoid O(K²) prepending
-	newBlocks := make([]ocommon.Point, 0, securityParam)
 	iterationCount := 0
 	for {
 		if iterationCount >= securityParam {

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1765,3 +1765,170 @@ func TestChainRollbackNonPrimaryAfterPrimaryRollback(t *testing.T) {
 		t.Fatalf("expected ErrIteratorChainTip on iter2, got: %v", err)
 	}
 }
+
+// TestChainMultipleNonPrimaryChainsIndependentRollback verifies that
+// two non-primary chains rooted at different points on the primary
+// chain reconcile independently after the primary chain rolls back
+// past both fork points, and that rolling back one fork chain has no
+// effect on the other.
+//
+// Setup:
+//   - Primary chain: 8 blocks (P1..P8, slots 0..140).
+//   - Fork A: branches at P3 with divergent A4', A5', A6'.
+//   - Fork B: branches at P5 with divergent B6', B7', B8'.
+//   - Primary rolls back to P2 (depth 6 with K=6).
+//
+// After rollback, iterating each fork from origin must deliver the
+// retained primary prefix plus that fork's divergent tail. Rolling
+// back fork A then leaves fork B's view unchanged.
+func TestChainMultipleNonPrimaryChainsIndependentRollback(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 6)
+	primaryChain := cm.PrimaryChain()
+
+	var origin common.Blake2b256
+	primaryBlocks := generateTestChain(t, 1, origin, 0, 20, 8)
+	for i, b := range primaryBlocks {
+		if err := primaryChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock primary[%d]: %s", i, err)
+		}
+	}
+
+	const forkAIdx = 2 // primary block 3
+	forkAPoint := ocommon.Point{
+		Slot: primaryBlocks[forkAIdx].SlotNumber(),
+		Hash: primaryBlocks[forkAIdx].Hash().Bytes(),
+	}
+	forkA, err := cm.NewChainFromIntersect(
+		[]ocommon.Point{forkAPoint},
+	)
+	if err != nil {
+		t.Fatalf("NewChainFromIntersect A: %s", err)
+	}
+	forkABlocks := generateTestChain(
+		t,
+		uint64(forkAIdx+2),
+		primaryBlocks[forkAIdx].Hash(),
+		primaryBlocks[forkAIdx].SlotNumber()+20,
+		20,
+		3,
+	)
+	for i, b := range forkABlocks {
+		if err := forkA.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock forkA[%d]: %s", i, err)
+		}
+	}
+
+	const forkBIdx = 4 // primary block 5
+	forkBPoint := ocommon.Point{
+		Slot: primaryBlocks[forkBIdx].SlotNumber(),
+		Hash: primaryBlocks[forkBIdx].Hash().Bytes(),
+	}
+	forkB, err := cm.NewChainFromIntersect(
+		[]ocommon.Point{forkBPoint},
+	)
+	if err != nil {
+		t.Fatalf("NewChainFromIntersect B: %s", err)
+	}
+	forkBBlocks := generateTestChain(
+		t,
+		uint64(forkBIdx+2),
+		primaryBlocks[forkBIdx].Hash(),
+		primaryBlocks[forkBIdx].SlotNumber()+20,
+		20,
+		3,
+	)
+	for i, b := range forkBBlocks {
+		if err := forkB.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock forkB[%d]: %s", i, err)
+		}
+	}
+
+	rbPrimary := ocommon.Point{
+		Slot: primaryBlocks[1].SlotNumber(),
+		Hash: primaryBlocks[1].Hash().Bytes(),
+	}
+	if err := primaryChain.Rollback(rbPrimary); err != nil {
+		t.Fatalf("Rollback primary: %s", err)
+	}
+
+	checkSequence := func(name string, c *chain.Chain, expected []ledger.Block) {
+		t.Helper()
+		iter, err := c.FromPoint(ocommon.NewPointOrigin(), false)
+		if err != nil {
+			t.Fatalf("%s FromPoint: %s", name, err)
+		}
+		for i, want := range expected {
+			next, err := iter.Next(false)
+			if err != nil {
+				t.Fatalf("%s iter.Next idx %d: %s", name, i, err)
+			}
+			if next == nil || next.Rollback {
+				t.Fatalf(
+					"%s iter.Next idx %d unexpected: %+v",
+					name, i, next,
+				)
+			}
+			if next.Block.Number != want.BlockNumber() {
+				t.Fatalf(
+					"%s idx %d block number: got %d want %d",
+					name, i, next.Block.Number, want.BlockNumber(),
+				)
+			}
+			if !bytes.Equal(next.Block.Hash, want.Hash().Bytes()) {
+				t.Fatalf(
+					"%s idx %d block hash: got %x want %x",
+					name, i, next.Block.Hash, want.Hash().Bytes(),
+				)
+			}
+		}
+		if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainTip) {
+			t.Fatalf(
+				"%s expected ErrIteratorChainTip, got: %v",
+				name, err,
+			)
+		}
+	}
+
+	expectedA := append(
+		[]ledger.Block{},
+		primaryBlocks[0],
+		primaryBlocks[1],
+		primaryBlocks[2],
+	)
+	expectedA = append(expectedA, forkABlocks...)
+	checkSequence("forkA initial", forkA, expectedA)
+
+	expectedB := append(
+		[]ledger.Block{},
+		primaryBlocks[0],
+		primaryBlocks[1],
+		primaryBlocks[2],
+		primaryBlocks[3],
+		primaryBlocks[4],
+	)
+	expectedB = append(expectedB, forkBBlocks...)
+	checkSequence("forkB initial", forkB, expectedB)
+
+	// Roll back fork A to its first divergent block; fork B must stay
+	// unaffected.
+	rbForkA := ocommon.Point{
+		Slot: forkABlocks[0].SlotNumber(),
+		Hash: forkABlocks[0].Hash().Bytes(),
+	}
+	if err := forkA.Rollback(rbForkA); err != nil {
+		t.Fatalf("Rollback forkA: %s", err)
+	}
+	expectedAAfter := []ledger.Block{
+		primaryBlocks[0],
+		primaryBlocks[1],
+		primaryBlocks[2],
+		forkABlocks[0],
+	}
+	checkSequence("forkA after rollback", forkA, expectedAAfter)
+	checkSequence("forkB unaffected", forkB, expectedB)
+}

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -15,6 +15,7 @@
 package chain_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -22,9 +23,13 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"golang.org/x/crypto/blake2b"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
@@ -922,6 +927,155 @@ func newTestDB(t *testing.T) *database.Database {
 	}
 	t.Cleanup(func() { db.Close() })
 	return db
+}
+
+// generateTestChain builds `count` Conway blocks that chain together via
+// PrevHash and survive a CBOR round-trip — that is, after re-decoding
+// each block's stored Cbor() via ledger.NewBlockFromCbor (the path used
+// by models.Block.Decode in chain.reconcile), the decoded block's
+// Hash() and PrevHash() match what the generator originally produced.
+//
+// The first block's PrevHash is set to prevHash. Each block's slot is
+// startSlot + i*slotIncrement; block numbers run startBlockNumber..+count-1.
+// All blocks have empty transactions/witnesses/auxiliary/invalid sets,
+// so they share the same block body hash.
+func generateTestChain(
+	t testing.TB,
+	startBlockNumber uint64,
+	prevHash common.Blake2b256,
+	startSlot, slotIncrement uint64,
+	count int,
+) []ledger.Block {
+	t.Helper()
+	if count <= 0 {
+		return nil
+	}
+	// All generated blocks have identical empty bodies, so the four
+	// component CBORs and the resulting block body hash are constant.
+	emptyTxsCbor, err := cbor.Encode([]ledger.ConwayTransactionBody{})
+	if err != nil {
+		t.Fatalf("encode empty tx bodies: %s", err)
+	}
+	emptyWitsCbor, err := cbor.Encode([]ledger.ConwayTransactionWitnessSet{})
+	if err != nil {
+		t.Fatalf("encode empty witnesses: %s", err)
+	}
+	emptyAuxCbor, err := cbor.Encode(common.TransactionMetadataSet{})
+	if err != nil {
+		t.Fatalf("encode empty metadata set: %s", err)
+	}
+	emptyInvalidCbor, err := cbor.Encode([]uint{})
+	if err != nil {
+		t.Fatalf("encode empty invalid txs: %s", err)
+	}
+	bodyHash := computeBlockBodyHash(
+		emptyTxsCbor, emptyWitsCbor, emptyAuxCbor, emptyInvalidCbor,
+	)
+	blocks := make([]ledger.Block, 0, count)
+	currentPrev := prevHash
+	for i := range count {
+		body := babbage.BabbageBlockHeaderBody{
+			BlockNumber: startBlockNumber + uint64(i),
+			Slot:        startSlot + uint64(i)*slotIncrement,
+			PrevHash:    currentPrev,
+			IssuerVkey:  common.IssuerVkey{},
+			VrfKey:      make([]byte, 32),
+			VrfResult: common.VrfResult{
+				Output: make([]byte, 64),
+				Proof:  make([]byte, 80),
+			},
+			BlockBodySize: 0,
+			BlockBodyHash: bodyHash,
+			OpCert: babbage.BabbageOpCert{
+				HotVkey:   make([]byte, 32),
+				Signature: make([]byte, 64),
+			},
+			ProtoVersion: babbage.BabbageProtoVersion{Major: 9, Minor: 0},
+		}
+		block := &ledger.ConwayBlock{
+			BlockHeader: &ledger.ConwayBlockHeader{
+				BabbageBlockHeader: ledger.BabbageBlockHeader{
+					Body:      body,
+					Signature: make([]byte, 64),
+				},
+			},
+		}
+		blockCbor, err := cbor.Encode(block)
+		if err != nil {
+			t.Fatalf("encode block %d: %s", i, err)
+		}
+		// Re-decode so the returned block carries the canonical Cbor()
+		// the reconcile path will observe, and so Hash() reads from the
+		// post-round-trip header bytes.
+		decoded, err := conway.NewConwayBlockFromCbor(blockCbor)
+		if err != nil {
+			t.Fatalf("decode generated block %d: %s", i, err)
+		}
+		if !bytes.Equal(decoded.Cbor(), blockCbor) {
+			t.Fatalf("block %d Cbor mismatch after round-trip", i)
+		}
+		blocks = append(blocks, decoded)
+		currentPrev = decoded.Hash()
+	}
+	return blocks
+}
+
+// computeBlockBodyHash returns blake2b256(blake2b256(p[0]) || ...) which
+// matches common.ValidateBlockBodyHash's expected derivation.
+func computeBlockBodyHash(parts ...[]byte) common.Blake2b256 {
+	var combined []byte
+	for _, p := range parts {
+		h := blake2b.Sum256(p)
+		combined = append(combined, h[:]...)
+	}
+	h := blake2b.Sum256(combined)
+	return common.NewBlake2b256(h[:])
+}
+
+func TestGenerateTestChainRoundTrip(t *testing.T) {
+	var origin common.Blake2b256
+	gen := generateTestChain(t, 1, origin, 0, 20, 5)
+	if len(gen) != 5 {
+		t.Fatalf("expected 5 blocks, got %d", len(gen))
+	}
+	for i, b := range gen {
+		decoded, err := ledger.NewBlockFromCbor(uint(b.Type()), b.Cbor())
+		if err != nil {
+			t.Fatalf("block %d decode failed: %s", i, err)
+		}
+		if decoded.Hash() != b.Hash() {
+			t.Fatalf(
+				"block %d hash changed after round-trip: %s -> %s",
+				i, b.Hash(), decoded.Hash(),
+			)
+		}
+		if decoded.PrevHash() != b.PrevHash() {
+			t.Fatalf(
+				"block %d prev hash changed after round-trip: %s -> %s",
+				i, b.PrevHash(), decoded.PrevHash(),
+			)
+		}
+		if decoded.BlockNumber() != uint64(i+1) {
+			t.Fatalf(
+				"block %d unexpected block number %d",
+				i, decoded.BlockNumber(),
+			)
+		}
+		if decoded.SlotNumber() != uint64(i)*20 {
+			t.Fatalf(
+				"block %d unexpected slot %d",
+				i, decoded.SlotNumber(),
+			)
+		}
+	}
+	for i := 1; i < len(gen); i++ {
+		if gen[i].PrevHash() != gen[i-1].Hash() {
+			t.Fatalf(
+				"chain link mismatch at index %d: prev=%s, want=%s",
+				i, gen[i].PrevHash(), gen[i-1].Hash(),
+			)
+		}
+	}
 }
 
 func TestChainRollbackExceedsSecurityParam(t *testing.T) {

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1932,3 +1932,86 @@ func TestChainMultipleNonPrimaryChainsIndependentRollback(t *testing.T) {
 	checkSequence("forkA after rollback", forkA, expectedAAfter)
 	checkSequence("forkB unaffected", forkB, expectedB)
 }
+
+// TestChainReconcileEmptyForkPreservesOrphanedTip exercises the
+// reconcile path on a non-primary chain that has *no* divergent blocks
+// of its own when the primary chain rolls back past the fork point.
+//
+// Setup:
+//   - Primary chain has 6 blocks (P1..P6).
+//   - A non-primary chain forks at P3 but no blocks are added to it.
+//   - Primary rolls back to P2.
+//
+// Even though the fork chain has no in-memory blocks, its tip is still
+// P3. After the primary rolls back past P3, reconcile must re-anchor
+// lastCommonBlockIndex to P2 while preserving P3 as the fork's
+// in-memory tip; otherwise iteration silently truncates at P2.
+func TestChainReconcileEmptyForkPreservesOrphanedTip(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 5)
+	primaryChain := cm.PrimaryChain()
+
+	var origin common.Blake2b256
+	primaryBlocks := generateTestChain(t, 1, origin, 0, 20, 6)
+	for i, b := range primaryBlocks {
+		if err := primaryChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock primary[%d]: %s", i, err)
+		}
+	}
+
+	// Fork at primary block 3, no divergent blocks added.
+	forkPoint := ocommon.Point{
+		Slot: primaryBlocks[2].SlotNumber(),
+		Hash: primaryBlocks[2].Hash().Bytes(),
+	}
+	forkChain, err := cm.NewChainFromIntersect(
+		[]ocommon.Point{forkPoint},
+	)
+	if err != nil {
+		t.Fatalf("NewChainFromIntersect: %s", err)
+	}
+
+	rbPrimary := ocommon.Point{
+		Slot: primaryBlocks[1].SlotNumber(),
+		Hash: primaryBlocks[1].Hash().Bytes(),
+	}
+	if err := primaryChain.Rollback(rbPrimary); err != nil {
+		t.Fatalf("Rollback primary: %s", err)
+	}
+
+	iter, err := forkChain.FromPoint(ocommon.NewPointOrigin(), false)
+	if err != nil {
+		t.Fatalf("FromPoint: %s", err)
+	}
+	expected := []ledger.Block{
+		primaryBlocks[0], primaryBlocks[1], primaryBlocks[2],
+	}
+	for i, want := range expected {
+		next, err := iter.Next(false)
+		if err != nil {
+			t.Fatalf("iter.Next idx %d: %s", i, err)
+		}
+		if next == nil || next.Rollback {
+			t.Fatalf("iter.Next idx %d unexpected: %+v", i, next)
+		}
+		if next.Block.Number != want.BlockNumber() {
+			t.Fatalf(
+				"idx %d block number: got %d want %d",
+				i, next.Block.Number, want.BlockNumber(),
+			)
+		}
+		if !bytes.Equal(next.Block.Hash, want.Hash().Bytes()) {
+			t.Fatalf(
+				"idx %d block hash: got %x want %x",
+				i, next.Block.Hash, want.Hash().Bytes(),
+			)
+		}
+	}
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainTip) {
+		t.Fatalf("expected ErrIteratorChainTip, got: %v", err)
+	}
+}

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1496,3 +1496,110 @@ func TestChainFork(t *testing.T) {
 		testBlockIdx++
 	}
 }
+
+// TestChainIterateNonPrimaryAfterPrimaryRollbackPastFork exercises the
+// reconcile path on a non-primary chain when the primary chain has
+// rolled back past the fork point.
+//
+// Setup:
+//   - Primary chain has 6 blocks (block numbers 1..6, slots 0..100).
+//   - Non-primary chain forks at primary block 3 and extends with three
+//     divergent blocks F4', F5', F6' (block numbers 4..6, slots 60..100).
+//   - Primary rolls back to block 2 (drops blocks 3..6, depth 4 with K=5).
+//
+// Expectation: iterating the non-primary chain from origin returns
+// primary blocks 1..3 followed by F4', F5', F6'. Reconcile must walk
+// back from the in-memory fork blocks through the rolled-back ancestor
+// retained in the LRU cache to re-anchor the fork against the shorter
+// primary chain.
+func TestChainIterateNonPrimaryAfterPrimaryRollbackPastFork(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	// K=5 allows rollback depth 4 (primary tip 6 -> rollback to 2).
+	mustSetLedger(t, cm, 5)
+	primaryChain := cm.PrimaryChain()
+
+	var origin common.Blake2b256
+	primaryBlocks := generateTestChain(t, 1, origin, 0, 20, 6)
+	for i, b := range primaryBlocks {
+		if err := primaryChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock primary[%d]: %s", i, err)
+		}
+	}
+
+	const forkIdx = 2 // primary block 3 (0-based index 2)
+	forkPoint := ocommon.Point{
+		Slot: primaryBlocks[forkIdx].SlotNumber(),
+		Hash: primaryBlocks[forkIdx].Hash().Bytes(),
+	}
+	forkChain, err := cm.NewChainFromIntersect(
+		[]ocommon.Point{forkPoint},
+	)
+	if err != nil {
+		t.Fatalf("NewChainFromIntersect: %s", err)
+	}
+
+	forkBlocks := generateTestChain(
+		t,
+		uint64(forkIdx+2), // block number 4
+		primaryBlocks[forkIdx].Hash(),
+		primaryBlocks[forkIdx].SlotNumber()+20,
+		20,
+		3,
+	)
+	for i, b := range forkBlocks {
+		if err := forkChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock fork[%d]: %s", i, err)
+		}
+	}
+
+	rollbackPoint := ocommon.Point{
+		Slot: primaryBlocks[1].SlotNumber(),
+		Hash: primaryBlocks[1].Hash().Bytes(),
+	}
+	if err := primaryChain.Rollback(rollbackPoint); err != nil {
+		t.Fatalf("Rollback primary: %s", err)
+	}
+
+	iter, err := forkChain.FromPoint(ocommon.NewPointOrigin(), false)
+	if err != nil {
+		t.Fatalf("FromPoint: %s", err)
+	}
+	expected := append(
+		[]ledger.Block{},
+		primaryBlocks[0],
+		primaryBlocks[1],
+		primaryBlocks[2],
+	)
+	expected = append(expected, forkBlocks...)
+	for i, want := range expected {
+		next, err := iter.Next(false)
+		if err != nil {
+			t.Fatalf("iter.Next at idx %d: %s", i, err)
+		}
+		if next == nil {
+			t.Fatalf("iter.Next at idx %d returned nil", i)
+		}
+		if next.Rollback {
+			t.Fatalf("iter.Next at idx %d unexpected rollback", i)
+		}
+		if next.Block.Number != want.BlockNumber() {
+			t.Fatalf(
+				"idx %d block number: got %d, want %d",
+				i, next.Block.Number, want.BlockNumber(),
+			)
+		}
+		if !bytes.Equal(next.Block.Hash, want.Hash().Bytes()) {
+			t.Fatalf(
+				"idx %d block hash: got %x, want %x",
+				i, next.Block.Hash, want.Hash().Bytes(),
+			)
+		}
+	}
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainTip) {
+		t.Fatalf("expected ErrIteratorChainTip at fork tip, got: %v", err)
+	}
+}

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1603,3 +1603,165 @@ func TestChainIterateNonPrimaryAfterPrimaryRollbackPastFork(t *testing.T) {
 		t.Fatalf("expected ErrIteratorChainTip at fork tip, got: %v", err)
 	}
 }
+
+// TestChainRollbackNonPrimaryAfterPrimaryRollback covers the case where
+// the non-primary chain is itself rolled back after the primary has
+// already rolled back past the fork point.
+//
+// Setup matches TestChainIterateNonPrimaryAfterPrimaryRollbackPastFork:
+// primary blocks 1..6, fork chain branches at primary block 3 with
+// divergent blocks F4', F5', F6', primary then rolls back to block 2.
+//
+// The test then iterates the fork chain to its tip (driving reconcile
+// under the new primary), rolls back the fork chain itself to the
+// original fork point (primary block 3, retained in the LRU cache),
+// and verifies:
+//   - the pre-existing iterator receives a rollback signal at the fork
+//     point followed by ErrIteratorChainTip;
+//   - a fresh iterator from origin delivers exactly P1, P2, P3.
+func TestChainRollbackNonPrimaryAfterPrimaryRollback(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 5)
+	primaryChain := cm.PrimaryChain()
+
+	var origin common.Blake2b256
+	primaryBlocks := generateTestChain(t, 1, origin, 0, 20, 6)
+	for i, b := range primaryBlocks {
+		if err := primaryChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock primary[%d]: %s", i, err)
+		}
+	}
+
+	const forkIdx = 2 // primary block 3
+	forkPoint := ocommon.Point{
+		Slot: primaryBlocks[forkIdx].SlotNumber(),
+		Hash: primaryBlocks[forkIdx].Hash().Bytes(),
+	}
+	forkChain, err := cm.NewChainFromIntersect(
+		[]ocommon.Point{forkPoint},
+	)
+	if err != nil {
+		t.Fatalf("NewChainFromIntersect: %s", err)
+	}
+
+	forkBlocks := generateTestChain(
+		t,
+		uint64(forkIdx+2),
+		primaryBlocks[forkIdx].Hash(),
+		primaryBlocks[forkIdx].SlotNumber()+20,
+		20,
+		3,
+	)
+	for i, b := range forkBlocks {
+		if err := forkChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock fork[%d]: %s", i, err)
+		}
+	}
+
+	rbPrimary := ocommon.Point{
+		Slot: primaryBlocks[1].SlotNumber(),
+		Hash: primaryBlocks[1].Hash().Bytes(),
+	}
+	if err := primaryChain.Rollback(rbPrimary); err != nil {
+		t.Fatalf("Rollback primary: %s", err)
+	}
+
+	// Drain the fork chain to its current tip; this triggers reconcile
+	// and produces a known iterator position before the fork rollback.
+	iter, err := forkChain.FromPoint(ocommon.NewPointOrigin(), false)
+	if err != nil {
+		t.Fatalf("FromPoint: %s", err)
+	}
+	preRollbackExpected := append(
+		[]ledger.Block{},
+		primaryBlocks[0],
+		primaryBlocks[1],
+		primaryBlocks[2],
+	)
+	preRollbackExpected = append(preRollbackExpected, forkBlocks...)
+	for i, want := range preRollbackExpected {
+		next, err := iter.Next(false)
+		if err != nil {
+			t.Fatalf("iter.Next pre-rollback idx %d: %s", i, err)
+		}
+		if next == nil || next.Rollback {
+			t.Fatalf("iter.Next pre-rollback idx %d unexpected: %+v", i, next)
+		}
+		if next.Block.Number != want.BlockNumber() {
+			t.Fatalf(
+				"pre-rollback idx %d block number: got %d want %d",
+				i, next.Block.Number, want.BlockNumber(),
+			)
+		}
+	}
+
+	// Roll back the fork chain itself to the original fork point (a
+	// primary block that the primary has already rolled back away).
+	rbFork := ocommon.Point{
+		Slot: primaryBlocks[forkIdx].SlotNumber(),
+		Hash: primaryBlocks[forkIdx].Hash().Bytes(),
+	}
+	if err := forkChain.Rollback(rbFork); err != nil {
+		t.Fatalf("Rollback fork: %s", err)
+	}
+
+	// The pre-existing iterator's lastPoint (F6', slot 100) is past the
+	// rollback point so it should observe a rollback signal at P3
+	// followed by tip.
+	next, err := iter.Next(false)
+	if err != nil {
+		t.Fatalf("iter.Next post-rollback: %s", err)
+	}
+	if next == nil || !next.Rollback {
+		t.Fatalf("expected rollback signal, got: %+v", next)
+	}
+	if next.Point.Slot != rbFork.Slot ||
+		!bytes.Equal(next.Point.Hash, rbFork.Hash) {
+		t.Fatalf(
+			"rollback point: got slot=%d hash=%x, want slot=%d hash=%x",
+			next.Point.Slot, next.Point.Hash,
+			rbFork.Slot, rbFork.Hash,
+		)
+	}
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainTip) {
+		t.Fatalf("expected ErrIteratorChainTip after rollback signal, got: %v", err)
+	}
+
+	// A fresh iterator should now reach exactly the rolled-back fork
+	// tip (P1, P2, P3) before hitting tip.
+	iter2, err := forkChain.FromPoint(ocommon.NewPointOrigin(), false)
+	if err != nil {
+		t.Fatalf("FromPoint 2: %s", err)
+	}
+	postRollbackExpected := []ledger.Block{
+		primaryBlocks[0], primaryBlocks[1], primaryBlocks[2],
+	}
+	for i, want := range postRollbackExpected {
+		next, err := iter2.Next(false)
+		if err != nil {
+			t.Fatalf("iter2.Next idx %d: %s", i, err)
+		}
+		if next == nil || next.Rollback {
+			t.Fatalf("iter2.Next idx %d unexpected: %+v", i, next)
+		}
+		if next.Block.Number != want.BlockNumber() {
+			t.Fatalf(
+				"iter2 idx %d block number: got %d want %d",
+				i, next.Block.Number, want.BlockNumber(),
+			)
+		}
+		if !bytes.Equal(next.Block.Hash, want.Hash().Bytes()) {
+			t.Fatalf(
+				"iter2 idx %d block hash: got %x want %x",
+				i, next.Block.Hash, want.Hash().Bytes(),
+			)
+		}
+	}
+	if _, err := iter2.Next(false); !errors.Is(err, chain.ErrIteratorChainTip) {
+		t.Fatalf("expected ErrIteratorChainTip on iter2, got: %v", err)
+	}
+}

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -268,10 +268,23 @@ func (cm *ChainManager) blockByPoint(
 func (cm *ChainManager) blockByHash(
 	blockHash []byte,
 ) (models.Block, error) {
-	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-	// Check in-memory cache
+	// Check in-memory cache (block cache has its own locking).
 	if blk, ok := cm.blockCache.Get(blockHash); ok {
+		return blk, nil
+	}
+	// Fall through to database. Reconcile of a non-primary chain
+	// walks back via prev-hash, and the ancestor it lands on may
+	// still be present on the primary chain (so not in the cache,
+	// which only holds rolled-back primary blocks and ephemeral
+	// non-primary blocks).
+	if cm.db != nil {
+		blk, err := database.BlockByHash(cm.db, blockHash)
+		if err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				return models.Block{}, models.ErrBlockNotFound
+			}
+			return models.Block{}, err
+		}
 		return blk, nil
 	}
 	return models.Block{}, models.ErrBlockNotFound


### PR DESCRIPTION
## Summary

- Adds `generateTestChain`, a CBOR-stable Conway-block generator so reconcile-path tests can drive the real `ledger.NewBlockFromCbor` decode path (the existing `MockBlock` fixture has no CBOR, so blocks could not survive the round-trip done by `models.Block.Decode` in `chain.reconcile`).
- Adds three multi-chain tests from #752's checklist:
  - Iterate a non-primary chain after the primary chain has rolled back past the fork point.
  - Roll back the non-primary chain after the primary rollback, then iterate (covers both the rollback signal delivered to a live iterator and a fresh re-iterate).
  - Two non-primary chains forked at different points reconcile independently and a rollback of one does not affect the other.
- Fixes a `chain.reconcile` bug surfaced by the first scenario: when the primary chain has rolled back past a fork point, walking backward through the fork's PrevHash chain encountered `ErrBlockNotFound` from `primaryChain.blockByIndex(tmpBlock.ID)` and aborted. Reconcile now treats that miss as "not common yet, keep walking back".
- Extends `manager.blockByHash` to fall through to the DB (matching the pattern in `blockByPoint`); the cache-only behavior could not find still-on-primary ancestors that were never rolled back. Also drops a redundant manager-level RLock — the block cache has its own lock.

## Coverage delta (chain package)

| | Before | After |
|---|---|---|
| `chain.reconcile` | 6.8% | 72.9% |
| `manager.blockByHash` | 0% | 60% |
| `manager.chainNeedsReconcile` | 30% | 100% |
| total | 54.9% | 61.2% |

## Test plan

- [ ] `go test -race ./chain/...` passes locally and in CI
- [ ] `golangci-lint run ./chain/...` clean
- [ ] Downstream callers (`ledger`, `chainsync`, `ouroboros`) still pass

closes #752

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CBOR-stable Conway block generator and four multi-chain reconcile tests from #752. Fixes `chain.reconcile` to walk past rolled-back ancestors and preserve an empty fork’s orphaned tip; extends `manager.blockByHash` to query the DB, improving correctness and coverage.

- **New Features**
  - Added `generateTestChain` to produce CBOR-stable blocks so tests exercise the real `ledger.NewBlockFromCbor` path.
  - Added multi-chain reconcile tests (from #752): iterate a non-primary after primary rollback past fork; rollback the non-primary after primary rollback (checks iterator signal and re-iterate); verify two non-primary forks reconcile independently; and handle an empty fork by preserving its orphaned tip after a primary rollback.

- **Bug Fixes**
  - `chain.reconcile`: when the primary rolled back past the fork, treat `ErrBlockNotFound` on `blockByIndex` as “not common yet” and keep walking via `PrevHash`; when the fork has no in-memory blocks, preserve its tip while re-anchoring against the primary.
  - `manager.blockByHash`: fall through to the DB (and drop a redundant manager-level RLock) so ancestors still on the primary are found.

<sup>Written for commit bf414749bd9c9645ed371da51899cb700fd7f237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain reconciliation to gracefully handle missing blocks when comparing forks against the primary chain, continuing the backward walk instead of aborting on block-not-found errors.

* **Tests**
  * Added comprehensive test coverage for non-primary chain reconciliation and rollback behavior following primary chain rollbacks past fork points.

* **Refactoring**
  * Optimized block lookup performance by removing unnecessary synchronization around cache access, with clarifying documentation on cache contents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->