### PR TITLE
fix(ledger): use chain intersects across snapshot gaps

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4202,7 +4202,7 @@ func (ls *LedgerState) GetBlock(point ocommon.Point) (models.Block, error) {
 	return ret, nil
 }
 
-func (ls *LedgerState) chainTipMatchesLedgerTip() bool {
+func (ls *LedgerState) primaryChainTipAtOrAheadOfLedgerTip() bool {
 	if ls.chain == nil {
 		return false
 	}
@@ -4210,6 +4210,9 @@ func (ls *LedgerState) chainTipMatchesLedgerTip() bool {
 	ledgerTip := ls.currentTip
 	ls.RUnlock()
 	chainTip := ls.chain.Tip()
+	if chainTip.Point.Slot > ledgerTip.Point.Slot {
+		return true
+	}
 	return chainTip.Point.Slot == ledgerTip.Point.Slot &&
 		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash)
 }
@@ -4316,7 +4319,7 @@ func (ls *LedgerState) IntersectPoints(
 	if count <= 0 {
 		return nil, nil
 	}
-	if ls.chain != nil && ls.chainTipMatchesLedgerTip() {
+	if ls.primaryChainTipAtOrAheadOfLedgerTip() {
 		points := ls.chain.IntersectPoints(count)
 		if len(points) > 0 {
 			return points, nil

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2344,7 +2344,7 @@ func TestIntersectPointsReturnsNoPointsWhenLedgerTipIsEmpty(
 	assert.Nil(t, points)
 }
 
-func TestIntersectPointsUsesLedgerTipWhenPrimaryChainIsAhead(t *testing.T) {
+func TestIntersectPointsUsesPrimaryChainWhenPrimaryChainIsAhead(t *testing.T) {
 	db, err := database.New(&database.Config{
 		BlobPlugin:     "badger",
 		MetadataPlugin: "sqlite",
@@ -2382,12 +2382,12 @@ func TestIntersectPointsUsesLedgerTipWhenPrimaryChainIsAhead(t *testing.T) {
 	points, err := ls.IntersectPoints(3)
 	require.NoError(t, err)
 	require.Len(t, points, 3)
-	assert.Equal(t, ledgerTipBlock.Slot, points[0].Slot)
-	assert.Equal(t, ledgerTipBlock.Hash, points[0].Hash)
-	assert.Equal(t, blocks[1].Slot, points[1].Slot)
-	assert.Equal(t, blocks[1].Hash, points[1].Hash)
-	assert.Equal(t, blocks[0].Slot, points[2].Slot)
-	assert.Equal(t, blocks[0].Hash, points[2].Hash)
+	assert.Equal(t, blocks[4].Slot, points[0].Slot)
+	assert.Equal(t, blocks[4].Hash, points[0].Hash)
+	assert.Equal(t, blocks[3].Slot, points[1].Slot)
+	assert.Equal(t, blocks[3].Hash, points[1].Hash)
+	assert.Equal(t, blocks[2].Slot, points[2].Slot)
+	assert.Equal(t, blocks[2].Hash, points[2].Hash)
 }
 
 func TestIntersectPointsUsesSparseLedgerTipSamples(t *testing.T) {


### PR DESCRIPTION
Closes #2250


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use primary chain intersects when its tip is at or ahead of the ledger tip to bridge snapshot gaps and avoid stalled sync. This enables reliable intersection across snapshot boundaries.

- **Bug Fixes**
  - IntersectPoints now uses `chain.IntersectPoints(count)` when the primary chain tip >= ledger tip.
  - Renamed helper to `primaryChainTipAtOrAheadOfLedgerTip` and updated logic.
  - Adjusted tests to expect chain-provided points when the chain is ahead.

<sup>Written for commit 189cecfe4489e782a97bc4ed66e697b8370c0a37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

