### PR TITLE
fix(database): governance query indexes on account/utxo

### DIFF
--- a/database/models/account.go
+++ b/database/models/account.go
@@ -67,9 +67,9 @@ func ValidatePredefinedDrepTypes(drepTypes []uint64) error {
 }
 
 type Account struct {
-	StakingKey    []byte `gorm:"uniqueIndex;size:28"`
+	StakingKey    []byte `gorm:"uniqueIndex;size:28;index:idx_account_drep_active_staking_key,priority:3;index:idx_account_drep_type_active_staking_key,priority:3"`
 	Pool          []byte `gorm:"index;size:28"`
-	Drep          []byte `gorm:"index;size:28"`
+	Drep          []byte `gorm:"index;size:28;index:idx_account_drep_active_staking_key,priority:1"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
 	CertificateID uint   `gorm:"index"`
@@ -80,8 +80,8 @@ type Account struct {
 	//   2 = AlwaysAbstain, 3 = AlwaysNoConfidence.
 	// A zero value (0) means either "key credential" or "no delegation set",
 	// disambiguated by whether Drep is nil.
-	DrepType uint64 `gorm:"default:0"`
-	Active   bool   `gorm:"default:true"`
+	DrepType uint64 `gorm:"default:0;index:idx_account_drep_type_active_staking_key,priority:1"`
+	Active   bool   `gorm:"default:true;index:idx_account_drep_active_staking_key,priority:2;index:idx_account_drep_type_active_staking_key,priority:2"`
 }
 
 func (a *Account) TableName() string {

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -65,7 +65,7 @@ type Utxo struct {
 	CollateralReturnForTxID *uint        `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
 	TxId                    []byte       `gorm:"uniqueIndex:tx_id_output_idx;size:32"`
 	PaymentKey              []byte       `gorm:"index;size:28"`
-	StakingKey              []byte       `gorm:"index;size:28"`
+	StakingKey              []byte       `gorm:"index;size:28;index:idx_utxo_deleted_staking_amount,priority:2"`
 	Assets                  []Asset      `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
 	Cbor                    []byte       `gorm:"-"`       // This is here for convenience but not represented in the metadata DB
 	DatumHash               []byte       `gorm:"size:32"` // Optional datum hash (32 bytes)
@@ -76,8 +76,8 @@ type Utxo struct {
 	CollateralByTxId        []byte       `gorm:"index;size:32"`
 	ID                      uint         `gorm:"primarykey"`
 	AddedSlot               uint64       `gorm:"index"`
-	DeletedSlot             uint64       `gorm:"index"`
-	Amount                  types.Uint64 `gorm:"index"`
+	DeletedSlot             uint64       `gorm:"index:idx_utxo_deleted_staking_amount,priority:1"`
+	Amount                  types.Uint64 `gorm:"index:idx_utxo_deleted_staking_amount,priority:3"`
 	OutputIdx               uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds composite indexes to `Account` and `Utxo` to fix slow governance voting-power queries and avoid full-table scans.

- **Bug Fixes**
  - `Account`: adds `idx_account_drep_active_staking_key` (Drep, Active, StakingKey) and `idx_account_drep_type_active_staking_key` (DrepType, Active, StakingKey).
  - `Utxo`: adds `idx_utxo_deleted_staking_amount` (DeletedSlot, StakingKey, Amount).

<sup>Written for commit a1aa03a1acb762eb3afa6ae7d766c4b7caa61b42. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2332?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database indexes to improve performance of account and transaction data lookups and processing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->