### PR TITLE
fix(database): hydrate snapshot UTxO provenance during bulk import

### DIFF
--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -91,7 +91,7 @@ type UtxoWithOrdering struct {
 // UtxoOrderingCursor is the keyset position for SearchUtxos.
 //
 // Text form (non-empty): slot:block_index:output_idx. GetUtxosByAddressWithOrdering
-// uses INNER JOIN transaction so these come from real chain position (no COALESCE).
+// uses the producing transaction position for ordering.
 type UtxoOrderingCursor struct {
 	Slot       uint64
 	BlockIndex uint32

--- a/database/plugin/metadata/importutil/importutil.go
+++ b/database/plugin/metadata/importutil/importutil.go
@@ -18,6 +18,7 @@ package importutil
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"gorm.io/gorm"
@@ -28,6 +29,14 @@ import (
 // (e.g. SQLite's SQLITE_MAX_VARIABLE_NUMBER, PostgreSQL's
 // 65535 parameter limit).
 const RefetchChunkSize = 500
+
+type utxoProvenanceUpdate struct {
+	txID                    []byte
+	transactionID           *uint
+	collateralReturnForTxID *uint
+	addedSlot               uint64
+	outputIdx               uint32
+}
 
 // BatchRefetchUtxoIDs resolves IDs for UTxOs whose ID was not
 // populated by GORM after an ON CONFLICT DO NOTHING insert. It
@@ -100,6 +109,158 @@ func BatchRefetchUtxoIDs(
 				"batch re-fetch",
 			missing,
 		)
+	}
+	return nil
+}
+
+// BatchHydrateUtxoProvenance attaches transaction provenance to UTxOs that
+// were inserted earlier from a ledger-state snapshot. The chain backfill later
+// replays the producing transaction with the same tx_id/output_idx pair, but
+// the bulk import uses ON CONFLICT DO NOTHING, so conflicted rows need this
+// second pass to gain their transaction foreign key and real added slot.
+func BatchHydrateUtxoProvenance(
+	db *gorm.DB,
+	utxos []models.Utxo,
+	chunkSize int,
+) error {
+	updates := make([]utxoProvenanceUpdate, 0, len(utxos))
+	for i := range utxos {
+		if utxos[i].TransactionID == nil &&
+			utxos[i].CollateralReturnForTxID == nil {
+			continue
+		}
+		updates = append(updates, utxoProvenanceUpdate{
+			txID:                    utxos[i].TxId,
+			outputIdx:               utxos[i].OutputIdx,
+			transactionID:           utxos[i].TransactionID,
+			collateralReturnForTxID: utxos[i].CollateralReturnForTxID,
+			addedSlot:               utxos[i].AddedSlot,
+		})
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = RefetchChunkSize
+	}
+
+	for i := 0; i < len(updates); i += chunkSize {
+		end := min(i+chunkSize, len(updates))
+		if err := hydrateUtxoProvenanceChunk(
+			db,
+			updates[i:end],
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hydrateUtxoProvenanceChunk(
+	db *gorm.DB,
+	updates []utxoProvenanceUpdate,
+) error {
+	txCases := make([]string, 0, len(updates))
+	collateralCases := make([]string, 0, len(updates))
+	slotCases := make([]string, 0, len(updates))
+	where := make([]string, 0, len(updates))
+
+	txArgs := make([]any, 0, len(updates)*3)
+	collateralArgs := make([]any, 0, len(updates)*3)
+	slotArgs := make([]any, 0, len(updates)*3)
+	whereArgs := make([]any, 0, len(updates)*2)
+
+	for i := range updates {
+		u := updates[i]
+		missingProvenance := make([]string, 0, 2)
+
+		if u.transactionID != nil {
+			missingProvenance = append(
+				missingProvenance,
+				"transaction_id IS NULL",
+			)
+			txCases = append(
+				txCases,
+				"WHEN tx_id = ? AND output_idx = ? AND transaction_id IS NULL THEN ?",
+			)
+			txArgs = append(txArgs, u.txID, u.outputIdx, *u.transactionID)
+			slotCases = append(
+				slotCases,
+				"WHEN tx_id = ? AND output_idx = ? AND transaction_id IS NULL THEN ?",
+			)
+			slotArgs = append(slotArgs, u.txID, u.outputIdx, u.addedSlot)
+		}
+		if u.collateralReturnForTxID != nil {
+			missingProvenance = append(
+				missingProvenance,
+				"collateral_return_for_tx_id IS NULL",
+			)
+			collateralCases = append(
+				collateralCases,
+				"WHEN tx_id = ? AND output_idx = ? AND collateral_return_for_tx_id IS NULL THEN ?",
+			)
+			collateralArgs = append(
+				collateralArgs,
+				u.txID,
+				u.outputIdx,
+				*u.collateralReturnForTxID,
+			)
+			slotCases = append(
+				slotCases,
+				"WHEN tx_id = ? AND output_idx = ? AND collateral_return_for_tx_id IS NULL THEN ?",
+			)
+			slotArgs = append(slotArgs, u.txID, u.outputIdx, u.addedSlot)
+		}
+		if len(missingProvenance) == 0 {
+			continue
+		}
+		where = append(
+			where,
+			"(tx_id = ? AND output_idx = ? AND ("+
+				strings.Join(missingProvenance, " OR ")+"))",
+		)
+		whereArgs = append(whereArgs, u.txID, u.outputIdx)
+	}
+
+	assignments := make([]string, 0, 3)
+	args := make([]any, 0, len(updates)*8)
+	if len(txCases) > 0 {
+		assignments = append(
+			assignments,
+			"transaction_id = CASE "+
+				strings.Join(txCases, " ")+" ELSE transaction_id END",
+		)
+		args = append(args, txArgs...)
+	}
+	if len(collateralCases) > 0 {
+		assignments = append(
+			assignments,
+			"collateral_return_for_tx_id = CASE "+
+				strings.Join(collateralCases, " ")+
+				" ELSE collateral_return_for_tx_id END",
+		)
+		args = append(args, collateralArgs...)
+	}
+	if len(slotCases) > 0 {
+		assignments = append(
+			assignments,
+			"added_slot = CASE "+
+				strings.Join(slotCases, " ")+" ELSE added_slot END",
+		)
+		args = append(args, slotArgs...)
+	}
+	if len(assignments) == 0 {
+		return nil
+	}
+	args = append(args, whereArgs...)
+
+	result := db.Exec(
+		"UPDATE utxo SET "+strings.Join(assignments, ", ")+
+			" WHERE "+strings.Join(where, " OR "),
+		args...,
+	)
+	if result.Error != nil {
+		return fmt.Errorf("hydrating UTxO provenance: %w", result.Error)
 	}
 	return nil
 }

--- a/database/plugin/metadata/mysql/import.go
+++ b/database/plugin/metadata/mysql/import.go
@@ -34,10 +34,12 @@ const importUtxoBatchSize = 500
 // so 1000 x 7 = 7000 parameters per batch.
 const importAssetBatchSize = 1000
 
-// ImportUtxos inserts UTxOs in bulk, ignoring duplicates.
-// Assets are inserted in a second pass to avoid cascading
-// the associated Assets into the same bulk INSERT, which can
-// push the packet size over MySQL limits.
+// ImportUtxos inserts UTxOs in bulk. Existing snapshot-imported
+// rows are hydrated with transaction provenance when backfill later
+// replays their producing transaction. Assets are inserted in a
+// second pass to avoid cascading the associated Assets into the
+// same bulk INSERT, which can push the packet size over MySQL
+// limits.
 func (d *MetadataStoreMysql) ImportUtxos(
 	utxos []models.Utxo,
 	txn types.Txn,
@@ -74,6 +76,7 @@ func importUtxosWithDB(
 	}
 
 	// Insert UTxOs (without assets)
+	var hydrationCandidates []models.Utxo
 	for i := 0; i < len(stripped); i += importUtxoBatchSize {
 		end := min(i+importUtxoBatchSize, len(stripped))
 		batch := stripped[i:end]
@@ -87,6 +90,22 @@ func importUtxosWithDB(
 		if result.Error != nil {
 			return fmt.Errorf("import utxos: %w", result.Error)
 		}
+		// Only skipped inserts can correspond to snapshot-imported
+		// rows that still need provenance hydration.
+		if result.RowsAffected != int64(len(batch)) {
+			hydrationCandidates = append(
+				hydrationCandidates,
+				batch...,
+			)
+		}
+	}
+
+	if err := importutil.BatchHydrateUtxoProvenance(
+		db,
+		hydrationCandidates,
+		importUtxoBatchSize,
+	); err != nil {
+		return fmt.Errorf("hydrating utxo provenance: %w", err)
 	}
 
 	// Link assets to their UTxO IDs and batch-insert.

--- a/database/plugin/metadata/postgres/import.go
+++ b/database/plugin/metadata/postgres/import.go
@@ -34,10 +34,12 @@ const importUtxoBatchSize = 500
 // so 1000 x 7 = 7000 parameters per batch.
 const importAssetBatchSize = 1000
 
-// ImportUtxos inserts UTxOs in bulk, ignoring duplicates.
-// Assets are inserted in a second pass to avoid cascading
-// the associated Assets into the same bulk INSERT, which can
-// push the parameter count over PostgreSQL limits.
+// ImportUtxos inserts UTxOs in bulk. Existing snapshot-imported
+// rows are hydrated with transaction provenance when backfill later
+// replays their producing transaction. Assets are inserted in a
+// second pass to avoid cascading the associated Assets into the
+// same bulk INSERT, which can push the parameter count over
+// PostgreSQL limits.
 func (d *MetadataStorePostgres) ImportUtxos(
 	utxos []models.Utxo,
 	txn types.Txn,
@@ -74,6 +76,7 @@ func importUtxosWithDB(
 	}
 
 	// Insert UTxOs (without assets)
+	var hydrationCandidates []models.Utxo
 	for i := 0; i < len(stripped); i += importUtxoBatchSize {
 		end := min(i+importUtxoBatchSize, len(stripped))
 		batch := stripped[i:end]
@@ -87,6 +90,22 @@ func importUtxosWithDB(
 		if result.Error != nil {
 			return fmt.Errorf("import utxos: %w", result.Error)
 		}
+		// Only skipped inserts can correspond to snapshot-imported
+		// rows that still need provenance hydration.
+		if result.RowsAffected != int64(len(batch)) {
+			hydrationCandidates = append(
+				hydrationCandidates,
+				batch...,
+			)
+		}
+	}
+
+	if err := importutil.BatchHydrateUtxoProvenance(
+		db,
+		hydrationCandidates,
+		importUtxoBatchSize,
+	); err != nil {
+		return fmt.Errorf("hydrating utxo provenance: %w", err)
 	}
 
 	// Link assets to their UTxO IDs and batch-insert.

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -35,10 +35,12 @@ const importUtxoBatchSize = 500
 // so 1000 x 7 = 7000 variables per batch.
 const importAssetBatchSize = 1000
 
-// ImportUtxos inserts UTxOs in bulk, ignoring duplicates.
-// Assets are inserted in a second pass to avoid cascading
-// the associated Assets into the same bulk INSERT, which can
-// push the variable count over SQLite limits.
+// ImportUtxos inserts UTxOs in bulk. Existing snapshot-imported
+// rows are hydrated with transaction provenance when backfill later
+// replays their producing transaction. Assets are inserted in a
+// second pass to avoid cascading the associated Assets into the
+// same bulk INSERT, which can push the variable count over SQLite
+// limits.
 func (d *MetadataStoreSqlite) ImportUtxos(
 	utxos []models.Utxo,
 	txn types.Txn,
@@ -77,6 +79,7 @@ func importUtxosWithDB(
 	}
 
 	// Insert UTxOs (without assets)
+	var hydrationCandidates []models.Utxo
 	for i := 0; i < len(stripped); i += importUtxoBatchSize {
 		end := min(i+importUtxoBatchSize, len(stripped))
 		batch := stripped[i:end]
@@ -90,6 +93,22 @@ func importUtxosWithDB(
 		if result.Error != nil {
 			return fmt.Errorf("import utxos: %w", result.Error)
 		}
+		// Only skipped inserts can correspond to snapshot-imported
+		// rows that still need provenance hydration.
+		if result.RowsAffected != int64(len(batch)) {
+			hydrationCandidates = append(
+				hydrationCandidates,
+				batch...,
+			)
+		}
+	}
+
+	if err := importutil.BatchHydrateUtxoProvenance(
+		db,
+		hydrationCandidates,
+		importUtxoBatchSize,
+	); err != nil {
+		return fmt.Errorf("hydrating utxo provenance: %w", err)
 	}
 
 	// Link assets to their UTxO IDs and batch-insert.

--- a/database/plugin/metadata/sqlite/import_test.go
+++ b/database/plugin/metadata/sqlite/import_test.go
@@ -16,12 +16,75 @@ package sqlite
 
 import (
 	"bytes"
+	"context"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 )
+
+type importSQLRecorder struct {
+	mu         sync.Mutex
+	statements []string
+}
+
+func (r *importSQLRecorder) LogMode(
+	gormlogger.LogLevel,
+) gormlogger.Interface {
+	return r
+}
+
+func (*importSQLRecorder) Info(
+	context.Context,
+	string,
+	...interface{},
+) {
+}
+
+func (*importSQLRecorder) Warn(
+	context.Context,
+	string,
+	...interface{},
+) {
+}
+
+func (*importSQLRecorder) Error(
+	context.Context,
+	string,
+	...interface{},
+) {
+}
+
+func (r *importSQLRecorder) Trace(
+	_ context.Context,
+	_ time.Time,
+	fc func() (string, int64),
+	_ error,
+) {
+	sql, _ := fc()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statements = append(r.statements, sql)
+}
+
+func (r *importSQLRecorder) containsUpdate(table string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, stmt := range r.statements {
+		normalized := strings.ToUpper(stmt)
+		if strings.Contains(normalized, "UPDATE") &&
+			strings.Contains(normalized, strings.ToUpper(table)) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestImportUtxosAddsMissingAssetsForExistingUtxo(t *testing.T) {
 	store := setupTestDB(t)
@@ -87,4 +150,157 @@ func TestImportUtxosAddsMissingAssetsForExistingUtxo(t *testing.T) {
 	assert.Equal(t, policyID, assets[1].PolicyId)
 	assert.Equal(t, []byte("61737365742d62"), assets[1].NameHex)
 	assert.Equal(t, []byte("fingerprint-b"), assets[1].Fingerprint)
+}
+
+func TestImportUtxosSkipsHydrationForFreshInsert(t *testing.T) {
+	store := setupTestDB(t)
+
+	txID := bytes.Repeat([]byte{0x41}, 32)
+	tx := models.Transaction{
+		Hash:       txID,
+		Slot:       100,
+		BlockIndex: 1,
+		Valid:      true,
+	}
+	require.NoError(t, store.DB().Create(&tx).Error)
+
+	recorder := &importSQLRecorder{}
+	db := store.DB().Session(&gorm.Session{
+		Logger: recorder,
+	})
+	require.NoError(t, importUtxosWithDB(db, []models.Utxo{{
+		TransactionID: &tx.ID,
+		TxId:          txID,
+		OutputIdx:     0,
+		AddedSlot:     tx.Slot,
+		Amount:        10,
+	}}))
+
+	assert.False(t, recorder.containsUpdate("utxo"))
+}
+
+func TestImportUtxosHydratesSnapshotProvenance(t *testing.T) {
+	store := setupTestDB(t)
+
+	txID := bytes.Repeat([]byte{0x51}, 32)
+	policyID := bytes.Repeat([]byte{0x42}, 28)
+	assetA := models.Asset{
+		PolicyId:    policyID,
+		Name:        []byte("asset-a"),
+		NameHex:     []byte("61737365742d61"),
+		Fingerprint: []byte("fingerprint-a"),
+		Amount:      1,
+	}
+	assetB := models.Asset{
+		PolicyId:    policyID,
+		Name:        []byte("asset-b"),
+		NameHex:     []byte("61737365742d62"),
+		Fingerprint: []byte("fingerprint-b"),
+		Amount:      2,
+	}
+
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 200,
+		Amount:    10,
+		Assets:    []models.Asset{assetA},
+	}}, nil))
+
+	tx := models.Transaction{
+		Hash:       txID,
+		Slot:       100,
+		BlockIndex: 2,
+		Valid:      true,
+	}
+	require.NoError(t, store.DB().Create(&tx).Error)
+
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TransactionID: &tx.ID,
+		TxId:          txID,
+		OutputIdx:     0,
+		AddedSlot:     tx.Slot,
+		Amount:        10,
+		Assets:        []models.Asset{assetA, assetB},
+	}}, nil))
+
+	var got models.Utxo
+	require.NoError(
+		t,
+		store.DB().
+			Where("tx_id = ? AND output_idx = ?", txID, 0).
+			First(&got).Error,
+	)
+	require.NotNil(t, got.TransactionID)
+	assert.Equal(t, tx.ID, *got.TransactionID)
+	assert.Equal(t, tx.Slot, got.AddedSlot)
+
+	var assets []models.Asset
+	require.NoError(
+		t,
+		store.DB().
+			Where("utxo_id = ?", got.ID).
+			Order("name ASC").
+			Find(&assets).Error,
+	)
+	require.Len(t, assets, 2)
+	assert.Equal(t, []byte("asset-a"), assets[0].Name)
+	assert.Equal(t, []byte("asset-b"), assets[1].Name)
+
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 300,
+		Amount:    10,
+		Assets:    []models.Asset{assetA},
+	}}, nil))
+
+	require.NoError(
+		t,
+		store.DB().
+			Where("tx_id = ? AND output_idx = ?", txID, 0).
+			First(&got).Error,
+	)
+	require.NotNil(t, got.TransactionID)
+	assert.Equal(t, tx.ID, *got.TransactionID)
+	assert.Equal(t, tx.Slot, got.AddedSlot)
+}
+
+func TestImportUtxosHydratesSnapshotCollateralReturnProvenance(t *testing.T) {
+	store := setupTestDB(t)
+
+	txID := bytes.Repeat([]byte{0x61}, 32)
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 400,
+		Amount:    10,
+	}}, nil))
+
+	tx := models.Transaction{
+		Hash:       txID,
+		Slot:       250,
+		BlockIndex: 1,
+		Valid:      false,
+	}
+	require.NoError(t, store.DB().Create(&tx).Error)
+
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		CollateralReturnForTxID: &tx.ID,
+		TxId:                    txID,
+		OutputIdx:               0,
+		AddedSlot:               tx.Slot,
+		Amount:                  10,
+	}}, nil))
+
+	var got models.Utxo
+	require.NoError(
+		t,
+		store.DB().
+			Where("tx_id = ? AND output_idx = ?", txID, 0).
+			First(&got).Error,
+	)
+	require.NotNil(t, got.CollateralReturnForTxID)
+	assert.Equal(t, tx.ID, *got.CollateralReturnForTxID)
+	assert.Equal(t, tx.Slot, got.AddedSlot)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hydrates snapshot-imported UTxOs with transaction provenance during bulk import, ensuring `transaction_id`/`collateral_return_for_tx_id` and the correct `added_slot` once backfill replays the producing transaction. Fixes stale snapshot rows and restores correct ordering and lookups.

- **Bug Fixes**
  - Added `importutil.BatchHydrateUtxoProvenance` to batch-update existing UTxOs via CASE-based updates in chunks.
  - Wired hydration into `ImportUtxos` for `mysql`, `postgres`, and `sqlite` after bulk insert; runs only when inserts were skipped (snapshot rows).
  - Added tests for normal outputs, collateral returns, and skipping hydration on fresh inserts; verifies assets link to the hydrated UTxO.
  - Clarified `UtxoOrderingCursor` comment to state ordering uses the producing transaction.

<sup>Written for commit f38ea06ac944a5573552389eddd379f4cba03ce1. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2364?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

