### PR TITLE
fix(leader): schedule-aware slot-to-epoch lookup

### DIFF
--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -57,6 +57,13 @@ type EpochInfoProvider interface {
 	// SlotsPerEpoch returns the number of slots in an epoch.
 	SlotsPerEpoch() uint64
 
+	// EpochForSlot returns the epoch containing slot, resolved against
+	// the ledger hard-fork summary so era boundaries and variable epoch
+	// lengths are respected. Returns an error when slot falls outside
+	// the known epoch range (the caller treats that as "schedule
+	// unknown" and declines to produce).
+	EpochForSlot(slot uint64) (uint64, error)
+
 	// ActiveSlotCoeff returns the active slot coefficient (f parameter).
 	ActiveSlotCoeff() float64
 
@@ -764,11 +771,16 @@ func (e *Election) queueScheduleCompute(epoch uint64) {
 // schedule for the slot's epoch. If no schedule is cached, it requests a
 // background computation and returns false.
 func (e *Election) ShouldProduceBlock(slot uint64) bool {
-	slotsPerEpoch := e.epochProvider.SlotsPerEpoch()
-	if slotsPerEpoch == 0 {
+	slotEpoch, err := e.epochProvider.EpochForSlot(slot)
+	if err != nil {
+		e.logger.Debug(
+			"slot outside known epoch range; declining production",
+			"component", "leader",
+			"slot", slot,
+			"error", err,
+		)
 		return false
 	}
-	slotEpoch := slot / slotsPerEpoch
 
 	e.mu.RLock()
 	var schedule *Schedule
@@ -836,12 +848,10 @@ func (e *Election) NextLeaderSlot(fromSlot uint64) (uint64, bool) {
 		return 0, false
 	}
 
-	slotsPerEpoch := e.epochProvider.SlotsPerEpoch()
-	if slotsPerEpoch == 0 {
+	epoch, err := e.epochProvider.EpochForSlot(fromSlot)
+	if err != nil {
 		return 0, false
 	}
-
-	epoch := fromSlot / slotsPerEpoch
 	schedule := e.schedules[epoch]
 	if schedule != nil {
 		for _, slot := range schedule.LeaderSlots {

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -17,6 +17,7 @@ package leader
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -96,6 +97,10 @@ type mockEpochProvider struct {
 	slotsPerEpoch   uint64
 	activeSlotCoeff float64
 	nextEpochReady  atomic.Uint64
+	// epochForSlot, when set, overrides EpochForSlot's default fixed
+	// division so tests can model variable epoch lengths or simulate
+	// past-horizon errors.
+	epochForSlot func(slot uint64) (uint64, error)
 }
 
 func newMockEpochProvider() *mockEpochProvider {
@@ -133,6 +138,16 @@ func (m *mockEpochProvider) NextEpochNonceReadyEpoch() (uint64, bool) {
 
 func (m *mockEpochProvider) SlotsPerEpoch() uint64 {
 	return m.slotsPerEpoch
+}
+
+func (m *mockEpochProvider) EpochForSlot(slot uint64) (uint64, error) {
+	if m.epochForSlot != nil {
+		return m.epochForSlot(slot)
+	}
+	if m.slotsPerEpoch == 0 {
+		return 0, errors.New("slotsPerEpoch unset")
+	}
+	return slot / m.slotsPerEpoch, nil
 }
 
 func (m *mockEpochProvider) ActiveSlotCoeff() float64 {
@@ -612,6 +627,139 @@ func TestElectionNextLeaderSlot(t *testing.T) {
 	assert.True(t, found, "should find a leader slot in the epoch")
 	assert.GreaterOrEqual(t, slot, epochStart,
 		"leader slot should be at or after epoch start")
+}
+
+// TestElectionShouldProduceBlock_UsesEpochForSlot pins that slot→epoch
+// lookup goes through EpochInfoProvider.EpochForSlot rather than fixed
+// division, so a network with non-uniform epoch lengths or non-zero
+// epoch starts still selects the correct cached schedule.
+func TestElectionShouldProduceBlock_UsesEpochForSlot(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	epochProvider := newMockEpochProvider()
+
+	// A network where epoch 10 doesn't start at slot 10*slotsPerEpoch.
+	// Slot 5_000 lands in epoch 10; slot 5_100 lands in epoch 11. Fixed
+	// division (slot/10 = 500 / 510) would land both in the wrong epoch.
+	const (
+		targetEpoch uint64 = 10
+		nextEpoch   uint64 = 11
+		inEpoch10   uint64 = 5_000
+		inEpoch11   uint64 = 5_100
+	)
+	epochProvider.epochForSlot = func(slot uint64) (uint64, error) {
+		switch {
+		case slot >= inEpoch11:
+			return nextEpoch, nil
+		case slot >= inEpoch10:
+			return targetEpoch, nil
+		default:
+			return 0, errors.New("before any known epoch")
+		}
+	}
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	// Seed the cache with a schedule for epoch 10 listing inEpoch10 as a
+	// leader slot, without going through async compute.
+	sched := NewSchedule(
+		targetEpoch, poolId, 1, 1, electionTestNonce,
+	)
+	sched.AddLeaderSlot(inEpoch10)
+	election.mu.Lock()
+	election.schedules = map[uint64]*Schedule{targetEpoch: sched}
+	election.mu.Unlock()
+
+	assert.True(t, election.ShouldProduceBlock(inEpoch10),
+		"slot resolving to epoch 10 must hit the cached schedule")
+	assert.False(t, election.ShouldProduceBlock(inEpoch11),
+		"slot resolving to epoch 11 must miss the cached schedule")
+}
+
+// TestElectionShouldProduceBlock_ReturnsFalseOnEpochResolveError pins
+// the safe-default: when EpochForSlot can't resolve (slot outside the
+// known range), the producer declines rather than running with an
+// incorrect epoch index. The compute path is not engaged because we
+// don't know which epoch's schedule to request.
+func TestElectionShouldProduceBlock_ReturnsFalseOnEpochResolveError(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	epochProvider := newMockEpochProvider()
+	epochProvider.epochForSlot = func(uint64) (uint64, error) {
+		return 0, errors.New("past horizon")
+	}
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		newMockStakeProvider(),
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	assert.False(t, election.ShouldProduceBlock(999_999),
+		"unresolvable slot must not produce")
+}
+
+// TestElectionNextLeaderSlot_UsesEpochForSlot pins that NextLeaderSlot
+// queries EpochForSlot rather than fixed division when picking which
+// epoch's cached schedule to scan.
+func TestElectionNextLeaderSlot_UsesEpochForSlot(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	epochProvider := newMockEpochProvider()
+	const (
+		targetEpoch uint64 = 10
+		epochStart  uint64 = 5_000
+		leaderSlot  uint64 = 5_020
+	)
+	epochProvider.epochForSlot = func(slot uint64) (uint64, error) {
+		if slot < epochStart {
+			return 0, errors.New("before epoch start")
+		}
+		return targetEpoch, nil
+	}
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		newMockStakeProvider(),
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+	sched := NewSchedule(
+		targetEpoch, poolId, 1, 1, electionTestNonce,
+	)
+	sched.AddLeaderSlot(leaderSlot)
+	election.mu.Lock()
+	election.schedules = map[uint64]*Schedule{targetEpoch: sched}
+	election.mu.Unlock()
+
+	got, found := election.NextLeaderSlot(epochStart)
+	assert.True(t, found, "leader slot in resolved epoch must be found")
+	assert.Equal(t, leaderSlot, got)
+
+	// Unresolvable slot: helper returns 0,false rather than scanning the
+	// wrong epoch's schedule.
+	got, found = election.NextLeaderSlot(0)
+	assert.False(t, found, "unresolvable slot must yield no result")
+	assert.Equal(t, uint64(0), got)
 }
 
 func TestElectionEpochTransition(t *testing.T) {

--- a/node_forging.go
+++ b/node_forging.go
@@ -365,6 +365,14 @@ func (a *epochInfoAdapter) SlotsPerEpoch() uint64 {
 	return a.ledgerState.SlotsPerEpoch()
 }
 
+func (a *epochInfoAdapter) EpochForSlot(slot uint64) (uint64, error) {
+	epoch, err := a.ledgerState.SlotToEpoch(slot)
+	if err != nil {
+		return 0, err
+	}
+	return epoch.EpochId, nil
+}
+
 func (a *epochInfoAdapter) ActiveSlotCoeff() float64 {
 	return a.ledgerState.ActiveSlotCoeff()
 }


### PR DESCRIPTION
## Summary

Resolves audit finding M2 (#2267). Leader election was computing a slot's epoch via fixed integer division (`slot / slotsPerEpoch`) at two sites in `ledger/leader/election.go`. That assumes every epoch starts at a multiple of `slotsPerEpoch` and that all epochs have the same length — neither is enforced, and both can be violated by hard forks, test networks, or future eras with different epoch shapes.

This change routes the lookup through the ledger's hard-fork summary, which is already the source of truth elsewhere in the codebase.

## Changes

- **`ledger/leader/election.go`** — added `EpochForSlot(slot uint64) (uint64, error)` to the `EpochInfoProvider` interface. `ShouldProduceBlock` and `NextLeaderSlot` now resolve slot→epoch via this method; an unresolved slot (outside the known epoch range) drops the producer to its existing safe defaults (decline production / no result) rather than reading the wrong cached schedule.
- **`node_forging.go`** — `epochInfoAdapter.EpochForSlot` delegates to the existing schedule-aware `LedgerState.SlotToEpoch`, which is already used by the nonce path and resolves via `HardForkSummary().SlotToEpoch(slot)`.
- **`ledger/leader/election_test.go`** — added an `epochForSlot` override hook on `mockEpochProvider` (defaults to fixed division, so existing tests are unchanged) plus three new tests covering: non-zero epoch start, past-horizon lookup error, and the same wiring through `NextLeaderSlot`.

`SlotsPerEpoch()` stays on the interface — it's still used legitimately for schedule iteration and metrics. Only the slot→epoch *resolution* uses the new method.

## Test plan

- [x] `go build ./...`
- [x] `go test ./ledger/... ./ -count=1` — all pass
- [x] `golangci-lint run ./ledger/leader/... ./` — clean
- [x] New tests cover: schedule found at non-zero epoch start; producer declines on unresolvable slot; `NextLeaderSlot` honors the same lookup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make leader election slot→epoch lookup schedule-aware to avoid wrong epoch selection on non-uniform eras and hard-fork boundaries. Addresses audit M2 (Linear #2267) and prevents producing blocks with an incorrect schedule.

- **Bug Fixes**
  - Added `EpochForSlot(slot uint64) (uint64, error)` to `EpochInfoProvider` and routed lookups through the hard-fork summary.
  - Updated `ShouldProduceBlock` and `NextLeaderSlot` in `ledger/leader/election.go` to use `EpochForSlot`; decline production when a slot is outside the known range.
  - Implemented `epochInfoAdapter.EpochForSlot` in `node_forging.go` via `LedgerState.SlotToEpoch`.
  - Added tests for non-zero epoch starts, past-horizon errors, and `NextLeaderSlot` wiring.

- **Migration**
  - If you implement `EpochInfoProvider`, add `EpochForSlot(slot uint64) (uint64, error)` using a schedule-aware source (e.g., `SlotToEpoch`).
  - Keep `SlotsPerEpoch()` as-is; no config changes.

<sup>Written for commit 58f448c2bcdd078889c1d1a2e5031e9ead812f9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

