### PR TITLE
docs: package comments for mempool/utxorpc

### DIFF
--- a/mempool/doc.go
+++ b/mempool/doc.go
@@ -19,10 +19,10 @@
 //
 // Mempool is the top-level type. It validates every submitted
 // transaction through the ledger package — UTxO resolution, fees,
-// ExUnit budgets, validity interval, size, and all 41 UTxO validation
-// rules — before admitting it. Transactions outside their validity
-// interval relative to the current tip are rejected at submission
-// time rather than held until expiry.
+// ExUnit budgets, validity interval, size, and the full UTxO validation
+// rules enforced by the ledger package — before admitting it. Transactions
+// outside their validity interval relative to the current tip are rejected
+// at submission time rather than held until expiry.
 //
 // # Eviction and watermarks
 //

--- a/utxorpc/doc.go
+++ b/utxorpc/doc.go
@@ -23,12 +23,12 @@
 //
 // # Predicate evaluation
 //
-// Search requests carry a TxPredicate tree with composite operators
-// (not / all_of / any_of) that wrap leaf predicates (address,
-// policy, certificate, consumes, produces, …). Predicate evaluation
-// lives alongside the leaf types (e.g. certificate_pattern.go,
-// plutusdata_cardano.go). A nil SearchUtxos predicate is treated as
-// "match everything", allowing a full UTxO scan.
+// SearchUtxos uses UtxoPredicate filters over live UTxOs; a nil
+// SearchUtxos predicate scans all addresses. TxPredicate evaluation for
+// transaction streams uses composite operators (not / all_of / any_of)
+// around leaf predicates (address, policy, certificate, consumes,
+// produces, …). That path is stricter: evalTxPredicateOutcome returns
+// predNoMatch for a nil converted TxPredicate node.
 //
 // # Authentication
 //


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified package docs for `mempool` and `utxorpc` to better describe validation and predicate behavior.
`mempool` now references the full ledger UTxO rules, and `utxorpc` explains that `SearchUtxos` treats a nil filter as scan-all while transaction stream predicates use strict evaluation and treat a nil converted predicate as no match.

<sup>Written for commit f08a783f115e15558b2ce7269edb44114b7fce1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ledger validation rules documentation regarding ExUnit budgets, validity intervals, and transaction rejection policies.
  * Updated predicate evaluation documentation for improved clarity on UTxO searching and transaction stream filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2297)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->