### PR TITLE
build(deps): plutigo 0.1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/blinklabs-io/bursa v0.16.0
 	github.com/blinklabs-io/gouroboros v0.170.1
 	github.com/blinklabs-io/ouroboros-mock v0.10.0
-	github.com/blinklabs-io/plutigo v0.1.11
+	github.com/blinklabs-io/plutigo v0.1.13
 	github.com/blockfrost/blockfrost-go v0.4.0
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/consensys/gnark-crypto v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/blinklabs-io/gouroboros v0.170.1 h1:Jt3q0z0cy+ffRcfTS/jnP/Ib9Hc/LYKiY
 github.com/blinklabs-io/gouroboros v0.170.1/go.mod h1:c0G+azc7ERyK4Oy8/TnrrrbQmePw5+rtcY8kyjSfmGI=
 github.com/blinklabs-io/ouroboros-mock v0.10.0 h1:8fhKaaTm3pDHSr8Yx91zEthooQH+o+NQhGfN2FKxwMI=
 github.com/blinklabs-io/ouroboros-mock v0.10.0/go.mod h1:1vWKSGxMtUfF3gkrVjUsjPTXdA+A665bQZjbVWpG5lg=
-github.com/blinklabs-io/plutigo v0.1.11 h1:KTOMd7NBoz17iIypzK3v8qIwHcrMRA2+joBK3G7dGzo=
-github.com/blinklabs-io/plutigo v0.1.11/go.mod h1:x0xLfDDoPKL/JCo+BBXJsG8lu4VSekQaJf9/cVhel/E=
+github.com/blinklabs-io/plutigo v0.1.13 h1:1NiHdu8thqVT72MFnWQljnDefSR9g4Q3Qx5Dkhjeyuk=
+github.com/blinklabs-io/plutigo v0.1.13/go.mod h1:YfwoijsrVjg5PsPdHvI/JfET4zPNEZzJ1a0AZeE6cZQ=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=
 github.com/blockfrost/blockfrost-go v0.4.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `github.com/blinklabs-io/plutigo` from v0.1.11 to v0.1.13 to pull in upstream fixes and improvements. Only updates go.mod and go.sum; no code changes.

<sup>Written for commit 1b7f3c06aa9c1b48f1b4776c7e013c0c43a35964. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2327?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

