### PR TITLE
fix(ledger): init metrics in NewLedgerState to avoid nil-deref in benchmark

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -587,6 +587,12 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 		epochNonceHexCache: make(map[uint64]string),
 		validationEnabled:  cfg.ValidateHistorical,
 	}
+	// Initialize metrics here so any constructed LedgerState is safe to
+	// use without requiring Start() to have been called. Benchmarks and
+	// other tests that exercise validateTxCore via a constructed-but-
+	// not-started LedgerState would otherwise nil-deref on the metrics
+	// counters.
+	ls.metrics.init(cfg.PromRegistry)
 	ls.slotsPerKESPeriod.Store(ls.loadSlotsPerKESPeriod())
 	ls.storeForgedBlockChecker(cfg.ForgedBlockChecker)
 	ls.storeSlotBattleRecorder(cfg.SlotBattleRecorder)
@@ -595,8 +601,6 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 
 func (ls *LedgerState) Start(ctx context.Context) error {
 	ls.ctx = ctx
-	// Init metrics
-	ls.metrics.init(ls.config.PromRegistry)
 	ls.metrics.nodeStartTime.Set(
 		float64(time.Now().Unix()),
 	)


### PR DESCRIPTION
## Summary

Move `metrics.init(cfg.PromRegistry)` from `Start()` into `NewLedgerState` so any constructed `LedgerState` has populated counters without requiring the full lifecycle. This is option 1 from the issue — it removes the partial-construction hazard rather than guarding a single call site.

`promauto.With(nil)` is safe (creates metric objects without registering them), so the change does not regress the `internal/node/load.go` call site that passes `PromRegistry: nil`. Production code paths that pass a real registry see registration shift a few milliseconds earlier — still well before `Start()` brings up any scrape surface.

## Reproduction

Before:

```
$ go test -bench=BenchmarkTransactionValidation -benchmem -run=^$ -benchtime=1x ./ledger/
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x259c0c6]
goroutine 20 [running]:
ledger.(*LedgerState).validateTxCore  ledger/state.go:5129
```

After:

```
BenchmarkTransactionValidation-16    	       1	      4025 ns/op	      64 B/op	       2 allocs/op
PASS
```

## Test plan

- [ ] `go test -race -count=1 ./ledger/...` (49.5s locally, all pass)
- [ ] `go test ./chain/... ./chainsync/... ./ouroboros/... ./mempool/...` (all pass)
- [ ] `golangci-lint run ./ledger/...` (0 issues)
- [ ] CI green on the full suite

## Follow-up not in this PR

The eight existing test-side `ls.metrics.init(prometheus.NewRegistry())` workarounds (6× `replay_recovery_test.go`, 1× `state_test.go`, 1× `chainsync_rollback_test.go`) become redundant after this fix. They overwrite the metric fields with counters bound to a fresh registry — harmless but dead code. Leaving cleanup to a follow-up to keep this PR focused.

closes #2099

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize metrics in `NewLedgerState` (instead of `Start()`) so any constructed `LedgerState` has non-nil counters. This fixes the nil-deref in benchmarks that call `validateTxCore` without starting, and remains safe when `PromRegistry` is nil via `promauto.With(nil)`.

<sup>Written for commit a568859c6886e757068168c5a80084291a85c37d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ledger state initialization for improved consistency and reliability during system operation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2244)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->