### PR TITLE
fix(sqlite):  Run SQLite planner stats before API-mode backfill

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -456,12 +456,7 @@ func runMithrilSync(
 	// Enable bulk-load optimizations before launching parallel
 	// goroutines so both importLedgerState and LoadBlobsWithDB
 	// share the same pragma settings without racing.
-	bulkLoadCleanup := node.WithBulkLoadPragmas(db, logger)
-	defer func() {
-		if bulkLoadCleanup != nil {
-			bulkLoadCleanup()
-		}
-	}()
+	defer node.WithBulkLoadPragmas(db, logger)()
 
 	// Import ledger state and copy blocks in parallel.
 	// Ledger state goes to metadata (SQLite), blocks go to the blob
@@ -760,8 +755,6 @@ func runMithrilSync(
 			"backfilling historical metadata for API mode",
 			"component", "mithril",
 		)
-		bulkLoadCleanup()
-		bulkLoadCleanup = nil
 		if err := node.RunPlannerStats(db, logger); err != nil {
 			return fmt.Errorf("running planner statistics before backfill: %w", err)
 		}

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -456,7 +456,12 @@ func runMithrilSync(
 	// Enable bulk-load optimizations before launching parallel
 	// goroutines so both importLedgerState and LoadBlobsWithDB
 	// share the same pragma settings without racing.
-	defer node.WithBulkLoadPragmas(db, logger)()
+	bulkLoadCleanup := node.WithBulkLoadPragmas(db, logger)
+	defer func() {
+		if bulkLoadCleanup != nil {
+			bulkLoadCleanup()
+		}
+	}()
 
 	// Import ledger state and copy blocks in parallel.
 	// Ledger state goes to metadata (SQLite), blocks go to the blob
@@ -755,6 +760,11 @@ func runMithrilSync(
 			"backfilling historical metadata for API mode",
 			"component", "mithril",
 		)
+		bulkLoadCleanup()
+		bulkLoadCleanup = nil
+		if err := node.RunPlannerStats(db, logger); err != nil {
+			return fmt.Errorf("running planner statistics before backfill: %w", err)
+		}
 		bf := node.NewBackfill(db, nodeCfg, logger)
 		bf.DisableNonceComputation()
 		if err := bf.Run(ctx); err != nil {

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -179,7 +179,11 @@ func resumeBackfill(
 		return clearBackfillSyncStatus(db)
 	}
 
-	// Enable bulk-load optimizations for the backfill
+	if err := node.RunPlannerStats(db, logger); err != nil {
+		return fmt.Errorf("running planner statistics before backfill: %w", err)
+	}
+
+	// Enable bulk-load optimizations for the backfill.
 	cleanup := node.WithBulkLoadPragmas(db, logger)
 	defer cleanup()
 

--- a/database/plugin/metadata/sqlite/analyze_test.go
+++ b/database/plugin/metadata/sqlite/analyze_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// insertTestUtxos inserts n UTxO rows so ANALYZE has data to measure.
+func insertTestUtxos(t *testing.T, store *MetadataStoreSqlite, n int) {
+	t.Helper()
+	for i := range n {
+		txID := bytes.Repeat([]byte{byte(i + 1)}, 32)
+		row := models.Utxo{
+			TxId:      txID,
+			OutputIdx: 0,
+			AddedSlot: uint64(i + 1),
+			Amount:    types.Uint64(uint64(i+1) * 1_000_000),
+		}
+		require.NoError(t, store.DB().Create(&row).Error)
+	}
+}
+
+func sqliteStatCount(t *testing.T, store *MetadataStoreSqlite, table string) int64 {
+	t.Helper()
+	var count int64
+	err := store.DB().Raw(
+		"SELECT COUNT(*) FROM sqlite_stat1 WHERE tbl = ?",
+		table,
+	).Scan(&count).Error
+	require.NoError(t, err)
+	return count
+}
+
+// TestUpdatePlannerStats_PopulatesStat1 verifies that after inserting rows and
+// calling UpdatePlannerStats, sqlite_stat1 is populated with at least one entry.
+func TestUpdatePlannerStats_PopulatesStat1(t *testing.T) {
+	store := setupTestDB(t)
+	insertTestUtxos(t, store, 5)
+
+	require.NoError(t, store.UpdatePlannerStats())
+
+	var count int64
+	err := store.DB().Raw("SELECT COUNT(*) FROM sqlite_stat1").Scan(&count).Error
+	require.NoError(t, err)
+	assert.Greater(t, count, int64(0), "sqlite_stat1 should have rows after ANALYZE")
+}
+
+// TestUpdatePlannerStats_CollectsUtxoTableStats verifies that the utxo table
+// specifically gets stats. This is the table that caused bad query plans.
+func TestUpdatePlannerStats_CollectsUtxoTableStats(t *testing.T) {
+	store := setupTestDB(t)
+	insertTestUtxos(t, store, 3)
+
+	require.NoError(t, store.UpdatePlannerStats())
+
+	tableName := (&models.Utxo{}).TableName()
+	assert.Positive(
+		t,
+		sqliteStatCount(t, store, tableName),
+		"sqlite_stat1 should have an entry for the utxo table",
+	)
+}
+
+// TestUpdatePlannerStats_EmptyDB verifies UpdatePlannerStats does not error
+// on a freshly created database with no rows.
+func TestUpdatePlannerStats_EmptyDB(t *testing.T) {
+	store := setupTestDB(t)
+	assert.NoError(t, store.UpdatePlannerStats())
+}
+
+// TestUpdatePlannerStats_Idempotent verifies that calling UpdatePlannerStats
+// more than once does not error. This matters for resume/restart paths.
+func TestUpdatePlannerStats_Idempotent(t *testing.T) {
+	store := setupTestDB(t)
+	insertTestUtxos(t, store, 3)
+
+	require.NoError(t, store.UpdatePlannerStats())
+	require.NoError(t, store.UpdatePlannerStats())
+	assert.Positive(
+		t,
+		sqliteStatCount(t, store, (&models.Utxo{}).TableName()),
+		"sqlite_stat1 should remain populated after repeated ANALYZE",
+	)
+}
+
+func TestUpdatePlannerStats_ReturnsErrorWhenDatabaseClosed(t *testing.T) {
+	store := setupTestDB(t)
+	require.NoError(t, store.Close())
+
+	err := store.UpdatePlannerStats()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "ANALYZE")
+}

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -700,3 +700,16 @@ func (d *MetadataStoreSqlite) RestoreNormalPragmas() error {
 	d.logger.Info("restored normal PRAGMAs")
 	return nil
 }
+
+func (d *MetadataStoreSqlite) UpdatePlannerStats() error {
+	start := time.Now()
+	d.logger.Info("SQLite ANALYZE: collecting query planner statistics")
+	if result := d.DB().Exec("ANALYZE"); result.Error != nil {
+		return fmt.Errorf("ANALYZE: %w", result.Error)
+	}
+	d.logger.Info(
+		"SQLite ANALYZE: complete",
+		"duration", time.Since(start),
+	)
+	return nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1154,6 +1154,12 @@ type BulkLoadOptimizer interface {
 	RestoreNormalPragmas() error
 }
 
+// PlannerStatsUpdater is an optional interface for metadata stores that can
+// collect query-planner statistics. SQLite runs ANALYZE; other backends no-op.
+type PlannerStatsUpdater interface {
+	UpdatePlannerStats() error
+}
+
 // New creates a new metadata store instance using the specified plugin
 func New(pluginName string) (MetadataStore, error) {
 	// Get and start the plugin

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -122,6 +122,19 @@ func WithBulkLoadPragmas(
 	}
 }
 
+// RunPlannerStats collects query-planner statistics on the metadata store
+// if it implements PlannerStatsUpdater. No-op for non-SQLite stores.
+func RunPlannerStats(db *database.Database, logger *slog.Logger) error {
+	updater, ok := db.Metadata().(metadata.PlannerStatsUpdater)
+	if !ok {
+		return nil
+	}
+	if err := updater.UpdatePlannerStats(); err != nil {
+		return fmt.Errorf("planner statistics maintenance: %w", err)
+	}
+	return nil
+}
+
 // LoadWithDB loads immutable DB blocks into the chain. If db is nil,
 // a new database connection is opened (and closed on return).
 func LoadWithDB(

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -448,4 +451,58 @@ func decodeImmutableBlockHeader(
 		)
 	}
 	return header, nil
+}
+
+// TestRunPlannerStats_WithSQLiteStore verifies that RunPlannerStats succeeds
+// against an in-memory SQLite database and populates sqlite_stat1.
+func TestRunPlannerStats_WithSQLiteStore(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.Metadata().ImportUtxos([]models.Utxo{
+		{
+			TxId:      []byte("run_planner_stats_tx_id_00000001"),
+			OutputIdx: 0,
+			AddedSlot: 1,
+			Amount:    types.Uint64(1),
+		},
+	}, nil))
+
+	require.NoError(t, RunPlannerStats(db, slog.Default()))
+
+	sqliteStore, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok, "test database should use SQLite metadata")
+
+	var count int64
+	err := sqliteStore.DB().Raw(
+		"SELECT COUNT(*) FROM sqlite_stat1",
+	).Scan(&count).Error
+	require.NoError(t, err)
+	assert.Positive(t, count, "sqlite_stat1 should be populated")
+}
+
+// TestRunPlannerStats_Idempotent verifies that repeated planner-stat
+// maintenance stays safe for resume/restart paths.
+func TestRunPlannerStats_Idempotent(t *testing.T) {
+	db := newTestDB(t)
+
+	require.NoError(t, RunPlannerStats(db, slog.Default()))
+	require.NoError(t, RunPlannerStats(db, slog.Default()))
+
+	sqliteStore, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok, "test database should use SQLite metadata")
+
+	var count int64
+	err := sqliteStore.DB().Raw(
+		"SELECT COUNT(*) FROM sqlite_stat1",
+	).Scan(&count).Error
+	require.NoError(t, err)
+	assert.Positive(t, count, "sqlite_stat1 should remain populated")
+}
+
+func TestRunPlannerStats_ReturnsErrorWhenUpdaterFails(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.Close())
+
+	err := RunPlannerStats(db, slog.Default())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "planner statistics maintenance")
 }


### PR DESCRIPTION
1. Added a PlannerStatsUpdater metadata-store interface and implemented sqlite planner stats maintenance with ANALYZE.
2. Made changes to run planner stats after mithril ledger-state/UTxO import and before API backfill.
3. Made changes to run planner stats again on backfill resume so interrupted syncs do not skip it indefinitely.
4. Made changes to restore bulk-load PRAGMAs before running ANALYZE.
5. Added log sqlite ANALYZE start/completion statements with duration.
6. Added tests for sqlite_stat1 population, idempotency, and failure cases.

Closes #2356 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs SQLite ANALYZE after Mithril ledger-state/UTxO import and before API-mode backfill, and again on backfill resume, to improve query plans and avoid slow backfills.

- **New Features**
  - Added `PlannerStatsUpdater` and SQLite `UpdatePlannerStats()` to run ANALYZE.
  - Introduced `node.RunPlannerStats()`; called before API backfill and on resume.
  - Runs stats without PRAGMA toggling; executed before bulk-load PRAGMAs.
  - Added logs for ANALYZE start/end with duration and tests for `sqlite_stat1`, idempotency, and failure paths.

<sup>Written for commit d096f91a163d18db5cd8358eb240a8186a0b528a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2367?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic database query statistics collection enables optimized query execution during synchronization and backfill operations.

* **Improvements**
  * Reordered bulk-load and statistics operations to ensure optimal query planner configuration before data processing.

* **Tests**
  * Comprehensive test coverage added for query statistics collection, including idempotency verification and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->