### PR TITLE
fix(utxorpc): use in-memory TLS cert

### DIFF
--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -276,15 +276,23 @@ func (u *Utxorpc) startServer(server *http.Server) error {
 	serverType := "non-TLS"
 	if useTLS {
 		serverType = "TLS"
-		if _, err := tls.LoadX509KeyPair(
+		cert, err := tls.LoadX509KeyPair(
 			u.config.TlsCertFilePath,
 			u.config.TlsKeyFilePath,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf(
 				"failed to load TLS keypair for utxorpc gRPC %s server: %w",
 				serverType, err,
 			)
 		}
+		if server.TLSConfig == nil {
+			server.TLSConfig = &tls.Config{}
+		}
+		server.TLSConfig.Certificates = append(
+			server.TLSConfig.Certificates,
+			cert,
+		)
 	}
 	ln, err := net.Listen("tcp", server.Addr)
 	if err != nil {
@@ -296,8 +304,8 @@ func (u *Utxorpc) startServer(server *http.Server) error {
 		if useTLS {
 			serveErr = server.ServeTLS(
 				ln,
-				u.config.TlsCertFilePath,
-				u.config.TlsKeyFilePath,
+				"",
+				"",
 			)
 		} else {
 			serveErr = server.Serve(ln)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch `utxorpc` to load TLS certs into memory and serve via `http.Server`’s `TLSConfig`, fixing TLS startup issues and avoiding file-based cert reads.

- **Bug Fixes**
  - Load cert/key with `tls.LoadX509KeyPair` and append to `server.TLSConfig.Certificates`.
  - Call `ServeTLS` with empty cert/key paths to use the in-memory config.

<sup>Written for commit 734446ea89274242c1c7c7bef4efdb9c0bbd0fed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

