### PR TITLE
fix(event): blocking delivery for ordering-critical ledger.chainsync

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -15,8 +15,10 @@
 package event
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -40,7 +42,14 @@ const (
 	AsyncQueueSize          = 1000
 	AsyncWorkerPoolSize     = 4
 	RemoteDeliverTimeout    = 5 * time.Second
+	blockingDeliverRetry    = 10 * time.Millisecond
 )
+
+// ErrEventBusStopped is returned by PublishBlocking when the EventBus is
+// stopping or closed before or during delivery.
+var ErrEventBusStopped = errors.New("event bus stopped")
+
+var errChannelSubscriberClosed = errors.New("channel subscriber closed")
 
 type EventType string
 
@@ -100,6 +109,7 @@ type EventBus struct {
 	stopCh     chan struct{}
 	closed     bool
 	stopped    bool
+	stopSeq    uint64
 	stopMu     sync.RWMutex
 	stopOpMu   sync.Mutex // Serializes Stop() calls to prevent duplicate worker pools
 }
@@ -225,6 +235,29 @@ func (c *channelSubscriber) Deliver(evt Event) (err error) {
 		}
 	}
 	return nil
+}
+
+func (c *channelSubscriber) DeliverBlocking(evt Event) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("channel deliver panic: %v", r)
+		}
+	}()
+	for {
+		c.mu.RLock()
+		if c.closed {
+			c.mu.RUnlock()
+			return errChannelSubscriberClosed
+		}
+		select {
+		case c.ch <- evt:
+			c.mu.RUnlock()
+			return nil
+		default:
+			c.mu.RUnlock()
+		}
+		time.Sleep(blockingDeliverRetry)
+	}
 }
 
 func (c *channelSubscriber) Close() {
@@ -503,6 +536,88 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 	}
 }
 
+// PublishBlocking delivers an event to all subscribers without dropping
+// in-memory channel events when subscriber buffers are full. This should be
+// reserved for ordering-critical streams where loss is worse than applying
+// producer backpressure. It returns ErrEventBusStopped when the bus is
+// stopping or closed before or during delivery.
+func (e *EventBus) PublishBlocking(eventType EventType, evt Event) error {
+	e.stopMu.RLock()
+	if e.stopped || e.closed {
+		e.stopMu.RUnlock()
+		return ErrEventBusStopped
+	}
+	stopSeq := e.stopSeq
+	e.stopMu.RUnlock()
+
+	e.mu.RLock()
+	subList := append([]subscriberEntry(nil), e.subscriberSnapshots[eventType]...)
+	e.mu.RUnlock()
+	if len(subList) == 0 {
+		if e.metrics != nil {
+			e.metrics.eventsTotal.WithLabelValues(string(eventType)).Inc()
+		}
+		return nil
+	}
+	var firstErr error
+	for _, item := range subList {
+		var deliverErr error
+		if item.channelSub != nil {
+			deliverErr = item.channelSub.DeliverBlocking(evt)
+		} else {
+			deliverErr = e.deliverWithTimeout(item.sub, evt)
+		}
+
+		if errors.Is(deliverErr, errChannelSubscriberClosed) {
+			e.stopMu.RLock()
+			stopped := e.stopped || e.closed || e.stopSeq != stopSeq
+			e.stopMu.RUnlock()
+			if stopped {
+				deliverErr = ErrEventBusStopped
+			} else {
+				deliverErr = nil
+			}
+		}
+		if deliverErr != nil {
+			if firstErr == nil {
+				firstErr = deliverErr
+			}
+			e.Unsubscribe(eventType, item.id)
+			if e.metrics != nil {
+				e.metrics.deliveryErrors.WithLabelValues(string(eventType), item.kind).
+					Inc()
+			}
+			if e.Logger != nil {
+				e.Logger.Debug(
+					"event delivery error",
+					"type",
+					eventType,
+					"err",
+					deliverErr,
+				)
+			} else {
+				slog.Default().Debug(
+					"event delivery error",
+					"type",
+					eventType,
+					"err",
+					deliverErr,
+				)
+			}
+		}
+	}
+	if e.metrics != nil {
+		e.metrics.eventsTotal.WithLabelValues(string(eventType)).Inc()
+	}
+	e.stopMu.RLock()
+	stopped := e.stopped || e.closed || e.stopSeq != stopSeq
+	e.stopMu.RUnlock()
+	if firstErr == nil && stopped {
+		firstErr = ErrEventBusStopped
+	}
+	return firstErr
+}
+
 // PublishAsync enqueues an event for asynchronous delivery to all subscribers.
 // This method returns immediately without blocking on subscriber delivery.
 // Use this for non-critical events where immediate delivery is not required.
@@ -597,6 +712,7 @@ func (e *EventBus) shutdown(restart bool) {
 		e.closed = true
 	}
 	e.stopped = true
+	e.stopSeq++
 	e.stopMu.Unlock()
 
 	if !wasAlreadyStopped {
@@ -668,5 +784,8 @@ func (e *EventBus) refreshSubscriberSnapshotLocked(eventType EventType) {
 		}
 		snapshot = append(snapshot, entry)
 	}
+	sort.Slice(snapshot, func(i, j int) bool {
+		return snapshot[i].id < snapshot[j].id
+	})
 	e.subscriberSnapshots[eventType] = snapshot
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -16,13 +16,64 @@ package event_test
 
 import (
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+type publishBlockingGateSubscriber struct {
+	targetData string
+	entered    chan struct{}
+	release    chan struct{}
+	enterOnce  sync.Once
+	closeOnce  sync.Once
+}
+
+func (s *publishBlockingGateSubscriber) Deliver(evt event.Event) error {
+	data, ok := evt.Data.(string)
+	if !ok || data != s.targetData {
+		return nil
+	}
+	s.enterOnce.Do(func() {
+		close(s.entered)
+	})
+	<-s.release
+	return nil
+}
+
+func (s *publishBlockingGateSubscriber) Close() {
+	s.closeOnce.Do(func() {
+		close(s.release)
+	})
+}
+
+func (s *publishBlockingGateSubscriber) Release() {
+	s.Close()
+}
+
+type publishBlockingProbeSubscriber struct {
+	targetData string
+	delivered  chan struct{}
+}
+
+func (s *publishBlockingProbeSubscriber) Deliver(evt event.Event) error {
+	data, ok := evt.Data.(string)
+	if !ok || data != s.targetData {
+		return nil
+	}
+	select {
+	case s.delivered <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *publishBlockingProbeSubscriber) Close() {}
 
 func TestEventBusSingleSubscriber(t *testing.T) {
 	var testEvtData int = 999
@@ -418,6 +469,172 @@ func TestPublishDropsEventsOnFullBuffer(t *testing.T) {
 			t.Fatal("expected buffered event not received")
 		}
 	}
+}
+
+func TestPublishBlockingWaitsForSubscriberCapacity(t *testing.T) {
+	const testEvtType event.EventType = "test.blocking"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	gateSub := &publishBlockingGateSubscriber{
+		targetData: "second",
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	require.NotZero(t, eb.RegisterSubscriber(testEvtType, gateSub))
+
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 1)
+
+	probeSub := &publishBlockingProbeSubscriber{
+		targetData: "second",
+		delivered:  make(chan struct{}, 1),
+	}
+	require.NotZero(t, eb.RegisterSubscriber(testEvtType, probeSub))
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "first"))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eb.PublishBlocking(
+			testEvtType,
+			event.NewEvent(testEvtType, "second"),
+		)
+	}()
+
+	testutil.RequireReceive(
+		t,
+		gateSub.entered,
+		time.Second,
+		"PublishBlocking should enter delivery before capacity is released",
+	)
+	gateSub.Release()
+	testutil.RequireNoReceive(
+		t,
+		probeSub.delivered,
+		50*time.Millisecond,
+		"PublishBlocking reached the next subscriber before channel capacity was available",
+	)
+
+	evt := testutil.RequireReceive(
+		t,
+		subCh,
+		time.Second,
+		"expected first buffered event",
+	)
+	require.Equal(t, "first", evt.Data)
+
+	testutil.RequireReceive(
+		t,
+		probeSub.delivered,
+		time.Second,
+		"PublishBlocking should reach the next subscriber after capacity is available",
+	)
+	err := testutil.RequireReceive(
+		t,
+		done,
+		time.Second,
+		"PublishBlocking did not unblock after capacity was available",
+	)
+	require.NoError(t, err)
+
+	evt = testutil.RequireReceive(
+		t,
+		subCh,
+		time.Second,
+		"expected second event",
+	)
+	require.Equal(t, "second", evt.Data)
+}
+
+func TestPublishBlockingUnblocksOnStop(t *testing.T) {
+	const testEvtType event.EventType = "test.blocking.stop"
+	eb := event.NewEventBus(nil, nil)
+
+	_, _ = eb.SubscribeWithBuffer(testEvtType, 1)
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "first"))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eb.PublishBlocking(
+			testEvtType,
+			event.NewEvent(testEvtType, "second"),
+		)
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		done,
+		50*time.Millisecond,
+		"PublishBlocking returned before Stop",
+	)
+
+	eb.Stop()
+
+	err := testutil.RequireReceive(
+		t,
+		done,
+		time.Second,
+		"PublishBlocking did not unblock after Stop",
+	)
+	require.ErrorIs(t, err, event.ErrEventBusStopped)
+}
+
+func TestPublishBlockingReturnsErrWhenStopCompletesDuringDelivery(
+	t *testing.T,
+) {
+	const testEvtType event.EventType = "test.blocking.stop.remote"
+	eb := event.NewEventBus(nil, nil)
+
+	gateSub := &publishBlockingGateSubscriber{
+		targetData: "blocked",
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	require.NotZero(t, eb.RegisterSubscriber(testEvtType, gateSub))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eb.PublishBlocking(
+			testEvtType,
+			event.NewEvent(testEvtType, "blocked"),
+		)
+	}()
+
+	testutil.RequireReceive(
+		t,
+		gateSub.entered,
+		time.Second,
+		"PublishBlocking did not enter subscriber delivery",
+	)
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		eb.Stop()
+	}()
+	testutil.RequireReceive(
+		t,
+		stopDone,
+		time.Second,
+		"Stop did not complete",
+	)
+
+	err := testutil.RequireReceive(
+		t,
+		done,
+		time.Second,
+		"PublishBlocking did not return after Stop",
+	)
+	require.ErrorIs(t, err, event.ErrEventBusStopped)
+}
+
+func TestPublishBlockingReturnsErrWhenClosed(t *testing.T) {
+	const testEvtType event.EventType = "test.blocking.closed"
+	eb := event.NewEventBus(nil, nil)
+	eb.Close()
+
+	err := eb.PublishBlocking(testEvtType, event.NewEvent(testEvtType, "closed"))
+	require.ErrorIs(t, err, event.ErrEventBusStopped)
 }
 
 // TestSubscribeUsesSmallDefaultBuffer is the regression test for #2106.

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -555,8 +555,10 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	) {
 		return nil
 	}
-	// Generate event
-	o.EventBus.Publish(
+	// Generate event. This stream is ordering-critical: dropping a
+	// rollback/header event can strand the ledger pipeline, so use blocking
+	// delivery to apply backpressure instead of lossy buffer overflow.
+	if err := o.EventBus.PublishBlocking(
 		ledger.ChainsyncEventType,
 		event.NewEvent(
 			ledger.ChainsyncEventType,
@@ -567,7 +569,9 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 				Tip:          tip,
 			},
 		),
-	)
+	); err != nil {
+		return err
+	}
 	o.EventBus.Publish(
 		chainselection.PeerRollbackEventType,
 		event.NewEvent(
@@ -705,7 +709,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				return nil
 			}
 		}
-		o.EventBus.Publish(
+		if err := o.EventBus.PublishBlocking(
 			ledger.ChainsyncEventType,
 			event.NewEvent(
 				ledger.ChainsyncEventType,
@@ -717,7 +721,9 @@ func (o *Ouroboros) chainsyncClientRollForward(
 					Tip:          tip,
 				},
 			),
-		)
+		); err != nil {
+			return err
+		}
 		if point.Slot == tip.Point.Slot &&
 			bytes.Equal(point.Hash, tip.Point.Hash) {
 			if o.ChainsyncState != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dropped `ledger.chainsync` events by adding blocking delivery to the `event` bus and using it in `ouroboros` roll-forward/backward. Applies backpressure and surfaces publish errors to avoid ledger stalls.

- **Bug Fixes**
  - Event bus: added `EventBus.PublishBlocking` and channel `DeliverBlocking` to wait for capacity (10ms retry), return `ErrEventBusStopped` when stopping/closed (including mid-delivery), unsubscribe on delivery error and bump metrics, and sort subscriber snapshots by ID for stable order.
  - Ouroboros: switched roll-forward/backward to `PublishBlocking` for `ledger.ChainsyncEventType` and propagate errors; tests cover capacity wait, unblock on `Stop`, error when `Stop` completes during delivery, and error on closed bus.

<sup>Written for commit f667fadabee56cb1243d609364302ab58cd72b5a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blocking delivery mode so critical events wait for subscriber capacity (or unblock on shutdown); an explicit "event bus stopped" error is exposed.

* **Behavior**
  * Core sync paths now use blocking publishes and propagate publish errors to their callbacks.

* **Tests**
  * Added regression tests for blocked delivery ordering, unblock-on-shutdown, and closed-bus error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->