### PR TITLE
fix(ledger): wire live reconciler into plateau watchdog (#2349)

### DIFF
--- a/Dockerfile.bbhmm-pr2349
+++ b/Dockerfile.bbhmm-pr2349
@@ -1,8 +1,0 @@
-# Overlay image for testing fix/2349-reconcile-chain-ahead.
-# Copies a locally-built patched dingo binary over the v0.46.4 release.
-#
-# Build:
-#   GOOS=linux GOARCH=amd64 go build -trimpath -ldflags='-s -w' -o dingo ./cmd/dingo
-#   docker build -f Dockerfile.bbhmm-pr2349 -t bbhmm-local/dingo:0.46.4-pr2349 .
-FROM ghcr.io/blinklabs-io/dingo:0.46.4
-COPY --chown=root:root dingo /bin/dingo

--- a/Dockerfile.bbhmm-pr2349
+++ b/Dockerfile.bbhmm-pr2349
@@ -1,0 +1,8 @@
+# Overlay image for testing fix/2349-reconcile-chain-ahead.
+# Copies a locally-built patched dingo binary over the v0.46.4 release.
+#
+# Build:
+#   GOOS=linux GOARCH=amd64 go build -trimpath -ldflags='-s -w' -o dingo ./cmd/dingo
+#   docker build -f Dockerfile.bbhmm-pr2349 -t bbhmm-local/dingo:0.46.4-pr2349 .
+FROM ghcr.io/blinklabs-io/dingo:0.46.4
+COPY --chown=root:root dingo /bin/dingo

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1334,6 +1334,64 @@ func TestReconcilePrimaryChainTipWithLedgerTipRollsBackMissingLedgerTipToCommonA
 	assert.Equal(t, fixture.ancestorTip.Point.Hash, rows[0].Hash)
 }
 
+// TestReconcileLivePrimaryChainLedgerDivergenceExportedWrapperRecoversSubKFork
+// pins the wire-in the plateau-watchdog path depends on
+// (node_chainsync_recycler.go). Sub-K same-slot fork resolutions can
+// advance chain.Tip() to the canonical hash while leaving the ledger
+// pipeline pinned on the abandoned hash, with no error returned and
+// therefore no caller of the existing in-package live-reconciler.
+// The exported wrapper is what node-level watchdog code can invoke
+// to repair the divergence in place — without it, the plateau path
+// can only recycle the upstream peer, which does not unstick a
+// locally-pinned ledger.
+func TestReconcileLivePrimaryChainLedgerDivergenceExportedWrapperRecoversSubKFork(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	forkHash := testHashBytes("live-sub-k-fork")
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        fixture.currentTip.Point.Slot + 5,
+			Hash:        forkHash,
+			BlockNumber: fixture.currentTip.BlockNumber + 1,
+			Type:        1,
+			PrevHash:    fixture.ancestorTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+	require.NotEqual(
+		t,
+		fixture.ls.chain.Tip(),
+		fixture.ls.currentTip,
+		"test setup must produce a chain/ledger tip divergence",
+	)
+	require.Equal(
+		t,
+		fixture.currentTip,
+		fixture.ls.currentTip,
+		"currentTip must remain at the post-switch abandoned hash",
+	)
+
+	reconciled, err := fixture.ls.ReconcileLivePrimaryChainLedgerDivergence(
+		"local tip plateau",
+		fixture.connId,
+	)
+	require.NoError(t, err)
+	require.True(
+		t,
+		reconciled,
+		"exported reconciler must report success",
+	)
+
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+	assert.True(
+		t,
+		bytes.Equal(fixture.ancestorNonce, fixture.ls.currentTipBlockNonce),
+	)
+}
+
 func TestReconcilePrimaryChainTipWithLedgerTipRewindsPrimaryChainWhenAheadBeyondK(
 	t *testing.T,
 ) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4318,6 +4318,22 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 	return nil
 }
 
+// ReconcileLivePrimaryChainLedgerDivergence is the exported entry
+// point into the live-divergence reconciler. The plateau watchdog
+// calls this when local tip has not advanced for plateau_duration
+// while peers report a higher tip: if primary chain has advanced but
+// the ledger pipeline is stuck on an abandoned same-slot fork, this
+// rolls back the ledger to the latest common ancestor so forward
+// application from the canonical chain can resume without a process
+// or container restart. Returns (true, nil) when reconciliation
+// happened, (false, nil) when no divergence was found.
+func (ls *LedgerState) ReconcileLivePrimaryChainLedgerDivergence(
+	reason string,
+	connId ouroboros.ConnectionId,
+) (bool, error) {
+	return ls.reconcileLivePrimaryChainLedgerDivergence(reason, connId)
+}
+
 func (ls *LedgerState) reconcileLivePrimaryChainLedgerDivergence(
 	reason string,
 	connId ouroboros.ConnectionId,

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -202,31 +202,74 @@ func (n *Node) processChainsyncRecyclerTick(
 						// instead of every tick.
 						*lastProgressAt = now
 					} else {
-						n.config.logger.Warn(
-							"local tip plateau detected, resyncing chainsync client",
-							"connection_id", connKey,
-							"local_tip_slot", localTipSlot,
-							"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
-							"plateau_duration", now.Sub(*lastProgressAt),
-						)
-						n.eventBus.Publish(
-							event.ChainsyncResyncEventType,
-							event.NewEvent(
+						// Before recycling the upstream peer, give the
+						// live reconciler a chance to repair a silent
+						// primary-chain / ledger divergence. The two
+						// existing call sites in ledger/chainsync.go
+						// only fire on ErrRollbackExceedsSecurityParam;
+						// sub-K same-slot fork resolutions can advance
+						// chain.Tip() while leaving the ledger pipeline
+						// pinned on the abandoned hash with no error to
+						// trigger reconcile. The plateau is the symptom
+						// — recycle the connection and the new peer
+						// will hand back the same canonical headers
+						// the ledger already refused to follow.
+						reconciledByLedger := false
+						if n.ledgerState != nil {
+							reconciled, err := n.ledgerState.ReconcileLivePrimaryChainLedgerDivergence(
+								"local tip plateau",
+								*targetConn,
+							)
+							if err != nil {
+								n.config.logger.Warn(
+									"plateau reconcile failed, falling through to peer recycle",
+									"connection_id", connKey,
+									"error", err.Error(),
+								)
+							} else if reconciled {
+								n.config.logger.Warn(
+									"local tip plateau resolved via ledger reconcile, skipping peer recycle",
+									"connection_id", connKey,
+									"local_tip_slot", localTipSlot,
+									"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+									"plateau_duration", now.Sub(*lastProgressAt),
+								)
+								// Reset the plateau clock so we don't
+								// immediately re-trigger on the next
+								// tick before forward application has
+								// had a chance to advance the ledger.
+								*lastProgressAt = now
+								lastRecycled[connKey] = now
+								reconciledByLedger = true
+							}
+						}
+						if !reconciledByLedger {
+							n.config.logger.Warn(
+								"local tip plateau detected, resyncing chainsync client",
+								"connection_id", connKey,
+								"local_tip_slot", localTipSlot,
+								"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+								"plateau_duration", now.Sub(*lastProgressAt),
+							)
+							n.eventBus.Publish(
 								event.ChainsyncResyncEventType,
-								event.ChainsyncResyncEvent{
-									ConnectionId: *targetConn,
-									Reason:       event.ChainsyncResyncReasonLocalTipPlateau,
-								},
-							),
-						)
-						n.realignOtherPeersAfterPlateau(
-							*targetConn,
-							trackedClients,
-							localTipSlot,
-						)
-						delete(recycleAt, connKey)
-						lastRecycled[connKey] = now
-						*lastProgressAt = now
+								event.NewEvent(
+									event.ChainsyncResyncEventType,
+									event.ChainsyncResyncEvent{
+										ConnectionId: *targetConn,
+										Reason:       event.ChainsyncResyncReasonLocalTipPlateau,
+									},
+								),
+							)
+							n.realignOtherPeersAfterPlateau(
+								*targetConn,
+								trackedClients,
+								localTipSlot,
+							)
+							delete(recycleAt, connKey)
+							lastRecycled[connKey] = now
+							*lastProgressAt = now
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Wires the existing `reconcileLivePrimaryChainLedgerDivergence` (PR #2322) into a 3rd call site — the plateau watchdog in `node_chainsync_recycler.go` — so it can repair silent sub-K same-slot fork divergences where there's no rollback error to trigger the existing two callers in `chainsync.go`.

This is a draft PR validating a fix proposal for #2349.

## Background

#2349 reports the chainsync client not adopting a rapid same-slot fork switch from the upstream peer. The earlier follow-up diagnosed the shape: `ls.chain.Tip()` (Chain object, advanced by header processing) advances to the canonical hash, but `ls.currentTip` (ledger pipeline position) stays pinned on the abandoned same-slot branch. Recovery currently requires a process restart.

`reconcileLivePrimaryChainLedgerDivergence` (introduced in PR #2322, merged 2026-05-15) is designed for exactly this divergence — it rolls the ledger back to the latest common ancestor so forward application from the canonical chain resumes. It's currently only invoked from the two `ErrRollbackExceedsSecurityParam` sites in `chainsync.go`. The sub-K silent case has no error to trigger it; the only signal is the plateau watchdog noticing the symptom (local tip not advancing while peers report a higher tip).

## Change

- `ledger/state.go` — export `LedgerState.ReconcileLivePrimaryChainLedgerDivergence` as a wrapper around the existing unexported method, so call sites outside `ledger/` can invoke it.
- `node_chainsync_recycler.go` — in the plateau branch, call the reconciler before recycling the upstream peer. On success: skip the peer recycle, re-arm the plateau timer, log. On no-op or error: fall through to the existing recycle path (no behaviour change vs. today).
- `ledger/chainsync_rollback_test.go` — add `TestReconcileLivePrimaryChainLedgerDivergenceExportedWrapperRecoversSubKFork` exercising the exported entry point against a sub-K (1-block-deep) same-slot fork scenario.

Diff is small: one exported wrapper + one call site with a fallback guard + one test. Existing `reconcileLivePrimaryChainLedgerDivergence` tests cover the reconciler itself.

## Validation — 7-hour soak on preview testnet

Ran the patched binary on a BP role and a relay role (overlay image on `ghcr.io/blinklabs-io/dingo:0.46.4`) for ~8 hours. Both roles hit the divergence in the same 30-second window, both resolved cleanly without operator action.

### Observed event — relay role, 2026-05-21T07:22Z

```
07:12:52.250Z  WARN  chain fork detected
                     fork_point_slot=112691567  fork_depth=1
                     alternate_head_slot=112691572  canonical_head_slot=112691567
07:18:05.212Z  WARN  chain fork detected
                     fork_point_slot=112691823  fork_depth=1
                     alternate_head_slot=112691885  canonical_head_slot=112691823
07:18:05.272Z  INFO  chain extended, new tip:
                     6656b8ad33cc2183a5757afff82a29d24a21ea2038a924c6055bb2638b83a2d6
                     at slot 112691885   source="chainsync"
                     # ledger pinned here for ~4 minutes
07:22:35.338Z  WARN  primary chain and ledger diverged during live chainsync recovery,
                     reconciling to common ancestor
                     reason="local tip plateau"
                     chain_tip_slot=112692140
                     chain_tip_hash="68d24fcc93c4756da09f47e89879d3b427f08711cdeae76f105beea4b7883001"
                     ledger_tip_slot=112691885
                     ledger_tip_hash="6656b8ad33cc2183a5757afff82a29d24a21ea2038a924c6055bb2638b83a2d6"
07:22:36.896Z  WARN  local tip plateau resolved via ledger reconcile, skipping peer recycle
                     local_tip_slot=112691885  best_peer_tip_slot=112692121
                     plateau_duration=270s
07:22:38.748Z  INFO  chain extended, new tip:
                     68d24fcc93c4756da09f47e89879d3b427f08711cdeae76f105beea4b7883001
                     at slot 112692140   source="chainsync"
                     # ledger on canonical, forward apply resumes
```

Chain pointer was at slot 112,692,140 hash `68d24fcc…`. Ledger pointer was 255 slots behind at 112,691,885 hash `6656b8ad…`. The reconciler rolled the ledger to the common ancestor and the chainsync pipeline picked up the canonical chain. ~3 seconds from divergence-detected to ledger-on-canonical. No process restart, no container restart, no peer recycle.

The BP role hit the same event in the same 30-second window (slot 112691885, plateau 240s, identical resolution).

### Soak counters (~8h on patched image)

| metric | count |
|---|---|
| RECONCILE_FIRED (success) | 2 (one per role, same fork) |
| RECONCILE_FAIL (errored) | 0 |
| Plateau-recycle fall-through (reconciler no-op) | 0 |
| Panic / fatal | 0 |
| Container restarts | 0 |

Both nodes currently at tip in lockstep, healthy.

## Testing

- `go test ./ledger/...` — green, including new test (~0.06s)
- `go test ./...` — green
- 8-hour live soak on preview testnet (BP role + relay role), described above

## Notes

- Marking draft: I'd like a maintainer eye on the call-site placement before promoting (current placement is the plateau-detect `else` branch immediately before the recycle action; alternatives could include calling it from the recycler entry point or as an explicit pre-check). Happy to revise.
- If the team prefers a different approach to surfacing the silent divergence — e.g., having the chain layer detect and emit a structured event instead of having the watchdog poll — I'm equally happy to follow that direction.
- Filed by an AI agent on behalf of the operator. (Wolf already knows.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hooks the live ledger reconciler into the plateau watchdog to fix silent same-slot fork plateaus. The node now reconciles the ledger to the common ancestor and resumes forward apply without peer recycle or restart.

- **Bug Fixes**
  - Exported `LedgerState.ReconcileLivePrimaryChainLedgerDivergence` for node-level callers.
  - Plateau watchdog calls the reconciler before recycling; on success, skips recycle and resets the plateau timer. On no-op/error, falls back to the current recycle path.
  - Added test `TestReconcileLivePrimaryChainLedgerDivergenceExportedWrapperRecoversSubKFork`.
  - Removed temporary `Dockerfile.bbhmm-pr2349` used for testing.

<sup>Written for commit 7c6dceb71faa5b4d2e3a91eaa9b8a914976e61ed. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved chain synchronization recovery by attempting to resolve potential ledger divergence before forcing a full resync.

* **Tests**
  * Added test coverage for ledger divergence recovery in fork scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->