### PR TITLE
feat(database): Use lightweight input-address lookup during API backfill

### DIFF
--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -355,6 +355,9 @@ func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
 	require.Equal(t, uint32(3), rows[0].TxIndex)
 }
 
+// TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys
+// verifies that API-mode batched address indexing includes every input class
+// resolved through the skinny address-key lookup.
 func TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys(t *testing.T) {
 	store := setupTestDBWithMode(t, types.StorageModeAPI)
 

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -310,21 +310,37 @@ func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
 	utxoTxId := bytes.Repeat([]byte{0xA1}, 32)
 	paymentKey := bytes.Repeat([]byte{0x11}, 28)
 	stakingKey := bytes.Repeat([]byte{0x22}, 28)
-	utxo := models.Utxo{
-		TxId:       utxoTxId,
-		OutputIdx:  0,
-		AddedSlot:  100,
-		PaymentKey: paymentKey,
-		StakingKey: stakingKey,
-		Amount:     types.Uint64(5000000),
+	refInputTxId := bytes.Repeat([]byte{0xA2}, 32)
+	refPaymentKey := bytes.Repeat([]byte{0x33}, 28)
+	refStakingKey := bytes.Repeat([]byte{0x44}, 28)
+	utxos := []models.Utxo{
+		{
+			TxId:       utxoTxId,
+			OutputIdx:  0,
+			AddedSlot:  100,
+			PaymentKey: paymentKey,
+			StakingKey: stakingKey,
+			Amount:     types.Uint64(5000000),
+		},
+		{
+			TxId:       refInputTxId,
+			OutputIdx:  1,
+			AddedSlot:  100,
+			PaymentKey: refPaymentKey,
+			StakingKey: refStakingKey,
+			Amount:     types.Uint64(6000000),
+		},
 	}
-	require.NoError(t, store.DB().Create(&utxo).Error)
+	require.NoError(t, store.DB().Create(&utxos).Error)
 
 	txHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0xB1}, 32))
 	tx := &mockTransactionWithInputs{
 		mockTransaction: mockTransaction{
 			hash:    txHash,
 			isValid: true,
+			refInputs: []lcommon.TransactionInput{
+				dbtestutil.NewMockInput(refInputTxId, 1),
+			},
 		},
 		consumed: []dbtestutil.MockInput{
 			{TxId: utxoTxId, IndexValue: 0},
@@ -346,13 +362,20 @@ func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
 	var rows []models.AddressTransaction
 	require.NoError(
 		t,
-		store.DB().Where("transaction_id = ?", dbTx.ID).Find(&rows).Error,
+		store.DB().
+			Where("transaction_id = ?", dbTx.ID).
+			Order("payment_key").
+			Find(&rows).Error,
 	)
-	require.Len(t, rows, 1, "duplicate addresses in one tx should be deduplicated")
+	require.Len(t, rows, 2, "duplicate addresses in one tx should be deduplicated")
 	require.Equal(t, paymentKey, rows[0].PaymentKey)
 	require.Equal(t, stakingKey, rows[0].StakingKey)
-	require.Equal(t, point.Slot, rows[0].Slot)
-	require.Equal(t, uint32(3), rows[0].TxIndex)
+	require.Equal(t, refPaymentKey, rows[1].PaymentKey)
+	require.Equal(t, refStakingKey, rows[1].StakingKey)
+	for _, row := range rows {
+		require.Equal(t, point.Slot, row.Slot)
+		require.Equal(t, uint32(3), row.TxIndex)
+	}
 }
 
 // TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys
@@ -430,8 +453,11 @@ func TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys(t *t
 	)
 	require.Len(t, indexed, 3)
 	require.Equal(t, rows[0].PaymentKey, indexed[0].PaymentKey)
+	require.Equal(t, rows[0].StakingKey, indexed[0].StakingKey)
 	require.Equal(t, rows[1].PaymentKey, indexed[1].PaymentKey)
+	require.Equal(t, rows[1].StakingKey, indexed[1].StakingKey)
 	require.Equal(t, rows[2].PaymentKey, indexed[2].PaymentKey)
+	require.Equal(t, rows[2].StakingKey, indexed[2].StakingKey)
 	for _, row := range indexed {
 		require.Equal(t, point.Slot, row.Slot)
 		require.Equal(t, uint32(4), row.TxIndex)

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -355,6 +355,86 @@ func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
 	require.Equal(t, uint32(3), rows[0].TxIndex)
 }
 
+func TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys(t *testing.T) {
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+
+	inputTxId := bytes.Repeat([]byte{0xA1}, 32)
+	collateralTxId := bytes.Repeat([]byte{0xA2}, 32)
+	referenceTxId := bytes.Repeat([]byte{0xA3}, 32)
+	rows := []models.Utxo{
+		{
+			TxId:       inputTxId,
+			OutputIdx:  0,
+			AddedSlot:  100,
+			PaymentKey: bytes.Repeat([]byte{0x11}, 28),
+			StakingKey: bytes.Repeat([]byte{0x21}, 28),
+			Amount:     types.Uint64(1),
+		},
+		{
+			TxId:       collateralTxId,
+			OutputIdx:  1,
+			AddedSlot:  100,
+			PaymentKey: bytes.Repeat([]byte{0x12}, 28),
+			StakingKey: bytes.Repeat([]byte{0x22}, 28),
+			Amount:     types.Uint64(2),
+		},
+		{
+			TxId:       referenceTxId,
+			OutputIdx:  2,
+			AddedSlot:  100,
+			PaymentKey: bytes.Repeat([]byte{0x13}, 28),
+			StakingKey: bytes.Repeat([]byte{0x23}, 28),
+			Amount:     types.Uint64(3),
+		},
+	}
+	require.NoError(t, store.DB().Create(&rows).Error)
+
+	txHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0xB2}, 32))
+	tx := &mockTransaction{
+		hash:    txHash,
+		isValid: true,
+		inputs: []lcommon.TransactionInput{
+			dbtestutil.NewMockInput(inputTxId, 0),
+		},
+		collateral: []lcommon.TransactionInput{
+			dbtestutil.NewMockInput(collateralTxId, 1),
+		},
+		refInputs: []lcommon.TransactionInput{
+			dbtestutil.NewMockInput(referenceTxId, 2),
+		},
+	}
+	point := ocommon.Point{
+		Hash: bytes.Repeat([]byte{0xC2}, 32),
+		Slot: 200,
+	}
+
+	acc := NewBatchAccumulator()
+	require.NoError(t, store.SetTransactionBatched(tx, point, 4, nil, acc, nil))
+	require.NoError(t, store.FlushBatch(acc, nil))
+
+	var dbTx models.Transaction
+	require.NoError(
+		t,
+		store.DB().Where("hash = ?", txHash.Bytes()).First(&dbTx).Error,
+	)
+	var indexed []models.AddressTransaction
+	require.NoError(
+		t,
+		store.DB().
+			Where("transaction_id = ?", dbTx.ID).
+			Order("payment_key").
+			Find(&indexed).Error,
+	)
+	require.Len(t, indexed, 3)
+	require.Equal(t, rows[0].PaymentKey, indexed[0].PaymentKey)
+	require.Equal(t, rows[1].PaymentKey, indexed[1].PaymentKey)
+	require.Equal(t, rows[2].PaymentKey, indexed[2].PaymentKey)
+	for _, row := range indexed {
+		require.Equal(t, point.Slot, row.Slot)
+		require.Equal(t, uint32(4), row.TxIndex)
+	}
+}
+
 // --- Rollback state restoration tests ---
 
 // TestRollbackAccountState tests that RestoreAccountStateAtSlot correctly

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -35,7 +35,7 @@ import (
 
 // setupTestDB creates and initializes a test SQLite database.
 // It returns the store and a cleanup function that should be deferred.
-func setupTestDB(t *testing.T) *MetadataStoreSqlite {
+func setupTestDB(t testing.TB) *MetadataStoreSqlite {
 	t.Helper()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1297,14 +1297,18 @@ func (d *MetadataStoreSqlite) SetTransaction(
 	// Address indexing, witnesses, scripts, redeemers, and plutus data only stored in API mode
 	if d.storageMode == types.StorageModeAPI {
 		// Index unique addresses participating in this transaction.
-		// Includes inputs, collateral inputs, outputs, and collateral return.
+		// Includes inputs, collateral inputs, reference inputs, outputs, and collateral return.
 		addressUtxos := make(
 			[]models.Utxo,
 			0,
-			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(tmpTx.Outputs)+1,
+			len(tmpTx.Inputs)+
+				len(tmpTx.Collateral)+
+				len(tmpTx.ReferenceInputs)+
+				len(tmpTx.Outputs)+1,
 		)
 		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
 		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
+		addressUtxos = append(addressUtxos, tmpTx.ReferenceInputs...)
 		addressUtxos = append(addressUtxos, tmpTx.Outputs...)
 		if tmpTx.CollateralReturn != nil {
 			addressUtxos = append(addressUtxos, *tmpTx.CollateralReturn)

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -236,26 +236,53 @@ func collectAddressTransactions(
 	txIndex uint32,
 	utxos []models.Utxo,
 ) []models.AddressTransaction {
-	ret := make([]models.AddressTransaction, 0, len(utxos))
-	seen := make(map[string]struct{}, len(utxos))
+	addressKeys := make([]UtxoAddressKeys, 0, len(utxos))
 	for _, utxo := range utxos {
-		if len(utxo.PaymentKey) == 0 && len(utxo.StakingKey) == 0 {
+		addressKeys = append(addressKeys, utxoAddressKeysFromUtxo(utxo))
+	}
+	return collectAddressTransactionsFromKeys(
+		transactionID,
+		slot,
+		txIndex,
+		addressKeys,
+	)
+}
+
+func collectAddressTransactionsFromKeys(
+	transactionID uint,
+	slot uint64,
+	txIndex uint32,
+	addressKeys []UtxoAddressKeys,
+) []models.AddressTransaction {
+	ret := make([]models.AddressTransaction, 0, len(addressKeys))
+	seen := make(map[string]struct{}, len(addressKeys))
+	for _, addressKey := range addressKeys {
+		if len(addressKey.PaymentKey) == 0 && len(addressKey.StakingKey) == 0 {
 			continue
 		}
-		key := fmt.Sprintf("%x|%x", utxo.PaymentKey, utxo.StakingKey)
+		key := fmt.Sprintf("%x|%x", addressKey.PaymentKey, addressKey.StakingKey)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
 		ret = append(ret, models.AddressTransaction{
-			PaymentKey:    bytes.Clone(utxo.PaymentKey),
-			StakingKey:    bytes.Clone(utxo.StakingKey),
+			PaymentKey:    bytes.Clone(addressKey.PaymentKey),
+			StakingKey:    bytes.Clone(addressKey.StakingKey),
 			TransactionID: transactionID,
 			Slot:          slot,
 			TxIndex:       txIndex,
 		})
 	}
 	return ret
+}
+
+func utxoAddressKeysFromUtxo(utxo models.Utxo) UtxoAddressKeys {
+	return UtxoAddressKeys{
+		TxId:       utxo.TxId,
+		OutputIdx:  utxo.OutputIdx,
+		PaymentKey: utxo.PaymentKey,
+		StakingKey: utxo.StakingKey,
+	}
 }
 
 // GetTransactionsByAddress returns transactions that involve
@@ -2530,6 +2557,9 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		local.AddCollateralReturn(*colRetUtxo)
 	}
 
+	var collateralAddressKeys map[string]UtxoAddressKeys
+	var refInputAddressKeys map[string]UtxoAddressKeys
+
 	// ------------------------------------------------------------------ //
 	// 3. Collateral / reference-input marker UPDATEs (immediate)         //
 	//    These update UTxOs that already exist from prior blocks.        //
@@ -2542,10 +2572,14 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				OutputIdx: input.Index(),
 			})
 		}
-		collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
+		var err error
+		collateralAddressKeys, err = d.GetUtxoAddressKeysBatch(
+			collateralRefs,
+			txn,
+		)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to batch fetch collateral UTXOs (batched): %w",
+				"failed to batch fetch collateral UTXO address keys (batched): %w",
 				err,
 			)
 		}
@@ -2557,7 +2591,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
 			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
-			if collateralUtxos[key] == nil {
+			if _, ok := collateralAddressKeys[key]; !ok {
 				continue
 			}
 			caseClauses = append(
@@ -2570,7 +2604,6 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				"(tx_id = ? AND output_idx = ?)",
 			)
 			whereArgs = append(whereArgs, inTxId, inIdx)
-			tmpTx.Collateral = append(tmpTx.Collateral, *collateralUtxos[key])
 		}
 		if len(caseClauses) > 0 {
 			args := append(caseArgs, whereArgs...)
@@ -2598,10 +2631,14 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				OutputIdx: input.Index(),
 			})
 		}
-		refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
+		var err error
+		refInputAddressKeys, err = d.GetUtxoAddressKeysBatch(
+			refInputRefs,
+			txn,
+		)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to batch fetch reference input UTXOs (batched): %w",
+				"failed to batch fetch reference input UTXO address keys (batched): %w",
 				err,
 			)
 		}
@@ -2613,7 +2650,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
 			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
-			if refInputUtxos[key] == nil {
+			if _, ok := refInputAddressKeys[key]; !ok {
 				continue
 			}
 			caseClauses = append(
@@ -2626,10 +2663,6 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				"(tx_id = ? AND output_idx = ?)",
 			)
 			whereArgs = append(whereArgs, inTxId, inIdx)
-			tmpTx.ReferenceInputs = append(
-				tmpTx.ReferenceInputs,
-				*refInputUtxos[key],
-			)
 		}
 		if len(caseClauses) > 0 {
 			args := append(caseArgs, whereArgs...)
@@ -2680,7 +2713,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			local.AddDeleteTxID(tmpTx.ID)
 		}
 
-		// Fetch input UTxOs for address-indexing below.
+		// Fetch input address keys for address-indexing below.
 		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
 		for _, input := range tx.Inputs() {
 			inputRefs = append(inputRefs, UtxoRef{
@@ -2688,37 +2721,52 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				OutputIdx: input.Index(),
 			})
 		}
-		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
+		inputAddressKeys, err := d.GetUtxoAddressKeysBatch(inputRefs, txn)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to batch fetch input UTXOs (batched): %w",
+				"failed to batch fetch input UTXO address keys (batched): %w",
 				err,
 			)
 		}
-		for _, input := range tx.Inputs() {
-			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
-			if u := inputUtxos[key]; u != nil {
-				tmpTx.Inputs = append(tmpTx.Inputs, *u)
-			}
-		}
 
 		// Address-transaction index.
-		addressUtxos := make(
-			[]models.Utxo,
+		addressKeys := make(
+			[]UtxoAddressKeys,
 			0,
-			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(outputModels)+1,
+			len(tx.Inputs())+
+				len(tx.Collateral())+
+				len(tx.ReferenceInputs())+
+				len(outputModels)+1,
 		)
-		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
-		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
-		addressUtxos = append(addressUtxos, outputModels...)
-		if colRetUtxo != nil {
-			addressUtxos = append(addressUtxos, *colRetUtxo)
+		for _, input := range tx.Inputs() {
+			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
+			if addressKey, ok := inputAddressKeys[key]; ok {
+				addressKeys = append(addressKeys, addressKey)
+			}
 		}
-		for _, atx := range collectAddressTransactions(
+		for _, input := range tx.Collateral() {
+			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
+			if addressKey, ok := collateralAddressKeys[key]; ok {
+				addressKeys = append(addressKeys, addressKey)
+			}
+		}
+		for _, input := range tx.ReferenceInputs() {
+			key := fmt.Sprintf("%x:%d", input.Id().Bytes(), input.Index())
+			if addressKey, ok := refInputAddressKeys[key]; ok {
+				addressKeys = append(addressKeys, addressKey)
+			}
+		}
+		for _, output := range outputModels {
+			addressKeys = append(addressKeys, utxoAddressKeysFromUtxo(output))
+		}
+		if colRetUtxo != nil {
+			addressKeys = append(addressKeys, utxoAddressKeysFromUtxo(*colRetUtxo))
+		}
+		for _, atx := range collectAddressTransactionsFromKeys(
 			tmpTx.ID,
 			point.Slot,
 			idx,
-			addressUtxos,
+			addressKeys,
 		) {
 			local.AddAddressTx(atx)
 		}

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -33,6 +33,14 @@ type UtxoRef struct {
 	OutputIdx uint32
 }
 
+// UtxoAddressKeys is the skinny UTxO projection needed for address indexing.
+type UtxoAddressKeys struct {
+	TxId       []byte `gorm:"column:tx_id"`
+	PaymentKey []byte `gorm:"column:payment_key"`
+	StakingKey []byte `gorm:"column:staking_key"`
+	OutputIdx  uint32 `gorm:"column:output_idx"`
+}
+
 // GetUtxo returns a Utxo by reference
 func (d *MetadataStoreSqlite) GetUtxo(
 	txId []byte,
@@ -136,6 +144,52 @@ func (d *MetadataStoreSqlite) GetUtxosBatch(
 		for j := range utxos {
 			key := fmt.Sprintf("%x:%d", utxos[j].TxId, utxos[j].OutputIdx)
 			result[key] = &utxos[j]
+		}
+	}
+
+	return result, nil
+}
+
+// GetUtxoAddressKeysBatch retrieves only the UTxO ref and address key columns
+// needed to build address_transaction rows.
+func (d *MetadataStoreSqlite) GetUtxoAddressKeysBatch(
+	refs []UtxoRef,
+	txn types.Txn,
+) (map[string]UtxoAddressKeys, error) {
+	if len(refs) == 0 {
+		return make(map[string]UtxoAddressKeys), nil
+	}
+
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]UtxoAddressKeys, len(refs))
+
+	for i := 0; i < len(refs); i += batchChunkSize {
+		end := min(i+batchChunkSize, len(refs))
+		chunk := refs[i:end]
+
+		conditions := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for _, ref := range chunk {
+			conditions = append(conditions, "(tx_id = ? AND output_idx = ?)")
+			args = append(args, ref.TxId, ref.OutputIdx)
+		}
+
+		var rows []UtxoAddressKeys
+		query := db.Table(utxoRefIndexedTable()).
+			Select("tx_id", "output_idx", "payment_key", "staking_key").
+			Where("deleted_slot = 0").
+			Where("("+strings.Join(conditions, " OR ")+")", args...)
+		if queryResult := query.Find(&rows); queryResult.Error != nil {
+			return nil, queryResult.Error
+		}
+
+		for j := range rows {
+			key := fmt.Sprintf("%x:%d", rows[j].TxId, rows[j].OutputIdx)
+			result[key] = rows[j]
 		}
 	}
 

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -216,6 +216,118 @@ func TestGetUtxosBatchUsesTxIdOutputIndex(t *testing.T) {
 	assert.NotContains(t, plan, "idx_utxo_deleted_slot")
 }
 
+func TestGetUtxoAddressKeysBatchUsesSkinnyTxIdOutputIndexLookup(t *testing.T) {
+	store := setupTestDB(t)
+
+	refs := make([]UtxoRef, 0, 12)
+	for i := range 12 {
+		txID := bytes.Repeat([]byte{byte(i + 1)}, 32)
+		outputIdx := uint32(i % 3) //nolint:gosec
+		row := models.Utxo{
+			TxId:       txID,
+			OutputIdx:  outputIdx,
+			AddedSlot:  uint64(i + 1), //nolint:gosec
+			PaymentKey: bytes.Repeat([]byte{byte(0x40 + i)}, 28),
+			StakingKey: bytes.Repeat([]byte{byte(0x70 + i)}, 28),
+			Amount:     types.Uint64(i + 1),
+		}
+		require.NoError(t, store.DB().Create(&row).Error)
+		refs = append(refs, UtxoRef{TxId: txID, OutputIdx: outputIdx})
+	}
+
+	var capturedSQL string
+	var capturedVars []any
+	callbackName := "test:capture_get_utxo_address_keys_batch_sql"
+	require.NoError(t, store.ReadDB().Callback().Query().
+		After("gorm:query").
+		Register(callbackName, func(tx *gorm.DB) {
+			if capturedSQL != "" {
+				return
+			}
+			capturedSQL = tx.Statement.SQL.String()
+			capturedVars = append([]any(nil), tx.Statement.Vars...)
+		}))
+
+	got, err := store.GetUtxoAddressKeysBatch(refs, nil)
+	require.NoError(t, err)
+	require.Len(t, got, len(refs))
+	require.NotEmpty(t, capturedSQL)
+	require.Contains(t, capturedSQL, "INDEXED BY "+utxoRefLookupIndex)
+	require.Contains(t, capturedSQL, "`tx_id`")
+	require.Contains(t, capturedSQL, "`output_idx`")
+	require.Contains(t, capturedSQL, "`payment_key`")
+	require.Contains(t, capturedSQL, "`staking_key`")
+	require.NotContains(t, capturedSQL, "`amount`")
+	require.NotContains(t, capturedSQL, "`datum_hash`")
+
+	planRows, err := store.DB().
+		Raw(
+			"EXPLAIN QUERY PLAN "+capturedSQL,
+			capturedVars...,
+		).Rows()
+	require.NoError(t, err)
+	defer planRows.Close()
+
+	var details []string
+	for planRows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, planRows.Err())
+	plan := strings.Join(details, "\n")
+	assert.Contains(t, plan, utxoRefLookupIndex)
+	assert.NotContains(t, plan, "idx_utxo_deleted_slot")
+}
+
+func BenchmarkGetUtxoAddressKeysBatch(b *testing.B) {
+	store := setupTestDB(b)
+
+	const rows = 512
+	refs := make([]UtxoRef, 0, rows)
+	for i := range rows {
+		txID := bytes.Repeat([]byte{byte((i % 250) + 1)}, 32)
+		txID[31] = byte(i / 250)
+		outputIdx := uint32(i % 4) //nolint:gosec
+		row := models.Utxo{
+			TxId:       txID,
+			OutputIdx:  outputIdx,
+			AddedSlot:  uint64(i + 1), //nolint:gosec
+			PaymentKey: bytes.Repeat([]byte{byte(0x20 + (i % 80))}, 28),
+			StakingKey: bytes.Repeat([]byte{byte(0x80 + (i % 80))}, 28),
+			Amount:     types.Uint64(i + 1),
+			DatumHash:  bytes.Repeat([]byte{byte(0x40 + (i % 80))}, 32),
+		}
+		require.NoError(b, store.DB().Create(&row).Error)
+		refs = append(refs, UtxoRef{TxId: txID, OutputIdx: outputIdx})
+	}
+
+	b.ReportAllocs()
+	b.Run("full-utxo", func(b *testing.B) {
+		for b.Loop() {
+			got, err := store.GetUtxosBatch(refs, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(got) != len(refs) {
+				b.Fatalf("got %d rows, want %d", len(got), len(refs))
+			}
+		}
+	})
+	b.Run("address-keys", func(b *testing.B) {
+		for b.Loop() {
+			got, err := store.GetUtxoAddressKeysBatch(refs, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(got) != len(refs) {
+				b.Fatalf("got %d rows, want %d", len(got), len(refs))
+			}
+		}
+	})
+}
+
 func sortUtxoIds(ids []models.UtxoId) {
 	sort.Slice(ids, func(i, j int) bool {
 		if c := bytes.Compare(ids[i].Hash, ids[j].Hash); c != 0 {

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -216,6 +216,9 @@ func TestGetUtxosBatchUsesTxIdOutputIndex(t *testing.T) {
 	assert.NotContains(t, plan, "idx_utxo_deleted_slot")
 }
 
+// TestGetUtxoAddressKeysBatchUsesSkinnyTxIdOutputIndexLookup verifies that the
+// address-key lookup selects only the address-index fields and uses the UTxO ref
+// index instead of a broader deleted-slot scan.
 func TestGetUtxoAddressKeysBatchUsesSkinnyTxIdOutputIndexLookup(t *testing.T) {
 	store := setupTestDB(t)
 
@@ -281,6 +284,8 @@ func TestGetUtxoAddressKeysBatchUsesSkinnyTxIdOutputIndexLookup(t *testing.T) {
 	assert.NotContains(t, plan, "idx_utxo_deleted_slot")
 }
 
+// BenchmarkGetUtxoAddressKeysBatch compares the full UTxO batch lookup with
+// the skinny address-key lookup used by API-mode backfill address indexing.
 func BenchmarkGetUtxoAddressKeysBatch(b *testing.B) {
 	store := setupTestDB(b)
 


### PR DESCRIPTION
1. Added a lightweight sqlite lookup for API-mode backfill address indexing and the new lookup fetches only tx_id, output_idx, payment_key, and staking_key. 
2. Added GetUtxoAddressKeysBatch where it query only for the fields needed for address_transaction and query uses tx_id_output_idx.
3. Made changes in SetTransactionBatched to use the skinny lookup for inputs, collateral inputs, and reference inputs. I just kept full utxo lookup in place for paths that need full utxo data.
4. Added tests for query shape, index usage, and batched address indexing.
5. Added a benchmark comparing full UTxO lookup vs lightweight address-key lookup.
6.  Added a test that verifies batched address indexing includes input, collateral, and reference-input address keys.

Closes #2354 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up API-mode backfill by using a skinny SQLite lookup that returns only UTxO address keys for inputs, collateral, and reference inputs. Cuts reads, uses the `tx_id/output_idx` index, and adds targeted tests and a benchmark; closes #2354.

- **Refactors**
  - Added `UtxoAddressKeys` and `GetUtxoAddressKeysBatch` to fetch only `tx_id`, `output_idx`, `payment_key`, and `staking_key` via the `tx_id/output_idx` index.
  - Updated `SetTransactionBatched` to use the skinny lookup for inputs, collateral, and reference inputs; kept full UTxO fetches only where needed. Non-batched `SetTransaction` now also indexes reference inputs.
  - Split address-index building into `collectAddressTransactionsFromKeys` with a helper to map UTxOs to keys.
  - Added tests for query shape and index usage, plus batched and non-batched address indexing covering inputs, collateral, and reference inputs; included a benchmark vs full UTxO lookup.

<sup>Written for commit 9b0a8a14b935366da0049b3f83a0f33d2496a9d3. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2363?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating batched transaction indexing across normal, collateral, and reference inputs; included deduplication and ordering checks
  * Added a benchmark comparing full vs. lightweight address-key batch lookups for performance and allocations

* **Refactor**
  * Address-transaction indexing now includes reference inputs and collateral when building index rows
  * Replaced full-record reads with a lightweight address-key batch lookup to reduce work and improve batched processing efficiency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->