### PR TITLE
ci(lint): migrate gomodguard to gomodguard_v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - fatcontext
     - gocheckcompilerdirectives
     - gochecksumtype
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - gosmopolitan
     - loggercheck


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates `.golangci.yml` to replace the `gomodguard` linter with `gomodguard_v2`, adopting the v2 rule set. Keeps CI linting aligned with the maintained linter package name.

<sup>Written for commit 0f55d3b4339f68250d62412e4952b1b613806637. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

