### PR TITLE
fix: improve sparse intersect collection

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -925,29 +925,26 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 	}
 	points := make([]ocommon.Point, 0, count)
 	seen := make(map[string]struct{}, count)
-	appendPoint := func(point ocommon.Point) bool {
+	appendPoint := func(point ocommon.Point) {
 		if len(points) >= count {
-			return false
+			return
 		}
 		key := fmt.Sprintf("%d:%x", point.Slot, point.Hash)
 		if _, ok := seen[key]; ok {
-			return true
+			return
 		}
 		points = append(points, point)
 		seen[key] = struct{}{}
-		return true
 	}
-	appendBlockPoint := func(blockIndex uint64) bool {
+	appendBlockPoint := func(blockIndex uint64) {
 		if len(points) >= count {
-			return false
+			return
 		}
 		blk, err := c.blockByIndex(blockIndex)
 		if err != nil {
-			return false
+			return
 		}
-		return appendPoint(
-			ocommon.NewPoint(blk.Slot, blk.Hash),
-		)
+		appendPoint(ocommon.NewPoint(blk.Slot, blk.Hash))
 	}
 	denseStartIndex := c.tipBlockIndex
 	tip := c.currentTip.Point
@@ -961,7 +958,8 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 	}
 	denseCount := min(count, intersectDensePointCount)
 	for idx := denseStartIndex; idx >= initialBlockIndex && len(points) < denseCount; idx-- {
-		if !appendBlockPoint(idx) {
+		appendBlockPoint(idx)
+		if idx == initialBlockIndex {
 			break
 		}
 	}
@@ -975,12 +973,10 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 		if offset == 0 || offset >= c.tipBlockIndex {
 			break
 		}
-		if !appendBlockPoint(c.tipBlockIndex - offset) {
-			break
-		}
+		appendBlockPoint(c.tipBlockIndex - offset)
 	}
 	if len(points) < count {
-		_ = appendBlockPoint(initialBlockIndex)
+		appendBlockPoint(initialBlockIndex)
 	}
 	return points
 }

--- a/chain/intersect_internal_test.go
+++ b/chain/intersect_internal_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -61,4 +62,53 @@ func TestIntersectPointsKeepsCurrentTipFallback(t *testing.T) {
 	require.Equal(t, pendingTip.Hash, points[0].Hash)
 	require.Equal(t, persistedBlock.Slot, points[1].Slot)
 	require.Equal(t, persistedBlock.Hash, points[1].Hash)
+}
+
+func TestIntersectPointsSkipsMissingDenseBlockIndex(t *testing.T) {
+	db, err := database.New(&database.Config{
+		DataDir:        t.TempDir(),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var prevHash []byte
+	for slot := uint64(1); slot <= 40; slot++ {
+		hash := bytes.Repeat([]byte{byte(slot)}, 32)
+		require.NoError(t, db.BlockCreate(models.Block{
+			ID:       slot,
+			Slot:     slot,
+			Hash:     hash,
+			Number:   slot,
+			Type:     1,
+			PrevHash: prevHash,
+			Cbor:     []byte{0x80},
+		}, nil))
+		prevHash = hash
+	}
+
+	cm, err := NewManager(db, nil)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+
+	txn := db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return db.Blob().Delete(
+			txn.Blob(),
+			dbtypes.BlockBlobIndexKey(39),
+		)
+	}))
+
+	points := c.IntersectPoints(40)
+	require.GreaterOrEqual(t, len(points), intersectDensePointCount)
+
+	pointSlots := make(map[uint64]struct{}, len(points))
+	for _, point := range points {
+		pointSlots[point.Slot] = struct{}{}
+	}
+	_, hasMissingIndexSlot := pointSlots[39]
+	require.False(t, hasMissingIndexSlot)
+	_, hasPreviousDenseSlot := pointSlots[38]
+	require.True(t, hasPreviousDenseSlot)
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4154,41 +4154,38 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 	}
 	points := make([]ocommon.Point, 0, count)
 	seen := make(map[string]struct{}, count)
-	appendBlock := func(block models.Block) bool {
+	appendBlock := func(block models.Block) {
 		if len(points) >= count {
-			return false
+			return
 		}
 		key := fmt.Sprintf("%d:%x", block.Slot, block.Hash)
 		if _, ok := seen[key]; ok {
-			return true
+			return
 		}
 		points = append(
 			points,
 			ocommon.NewPoint(block.Slot, block.Hash),
 		)
 		seen[key] = struct{}{}
-		return true
 	}
-	appendBlockByIndex := func(blockIndex uint64) bool {
+	appendBlockByIndex := func(blockIndex uint64) {
 		if len(points) >= count {
-			return false
+			return
 		}
 		block, err := ls.db.BlockByIndex(blockIndex, nil)
 		if err != nil {
-			return false
+			return
 		}
-		return appendBlock(block)
+		appendBlock(block)
 	}
-	tipBlock, err := database.BlockByHash(ls.db, currentTip.Point.Hash)
+	tipBlock, err := database.BlockByPoint(ls.db, currentTip.Point)
 	if err != nil {
-		// Tolerate missing blocks: a block lacking a hash
-		// index entry can be reported NotFound by the
-		// time-bounded BlockByHash scan fallback added in
-		// this PR. Returning the error here would leave us
-		// unable to send any intersect points to peers,
-		// which breaks both inbound chainsync (peers can't
-		// sync from us) and our own outbound chainsync setup
-		// (we ship MsgFindIntersect with these points).
+		// Tolerate a missing authoritative tip: returning the
+		// error here would leave us unable to send any intersect
+		// points to peers, which breaks both inbound chainsync
+		// (peers can't sync from us) and our own outbound
+		// chainsync setup (we ship MsgFindIntersect with these
+		// points).
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return points, nil
 		}
@@ -4203,9 +4200,7 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 	}
 	denseCount := min(count, ledgerIntersectDenseCount)
 	for idx := denseStartIndex; idx >= firstBlockIndex && len(points) < denseCount; idx-- {
-		if !appendBlockByIndex(idx) {
-			break
-		}
+		appendBlockByIndex(idx)
 		if idx == firstBlockIndex {
 			break
 		}
@@ -4218,13 +4213,11 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 			if offset == 0 || offset >= tipBlock.ID {
 				break
 			}
-			if !appendBlockByIndex(tipBlock.ID - offset) {
-				break
-			}
+			appendBlockByIndex(tipBlock.ID - offset)
 		}
 	}
 	if len(points) < count {
-		_ = appendBlockByIndex(firstBlockIndex)
+		appendBlockByIndex(firstBlockIndex)
 	}
 	return points, nil
 }

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2434,6 +2434,57 @@ func TestIntersectPointsUsesSparseLedgerTipSamples(t *testing.T) {
 	}
 }
 
+func TestIntersectPointsSkipsMissingDenseBlockIndex(t *testing.T) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 40)
+	for slot := uint64(1); slot <= 40; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append(
+				[]byte(nil),
+				blocks[len(blocks)-1].Hash...,
+			)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	blockBlobIndexKey := dbtypes.BlockBlobIndexKey(39)
+	txn := db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		indexBytes, err := db.Blob().Get(txn.Blob(), blockBlobIndexKey)
+		require.NoError(t, err)
+		require.NotNil(t, indexBytes)
+		return db.Blob().Delete(
+			txn.Blob(),
+			blockBlobIndexKey,
+		)
+	}))
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+	}
+
+	points, err := ls.IntersectPoints(40)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(points), ledgerIntersectDenseCount)
+
+	pointSlots := make(map[uint64]struct{}, len(points))
+	for _, point := range points {
+		pointSlots[point.Slot] = struct{}{}
+	}
+	_, hasMissingIndexSlot := pointSlots[39]
+	assert.False(t, hasMissingIndexSlot)
+	_, hasPreviousDenseSlot := pointSlots[38]
+	assert.True(t, hasPreviousDenseSlot)
+}
+
 func TestDensityWindow(t *testing.T) {
 	shelleyGenesisJSON := `{
 		"activeSlotsCoeff": 0.05,


### PR DESCRIPTION
Closes #2240 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve intersect point collection to skip missing block indexes and keep dense and sparse sampling going, preventing early exits and improving ChainSync reliability.

- **Bug Fixes**
  - In `chain.IntersectPoints` and `LedgerState.authoritativeRecentChainPoints`, skip missing blocks during dense and sparse passes; only stop at the first/initial index.
  - Use `database.BlockByPoint` for authoritative tip lookup; tolerate a missing tip by returning available points.
  - Add tests for missing dense block index in both chain and ledger paths, ensuring we still meet the dense quota.

<sup>Written for commit 1fd055a4c6b0fd3c01b87fdad466c9771566c0f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control flow logic when handling missing dense block index entries, preventing underflow errors and ensuring the system continues operating gracefully instead of halting unexpectedly.

* **Tests**
  * Added test coverage for scenarios with missing block index data to validate proper fallback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->