### PR TITLE
feat(chain): chain backward iterator

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -818,6 +818,18 @@ func (c *Chain) rollbackLocked(
 	c.tipBlockIndex = rollbackBlockIndex
 	// Update iterators for rollback
 	for _, iter := range c.iterators {
+		// Reverse iterators never deliver rollback markers, but if a
+		// rollback shortened the chain past nextBlockIndex the
+		// iterator must be clamped to the new tip so subsequent Next
+		// calls return the still-present predecessor blocks instead
+		// of mistaking missing blocks for origin.
+		if iter.reverse {
+			if iter.nextBlockIndex > rollbackBlockIndex &&
+				rollbackBlockIndex > 0 {
+				iter.nextBlockIndex = rollbackBlockIndex
+			}
+			continue
+		}
 		// Use startPoint for iterators that haven't delivered any blocks
 		// yet (lastPoint is zero-value). Without this, newly created
 		// iterators miss rollback signals entirely.
@@ -1049,6 +1061,34 @@ func (c *Chain) FromPoint(
 		c,
 		point,
 		inclusive,
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c.iterators = append(c.iterators, iter)
+	return iter, nil
+}
+
+// FromPointReverse returns a ChainIterator that walks backward from the
+// specified point toward chain origin. If inclusive is true the iterator
+// yields the start point first; otherwise it yields the block preceding it.
+// Blocking Next calls on a reverse iterator do not wait for new blocks; once
+// origin is reached, Next returns ErrIteratorChainOrigin.
+func (c *Chain) FromPointReverse(
+	point ocommon.Point,
+	inclusive bool,
+) (*ChainIterator, error) {
+	if c == nil {
+		return nil, errors.New("chain is nil")
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	iter, err := newChainIterator(
+		c,
+		point,
+		inclusive,
+		true,
 	)
 	if err != nil {
 		return nil, err
@@ -1118,7 +1158,8 @@ func (c *Chain) iterNext(
 			c.manager.mutex.RUnlock()
 			return nil, err
 		}
-		// Check for pending rollback
+		// Check for pending rollback (forward iterators only; reverse
+		// iterators never have rollbacks queued).
 		if iter.needsRollback {
 			ret := &ChainIteratorResult{}
 			ret.Point = iter.rollbackPoint
@@ -1147,6 +1188,14 @@ func (c *Chain) iterNext(
 			c.manager.mutex.RUnlock()
 			return ret, nil
 		}
+		// Reverse iterators terminate when they walk past origin.
+		// nextBlockIndex == 0 is the sentinel set by newChainIterator
+		// for "no more blocks available behind this point".
+		if iter.reverse && iter.nextBlockIndex < initialBlockIndex {
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return nil, ErrIteratorChainOrigin
+		}
 		ret := &ChainIteratorResult{}
 		// Lookup next block in metadata DB
 		tmpBlock, err := c.blockByIndex(iter.nextBlockIndex)
@@ -1154,7 +1203,18 @@ func (c *Chain) iterNext(
 		if err == nil {
 			ret.Point = ocommon.NewPoint(tmpBlock.Slot, tmpBlock.Hash)
 			ret.Block = tmpBlock
-			iter.nextBlockIndex++
+			if iter.reverse {
+				if iter.nextBlockIndex == initialBlockIndex {
+					// Just delivered the genesis block; mark
+					// the iterator as past origin so the next
+					// call returns ErrIteratorChainOrigin.
+					iter.nextBlockIndex = 0
+				} else {
+					iter.nextBlockIndex--
+				}
+			} else {
+				iter.nextBlockIndex++
+			}
 			iter.lastPoint = ret.Point
 			c.mutex.Unlock()
 			c.manager.mutex.RUnlock()
@@ -1165,6 +1225,12 @@ func (c *Chain) iterNext(
 			c.mutex.Unlock()
 			c.manager.mutex.RUnlock()
 			return ret, err
+		}
+		// Reverse iterators never wait — origin does not grow.
+		if iter.reverse {
+			c.mutex.Unlock()
+			c.manager.mutex.RUnlock()
+			return nil, ErrIteratorChainOrigin
 		}
 		// Return immediately if we're not blocking
 		if !blocking {

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -822,10 +822,13 @@ func (c *Chain) rollbackLocked(
 		// rollback shortened the chain past nextBlockIndex the
 		// iterator must be clamped to the new tip so subsequent Next
 		// calls return the still-present predecessor blocks instead
-		// of mistaking missing blocks for origin.
+		// of mistaking missing blocks for origin. Clamping also
+		// applies to rollback-to-origin (rollbackBlockIndex == 0,
+		// the pre-genesis index — initialBlockIndex is 1): without
+		// it, a regrown chain reaching the iterator's stale index
+		// would silently hand out unrelated blocks.
 		if iter.reverse {
-			if iter.nextBlockIndex > rollbackBlockIndex &&
-				rollbackBlockIndex > 0 {
+			if iter.nextBlockIndex > rollbackBlockIndex {
 				iter.nextBlockIndex = rollbackBlockIndex
 			}
 			continue

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -449,15 +449,14 @@ func TestChainIteratorReverseBlockingTerminatesAtOrigin(t *testing.T) {
 		_, err := iter.Next(true)
 		done <- err
 	}()
-	select {
-	case err := <-done:
-		if !errors.Is(err, chain.ErrIteratorChainOrigin) {
-			t.Fatalf(
-				"expected ErrIteratorChainOrigin, got %v", err,
-			)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("blocking reverse Next did not terminate at origin")
+	gotErr := testutil.RequireReceive(
+		t, done, time.Second,
+		"blocking reverse Next did not terminate at origin",
+	)
+	if !errors.Is(gotErr, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"expected ErrIteratorChainOrigin, got %v", gotErr,
+		)
 	}
 }
 
@@ -539,6 +538,66 @@ func TestChainIteratorReverseIgnoresRollback(t *testing.T) {
 	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
 		t.Fatalf(
 			"expected ErrIteratorChainOrigin after post-rollback exhaustion, got %v",
+			err,
+		)
+	}
+}
+
+// TestChainIteratorReverseRollbackToOriginClamps verifies that a reverse
+// iterator whose nextBlockIndex points past a chain that has been rolled
+// back to origin gets clamped, so that a subsequent regrowth of the chain
+// does not cause the iterator to silently emit blocks from the new chain.
+// Regression test for the rollback-hook condition: origin lives at block
+// index 0 (pre-genesis), so the clamp must trigger when rollbackBlockIndex
+// is 0 as well.
+func TestChainIteratorReverseRollbackToOriginClamps(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := chain.NewManager(nil, eventBus)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	// Use a small security param so the entire chain is allowed to be
+	// rolled back during initial-sync semantics.
+	mustSetLedger(t, cm, 100)
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	// Start a reverse iterator at the tip but do not consume any blocks
+	// yet — nextBlockIndex equals the tip's index.
+	tip := testBlocks[len(testBlocks)-1]
+	tipPoint := ocommon.NewPoint(tip.MockSlot, decodeHex(tip.MockHash))
+	iter, err := c.FromPointReverse(tipPoint, true)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	// Roll back to origin (clears the entire chain).
+	if err := c.Rollback(ocommon.NewPointOrigin()); err != nil {
+		t.Fatalf("unexpected rollback error: %s", err)
+	}
+	// The iterator must terminate at origin — chain is empty.
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"expected ErrIteratorChainOrigin after rollback to origin, got %v",
+			err,
+		)
+	}
+	// Regrow the chain. With clamping, the iterator stays terminated.
+	// Without the fix, blockByIndex at the old (stale) tip index would
+	// hand out the regrown chain's block of the same index.
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf(
+				"unexpected error re-adding block to chain: %s", err,
+			)
+		}
+	}
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"reverse iterator must stay terminated after chain regrowth; got %v",
 			err,
 		)
 	}

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -227,6 +227,323 @@ func TestChainBasic(t *testing.T) {
 	}
 }
 
+func TestChainIteratorReverseFromTipInclusive(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	tip := testBlocks[len(testBlocks)-1]
+	tipPoint := ocommon.NewPoint(tip.MockSlot, decodeHex(tip.MockHash))
+	iter, err := c.FromPointReverse(tipPoint, true)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	expectedIdx := len(testBlocks) - 1
+	for {
+		next, err := iter.Next(false)
+		if err != nil {
+			if errors.Is(err, chain.ErrIteratorChainOrigin) {
+				if expectedIdx >= 0 {
+					t.Fatalf(
+						"hit origin before consuming all blocks; remaining=%d",
+						expectedIdx+1,
+					)
+				}
+				break
+			}
+			t.Fatalf("unexpected error from reverse iterator: %s", err)
+		}
+		if next == nil {
+			t.Fatal("unexpected nil result from reverse iterator")
+		}
+		if next.Rollback {
+			t.Fatal("reverse iterator must not emit rollback markers")
+		}
+		if expectedIdx < 0 {
+			t.Fatal("reverse iterator produced more blocks than expected")
+		}
+		expectedHash := testBlocks[expectedIdx].MockHash
+		gotHash := hex.EncodeToString(next.Block.Hash)
+		if gotHash != expectedHash {
+			t.Fatalf(
+				"reverse iterator wrong block: got %s, want %s (idx=%d)",
+				gotHash, expectedHash, expectedIdx,
+			)
+		}
+		expectedIdx--
+	}
+	// Subsequent calls should keep returning ErrIteratorChainOrigin.
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"expected ErrIteratorChainOrigin after exhaustion, got %v",
+			err,
+		)
+	}
+}
+
+func TestChainIteratorReverseFromTipNonInclusive(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	tip := testBlocks[len(testBlocks)-1]
+	tipPoint := ocommon.NewPoint(tip.MockSlot, decodeHex(tip.MockHash))
+	iter, err := c.FromPointReverse(tipPoint, false)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	// Non-inclusive reverse from tip must yield the block before tip first.
+	next, err := iter.Next(false)
+	if err != nil {
+		t.Fatalf("unexpected error from reverse iterator: %s", err)
+	}
+	want := testBlocks[len(testBlocks)-2].MockHash
+	got := hex.EncodeToString(next.Block.Hash)
+	if got != want {
+		t.Fatalf(
+			"non-inclusive reverse first block: got %s, want %s",
+			got, want,
+		)
+	}
+}
+
+func TestChainIteratorReverseFromMiddleInclusive(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	// Start at the 4th block (idx 3), inclusive.
+	startIdx := 3
+	start := testBlocks[startIdx]
+	startPoint := ocommon.NewPoint(start.MockSlot, decodeHex(start.MockHash))
+	iter, err := c.FromPointReverse(startPoint, true)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	for i := startIdx; i >= 0; i-- {
+		next, err := iter.Next(false)
+		if err != nil {
+			t.Fatalf(
+				"unexpected error from reverse iterator at idx %d: %s",
+				i, err,
+			)
+		}
+		got := hex.EncodeToString(next.Block.Hash)
+		want := testBlocks[i].MockHash
+		if got != want {
+			t.Fatalf(
+				"reverse iterator wrong block at idx %d: got %s, want %s",
+				i, got, want,
+			)
+		}
+	}
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"expected ErrIteratorChainOrigin after exhaustion, got %v",
+			err,
+		)
+	}
+}
+
+func TestChainIteratorReverseFromOrigin(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	iter, err := c.FromPointReverse(ocommon.NewPointOrigin(), true)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"reverse from origin should return ErrIteratorChainOrigin immediately, got %v",
+			err,
+		)
+	}
+}
+
+func TestChainIteratorReverseFromGenesisNonInclusive(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	genesis := testBlocks[0]
+	genesisPoint := ocommon.NewPoint(
+		genesis.MockSlot, decodeHex(genesis.MockHash),
+	)
+	iter, err := c.FromPointReverse(genesisPoint, false)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	// The genesis block has no predecessor; non-inclusive must terminate.
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"non-inclusive reverse from genesis: expected ErrIteratorChainOrigin, got %v",
+			err,
+		)
+	}
+}
+
+func TestChainIteratorReverseBlockingTerminatesAtOrigin(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	genesis := testBlocks[0]
+	genesisPoint := ocommon.NewPoint(
+		genesis.MockSlot, decodeHex(genesis.MockHash),
+	)
+	iter, err := c.FromPointReverse(genesisPoint, true)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	// Consume the genesis block.
+	if _, err := iter.Next(true); err != nil {
+		t.Fatalf("unexpected error reading genesis block: %s", err)
+	}
+	// Now blocking=true must NOT wait — reverse iterators terminate at origin.
+	done := make(chan error, 1)
+	go func() {
+		_, err := iter.Next(true)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, chain.ErrIteratorChainOrigin) {
+			t.Fatalf(
+				"expected ErrIteratorChainOrigin, got %v", err,
+			)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocking reverse Next did not terminate at origin")
+	}
+}
+
+func TestChainIteratorReverseIgnoresRollback(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := chain.NewManager(nil, eventBus)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 100)
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	// Start a reverse iterator at the tip.
+	tip := testBlocks[len(testBlocks)-1]
+	tipPoint := ocommon.NewPoint(tip.MockSlot, decodeHex(tip.MockHash))
+	iter, err := c.FromPointReverse(tipPoint, true)
+	if err != nil {
+		t.Fatalf("unexpected error creating reverse chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	// Consume the tip block.
+	first, err := iter.Next(false)
+	if err != nil {
+		t.Fatalf("unexpected error consuming tip block: %s", err)
+	}
+	if first.Rollback {
+		t.Fatal("reverse iterator must not emit rollback markers")
+	}
+	// Roll back to the third block — this crosses the iterator's
+	// current position. A forward iterator would observe a rollback
+	// marker on the next call; a reverse iterator must not.
+	rollbackTo := testBlocks[2]
+	rollbackPoint := ocommon.NewPoint(
+		rollbackTo.MockSlot, decodeHex(rollbackTo.MockHash),
+	)
+	if err := c.Rollback(rollbackPoint); err != nil {
+		t.Fatalf("unexpected rollback error: %s", err)
+	}
+	// Next call must return a block (not a rollback marker) and that
+	// block must be the rollback target (the new tip), since the
+	// iterator was clamped from past-tip back to the new tip.
+	next, err := iter.Next(false)
+	if err != nil {
+		t.Fatalf("unexpected error after rollback: %s", err)
+	}
+	if next.Rollback {
+		t.Fatal("reverse iterator emitted a rollback marker")
+	}
+	gotHash := hex.EncodeToString(next.Block.Hash)
+	if gotHash != rollbackTo.MockHash {
+		t.Fatalf(
+			"post-rollback reverse iterator: got %s, want %s",
+			gotHash, rollbackTo.MockHash,
+		)
+	}
+	// Continue down to origin — the iterator should walk back to genesis
+	// over the still-present blocks.
+	for i := 1; i >= 0; i-- {
+		next, err := iter.Next(false)
+		if err != nil {
+			t.Fatalf(
+				"unexpected error continuing reverse after rollback at idx %d: %s",
+				i, err,
+			)
+		}
+		gotHash := hex.EncodeToString(next.Block.Hash)
+		wantHash := testBlocks[i].MockHash
+		if gotHash != wantHash {
+			t.Fatalf(
+				"post-rollback reverse at idx %d: got %s, want %s",
+				i, gotHash, wantHash,
+			)
+		}
+	}
+	if _, err := iter.Next(false); !errors.Is(err, chain.ErrIteratorChainOrigin) {
+		t.Fatalf(
+			"expected ErrIteratorChainOrigin after post-rollback exhaustion, got %v",
+			err,
+		)
+	}
+}
+
 func TestHandleBlockProposedEventAddsBlockAndAcks(t *testing.T) {
 	cm, err := chain.NewManager(nil, nil)
 	if err != nil {

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -46,6 +46,9 @@ var (
 	ErrIteratorChainTip = errors.New(
 		"chain iterator is at chain tip",
 	)
+	ErrIteratorChainOrigin = errors.New(
+		"chain iterator is at chain origin",
+	)
 	ErrHeaderQueueFull = errors.New(
 		"header queue at maximum capacity",
 	)

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -28,6 +28,7 @@ type ChainIterator struct {
 	rollbackPoint  ocommon.Point
 	nextBlockIndex uint64
 	needsRollback  bool
+	reverse        bool
 	ctx            context.Context
 	cancel         context.CancelFunc
 }
@@ -42,12 +43,14 @@ func newChainIterator(
 	chain *Chain,
 	startPoint ocommon.Point,
 	inclusive bool,
+	reverse bool,
 ) (*ChainIterator, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ci := &ChainIterator{
 		chain:          chain,
 		startPoint:     startPoint,
 		nextBlockIndex: initialBlockIndex,
+		reverse:        reverse,
 		ctx:            ctx,
 		cancel:         cancel,
 	}
@@ -58,10 +61,24 @@ func newChainIterator(
 			return nil, err
 		}
 		ci.nextBlockIndex = tmpBlock.ID
-		// Increment next block number if non-inclusive
 		if !inclusive {
-			ci.nextBlockIndex++
+			if reverse {
+				// Walking backward: the first block returned must
+				// precede startPoint.
+				if ci.nextBlockIndex <= initialBlockIndex {
+					// Non-inclusive reverse from the first block has
+					// no predecessor; mark as already past origin.
+					ci.nextBlockIndex = 0
+				} else {
+					ci.nextBlockIndex--
+				}
+			} else {
+				ci.nextBlockIndex++
+			}
 		}
+	} else if reverse {
+		// Reverse iteration from origin has no blocks to deliver.
+		ci.nextBlockIndex = 0
 	}
 	return ci, nil
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4615,6 +4615,16 @@ func (ls *LedgerState) GetChainFromPoint(
 	return ls.chain.FromPoint(point, inclusive)
 }
 
+// GetChainFromPointReverse returns a ChainIterator that walks backward from
+// the specified point toward chain origin. If inclusive is true the iterator
+// yields the start point first; otherwise it yields the preceding block.
+func (ls *LedgerState) GetChainFromPointReverse(
+	point ocommon.Point,
+	inclusive bool,
+) (*chain.ChainIterator, error) {
+	return ls.chain.FromPointReverse(point, inclusive)
+}
+
 // Tip returns the current chain tip
 func (ls *LedgerState) Tip() ochainsync.Tip {
 	ls.RLock()


### PR DESCRIPTION
Closes #402 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a reverse chain iterator to step backward from any point toward origin. It adds `chain.FromPointReverse` and a ledger accessor; reverse iteration never blocks and ends with `ErrIteratorChainOrigin`.

- **New Features**
  - `chain.FromPointReverse(point, inclusive)` returns a reverse `ChainIterator`. It yields `point` first when inclusive, otherwise its predecessor. `Next` never waits and returns `ErrIteratorChainOrigin` at/past origin.
  - Reverse iterators never emit rollback markers. If a rollback crosses the iterator (including rollback to origin), it is clamped to the new tip and, once at origin, stays terminated to avoid emitting blocks from a regrown chain.
  - `ledger.GetChainFromPointReverse(point, inclusive)` exposes reverse iteration via the ledger API.

<sup>Written for commit 08fde6ad458fdba49562d097ca272db78100194b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official reverse chain traversal API to iterate backward toward chain origin.
  * New public indicator for the iterator-at-origin condition.

* **Behavior Changes**
  * Reverse iterators now terminate at origin (do not wait for new blocks) and are clamped during rollbacks to avoid resuming from regrown blocks.
  * Reverse iteration advances and termination semantics clarified and made deterministic.

* **Tests**
  * Expanded tests covering reverse traversal from tip, middle, genesis, origin, blocking semantics, and rollback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2318)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->