### PR TITLE
build(deps): bump ouroboros-mock to v0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
 	github.com/blinklabs-io/gouroboros v0.170.1
-	github.com/blinklabs-io/ouroboros-mock v0.10.0
+	github.com/blinklabs-io/ouroboros-mock v0.11.0
 	github.com/blinklabs-io/plutigo v0.1.13
 	github.com/blockfrost/blockfrost-go v0.4.0
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yU
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.170.1 h1:Jt3q0z0cy+ffRcfTS/jnP/Ib9Hc/LYKiYbJYaRTb8sE=
 github.com/blinklabs-io/gouroboros v0.170.1/go.mod h1:c0G+azc7ERyK4Oy8/TnrrrbQmePw5+rtcY8kyjSfmGI=
-github.com/blinklabs-io/ouroboros-mock v0.10.0 h1:8fhKaaTm3pDHSr8Yx91zEthooQH+o+NQhGfN2FKxwMI=
-github.com/blinklabs-io/ouroboros-mock v0.10.0/go.mod h1:1vWKSGxMtUfF3gkrVjUsjPTXdA+A665bQZjbVWpG5lg=
+github.com/blinklabs-io/ouroboros-mock v0.11.0 h1:4Y2lFL+eCA1dNOKQqSVNQQPxjpoDoJ1jwzmm6VsYSNQ=
+github.com/blinklabs-io/ouroboros-mock v0.11.0/go.mod h1:CSlsrVl4qAh8UG0uClYqoOTCeZeyuO/Wv34GSOkBhTo=
 github.com/blinklabs-io/plutigo v0.1.13 h1:1NiHdu8thqVT72MFnWQljnDefSR9g4Q3Qx5Dkhjeyuk=
 github.com/blinklabs-io/plutigo v0.1.13/go.mod h1:YfwoijsrVjg5PsPdHvI/JfET4zPNEZzJ1a0AZeE6cZQ=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=


### PR DESCRIPTION
## Summary

- Bumps `github.com/blinklabs-io/ouroboros-mock` from v0.10.0 to v0.11.0.
- Pulls in the rollback event type + harness replay (ouroboros-mock#191) and the synthetic rollback vector + replay reward-balance fix (ouroboros-mock#192).
- `TestRulesConformanceVectors` now runs 315 vectors (314 Amaru + 1 synthetic rollback) with 100% pass rate.

## Why

Phase 2C of #1856 — the conformance-vector expansion plan. With this bump the rollback machinery is exercised end-to-end against `DingoStateManager`. As predicted in [the plan](https://github.com/blinklabs-io/dingo/issues/1856#issuecomment-4455817250), no adapter code changes were required: the harness-side replay model means `DingoStateManager.Reset()` + `LoadInitialState()` are sufficient for rollback support.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/test/conformance/...` — `ok` (10.6s)
- [x] `TestRulesConformanceVectorsWithResults` reports 315/315 (100%)
- [x] The new `synthetic/rollback/CurrentTreasuryValue_V1` vector passes against `DingoStateManager`

Closes part of #1856 (phase 2C). Phases 3+ (hard-fork transitions, trace-derived pipeline, more EPOCH vectors) remain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github.com/blinklabs-io/ouroboros-mock` to v0.11.0 to add rollback replay support and synthetic rollback vectors; conformance now runs 315 vectors with a 100% pass rate. No adapter changes needed, and this advances #1856 Phase 2C.

<sup>Written for commit 32bf4ad3e3c10a99e11556af3b9c162ed832a0cf. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2330?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->