### PR TITLE
fix(peergov): guard clearing ConnectedAt tracking

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -42,6 +42,13 @@ const (
 	chainsyncRestartTimeout = 30 * time.Second
 )
 
+func effectiveChainsyncBlockTimeout(timeout time.Duration) time.Duration {
+	if timeout < ochainsync.MustReplyTimeoutMax {
+		return ochainsync.MustReplyTimeoutMax
+	}
+	return timeout
+}
+
 func (o *Ouroboros) chainsyncServerConnOpts() []ochainsync.ChainSyncOptionFunc {
 	return []ochainsync.ChainSyncOptionFunc{
 		ochainsync.WithFindIntersectFunc(
@@ -59,6 +66,7 @@ func (o *Ouroboros) chainsyncServerConnOpts() []ochainsync.ChainSyncOptionFunc {
 		// server connections alive during periods of low block
 		// production (e.g. DevNets with low activeSlotsCoeff).
 		ochainsync.WithIdleTimeout(1 * time.Hour),
+		ochainsync.WithBlockTimeout(o.config.ChainsyncBlockTimeout),
 	}
 }
 
@@ -83,6 +91,7 @@ func (o *Ouroboros) chainsyncClientConnOpts() []ochainsync.ChainSyncOptionFunc {
 		// under load (e.g. fast DevNet block production or initial
 		// sync from genesis).
 		ochainsync.WithIntersectTimeout(30 * time.Second),
+		ochainsync.WithBlockTimeout(o.config.ChainsyncBlockTimeout),
 	}
 }
 

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -154,6 +154,65 @@ func newTestLedgerState(t *testing.T) *ledger.LedgerState {
 	return ls
 }
 
+func snapshotChainsyncNtNTimeouts() map[string]struct {
+	timeout        time.Duration
+	hasTimeoutFunc bool
+} {
+	snapshot := make(map[string]struct {
+		timeout        time.Duration
+		hasTimeoutFunc bool
+	})
+	for state, entry := range ochainsync.StateMapNtN {
+		switch state.Name {
+		case "CanAwait", "MustReply":
+			snapshot[state.Name] = struct {
+				timeout        time.Duration
+				hasTimeoutFunc bool
+			}{
+				timeout:        entry.Timeout,
+				hasTimeoutFunc: entry.TimeoutFunc != nil,
+			}
+		}
+	}
+	return snapshot
+}
+
+func TestNewOuroborosDoesNotMutateChainsyncNtNTimeouts(t *testing.T) {
+	originalStateMap := ochainsync.StateMapNtN.Copy()
+	t.Cleanup(func() {
+		clear(ochainsync.StateMapNtN)
+		for state, entry := range originalStateMap {
+			ochainsync.StateMapNtN[state] = entry
+		}
+	})
+
+	before := snapshotChainsyncNtNTimeouts()
+
+	_ = NewOuroboros(OuroborosConfig{
+		ChainsyncBlockTimeout: 10 * time.Minute,
+	})
+	require.Equal(t, before, snapshotChainsyncNtNTimeouts())
+
+	_ = NewOuroboros(OuroborosConfig{
+		ChainsyncBlockTimeout: 20 * time.Minute,
+	})
+	require.Equal(t, before, snapshotChainsyncNtNTimeouts())
+}
+
+func TestChainsyncConnOptsUseConfiguredBlockTimeout(t *testing.T) {
+	const blockTimeout = 20 * time.Minute
+
+	o := NewOuroboros(OuroborosConfig{
+		ChainsyncBlockTimeout: blockTimeout,
+	})
+
+	clientCfg := ochainsync.NewConfig(o.chainsyncClientConnOpts()...)
+	serverCfg := ochainsync.NewConfig(o.chainsyncServerConnOpts()...)
+
+	require.Equal(t, blockTimeout, clientCfg.BlockTimeout)
+	require.Equal(t, blockTimeout, serverCfg.BlockTimeout)
+}
+
 func TestNormalizeIntersectPoints(t *testing.T) {
 	points := []ocommon.Point{
 		ocommon.NewPoint(20, []byte("b")),

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -86,6 +86,10 @@ type OuroborosConfig struct {
 	PeerSharing     bool
 	IntersectTip    bool
 	PromRegistry    prometheus.Registerer
+	// ChainsyncBlockTimeout bounds how long NtN chain-sync can wait for a
+	// block reply after a peer enters a server-agency state. Low-density
+	// networks may legitimately go longer than the default protocol window.
+	ChainsyncBlockTimeout time.Duration
 	// MaxTxSubmissionsPerSecond is the maximum number of transaction
 	// submissions accepted per peer per second via the TxSubmission
 	// mini-protocol. A value of 0 disables rate limiting, which is the
@@ -120,6 +124,9 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
 	cfg.Logger = cfg.Logger.With("component", "ouroboros")
+	cfg.ChainsyncBlockTimeout = effectiveChainsyncBlockTimeout(
+		cfg.ChainsyncBlockTimeout,
+	)
 	o := &Ouroboros{
 		config:           cfg,
 		EventBus:         cfg.EventBus,

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -667,40 +667,52 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 			oldConn,
 			peer,
 		)
-		if peer.Source != PeerSourceInboundConn {
-			peer.ConnectedAt = time.Time{}
-		}
 		p.updatePeerMetrics()
 		// Only reconnect for outbound peers that are not on the deny list
-		if peer.Source != PeerSourceInboundConn &&
-			!p.isDeniedLocked(peer.NormalizedAddress) {
+		shouldReconnect := peer.Source != PeerSourceInboundConn &&
+			!p.isDeniedLocked(peer.NormalizedAddress)
+		if peer.Source != PeerSourceInboundConn {
 			// Apply backoff for short-lived connections to prevent
 			// rapid reconnection cycles that exhaust ephemeral ports.
 			// Only reset backoff when connection proved stable.
-			connDur := time.Since(peer.ConnectedAt)
-			if !peer.ConnectedAt.IsZero() &&
-				connDur >= minStableConnectionDuration {
-				// Connection was stable, reset backoff
-				peer.ReconnectCount = 0
-				peer.ReconnectDelay = 0
-			} else if !peer.ConnectedAt.IsZero() {
-				// Short-lived connection: apply exponential backoff
-				if peer.ReconnectDelay == 0 {
-					peer.ReconnectDelay = initialReconnectDelay
-				} else if peer.ReconnectDelay < maxReconnectDelay {
-					peer.ReconnectDelay *= reconnectBackoffFactor
-					if peer.ReconnectDelay > maxReconnectDelay {
-						peer.ReconnectDelay = maxReconnectDelay
-					}
+			if shouldReconnect {
+				connDur := connClosedAt.Sub(peer.ConnectedAt)
+				if connDur < 0 {
+					p.config.Logger.Warn(
+						"connection close timestamp predates connection start, clamping duration",
+						"address", peer.Address,
+						"connected_at", peer.ConnectedAt,
+						"closed_at", connClosedAt,
+						"raw_duration", connDur,
+					)
+					connDur = 0
 				}
-				p.config.Logger.Warn(
-					"short-lived connection detected, applying backoff",
-					"address", peer.Address,
-					"connection_duration", connDur,
-					"next_delay", peer.ReconnectDelay,
-				)
+				if !peer.ConnectedAt.IsZero() &&
+					connDur >= minStableConnectionDuration {
+					// Connection was stable, reset backoff
+					peer.ReconnectCount = 0
+					peer.ReconnectDelay = 0
+				} else if !peer.ConnectedAt.IsZero() {
+					// Short-lived connection: apply exponential backoff
+					if peer.ReconnectDelay == 0 {
+						peer.ReconnectDelay = initialReconnectDelay
+					} else if peer.ReconnectDelay < maxReconnectDelay {
+						peer.ReconnectDelay *= reconnectBackoffFactor
+						if peer.ReconnectDelay > maxReconnectDelay {
+							peer.ReconnectDelay = maxReconnectDelay
+						}
+					}
+					p.config.Logger.Warn(
+						"short-lived connection detected, applying backoff",
+						"address", peer.Address,
+						"connection_duration", connDur,
+						"next_delay", peer.ReconnectDelay,
+					)
+				}
 			}
 			peer.ConnectedAt = time.Time{} // Reset for next connection
+		}
+		if shouldReconnect {
 			// Only spawn a new reconnect goroutine if one is not
 			// already running. The active goroutine's defer
 			// cleanup in createOutboundConnection will clear

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -15,16 +15,21 @@
 package peergov
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
-	"log/slog"
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 )
 
 func TestIsExpectedConnectionCloseError(t *testing.T) {
@@ -259,6 +264,151 @@ func TestIsAddrInUseError(t *testing.T) {
 	}
 }
 
+func TestHandleConnectionClosedEvent_StableOutboundResetsBackoff(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	connId := outboundTestConnId()
+	peer := &Peer{
+		Address:           "192.168.12.101:3003",
+		NormalizedAddress: "192.168.12.101:3003",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateWarm,
+		Connection: &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		},
+		ConnectedAt:    time.Now().Add(-minStableConnectionDuration - time.Second),
+		ReconnectCount: 5,
+		ReconnectDelay: 8 * time.Second,
+		// Suppress reconnect goroutine; this test only checks close accounting.
+		Reconnecting: true,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	pg.handleConnectionClosedEvent(event.NewEvent(
+		connmanager.ConnectionClosedEventType,
+		connmanager.ConnectionClosedEvent{
+			ConnectionId: connId,
+			Error: errors.New(
+				"protocol error: chain-sync: timeout waiting on transition",
+			),
+		},
+	))
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	if peer.Connection != nil {
+		t.Fatal("connection should be cleared")
+	}
+	if peer.State != PeerStateCold {
+		t.Fatalf("state = %s, want cold", peer.State)
+	}
+	if !peer.ConnectedAt.IsZero() {
+		t.Fatalf("ConnectedAt should be reset, got %s", peer.ConnectedAt)
+	}
+	if peer.ReconnectCount != 0 {
+		t.Fatalf("ReconnectCount = %d, want 0", peer.ReconnectCount)
+	}
+	if peer.ReconnectDelay != 0 {
+		t.Fatalf("ReconnectDelay = %s, want 0", peer.ReconnectDelay)
+	}
+}
+
+func TestHandleConnectionClosedEvent_ShortLivedOutboundAppliesBackoff(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	connId := outboundTestConnId()
+	peer := &Peer{
+		Address:           "192.168.12.101:3003",
+		NormalizedAddress: "192.168.12.101:3003",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateWarm,
+		Connection: &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		},
+		ConnectedAt:    time.Now().Add(-minStableConnectionDuration / 2),
+		ReconnectDelay: 2 * time.Second,
+		// Suppress reconnect goroutine; this test only checks close accounting.
+		Reconnecting: true,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	pg.handleConnectionClosedEvent(event.NewEvent(
+		connmanager.ConnectionClosedEventType,
+		connmanager.ConnectionClosedEvent{
+			ConnectionId: connId,
+			Error:        io.EOF,
+		},
+	))
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	if !peer.ConnectedAt.IsZero() {
+		t.Fatalf("ConnectedAt should be reset, got %s", peer.ConnectedAt)
+	}
+	if peer.ReconnectDelay != 4*time.Second {
+		t.Fatalf("ReconnectDelay = %s, want 4s", peer.ReconnectDelay)
+	}
+}
+
+func TestHandleConnectionClosedEvent_NegativeOutboundDurationLogsAndClamps(t *testing.T) {
+	var logBuf bytes.Buffer
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(&logBuf, nil)),
+	})
+	connId := outboundTestConnId()
+	peer := &Peer{
+		Address:           "192.168.12.101:3003",
+		NormalizedAddress: "192.168.12.101:3003",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateWarm,
+		Connection: &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		},
+		ConnectedAt: time.Now().Add(time.Second),
+		// Suppress reconnect goroutine; this test only checks close accounting.
+		Reconnecting: true,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	pg.handleConnectionClosedEvent(event.NewEvent(
+		connmanager.ConnectionClosedEventType,
+		connmanager.ConnectionClosedEvent{
+			ConnectionId: connId,
+			Error:        io.EOF,
+		},
+	))
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	if !peer.ConnectedAt.IsZero() {
+		t.Fatalf("ConnectedAt should be reset, got %s", peer.ConnectedAt)
+	}
+	if peer.ReconnectDelay != initialReconnectDelay {
+		t.Fatalf(
+			"ReconnectDelay = %s, want %s",
+			peer.ReconnectDelay,
+			initialReconnectDelay,
+		)
+	}
+	if !strings.Contains(
+		logBuf.String(),
+		"connection close timestamp predates connection start, clamping duration",
+	) {
+		t.Fatalf("expected negative duration log, got %s", logBuf.String())
+	}
+}
+
 func TestCreateOutboundConnection_SuppressesRetryWhenReusableInboundSatisfiesValency(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -303,5 +453,18 @@ func TestCreateOutboundConnection_SuppressesRetryWhenReusableInboundSatisfiesVal
 	}
 	if topologyPeer.ReconnectCount != 0 {
 		t.Fatalf("reconnect count changed unexpectedly: %d", topologyPeer.ReconnectCount)
+	}
+}
+
+func outboundTestConnId() ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.ParseIP("192.168.12.201"),
+			Port: 3005,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.ParseIP("192.168.12.101"),
+			Port: 3003,
+		},
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents reconnection storms by gating outbound backoff and `ConnectedAt` clearing in `peergov`. Adds a configurable NtN chain-sync block timeout in `ouroboros` with a safe minimum, applied via options without mutating protocol globals.

- **Bug Fixes**
  - Clear `ConnectedAt` only for outbound peers after backoff accounting; compute backoff from the connection-closed timestamp and clamp/log negative durations.
  - Apply backoff only when we will reconnect (not inbound or deny-listed); reset for stable links and exponentially back off short‑lived ones; avoid duplicate reconnect goroutines.
  - Added tests for stable outbound resets, short‑lived outbound backoff, and negative‑duration clamp logging.

- **New Features**
  - Introduced `OuroborosConfig.ChainsyncBlockTimeout` with a floor at `ochainsync.MustReplyTimeoutMax`.
  - Applied via `WithBlockTimeout` on client and server; verified by tests and does not mutate `ochainsync` NtN state timeouts.

<sup>Written for commit 2c23b2aa10350afa130152c62d3297cf6a6c50fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

