### PR TITLE
fix(node):  return error on genesis snapshot failure for block producers

### DIFF
--- a/node.go
+++ b/node.go
@@ -367,10 +367,9 @@ func (n *Node) Run(ctx context.Context) error {
 	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
 	// Capture genesis stake snapshot (epoch 0) so leader election works at epoch 2
 	if err := n.snapshotMgr.CaptureGenesisSnapshot(ctx); err != nil {
-		n.config.logger.Warn(
-			"failed to capture genesis snapshot",
-			"error", err,
-		)
+		if err := n.handleGenesisSnapshotError(err); err != nil {
+			return err
+		}
 	}
 	if err := n.snapshotMgr.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("failed to start snapshot manager: %w", err)

--- a/node_forging.go
+++ b/node_forging.go
@@ -155,6 +155,20 @@ func (n *Node) validateBlockProducerLedgerWithView(
 	return nil
 }
 
+// handleGenesisSnapshotError returns a fatal error for block producers (which
+// require the genesis snapshot for leader election) and logs a warning for
+// relay nodes (which do not perform leader election).
+func (n *Node) handleGenesisSnapshotError(err error) error {
+	if n.config.blockProducer {
+		return fmt.Errorf("failed to capture genesis snapshot: %w", err)
+	}
+	n.config.logger.Warn(
+		"failed to capture genesis snapshot",
+		"error", err,
+	)
+	return nil
+}
+
 // initBlockForger initializes the block forger for production mode.
 // This requires VRF, KES, and OpCert key files to be configured.
 func (n *Node) initBlockForger(

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -213,3 +213,36 @@ func TestValidateBlockProducerLedger_DevnetVRFMismatchWarns(t *testing.T) {
 		t.Fatalf("devnet mismatch should warn and continue: %v", err)
 	}
 }
+
+func TestHandleGenesisSnapshotError_BlockProducerFatal(t *testing.T) {
+	n := &Node{
+		config: Config{
+			logger:        slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			blockProducer: true,
+		},
+	}
+	sentinel := errors.New("db unavailable")
+	err := n.handleGenesisSnapshotError(sentinel)
+	if err == nil {
+		t.Fatal("expected fatal error for block producer, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel wrapped in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to capture genesis snapshot") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestHandleGenesisSnapshotError_RelayWarnsAndContinues(t *testing.T) {
+	n := &Node{
+		config: Config{
+			logger:        slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			blockProducer: false,
+		},
+	}
+	err := n.handleGenesisSnapshotError(errors.New("db unavailable"))
+	if err != nil {
+		t.Errorf("expected nil for relay node, got: %v", err)
+	}
+}


### PR DESCRIPTION
closes #1522 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail startup for block producers when genesis snapshot capture fails, so we don’t continue without a valid leader election state. Relay nodes still warn and continue.

- **Bug Fixes**
  - Added `handleGenesisSnapshotError` to return a fatal error for block producers and log a warning for relays; used in `Node.Run`.
  - Added tests for both behaviors to prevent regressions.

<sup>Written for commit cad8372b6117f01903b401f3a3b00bb6242aa6cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Genesis stake snapshot capture failures now cause node startup to abort for block producers; relay nodes continue with a warning.

* **Tests**
  * Added unit tests for genesis snapshot error handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2298)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->