### PR TITLE
fix(ledger): use mithril sync intersect in point selection

### DIFF
--- a/database/block.go
+++ b/database/block.go
@@ -220,6 +220,17 @@ func BlockByHash(db *Database, hash []byte) (models.Block, error) {
 	return ret, err
 }
 
+func BlockBySlot(db *Database, slot uint64) (models.Block, error) {
+	var ret models.Block
+	txn := db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		var err error
+		ret, err = BlockBySlotTxn(txn, slot)
+		return err
+	})
+	return ret, err
+}
+
 func BlockURL(
 	ctx context.Context,
 	db *Database,
@@ -375,6 +386,76 @@ func BlockByHashTxn(txn *Txn, hash []byte) (models.Block, error) {
 		return models.Block{}, err
 	}
 	return models.Block{}, models.ErrBlockNotFound
+}
+
+func BlockBySlotTxn(txn *Txn, slot uint64) (models.Block, error) {
+	if txn == nil {
+		return models.Block{}, types.ErrNilTxn
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return models.Block{}, types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return models.Block{}, types.ErrBlobStoreUnavailable
+	}
+	slotPrefix := slices.Concat(
+		[]byte(types.BlockBlobKeyPrefix),
+		types.BlockBlobKeyUint64ToBytes(slot),
+	)
+	iterOpts := types.BlobIteratorOptions{
+		Prefix: slotPrefix,
+	}
+	it := blob.NewIterator(blobTxn, iterOpts)
+	if it == nil {
+		return models.Block{}, errors.New("blob iterator is nil")
+	}
+	defer it.Close()
+	var ret models.Block
+	found := false
+	for it.Seek(slotPrefix); it.ValidForPrefix(slotPrefix); it.Next() {
+		item := it.Item()
+		if item == nil {
+			continue
+		}
+		k := item.Key()
+		if k == nil {
+			continue
+		}
+		if strings.HasSuffix(string(k), types.BlockBlobMetadataKeySuffix) {
+			continue
+		}
+		block, err := blockByKey(txn, k)
+		if err != nil {
+			return models.Block{}, err
+		}
+		if block.Slot != slot {
+			continue
+		}
+		indexedBlock, err := txn.DB().BlockByIndex(block.ID, txn)
+		if err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				continue
+			}
+			return models.Block{}, err
+		}
+		if indexedBlock.Slot != block.Slot ||
+			!bytes.Equal(indexedBlock.Hash, block.Hash) {
+			continue
+		}
+		if !found || block.ID > ret.ID {
+			ret = block
+			found = true
+		}
+	}
+	if err := it.Err(); err != nil {
+		return models.Block{}, err
+	}
+	if !found {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	return ret, nil
 }
 
 func (d *Database) BlockByIndex(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4577,10 +4577,154 @@ func (ls *LedgerState) IntersectPoints(
 	if ls.primaryChainTipAtOrAheadOfLedgerTip() {
 		points := ls.chain.IntersectPoints(count)
 		if len(points) > 0 {
-			return points, nil
+			return ls.withMithrilTrustBoundaryIntersectPoint(
+				points,
+				count,
+			), nil
 		}
 	}
-	return ls.RecentChainPoints(count)
+	points, err := ls.RecentChainPoints(count)
+	if err != nil {
+		return nil, err
+	}
+	return ls.withMithrilTrustBoundaryIntersectPoint(points, count), nil
+}
+
+func (ls *LedgerState) withMithrilTrustBoundaryIntersectPoint(
+	points []ocommon.Point,
+	count int,
+) []ocommon.Point {
+	if count <= 0 {
+		return points
+	}
+	point, ok := ls.mithrilTrustBoundaryPoint()
+	if !ok {
+		return points
+	}
+	for _, existing := range points {
+		if existing.Slot == point.Slot &&
+			bytes.Equal(existing.Hash, point.Hash) {
+			return points
+		}
+	}
+
+	insertAt := len(points)
+	for idx, existing := range points {
+		if point.Slot > existing.Slot {
+			insertAt = idx
+			break
+		}
+	}
+	ret := make([]ocommon.Point, 0, len(points)+1)
+	ret = append(ret, points[:insertAt]...)
+	ret = append(ret, point)
+	ret = append(ret, points[insertAt:]...)
+	if len(ret) <= count {
+		return ret
+	}
+	if insertAt >= count {
+		ret[count-1] = point
+	}
+	return ret[:count]
+}
+
+func (ls *LedgerState) mithrilTrustBoundaryPoint() (ocommon.Point, bool) {
+	if ls == nil || ls.db == nil {
+		return ocommon.Point{}, false
+	}
+	ls.RLock()
+	boundarySlot := ls.mithrilLedgerSlot
+	currentTip := ls.currentTip
+	ls.RUnlock()
+	if boundarySlot == 0 || boundarySlot == ^uint64(0) {
+		return ocommon.Point{}, false
+	}
+	if currentTip.Point.Slot == 0 && len(currentTip.Point.Hash) == 0 {
+		return ocommon.Point{}, false
+	}
+	if boundarySlot > currentTip.Point.Slot {
+		return ocommon.Point{}, false
+	}
+	block, err := ls.authoritativeLedgerBlockAtSlot(
+		boundarySlot,
+		currentTip.Point,
+	)
+	if err != nil {
+		if ls.config.Logger != nil &&
+			!errors.Is(err, models.ErrBlockNotFound) {
+			ls.config.Logger.Debug(
+				"failed to load Mithril trust boundary intersect point",
+				"component", "ledger",
+				"mithril_ledger_slot", boundarySlot,
+				"error", err,
+			)
+		}
+		return ocommon.Point{}, false
+	}
+	if block.Slot != boundarySlot || len(block.Hash) == 0 {
+		return ocommon.Point{}, false
+	}
+	return ocommon.NewPoint(block.Slot, block.Hash), true
+}
+
+func (ls *LedgerState) authoritativeLedgerBlockAtSlot(
+	slot uint64,
+	tipPoint ocommon.Point,
+) (models.Block, error) {
+	var ret models.Block
+	txn := ls.db.Transaction(false)
+	err := txn.Do(func(txn *database.Txn) error {
+		block, err := database.BlockByPointTxn(txn, tipPoint)
+		if err != nil {
+			return err
+		}
+		if slot > block.Slot {
+			return models.ErrBlockNotFound
+		}
+		// Same-slot fork blocks can coexist in blob storage. Only the
+		// current tip's PrevHash chain proves the boundary is canonical.
+		for remaining := block.Slot - slot + 1; remaining > 0; remaining-- {
+			if block.Slot == slot {
+				ret = block
+				return nil
+			}
+			if block.Slot < slot {
+				return models.ErrBlockNotFound
+			}
+			prevHash, err := blockPrevHash(block)
+			if err != nil {
+				return err
+			}
+			if len(prevHash) == 0 {
+				return models.ErrBlockNotFound
+			}
+			block, err = database.BlockByHashTxn(txn, prevHash)
+			if err != nil {
+				return err
+			}
+		}
+		return models.ErrBlockNotFound
+	})
+	return ret, err
+}
+
+func blockPrevHash(block models.Block) ([]byte, error) {
+	if len(block.PrevHash) > 0 {
+		return block.PrevHash, nil
+	}
+	decodedBlock, err := block.Decode()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode block at slot %d for previous hash: %w",
+			block.Slot,
+			err,
+		)
+	}
+	prevHash := decodedBlock.PrevHash().Bytes()
+	if len(prevHash) == 0 {
+		return nil, nil
+	}
+	return prevHash, nil
 }
 
 // GetIntersectPoint returns the intersect between the specified points and the current chain

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2434,6 +2434,321 @@ func TestIntersectPointsUsesSparseLedgerTipSamples(t *testing.T) {
 	}
 }
 
+func TestIntersectPointsIncludesMithrilTrustBoundary(t *testing.T) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := make([]models.Block, 0, 256)
+	for slot := uint64(1); slot <= 256; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: 173,
+	}
+
+	points, err := ls.IntersectPoints(40)
+	require.NoError(t, err)
+
+	boundarySlot := uint64(173)
+	var boundaryPoint *ocommon.Point
+	for _, point := range points {
+		if point.Slot == boundarySlot {
+			point := point
+			boundaryPoint = &point
+			break
+		}
+	}
+	require.NotNil(t, boundaryPoint)
+	assert.Equal(t, blocks[boundarySlot-1].Hash, boundaryPoint.Hash)
+}
+
+func TestIntersectPointsSkipsZeroMithrilTrustBoundary(t *testing.T) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 10)
+	for slot := uint64(1); slot <= 10; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: 0,
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.NotEmpty(t, points)
+	assertNoIntersectPointAtSlot(t, points, 0)
+}
+
+func TestIntersectPointsSkipsFutureMithrilTrustBoundary(t *testing.T) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 10)
+	for slot := uint64(1); slot <= 10; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	boundarySlot := ledgerTipBlock.Slot + 1
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: boundarySlot,
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.NotEmpty(t, points)
+	assertNoIntersectPointAtSlot(t, points, boundarySlot)
+}
+
+func TestIntersectPointsSkipsMissingMithrilTrustBoundaryBlock(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+
+	var blocks []models.Block
+	for slot := uint64(1); slot <= 10; slot++ {
+		if slot == 5 {
+			continue
+		}
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	boundarySlot := uint64(5)
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: boundarySlot,
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.NotEmpty(t, points)
+	assertNoIntersectPointAtSlot(t, points, boundarySlot)
+}
+
+func TestIntersectPointsSkipsMithrilTrustBoundaryOnLookupError(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 10)
+	for slot := uint64(1); slot <= 10; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	boundarySlot := uint64(5)
+	txn := db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return db.Blob().Set(
+			txn.Blob(),
+			dbtypes.BlockHashIndexKey(blocks[boundarySlot-1].Hash),
+			[]byte("bad"),
+		)
+	}))
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: boundarySlot,
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.NotEmpty(t, points)
+	assertNoIntersectPointAtSlot(t, points, boundarySlot)
+}
+
+func TestIntersectPointsUsesCanonicalMithrilTrustBoundary(t *testing.T) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 64)
+	for slot := uint64(1); slot <= 64; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	boundarySlot := uint64(20)
+	canonicalBoundaryBlock := blocks[boundarySlot-1]
+	nonCanonicalBoundaryBlock := makeTestBlock(boundarySlot, 1000)
+	nonCanonicalBoundaryBlock.Hash = bytes.Repeat([]byte{0xff}, 32)
+	nonCanonicalBoundaryBlock.PrevHash = append(
+		[]byte(nil),
+		blocks[boundarySlot-2].Hash...,
+	)
+	require.NoError(t, db.BlockCreate(nonCanonicalBoundaryBlock, nil))
+
+	rawBoundaryBlock, err := database.BlockBeforeSlot(
+		db,
+		boundarySlot+1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, nonCanonicalBoundaryBlock.Hash, rawBoundaryBlock.Hash)
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: boundarySlot,
+	}
+
+	points, err := ls.IntersectPoints(40)
+	require.NoError(t, err)
+
+	var boundaryPoint *ocommon.Point
+	for _, point := range points {
+		if point.Slot == boundarySlot {
+			point := point
+			boundaryPoint = &point
+			break
+		}
+	}
+	require.NotNil(t, boundaryPoint)
+	assert.Equal(t, canonicalBoundaryBlock.Hash, boundaryPoint.Hash)
+	assert.NotEqual(t, nonCanonicalBoundaryBlock.Hash, boundaryPoint.Hash)
+}
+
+func TestAuthoritativeLedgerBlockAtSlotDoesNotRequireMonotonicBlockIDs(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 64)
+	for slot := uint64(1); slot <= 64; slot++ {
+		id := slot
+		switch slot {
+		case 20:
+			id = 50
+		case 50:
+			id = 20
+		}
+		block := makeTestBlock(slot, id)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{db: db}
+
+	block, err := ls.authoritativeLedgerBlockAtSlot(
+		20,
+		makeTestPoint(ledgerTipBlock),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(20), block.Slot)
+	assert.Equal(t, blocks[19].Hash, block.Hash)
+}
+
+func TestIntersectPointsKeepsMithrilTrustBoundaryWhenPointListIsFull(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+
+	blocks := make([]models.Block, 0, 10)
+	for slot := uint64(1); slot <= 10; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	ledgerTipBlock := blocks[len(blocks)-1]
+	ls := &LedgerState{
+		db: db,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(ledgerTipBlock),
+			BlockNumber: ledgerTipBlock.Number,
+		},
+		mithrilLedgerSlot: 5,
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.Len(t, points, 4)
+	assert.Equal(t, uint64(10), points[0].Slot)
+	assert.Equal(t, uint64(9), points[1].Slot)
+	assert.Equal(t, uint64(8), points[2].Slot)
+	assert.Equal(t, uint64(5), points[3].Slot)
+}
+
+func assertNoIntersectPointAtSlot(
+	t *testing.T,
+	points []ocommon.Point,
+	slot uint64,
+) {
+	t.Helper()
+	for _, point := range points {
+		assert.NotEqual(t, slot, point.Slot)
+	}
+}
+
 func TestIntersectPointsSkipsMissingDenseBlockIndex(t *testing.T) {
 	db := newTestDB(t)
 


### PR DESCRIPTION
Closes #2349 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects the Mithril trust boundary into intersect point selection so nodes reliably include it during Mithril sync, always using the canonical block at that slot. Adds slot-based lookups and prev-hash traversal to resolve the boundary, even with non‑monotonic block IDs.

- **Bug Fixes**
  - Ensures `LedgerState.IntersectPoints` augments both fast and fallback paths with `withMithrilTrustBoundaryIntersectPoint`; dedupes, keeps order, and preserves the boundary when trimming to `count`.
  - Resolves the boundary via `mithrilTrustBoundaryPoint` and `authoritativeLedgerBlockAtSlot` by walking the tip’s prev-hash (`database.BlockByPointTxn`, `database.BlockByHashTxn`) to select the canonical block; skips zero/future slots or missing blocks and logs on errors.
  - Adds `database.BlockBySlot`/`database.BlockBySlotTxn` for slot-based retrieval, and tests for boundary inclusion, canonical selection with competing blocks, retention when the list is full, handling of non‑monotonic block IDs, and skipping invalid/error cases.

<sup>Written for commit 559a8799799f3b6205fb1d5c8190050dc84fab3c. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intersection candidate lists now include a Mithril trust-boundary point when available, de-duplicated and preserved in newest-to-oldest order; slot-based block lookup added to fetch authoritative blocks by slot.

* **Tests**
  * Added tests covering Mithril boundary inclusion, omission cases (zero/future/missing/lookup error), canonical boundary selection, preservation when lists are full, and correct block retrieval by slot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->