### PR TITLE
feat(chain): block proposed event

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -168,6 +168,20 @@ func (c *Chain) AddBlock(
 	return nil
 }
 
+// HandleBlockProposedEvent applies locally forged block proposals published on
+// the EventBus and acknowledges the result to the proposer when requested.
+func (c *Chain) HandleBlockProposedEvent(evt event.Event) {
+	proposal, ok := evt.Data.(BlockProposedEvent)
+	if !ok {
+		return
+	}
+	if proposal.Block == nil {
+		proposal.Respond(errors.New("proposed block is nil"))
+		return
+	}
+	proposal.Respond(c.AddBlock(proposal.Block, nil))
+}
+
 // AddBlockWithPoint adds a block using a caller-supplied point. This avoids
 // recomputing the block hash when the caller already has the canonical slot/hash
 // pair from a validated upstream source such as blockfetch.

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
@@ -223,6 +224,43 @@ func TestChainBasic(t *testing.T) {
 			)
 		}
 		testBlockIdx++
+	}
+}
+
+func TestHandleBlockProposedEventAddsBlockAndAcks(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	ack := make(chan error, 1)
+
+	c.HandleBlockProposedEvent(
+		event.NewEvent(
+			chain.BlockProposedEventType,
+			chain.BlockProposedEvent{
+				Block: testBlocks[0],
+				Ack:   ack,
+			},
+		),
+	)
+
+	if err := testutil.RequireReceive(
+		t,
+		ack,
+		time.Second,
+		"block proposal ack",
+	); err != nil {
+		t.Fatalf("unexpected block proposal error: %s", err)
+	}
+	tip := c.Tip()
+	if tip.Point.Slot != testBlocks[0].MockSlot ||
+		!bytes.Equal(tip.Point.Hash, testBlocks[0].Hash().Bytes()) {
+		t.Fatalf(
+			"unexpected tip after block proposal: %d.%x",
+			tip.Point.Slot,
+			tip.Point.Hash,
+		)
 	}
 }
 

--- a/chain/event.go
+++ b/chain/event.go
@@ -16,17 +16,37 @@ package chain
 
 import (
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 const (
-	ChainUpdateEventType = "chain.update"
-	ChainForkEventType   = "chain.fork_detected"
+	ChainUpdateEventType   = "chain.update"
+	ChainForkEventType     = "chain.fork_detected"
+	BlockProposedEventType = "chain.block_proposed"
 )
 
 type ChainBlockEvent struct {
 	Point ocommon.Point
 	Block models.Block
+}
+
+// BlockProposedEvent carries a locally forged block to the chain component for
+// adoption. Ack is optional; when set, the chain handler reports the AddBlock
+// result without blocking if the sender has already moved on.
+type BlockProposedEvent struct {
+	Block ledger.Block
+	Ack   chan<- error
+}
+
+func (e BlockProposedEvent) Respond(err error) {
+	if e.Ack == nil {
+		return
+	}
+	select {
+	case e.Ack <- err:
+	default:
+	}
 }
 
 type ChainRollbackEvent struct {

--- a/node.go
+++ b/node.go
@@ -70,6 +70,7 @@ type Node struct {
 	ctx                              context.Context
 	cancel                           context.CancelFunc
 	shutdownOnce                     sync.Once
+	shutdownErr                      error
 	chainsyncIngressEligibilityMu    sync.RWMutex
 	chainsyncIngressEligibilityCache map[ouroboros.ConnectionId]bool
 }
@@ -198,6 +199,10 @@ func (n *Node) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to load chain manager: %w", err)
 	}
 	n.chainManager = cm
+	n.eventBus.SubscribeFunc(
+		chain.BlockProposedEventType,
+		n.chainManager.PrimaryChain().HandleBlockProposedEvent,
+	)
 	n.chainsyncIngressEligibilityCache = make(
 		map[ouroboros.ConnectionId]bool,
 	)

--- a/node_forging.go
+++ b/node_forging.go
@@ -16,6 +16,7 @@ package dingo
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -186,7 +187,6 @@ func (n *Node) initBlockForger(
 
 	// Create block broadcaster (uses the chain manager and event bus)
 	broadcaster := &blockBroadcaster{
-		chain:    n.chainManager.PrimaryChain(),
 		eventBus: n.eventBus,
 		logger:   n.config.logger,
 	}
@@ -227,9 +227,6 @@ func (n *Node) initBlockForger(
 		return fmt.Errorf("failed to start leader election: %w", err)
 	}
 
-	// Store election for cleanup during shutdown
-	n.leaderElection = election
-
 	// Create slot clock adapter for the forger
 	slotClock := &slotClockAdapter{ledgerState: n.ledgerState}
 
@@ -259,6 +256,9 @@ func (n *Node) initBlockForger(
 		return fmt.Errorf("failed to start block forger: %w", err)
 	}
 
+	// Store election for cleanup during shutdown only after the forger is
+	// fully created and running.
+	n.leaderElection = election
 	n.blockForger = forger
 	n.config.logger.Info(
 		"block forger started in production mode with leader election",
@@ -286,25 +286,58 @@ func (a *mempoolAdapter) Transactions() []forging.MempoolTransaction {
 	return result
 }
 
-// blockBroadcaster implements forging.BlockBroadcaster using the chain manager.
+// blockBroadcaster implements forging.BlockBroadcaster by proposing locally
+// forged blocks to the chain component over the EventBus.
 type blockBroadcaster struct {
-	chain    *chain.Chain
 	eventBus *event.EventBus
 	logger   *slog.Logger
 }
+
+const blockProposalAckTimeout = 30 * time.Second
 
 func (b *blockBroadcaster) AddBlock(
 	block gledger.Block,
 	_ []byte,
 ) error {
-	// Add block to the chain (CBOR is stored internally by the block).
-	// addBlockInternal notifies iterators after storing the block.
-	if err := b.chain.AddBlock(block, nil); err != nil {
-		return fmt.Errorf("failed to add block to chain: %w", err)
+	if block == nil {
+		return errors.New("proposed block is nil")
+	}
+	if b.eventBus == nil {
+		return errors.New("event bus unavailable")
+	}
+	if !b.eventBus.HasSubscribers(chain.BlockProposedEventType) {
+		return errors.New("no chain block proposal subscribers")
+	}
+
+	ack := make(chan error, 1)
+	b.eventBus.Publish(
+		chain.BlockProposedEventType,
+		event.NewEvent(
+			chain.BlockProposedEventType,
+			chain.BlockProposedEvent{
+				Block: block,
+				Ack:   ack,
+			},
+		),
+	)
+
+	timer := time.NewTimer(blockProposalAckTimeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-ack:
+		if err != nil {
+			return fmt.Errorf("chain rejected proposed block: %w", err)
+		}
+	case <-timer.C:
+		return fmt.Errorf(
+			"timed out waiting for proposed block ack after %s",
+			blockProposalAckTimeout,
+		)
 	}
 
 	b.logger.Info(
-		"block added to chain",
+		"block proposal accepted by chain",
 		"slot", block.SlotNumber(),
 		"hash", block.Hash(),
 		"block_number", block.BlockNumber(),
@@ -314,34 +347,75 @@ func (b *blockBroadcaster) AddBlock(
 }
 
 // stakeDistributionAdapter adapts ledger.LedgerState to leader.StakeDistributionProvider.
-// It queries the metadata store directly with a nil transaction so the SQLite
-// read pool is used, avoiding contention with block-processing write locks.
+// It queries through LedgerView so leader election observes the same stake
+// snapshot rotation semantics as other ledger queries.
 type stakeDistributionAdapter struct {
 	ledgerState *ledger.LedgerState
+}
+
+func (a *stakeDistributionAdapter) getStakeDistribution(
+	epoch uint64,
+) (_ *ledger.StakeDistribution, err error) {
+	if a.ledgerState == nil {
+		return nil, errors.New("ledger state unavailable")
+	}
+	db := a.ledgerState.Database()
+	if db == nil {
+		return nil, errors.New("database unavailable")
+	}
+	txn := db.MetadataTxn(false)
+	if txn == nil {
+		return nil, errors.New("metadata transaction unavailable")
+	}
+	defer func() {
+		if rollbackErr := txn.Rollback(); rollbackErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf(
+					"release stake distribution transaction: %w",
+					rollbackErr,
+				),
+			)
+		}
+	}()
+	return a.ledgerState.NewView(txn).GetStakeDistribution(epoch)
 }
 
 func (a *stakeDistributionAdapter) GetPoolStake(
 	epoch uint64,
 	poolKeyHash []byte,
 ) (uint64, error) {
-	snapshot, err := a.ledgerState.Database().Metadata().GetPoolStakeSnapshot(
-		epoch, "mark", poolKeyHash, nil,
-	)
+	dist, err := a.getStakeDistribution(epoch)
+	poolKey := hex.EncodeToString(poolKeyHash)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf(
+			"get stake distribution for epoch %d pool %s: %w",
+			epoch,
+			poolKey,
+			err,
+		)
 	}
-	if snapshot == nil {
+	if dist == nil {
 		return 0, nil
 	}
-	return uint64(snapshot.TotalStake), nil
+	return dist.PoolStakes[poolKey], nil
 }
 
 func (a *stakeDistributionAdapter) GetTotalActiveStake(
 	epoch uint64,
 ) (uint64, error) {
-	return a.ledgerState.Database().Metadata().GetTotalActiveStake(
-		epoch, "mark", nil,
-	)
+	dist, err := a.getStakeDistribution(epoch)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"get stake distribution for epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	if dist == nil {
+		return 0, nil
+	}
+	return dist.TotalStake, nil
 }
 
 // epochInfoAdapter adapts ledger.LedgerState to leader.EpochInfoProvider.

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -22,11 +22,55 @@ import (
 )
 
 func (n *Node) Stop() error {
-	var err error
 	n.shutdownOnce.Do(func() {
-		err = n.shutdown()
+		n.shutdownErr = n.shutdown()
 	})
-	return err
+	return n.shutdownErr
+}
+
+func (n *Node) closeWithShutdownTimeout(
+	ctx context.Context,
+	resource string,
+	shutdownTimeout time.Duration,
+	closeFn func() error,
+) error {
+	closeCtx, cancel := context.WithTimeout(ctx, shutdownTimeout)
+	defer cancel()
+
+	t := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		done <- closeFn()
+	}()
+
+	select {
+	case closeErr := <-done:
+		elapsed := time.Since(t).Round(time.Millisecond)
+		if closeErr != nil {
+			n.config.logger.Error(
+				"shutdown resource close failed",
+				"resource", resource,
+				"elapsed", elapsed,
+				"error", closeErr,
+			)
+			return closeErr
+		}
+		n.config.logger.Info(
+			"shutdown resource closed",
+			"resource", resource,
+			"elapsed", elapsed,
+		)
+		return nil
+	case <-closeCtx.Done():
+		n.config.logger.Warn(
+			"shutdown resource close timed out",
+			"resource", resource,
+			"timeout", shutdownTimeout,
+			"elapsed", time.Since(t).Round(time.Millisecond),
+			"error", closeCtx.Err(),
+		)
+		return closeCtx.Err()
+	}
 }
 
 func (n *Node) shutdown() error {
@@ -157,32 +201,32 @@ func (n *Node) shutdown() error {
 
 	if n.ledgerState != nil {
 		n.config.logger.Info("closing ledger state")
-		t := time.Now()
-		if closeErr := n.ledgerState.Close(); closeErr != nil {
+		if closeErr := n.closeWithShutdownTimeout(
+			ctx,
+			"ledgerState",
+			shutdownTimeout,
+			n.ledgerState.Close,
+		); closeErr != nil {
 			err = errors.Join(
 				err,
 				fmt.Errorf("ledger state close: %w", closeErr),
 			)
 		}
-		n.config.logger.Info(
-			"ledger state closed",
-			"elapsed", time.Since(t).Round(time.Millisecond),
-		)
 	}
 
 	if n.db != nil {
 		n.config.logger.Info("closing database")
-		t := time.Now()
-		if closeErr := n.db.Close(); closeErr != nil {
+		if closeErr := n.closeWithShutdownTimeout(
+			ctx,
+			"database",
+			shutdownTimeout,
+			n.db.Close,
+		); closeErr != nil {
 			err = errors.Join(
 				err,
 				fmt.Errorf("database close: %w", closeErr),
 			)
 		}
-		n.config.logger.Info(
-			"database closed",
-			"elapsed", time.Since(t).Round(time.Millisecond),
-		)
 	}
 
 	n.config.logger.Info(

--- a/node_test.go
+++ b/node_test.go
@@ -15,6 +15,8 @@
 package dingo
 
 import (
+	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -647,4 +649,54 @@ func TestRunStallCheckerLoopRecoversAndSupportsRestart(t *testing.T) {
 	})
 
 	assert.Equal(t, int32(2), attempts.Load())
+}
+
+func TestStopReturnsSameShutdownErrorAfterFirstCall(t *testing.T) {
+	wantErr := errors.New("shutdown failed")
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		shutdownFuncs: []func(context.Context) error{
+			func(context.Context) error {
+				return wantErr
+			},
+		},
+	}
+
+	firstErr := n.Stop()
+	secondErr := n.Stop()
+	require.ErrorIs(t, firstErr, wantErr)
+	require.ErrorIs(t, secondErr, wantErr)
+	require.Equal(t, firstErr, secondErr)
+}
+
+func TestCloseWithShutdownTimeoutReturnsTimeoutError(t *testing.T) {
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	releaseClose := make(chan struct{})
+	closeDone := make(chan struct{})
+
+	err := n.closeWithShutdownTimeout(
+		context.Background(),
+		"test",
+		0,
+		func() error {
+			defer close(closeDone)
+			<-releaseClose
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	close(releaseClose)
+	testutil.RequireReceive(
+		t,
+		closeDone,
+		time.Second,
+		"close function completion",
+	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `chain.block_proposed` event and wires the forger to publish locally forged blocks with an optional ack, decoupling forging from chain writes. Also improves leader election stake reads and makes shutdown idempotent with timed resource closes.

- New Features
  - Added `BlockProposedEventType` and `BlockProposedEvent` with optional, non-blocking ack.
  - `chain.HandleBlockProposedEvent` validates input, adds the block, and responds (errors if block is nil).
  - Forger broadcaster now publishes proposals over the EventBus and waits up to 30s for ack; `Node` subscribes on start.

- Refactors
  - Leader election reads stake via `LedgerState.NewView(...).GetStakeDistribution` using a safe metadata txn for consistent snapshots.
  - Delay setting `leaderElection` until the forger is fully running.
  - Added `closeWithShutdownTimeout` and `shutdownErr` so `Stop()` is idempotent and resource closes honor a timeout.

<sup>Written for commit 57df5254e78f33abfca80d37b26dc1d5ec9fe229. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced block proposal event handling mechanism enabling locally forged block proposals through the event system

* **Improvements**
  * Enhanced node shutdown with consistent error handling and improved resource cleanup with timeout management
  * Updated block forging to use event-based broadcasting with acknowledgment protocol for proposed blocks
  * Improved stake distribution reading using updated ledger view methods

* **Tests**
  * Added comprehensive tests for block proposal event handling and shutdown error consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2295)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->