### PR TITLE
test(ledger): governance tally and enact

### DIFF
--- a/ledger/governance/enact_test.go
+++ b/ledger/governance/enact_test.go
@@ -280,3 +280,46 @@ func TestApplyTreasuryWithdrawal_CreditsRewardsAndDebitsTreasury(
 	assert.Equal(t, uint64(93), uint64(state.Treasury))
 	assert.Equal(t, uint64(20), uint64(state.Reserves))
 }
+
+func TestApplyTreasuryWithdrawal_RejectsOverdrawnTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 2)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+	require.NoError(t, store.SetNetworkState(6, 20, 1, nil))
+
+	a := &lcommon.TreasuryWithdrawalGovAction{
+		Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 7},
+	}
+	err = applyTreasuryWithdrawal(&EnactmentContext{
+		DB:   db,
+		Slot: 123,
+	}, a)
+	require.ErrorContains(
+		t,
+		err,
+		"treasury withdrawal of 7 exceeds tracked treasury balance 6",
+	)
+
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(5), uint64(account.Reward))
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(6), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -55,6 +55,71 @@ func TestRefundProposalDepositCreditsRewardAccount(t *testing.T) {
 	assert.Equal(t, uint64(12), uint64(account.Reward))
 }
 
+func TestProcessEpochExpiresProposalAndRefundsDeposit(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 2)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	rewardAddrBytes, err := rewardAddr.Bytes()
+	require.NoError(t, err)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+	txHash := testBytes(32, 3)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeInfo),
+		ProposedEpoch: 1,
+		ExpiresEpoch:  4,
+		AnchorURL:     "https://example.invalid/expired",
+		AnchorHash:    testBytes(32, 4),
+		Deposit:       7,
+		ReturnAddress: rewardAddrBytes,
+		AddedSlot:     100,
+	}, nil))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(
+			pparams lcommon.ProtocolParameters,
+			_ any,
+		) (lcommon.ProtocolParameters, error) {
+			return pparams, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	assert.Equal(t, 1, out.ExpiredCount)
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(12), uint64(account.Reward))
+
+	proposal, err := db.GetGovernanceProposal(txHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, proposal.ExpiredEpoch)
+	require.NotNil(t, proposal.ExpiredSlot)
+	assert.Equal(t, uint64(5), *proposal.ExpiredEpoch)
+	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
+}
+
 func TestRewardCreditsRollbackBySlot(t *testing.T) {
 	db, store := newTallyTestDB(t)
 	stakeCred := testBytes(28, 1)

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -282,12 +282,12 @@ func tallyDRepVotes(
 // distribution snapshot at StakeEpoch. Pools that did not vote are not
 // counted.
 //
-// TODO(#1988): account for the SPO reward-account delegation rules from
+// TODO(#2369): account for the SPO reward-account delegation rules from
 // CIP-1694. Pools whose reward account delegates to AlwaysNoConfidence
 // auto-vote per the action's NoConfidence handling, and pools delegating
 // to AlwaysAbstain count toward abstain stake (excluded from the
-// denominator). Wiring this requires the reward-account credit/lookup
-// path tracked alongside #1988.
+// denominator). This is related to the reward-account plumbing from
+// #1988, but the delegation semantics are separate follow-up work.
 func tallySPOVotes(
 	ctx *TallyContext,
 	votes []*models.GovernanceVote,


### PR DESCRIPTION
Closes #1988 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for governance reward-credit and treasury debit paths: reject overdrawn treasury withdrawals and refund deposits when proposals expire, with correct balance and proposal metadata updates. Supports #1988 by verifying reward credits and state changes; also updates a TODO in `tally.go` to `#2369` for SPO delegation follow-up.

<sup>Written for commit 57abed2f7c8364f4e3b1a4aa7e5c2ef25eba150d. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2370?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for treasury withdrawal validation against available balance
  * Added test coverage for proposal expiration handling and deposit refund mechanisms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->