### PR TITLE
fix(chainsync): reconnect post-plateau realign peers

### DIFF
--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -347,8 +347,8 @@ func (n *Node) processChainsyncRecyclerTick(
 	}
 }
 
-// realignOtherPeersAfterPlateau requests a chainsync resync via the
-// default Stop+Start+Sync path for every ingress-eligible tracked peer
+// realignOtherPeersAfterPlateau requests a fresh-connection chainsync
+// resync for every ingress-eligible tracked peer
 // other than the one being closed for plateau. Without realignment, a
 // peer that has been streaming RollForwards while the active peer was
 // stuck holds a server-side cursor far past our local tip; the chain

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -134,6 +134,7 @@ func sameConnectionId(a, b ouroboros.ConnectionId) bool {
 func chainsyncResyncRequiresFreshConnection(reason string) bool {
 	switch reason {
 	case event.ChainsyncResyncReasonLocalTipPlateau,
+		event.ChainsyncResyncReasonPostPlateauRealign,
 		event.ChainsyncResyncReasonRollbackNotFound,
 		event.ChainsyncResyncReasonPersistentFork,
 		event.ChainsyncResyncReasonRollbackExceedsK,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -735,6 +735,7 @@ func TestSubscribeChainsyncResyncClosesConnectionForFreshSyncReasons(
 ) {
 	reasons := []string{
 		event.ChainsyncResyncReasonLocalTipPlateau,
+		event.ChainsyncResyncReasonPostPlateauRealign,
 		event.ChainsyncResyncReasonRollbackNotFound,
 		event.ChainsyncResyncReasonPersistentFork,
 		event.ChainsyncResyncReasonRollbackExceedsK,


### PR DESCRIPTION
Closes #2333 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Post-plateau peer realignment now reconnects with a fresh `chainsync` session. This avoids stale server-side cursors and ensures resync starts from the correct tip.

- **Bug Fixes**
  - Added `ChainsyncResyncReasonPostPlateauRealign` to the fresh-connection list in `chainsyncResyncRequiresFreshConnection`.
  - Updated test to cover this reason and clarified recycler comment to reflect fresh-connection resync.

<sup>Written for commit 4cc759ed36ec4bb3ba413e930cbc2d8b64c0ffce. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chain synchronization reliability by improving connection handling during peer realignment operations, ensuring fresh connections are properly established when recovering from synchronization plateaus to maintain optimal network stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->