### PR TITLE
fix: return errors instead of panicking on missing required dependencies

### DIFF
--- a/bark/bark.go
+++ b/bark/bark.go
@@ -50,7 +50,10 @@ type BarkConfig struct {
 	Port            uint
 }
 
-func NewBark(cfg BarkConfig) *Bark {
+func NewBark(cfg BarkConfig) (*Bark, error) {
+	if cfg.DB == nil {
+		return nil, errors.New("bark: db is required")
+	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
@@ -60,12 +63,9 @@ func NewBark(cfg BarkConfig) *Bark {
 	if cfg.Port == 0 {
 		cfg.Port = 9091
 	}
-	if cfg.DB == nil {
-		panic("db is required")
-	}
 	return &Bark{
 		config: cfg,
-	}
+	}, nil
 }
 
 func (b *Bark) Start(ctx context.Context) error {

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -56,9 +56,9 @@ type BlobStoreBark struct {
 func NewBarkBlobStore(
 	config BlobStoreBarkConfig,
 	upstream blob.BlobStore,
-) *BlobStoreBark {
+) (*BlobStoreBark, error) {
 	if config.LedgerState == nil {
-		panic("bark: ledger state is required")
+		return nil, errors.New("bark: ledger state is required")
 	}
 
 	httpClient := config.HTTPClient
@@ -76,7 +76,7 @@ func NewBarkBlobStore(
 		),
 		httpClient: httpClient,
 		upstream:   upstream,
-	}
+	}, nil
 }
 
 func (b *BlobStoreBark) Close() error {

--- a/bark/constructor_test.go
+++ b/bark/constructor_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bark
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewBark_RejectsNilDB pins that the constructor returns an error
+// rather than panicking when the required database dependency is nil.
+func TestNewBark_RejectsNilDB(t *testing.T) {
+	b, err := NewBark(BarkConfig{DB: nil})
+	require.Error(t, err)
+	assert.Nil(t, b)
+	assert.Contains(t, err.Error(), "db is required")
+}
+
+// TestNewBarkBlobStore_RejectsNilLedgerState pins that the constructor
+// returns an error rather than panicking when the required ledger state
+// dependency is nil.
+func TestNewBarkBlobStore_RejectsNilLedgerState(t *testing.T) {
+	bs, err := NewBarkBlobStore(BlobStoreBarkConfig{LedgerState: nil}, nil)
+	require.Error(t, err)
+	assert.Nil(t, bs)
+	assert.Contains(t, err.Error(), "ledger state is required")
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -292,6 +292,13 @@ func (o *utxoOverlay) simulateRemoveBatch(
 	return consumed, created
 }
 
+// ErrNilValidator is returned by runtime mempool operations that require
+// a non-nil validator. The constructor refuses to build a Mempool without
+// one, so seeing this in a running node is a programmer error — but
+// returning it lets the chain-update loop log and continue rather than
+// crash the node.
+var ErrNilValidator = errors.New("mempool: validator is nil")
+
 type MempoolFullError struct {
 	CurrentSize int
 	TxSize      int
@@ -307,9 +314,9 @@ func (e *MempoolFullError) Error() string {
 	)
 }
 
-func NewMempool(config MempoolConfig) *Mempool {
+func NewMempool(config MempoolConfig) (*Mempool, error) {
 	if config.Validator == nil {
-		panic("mempool: validator must not be nil")
+		return nil, ErrNilValidator
 	}
 	evictionWatermark := config.EvictionWatermark
 	if evictionWatermark == 0 {
@@ -393,7 +400,7 @@ func NewMempool(config MempoolConfig) *Mempool {
 	go m.processChainEvents()
 	// Start TTL cleanup goroutine
 	go m.expireTransactions()
-	return m
+	return m, nil
 }
 
 func (m *Mempool) AddConsumer(connId ouroboros.ConnectionId) *MempoolConsumer {
@@ -478,8 +485,16 @@ func (m *Mempool) processChainEvents() {
 			continue
 		}
 		// Rebuild overlay: re-validate each pending TX in order against
-		// a fresh overlay, removing TXs that no longer validate.
-		m.rebuildOverlay()
+		// a fresh overlay, removing TXs that no longer validate. Log
+		// and continue on error — the next chain update will try
+		// again rather than crashing the node.
+		if err := m.rebuildOverlay(); err != nil {
+			m.logger.Error(
+				"mempool overlay rebuild failed",
+				"component", "mempool",
+				"error", err,
+			)
+		}
 		lastValidationTime = time.Now()
 	}
 }
@@ -490,9 +505,12 @@ func (m *Mempool) processChainEvents() {
 // AddTransaction (which also holds the write lock when updating the overlay).
 // This is safe because mempool TX submission rate is low at tip and
 // cardano-node also serializes mempool additions.
-func (m *Mempool) rebuildOverlay() {
+//
+// Returns ErrNilValidator if called on a Mempool whose validator is nil —
+// a programmer error the chain-update loop logs rather than crashes on.
+func (m *Mempool) rebuildOverlay() error {
 	if m.validator == nil {
-		panic("mempool: validator is nil in rebuildOverlay")
+		return ErrNilValidator
 	}
 	m.Lock()
 	prevApplied := make([]appliedTx, len(m.overlay.applied))
@@ -500,7 +518,7 @@ func (m *Mempool) rebuildOverlay() {
 
 	if len(prevApplied) == 0 {
 		m.Unlock()
-		return
+		return nil
 	}
 
 	// Re-validate each TX in order against a fresh overlay.
@@ -571,6 +589,7 @@ func (m *Mempool) rebuildOverlay() {
 			m.eventBus.Publish(RemoveTransactionEventType, evt)
 		}
 	}
+	return nil
 }
 
 // expireTransactions periodically removes transactions that have

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -96,13 +96,15 @@ const testTxHex = "84a700818258200c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a5359
 // newTestMempool creates a mempool configured for testing
 func newTestMempool(t *testing.T) *Mempool {
 	t.Helper()
-	return NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        event.NewEventBus(nil, nil),
 		PromRegistry:    prometheus.NewRegistry(),
 		Validator:       newMockValidator(),
 		MempoolCapacity: 1024 * 1024, // 1MB
 	})
+	require.NoError(t, err)
+	return m
 }
 
 // newTestMempoolWithValidator creates a mempool with a specific validator
@@ -111,13 +113,15 @@ func newTestMempoolWithValidator(
 	v TxValidator,
 ) *Mempool {
 	t.Helper()
-	return NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        event.NewEventBus(nil, nil),
 		PromRegistry:    prometheus.NewRegistry(),
 		Validator:       v,
 		MempoolCapacity: 1024 * 1024,
 	})
+	require.NoError(t, err)
+	return m
 }
 
 // newTestConnectionId creates a unique connection ID for testing
@@ -173,12 +177,13 @@ func getTestTxBytes(t *testing.T) []byte {
 
 func TestMempool_Stop(t *testing.T) {
 	// Create a mempool with minimal config
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:     event.NewEventBus(nil, nil),
 		PromRegistry: prometheus.NewRegistry(),
 		Validator:    newMockValidator(),
 	})
+	require.NoError(t, err)
 
 	// Add a consumer to test cleanup
 	localAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
@@ -1350,18 +1355,19 @@ func TestMempool_AddTransaction_ValidationFailure(t *testing.T) {
 }
 
 func TestMempool_MempoolFull(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        event.NewEventBus(nil, nil),
 		PromRegistry:    prometheus.NewRegistry(),
 		Validator:       newMockValidator(),
 		MempoolCapacity: 100, // Very small capacity
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	// Add transaction that exceeds capacity
 	txBytes := getTestTxBytes(t)
-	err := m.AddTransaction(uint(conway.EraIdConway), txBytes)
+	err = m.AddTransaction(uint(conway.EraIdConway), txBytes)
 
 	require.Error(t, err, "should fail due to capacity")
 	var fullErr *MempoolFullError
@@ -1377,7 +1383,7 @@ func TestMempool_MempoolFull(t *testing.T) {
 const testTxWithValidityStartHex = "84a8081a02faf08000818258200c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8010181a20058390073a817bb425cbe179af824529d96ceb93c41c3ab507380095d1be4ebd64c93ef0094f5c179e5380109ebeef022245944e3914f5bcca3a793011a02dc6c00021a001e84800b5820192d0c0c2c2320e843e080b5f91a9ca35155bc50f3ef3bfdbc72c1711b86367e0d818258203af629a5cd75f76d0cc21172e1193b85f199ca78e837c3965d77d7d6bc90206b0010a20058390073a817bb425cbe179af824529d96ceb93c41c3ab507380095d1be4ebd64c93ef0094f5c179e5380109ebeef022245944e3914f5bcca3a793011a006acfc0111a002dc6c0a4008182582025fcacade3fffc096b53bdaf4c7d012bded303c9edbee686d24b372dae60aa1b58409da928a064ff9f795110bdcb8ab05d2a7a023dd15ebc42044f102ce366c0c9077024c7951c2d63584b7d2eea7bf1da4a7453bde4c99dd083889c1e2e2e3db804048119077a0581840000187b820a0a06814746010000222601f4f6"
 
 func TestMempool_AddTransaction_RejectsValidityIntervalBeyondCurrentSlot(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        event.NewEventBus(nil, nil),
 		PromRegistry:    prometheus.NewRegistry(),
@@ -1385,6 +1391,7 @@ func TestMempool_AddTransaction_RejectsValidityIntervalBeyondCurrentSlot(t *test
 		MempoolCapacity: 1024 * 1024,
 		CurrentSlotFunc: func() uint64 { return 40_000_000 },
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	txBytes, err := hex.DecodeString(testTxWithValidityStartHex)
@@ -1398,7 +1405,7 @@ func TestMempool_AddTransaction_RejectsValidityIntervalBeyondCurrentSlot(t *test
 }
 
 func TestMempool_AddTransaction_AcceptsValidityIntervalAtOrBelowCurrentSlot(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        event.NewEventBus(nil, nil),
 		PromRegistry:    prometheus.NewRegistry(),
@@ -1406,6 +1413,7 @@ func TestMempool_AddTransaction_AcceptsValidityIntervalAtOrBelowCurrentSlot(t *t
 		MempoolCapacity: 1024 * 1024,
 		CurrentSlotFunc: func() uint64 { return 60_000_000 },
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	txBytes, err := hex.DecodeString(testTxWithValidityStartHex)
@@ -1418,7 +1426,7 @@ func TestMempool_AddTransaction_AcceptsValidityIntervalAtOrBelowCurrentSlot(t *t
 }
 
 func TestMempool_AddTransaction_NoValidityStart_BypassesCheck(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        event.NewEventBus(nil, nil),
 		PromRegistry:    prometheus.NewRegistry(),
@@ -1426,11 +1434,12 @@ func TestMempool_AddTransaction_NoValidityStart_BypassesCheck(t *testing.T) {
 		MempoolCapacity: 1024 * 1024,
 		CurrentSlotFunc: func() uint64 { return 1 }, // very low current slot
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	// Original test TX has ValidityIntervalStart=0 (no lower bound)
 	txBytes := getTestTxBytes(t)
-	err := m.AddTransaction(uint(conway.EraIdConway), txBytes)
+	err = m.AddTransaction(uint(conway.EraIdConway), txBytes)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(m.Transactions()), "TX with no validity start should bypass check")
 }
@@ -1656,7 +1665,7 @@ func newTestMempoolWithCapacity(
 	rejectionWM float64,
 ) *Mempool {
 	t.Helper()
-	return NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
@@ -1667,6 +1676,8 @@ func newTestMempoolWithCapacity(
 		EvictionWatermark:  evictionWM,
 		RejectionWatermark: rejectionWM,
 	})
+	require.NoError(t, err)
+	return m
 }
 
 // addMockTransactionsOfSize adds mock transactions with CBOR
@@ -1890,7 +1901,7 @@ func TestMempool_Eviction_CounterIncrements(t *testing.T) {
 }
 
 func TestMempool_DefaultWatermarkValues(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
@@ -1899,6 +1910,7 @@ func TestMempool_DefaultWatermarkValues(t *testing.T) {
 		Validator:       newMockValidator(),
 		MempoolCapacity: 1024 * 1024,
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	assert.Equal(
@@ -1916,7 +1928,7 @@ func TestMempool_DefaultWatermarkValues(t *testing.T) {
 }
 
 func TestMempool_CustomWatermarkValues(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
@@ -1927,6 +1939,7 @@ func TestMempool_CustomWatermarkValues(t *testing.T) {
 		EvictionWatermark:  0.75,
 		RejectionWatermark: 0.85,
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	assert.Equal(
@@ -2065,7 +2078,7 @@ func newTestMempoolWithTTL(
 	cleanupInterval time.Duration,
 ) *Mempool {
 	t.Helper()
-	return NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
@@ -2076,6 +2089,8 @@ func newTestMempoolWithTTL(
 		TransactionTTL:  ttl,
 		CleanupInterval: cleanupInterval,
 	})
+	require.NoError(t, err)
+	return m
 }
 
 func TestMempool_TTL_ExpiredTransactionsRemoved(t *testing.T) {
@@ -2392,7 +2407,7 @@ func TestMempool_TTL_ConsumerIndexAdjustedOnExpiry(t *testing.T) {
 }
 
 func TestMempool_TTL_DefaultValues(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
@@ -2401,6 +2416,7 @@ func TestMempool_TTL_DefaultValues(t *testing.T) {
 		Validator:       newMockValidator(),
 		MempoolCapacity: 1024 * 1024,
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	assert.Equal(
@@ -2414,7 +2430,7 @@ func TestMempool_TTL_DefaultValues(t *testing.T) {
 }
 
 func TestMempool_TTL_CustomValues(t *testing.T) {
-	m := NewMempool(MempoolConfig{
+	m, err := NewMempool(MempoolConfig{
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
@@ -2425,6 +2441,7 @@ func TestMempool_TTL_CustomValues(t *testing.T) {
 		TransactionTTL:  10 * time.Minute,
 		CleanupInterval: 30 * time.Second,
 	})
+	require.NoError(t, err)
 	defer m.Stop(context.Background())
 
 	assert.Equal(
@@ -3176,7 +3193,7 @@ func TestOverlayRebuildOnChainUpdate(t *testing.T) {
 	v.removeBaseUtxo(realInputKey)
 
 	// Rebuild overlay (simulates what processChainEvents does)
-	m.rebuildOverlay()
+	require.NoError(t, m.rebuildOverlay())
 
 	// TX should be evicted because its input is no longer in base UTxOs
 	m.RLock()
@@ -3186,4 +3203,28 @@ func TestOverlayRebuildOnChainUpdate(t *testing.T) {
 		"TX should be removed after its input was consumed by a confirmed block",
 	)
 	m.RUnlock()
+}
+
+// TestRebuildOverlayReturnsErrorOnNilValidator pins that the chain-update
+// loop's overlay rebuild fails gracefully instead of crashing the node
+// when the validator is missing. NewMempool refuses to construct one
+// without a validator, so this path is only reachable through a
+// programming error — but it should not panic.
+func TestRebuildOverlayReturnsErrorOnNilValidator(t *testing.T) {
+	m := &Mempool{}
+	err := m.rebuildOverlay()
+	require.ErrorIs(t, err, ErrNilValidator)
+}
+
+// TestNewMempool_RejectsNilValidator pins that the constructor returns
+// ErrNilValidator rather than panicking when the validator is missing.
+func TestNewMempool_RejectsNilValidator(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     event.NewEventBus(nil, nil),
+		PromRegistry: prometheus.NewRegistry(),
+		Validator:    nil,
+	})
+	require.ErrorIs(t, err, ErrNilValidator)
+	assert.Nil(t, m)
 }

--- a/node.go
+++ b/node.go
@@ -323,14 +323,18 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 
 	if n.config.barkBaseUrl != "" {
-		n.db.SetBlobStore(bark.NewBarkBlobStore(bark.BlobStoreBarkConfig{
+		barkBlobStore, err := bark.NewBarkBlobStore(bark.BlobStoreBarkConfig{
 			BaseUrl: n.config.barkBaseUrl,
 			HTTPClient: &http.Client{
 				Timeout: 30 * time.Second,
 			},
 			LedgerState: state,
 			Logger:      n.config.logger,
-		}, n.db.Blob()))
+		}, n.db.Blob())
+		if err != nil {
+			return fmt.Errorf("failed to create bark blob store: %w", err)
+		}
+		n.db.SetBlobStore(barkBlobStore)
 
 		prunerFreq := n.config.barkPrunerFrequency
 		if prunerFreq <= 0 {
@@ -382,7 +386,7 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	started = append(started, func() { _ = n.snapshotMgr.Stop() })
 	// Initialize mempool
-	n.mempool = mempool.NewMempool(mempool.MempoolConfig{
+	n.mempool, err = mempool.NewMempool(mempool.MempoolConfig{
 		MempoolCapacity:    n.config.mempoolCapacity,
 		EvictionWatermark:  n.config.evictionWatermark,
 		RejectionWatermark: n.config.rejectionWatermark,
@@ -393,6 +397,9 @@ func (n *Node) Run(ctx context.Context) error {
 		CurrentSlotFunc:    n.ledgerState.CurrentOrTipSlot,
 	},
 	)
+	if err != nil {
+		return fmt.Errorf("failed to create mempool: %w", err)
+	}
 	started = append(started, func() { //nolint:contextcheck
 		if err := n.mempool.Stop(context.Background()); err != nil {
 			n.config.logger.Error(
@@ -742,7 +749,8 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 
 	if n.config.barkPort > 0 {
-		n.bark = bark.NewBark(
+		var err error
+		n.bark, err = bark.NewBark(
 			bark.BarkConfig{
 				Logger:          n.config.logger,
 				DB:              db,
@@ -751,6 +759,9 @@ func (n *Node) Run(ctx context.Context) error {
 				Port:            n.config.barkPort,
 			},
 		)
+		if err != nil {
+			return fmt.Errorf("failed to create bark server: %w", err)
+		}
 		if err := n.bark.Start(n.ctx); err != nil { //nolint:contextcheck
 			return fmt.Errorf("failed to start bark server: %w", err)
 		}

--- a/utxorpc/rpc_connect_test.go
+++ b/utxorpc/rpc_connect_test.go
@@ -193,12 +193,13 @@ func newUtxorpcConnectHarness(t *testing.T, opts utxorpcHarnessOptions) *utxorpc
 		_ = ls.Close()
 	})
 
-	mp := mempool.NewMempool(mempool.MempoolConfig{
+	mp, err := mempool.NewMempool(mempool.MempoolConfig{
 		Validator:       noopTxValidator{},
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:        apiBus,
 		MempoolCapacity: 1 << 30,
 	})
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = mp.Stop(context.Background()) })
 
 	maxHist := opts.maxHistoryItems


### PR DESCRIPTION
## Summary

Resolves audit finding H4 (#2281). Three constructor panics plus one runtime panic in mempool/bark converted to returned errors, so missing required dependencies surface as ordinary error returns rather than crashing the node.

## Changes

**Runtime path (high-risk):**
- `mempool/mempool.go` — added `ErrNilValidator` sentinel; `rebuildOverlay()` now returns `error` instead of panicking when the validator is nil. The chain-update loop in `processChainEvents` logs and continues rather than crashing — the next chain update can retry once the underlying programmer error is fixed.

**Constructors:**
- `mempool/mempool.go` — `NewMempool` returns `(*Mempool, error)`; returns `ErrNilValidator` for a nil validator.
- `bark/bark.go` — `NewBark` returns `(*Bark, error)`; returns an error for a nil DB.
- `bark/blob.go` — `NewBarkBlobStore` returns `(*BlobStoreBark, error)`; returns an error for a nil ledger state.

**Callers updated:**
- `node.go` — production initialization handles the three new error returns.
- `utxorpc/rpc_connect_test.go` — one test caller updated.
- `mempool/mempool_test.go` — four test helpers absorb the error; the inline test sites are updated to receive and check the error.

**New tests:**
- `TestRebuildOverlayReturnsErrorOnNilValidator` — pins that the runtime nil-validator path returns `ErrNilValidator` instead of panicking.
- `TestNewMempool_RejectsNilValidator` — pins the constructor error path.
- `TestNewBark_RejectsNilDB`, `TestNewBarkBlobStore_RejectsNilLedgerState` — pins the bark constructor error paths.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` — all packages pass except an unrelated S3 integration test that fails on missing AWS credentials in the local environment
- [x] `golangci-lint run ./mempool/... ./bark/... ./utxorpc/... ./` — clean
- [x] All four new tests pass; existing tests in `mempool`, `bark`, `utxorpc` still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced panics with returned errors when required dependencies are missing in `mempool` and `bark`, preventing node crashes and surfacing clear failures. Addresses audit finding H4 (#2281).

- **Bug Fixes**
  - `mempool`: `NewMempool` now returns `(*Mempool, error)` and rejects a nil validator; overlay `rebuildOverlay()` returns an error instead of panicking; chain updates log and continue on error.
  - `bark`: `NewBark` and `NewBarkBlobStore` now return errors on nil DB or ledger state.
  - Node init updated to handle these errors; tests added to pin behaviors.

- **Migration**
  - Update all calls to `NewMempool`, `NewBark`, and `NewBarkBlobStore` to handle `(obj, err)` and check for `err` before use.
  - If you call `rebuildOverlay()` directly, handle its error return.

<sup>Written for commit 8168ad1d242af2eb1c37ba37065c46bf0ebb9797. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved initialization error handling to gracefully manage configuration validation failures instead of unexpected crashes during startup.

* **Tests**
  * Added comprehensive test coverage for constructor validation scenarios and error handling paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2305)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->