### PR TITLE
chore: update comment to not reference local file

### DIFF
--- a/config.go
+++ b/config.go
@@ -224,8 +224,8 @@ const rtsMetricsUpdateInterval = 10 * time.Second
 // rtsMetrics holds Haskell-cardano-node-style RTS memory gauges backed
 // by Go runtime.MemStats. Matching the Haskell naming lets existing
 // cardano-node dashboards and alert rules work against Dingo without
-// rewriting queries. See docs/plans/RTS_METRICS.md for the semantic
-// mapping between Go and Haskell GC concepts.
+// rewriting queries. The gauges are approximate mappings from Go heap
+// statistics to Haskell RTS GC concepts.
 type rtsMetrics struct {
 	gcLiveBytes prometheus.Gauge
 	gcHeapBytes prometheus.Gauge


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the reference to a local docs file in the RTS metrics comment. The comment now states the gauges are approximate mappings from Go heap stats to Haskell RTS GC concepts.

<sup>Written for commit 83a547fc52aa72c610ff9c543f52e5176b690f95. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for RTS metrics with inline descriptions clarifying the relationship between Go heap statistics and Haskell RTS garbage collection concepts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->