### PR TITLE
feat: configurable chainsync stall timeout

### DIFF
--- a/config.go
+++ b/config.go
@@ -831,7 +831,7 @@ func WithChainsyncMaxClients(
 
 // WithChainsyncStallTimeout specifies the duration after
 // which a chainsync client with no activity is considered
-// stalled. Default is 30 seconds.
+// stalled. Default is 2 minutes.
 func WithChainsyncStallTimeout(
 	timeout time.Duration,
 ) ConfigOptionFunc {

--- a/node.go
+++ b/node.go
@@ -216,6 +216,7 @@ func (n *Node) Run(ctx context.Context) error {
 		IntersectTip:             n.config.intersectTip,
 		IntersectPoints:          n.config.intersectPoints,
 		PromRegistry:             n.config.promRegistry,
+		ChainsyncBlockTimeout:    n.config.chainsyncStallTimeout,
 		EnableLeios:              n.config.runMode == runModeLeios,
 		ChainsyncIngressEligible: n.isChainsyncIngressEligible,
 	})

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -47,6 +47,24 @@ type lockedBuffer struct {
 	buf bytes.Buffer
 }
 
+func TestEffectiveChainsyncBlockTimeoutUsesProtocolMaxAsFloor(t *testing.T) {
+	require.Equal(
+		t,
+		ochainsync.MustReplyTimeoutMax,
+		effectiveChainsyncBlockTimeout(0),
+	)
+	require.Equal(
+		t,
+		ochainsync.MustReplyTimeoutMax,
+		effectiveChainsyncBlockTimeout(time.Minute),
+	)
+	require.Equal(
+		t,
+		10*time.Minute,
+		effectiveChainsyncBlockTimeout(10*time.Minute),
+	)
+}
+
 func (b *lockedBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -87,8 +87,8 @@ type OuroborosConfig struct {
 	IntersectTip    bool
 	PromRegistry    prometheus.Registerer
 	// ChainsyncBlockTimeout bounds how long NtN chain-sync can wait for a
-	// block reply after a peer enters a server-agency state. Low-density
-	// networks may legitimately go longer than the default protocol window.
+	// block reply after a peer enters a server-agency state. Values below
+	// the protocol maximum are raised to the protocol maximum.
 	ChainsyncBlockTimeout time.Duration
 	// MaxTxSubmissionsPerSecond is the maximum number of transaction
 	// submissions accepted per peer per second via the TxSubmission


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the chainsync stall timeout configurable and apply it consistently across the client and protocol state. Default is 2 minutes to reduce false stalls while enforcing the protocol minimum.

- **New Features**
  - Add `WithChainsyncStallTimeout(time.Duration)` to set the chainsync block/stall timeout (floored to `ochainsync.MustReplyTimeoutMax`).
  - Pass through to `Ouroboros` as `ChainsyncBlockTimeout`; runtime applies it via `ochainsync.WithBlockTimeout`.
  - Add test to ensure values below the protocol max are raised to the max.

<sup>Written for commit 4a3c45298bd965cb04bfac819fbb8b959c5060ae. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated chainsync timeout default documentation to reflect 2-minute threshold.

* **Tests**
  * Added validation tests for timeout behavior and configuration updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2319)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->