### PR TITLE
fix(ledger): rollback error propagation

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -716,7 +716,7 @@ func (ls *LedgerState) findPeerForkPath(
 	}
 	for depth := 0; depth < maxPeerHeaderHistoryPerConn &&
 		len(prevHash) > 0; depth++ {
-		ancestorBlock, err := database.BlockByHash(ls.db, prevHash)
+		ancestorBlock, err := ls.blockByHash(prevHash)
 		if err == nil {
 			point := ocommon.NewPoint(
 				ancestorBlock.Slot,
@@ -764,6 +764,13 @@ func (ls *LedgerState) findPeerForkPath(
 		prevHash = append(prevHash[:0], record.prevHash...)
 	}
 	return nil, nil, nil
+}
+
+func (ls *LedgerState) blockByHash(hash []byte) (models.Block, error) {
+	if ls.lookupBlockByHash != nil {
+		return ls.lookupBlockByHash(hash)
+	}
+	return database.BlockByHash(ls.db, hash)
 }
 
 func connIdKey(connId ouroboros.ConnectionId) string {
@@ -1922,7 +1929,7 @@ func (ls *LedgerState) tryResolveFork(
 		)
 		return true, nil
 	}
-	ancestorBlock, err := database.BlockByHash(ls.db, ancestorPoint.Hash)
+	ancestorBlock, err := ls.blockByHash(ancestorPoint.Hash)
 	if err != nil {
 		return false, fmt.Errorf(
 			"failed to reload common ancestor block %s: %w",
@@ -2020,6 +2027,7 @@ func (ls *LedgerState) tryResolveFork(
 					),
 				)
 			}
+			return true, nil
 		} else {
 			ls.config.Logger.Error(
 				"failed to roll back to common ancestor",
@@ -2027,8 +2035,11 @@ func (ls *LedgerState) tryResolveFork(
 				"error", err,
 				"ancestor_slot", ancestorBlock.Slot,
 			)
+			return false, fmt.Errorf(
+				"failed to roll back to common ancestor: %w",
+				err,
+			)
 		}
-		return false, nil
 	}
 
 	// Mark state as rollback so the next block header event logs

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -276,6 +278,89 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	dbTip, err := fixture.ls.db.GetTip(nil)
 	require.NoError(t, err)
 	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestTryResolveForkPropagatesAncestorLookupError(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ancestorLookupErr := errors.New("ancestor lookup failed")
+	fixture.ls.lookupBlockByHash = func([]byte) (models.Block, error) {
+		return models.Block{}, ancestorLookupErr
+	}
+
+	forkHash := testHashBytes("lookup-error-fork-block")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(testHashBytes("lookup-error-ancestor")),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 10,
+	}
+	err := fixture.ls.chain.AddBlockHeader(header)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved, err := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		},
+		notFitErr,
+	)
+
+	require.False(t, resolved)
+	require.ErrorIs(t, err, ancestorLookupErr)
+	require.NotErrorIs(t, err, models.ErrBlockNotFound)
+}
+
+func TestHandleEventChainsyncBlockHeaderRestoresMismatchCountOnAncestorLookupError(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	ancestorLookupErr := errors.New("ancestor lookup failed")
+	fixture.ls.lookupBlockByHash = func([]byte) (models.Block, error) {
+		return models.Block{}, ancestorLookupErr
+	}
+	fixture.ls.headerMismatchCount = 7
+
+	forkHash := testHashBytes("handler-lookup-error-fork-block")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(testHashBytes("handler-lookup-error-ancestor")),
+		blockNumber: fixture.currentTip.BlockNumber + 1,
+		slot:        fixture.currentTip.Point.Slot + 10,
+	}
+
+	err := fixture.ls.handleEventChainsyncBlockHeader(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		},
+	)
+
+	require.ErrorIs(t, err, ancestorLookupErr)
+	require.NotErrorIs(t, err, models.ErrBlockNotFound)
+	assert.Equal(t, 7, fixture.ls.headerMismatchCount)
 }
 
 func TestTryResolveForkDoesNotAdvanceLaggingLedgerTip(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -533,6 +533,8 @@ type LedgerState struct {
 	headerMismatchCount  int // consecutive header mismatch count
 	bufferedHeaderEvents map[string][]ChainsyncEvent
 	peerHeaderHistory    map[string]*peerHeaderChain
+	// Test hook for fork ancestor lookups.
+	lookupBlockByHash func([]byte) (models.Block, error)
 }
 
 // EraTransitionResult holds computed state from an era transition


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes rollback error propagation in `ledger` chain sync so ancestor lookup and rollback errors bubble up instead of being swallowed. Adds a block lookup hook for tests and keeps mismatch counters intact on lookup errors.

- **Bug Fixes**
  - `tryResolveFork` now returns `false, error` when rollback to the common ancestor fails, and `true, nil` on success.
  - Ancestor block lookups use a wrapper that can fail fast; lookup errors are propagated to callers.
  - Preserves `headerMismatchCount` when ancestor lookup fails.
  - Added tests to cover error propagation and mismatch counter behavior.

- **Refactors**
  - Introduced `blockByHash` wrapper with optional `lookupBlockByHash` hook; replaced direct `database.BlockByHash` calls.

<sup>Written for commit 87c9a9ca698dcf127416d83ffed4c8572c6b4f04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

