### PR TITLE
fix(database): avoid duplicate UTxO offset writes during Mithril API…

### DIFF
--- a/database/batch.go
+++ b/database/batch.go
@@ -52,6 +52,23 @@ func (d *Database) FlushBatch(
 	return d.metadata.FlushBatch(acc, metadataTxn)
 }
 
+// BatchedTxIngestOpts toggles optional behaviors of SetTransactionBatched.
+//
+// Defaults preserve the original full-write behavior; setters opt callers
+// (currently API-mode Mithril backfill) into write-elision when the offsets
+// are known to already be present.
+type BatchedTxIngestOpts struct {
+	// SkipProducedUtxoOffsetWrites elides blob.SetUtxo calls for produced
+	// outputs. Use when the produced-UTxO offset references for this block
+	// have already been written (e.g. by the Mithril immutable-copy phase
+	// reflected in the immutable_utxo_offsets_tip sync-state key). Offsets
+	// must still be computed and present in the BlockIngestionResult — the
+	// guarantee is verified, only the redundant blob write is dropped.
+	// TX offset writes, metadata writes, and consumed-input handling are
+	// unaffected.
+	SkipProducedUtxoOffsetWrites bool
+}
+
 // SetTransactionBatched stores transaction blob offsets and immediate
 // metadata, while accumulating bulk metadata rows into acc for a later
 // FlushBatch.
@@ -65,6 +82,27 @@ func (d *Database) SetTransactionBatched(
 	offsets *BlockIngestionResult,
 	acc BatchAccumulator,
 	txn *Txn,
+) (retErr error) {
+	return d.SetTransactionBatchedWithOpts(
+		tx, point, idx, updateEpoch, pparamUpdates,
+		certDeposits, offsets, acc, txn,
+		BatchedTxIngestOpts{},
+	)
+}
+
+// SetTransactionBatchedWithOpts is the option-aware form of
+// SetTransactionBatched. See BatchedTxIngestOpts for the available toggles.
+func (d *Database) SetTransactionBatchedWithOpts(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	updateEpoch uint64,
+	pparamUpdates map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate,
+	certDeposits map[int]uint64,
+	offsets *BlockIngestionResult,
+	acc BatchAccumulator,
+	txn *Txn,
+	opts BatchedTxIngestOpts,
 ) (retErr error) {
 	if acc == nil {
 		return errors.New("batch accumulator must not be nil")
@@ -132,6 +170,13 @@ func (d *Database) SetTransactionBatched(
 				outputIdx,
 				point.Slot,
 			)
+		}
+		if opts.SkipProducedUtxoOffsetWrites {
+			// Offset is required to be computed (validated above) so a
+			// regression in the indexer is still caught, but the blob
+			// write itself is elided: the immutable-copy phase already
+			// persisted this exact reference.
+			continue
 		}
 		offsetData := EncodeUtxoOffset(&offset)
 		if err := blob.SetUtxo(blobTxn, txID, outputIdx, offsetData); err != nil {

--- a/database/batch_skip_test.go
+++ b/database/batch_skip_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetTransactionBatchedWithOpts_SkipsProducedUtxoWrites validates the
+// SkipProducedUtxoOffsetWrites optimisation: when the option is set, the
+// per-produced-output blob.SetUtxo calls must be elided so the existing
+// blob entry (written by the Mithril immutable-copy phase) is preserved.
+// The transaction blob and metadata writes must still happen.
+func TestSetTransactionBatchedWithOpts_SkipsProducedUtxoWrites(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+
+	produced := candidate.producerTx.Produced()
+	require.NotEmpty(t, produced, "producer tx must have at least one output")
+
+	// Sentinel value the test will look up after the write. If the skip
+	// path is honored, this exact byte sequence stays under the blob key;
+	// if the skip is broken and SetTransactionBatchedWithOpts wrote the
+	// real offset encoding, the bytes will differ.
+	sentinel := []byte("SENTINEL-OFFSET-VALUE-FOR-SKIP-TEST")
+
+	producedIdx := produced[0].Id.Index()
+	producedTxId := produced[0].Id.Id().Bytes()
+
+	// Stage the sentinel under the produced-UTxO blob key so we can detect
+	// whether a subsequent write actually clobbered it.
+	{
+		txn := db.Transaction(true)
+		require.NoError(t, txn.Do(func(txn *Txn) error {
+			return txn.DB().Blob().SetUtxo(
+				txn.Blob(), producedTxId, producedIdx, sentinel,
+			)
+		}))
+		txn.Release()
+	}
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{SkipProducedUtxoOffsetWrites: true},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+
+	// The sentinel must survive — proves the produced-UTxO write was elided.
+	readTxn := db.Transaction(false)
+	defer readTxn.Release()
+	got, err := readTxn.DB().Blob().GetUtxo(
+		readTxn.Blob(), producedTxId, producedIdx,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, sentinel, got,
+		"SkipProducedUtxoOffsetWrites=true must leave the existing blob value untouched",
+	)
+
+	// The tx-offset blob entry must have been written regardless: the
+	// immutable-copy phase never writes tx offsets, so backfill is the
+	// only source for them.
+	txHash := candidate.producerTx.Hash().Bytes()
+	txBlob, err := readTxn.DB().Blob().GetTx(readTxn.Blob(), txHash)
+	require.NoError(t, err)
+	require.NotEmpty(t, txBlob, "TX offset must still be written when skipping UTxO offsets")
+	require.True(
+		t, IsTxOffsetStorage(txBlob),
+		"TX blob entry must be a valid TX offset reference",
+	)
+}
+
+// TestSetTransactionBatchedWithOpts_DefaultBehaviorWrites confirms that the
+// default (zero-value) options still write the produced-UTxO offset blob,
+// overwriting any prior bytes under that key.
+func TestSetTransactionBatchedWithOpts_DefaultBehaviorWrites(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+
+	produced := candidate.producerTx.Produced()
+	require.NotEmpty(t, produced)
+
+	sentinel := []byte("SHOULD-BE-OVERWRITTEN")
+	producedIdx := produced[0].Id.Index()
+	producedTxId := produced[0].Id.Id().Bytes()
+
+	{
+		txn := db.Transaction(true)
+		require.NoError(t, txn.Do(func(txn *Txn) error {
+			return txn.DB().Blob().SetUtxo(
+				txn.Blob(), producedTxId, producedIdx, sentinel,
+			)
+		}))
+		txn.Release()
+	}
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{}, // default: no skip
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+
+	readTxn := db.Transaction(false)
+	defer readTxn.Release()
+	got, err := readTxn.DB().Blob().GetUtxo(
+		readTxn.Blob(), producedTxId, producedIdx,
+	)
+	require.NoError(t, err)
+	require.NotEqual(
+		t, sentinel, got,
+		"default opts must overwrite the existing blob value with the offset encoding",
+	)
+	require.True(
+		t, IsUtxoOffsetStorage(got),
+		"new blob value must be a valid UTxO offset reference",
+	)
+}
+
+// TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping pins down
+// the invariant that even though the per-output blob write is elided, the
+// indexer-supplied offset must still be present. This catches a regression
+// in offset computation that would otherwise be hidden by the skip path.
+func TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping(
+	t *testing.T,
+) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+
+	// Build an offsets struct missing the first produced UTxO. Skipping
+	// the write must NOT also skip this validity check.
+	complete := mustBlockOffsets(t, candidate.producerBlock)
+	produced := candidate.producerTx.Produced()
+	require.NotEmpty(t, produced)
+	var txHashArray [32]byte
+	copy(txHashArray[:], candidate.producerTx.Hash().Bytes())
+	missingRef := UtxoRef{
+		TxId:      txHashArray,
+		OutputIdx: produced[0].Id.Index(),
+	}
+	require.Contains(t, complete.UtxoOffsets, missingRef)
+	delete(complete.UtxoOffsets, missingRef)
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	err = db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		complete,
+		acc,
+		txn,
+		BatchedTxIngestOpts{SkipProducedUtxoOffsetWrites: true},
+	)
+	require.Error(t, err, "missing offset must still error even with skip enabled")
+	require.Contains(t, err.Error(), "missing UTxO offset")
+}
+
+// TestSetTransactionBatchedWithOpts_BlobStoreUnused proves the skip path
+// makes zero Set/Get calls against the blob store for produced UTxOs.
+// We assert this indirectly by passing a UTxO ref that points to a different
+// (uninitialised) tx id and verifying GetUtxo returns ErrBlobKeyNotFound after
+// the operation — i.e. the skip didn't silently fall back to writing.
+func TestSetTransactionBatchedWithOpts_BlobStoreUnused(t *testing.T) {
+	db, err := New(&Config{
+		DataDir:        t.TempDir(),
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{SkipProducedUtxoOffsetWrites: true},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+
+	// Probe a deliberately-untouched key: the skip path must not have
+	// written under any unrelated produced refs (sanity check the
+	// implementation didn't accidentally broaden the elision).
+	probeTxId := bytes.Repeat([]byte{0xFE}, 32)
+	readTxn := db.Transaction(false)
+	defer readTxn.Release()
+	_, err = readTxn.DB().Blob().GetUtxo(readTxn.Blob(), probeTxId, 0)
+	require.Error(t, err)
+	require.True(
+		t,
+		errors.Is(err, types.ErrBlobKeyNotFound),
+		"expected ErrBlobKeyNotFound for an unrelated key, got %v",
+		err,
+	)
+}

--- a/database/batch_skip_test.go
+++ b/database/batch_skip_test.go
@@ -15,22 +15,86 @@
 package database
 
 import (
-	"bytes"
-	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
 
-	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSetTransactionBatchedWithOpts_SkipsProducedUtxoWrites validates the
-// SkipProducedUtxoOffsetWrites optimisation: when the option is set, the
-// per-produced-output blob.SetUtxo calls must be elided so the existing
-// blob entry (written by the Mithril immutable-copy phase) is preserved.
-// The transaction blob and metadata writes must still happen.
-func TestSetTransactionBatchedWithOpts_SkipsProducedUtxoWrites(t *testing.T) {
+// producedSentinel returns a deterministic per-output sentinel that
+// (importantly) is NOT a valid CborOffset encoding, so a successful
+// blob.SetUtxo call from the production code path will overwrite it
+// with bytes that pass IsUtxoOffsetStorage.
+func producedSentinel(idx uint32) []byte {
+	return []byte(fmt.Sprintf("SENTINEL-PRODUCED-UTXO-%d", idx))
+}
+
+// txSentinel returns a non-offset byte sequence used to seed a TX blob
+// key so we can detect whether SetTransactionBatchedWithOpts overwrote
+// it with a real EncodeTxOffset result.
+func txSentinel() []byte {
+	return []byte("SENTINEL-TX-NOT-AN-OFFSET-ENCODING")
+}
+
+// stagedProducer stores the candidate producer block, then replaces every
+// produced-UTxO blob entry with a sentinel. The returned map gives the
+// caller a sentinel-per-ref lookup for post-condition assertions.
+func stagedProducer(
+	t *testing.T,
+	db *Database,
+	candidate batchedCrossBlockSpendCandidate,
+) map[UtxoRef][]byte {
+	t.Helper()
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+
+	var txHashArray [32]byte
+	copy(txHashArray[:], candidate.producerTx.Hash().Bytes())
+
+	sentinels := make(map[UtxoRef][]byte)
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		blob := txn.DB().Blob()
+		for _, utxo := range candidate.producerTx.Produced() {
+			ref := UtxoRef{
+				TxId:      txHashArray,
+				OutputIdx: utxo.Id.Index(),
+			}
+			s := producedSentinel(ref.OutputIdx)
+			sentinels[ref] = s
+			if err := blob.SetUtxo(
+				txn.Blob(),
+				ref.TxId[:],
+				ref.OutputIdx,
+				s,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+	txn.Release()
+	return sentinels
+}
+
+// stageTxSentinel overwrites the tx-blob entry for the producer tx with
+// a non-offset sentinel so the test can prove SetTransactionBatchedWithOpts
+// actually called blob.SetTx (rather than relying on the seed left behind
+// by storeBlockOffsetsOnly).
+func stageTxSentinel(t *testing.T, db *Database, txHash []byte) []byte {
+	t.Helper()
+	s := txSentinel()
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		return txn.DB().Blob().SetTx(txn.Blob(), txHash, s)
+	}))
+	txn.Release()
+	return s
+}
+
+func openTestDB(t *testing.T) *Database {
+	t.Helper()
 	db, err := New(&Config{
 		DataDir:        t.TempDir(),
 		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -38,33 +102,95 @@ func TestSetTransactionBatchedWithOpts_SkipsProducedUtxoWrites(t *testing.T) {
 		MetadataPlugin: "sqlite",
 	})
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		db.Close() //nolint:errcheck
+	})
+	return db
+}
+
+// TestSetTransactionBatchedWithOpts_SkipsAllProducedUtxoWrites verifies the
+// SkipProducedUtxoOffsetWrites optimisation elides the blob.SetUtxo call for
+// EVERY produced output of the transaction. The test stages a unique sentinel
+// under every produced-UTxO key; if the skip path is honored, all sentinels
+// survive. If any one was overwritten, the implementation would have to be
+// silently writing some refs while elising others.
+//
+// Addresses reviewer feedback that the prior version probed only one or an
+// unrelated key, which could not detect a partial regression.
+func TestSetTransactionBatchedWithOpts_SkipsAllProducedUtxoWrites(t *testing.T) {
+	db := openTestDB(t)
 
 	candidate := findBatchedCrossBlockSpendCandidate(t)
-	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+	sentinels := stagedProducer(t, db, candidate)
+	require.NotEmpty(t, sentinels, "producer tx must have at least one output")
 
-	produced := candidate.producerTx.Produced()
-	require.NotEmpty(t, produced, "producer tx must have at least one output")
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
 
-	// Sentinel value the test will look up after the write. If the skip
-	// path is honored, this exact byte sequence stays under the blob key;
-	// if the skip is broken and SetTransactionBatchedWithOpts wrote the
-	// real offset encoding, the bytes will differ.
-	sentinel := []byte("SENTINEL-OFFSET-VALUE-FOR-SKIP-TEST")
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{SkipProducedUtxoOffsetWrites: true},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
 
-	producedIdx := produced[0].Id.Index()
-	producedTxId := produced[0].Id.Id().Bytes()
+	// Every produced ref must still hold its sentinel. This is the
+	// direct proof that no blob.SetUtxo call landed on any produced key.
+	readTxn := db.Transaction(false)
+	defer readTxn.Release()
+	for ref, want := range sentinels {
+		got, err := readTxn.DB().Blob().GetUtxo(
+			readTxn.Blob(), ref.TxId[:], ref.OutputIdx,
+		)
+		require.NoError(t, err, "GetUtxo %x#%d", ref.TxId[:8], ref.OutputIdx)
+		require.Equalf(
+			t, want, got,
+			"produced UTxO %x#%d was overwritten — skip did not elide its write",
+			ref.TxId[:8], ref.OutputIdx,
+		)
+	}
+}
 
-	// Stage the sentinel under the produced-UTxO blob key so we can detect
-	// whether a subsequent write actually clobbered it.
+// TestSetTransactionBatchedWithOpts_TxOffsetStillWritten proves that even
+// when produced-UTxO writes are elided, the TX offset write still happens.
+// The seed left by storeBlockOffsetsOnly is replaced with a non-offset
+// sentinel so the post-condition is meaningful: the tx blob must be a valid
+// offset reference after the call (which it is not before).
+//
+// Addresses reviewer feedback that the prior assertion was tautological
+// because storeBlockOffsetsOnly had already seeded the tx key.
+func TestSetTransactionBatchedWithOpts_TxOffsetStillWritten(t *testing.T) {
+	db := openTestDB(t)
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	stagedProducer(t, db, candidate)
+
+	txHash := candidate.producerTx.Hash().Bytes()
+	sentinel := stageTxSentinel(t, db, txHash)
+
+	// Sanity-check the seed: before the call, the tx-blob entry must NOT
+	// look like a valid offset. Without this, a no-op implementation
+	// would still pass the post-condition.
 	{
-		txn := db.Transaction(true)
-		require.NoError(t, txn.Do(func(txn *Txn) error {
-			return txn.DB().Blob().SetUtxo(
-				txn.Blob(), producedTxId, producedIdx, sentinel,
-			)
-		}))
-		txn.Release()
+		readTxn := db.Transaction(false)
+		got, err := readTxn.DB().Blob().GetTx(readTxn.Blob(), txHash)
+		readTxn.Release()
+		require.NoError(t, err)
+		require.Equal(t, sentinel, got)
+		require.False(
+			t, IsTxOffsetStorage(got),
+			"sentinel must not be confusable with a valid offset encoding",
+		)
 	}
 
 	acc := db.NewBatchAccumulator()
@@ -87,63 +213,28 @@ func TestSetTransactionBatchedWithOpts_SkipsProducedUtxoWrites(t *testing.T) {
 	require.NoError(t, db.FlushBatch(acc, txn))
 	require.NoError(t, txn.Commit())
 
-	// The sentinel must survive — proves the produced-UTxO write was elided.
 	readTxn := db.Transaction(false)
 	defer readTxn.Release()
-	got, err := readTxn.DB().Blob().GetUtxo(
-		readTxn.Blob(), producedTxId, producedIdx,
-	)
+	got, err := readTxn.DB().Blob().GetTx(readTxn.Blob(), txHash)
 	require.NoError(t, err)
-	require.Equal(
+	require.NotEqual(
 		t, sentinel, got,
-		"SkipProducedUtxoOffsetWrites=true must leave the existing blob value untouched",
+		"TX sentinel must be overwritten — TX offset writes are not part of the skip",
 	)
-
-	// The tx-offset blob entry must have been written regardless: the
-	// immutable-copy phase never writes tx offsets, so backfill is the
-	// only source for them.
-	txHash := candidate.producerTx.Hash().Bytes()
-	txBlob, err := readTxn.DB().Blob().GetTx(readTxn.Blob(), txHash)
-	require.NoError(t, err)
-	require.NotEmpty(t, txBlob, "TX offset must still be written when skipping UTxO offsets")
 	require.True(
-		t, IsTxOffsetStorage(txBlob),
-		"TX blob entry must be a valid TX offset reference",
+		t, IsTxOffsetStorage(got),
+		"TX blob entry must be a valid TX offset reference after the call",
 	)
 }
 
-// TestSetTransactionBatchedWithOpts_DefaultBehaviorWrites confirms that the
-// default (zero-value) options still write the produced-UTxO offset blob,
-// overwriting any prior bytes under that key.
-func TestSetTransactionBatchedWithOpts_DefaultBehaviorWrites(t *testing.T) {
-	db, err := New(&Config{
-		DataDir:        t.TempDir(),
-		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
-		BlobPlugin:     "badger",
-		MetadataPlugin: "sqlite",
-	})
-	require.NoError(t, err)
-	defer db.Close()
+// TestSetTransactionBatchedWithOpts_DefaultBehaviorOverwrites confirms the
+// default (zero-value) options still write produced-UTxO offset blobs.
+func TestSetTransactionBatchedWithOpts_DefaultBehaviorOverwrites(t *testing.T) {
+	db := openTestDB(t)
 
 	candidate := findBatchedCrossBlockSpendCandidate(t)
-	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
-
-	produced := candidate.producerTx.Produced()
-	require.NotEmpty(t, produced)
-
-	sentinel := []byte("SHOULD-BE-OVERWRITTEN")
-	producedIdx := produced[0].Id.Index()
-	producedTxId := produced[0].Id.Id().Bytes()
-
-	{
-		txn := db.Transaction(true)
-		require.NoError(t, txn.Do(func(txn *Txn) error {
-			return txn.DB().Blob().SetUtxo(
-				txn.Blob(), producedTxId, producedIdx, sentinel,
-			)
-		}))
-		txn.Release()
-	}
+	sentinels := stagedProducer(t, db, candidate)
+	require.NotEmpty(t, sentinels)
 
 	acc := db.NewBatchAccumulator()
 	txn := db.Transaction(true)
@@ -167,35 +258,31 @@ func TestSetTransactionBatchedWithOpts_DefaultBehaviorWrites(t *testing.T) {
 
 	readTxn := db.Transaction(false)
 	defer readTxn.Release()
-	got, err := readTxn.DB().Blob().GetUtxo(
-		readTxn.Blob(), producedTxId, producedIdx,
-	)
-	require.NoError(t, err)
-	require.NotEqual(
-		t, sentinel, got,
-		"default opts must overwrite the existing blob value with the offset encoding",
-	)
-	require.True(
-		t, IsUtxoOffsetStorage(got),
-		"new blob value must be a valid UTxO offset reference",
-	)
+	for ref, sentinel := range sentinels {
+		got, err := readTxn.DB().Blob().GetUtxo(
+			readTxn.Blob(), ref.TxId[:], ref.OutputIdx,
+		)
+		require.NoError(t, err)
+		require.NotEqualf(
+			t, sentinel, got,
+			"default opts must overwrite produced UTxO %x#%d",
+			ref.TxId[:8], ref.OutputIdx,
+		)
+		require.True(
+			t, IsUtxoOffsetStorage(got),
+			"overwritten value must be a valid UTxO offset reference",
+		)
+	}
 }
 
-// TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping pins down
-// the invariant that even though the per-output blob write is elided, the
+// TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping pins the
+// invariant that even though the per-output blob write is elided, the
 // indexer-supplied offset must still be present. This catches a regression
 // in offset computation that would otherwise be hidden by the skip path.
 func TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping(
 	t *testing.T,
 ) {
-	db, err := New(&Config{
-		DataDir:        t.TempDir(),
-		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
-		BlobPlugin:     "badger",
-		MetadataPlugin: "sqlite",
-	})
-	require.NoError(t, err)
-	defer db.Close()
+	db := openTestDB(t)
 
 	candidate := findBatchedCrossBlockSpendCandidate(t)
 	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
@@ -219,7 +306,7 @@ func TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping(
 	defer txn.Release()
 	defer txn.Rollback() //nolint:errcheck
 
-	err = db.SetTransactionBatchedWithOpts(
+	err := db.SetTransactionBatchedWithOpts(
 		candidate.producerTx,
 		candidate.producerPoint,
 		candidate.producerIdx,
@@ -233,58 +320,4 @@ func TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping(
 	)
 	require.Error(t, err, "missing offset must still error even with skip enabled")
 	require.Contains(t, err.Error(), "missing UTxO offset")
-}
-
-// TestSetTransactionBatchedWithOpts_BlobStoreUnused proves the skip path
-// makes zero Set/Get calls against the blob store for produced UTxOs.
-// We assert this indirectly by passing a UTxO ref that points to a different
-// (uninitialised) tx id and verifying GetUtxo returns ErrBlobKeyNotFound after
-// the operation — i.e. the skip didn't silently fall back to writing.
-func TestSetTransactionBatchedWithOpts_BlobStoreUnused(t *testing.T) {
-	db, err := New(&Config{
-		DataDir:        t.TempDir(),
-		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
-		BlobPlugin:     "badger",
-		MetadataPlugin: "sqlite",
-	})
-	require.NoError(t, err)
-	defer db.Close()
-
-	candidate := findBatchedCrossBlockSpendCandidate(t)
-	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
-
-	acc := db.NewBatchAccumulator()
-	txn := db.Transaction(true)
-	defer txn.Release()
-	defer txn.Rollback() //nolint:errcheck
-
-	require.NoError(t, db.SetTransactionBatchedWithOpts(
-		candidate.producerTx,
-		candidate.producerPoint,
-		candidate.producerIdx,
-		0,
-		nil,
-		nil,
-		mustBlockOffsets(t, candidate.producerBlock),
-		acc,
-		txn,
-		BatchedTxIngestOpts{SkipProducedUtxoOffsetWrites: true},
-	))
-	require.NoError(t, db.FlushBatch(acc, txn))
-	require.NoError(t, txn.Commit())
-
-	// Probe a deliberately-untouched key: the skip path must not have
-	// written under any unrelated produced refs (sanity check the
-	// implementation didn't accidentally broaden the elision).
-	probeTxId := bytes.Repeat([]byte{0xFE}, 32)
-	readTxn := db.Transaction(false)
-	defer readTxn.Release()
-	_, err = readTxn.DB().Blob().GetUtxo(readTxn.Blob(), probeTxId, 0)
-	require.Error(t, err)
-	require.True(
-		t,
-		errors.Is(err, types.ErrBlobKeyNotFound),
-		"expected ErrBlobKeyNotFound for an unrelated key, got %v",
-		err,
-	)
 }

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -61,9 +61,15 @@ type Backfill struct {
 
 	// immutableUtxoOffsetsTipSlot is the highest slot for which the Mithril
 	// immutable-copy phase already persisted produced-UTxO offset references.
-	// Blocks at or below this slot can have their per-block produced-UTxO
-	// blob writes elided. Zero (the default) means "no skip threshold".
+	// Blocks at or below this slot have their per-block produced-UTxO blob
+	// writes elided. Zero is a legitimate "no skip" value when explicitly set.
 	immutableUtxoOffsetsTipSlot uint64
+	// immutableUtxoOffsetsTipSet records whether the threshold above was
+	// provided by a caller (true) or should be auto-detected at Run() time
+	// (false). This distinguishes "caller explicitly disabled skipping with
+	// SetImmutableUtxoOffsetsTipSlot(0)" from "caller did not configure the
+	// field; auto-detect from the sync-state key".
+	immutableUtxoOffsetsTipSet bool
 
 	// Counters surfaced in the completion log to make the optimisation
 	// observable.
@@ -96,10 +102,14 @@ func (b *Backfill) DisableNonceComputation() {
 // SetImmutableUtxoOffsetsTipSlot informs the backfill that produced-UTxO
 // offset references have already been persisted by the Mithril immutable-copy
 // phase for every block at or below the given slot. The backfill will then
-// elide the redundant blob writes for those blocks. Passing 0 disables the
-// optimisation. Has no effect if called after Run has started.
+// elide the redundant blob writes for those blocks. Passing 0 explicitly
+// disables the optimisation (every block will write offsets even when a
+// matching sync-state marker exists). Calls take effect at Run() entry and
+// suppress the auto-detect from the sync-state key. Has no effect if invoked
+// after Run has started.
 func (b *Backfill) SetImmutableUtxoOffsetsTipSlot(slot uint64) {
 	b.immutableUtxoOffsetsTipSlot = slot
+	b.immutableUtxoOffsetsTipSet = true
 }
 
 // NeedsBackfill checks if there's an incomplete backfill checkpoint.
@@ -567,13 +577,12 @@ func (b *Backfill) Run(ctx context.Context) error {
 		return nil
 	}
 
-	// Auto-detect the immutable-copy offset tip once. Callers that have
-	// already set a threshold via SetImmutableUtxoOffsetsTipSlot keep
-	// their override; otherwise we read the sync state written by the
-	// Mithril immutable-copy phase so the optimisation works even when
-	// Run is invoked outside the mithril sync command (e.g. a recovery
-	// rerun against an existing data directory).
-	if b.immutableUtxoOffsetsTipSlot == 0 {
+	// Auto-detect the immutable-copy offset tip once unless a caller already
+	// configured it via SetImmutableUtxoOffsetsTipSlot. Explicitly-set
+	// values (including 0) are honored; auto-detect only fills an
+	// unconfigured field. This preserves the documented semantics that
+	// SetImmutableUtxoOffsetsTipSlot(0) disables the optimisation.
+	if !b.immutableUtxoOffsetsTipSet {
 		if slot, ok, tipErr := ImmutableUtxoOffsetsTipSlot(b.db); tipErr != nil {
 			b.logger.Warn(
 				"failed to read immutable UTxO offset tip; "+
@@ -590,6 +599,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 				"immutable_utxo_offsets_tip_slot", slot,
 			)
 		}
+		b.immutableUtxoOffsetsTipSet = true
 	}
 
 	tipBlocks, err := database.BlocksRecent(b.db, 1)

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -58,6 +58,17 @@ type Backfill struct {
 	runningNonce   []byte
 	computeNonces  bool
 	epochIdx       int // moving index into epochs for O(1) lookup
+
+	// immutableUtxoOffsetsTipSlot is the highest slot for which the Mithril
+	// immutable-copy phase already persisted produced-UTxO offset references.
+	// Blocks at or below this slot can have their per-block produced-UTxO
+	// blob writes elided. Zero (the default) means "no skip threshold".
+	immutableUtxoOffsetsTipSlot uint64
+
+	// Counters surfaced in the completion log to make the optimisation
+	// observable.
+	skippedBlocks   uint64
+	skippedUtxoRefs uint64
 }
 
 // NewBackfill creates a new Backfill instance.
@@ -80,6 +91,15 @@ func NewBackfill(
 // nonce rows.
 func (b *Backfill) DisableNonceComputation() {
 	b.computeNonces = false
+}
+
+// SetImmutableUtxoOffsetsTipSlot informs the backfill that produced-UTxO
+// offset references have already been persisted by the Mithril immutable-copy
+// phase for every block at or below the given slot. The backfill will then
+// elide the redundant blob writes for those blocks. Passing 0 disables the
+// optimisation. Has no effect if called after Run has started.
+func (b *Backfill) SetImmutableUtxoOffsetsTipSlot(slot uint64) {
+	b.immutableUtxoOffsetsTipSlot = slot
 }
 
 // NeedsBackfill checks if there's an incomplete backfill checkpoint.
@@ -547,6 +567,31 @@ func (b *Backfill) Run(ctx context.Context) error {
 		return nil
 	}
 
+	// Auto-detect the immutable-copy offset tip once. Callers that have
+	// already set a threshold via SetImmutableUtxoOffsetsTipSlot keep
+	// their override; otherwise we read the sync state written by the
+	// Mithril immutable-copy phase so the optimisation works even when
+	// Run is invoked outside the mithril sync command (e.g. a recovery
+	// rerun against an existing data directory).
+	if b.immutableUtxoOffsetsTipSlot == 0 {
+		if slot, ok, tipErr := ImmutableUtxoOffsetsTipSlot(b.db); tipErr != nil {
+			b.logger.Warn(
+				"failed to read immutable UTxO offset tip; "+
+					"backfill will write all offsets",
+				"component", "backfill",
+				"error", tipErr,
+			)
+		} else if ok {
+			b.immutableUtxoOffsetsTipSlot = slot
+			b.logger.Info(
+				"detected immutable UTxO offset tip; "+
+					"redundant blob writes will be skipped below it",
+				"component", "backfill",
+				"immutable_utxo_offsets_tip_slot", slot,
+			)
+		}
+	}
+
 	tipBlocks, err := database.BlocksRecent(b.db, 1)
 	if err != nil {
 		return fmt.Errorf("reading chain tip: %w", err)
@@ -894,6 +939,8 @@ func (b *Backfill) Run(ctx context.Context) error {
 		"blocks_processed", processedBlocks,
 		"transactions_stored", processedTxs,
 		"elapsed", elapsed.Round(time.Second),
+		"skipped_utxo_offset_block_writes", b.skippedBlocks,
+		"skipped_utxo_offset_refs", b.skippedUtxoRefs,
 	)
 	return nil
 }
@@ -910,15 +957,26 @@ func (b *Backfill) processBlockTxsBatched(
 	acc database.BatchAccumulator,
 	txn *database.Txn,
 ) error {
+	opts := database.BatchedTxIngestOpts{
+		SkipProducedUtxoOffsetWrites: b.immutableUtxoOffsetsTipSlot > 0 &&
+			point.Slot <= b.immutableUtxoOffsetsTipSlot,
+	}
+	if opts.SkipProducedUtxoOffsetWrites {
+		b.skippedBlocks++
+	}
 	for i, tx := range txs {
 		updateEpoch, paramUpdates := tx.ProtocolParameterUpdates()
 		certDeposits := b.calculateCertDeposits(
 			tx, eraId, pp,
 		)
-		if err := b.db.SetTransactionBatched(
+		if opts.SkipProducedUtxoOffsetWrites {
+			// Counter is informational; Produced() is cheap (slice length).
+			b.skippedUtxoRefs += uint64(len(tx.Produced()))
+		}
+		if err := b.db.SetTransactionBatchedWithOpts(
 			tx, point, uint32(i), // #nosec G115
 			updateEpoch, paramUpdates,
-			certDeposits, offsets, acc, txn,
+			certDeposits, offsets, acc, txn, opts,
 		); err != nil {
 			return fmt.Errorf("storing TX: %w", err)
 		}

--- a/internal/node/backfill_test.go
+++ b/internal/node/backfill_test.go
@@ -276,6 +276,92 @@ func TestRun_IncompleteCheckpointAtZeroVisitsSlotZero(t *testing.T) {
 		"iterator must also visit slot 1")
 }
 
+// TestBackfill_AutoDetectsImmutableUtxoOffsetsTip ensures that without an
+// explicit setter call, Run() picks up the sync-state marker and applies it
+// as the skip threshold. This is the path Mithril sync depends on.
+func TestBackfill_AutoDetectsImmutableUtxoOffsetsTip(t *testing.T) {
+	db := newTestDB(t)
+	bf := NewBackfill(db, nil, slog.Default())
+
+	require.NoError(t, db.SetSyncState(
+		immutableUtxoOffsetsSyncStateKey, "4242", nil,
+	))
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(
+		&models.BackfillCheckpoint{
+			Phase:      BackfillPhase,
+			LastSlot:   0,
+			TotalSlots: 1,
+			StartedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}, nil,
+	))
+
+	// Empty blob store: Run completes the checkpoint after auto-detect.
+	require.NoError(t, bf.Run(context.Background()))
+	assert.Equal(t, uint64(4242), bf.immutableUtxoOffsetsTipSlot)
+	assert.True(t, bf.immutableUtxoOffsetsTipSet)
+}
+
+// TestBackfill_ExplicitZeroOverridesAutoDetect addresses the reviewer
+// concern that SetImmutableUtxoOffsetsTipSlot(0) is documented as disabling
+// the optimisation. The override bit must beat auto-detection so callers
+// that intentionally need offset repair below the immutable-copy tip cannot
+// have the optimisation silently re-enabled behind their back.
+func TestBackfill_ExplicitZeroOverridesAutoDetect(t *testing.T) {
+	db := newTestDB(t)
+	bf := NewBackfill(db, nil, slog.Default())
+
+	require.NoError(t, db.SetSyncState(
+		immutableUtxoOffsetsSyncStateKey, "4242", nil,
+	))
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(
+		&models.BackfillCheckpoint{
+			Phase:      BackfillPhase,
+			LastSlot:   0,
+			TotalSlots: 1,
+			StartedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}, nil,
+	))
+
+	// Explicit "disable the optimisation" before Run.
+	bf.SetImmutableUtxoOffsetsTipSlot(0)
+	require.NoError(t, bf.Run(context.Background()))
+
+	assert.Equal(
+		t, uint64(0), bf.immutableUtxoOffsetsTipSlot,
+		"explicit SetImmutableUtxoOffsetsTipSlot(0) must beat sync-state auto-detect",
+	)
+}
+
+// TestBackfill_ExplicitNonZeroOverridesAutoDetect rounds out the override
+// semantics: a non-zero explicit value also wins over a different sync-state
+// value, so callers can target a specific threshold (e.g. a unit-test fake
+// or a stricter repair threshold) without depending on what the
+// immutable-copy phase happened to leave behind.
+func TestBackfill_ExplicitNonZeroOverridesAutoDetect(t *testing.T) {
+	db := newTestDB(t)
+	bf := NewBackfill(db, nil, slog.Default())
+
+	require.NoError(t, db.SetSyncState(
+		immutableUtxoOffsetsSyncStateKey, "4242", nil,
+	))
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(
+		&models.BackfillCheckpoint{
+			Phase:      BackfillPhase,
+			LastSlot:   0,
+			TotalSlots: 1,
+			StartedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}, nil,
+	))
+
+	bf.SetImmutableUtxoOffsetsTipSlot(100)
+	require.NoError(t, bf.Run(context.Background()))
+
+	assert.Equal(t, uint64(100), bf.immutableUtxoOffsetsTipSlot)
+}
+
 func TestRun_CancelledContext_WithBlocks(t *testing.T) {
 	db := newTestDB(t)
 	bf := NewBackfill(db, nil, slog.Default())

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -636,28 +636,46 @@ func immutableUtxoOffsetsComplete(
 	db *database.Database,
 	immutableTipSlot uint64,
 ) (bool, error) {
+	slot, ok, err := ImmutableUtxoOffsetsTipSlot(db)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	return slot >= immutableTipSlot, nil
+}
+
+// ImmutableUtxoOffsetsTipSlot reports the latest slot for which the Mithril
+// immutable-copy phase persisted produced-UTxO offset references. The second
+// return value is false when no immutable copy has run (the sync-state key is
+// unset); callers must treat that as "no skip threshold" and write offsets
+// normally.
+func ImmutableUtxoOffsetsTipSlot(
+	db *database.Database,
+) (uint64, bool, error) {
 	val, err := db.GetSyncState(
 		immutableUtxoOffsetsSyncStateKey,
 		nil,
 	)
 	if err != nil {
-		return false, fmt.Errorf(
+		return 0, false, fmt.Errorf(
 			"checking immutable UTxO offset state: %w",
 			err,
 		)
 	}
 	if val == "" {
-		return false, nil
+		return 0, false, nil
 	}
 	slot, err := strconv.ParseUint(val, 10, 64)
 	if err != nil {
-		return false, fmt.Errorf(
+		return 0, false, fmt.Errorf(
 			"parsing immutable UTxO offset state %q: %w",
 			val,
 			err,
 		)
 	}
-	return slot >= immutableTipSlot, nil
+	return slot, true, nil
 }
 
 func markImmutableUtxoOffsetsComplete(


### PR DESCRIPTION
Closes #2352 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip redundant produced UTxO offset writes during Mithril API backfill when the immutable-copy phase already persisted them, reducing blob writes without losing correctness. TX-offset and metadata writes still happen; offsets are still computed and verified.

- **New Features**
  - `database`: Added `BatchedTxIngestOpts` and `SetTransactionBatchedWithOpts`; `SkipProducedUtxoOffsetWrites` elides produced-UTxO blob writes while keeping validation and all other writes; default behavior unchanged.
  - `internal/node`: Backfill auto-detects `immutable_utxo_offsets_tip_slot` and supports `SetImmutableUtxoOffsetsTipSlot` (0 disables); per-block skipping; logs `skipped_utxo_offset_block_writes` and `skipped_utxo_offset_refs`; extracted `ImmutableUtxoOffsetsTipSlot`.
  - Tests: Added cases confirming all produced refs are skipped, TX offsets still written, missing offsets still error; verified auto-detect and explicit override semantics.

<sup>Written for commit 40c04271b2c49d07555ef6a8e0d5bf8f8081b997. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimization to skip redundant produced UTxO offset writes for immutable blocks, reducing unnecessary operations during backfill.
  * New metrics now track skipped block writes and offset references.

* **Tests**
  * Added comprehensive test coverage validating the new offset-skipping behavior, including offset validation and blob-store interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->