### PR TITLE
test: fuzz tests

### DIFF
--- a/blockfrost/pagination_fuzz_test.go
+++ b/blockfrost/pagination_fuzz_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfrost
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func FuzzParsePagination(f *testing.F) {
+	f.Add("")
+	f.Add("count=0&page=0&order=ASC")
+	f.Add("count=101&page=-1&order=desc")
+	f.Add("count=abc&page=1&order=asc")
+
+	f.Fuzz(func(t *testing.T, rawQuery string) {
+		if len(rawQuery) > 16*1024 {
+			t.Skip("query input is too large for fast fuzzing")
+		}
+
+		req := &http.Request{URL: &url.URL{RawQuery: rawQuery}}
+		params, err := ParsePagination(req)
+		if err != nil {
+			return
+		}
+		if params.Count < 1 || params.Count > MaxPaginationCount {
+			t.Fatalf("count = %d, want 1..%d", params.Count, MaxPaginationCount)
+		}
+		if params.Page < 1 {
+			t.Fatalf("page = %d, want >= 1", params.Page)
+		}
+		if params.Order != PaginationOrderAsc && params.Order != PaginationOrderDesc {
+			t.Fatalf("order = %q, want asc or desc", params.Order)
+		}
+	})
+}

--- a/chainselection/vrf_fuzz_test.go
+++ b/chainselection/vrf_fuzz_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzCompareVRFOutputs(f *testing.F) {
+	f.Add([]byte(nil), []byte(nil))
+	f.Add(make([]byte, VRFOutputSize), make([]byte, VRFOutputSize))
+	f.Add(append([]byte{0x00}, bytes.Repeat([]byte{0xff}, VRFOutputSize-1)...), bytes.Repeat([]byte{0xff}, VRFOutputSize))
+	f.Add(bytes.Repeat([]byte{0xff}, VRFOutputSize), append([]byte{0x00}, bytes.Repeat([]byte{0xff}, VRFOutputSize-1)...))
+
+	f.Fuzz(func(t *testing.T, vrfA, vrfB []byte) {
+		result := CompareVRFOutputs(vrfA, vrfB)
+		reversed := CompareVRFOutputs(vrfB, vrfA)
+
+		if len(vrfA) != VRFOutputSize || len(vrfB) != VRFOutputSize {
+			if result != ChainEqual || reversed != ChainEqual {
+				t.Fatalf(
+					"invalid VRF lengths returned (%v,%v), want (ChainEqual,ChainEqual)",
+					result,
+					reversed,
+				)
+			}
+			return
+		}
+
+		switch cmp := bytes.Compare(vrfA, vrfB); {
+		case cmp < 0:
+			if result != ChainABetter || reversed != ChainBBetter {
+				t.Fatalf("lower A comparison = (%v,%v), want (A better,B better)", result, reversed)
+			}
+		case cmp > 0:
+			if result != ChainBBetter || reversed != ChainABetter {
+				t.Fatalf("lower B comparison = (%v,%v), want (B better,A better)", result, reversed)
+			}
+		default:
+			if result != ChainEqual || reversed != ChainEqual {
+				t.Fatalf("equal VRFs comparison = (%v,%v), want equal", result, reversed)
+			}
+		}
+	})
+}

--- a/config/cardano/node_fuzz_test.go
+++ b/config/cardano/node_fuzz_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"bytes"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func FuzzNewCardanoNodeConfigFromReader(f *testing.F) {
+	f.Add("")
+	f.Add("Protocol: Cardano\nRequiresNetworkMagic: RequiresMagic\n")
+	f.Add("PeerSharing: true\nTargetNumberOfActivePeers: 20\n")
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 64*1024 {
+			t.Skip("config input is too large for fast fuzzing")
+		}
+
+		cfg, err := NewCardanoNodeConfigFromReader(bytes.NewBufferString(data))
+		if err != nil {
+			return
+		}
+		if cfg == nil {
+			t.Fatalf("NewCardanoNodeConfigFromReader returned nil without an error")
+		}
+
+		encoded, err := yaml.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("yaml.Marshal(parsed config): %v", err)
+		}
+		if _, err := NewCardanoNodeConfigFromReader(bytes.NewReader(encoded)); err != nil {
+			t.Fatalf("reparse marshaled config: %v", err)
+		}
+	})
+}

--- a/connmanager/address_fuzz_test.go
+++ b/connmanager/address_fuzz_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func FuzzNormalizePeerAddr(f *testing.F) {
+	f.Add("")
+	f.Add("Example.COM:3001")
+	f.Add("127.000.000.001:3001")
+	f.Add("[0:0:0:0:0:0:0:1]:3001")
+	f.Add("malformed:address:with:colons")
+
+	f.Fuzz(func(t *testing.T, peerAddr string) {
+		normalized := NormalizePeerAddr(peerAddr)
+		if NormalizePeerAddr(normalized) != normalized {
+			t.Fatalf("NormalizePeerAddr is not idempotent: %q -> %q",
+				normalized,
+				NormalizePeerAddr(normalized),
+			)
+		}
+
+		inputHost, inputPort, err := net.SplitHostPort(peerAddr)
+		if err != nil {
+			if normalized != strings.ToLower(peerAddr) {
+				t.Fatalf("malformed address normalized to %q, want lowercase %q",
+					normalized,
+					strings.ToLower(peerAddr),
+				)
+			}
+			return
+		}
+
+		host, port, err := net.SplitHostPort(normalized)
+		if err != nil {
+			t.Fatalf("normalized address is not host:port: %q", normalized)
+		}
+		if port != inputPort {
+			t.Fatalf("normalized port = %q, want %q", port, inputPort)
+		}
+		if net.ParseIP(inputHost) == nil && host != strings.ToLower(inputHost) {
+			t.Fatalf("normalized hostname = %q, want %q", host, strings.ToLower(inputHost))
+		}
+	})
+}

--- a/database/cbor_offset_fuzz_test.go
+++ b/database/cbor_offset_fuzz_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func FuzzCborOffsetRoundTrip(f *testing.F) {
+	f.Add(uint64(0), make([]byte, 32), uint32(0), uint32(0))
+	f.Add(
+		uint64(12345678),
+		bytes.Repeat([]byte{0xab}, 32),
+		uint32(1024),
+		uint32(256),
+	)
+	f.Add(
+		uint64(math.MaxUint64),
+		bytes.Repeat([]byte{0xff}, 32),
+		uint32(math.MaxUint32),
+		uint32(math.MaxUint32),
+	)
+
+	f.Fuzz(func(
+		t *testing.T,
+		blockSlot uint64,
+		blockHashBytes []byte,
+		byteOffset uint32,
+		byteLength uint32,
+	) {
+		var blockHash [32]byte
+		copy(blockHash[:], blockHashBytes)
+
+		original := CborOffset{
+			BlockSlot:  blockSlot,
+			BlockHash:  blockHash,
+			ByteOffset: byteOffset,
+			ByteLength: byteLength,
+		}
+		decoded, err := DecodeCborOffset(original.Encode())
+		if err != nil {
+			t.Fatalf("DecodeCborOffset(encoded): %v", err)
+		}
+		if *decoded != original {
+			t.Fatalf("decoded offset = %#v, want %#v", *decoded, original)
+		}
+	})
+}
+
+func FuzzDecodeCborOffset(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte("DOFF"))
+	f.Add((&CborOffset{
+		BlockSlot:  42,
+		BlockHash:  [32]byte{0x01, 0x02, 0x03},
+		ByteOffset: 12,
+		ByteLength: 34,
+	}).Encode())
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		decoded, err := DecodeCborOffset(data)
+		if err != nil {
+			if IsUtxoOffsetStorage(data) || IsTxOffsetStorage(data) {
+				t.Fatalf("storage detector accepted data DecodeCborOffset rejected: %v", err)
+			}
+			return
+		}
+
+		if !IsUtxoOffsetStorage(data) {
+			t.Fatalf("IsUtxoOffsetStorage returned false for decoded offset")
+		}
+		if !IsTxOffsetStorage(data) {
+			t.Fatalf("IsTxOffsetStorage returned false for decoded offset")
+		}
+		if !bytes.Equal(decoded.Encode(), data) {
+			t.Fatalf("DecodeCborOffset re-encoded to %x, want %x", decoded.Encode(), data)
+		}
+	})
+}
+
+func FuzzDecodeTxCborParts(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte("DTXP"))
+	f.Add((&TxCborParts{
+		BlockSlot:      42,
+		BlockHash:      [32]byte{0x01, 0x02, 0x03},
+		BodyOffset:     1,
+		BodyLength:     2,
+		WitnessOffset:  3,
+		WitnessLength:  4,
+		MetadataOffset: 5,
+		MetadataLength: 6,
+		IsValid:        true,
+	}).Encode())
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		decoded, err := DecodeTxCborParts(data)
+		if err != nil {
+			if IsTxCborPartsStorage(data) {
+				t.Fatalf("storage detector accepted data DecodeTxCborParts rejected: %v", err)
+			}
+			return
+		}
+
+		if !IsTxCborPartsStorage(data) {
+			t.Fatalf("IsTxCborPartsStorage returned false for decoded tx parts")
+		}
+
+		roundTrip, err := DecodeTxCborParts(decoded.Encode())
+		if err != nil {
+			t.Fatalf("DecodeTxCborParts(decoded.Encode()): %v", err)
+		}
+		if *roundTrip != *decoded {
+			t.Fatalf("round-trip tx parts = %#v, want %#v", *roundTrip, *decoded)
+		}
+	})
+}

--- a/database/plugin/blob/badger/metadata_fuzz_test.go
+++ b/database/plugin/blob/badger/metadata_fuzz_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package badger
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+func FuzzCompactBlockMetadataRoundTrip(f *testing.F) {
+	f.Add(uint64(0), uint64(0), uint64(0), []byte(nil))
+	f.Add(uint64(42), uint64(7), uint64(99), bytes.Repeat([]byte{0xab}, 32))
+	f.Add(uint64(1), uint64(2), uint64(3), bytes.Repeat([]byte{0xcd}, 33))
+
+	f.Fuzz(func(t *testing.T, id uint64, typeValue uint64, height uint64, prevHash []byte) {
+		if len(prevHash) > blockMetadataPrevHashMaxLen {
+			return
+		}
+
+		metadata := types.BlockMetadata{
+			ID:       id,
+			Type:     uint(typeValue),
+			Height:   height,
+			PrevHash: append([]byte(nil), prevHash...),
+		}
+		dst := make([]byte, 32+len(prevHash))
+		err := marshalBlockMetadataInto(dst, metadata)
+		if err != nil {
+			t.Fatalf("marshalBlockMetadataInto: %v", err)
+		}
+
+		decoded, err := unmarshalBlockMetadata(dst)
+		if err != nil {
+			t.Fatalf("unmarshalBlockMetadata(compact): %v", err)
+		}
+		if decoded.ID != metadata.ID ||
+			decoded.Type != metadata.Type ||
+			decoded.Height != metadata.Height ||
+			!bytes.Equal(decoded.PrevHash, metadata.PrevHash) {
+			t.Fatalf("decoded metadata = %#v, want %#v", decoded, metadata)
+		}
+	})
+}
+
+func FuzzUnmarshalBlockMetadata(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte("DBM1"))
+	seed := make([]byte, 32)
+	if err := marshalBlockMetadataInto(seed, types.BlockMetadata{ID: 1}); err != nil {
+		f.Fatalf("marshal compact metadata seed: %v", err)
+	}
+	f.Add(seed)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			t.Skip("metadata input is too large for fast fuzzing")
+		}
+
+		metadata, err := unmarshalBlockMetadata(data)
+		if err != nil {
+			return
+		}
+		if len(metadata.PrevHash) > blockMetadataPrevHashMaxLen {
+			t.Fatalf("metadata prev hash length = %d, want <= %d",
+				len(metadata.PrevHash),
+				blockMetadataPrevHashMaxLen,
+			)
+		}
+	})
+}

--- a/database/plugin/metadata/labelcodec/labelcodec_fuzz_test.go
+++ b/database/plugin/metadata/labelcodec/labelcodec_fuzz_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labelcodec
+
+import (
+	"bytes"
+	"math"
+	"math/big"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func FuzzExtractFromCborRawValues(f *testing.F) {
+	f.Add([]byte(nil))
+	addMetadatumSeed(f, lcommon.MetaMap{
+		Pairs: []lcommon.MetaPair{
+			{
+				Key:   lcommon.MetaInt{Value: big.NewInt(721)},
+				Value: lcommon.MetaText{Value: "hello"},
+			},
+		},
+	})
+	addMetadatumSeed(f, lcommon.MetaMap{
+		Pairs: []lcommon.MetaPair{
+			{
+				Key: lcommon.MetaInt{
+					Value: new(big.Int).SetUint64(math.MaxUint64),
+				},
+				Value: lcommon.MetaList{
+					Items: []lcommon.TransactionMetadatum{
+						lcommon.MetaBytes{Value: []byte{0x00, 0x01, 0xff}},
+						lcommon.MetaInt{Value: big.NewInt(-1)},
+						lcommon.MetaMap{
+							Pairs: []lcommon.MetaPair{
+								{
+									Key:   lcommon.MetaText{Value: "nested"},
+									Value: lcommon.MetaText{Value: "value"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	f.Fuzz(func(t *testing.T, metadataCbor []byte) {
+		if len(metadataCbor) > 64*1024 {
+			t.Skip("metadata corpus input is too large for fast fuzzing")
+		}
+
+		entries, err := extractFromCbor(metadataCbor)
+		if err != nil {
+			return
+		}
+
+		for i, entry := range entries {
+			if i > 0 && entries[i-1].Label >= entry.Label {
+				t.Fatalf(
+					"entries not strictly sorted by label: %d before %d",
+					entries[i-1].Label,
+					entry.Label,
+				)
+			}
+
+			jsonValue, cborValue, err := RawValues(metadataCbor, entry.Label)
+			if err != nil {
+				t.Fatalf("RawValues(label=%d): %v", entry.Label, err)
+			}
+			if string(jsonValue) != entry.JsonValue {
+				t.Fatalf(
+					"RawValues JSON for label %d = %s, want %s",
+					entry.Label,
+					jsonValue,
+					entry.JsonValue,
+				)
+			}
+			if !bytes.Equal(cborValue, entry.CborValue) {
+				t.Fatalf(
+					"RawValues CBOR for label %d = %x, want %x",
+					entry.Label,
+					cborValue,
+					entry.CborValue,
+				)
+			}
+		}
+	})
+}
+
+func addMetadatumSeed(f *testing.F, metadata lcommon.TransactionMetadatum) {
+	metadataCbor, err := metadatumCbor(metadata)
+	if err != nil {
+		f.Fatalf("metadatumCbor seed: %v", err)
+	}
+	f.Add(metadataCbor)
+}

--- a/database/types/keys_fuzz_test.go
+++ b/database/types/keys_fuzz_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+func FuzzParseBlockBlobKey(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte("bp"))
+	f.Add(types.BlockBlobKey(0, make([]byte, 32)))
+	f.Add(types.BlockBlobKey(42, bytes.Repeat([]byte{0xab}, 32)))
+
+	f.Fuzz(func(t *testing.T, key []byte) {
+		slot, hash, err := types.ParseBlockBlobKey(key)
+		if err != nil {
+			if len(key) == types.BlockBlobKeySize &&
+				bytes.HasPrefix(key, []byte(types.BlockBlobKeyPrefix)) {
+				t.Fatalf("ParseBlockBlobKey rejected a well-shaped key: %v", err)
+			}
+			return
+		}
+
+		if len(hash) != 32 {
+			t.Fatalf("parsed hash length = %d, want 32", len(hash))
+		}
+
+		encoded := types.BlockBlobKey(slot, hash)
+		if !bytes.Equal(encoded, key) {
+			t.Fatalf("BlockBlobKey(ParseBlockBlobKey(key)) = %x, want %x", encoded, key)
+		}
+	})
+}

--- a/internal/config/flags_fuzz_test.go
+++ b/internal/config/flags_fuzz_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzNormalizeRunMode(f *testing.F) {
+	f.Add("")
+	f.Add("serve")
+	f.Add("LOAD")
+	f.Add("dev")
+	f.Add("leios")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		normalized, err := normalizeRunMode(value)
+		if err != nil {
+			return
+		}
+		if normalized != strings.ToLower(value) {
+			t.Fatalf("normalizeRunMode(%q) = %q, want lowercase input", value, normalized)
+		}
+		switch normalized {
+		case "", string(RunModeServe), string(RunModeLoad), string(RunModeDev), string(RunModeLeios):
+		default:
+			t.Fatalf("normalizeRunMode accepted unknown mode %q", normalized)
+		}
+	})
+}
+
+func FuzzNormalizeStorageMode(f *testing.F) {
+	f.Add("")
+	f.Add("core")
+	f.Add("API")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		normalized, err := normalizeStorageMode(value)
+		if err != nil {
+			return
+		}
+		if normalized != strings.ToLower(value) {
+			t.Fatalf("normalizeStorageMode(%q) = %q, want lowercase input", value, normalized)
+		}
+		switch normalized {
+		case storageModeCore, storageModeAPI:
+		default:
+			t.Fatalf("normalizeStorageMode accepted unknown mode %q", normalized)
+		}
+	})
+}

--- a/internal/node/load_fuzz_test.go
+++ b/internal/node/load_fuzz_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"bytes"
+	"testing"
+
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
+	fxcbor "github.com/fxamacker/cbor/v2"
+)
+
+func FuzzCborArrayHeaderLen(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte{0x80})
+	f.Add([]byte{0x98, 0x02})
+	f.Add([]byte{0x9f, 0xff})
+	f.Add([]byte{0xa0})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		headerLen, err := cborArrayHeaderLen(data)
+		if err != nil {
+			return
+		}
+		if headerLen < 1 || headerLen > 9 {
+			t.Fatalf("header length = %d, want 1..9", headerLen)
+		}
+		if headerLen > len(data) {
+			t.Fatalf("header length %d exceeds input length %d", headerLen, len(data))
+		}
+		if data[0]&gcbor.CborTypeMask != gcbor.CborTypeArray {
+			t.Fatalf("accepted non-array CBOR major type: 0x%x", data[0])
+		}
+	})
+}
+
+func FuzzExtractHeaderCbor(f *testing.F) {
+	addBlockSeed(f, []byte{0x01}, []byte{0x02})
+	addBlockSeed(f, []byte{0x82, 0x00, 0x01}, []byte{0x80})
+	f.Add([]byte(nil))
+	f.Add([]byte{0x80})
+	f.Add([]byte{0x81, 0x01})
+
+	f.Fuzz(func(t *testing.T, blockCbor []byte) {
+		if len(blockCbor) > 64*1024 {
+			t.Skip("block CBOR input is too large for fast fuzzing")
+		}
+
+		header, err := extractHeaderCbor(blockCbor)
+		if err != nil {
+			return
+		}
+		if len(header) == 0 {
+			t.Fatalf("extractHeaderCbor returned an empty header")
+		}
+
+		headerLen, err := cborArrayHeaderLen(blockCbor)
+		if err != nil {
+			t.Fatalf("cborArrayHeaderLen rejected block accepted by extractHeaderCbor: %v", err)
+		}
+		if !bytes.HasPrefix(blockCbor[headerLen:], header) {
+			t.Fatalf("extracted header %x is not the first element after array header", header)
+		}
+	})
+}
+
+func FuzzExtractInvalidTxIndices(f *testing.F) {
+	addInvalidTxSeed(f, []uint{})
+	addInvalidTxSeed(f, []uint{0, 1, 42})
+	f.Add([]byte(nil))
+	f.Add([]byte{0x80})
+
+	f.Fuzz(func(t *testing.T, blockCbor []byte) {
+		if len(blockCbor) > 64*1024 {
+			t.Skip("block CBOR input is too large for fast fuzzing")
+		}
+
+		indices, err := extractInvalidTxIndices(blockCbor)
+		if err != nil {
+			return
+		}
+		for idx := range indices {
+			if idx < 0 {
+				t.Fatalf("invalid transaction index is negative: %d", idx)
+			}
+		}
+	})
+}
+
+func FuzzTxBodyMapValueRange(f *testing.F) {
+	addTxBodyMapSeed(f, map[uint64]any{
+		0: uint64(1),
+		7: []byte{0xde, 0xad, 0xbe, 0xef},
+	}, 7)
+	addTxBodyMapSeed(f, map[uint64]any{
+		2: []uint64{1, 2, 3},
+	}, 2)
+	f.Add([]byte(nil), uint32(0), uint64(0))
+	f.Add([]byte{0xa0}, uint32(0), uint64(0))
+
+	f.Fuzz(func(t *testing.T, bodyCbor []byte, bodyOffset uint32, key uint64) {
+		if len(bodyCbor) > 64*1024 {
+			t.Skip("tx body CBOR input is too large for fast fuzzing")
+		}
+
+		valueOffset, valueLen, found, err := txBodyMapValueRange(bodyCbor, bodyOffset, key)
+		if err != nil || !found {
+			return
+		}
+		if valueOffset < bodyOffset {
+			t.Fatalf("value offset %d precedes body offset %d", valueOffset, bodyOffset)
+		}
+		relativeOffset := uint64(valueOffset - bodyOffset)
+		end := relativeOffset + uint64(valueLen)
+		if end > uint64(len(bodyCbor)) {
+			t.Fatalf(
+				"value range [%d:%d] exceeds tx body length %d",
+				relativeOffset,
+				end,
+				len(bodyCbor),
+			)
+		}
+	})
+}
+
+func addBlockSeed(f *testing.F, header, body []byte) {
+	blockCbor, err := fxcbor.Marshal([]gcbor.RawMessage{
+		gcbor.RawMessage(header),
+		gcbor.RawMessage(body),
+	})
+	if err != nil {
+		f.Fatalf("marshal block seed: %v", err)
+	}
+	f.Add(blockCbor)
+}
+
+func addInvalidTxSeed(f *testing.F, invalidTxs []uint) {
+	blockCbor, err := gcbor.Encode([]any{
+		uint64(0),
+		[]any{},
+		[]any{},
+		map[uint64]any{},
+		invalidTxs,
+	})
+	if err != nil {
+		f.Fatalf("marshal invalid tx seed: %v", err)
+	}
+	f.Add(blockCbor)
+}
+
+func addTxBodyMapSeed(f *testing.F, body map[uint64]any, key uint64) {
+	bodyCbor, err := gcbor.Encode(body)
+	if err != nil {
+		f.Fatalf("marshal tx body seed: %v", err)
+	}
+	f.Add(bodyCbor, uint32(12), key)
+}

--- a/ledgerstate/utxo_fuzz_test.go
+++ b/ledgerstate/utxo_fuzz_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+func FuzzDecodeTxInFromBytes(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add(make([]byte, 34))
+	addTxInArraySeed(f, bytes.Repeat([]byte{0xab}, 32), 7)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			t.Skip("TxIn input is too large for fast fuzzing")
+		}
+
+		txHash, outputIndex, err := decodeTxInFromBytes(data)
+		if err != nil {
+			return
+		}
+		if len(data) == 34 {
+			if !bytes.Equal(txHash, data[:32]) {
+				t.Fatalf("binary TxIn hash = %x, want %x", txHash, data[:32])
+			}
+			expectedIndex := uint32(binary.BigEndian.Uint16(data[32:34]))
+			if outputIndex != expectedIndex {
+				t.Fatalf("binary TxIn index = %d, want %d", outputIndex, expectedIndex)
+			}
+		}
+	})
+}
+
+func FuzzUnwrapCborBytes(f *testing.F) {
+	addByteStringSeed(f, []byte(nil))
+	addByteStringSeed(f, []byte{0xde, 0xad, 0xbe, 0xef})
+	f.Add([]byte{0xd8, 0x18, 0x42, 0x01, 0x02})
+	f.Add([]byte(nil))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > 64*1024 {
+			t.Skip("CBOR input is too large for fast fuzzing")
+		}
+
+		unwrapped, err := unwrapCborBytes(cbor.RawMessage(raw))
+		if err != nil {
+			return
+		}
+		if len(unwrapped) > 64*1024 {
+			t.Fatalf("unwrapCborBytes returned %d bytes, want <= 65536", len(unwrapped))
+		}
+
+		encoded, err := cbor.Encode([]byte(unwrapped))
+		if err != nil {
+			t.Fatalf("cbor.Encode(unwrapped): %v", err)
+		}
+		roundTrip, err := unwrapCborBytes(cbor.RawMessage(encoded))
+		if err != nil {
+			t.Fatalf("unwrapCborBytes(re-encoded unwrapped): %v", err)
+		}
+		if !bytes.Equal(roundTrip, unwrapped) {
+			t.Fatalf("re-encoded unwrap = %x, want %x", roundTrip, unwrapped)
+		}
+	})
+}
+
+func addTxInArraySeed(f *testing.F, txHash []byte, outputIndex uint32) {
+	data, err := cbor.Encode([]any{txHash, outputIndex})
+	if err != nil {
+		f.Fatalf("marshal TxIn seed: %v", err)
+	}
+	f.Add(data)
+}
+
+func addByteStringSeed(f *testing.F, data []byte) {
+	encoded, err := cbor.Encode(data)
+	if err != nil {
+		f.Fatalf("marshal byte string seed: %v", err)
+	}
+	f.Add(encoded)
+}

--- a/mithril/parsing_fuzz_test.go
+++ b/mithril/parsing_fuzz_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mithril
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func FuzzParseVerificationKey(f *testing.F) {
+	f.Add("")
+	f.Add("0x00")
+	f.Add("ce13cd433cdcb3dfb00c04e216956aeb622dcd7f282b03304d9fc9de804723b2")
+	f.Add(`{
+  "type": "PaymentVerificationKeyShelley_ed25519",
+  "description": "Payment Verification Key",
+  "cborHex": "5820ce13cd433cdcb3dfb00c04e216956aeb622dcd7f282b03304d9fc9de804723b2"
+}`)
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 64*1024 {
+			t.Skip("verification key input is too large for fast fuzzing")
+		}
+
+		key, err := ParseVerificationKey(data)
+		if err != nil {
+			return
+		}
+		if key == nil {
+			t.Fatalf("ParseVerificationKey returned nil without an error")
+		}
+		if len(key.RawKeyBytes) == 0 {
+			t.Fatalf("ParseVerificationKey returned an empty raw key")
+		}
+		if _, err := hex.DecodeString(key.RawKeyBytesHex()); err != nil {
+			t.Fatalf("RawKeyBytesHex is not valid hex: %v", err)
+		}
+	})
+}
+
+func FuzzDecodePrimaryEncodedBytes(f *testing.F) {
+	f.Add("")
+	f.Add("00ff")
+	f.Add("AP8=")
+	f.Add("AP8")
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 64*1024 {
+			t.Skip("encoded input is too large for fast fuzzing")
+		}
+
+		decoded, ok := decodePrimaryEncodedBytes(data)
+		if !ok {
+			return
+		}
+		if decoded == nil {
+			t.Fatalf("decodePrimaryEncodedBytes returned nil with ok=true")
+		}
+	})
+}
+
+func FuzzParseSTMSignerVerificationKey(f *testing.F) {
+	f.Add("")
+	f.Add(hex.EncodeToString(make([]byte, 96)))
+	f.Add(hex.EncodeToString([]byte(`{"vk":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","pop":""}`)))
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 64*1024 {
+			t.Skip("signer key input is too large for fast fuzzing")
+		}
+
+		_, err := parseSTMSignerVerificationKey(data)
+		if err != nil {
+			return
+		}
+	})
+}
+
+func FuzzParseSTMAggregateSignatureBytes(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte{0})
+	f.Add(append([]byte{0}, make([]byte, 8)...))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > 64*1024 {
+			t.Skip("aggregate signature input is too large for fast fuzzing")
+		}
+
+		sig, err := parseSTMAggregateSignatureBytes(raw)
+		if err != nil {
+			return
+		}
+		if sig == nil {
+			t.Fatalf("parseSTMAggregateSignatureBytes returned nil without an error")
+		}
+	})
+}

--- a/peergov/address_fuzz_test.go
+++ b/peergov/address_fuzz_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func FuzzNormalizeAddress(f *testing.F) {
+	f.Add("")
+	f.Add("Example.COM:3001")
+	f.Add("[0:0:0:0:0:0:0:1]:3001")
+	f.Add("malformed:address:with:colons")
+
+	f.Fuzz(func(t *testing.T, address string) {
+		var p PeerGovernor
+		normalized := p.normalizeAddress(address)
+		if p.normalizeAddress(normalized) != normalized {
+			t.Fatalf("normalizeAddress is not idempotent: %q -> %q",
+				normalized,
+				p.normalizeAddress(normalized),
+			)
+		}
+
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			if normalized != strings.ToLower(address) {
+				t.Fatalf("malformed address normalized to %q, want lowercase %q",
+					normalized,
+					strings.ToLower(address),
+				)
+			}
+			return
+		}
+		normalizedHost, normalizedPort, err := net.SplitHostPort(normalized)
+		if err != nil {
+			t.Fatalf("normalized address is not host:port: %q", normalized)
+		}
+		if normalizedPort != port {
+			t.Fatalf("normalized port = %q, want %q", normalizedPort, port)
+		}
+		if net.ParseIP(host) == nil && normalizedHost != strings.ToLower(host) {
+			t.Fatalf("normalized hostname = %q, want %q", normalizedHost, strings.ToLower(host))
+		}
+	})
+}
+
+func FuzzAddressHost(f *testing.F) {
+	f.Add("")
+	f.Add("Example.COM:3001")
+	f.Add("[0:0:0:0:0:0:0:1]:3001")
+
+	f.Fuzz(func(t *testing.T, address string) {
+		host := addressHost(address)
+		inputHost, _, err := net.SplitHostPort(address)
+		if err != nil {
+			if host != "" {
+				t.Fatalf("addressHost(%q) = %q, want empty on parse failure", address, host)
+			}
+			return
+		}
+		if ip := net.ParseIP(inputHost); ip != nil {
+			if host != ip.String() {
+				t.Fatalf("addressHost IP = %q, want %q", host, ip.String())
+			}
+			return
+		}
+		if host != strings.ToLower(inputHost) {
+			t.Fatalf("addressHost hostname = %q, want %q", host, strings.ToLower(inputHost))
+		}
+	})
+}
+
+func FuzzIsRoutableAddr(f *testing.F) {
+	f.Add("")
+	f.Add("127.0.0.1:3001")
+	f.Add("10.0.0.1:3001")
+	f.Add("8.8.8.8:3001")
+	f.Add("relay.example.com:3001")
+
+	f.Fuzz(func(t *testing.T, address string) {
+		routable := isRoutableAddr(address)
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			host = address
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			if !routable {
+				t.Fatalf("hostname or malformed address %q should be treated as routable", address)
+			}
+			return
+		}
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+			if routable {
+				t.Fatalf("non-routable IP %q was accepted", address)
+			}
+		} else if !routable {
+			t.Fatalf("routable IP %q was rejected (isRoutableAddr=%v)", address, routable)
+		}
+	})
+}

--- a/topology/topology_fuzz_test.go
+++ b/topology/topology_fuzz_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topology_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/topology"
+)
+
+func FuzzNewTopologyConfigFromReader(f *testing.F) {
+	for _, tc := range topologyTests {
+		f.Add(tc.jsonData)
+	}
+	f.Add(`{"localRoots":[],"publicRoots":[],"bootstrapPeers":[],"useLedgerAfterSlot":0}`)
+
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1024*1024 {
+			t.Skip("topology corpus input is too large for fast fuzzing")
+		}
+
+		cfg, err := topology.NewTopologyConfigFromReader(strings.NewReader(input))
+		if err != nil {
+			return
+		}
+		if cfg == nil {
+			return
+		}
+
+		encoded, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("json.Marshal(parsed topology): %v", err)
+		}
+
+		roundTrip, err := topology.NewTopologyConfigFromReader(bytes.NewReader(encoded))
+		if err != nil {
+			t.Fatalf("NewTopologyConfigFromReader(marshaled topology): %v", err)
+		}
+		if roundTrip == nil {
+			return
+		}
+		if !reflect.DeepEqual(roundTrip, cfg) {
+			t.Fatalf("round-trip topology = %#v, want %#v", roundTrip, cfg)
+		}
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fuzz tests across core packages to harden parsing, normalization, and CBOR encode/decode paths and catch edge cases early.

Targets: `blockfrost` pagination, `chainselection` VRF compare, config loaders (`config/cardano`, `topology`) and flag normalization (`internal/config`), address normalization (`connmanager`, `peergov`), database encoders/keys and metadata (`database` + plugins incl. `labelcodec`, `blob/badger`), UTXO parsing (`ledgerstate`), block/tx CBOR helpers (`internal/node`), and Mithril key/signature parsing (`mithril`).

<sup>Written for commit 8af4918a1aa84f59e1f70266518391e0d81a76ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fuzz testing across multiple subsystems to improve code robustness and reliability by testing core functionality with random and edge-case inputs, including pagination handling, VRF comparisons, configuration parsing, address normalization, CBOR encoding/decoding, cryptographic operations, and topology configuration management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2239)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->