### PR TITLE
fix(database): prevent double close

### DIFF
--- a/database/close_test.go
+++ b/database/close_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseIsIdempotentWithSizeMetrics(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		PromRegistry:   prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, db.sizeMetricsStop)
+
+	require.NoError(t, db.Close())
+	require.NoError(t, db.Close())
+}

--- a/database/database.go
+++ b/database/database.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin"
@@ -57,6 +58,8 @@ type Database struct {
 	cborCache       *TieredCborCache
 	sizeMetricsStop chan struct{}
 	sizeMetricsDone chan struct{}
+	closeOnce       sync.Once
+	closeErr        error
 }
 
 // Blob returns the underling blob store instance
@@ -101,19 +104,20 @@ func (d *Database) MetadataTxn(readWrite bool) *Txn {
 
 // Close cleans up the database connections
 func (d *Database) Close() error {
-	// Stop the metrics goroutine if running
-	if d.sizeMetricsStop != nil {
-		close(d.sizeMetricsStop)
-		<-d.sizeMetricsDone
-	}
-	var err error
-	if d.metadata != nil {
-		err = errors.Join(err, d.metadata.Close())
-	}
-	if d.blob != nil {
-		err = errors.Join(err, d.blob.Close())
-	}
-	return err
+	d.closeOnce.Do(func() {
+		// Stop the metrics goroutine if running
+		if d.sizeMetricsStop != nil {
+			close(d.sizeMetricsStop)
+			<-d.sizeMetricsDone
+		}
+		if d.metadata != nil {
+			d.closeErr = errors.Join(d.closeErr, d.metadata.Close())
+		}
+		if d.blob != nil {
+			d.closeErr = errors.Join(d.closeErr, d.blob.Close())
+		}
+	})
+	return d.closeErr
 }
 
 func (d *Database) init() error {


### PR DESCRIPTION
Closes #2313 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `Database.Close` idempotent so multiple calls are safe and return the same error, preventing duplicate closes and races with the size metrics goroutine. Adds a unit test to verify behavior when size metrics are enabled.

- **Bug Fixes**
  - Use `sync.Once` and `closeErr` to guard `Close`.
  - Stop the size metrics goroutine and close `metadata`/`blob` only once.
  - Add `TestCloseIsIdempotentWithSizeMetrics`.

<sup>Written for commit 46b18ce0f9801dd2be1f927488ebf0cb698859c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Database shutdown can now be safely called multiple times without errors or redundant operations.

* **Tests**
  * Added verification test for shutdown behavior with metrics enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2315)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->