### PR TITLE
perf(database): force sqlite to use tx_id_output_idx

### DIFF
--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -352,7 +352,10 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 		args = append(args, spentAtArgs...)
 		args = append(args, whereArgs...)
 		sql := fmt.Sprintf(
-			"UPDATE utxo SET deleted_slot = CASE %s ELSE deleted_slot END, spent_at_tx_id = CASE %s ELSE spent_at_tx_id END WHERE deleted_slot = 0 AND (%s)",
+			"UPDATE "+utxoRefIndexedTable()+
+				" SET deleted_slot = CASE %s ELSE deleted_slot END, "+
+				"spent_at_tx_id = CASE %s ELSE spent_at_tx_id END "+
+				"WHERE deleted_slot = 0 AND (%s)",
 			strings.Join(deletedSlotCases, " "),
 			strings.Join(spentAtCases, " "),
 			strings.Join(whereConditions, " OR "),

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1090,7 +1090,9 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			if len(caseClauses) > 0 {
 				args := append(caseArgs, whereArgs...)
 				sql := fmt.Sprintf(
-					"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+					"UPDATE "+utxoRefIndexedTable()+
+						" SET collateral_by_tx_id = CASE %s "+
+						"ELSE collateral_by_tx_id END WHERE %s",
 					strings.Join(caseClauses, " "),
 					strings.Join(whereConditions, " OR "),
 				)
@@ -1151,7 +1153,9 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			if len(caseClauses) > 0 {
 				args := append(caseArgs, whereArgs...)
 				sql := fmt.Sprintf(
-					"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+					"UPDATE "+utxoRefIndexedTable()+
+						" SET referenced_by_tx_id = CASE %s "+
+						"ELSE referenced_by_tx_id END WHERE %s",
 					strings.Join(caseClauses, " "),
 					strings.Join(whereConditions, " OR "),
 				)
@@ -1204,7 +1208,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				updateArgs = append(updateArgs, ref.txID, ref.idx)
 			}
 			sql := fmt.Sprintf(
-				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
+				"UPDATE "+utxoRefIndexedTable()+
+					" SET deleted_slot = ?, spent_at_tx_id = ? "+
 					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
 				strings.Join(whereConditions, " OR "),
 			)
@@ -2570,7 +2575,9 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		if len(caseClauses) > 0 {
 			args := append(caseArgs, whereArgs...)
 			sql := fmt.Sprintf(
-				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
+				"UPDATE "+utxoRefIndexedTable()+
+					" SET collateral_by_tx_id = CASE %s "+
+					"ELSE collateral_by_tx_id END WHERE %s",
 				strings.Join(caseClauses, " "),
 				strings.Join(whereConditions, " OR "),
 			)
@@ -2627,7 +2634,9 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		if len(caseClauses) > 0 {
 			args := append(caseArgs, whereArgs...)
 			sql := fmt.Sprintf(
-				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
+				"UPDATE "+utxoRefIndexedTable()+
+					" SET referenced_by_tx_id = CASE %s "+
+					"ELSE referenced_by_tx_id END WHERE %s",
 				strings.Join(caseClauses, " "),
 				strings.Join(whereConditions, " OR "),
 			)

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -84,6 +84,12 @@ func (d *MetadataStoreSqlite) GetUtxoIncludingSpent(
 // under SQLite's default SQLITE_MAX_VARIABLE_NUMBER limit of 999 bind parameters.
 const batchChunkSize = 499
 
+const utxoRefLookupIndex = "tx_id_output_idx"
+
+func utxoRefIndexedTable() string {
+	return (&models.Utxo{}).TableName() + " INDEXED BY " + utxoRefLookupIndex
+}
+
 // GetUtxosBatch retrieves multiple UTXOs by their references in a single query.
 // Returns a map keyed by "txid:outputidx" for easy lookup.
 // Large batches are automatically chunked to avoid SQLite expression limits.
@@ -119,7 +125,8 @@ func (d *MetadataStoreSqlite) GetUtxosBatch(
 		// Wrap OR conditions in parentheses to ensure deleted_slot=0 applies to all refs.
 		// Without parens, SQL operator precedence (AND > OR) causes deleted_slot=0
 		// to only apply to the first condition.
-		query := db.Where("deleted_slot = 0").
+		query := db.Table(utxoRefIndexedTable()).
+			Where("deleted_slot = 0").
 			Where("("+strings.Join(conditions, " OR ")+")", args...)
 		if queryResult := query.Find(&utxos); queryResult.Error != nil {
 			return nil, queryResult.Error
@@ -750,9 +757,12 @@ func (d *MetadataStoreSqlite) MarkUtxosDeletedAtSlot(
 			args = append(args, r.TxId, r.OutputIdx)
 		}
 		whereClause := "deleted_slot = 0 AND (" + clauses.String() + ")"
-		result := db.Model(&models.Utxo{}).
-			Where(whereClause, args...).
-			Update("deleted_slot", atSlot)
+		updateArgs := append([]any{atSlot}, args...)
+		result := db.Exec(
+			"UPDATE "+utxoRefIndexedTable()+
+				" SET deleted_slot = ? WHERE "+whereClause,
+			updateArgs...,
+		)
 		if result.Error != nil {
 			return result.Error
 		}

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -17,10 +17,12 @@ package sqlite
 import (
 	"bytes"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -155,6 +157,63 @@ func TestGetLiveUtxosBySlotExcludesSpentAtSameSlot(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, live.TxId, got[0].Hash)
 	assert.Equal(t, live.OutputIdx, got[0].Idx)
+}
+
+func TestGetUtxosBatchUsesTxIdOutputIndex(t *testing.T) {
+	store := setupTestDB(t)
+
+	refs := make([]UtxoRef, 0, 12)
+	for i := range 12 {
+		txID := bytes.Repeat([]byte{byte(i + 1)}, 32)
+		outputIdx := uint32(i % 3) //nolint:gosec
+		row := models.Utxo{
+			TxId:      txID,
+			OutputIdx: outputIdx,
+			AddedSlot: uint64(i + 1), //nolint:gosec
+			Amount:    types.Uint64(i + 1),
+		}
+		require.NoError(t, store.DB().Create(&row).Error)
+		refs = append(refs, UtxoRef{TxId: txID, OutputIdx: outputIdx})
+	}
+
+	var capturedSQL string
+	var capturedVars []any
+	callbackName := "test:capture_get_utxos_batch_sql"
+	require.NoError(t, store.ReadDB().Callback().Query().
+		After("gorm:query").
+		Register(callbackName, func(tx *gorm.DB) {
+			if capturedSQL != "" {
+				return
+			}
+			capturedSQL = tx.Statement.SQL.String()
+			capturedVars = append([]any(nil), tx.Statement.Vars...)
+		}))
+
+	got, err := store.GetUtxosBatch(refs, nil)
+	require.NoError(t, err)
+	require.Len(t, got, len(refs))
+	require.NotEmpty(t, capturedSQL)
+	require.Contains(t, capturedSQL, "INDEXED BY "+utxoRefLookupIndex)
+
+	planRows, err := store.DB().
+		Raw(
+			"EXPLAIN QUERY PLAN "+capturedSQL,
+			capturedVars...,
+		).Rows()
+	require.NoError(t, err)
+	defer planRows.Close()
+
+	var details []string
+	for planRows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, planRows.Err())
+	plan := strings.Join(details, "\n")
+	assert.Contains(t, plan, utxoRefLookupIndex)
+	assert.NotContains(t, plan, "idx_utxo_deleted_slot")
 }
 
 func sortUtxoIds(ids []models.UtxoId) {


### PR DESCRIPTION
Closes #2351 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force SQLite to use the tx_id_output_idx for UTXO lookups and updates by targeting the indexed table with INDEXED BY. This reduces table scans and speeds up spend, collateral, reference, and delete-slot updates.

- **Performance**
  - Added utxoRefLookupIndex and utxoRefIndexedTable(); applied INDEXED BY tx_id_output_idx across SELECT and UPDATE paths.
  - Switched batch spend, collateral/reference setters, spent_at updates, and MarkUtxosDeletedAtSlot to update the indexed table.
  - Updated GetUtxosBatch to use the indexed table; test asserts the plan uses tx_id_output_idx and excludes idx_utxo_deleted_slot.

<sup>Written for commit 73ffe8fd507cd4ce710e50dc0a583632bb1b8382. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2342?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

