### PR TITLE
fix(database): skip offset indexing for byron ebb

### DIFF
--- a/database/block_indexer.go
+++ b/database/block_indexer.go
@@ -122,16 +122,18 @@ func (bi *BlockIndexer) ComputeOffsets(
 		result.ScriptOffsets = make(map[[32]byte]CborOffset)
 	}
 
+	// Avoid running the era-agnostic offset extractor on blocks that the
+	// era decoder already proved have no transactions. Byron EBBs in
+	// particular can otherwise be mistaken for a Shelley-style body layout.
+	txs := block.Transactions()
+	if len(txs) == 0 {
+		return result, nil
+	}
+
 	// Extract transaction-level offsets from block CBOR
 	txOffsets, err := common.ExtractTransactionOffsets(blockCbor)
 	if err != nil {
 		return nil, fmt.Errorf("extract transaction offsets: %w", err)
-	}
-
-	// Get transactions from the parsed block
-	txs := block.Transactions()
-	if len(txs) == 0 {
-		return result, nil
 	}
 
 	// Verify we have offsets for all transactions

--- a/database/block_indexer_test.go
+++ b/database/block_indexer_test.go
@@ -17,8 +17,10 @@ package database
 import (
 	"testing"
 
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	fxcbor "github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -152,6 +154,29 @@ func TestBlockIndexerEmptyBlock(t *testing.T) {
 	assert.Error(t, err, "expected error for nil block")
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "block cannot be nil")
+}
+
+func TestBlockIndexerNoTxBlockSkipsOffsetExtractor(t *testing.T) {
+	bodyCbor, err := fxcbor.Marshal([]gcbor.RawMessage{{0x00}, {0x01}})
+	require.NoError(t, err)
+	extraCbor, err := fxcbor.Marshal([]gcbor.RawMessage{{0x02}})
+	require.NoError(t, err)
+	blockCbor, err := fxcbor.Marshal([]gcbor.RawMessage{
+		{0x80},
+		gcbor.RawMessage(bodyCbor),
+		gcbor.RawMessage(extraCbor),
+	})
+	require.NoError(t, err)
+
+	indexer := NewBlockIndexer(0, make([]byte, 32))
+	result, err := indexer.ComputeOffsets(
+		blockCbor,
+		&ledger.ByronEpochBoundaryBlock{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.TxOffsets)
+	assert.Empty(t, result.UtxoOffsets)
 }
 
 // findCborInBytes searches for a CBOR byte sequence within a larger byte slice.

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -729,6 +729,12 @@ func storeRawBlockUtxoOffsets(
 	txn *database.Txn,
 	block chain.RawBlock,
 ) (int, error) {
+	// Byron epoch-boundary blocks carry no transactions. Mainnet's slot-0
+	// EBB body can look like a large Shelley-style tx body array to the
+	// generic offset extractor, so skip it before attempting extraction.
+	if block.Type == gledger.BlockTypeByronEbb {
+		return 0, nil
+	}
 	if txn == nil || txn.Blob() == nil {
 		return 0, errors.New("blob transaction not available")
 	}

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -330,6 +330,36 @@ func TestStoreRawBlockUtxoOffsetsPropagatesExtractError(t *testing.T) {
 	)
 }
 
+func TestStoreRawBlockUtxoOffsetsSkipsByronEbb(t *testing.T) {
+	db := newTestDB(t)
+	txn := db.BlobTxn(true)
+	defer txn.Rollback() //nolint:errcheck
+
+	bodyItems := make([]gcbor.RawMessage, 21_600)
+	for i := range bodyItems {
+		bodyItems[i] = gcbor.RawMessage{0x00}
+	}
+	bodyCbor, err := fxcbor.Marshal(bodyItems)
+	require.NoError(t, err)
+	extraCbor, err := fxcbor.Marshal([]gcbor.RawMessage{{0x00}})
+	require.NoError(t, err)
+	blockCbor, err := fxcbor.Marshal([]gcbor.RawMessage{
+		{0x80},
+		gcbor.RawMessage(bodyCbor),
+		gcbor.RawMessage(extraCbor),
+	})
+	require.NoError(t, err)
+
+	stored, err := storeRawBlockUtxoOffsets(txn, chain.RawBlock{
+		Slot: 0,
+		Hash: bytes.Repeat([]byte{0x42}, 32),
+		Cbor: blockCbor,
+		Type: gledger.BlockTypeByronEbb,
+	})
+	require.NoError(t, err)
+	require.Zero(t, stored)
+}
+
 func TestCopyBlocksRawWithCallback_BackfillsWhenChainTipPastImmutableTip(
 	t *testing.T,
 ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip offset extraction for Byron epoch-boundary blocks and any block with no transactions to prevent mis-parsing and bogus UTXO offsets. This avoids false positives on mainnet slot-0 EBB and reduces unnecessary work.

- **Bug Fixes**
  - In `database/block_indexer.go`, return early if `block.Transactions()` is empty before running the era-agnostic extractor.
  - In `internal/node/load.go`, bypass extraction for `gledger.BlockTypeByronEbb`.
  - Added tests to ensure no offsets are produced or stored for EBBs and empty blocks.

<sup>Written for commit e46c9802eeea126efbda69f5e10d3a382fe2629b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blocks with no transactions by skipping unnecessary offset extraction.
  * Enhanced processing of Byron epoch-boundary blocks to prevent misinterpretation and ensure correct offset storage behavior.
  * Added validation tests to verify proper handling of edge-case block formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->