### PR TITLE
fix(mithril): idle-stall detection and retry/resume support

### DIFF
--- a/mithril/download.go
+++ b/mithril/download.go
@@ -28,6 +28,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,13 @@ type DownloadProgress struct {
 // ProgressFunc is a callback invoked periodically during download
 // to report progress.
 type ProgressFunc func(DownloadProgress)
+
+const (
+	defaultDownloadIdleTimeout = 2 * time.Minute
+	defaultDownloadIdleRetries = 3
+)
+
+var errDownloadIdleTimeout = errors.New("download idle timeout")
 
 type countingReader struct {
 	reader io.Reader
@@ -75,6 +83,154 @@ type DownloadConfig struct {
 	Logger *slog.Logger
 	// OnProgress is called periodically with download progress.
 	OnProgress ProgressFunc
+	// IdleTimeout is the maximum time to wait for response headers
+	// or body bytes before retrying. If zero, a conservative default
+	// is used. If negative, idle detection is disabled.
+	IdleTimeout time.Duration
+	// MaxIdleRetries is the number of retry attempts after an idle
+	// timeout. If zero, a conservative default is used.
+	MaxIdleRetries int
+}
+
+// Validate checks DownloadConfig values before use.
+func (cfg DownloadConfig) Validate() error {
+	if cfg.MaxIdleRetries < 0 {
+		return fmt.Errorf(
+			"download config MaxIdleRetries must be >= 0, got %d",
+			cfg.MaxIdleRetries,
+		)
+	}
+	return nil
+}
+
+type idleTimeoutReader struct {
+	reader io.Reader
+	timer  *idleTimer
+}
+
+func newIdleTimeoutReader(
+	reader io.Reader,
+	timeout time.Duration,
+	onIdle func(),
+) *idleTimeoutReader {
+	if timeout <= 0 {
+		return &idleTimeoutReader{reader: reader}
+	}
+	return &idleTimeoutReader{
+		reader: reader,
+		timer:  newIdleTimer(timeout, onIdle),
+	}
+}
+
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	if r.timer != nil {
+		r.timer.Reset()
+		defer r.timer.Stop()
+	}
+	return r.reader.Read(p)
+}
+
+func (r *idleTimeoutReader) Stop() {
+	if r.timer != nil {
+		r.timer.Stop()
+	}
+}
+
+type idleTimer struct {
+	timeout time.Duration
+	onIdle  func()
+
+	mu      sync.Mutex
+	current *idleTimerRun
+}
+
+type idleTimerRun struct {
+	timer *time.Timer
+	done  chan struct{}
+	once  sync.Once
+}
+
+func newIdleTimer(timeout time.Duration, onIdle func()) *idleTimer {
+	if timeout <= 0 {
+		return nil
+	}
+	timer := &idleTimer{
+		timeout: timeout,
+		onIdle:  onIdle,
+	}
+	timer.Reset()
+	return timer
+}
+
+func (t *idleTimer) Reset() {
+	if t == nil {
+		return
+	}
+	t.stopCurrent()
+	t.mu.Lock()
+	t.current = newIdleTimerRun(t.timeout, t.onIdle)
+	t.mu.Unlock()
+}
+
+func (t *idleTimer) Stop() {
+	if t == nil {
+		return
+	}
+	t.stopCurrent()
+}
+
+func (t *idleTimer) stopCurrent() {
+	t.mu.Lock()
+	current := t.current
+	t.current = nil
+	t.mu.Unlock()
+	if current != nil {
+		current.stopAndWait()
+	}
+}
+
+func newIdleTimerRun(timeout time.Duration, onIdle func()) *idleTimerRun {
+	run := &idleTimerRun{done: make(chan struct{})}
+	run.timer = time.AfterFunc(timeout, func() {
+		defer run.closeDone()
+		onIdle()
+	})
+	return run
+}
+
+func (r *idleTimerRun) stopAndWait() {
+	if r.timer.Stop() {
+		r.closeDone()
+	}
+	<-r.done
+}
+
+func (r *idleTimerRun) closeDone() {
+	r.once.Do(func() {
+		close(r.done)
+	})
+}
+
+func (cfg DownloadConfig) idleTimeout() time.Duration {
+	switch {
+	case cfg.IdleTimeout < 0:
+		return 0
+	case cfg.IdleTimeout > 0:
+		return cfg.IdleTimeout
+	default:
+		return defaultDownloadIdleTimeout
+	}
+}
+
+func (cfg DownloadConfig) maxIdleRetries() int {
+	if cfg.MaxIdleRetries > 0 {
+		return cfg.MaxIdleRetries
+	}
+	return defaultDownloadIdleRetries
+}
+
+func downloadIdleTimeoutCause(timeout time.Duration) error {
+	return fmt.Errorf("%w after %s without data", errDownloadIdleTimeout, timeout)
 }
 
 // progressWriter wraps an io.Writer to track bytes written and
@@ -171,12 +327,48 @@ func DownloadSnapshot(
 	ctx context.Context,
 	cfg DownloadConfig,
 ) (string, error) {
+	if err := cfg.Validate(); err != nil {
+		return "", err
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	maxAttempts := cfg.maxIdleRetries() + 1
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		path, err := downloadSnapshotOnce(ctx, cfg)
+		if err == nil {
+			return path, nil
+		}
+		if !errors.Is(err, errDownloadIdleTimeout) ||
+			attempt == maxAttempts ||
+			ctx.Err() != nil {
+			return "", err
+		}
+		cfg.Logger.Warn(
+			"snapshot download stalled, retrying",
+			"component", "mithril",
+			"attempt", attempt,
+			"max_attempts", maxAttempts,
+			"idle_timeout", cfg.idleTimeout(),
+			"error", err,
+		)
+	}
+	return "", errors.New("download retry loop exhausted")
+}
+
+func downloadSnapshotOnce(
+	ctx context.Context,
+	cfg DownloadConfig,
+) (string, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
 	if cfg.URL == "" {
 		return "", errors.New("download URL is empty")
 	}
+	idleTimeout := cfg.idleTimeout()
+	downloadCtx, cancelDownload := context.WithCancelCause(ctx)
+	defer cancelDownload(nil)
 
 	// Ensure destination directory exists
 	if err := os.MkdirAll(cfg.DestDir, 0o750); err != nil {
@@ -199,7 +391,7 @@ func DownloadSnapshot(
 	}
 
 	req, err := http.NewRequestWithContext(
-		ctx,
+		downloadCtx,
 		http.MethodGet,
 		cfg.URL,
 		nil,
@@ -220,10 +412,22 @@ func DownloadSnapshot(
 		Timeout:       0, // No timeout for large downloads
 		CheckRedirect: httpsOnlyRedirect,
 	}
+	var headerTimer *idleTimer
+	if idleTimeout > 0 {
+		headerTimer = newIdleTimer(idleTimeout, func() {
+			cancelDownload(downloadIdleTimeoutCause(idleTimeout))
+		})
+	}
 	resp, err := client.Do( //nolint:gosec // URL from caller-provided config; HTTPS-only redirect policy prevents downgrade
 		req,
 	)
+	if headerTimer != nil {
+		headerTimer.Stop()
+	}
 	if err != nil {
+		if cause := context.Cause(downloadCtx); errors.Is(cause, errDownloadIdleTimeout) {
+			return "", fmt.Errorf("downloading snapshot: %w", cause)
+		}
 		return "", fmt.Errorf("downloading snapshot: %w", err)
 	}
 	if resp == nil || resp.Body == nil {
@@ -292,7 +496,7 @@ func DownloadSnapshot(
 			}
 			// Re-issue request without Range header
 			req, err = http.NewRequestWithContext(
-				ctx,
+				downloadCtx,
 				http.MethodGet,
 				cfg.URL,
 				nil,
@@ -304,11 +508,23 @@ func DownloadSnapshot(
 					err,
 				)
 			}
+			if idleTimeout > 0 {
+				headerTimer = newIdleTimer(idleTimeout, func() {
+					cancelDownload(downloadIdleTimeoutCause(idleTimeout))
+				})
+			}
 			resp2, err := client.Do( //nolint:gosec // same URL retried after Content-Range mismatch
 				req,
 			)
+			if headerTimer != nil {
+				headerTimer.Stop()
+				headerTimer = nil
+			}
 			if err != nil {
 				file.Close()
+				if cause := context.Cause(downloadCtx); errors.Is(cause, errDownloadIdleTimeout) {
+					return "", fmt.Errorf("restarting download: %w", cause)
+				}
 				return "", fmt.Errorf(
 					"restarting download: %w",
 					err,
@@ -438,11 +654,19 @@ func DownloadSnapshot(
 		onProgress:  cfg.OnProgress,
 	}
 
-	if _, err := io.Copy(pw, resp.Body); err != nil {
+	body := newIdleTimeoutReader(resp.Body, idleTimeout, func() {
+		cancelDownload(downloadIdleTimeoutCause(idleTimeout))
+	})
+	if _, err := io.Copy(pw, body); err != nil {
+		body.Stop()
 		file.Close()
 		file = nil
+		if cause := context.Cause(downloadCtx); errors.Is(cause, errDownloadIdleTimeout) {
+			return "", fmt.Errorf("writing snapshot data: %w", cause)
+		}
 		return "", fmt.Errorf("writing snapshot data: %w", err)
 	}
+	body.Stop()
 
 	// Close the file explicitly so write errors (e.g. ENOSPC
 	// during a deferred flush) are not silently ignored.

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -25,7 +25,9 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,6 +125,116 @@ func TestDownloadSnapshotResume(t *testing.T) {
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, fullContent, data)
+}
+
+func TestDownloadSnapshotIdleTimeoutRetriesAndResumes(t *testing.T) {
+	fullContent := []byte("AAABBB")
+	var requestCount atomic.Int32
+	resumeRangeCh := make(chan string, 1)
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch requestCount.Add(1) {
+			case 1:
+				w.Header().Set("Content-Length", fmt.Sprintf("%d", len(fullContent)))
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(fullContent[:3])
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				<-r.Context().Done()
+			default:
+				select {
+				case resumeRangeCh <- r.Header.Get("Range"):
+				default:
+				}
+				w.Header().Set("Content-Range", "bytes 3-5/6")
+				w.Header().Set("Content-Length", "3")
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write(fullContent[3:])
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	destDir := t.TempDir()
+	cfg := DownloadConfig{
+		URL:            server.URL + "/snapshot.tar.zst",
+		DestDir:        destDir,
+		Filename:       "idle-retry.tar.zst",
+		ExpectedSize:   int64(len(fullContent)),
+		IdleTimeout:    50 * time.Millisecond,
+		MaxIdleRetries: 1,
+	}
+	timeout := cfg.IdleTimeout*time.Duration(cfg.MaxIdleRetries+1) +
+		500*time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	path, err := DownloadSnapshot(
+		ctx,
+		cfg,
+	)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(destDir, "idle-retry.tar.zst"), path)
+	require.Equal(t, int32(2), requestCount.Load())
+	require.Equal(
+		t,
+		"bytes=3-",
+		testutil.RequireReceive(
+			t,
+			resumeRangeCh,
+			time.Second,
+			"retry resume range",
+		),
+	)
+	testutil.RequireNoReceive(
+		t,
+		resumeRangeCh,
+		100*time.Millisecond,
+		"no extra resume retries",
+	)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, fullContent, data)
+}
+
+func TestDownloadSnapshotRejectsNegativeMaxIdleRetries(t *testing.T) {
+	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:            "http://example.invalid/snapshot.tar.zst",
+		DestDir:        t.TempDir(),
+		MaxIdleRetries: -1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MaxIdleRetries")
+}
+
+func TestIdleTimeoutReaderStopsTimerBetweenReads(t *testing.T) {
+	idleCh := make(chan struct{}, 1)
+	reader := newIdleTimeoutReader(
+		bytes.NewReader([]byte("abc")),
+		20*time.Millisecond,
+		func() {
+			select {
+			case idleCh <- struct{}{}:
+			default:
+			}
+		},
+	)
+
+	buf := make([]byte, 1)
+	n, err := reader.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, []byte("a"), buf)
+
+	testutil.RequireNoReceive(
+		t,
+		idleCh,
+		50*time.Millisecond,
+		"idle timer should be stopped between reads",
+	)
 }
 
 func TestDownloadSnapshotContextCancel(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects stalls and adds retry/resume for `mithril` snapshot downloads. Prevents hanging downloads and resumes from partial data on network stalls.

- **Bug Fixes**
  - Idle detection on headers and body; cancel on timeout and retry (default 2m, up to 3 retries). Config via IdleTimeout (0 uses default, negative disables) and MaxIdleRetries (must be >= 0).
  - Resume from last byte with HTTP Range; fall back to full download on Content-Range mismatch.
  - Tests cover idle-timeout retry with Range resume, idle timer stopping between reads, and rejecting negative MaxIdleRetries.

<sup>Written for commit 36cf484030f485aba59a80b2ee02348dba0485b3. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2365?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot downloads now support configurable idle-timeout handling with automatic retries and resume support—stalled downloads will retry and continue from the interruption point to improve reliability on slow or unstable networks.
* **Tests**
  * Added unit tests validating retry/resume behavior and idle-timer correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->