### PR TITLE
build(deps): gouroboros 0.170.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.25.1
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.170.0
+	github.com/blinklabs-io/gouroboros v0.170.1
 	github.com/blinklabs-io/ouroboros-mock v0.10.0
 	github.com/blinklabs-io/plutigo v0.1.11
 	github.com/blockfrost/blockfrost-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.170.0 h1:nIDDSZu6m9Cn12TAVaAPMvyW9/IOBs2Ewb4ougEQSVE=
-github.com/blinklabs-io/gouroboros v0.170.0/go.mod h1:c0G+azc7ERyK4Oy8/TnrrrbQmePw5+rtcY8kyjSfmGI=
+github.com/blinklabs-io/gouroboros v0.170.1 h1:Jt3q0z0cy+ffRcfTS/jnP/Ib9Hc/LYKiYbJYaRTb8sE=
+github.com/blinklabs-io/gouroboros v0.170.1/go.mod h1:c0G+azc7ERyK4Oy8/TnrrrbQmePw5+rtcY8kyjSfmGI=
 github.com/blinklabs-io/ouroboros-mock v0.10.0 h1:8fhKaaTm3pDHSr8Yx91zEthooQH+o+NQhGfN2FKxwMI=
 github.com/blinklabs-io/ouroboros-mock v0.10.0/go.mod h1:1vWKSGxMtUfF3gkrVjUsjPTXdA+A665bQZjbVWpG5lg=
 github.com/blinklabs-io/plutigo v0.1.11 h1:KTOMd7NBoz17iIypzK3v8qIwHcrMRA2+joBK3G7dGzo=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `github.com/blinklabs-io/gouroboros` from v0.170.0 to v0.170.1. This pulls in the latest upstream fixes and keeps the dependency current.

<sup>Written for commit d17217de8188633ebecbe234f44fb6b12fc00d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

