### PR TITLE
test: default erastest excludes vanRossem

### DIFF
--- a/internal/test/erastest/run-tests.sh
+++ b/internal/test/erastest/run-tests.sh
@@ -32,9 +32,11 @@ TESTNET_YAML="${SCRIPT_DIR}/testnet.yaml"
 
 KEEP_UP=false
 TEST_ARGS=()
+HAS_RUN=false
 for arg in "$@"; do
   case "${arg}" in
     --keep-up) KEEP_UP=true ;;
+    -run|-run=*) HAS_RUN=true; TEST_ARGS+=("${arg}") ;;
     *)         TEST_ARGS+=("${arg}") ;;
   esac
 done
@@ -115,6 +117,10 @@ export ERASTEST_DINGO_ADDR="localhost:${DINGO_PORT}"
 export ERASTEST_CARDANO_ADDR="localhost:${CARDANO_PORT}"
 export ERASTEST_RELAY_ADDR="localhost:${RELAY_PORT}"
 export ERASTEST_TESTNET_YAML="${TESTNET_YAML}"
+
+if [[ "${HAS_RUN}" == "false" ]]; then
+  TEST_ARGS=(-run 'TestEraTransitions|TestPV11Readiness' "${TEST_ARGS[@]}")
+fi
 
 # Default timeout: ~6 epochs * 75s ≈ 7.5 min for a healthy traversal
 # plus margin for bootstrap and the test cascade. Set TEST_TIMEOUT in


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default erastest now runs only TestEraTransitions and TestPV11Readiness (vanRossem excluded) when no -run is given. If -run or -run=* is provided, it is respected and the default filter is not applied.

<sup>Written for commit 7b98ef92fbde58565e68bb6648dcb427d1d1a96a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

