### PR TITLE
fix(ledger): sparse intersect points

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -60,6 +60,8 @@ import (
 const (
 	cleanupConsumedUtxosInterval = 5 * time.Minute
 	batchSize                    = 50 // Number of blocks to process in a single DB transaction
+	ledgerIntersectDenseCount    = 32
+	firstBlockIndex              = 1
 )
 
 type metadataDbReader interface {
@@ -4151,36 +4153,78 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 		return nil, nil
 	}
 	points := make([]ocommon.Point, 0, count)
-	nextHash := append([]byte(nil), currentTip.Point.Hash...)
-	for len(points) < count && len(nextHash) > 0 {
-		block, err := database.BlockByHash(ls.db, nextHash)
-		if err != nil {
-			// Tolerate missing blocks: a block lacking a hash
-			// index entry can be reported NotFound by the
-			// time-bounded BlockByHash scan fallback added in
-			// this PR. Returning the error here would leave us
-			// unable to send any intersect points to peers,
-			// which breaks both inbound chainsync (peers can't
-			// sync from us) and our own outbound chainsync setup
-			// (we ship MsgFindIntersect with these points).
-			// Stopping the walk returns whatever we collected
-			// so far — chainsync negotiation handles a short
-			// candidate list, and the next chain extension or
-			// rollback will refill the recent window with
-			// fully-indexed blocks.
-			if errors.Is(err, models.ErrBlockNotFound) {
-				break
-			}
-			return nil, err
+	seen := make(map[string]struct{}, count)
+	appendBlock := func(block models.Block) bool {
+		if len(points) >= count {
+			return false
+		}
+		key := fmt.Sprintf("%d:%x", block.Slot, block.Hash)
+		if _, ok := seen[key]; ok {
+			return true
 		}
 		points = append(
 			points,
 			ocommon.NewPoint(block.Slot, block.Hash),
 		)
-		if len(block.PrevHash) == 0 {
+		seen[key] = struct{}{}
+		return true
+	}
+	appendBlockByIndex := func(blockIndex uint64) bool {
+		if len(points) >= count {
+			return false
+		}
+		block, err := ls.db.BlockByIndex(blockIndex, nil)
+		if err != nil {
+			return false
+		}
+		return appendBlock(block)
+	}
+	tipBlock, err := database.BlockByHash(ls.db, currentTip.Point.Hash)
+	if err != nil {
+		// Tolerate missing blocks: a block lacking a hash
+		// index entry can be reported NotFound by the
+		// time-bounded BlockByHash scan fallback added in
+		// this PR. Returning the error here would leave us
+		// unable to send any intersect points to peers,
+		// which breaks both inbound chainsync (peers can't
+		// sync from us) and our own outbound chainsync setup
+		// (we ship MsgFindIntersect with these points).
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return points, nil
+		}
+		return nil, err
+	}
+	appendBlock(tipBlock)
+	denseStartIndex := tipBlock.ID
+	if denseStartIndex > firstBlockIndex {
+		denseStartIndex--
+	} else {
+		denseStartIndex = 0
+	}
+	denseCount := min(count, ledgerIntersectDenseCount)
+	for idx := denseStartIndex; idx >= firstBlockIndex && len(points) < denseCount; idx-- {
+		if !appendBlockByIndex(idx) {
 			break
 		}
-		nextHash = append(nextHash[:0], block.PrevHash...)
+		if idx == firstBlockIndex {
+			break
+		}
+	}
+	if len(points) >= count {
+		return points, nil
+	}
+	if tipBlock.ID > firstBlockIndex {
+		for offset := uint64(denseCount); len(points) < count; offset *= 2 {
+			if offset == 0 || offset >= tipBlock.ID {
+				break
+			}
+			if !appendBlockByIndex(tipBlock.ID - offset) {
+				break
+			}
+		}
+	}
+	if len(points) < count {
+		_ = appendBlockByIndex(firstBlockIndex)
 	}
 	return points, nil
 }

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2390,6 +2390,50 @@ func TestIntersectPointsUsesLedgerTipWhenPrimaryChainIsAhead(t *testing.T) {
 	assert.Equal(t, blocks[0].Hash, points[2].Hash)
 }
 
+func TestIntersectPointsUsesSparseLedgerTipSamples(t *testing.T) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := make([]models.Block, 0, 256)
+	for slot := uint64(1); slot <= 256; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+	}
+
+	points, err := ls.IntersectPoints(40)
+	require.NoError(t, err)
+	require.Greater(t, len(points), ledgerIntersectDenseCount)
+	assert.Equal(t, ledgerTipBlock.Slot, points[0].Slot)
+	assert.Equal(t, ledgerTipBlock.Hash, points[0].Hash)
+
+	pointSlots := make(map[uint64]struct{}, len(points))
+	for _, point := range points {
+		pointSlots[point.Slot] = struct{}{}
+	}
+	for _, slot := range []uint64{224, 192, 128, 1} {
+		_, ok := pointSlots[slot]
+		assert.True(t, ok, "missing sparse intersect point at slot %d", slot)
+	}
+}
+
 func TestDensityWindow(t *testing.T) {
 	shelleyGenesisJSON := `{
 		"activeSlotsCoeff": 0.05,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix intersect point selection in `ledger` to return a dense set near the tip and sparse samples back to genesis, improving chainsync reliability and performance.

- **Bug Fixes**
  - Collect up to the requested count with 32 dense tip points, then exponentially spaced points toward the first block.
  - Use block index lookups with de-dup and tolerate missing hash index entries to avoid breaking sync.
  - Add tests to ensure the tip is included and sparse points cover earlier slots (e.g., 224, 192, 128, 1).

<sup>Written for commit f962ec4aed6627c577174b64e45e05de644082e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

