### PR TITLE
fix(database): transaction label exceeds sqlite uint64

### DIFF
--- a/database/models/transaction_metadata_label.go
+++ b/database/models/transaction_metadata_label.go
@@ -14,13 +14,15 @@
 
 package models
 
+import "github.com/blinklabs-io/dingo/database/types"
+
 // TransactionMetadataLabel stores per-label transaction metadata values
 // for efficient label-based querying.
 type TransactionMetadataLabel struct {
-	ID            uint   `gorm:"primaryKey"`
-	TransactionID uint   `gorm:"uniqueIndex:idx_tx_metadata_label_tx_label"`
-	Label         uint64 `gorm:"index;uniqueIndex:idx_tx_metadata_label_tx_label"`
-	Slot          uint64 `gorm:"index"`
+	ID            uint         `gorm:"primaryKey"`
+	TransactionID uint         `gorm:"uniqueIndex:idx_tx_metadata_label_tx_label"`
+	Label         types.Uint64 `gorm:"index;uniqueIndex:idx_tx_metadata_label_tx_label"`
+	Slot          uint64       `gorm:"index"`
 	CborValue     []byte
 	JsonValue     string `gorm:"type:text"`
 }

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -542,7 +542,7 @@ func (d *MetadataStoreMysql) GetTransactionsByMetadataLabel(
 
 	subQuery := db.Model(&models.TransactionMetadataLabel{}).
 		Select("transaction_id").
-		Where("label = ?", label)
+		Where("label = ?", types.Uint64(label))
 
 	query := db.
 		Where("id IN (?)", subQuery).
@@ -584,7 +584,7 @@ func (d *MetadataStoreMysql) CountTransactionsByMetadataLabel(
 
 	var count int64
 	if result := db.Model(&models.TransactionMetadataLabel{}).
-		Where("label = ?", label).
+		Where("label = ?", types.Uint64(label)).
 		Count(&count); result.Error != nil {
 		return 0, fmt.Errorf(
 			"count txs by metadata label %d: %w",
@@ -877,7 +877,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 		for _, tmpLabel := range metadataLabels {
 			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
 				TransactionID: tmpTx.ID,
-				Label:         tmpLabel.Label,
+				Label:         types.Uint64(tmpLabel.Label),
 				Slot:          point.Slot,
 				CborValue:     tmpLabel.CborValue,
 				JsonValue:     tmpLabel.JsonValue,
@@ -2327,7 +2327,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 		for _, tmpLabel := range metadataLabels {
 			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
 				TransactionID: tmpTx.ID,
-				Label:         tmpLabel.Label,
+				Label:         types.Uint64(tmpLabel.Label),
 				Slot:          point.Slot,
 				CborValue:     tmpLabel.CborValue,
 				JsonValue:     tmpLabel.JsonValue,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -542,7 +542,7 @@ func (d *MetadataStorePostgres) GetTransactionsByMetadataLabel(
 
 	subQuery := db.Model(&models.TransactionMetadataLabel{}).
 		Select("transaction_id").
-		Where("label = ?", label)
+		Where("label = ?", types.Uint64(label))
 
 	query := db.
 		Where("id IN (?)", subQuery).
@@ -584,7 +584,7 @@ func (d *MetadataStorePostgres) CountTransactionsByMetadataLabel(
 
 	var count int64
 	if result := db.Model(&models.TransactionMetadataLabel{}).
-		Where("label = ?", label).
+		Where("label = ?", types.Uint64(label)).
 		Count(&count); result.Error != nil {
 		return 0, fmt.Errorf(
 			"count txs by metadata label %d: %w",
@@ -879,7 +879,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 		for _, tmpLabel := range metadataLabels {
 			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
 				TransactionID: tmpTx.ID,
-				Label:         tmpLabel.Label,
+				Label:         types.Uint64(tmpLabel.Label),
 				Slot:          point.Slot,
 				CborValue:     tmpLabel.CborValue,
 				JsonValue:     tmpLabel.JsonValue,
@@ -2335,7 +2335,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 		for _, tmpLabel := range metadataLabels {
 			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
 				TransactionID: tmpTx.ID,
-				Label:         tmpLabel.Label,
+				Label:         types.Uint64(tmpLabel.Label),
 				Slot:          point.Slot,
 				CborValue:     tmpLabel.CborValue,
 				JsonValue:     tmpLabel.JsonValue,

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -322,6 +322,7 @@ func TestSetTransactionIdempotentlyStoresCollateralReturn(t *testing.T) {
 
 func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {
 	sqliteStore := setupTestDBWithMode(t, types.StorageModeAPI)
+	highBitLabel := uint64(16450635129309362000)
 
 	makeMetadata := func(labels map[uint64]lcommon.TransactionMetadatum) lcommon.TransactionMetadatum {
 		pairs := make([]lcommon.MetaPair, 0, len(labels))
@@ -363,6 +364,7 @@ func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {
 					},
 				},
 			},
+			highBitLabel: lcommon.MetaText{Value: "high-bit-label"},
 		}),
 	}
 
@@ -397,8 +399,8 @@ func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {
 		Find(&rows).Error; err != nil {
 		t.Fatalf("query metadata labels failed: %v", err)
 	}
-	if len(rows) != 3 {
-		t.Fatalf("expected 3 metadata label rows, got %d", len(rows))
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 metadata label rows, got %d", len(rows))
 	}
 	for _, row := range rows {
 		if len(row.CborValue) == 0 {
@@ -450,6 +452,35 @@ func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {
 	}
 	if count721 != 2 {
 		t.Fatalf("expected count 2 for label 721, got %d", count721)
+	}
+
+	txsHighBit, err := sqliteStore.GetTransactionsByMetadataLabel(
+		highBitLabel,
+		10,
+		0,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("GetTransactionsByMetadataLabel high-bit label failed: %v", err)
+	}
+	if len(txsHighBit) != 1 || txsHighBit[0].Slot != 200 {
+		t.Fatalf("unexpected high-bit label query result: %#v", txsHighBit)
+	}
+
+	countHighBit, err := sqliteStore.CountTransactionsByMetadataLabel(
+		highBitLabel,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CountTransactionsByMetadataLabel high-bit label failed: %v", err)
+	}
+	if countHighBit != 1 {
+		t.Fatalf(
+			"expected count 1 for high-bit label %d, got %d",
+			highBitLabel,
+			countHighBit,
+		)
 	}
 }
 

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -566,7 +566,7 @@ func (d *MetadataStoreSqlite) GetTransactionsByMetadataLabel(
 
 	subQuery := db.Model(&models.TransactionMetadataLabel{}).
 		Select("transaction_id").
-		Where("label = ?", label)
+		Where("label = ?", types.Uint64(label))
 
 	query := db.
 		Where("id IN (?)", subQuery).
@@ -608,7 +608,7 @@ func (d *MetadataStoreSqlite) CountTransactionsByMetadataLabel(
 
 	var count int64
 	if result := db.Model(&models.TransactionMetadataLabel{}).
-		Where("label = ?", label).
+		Where("label = ?", types.Uint64(label)).
 		Count(&count); result.Error != nil {
 		return 0, fmt.Errorf(
 			"count txs by metadata label %d: %w",
@@ -967,7 +967,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 		for _, tmpLabel := range metadataLabels {
 			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
 				TransactionID: tmpTx.ID,
-				Label:         tmpLabel.Label,
+				Label:         types.Uint64(tmpLabel.Label),
 				Slot:          point.Slot,
 				CborValue:     tmpLabel.CborValue,
 				JsonValue:     tmpLabel.JsonValue,
@@ -2489,7 +2489,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		for _, tmpLabel := range metadataLabels {
 			labelRecords = append(labelRecords, models.TransactionMetadataLabel{
 				TransactionID: tmpTx.ID,
-				Label:         tmpLabel.Label,
+				Label:         types.Uint64(tmpLabel.Label),
 				Slot:          point.Slot,
 				CborValue:     tmpLabel.CborValue,
 				JsonValue:     tmpLabel.JsonValue,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix high-bit transaction metadata label overflow by storing labels as `types.Uint64` and casting query params across all backends. Also improves SQLite UTXO query/update performance by forcing the `tx_id_output_idx` index.

- **Bug Fixes**
  - Store metadata labels as `types.Uint64` to support values > 2^63−1.
  - Cast label params to `types.Uint64` in label queries/inserts for SQLite/MySQL/Postgres.
  - Add SQLite tests covering high-bit label query and count.

- **Performance**
  - Use `utxoRefIndexedTable()` to apply `INDEXED BY` with `tx_id_output_idx` in UTXO selects and updates.
  - Add tests asserting the SQLite query plan uses `tx_id_output_idx` and avoids `idx_utxo_deleted_slot`.

<sup>Written for commit 5a94cebaae474a02637bf44fc80f0a1f575807bd. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2357?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent handling of metadata label values across database operations.

* **Performance**
  * Optimized UTXO lookups to use indexed table queries for improved efficiency.

* **Tests**
  * Extended metadata label test coverage, including high-bit label scenarios.
  * Added verification test for query index usage in UTXO batch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->