### PR TITLE
fix(ouroboros/blockfetch): demote NoBlocks responses to Debug

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -101,7 +101,7 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 	// Validate that the requested slot range is not too large
 	slotRange := end.Slot - start.Slot
 	if slotRange > MaxBlockFetchRange {
-		o.config.Logger.Warn(
+		o.config.Logger.Debug(
 			"blockfetch: requested range exceeds maximum, sending NoBlocks",
 			"connection_id", ctx.ConnectionId.String(),
 			"start_slot", start.Slot,
@@ -120,7 +120,7 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 	// Validate that the start point exists in our chain (#397)
 	chainIter, err := o.LedgerState.GetChainFromPoint(start, true)
 	if err != nil {
-		o.config.Logger.Warn(
+		o.config.Logger.Debug(
 			"blockfetch: start point not found in chain, sending NoBlocks",
 			"connection_id", ctx.ConnectionId.String(),
 			"start_slot", start.Slot,

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -203,6 +203,18 @@ func TestBlockfetchServerRequestRange_OversizedRange(t *testing.T) {
 		"range exceeds maximum",
 		"expected log message about oversized range",
 	)
+	assert.Contains(
+		t,
+		logOutput,
+		`"level":"DEBUG"`,
+		"oversized range NoBlocks should log at DEBUG, not WARN",
+	)
+	assert.NotContains(
+		t,
+		logOutput,
+		`"level":"WARN"`,
+		"oversized range NoBlocks should not produce a WARN line",
+	)
 }
 
 func TestBlockfetchServerRequestRange_RangeWithinLimit(t *testing.T) {


### PR DESCRIPTION
## Summary

Drop the two NoBlocks-response log lines in `blockfetchServerRequestRange` from `Warn` to `Debug`:

- `blockfetch: requested range exceeds maximum, sending NoBlocks`
- `blockfetch: start point not found in chain, sending NoBlocks`

These are protocol-normal outcomes from the server's perspective — a peer on a different fork or with a stale tip will hit them in steady state. Logging them at WARN treats normal protocol behaviour as a problem, obscures real warnings, and (per the field report) burns CPU on log formatting when a misbehaving peer retries without backoff (~833 WARN lines in 25 minutes during an epoch-1281 redeploy).

The `start after end` path is left at WARN because that's a genuinely invalid protocol request, not a stuck-peer pattern.

## Test plan

- [x] `go test -race -count=1 ./ouroboros/...` (2.8s locally, all pass)
- [x] `go build ./...` clean
- [x] `golangci-lint run ./ouroboros/...` 0 issues
- [x] `TestBlockfetchServerRequestRange_OversizedRange` extended to assert the log line is now emitted at DEBUG level, not WARN

## Not in this PR

The rate-limit / stuck-peer-detection work — both options described in #2070 ("Optionally") — is filed as #2248 for separate consideration. The log-level change alone removes the observed log + CPU spam; the rate-limit work needs real design (per-connection state keyed on `(connId, slot, hash)`, choice between throttle vs close-on-stuck) that's bigger than this fix.

closes #2070

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demotes noisy WARN logs for normal NoBlocks responses in `ouroboros` blockfetch to DEBUG to cut log/CPU spam and keep real warnings visible. Adds a test to confirm the oversized range case logs at DEBUG.

- **Bug Fixes**
  - Downgraded WARN to DEBUG for “range exceeds maximum” and “start point not found in chain” NoBlocks responses in `ouroboros/blockfetch`.
  - Kept “start after end” at WARN as an invalid request.
  - Extended `TestBlockfetchServerRequestRange_OversizedRange` to assert DEBUG and ensure no WARN.

<sup>Written for commit d803b9140531c83fb210ba413c1f6ac983837a3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging levels for block fetch validation scenarios.

* **Tests**
  * Enhanced test coverage for block fetch logging behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->