### PR TITLE
fix(ouroboros): drop connections on k rejections

### DIFF
--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -24,6 +24,20 @@ import (
 // or rollback exceeds the security parameter).
 const ChainsyncResyncEventType = EventType("chainsync.resync")
 
+const (
+	ChainsyncResyncReasonLocalTipPlateau              = "local_tip_plateau"
+	ChainsyncResyncReasonPostPlateauRealign           = "post_plateau_realign"
+	ChainsyncResyncReasonRollbackAhead                = "rollback point ahead of local tip"
+	ChainsyncResyncReasonRollbackNotFound             = "rollback point not found"
+	ChainsyncResyncReasonRollbackLoop                 = "rollback loop detected"
+	ChainsyncResyncReasonPersistentFork               = "persistent chain fork"
+	ChainsyncResyncReasonRollbackExceedsK             = "rollback exceeds security parameter K"
+	ChainsyncResyncReasonForkResolutionExceedsK       = "fork resolution exceeds security parameter K"
+	ChainsyncResyncReasonLocalLedgerRollback          = "local ledger rollback"
+	ChainsyncResyncReasonLiveTxValidationRecovery     = "live tx validation recovery"
+	ChainsyncResyncReasonBlockfetchTimeoutRetryFailed = "blockfetch timeout retry failed on all available connections"
+)
+
 // ChainsyncResyncEvent carries the connection ID that should
 // be re-synced.
 type ChainsyncResyncEvent struct {

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -116,11 +116,6 @@ const (
 	// in multi-producer networks where short forks are expected.
 	headerMismatchResyncThreshold = 20
 
-	// Chainsync re-sync reasons
-	resyncReasonRollbackAhead    = "rollback point ahead of local tip"
-	resyncReasonRollbackNotFound = "rollback point not found"
-	resyncReasonRollbackLoop     = "rollback loop detected"
-
 	maxPeerHeaderHistoryPerConn = 256
 )
 
@@ -180,7 +175,7 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 							event.ChainsyncResyncEventType,
 							event.ChainsyncResyncEvent{
 								ConnectionId: e.ConnectionId,
-								Reason:       resyncReasonRollbackLoop,
+								Reason:       event.ChainsyncResyncReasonRollbackLoop,
 							},
 						),
 					)
@@ -1186,7 +1181,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 					event.ChainsyncResyncEventType,
 					event.ChainsyncResyncEvent{
 						ConnectionId: e.ConnectionId,
-						Reason:       resyncReasonRollbackAhead,
+						Reason:       event.ChainsyncResyncReasonRollbackAhead,
 					},
 				),
 			)
@@ -1224,7 +1219,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 						event.ChainsyncResyncEventType,
 						event.ChainsyncResyncEvent{
 							ConnectionId: e.ConnectionId,
-							Reason:       resyncReasonRollbackNotFound,
+							Reason:       event.ChainsyncResyncReasonRollbackNotFound,
 						},
 					),
 				)
@@ -1259,7 +1254,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 						event.ChainsyncResyncEventType,
 						event.ChainsyncResyncEvent{
 							ConnectionId: e.ConnectionId,
-							Reason:       "rollback exceeds security parameter K",
+							Reason:       event.ChainsyncResyncReasonRollbackExceedsK,
 						},
 					),
 				)
@@ -1626,7 +1621,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 				)
 				ls.requestChainsyncResync(
 					e.ConnectionId,
-					"persistent chain fork",
+					event.ChainsyncResyncReasonPersistentFork,
 				)
 			}
 			return nil
@@ -1824,7 +1819,7 @@ func (ls *LedgerState) tryResolveFork(
 		)
 		ls.requestChainsyncResync(
 			e.ConnectionId,
-			resyncReasonRollbackNotFound,
+			event.ChainsyncResyncReasonRollbackNotFound,
 		)
 		return true, nil
 	}
@@ -1921,7 +1916,7 @@ func (ls *LedgerState) tryResolveFork(
 						event.ChainsyncResyncEventType,
 						event.ChainsyncResyncEvent{
 							ConnectionId: e.ConnectionId,
-							Reason:       "fork resolution exceeds security parameter K",
+							Reason:       event.ChainsyncResyncReasonForkResolutionExceedsK,
 						},
 					),
 				)
@@ -3443,7 +3438,7 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 							event.ChainsyncResyncEventType,
 							event.ChainsyncResyncEvent{
 								ConnectionId: retryConnId,
-								Reason:       "blockfetch timeout retry failed on all available connections",
+								Reason:       event.ChainsyncResyncReasonBlockfetchTimeoutRetryFailed,
 							},
 						),
 					)

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -604,7 +604,11 @@ func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
 	select {
 	case resync := <-resyncCh:
 		assert.Equal(t, fixture.connId, resync.ConnectionId)
-		assert.Equal(t, resyncReasonRollbackNotFound, resync.Reason)
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonRollbackNotFound,
+			resync.Reason,
+		)
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected chainsync resync event")
 	}
@@ -642,7 +646,11 @@ func TestRollbackPublishesChainsyncResyncAtRollbackPoint(t *testing.T) {
 
 	select {
 	case resync := <-resyncCh:
-		assert.Equal(t, "local ledger rollback", resync.Reason)
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonLocalLedgerRollback,
+			resync.Reason,
+		)
 		assert.Equal(t, fixture.ancestorTip.Point, resync.Point)
 		assert.Equal(t, ouroboros.ConnectionId{}, resync.ConnectionId)
 	case <-time.After(2 * time.Second):

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -300,7 +300,7 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 			event.NewEvent(
 				event.ChainsyncResyncEventType,
 				event.ChainsyncResyncEvent{
-					Reason: "live tx validation recovery",
+					Reason: event.ChainsyncResyncReasonLiveTxValidationRecovery,
 					Point:  rewindPoint,
 				},
 			),

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1891,7 +1891,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 			event.NewEvent(
 				event.ChainsyncResyncEventType,
 				event.ChainsyncResyncEvent{
-					Reason: "local ledger rollback",
+					Reason: event.ChainsyncResyncReasonLocalLedgerRollback,
 					Point:  point,
 				},
 			),

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -215,7 +215,7 @@ func (n *Node) processChainsyncRecyclerTick(
 								event.ChainsyncResyncEventType,
 								event.ChainsyncResyncEvent{
 									ConnectionId: *targetConn,
-									Reason:       "local_tip_plateau",
+									Reason:       event.ChainsyncResyncReasonLocalTipPlateau,
 								},
 							),
 						)
@@ -387,7 +387,7 @@ func (n *Node) realignOtherPeersAfterPlateau(
 				event.ChainsyncResyncEventType,
 				event.ChainsyncResyncEvent{
 					ConnectionId: conn.ConnId,
-					Reason:       "post_plateau_realign",
+					Reason:       event.ChainsyncResyncReasonPostPlateauRealign,
 				},
 			),
 		)

--- a/node_test.go
+++ b/node_test.go
@@ -408,7 +408,11 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 		resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
 		require.True(t, ok)
 		assert.Equal(t, activeConn, resyncEvt.ConnectionId)
-		assert.Equal(t, "local_tip_plateau", resyncEvt.Reason)
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonLocalTipPlateau,
+			resyncEvt.Reason,
+		)
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected plateau resync event")
 	}
@@ -579,13 +583,13 @@ func TestProcessChainsyncRecyclerTickRealignsOtherPeersOnPlateau(t *testing.T) {
 			resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
 			require.True(t, ok)
 			switch {
-			case resyncEvt.Reason == "local_tip_plateau" &&
+			case resyncEvt.Reason == event.ChainsyncResyncReasonLocalTipPlateau &&
 				resyncEvt.ConnectionId == stalledConn:
 				gotPlateauForStalled = true
-			case resyncEvt.Reason == "post_plateau_realign" &&
+			case resyncEvt.Reason == event.ChainsyncResyncReasonPostPlateauRealign &&
 				resyncEvt.ConnectionId == candidateConn:
 				gotRealignForCandidate = true
-			case resyncEvt.Reason == "post_plateau_realign" &&
+			case resyncEvt.Reason == event.ChainsyncResyncReasonPostPlateauRealign &&
 				resyncEvt.ConnectionId == farBehindConn:
 				t.Fatalf(
 					"unexpected realign for peer at-or-below local tip: %+v",

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -117,6 +117,20 @@ func sameConnectionId(a, b ouroboros.ConnectionId) bool {
 	return a.String() == b.String()
 }
 
+func chainsyncResyncRequiresFreshConnection(reason string) bool {
+	switch reason {
+	case event.ChainsyncResyncReasonLocalTipPlateau,
+		event.ChainsyncResyncReasonRollbackNotFound,
+		event.ChainsyncResyncReasonPersistentFork,
+		event.ChainsyncResyncReasonRollbackExceedsK,
+		event.ChainsyncResyncReasonForkResolutionExceedsK,
+		event.ChainsyncResyncReasonRollbackLoop:
+		return true
+	default:
+		return false
+	}
+}
+
 func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
 	connId ouroboros.ConnectionId,
 ) ([]ocommon.Point, error) {
@@ -967,7 +981,7 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 				connIds = append(connIds, e.ConnectionId)
 			} else if o.ChainsyncState != nil {
 				connIds = o.ChainsyncState.RewindTrackedClientsTo(e.Point)
-				if e.Reason == "local ledger rollback" &&
+				if e.Reason == event.ChainsyncResyncReasonLocalLedgerRollback &&
 					len(connIds) == 0 {
 					connIds = o.ChainsyncState.GetClientConnIds()
 				}
@@ -979,7 +993,7 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 					o.ChainsyncState.ClearSeenHeaders()
 				}
 			}
-			if e.Reason == "local ledger rollback" {
+			if e.Reason == event.ChainsyncResyncReasonLocalLedgerRollback {
 				if o.LedgerState == nil {
 					return
 				}
@@ -1039,16 +1053,14 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 			if len(connIds) == 0 {
 				return
 			}
-			// Plateau and unresolved fork events close the connection
-			// immediately rather than attempting an in-place
+			// Events that require a fresh ChainSync bearer close the
+			// connection immediately rather than attempting an in-place
 			// Stop→Start→Sync restart. Stop() blocks for up to 30s
 			// when the protocol is in MustReply state, during which
 			// no recovery can happen. Closing lets peer governance
 			// reconnect with a fresh bearer and updated intersect
 			// points.
-			if e.Reason == "local_tip_plateau" ||
-				e.Reason == "rollback point not found" ||
-				e.Reason == "persistent chain fork" {
+			if chainsyncResyncRequiresFreshConnection(e.Reason) {
 				for _, connId := range connIds {
 					if o.ChainsyncState != nil {
 						o.ChainsyncState.ClearObservedHeaderHistory(connId)
@@ -1061,7 +1073,7 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 						continue
 					}
 					o.config.Logger.Info(
-						"closing stalled connection for fresh chainsync",
+						"closing connection for fresh chainsync",
 						"connection_id", connId.String(),
 						"reason", e.Reason,
 					)

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -600,7 +600,7 @@ func TestSubscribeChainsyncResyncRewindsClientsWithoutRecycle(
 		event.NewEvent(
 			event.ChainsyncResyncEventType,
 			event.ChainsyncResyncEvent{
-				Reason: "local ledger rollback",
+				Reason: event.ChainsyncResyncReasonLocalLedgerRollback,
 				Point:  rollbackPoint,
 			},
 		),
@@ -656,7 +656,7 @@ func TestSubscribeChainsyncResyncDoesNotRecycleOnLocalRollbackWithoutPeerHistory
 		event.NewEvent(
 			event.ChainsyncResyncEventType,
 			event.ChainsyncResyncEvent{
-				Reason: "local ledger rollback",
+				Reason: event.ChainsyncResyncReasonLocalLedgerRollback,
 				Point:  rollbackPoint,
 			},
 		),
@@ -671,101 +671,121 @@ func TestSubscribeChainsyncResyncDoesNotRecycleOnLocalRollbackWithoutPeerHistory
 	}
 }
 
-func TestSubscribeChainsyncResyncClosesConnectionOnPersistentFork(
+func TestSubscribeChainsyncResyncClosesConnectionForFreshSyncReasons(
 	t *testing.T,
 ) {
-	logBuf := &lockedBuffer{}
-	logger := slog.New(
-		slog.NewJSONHandler(
-			logBuf,
-			&slog.HandlerOptions{Level: slog.LevelDebug},
-		),
-	)
-	bus := event.NewEventBus(nil, logger)
-	defer bus.Close()
+	reasons := []string{
+		event.ChainsyncResyncReasonLocalTipPlateau,
+		event.ChainsyncResyncReasonRollbackNotFound,
+		event.ChainsyncResyncReasonPersistentFork,
+		event.ChainsyncResyncReasonRollbackExceedsK,
+		event.ChainsyncResyncReasonForkResolutionExceedsK,
+		event.ChainsyncResyncReasonRollbackLoop,
+	}
+	for _, reason := range reasons {
+		reason := reason
+		t.Run(reason, func(t *testing.T) {
+			logBuf := &lockedBuffer{}
+			logger := slog.New(
+				slog.NewJSONHandler(
+					logBuf,
+					&slog.HandlerOptions{Level: slog.LevelDebug},
+				),
+			)
+			bus := event.NewEventBus(nil, logger)
+			defer bus.Close()
 
-	connManager := connmanager.NewConnectionManager(
-		connmanager.ConnectionManagerConfig{
-			EventBus: bus,
-			Logger:   logger,
-		},
-	)
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(
-			context.Background(),
-			5*time.Second,
-		)
-		defer stopCancel()
-		_ = connManager.Stop(stopCtx)
-	})
+			connManager := connmanager.NewConnectionManager(
+				connmanager.ConnectionManagerConfig{
+					EventBus: bus,
+					Logger:   logger,
+				},
+			)
+			t.Cleanup(func() {
+				stopCtx, stopCancel := context.WithTimeout(
+					context.Background(),
+					5*time.Second,
+				)
+				defer stopCancel()
+				_ = connManager.Stop(stopCtx)
+			})
 
-	mockConn := ouroboros_mock.NewConnection(
-		ouroboros_mock.ProtocolRoleClient,
-		ouroboros_mock.ConversationKeepAlive,
-	)
-	oConn, err := ouroboros.New(
-		ouroboros.WithConnection(mockConn),
-		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
-		ouroboros.WithNodeToNode(true),
-		ouroboros.WithKeepAlive(true),
-		ouroboros.WithKeepAliveConfig(
-			keepalive.NewConfig(
-				keepalive.WithCookie(ouroboros_mock.MockKeepAliveCookie),
-				keepalive.WithPeriod(30*time.Second),
-				keepalive.WithTimeout(15*time.Second),
-			),
-		),
-	)
-	require.NoError(t, err)
-	connManager.AddConnection(oConn, false, "127.0.0.1:1234")
+			mockConn := ouroboros_mock.NewConnection(
+				ouroboros_mock.ProtocolRoleClient,
+				ouroboros_mock.ConversationKeepAlive,
+			)
+			oConn, err := ouroboros.New(
+				ouroboros.WithConnection(mockConn),
+				ouroboros.WithNetworkMagic(
+					ouroboros_mock.MockNetworkMagic,
+				),
+				ouroboros.WithNodeToNode(true),
+				ouroboros.WithKeepAlive(true),
+				ouroboros.WithKeepAliveConfig(
+					keepalive.NewConfig(
+						keepalive.WithCookie(
+							ouroboros_mock.MockKeepAliveCookie,
+						),
+						keepalive.WithPeriod(30*time.Second),
+						keepalive.WithTimeout(15*time.Second),
+					),
+				),
+			)
+			require.NoError(t, err)
+			connManager.AddConnection(oConn, false, "127.0.0.1:1234")
 
-	o := NewOuroboros(OuroborosConfig{
-		EventBus: bus,
-		Logger:   logger,
-	})
-	o.EventBus = bus
-	o.ConnManager = connManager
+			o := NewOuroboros(OuroborosConfig{
+				EventBus: bus,
+				Logger:   logger,
+			})
+			o.EventBus = bus
+			o.ConnManager = connManager
 
-	ctx := t.Context()
-	o.SubscribeChainsyncResync(ctx)
+			ctx := t.Context()
+			o.SubscribeChainsyncResync(ctx)
 
-	connId := oConn.Id()
-	bus.Publish(
-		event.ChainsyncResyncEventType,
-		event.NewEvent(
-			event.ChainsyncResyncEventType,
-			event.ChainsyncResyncEvent{
-				ConnectionId: connId,
-				Reason:       "persistent chain fork",
-			},
-		),
-	)
+			connId := oConn.Id()
+			bus.Publish(
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
+					event.ChainsyncResyncEventType,
+					event.ChainsyncResyncEvent{
+						ConnectionId: connId,
+						Reason:       reason,
+					},
+				),
+			)
 
-	require.Eventually(
-		t,
-		func() bool {
-			return connManager.GetConnectionById(connId) == nil
-		},
-		2*time.Second,
-		20*time.Millisecond,
-	)
-	require.Eventually(
-		t,
-		func() bool {
-			logs := logBuf.String()
-			return strings.Contains(
-				logs,
-				`"msg":"closing stalled connection for fresh chainsync"`,
-			) && strings.Contains(logs, `"reason":"persistent chain fork"`)
-		},
-		2*time.Second,
-		20*time.Millisecond,
-	)
-	require.NotContains(
-		t,
-		logBuf.String(),
-		`"msg":"restarting chainsync client"`,
-	)
+			require.Eventually(
+				t,
+				func() bool {
+					return connManager.GetConnectionById(connId) == nil
+				},
+				2*time.Second,
+				20*time.Millisecond,
+			)
+			require.Eventually(
+				t,
+				func() bool {
+					logs := logBuf.String()
+					return strings.Contains(
+						logs,
+						`"msg":"closing connection for fresh chainsync"`,
+					) && strings.Contains(
+						logs,
+						`"reason":"`+reason+`"`,
+					)
+				},
+				2*time.Second,
+				20*time.Millisecond,
+			)
+			require.NotContains(
+				t,
+				logBuf.String(),
+				`"msg":"restarting chainsync client"`,
+			)
+		})
+	}
 }
 
 func TestHeaderPreviouslySeenFromOtherConnTreatsEquivalentConnIdsAsSame(


### PR DESCRIPTION
Closes #2230 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close `ouroboros` ChainSync connections on K-limit rejections and other unrecoverable resync reasons to force a fresh sync with new intersect points. This prevents stalls and improves recovery on forks and rollbacks.

- **Bug Fixes**
  - Close the connection for these resync reasons: local_tip_plateau, rollback point not found, persistent chain fork, rollback exceeds K, fork resolution exceeds K, rollback loop.
  - Added a helper to detect these reasons, standardized them as `event` constants, cleared observed header history, and logged "closing connection for fresh chainsync" before dropping.
  - Replaced the single-case test with a table-driven test that covers all fresh-sync reasons.

<sup>Written for commit 4663e36a45012bcef0716b866b7cef51d4b7696d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced chain synchronization connection management to establish fresh connections in additional edge cases, including rollback scenarios and fork resolution situations, improving overall synchronization stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2253)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->