### PR TITLE
fix(ledger): skip rollback if it is ahead of ledger tip

### DIFF
--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -278,6 +278,109 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestTryResolveForkDoesNotAdvanceLaggingLedgerTip(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	aheadHash := testHashBytes("raw-chain-ahead-of-ledger")
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        fixture.currentTip.Point.Slot + 10,
+			Hash:        aheadHash,
+			BlockNumber: fixture.currentTip.BlockNumber + 1,
+			Type:        1,
+			PrevHash:    fixture.currentTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+	require.Equal(
+		t,
+		fixture.currentTip.Point.Slot+10,
+		fixture.ls.chain.Tip().Point.Slot,
+	)
+
+	// Simulate the raw primary chain being well ahead of the metadata
+	// ledger apply loop during historical catch-up.
+	require.NoError(t, fixture.ls.db.SetTip(fixture.ancestorTip, nil))
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+	preRollbackSeq := fixture.ls.lastLocalRollbackSeq
+
+	forkHash := testHashBytes("ahead-raw-chain-fork")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+		blockNumber: fixture.currentTip.BlockNumber + 2,
+		slot:        fixture.currentTip.Point.Slot + 20,
+	}
+	err := fixture.ls.chain.AddBlockHeader(header)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved, err := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		},
+		notFitErr,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+	assert.Equal(t, preRollbackSeq, fixture.ls.lastLocalRollbackSeq)
+	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+
+	select {
+	case resync := <-resyncCh:
+		t.Fatalf("expected no local rollback resync event, got: %#v", resync)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestTryResolveForkQueuesKnownPeerForkSegment(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1456,6 +1456,17 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 		bytes.Equal(currentTip.Point.Hash, point.Hash) {
 		return nil
 	}
+	if point.Slot > currentTip.Point.Slot {
+		ls.config.Logger.Debug(
+			"rollback point ahead of ledger tip, skipping metadata rollback",
+			"component", "ledger",
+			"rollback_slot", point.Slot,
+			"ledger_tip_slot", currentTip.Point.Slot,
+			"rollback_hash", hex.EncodeToString(point.Hash),
+			"ledger_tip_hash", hex.EncodeToString(currentTip.Point.Hash),
+		)
+		return nil
+	}
 	// Track new tip value built during transaction
 	var newTip ochainsync.Tip
 	var newNonce []byte


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip metadata rollback when the requested rollback point is ahead of the `ledger` tip. Prevents advancing a lagging ledger during catch-up and avoids unnecessary resyncs.

- **Bug Fixes**
  - Guarded `rollback` to no-op (with debug log) if rollback point slot > current tip slot.
  - Added `TestTryResolveForkDoesNotAdvanceLaggingLedgerTip` to verify the ledger tip and DB tip remain unchanged and no resync event is emitted when the raw chain is ahead.

<sup>Written for commit d753253f4820f6e1e2aa1598251e481d80c15d04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for chain synchronization fork resolution when the ledger tip lags behind the blockchain state.

* **Bug Fixes**
  * Enhanced rollback mechanism to properly handle edge cases where the requested rollback point is ahead of the current ledger state, preventing unintended metadata rollbacks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2242)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->