### PR TITLE
fix: divergent peer handling

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -40,6 +40,11 @@ const (
 	// chainsync client can take before we give up and close the
 	// connection. Increase this for slow or congested networks.
 	chainsyncRestartTimeout = 30 * time.Second
+
+	// chainsyncDivergentPeerCooldown slows peers that repeatedly offer a
+	// rollback we cannot safely follow. This prevents full-duplex reconnects
+	// from immediately re-entering the same rollback loop.
+	chainsyncDivergentPeerCooldown = 2 * time.Minute
 )
 
 func effectiveChainsyncBlockTimeout(timeout time.Duration) time.Duration {
@@ -138,6 +143,36 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 	default:
 		return false
 	}
+}
+
+func chainsyncResyncDeniesPeer(reason string) bool {
+	switch reason {
+	case event.ChainsyncResyncReasonRollbackExceedsK,
+		event.ChainsyncResyncReasonForkResolutionExceedsK:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o *Ouroboros) denyDivergentChainsyncPeer(
+	connId ouroboros.ConnectionId,
+	reason string,
+) {
+	if o.PeerGov == nil ||
+		connId.RemoteAddr == nil ||
+		!chainsyncResyncDeniesPeer(reason) {
+		return
+	}
+	address := connId.RemoteAddr.String()
+	o.PeerGov.DenyPeer(address, chainsyncDivergentPeerCooldown)
+	o.config.Logger.Warn(
+		"temporarily denying divergent chainsync peer",
+		"connection_id", connId.String(),
+		"address", address,
+		"reason", reason,
+		"duration", chainsyncDivergentPeerCooldown,
+	)
 }
 
 func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
@@ -1073,6 +1108,7 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 			// points.
 			if chainsyncResyncRequiresFreshConnection(e.Reason) {
 				for _, connId := range connIds {
+					o.denyDivergentChainsyncPeer(connId, e.Reason)
 					if o.ChainsyncState != nil {
 						o.ChainsyncState.ClearObservedHeaderHistory(connId)
 					}

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -847,6 +847,98 @@ func TestSubscribeChainsyncResyncClosesConnectionForFreshSyncReasons(
 	}
 }
 
+func TestSubscribeChainsyncResyncDeniesDivergentPeer(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	peerGov := peergov.NewPeerGovernor(peergov.PeerGovernorConfig{
+		Logger: logger,
+	})
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		Logger:   logger,
+	})
+	o.EventBus = bus
+	o.PeerGov = peerGov
+	o.SubscribeChainsyncResync(t.Context())
+
+	localAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:3001")
+	require.NoError(t, err)
+	remoteAddr, err := net.ResolveTCPAddr("tcp", "10.0.0.1:3001")
+	require.NoError(t, err)
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+
+	bus.Publish(
+		event.ChainsyncResyncEventType,
+		event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{
+				ConnectionId: connId,
+				Reason:       event.ChainsyncResyncReasonRollbackExceedsK,
+			},
+		),
+	)
+
+	require.Eventually(
+		t,
+		func() bool {
+			return peerGov.IsDenied(remoteAddr.String())
+		},
+		2*time.Second,
+		20*time.Millisecond,
+	)
+}
+
+func TestSubscribeChainsyncResyncDoesNotDenyRollbackLoop(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	peerGov := peergov.NewPeerGovernor(peergov.PeerGovernorConfig{
+		Logger: logger,
+	})
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		Logger:   logger,
+	})
+	o.EventBus = bus
+	o.PeerGov = peerGov
+	o.SubscribeChainsyncResync(t.Context())
+
+	localAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:3001")
+	require.NoError(t, err)
+	remoteAddr, err := net.ResolveTCPAddr("tcp", "10.0.0.1:3001")
+	require.NoError(t, err)
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+
+	bus.Publish(
+		event.ChainsyncResyncEventType,
+		event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{
+				ConnectionId: connId,
+				Reason:       event.ChainsyncResyncReasonRollbackLoop,
+			},
+		),
+	)
+
+	require.Never(
+		t,
+		func() bool {
+			return peerGov.IsDenied(remoteAddr.String())
+		},
+		200*time.Millisecond,
+		20*time.Millisecond,
+	)
+}
+
 func TestHeaderPreviouslySeenFromOtherConnTreatsEquivalentConnIdsAsSame(
 	t *testing.T,
 ) {

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -130,6 +130,14 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		return
 	}
 	currentPeer := p.peers[idx]
+	if p.isPeerDeniedLocked(currentPeer) {
+		p.mu.Unlock()
+		p.config.Logger.Debug(
+			"outbound: peer denied, skipping connection attempts",
+			"address", peer.Address,
+		)
+		return
+	}
 	if currentPeer.Reconnecting {
 		p.mu.Unlock()
 		p.config.Logger.Debug(
@@ -194,7 +202,8 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			)
 			return
 		}
-		if p.isDeniedLocked(peer.NormalizedAddress) {
+		currentPeer = p.peers[peerIdx]
+		if p.isPeerDeniedLocked(currentPeer) {
 			p.mu.Unlock()
 			p.config.Logger.Debug(
 				"outbound: peer denied, stopping connection attempts",
@@ -202,7 +211,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			)
 			return
 		}
-		if currentPeer := p.peers[peerIdx]; p.inboundSatisfiesTopologyValencyLocked(currentPeer) {
+		if p.inboundSatisfiesTopologyValencyLocked(currentPeer) {
 			p.mu.Unlock()
 			p.config.Logger.Info(
 				"outbound: inbound reusable topology connections already satisfy valency, suppressing outbound attempts",
@@ -259,18 +268,27 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			// Re-check that peer is still valid after connection was created
 			// to eliminate TOCTOU race window
 			peerIdx := p.peerIndexByAddress(peer.NormalizedAddress)
-			if peerIdx == -1 || p.isDeniedLocked(peer.NormalizedAddress) {
+			if peerIdx == -1 {
 				p.mu.Unlock()
-				// Peer was removed or denied while connecting, close connection
+				// Peer was removed while connecting, close connection
 				conn.Close()
 				p.config.Logger.Debug(
-					"outbound: peer removed/denied during connection, closing",
+					"outbound: peer removed during connection, closing",
 					"address", peer.Address,
 				)
 				return
 			}
 			// Use the peer from the slice in case the pointer changed
 			currentPeer := p.peers[peerIdx]
+			if p.isPeerDeniedLocked(currentPeer) {
+				p.mu.Unlock()
+				conn.Close()
+				p.config.Logger.Debug(
+					"outbound: peer denied during connection, closing",
+					"address", peer.Address,
+				)
+				return
+			}
 			oldSource := currentPeer.Source
 			oldConn := clonePeerConnection(currentPeer.Connection)
 			currentPeer.ConnectedAt = time.Now()
@@ -496,7 +514,19 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			"denied inbound peer during cooldown",
 			"address", address,
 		)
+		connManager := p.config.ConnManager
+		connId := e.ConnectionId
 		p.mu.Unlock()
+		if connManager != nil {
+			if conn := connManager.GetConnectionById(connId); conn != nil {
+				p.config.Logger.Info(
+					"closing denied inbound peer",
+					"address", address,
+					"connection_id", connId.String(),
+				)
+				conn.Close()
+			}
+		}
 		return
 	}
 	peerIdx, topologyGroupID := p.resolveInboundIdentity(address, normalized)
@@ -636,6 +666,7 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 		oldSource := peer.Source
 		oldConn := clonePeerConnection(peer.Connection)
 		connClosedAt := time.Now()
+		denied := p.isPeerDeniedLocked(peer)
 		if peer.Source == PeerSourceInboundConn {
 			connDur := time.Duration(0)
 			if !peer.InboundConnectedAt.IsZero() {
@@ -669,8 +700,7 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 		)
 		p.updatePeerMetrics()
 		// Only reconnect for outbound peers that are not on the deny list
-		shouldReconnect := peer.Source != PeerSourceInboundConn &&
-			!p.isDeniedLocked(peer.NormalizedAddress)
+		shouldReconnect := peer.Source != PeerSourceInboundConn && !denied
 		if peer.Source != PeerSourceInboundConn {
 			// Apply backoff for short-lived connections to prevent
 			// rapid reconnection cycles that exhaust ephemeral ports.
@@ -740,15 +770,20 @@ func (p *PeerGovernor) DenyPeer(address string, duration time.Duration) {
 	}
 	// Resolve address before acquiring lock to avoid blocking DNS
 	normalized := p.resolveAddress(address)
+	hostnameNormalized := p.normalizeAddress(address)
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	expiry := time.Now().Add(duration)
 	if idx := p.peerIndexByAddress(address); idx != -1 && p.peers[idx] != nil {
-		p.denyList[p.peers[idx].NormalizedAddress] = time.Now().Add(duration)
-		p.denyList[p.normalizeAddress(p.peers[idx].Address)] = time.Now().
-			Add(duration)
+		p.addPeerDenyKeysLocked(p.peers[idx], expiry, normalized, hostnameNormalized)
+	} else if idx := p.peerIndexByConnectionRemoteAddressLocked(
+		normalized,
+		hostnameNormalized,
+	); idx != -1 && p.peers[idx] != nil {
+		p.addPeerDenyKeysLocked(p.peers[idx], expiry, normalized, hostnameNormalized)
 	} else {
-		p.denyList[normalized] = time.Now().Add(duration)
-		p.denyList[p.normalizeAddress(address)] = time.Now().Add(duration)
+		p.denyList[normalized] = expiry
+		p.denyList[hostnameNormalized] = expiry
 	}
 	p.config.Logger.Debug(
 		"peer added to deny list",
@@ -789,6 +824,72 @@ func (p *PeerGovernor) isDeniedLocked(address string) bool {
 		return false
 	}
 	return true
+}
+
+func (p *PeerGovernor) peerIndexByConnectionRemoteAddressLocked(
+	addresses ...string,
+) int {
+	for i, peer := range p.peers {
+		if peer == nil ||
+			peer.Connection == nil ||
+			peer.Connection.Id.RemoteAddr == nil {
+			continue
+		}
+		remoteAddress := peer.Connection.Id.RemoteAddr.String()
+		remoteNormalized := connmanager.NormalizePeerAddr(remoteAddress)
+		remoteHostnameNormalized := p.normalizeAddress(remoteAddress)
+		for _, address := range addresses {
+			if address == "" {
+				continue
+			}
+			if address == remoteNormalized || address == remoteHostnameNormalized {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func (p *PeerGovernor) addPeerDenyKeysLocked(
+	peer *Peer,
+	expiry time.Time,
+	addresses ...string,
+) {
+	for _, address := range addresses {
+		if address != "" {
+			p.denyList[address] = expiry
+		}
+	}
+	if peer == nil {
+		return
+	}
+	if peer.NormalizedAddress != "" {
+		p.denyList[peer.NormalizedAddress] = expiry
+	}
+	if peer.Address != "" {
+		p.denyList[p.normalizeAddress(peer.Address)] = expiry
+	}
+	if peer.Connection != nil && peer.Connection.Id.RemoteAddr != nil {
+		remoteAddress := peer.Connection.Id.RemoteAddr.String()
+		p.denyList[connmanager.NormalizePeerAddr(remoteAddress)] = expiry
+		p.denyList[p.normalizeAddress(remoteAddress)] = expiry
+	}
+}
+
+func (p *PeerGovernor) isPeerDeniedLocked(peer *Peer) bool {
+	if peer == nil {
+		return false
+	}
+	if p.isDeniedLocked(peer.NormalizedAddress) ||
+		p.isDeniedLocked(p.normalizeAddress(peer.Address)) {
+		return true
+	}
+	if peer.Connection != nil && peer.Connection.Id.RemoteAddr != nil {
+		remoteAddress := peer.Connection.Id.RemoteAddr.String()
+		return p.isDeniedLocked(connmanager.NormalizePeerAddr(remoteAddress)) ||
+			p.isDeniedLocked(p.normalizeAddress(remoteAddress))
+	}
+	return false
 }
 
 // cleanupDenyList removes expired entries from the deny list.

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -16,6 +16,7 @@ package peergov
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +28,7 @@ import (
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -1012,6 +1014,62 @@ func TestPeerGovernor_HandleInboundConnection(t *testing.T) {
 	}
 }
 
+func TestPeerGovernor_HandleInboundConnectionDeniedPeer(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	connManager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{
+			Logger: logger,
+		},
+	)
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = connManager.Stop(stopCtx)
+	})
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       logger,
+		ConnManager:  connManager,
+		DenyDuration: time.Hour,
+	})
+
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		[]ouroboros_mock.ConversationEntry{
+			ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+			ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		},
+	)
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(false),
+	)
+	require.NoError(t, err)
+	connId := oConn.Id()
+	address := connId.RemoteAddr.String()
+	require.True(t, connManager.AddConnection(oConn, true, address))
+	pg.DenyPeer(connmanager.NormalizePeerAddr(address), 0)
+
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId:         connId,
+			LocalAddr:            connId.LocalAddr,
+			RemoteAddr:           connId.RemoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(address),
+			IsDuplex:             true,
+		},
+	})
+
+	require.Empty(t, pg.GetPeers())
+	require.True(t, pg.IsDenied(address))
+	require.Eventually(t, func() bool {
+		return connManager.GetConnectionById(connId) == nil
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestPeerGovernor_HandleConnectionClosed(t *testing.T) {
 	eventBus := newMockEventBus()
 	reg := prometheus.NewRegistry()
@@ -1342,6 +1400,56 @@ func TestPeerGovernor_DenyPeer_CaseInsensitive(t *testing.T) {
 		exists,
 		"deny list should store normalized (lowercase) address",
 	)
+}
+
+func TestPeerGovernor_DenyPeer_MatchesActiveConnectionRemoteAddress(
+	t *testing.T,
+) {
+	oldLookupIP := lookupIP
+	lookupIP = func(string) ([]net.IP, error) {
+		return nil, errors.New("lookup failed")
+	}
+	t.Cleanup(func() { lookupIP = oldLookupIP })
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DenyDuration: time.Hour,
+	})
+	localAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:3001")
+	require.NoError(t, err)
+	remoteAddr, err := net.ResolveTCPAddr("tcp", "195.191.47.210:3001")
+	require.NoError(t, err)
+	connID := ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+	peer := &Peer{
+		Address:           "prv-relay1.apexpool.info:3001",
+		NormalizedAddress: "203.0.113.10:3001",
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateWarm,
+		Connection: &PeerConnection{
+			Id:       connID,
+			IsClient: true,
+		},
+	}
+	pg.peers = append(pg.peers, peer)
+
+	pg.DenyPeer(remoteAddr.String(), 0)
+
+	assert.True(t, pg.IsDenied(remoteAddr.String()))
+	assert.True(t, pg.IsDenied(peer.Address))
+	assert.True(t, pg.IsDenied(peer.NormalizedAddress))
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	assert.True(t, pg.isPeerDeniedLocked(peer))
+	_, remoteDenied := pg.denyList["195.191.47.210:3001"]
+	assert.True(t, remoteDenied)
+	_, hostnameDenied := pg.denyList["prv-relay1.apexpool.info:3001"]
+	assert.True(t, hostnameDenied)
+	_, configuredDenied := pg.denyList["203.0.113.10:3001"]
+	assert.True(t, configuredDenied)
 }
 
 func TestPeerGovernor_IsDenied_Expiry(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Temporarily deny divergent chainsync peers and enforce the deny list across connection flows to stop rollback loops and reduce reconnect churn. Denied inbound connections are now closed immediately.

- **Bug Fixes**
  - In `ouroboros`, auto-deny chainsync peers on unsafe rollback/fork (>k) with a 2-minute cooldown; logs and clears header history.
  - In `peergov`, check denial before and during outbound connects; stop attempts and close connections if the peer becomes denied; suppress reconnects when denied.
  - Close denied inbound connections via `connmanager` and skip adding the peer.
  - Broaden deny matching to normalized, hostname, and active connection remote addresses for consistent enforcement.

<sup>Written for commit acbe048ffc41af678d9268d558a579609efc9705. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

