### PR TITLE
fix(ledger): live rollback reconcile

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1234,6 +1234,21 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			return nil
 		}
 		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
+			reconciled, reconcileErr := ls.reconcileLivePrimaryChainLedgerDivergence(
+				"chainsync rollback exceeds security parameter K",
+				e.ConnectionId,
+			)
+			if reconcileErr != nil {
+				return fmt.Errorf(
+					"reconcile primary chain and ledger after over-K rollback: %w",
+					reconcileErr,
+				)
+			}
+			if reconciled {
+				ls.resetChainsyncResyncState()
+				ls.chainsyncState = SyncingChainsyncState
+				return nil
+			}
 			// The peer's chain has diverged beyond K blocks from
 			// ours. This is a security violation — we must not
 			// follow a chain that requires rolling back more than
@@ -1996,6 +2011,21 @@ func (ls *LedgerState) tryResolveFork(
 
 	if err := ls.rollbackChainAndState(rollbackPoint); err != nil {
 		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
+			reconciled, reconcileErr := ls.reconcileLivePrimaryChainLedgerDivergence(
+				"fork resolution exceeds security parameter K",
+				e.ConnectionId,
+			)
+			if reconcileErr != nil {
+				return false, fmt.Errorf(
+					"reconcile primary chain and ledger after over-K fork resolution: %w",
+					reconcileErr,
+				)
+			}
+			if reconciled {
+				ls.resetChainsyncResyncState()
+				ls.chainsyncState = SyncingChainsyncState
+				return true, nil
+			}
 			// Fork exceeds security parameter K. We must not
 			// follow a chain that requires rolling back more
 			// than K blocks — this is a fundamental Ouroboros

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -232,6 +233,42 @@ func TestHandleEventChainsyncRollbackSkipsSamePeerLoop(
 	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
 }
 
+func TestHandleEventChainsyncRollbackExceedsKReconcilesDivergedLedgerTip(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	putPrimaryChainOnForkBeyondK(t, fixture, "live-rollback")
+
+	require.NoError(t, fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        ocommon.Point{},
+		},
+	))
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+	assert.Equal(t, SyncingChainsyncState, fixture.ls.chainsyncState)
+	assert.Zero(t, fixture.ls.chain.HeaderCount())
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+
+	rows, err := fixture.ls.db.GetBlockNoncesInSlotRange(
+		fixture.ancestorTip.Point.Slot,
+		fixture.currentTip.Point.Slot+1,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, fixture.ancestorTip.Point.Hash, rows[0].Hash)
+}
+
 func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 
@@ -274,6 +311,57 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
 	)
 	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
+
+	dbTip, err := fixture.ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, dbTip)
+}
+
+func TestTryResolveForkExceedsKReconcilesDivergedLedgerTip(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	putPrimaryChainOnForkBeyondK(t, fixture, "live-fork-resolution")
+
+	localTip := fixture.ls.chain.Tip()
+	forkHash := testHashBytes("over-k-fork-resolution-block")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: localTip.BlockNumber + 1,
+		slot:        localTip.Point.Slot + 10,
+	}
+	err := fixture.ls.chain.AddBlockHeader(header)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved, err := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockHeader: header,
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					header.SlotNumber(),
+					header.Hash().Bytes(),
+				),
+				BlockNumber: header.BlockNumber(),
+			},
+		},
+		notFitErr,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+	assert.Zero(t, fixture.ls.headerMismatchCount)
+	assert.Zero(t, fixture.ls.chain.HeaderCount())
 
 	dbTip, err := fixture.ls.db.GetTip(nil)
 	require.NoError(t, err)
@@ -1416,6 +1504,34 @@ func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {
 		ancestorNonce: ancestorNonce,
 		forkPoint:     ocommon.NewPoint(currentBlock.Slot+10, testHashBytes("fork-point")),
 	}
+}
+
+func putPrimaryChainOnForkBeyondK(
+	t *testing.T,
+	fixture *chainsyncRollbackFixture,
+	seedPrefix string,
+) {
+	t.Helper()
+
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	prevHash := fixture.ancestorTip.Point.Hash
+	blocks := make([]chain.RawBlock, 0, 3)
+	for idx := range 3 {
+		blockOffset := uint64(idx + 1)
+		hash := testHashBytes(fmt.Sprintf("%s-fork-%d", seedPrefix, idx))
+		blocks = append(blocks, chain.RawBlock{
+			Slot:        fixture.currentTip.Point.Slot + blockOffset*5,
+			Hash:        hash,
+			BlockNumber: fixture.ancestorTip.BlockNumber + blockOffset,
+			Type:        1,
+			PrevHash:    prevHash,
+			Cbor:        []byte{0x80},
+		})
+		prevHash = hash
+	}
+	require.NoError(t, fixture.ls.chain.AddRawBlocks(blocks))
+	require.NotEqual(t, fixture.currentTip, fixture.ls.chain.Tip())
+	require.Equal(t, fixture.currentTip, fixture.ls.currentTip)
 }
 
 func testHashBytes(seed string) []byte {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4324,6 +4324,55 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 	return nil
 }
 
+func (ls *LedgerState) reconcileLivePrimaryChainLedgerDivergence(
+	reason string,
+	connId ouroboros.ConnectionId,
+) (bool, error) {
+	if ls.chain == nil || ls.config.ChainManager == nil {
+		return false, nil
+	}
+	ls.RLock()
+	ledgerTip := ls.currentTip
+	ls.RUnlock()
+	chainTip := ls.chain.Tip()
+	if chainTip.Point.Slot == ledgerTip.Point.Slot &&
+		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash) {
+		return false, nil
+	}
+
+	shouldReconcile := chainTip.Point.Slot < ledgerTip.Point.Slot
+	if !shouldReconcile {
+		containsLedgerTip, err := ls.primaryChainContainsPoint(
+			ledgerTip.Point,
+		)
+		if err != nil {
+			return false, fmt.Errorf(
+				"check ledger tip on primary chain: %w",
+				err,
+			)
+		}
+		shouldReconcile = !containsLedgerTip
+	}
+	if !shouldReconcile {
+		return false, nil
+	}
+
+	ls.config.Logger.Warn(
+		"primary chain and ledger diverged during live chainsync recovery, reconciling to common ancestor",
+		"component", "ledger",
+		"reason", reason,
+		"connection_id", connId.String(),
+		"chain_tip_slot", chainTip.Point.Slot,
+		"ledger_tip_slot", ledgerTip.Point.Slot,
+		"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+		"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+	)
+	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (ls *LedgerState) primaryChainAheadBeyondLedgerSafetyWindow(
 	chainTip ochainsync.Tip,
 	ledgerTip ochainsync.Tip,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Recover chainsync during live rollbacks and fork resolution by reconciling the primary chain and ledger when a rollback would exceed K, so syncing resumes without manual intervention.

- **Bug Fixes**
  - On `chain.ErrRollbackExceedsSecurityParam`, attempt reconciliation to a common ancestor and reset to `SyncingChainsyncState` if successful.
  - Added `reconcileLivePrimaryChainLedgerDivergence` to detect divergence (ledger tip behind or not on primary chain) and call existing reconciliation.
  - Tests cover over-K rollback and fork cases, verifying chain tip, DB tip, nonce integrity, and resync state; includes helper to place primary chain on a fork beyond K.

<sup>Written for commit d7983bc5ebe3774e47adc551844aa0fad8413b86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

