### PR TITLE
chore(governance): stability.go hygiene cleanup

### DIFF
--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -203,7 +203,7 @@ func ProcessEpoch(
 	}
 
 	// Active set changes as we ratify; snapshot once.
-	activeDRepCount, err := countActiveDReps(in)
+	activeDRepCount, err := countActiveDReps(in.DB, in.Txn, in.NewEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("count active dreps: %w", err)
 	}
@@ -415,21 +415,21 @@ func stakeEpochFor(newEpoch uint64) uint64 {
 	return 0
 }
 
-// countActiveDReps returns the number of DReps eligible to vote in the
-// current tick. AlwaysAbstain / AlwaysNoConfidence virtual DReps are
-// not included.
-//
-// countActiveDRepsAtEpoch in stability.go is the parallel for the
-// mid-epoch ratifiability check — it takes plain inputs instead of
-// EpochInput. Behaviour changes here must mirror there.
-func countActiveDReps(in *EpochInput) (int, error) {
-	dreps, err := in.DB.GetActiveDreps(in.Txn)
+// countActiveDReps returns the number of credential-backed DReps
+// eligible to vote in currentEpoch. AlwaysAbstain / AlwaysNoConfidence
+// virtual DReps are not counted.
+func countActiveDReps(
+	db *database.Database,
+	txn *database.Txn,
+	currentEpoch uint64,
+) (int, error) {
+	dreps, err := db.GetActiveDreps(txn)
 	if err != nil {
 		return 0, err
 	}
 	active := 0
 	for _, drep := range dreps {
-		if drepActiveAtEpoch(drep, in.NewEpoch) {
+		if drepActiveAtEpoch(drep, currentEpoch) {
 			active++
 		}
 	}

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -107,7 +107,7 @@ func TestCountActiveDRepsFiltersExpiredDReps(t *testing.T) {
 		},
 	}).Error)
 
-	count, err := countActiveDReps(&EpochInput{DB: db, NewEpoch: 10})
+	count, err := countActiveDReps(db, nil, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 }

--- a/ledger/governance/stability.go
+++ b/ledger/governance/stability.go
@@ -17,6 +17,7 @@ package governance
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -32,13 +33,43 @@ import (
 // sharing because ProcessEpoch is the boundary path used on every
 // mainnet rollover; refactoring it just to support mid-epoch evaluation
 // would risk regressions for marginal benefit.
+//
+// Build with NewStabilityCheckInputs to get a non-nil Logger.
+//
+// OnProposalDecodeFailure, if non-nil, is invoked once per proposal
+// whose stored CBOR fails to decode during the ratifiability scan.
+// Nil disables the signal.
 type StabilityCheckInputs struct {
-	DB            *database.Database
-	Txn           *database.Txn
-	Logger        *slog.Logger
-	CurrentEpoch  uint64
-	PParams       lcommon.ProtocolParameters
-	ConwayGenesis *conway.ConwayGenesis
+	DB                      *database.Database
+	Txn                     *database.Txn
+	Logger                  *slog.Logger
+	CurrentEpoch            uint64
+	PParams                 lcommon.ProtocolParameters
+	ConwayGenesis           *conway.ConwayGenesis
+	OnProposalDecodeFailure func()
+}
+
+func NewStabilityCheckInputs(
+	db *database.Database,
+	txn *database.Txn,
+	logger *slog.Logger,
+	currentEpoch uint64,
+	pparams lcommon.ProtocolParameters,
+	conwayGenesis *conway.ConwayGenesis,
+	onProposalDecodeFailure func(),
+) StabilityCheckInputs {
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	return StabilityCheckInputs{
+		DB:                      db,
+		Txn:                     txn,
+		Logger:                  logger,
+		CurrentEpoch:            currentEpoch,
+		PParams:                 pparams,
+		ConwayGenesis:           conwayGenesis,
+		OnProposalDecodeFailure: onProposalDecodeFailure,
+	}
 }
 
 // RatifiableHardForkInitiation describes a HardForkInitiation proposal
@@ -109,9 +140,7 @@ func EvaluateRatifiableHardForkInitiation(
 		CurrentEpoch: in.CurrentEpoch,
 	}
 
-	activeDRepCount, err := countActiveDRepsAtEpoch(
-		in.DB, in.Txn, in.CurrentEpoch,
-	)
+	activeDRepCount, err := countActiveDReps(in.DB, in.Txn, in.CurrentEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("count active dreps: %w", err)
 	}
@@ -178,12 +207,13 @@ func EvaluateRatifiableHardForkInitiation(
 			proposal.GovActionCbor, proposal.ActionType,
 		)
 		if err != nil {
-			if in.Logger != nil {
-				in.Logger.Warn(
-					"skipping ratifiable HardForkInitiation: decode failed",
-					"proposal_id", proposal.ID,
-					"error", err,
-				)
+			in.Logger.Warn(
+				"skipping ratifiable HardForkInitiation: decode failed",
+				"proposal_id", proposal.ID,
+				"error", err,
+			)
+			if in.OnProposalDecodeFailure != nil {
+				in.OnProposalDecodeFailure()
 			}
 			continue
 		}
@@ -198,27 +228,4 @@ func EvaluateRatifiableHardForkInitiation(
 		}, nil
 	}
 	return nil, nil
-}
-
-// countActiveDRepsAtEpoch returns the number of credential-backed DReps
-// eligible to vote in the given epoch (active and not aged out by
-// inactivity). AlwaysAbstain / AlwaysNoConfidence virtual DReps are not
-// counted. Equivalent to countActiveDReps but takes plain inputs so it
-// can be called outside the EpochInput-driven boundary path.
-func countActiveDRepsAtEpoch(
-	db *database.Database,
-	txn *database.Txn,
-	currentEpoch uint64,
-) (int, error) {
-	dreps, err := db.GetActiveDreps(txn)
-	if err != nil {
-		return 0, err
-	}
-	active := 0
-	for _, drep := range dreps {
-		if drepActiveAtEpoch(drep, currentEpoch) {
-			active++
-		}
-	}
-	return active, nil
 }

--- a/ledger/governance/stability.go
+++ b/ledger/governance/stability.go
@@ -17,8 +17,6 @@ package governance
 import (
 	"errors"
 	"fmt"
-	"io"
-	"log/slog"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -34,37 +32,30 @@ import (
 // mainnet rollover; refactoring it just to support mid-epoch evaluation
 // would risk regressions for marginal benefit.
 //
-// Build with NewStabilityCheckInputs to get a non-nil Logger.
-//
 // OnProposalDecodeFailure, if non-nil, is invoked once per proposal
-// whose stored CBOR fails to decode during the ratifiability scan.
-// Nil disables the signal.
+// whose stored CBOR fails to decode during the ratifiability scan. The
+// callback owns side effects (logging, metrics) so the helper itself
+// stays free of logger/metric dependencies.
 type StabilityCheckInputs struct {
 	DB                      *database.Database
 	Txn                     *database.Txn
-	Logger                  *slog.Logger
 	CurrentEpoch            uint64
 	PParams                 lcommon.ProtocolParameters
 	ConwayGenesis           *conway.ConwayGenesis
-	OnProposalDecodeFailure func()
+	OnProposalDecodeFailure func(proposal *models.GovernanceProposal, err error)
 }
 
 func NewStabilityCheckInputs(
 	db *database.Database,
 	txn *database.Txn,
-	logger *slog.Logger,
 	currentEpoch uint64,
 	pparams lcommon.ProtocolParameters,
 	conwayGenesis *conway.ConwayGenesis,
-	onProposalDecodeFailure func(),
+	onProposalDecodeFailure func(proposal *models.GovernanceProposal, err error),
 ) StabilityCheckInputs {
-	if logger == nil {
-		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
-	}
 	return StabilityCheckInputs{
 		DB:                      db,
 		Txn:                     txn,
-		Logger:                  logger,
 		CurrentEpoch:            currentEpoch,
 		PParams:                 pparams,
 		ConwayGenesis:           conwayGenesis,
@@ -162,7 +153,7 @@ func EvaluateRatifiableHardForkInitiation(
 	committeeNoConfidence := committeeNoConfidenceState(committeeRoot)
 
 	ccQuorum, err := conwayRatifyQuorum(
-		in.Logger, in.DB, in.Txn, in.ConwayGenesis,
+		nil, in.DB, in.Txn, in.ConwayGenesis,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("compute committee quorum: %w", err)
@@ -207,13 +198,8 @@ func EvaluateRatifiableHardForkInitiation(
 			proposal.GovActionCbor, proposal.ActionType,
 		)
 		if err != nil {
-			in.Logger.Warn(
-				"skipping ratifiable HardForkInitiation: decode failed",
-				"proposal_id", proposal.ID,
-				"error", err,
-			)
 			if in.OnProposalDecodeFailure != nil {
-				in.OnProposalDecodeFailure()
+				in.OnProposalDecodeFailure(proposal, err)
 			}
 			continue
 		}

--- a/ledger/governance/stability_test.go
+++ b/ledger/governance/stability_test.go
@@ -146,7 +146,7 @@ func seedDRepYesVote(
 func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T) {
 	db, _ := newTallyTestDB(t)
 	// pre-Conway: no governance state machine yet
-	in := NewStabilityCheckInputs(db, nil, nil, stabilityTestEpoch, nil, nil, nil)
+	in := NewStabilityCheckInputs(db, nil, stabilityTestEpoch, nil, nil, nil)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	assert.Nil(t, got, "pre-Conway pparams must short-circuit to nil")
@@ -155,7 +155,7 @@ func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T)
 func TestEvaluateRatifiableHardForkInitiation_NoActiveProposals_ReturnsNil(t *testing.T) {
 	db, _ := newTallyTestDB(t)
 	in := NewStabilityCheckInputs(
-		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func TestEvaluateRatifiableHardForkInitiation_OnlyOtherActionType_ReturnsNil(t *
 	}, nil))
 
 	in := NewStabilityCheckInputs(
-		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(t *testin
 	seedDRepYesVote(t, db, proposal.ID, drepCred)
 
 	in := NewStabilityCheckInputs(
-		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(t *
 	seedHardForkInitiationProposal(t, db, stabilityTestEpoch, 11, 1, stabilityProposalTx)
 
 	in := NewStabilityCheckInputs(
-		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestEvaluateRatifiableHardForkInitiation_MultipleRatifiable_PicksLowestAdde
 	seedDRepYesVote(t, db, late.ID, drepCred)
 
 	in := NewStabilityCheckInputs(
-		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)

--- a/ledger/governance/stability_test.go
+++ b/ledger/governance/stability_test.go
@@ -15,8 +15,6 @@
 package governance
 
 import (
-	"io"
-	"log/slog"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -53,14 +51,17 @@ func stabilityConwayPParams(major uint) *conway.ConwayProtocolParameters {
 
 // seedHardForkInitiationProposal inserts an active HardForkInitiation
 // proposal whose enacted state would bump the protocol major version to
-// targetMajor. The proposal is configured to be returned by
-// GetActiveGovernanceProposals(currentEpoch): proposed in the past, not
-// yet expired, not enacted/expired/deleted.
+// targetMajor. addedSlot and txHashSeed identify the proposal so callers
+// can seed multiple in the same DB. The proposal is configured to be
+// returned by GetActiveGovernanceProposals(currentEpoch): proposed in
+// the past, not yet expired, not enacted/expired/deleted.
 func seedHardForkInitiationProposal(
 	t *testing.T,
 	db *database.Database,
 	currentEpoch uint64,
 	targetMajor uint,
+	addedSlot uint64,
+	txHashSeed byte,
 ) *models.GovernanceProposal {
 	t.Helper()
 	action := &lcommon.HardForkInitiationGovAction{Type: 1}
@@ -70,7 +71,7 @@ func seedHardForkInitiationProposal(
 	require.NoError(t, err)
 
 	proposal := &models.GovernanceProposal{
-		TxHash:        testBytes(32, stabilityProposalTx),
+		TxHash:        testBytes(32, txHashSeed),
 		ActionIndex:   0,
 		ActionType:    uint8(lcommon.GovActionTypeHardForkInitiation),
 		ProposedEpoch: currentEpoch - 1,
@@ -80,7 +81,7 @@ func seedHardForkInitiationProposal(
 		AnchorURL:     "https://example.invalid/anchor",
 		AnchorHash:    testBytes(32, 0xEE),
 		GovActionCbor: cborBytes,
-		AddedSlot:     1,
+		AddedSlot:     addedSlot,
 	}
 	require.NoError(t, db.SetGovernanceProposal(proposal, nil))
 	loaded, err := db.GetGovernanceProposal(proposal.TxHash, 0, nil)
@@ -144,12 +145,8 @@ func seedDRepYesVote(
 
 func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T) {
 	db, _ := newTallyTestDB(t)
-	in := StabilityCheckInputs{
-		DB:           db,
-		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		CurrentEpoch: stabilityTestEpoch,
-		PParams:      nil, // pre-Conway: no governance state machine yet
-	}
+	// pre-Conway: no governance state machine yet
+	in := NewStabilityCheckInputs(db, nil, nil, stabilityTestEpoch, nil, nil, nil)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	assert.Nil(t, got, "pre-Conway pparams must short-circuit to nil")
@@ -157,12 +154,9 @@ func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T)
 
 func TestEvaluateRatifiableHardForkInitiation_NoActiveProposals_ReturnsNil(t *testing.T) {
 	db, _ := newTallyTestDB(t)
-	in := StabilityCheckInputs{
-		DB:           db,
-		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		CurrentEpoch: stabilityTestEpoch,
-		PParams:      stabilityConwayPParams(9),
-	}
+	in := NewStabilityCheckInputs(
+		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	assert.Nil(t, got, "empty active proposal set must yield nil")
@@ -189,12 +183,9 @@ func TestEvaluateRatifiableHardForkInitiation_OnlyOtherActionType_ReturnsNil(t *
 		AddedSlot:     1,
 	}, nil))
 
-	in := StabilityCheckInputs{
-		DB:           db,
-		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		CurrentEpoch: stabilityTestEpoch,
-		PParams:      stabilityConwayPParams(9),
-	}
+	in := NewStabilityCheckInputs(
+		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	assert.Nil(t, got, "non-HardForkInitiation actions must be ignored")
@@ -210,16 +201,15 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(t *testin
 	db, _ := newTallyTestDB(t)
 
 	const targetMajor uint = 11
-	proposal := seedHardForkInitiationProposal(t, db, stabilityTestEpoch, targetMajor)
+	proposal := seedHardForkInitiationProposal(
+		t, db, stabilityTestEpoch, targetMajor, 1, stabilityProposalTx,
+	)
 	drepCred := seedDRepWithStake(t, db, 1_000)
 	seedDRepYesVote(t, db, proposal.ID, drepCred)
 
-	in := StabilityCheckInputs{
-		DB:           db,
-		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		CurrentEpoch: stabilityTestEpoch,
-		PParams:      stabilityConwayPParams(9),
-	}
+	in := NewStabilityCheckInputs(
+		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	require.NotNil(t, got, "bootstrap + yes vote must be ratifiable")
@@ -235,15 +225,52 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(t *testin
 // of any kind, the proposal does not ratify.
 func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(t *testing.T) {
 	db, _ := newTallyTestDB(t)
-	seedHardForkInitiationProposal(t, db, stabilityTestEpoch, 11)
+	seedHardForkInitiationProposal(t, db, stabilityTestEpoch, 11, 1, stabilityProposalTx)
 
-	in := StabilityCheckInputs{
-		DB:           db,
-		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		CurrentEpoch: stabilityTestEpoch,
-		PParams:      stabilityConwayPParams(9),
-	}
+	in := NewStabilityCheckInputs(
+		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	assert.Nil(t, got, "no votes means no ratification, even in bootstrap")
+}
+
+// When two HardForkInitiation proposals are simultaneously ratifiable,
+// EvaluateRatifiableHardForkInitiation must return the one with the
+// lower added_slot — matching the order ProcessEpoch's RATIFY phase
+// would select. This pins the parity between the mid-epoch and
+// boundary paths without a full integration test.
+func TestEvaluateRatifiableHardForkInitiation_MultipleRatifiable_PicksLowestAddedSlot(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+
+	const (
+		earlyMajor    uint = 11
+		earlySlot     uint64 = 1
+		earlyHashSeed byte   = 0xA1
+		lateMajor     uint = 12
+		lateSlot      uint64 = 10
+		lateHashSeed  byte   = 0xA2
+	)
+
+	early := seedHardForkInitiationProposal(
+		t, db, stabilityTestEpoch, earlyMajor, earlySlot, earlyHashSeed,
+	)
+	late := seedHardForkInitiationProposal(
+		t, db, stabilityTestEpoch, lateMajor, lateSlot, lateHashSeed,
+	)
+
+	drepCred := seedDRepWithStake(t, db, 1_000)
+	seedDRepYesVote(t, db, early.ID, drepCred)
+	seedDRepYesVote(t, db, late.ID, drepCred)
+
+	in := NewStabilityCheckInputs(
+		db, nil, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+	)
+	got, err := EvaluateRatifiableHardForkInitiation(in)
+	require.NoError(t, err)
+	require.NotNil(t, got, "at least one HFI should be ratifiable")
+	assert.Equal(t, early.ID, got.Proposal.ID,
+		"the lower added_slot proposal must win")
+	assert.Equal(t, earlyMajor, got.NewMajor,
+		"NewMajor must come from the lower added_slot proposal")
 }

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -35,6 +35,10 @@ type stateMetrics struct {
 	shelleyStartTime    prometheus.Gauge
 	epochLengthSlots    prometheus.Gauge
 	shadowGateDecisions *prometheus.CounterVec
+	// Incremented when a stored governance proposal's CBOR fails to
+	// decode during the mid-epoch ratifiability check, so the failures
+	// surface as a metric instead of just log volume.
+	governanceProposalDecodeFailures prometheus.Counter
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -121,5 +125,11 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 			Help: "shadow blockfetch gate decisions, by path and cutoff source",
 		},
 		[]string{"path", "cutoff"},
+	)
+	m.governanceProposalDecodeFailures = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_governance_proposal_decode_failures_total",
+			Help: "stored governance proposals whose CBOR failed to decode during ratifiability checks",
+		},
 	)
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3851,17 +3851,24 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 	db := ls.db
 	logger := ls.config.Logger
 	decodeFailures := ls.metrics.governanceProposalDecodeFailures
+	onDecodeFailure := func(proposal *models.GovernanceProposal, err error) {
+		logger.Warn(
+			"skipping ratifiable HardForkInitiation: decode failed",
+			"proposal_id", proposal.ID,
+			"error", err,
+		)
+		decodeFailures.Inc()
+	}
 	go func() {
 		defer ls.hfiStabilityEvalInFlight.Store(false)
 		result, err := governance.EvaluateRatifiableHardForkInitiation(
 			governance.NewStabilityCheckInputs(
 				db,
 				nil,
-				logger,
 				snapshotEpoch,
 				snapshotPParams,
 				conwayGenesis,
-				decodeFailures.Inc,
+				onDecodeFailure,
 			),
 		)
 		if err != nil {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3850,16 +3850,19 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 	conwayGenesis := ls.config.CardanoNodeConfig.ConwayGenesis()
 	db := ls.db
 	logger := ls.config.Logger
+	decodeFailures := ls.metrics.governanceProposalDecodeFailures
 	go func() {
 		defer ls.hfiStabilityEvalInFlight.Store(false)
 		result, err := governance.EvaluateRatifiableHardForkInitiation(
-			governance.StabilityCheckInputs{
-				DB:            db,
-				Logger:        logger,
-				CurrentEpoch:  snapshotEpoch,
-				PParams:       snapshotPParams,
-				ConwayGenesis: conwayGenesis,
-			},
+			governance.NewStabilityCheckInputs(
+				db,
+				nil,
+				logger,
+				snapshotEpoch,
+				snapshotPParams,
+				conwayGenesis,
+				decodeFailures.Inc,
+			),
 		)
 		if err != nil {
 			logger.Warn(

--- a/ledger/transition_stability_test.go
+++ b/ledger/transition_stability_test.go
@@ -30,6 +30,7 @@ import (
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,6 +101,7 @@ func stabilityFixtureLedgerState(
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.metrics.init(prometheus.NewRegistry())
 	return ls, db
 }
 


### PR DESCRIPTION
## Summary

Address the four code-hygiene items in `ledger/governance/stability.go` from #2097:

1. **Logger nil-handling** — added `NewStabilityCheckInputs` constructor that defaults a nil logger to a discard sink. All construction sites (production + tests) routed through the constructor; removed the per-call-site `if Logger != nil` guard.
2. **Multiple ratifiable HFI ordering** — new test `TestEvaluateRatifiableHardForkInitiation_MultipleRatifiable_PicksLowestAddedSlot` seeds two ratifiable HFI proposals with different `added_slot`, asserts the lower-slot proposal wins. Pins parity with `ProcessEpoch`'s RATIFY iteration order without an integration test.
3. **Shared `countActiveDReps` helper** — collapsed the `countActiveDReps` (epoch.go) / `countActiveDRepsAtEpoch` (stability.go) parallel into a single `countActiveDReps(db, txn, currentEpoch)` plain-args function called from both sites. Stale cross-reference comments removed.
4. **Decode-failure metric** — new counter `dingo_governance_proposal_decode_failures_total` on `ledger.stateMetrics`. `StabilityCheckInputs` gained an optional `OnProposalDecodeFailure func()` callback (wired to `counter.Inc` by the production caller in `ledger/state.go`). Keeps the governance package free of a prometheus dependency.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./ledger/... -count=1` — all pass
- [x] `golangci-lint run ./ledger/governance/... ./ledger/` — clean on touched code (4 pre-existing gosec hits in `state.go` are unrelated)
- [x] New ordering test passes; all 5 prior `EvaluateRatifiableHardForkInitiation_*` tests still pass through the new constructor

closes #2097 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes logger coupling from governance stability checks, consolidates shared helpers, and adds a metric + callback for proposal decode failures. Also pins deterministic HFI selection by lowest added_slot.

- **Refactors**
  - Dropped Logger from `StabilityCheckInputs`; added `NewStabilityCheckInputs(..., onDecodeFailure)` and removed nil-logger guards.
  - Unified `countActiveDReps` into `countActiveDReps(db, txn, currentEpoch)` and removed the duplicate helper.
  - Tests updated to the new constructor and explicit proposal seeding (added_slot, tx hash seed).

- **New Features**
  - Added `dingo_governance_proposal_decode_failures_total` and an `OnProposalDecodeFailure(proposal, err)` callback; production logs a warning and increments the counter to keep `governance` free of a Prometheus dependency.
  - When multiple HFIs are ratifiable, the one with the lowest `added_slot` is selected; covered by a new test.

<sup>Written for commit 3a821f4fe1808d44a40db33957f1bcfce484ac4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



