### PR TITLE
fix(database): reward existing accounts and fallback to treasury

### DIFF
--- a/ledger/governance/enact.go
+++ b/ledger/governance/enact.go
@@ -38,6 +38,13 @@ type EnactmentContext struct {
 	Slot     uint64
 	PParams  lcommon.ProtocolParameters
 	UpdateFn func(lcommon.ProtocolParameters, any) (lcommon.ProtocolParameters, error)
+
+	// TreasuryWithdrawalRemaining tracks the ENACT rule's cumulative
+	// withdrawal limit across all treasury-withdrawal actions enacted in
+	// the same epoch boundary. Actual treasury can differ when a withdrawal
+	// target is unregistered because unclaimed amounts remain in treasury.
+	TreasuryWithdrawalRemaining    uint64
+	TreasuryWithdrawalRemainingSet bool
 }
 
 // EnactmentResult is returned from EnactProposal when an action mutates
@@ -178,7 +185,8 @@ func EnactProposal(
 }
 
 // applyTreasuryWithdrawal debits the treasury by the sum of the
-// per-address amounts and credits each destination reward account.
+// per-address amounts, credits registered destination reward accounts,
+// and leaves unclaimed withdrawals in the treasury.
 func applyTreasuryWithdrawal(
 	ctx *EnactmentContext,
 	a *lcommon.TreasuryWithdrawalGovAction,
@@ -206,12 +214,18 @@ func applyTreasuryWithdrawal(
 		}
 		total += amount
 	}
-	if total > treasury {
+	if !ctx.TreasuryWithdrawalRemainingSet {
+		ctx.TreasuryWithdrawalRemaining = treasury
+		ctx.TreasuryWithdrawalRemainingSet = true
+	}
+	if total > ctx.TreasuryWithdrawalRemaining {
 		return fmt.Errorf(
-			"treasury withdrawal of %d exceeds tracked treasury balance %d",
-			total, treasury,
+			"treasury withdrawal of %d exceeds tracked treasury withdrawal capacity %d",
+			total, ctx.TreasuryWithdrawalRemaining,
 		)
 	}
+	ctx.TreasuryWithdrawalRemaining -= total
+	var unclaimed uint64
 	for rewardAddr, amount := range a.Withdrawals {
 		if amount == 0 {
 			continue
@@ -229,19 +243,80 @@ func applyTreasuryWithdrawal(
 		if err != nil {
 			return fmt.Errorf("treasury withdrawal reward account: %w", err)
 		}
-		if err := ctx.DB.AddAccountReward(
+		credited, err := creditRegisteredRewardAccount(
+			ctx.DB,
+			ctx.Txn,
 			stakeCredential,
 			amount,
 			ctx.Slot,
-			ctx.Txn,
-		); err != nil {
-			return fmt.Errorf("credit reward account: %w", err)
+		)
+		if err != nil {
+			return err
+		}
+		if !credited {
+			if unclaimed > ^uint64(0)-amount {
+				return errors.New("unclaimed treasury withdrawal overflow")
+			}
+			unclaimed += amount
 		}
 	}
 	return ctx.DB.Metadata().SetNetworkState(
-		treasury-total,
+		treasury-total+unclaimed,
 		reserves,
 		ctx.Slot,
+		metaTxn,
+	)
+}
+
+func creditRegisteredRewardAccount(
+	db *database.Database,
+	txn *database.Txn,
+	stakeCredential []byte,
+	amount uint64,
+	slot uint64,
+) (bool, error) {
+	err := db.AddAccountReward(stakeCredential, amount, slot, txn)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, models.ErrAccountNotFound) {
+		return false, nil
+	}
+	return false, fmt.Errorf("credit reward account: %w", err)
+}
+
+func addUnclaimedToTreasury(
+	db *database.Database,
+	txn *database.Txn,
+	amount uint64,
+	slot uint64,
+) error {
+	if amount == 0 {
+		return nil
+	}
+	var metaTxn types.Txn
+	if txn != nil {
+		metaTxn = txn.Metadata()
+	}
+	state, err := db.Metadata().GetNetworkState(metaTxn)
+	if err != nil {
+		return fmt.Errorf("get network state: %w", err)
+	}
+	var treasury, reserves uint64
+	if state != nil {
+		treasury = uint64(state.Treasury)
+		reserves = uint64(state.Reserves)
+	}
+	if treasury > ^uint64(0)-amount {
+		return fmt.Errorf(
+			"treasury overflow adding unclaimed reward amount %d",
+			amount,
+		)
+	}
+	return db.Metadata().SetNetworkState(
+		treasury+amount,
+		reserves,
+		slot,
 		metaTxn,
 	)
 }

--- a/ledger/governance/enact_test.go
+++ b/ledger/governance/enact_test.go
@@ -310,7 +310,7 @@ func TestApplyTreasuryWithdrawal_RejectsOverdrawnTreasury(
 	require.ErrorContains(
 		t,
 		err,
-		"treasury withdrawal of 7 exceeds tracked treasury balance 6",
+		"treasury withdrawal of 7 exceeds tracked treasury withdrawal capacity 6",
 	)
 
 	account, err := store.GetAccount(stakeCred, false, nil)
@@ -322,4 +322,128 @@ func TestApplyTreasuryWithdrawal_RejectsOverdrawnTreasury(
 	require.NotNil(t, state)
 	assert.Equal(t, uint64(6), uint64(state.Treasury))
 	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}
+
+func TestApplyTreasuryWithdrawal_LeavesMissingRewardAccountInTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 2)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	a := &lcommon.TreasuryWithdrawalGovAction{
+		Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 7},
+	}
+	err = applyTreasuryWithdrawal(&EnactmentContext{
+		DB:   db,
+		Slot: 123,
+	}, a)
+	require.NoError(t, err)
+
+	active, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	assert.Nil(t, active, "withdrawal must not create a reward account")
+	account, err := store.GetAccount(stakeCred, true, nil)
+	require.NoError(t, err)
+	assert.Nil(t, account)
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(100), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}
+
+func TestApplyTreasuryWithdrawal_LeavesInactiveRewardAccountInTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 3)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+	require.NoError(t, store.DB().
+		Model(&models.Account{}).
+		Where("staking_key = ?", stakeCred).
+		Update("active", false).Error)
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	a := &lcommon.TreasuryWithdrawalGovAction{
+		Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 7},
+	}
+	err = applyTreasuryWithdrawal(&EnactmentContext{
+		DB:   db,
+		Slot: 123,
+	}, a)
+	require.NoError(t, err)
+
+	active, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	assert.Nil(t, active, "withdrawal must not reactivate the reward account")
+	account, err := store.GetAccount(stakeCred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.False(t, account.Active)
+	assert.Equal(t, uint64(5), uint64(account.Reward))
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(100), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}
+
+func TestApplyTreasuryWithdrawal_UnclaimedStillCountsAgainstCapacity(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 4)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	ctx := &EnactmentContext{
+		DB:   db,
+		Slot: 123,
+	}
+	first := &lcommon.TreasuryWithdrawalGovAction{
+		Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 70},
+	}
+	require.NoError(t, applyTreasuryWithdrawal(ctx, first))
+
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(100), uint64(state.Treasury))
+	assert.Equal(t, uint64(30), ctx.TreasuryWithdrawalRemaining)
+
+	second := &lcommon.TreasuryWithdrawalGovAction{
+		Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 40},
+	}
+	err = applyTreasuryWithdrawal(ctx, second)
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"exceeds tracked treasury withdrawal capacity",
+	)
 }

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -100,13 +100,24 @@ func ProcessEpoch(
 	}
 
 	// --- ENACTMENT ----------------------------------------------------
+	initialNetworkState, err := in.DB.Metadata().
+		GetNetworkState(in.Txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf("get initial network state: %w", err)
+	}
+	var treasuryWithdrawalRemaining uint64
+	if initialNetworkState != nil {
+		treasuryWithdrawalRemaining = uint64(initialNetworkState.Treasury)
+	}
 	enactCtx := &EnactmentContext{
-		DB:       in.DB,
-		Txn:      in.Txn,
-		Epoch:    in.NewEpoch,
-		Slot:     in.BoundarySlot,
-		PParams:  in.PParams,
-		UpdateFn: in.UpdateFn,
+		DB:                             in.DB,
+		Txn:                            in.Txn,
+		Epoch:                          in.NewEpoch,
+		Slot:                           in.BoundarySlot,
+		PParams:                        in.PParams,
+		UpdateFn:                       in.UpdateFn,
+		TreasuryWithdrawalRemaining:    treasuryWithdrawalRemaining,
+		TreasuryWithdrawalRemainingSet: true,
 	}
 	ratified, err := in.DB.GetRatifiedGovernanceProposals(in.Txn)
 	if err != nil {
@@ -482,9 +493,9 @@ func isDelayingActionPurpose(purpose govActionPurpose) bool {
 	}
 }
 
-// refundProposalDeposit credits the proposal deposit back to the
-// proposer's reward account. The caller marks the proposal final only
-// after this succeeds so a failed credit rolls back the epoch tick.
+// refundProposalDeposit returns the proposal deposit to the proposer when
+// the return reward account is still registered. If the reward account is
+// missing or inactive, the unclaimed deposit returns to the treasury.
 func refundProposalDeposit(
 	db *database.Database,
 	txn *database.Txn,
@@ -503,13 +514,28 @@ func refundProposalDeposit(
 	if err != nil {
 		return err
 	}
-	if err := db.AddAccountReward(
+	credited, err := creditRegisteredRewardAccount(
+		db,
+		txn,
 		stakeCredential,
 		proposal.Deposit,
 		slot,
-		txn,
-	); err != nil {
-		return fmt.Errorf("credit reward account: %w", err)
+	)
+	if err != nil {
+		return err
+	}
+	if !credited {
+		if err := addUnclaimedToTreasury(
+			db,
+			txn,
+			proposal.Deposit,
+			slot,
+		); err != nil {
+			return fmt.Errorf(
+				"return unclaimed proposal deposit to treasury: %w",
+				err,
+			)
+		}
 	}
 	return nil
 }

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,228 @@ func TestProcessEpochExpiresProposalAndRefundsDeposit(t *testing.T) {
 	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
 }
 
+func TestProcessEpochReturnsMissingRewardAccountRefundToTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 2)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	rewardAddrBytes, err := rewardAddr.Bytes()
+	require.NoError(t, err)
+	txHash := testBytes(32, 3)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeInfo),
+		ProposedEpoch: 1,
+		ExpiresEpoch:  4,
+		AnchorURL:     "https://example.invalid/expired",
+		AnchorHash:    testBytes(32, 4),
+		Deposit:       7,
+		ReturnAddress: rewardAddrBytes,
+		AddedSlot:     100,
+	}, nil))
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(
+			pparams lcommon.ProtocolParameters,
+			_ any,
+		) (lcommon.ProtocolParameters, error) {
+			return pparams, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+	assert.Equal(t, 1, out.ExpiredCount)
+
+	active, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	assert.Nil(t, active, "refund must not create a reward account")
+	account, err := store.GetAccount(stakeCred, true, nil)
+	require.NoError(t, err)
+	assert.Nil(t, account)
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(107), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+
+	proposal, err := db.GetGovernanceProposal(txHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, proposal.ExpiredEpoch)
+	require.NotNil(t, proposal.ExpiredSlot)
+	assert.Equal(t, uint64(5), *proposal.ExpiredEpoch)
+	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
+}
+
+func TestProcessEpochUnclaimedDepositDoesNotIncreaseWithdrawalCapacity(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	missingStakeCred := testBytes(28, 5)
+	missingReturnAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		missingStakeCred,
+	)
+	require.NoError(t, err)
+	missingReturnAddrBytes, err := missingReturnAddr.Bytes()
+	require.NoError(t, err)
+
+	withdrawStakeCred := testBytes(28, 6)
+	withdrawAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		withdrawStakeCred,
+	)
+	require.NoError(t, err)
+	withdrawAddrBytes, err := withdrawAddr.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: withdrawStakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	constitutionAction := &lcommon.NewConstitutionGovAction{Type: 5}
+	constitutionAction.Constitution.Anchor.Url =
+		"https://example.invalid/constitution"
+	copy(
+		constitutionAction.Constitution.Anchor.DataHash[:],
+		testBytes(32, 7),
+	)
+	constitutionCbor, err := cbor.Encode(constitutionAction)
+	require.NoError(t, err)
+	withdrawalCbor, err := cbor.Encode(
+		&lcommon.TreasuryWithdrawalGovAction{
+			Type: 2,
+			Withdrawals: map[*lcommon.Address]uint64{
+				&withdrawAddr: 120,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        testBytes(32, 8),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeNewConstitution),
+		ProposedEpoch: 3,
+		ExpiresEpoch:  10,
+		RatifiedEpoch: &ratifiedEpoch,
+		RatifiedSlot:  &ratifiedSlot,
+		AnchorURL:     "https://example.invalid/proposal-a",
+		AnchorHash:    testBytes(32, 9),
+		Deposit:       50,
+		ReturnAddress: missingReturnAddrBytes,
+		GovActionCbor: constitutionCbor,
+		AddedSlot:     100,
+	}, nil))
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        testBytes(32, 10),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		ProposedEpoch: 3,
+		ExpiresEpoch:  10,
+		RatifiedEpoch: &ratifiedEpoch,
+		RatifiedSlot:  &ratifiedSlot,
+		AnchorURL:     "https://example.invalid/proposal-b",
+		AnchorHash:    testBytes(32, 11),
+		Deposit:       0,
+		ReturnAddress: withdrawAddrBytes,
+		GovActionCbor: withdrawalCbor,
+		AddedSlot:     101,
+	}, nil))
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	_, err = ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(
+			pparams lcommon.ProtocolParameters,
+			_ any,
+		) (lcommon.ProtocolParameters, error) {
+			return pparams, nil
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"exceeds tracked treasury withdrawal capacity 100",
+	)
+}
+
+func TestRefundProposalDepositReturnsInactiveRewardAccountToTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 5)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	rewardAddrBytes, err := rewardAddr.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(5),
+		Active:     true,
+	}).Error)
+	require.NoError(t, store.DB().
+		Model(&models.Account{}).
+		Where("staking_key = ?", stakeCred).
+		Update("active", false).Error)
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	err = refundProposalDeposit(db, nil, &models.GovernanceProposal{
+		Deposit:       7,
+		ReturnAddress: rewardAddrBytes,
+	}, 123)
+	require.NoError(t, err)
+
+	active, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	assert.Nil(t, active, "refund must not reactivate the reward account")
+	account, err := store.GetAccount(stakeCred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.False(t, account.Active)
+	assert.Equal(t, uint64(5), uint64(account.Reward))
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(107), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}
 func TestRewardCreditsRollbackBySlot(t *testing.T) {
 	db, store := newTallyTestDB(t)
 	stakeCred := testBytes(28, 1)


### PR DESCRIPTION
Closes #2360 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes governance rewards and proposal deposit refunds to credit only existing, active reward accounts; unclaimed amounts return to the treasury. Enforces a per-epoch treasury withdrawal capacity tracked across all actions at the epoch boundary.

- **Bug Fixes**
  - Treasury withdrawals use remaining per-epoch capacity (initialized from the epoch’s starting treasury) and reject over-capacity; unclaimed payouts stay in treasury and still consume capacity, with no account creation or reactivation.
  - Proposal deposit refunds credit the proposer only if their reward account is registered and active; otherwise the deposit goes back to the treasury and does not increase withdrawal capacity.
  - Added tests for missing/inactive reward accounts, capacity enforcement across multiple withdrawals, and refund behavior.

<sup>Written for commit 8e14ac2b0db9287bc6c2506e4fc1a899f50a9a5e. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-epoch tracking of treasury withdrawal capacity, initialized during epoch processing.

* **Bug Fixes**
  * Preserve unclaimed amounts when destination reward accounts are missing or inactive; only registered accounts are credited.
  * Update treasury accounting to subtract requested totals then restore unclaimed amounts; enforce withdrawals against tracked remaining capacity.

* **Tests**
  * Added tests for missing/inactive reward accounts and capacity enforcement across withdrawals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->