### PR TITLE
fix: match cardano-node Praos chain selection

### DIFF
--- a/chainselection/comparison.go
+++ b/chainselection/comparison.go
@@ -30,33 +30,20 @@ const (
 	ChainComparisonUnknown ChainComparisonResult = 2
 )
 
-// CompareChains compares two chain tips according to Ouroboros Praos rules:
-//  1. Higher block number wins (longer chain)
-//  2. At equal block number, lower slot wins (denser chain)
-//  3. At equal block number AND equal slot (a slot battle between two
-//     pools' competing forges), lower block hash wins.
+// ComparePraosTips compares two Praos-era tips using cardano-node's
+// equal-length tiebreaker shape:
+//  1. Higher block number wins.
+//  2. At equal block number, prefer a candidate with the same issuer and slot
+//     only when it has a higher opcert issue number.
+//  3. Otherwise compare the tip VRF only when the era's VRF tiebreaker flavor
+//     is armed. Conway restricts this to tips at most 5 slots apart.
 //
-// Rule 3 is the deterministic tiebreak the chainsync handler needs to
-// pick a side at a slot battle. Without it, two competing forges at
-// the same slot+length collapse to ChainEqual, the handler refuses to
-// switch in either direction, and the local chain permanently keeps
-// whichever block was adopted first. The losing block's VRF output
-// then keeps folding into the local evolving nonce, and the drift
-// compounds across epochs until eta0 disagreement breaks header
-// verification at the next epoch boundary.
-//
-// Block hash is a deterministic function of every input the full
-// Praos select-view comparator (chain length → slot → self-issued →
-// issuer hash → VRF output → opcert counter) considers, so two peers
-// independently applying "lower hash wins" to the same pair of
-// competing tips arrive at the same decision and the chains converge.
-//
-// Returns:
-//   - ChainABetter (1) if tipA represents a better chain
-//   - ChainBBetter (-1) if tipB represents a better chain
-//   - ChainEqual (0) only when both tips refer to the same block
-func CompareChains(tipA, tipB ochainsync.Tip) ChainComparisonResult {
-	// Rule 1: Higher block number wins (longer chain)
+// If neither reference implementation rule applies, this returns ChainEqual so
+// callers keep the incumbent.
+func ComparePraosTips(
+	tipA, tipB ochainsync.Tip,
+	viewA, viewB PraosTiebreakerView,
+) ChainComparisonResult {
 	if tipA.BlockNumber > tipB.BlockNumber {
 		return ChainABetter
 	}
@@ -64,176 +51,82 @@ func CompareChains(tipA, tipB ochainsync.Tip) ChainComparisonResult {
 		return ChainBBetter
 	}
 
-	// Rule 2: At equal block number, lower slot wins (denser chain)
-	if tipA.Point.Slot < tipB.Point.Slot {
+	if tipA.Point.Slot == tipB.Point.Slot &&
+		bytes.Equal(tipA.Point.Hash, tipB.Point.Hash) {
+		return ChainEqual
+	}
+
+	if PreferPraosCandidate(viewB, viewA) {
 		return ChainABetter
 	}
-	if tipB.Point.Slot < tipA.Point.Slot {
+	if PreferPraosCandidate(viewA, viewB) {
 		return ChainBBetter
 	}
-
-	// Rule 3: At a slot battle (same length, same slot, different
-	// hash), lower hash wins.
-	if cmp := bytes.Compare(tipA.Point.Hash, tipB.Point.Hash); cmp != 0 {
-		if cmp < 0 {
-			return ChainABetter
-		}
-		return ChainBBetter
-	}
-
-	// Tips refer to the same block.
 	return ChainEqual
 }
 
-// IsBetterChain returns true if newTip represents a better chain than
-// currentTip according to Ouroboros Praos rules.
-func IsBetterChain(newTip, currentTip ochainsync.Tip) bool {
-	return CompareChains(newTip, currentTip) == ChainABetter
-}
-
-// IsSignificantlyBetter returns true if newTip is better than currentTip by
-// at least the specified minimum block difference. This can be used to avoid
-// frequent chain switches for marginal improvements.
-func IsSignificantlyBetter(
-	newTip, currentTip ochainsync.Tip,
-	minBlockDiff uint64,
+// PreferPraosCandidate mirrors ouroboros-consensus'
+// preferCandidate cfg ours cand for equal-length Praos chains.
+func PreferPraosCandidate(
+	ours, cand PraosTiebreakerView,
 ) bool {
-	if newTip.BlockNumber <= currentTip.BlockNumber {
+	if praosIssueNoArmed(ours, cand) {
+		if cand.IssueNo > ours.IssueNo {
+			return true
+		}
+		if cand.IssueNo < ours.IssueNo {
+			return false
+		}
+	}
+	if !praosVRFArmed(ours, cand) {
 		return false
 	}
-	return newTip.BlockNumber-currentTip.BlockNumber >= minBlockDiff
-}
-
-// CompareChainsWithDensity compares two chain tips using density-based
-// comparison according to Ouroboros Praos rules:
-// 1. Higher block number wins (longer chain)
-// 2. At equal block number, higher density wins (more blocks in 3k/f window)
-// 3. At equal density, lower slot wins (tie-breaker)
-//
-// The blocksInWindowA and blocksInWindowB parameters represent the number of
-// blocks in the stability window (3k/f slots) for each chain tip. These values
-// should be computed by counting blocks within the window ending at each tip.
-//
-// Returns:
-//   - ChainABetter (1) if tipA represents a better chain
-//   - ChainBBetter (-1) if tipB represents a better chain
-//   - ChainEqual (0) if they are equal
-func CompareChainsWithDensity(
-	tipA, tipB ochainsync.Tip,
-	blocksInWindowA, blocksInWindowB uint64,
-) ChainComparisonResult {
-	// Rule 1: Higher block number wins (longer chain)
-	if tipA.BlockNumber > tipB.BlockNumber {
-		return ChainABetter
-	}
-	if tipB.BlockNumber > tipA.BlockNumber {
-		return ChainBBetter
-	}
-
-	// Rule 2: At equal block number, higher density wins
-	// (more blocks in 3k/f window)
-	if blocksInWindowA > blocksInWindowB {
-		return ChainABetter
-	}
-	if blocksInWindowB > blocksInWindowA {
-		return ChainBBetter
-	}
-
-	// Rule 3: At equal density, lower slot wins (tie-breaker)
-	if tipA.Point.Slot < tipB.Point.Slot {
-		return ChainABetter
-	}
-	if tipB.Point.Slot < tipA.Point.Slot {
-		return ChainBBetter
-	}
-
-	// Chains are equal
-	return ChainEqual
-}
-
-// IsBetterChainWithDensity returns true if newTip represents a better chain
-// than currentTip according to Ouroboros Praos density-based rules.
-func IsBetterChainWithDensity(
-	newTip, currentTip ochainsync.Tip,
-	blocksInWindowNew, blocksInWindowCurrent uint64,
-) bool {
-	return CompareChainsWithDensity(
-		newTip,
-		currentTip,
-		blocksInWindowNew,
-		blocksInWindowCurrent,
+	return CompareVRFOutputs(
+		cand.TieBreakVRF,
+		ours.TieBreakVRF,
 	) == ChainABetter
 }
 
-// CompareChainsWithVRF compares two chain tips using the complete Ouroboros
-// Praos chain selection algorithm including VRF tie-breaking:
-// 1. Higher block number wins (longer chain)
-// 2. At equal block number, higher density wins (more blocks in 3k/f window)
-// 3. At equal density, lower VRF output wins (deterministic tie-breaker)
-//
-// The vrfOutputA and vrfOutputB parameters are the VRF outputs from the tip
-// blocks of each chain. These should be extracted using GetVRFOutput() from
-// the block headers. If VRF outputs are nil, falls back to slot-based comparison.
-//
-// Returns:
-//   - ChainABetter (1) if tipA represents a better chain
-//   - ChainBBetter (-1) if tipB represents a better chain
-//   - ChainEqual (0) if they are equal
-func CompareChainsWithVRF(
-	tipA, tipB ochainsync.Tip,
-	blocksInWindowA, blocksInWindowB uint64,
-	vrfOutputA, vrfOutputB []byte,
-) ChainComparisonResult {
-	// Rule 1: Higher block number wins (longer chain)
-	if tipA.BlockNumber > tipB.BlockNumber {
-		return ChainABetter
-	}
-	if tipB.BlockNumber > tipA.BlockNumber {
-		return ChainBBetter
-	}
-
-	// Rule 2: At equal block number, higher density wins
-	// (more blocks in 3k/f window)
-	if blocksInWindowA > blocksInWindowB {
-		return ChainABetter
-	}
-	if blocksInWindowB > blocksInWindowA {
-		return ChainBBetter
-	}
-
-	// Rule 3: At equal density, lower VRF output wins (per Ouroboros Praos)
-	if vrfOutputA != nil && vrfOutputB != nil {
-		vrfResult := CompareVRFOutputs(vrfOutputA, vrfOutputB)
-		if vrfResult != ChainEqual {
-			return vrfResult
-		}
-	}
-
-	// Fallback: At equal VRF (or if VRF unavailable), lower slot wins
-	if tipA.Point.Slot < tipB.Point.Slot {
-		return ChainABetter
-	}
-	if tipB.Point.Slot < tipA.Point.Slot {
-		return ChainBBetter
-	}
-
-	// Chains are equal
-	return ChainEqual
+func praosIssueNoArmed(ours, cand PraosTiebreakerView) bool {
+	return ours.Slot == cand.Slot &&
+		ours.hasIssuerIssueNo() &&
+		cand.hasIssuerIssueNo() &&
+		bytes.Equal(ours.Issuer, cand.Issuer)
 }
 
-// IsBetterChainWithVRF returns true if newTip represents a better chain than
-// currentTip according to the complete Ouroboros Praos rules including VRF.
-func IsBetterChainWithVRF(
-	newTip, currentTip ochainsync.Tip,
-	blocksInWindowNew, blocksInWindowCurrent uint64,
-	vrfOutputNew, vrfOutputCurrent []byte,
-) bool {
-	return CompareChainsWithVRF(
-		newTip,
-		currentTip,
-		blocksInWindowNew,
-		blocksInWindowCurrent,
-		vrfOutputNew,
-		vrfOutputCurrent,
-	) == ChainABetter
+func praosVRFArmed(ours, cand PraosTiebreakerView) bool {
+	config, ok := praosTiebreakerConfig(ours, cand)
+	if !ok {
+		return false
+	}
+	switch config.Flavor {
+	case PraosTiebreakerUnknown:
+		return false
+	case PraosTiebreakerUnrestricted:
+		return true
+	case PraosTiebreakerRestricted:
+		return praosSlotDistance(ours.Slot, cand.Slot) <=
+			config.MaxSlotDistance
+	default:
+		return false
+	}
+}
+
+func praosTiebreakerConfig(
+	ours, cand PraosTiebreakerView,
+) (PraosTiebreakerConfig, bool) {
+	if ours.TiebreakerConfig.known() {
+		return ours.TiebreakerConfig, true
+	}
+	if cand.TiebreakerConfig.known() {
+		return cand.TiebreakerConfig, true
+	}
+	return PraosTiebreakerConfig{}, false
+}
+
+func praosSlotDistance(a, b uint64) uint64 {
+	if a >= b {
+		return a - b
+	}
+	return b - a
 }

--- a/chainselection/comparison_test.go
+++ b/chainselection/comparison_test.go
@@ -22,391 +22,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCompareChains(t *testing.T) {
-	tests := []struct {
-		name     string
-		tipA     ochainsync.Tip
-		tipB     ochainsync.Tip
-		expected ChainComparisonResult
-	}{
-		{
-			name: "higher block number wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 40,
-			},
-			expected: ChainABetter,
-		},
-		{
-			name: "lower block number loses",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 40,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			expected: ChainBBetter,
-		},
-		{
-			name: "equal block number lower slot wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			expected: ChainABetter,
-		},
-		{
-			name: "equal block number higher slot loses",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			expected: ChainBBetter,
-		},
-		{
-			// Same length, same slot, different hashes: a slot
-			// battle. Lower-hash tiebreak (rule 3) selects tipA.
-			name: "slot battle resolves by lower hash",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			expected: ChainABetter,
-		},
-		{
-			// Same length, same slot, identical hash: the same
-			// block, so genuinely equal.
-			name: "identical tips compare equal",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			expected: ChainEqual,
-		},
-		{
-			name: "origin tips",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 0, Hash: nil},
-				BlockNumber: 0,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 0, Hash: nil},
-				BlockNumber: 0,
-			},
-			expected: ChainEqual,
-		},
+func TestComparePraosTipsLongerChainWins(t *testing.T) {
+	shorter := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("shorter")},
+		BlockNumber: 40,
+	}
+	longer := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("longer")},
+		BlockNumber: 41,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := CompareChains(tt.tipA, tt.tipB)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	assert.Equal(
+		t,
+		ChainBBetter,
+		ComparePraosTips(shorter, longer, PraosTiebreakerView{}, PraosTiebreakerView{}),
+	)
+	assert.Equal(
+		t,
+		ChainABetter,
+		ComparePraosTips(longer, shorter, PraosTiebreakerView{}, PraosTiebreakerView{}),
+	)
 }
 
-func TestIsBetterChain(t *testing.T) {
-	newTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
+func TestComparePraosTipsEqualLengthDoesNotUseSlotOrHashFallback(t *testing.T) {
+	lowerSlotLowerHash := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 90, Hash: []byte("a")},
 		BlockNumber: 50,
 	}
-	currentTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
-		BlockNumber: 45,
-	}
-	equalTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("equal")},
+	higherSlotHigherHash := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("z")},
 		BlockNumber: 50,
 	}
 
-	assert.True(t, IsBetterChain(newTip, currentTip))
-	assert.False(t, IsBetterChain(currentTip, newTip))
-	assert.False(t, IsBetterChain(newTip, equalTip))
-}
-
-func TestIsSignificantlyBetter(t *testing.T) {
-	tests := []struct {
-		name         string
-		newTip       ochainsync.Tip
-		currentTip   ochainsync.Tip
-		minBlockDiff uint64
-		expected     bool
-	}{
-		{
-			name: "significantly better",
-			newTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
-				BlockNumber: 55,
-			},
-			currentTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
-				BlockNumber: 50,
-			},
-			minBlockDiff: 5,
-			expected:     true,
-		},
-		{
-			name: "not significantly better - below threshold",
-			newTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
-				BlockNumber: 52,
-			},
-			currentTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
-				BlockNumber: 50,
-			},
-			minBlockDiff: 5,
-			expected:     false,
-		},
-		{
-			name: "equal block numbers",
-			newTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
-				BlockNumber: 50,
-			},
-			currentTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
-				BlockNumber: 50,
-			},
-			minBlockDiff: 1,
-			expected:     false,
-		},
-		{
-			name: "new tip worse",
-			newTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
-				BlockNumber: 45,
-			},
-			currentTip: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
-				BlockNumber: 50,
-			},
-			minBlockDiff: 1,
-			expected:     false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsSignificantlyBetter(
-				tt.newTip,
-				tt.currentTip,
-				tt.minBlockDiff,
-			)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestCompareChainsWithDensity(t *testing.T) {
-	tests := []struct {
-		name            string
-		tipA            ochainsync.Tip
-		tipB            ochainsync.Tip
-		blocksInWindowA uint64
-		blocksInWindowB uint64
-		expected        ChainComparisonResult
-	}{
-		{
-			name: "higher block number wins regardless of density",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 40,
-			},
-			blocksInWindowA: 10,
-			blocksInWindowB: 20, // B has higher density but lower block number
-			expected:        ChainABetter,
-		},
-		{
-			name: "lower block number loses regardless of density",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 40,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 20, // A has higher density but lower block number
-			blocksInWindowB: 10,
-			expected:        ChainBBetter,
-		},
-		{
-			name: "equal block number higher density wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 25,
-			blocksInWindowB: 20,
-			expected:        ChainABetter,
-		},
-		{
-			name: "equal block number lower density loses",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 20,
-			blocksInWindowB: 25,
-			expected:        ChainBBetter,
-		},
-		{
-			name: "equal block number and density lower slot wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 20,
-			blocksInWindowB: 20,
-			expected:        ChainABetter,
-		},
-		{
-			name: "equal block number and density higher slot loses",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 20,
-			blocksInWindowB: 20,
-			expected:        ChainBBetter,
-		},
-		{
-			name: "completely equal chains",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("a")},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100, Hash: []byte("b")},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 20,
-			blocksInWindowB: 20,
-			expected:        ChainEqual,
-		},
-		{
-			name: "origin tips with zero density",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 0, Hash: nil},
-				BlockNumber: 0,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 0, Hash: nil},
-				BlockNumber: 0,
-			},
-			blocksInWindowA: 0,
-			blocksInWindowB: 0,
-			expected:        ChainEqual,
-		},
-		{
-			name: "density matters only at equal block number",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 1000, Hash: []byte("a")},
-				BlockNumber: 100,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 900, Hash: []byte("b")},
-				BlockNumber: 100,
-			},
-			blocksInWindowA: 50,
-			blocksInWindowB: 40,
-			expected:        ChainABetter,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := CompareChainsWithDensity(
-				tt.tipA,
-				tt.tipB,
-				tt.blocksInWindowA,
-				tt.blocksInWindowB,
-			)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestIsBetterChainWithDensity(t *testing.T) {
-	newTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("new")},
-		BlockNumber: 50,
-	}
-	currentTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 90, Hash: []byte("current")},
-		BlockNumber: 45,
-	}
-	equalBlockTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("equal")},
-		BlockNumber: 50,
-	}
-
-	// New tip has higher block number - wins regardless of density
-	assert.True(
+	assert.Equal(
 		t,
-		IsBetterChainWithDensity(newTip, currentTip, 10, 20),
-	)
-	assert.False(
-		t,
-		IsBetterChainWithDensity(currentTip, newTip, 20, 10),
-	)
-
-	// Equal block numbers - density decides
-	assert.True(
-		t,
-		IsBetterChainWithDensity(newTip, equalBlockTip, 25, 20),
-	)
-	assert.False(
-		t,
-		IsBetterChainWithDensity(newTip, equalBlockTip, 20, 25),
-	)
-
-	// Equal block numbers and density - slot decides
-	assert.False(
-		t,
-		IsBetterChainWithDensity(newTip, equalBlockTip, 20, 20),
+		ChainEqual,
+		ComparePraosTips(
+			lowerSlotLowerHash,
+			higherSlotHigherHash,
+			PraosTiebreakerView{},
+			PraosTiebreakerView{},
+		),
 	)
 }

--- a/chainselection/doc.go
+++ b/chainselection/doc.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package chainselection implements Ouroboros Praos multi-peer chain
-// selection. It tracks the tip reported by each connected peer and picks
-// the best candidate chain to follow using the standard Praos rules:
-// longer chain wins, then density within the security window, then VRF
-// tie-break.
+// Package chainselection implements multi-peer chain selection. It tracks the
+// tip reported by each connected peer and, for Shelley-family headers, uses the
+// Praos select view projected from the observed header: longer chain first,
+// then the reference implementation's equal-length opcert/VRF tiebreaker when
+// it is armed.
 //
 // Genesis selection mode can be enabled at startup to prefer observed
 // density during bootstrap before automatically falling back to Praos once

--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -37,6 +37,7 @@ type PeerTipUpdateEvent struct {
 	Tip          ochainsync.Tip
 	ObservedTip  ochainsync.Tip
 	VRFOutput    []byte // VRF output from observed block header for tie-breaking
+	PraosView    PraosTiebreakerView
 }
 
 // PeerActivityEvent is published when a peer has recent protocol activity

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -28,6 +28,7 @@ type PeerChainTip struct {
 	Tip           ochainsync.Tip
 	ObservedTip   ochainsync.Tip
 	VRFOutput     []byte // VRF output from tip block for tie-breaking
+	PraosView     PraosTiebreakerView
 	LastUpdated   time.Time
 	observedSlots []uint64
 }
@@ -44,7 +45,12 @@ func NewPeerChainTip(
 		Tip:          tip,
 		ObservedTip:  tip,
 		VRFOutput:    vrfOutput,
-		LastUpdated:  time.Now(),
+		PraosView: PraosTiebreakerViewFromTip(
+			tip,
+			vrfOutput,
+			PraosTiebreakerConfigUnknown(),
+		),
+		LastUpdated: time.Now(),
 	}
 }
 
@@ -60,9 +66,34 @@ func (p *PeerChainTip) UpdateTipWithObserved(
 	observedTip ochainsync.Tip,
 	vrfOutput []byte,
 ) {
+	p.UpdateTipWithObservedPraosView(
+		tip,
+		observedTip,
+		vrfOutput,
+		PraosTiebreakerViewFromTip(
+			observedTip,
+			vrfOutput,
+			PraosTiebreakerConfigUnknown(),
+		),
+	)
+}
+
+// UpdateTipWithObservedPraosView updates the remote advertised tip, the latest
+// locally observed frontier, the VRF output, and the Praos tiebreaker view for
+// the peer. Callers must provide a PraosTiebreakerView derived from observedTip
+// and the supplied vrfOutput when that VRF output participates in the view.
+// The view is stored as supplied; this method does not validate consistency, so
+// an inconsistent view can make later chain-selection comparisons incorrect.
+func (p *PeerChainTip) UpdateTipWithObservedPraosView(
+	tip ochainsync.Tip,
+	observedTip ochainsync.Tip,
+	vrfOutput []byte,
+	praosView PraosTiebreakerView,
+) {
 	p.Tip = tip
 	p.ObservedTip = observedTip
 	p.VRFOutput = vrfOutput
+	p.PraosView = praosView
 	p.LastUpdated = time.Now()
 }
 
@@ -78,6 +109,7 @@ func (p *PeerChainTip) ApplyRollback(
 	p.Tip = tip
 	p.ObservedTip = tip
 	p.VRFOutput = nil
+	p.PraosView = PraosTiebreakerView{}
 	p.LastUpdated = time.Now()
 	if point.Slot == 0 || len(p.observedSlots) == 0 {
 		p.observedSlots = nil

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -15,6 +15,7 @@
 package chainselection
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -39,7 +40,6 @@ func safeAddUint64(a, b uint64) uint64 {
 const (
 	defaultEvaluationInterval = 10 * time.Second
 	defaultStaleTipThreshold  = 60 * time.Second
-	defaultMinSwitchBlockDiff = 2
 
 	// DefaultMaxTrackedPeers is the maximum number of peers tracked by
 	// the ChainSelector. When a new peer is added and the limit is reached,
@@ -80,7 +80,6 @@ type ChainSelectorConfig struct {
 	EventBus           *event.EventBus
 	EvaluationInterval time.Duration
 	StaleTipThreshold  time.Duration
-	MinSwitchBlockDiff uint64
 	SecurityParam      uint64
 	GenesisMode        bool
 	GenesisWindowSlots uint64
@@ -89,13 +88,13 @@ type ChainSelectorConfig struct {
 	ConnectionPriority func(ouroboros.ConnectionId) int
 	MaxTrackedPeers    int // 0 means use DefaultMaxTrackedPeers
 	// BlockfetchLatency returns the EWMA first-block latency for a
-	// connection and whether any samples exist. Used as a tiebreaker
-	// when two peers share the same SelectionTip and VRF output.
+	// connection and whether any samples exist. Used only to choose a
+	// peer when two peers advertise the exact same selected block.
 	BlockfetchLatency func(ouroboros.ConnectionId) (time.Duration, bool)
 }
 
 // ChainSelector tracks chain tips from multiple peers and selects the best
-// chain according to Ouroboros Praos rules.
+// chain using the active mode's comparison rules.
 type ChainSelector struct {
 	config            ChainSelectorConfig
 	securityParam     uint64
@@ -123,9 +122,6 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 	}
 	if cfg.StaleTipThreshold == 0 {
 		cfg.StaleTipThreshold = defaultStaleTipThreshold
-	}
-	if cfg.MinSwitchBlockDiff == 0 {
-		cfg.MinSwitchBlockDiff = defaultMinSwitchBlockDiff
 	}
 	maxPeers := cfg.MaxTrackedPeers
 	if maxPeers <= 0 {
@@ -256,6 +252,26 @@ func (cs *ChainSelector) updatePeerTipObserved(
 	observedTip ochainsync.Tip,
 	vrfOutput []byte,
 ) bool {
+	return cs.updatePeerTipObservedPraosView(
+		connId,
+		tip,
+		observedTip,
+		vrfOutput,
+		PraosTiebreakerViewFromTip(
+			observedTip,
+			vrfOutput,
+			PraosTiebreakerConfigUnknown(),
+		),
+	)
+}
+
+func (cs *ChainSelector) updatePeerTipObservedPraosView(
+	connId ouroboros.ConnectionId,
+	tip ochainsync.Tip,
+	observedTip ochainsync.Tip,
+	vrfOutput []byte,
+	praosView PraosTiebreakerView,
+) bool {
 	if cs.config.ConnectionLive != nil &&
 		!cs.config.ConnectionLive(connId) {
 		cs.config.Logger.Debug(
@@ -337,10 +353,11 @@ func (cs *ChainSelector) updatePeerTipObserved(
 		}
 
 		if peerTip, exists := cs.peerTips[connId]; exists {
-			peerTip.UpdateTipWithObserved(
+			peerTip.UpdateTipWithObservedPraosView(
 				tip,
 				observedTip,
 				vrfOutput,
+				praosView,
 			)
 			peerTip.recordObservedSlot(
 				observedTip.Point.Slot,
@@ -361,8 +378,14 @@ func (cs *ChainSelector) updatePeerTipObserved(
 					return
 				}
 			}
-			peerTip := NewPeerChainTip(connId, tip, vrfOutput)
-			peerTip.ObservedTip = observedTip
+			peerTip := &PeerChainTip{
+				ConnectionId: connId,
+				Tip:          tip,
+				ObservedTip:  observedTip,
+				VRFOutput:    vrfOutput,
+				PraosView:    praosView,
+				LastUpdated:  time.Now(),
+			}
 			peerTip.recordObservedSlot(
 				observedTip.Point.Slot,
 				cs.genesisWindowSlotsLocked(),
@@ -384,30 +407,12 @@ func (cs *ChainSelector) updatePeerTipObserved(
 			shouldEvaluate = true
 		} else if cs.bestPeerConn != nil {
 			if bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]; ok {
-				if cs.mode == SelectionModeGenesis {
-					shouldEvaluate = cs.comparePeerTips(
-						connId,
-						cs.peerTips[connId],
-						*cs.bestPeerConn,
-						bestPeerTip,
-					) == ChainABetter
-				} else {
-					comparison := CompareChains(
-						cs.peerTips[connId].SelectionTip(),
-						bestPeerTip.SelectionTip(),
-					)
-					if comparison == ChainABetter {
-						shouldEvaluate = true
-					} else if comparison == ChainEqual &&
-						cs.comparePeerTips(
-							connId,
-							cs.peerTips[connId],
-							*cs.bestPeerConn,
-							bestPeerTip,
-						) == ChainABetter {
-						shouldEvaluate = true
-					}
-				}
+				shouldEvaluate = cs.comparePeerTips(
+					connId,
+					cs.peerTips[connId],
+					*cs.bestPeerConn,
+					bestPeerTip,
+				) == ChainABetter
 			}
 		} else {
 			// No best peer yet, trigger evaluation
@@ -653,6 +658,7 @@ func (cs *ChainSelector) GetPeerTip(
 		tipCopy.VRFOutput = make([]byte, len(pt.VRFOutput))
 		copy(tipCopy.VRFOutput, pt.VRFOutput)
 	}
+	tipCopy.PraosView = clonePraosTiebreakerView(pt.PraosView)
 	if len(pt.observedSlots) > 0 {
 		tipCopy.observedSlots = make([]uint64, len(pt.observedSlots))
 		copy(tipCopy.observedSlots, pt.observedSlots)
@@ -674,6 +680,7 @@ func (cs *ChainSelector) GetAllPeerTips() map[ouroboros.ConnectionId]*PeerChainT
 			tipCopy.VRFOutput = make([]byte, len(v.VRFOutput))
 			copy(tipCopy.VRFOutput, v.VRFOutput)
 		}
+		tipCopy.PraosView = clonePraosTiebreakerView(v.PraosView)
 		if len(v.observedSlots) > 0 {
 			tipCopy.observedSlots = make([]uint64, len(v.observedSlots))
 			copy(tipCopy.observedSlots, v.observedSlots)
@@ -888,14 +895,23 @@ func (cs *ChainSelector) comparePeerTipsPraos(
 	connIdB ouroboros.ConnectionId,
 	peerTipB *PeerChainTip,
 ) ChainComparisonResult {
-	comparison := CompareChains(
-		peerTipA.SelectionTip(),
-		peerTipB.SelectionTip(),
+	tipA := peerTipA.SelectionTip()
+	tipB := peerTipB.SelectionTip()
+	comparison := ComparePraosTips(
+		tipA,
+		tipB,
+		peerTipA.PraosView,
+		peerTipB.PraosView,
 	)
 	switch comparison {
 	case ChainABetter, ChainBBetter, ChainComparisonUnknown:
 		return comparison
 	case ChainEqual:
+		if !sameSelectionTip(tipA, tipB) {
+			return ChainEqual
+		}
+		// The chains are the same block. The remaining checks choose a
+		// peer transport for that block, not a different chain.
 		priorityA := cs.connectionPriority(connIdA)
 		priorityB := cs.connectionPriority(connIdB)
 		if priorityA > priorityB {
@@ -903,15 +919,6 @@ func (cs *ChainSelector) comparePeerTipsPraos(
 		}
 		if priorityB > priorityA {
 			return ChainBBetter
-		}
-		vrfComparison := CompareVRFOutputs(
-			peerTipA.VRFOutput,
-			peerTipB.VRFOutput,
-		)
-		switch vrfComparison {
-		case ChainABetter, ChainBBetter:
-			return vrfComparison
-		case ChainEqual, ChainComparisonUnknown:
 		}
 		// Latency tiebreaker: prefer the peer with lower blockfetch
 		// EWMA when VRF and SelectionTip are equal. Only fires when
@@ -939,6 +946,12 @@ func (cs *ChainSelector) comparePeerTipsPraos(
 	default:
 		return ChainComparisonUnknown
 	}
+}
+
+func sameSelectionTip(a, b ochainsync.Tip) bool {
+	return a.BlockNumber == b.BlockNumber &&
+		a.Point.Slot == b.Point.Slot &&
+		bytes.Equal(a.Point.Hash, b.Point.Hash)
 }
 
 func (cs *ChainSelector) handlePeerEligibilityChangedEvent(evt event.Event) {
@@ -1009,42 +1022,27 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 			if !ok {
 				return false, nil, nil
 			}
-			if CompareChains(
+			if ComparePraosTips(
 				newPeerTip.SelectionTip(),
 				previousPeerTip.SelectionTip(),
+				newPeerTip.PraosView,
+				previousPeerTip.PraosView,
 			) == ChainEqual {
 				// When two peers have delivered the same observed frontier,
-				// keep following the incumbent. The first peer to deliver the
-				// fitting header already won on latency; switching on source
-				// priority or VRF alone just creates churn near tip.
+				// or the reference implementation's equal-length Praos
+				// tiebreaker is not armed, keep following the incumbent.
 				newBest = previousBest
-			} else if
-			// Preserve the incumbent only when it still wins the same
-			// full comparison used during normal best-peer selection.
-			cs.comparePeerTips(
-				*previousBest,
-				previousPeerTip,
-				*newBest,
-				newPeerTip,
-			) == ChainABetter {
-				newBest = previousBest
-			} else if newPeerTip.SelectionTip().BlockNumber >
-				previousPeerTip.SelectionTip().BlockNumber &&
-				!IsSignificantlyBetter(
-					newPeerTip.SelectionTip(),
-					previousPeerTip.SelectionTip(),
-					cs.config.MinSwitchBlockDiff,
-				) {
-				// Suppress switches where the challenger is only marginally
-				// ahead in SelectionTip (observed frontier, which includes
-				// in-flight headers from RollForward). The original guard used
-				// Tip.BlockNumber (the peer's claimed remote tip), which can be
-				// ahead of ObservedTip when a peer advertises N+1 in a
-				// RollForward tip claim before actually delivering the N+1
-				// header. That caused both peers to show Tip.BlockNumber=N+1
-				// while only one had SelectionTip=N+1, making the `>` guard
-				// fail and allowing a switch for a 1-block observed lead.
-				newBest = previousBest
+			} else {
+				// Preserve the incumbent only when it still wins the same
+				// full comparison used during normal best-peer selection.
+				if cs.comparePeerTips(
+					*previousBest,
+					previousPeerTip,
+					*newBest,
+					newPeerTip,
+				) == ChainABetter {
+					newBest = previousBest
+				}
 			}
 		}
 	}
@@ -1075,7 +1073,17 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 				}
 			}
 			// Compute comparison result and block difference
-			comparisonResult := CompareChains(newTip, previousTip)
+			comparisonResult := ChainComparisonUnknown
+			if previousBest != nil {
+				if previousPeerTip, ok := cs.peerTips[*previousBest]; ok {
+					comparisonResult = cs.comparePeerTips(
+						*newBest,
+						newPeerTip,
+						*previousBest,
+						previousPeerTip,
+					)
+				}
+			}
 			blockDiff := safeBlockDiff(
 				newTip.BlockNumber,
 				previousTip.BlockNumber,
@@ -1143,11 +1151,12 @@ func (cs *ChainSelector) HandlePeerTipUpdateEvent(evt event.Event) {
 		)
 		return
 	}
-	cs.updatePeerTipObserved(
+	cs.updatePeerTipObservedPraosView(
 		e.ConnectionId,
 		e.Tip,
 		e.ObservedTip,
 		e.VRFOutput,
+		e.PraosView,
 	)
 }
 

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -83,6 +83,26 @@ func markSelectorPeerStale(
 	peerTip.LastUpdated = time.Now().Add(-(threshold + time.Millisecond))
 }
 
+func updatePeerTipWithPraosView(
+	t *testing.T,
+	cs *ChainSelector,
+	connId ouroboros.ConnectionId,
+	tip ochainsync.Tip,
+	vrfOutput []byte,
+	config PraosTiebreakerConfig,
+) {
+	t.Helper()
+
+	accepted := cs.updatePeerTipObservedPraosView(
+		connId,
+		tip,
+		tip,
+		vrfOutput,
+		PraosTiebreakerViewFromTip(tip, vrfOutput, config),
+	)
+	require.True(t, accepted)
+}
+
 func TestChainSelectorUpdatePeerTip(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{})
 
@@ -331,7 +351,7 @@ func TestChainSelectorSelectBestChain(t *testing.T) {
 	}
 	tip3 := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip3")},
-		BlockNumber: 50,
+		BlockNumber: 45,
 	}
 
 	cs.UpdatePeerTip(connId1, tip1, nil)
@@ -419,7 +439,7 @@ func TestIncumbentAdvantageSwitchesWhenBehind(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
-func TestIncumbentAdvantageKeepsPeerOnMarginalLead(t *testing.T) {
+func TestIncumbentAdvantageSwitchesOnOneBlockLead(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{})
 
 	connId1 := newTestConnectionId(1)
@@ -437,7 +457,7 @@ func TestIncumbentAdvantageKeepsPeerOnMarginalLead(t *testing.T) {
 		BlockNumber: 51,
 	}, nil)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, connId1, *cs.GetBestPeer())
+	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
 func TestNoOscillationWithMultiplePeersAtSameTip(t *testing.T) {
@@ -616,16 +636,10 @@ func TestChainSelectorPreservesEqualTipIncumbentAtSamePriority(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
-func TestChainSelectorDoesNotSwitchOnOneBlockObservedTipLead(t *testing.T) {
-	// Regression: when two peers track the same chain, the one that announces
-	// the next block header milliseconds sooner gains a 1-block ObservedTip
-	// (SelectionTip) lead. The old guard used Tip.BlockNumber (confirmed only)
-	// and missed this case, causing a switch per block near tip.
+func TestChainSelectorSwitchesOnOneBlockObservedTipLead(t *testing.T) {
 	incumbentConn := newTestConnectionId(1)
 	challengerConn := newTestConnectionId(2)
-	cs := NewChainSelector(ChainSelectorConfig{
-		MinSwitchBlockDiff: 2,
-	})
+	cs := NewChainSelector(ChainSelectorConfig{})
 
 	confirmedTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 100, Hash: []byte("confirmed")},
@@ -659,9 +673,13 @@ func TestChainSelectorDoesNotSwitchOnOneBlockObservedTipLead(t *testing.T) {
 	cs.mutex.Unlock()
 
 	switched := cs.EvaluateAndSwitch()
-	assert.False(t, switched, "should not switch for a 1-block observed tip lead with MinSwitchBlockDiff=2")
+	assert.True(
+		t,
+		switched,
+		"reference implementation chain selection follows the longer chain",
+	)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
+	assert.Equal(t, challengerConn, *cs.GetBestPeer())
 }
 
 func TestChainSelectorPreservesEqualTipIncumbentAtSamePriorityWithVRF(
@@ -848,7 +866,7 @@ func TestChainSelectorDoesNotPreserveImplausiblyBehindIncumbent(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 }
 
-func TestChainSelectorKeepsChallengerWhenItWinsFullTieBreak(t *testing.T) {
+func TestChainSelectorKeepsIncumbentWhenPraosTiebreakerNotArmed(t *testing.T) {
 	incumbentConn := newTestConnectionId(1)
 	challengerConn := newTestConnectionId(2)
 	cs := NewChainSelector(ChainSelectorConfig{})
@@ -868,7 +886,7 @@ func TestChainSelectorKeepsChallengerWhenItWinsFullTieBreak(t *testing.T) {
 
 	cs.UpdatePeerTip(challengerConn, challengerTip, nil)
 	require.NotNil(t, cs.GetBestPeer())
-	assert.Equal(t, challengerConn, *cs.GetBestPeer())
+	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 }
 
 func TestChainSelectorStalePeerFiltering(t *testing.T) {
@@ -1126,10 +1144,9 @@ func TestChainSelectorTouchPeerActivityRevivesStaleBestPeer(t *testing.T) {
 	assert.Equal(t, bestConn, *cs.GetBestPeer())
 }
 
-func TestChainSelectorTouchPeerActivityHonorsMinSwitchBlockDiff(t *testing.T) {
+func TestChainSelectorTouchPeerActivitySwitchesToLongerChain(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
-		StaleTipThreshold:  50 * time.Millisecond,
-		MinSwitchBlockDiff: 2,
+		StaleTipThreshold: 50 * time.Millisecond,
 	})
 
 	revivedConn := newTestConnectionId(1)
@@ -1164,9 +1181,9 @@ func TestChainSelectorTouchPeerActivityHonorsMinSwitchBlockDiff(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(
 		t,
-		incumbentConn,
+		revivedConn,
 		*cs.GetBestPeer(),
-		"activity-only revival should not bypass MinSwitchBlockDiff",
+		"a revived one-block-longer peer must win under reference implementation chain selection",
 	)
 }
 
@@ -1175,9 +1192,8 @@ func TestChainSelectorTouchPeerActivityEmitsChainSwitchEvent(t *testing.T) {
 	defer eventBus.Stop()
 
 	cs := NewChainSelector(ChainSelectorConfig{
-		EventBus:           eventBus,
-		StaleTipThreshold:  50 * time.Millisecond,
-		MinSwitchBlockDiff: 2,
+		EventBus:          eventBus,
+		StaleTipThreshold: 50 * time.Millisecond,
 	})
 
 	revivedConn := newTestConnectionId(1)
@@ -1251,9 +1267,13 @@ func TestChainSelectorVRFTiebreaker(t *testing.T) {
 	connId1 := newTestConnectionId(1)
 	connId2 := newTestConnectionId(2)
 
-	// Two peers with identical tips (same block number and slot)
-	tip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100, Hash: []byte("same")},
+	// Two peers with competing tips at the same block number and slot.
+	tip1 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip1")},
+		BlockNumber: 50,
+	}
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
 		BlockNumber: 50,
 	}
 
@@ -1263,9 +1283,23 @@ func TestChainSelectorVRFTiebreaker(t *testing.T) {
 	vrfHigher := make64ByteVRF(0x01)
 
 	// Add peer with higher VRF first
-	cs.UpdatePeerTip(connId1, tip, vrfHigher)
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId1,
+		tip1,
+		vrfHigher,
+		PraosTiebreakerConfigConway(),
+	)
 	// Add peer with lower VRF second
-	cs.UpdatePeerTip(connId2, tip, vrfLower)
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId2,
+		tip2,
+		vrfLower,
+		PraosTiebreakerConfigConway(),
+	)
 
 	// The peer with lower VRF should win
 	bestPeer := cs.SelectBestChain()
@@ -1287,11 +1321,25 @@ func TestChainSelectorUpdatePeerTipPreservesEqualTipIncumbentOnVRF(
 	vrfLower := make64ByteVRF(0x00)
 	vrfHigher := make64ByteVRF(0x01)
 
-	cs.UpdatePeerTip(connId1, tip, vrfHigher)
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId1,
+		tip,
+		vrfHigher,
+		PraosTiebreakerConfigConway(),
+	)
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, connId1, *cs.GetBestPeer())
 
-	cs.UpdatePeerTip(connId2, tip, vrfLower)
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId2,
+		tip,
+		vrfLower,
+		PraosTiebreakerConfigConway(),
+	)
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(
 		t,
@@ -1319,17 +1367,13 @@ func TestChainSelectorVRFTiebreakerWithNilVRF(t *testing.T) {
 	cs.UpdatePeerTip(connId1, tip, vrf)
 	cs.UpdatePeerTip(connId2, tip, nil)
 
-	// When VRF comparison returns equal (due to nil), fall back to connection ID
-	// connId1 vs connId2 - the one with lexicographically smaller string wins
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
-	// Since VRF comparison returns ChainEqual when one is nil,
-	// it falls back to connection ID comparison
 	assert.Equal(
 		t,
 		connId1,
 		*bestPeer,
-		"should fall back to connection ID ordering when one peer has nil VRF",
+		"nil VRF must not let the challenger replace the incumbent",
 	)
 }
 
@@ -1367,19 +1411,19 @@ func TestChainSelectorVRFDoesNotOverrideBlockNumber(t *testing.T) {
 	)
 }
 
-func TestChainSelectorVRFDoesNotOverrideSlot(t *testing.T) {
+func TestChainSelectorPraosVRFOverridesSlot(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{})
 
 	connId1 := newTestConnectionId(1)
 	connId2 := newTestConnectionId(2)
 
 	// Both have same block number
-	// Peer 1: higher slot (less dense) but lower VRF
+	// Peer 1: higher slot but lower VRF
 	tip1 := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 110, Hash: []byte("tip1")},
+		Point:       ocommon.Point{Slot: 105, Hash: []byte("tip1")},
 		BlockNumber: 50,
 	}
-	// Peer 2: lower slot (more dense) but higher VRF
+	// Peer 2: lower slot but higher VRF
 	tip2 := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 100, Hash: []byte("tip2")},
 		BlockNumber: 50,
@@ -1388,13 +1432,72 @@ func TestChainSelectorVRFDoesNotOverrideSlot(t *testing.T) {
 	vrfLower := make64ByteVRF(0x00)
 	vrfHigher := make64ByteVRF(0xFF)
 
-	cs.UpdatePeerTip(connId1, tip1, vrfLower)
-	cs.UpdatePeerTip(connId2, tip2, vrfHigher)
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId1,
+		tip1,
+		vrfLower,
+		PraosTiebreakerConfigConway(),
+	)
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId2,
+		tip2,
+		vrfHigher,
+		PraosTiebreakerConfigConway(),
+	)
 
-	// Slot takes precedence - peer 2 (lower slot) should win despite higher VRF
+	// Praos VRF takes precedence at equal block number.
 	bestPeer := cs.SelectBestChain()
 	require.NotNil(t, bestPeer)
-	assert.Equal(t, connId2, *bestPeer, "lower slot should win over lower VRF")
+	assert.Equal(t, connId1, *bestPeer, "lower VRF should win over lower slot")
+}
+
+func TestChainSelectorUpdatesBestPeerWhenLaterSlotWinsVRF(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	connId1 := newTestConnectionId(1)
+	connId2 := newTestConnectionId(2)
+
+	incumbentTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 111962097, Hash: []byte("dingo")},
+		BlockNumber: 4275844,
+	}
+	challengerTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 111962102, Hash: []byte("ref-impl")},
+		BlockNumber: 4275844,
+	}
+
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId1,
+		incumbentTip,
+		make64ByteVRFFirstByte(0xBD),
+		PraosTiebreakerConfigConway(),
+	)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, connId1, *cs.GetBestPeer())
+
+	updatePeerTipWithPraosView(
+		t,
+		cs,
+		connId2,
+		challengerTip,
+		make64ByteVRFFirstByte(0x6E),
+		PraosTiebreakerConfigConway(),
+	)
+
+	bestPeer := cs.GetBestPeer()
+	require.NotNil(t, bestPeer)
+	assert.Equal(
+		t,
+		connId2,
+		*bestPeer,
+		"equal-height later-slot challenger must replace the incumbent when VRF wins",
+	)
 }
 
 func TestPeerChainTipVRFOutputStored(t *testing.T) {

--- a/chainselection/slot_battle_tiebreak_test.go
+++ b/chainselection/slot_battle_tiebreak_test.go
@@ -23,60 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCompareChains_SlotBattleAtSameLengthAndSlotIsAmbiguous shows the
-// gap that lets the eras-DevNet VRF-failure cascade get started:
-// IsBetterChain treats two competing tips at the same block count AND
-// the same slot — the exact shape of a slot-battle pair — as "equal"
-// and refuses to switch in either direction. cardano-node's Praos
-// chain selection breaks this case with a deterministic tie-breaker
-// (the lower VRF leader output). With no tie-break here, dingo cannot
-// pick a side on its own; whichever chain it stays on is whichever
-// chain happened to land first.
-//
-// Why it matters in the eras DevNet:
-//
-// At slot 40 of a recent run, dingo forged a Shelley block 5c25... on
-// top of slot 38. cardano-producer concurrently forged a different
-// Shelley block 0c54... on top of the same slot 38. Two valid chains
-// of equal length, both ending at slot 40. cardano-relay (cardano-
-// node) ran its Praos tie-break and picked 0c54. dingo's chainsync
-// client received a cursor-mismatch from the relay, the relay closed
-// the connection (TCP RST), dingo reconnected, re-intersected, rolled
-// back to slot 38, and adopted 0c54. The "slot battle" log line on
-// dingo confirms local_won=false — its locally-forged 5c25 was
-// dropped.
-//
-// All nine slot battles in that run came back local_won=false. The
-// run's full canonical chain (the relay's view) ended with zero
-// dingo-issued blocks across every era, even though dingo successfully
-// produced 95 blocks. That's not 50/50 randomness; it's the signature
-// of a chain-selection asymmetry between dingo and cardano-node.
-//
-// In dingo, the chainsync-driven rollback hides the asymmetry at slots
-// where a battle is recognised — chainsync is authoritative over local
-// chain selection there. But the absence of a same-slot tie-break
-// elsewhere means: when dingo's local chain selection considers the
-// peer's tip and finds it "equal", it makes no decision either way.
-// Anywhere chainsync is not actively forcing a rollback, the chains
-// are free to drift, and the evolving nonce — which carries across
-// epoch boundaries without resetting — picks up the drift. By the
-// next era boundary the candidate-nonce inputs disagree, eta0
-// disagrees, and every header from the peer VRF-fails.
-//
-// The fix is to extend CompareChains so the equal-length-equal-slot
-// case has a deterministic tie-break (lower hash, matching cardano-
-// node's effective ordering once block hashes become available).
-// After that, dingo's local chain-selection decisions match cardano-
-// node's at every slot battle, the run-by-run "always lose" pattern
-// stops, and chains converge cleanly.
-func TestCompareChains_SlotBattleAtSameLengthAndSlotIsAmbiguous(t *testing.T) {
-	// Two Shelley blocks at slot 40, both extending the same slot-38
-	// parent, block_number=11 (same length past the common ancestor).
+func TestComparePraosTipsSlotBattleWithoutSelectViewDoesNotInventHashTieBreak(
+	t *testing.T,
+) {
 	dingoTip := ochainsync.Tip{
 		BlockNumber: 11,
 		Point: ocommon.Point{
 			Slot: 40,
-			// 5c259f44... — the dingo-forged hash from the run.
 			Hash: []byte{
 				0x5c, 0x25, 0x9f, 0x44, 0x42, 0xe1, 0x49, 0x33,
 				0x72, 0xe2, 0x07, 0x83, 0xaa, 0xb3, 0x06, 0x39,
@@ -89,7 +42,6 @@ func TestCompareChains_SlotBattleAtSameLengthAndSlotIsAmbiguous(t *testing.T) {
 		BlockNumber: 11,
 		Point: ocommon.Point{
 			Slot: 40,
-			// 0c541182... — the cardano-producer-forged hash.
 			Hash: []byte{
 				0x0c, 0x54, 0x11, 0x82, 0xc9, 0xa9, 0xa6, 0x6d,
 				0xa2, 0xf7, 0xc3, 0x1a, 0x1f, 0x9b, 0x9e, 0x4a,
@@ -99,38 +51,19 @@ func TestCompareChains_SlotBattleAtSameLengthAndSlotIsAmbiguous(t *testing.T) {
 		},
 	}
 
-	// cardanoTip's hash (0c54…) is lower than dingoTip's (5c25…), so
-	// the rule-3 tiebreak selects cardanoTip. CompareChains must
-	// return ChainBBetter and IsBetterChain(cardano, dingo) must be
-	// true so the local selector adopts the lower-hash forge
-	// independently of chainsync arrival order.
-	got := chainselection.CompareChains(dingoTip, cardanoTip)
-	require.Equalf(
-		t,
-		chainselection.ChainBBetter,
-		got,
-		"CompareChains at a slot battle must apply the lower-hash "+
-			"tiebreak. Got %d. ChainEqual here is the original gap: "+
-			"the local chain-selection result becomes order-dependent, "+
-			"the locally-forged block is kept, and its VRF output "+
-			"folds into the evolving nonce — seeding the eta0 drift "+
-			"that breaks header verification at the next era boundary.",
-		got,
+	got := chainselection.ComparePraosTips(
+		dingoTip,
+		cardanoTip,
+		chainselection.PraosTiebreakerViewFromTip(
+			dingoTip,
+			nil,
+			chainselection.PraosTiebreakerConfigConway(),
+		),
+		chainselection.PraosTiebreakerViewFromTip(
+			cardanoTip,
+			nil,
+			chainselection.PraosTiebreakerConfigConway(),
+		),
 	)
-
-	require.Falsef(
-		t,
-		chainselection.IsBetterChain(dingoTip, cardanoTip),
-		"IsBetterChain(higher-hash, lower-hash) must be false: the "+
-			"higher-hash forge does not win the rule-3 tiebreak.",
-	)
-	require.Truef(
-		t,
-		chainselection.IsBetterChain(cardanoTip, dingoTip),
-		"IsBetterChain(lower-hash, higher-hash) must be true so the "+
-			"local selector adopts the lower-hash forge. Returning "+
-			"false re-introduces the original gap where the chains "+
-			"are free to drift between slot battles and chainsync is "+
-			"the only path that ever resolves them.",
-	)
+	require.Equal(t, chainselection.ChainEqual, got)
 }

--- a/chainselection/vrf.go
+++ b/chainselection/vrf.go
@@ -24,10 +24,133 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
 
 // VRFOutputSize is the expected size of a VRF output in bytes.
 const VRFOutputSize = 64
+
+const praosRestrictedTiebreakerMaxSlotDistance = 5
+
+// PraosTiebreakerFlavor matches ouroboros-consensus' VRFTiebreakerFlavor.
+type PraosTiebreakerFlavor uint8
+
+const (
+	PraosTiebreakerUnknown PraosTiebreakerFlavor = iota
+	PraosTiebreakerUnrestricted
+	PraosTiebreakerRestricted
+)
+
+// PraosTiebreakerConfig is the chain-order config projected from the current
+// Shelley-family block config. The reference implementation uses unrestricted
+// VRF before Conway and restricted VRF with max distance 5 from Conway onward.
+type PraosTiebreakerConfig struct {
+	Flavor          PraosTiebreakerFlavor
+	MaxSlotDistance uint64
+}
+
+// PraosTiebreakerView mirrors ouroboros-consensus' PraosTiebreakerView for
+// equal-length chain selection.
+type PraosTiebreakerView struct {
+	Slot              uint64
+	Issuer            []byte
+	IssueNo           uint64
+	TieBreakVRF       []byte
+	TiebreakerConfig  PraosTiebreakerConfig
+	hasIssuerAndIssue bool
+}
+
+func PraosTiebreakerConfigBeforeConway() PraosTiebreakerConfig {
+	return PraosTiebreakerConfig{
+		Flavor: PraosTiebreakerUnrestricted,
+	}
+}
+
+func PraosTiebreakerConfigConway() PraosTiebreakerConfig {
+	return PraosTiebreakerConfig{
+		Flavor:          PraosTiebreakerRestricted,
+		MaxSlotDistance: praosRestrictedTiebreakerMaxSlotDistance,
+	}
+}
+
+func PraosTiebreakerConfigUnknown() PraosTiebreakerConfig {
+	return PraosTiebreakerConfig{}
+}
+
+func (c PraosTiebreakerConfig) known() bool {
+	return c.Flavor == PraosTiebreakerUnrestricted ||
+		c.Flavor == PraosTiebreakerRestricted
+}
+
+func (v PraosTiebreakerView) hasIssuerIssueNo() bool {
+	return v.hasIssuerAndIssue && len(v.Issuer) > 0
+}
+
+// PraosTiebreakerViewFromTip builds a partial view when only a chainsync tip
+// and VRF are available. The issuer/opcert rule cannot be applied to partial
+// views.
+func PraosTiebreakerViewFromTip(
+	tip ochainsync.Tip,
+	vrfOutput []byte,
+	config PraosTiebreakerConfig,
+) PraosTiebreakerView {
+	return PraosTiebreakerView{
+		Slot:             tip.Point.Slot,
+		TieBreakVRF:      cloneBytes(vrfOutput),
+		TiebreakerConfig: config,
+	}
+}
+
+// GetPraosTiebreakerView extracts the Praos select-view fields from a
+// Shelley-family header.
+func GetPraosTiebreakerView(
+	header ledger.BlockHeader,
+) (PraosTiebreakerView, bool) {
+	if header == nil {
+		return PraosTiebreakerView{}, false
+	}
+	issueNo, ok := headerIssueNo(header)
+	if !ok {
+		return PraosTiebreakerView{}, false
+	}
+	issuer := header.IssuerVkey()
+	return PraosTiebreakerView{
+		Slot:              header.SlotNumber(),
+		Issuer:            cloneBytes(issuer[:]),
+		IssueNo:           issueNo,
+		TieBreakVRF:       cloneBytes(GetVRFOutput(header)),
+		TiebreakerConfig:  praosTiebreakerConfigForHeader(header),
+		hasIssuerAndIssue: true,
+	}, true
+}
+
+func headerIssueNo(header ledger.BlockHeader) (uint64, bool) {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *allegra.AllegraBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *mary.MaryBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *alonzo.AlonzoBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *babbage.BabbageBlockHeader:
+		return uint64(h.Body.OpCert.SequenceNumber), true
+	case *conway.ConwayBlockHeader:
+		return uint64(h.Body.OpCert.SequenceNumber), true
+	default:
+		return 0, false
+	}
+}
+
+func praosTiebreakerConfigForHeader(
+	header ledger.BlockHeader,
+) PraosTiebreakerConfig {
+	if header.Era().Id >= conway.EraIdConway {
+		return PraosTiebreakerConfigConway()
+	}
+	return PraosTiebreakerConfigBeforeConway()
+}
 
 // GetVRFOutput extracts the VRF output from a block header.
 // Returns nil if the header type is not supported or doesn't contain VRF data.
@@ -80,11 +203,19 @@ func CompareVRFOutputs(vrfA, vrfB []byte) ChainComparisonResult {
 	return ChainEqual
 }
 
-// CompareHeaders compares two block headers for chain selection tie-breaking
-// using their VRF outputs. This is a convenience wrapper around GetVRFOutput
-// and CompareVRFOutputs.
-func CompareHeaders(headerA, headerB ledger.BlockHeader) ChainComparisonResult {
-	vrfA := GetVRFOutput(headerA)
-	vrfB := GetVRFOutput(headerB)
-	return CompareVRFOutputs(vrfA, vrfB)
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func clonePraosTiebreakerView(
+	src PraosTiebreakerView,
+) PraosTiebreakerView {
+	src.Issuer = cloneBytes(src.Issuer)
+	src.TieBreakVRF = cloneBytes(src.TieBreakVRF)
+	return src
 }

--- a/chainselection/vrf_test.go
+++ b/chainselection/vrf_test.go
@@ -89,180 +89,125 @@ func TestCompareVRFOutputs(t *testing.T) {
 	}
 }
 
-func TestCompareChainsWithVRF(t *testing.T) {
-	testCases := []struct {
-		name            string
-		tipA            ochainsync.Tip
-		tipB            ochainsync.Tip
-		blocksInWindowA uint64
-		blocksInWindowB uint64
-		vrfA            []byte
-		vrfB            []byte
-		expected        ChainComparisonResult
-	}{
-		{
-			name: "higher block number wins regardless of VRF",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 40,
-			},
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            make64ByteVRF(0xFF), // Higher VRF
-			vrfB:            make64ByteVRF(0x00), // Lower VRF
-			expected:        ChainABetter,        // Block number wins over VRF
-		},
-		{
-			name: "equal block number - higher density wins regardless of VRF",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 100,                 // Higher density
-			blocksInWindowB: 80,                  // Lower density
-			vrfA:            make64ByteVRF(0xFF), // Higher VRF
-			vrfB:            make64ByteVRF(0x00), // Lower VRF
-			expected:        ChainABetter,        // Density wins over VRF
-		},
-		{
-			name: "equal block number and density - VRF tie-breaker A wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            make64ByteVRF(0x00), // Lower VRF wins
-			vrfB:            make64ByteVRF(0xFF),
-			expected:        ChainABetter,
-		},
-		{
-			name: "equal block number and density - VRF tie-breaker B wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            make64ByteVRF(0xFF), // Higher VRF loses
-			vrfB:            make64ByteVRF(0x00), // Lower VRF wins
-			expected:        ChainBBetter,
-		},
-		{
-			name: "equal VRF - falls back to slot comparison A wins",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90},
-				BlockNumber: 50,
-			}, // Lower slot
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			}, // Higher slot
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            make64ByteVRF(0x50),
-			vrfB:            make64ByteVRF(0x50), // Equal VRF
-			expected:        ChainABetter,        // Lower slot wins
-		},
-		{
-			name: "nil VRF - falls back to slot comparison",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            nil,
-			vrfB:            nil,
-			expected:        ChainABetter, // Lower slot wins as fallback
-		},
-		{
-			name: "one nil VRF - falls back to slot comparison",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 90},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            make64ByteVRF(0x00), // Has VRF but B is nil
-			vrfB:            nil,
-			expected:        ChainBBetter, // B has lower slot, VRF comparison skipped
-		},
-		{
-			name: "completely equal chains",
-			tipA: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			tipB: ochainsync.Tip{
-				Point:       ocommon.Point{Slot: 100},
-				BlockNumber: 50,
-			},
-			blocksInWindowA: 100,
-			blocksInWindowB: 100,
-			vrfA:            make64ByteVRF(0x50),
-			vrfB:            make64ByteVRF(0x50),
-			expected:        ChainEqual,
-		},
+func TestComparePraosTipsVRFPrecedesSlot(t *testing.T) {
+	lowerSlotHigherVRF := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 111962097, Hash: []byte("ours")},
+		BlockNumber: 4275844,
+	}
+	laterSlotLowerVRF := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 111962102, Hash: []byte("candidate")},
+		BlockNumber: 4275844,
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := CompareChainsWithVRF(
-				tc.tipA, tc.tipB,
-				tc.blocksInWindowA, tc.blocksInWindowB,
-				tc.vrfA, tc.vrfB,
-			)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
+	result := ComparePraosTips(
+		lowerSlotHigherVRF,
+		laterSlotLowerVRF,
+		PraosTiebreakerViewFromTip(
+			lowerSlotHigherVRF,
+			make64ByteVRFFirstByte(0xBD),
+			PraosTiebreakerConfigConway(),
+		),
+		PraosTiebreakerViewFromTip(
+			laterSlotLowerVRF,
+			make64ByteVRFFirstByte(0x6E),
+			PraosTiebreakerConfigConway(),
+		),
+	)
+
+	assert.Equal(
+		t,
+		ChainBBetter,
+		result,
+		"equal-height Praos comparison must use VRF before slot",
+	)
 }
 
-func TestIsBetterChainWithVRF(t *testing.T) {
-	// Test that IsBetterChainWithVRF correctly wraps CompareChainsWithVRF
-	newTip := ochainsync.Tip{Point: ocommon.Point{Slot: 100}, BlockNumber: 50}
-	currentTip := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 100},
+func TestComparePraosTipsDoesNotInventFallbackWithoutVRF(t *testing.T) {
+	lowerSlot := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 90, Hash: []byte("lower-slot")},
+		BlockNumber: 50,
+	}
+	higherSlot := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("higher-slot")},
 		BlockNumber: 50,
 	}
 
-	// New chain has lower VRF - should be better
-	assert.True(t, IsBetterChainWithVRF(
-		newTip, currentTip,
-		100, 100, // Equal density
-		make64ByteVRF(0x00), make64ByteVRF(0xFF), // New has lower VRF
-	))
+	result := ComparePraosTips(
+		lowerSlot,
+		higherSlot,
+		PraosTiebreakerViewFromTip(
+			lowerSlot,
+			nil,
+			PraosTiebreakerConfigConway(),
+		),
+		PraosTiebreakerViewFromTip(
+			higherSlot,
+			nil,
+			PraosTiebreakerConfigConway(),
+		),
+	)
 
-	// New chain has higher VRF - should not be better
-	assert.False(t, IsBetterChainWithVRF(
-		newTip, currentTip,
-		100, 100, // Equal density
-		make64ByteVRF(0xFF), make64ByteVRF(0x00), // New has higher VRF
-	))
+	assert.Equal(t, ChainEqual, result)
+}
+
+func TestComparePraosTipsConwayRestrictionDisarmsDistantVRF(t *testing.T) {
+	ours := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("ours")},
+		BlockNumber: 50,
+	}
+	candidate := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 106, Hash: []byte("candidate")},
+		BlockNumber: 50,
+	}
+
+	result := ComparePraosTips(
+		ours,
+		candidate,
+		PraosTiebreakerViewFromTip(
+			ours,
+			make64ByteVRFFirstByte(0xBD),
+			PraosTiebreakerConfigConway(),
+		),
+		PraosTiebreakerViewFromTip(
+			candidate,
+			make64ByteVRFFirstByte(0x6E),
+			PraosTiebreakerConfigConway(),
+		),
+	)
+
+	assert.Equal(t, ChainEqual, result)
+}
+
+func TestComparePraosTipsSameIssuerSlotHigherOCertWins(t *testing.T) {
+	ours := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("ours")},
+		BlockNumber: 50,
+	}
+	candidate := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("candidate")},
+		BlockNumber: 50,
+	}
+	issuer := []byte("issuer")
+	oursView := PraosTiebreakerViewFromTip(
+		ours,
+		make64ByteVRFFirstByte(0xAA),
+		PraosTiebreakerConfigConway(),
+	)
+	oursView.Issuer = issuer
+	oursView.IssueNo = 1
+	oursView.hasIssuerAndIssue = true
+	candidateView := PraosTiebreakerViewFromTip(
+		candidate,
+		make64ByteVRFFirstByte(0xAA),
+		PraosTiebreakerConfigConway(),
+	)
+	candidateView.Issuer = issuer
+	candidateView.IssueNo = 2
+	candidateView.hasIssuerAndIssue = true
+
+	result := ComparePraosTips(ours, candidate, oursView, candidateView)
+
+	assert.Equal(t, ChainBBetter, result)
 }
 
 func TestCompareVRFOutputs_InvalidLength(t *testing.T) {
@@ -330,37 +275,28 @@ func TestCompareVRFOutputs_InvalidLength(t *testing.T) {
 	}
 }
 
-// TestGetVRFOutput_ByronReturnsNil pins the cross-era no-tiebreaker
-// invariant for Byron↔Shelley boundaries. Byron blocks have no VRF
-// (PBFT, not Praos), so any chain-selection tie that includes a Byron
-// tip must NOT use a VRF-derived field. The defense in dingo lives in
-// two layers:
-//
-//  1. GetVRFOutput's default branch returns nil for any header type it
-//     does not recognise — Byron is intentionally absent from the type
-//     switch.
-//  2. CompareVRFOutputs treats nil/wrong-length as ChainEqual, falling
-//     through to the connection-id tiebreak in selector.go.
-//
-// Together these implement the same semantic as Haskell's
-// Cardano/CanHardFork.hs:hardForkChainSel, which is `NoTiebreakerAcrossEras`
-// for Byron↔Shelley and `SameTiebreakerAcrossEras` (PraosTiebreakerView)
-// for inter-Shelley boundaries. This test pins layer 1 explicitly via a
-// real Byron header value, so a future addition to GetVRFOutput's switch
-// (e.g. a "Byron returns h.something" case introduced by mistake) fails
-// loudly. The existing nil-VRF cases in TestCompareVRFOutputs cover
-// layer 2.
+// TestGetVRFOutput_ByronReturnsNil pins the cross-era no-tiebreaker invariant
+// for Byron<->Shelley boundaries. Byron blocks have no VRF (PBFT, not Praos),
+// so any chain-selection tie that includes a Byron tip must not use a
+// VRF-derived field. The reference implementation uses
+// NoTiebreakerAcrossEras at Byron<->Shelley.
 func TestGetVRFOutput_ByronReturnsNil(t *testing.T) {
 	byronHeader := &byron.ByronMainBlockHeader{}
 	assert.Nil(t, GetVRFOutput(byronHeader),
 		"Byron headers must yield nil VRF output (no VRF in PBFT)")
 
 	shelleyHeader := &shelley.ShelleyBlockHeader{}
-	cmp := CompareHeaders(byronHeader, shelleyHeader)
+	cmp := CompareVRFOutputs(
+		GetVRFOutput(byronHeader),
+		GetVRFOutput(shelleyHeader),
+	)
 	assert.Equal(t, ChainEqual, cmp,
 		"a tie that includes a Byron tip must not be broken by VRF "+
-			"(NoTiebreakerAcrossEras at Byron↔Shelley)")
-	cmp = CompareHeaders(shelleyHeader, byronHeader)
+			"(NoTiebreakerAcrossEras at Byron<->Shelley)")
+	cmp = CompareVRFOutputs(
+		GetVRFOutput(shelleyHeader),
+		GetVRFOutput(byronHeader),
+	)
 	assert.Equal(t, ChainEqual, cmp,
 		"NoTiebreakerAcrossEras must be symmetric")
 }

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -39,7 +39,13 @@ func (d *MetadataStoreMysql) GetPool(
 	result := db.
 		Preload(
 			"Registration",
-			func(db *gorm.DB) *gorm.DB { return db.Order("added_slot DESC, id DESC").Limit(1) },
+			func(db *gorm.DB) *gorm.DB {
+				return db.Select("pool_registration.*").
+					Joins("LEFT JOIN certs ON certs.id = pool_registration.certificate_id").
+					Joins("LEFT JOIN transaction ON transaction.id = certs.transaction_id").
+					Order("pool_registration.added_slot DESC, COALESCE(transaction.block_index, 0) DESC, COALESCE(certs.cert_index, 0) DESC").
+					Limit(1)
+			},
 		).
 		Preload("Registration.Owners").
 		Preload("Registration.Relays").

--- a/internal/test/devnet/configurator.sh
+++ b/internal/test/devnet/configurator.sh
@@ -170,7 +170,23 @@ for pool in $pools; do
   config_config_json "$pool"
 done
 
-# Test-only credentials: relax permissions so consuming containers running as
-# non-root (e.g. the dingo image runs as uid 100) can read pool keys and
-# genesis/config files.
-chmod -R a+rX /configs
+# Test-only credentials: make config + genesis files world-readable so any
+# consuming container's user can read them.
+find /configs -type d -exec chmod 0755 {} +
+find /configs -type f -exec chmod 0644 {} +
+
+# cardano-node refuses to start when vrf.skey has "other" read permissions,
+# so the per-pool keys directories must be 0700/0600. Pool 1 is consumed by
+# the dingo container (uid 100, gid 101 in the dingo image), so chown it to
+# match. Pool 2 stays root-owned for the cardano-producer container, which
+# runs as root.
+for pool_dir in /configs/[0-9]*; do
+    keys_dir="$pool_dir/keys"
+    if [ -d "$keys_dir" ]; then
+        chmod 0700 "$keys_dir"
+        find "$keys_dir" -type f -exec chmod 0600 {} +
+    fi
+done
+if [ -d /configs/1/keys ]; then
+    chown -R 100:101 /configs/1/keys
+fi

--- a/internal/test/devnet/harness.go
+++ b/internal/test/devnet/harness.go
@@ -215,6 +215,39 @@ func (h *TestHarness) WaitForNodeSlot(
 	)
 }
 
+// WaitForNodeBlockAbove polls a specific endpoint until it reports a chain
+// tip above minBlock, or the timeout expires. This waits for selected-chain
+// growth without assuming the block number will be greater at an arbitrary
+// slot boundary; competing producers may validly trigger rollbacks first.
+func (h *TestHarness) WaitForNodeBlockAbove(
+	endpoint NodeEndpoint,
+	minBlock uint64,
+	timeout time.Duration,
+) ChainTip {
+	h.t.Helper()
+	var lastTip ChainTip
+	require.Eventually(h.t, func() bool {
+		tip, err := h.GetChainTip(endpoint)
+		if err != nil {
+			h.t.Logf(
+				"WaitForNodeBlockAbove: error querying %s: %v",
+				endpoint.Name, err,
+			)
+			return false
+		}
+		lastTip = tip
+		h.t.Logf(
+			"WaitForNodeBlockAbove: %s at slot %d, block %d",
+			endpoint.Name, tip.SlotNumber, tip.BlockNumber,
+		)
+		return tip.BlockNumber > minBlock
+	}, timeout, 2*time.Second,
+		"%s did not advance beyond block %d within %s",
+		endpoint.Name, minBlock, timeout,
+	)
+	return lastTip
+}
+
 // VerifyChainConsensus polls all nodes until their chain tips are within
 // slotTolerance of each other, or the timeout expires. This accounts for
 // propagation delays and temporary divergence during catch-up.

--- a/internal/test/devnet/scenarios/basic_forging_test.go
+++ b/internal/test/devnet/scenarios/basic_forging_test.go
@@ -31,7 +31,7 @@ import (
 //  1. Connects to all 3 nodes (dingo-producer, cardano-producer, cardano-relay)
 //  2. Waits for Dingo to advance past genesis (bootstrap grace period)
 //  3. Waits for the chain to advance 10 slots beyond the current tip
-//  4. Verifies that Dingo forged at least one block (chain tip advances)
+//  4. Verifies that Dingo's selected chain advances
 //  5. Verifies that all nodes agree on the chain tip within tolerance
 func TestBasicBlockForging(t *testing.T) {
 	cfg, err := devnet.LoadDevNetConfig()
@@ -84,15 +84,19 @@ func TestBasicBlockForging(t *testing.T) {
 	h.WaitForNodeSlot(dingoEndpoint, targetSlot, slotTimeout)
 	t.Logf("Dingo has reached slot %d", targetSlot)
 
-	// Step 5: Verify Dingo forged at least one block
-	dingoTip, err := h.GetChainTip(dingoEndpoint)
-	require.NoError(t, err, "failed to get Dingo chain tip after wait")
-	t.Logf(
-		"Dingo tip after wait: slot=%d block=%d",
-		dingoTip.SlotNumber, dingoTip.BlockNumber,
+	// Step 5: Verify Dingo's selected chain advances. Valid Praos
+	// tiebreaks may roll back an early local block and leave the selected
+	// chain at the same block height at the target slot, so wait for
+	// eventual height growth instead of sampling once.
+	growthTimeout := cfg.ExpectedBlockTime() * 20
+	dingoTip := h.WaitForNodeBlockAbove(
+		dingoEndpoint,
+		initialTip.BlockNumber,
+		growthTimeout,
 	)
-	require.Greater(t, dingoTip.BlockNumber, initialTip.BlockNumber,
-		"Dingo producer should have forged at least one block",
+	t.Logf(
+		"Dingo tip after growth: slot=%d block=%d",
+		dingoTip.SlotNumber, dingoTip.BlockNumber,
 	)
 
 	// Step 6: Verify all nodes converge within 3*securityParam slots.
@@ -108,7 +112,7 @@ func TestBasicBlockForging(t *testing.T) {
 }
 
 // TestDingoChainAdvances is a simpler test that just verifies
-// the Dingo node's chain is advancing (forging blocks).
+// the Dingo node's selected chain is advancing.
 func TestDingoChainAdvances(t *testing.T) {
 	cfg, err := devnet.LoadDevNetConfig()
 	require.NoError(t, err, "failed to load devnet config from testnet.yaml")
@@ -136,14 +140,19 @@ func TestDingoChainAdvances(t *testing.T) {
 		cfg.ExpectedBlockTime()*5
 	h.WaitForNodeSlot(dingoEndpoint, targetSlot, slotTimeout)
 
-	// Verify chain advanced
-	newTip, err := h.GetChainTip(dingoEndpoint)
-	require.NoError(t, err, "failed to get new tip")
+	// Verify selected-chain height advances. Do not require the block
+	// number to be greater at a single target slot: Praos selection
+	// compatible with the reference implementation can roll back an early
+	// block in favor of an equal-height lower-VRF competitor before the
+	// chain grows again.
+	growthTimeout := cfg.ExpectedBlockTime() * 20
+	newTip := h.WaitForNodeBlockAbove(
+		dingoEndpoint,
+		initialTip.BlockNumber,
+		growthTimeout,
+	)
 	require.Greater(t, newTip.SlotNumber, initialTip.SlotNumber,
 		"Dingo chain should have advanced",
-	)
-	require.Greater(t, newTip.BlockNumber, initialTip.BlockNumber,
-		"Dingo should have forged new blocks",
 	)
 
 	t.Logf(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1293,6 +1293,109 @@ func pointMatches(a, b ocommon.Point) bool {
 	return a.Slot == b.Slot && bytes.Equal(a.Hash, b.Hash)
 }
 
+func observedHeaderTip(e ChainsyncEvent) ochainsync.Tip {
+	if e.BlockHeader == nil {
+		return e.Tip
+	}
+	return ochainsync.Tip{
+		Point:       e.Point,
+		BlockNumber: e.BlockHeader.BlockNumber(),
+	}
+}
+
+func (ls *LedgerState) localTipPraosView(
+	localTip ochainsync.Tip,
+) chainselection.PraosTiebreakerView {
+	if ls == nil || ls.db == nil || len(localTip.Point.Hash) == 0 {
+		return chainselection.PraosTiebreakerView{}
+	}
+	block, err := database.BlockByHash(ls.db, localTip.Point.Hash)
+	if err != nil {
+		if ls.config.Logger != nil {
+			ls.config.Logger.Debug(
+				"local tip Praos view unavailable: block lookup failed",
+				"component", "ledger",
+				"slot", localTip.Point.Slot,
+				"hash", hex.EncodeToString(localTip.Point.Hash),
+				"error", err,
+			)
+		}
+		return chainselection.PraosTiebreakerView{}
+	}
+	decoded, err := block.Decode()
+	if err != nil {
+		if ls.config.Logger != nil {
+			ls.config.Logger.Debug(
+				"local tip Praos view unavailable: block decode failed",
+				"component", "ledger",
+				"slot", localTip.Point.Slot,
+				"hash", hex.EncodeToString(localTip.Point.Hash),
+				"error", err,
+			)
+		}
+		return chainselection.PraosTiebreakerView{}
+	}
+	if decoded == nil {
+		return chainselection.PraosTiebreakerView{}
+	}
+	view, _ := chainselection.GetPraosTiebreakerView(decoded.Header())
+	return view
+}
+
+func (ls *LedgerState) compareIncomingHeaderToLocalTip(
+	e ChainsyncEvent,
+	localTip ochainsync.Tip,
+) chainselection.ChainComparisonResult {
+	observedTip := observedHeaderTip(e)
+	if observedTip.BlockNumber == 0 && e.Tip.BlockNumber > 0 {
+		observedTip = e.Tip
+	}
+
+	incomingView, _ := chainselection.GetPraosTiebreakerView(e.BlockHeader)
+	result := chainselection.ComparePraosTips(
+		observedTip,
+		localTip,
+		incomingView,
+		ls.localTipPraosView(localTip),
+	)
+	if result != chainselection.ChainEqual {
+		return result
+	}
+
+	// If the peer has advertised a further tip than the header just delivered,
+	// use that only when block number alone decides the comparison. We do not
+	// have the advertised tip's Praos select view until its header arrives.
+	if e.Tip.BlockNumber > observedTip.BlockNumber {
+		switch {
+		case e.Tip.BlockNumber > localTip.BlockNumber:
+			return chainselection.ChainABetter
+		case e.Tip.BlockNumber < localTip.BlockNumber:
+			return chainselection.ChainBBetter
+		}
+	}
+	return result
+}
+
+func (ls *LedgerState) earlierHeaderCanBeatLocalTip(
+	e ChainsyncEvent,
+	localTip ochainsync.Tip,
+) bool {
+	observedTip := observedHeaderTip(e)
+	if observedTip.BlockNumber > localTip.BlockNumber {
+		return true
+	}
+	if observedTip.BlockNumber < localTip.BlockNumber {
+		return false
+	}
+	incomingView, _ := chainselection.GetPraosTiebreakerView(e.BlockHeader)
+	return chainselection.ComparePraosTips(
+		observedTip,
+		localTip,
+		incomingView,
+		ls.localTipPraosView(localTip),
+	) == chainselection.ChainABetter
+}
+
 type LocalRollbackRecoveryResult struct {
 	Recovered           bool
 	SkipConnectionClose bool
@@ -1554,20 +1657,19 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		var notFitErr chain.BlockNotFitChainTipError
 		if errors.As(err, &notFitErr) {
 			localTip := ls.chain.Tip()
-			// A header strictly behind the local tip is genuinely
-			// stale and can be dropped. A header AT the same slot
-			// as the local tip with a different hash is a slot
-			// battle — both pools forged at the same slot — and
-			// must fall through to the fork-resolution path so
-			// chainselection's tiebreak picks a side. Treating
-			// equal-slot mismatches as stale here drops the peer's
-			// forge before tryResolveFork ever sees it, locks
-			// dingo onto whichever block it adopted first, and
-			// diverges the chain from peers that resolved the
-			// same battle the other way; that drift then folds
-			// into the evolving nonce and breaks header
-			// verification at the next epoch boundary.
-			if e.Point.Slot < localTip.Point.Slot {
+			// A header behind the local tip is stale only if the
+			// Praos comparison also says it cannot beat the local
+			// tip. At equal block number, cardano-node resolves the
+			// fork by Praos select view, even when the winning
+			// header is at an earlier slot. Without both select
+			// views, keep the old stale behavior for earlier-slot
+			// headers and let a future observed header prove the
+			// advertised tip.
+			if e.Point.Slot < localTip.Point.Slot &&
+				!ls.earlierHeaderCanBeatLocalTip(
+					e,
+					localTip,
+				) {
 				ls.config.Logger.Debug(
 					"ignoring stale roll forward behind local tip",
 					"component", "ledger",
@@ -1775,16 +1877,13 @@ func (ls *LedgerState) tryResolveFork(
 	notFitErr chain.BlockNotFitChainTipError,
 ) (bool, error) {
 	// Only resolve forks when the peer's chain is genuinely better than
-	// ours per Praos rules (longer wins; at equal length, lower slot wins).
-	// A bare slot comparison would force a rollback whenever the peer's tip
-	// happens to land on a later slot — even when the two chains have the
-	// same block count and our local tip is at the lower (denser) slot, in
-	// which case Praos says we should keep ours. With two block producers
-	// this misorders fork resolution: every locally-forged block forks at
-	// the same length as the peer's, the peer's later-slot tip wins the
-	// gate here, and the local block is rolled back.
+	// ours per Praos rules. Longer chains win first; at equal length,
+	// cardano-node uses the Praos VRF tiebreaker, not a lower-slot rule.
 	localTip := ls.chain.Tip()
-	if !chainselection.IsBetterChain(e.Tip, localTip) {
+	if ls.compareIncomingHeaderToLocalTip(
+		e,
+		localTip,
+	) != chainselection.ChainABetter {
 		return false, nil
 	}
 

--- a/ledger/chainsync_slot_battle_test.go
+++ b/ledger/chainsync_slot_battle_test.go
@@ -51,7 +51,8 @@ import (
 // before incrementing headerMismatchCount or invoking tryResolveFork.
 // Asserting that headerMismatchCount becomes 1 demonstrates the
 // header took the not-stale branch and reached the fork-resolution
-// gate where chainselection can pick the rule-3 lower-hash winner.
+// gate where chainselection can apply the reference implementation's
+// Praos select-view rules.
 func TestHandleEventChainsyncBlockHeaderRoutesSlotBattleToForkResolution(
 	t *testing.T,
 ) {
@@ -118,10 +119,10 @@ func TestHandleEventChainsyncBlockHeaderRoutesSlotBattleToForkResolution(
 	//     peer's competing header → chain.Tip() moves off the
 	//     original currentTip; chainsyncState flips to
 	//     RollbackChainsyncState.
-	//   - declines via IsBetterChain (peer not better under the
-	//     rule-3 lower-hash tiebreak) → headerMismatchCount stays at
-	//     1 because nothing in tryResolveFork's success branches
-	//     reset it.
+	//   - declines because the reference implementation's Praos
+	//     equal-length tiebreaker is not armed for this peer/header
+	//     pair -> headerMismatchCount stays at 1 because nothing in
+	//     tryResolveFork's success branches reset it.
 	//
 	// The stale-drop early return takes neither path: chain stays
 	// put, chainsyncState stays SyncingChainsyncState, AND

--- a/ledger/forging/bootstrap_forge_gate_test.go
+++ b/ledger/forging/bootstrap_forge_gate_test.go
@@ -91,9 +91,8 @@ func TestForgeSyncToleranceLargerThanShortTestnetEpoch(t *testing.T) {
 // TestChainSelectionPrefersLongerChainOverLowerSlot is the chainselection
 // half of the Shelley=0 mechanism. Once the forge gate has waved
 // dingo's leader slots through during bootstrap (above), the surviving
-// blocks are picked by Praos chain selection. The rule is "longer
-// chain wins; at equal length, lower slot wins" — so a dingo local
-// chain whose forge count lags cardano-producer's loses every fork
+// blocks are picked by Praos chain selection. Longer chain wins, so a dingo
+// local chain whose forge count lags cardano-producer's loses every fork
 // resolution regardless of how low its tip slot is.
 //
 // Concretely: dingo joins late, forges one block at slot 5; chainsync
@@ -121,16 +120,25 @@ func TestChainSelectionPrefersLongerChainOverLowerSlot(t *testing.T) {
 
 	require.Truef(
 		t,
-		chainselection.IsBetterChain(cardanoIncomingTip, dingoLocalTip),
+		chainselection.ComparePraosTips(
+			cardanoIncomingTip,
+			dingoLocalTip,
+			chainselection.PraosTiebreakerView{},
+			chainselection.PraosTiebreakerView{},
+		) == chainselection.ChainABetter,
 		"cardano's longer (block_number=3) chain must beat dingo's "+
 			"local (block_number=1) chain even though dingo's tip "+
-			"slot is lower (%d < %d). The lower-slot tie-breaker "+
-			"only fires at EQUAL block count.",
+			"slot is lower (%d < %d).",
 		dingoLocalTip.Point.Slot, cardanoIncomingTip.Point.Slot,
 	)
 	require.Falsef(
 		t,
-		chainselection.IsBetterChain(dingoLocalTip, cardanoIncomingTip),
+		chainselection.ComparePraosTips(
+			dingoLocalTip,
+			cardanoIncomingTip,
+			chainselection.PraosTiebreakerView{},
+			chainselection.PraosTiebreakerView{},
+		) == chainselection.ChainABetter,
 		"dingo's local chain at lower slot but fewer blocks must "+
 			"NOT win against cardano's longer chain. If it did, "+
 			"dingo would entrench a forked solo-extension chain "+

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -31,6 +31,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/vrf"
 )
 
+var ErrVRFKeyHashMismatch = errors.New("VRF key hash mismatch")
+
 // PoolCredentials holds the cryptographic keys required for block production.
 // All keys are loaded using Bursa from standard cardano-cli format files.
 // Fields are unexported to enforce thread-safe access via the mutex.
@@ -466,8 +468,9 @@ type LedgerView interface {
 //     matched our loaded VRF verification key. False otherwise (also
 //     false when registered is false or the VRF verification key is
 //     unavailable, e.g. for a seed-only VRF skey).
-//   - err: a non-nil error means the node should refuse to start. Used
-//     for VRF mismatch and stale opcert counter.
+//   - err: a non-nil error means the ledger view disagrees with the
+//     loaded credentials. Normal networks refuse startup for these;
+//     devnet callers may choose to warn on ErrVRFKeyHashMismatch.
 func (pc *PoolCredentials) ValidateAgainstLedger(
 	view LedgerView,
 ) (registered, vrfMatched bool, err error) {
@@ -490,11 +493,18 @@ func (pc *PoolCredentials) ValidateAgainstLedger(
 	if !found {
 		return false, false, nil
 	}
+	if regVRF == ([32]byte{}) {
+		// Fresh devnets and partially bootstrapped ledgers can expose a
+		// placeholder pool row before a trustworthy VRF hash is available.
+		// Treat that like "not registered yet" so startup can continue.
+		return false, false, nil
+	}
 	if pc.vrfVKey != nil {
 		ourVRF := lcommon.Blake2b256Hash(pc.vrfVKey)
 		if ourVRF != regVRF {
 			return true, false, fmt.Errorf(
-				"VRF key hash mismatch: pool registration has %x but loaded VRF key hashes to %x",
+				"%w: pool registration has %x but loaded VRF key hashes to %x",
+				ErrVRFKeyHashMismatch,
 				regVRF, ourVRF,
 			)
 		}

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -747,8 +748,29 @@ func TestValidateAgainstLedger_VRFMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected mismatch error")
 	}
+	if !errors.Is(err, ErrVRFKeyHashMismatch) {
+		t.Errorf("expected ErrVRFKeyHashMismatch, got: %v", err)
+	}
 	if !strings.Contains(err.Error(), "VRF key hash mismatch") {
 		t.Errorf("expected mismatch in error, got: %v", err)
+	}
+}
+
+func TestValidateAgainstLedger_ZeroVRFHashIsUnknown(t *testing.T) {
+	pc := newCredsForLedger(t)
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: [32]byte{},
+	}
+	registered, matched, err := pc.ValidateAgainstLedger(view)
+	if err != nil {
+		t.Errorf("ValidateAgainstLedger: %v", err)
+	}
+	if registered || matched {
+		t.Errorf("expected registered=false, matched=false; got %v %v", registered, matched)
+	}
+	if view.calledSeq {
+		t.Error("opcert sequence lookup should be skipped when VRF hash is unknown")
 	}
 }
 
@@ -795,9 +817,9 @@ func TestValidateAgainstLedger_OpCertEqualOrAhead(t *testing.T) {
 	// Equal counter is fine; ahead-of-ledger is fine (the ledger may
 	// just not have observed our latest opcert yet).
 	cases := []struct {
-		name       string
-		ourSeq     uint64
-		ledgerSeq  uint64
+		name      string
+		ourSeq    uint64
+		ledgerSeq uint64
 	}{
 		{"equal", 5, 5},
 		{"ahead", 6, 5},

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -960,7 +960,15 @@ func (ls *LedgerState) PoolRegistrationVRFKeyHash(
 		}
 		return [32]byte{}, false, err
 	}
-	if pool == nil || len(pool.VrfKeyHash) != 32 {
+	if pool == nil {
+		return [32]byte{}, false, nil
+	}
+	if len(pool.Registration) > 0 &&
+		len(pool.Registration[0].VrfKeyHash) == 32 {
+		copy(vrfHash[:], pool.Registration[0].VrfKeyHash)
+		return vrfHash, true, nil
+	}
+	if len(pool.VrfKeyHash) != 32 {
 		return [32]byte{}, false, nil
 	}
 	copy(vrfHash[:], pool.VrfKeyHash)

--- a/node_forging.go
+++ b/node_forging.go
@@ -106,12 +106,29 @@ func (v blockProducerLedgerView) LatestOpCertSequence(
 func (n *Node) validateBlockProducerLedger(
 	creds *forging.PoolCredentials,
 ) error {
+	view := blockProducerLedgerView{ls: n.ledgerState}
+	return n.validateBlockProducerLedgerWithView(creds, view)
+}
+
+func (n *Node) validateBlockProducerLedgerWithView(
+	creds *forging.PoolCredentials,
+	view forging.LedgerView,
+) error {
 	if creds == nil {
 		return errors.New("nil pool credentials")
 	}
-	view := blockProducerLedgerView{ls: n.ledgerState}
 	registered, vrfMatched, err := creds.ValidateAgainstLedger(view)
 	if err != nil {
+		if errors.Is(err, forging.ErrVRFKeyHashMismatch) &&
+			n.config.network == "devnet" {
+			n.config.logger.Warn(
+				"devnet block producer VRF cross-check failed; node will continue",
+				"component", "node",
+				"pool_id", creds.GetPoolID().String(),
+				"error", err,
+			)
+			return nil
+		}
 		return err
 	}
 	poolID := creds.GetPoolID().String()

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -15,6 +15,7 @@
 package dingo
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/ledger/forging"
 )
 
 // devnetKeysDir locates the credential fixtures shipped with the repo.
@@ -142,5 +144,72 @@ func TestValidateBlockProducerStartup_MissingFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "load pool credentials") {
 		t.Errorf("expected 'load pool credentials' in error, got: %v", err)
+	}
+}
+
+type testBlockProducerLedgerView struct {
+	registered bool
+	regVRFHash [32]byte
+}
+
+func (v testBlockProducerLedgerView) PoolRegistrationVRFKeyHash(
+	[28]byte,
+) ([32]byte, bool, error) {
+	return v.regVRFHash, v.registered, nil
+}
+
+func (v testBlockProducerLedgerView) LatestOpCertSequence(
+	[28]byte,
+) (uint64, bool, error) {
+	return 0, false, nil
+}
+
+func mismatchedVRFHash() [32]byte {
+	var h [32]byte
+	for i := range h {
+		h[i] = 0xdd
+	}
+	return h
+}
+
+func TestValidateBlockProducerLedger_NonDevnetVRFMismatchIsFatal(t *testing.T) {
+	vrf, kes, opcert := devnetCredPaths()
+	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
+	n.config.network = "preview"
+	creds, err := n.validateBlockProducerStartup()
+	if err != nil {
+		t.Fatalf("validateBlockProducerStartup: %v", err)
+	}
+	err = n.validateBlockProducerLedgerWithView(
+		creds,
+		testBlockProducerLedgerView{
+			registered: true,
+			regVRFHash: mismatchedVRFHash(),
+		},
+	)
+	if !errors.Is(err, forging.ErrVRFKeyHashMismatch) {
+		t.Fatalf("expected VRF mismatch error, got: %v", err)
+	}
+}
+
+func TestValidateBlockProducerLedger_DevnetVRFMismatchWarns(t *testing.T) {
+	vrf, kes, opcert := devnetCredPaths()
+	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
+	n.config.network = "devnet"
+	creds, err := n.validateBlockProducerStartup()
+	if err != nil {
+		t.Fatalf("validateBlockProducerStartup: %v", err)
+	}
+	err = n.validateBlockProducerLedgerWithView(
+		creds,
+		testBlockProducerLedgerView{
+			registered: true,
+			regVRFHash: mismatchedVRFHash(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("devnet mismatch should warn and continue: %v", err)
 	}
 }

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -537,6 +537,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// selection tie-breaking (used in both dedup and normal
 		// paths below).
 		vrfOutput := chainselection.GetVRFOutput(v)
+		praosView, _ := chainselection.GetPraosTiebreakerView(v)
 		// Ingress eligibility is the sole gate for feeding the ledger
 		// and chain selection. reconcileChainsyncIngressAdmission
 		// defers to ChainsyncIngressEligible (peergov), which already
@@ -594,6 +595,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 						Tip:          tip,
 						ObservedTip:  observedTip,
 						VRFOutput:    vrfOutput,
+						PraosView:    praosView,
 					},
 				),
 			)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Praos chain selection with cardano-node. Equal-length forks now use opcert issue number and VRF (Conway restricts VRF to 5-slot distance), removing slot/density/hash fallbacks and preventing nonce drift and stale fork preference.

- **Bug Fixes**
  - Added `ComparePraosTips` with reference rules: higher block count first; at equal length: same issuer+slot prefers higher opcert issue; otherwise compare VRF when the era’s flavor is armed (Conway: max 5-slot distance).
  - Removed slot/density/lower-hash tie-breakers; when the reference tiebreaker isn’t armed, equal-length chains compare equal and the incumbent is kept.
  - Propagated `PraosTiebreakerView` from `chainsync` headers through `ledger` to `chainselection` so earlier headers aren’t dropped as stale when VRF can win; fork resolution now matches the reference select-view.
  - Selector switches to any longer chain (including 1-block leads); for the same selected block, peer choice falls back to connection priority and `BlockfetchLatency` only.
  - VRF cross-checks: treat a zero VRF hash as “unknown”; VRF key hash mismatch now warns on `devnet` instead of aborting; configurator fixes permissions (configs world-readable; pool key dirs 0700/0600, pool 1 chowned for the `dingo` container).
  - Database/ledger: fixed pool registration preload ordering to pick the latest registration for VRF/opcert; `ledger` reads the VRF hash from the latest registration row when present.

- **Migration**
  - Replace removed `CompareChains*`/`IsBetterChain*` helpers with `ComparePraosTips`.
  - Provide a `PraosTiebreakerView` via `GetPraosTiebreakerView(header)` or `PraosTiebreakerViewFromTip(tip, vrf, PraosTiebreakerConfig*)` (use `PraosTiebreakerConfigConway()` in Conway; otherwise `PraosTiebreakerConfigBeforeConway()` or unknown when the era isn’t known).
  - `ChainSelectorConfig.MinSwitchBlockDiff` is removed.

<sup>Written for commit c03d8a7377aa14384a5d955b709257789cdbcf4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced chain selection algorithm using Ouroboros Praos rules with improved tie-breaking logic (longer chain preference, VRF-based precedence).
  * Improved block synchronization validation with more robust chain advancement detection.

* **Bug Fixes**
  * Enhanced VRF key hash validation with better error handling for mismatched credentials.
  * More reliable chain fork resolution based on updated consensus rules.

* **Tests**
  * Updated test suite to verify new chain selection behavior and improved block synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2252)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->