### PR TITLE
fix(metrics): always trigger forge counter

### DIFF
--- a/ledger/forged_block_metrics_test.go
+++ b/ledger/forged_block_metrics_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	dingotestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+type recordForgedBlockTestBlock struct {
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	slot        uint64
+	blockNumber uint64
+	cbor        []byte
+}
+
+func newRecordForgedBlockTestBlock(
+	slot uint64,
+	blockNumber uint64,
+) *recordForgedBlockTestBlock {
+	return &recordForgedBlockTestBlock{
+		hash:        lcommon.NewBlake2b256(bytes.Repeat([]byte{0x10}, 32)),
+		prevHash:    lcommon.NewBlake2b256(bytes.Repeat([]byte{0x20}, 32)),
+		slot:        slot,
+		blockNumber: blockNumber,
+		cbor:        []byte{0x83, 0x01, 0x02},
+	}
+}
+
+func (b *recordForgedBlockTestBlock) Header() lcommon.BlockHeader { return b }
+func (b *recordForgedBlockTestBlock) Type() int {
+	return int(babbage.BlockTypeBabbage)
+}
+func (b *recordForgedBlockTestBlock) Transactions() []lcommon.Transaction {
+	return nil
+}
+func (b *recordForgedBlockTestBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
+	return nil, nil
+}
+func (b *recordForgedBlockTestBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+func (b *recordForgedBlockTestBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+func (b *recordForgedBlockTestBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+func (b *recordForgedBlockTestBlock) SlotNumber() uint64 {
+	return b.slot
+}
+func (b *recordForgedBlockTestBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+func (b *recordForgedBlockTestBlock) BlockBodySize() uint64 {
+	return 0
+}
+func (b *recordForgedBlockTestBlock) Era() lcommon.Era {
+	return babbage.EraBabbage
+}
+func (b *recordForgedBlockTestBlock) Cbor() []byte {
+	return b.cbor
+}
+func (b *recordForgedBlockTestBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func TestRecordForgedBlockIncrementsCounterBeforeAdoption(t *testing.T) {
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+	_, events := eb.Subscribe(event.BlockForgedEventType)
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus: eb,
+			Logger: slog.New(
+				slog.NewJSONHandler(io.Discard, nil),
+			),
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+
+	block := newRecordForgedBlockTestBlock(42, 7)
+	blockCbor := []byte{0x83, 0xaa, 0xbb}
+	expectedHash := block.Hash().Bytes()
+	expectedTxCount := uint(len(block.Transactions()))
+	beforeRecord := time.Now()
+	ls.RecordForgedBlock(block, blockCbor, 5*time.Millisecond)
+	afterRecord := time.Now()
+
+	assert.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(ls.metrics.blocksForgedTotal),
+	)
+	evt := dingotestutil.RequireReceive(
+		t,
+		events,
+		time.Second,
+		"block forged event",
+	)
+	forged, ok := evt.Data.(event.BlockForgedEvent)
+	require.True(t, ok)
+	assert.Equal(t, uint64(42), forged.Slot)
+	assert.Equal(t, uint64(7), forged.BlockNumber)
+	assert.Equal(t, expectedHash, forged.BlockHash)
+	assert.Equal(t, expectedTxCount, forged.TxCount)
+	assert.Equal(t, uint(len(blockCbor)), forged.BlockSize)
+	assert.False(t, forged.Timestamp.Before(beforeRecord))
+	assert.False(t, forged.Timestamp.After(afterRecord))
+}

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -64,6 +65,7 @@ type BlockForger struct {
 	leaderChecker    LeaderChecker
 	blockBuilder     BlockBuilder
 	blockBroadcaster BlockBroadcaster
+	blockForged      BlockForgedObserver
 	slotClock        SlotClockProvider
 	slotDuration     time.Duration
 
@@ -105,6 +107,14 @@ type BlockBroadcaster interface {
 	AddBlock(block ledger.Block, cbor []byte) error
 }
 
+// BlockForgedObserver observes blocks after they are successfully built,
+// before chain adoption is attempted.
+type BlockForgedObserver func(
+	block ledger.Block,
+	cbor []byte,
+	latency time.Duration,
+)
+
 // SlotClockProvider provides current slot information from the slot clock.
 type SlotClockProvider interface {
 	// CurrentSlot returns the current slot number based on wall-clock time.
@@ -131,6 +141,7 @@ type ForgerConfig struct {
 	LeaderChecker    LeaderChecker
 	BlockBuilder     BlockBuilder
 	BlockBroadcaster BlockBroadcaster
+	BlockForged      BlockForgedObserver
 	SlotClock        SlotClockProvider
 
 	// ForgeSyncToleranceSlots controls how far the local chain can lag the
@@ -162,6 +173,7 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		leaderChecker:    cfg.LeaderChecker,
 		blockBuilder:     cfg.BlockBuilder,
 		blockBroadcaster: cfg.BlockBroadcaster,
+		blockForged:      cfg.BlockForged,
 		slotClock:        cfg.SlotClock,
 		slotTracker:      NewSlotTracker(),
 	}
@@ -369,6 +381,8 @@ func (f *BlockForger) checkAndForge(ctx context.Context) error {
 
 // checkAndForgeProduction implements production mode forging.
 func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
+	forgeStartTime := time.Now()
+
 	// Get current slot from slot clock
 	currentSlot, err := f.slotClock.CurrentSlot()
 	if err != nil {
@@ -495,6 +509,20 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		f.metrics.blockTxCount.Observe(
 			float64(len(block.Transactions())),
 		)
+	}
+	if f.blockForged != nil {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					f.logger.Error(
+						"blockForged observer panic",
+						"panic", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}()
+			f.blockForged(block, blockCbor, time.Since(forgeStartTime))
+		}()
 	}
 
 	// Add block to chain and broadcast

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+type forgerTestLeader struct{}
+
+func (forgerTestLeader) ShouldProduceBlock(uint64) bool { return true }
+
+func (forgerTestLeader) NextLeaderSlot(
+	fromSlot uint64,
+) (uint64, bool) {
+	return fromSlot, true
+}
+
+type forgerTestSlotClock struct {
+	currentSlot       uint64
+	chainTipSlot      uint64
+	upstreamTipSlot   uint64
+	slotsPerKESPeriod uint64
+}
+
+func (c forgerTestSlotClock) CurrentSlot() (uint64, error) {
+	return c.currentSlot, nil
+}
+
+func (c forgerTestSlotClock) SlotsPerKESPeriod() uint64 {
+	return c.slotsPerKESPeriod
+}
+
+func (c forgerTestSlotClock) ChainTipSlot() uint64 {
+	return c.chainTipSlot
+}
+
+func (forgerTestSlotClock) NextSlotTime() (time.Time, error) {
+	return time.Now(), nil
+}
+
+func (c forgerTestSlotClock) UpstreamTipSlot() uint64 {
+	return c.upstreamTipSlot
+}
+
+type forgerTestBuilder struct {
+	block ledger.Block
+	cbor  []byte
+	calls int
+}
+
+func (b *forgerTestBuilder) BuildBlock(
+	uint64,
+	uint64,
+) (ledger.Block, []byte, error) {
+	b.calls++
+	return b.block, b.cbor, nil
+}
+
+type forgerTestBroadcaster struct {
+	err   error
+	calls int
+}
+
+func (b *forgerTestBroadcaster) AddBlock(
+	ledger.Block,
+	[]byte,
+) error {
+	b.calls++
+	return b.err
+}
+
+type forgerTestBlock struct {
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	slot        uint64
+	blockNumber uint64
+	cbor        []byte
+}
+
+func newForgerTestBlock(slot, blockNumber uint64) *forgerTestBlock {
+	return &forgerTestBlock{
+		hash:        lcommon.NewBlake2b256(bytes.Repeat([]byte{0x01}, 32)),
+		prevHash:    lcommon.NewBlake2b256(bytes.Repeat([]byte{0x02}, 32)),
+		slot:        slot,
+		blockNumber: blockNumber,
+		cbor:        []byte{0x83, 0x01, 0x02},
+	}
+}
+
+func (b *forgerTestBlock) Header() lcommon.BlockHeader { return b }
+func (b *forgerTestBlock) Type() int                   { return int(babbage.BlockTypeBabbage) }
+func (b *forgerTestBlock) Transactions() []lcommon.Transaction {
+	return nil
+}
+func (b *forgerTestBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
+	return nil, nil
+}
+func (b *forgerTestBlock) Hash() lcommon.Blake2b256          { return b.hash }
+func (b *forgerTestBlock) PrevHash() lcommon.Blake2b256      { return b.prevHash }
+func (b *forgerTestBlock) BlockNumber() uint64               { return b.blockNumber }
+func (b *forgerTestBlock) SlotNumber() uint64                { return b.slot }
+func (b *forgerTestBlock) IssuerVkey() lcommon.IssuerVkey    { return lcommon.IssuerVkey{} }
+func (b *forgerTestBlock) BlockBodySize() uint64             { return 0 }
+func (b *forgerTestBlock) Era() lcommon.Era                  { return babbage.EraBabbage }
+func (b *forgerTestBlock) Cbor() []byte                      { return b.cbor }
+func (b *forgerTestBlock) BlockBodyHash() lcommon.Blake2b256 { return lcommon.Blake2b256{} }
+
+func TestCheckAndForgeProductionObservesForgedBlockWhenNotAdopted(
+	t *testing.T,
+) {
+	creds := setupTestCredentials(t)
+	block := newForgerTestBlock(10, 2)
+	blockCbor := []byte{0x83, 0xaa, 0xbb}
+	builder := &forgerTestBuilder{
+		block: block,
+		cbor:  blockCbor,
+	}
+	broadcaster := &forgerTestBroadcaster{
+		err: errors.New("not adopted"),
+	}
+	var (
+		observedBlock   ledger.Block
+		observedCbor    []byte
+		observedLatency time.Duration
+	)
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		BlockForged: func(
+			block ledger.Block,
+			cbor []byte,
+			latency time.Duration,
+		) {
+			observedBlock = block
+			observedCbor = append([]byte(nil), cbor...)
+			observedLatency = latency
+		},
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      9,
+			slotsPerKESPeriod: 100,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	err = forger.checkAndForgeProduction(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to add block")
+
+	require.Same(t, block, observedBlock)
+	assert.Equal(t, blockCbor, observedCbor)
+	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
+	assert.Equal(t, 1, builder.calls)
+	assert.Equal(t, 1, broadcaster.calls)
+	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeForged))
+	assert.Equal(t, float64(0), testutil.ToFloat64(forger.metrics.forgeAdopted))
+}
+
+func TestCheckAndForgeProductionRecoversBlockForgedObserverPanic(
+	t *testing.T,
+) {
+	creds := setupTestCredentials(t)
+	block := newForgerTestBlock(10, 2)
+	blockCbor := []byte{0x83, 0xaa, 0xbb}
+	builder := &forgerTestBuilder{
+		block: block,
+		cbor:  blockCbor,
+	}
+	broadcaster := &forgerTestBroadcaster{}
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		BlockForged: func(
+			ledger.Block,
+			[]byte,
+			time.Duration,
+		) {
+			panic("observer panic")
+		},
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      9,
+			slotsPerKESPeriod: 100,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	assert.Equal(t, 1, builder.calls)
+	assert.Equal(t, 1, broadcaster.calls)
+	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeForged))
+	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeAdopted))
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -5619,6 +5619,43 @@ func (ls *LedgerState) loadSlotBattleRecorder() SlotBattleRecorder {
 	return recorder.recorder
 }
 
+// RecordForgedBlock records observability for a block that this node
+// successfully forged. Adoption into the local chain is tracked separately.
+func (ls *LedgerState) RecordForgedBlock(
+	block ledger.Block,
+	blockCbor []byte,
+	forgingLatency time.Duration,
+) {
+	if ls == nil || block == nil {
+		return
+	}
+	if ls.metrics.blocksForgedTotal != nil {
+		ls.metrics.blocksForgedTotal.Inc()
+	}
+	if ls.metrics.blockForgingLatency != nil {
+		ls.metrics.blockForgingLatency.Observe(
+			forgingLatency.Seconds(),
+		)
+	}
+	if ls.config.EventBus == nil {
+		return
+	}
+	ls.config.EventBus.Publish(
+		event.BlockForgedEventType,
+		event.NewEvent(
+			event.BlockForgedEventType,
+			event.BlockForgedEvent{
+				Slot:        block.SlotNumber(),
+				BlockNumber: block.BlockNumber(),
+				BlockHash:   block.Hash().Bytes(),
+				TxCount:     uint(len(block.Transactions())),
+				BlockSize:   uint(len(blockCbor)),
+				Timestamp:   time.Now(),
+			},
+		),
+	)
+}
+
 // forgeBlock creates a conway block with transactions from mempool
 // Also adds it to the primary chain
 func (ls *LedgerState) forgeBlock() {
@@ -5917,6 +5954,9 @@ func (ls *LedgerState) forgeBlock() {
 		return
 	}
 
+	forgingLatency := time.Since(forgeStartTime)
+	ls.RecordForgedBlock(ledgerBlock, blockCbor, forgingLatency)
+
 	// Add the block to the primary chain
 	err = ls.chain.AddBlock(ledgerBlock, nil)
 	if err != nil {
@@ -5931,31 +5971,6 @@ func (ls *LedgerState) forgeBlock() {
 	// Wake chainsync server iterators so connected peers discover
 	// the newly forged block immediately.
 	ls.chain.NotifyIterators()
-
-	// Calculate forging latency
-	forgingLatency := time.Since(forgeStartTime)
-
-	// Update forging metrics
-	ls.metrics.blocksForgedTotal.Inc()
-	ls.metrics.blockForgingLatency.Observe(forgingLatency.Seconds())
-
-	// Publish BlockForgedEvent for observability and monitoring
-	if ls.config.EventBus != nil {
-		ls.config.EventBus.Publish(
-			event.BlockForgedEventType,
-			event.NewEvent(
-				event.BlockForgedEventType,
-				event.BlockForgedEvent{
-					Slot:        ledgerBlock.SlotNumber(),
-					BlockNumber: ledgerBlock.BlockNumber(),
-					BlockHash:   ledgerBlock.Hash().Bytes(),
-					TxCount:     uint(len(transactionBodies)),
-					BlockSize:   uint(len(blockCbor)),
-					Timestamp:   time.Now(),
-				},
-			),
-		)
-	}
 
 	// Log the successful block creation
 	ls.config.Logger.Info(

--- a/node_forging.go
+++ b/node_forging.go
@@ -252,6 +252,7 @@ func (n *Node) initBlockForger(
 		LeaderChecker:               election,
 		BlockBuilder:                builder,
 		BlockBroadcaster:            broadcaster,
+		BlockForged:                 n.ledgerState.RecordForgedBlock,
 		SlotClock:                   slotClock,
 		ForgeSyncToleranceSlots:     n.config.forgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: n.config.forgeStaleGapThresholdSlots,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure forged blocks are counted and reported as soon as they’re built, even if chain adoption fails. This fixes undercounted forge metrics and improves observability.

- **Bug Fixes**
  - Added `BlockForgedObserver` to the forger, invoked immediately after a block is built with latency; safely recovers from panics.
  - Implemented `LedgerState.RecordForgedBlock` to increment `blocksForgedTotal`, observe `blockForgingLatency`, and publish `BlockForgedEvent` (slot, block number, hash, tx count, size, timestamp).
  - Wired the observer in `node_forging` to `ledgerState.RecordForgedBlock` and updated `forgeBlock` to call it directly so metrics always fire, even when adoption fails.
  - Added tests to confirm pre-adoption metrics/events and observer panic recovery.

<sup>Written for commit a0ec38751692392ea7715af71446a5705a8f5f0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block forging metrics and events are now automatically recorded and published when blocks are created, including timing information and block details, improving system observability.

* **Tests**
  * Added comprehensive tests for block forging metrics recording and event publication functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2323)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->