### PR TITLE
fix(database): harden genesis bootstrap consistency across metdata pl…

### DIFF
--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -584,15 +584,20 @@ func batchFetchRegistration(
 		CertIndex  uint32
 	}
 	var records []result
+	// LEFT JOIN so synthetic genesis Registration rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM registration t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -702,15 +707,20 @@ func batchFetchStakeDelegation(
 		CertIndex   uint32
 	}
 	var records []result
+	// LEFT JOIN so genesis stake_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -749,15 +759,20 @@ func batchFetchStakeVoteDelegation(
 		CertIndex   uint32
 	}
 	var records []result
+	// LEFT JOIN so genesis stake_vote_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_vote_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -806,15 +821,20 @@ func batchFetchVoteDelegation(
 		CertIndex  uint32
 	}
 	var records []result
+	// LEFT JOIN so genesis vote_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM vote_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -3658,6 +3658,18 @@ func (d *MetadataStoreMysql) DeleteTransactionsAfterSlot(
 // SetGenesisStaking stores genesis pool registrations and stake delegations
 // from the shelley-genesis.json staking section. It creates Pool,
 // PoolRegistration, and Account records at slot 0.
+//
+// Idempotency notes:
+//   - The slot-0 PoolRegistration is written with OnConflict{DoNothing}. Re-running
+//     with mutated genesis data would leave stale historical fields on the slot-0
+//     row, but a network's genesis file is immutable so this is intentional;
+//     callers must not re-bootstrap with a different genesis against an existing
+//     database.
+//   - No synthetic slot-0 Registration / StakeDelegation history row is written
+//     for the stakeDelegations entries here, unlike SetGenesisGovernance. Shelley
+//     stake credentials predate the Conway registration-deposit model, and
+//     rollback past on-chain certs on Shelley-genesis-delegated keys has worked
+//     correctly on mainnet via the Account.added_slot=0 invariant alone.
 func (d *MetadataStoreMysql) SetGenesisStaking(
 	pools map[string]lcommon.PoolRegistrationCertificate,
 	stakeDelegations map[string]string,
@@ -3800,9 +3812,14 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 			Active:     true,
 			AddedSlot:  0,
 		}
+		// Include added_slot in DoUpdates so a pre-existing later-slot
+		// row is reset to 0 — genesis-rooted accounts must report slot 0
+		// for downstream history queries.
 		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
-			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
+			Columns: []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"pool", "active", "added_slot"},
+			),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -3666,10 +3666,14 @@ func (d *MetadataStoreMysql) DeleteTransactionsAfterSlot(
 //     callers must not re-bootstrap with a different genesis against an existing
 //     database.
 //   - No synthetic slot-0 Registration / StakeDelegation history row is written
-//     for the stakeDelegations entries here, unlike SetGenesisGovernance. Shelley
-//     stake credentials predate the Conway registration-deposit model, and
-//     rollback past on-chain certs on Shelley-genesis-delegated keys has worked
-//     correctly on mainnet via the Account.added_slot=0 invariant alone.
+//     for the stakeDelegations entries here, unlike SetGenesisGovernance. This
+//     leaves a known rollback hole: a later on-chain cert touching a
+//     Shelley-genesis-delegated key, followed by a rollback past that cert, can
+//     delete the genesis-rooted account because RestoreAccountStateAtSlot keys
+//     off the registration table rather than Account.added_slot. Mainnet does
+//     not exercise this path (its shelley-genesis declares no stake
+//     delegations), so the hole has not been triaged for the test networks;
+//     closing it is tracked separately.
 func (d *MetadataStoreMysql) SetGenesisStaking(
 	pools map[string]lcommon.PoolRegistrationCertificate,
 	stakeDelegations map[string]string,
@@ -3812,14 +3816,14 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 			Active:     true,
 			AddedSlot:  0,
 		}
-		// Include added_slot in DoUpdates so a pre-existing later-slot
-		// row is reset to 0 — genesis-rooted accounts must report slot 0
-		// for downstream history queries.
+		// DoUpdates intentionally omits added_slot: RestoreAccountStateAtSlot
+		// selects rows by `added_slot > rollback_slot`, so resetting a
+		// non-zero added_slot back to 0 on a re-bootstrap (e.g. resumed
+		// Mithril after partial sync) would make that row invisible to
+		// every future rollback.
 		result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "staking_key"}},
-			DoUpdates: clause.AssignmentColumns(
-				[]string{"pool", "active", "added_slot"},
-			),
+			Columns:   []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -584,15 +584,20 @@ func batchFetchRegistration(
 		CertIndex  uint32
 	}
 	var records []result
+	// LEFT JOIN so synthetic genesis Registration rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM registration t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -702,15 +707,20 @@ func batchFetchStakeDelegation(
 		CertIndex   uint32
 	}
 	var records []result
+	// LEFT JOIN so genesis stake_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.pool_key_hash, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -749,15 +759,20 @@ func batchFetchStakeVoteDelegation(
 		CertIndex   uint32
 	}
 	var records []result
+	// LEFT JOIN so genesis stake_vote_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_vote_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
@@ -806,15 +821,20 @@ func batchFetchVoteDelegation(
 		CertIndex  uint32
 	}
 	var records []result
+	// LEFT JOIN so genesis vote_delegation rows (no certs row,
+	// certificate_id=0) still surface; cert_index defaults to 0, which is
+	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot,
+				COALESCE(tx.block_index, 0) AS block_index,
+				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
 					PARTITION BY t.staking_key
-					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
+					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM vote_delegation t
-			INNER JOIN certs c ON c.id = t.certificate_id
+			LEFT JOIN certs c ON c.id = t.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -3666,6 +3666,18 @@ func (d *MetadataStorePostgres) DeleteTransactionsAfterSlot(
 // SetGenesisStaking stores genesis pool registrations and stake delegations
 // from the shelley-genesis.json staking section. It creates Pool,
 // PoolRegistration, and Account records at slot 0.
+//
+// Idempotency notes:
+//   - The slot-0 PoolRegistration is written with OnConflict{DoNothing}. Re-running
+//     with mutated genesis data would leave stale historical fields on the slot-0
+//     row, but a network's genesis file is immutable so this is intentional;
+//     callers must not re-bootstrap with a different genesis against an existing
+//     database.
+//   - No synthetic slot-0 Registration / StakeDelegation history row is written
+//     for the stakeDelegations entries here, unlike SetGenesisGovernance. Shelley
+//     stake credentials predate the Conway registration-deposit model, and
+//     rollback past on-chain certs on Shelley-genesis-delegated keys has worked
+//     correctly on mainnet via the Account.added_slot=0 invariant alone.
 func (d *MetadataStorePostgres) SetGenesisStaking(
 	pools map[string]lcommon.PoolRegistrationCertificate,
 	stakeDelegations map[string]string,
@@ -3808,9 +3820,14 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 			Active:     true,
 			AddedSlot:  0,
 		}
+		// Include added_slot in DoUpdates so a pre-existing later-slot
+		// row is reset to 0 — genesis-rooted accounts must report slot 0
+		// for downstream history queries.
 		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
-			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
+			Columns: []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"pool", "active", "added_slot"},
+			),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -3674,10 +3674,14 @@ func (d *MetadataStorePostgres) DeleteTransactionsAfterSlot(
 //     callers must not re-bootstrap with a different genesis against an existing
 //     database.
 //   - No synthetic slot-0 Registration / StakeDelegation history row is written
-//     for the stakeDelegations entries here, unlike SetGenesisGovernance. Shelley
-//     stake credentials predate the Conway registration-deposit model, and
-//     rollback past on-chain certs on Shelley-genesis-delegated keys has worked
-//     correctly on mainnet via the Account.added_slot=0 invariant alone.
+//     for the stakeDelegations entries here, unlike SetGenesisGovernance. This
+//     leaves a known rollback hole: a later on-chain cert touching a
+//     Shelley-genesis-delegated key, followed by a rollback past that cert, can
+//     delete the genesis-rooted account because RestoreAccountStateAtSlot keys
+//     off the registration table rather than Account.added_slot. Mainnet does
+//     not exercise this path (its shelley-genesis declares no stake
+//     delegations), so the hole has not been triaged for the test networks;
+//     closing it is tracked separately.
 func (d *MetadataStorePostgres) SetGenesisStaking(
 	pools map[string]lcommon.PoolRegistrationCertificate,
 	stakeDelegations map[string]string,
@@ -3820,14 +3824,14 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 			Active:     true,
 			AddedSlot:  0,
 		}
-		// Include added_slot in DoUpdates so a pre-existing later-slot
-		// row is reset to 0 — genesis-rooted accounts must report slot 0
-		// for downstream history queries.
+		// DoUpdates intentionally omits added_slot: RestoreAccountStateAtSlot
+		// selects rows by `added_slot > rollback_slot`, so resetting a
+		// non-zero added_slot back to 0 on a re-bootstrap (e.g. resumed
+		// Mithril after partial sync) would make that row invisible to
+		// every future rollback.
 		result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "staking_key"}},
-			DoUpdates: clause.AssignmentColumns(
-				[]string{"pool", "active", "added_slot"},
-			),
+			Columns:   []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -3700,6 +3700,18 @@ func (d *MetadataStoreSqlite) SetGenesisTransaction(
 // SetGenesisStaking stores genesis pool registrations and stake delegations
 // from the shelley-genesis.json staking section. It creates Pool,
 // PoolRegistration, and Account records at slot 0.
+//
+// Idempotency notes:
+//   - The slot-0 PoolRegistration is written with OnConflict{DoNothing}. Re-running
+//     with mutated genesis data would leave stale historical fields on the slot-0
+//     row, but a network's genesis file is immutable so this is intentional;
+//     callers must not re-bootstrap with a different genesis against an existing
+//     database.
+//   - No synthetic slot-0 Registration / StakeDelegation history row is written
+//     for the stakeDelegations entries here, unlike SetGenesisGovernance. Shelley
+//     stake credentials predate the Conway registration-deposit model, and
+//     rollback past on-chain certs on Shelley-genesis-delegated keys has worked
+//     correctly on mainnet via the Account.added_slot=0 invariant alone.
 func (d *MetadataStoreSqlite) SetGenesisStaking(
 	pools map[string]lcommon.PoolRegistrationCertificate,
 	stakeDelegations map[string]string,
@@ -3842,9 +3854,14 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 			Active:     true,
 			AddedSlot:  0,
 		}
+		// Include added_slot in DoUpdates so a pre-existing later-slot
+		// row is reset to 0 — genesis-rooted accounts must report slot 0
+		// for downstream history queries.
 		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
-			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
+			Columns: []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns(
+				[]string{"pool", "active", "added_slot"},
+			),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -3708,10 +3708,14 @@ func (d *MetadataStoreSqlite) SetGenesisTransaction(
 //     callers must not re-bootstrap with a different genesis against an existing
 //     database.
 //   - No synthetic slot-0 Registration / StakeDelegation history row is written
-//     for the stakeDelegations entries here, unlike SetGenesisGovernance. Shelley
-//     stake credentials predate the Conway registration-deposit model, and
-//     rollback past on-chain certs on Shelley-genesis-delegated keys has worked
-//     correctly on mainnet via the Account.added_slot=0 invariant alone.
+//     for the stakeDelegations entries here, unlike SetGenesisGovernance. This
+//     leaves a known rollback hole: a later on-chain cert touching a
+//     Shelley-genesis-delegated key, followed by a rollback past that cert, can
+//     delete the genesis-rooted account because RestoreAccountStateAtSlot keys
+//     off the registration table rather than Account.added_slot. Mainnet does
+//     not exercise this path (its shelley-genesis declares no stake
+//     delegations), so the hole has not been triaged for the test networks;
+//     closing it is tracked separately.
 func (d *MetadataStoreSqlite) SetGenesisStaking(
 	pools map[string]lcommon.PoolRegistrationCertificate,
 	stakeDelegations map[string]string,
@@ -3854,14 +3858,14 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 			Active:     true,
 			AddedSlot:  0,
 		}
-		// Include added_slot in DoUpdates so a pre-existing later-slot
-		// row is reset to 0 — genesis-rooted accounts must report slot 0
-		// for downstream history queries.
+		// DoUpdates intentionally omits added_slot: RestoreAccountStateAtSlot
+		// selects rows by `added_slot > rollback_slot`, so resetting a
+		// non-zero added_slot back to 0 on a re-bootstrap (e.g. resumed
+		// Mithril after partial sync) would make that row invisible to
+		// every future rollback.
 		result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "staking_key"}},
-			DoUpdates: clause.AssignmentColumns(
-				[]string{"pool", "active", "added_slot"},
-			),
+			Columns:   []clause.Column{{Name: "staking_key"}},
+			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
Closes #2343 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens genesis bootstrap consistency across metadata plugins. Genesis rows now surface in account history, and re-bootstrap keeps `added_slot` unchanged to preserve rollback behavior across `mysql`, `postgres`, and `sqlite`.

- **Bug Fixes**
  - Account history queries: LEFT JOIN certs and COALESCE cert_index to 0; keep ordering stable. Returns genesis rows (certificate_id=0) for registration, stake_delegation, stake_vote_delegation, and vote_delegation.
  - SetGenesisStaking: keep PoolRegistration slot-0 inserts idempotent (DoNothing). Do not update added_slot on upsert to avoid rollback invisibility; add notes on genesis immutability and the Shelley-genesis stakeDelegations rollback caveat.

<sup>Written for commit 49a5480f9bca88ec3d277de6e00d641fd21e6c23. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2344?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account state restoration to properly handle genesis and synthetic registration/delegation records across all supported database backends.
  * Fixed bootstrap re-initialization behavior to correctly reset account metadata fields, ensuring accurate account history queries and improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->