### PR TITLE
fix: mithril sync metrics

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -256,7 +256,57 @@ func runMithrilSync(
 	cfg *config.Config,
 	logger *slog.Logger,
 	network string,
-) error {
+) (err error) {
+	metrics, metricsHandler := newMithrilSyncMetricsHandler(network)
+	metricsServer, err := startPrometheusMetricsServerWithHandler(
+		logger,
+		cfg.BindAddr,
+		cfg.MetricsPort,
+		"mithril",
+		metricsHandler,
+	)
+	if err != nil {
+		metrics.recordError()
+		logger.Warn(
+			"failed to start prometheus metrics server; continuing",
+			"component", "mithril",
+			"port", cfg.MetricsPort,
+			"error", err,
+		)
+		err = nil
+	}
+	defer func() {
+		if err != nil {
+			metrics.recordError()
+		}
+		if metricsServer == nil {
+			return
+		}
+		shutdownCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			5*time.Second,
+		)
+		defer cancel()
+		if shutdownErr := metricsServer.Shutdown(shutdownCtx); shutdownErr != nil {
+			logger.Warn(
+				"failed to stop prometheus metrics server",
+				"component", "mithril",
+				"error", shutdownErr,
+			)
+		}
+	}()
+	if metricsServer != nil {
+		go func() {
+			if serverErr := <-metricsServer.Err(); serverErr != nil {
+				logger.Error(
+					"prometheus metrics server stopped",
+					"component", "mithril",
+					"error", serverErr,
+				)
+			}
+		}()
+	}
+
 	cardanoConfigPath := cfg.CardanoConfig
 	if cardanoConfigPath == "" {
 		cardanoConfigPath = filepath.Join(network, "config.json")
@@ -287,6 +337,7 @@ func runMithrilSync(
 		)
 	}
 
+	metrics.setPhaseActive(mithrilSyncPhaseBootstrap, true)
 	result, err := mithril.Bootstrap(
 		ctx,
 		mithril.BootstrapConfig{
@@ -307,6 +358,7 @@ func runMithrilSync(
 				lastLoggedPercent := -progressLogPercentStep
 
 				return func(p mithril.DownloadProgress) {
+					metrics.recordDownloadProgress(p)
 					if p.TotalBytes <= 0 {
 						return
 					}
@@ -333,9 +385,11 @@ func runMithrilSync(
 			}(),
 		},
 	)
+	metrics.setPhaseActive(mithrilSyncPhaseBootstrap, false)
 	if err != nil {
 		return fmt.Errorf("mithril bootstrap failed: %w", err)
 	}
+	metrics.recordSnapshot(result.Snapshot)
 
 	// Open database once and reuse for both import and ImmutableDB load
 	db, err := database.New(&database.Config{
@@ -413,18 +467,25 @@ func runMithrilSync(
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
+		metrics.setPhaseActive(mithrilSyncPhaseLedgerImport, true)
+		defer metrics.setPhaseActive(mithrilSyncPhaseLedgerImport, false)
 		slot, hash, importErr := importLedgerState(
-			gctx, db, logger, nodeCfg, result,
+			gctx, db, logger, nodeCfg, result, metrics,
 		)
 		if importErr != nil {
 			return fmt.Errorf("importing ledger state: %w", importErr)
 		}
 		ledgerStateSlot = slot
 		ledgerStateHash = hash
+		if len(hash) > 0 {
+			metrics.recordLedgerStateSlot(slot)
+		}
 		return nil
 	})
 
 	g.Go(func() error {
+		metrics.setPhaseActive(mithrilSyncPhaseImmutableCopy, true)
+		defer metrics.setPhaseActive(mithrilSyncPhaseImmutableCopy, false)
 		logger.Info(
 			"loading ImmutableDB blocks into blob store",
 			"component", "mithril",
@@ -433,9 +494,18 @@ func runMithrilSync(
 		var loadErr error
 		loadResult, loadErr = node.LoadBlobsWithDB(
 			gctx, cfg, logger, result.ImmutableDir, db,
+			node.WithLoadBlobsProgress(metrics.recordImmutableProgress),
 		)
 		if loadErr != nil {
 			return fmt.Errorf("loading ImmutableDB: %w", loadErr)
+		}
+		if loadResult != nil {
+			metrics.recordImmutableProgress(node.LoadBlobsProgress{
+				BlocksCopied: loadResult.BlocksCopied,
+				CurrentSlot:  loadResult.ImmutableTipSlot,
+				TipSlot:      loadResult.ImmutableTipSlot,
+				Percent:      100,
+			})
 		}
 		return nil
 	})
@@ -490,6 +560,7 @@ func runMithrilSync(
 	if len(recentBlocks) > 0 &&
 		recentBlocks[0].Slot > immutableTipSlot &&
 		immutableTipSlot < ledgerStateSlot {
+		metrics.setPhaseActive(mithrilSyncPhaseGapBlocks, true)
 		resumeGapEnd := min(recentBlocks[0].Slot, ledgerStateSlot)
 		logger.Info(
 			"processing stored volatile gap blocks from blob store",
@@ -593,6 +664,7 @@ func runMithrilSync(
 					"ledger_state_slot", ledgerStateSlot,
 				)
 			}
+			metrics.recordGapBlocks(len(storedGapBlocks))
 			if err := processGapBlocks(
 				ctx,
 				db,
@@ -612,8 +684,10 @@ func runMithrilSync(
 				)
 			}
 		}
+		metrics.setPhaseActive(mithrilSyncPhaseGapBlocks, false)
 	}
 	if len(recentBlocks) > 0 && ledgerStateSlot > recentBlocks[0].Slot {
+		metrics.setPhaseActive(mithrilSyncPhaseGapBlocks, true)
 		immutableTip := recentBlocks[0]
 		logger.Info(
 			"fetching volatile blocks to close gap",
@@ -629,6 +703,7 @@ func runMithrilSync(
 		if fetchErr != nil {
 			return fmt.Errorf("fetching volatile blocks: %w", fetchErr)
 		}
+		metrics.recordGapBlocks(len(gapBlocks))
 		// Store gap blocks to the blob store, then index
 		// their metadata. These two steps are not atomic:
 		// if processGapBlocks fails, re-running the sync
@@ -648,7 +723,9 @@ func runMithrilSync(
 			"component", "mithril",
 			"count", len(gapBlocks),
 		)
+		metrics.setPhaseActive(mithrilSyncPhaseGapBlocks, false)
 	}
+	metrics.setPhaseActive(mithrilSyncPhasePostLedger, true)
 	if err := processPostLedgerStateBlocks(
 		ctx,
 		db,
@@ -658,6 +735,7 @@ func runMithrilSync(
 	); err != nil {
 		return err
 	}
+	metrics.setPhaseActive(mithrilSyncPhasePostLedger, false)
 
 	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
 		if err := updateMithrilReadyState(
@@ -672,6 +750,7 @@ func runMithrilSync(
 	// This replays all stored blocks to populate transaction
 	// records needed for API queries (Blockfrost, UTxO RPC).
 	if dingo.StorageMode(cfg.StorageMode).IsAPI() {
+		metrics.setPhaseActive(mithrilSyncPhaseBackfill, true)
 		logger.Info(
 			"backfilling historical metadata for API mode",
 			"component", "mithril",
@@ -681,6 +760,7 @@ func runMithrilSync(
 		if err := bf.Run(ctx); err != nil {
 			return fmt.Errorf("backfill: %w", err)
 		}
+		metrics.setPhaseActive(mithrilSyncPhaseBackfill, false)
 	}
 
 	if err := updateMithrilReadyState(
@@ -690,6 +770,7 @@ func runMithrilSync(
 		return err
 	}
 	syncComplete = true
+	metrics.markComplete()
 
 	// Clean up temporary files after a successful complete load.
 	if cfg.Mithril.CleanupAfterLoad {
@@ -858,6 +939,7 @@ func importLedgerState(
 	logger *slog.Logger,
 	nodeCfg *cardano.CardanoNodeConfig,
 	result *mithril.BootstrapResult,
+	metrics *mithrilSyncMetrics,
 ) (ledgerStateSlot uint64, ledgerStateHash []byte, err error) {
 	// Search for ledger state: prefer ancillary dir, fall back to
 	// main extract dir.
@@ -963,6 +1045,7 @@ func importLedgerState(
 				nodeCfg,
 			),
 			OnProgress: func(p ledgerstate.ImportProgress) {
+				metrics.recordLedgerImportProgress(p)
 				attrs := []any{
 					"component", "mithril",
 					"stage", p.Stage,

--- a/cmd/dingo/mithril_metrics.go
+++ b/cmd/dingo/mithril_metrics.go
@@ -1,0 +1,358 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/node"
+	"github.com/blinklabs-io/dingo/ledgerstate"
+	"github.com/blinklabs-io/dingo/mithril"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	mithrilSyncPhaseBootstrap     = "bootstrap"
+	mithrilSyncPhaseLedgerImport  = "ledger_import"
+	mithrilSyncPhaseImmutableCopy = "immutable_copy"
+	mithrilSyncPhaseGapBlocks     = "gap_blocks"
+	mithrilSyncPhasePostLedger    = "post_ledger_state"
+	mithrilSyncPhaseBackfill      = "backfill"
+	mithrilSyncPhaseComplete      = "complete"
+)
+
+type prometheusMetricsServer struct {
+	server *http.Server
+	errCh  <-chan error
+	addr   string
+}
+
+func startPrometheusMetricsServerWithHandler(
+	logger *slog.Logger,
+	bindAddr string,
+	port uint,
+	component string,
+	handler http.Handler,
+) (*prometheusMetricsServer, error) {
+	addr := net.JoinHostPort(bindAddr, strconv.FormatUint(uint64(port), 10))
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("starting metrics listener on %s: %w", addr, err)
+	}
+	actualAddr := listener.Addr().String()
+	logger.Info(
+		"serving prometheus metrics on "+actualAddr,
+		"component", component,
+	)
+	server := &http.Server{
+		Addr:              actualAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 60 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		if err := server.Serve(listener); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("metrics server: %w", err)
+		}
+	}()
+	return &prometheusMetricsServer{
+		server: server,
+		errCh:  errCh,
+		addr:   actualAddr,
+	}, nil
+}
+
+func (s *prometheusMetricsServer) Shutdown(ctx context.Context) error {
+	if s == nil || s.server == nil {
+		return nil
+	}
+	return s.server.Shutdown(ctx)
+}
+
+func (s *prometheusMetricsServer) Err() <-chan error {
+	if s == nil {
+		errCh := make(chan error)
+		close(errCh)
+		return errCh
+	}
+	return s.errCh
+}
+
+type mithrilSyncMetrics struct {
+	phaseActive *prometheus.GaugeVec
+
+	startedAt prometheus.Gauge
+	completed prometheus.Gauge
+	errors    prometheus.Counter
+
+	downloadBytes          prometheus.Gauge
+	downloadTotalBytes     prometheus.Gauge
+	downloadPercent        prometheus.Gauge
+	downloadBytesPerSecond prometheus.Gauge
+
+	snapshotSize                prometheus.Gauge
+	snapshotAncillarySize       prometheus.Gauge
+	snapshotEpoch               prometheus.Gauge
+	snapshotImmutableFileNumber prometheus.Gauge
+
+	ledgerImportCurrent *prometheus.GaugeVec
+	ledgerImportTotal   *prometheus.GaugeVec
+	ledgerImportPercent *prometheus.GaugeVec
+	ledgerStateSlot     *prometheus.GaugeVec
+
+	immutableBlocksCopied prometheus.Gauge
+	immutableCurrentSlot  prometheus.Gauge
+	immutableTipSlot      prometheus.Gauge
+	immutablePercent      prometheus.Gauge
+	immutableBlocksPerSec prometheus.Gauge
+
+	gapBlocks prometheus.Gauge
+}
+
+func newMithrilSyncMetrics(reg prometheus.Registerer) *mithrilSyncMetrics {
+	factory := promauto.With(reg)
+	m := &mithrilSyncMetrics{
+		phaseActive: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_phase_active",
+				Help: "Whether the Mithril sync phase is currently active.",
+			},
+			[]string{"phase"},
+		),
+		startedAt: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_started_at_seconds",
+			Help: "Unix timestamp when the Mithril sync command started.",
+		}),
+		completed: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_completed",
+			Help: "Whether the Mithril sync command completed successfully.",
+		}),
+		errors: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_mithril_sync_errors_total",
+			Help: "Total number of Mithril sync command errors.",
+		}),
+		downloadBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_download_bytes",
+			Help: "Bytes downloaded for the current Mithril artifact.",
+		}),
+		downloadTotalBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_download_total_bytes",
+			Help: "Total bytes expected for the current Mithril artifact.",
+		}),
+		downloadPercent: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_download_percent",
+			Help: "Download completion percentage for the current Mithril artifact.",
+		}),
+		downloadBytesPerSecond: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_download_bytes_per_second",
+			Help: "Current Mithril artifact download speed in bytes per second.",
+		}),
+		snapshotSize: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_snapshot_size_bytes",
+			Help: "Selected Mithril snapshot archive size in bytes.",
+		}),
+		snapshotAncillarySize: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_snapshot_ancillary_size_bytes",
+			Help: "Selected Mithril ancillary archive size in bytes.",
+		}),
+		snapshotEpoch: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_snapshot_epoch",
+			Help: "Selected Mithril snapshot epoch.",
+		}),
+		snapshotImmutableFileNumber: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_snapshot_immutable_file_number",
+			Help: "Selected Mithril snapshot immutable file number.",
+		}),
+		ledgerImportCurrent: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_ledger_import_current",
+				Help: "Current item count for the active ledger-state import stage.",
+			},
+			[]string{"stage"},
+		),
+		ledgerImportTotal: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_ledger_import_total",
+				Help: "Total item count for the active ledger-state import stage.",
+			},
+			[]string{"stage"},
+		),
+		ledgerImportPercent: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_ledger_import_percent",
+				Help: "Completion percentage for the active ledger-state import stage.",
+			},
+			[]string{"stage"},
+		),
+		ledgerStateSlot: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_ledger_state_slot",
+				Help: "Slot of the Mithril ledger state tip.",
+			},
+			[]string{},
+		),
+		immutableBlocksCopied: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_immutable_blocks_copied",
+			Help: "ImmutableDB blocks copied into the blob store during Mithril sync.",
+		}),
+		immutableCurrentSlot: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_immutable_current_slot",
+			Help: "Current ImmutableDB slot copied into the blob store.",
+		}),
+		immutableTipSlot: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_immutable_tip_slot",
+			Help: "ImmutableDB tip slot for the selected Mithril snapshot.",
+		}),
+		immutablePercent: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_immutable_copy_percent",
+			Help: "Completion percentage for ImmutableDB block copying.",
+		}),
+		immutableBlocksPerSec: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_immutable_blocks_per_second",
+			Help: "ImmutableDB block copy rate during Mithril sync.",
+		}),
+		gapBlocks: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_gap_blocks",
+			Help: "Volatile gap blocks fetched or reused during Mithril sync.",
+		}),
+	}
+	m.startedAt.SetToCurrentTime()
+	return m
+}
+
+func newMithrilSyncMetricsHandler(
+	network string,
+) (*mithrilSyncMetrics, http.Handler) {
+	registry := prometheus.NewRegistry()
+	metrics := newMithrilSyncMetrics(
+		prometheus.WrapRegistererWith(
+			prometheus.Labels{"network": network},
+			registry,
+		),
+	)
+	handler := promhttp.HandlerFor(
+		prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registry,
+		},
+		promhttp.HandlerOpts{},
+	)
+	return metrics, handler
+}
+
+func (m *mithrilSyncMetrics) setPhaseActive(phase string, active bool) {
+	if m == nil {
+		return
+	}
+	value := 0.0
+	if active {
+		value = 1
+	}
+	m.phaseActive.WithLabelValues(phase).Set(value)
+}
+
+func (m *mithrilSyncMetrics) recordDownloadProgress(
+	p mithril.DownloadProgress,
+) {
+	if m == nil {
+		return
+	}
+	m.downloadBytes.Set(float64(p.BytesDownloaded))
+	m.downloadTotalBytes.Set(float64(p.TotalBytes))
+	m.downloadPercent.Set(p.Percent)
+	m.downloadBytesPerSecond.Set(p.BytesPerSecond)
+}
+
+func (m *mithrilSyncMetrics) recordSnapshot(snapshot *mithril.SnapshotListItem) {
+	if m == nil || snapshot == nil {
+		return
+	}
+	m.snapshotSize.Set(float64(snapshot.Size))
+	m.snapshotAncillarySize.Set(float64(snapshot.AncillarySize))
+	m.snapshotEpoch.Set(float64(snapshot.Beacon.Epoch))
+	m.snapshotImmutableFileNumber.Set(
+		float64(snapshot.Beacon.ImmutableFileNumber),
+	)
+}
+
+func (m *mithrilSyncMetrics) recordLedgerImportProgress(
+	p ledgerstate.ImportProgress,
+) {
+	if m == nil || p.Stage == "" {
+		return
+	}
+	m.ledgerImportCurrent.WithLabelValues(p.Stage).Set(float64(p.Current))
+	m.ledgerImportTotal.WithLabelValues(p.Stage).Set(float64(p.Total))
+	percent := p.Percent
+	if percent == 0 && p.Total > 0 {
+		percent = float64(p.Current) / float64(p.Total) * 100
+	}
+	m.ledgerImportPercent.WithLabelValues(p.Stage).Set(percent)
+}
+
+func (m *mithrilSyncMetrics) recordLedgerStateSlot(slot uint64) {
+	if m == nil {
+		return
+	}
+	m.ledgerStateSlot.WithLabelValues().Set(float64(slot))
+}
+
+func (m *mithrilSyncMetrics) recordImmutableProgress(
+	p node.LoadBlobsProgress,
+) {
+	if m == nil {
+		return
+	}
+	m.immutableBlocksCopied.Set(float64(p.BlocksCopied))
+	m.immutableCurrentSlot.Set(float64(p.CurrentSlot))
+	m.immutableTipSlot.Set(float64(p.TipSlot))
+	m.immutablePercent.Set(p.Percent)
+	m.immutableBlocksPerSec.Set(p.BlocksPerSecond)
+}
+
+func (m *mithrilSyncMetrics) recordGapBlocks(count int) {
+	if m == nil {
+		return
+	}
+	m.gapBlocks.Set(float64(count))
+}
+
+func (m *mithrilSyncMetrics) markComplete() {
+	if m == nil {
+		return
+	}
+	m.completed.Set(1)
+	m.setPhaseActive(mithrilSyncPhaseComplete, true)
+}
+
+func (m *mithrilSyncMetrics) recordError() {
+	if m == nil {
+		return
+	}
+	m.errors.Inc()
+}

--- a/cmd/dingo/mithril_metrics_test.go
+++ b/cmd/dingo/mithril_metrics_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/node"
+	"github.com/blinklabs-io/dingo/ledgerstate"
+	"github.com/blinklabs-io/dingo/mithril"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMithrilSyncMetricsRecordProgress(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := newMithrilSyncMetrics(reg)
+
+	metrics.setPhaseActive(mithrilSyncPhaseBootstrap, true)
+	metrics.recordDownloadProgress(mithril.DownloadProgress{
+		BytesDownloaded: 128,
+		TotalBytes:      256,
+		Percent:         50,
+		BytesPerSecond:  64,
+	})
+	metrics.recordSnapshot(&mithril.SnapshotListItem{
+		SnapshotBase: mithril.SnapshotBase{
+			Size:          1024,
+			AncillarySize: 128,
+			Beacon: mithril.Beacon{
+				Epoch:               42,
+				ImmutableFileNumber: 9001,
+			},
+		},
+	})
+	metrics.recordLedgerImportProgress(ledgerstate.ImportProgress{
+		Stage:   "utxo",
+		Current: 5,
+		Total:   10,
+		Percent: 50,
+	})
+	metrics.recordLedgerStateSlot(1234)
+	metrics.recordImmutableProgress(node.LoadBlobsProgress{
+		BlocksCopied:    7,
+		CurrentSlot:     1200,
+		TipSlot:         1234,
+		BlocksPerSecond: 3.5,
+		Percent:         97.2,
+	})
+	metrics.recordGapBlocks(3)
+	metrics.markComplete()
+	metrics.recordError()
+
+	require.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(
+			metrics.phaseActive.WithLabelValues(mithrilSyncPhaseBootstrap),
+		),
+	)
+	require.Equal(t, float64(128), promtestutil.ToFloat64(metrics.downloadBytes))
+	require.Equal(t, float64(256), promtestutil.ToFloat64(metrics.downloadTotalBytes))
+	require.Equal(t, float64(50), promtestutil.ToFloat64(metrics.downloadPercent))
+	require.Equal(
+		t,
+		float64(64),
+		promtestutil.ToFloat64(metrics.downloadBytesPerSecond),
+	)
+	require.Equal(t, float64(1024), promtestutil.ToFloat64(metrics.snapshotSize))
+	require.Equal(
+		t,
+		float64(128),
+		promtestutil.ToFloat64(metrics.snapshotAncillarySize),
+	)
+	require.Equal(t, float64(42), promtestutil.ToFloat64(metrics.snapshotEpoch))
+	require.Equal(
+		t,
+		float64(9001),
+		promtestutil.ToFloat64(metrics.snapshotImmutableFileNumber),
+	)
+	require.Equal(
+		t,
+		float64(5),
+		promtestutil.ToFloat64(
+			metrics.ledgerImportCurrent.WithLabelValues("utxo"),
+		),
+	)
+	require.Equal(
+		t,
+		float64(10),
+		promtestutil.ToFloat64(
+			metrics.ledgerImportTotal.WithLabelValues("utxo"),
+		),
+	)
+	require.Equal(
+		t,
+		float64(50),
+		promtestutil.ToFloat64(
+			metrics.ledgerImportPercent.WithLabelValues("utxo"),
+		),
+	)
+	require.Equal(
+		t,
+		float64(1234),
+		promtestutil.ToFloat64(metrics.ledgerStateSlot.WithLabelValues()),
+	)
+	require.Equal(
+		t,
+		float64(7),
+		promtestutil.ToFloat64(metrics.immutableBlocksCopied),
+	)
+	require.Equal(
+		t,
+		float64(1200),
+		promtestutil.ToFloat64(metrics.immutableCurrentSlot),
+	)
+	require.Equal(t, float64(1234), promtestutil.ToFloat64(metrics.immutableTipSlot))
+	require.Equal(t, float64(97.2), promtestutil.ToFloat64(metrics.immutablePercent))
+	require.Equal(
+		t,
+		float64(3.5),
+		promtestutil.ToFloat64(metrics.immutableBlocksPerSec),
+	)
+	require.Equal(t, float64(3), promtestutil.ToFloat64(metrics.gapBlocks))
+	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.completed))
+	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.errors))
+}
+
+func TestStartPrometheusMetricsServerWithHandlerServesMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_mithril_metric",
+		Help: "Test metric exposed by the command metrics server.",
+	})
+	reg.MustRegister(gauge)
+	gauge.Set(42)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server, err := startPrometheusMetricsServerWithHandler(
+		logger,
+		"127.0.0.1",
+		0,
+		"mithril",
+		promhttp.HandlerFor(reg, promhttp.HandlerOpts{}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		require.NoError(t, server.Shutdown(ctx))
+	})
+
+	client := http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://" + server.addr + "/metrics")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "test_mithril_metric 42")
+}
+
+func TestMithrilSyncMetricsLedgerStateSlotAbsentUntilRecorded(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	newMithrilSyncMetrics(reg)
+
+	metricFamilies, err := reg.Gather()
+	require.NoError(t, err)
+	for _, metricFamily := range metricFamilies {
+		require.NotEqual(
+			t,
+			"dingo_mithril_sync_ledger_state_slot",
+			metricFamily.GetName(),
+		)
+	}
+}

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -246,6 +246,31 @@ type LoadBlobsResult struct {
 	ImmutableTipSlot uint64
 }
 
+// LoadBlobsProgress reports ImmutableDB blob-copy progress.
+type LoadBlobsProgress struct {
+	BlocksCopied    int
+	CurrentSlot     uint64
+	TipSlot         uint64
+	BlocksPerSecond float64
+	Percent         float64
+}
+
+type loadBlobsOptions struct {
+	onProgress func(LoadBlobsProgress)
+}
+
+// LoadBlobsOption customizes LoadBlobsWithDB behavior.
+type LoadBlobsOption func(*loadBlobsOptions)
+
+// WithLoadBlobsProgress registers a callback for blob-copy progress.
+func WithLoadBlobsProgress(
+	onProgress func(LoadBlobsProgress),
+) LoadBlobsOption {
+	return func(opts *loadBlobsOptions) {
+		opts.onProgress = onProgress
+	}
+}
+
 // LoadBlobsWithDB copies blocks from an ImmutableDB directory into the blob
 // store without starting the ledger processing pipeline. This is used after
 // a Mithril snapshot import where the ledger state has already been loaded
@@ -257,7 +282,15 @@ func LoadBlobsWithDB(
 	logger *slog.Logger,
 	immutableDir string,
 	db *database.Database,
+	options ...LoadBlobsOption,
 ) (*LoadBlobsResult, error) {
+	opts := loadBlobsOptions{}
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		option(&opts)
+	}
 	// Load database (open new one if not provided)
 	callerProvidedDB := db != nil
 	db, closeDB, err := ensureDB(cfg, logger, db)
@@ -293,6 +326,7 @@ func LoadBlobsWithDB(
 			utxoOffsetsStored += stored
 			return nil
 		},
+		opts.onProgress,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("loading blocks: %w", err)
@@ -441,6 +475,7 @@ func copyBlocksRawWithCallback(
 	db *database.Database,
 	c *chain.Chain,
 	callback func(chain.RawBlock, *database.Txn) error,
+	onProgress func(LoadBlobsProgress),
 ) (int, uint64, error) {
 	imm, err := immutable.New(immutableDir)
 	if err != nil {
@@ -560,6 +595,13 @@ func copyBlocksRawWithCallback(
 			lastProgressSlot = blockBatch[tmpLen-1].Slot
 		}
 		blockBatch = blockBatch[:0]
+		reportLoadBlobsProgress(
+			onProgress,
+			blocksCopied,
+			lastProgressSlot,
+			immutableTip.Slot,
+			startTime,
+		)
 		maybeLogBlockCopyProgress(
 			logger,
 			"copying blocks from immutable DB",
@@ -919,6 +961,31 @@ func checkedUint32(v int) (uint32, error) {
 		return 0, fmt.Errorf("value %d overflows uint32", v)
 	}
 	return uint32(v), nil // #nosec G115
+}
+
+func reportLoadBlobsProgress(
+	onProgress func(LoadBlobsProgress),
+	blocksCopied int,
+	currentSlot uint64,
+	tipSlot uint64,
+	startTime time.Time,
+) {
+	if onProgress == nil {
+		return
+	}
+	elapsed := time.Since(startTime).Seconds()
+	progress := LoadBlobsProgress{
+		BlocksCopied: blocksCopied,
+		CurrentSlot:  currentSlot,
+		TipSlot:      tipSlot,
+	}
+	if elapsed > 0 {
+		progress.BlocksPerSecond = float64(blocksCopied) / elapsed
+	}
+	if tipSlot > 0 {
+		progress.Percent = float64(currentSlot) / float64(tipSlot) * 100
+	}
+	onProgress(progress)
 }
 
 func maybeLogBlockCopyProgress(

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -178,6 +178,7 @@ func TestCopyBlocksRaw_PreservesByronEbbLinkageAtOrigin(t *testing.T) {
 		db,
 		cm.PrimaryChain(),
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	require.Greater(t, blocksCopied, 1)
@@ -282,6 +283,7 @@ func TestCopyBlocksRawWithCallback_StoresUtxoOffsets(t *testing.T) {
 			_, err := storeRawBlockUtxoOffsets(txn, rb)
 			return err
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	require.Greater(t, blocksCopied, 1)
@@ -385,6 +387,7 @@ func TestCopyBlocksRawWithCallback_BackfillsWhenChainTipPastImmutableTip(
 		db,
 		cm.PrimaryChain(),
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -418,6 +421,7 @@ func TestCopyBlocksRawWithCallback_BackfillsWhenChainTipPastImmutableTip(
 			offsetsStored += stored
 			return err
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 0, blocksCopied)


### PR DESCRIPTION
Closes #2339 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detailed Prometheus metrics and a lightweight metrics server for the Mithril sync command, covering download, ledger import, ImmutableDB copy, gap handling, and completion. Also adds a progress callback to ImmutableDB loading to power these metrics.

- New Features
  - Exposes per-phase gauges and progress metrics: download (bytes, total, percent, bytes/sec), snapshot info, ledger import (per-stage current/total/percent), ledger state slot, ImmutableDB copy (blocks, slot, percent, blocks/sec), gap blocks, completion, and error count. All metrics include a `network` label.
  - Starts a dedicated Prometheus server for the Mithril component with graceful shutdown and background error reporting; continues if the server cannot start.
  - Adds `node.WithLoadBlobsProgress` and `LoadBlobsProgress` to `internal/node.LoadBlobsWithDB`, and wires progress + phase tracking in `cmd/dingo/mithril.go`.
  - Adds tests for metrics recording and the metrics server.

<sup>Written for commit 5870fa98dfb986fb90ffe069ca172fc0c7c599f4. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2341?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics instrumentation for Mithril sync operations, enabling real-time monitoring of sync phases, download progress, and ledger import status.
  * Added progress reporting callbacks for immutable block loading operations.

* **Tests**
  * Added test coverage for metrics recording and Prometheus metrics HTTP server functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->