### PR TITLE
fix(ledger): primary chain tip ancestor check

### DIFF
--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1129,6 +1129,110 @@ func TestReconcilePrimaryChainTipWithLedgerTipRollsBackMetadata(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestReconcilePrimaryChainTipWithLedgerTipRollsBackMissingLedgerTipToCommonAncestor(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	forkHash := testHashBytes("startup-primary-chain-fork")
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        fixture.currentTip.Point.Slot + 5,
+			Hash:        forkHash,
+			BlockNumber: fixture.currentTip.BlockNumber + 1,
+			Type:        1,
+			PrevHash:    fixture.ancestorTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+
+	require.NoError(t, fixture.ls.reconcilePrimaryChainTipWithLedgerTip())
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+
+	rows, err := fixture.ls.db.GetBlockNoncesInSlotRange(
+		fixture.ancestorTip.Point.Slot,
+		fixture.currentTip.Point.Slot+1,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, fixture.ancestorTip.Point.Hash, rows[0].Hash)
+}
+
+func TestReconcilePrimaryChainTipWithLedgerTipRewindsPrimaryChainWhenAheadBeyondK(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.currentEra.Id = 1
+	fixture.ls.config.CardanoNodeConfig.ShelleyGenesis().SecurityParam = 2
+	prevHash := fixture.currentTip.Point.Hash
+	blocks := make([]chain.RawBlock, 0, 3)
+	for idx, seed := range []string{
+		"startup-primary-chain-ahead-1",
+		"startup-primary-chain-ahead-2",
+		"startup-primary-chain-ahead-3",
+	} {
+		hash := testHashBytes(seed)
+		blockOffset := uint64(idx + 1)
+		blocks = append(blocks, chain.RawBlock{
+			Slot:        fixture.currentTip.Point.Slot + blockOffset,
+			Hash:        hash,
+			BlockNumber: fixture.currentTip.BlockNumber + blockOffset,
+			Type:        1,
+			PrevHash:    prevHash,
+			Cbor:        []byte{0x80},
+		})
+		prevHash = hash
+	}
+	require.NoError(t, fixture.ls.chain.AddRawBlocks(blocks))
+	require.Equal(
+		t,
+		fixture.currentTip.Point.Slot+3,
+		fixture.ls.chain.Tip().Point.Slot,
+	)
+
+	require.NoError(t, fixture.ls.reconcilePrimaryChainTipWithLedgerTip())
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.currentTip, dbTip)
+}
+
+func TestIntersectPointsDoesNotUsePrimaryChainWhenLedgerTipMissing(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	forkHash := testHashBytes("intersect-primary-chain-fork")
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        fixture.currentTip.Point.Slot + 5,
+			Hash:        forkHash,
+			BlockNumber: fixture.currentTip.BlockNumber + 1,
+			Type:        1,
+			PrevHash:    fixture.ancestorTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+
+	points, err := fixture.ls.IntersectPoints(4)
+	require.NoError(t, err)
+
+	require.Empty(t, points)
+}
+
 func TestProcessChainIteratorRollbackAppliesMatchingRollback(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -65,6 +65,7 @@ const (
 	cleanupConsumedUtxosInterval = 5 * time.Minute
 	batchSize                    = 50 // Number of blocks to process in a single DB transaction
 	ledgerIntersectDenseCount    = 32
+	ledgerAncestorSearchWindow   = 10_000
 	firstBlockIndex              = 1
 )
 
@@ -2274,27 +2275,70 @@ func (ls *LedgerState) ledgerReadChain(
 	// Without this, the consumer blocks forever on the channel
 	// read if the reader goroutine exits silently on an error.
 	defer close(resultCh)
-	// Snapshot the current tip under lock to avoid a data race with
-	// concurrent rollbacks that update ls.currentTip.
-	ls.RLock()
-	startPoint := ls.currentTip.Point
-	ls.RUnlock()
-	// Create chain iterator
-	iter, err := ls.chain.FromPoint(startPoint, false)
-	if err != nil {
-		// The start point may have been rolled back off the chain
-		// between the snapshot and iterator creation. Log and return —
-		// the outer loop in ledgerProcessBlocks will retry after the
-		// rollback updates ls.currentTip.
-		ls.config.Logger.Warn(
-			"chain iterator start point not on chain, will retry",
-			"error", err,
-			"start_slot", startPoint.Slot,
-		)
+	const maxReconcileRetries = 3
+	reconcileRetries := 0
+	for {
+		// Snapshot the current tip under lock to avoid a data race with
+		// concurrent rollbacks that update ls.currentTip.
+		ls.RLock()
+		startPoint := ls.currentTip.Point
+		ls.RUnlock()
+		// Create chain iterator
+		iter, err := ls.chain.FromPoint(startPoint, false)
+		if err != nil {
+			if !errors.Is(err, models.ErrBlockNotFound) {
+				ls.config.Logger.Warn(
+					"failed to create chain iterator",
+					"error", err,
+					"start_slot", startPoint.Slot,
+				)
+				return
+			}
+			if reconcileRetries >= maxReconcileRetries {
+				ls.config.Logger.Error(
+					"exhausted ledger rollback retries for missing chain iterator start point",
+					"error", err,
+					"start_slot", startPoint.Slot,
+					"start_hash", hex.EncodeToString(startPoint.Hash),
+					"retries", reconcileRetries,
+					"max_retries", maxReconcileRetries,
+				)
+				return
+			}
+			ls.config.Logger.Warn(
+				"chain iterator start point not on chain, attempting ledger rollback",
+				"error", err,
+				"start_slot", startPoint.Slot,
+				"start_hash", hex.EncodeToString(startPoint.Hash),
+			)
+			if reconcileErr := ls.reconcilePrimaryChainTipWithLedgerTip(); reconcileErr != nil {
+				ls.config.Logger.Error(
+					"failed to recover missing chain iterator start point",
+					"error", reconcileErr,
+					"start_slot", startPoint.Slot,
+					"start_hash", hex.EncodeToString(startPoint.Hash),
+				)
+				return
+			}
+			reconcileRetries++
+			ls.RLock()
+			recoveredPoint := ls.currentTip.Point
+			ls.RUnlock()
+			if recoveredPoint.Slot == startPoint.Slot &&
+				bytes.Equal(recoveredPoint.Hash, startPoint.Hash) {
+				ls.config.Logger.Error(
+					"ledger rollback did not change missing chain iterator start point",
+					"start_slot", startPoint.Slot,
+					"start_hash", hex.EncodeToString(startPoint.Hash),
+				)
+				return
+			}
+			continue
+		}
+		defer iter.Cancel()
+		ls.ledgerReadChainIterator(ctx, iter, resultCh)
 		return
 	}
-	defer iter.Cancel()
-	ls.ledgerReadChainIterator(ctx, iter, resultCh)
 }
 
 func (ls *LedgerState) ledgerReadChainIterator(
@@ -4175,7 +4219,9 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 	if ls.chain == nil || ls.config.ChainManager == nil {
 		return nil
 	}
+	ls.RLock()
 	ledgerTip := ls.currentTip
+	ls.RUnlock()
 	chainTip := ls.chain.Tip()
 	if chainTip.Point.Slot == ledgerTip.Point.Slot &&
 		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash) {
@@ -4198,15 +4244,158 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 		}
 		return nil
 	}
+	containsLedgerTip, err := ls.primaryChainContainsPoint(ledgerTip.Point)
+	if err != nil {
+		return fmt.Errorf("check ledger tip on primary chain: %w", err)
+	}
+	if containsLedgerTip {
+		if gap, unsafe := ls.primaryChainAheadBeyondLedgerSafetyWindow(
+			chainTip,
+			ledgerTip,
+		); unsafe {
+			ls.config.Logger.Warn(
+				"primary chain tip too far ahead of ledger tip at startup, rewinding primary chain",
+				"component", "ledger",
+				"chain_tip_slot", chainTip.Point.Slot,
+				"ledger_tip_slot", ledgerTip.Point.Slot,
+				"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+				"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+				"block_gap", gap,
+				"security_param", ls.SecurityParam(),
+			)
+			if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
+				ledgerTip.Point,
+			); err != nil {
+				return fmt.Errorf(
+					"rewind primary chain to ledger tip: %w",
+					err,
+				)
+			}
+			return nil
+		}
+		ls.config.Logger.Warn(
+			"primary chain tip ahead of ledger tip at startup; ledgerProcessBlocks will catch up via chainsync",
+			"component", "ledger",
+			"chain_tip_slot", chainTip.Point.Slot,
+			"ledger_tip_slot", ledgerTip.Point.Slot,
+			"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+			"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+		)
+		return nil
+	}
+	ancestor, found, err := ls.latestLedgerPrimaryChainAncestor(
+		ledgerTip.Point,
+		containsLedgerTip,
+	)
+	if err != nil {
+		return fmt.Errorf("find common primary-chain ancestor for ledger tip: %w", err)
+	}
+	if !found {
+		return fmt.Errorf(
+			"ledger tip %d/%s is not on primary chain and no common ancestor was found",
+			ledgerTip.Point.Slot,
+			hex.EncodeToString(ledgerTip.Point.Hash),
+		)
+	}
 	ls.config.Logger.Warn(
-		"primary chain tip ahead of ledger tip at startup, replaying metadata from selected chain",
+		"ledger tip not on primary chain at startup, rolling back metadata to common ancestor",
 		"component", "ledger",
 		"chain_tip_slot", chainTip.Point.Slot,
 		"ledger_tip_slot", ledgerTip.Point.Slot,
 		"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
 		"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+		"ancestor_slot", ancestor.Slot,
+		"ancestor_hash", hex.EncodeToString(ancestor.Hash),
 	)
+	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
+		ancestor,
+	); err != nil {
+		return fmt.Errorf(
+			"rewind primary chain to common primary-chain ancestor: %w",
+			err,
+		)
+	}
+	if err := ls.rollback(ancestor); err != nil {
+		return fmt.Errorf(
+			"rollback ledger tip to common primary-chain ancestor: %w",
+			err,
+		)
+	}
 	return nil
+}
+
+func (ls *LedgerState) primaryChainAheadBeyondLedgerSafetyWindow(
+	chainTip ochainsync.Tip,
+	ledgerTip ochainsync.Tip,
+) (uint64, bool) {
+	if chainTip.BlockNumber <= ledgerTip.BlockNumber {
+		return 0, false
+	}
+	gap := chainTip.BlockNumber - ledgerTip.BlockNumber
+	if ls.config.CardanoNodeConfig == nil {
+		return gap, false
+	}
+	securityParam := ls.SecurityParam()
+	if securityParam <= 0 {
+		return gap, false
+	}
+	return gap, gap > uint64(securityParam)
+}
+
+func (ls *LedgerState) primaryChainContainsPoint(point ocommon.Point) (bool, error) {
+	if point.Slot == 0 && len(point.Hash) == 0 {
+		return true, nil
+	}
+	if ls.db == nil {
+		return false, nil
+	}
+	_, err := database.BlockByPoint(ls.db, point)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, models.ErrBlockNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (ls *LedgerState) latestLedgerPrimaryChainAncestor(
+	point ocommon.Point,
+	containsPoint bool,
+) (ocommon.Point, bool, error) {
+	if containsPoint {
+		return point, true, nil
+	}
+	if ls.db == nil {
+		return ocommon.Point{}, false, nil
+	}
+	end := point.Slot
+	for {
+		start := uint64(0)
+		if end > ledgerAncestorSearchWindow {
+			start = end - ledgerAncestorSearchWindow
+		}
+		blockNonces, err := ls.db.GetBlockNoncesInSlotRange(start, end, nil)
+		if err != nil {
+			return ocommon.Point{}, false, err
+		}
+		for i := len(blockNonces); i > 0; i-- {
+			blockNonce := blockNonces[i-1]
+			ancestor := ocommon.NewPoint(blockNonce.Slot, blockNonce.Hash)
+			containsAncestor, err := ls.primaryChainContainsPoint(ancestor)
+			if err != nil {
+				return ocommon.Point{}, false, err
+			}
+			if containsAncestor {
+				return ancestor, true, nil
+			}
+		}
+		if start == 0 {
+			break
+		}
+		end = start
+	}
+	return ocommon.Point{}, false, nil
 }
 
 func (ls *LedgerState) GetBlock(point ocommon.Point) (models.Block, error) {
@@ -4226,7 +4415,24 @@ func (ls *LedgerState) primaryChainTipAtOrAheadOfLedgerTip() bool {
 	ls.RUnlock()
 	chainTip := ls.chain.Tip()
 	if chainTip.Point.Slot > ledgerTip.Point.Slot {
-		return true
+		if _, unsafe := ls.primaryChainAheadBeyondLedgerSafetyWindow(
+			chainTip,
+			ledgerTip,
+		); unsafe {
+			return false
+		}
+		containsLedgerTip, err := ls.primaryChainContainsPoint(ledgerTip.Point)
+		if err != nil {
+			ls.config.Logger.Warn(
+				"failed to confirm ledger tip is on primary chain",
+				"component", "ledger",
+				"ledger_tip_slot", ledgerTip.Point.Slot,
+				"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+				"error", err,
+			)
+			return false
+		}
+		return containsLedgerTip
 	}
 	return chainTip.Point.Slot == ledgerTip.Point.Slot &&
 		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ledger startup and chainsync when the ledger tip diverges or when the primary chain runs far ahead. We now verify the ledger tip against the selected chain, find the latest common ancestor, rewind as needed, and safely resume reading.

- **Bug Fixes**
  - If the ledger tip isn’t on the selected chain, find the latest common primary-chain ancestor via a 10k-slot nonce scan, rewind the primary chain to it, and roll back the ledger to match.
  - Respect security param `k`: when the primary chain is >k blocks ahead and the ledger tip is on the selected chain, rewind the primary chain to the ledger tip; otherwise, let chainsync catch up.
  - Treat the chain tip as “ahead” only when the ledger tip is on the selected chain and within the safety window; use a DB-backed membership check.
  - Make chain reading resilient: on a missing iterator start point, reconcile and retry up to 3 times with clearer logs; add tests for common-ancestor rollback, ahead-beyond-`k` rewind, and skipping primary-chain intersect when the ledger tip is missing.

<sup>Written for commit 6ab1f0643a8a217498612b12e459d45b64690e18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger synchronization during startup with better reconciliation between primary chain and ledger state.
  * Enhanced handling of edge cases where the ledger tip is missing or diverges from the primary chain.
  * Added safety checks to prevent ledger inconsistencies when the primary chain is significantly ahead.

* **Tests**
  * Added comprehensive test cases for chainsync rollback reconciliation edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2309)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->