### PR TITLE
fix(database): do not prune spent UTxOs in API storage mode

### DIFF
--- a/database/blob_iterator_test.go
+++ b/database/blob_iterator_test.go
@@ -26,8 +26,17 @@ import (
 // newTestDB creates an in-memory Database instance for testing.
 func newTestDB(t *testing.T) *Database {
 	t.Helper()
+	return newTestDBWithMode(t, "")
+}
+
+// newTestDBWithMode creates an in-memory Database instance for testing
+// configured with the given storage mode. An empty mode defaults to
+// "core" (per Database.New).
+func newTestDBWithMode(t *testing.T, mode string) *Database {
+	t.Helper()
 	config := &Config{
-		DataDir: "", // In-memory
+		DataDir:     "", // In-memory
+		StorageMode: mode,
 	}
 	db, err := New(config)
 	require.NoError(t, err, "failed to create test database")

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -124,6 +124,36 @@ func (d *MetadataStoreMysql) GetLiveUtxosBySlot(
 	return ret, nil
 }
 
+// GetUtxosBySlot returns the references of every UTxO created at the given
+// slot, including rows soft-marked as spent (deleted_slot != 0). Only TxId
+// and OutputIdx are populated.
+func (d *MetadataStoreMysql) GetUtxosBySlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.UtxoId, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		TxId      []byte `gorm:"column:tx_id"`
+		OutputIdx uint32 `gorm:"column:output_idx"`
+	}
+	result := db.
+		Model(&models.Utxo{}).
+		Where("added_slot = ?", slot).
+		Select("tx_id", "output_idx").
+		Find(&rows)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	ret := make([]models.UtxoId, len(rows))
+	for i, r := range rows {
+		ret[i] = models.UtxoId{Hash: r.TxId, Idx: r.OutputIdx}
+	}
+	return ret, nil
+}
+
 // GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
 func (d *MetadataStoreMysql) GetUtxosDeletedBeforeSlot(
 	slot uint64,

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -153,6 +153,36 @@ func (d *MetadataStorePostgres) GetLiveUtxosBySlot(
 	return ret, nil
 }
 
+// GetUtxosBySlot returns the references of every UTxO created at the given
+// slot, including rows soft-marked as spent (deleted_slot != 0). Only TxId
+// and OutputIdx are populated.
+func (d *MetadataStorePostgres) GetUtxosBySlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.UtxoId, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		TxId      []byte `gorm:"column:tx_id"`
+		OutputIdx uint32 `gorm:"column:output_idx"`
+	}
+	result := db.
+		Model(&models.Utxo{}).
+		Where("added_slot = ?", slot).
+		Select("tx_id", "output_idx").
+		Find(&rows)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	ret := make([]models.UtxoId, len(rows))
+	for i, r := range rows {
+		ret[i] = models.UtxoId{Hash: r.TxId, Idx: r.OutputIdx}
+	}
+	return ret, nil
+}
+
 // GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
 func (d *MetadataStorePostgres) GetUtxosDeletedBeforeSlot(
 	slot uint64,

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -244,6 +244,36 @@ func (d *MetadataStoreSqlite) GetLiveUtxosBySlot(
 	return ret, nil
 }
 
+// GetUtxosBySlot returns the references of every UTxO created at the given
+// slot, including rows soft-marked as spent (deleted_slot != 0). Only TxId
+// and OutputIdx are populated.
+func (d *MetadataStoreSqlite) GetUtxosBySlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.UtxoId, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		TxId      []byte `gorm:"column:tx_id"`
+		OutputIdx uint32 `gorm:"column:output_idx"`
+	}
+	result := db.
+		Model(&models.Utxo{}).
+		Where("added_slot = ?", slot).
+		Select("tx_id", "output_idx").
+		Find(&rows)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	ret := make([]models.UtxoId, len(rows))
+	for i, r := range rows {
+		ret[i] = models.UtxoId{Hash: r.TxId, Idx: r.OutputIdx}
+	}
+	return ret, nil
+}
+
 // GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
 func (d *MetadataStoreSqlite) GetUtxosDeletedBeforeSlot(
 	slot uint64,

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -333,6 +333,61 @@ func BenchmarkGetUtxoAddressKeysBatch(b *testing.B) {
 	})
 }
 
+// TestGetUtxosBySlotIncludesSpent verifies that GetUtxosBySlot returns
+// every UTxO created at the slot, including rows soft-marked as spent.
+// API storage mode relies on this so the pruner can materialize CBOR
+// bytes for retained spent UTxOs before tombstoning the source block.
+func TestGetUtxosBySlotIncludesSpent(t *testing.T) {
+	store := setupTestDB(t)
+
+	live := models.Utxo{
+		TxId:      bytes.Repeat([]byte{0xAA}, 32),
+		OutputIdx: 0,
+		AddedSlot: 500,
+		Amount:    types.Uint64(1),
+	}
+	spentLater := models.Utxo{
+		TxId:        bytes.Repeat([]byte{0xBB}, 32),
+		OutputIdx:   0,
+		AddedSlot:   500,
+		DeletedSlot: 700,
+		Amount:      types.Uint64(2),
+	}
+	spentSameSlot := models.Utxo{
+		TxId:        bytes.Repeat([]byte{0xDD}, 32),
+		OutputIdx:   0,
+		AddedSlot:   500,
+		DeletedSlot: 500,
+		Amount:      types.Uint64(3),
+	}
+	otherSlot := models.Utxo{
+		TxId:      bytes.Repeat([]byte{0xFF}, 32),
+		OutputIdx: 0,
+		AddedSlot: 600,
+		Amount:    types.Uint64(4),
+	}
+	for _, u := range []*models.Utxo{&live, &spentLater, &spentSameSlot, &otherSlot} {
+		require.NoError(t, store.DB().Create(u).Error)
+	}
+
+	got, err := store.GetUtxosBySlot(500, nil)
+	require.NoError(t, err)
+	sortUtxoIds(got)
+	want := []models.UtxoId{
+		{Hash: live.TxId, Idx: 0},
+		{Hash: spentLater.TxId, Idx: 0},
+		{Hash: spentSameSlot.TxId, Idx: 0},
+	}
+	sortUtxoIds(want)
+	assert.Equal(t, want, got)
+
+	// Sanity: GetLiveUtxosBySlot only returns the unspent row.
+	gotLive, err := store.GetLiveUtxosBySlot(500, nil)
+	require.NoError(t, err)
+	require.Len(t, gotLive, 1)
+	assert.Equal(t, live.TxId, gotLive[0].Hash)
+}
+
 func sortUtxoIds(ids []models.UtxoId) {
 	sort.Slice(ids, func(i, j int) bool {
 		if c := bytes.Compare(ids[i].Hash, ids[j].Hash); c != 0 {

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -646,6 +646,14 @@ type MetadataStore interface {
 	// source block.
 	GetLiveUtxosBySlot(uint64, types.Txn) ([]models.UtxoId, error)
 
+	// GetUtxosBySlot returns the references ({TxId, OutputIdx}) of every
+	// UTxO created at the given slot, including rows soft-marked as spent
+	// (deleted_slot != 0). Used by the pruner in API storage mode to
+	// materialize CBOR bytes for retained spent UTxOs before tombstoning
+	// the source block, since API mode keeps spent rows past the stability
+	// window for historical transaction queries.
+	GetUtxosBySlot(uint64, types.Txn) ([]models.UtxoId, error)
+
 	// GetUtxosByAddress retrieves all UTxOs for a given address.
 	GetUtxosByAddress(ledger.Address, types.Txn) ([]models.Utxo, error)
 

--- a/database/prune.go
+++ b/database/prune.go
@@ -35,28 +35,45 @@ import (
 // UTxO blob entries are stored as 52-byte CborOffset references that point
 // into a source block's CBOR. Tombstoning a block while live UTxOs still
 // reference it would leave those UTxOs unresolvable. To preserve them,
-// PruneBlock first finds every live UTxO with added_slot equal to the
-// pruned block's slot, decodes its offset, slices the underlying CBOR out
-// of the block, and rewrites the UTxO blob entry as raw CBOR (which the
-// resolver treats as the legacy non-offset format). The block tombstone
-// and all UTxO rewrites happen in a single blob transaction, so the block
-// is never tombstoned while live UTxOs still depend on it.
+// PruneBlock first finds every UTxO with added_slot equal to the pruned
+// block's slot, decodes its offset, slices the underlying CBOR out of the
+// block, and rewrites the UTxO blob entry as raw CBOR (which the resolver
+// treats as the legacy non-offset format). The block tombstone and all
+// UTxO rewrites happen in a single blob transaction, so the block is
+// never tombstoned while live UTxOs still depend on it.
+//
+// In core storage mode only live (deleted_slot = 0) UTxOs at the slot are
+// considered, because spent UTxOs are hard-deleted by the periodic
+// stability-window cleanup and need no historical resolution. In API
+// storage mode the cleanup is skipped and spent UTxO rows are retained
+// indefinitely for historical transaction queries; in that mode every
+// UTxO at the slot (including spent rows whose blob entries still hold
+// offset references) is materialized so CBOR resolution survives the
+// block tombstone without requiring a wrapping archive proxy.
 //
 // Returns the number of UTxOs that were materialized.
 func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
-	// Read live UTxO refs for this slot from metadata. This is a separate
+	// Read UTxO refs for this slot from metadata. This is a separate
 	// transaction so the blob write txn below has a single, simple commit
 	// scope. A UTxO consumed between this read and the blob write is
 	// handled below: GetUtxo will return ErrBlobKeyNotFound and the entry
-	// is skipped. Release the read txn as soon as liveUtxos is
+	// is skipped. Release the read txn as soon as the refs are
 	// materialized so the connection is freed before the blob write txn
 	// and block operations run.
 	mdTxn := d.MetadataTxn(false)
-	liveUtxos, err := d.metadata.GetLiveUtxosBySlot(slot, mdTxn.Metadata())
+	var (
+		utxoRefs []models.UtxoId
+		err      error
+	)
+	if d.config.StorageMode == types.StorageModeAPI {
+		utxoRefs, err = d.metadata.GetUtxosBySlot(slot, mdTxn.Metadata())
+	} else {
+		utxoRefs, err = d.metadata.GetLiveUtxosBySlot(slot, mdTxn.Metadata())
+	}
 	mdTxn.Release()
 	if err != nil {
 		return 0, fmt.Errorf(
-			"prune block (slot=%d): list live utxos: %w",
+			"prune block (slot=%d): list utxos: %w",
 			slot,
 			err,
 		)
@@ -73,7 +90,7 @@ func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
 				err,
 			)
 		}
-		for _, ref := range liveUtxos {
+		for _, ref := range utxoRefs {
 			n, err := d.materializeUtxo(txn.Blob(), slot, hash, blockCbor, ref)
 			if err != nil {
 				return err

--- a/database/prune_test.go
+++ b/database/prune_test.go
@@ -271,6 +271,91 @@ func TestPruneBlock_LeavesChainIteratorAtTombstone(t *testing.T) {
 	assert.NotErrorIs(t, err, models.ErrBlockNotFound)
 }
 
+// TestPruneBlock_APIModeMaterializesSpentUtxos verifies that in API
+// storage mode the pruner materializes CBOR bytes for retained spent
+// UTxOs at the slot as well as live ones. This is the counterpart fix
+// to skipping cleanupConsumedUtxos in API mode: with spent rows
+// retained for historical transaction queries, the source block can
+// still be tombstoned, but the spent UTxO blob entries — which hold
+// offset references into the (now-tombstoned) block — must be rewritten
+// to raw CBOR up front so resolution does not require a wrapping
+// archive proxy to fetch the source block.
+func TestPruneBlock_APIModeMaterializesSpentUtxos(t *testing.T) {
+	db := newTestDBWithMode(t, types.StorageModeAPI)
+
+	const slot uint64 = 100
+	txId := bytes.Repeat([]byte{0xA1}, 32)
+	livePayload := []byte("live-cbor-payload-api-mode")
+	spentPayload := []byte("spent-cbor-payload-api-mode")
+
+	hash, _ := seedPrunableBlock(t, db, slot, txId, map[uint32][]byte{
+		0: livePayload,
+		1: spentPayload,
+	})
+
+	// Live UTxO at slot 100; spent UTxO consumed at slot 150. In API mode
+	// the spent row is retained past the stability window, and its blob
+	// entry — still an offset reference to slot 100 — must be materialized
+	// before the block is tombstoned.
+	seedUtxoMetadata(t, db, txId, 0, slot, 0)
+	seedUtxoMetadata(t, db, txId, 1, slot, 150)
+
+	n, err := db.PruneBlock(slot, hash)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n,
+		"API mode must materialize both live and retained spent UTxOs")
+
+	blobTxn := db.BlobTxn(false)
+	defer blobTxn.Release()
+
+	postLive, err := db.Blob().GetUtxo(blobTxn.Blob(), txId, 0)
+	require.NoError(t, err)
+	assert.False(t, IsUtxoOffsetStorage(postLive),
+		"live UTxO blob entry must be rewritten to raw CBOR")
+	assert.Equal(t, livePayload, postLive)
+
+	postSpent, err := db.Blob().GetUtxo(blobTxn.Blob(), txId, 1)
+	require.NoError(t, err)
+	assert.False(t, IsUtxoOffsetStorage(postSpent),
+		"spent UTxO blob entry must also be rewritten to raw CBOR in API mode")
+	assert.Equal(t, spentPayload, postSpent)
+}
+
+// TestPruneBlock_CoreModeLeavesSpentUtxos verifies the existing core-mode
+// invariant: spent UTxOs at the slot are NOT materialized. Core mode
+// hard-deletes consumed UTxOs in the stability-window cleanup, so by the
+// time the pruner runs the spent row is gone — but until then any leftover
+// spent blob entry must remain as the original offset reference (and is
+// then deleted by the next cleanup pass).
+func TestPruneBlock_CoreModeLeavesSpentUtxos(t *testing.T) {
+	db := newTestDBWithMode(t, types.StorageModeCore)
+
+	const slot uint64 = 100
+	txId := bytes.Repeat([]byte{0xA2}, 32)
+	livePayload := []byte("live-cbor-payload-core-mode")
+	spentPayload := []byte("spent-cbor-payload-core-mode")
+
+	hash, _ := seedPrunableBlock(t, db, slot, txId, map[uint32][]byte{
+		0: livePayload,
+		1: spentPayload,
+	})
+	seedUtxoMetadata(t, db, txId, 0, slot, 0)
+	seedUtxoMetadata(t, db, txId, 1, slot, 150)
+
+	n, err := db.PruneBlock(slot, hash)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n,
+		"core mode must materialize only the live UTxO at the slot")
+
+	blobTxn := db.BlobTxn(false)
+	defer blobTxn.Release()
+
+	postSpent, err := db.Blob().GetUtxo(blobTxn.Blob(), txId, 1)
+	require.NoError(t, err)
+	assert.True(t, IsUtxoOffsetStorage(postSpent),
+		"core mode must leave spent UTxO blob entry as offset storage")
+}
+
 func TestPruneBlock_SkipsAlreadyMaterializedUtxo(t *testing.T) {
 	db := newTestDB(t)
 

--- a/ledger/cleanup_consumed_utxos_test.go
+++ b/ledger/cleanup_consumed_utxos_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// newTestDBForCleanup builds an in-memory Database in the requested storage
+// mode. An empty mode defaults to core (per Database.New).
+func newTestDBForCleanup(t *testing.T, mode string) *database.Database {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		DataDir:     "",
+		StorageMode: mode,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// seedSpentUtxoForCleanup writes a single spent UTxO row directly. The
+// row is "consumed at deletedSlot but still well within the periodic
+// cleanup eligibility window" — matching what a normal block application
+// would produce after the consumed input was soft-marked.
+func seedSpentUtxoForCleanup(
+	t *testing.T,
+	db *database.Database,
+	txId []byte,
+	outputIdx uint32,
+	addedSlot, deletedSlot uint64,
+) {
+	t.Helper()
+	mdTxn := db.MetadataTxn(true)
+	require.NoError(t, mdTxn.Do(func(txn *database.Txn) error {
+		return db.CreateUtxo(txn, &models.Utxo{
+			TxId:        txId,
+			OutputIdx:   outputIdx,
+			AddedSlot:   addedSlot,
+			DeletedSlot: deletedSlot,
+			Amount:      types.Uint64(1),
+		})
+	}))
+}
+
+// newLedgerStateForCleanup wires the minimum surface area
+// cleanupConsumedUtxos needs: db, currentTip, currentEra, and a logger.
+// CardanoNodeConfig is intentionally left nil so
+// calculateStabilityWindowForEra returns the default
+// (blockfetchBatchSlotThresholdDefault = 50000); the tip slot is then
+// chosen well past that window so consumed-UTxO cleanup is eligible to
+// run in core mode.
+func newLedgerStateForCleanup(
+	db *database.Database,
+	tipSlot uint64,
+) *LedgerState {
+	return &LedgerState{
+		db:         db,
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(tipSlot, nil),
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+// TestCleanupConsumedUtxos_CoreModePrunes asserts the pre-existing
+// invariant that core mode hard-deletes consumed UTxO rows once the
+// stability window has passed. Without this baseline, the API-mode
+// retention test below could pass by accident if the cleanup loop were
+// silently dead for both modes.
+func TestCleanupConsumedUtxos_CoreModePrunes(t *testing.T) {
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	txId := bytes.Repeat([]byte{0xA1}, 32)
+	const (
+		addedSlot   uint64 = 1_000
+		deletedSlot uint64 = 5_000
+		tipSlot     uint64 = 100_000 // > 50_000 default stability window
+	)
+	seedSpentUtxoForCleanup(t, db, txId, 0, addedSlot, deletedSlot)
+
+	pre, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pre, "seed must succeed before cleanup")
+
+	ls := newLedgerStateForCleanup(db, tipSlot)
+	ls.cleanupConsumedUtxos()
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(
+		t, post,
+		"core mode must hard-delete consumed UTxO rows after stability "+
+			"window",
+	)
+}
+
+// TestCleanupConsumedUtxos_APIModeRetains is the regression fix for
+// issue #2350: in API storage mode the periodic cleanup must leave
+// spent UTxO metadata rows in place so historical transaction queries
+// can resolve input / collateral / reference-input associations via
+// spent_at_tx_id, collateral_by_tx_id, and referenced_by_tx_id.
+func TestCleanupConsumedUtxos_APIModeRetains(t *testing.T) {
+	db := newTestDBForCleanup(t, types.StorageModeAPI)
+	txId := bytes.Repeat([]byte{0xA2}, 32)
+	const (
+		addedSlot   uint64 = 1_000
+		deletedSlot uint64 = 5_000
+		tipSlot     uint64 = 100_000
+	)
+	seedSpentUtxoForCleanup(t, db, txId, 0, addedSlot, deletedSlot)
+
+	ls := newLedgerStateForCleanup(db, tipSlot)
+	ls.cleanupConsumedUtxos()
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(
+		t, post,
+		"API mode must retain spent UTxO row past the cleanup threshold "+
+			"so historical transaction queries can still resolve input / "+
+			"collateral / reference-input associations",
+	)
+	assert.Equal(
+		t, deletedSlot, post.DeletedSlot,
+		"retained row must keep deleted_slot as the spent-state encoding",
+	)
+
+	// Live-UTxO queries must still filter the retained row out: it has
+	// a non-zero deleted_slot so it is no longer part of the active set.
+	live, err := db.Metadata().GetUtxo(txId, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(t, live,
+		"live UTxO view must continue to exclude spent rows in API mode")
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1420,6 +1420,15 @@ func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
 }
 
 func (ls *LedgerState) cleanupConsumedUtxos() {
+	// In API storage mode we retain spent UTxO metadata rows past the
+	// stability window so historical transaction queries can resolve
+	// input/collateral/reference-input details via spent_at_tx_id,
+	// collateral_by_tx_id, and referenced_by_tx_id. Spent state is already
+	// encoded by deleted_slot and spent_at_tx_id; live-UTxO queries continue
+	// to filter on deleted_slot = 0.
+	if ls.db.StorageMode() == types.StorageModeAPI {
+		return
+	}
 	// Get the current tip slot while holding the read lock to avoid TOCTOU race.
 	// We capture only the slot value we need, so even if currentTip changes after
 	// we release the lock, we're working with a consistent snapshot of the slot.


### PR DESCRIPTION
Closes #2350 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect UTxO handling in API storage mode by retaining spent UTxO rows and materializing their CBOR before tombstoning blocks. This preserves historical transaction queries and avoids broken offset resolution.

- **Bug Fixes**
  - In API mode, skip consumed-UTxO cleanup and retain spent rows; core mode behavior unchanged.
  - Pruner materializes CBOR for all UTxOs at the block slot in API mode (live + spent); core mode materializes only live UTxOs.
  - Added `GetUtxosBySlot` to metadata stores (MySQL/Postgres/SQLite) to support API-mode pruning, plus tests for API/core cleanup and materialization paths.

<sup>Written for commit 325489e9b2d6491ac8eaca3ae4b5200f0a1d73ae. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2361?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage-mode-aware block pruning: API mode materializes and preserves both live and spent UTxOs; Core mode continues live-only pruning.
  * Added a storage-mode-aware way to fetch all UTxO references created at a given slot (including spent) to support pruning/materialization.

* **Tests**
  * Added tests covering API vs Core pruning behavior, UTxO-by-slot behavior (including spent rows), and storage-mode-specific cleanup.
  * Minor test helper improvements for in-memory test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->