### PR TITLE
ci(publish): disable proxy pull until it supports go 1.26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -425,9 +425,10 @@ jobs:
             }
 
       # This updates the documentation on pkg.go.dev and the latest version available via the Go module proxy
-      - name: Pull new module version
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: andrewslotin/go-proxy-pull-action@e5aea3b8b3478fc5b76befda4390513868ed2dc8 # v1.4.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.4.0
+      ### TODO: this is broken
+      #- name: Pull new module version
+      #  if: startsWith(github.ref, 'refs/tags/')
+      #  uses: andrewslotin/go-proxy-pull-action@e5aea3b8b3478fc5b76befda4390513868ed2dc8 # v1.4.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.4.0
 
   npm-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #2219 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Temporarily disable the "Pull new module version" step in `.github/workflows/publish.yml` because `andrewslotin/go-proxy-pull-action` doesn’t support Go 1.26. This avoids failed publish jobs on tag pushes; pkg.go.dev/proxy updates may lag until the action is updated and re-enabled.

<sup>Written for commit fab00d75ecdc607b644c141f2dcce024382a0243. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

