### PR TITLE
fix(devnet): also build configurator image to pick up configurator.sh…

### DIFF
--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -88,7 +88,7 @@ fi
 # --------------------------------------------------------------------------- #
 
 log "Building Dingo Docker image..."
-docker compose -f "${COMPOSE_FILE}" build dingo-producer
+docker compose -f "${COMPOSE_FILE}" build configurator dingo-producer
 
 log "Starting DevNet containers..."
 docker compose -f "${COMPOSE_FILE}" up -d


### PR DESCRIPTION
… changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure DevNet tests rebuild the configurator image so changes to configurator.sh are applied. The test script now builds both configurator and dingo-producer before starting the stack.

<sup>Written for commit 25091622a0851934f462455d2ac115d9c6a01037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development test environment configuration and setup procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2312)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->