### PR TITLE
fix: mithril restore boundary

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -649,6 +649,15 @@ func runMithrilSync(
 			"count", len(gapBlocks),
 		)
 	}
+	if err := processPostLedgerStateBlocks(
+		ctx,
+		db,
+		logger,
+		ledgerStateSlot,
+		ledgerStateHash,
+	); err != nil {
+		return err
+	}
 
 	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
 		if err := updateMithrilReadyState(
@@ -1387,6 +1396,55 @@ func validateStoredGapBlocks(
 			last.Slot,
 			last.Hash,
 			ledgerStateHash,
+		)
+	}
+	return nil
+}
+
+func processPostLedgerStateBlocks(
+	ctx context.Context,
+	db *database.Database,
+	logger *slog.Logger,
+	ledgerStateSlot uint64,
+	ledgerStateHash []byte,
+) error {
+	recentBlocks, err := database.BlocksRecent(db, 1)
+	if err != nil {
+		return fmt.Errorf("reading chain tip for post-ledger processing: %w", err)
+	}
+	if len(recentBlocks) == 0 || recentBlocks[0].Slot <= ledgerStateSlot {
+		return nil
+	}
+	logger.Info(
+		"processing post-ledger-state blocks from blob store",
+		"component", "mithril",
+		"ledger_state_slot", ledgerStateSlot,
+		"stored_tip_slot", recentBlocks[0].Slot,
+	)
+	postLedgerBlocks, err := loadGapBlocksFromBlob(
+		db,
+		ledgerStateSlot+1,
+		recentBlocks[0].Slot,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"loading post-ledger-state blocks from blob store: %w",
+			err,
+		)
+	}
+	if err := validateStoredGapContinuity(
+		postLedgerBlocks,
+		models.Block{Slot: ledgerStateSlot, Hash: ledgerStateHash},
+	); err != nil {
+		return fmt.Errorf(
+			"validating post-ledger-state block continuity: %w",
+			err,
+		)
+	}
+	if err := processGapBlocks(ctx, db, logger, postLedgerBlocks); err != nil {
+		return fmt.Errorf(
+			"processing post-ledger-state block transactions: %w",
+			err,
 		)
 	}
 	return nil

--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -32,6 +32,7 @@ const (
 	ChainsyncResyncReasonRollbackLoop                 = "rollback loop detected"
 	ChainsyncResyncReasonPersistentFork               = "persistent chain fork"
 	ChainsyncResyncReasonRollbackExceedsK             = "rollback exceeds security parameter K"
+	ChainsyncResyncReasonRollbackExceedsMithril       = "rollback exceeds Mithril trust boundary"
 	ChainsyncResyncReasonForkResolutionExceedsK       = "fork resolution exceeds security parameter K"
 	ChainsyncResyncReasonLocalLedgerRollback          = "local ledger rollback"
 	ChainsyncResyncReasonLiveTxValidationRecovery     = "live tx validation recovery"

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -127,6 +127,10 @@ var ErrRollbackLoopDetected = errors.New(
 	"rollback loop detected: same slot rolled back too many times within window",
 )
 
+var ErrRollbackExceedsMithrilBoundary = errors.New(
+	"rollback exceeds Mithril trust boundary",
+)
+
 type peerHeaderRecord struct {
 	event    ChainsyncEvent
 	prevHash []byte
@@ -1283,6 +1287,36 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			}
 			return nil
 		}
+		if errors.Is(err, ErrRollbackExceedsMithrilBoundary) {
+			// The Mithril snapshot is the local trust anchor. Blocks at
+			// or below its boundary were certified as a single ledger
+			// state, so we cannot reconstruct intermediate UTxO states
+			// for a replacement fork below that point. Reject the peer
+			// chain and force a fresh intersection instead.
+			ls.config.Logger.Error(
+				"chainsync rollback exceeds Mithril trust boundary, rejecting peer chain",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"hash", hex.EncodeToString(e.Point.Hash),
+				"mithril_ledger_slot", ls.mithrilLedgerSlot,
+				"connection_id", e.ConnectionId.String(),
+			)
+			ls.resetChainsyncResyncState()
+			ls.chainsyncState = SyncingChainsyncState
+			if ls.config.EventBus != nil {
+				ls.config.EventBus.Publish(
+					event.ChainsyncResyncEventType,
+					event.NewEvent(
+						event.ChainsyncResyncEventType,
+						event.ChainsyncResyncEvent{
+							ConnectionId: e.ConnectionId,
+							Reason:       event.ChainsyncResyncReasonRollbackExceedsMithril,
+						},
+					),
+				)
+			}
+			return nil
+		}
 		return fmt.Errorf("chain rollback failed: %w", err)
 	}
 	return nil
@@ -1610,7 +1644,10 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	// Skip during historical sync (validationEnabled=false) because
 	// historical blocks were already validated by the network and the
 	// epoch nonce may not be fully computed yet (e.g. Byron→Shelley).
-	if ls.validationEnabled {
+	// Also skip headers covered by a Mithril snapshot: those slots were
+	// verified by the certificate chain during import, and the restored
+	// database intentionally does not keep every historical epoch nonce.
+	if ls.shouldVerifyChainsyncHeaderCrypto(e.Point.Slot) {
 		if err := ls.verifyBlockHeaderOnlyCrypto(e.BlockHeader); err != nil {
 			if ls.config.EventBus != nil {
 				ls.config.Logger.Warn(
@@ -1875,6 +1912,13 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		return nil
 	}
 	return nil
+}
+
+func (ls *LedgerState) shouldVerifyChainsyncHeaderCrypto(slot uint64) bool {
+	if !ls.validationEnabled {
+		return false
+	}
+	return ls.mithrilLedgerSlot == 0 || slot > ls.mithrilLedgerSlot
 }
 
 // tryResolveFork attempts to resolve a chain fork when an incoming header

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -79,6 +79,83 @@ func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestHandleEventChainsyncRollbackRejectsBelowMithrilBoundary(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+	fixture.ls.mithrilLedgerSlot = fixture.currentTip.Point.Slot
+	require.NoError(
+		t,
+		fixture.ls.db.SetSyncState("mithril_ledger_slot", "20", nil),
+	)
+	timer := time.NewTimer(time.Hour)
+	t.Cleanup(func() { timer.Stop() })
+	fixture.ls.activeBlockfetchConnId = fixture.connId
+	fixture.ls.selectedBlockfetchConnId = fixture.connId
+	fixture.ls.shadowBlockfetchConnId = fixture.connId
+	fixture.ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	fixture.ls.chainsyncBlockfetchTimeoutTimer = timer
+	fixture.ls.pendingBlockfetchEvents = []BlockfetchEvent{
+		{Point: fixture.currentTip.Point},
+	}
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
+	storedBoundary, err := fixture.ls.db.GetSyncState(
+		"mithril_ledger_slot",
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "20", storedBoundary)
+
+	select {
+	case e := <-resyncCh:
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonRollbackExceedsMithril,
+			e.Reason,
+		)
+		assert.Equal(t, fixture.connId, e.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal("expected Mithril rollback-boundary resync event")
+	}
+	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.activeBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.selectedBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.shadowBlockfetchConnId)
+	assert.Nil(t, fixture.ls.chainsyncBlockfetchReadyChan)
+	assert.Nil(t, fixture.ls.chainsyncBlockfetchTimeoutTimer)
+	assert.Empty(t, fixture.ls.pendingBlockfetchEvents)
+}
+
 func TestHandleEventChainsyncRollbackPrunesStaleBlockNonces(
 	t *testing.T,
 ) {

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1111,6 +1111,44 @@ func TestHandleEventChainsyncBlockHeaderIgnoresStaleHeaderBehindChainTip(
 	)
 }
 
+func TestHandleEventChainsyncBlockHeaderSkipsMithrilBoundaryHeaderVerification(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.validationEnabled = true
+	fixture.ls.mithrilLedgerSlot = fixture.currentTip.Point.Slot
+
+	staleHash := lcommon.NewBlake2b256([]byte("mithril-stale-header"))
+	err := fixture.ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		BlockHeader: mockHeader{
+			hash:        staleHash,
+			prevHash:    lcommon.NewBlake2b256(nil),
+			blockNumber: 2,
+			slot:        fixture.ancestorTip.Point.Slot + 5,
+		},
+		Point: ocommon.NewPoint(
+			fixture.ancestorTip.Point.Slot+5,
+			staleHash.Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				fixture.currentTip.Point.Slot+10,
+				[]byte("tip-after-mithril"),
+			),
+			BlockNumber: fixture.currentTip.BlockNumber + 1,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, fixture.ls.headerMismatchCount)
+	assert.Equal(t, 0, fixture.ls.chain.HeaderCount())
+	assert.Equal(
+		t,
+		fixture.currentTip.Point.Slot,
+		fixture.ls.chain.Tip().Point.Slot,
+	)
+}
+
 func TestHandleEventChainsyncRollbackClearsBufferedHeadersForNonActivePeer(
 	t *testing.T,
 ) {

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -182,6 +183,16 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		"rollback_slot", candidate.RollbackPoint.Slot,
 		"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
 	)
+	if ls.replayRecoveryRollbackExceedsMithrilBoundary(candidate.RollbackPoint) {
+		if err := ls.rejectReplayRecoveryAtMithrilBoundary(
+			validationErr,
+			candidate,
+			producerTxHash,
+		); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	if err := ls.rollback(candidate.RollbackPoint); err != nil {
 		return false, fmt.Errorf(
 			"rollback ledger state for replay recovery: %w",
@@ -189,6 +200,77 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		)
 	}
 	return true, nil
+}
+
+func (ls *LedgerState) replayRecoveryRollbackExceedsMithrilBoundary(
+	point ocommon.Point,
+) bool {
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.mithrilLedgerSlot > 0 && point.Slot < ls.mithrilLedgerSlot
+}
+
+func (ls *LedgerState) rejectReplayRecoveryAtMithrilBoundary(
+	validationErr *txValidationError,
+	candidate *replayRecoveryCandidate,
+	producerTxHash string,
+) error {
+	ls.RLock()
+	mithrilLedgerSlot := ls.mithrilLedgerSlot
+	rewindPoint := ls.currentTip.Point
+	ls.RUnlock()
+	if ls.config.ChainManager == nil {
+		return fmt.Errorf(
+			"replay recovery rollback exceeds Mithril trust boundary: %w",
+			ErrRollbackExceedsMithrilBoundary,
+		)
+	}
+	ls.config.Logger.Warn(
+		"detected replay recovery below Mithril trust boundary, rejecting peer chain",
+		"component", "ledger",
+		"recovery_strategy", candidate.Strategy,
+		"tx_hash", hex.EncodeToString(validationErr.TxHash),
+		"failing_block_slot", validationErr.BlockPoint.Slot,
+		"missing_input", candidate.Input.String(),
+		"producer_tx_hash", producerTxHash,
+		"producer_block_slot", candidate.ProducerBlock.Slot,
+		"rollback_slot", candidate.RollbackPoint.Slot,
+		"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
+		"mithril_ledger_slot", mithrilLedgerSlot,
+		"rewind_target_slot", rewindPoint.Slot,
+		"rewind_target_hash", hex.EncodeToString(rewindPoint.Hash),
+	)
+	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(rewindPoint); err != nil {
+		return fmt.Errorf(
+			"rewind primary chain to Mithril trust boundary: %w",
+			err,
+		)
+	}
+	ls.chainsyncMutex.Lock()
+	ls.resetChainsyncResyncState()
+	ls.chainsyncState = SyncingChainsyncState
+	ls.chainsyncMutex.Unlock()
+	if ls.config.EventBus != nil {
+		var activeConnId ouroboros.ConnectionId
+		if ls.config.GetActiveConnectionFunc != nil {
+			if connId := ls.config.GetActiveConnectionFunc(); connId != nil {
+				activeConnId = *connId
+			}
+		}
+		ls.config.EventBus.Publish(
+			event.ChainsyncResyncEventType,
+			event.NewEvent(
+				event.ChainsyncResyncEventType,
+				event.ChainsyncResyncEvent{
+					ConnectionId: activeConnId,
+					Reason: event.
+						ChainsyncResyncReasonRollbackExceedsMithril,
+					Point: rewindPoint,
+				},
+			),
+		)
+	}
+	return nil
 }
 
 func (ls *LedgerState) recoverAtTipFromTxValidationError(

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -20,13 +20,18 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -207,6 +212,193 @@ func TestTryRecoverFromTxValidationErrorRollsBackToEarliestProducerParent(
 	dbTip, err := ls.db.GetTip(nil)
 	require.NoError(t, err)
 	assert.Equal(t, parentTip, dbTip)
+}
+
+func TestTryRecoverFromTxValidationErrorRejectsReplayBelowMithrilBoundary(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("mithril-recovery-parent", 100, 1, nil)
+	producerBlock := testRawBlock(
+		"mithril-recovery-producer",
+		120,
+		2,
+		parentBlock.Hash,
+	)
+	boundaryBlock := testRawBlock(
+		"mithril-recovery-boundary",
+		200,
+		3,
+		producerBlock.Hash,
+	)
+	failingBlock := testRawBlock(
+		"mithril-recovery-failing",
+		220,
+		4,
+		boundaryBlock.Hash,
+	)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{
+				parentBlock,
+				producerBlock,
+				boundaryBlock,
+				failingBlock,
+			},
+		),
+	)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	activeConnId := ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 3000,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.ParseIP("192.0.2.10"),
+			Port: 3001,
+		},
+	}
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		EventBus:          bus,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+			return &activeConnId
+		},
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	shadowConnId := ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 3000,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.ParseIP("192.0.2.11"),
+			Port: 3001,
+		},
+	}
+
+	boundaryTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(boundaryBlock.Slot, boundaryBlock.Hash),
+		BlockNumber: boundaryBlock.BlockNumber,
+	}
+	require.NoError(t, db.SetTip(boundaryTip, nil))
+	ls.currentTip = boundaryTip
+	ls.currentTipBlockNonce = []byte("nonce-boundary")
+	ls.mithrilLedgerSlot = boundaryTip.Point.Slot
+	timer := time.NewTimer(time.Hour)
+	t.Cleanup(func() { timer.Stop() })
+	ls.activeBlockfetchConnId = activeConnId
+	ls.selectedBlockfetchConnId = activeConnId
+	ls.shadowBlockfetchConnId = shadowConnId
+	ls.shadowBlockReceivedHashes = map[string]struct{}{"stale": {}}
+	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	ls.chainsyncBlockfetchTimeoutTimer = timer
+	ls.pendingBlockfetchEvents = []BlockfetchEvent{{Point: boundaryTip.Point}}
+	ls.firstBlockReceived = true
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+	producerTxHash := testHashBytes("mithril-recovery-producer-tx")
+	require.NoError(
+		t,
+		store.DB().Create(&models.Transaction{
+			Hash:       producerTxHash,
+			BlockHash:  producerBlock.Hash,
+			Slot:       producerBlock.Slot,
+			Type:       1,
+			Valid:      true,
+			BlockIndex: 0,
+		}).Error,
+	)
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: ocommon.NewPoint(
+				failingBlock.Slot,
+				failingBlock.Hash,
+			),
+			TxHash: testHashBytes("mithril-recovery-failing-tx"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  producerTxHash,
+					index: 0,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	assert.Equal(t, boundaryTip, ls.currentTip)
+	assert.Equal(t, boundaryTip, ls.chain.Tip())
+	dbTip, err := db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, boundaryTip, dbTip)
+	_, err = database.BlockByPoint(
+		db,
+		ocommon.NewPoint(failingBlock.Slot, failingBlock.Hash),
+	)
+	assert.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	resync := testutil.RequireReceive(
+		t,
+		resyncCh,
+		time.Second,
+		"expected Mithril boundary resync after replay recovery rejection",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonRollbackExceedsMithril,
+		resync.Reason,
+	)
+	assert.Equal(t, activeConnId.String(), resync.ConnectionId.String())
+	assert.Equal(t, boundaryTip.Point, resync.Point)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.activeBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.selectedBlockfetchConnId)
+	assert.Equal(t, ouroboros.ConnectionId{}, ls.shadowBlockfetchConnId)
+	assert.Nil(t, ls.shadowBlockReceivedHashes)
+	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
+	assert.Nil(t, ls.chainsyncBlockfetchTimeoutTimer)
+	assert.Empty(t, ls.pendingBlockfetchEvents)
+	assert.False(t, ls.firstBlockReceived)
 }
 
 func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1473,6 +1473,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	// current tip" branch (issue #2177).
 	ls.RLock()
 	currentTip := ls.currentTip
+	mithrilLedgerSlot := ls.mithrilLedgerSlot
 	ls.RUnlock()
 	if currentTip.Point.Slot == point.Slot &&
 		bytes.Equal(currentTip.Point.Hash, point.Hash) {
@@ -1488,6 +1489,9 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 			"ledger_tip_hash", hex.EncodeToString(currentTip.Point.Hash),
 		)
 		return nil
+	}
+	if mithrilLedgerSlot > 0 && point.Slot < mithrilLedgerSlot {
+		return ErrRollbackExceedsMithrilBoundary
 	}
 	// Track new tip value built during transaction
 	var newTip ochainsync.Tip
@@ -1866,31 +1870,6 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.hfiEvalDoneEpoch = 0
 	ls.hfiEvalGeneration.Add(1)
 	ls.evaluateHardForkInitiationStability()
-	// If rolling back behind the Mithril trust boundary, clear it.
-	// A rollback inside the gap means replacement blocks on the new
-	// fork were NOT processed by SetGapBlockTransaction and must go
-	// through normal block processing.
-	if ls.mithrilLedgerSlot > 0 && point.Slot < ls.mithrilLedgerSlot {
-		ls.config.Logger.Warn(
-			"rollback behind Mithril trust boundary, clearing",
-			"component", "ledger",
-			"rollback_slot", point.Slot,
-			"mithril_ledger_slot", ls.mithrilLedgerSlot,
-		)
-		ls.mithrilLedgerSlot = 0
-		// Also clear the persisted value so a restart doesn't
-		// reload the stale boundary and skip replacement-fork
-		// blocks.
-		if err := ls.db.DeleteSyncState(
-			"mithril_ledger_slot", nil,
-		); err != nil {
-			ls.config.Logger.Warn(
-				"failed to clear persisted Mithril trust boundary",
-				"component", "ledger",
-				"error", err,
-			)
-		}
-	}
 	// Always update nonce - clear it on genesis rollback, set
 	// it otherwise
 	ls.currentTipBlockNonce = newNonce
@@ -1932,6 +1911,12 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 // rollbackChainAndState rewinds the primary chain and then synchronizes the
 // metadata-backed ledger state to the same point.
 func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
+	ls.RLock()
+	mithrilLedgerSlot := ls.mithrilLedgerSlot
+	ls.RUnlock()
+	if mithrilLedgerSlot > 0 && point.Slot < mithrilLedgerSlot {
+		return ErrRollbackExceedsMithrilBoundary
+	}
 	if err := ls.chain.Rollback(point); err != nil {
 		return err
 	}

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -132,6 +132,7 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 		event.ChainsyncResyncReasonRollbackNotFound,
 		event.ChainsyncResyncReasonPersistentFork,
 		event.ChainsyncResyncReasonRollbackExceedsK,
+		event.ChainsyncResyncReasonRollbackExceedsMithril,
 		event.ChainsyncResyncReasonForkResolutionExceedsK,
 		event.ChainsyncResyncReasonRollbackLoop:
 		return true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces the Mithril trust boundary during rollbacks, replay recovery, and header validation. Also processes post-ledger-state blocks from the blob store after a Mithril restore to rebuild transaction metadata.

- **Bug Fixes**
  - Prevent rollbacks below the Mithril boundary, returning ErrRollbackExceedsMithrilBoundary and emitting ChainsyncResyncReasonRollbackExceedsMithril (requires a fresh chainsync connection).
  - Reject replay recovery that would cross the boundary and rewind to the boundary tip, publishing a resync event with the rewind point.
  - Skip header-only crypto checks for slots at or before the boundary to avoid nonce gaps in restored databases.

- **New Features**
  - After a Mithril restore, load and validate continuity of post-ledger-state blocks from the blob store and run processGapBlocks to populate transaction metadata.

<sup>Written for commit 7939ba702a3bc219affe32b54ad99e0db4ceeb3d. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

