### PR TITLE
test(ledger): wait for hard fork init eval helper

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1847,16 +1847,19 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	//     a HardForkInitiation governance action survived the
 	//     rollback and is still ratifiable past the voting deadline.
 	//
-	// Without these re-derivations a client querying era history
-	// between rollback completion and the next block-apply would see
-	// a transient Unknown that doesn't reflect the actual chain
-	// state.
+	// These re-derivations are best-effort at rollback time: if an
+	// HFI stability tally is already in flight, the generation bump
+	// below invalidates that result and the fresh tally may be
+	// deferred until the next block reopens the evaluator. That can
+	// leave a transient Unknown between rollback completion and the
+	// next successful evaluation, but prevents stale pre-rollback HFI
+	// results from committing.
 	ls.transitionInfo = hardfork.NewTransitionUnknown()
 	ls.reconstructTransitionInfo()
-	// Reopen the once-per-epoch gate so rollback can re-derive
-	// transitionInfo immediately, and bump the generation counter so
-	// any in-flight tally from before the rollback drops its result
-	// instead of committing stale data.
+	// Reopen the once-per-epoch gate so rollback can attempt to
+	// re-derive transitionInfo, and bump the generation counter so any
+	// in-flight tally from before the rollback drops its result instead
+	// of committing stale data.
 	ls.hfiEvalDoneEpoch = 0
 	ls.hfiEvalGeneration.Add(1)
 	ls.evaluateHardForkInitiationStability()

--- a/ledger/transition_stability_test.go
+++ b/ledger/transition_stability_test.go
@@ -57,6 +57,14 @@ func awaitTransitionInfo(
 	return ls.transitionInfo
 }
 
+func awaitHFIEvalIdle(t *testing.T, ls *LedgerState) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return !ls.hfiStabilityEvalInFlight.Load()
+	}, 2*time.Second, 5*time.Millisecond,
+		"HFI stability evaluation did not become idle")
+}
+
 // stabilityFixtureEpoch parameters: Shelley-style 432_000-slot epoch,
 // safeZone = ceil(3*432/0.05) = 25_920, voting deadline distance from
 // epoch end is 2 * safeZone = 51_840. So an epoch ending at slot
@@ -230,6 +238,7 @@ func TestEvaluateHardForkInitiationStability_PostDeadline_NotRatifiable_NoChange
 
 	ls.evaluateHardForkInitiationStability()
 
+	awaitHFIEvalIdle(t, ls)
 	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"no ratifiable proposal means transitionInfo stays Unknown")
 }
@@ -253,6 +262,7 @@ func TestEvaluateHardForkInitiationStability_PreConwayPParams_NoOp(t *testing.T)
 
 	ls.evaluateHardForkInitiationStability()
 
+	awaitHFIEvalIdle(t, ls)
 	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"pre-Conway pparams must short-circuit without promotion")
 }
@@ -329,6 +339,7 @@ func TestEvaluateHardForkInitiationStability_IntraEraHFI_DoesNotSetKnown(t *test
 
 	ls.evaluateHardForkInitiationStability()
 
+	awaitHFIEvalIdle(t, ls)
 	assert.Equal(t, hardfork.TransitionUnknown, ls.transitionInfo.State,
 		"intra-era HardForkInitiation must not be surfaced as TransitionKnown")
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a test helper to wait until the Hard Fork Initiation stability evaluator is idle, preventing flaky assertions in `ledger/transition_stability_test.go`. Clarify rollback behavior in `ledger/state.go`: re-derivation is best-effort, we reopen the per-epoch gate, bump the HFI eval generation to invalidate in-flight tallies, and then re-evaluate.

<sup>Written for commit 8dd8333ed337b04de359a268c4dbb349acb3ef55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated explanatory comments in the rollback completion process to improve code documentation clarity.

* **Tests**
  * Enhanced test reliability with a new helper function ensuring that asynchronous stability evaluation operations fully complete before test assertions are evaluated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2301)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->