### PR TITLE
fix(database): index to optimize get stake by pools

### DIFF
--- a/database/models/account.go
+++ b/database/models/account.go
@@ -67,8 +67,8 @@ func ValidatePredefinedDrepTypes(drepTypes []uint64) error {
 }
 
 type Account struct {
-	StakingKey    []byte `gorm:"uniqueIndex;size:28;index:idx_account_drep_active_staking_key,priority:3;index:idx_account_drep_type_active_staking_key,priority:3"`
-	Pool          []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"uniqueIndex;size:28;index:idx_account_drep_active_staking_key,priority:3;index:idx_account_drep_type_active_staking_key,priority:3;index:idx_account_active_pool_staking_key,priority:3"`
+	Pool          []byte `gorm:"index;size:28;index:idx_account_active_pool_staking_key,priority:2"`
 	Drep          []byte `gorm:"index;size:28;index:idx_account_drep_active_staking_key,priority:1"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -81,7 +81,7 @@ type Account struct {
 	// A zero value (0) means either "key credential" or "no delegation set",
 	// disambiguated by whether Drep is nil.
 	DrepType uint64 `gorm:"default:0;index:idx_account_drep_type_active_staking_key,priority:1"`
-	Active   bool   `gorm:"default:true;index:idx_account_drep_active_staking_key,priority:2;index:idx_account_drep_type_active_staking_key,priority:2"`
+	Active   bool   `gorm:"default:true;index:idx_account_drep_active_staking_key,priority:2;index:idx_account_drep_type_active_staking_key,priority:2;index:idx_account_active_pool_staking_key,priority:1"`
 }
 
 func (a *Account) TableName() string {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add composite index `idx_account_active_pool_staking_key` on `Account` (Active, Pool, StakingKey) to speed stake lookups by pool. Updates `gorm` tags on StakingKey, Pool, and Active; no behavior change, only an index for faster queries.

<sup>Written for commit 102933806e1be2f411a2c402843df5aa5f8c9014. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

