### PR TITLE
feat(ledger): implement CIP-1694 SPO reward-account delegation semantics

### DIFF
--- a/database/models/stake_snapshot.go
+++ b/database/models/stake_snapshot.go
@@ -60,10 +60,20 @@ type PoolStakeSnapshot struct {
 	// RewardAccountAutoVote captures the CIP-1694 SPO auto-vote
 	// outcome implied by the pool's reward-account DRep delegation at
 	// the snapshot epoch. Values come from PoolRewardAccountAutoVote*.
-	// Zero is the safe default both for "no auto-vote" and for
-	// snapshots written by pre-CIP-1694 code (before the column
-	// existed) — both cases behave identically at tally time.
+	// This field is only meaningful when RewardAccountAutoVoteResolved
+	// is true; otherwise its value is undefined and must not be read
+	// by the tally.
 	RewardAccountAutoVote uint8 `gorm:"not null;default:0"`
+	// RewardAccountAutoVoteResolved disambiguates "resolved as none"
+	// from "never resolved". The resolver sets this to true after it
+	// has computed RewardAccountAutoVote against snapshot-era state.
+	// Rows imported by Mithril for set/go rotations (which only have
+	// live state available at import time and cannot be faithfully
+	// resolved against historical boundaries) intentionally leave this
+	// false; the tally treats them as PoolRewardAccountAutoVoteNone,
+	// matching pre-CIP-1694 behaviour for those rows. Pre-CIP-1694
+	// rows in upgraded databases also remain false until re-resolved.
+	RewardAccountAutoVoteResolved bool `gorm:"not null;default:false"`
 }
 
 // TableName returns the table name

--- a/database/models/stake_snapshot.go
+++ b/database/models/stake_snapshot.go
@@ -22,6 +22,31 @@ import (
 	"gorm.io/gorm"
 )
 
+// PoolRewardAccountAutoVote enumerates the CIP-1694 reward-account
+// DRep-delegation outcomes that produce an implicit SPO vote when a
+// pool did not cast an explicit vote on a proposal. Resolved and
+// frozen at the epoch boundary that captures the stake snapshot so
+// the governance tally uses snapshot-era state rather than live state.
+const (
+	// PoolRewardAccountAutoVoteNone means the pool's reward account is
+	// unset, deregistered, or delegated to anything other than the
+	// predefined Always{Abstain,NoConfidence} DRep options. Such a
+	// pool contributes to SPOTotalStake only and counts as implicit
+	// no under CIP-1694.
+	PoolRewardAccountAutoVoteNone uint8 = 0
+	// PoolRewardAccountAutoVoteAbstain means the pool's reward
+	// account delegates to AlwaysAbstain at the snapshot epoch. Its
+	// stake is bucketed into SPOAbstainStake (excluded from the
+	// active denominator).
+	PoolRewardAccountAutoVoteAbstain uint8 = 1
+	// PoolRewardAccountAutoVoteNoConfidence means the pool's reward
+	// account delegates to AlwaysNoConfidence at the snapshot epoch.
+	// For NoConfidence actions the pool stake is bucketed Yes; for
+	// any other action type it is bucketed No (mirrors the
+	// AlwaysNoConfidence DRep handling).
+	PoolRewardAccountAutoVoteNoConfidence uint8 = 2
+)
+
 // PoolStakeSnapshot captures aggregated pool stake at an epoch boundary.
 // Used for leader election in Ouroboros Praos consensus.
 type PoolStakeSnapshot struct {
@@ -32,6 +57,13 @@ type PoolStakeSnapshot struct {
 	TotalStake     types.Uint64 `gorm:"not null"`
 	DelegatorCount uint64       `gorm:"not null"`
 	CapturedSlot   uint64       `gorm:"not null"`
+	// RewardAccountAutoVote captures the CIP-1694 SPO auto-vote
+	// outcome implied by the pool's reward-account DRep delegation at
+	// the snapshot epoch. Values come from PoolRewardAccountAutoVote*.
+	// Zero is the safe default both for "no auto-vote" and for
+	// snapshots written by pre-CIP-1694 code (before the column
+	// existed) — both cases behave identically at tally time.
+	RewardAccountAutoVote uint8 `gorm:"not null;default:0"`
 }
 
 // TableName returns the table name

--- a/database/plugin/metadata/mysql/stake_snapshot.go
+++ b/database/plugin/metadata/mysql/stake_snapshot.go
@@ -63,10 +63,16 @@ func (d *MetadataStoreMysql) SavePoolStakeSnapshots(
 				{Name: "snapshot_type"},
 				{Name: "pool_key_hash"},
 			},
+			// reward_account_auto_vote{,_resolved} must be assigned
+			// on conflict so a re-save of an existing snapshot row
+			// does not silently revert a freshly resolved Always*
+			// auto-vote back to the previous (often default-0) value.
 			DoUpdates: clause.AssignmentColumns([]string{
 				"total_stake",
 				"delegator_count",
 				"captured_slot",
+				"reward_account_auto_vote",
+				"reward_account_auto_vote_resolved",
 			}),
 		},
 	).Create(snapshots).Error; err != nil {

--- a/database/plugin/metadata/postgres/stake_snapshot.go
+++ b/database/plugin/metadata/postgres/stake_snapshot.go
@@ -63,10 +63,16 @@ func (d *MetadataStorePostgres) SavePoolStakeSnapshots(
 				{Name: "snapshot_type"},
 				{Name: "pool_key_hash"},
 			},
+			// reward_account_auto_vote{,_resolved} must be assigned
+			// on conflict so a re-save of an existing snapshot row
+			// does not silently revert a freshly resolved Always*
+			// auto-vote back to the previous (often default-0) value.
 			DoUpdates: clause.AssignmentColumns([]string{
 				"total_stake",
 				"delegator_count",
 				"captured_slot",
+				"reward_account_auto_vote",
+				"reward_account_auto_vote_resolved",
 			}),
 		},
 	).Create(snapshots).Error; err != nil {

--- a/database/plugin/metadata/sqlite/stake_snapshot.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot.go
@@ -63,10 +63,20 @@ func (d *MetadataStoreSqlite) SavePoolStakeSnapshots(
 				{Name: "snapshot_type"},
 				{Name: "pool_key_hash"},
 			},
+			// All non-key columns must be in DoUpdates so a re-save
+			// for an existing (epoch, snapshot_type, pool_key_hash)
+			// row carries every freshly computed value. Notably the
+			// CIP-1694 reward_account_auto_vote{,_resolved} pair: if
+			// it were missing here, a resolved Always{Abstain,
+			// NoConfidence} would silently revert to the previous
+			// row's (often default 0 / false) values and the tally
+			// would misclassify the pool as implicit no.
 			DoUpdates: clause.AssignmentColumns([]string{
 				"total_stake",
 				"delegator_count",
 				"captured_slot",
+				"reward_account_auto_vote",
+				"reward_account_auto_vote_resolved",
 			}),
 		},
 	).Create(snapshots).Error; err != nil {

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -336,26 +336,39 @@ func TestSavePoolStakeSnapshotsUpsertsExistingRows(t *testing.T) {
 	defer store.Close() //nolint:errcheck
 
 	poolKeyHash := []byte("pool_key_hash_12345678901234")
+	// Initial row: unresolved auto-vote (typical Mithril import for
+	// an N-1 / N-2 seed row). Tally would treat as implicit no.
 	initial := []*models.PoolStakeSnapshot{
 		{
-			Epoch:          100,
-			SnapshotType:   "mark",
-			PoolKeyHash:    poolKeyHash,
-			TotalStake:     1,
-			DelegatorCount: 1,
-			CapturedSlot:   100,
+			Epoch:                         100,
+			SnapshotType:                  "mark",
+			PoolKeyHash:                   poolKeyHash,
+			TotalStake:                    1,
+			DelegatorCount:                1,
+			CapturedSlot:                  100,
+			RewardAccountAutoVote:         models.PoolRewardAccountAutoVoteNone,
+			RewardAccountAutoVoteResolved: false,
 		},
 	}
 	require.NoError(t, store.SavePoolStakeSnapshots(initial, nil))
 
+	// Re-save: stake numbers change AND the row is now resolved
+	// against snapshot-era state as AlwaysAbstain (e.g. the live
+	// epoch boundary catches up to this target epoch and the
+	// resolver runs). The upsert must carry every non-key column
+	// through — if reward_account_auto_vote{,_resolved} are missing
+	// from DoUpdates, the row keeps the initial (None, false) pair
+	// and the tally silently misclassifies the pool as implicit no.
 	updated := []*models.PoolStakeSnapshot{
 		{
-			Epoch:          100,
-			SnapshotType:   "mark",
-			PoolKeyHash:    poolKeyHash,
-			TotalStake:     999,
-			DelegatorCount: 9,
-			CapturedSlot:   200,
+			Epoch:                         100,
+			SnapshotType:                  "mark",
+			PoolKeyHash:                   poolKeyHash,
+			TotalStake:                    999,
+			DelegatorCount:                9,
+			CapturedSlot:                  200,
+			RewardAccountAutoVote:         models.PoolRewardAccountAutoVoteAbstain,
+			RewardAccountAutoVoteResolved: true,
 		},
 	}
 	require.NoError(t, store.SavePoolStakeSnapshots(updated, nil))
@@ -366,6 +379,17 @@ func TestSavePoolStakeSnapshotsUpsertsExistingRows(t *testing.T) {
 	assert.Equal(t, uint64(999), uint64(retrieved.TotalStake))
 	assert.Equal(t, uint64(9), retrieved.DelegatorCount)
 	assert.Equal(t, uint64(200), retrieved.CapturedSlot)
+	assert.Equal(
+		t,
+		models.PoolRewardAccountAutoVoteAbstain,
+		retrieved.RewardAccountAutoVote,
+		"resolved RewardAccountAutoVote must survive an upsert",
+	)
+	assert.True(
+		t,
+		retrieved.RewardAccountAutoVoteResolved,
+		"RewardAccountAutoVoteResolved must survive an upsert",
+	)
 }
 
 func TestSaveEpochSummaryUpsertsExistingRow(t *testing.T) {

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ResolvePoolRewardAccountAutoVotes classifies each PoolStakeSnapshot
+// with the CIP-1694 reward-account DRep-delegation outcome and writes
+// the result onto snapshot.RewardAccountAutoVote in place. Callers
+// invoke this immediately before persisting the snapshots so the
+// auto-vote signal is frozen with the snapshot rather than re-derived
+// from live state at tally time.
+//
+// Resolution proceeds in two batched lookups:
+//  1. Pool rows yield each pool's reward-account stake credential.
+//  2. Account rows yield the DRep delegation type for each credential.
+//
+// Only ACTIVE accounts are considered. A deregistered reward account
+// — even one whose row still carries an AlwaysAbstain or
+// AlwaysNoConfidence delegation flag — yields PoolRewardAccountAutoVoteNone,
+// since CIP-1694 treats unregistered reward accounts as implicit no.
+func (d *Database) ResolvePoolRewardAccountAutoVotes(
+	snapshots []*models.PoolStakeSnapshot,
+	txn *Txn,
+) error {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+
+	// Group snapshots per pool key so a single pool with multiple
+	// snapshot rows (e.g. mark/set/go imported together) is resolved
+	// once and then fanned out.
+	snapshotsByPool := make(map[string][]*models.PoolStakeSnapshot, len(snapshots))
+	pkhs := make([]lcommon.PoolKeyHash, 0, len(snapshots))
+	for _, s := range snapshots {
+		// Reset to ensure callers can re-run resolution without
+		// stale values leaking through from a previous attempt.
+		s.RewardAccountAutoVote = models.PoolRewardAccountAutoVoteNone
+		key := string(s.PoolKeyHash)
+		if _, seen := snapshotsByPool[key]; !seen {
+			pkhs = append(pkhs, lcommon.PoolKeyHash(s.PoolKeyHash))
+		}
+		snapshotsByPool[key] = append(snapshotsByPool[key], s)
+	}
+
+	pools, err := d.GetPools(pkhs, txn)
+	if err != nil {
+		return fmt.Errorf("get pools: %w", err)
+	}
+
+	rewardAcctByPool := make(map[string][]byte, len(pools))
+	rewardAccounts := make([][]byte, 0, len(pools))
+	for i := range pools {
+		ra := pools[i].RewardAccount
+		if len(ra) == 0 {
+			continue
+		}
+		poolKey := string(pools[i].PoolKeyHash)
+		if _, dup := rewardAcctByPool[poolKey]; dup {
+			continue
+		}
+		rewardAcctByPool[poolKey] = ra
+		rewardAccounts = append(rewardAccounts, ra)
+	}
+	if len(rewardAccounts) == 0 {
+		return nil
+	}
+
+	// includeInactive=false so a deregistered reward account that
+	// still carries a stale predefined-DRep flag does not auto-vote.
+	accounts, err := d.GetAccounts(rewardAccounts, false, txn)
+	if err != nil {
+		return fmt.Errorf("get reward accounts: %w", err)
+	}
+
+	for poolKey, ra := range rewardAcctByPool {
+		acct, ok := accounts[string(ra)]
+		if !ok {
+			continue
+		}
+		var autoVote uint8
+		switch acct.DrepType {
+		case models.DrepTypeAlwaysAbstain:
+			autoVote = models.PoolRewardAccountAutoVoteAbstain
+		case models.DrepTypeAlwaysNoConfidence:
+			autoVote = models.PoolRewardAccountAutoVoteNoConfidence
+		default:
+			continue
+		}
+		for _, s := range snapshotsByPool[poolKey] {
+			s.RewardAccountAutoVote = autoVote
+		}
+	}
+	return nil
+}

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -56,7 +56,12 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 	for _, s := range snapshots {
 		// Reset to ensure callers can re-run resolution without
 		// stale values leaking through from a previous attempt.
+		// Mark the row as resolved up-front: every snapshot passed
+		// to this resolver runs against snapshot-era state by
+		// contract, so the absence of an Always{Abstain,NoConfidence}
+		// delegation is a real "none" answer, not "unknown".
 		s.RewardAccountAutoVote = models.PoolRewardAccountAutoVoteNone
+		s.RewardAccountAutoVoteResolved = true
 		key := string(s.PoolKeyHash)
 		if _, seen := snapshotsByPool[key]; !seen {
 			pkhs = append(pkhs, lcommon.PoolKeyHash(s.PoolKeyHash))

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -25,6 +25,17 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// poolAutoVote enumerates the CIP-1694 reward-account delegation
+// outcomes that produce an implicit SPO vote when the pool itself did
+// not cast an explicit vote.
+type poolAutoVote uint8
+
+const (
+	poolAutoVoteNone poolAutoVote = iota
+	poolAutoVoteAbstain
+	poolAutoVoteNoConfidence
+)
+
 // ProposalTally captures the aggregated vote totals for a governance
 // proposal across DReps, stake pools, and the constitutional committee.
 // Stake values are lovelace; CC counts are member counts.
@@ -278,16 +289,27 @@ func tallyDRepVotes(
 	return nil
 }
 
-// tallySPOVotes sums pool stake for votes matched against the stake
-// distribution snapshot at StakeEpoch. Pools that did not vote are not
-// counted.
+// tallySPOVotes computes SPO yes/no/abstain stake against the pool
+// stake distribution snapshot at StakeEpoch, applying the CIP-1694
+// reward-account delegation rules:
 //
-// TODO(#2369): account for the SPO reward-account delegation rules from
-// CIP-1694. Pools whose reward account delegates to AlwaysNoConfidence
-// auto-vote per the action's NoConfidence handling, and pools delegating
-// to AlwaysAbstain count toward abstain stake (excluded from the
-// denominator). This is related to the reward-account plumbing from
-// #1988, but the delegation semantics are separate follow-up work.
+//   - Pools with an explicit vote in `votes` use that vote.
+//   - Pools without an explicit vote fall back to the DRep delegation
+//     attached to their reward-account stake credential:
+//     AlwaysAbstain      → Abstain (excluded from the active
+//     denominator via SPOYesRatio).
+//     AlwaysNoConfidence → Yes for NoConfidence actions, No for any
+//     other action type (matches the DRep
+//     AlwaysNoConfidence handling).
+//   - Any other delegation (regular DRep, no DRep set, or unregistered
+//     reward account) does NOT auto-vote; the pool's stake remains in
+//     SPOTotalStake and is implicitly "no" under CIP-1694 (in the
+//     denominator, not the numerator).
+//
+// Reward-account → DRep delegation is read from the current Account
+// state. This matches tallyDRepVotes, which also uses live state; a
+// per-snapshot historical lookup would require schema additions Dingo
+// does not yet maintain.
 func tallySPOVotes(
 	ctx *TallyContext,
 	votes []*models.GovernanceVote,
@@ -306,30 +328,117 @@ func tallySPOVotes(
 		return fmt.Errorf("get pool stake snapshot: %w", err)
 	}
 
-	poolStake := make(map[string]uint64, len(dist))
 	var total uint64
 	for _, s := range dist {
-		stake := uint64(s.TotalStake)
-		poolStake[string(s.PoolKeyHash)] = stake
-		total += stake
+		total += uint64(s.TotalStake)
 	}
 	tally.SPOTotalStake = total
+	if len(dist) == 0 {
+		return nil
+	}
 
+	// Explicit vote precedence: build a pool-keyed view first so we
+	// can short-circuit auto-vote lookup for pools that did vote.
+	voteByPool := make(map[string]uint8, len(votes))
 	for _, v := range votes {
-		stake, ok := poolStake[string(v.VoterCredential)]
-		if !ok {
+		voteByPool[string(v.VoterCredential)] = v.Vote
+	}
+
+	autoVoteByPool, err := loadPoolAutoVotes(ctx, dist)
+	if err != nil {
+		return fmt.Errorf("load pool reward-account auto-votes: %w", err)
+	}
+
+	isNoConfidenceAction := lcommon.GovActionType(tally.ActionType) ==
+		lcommon.GovActionTypeNoConfidence
+
+	for _, s := range dist {
+		stake := uint64(s.TotalStake)
+		poolKey := string(s.PoolKeyHash)
+
+		if v, voted := voteByPool[poolKey]; voted {
+			switch v {
+			case models.VoteYes:
+				tally.SPOYesStake += stake
+			case models.VoteNo:
+				tally.SPONoStake += stake
+			case models.VoteAbstain:
+				tally.SPOAbstainStake += stake
+			}
 			continue
 		}
-		switch v.Vote {
-		case models.VoteYes:
-			tally.SPOYesStake += stake
-		case models.VoteNo:
-			tally.SPONoStake += stake
-		case models.VoteAbstain:
+
+		switch autoVoteByPool[poolKey] {
+		case poolAutoVoteAbstain:
 			tally.SPOAbstainStake += stake
+		case poolAutoVoteNoConfidence:
+			if isNoConfidenceAction {
+				tally.SPOYesStake += stake
+			} else {
+				tally.SPONoStake += stake
+			}
+		case poolAutoVoteNone:
+			// No auto-vote: pool contributes only to SPOTotalStake
+			// (implicit no under CIP-1694).
 		}
 	}
 	return nil
+}
+
+// loadPoolAutoVotes resolves each pool in the snapshot to its
+// reward-account DRep delegation and returns the implied auto-vote.
+// Pools whose reward account is unset, unregistered, or delegated to
+// anything other than the predefined AlwaysAbstain /
+// AlwaysNoConfidence DReps map to poolAutoVoteNone (no auto-vote).
+func loadPoolAutoVotes(
+	ctx *TallyContext,
+	dist []*models.PoolStakeSnapshot,
+) (map[string]poolAutoVote, error) {
+	pkhs := make([]lcommon.PoolKeyHash, 0, len(dist))
+	for _, s := range dist {
+		pkhs = append(pkhs, lcommon.PoolKeyHash(s.PoolKeyHash))
+	}
+	pools, err := ctx.DB.GetPools(pkhs, ctx.Txn)
+	if err != nil {
+		return nil, fmt.Errorf("get pools: %w", err)
+	}
+
+	rewardAcctByPool := make(map[string][]byte, len(pools))
+	rewardAccounts := make([][]byte, 0, len(pools))
+	for i := range pools {
+		ra := pools[i].RewardAccount
+		if len(ra) == 0 {
+			continue
+		}
+		rewardAcctByPool[string(pools[i].PoolKeyHash)] = ra
+		rewardAccounts = append(rewardAccounts, ra)
+	}
+	if len(rewardAccounts) == 0 {
+		return map[string]poolAutoVote{}, nil
+	}
+
+	// includeInactive=true so a deregistered reward account that still
+	// carries an AlwaysAbstain/AlwaysNoConfidence delegation flag is
+	// not silently dropped before we can decide.
+	accounts, err := ctx.DB.GetAccounts(rewardAccounts, true, ctx.Txn)
+	if err != nil {
+		return nil, fmt.Errorf("get reward accounts: %w", err)
+	}
+
+	out := make(map[string]poolAutoVote, len(rewardAcctByPool))
+	for poolKey, ra := range rewardAcctByPool {
+		acct, ok := accounts[string(ra)]
+		if !ok {
+			continue
+		}
+		switch acct.DrepType {
+		case models.DrepTypeAlwaysAbstain:
+			out[poolKey] = poolAutoVoteAbstain
+		case models.DrepTypeAlwaysNoConfidence:
+			out[poolKey] = poolAutoVoteNoConfidence
+		}
+	}
+	return out, nil
 }
 
 // tallyCCVotes counts per-member votes restricted to currently active

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -353,6 +353,15 @@ func tallySPOVotes(
 			continue
 		}
 
+		// Only trust RewardAccountAutoVote when the row is flagged
+		// as resolved. Unresolved rows (Mithril-imported set/go
+		// rotations, or rows written by pre-CIP-1694 code) fall
+		// back to PoolRewardAccountAutoVoteNone — implicit no — so
+		// stale or never-computed values can never silently bucket
+		// stake into Abstain or NoConfidence.
+		if !s.RewardAccountAutoVoteResolved {
+			continue
+		}
 		switch s.RewardAccountAutoVote {
 		case models.PoolRewardAccountAutoVoteAbstain:
 			tally.SPOAbstainStake += stake

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -25,17 +25,6 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
-// poolAutoVote enumerates the CIP-1694 reward-account delegation
-// outcomes that produce an implicit SPO vote when the pool itself did
-// not cast an explicit vote.
-type poolAutoVote uint8
-
-const (
-	poolAutoVoteNone poolAutoVote = iota
-	poolAutoVoteAbstain
-	poolAutoVoteNoConfidence
-)
-
 // ProposalTally captures the aggregated vote totals for a governance
 // proposal across DReps, stake pools, and the constitutional committee.
 // Stake values are lovelace; CC counts are member counts.
@@ -294,22 +283,24 @@ func tallyDRepVotes(
 // reward-account delegation rules:
 //
 //   - Pools with an explicit vote in `votes` use that vote.
-//   - Pools without an explicit vote fall back to the DRep delegation
-//     attached to their reward-account stake credential:
-//     AlwaysAbstain      → Abstain (excluded from the active
+//   - Pools without an explicit vote fall back to the auto-vote
+//     pre-computed at snapshot capture time
+//     (PoolStakeSnapshot.RewardAccountAutoVote):
+//     Abstain        → SPOAbstainStake (excluded from the active
 //     denominator via SPOYesRatio).
-//     AlwaysNoConfidence → Yes for NoConfidence actions, No for any
-//     other action type (matches the DRep
+//     NoConfidence   → Yes for NoConfidence actions, No for any
+//     other action type (mirrors the DRep
 //     AlwaysNoConfidence handling).
-//   - Any other delegation (regular DRep, no DRep set, or unregistered
-//     reward account) does NOT auto-vote; the pool's stake remains in
-//     SPOTotalStake and is implicitly "no" under CIP-1694 (in the
-//     denominator, not the numerator).
+//   - Any other delegation (regular DRep, no DRep set, deregistered
+//     reward account, etc.) maps to None at snapshot time; the pool's
+//     stake remains in SPOTotalStake and counts as implicit no under
+//     CIP-1694 (in the denominator, not the numerator).
 //
-// Reward-account → DRep delegation is read from the current Account
-// state. This matches tallyDRepVotes, which also uses live state; a
-// per-snapshot historical lookup would require schema additions Dingo
-// does not yet maintain.
+// Reading the auto-vote off the snapshot row makes the tally
+// snapshot-correct: a pool that re-delegates its reward account or
+// changes its reward account between StakeEpoch and the ratification
+// epoch does not retroactively shift the tally, matching
+// cardano-ledger's ssDelegations/ssDReps semantics.
 func tallySPOVotes(
 	ctx *TallyContext,
 	votes []*models.GovernanceVote,
@@ -338,15 +329,10 @@ func tallySPOVotes(
 	}
 
 	// Explicit vote precedence: build a pool-keyed view first so we
-	// can short-circuit auto-vote lookup for pools that did vote.
+	// can short-circuit the auto-vote branch for pools that did vote.
 	voteByPool := make(map[string]uint8, len(votes))
 	for _, v := range votes {
 		voteByPool[string(v.VoterCredential)] = v.Vote
-	}
-
-	autoVoteByPool, err := loadPoolAutoVotes(ctx, dist)
-	if err != nil {
-		return fmt.Errorf("load pool reward-account auto-votes: %w", err)
 	}
 
 	isNoConfidenceAction := lcommon.GovActionType(tally.ActionType) ==
@@ -354,9 +340,8 @@ func tallySPOVotes(
 
 	for _, s := range dist {
 		stake := uint64(s.TotalStake)
-		poolKey := string(s.PoolKeyHash)
 
-		if v, voted := voteByPool[poolKey]; voted {
+		if v, voted := voteByPool[string(s.PoolKeyHash)]; voted {
 			switch v {
 			case models.VoteYes:
 				tally.SPOYesStake += stake
@@ -368,77 +353,21 @@ func tallySPOVotes(
 			continue
 		}
 
-		switch autoVoteByPool[poolKey] {
-		case poolAutoVoteAbstain:
+		switch s.RewardAccountAutoVote {
+		case models.PoolRewardAccountAutoVoteAbstain:
 			tally.SPOAbstainStake += stake
-		case poolAutoVoteNoConfidence:
+		case models.PoolRewardAccountAutoVoteNoConfidence:
 			if isNoConfidenceAction {
 				tally.SPOYesStake += stake
 			} else {
 				tally.SPONoStake += stake
 			}
-		case poolAutoVoteNone:
+		case models.PoolRewardAccountAutoVoteNone:
 			// No auto-vote: pool contributes only to SPOTotalStake
 			// (implicit no under CIP-1694).
 		}
 	}
 	return nil
-}
-
-// loadPoolAutoVotes resolves each pool in the snapshot to its
-// reward-account DRep delegation and returns the implied auto-vote.
-// Pools whose reward account is unset, unregistered, or delegated to
-// anything other than the predefined AlwaysAbstain /
-// AlwaysNoConfidence DReps map to poolAutoVoteNone (no auto-vote).
-func loadPoolAutoVotes(
-	ctx *TallyContext,
-	dist []*models.PoolStakeSnapshot,
-) (map[string]poolAutoVote, error) {
-	pkhs := make([]lcommon.PoolKeyHash, 0, len(dist))
-	for _, s := range dist {
-		pkhs = append(pkhs, lcommon.PoolKeyHash(s.PoolKeyHash))
-	}
-	pools, err := ctx.DB.GetPools(pkhs, ctx.Txn)
-	if err != nil {
-		return nil, fmt.Errorf("get pools: %w", err)
-	}
-
-	rewardAcctByPool := make(map[string][]byte, len(pools))
-	rewardAccounts := make([][]byte, 0, len(pools))
-	for i := range pools {
-		ra := pools[i].RewardAccount
-		if len(ra) == 0 {
-			continue
-		}
-		rewardAcctByPool[string(pools[i].PoolKeyHash)] = ra
-		rewardAccounts = append(rewardAccounts, ra)
-	}
-	if len(rewardAccounts) == 0 {
-		return map[string]poolAutoVote{}, nil
-	}
-
-	// includeInactive=true so a deregistered reward account that still
-	// carries an AlwaysAbstain/AlwaysNoConfidence delegation flag is
-	// not silently dropped before we can decide.
-	accounts, err := ctx.DB.GetAccounts(rewardAccounts, true, ctx.Txn)
-	if err != nil {
-		return nil, fmt.Errorf("get reward accounts: %w", err)
-	}
-
-	out := make(map[string]poolAutoVote, len(rewardAcctByPool))
-	for poolKey, ra := range rewardAcctByPool {
-		acct, ok := accounts[string(ra)]
-		if !ok {
-			continue
-		}
-		switch acct.DrepType {
-		case models.DrepTypeAlwaysAbstain:
-			out[poolKey] = poolAutoVoteAbstain
-		case models.DrepTypeAlwaysNoConfidence:
-			out[poolKey] = poolAutoVoteNoConfidence
-		}
-	}
-	return out, nil
 }
 
 // tallyCCVotes counts per-member votes restricted to currently active

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -497,7 +497,10 @@ func resolveSnapshotAutoVotes(
 			DB().
 			Model(&models.PoolStakeSnapshot{}).
 			Where("id = ?", s.ID).
-			Update("reward_account_auto_vote", s.RewardAccountAutoVote).
+			Updates(map[string]any{
+				"reward_account_auto_vote":          s.RewardAccountAutoVote,
+				"reward_account_auto_vote_resolved": s.RewardAccountAutoVoteResolved,
+			}).
 			Error)
 	}
 }
@@ -813,6 +816,53 @@ func TestTallySPOVotesMixedExplicitAndAutoVotes(t *testing.T) {
 	assert.Equal(t, uint64(200), tally.SPOAbstainStake)
 	// yes / (total - abstain) = 100 / (375 - 200) = 100 / 175 = 4/7
 	assert.Equal(t, big.NewRat(4, 7), tally.SPOYesRatio())
+}
+
+// TestTallySPOVotesUnresolvedSnapshotRowFallsBackToImplicitNo asserts
+// that a snapshot row with RewardAccountAutoVoteResolved=false is
+// treated as PoolRewardAccountAutoVoteNone regardless of what
+// RewardAccountAutoVote happens to contain — covering the Mithril
+// set/go import path that intentionally skips resolution, plus any
+// pre-CIP-1694 row left over from an upgrade. Without this guard, a
+// stale or never-resolved Abstain/NoConfidence value would silently
+// flip the tally.
+func TestTallySPOVotesUnresolvedSnapshotRowFallsBackToImplicitNo(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 130)
+	rewardAccount := testBytes(28, 131)
+
+	// Write a snapshot row directly with RewardAccountAutoVote set to
+	// Abstain but Resolved=false. This mimics either a Mithril-imported
+	// set/go row that the import path declined to resolve, or a row
+	// from a pre-flag schema where the column happens to be non-zero.
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash:   poolKeyHash,
+		RewardAccount: rewardAccount,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:                 15,
+		SnapshotType:          "mark",
+		PoolKeyHash:           poolKeyHash,
+		TotalStake:            types.Uint64(500),
+		RewardAccountAutoVote: models.PoolRewardAccountAutoVoteAbstain,
+		// RewardAccountAutoVoteResolved intentionally zero-value (false).
+	}).Error)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 15},
+		nil,
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(500), tally.SPOTotalStake)
+	assert.Equal(t, uint64(0), tally.SPOAbstainStake,
+		"unresolved row must not bucket stake into Abstain even when the column says Abstain")
+	assert.Equal(t, uint64(0), tally.SPOYesStake)
+	assert.Equal(t, uint64(0), tally.SPONoStake)
 }
 
 // TestTallySPOVotesSnapshotIsFrozenAgainstLiveStateChanges proves the

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -429,7 +429,9 @@ func testBytes(length int, seed byte) []byte {
 
 // seedPoolWithStake registers a pool with the given reward account
 // stake credential and writes a "mark" stake-snapshot row for the
-// given epoch so tallySPOVotes finds it.
+// given epoch so tallySPOVotes finds it. The snapshot's
+// RewardAccountAutoVote is left at None — callers populate it via
+// resolveSnapshotAutoVotes after seeding any Account delegation.
 func seedPoolWithStake(
 	t *testing.T,
 	store *sqliteplugin.MetadataStoreSqlite,
@@ -472,6 +474,34 @@ func seedRewardAccountDelegation(
 	}).Error)
 }
 
+// resolveSnapshotAutoVotes drives the production snapshot-capture
+// pathway in tests: it fetches the "mark" snapshots at the given
+// epoch, runs ResolvePoolRewardAccountAutoVotes against live Pool +
+// Account state, and writes the resolved auto-vote back. Callers
+// invoke this after seeding both pool and reward-account delegation
+// so the snapshot row carries the same RewardAccountAutoVote value
+// the live rotation/import path would have produced.
+func resolveSnapshotAutoVotes(
+	t *testing.T,
+	db *database.Database,
+	epoch uint64,
+) {
+	t.Helper()
+	snapshots, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+		epoch, "mark", nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.ResolvePoolRewardAccountAutoVotes(snapshots, nil))
+	for _, s := range snapshots {
+		require.NoError(t, db.Metadata().(*sqliteplugin.MetadataStoreSqlite).
+			DB().
+			Model(&models.PoolStakeSnapshot{}).
+			Where("id = ?", s.ID).
+			Update("reward_account_auto_vote", s.RewardAccountAutoVote).
+			Error)
+	}
+}
+
 // TestTallySPOVotesExplicitVoteWins exercises the original behaviour:
 // pools with an explicit vote bypass the reward-account auto-vote
 // machinery even when their reward account is delegated to
@@ -485,6 +515,7 @@ func TestTallySPOVotesExplicitVoteWins(t *testing.T) {
 	seedRewardAccountDelegation(
 		t, store, rewardAccount, nil, models.DrepTypeAlwaysNoConfidence,
 	)
+	resolveSnapshotAutoVotes(t, db, 5)
 
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
@@ -519,6 +550,7 @@ func TestTallySPOVotesAlwaysAbstainDelegation(t *testing.T) {
 	seedRewardAccountDelegation(
 		t, store, rewardAccount, nil, models.DrepTypeAlwaysAbstain,
 	)
+	resolveSnapshotAutoVotes(t, db, 7)
 
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
@@ -579,6 +611,7 @@ func TestTallySPOVotesAlwaysNoConfidenceFlipsByActionType(t *testing.T) {
 				t, store, noConfidenceRewardAcct, nil,
 				models.DrepTypeAlwaysNoConfidence,
 			)
+			resolveSnapshotAutoVotes(t, db, 11)
 
 			tally := &ProposalTally{ActionType: uint8(tc.actionType)}
 			err := tallySPOVotes(
@@ -609,6 +642,7 @@ func TestTallySPOVotesOrdinaryDRepNoAutoVote(t *testing.T) {
 	seedRewardAccountDelegation(
 		t, store, rewardAccount, regularDRep, models.DrepTypeAddrKeyHash,
 	)
+	resolveSnapshotAutoVotes(t, db, 4)
 
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
@@ -650,6 +684,7 @@ func TestTallySPOVotesNoRewardAccountDelegation(t *testing.T) {
 		AddedSlot:  1,
 		Active:     true,
 	}).Error)
+	resolveSnapshotAutoVotes(t, db, 8)
 
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
@@ -665,6 +700,64 @@ func TestTallySPOVotesNoRewardAccountDelegation(t *testing.T) {
 	assert.Equal(t, uint64(0), tally.SPOYesStake)
 	assert.Equal(t, uint64(0), tally.SPONoStake)
 	assert.Equal(t, uint64(0), tally.SPOAbstainStake)
+}
+
+// TestTallySPOVotesDeregisteredRewardAccountDoesNotAutoVote asserts
+// that a pool whose reward-account stake credential is deregistered
+// (Account.Active == false) but still carries a stale
+// AlwaysAbstain/AlwaysNoConfidence flag must NOT auto-vote — its
+// stake falls back to implicit no, contributing only to
+// SPOTotalStake. Protects against the active-filter regression flagged
+// in code review.
+func TestTallySPOVotesDeregisteredRewardAccountDoesNotAutoVote(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	abstainPool := testBytes(28, 110)
+	abstainAcct := testBytes(28, 111)
+	noConfidencePool := testBytes(28, 112)
+	noConfidenceAcct := testBytes(28, 113)
+
+	seedPoolWithStake(t, store, abstainPool, abstainAcct, 100, 12)
+	seedPoolWithStake(
+		t, store, noConfidencePool, noConfidenceAcct, 200, 12,
+	)
+	// Both reward accounts carry a predefined-DRep flag but are
+	// flagged inactive (deregistered). The follow-up Update is
+	// needed because models.Account has gorm:"default:true" on
+	// Active, which rewrites a literal-false insert back to true.
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: abstainAcct,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		AddedSlot:  1,
+	}).Error)
+	require.NoError(t, store.DB().Model(&models.Account{}).
+		Where("staking_key = ?", abstainAcct).
+		Update("active", false).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: noConfidenceAcct,
+		DrepType:   models.DrepTypeAlwaysNoConfidence,
+		AddedSlot:  1,
+	}).Error)
+	require.NoError(t, store.DB().Model(&models.Account{}).
+		Where("staking_key = ?", noConfidenceAcct).
+		Update("active", false).Error)
+	resolveSnapshotAutoVotes(t, db, 12)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeNoConfidence),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 12},
+		nil,
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(300), tally.SPOTotalStake)
+	assert.Equal(t, uint64(0), tally.SPOYesStake,
+		"deregistered AlwaysNoConfidence delegation must not auto-Yes on NoConfidence action")
+	assert.Equal(t, uint64(0), tally.SPONoStake)
+	assert.Equal(t, uint64(0), tally.SPOAbstainStake,
+		"deregistered AlwaysAbstain delegation must not auto-abstain")
 }
 
 // TestTallySPOVotesMixedExplicitAndAutoVotes is the end-to-end mix:
@@ -698,6 +791,7 @@ func TestTallySPOVotesMixedExplicitAndAutoVotes(t *testing.T) {
 		models.DrepTypeAlwaysNoConfidence,
 	)
 	// silentAcct: no Account row ⇒ no auto-vote.
+	resolveSnapshotAutoVotes(t, db, 9)
 
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
@@ -719,4 +813,59 @@ func TestTallySPOVotesMixedExplicitAndAutoVotes(t *testing.T) {
 	assert.Equal(t, uint64(200), tally.SPOAbstainStake)
 	// yes / (total - abstain) = 100 / (375 - 200) = 100 / 175 = 4/7
 	assert.Equal(t, big.NewRat(4, 7), tally.SPOYesRatio())
+}
+
+// TestTallySPOVotesSnapshotIsFrozenAgainstLiveStateChanges proves the
+// snapshot-correctness property that motivated the schema change:
+// once a pool's RewardAccountAutoVote is captured on the snapshot row,
+// later changes to the pool's reward account, the reward-account
+// holder's DRep delegation, or the account's active flag must NOT
+// shift the tally for that epoch. Mirrors the cardano-ledger
+// ssDelegations/ssDReps semantics flagged in the PR review.
+func TestTallySPOVotesSnapshotIsFrozenAgainstLiveStateChanges(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 120)
+	originalRewardAcct := testBytes(28, 121)
+	rotatedRewardAcct := testBytes(28, 122)
+	regularDRep := testBytes(28, 123)
+
+	// Snapshot-era state: pool reward account delegated to
+	// AlwaysAbstain. Resolver captures Abstain on the snapshot.
+	seedPoolWithStake(
+		t, store, poolKeyHash, originalRewardAcct, 400, 13,
+	)
+	seedRewardAccountDelegation(
+		t, store, originalRewardAcct, nil, models.DrepTypeAlwaysAbstain,
+	)
+	resolveSnapshotAutoVotes(t, db, 13)
+
+	// Post-snapshot mutations: re-delegate the original credential to
+	// a regular DRep AND rotate the pool's reward account to a brand
+	// new credential. Under live-state lookup this would zero out the
+	// abstain bucket; the snapshot-frozen tally must ignore both.
+	require.NoError(t, store.DB().Model(&models.Account{}).
+		Where("staking_key = ?", originalRewardAcct).
+		Updates(map[string]any{
+			"drep":      regularDRep,
+			"drep_type": models.DrepTypeAddrKeyHash,
+		}).Error)
+	require.NoError(t, store.DB().Model(&models.Pool{}).
+		Where("pool_key_hash = ?", poolKeyHash).
+		Update("reward_account", rotatedRewardAcct).Error)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 13},
+		nil,
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(400), tally.SPOTotalStake)
+	assert.Equal(t, uint64(400), tally.SPOAbstainStake,
+		"snapshot-era AlwaysAbstain must survive a post-snapshot redelegation + reward-account rotation")
+	assert.Equal(t, uint64(0), tally.SPOYesStake)
+	assert.Equal(t, uint64(0), tally.SPONoStake)
 }

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -426,3 +426,297 @@ func testBytes(length int, seed byte) []byte {
 	}
 	return out
 }
+
+// seedPoolWithStake registers a pool with the given reward account
+// stake credential and writes a "mark" stake-snapshot row for the
+// given epoch so tallySPOVotes finds it.
+func seedPoolWithStake(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	poolKeyHash []byte,
+	rewardAccount []byte,
+	stake uint64,
+	epoch uint64,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash:   poolKeyHash,
+		RewardAccount: rewardAccount,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        epoch,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(stake),
+	}).Error)
+}
+
+// seedRewardAccountDelegation writes an Account row that pins the
+// reward-account stake credential to a specific DRep delegation type.
+// Use models.DrepTypeAlwaysAbstain or models.DrepTypeAlwaysNoConfidence
+// to exercise the auto-vote paths.
+func seedRewardAccountDelegation(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	stakeCred []byte,
+	drepCred []byte,
+	drepType uint64,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Drep:       drepCred,
+		DrepType:   drepType,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+}
+
+// TestTallySPOVotesExplicitVoteWins exercises the original behaviour:
+// pools with an explicit vote bypass the reward-account auto-vote
+// machinery even when their reward account is delegated to
+// AlwaysNoConfidence.
+func TestTallySPOVotesExplicitVoteWins(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 50)
+	rewardAccount := testBytes(28, 51)
+
+	seedPoolWithStake(t, store, poolKeyHash, rewardAccount, 100, 5)
+	seedRewardAccountDelegation(
+		t, store, rewardAccount, nil, models.DrepTypeAlwaysNoConfidence,
+	)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 5},
+		[]*models.GovernanceVote{{
+			VoterType:       models.VoterTypeSPO,
+			VoterCredential: poolKeyHash,
+			Vote:            models.VoteYes,
+		}},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(100), tally.SPOTotalStake)
+	assert.Equal(t, uint64(100), tally.SPOYesStake)
+	assert.Equal(t, uint64(0), tally.SPONoStake)
+	assert.Equal(t, uint64(0), tally.SPOAbstainStake)
+}
+
+// TestTallySPOVotesAlwaysAbstainDelegation asserts that a pool with no
+// explicit vote whose reward account delegates to AlwaysAbstain has
+// its stake bucketed as abstain (and thus excluded from the SPO yes
+// ratio denominator).
+func TestTallySPOVotesAlwaysAbstainDelegation(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 60)
+	rewardAccount := testBytes(28, 61)
+
+	seedPoolWithStake(t, store, poolKeyHash, rewardAccount, 200, 7)
+	seedRewardAccountDelegation(
+		t, store, rewardAccount, nil, models.DrepTypeAlwaysAbstain,
+	)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 7},
+		nil,
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(200), tally.SPOTotalStake)
+	assert.Equal(t, uint64(200), tally.SPOAbstainStake)
+	assert.Equal(t, uint64(0), tally.SPOYesStake)
+	assert.Equal(t, uint64(0), tally.SPONoStake)
+	// 0 / (total - abstain) = 0 / 0 ⇒ ratioOf returns the zero rat.
+	assert.Equal(t, 0, tally.SPOYesRatio().Sign())
+}
+
+// TestTallySPOVotesAlwaysNoConfidenceFlipsByActionType asserts that
+// AlwaysNoConfidence reward-account delegation produces an auto-Yes on
+// NoConfidence actions and an auto-No on non-NoConfidence actions,
+// mirroring the AlwaysNoConfidence DRep handling.
+func TestTallySPOVotesAlwaysNoConfidenceFlipsByActionType(t *testing.T) {
+	noConfidencePoolKey := testBytes(28, 70)
+	noConfidenceRewardAcct := testBytes(28, 71)
+
+	cases := []struct {
+		name              string
+		actionType        lcommon.GovActionType
+		expectYesStake    uint64
+		expectNoStake     uint64
+		expectAbstainStake uint64
+	}{
+		{
+			name:              "NoConfidence action → auto Yes",
+			actionType:        lcommon.GovActionTypeNoConfidence,
+			expectYesStake:    300,
+			expectNoStake:     0,
+			expectAbstainStake: 0,
+		},
+		{
+			name:              "TreasuryWithdrawal action → auto No",
+			actionType:        lcommon.GovActionTypeTreasuryWithdrawal,
+			expectYesStake:    0,
+			expectNoStake:     300,
+			expectAbstainStake: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, store := newTallyTestDB(t)
+			seedPoolWithStake(
+				t, store, noConfidencePoolKey, noConfidenceRewardAcct,
+				300, 11,
+			)
+			seedRewardAccountDelegation(
+				t, store, noConfidenceRewardAcct, nil,
+				models.DrepTypeAlwaysNoConfidence,
+			)
+
+			tally := &ProposalTally{ActionType: uint8(tc.actionType)}
+			err := tallySPOVotes(
+				&TallyContext{DB: db, StakeEpoch: 11},
+				nil,
+				tally,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(300), tally.SPOTotalStake)
+			assert.Equal(t, tc.expectYesStake, tally.SPOYesStake)
+			assert.Equal(t, tc.expectNoStake, tally.SPONoStake)
+			assert.Equal(t, tc.expectAbstainStake, tally.SPOAbstainStake)
+		})
+	}
+}
+
+// TestTallySPOVotesOrdinaryDRepNoAutoVote asserts that pools with a
+// reward account delegated to an ordinary credential-backed DRep do
+// NOT auto-vote: their stake stays in SPOTotalStake (implicit no) and
+// is not added to any bucket.
+func TestTallySPOVotesOrdinaryDRepNoAutoVote(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 80)
+	rewardAccount := testBytes(28, 81)
+	regularDRep := testBytes(28, 82)
+
+	seedPoolWithStake(t, store, poolKeyHash, rewardAccount, 150, 4)
+	seedRewardAccountDelegation(
+		t, store, rewardAccount, regularDRep, models.DrepTypeAddrKeyHash,
+	)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 4},
+		nil,
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(150), tally.SPOTotalStake)
+	assert.Equal(t, uint64(0), tally.SPOYesStake)
+	assert.Equal(t, uint64(0), tally.SPONoStake)
+	assert.Equal(t, uint64(0), tally.SPOAbstainStake)
+}
+
+// TestTallySPOVotesNoRewardAccountDelegation asserts the no-delegation
+// case: a pool whose reward account exists but has no DRep set, and a
+// pool whose reward account is not registered at all, both contribute
+// only to SPOTotalStake (implicit no).
+func TestTallySPOVotesNoRewardAccountDelegation(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	registeredPool := testBytes(28, 90)
+	registeredRewardAcct := testBytes(28, 91)
+	unregisteredPool := testBytes(28, 92)
+	unregisteredRewardAcct := testBytes(28, 93)
+
+	seedPoolWithStake(
+		t, store, registeredPool, registeredRewardAcct, 50, 8,
+	)
+	seedPoolWithStake(
+		t, store, unregisteredPool, unregisteredRewardAcct, 70, 8,
+	)
+	// Only the first pool's reward account is registered. The Account
+	// row has no DRep delegation set (zero value DrepType + nil Drep).
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: registeredRewardAcct,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 8},
+		nil,
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(120), tally.SPOTotalStake)
+	assert.Equal(t, uint64(0), tally.SPOYesStake)
+	assert.Equal(t, uint64(0), tally.SPONoStake)
+	assert.Equal(t, uint64(0), tally.SPOAbstainStake)
+}
+
+// TestTallySPOVotesMixedExplicitAndAutoVotes is the end-to-end mix:
+// one pool votes Yes explicitly, one delegates AlwaysAbstain, one
+// delegates AlwaysNoConfidence (auto-No on a non-NoConfidence action),
+// and one has no auto-vote at all (implicit no). The buckets must add
+// up so SPOYesRatio reflects only the explicit Yes against the
+// active-stake denominator.
+func TestTallySPOVotesMixedExplicitAndAutoVotes(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	explicitYesPool := testBytes(28, 100)
+	explicitYesAcct := testBytes(28, 101)
+	abstainPool := testBytes(28, 102)
+	abstainAcct := testBytes(28, 103)
+	noConfidencePool := testBytes(28, 104)
+	noConfidenceAcct := testBytes(28, 105)
+	silentPool := testBytes(28, 106)
+	silentAcct := testBytes(28, 107)
+
+	seedPoolWithStake(t, store, explicitYesPool, explicitYesAcct, 100, 9)
+	seedPoolWithStake(t, store, abstainPool, abstainAcct, 200, 9)
+	seedPoolWithStake(t, store, noConfidencePool, noConfidenceAcct, 50, 9)
+	seedPoolWithStake(t, store, silentPool, silentAcct, 25, 9)
+
+	seedRewardAccountDelegation(
+		t, store, abstainAcct, nil, models.DrepTypeAlwaysAbstain,
+	)
+	seedRewardAccountDelegation(
+		t, store, noConfidenceAcct, nil,
+		models.DrepTypeAlwaysNoConfidence,
+	)
+	// silentAcct: no Account row ⇒ no auto-vote.
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 9},
+		[]*models.GovernanceVote{{
+			VoterType:       models.VoterTypeSPO,
+			VoterCredential: explicitYesPool,
+			Vote:            models.VoteYes,
+		}},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(375), tally.SPOTotalStake)
+	assert.Equal(t, uint64(100), tally.SPOYesStake)
+	assert.Equal(t, uint64(50), tally.SPONoStake)
+	assert.Equal(t, uint64(200), tally.SPOAbstainStake)
+	// yes / (total - abstain) = 100 / (375 - 200) = 100 / 175 = 4/7
+	assert.Equal(t, big.NewRat(4, 7), tally.SPOYesRatio())
+}

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -429,9 +429,16 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		BoundarySlot: 0,
 		SnapshotSlot: 0,
 	}
+	// Same rule as the seeding loop below: resolveAutoVote only when
+	// the target epoch matches the current live-state epoch. For a
+	// true fresh-sync currentEpochId is 0 and live Pool/Account state
+	// IS the genesis boundary, so resolving is correct. For post-
+	// Mithril bootstrap currentEpochId > 0 and `distribution` plus
+	// the live tables reflect that later epoch — passing true here
+	// would freeze today's delegation map onto an epoch-0 row.
 	if err := m.saveSnapshot(
 		ctx, 0, "mark", distribution, evt,
-		true, // resolveAutoVote: live state == genesis boundary
+		currentEpochId == 0,
 	); err != nil {
 		if m.metrics != nil {
 			m.metrics.captureFailureTotal.Inc()

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -304,13 +304,16 @@ func (m *Manager) captureMarkSnapshot(
 		return fmt.Errorf("calculate stake distribution: %w", err)
 	}
 
-	// Save as Mark snapshot for the new epoch
+	// Save as Mark snapshot for the new epoch. At a normal epoch
+	// transition live Pool/Account state matches the boundary, so
+	// the CIP-1694 reward-account auto-vote resolves correctly.
 	if err := m.saveSnapshot(
 		ctx,
 		evt.NewEpoch,
 		"mark",
 		distribution,
 		evt,
+		true, // resolveAutoVote: live state == boundary at this call site
 	); err != nil {
 		if m.metrics != nil {
 			m.metrics.captureFailureTotal.Inc()
@@ -426,7 +429,10 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		BoundarySlot: 0,
 		SnapshotSlot: 0,
 	}
-	if err := m.saveSnapshot(ctx, 0, "mark", distribution, evt); err != nil {
+	if err := m.saveSnapshot(
+		ctx, 0, "mark", distribution, evt,
+		true, // resolveAutoVote: live state == genesis boundary
+	); err != nil {
 		if m.metrics != nil {
 			m.metrics.captureFailureTotal.Inc()
 			m.metrics.captureDurationSeconds.Observe(time.Since(start).Seconds())
@@ -450,8 +456,17 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 			seedEvt := event.EpochTransitionEvent{
 				NewEpoch: seedEpoch,
 			}
+			// resolveAutoVote only on offset==0 (seedEpoch ==
+			// currentEpochId) — that's the one iteration where live
+			// Pool/Account state matches the target boundary. For
+			// offset 1 and 2 we are seeding boundaries that predate
+			// the live state by 1–2 epochs, so resolving would freeze
+			// today's delegation map onto a historical row. Those
+			// rows go in with RewardAccountAutoVoteResolved=false and
+			// the tally treats them as implicit no.
 			if err := m.saveSnapshot(
 				ctx, seedEpoch, "mark", distribution, seedEvt,
+				offset == 0,
 			); err != nil {
 				if m.metrics != nil {
 					m.metrics.captureFailureTotal.Inc()

--- a/ledger/snapshot/manager_test.go
+++ b/ledger/snapshot/manager_test.go
@@ -78,6 +78,104 @@ func TestCaptureGenesisSnapshot_PostMithril(t *testing.T) {
 	}
 }
 
+// TestCaptureGenesisSnapshot_PostMithrilAutoVoteFlagOnlyOnCurrentEpoch
+// asserts the CIP-1694 reward-account auto-vote resolution gate on
+// the post-Mithril seeding loop: live Pool/Account state at bootstrap
+// time matches only the current epoch's boundary, so only the
+// currentEpochId mark row should land with
+// RewardAccountAutoVoteResolved=true. The N-1 and N-2 mark rows seeded
+// in the same loop represent older boundaries — resolving them would
+// freeze today's delegation map into a historical snapshot, so those
+// rows must keep Resolved=false and the tally must treat them as
+// implicit no.
+func TestCaptureGenesisSnapshot_PostMithrilAutoVoteFlagOnlyOnCurrentEpoch(t *testing.T) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	for _, e := range []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+		{EpochId: 148, StartSlot: 63936000, LengthInSlots: 432000},
+		{EpochId: 149, StartSlot: 64368000, LengthInSlots: 432000},
+		{EpochId: 150, StartSlot: 64800000, LengthInSlots: 432000},
+	} {
+		require.NoError(t, gormDB.Create(&e).Error)
+	}
+
+	poolHash := []byte("poolM_12345678901234567890CD")
+	rewardAccount := []byte("rewardCD_12345678901234567890")
+	seedPoolAndDelegations(t, sqliteStore, poolHash, []struct {
+		stakingKey  []byte
+		utxoAmounts []types.Uint64
+	}{
+		{
+			stakingKey:  []byte("aliceCD_staking_key_1234567890"),
+			utxoAmounts: []types.Uint64{50000000},
+		},
+	}, 64800000)
+
+	// Overwrite the pool's reward account to a credential we control
+	// and seed an AlwaysAbstain delegation for that credential. The
+	// resolver, if it runs, will produce Abstain. We then verify it
+	// only ran for the currentEpoch row.
+	require.NoError(t, gormDB.Model(&models.Pool{}).
+		Where("pool_key_hash = ?", poolHash).
+		Update("reward_account", rewardAccount).Error)
+	require.NoError(t, gormDB.Create(&models.Account{
+		StakingKey: rewardAccount,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		AddedSlot:  64800000,
+		Active:     true,
+	}).Error)
+
+	eventBus := event.NewEventBus(nil, nil)
+	mgr := NewManager(db, eventBus, nil)
+
+	require.NoError(t, mgr.CaptureGenesisSnapshot(context.Background()))
+
+	cases := []struct {
+		epoch        uint64
+		wantResolved bool
+		wantAutoVote uint8
+		note         string
+	}{
+		{
+			epoch:        150,
+			wantResolved: true,
+			wantAutoVote: models.PoolRewardAccountAutoVoteAbstain,
+			note:         "current epoch: live state == boundary, resolver runs",
+		},
+		{
+			epoch:        149,
+			wantResolved: false,
+			wantAutoVote: models.PoolRewardAccountAutoVoteNone,
+			note:         "N-1 seed: live state too new, resolver skipped",
+		},
+		{
+			epoch:        148,
+			wantResolved: false,
+			wantAutoVote: models.PoolRewardAccountAutoVoteNone,
+			note:         "N-2 seed: live state too new, resolver skipped",
+		},
+	}
+	for _, tc := range cases {
+		snapshot, sErr := db.Metadata().GetPoolStakeSnapshot(
+			tc.epoch, "mark", poolHash, nil,
+		)
+		require.NoError(t, sErr, "epoch %d", tc.epoch)
+		require.NotNil(t, snapshot, "epoch %d snapshot must exist", tc.epoch)
+		require.Equal(
+			t, tc.wantResolved, snapshot.RewardAccountAutoVoteResolved,
+			"epoch %d (%s): RewardAccountAutoVoteResolved mismatch",
+			tc.epoch, tc.note,
+		)
+		require.Equal(
+			t, tc.wantAutoVote, snapshot.RewardAccountAutoVote,
+			"epoch %d (%s): RewardAccountAutoVote mismatch",
+			tc.epoch, tc.note,
+		)
+	}
+}
+
 // TestCaptureGenesisSnapshot_FreshSync verifies that on a fresh sync
 // (no Mithril), only epoch 0 gets a snapshot and no extra epochs are
 // seeded.

--- a/ledger/snapshot/manager_test.go
+++ b/ledger/snapshot/manager_test.go
@@ -156,6 +156,14 @@ func TestCaptureGenesisSnapshot_PostMithrilAutoVoteFlagOnlyOnCurrentEpoch(t *tes
 			wantAutoVote: models.PoolRewardAccountAutoVoteNone,
 			note:         "N-2 seed: live state too new, resolver skipped",
 		},
+		{
+			epoch:        0,
+			wantResolved: false,
+			wantAutoVote: models.PoolRewardAccountAutoVoteNone,
+			note: "epoch 0 in post-Mithril bootstrap is a historical " +
+				"boundary, not the current one — live state must not " +
+				"be frozen onto the genesis row",
+		},
 	}
 	for _, tc := range cases {
 		snapshot, sErr := db.Metadata().GetPoolStakeSnapshot(
@@ -216,6 +224,15 @@ func TestCaptureGenesisSnapshot_FreshSync(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snapshot, "epoch 0 must have a snapshot")
 	require.NotZero(t, snapshot.TotalStake)
+	// Fresh-sync: live state IS the genesis boundary, so the
+	// CIP-1694 reward-account auto-vote resolver runs and the row
+	// must come out flagged Resolved. Symmetric with the
+	// post-Mithril case where epoch 0 stays unresolved.
+	require.True(
+		t,
+		snapshot.RewardAccountAutoVoteResolved,
+		"fresh-sync epoch 0 row must be resolved",
+	)
 
 	// No spurious snapshots for epochs that don't exist
 	snapshot2, err := db.Metadata().GetPoolStakeSnapshot(

--- a/ledger/snapshot/rotation.go
+++ b/ledger/snapshot/rotation.go
@@ -25,12 +25,25 @@ import (
 )
 
 // saveSnapshot saves a stake distribution as a snapshot of the given type.
+//
+// resolveAutoVote controls whether the CIP-1694 reward-account
+// auto-vote is computed against the live Pool/Account tables and
+// frozen onto the snapshot rows. It MUST be true only when the
+// caller knows that live state matches the target epoch boundary
+// (e.g. the normal epoch-transition call at the boundary moment, or
+// a genesis bootstrap). For historical seed writes — most notably
+// the post-Mithril N-1 / N-2 seeding loop — pass false: those rows
+// represent older boundaries than the live state and resolving them
+// would silently freeze today's delegation map onto a historical
+// snapshot. They are stored with RewardAccountAutoVoteResolved=false
+// so the tally treats them as PoolRewardAccountAutoVoteNone.
 func (m *Manager) saveSnapshot(
 	ctx context.Context,
 	epoch uint64,
 	snapshotType string,
 	distribution *StakeDistribution,
 	evt event.EpochTransitionEvent,
+	resolveAutoVote bool,
 ) error {
 	_ = ctx
 	txn := m.db.Transaction(true) // read-write transaction
@@ -56,11 +69,15 @@ func (m *Manager) saveSnapshot(
 	// Freeze the CIP-1694 SPO reward-account auto-vote per pool at
 	// the snapshot boundary so governance ratification at epoch N
 	// reads snapshot-era delegation rather than the live, possibly
-	// re-delegated state.
-	if err := m.db.ResolvePoolRewardAccountAutoVotes(
-		snapshots, txn,
-	); err != nil {
-		return fmt.Errorf("resolve reward-account auto-votes: %w", err)
+	// re-delegated state. Skipped (rows left Resolved=false) when
+	// the caller is seeding historical epochs where live state does
+	// not match the target boundary.
+	if resolveAutoVote {
+		if err := m.db.ResolvePoolRewardAccountAutoVotes(
+			snapshots, txn,
+		); err != nil {
+			return fmt.Errorf("resolve reward-account auto-votes: %w", err)
+		}
 	}
 
 	if err := meta.SavePoolStakeSnapshots(snapshots, metaTxn); err != nil {

--- a/ledger/snapshot/rotation.go
+++ b/ledger/snapshot/rotation.go
@@ -53,6 +53,16 @@ func (m *Manager) saveSnapshot(
 		})
 	}
 
+	// Freeze the CIP-1694 SPO reward-account auto-vote per pool at
+	// the snapshot boundary so governance ratification at epoch N
+	// reads snapshot-era delegation rather than the live, possibly
+	// re-delegated state.
+	if err := m.db.ResolvePoolRewardAccountAutoVotes(
+		snapshots, txn,
+	); err != nil {
+		return fmt.Errorf("resolve reward-account auto-votes: %w", err)
+	}
+
 	if err := meta.SavePoolStakeSnapshots(snapshots, metaTxn); err != nil {
 		return fmt.Errorf("save pool snapshots: %w", err)
 	}

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1213,6 +1213,21 @@ func persistImportedSnapshot(
 	}
 
 	if len(poolSnapshots) > 0 {
+		// importCertState runs before importSnapShots, so Pool and
+		// Account rows reflect the imported ledger state and the
+		// resolver can classify the CIP-1694 reward-account
+		// auto-vote per snapshot.
+		if err := cfg.Database.ResolvePoolRewardAccountAutoVotes(
+			poolSnapshots, txn,
+		); err != nil {
+			return fmt.Errorf(
+				"resolving reward-account auto-votes for "+
+					"%s snapshot epoch %d: %w",
+				st.name,
+				st.targetEpoch,
+				err,
+			)
+		}
 		if err := store.SavePoolStakeSnapshots(
 			poolSnapshots, metaTxn,
 		); err != nil {

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1213,20 +1213,32 @@ func persistImportedSnapshot(
 	}
 
 	if len(poolSnapshots) > 0 {
-		// importCertState runs before importSnapShots, so Pool and
-		// Account rows reflect the imported ledger state and the
-		// resolver can classify the CIP-1694 reward-account
-		// auto-vote per snapshot.
-		if err := cfg.Database.ResolvePoolRewardAccountAutoVotes(
-			poolSnapshots, txn,
-		); err != nil {
-			return fmt.Errorf(
-				"resolving reward-account auto-votes for "+
-					"%s snapshot epoch %d: %w",
-				st.name,
-				st.targetEpoch,
-				err,
-			)
+		// CIP-1694 reward-account auto-vote can only be faithfully
+		// resolved when live Pool/Account state matches the row's
+		// target boundary. All three import targets are persisted as
+		// "mark" rows (only the target epoch differs: N, N-1, N-2),
+		// so gating on the source rotation name would be fragile —
+		// every row's SnapshotType is "mark" by the time it reaches
+		// this function. The correct semantic check is "is the
+		// target epoch equal to the current import-time epoch?"
+		// Only that one row's boundary matches the live state we'd
+		// read; the other two represent older boundaries and must be
+		// left RewardAccountAutoVoteResolved=false so the tally
+		// treats them as PoolRewardAccountAutoVoteNone (implicit no)
+		// instead of freezing today's delegation map onto an older
+		// boundary.
+		if st.targetEpoch == cfg.State.Epoch {
+			if err := cfg.Database.ResolvePoolRewardAccountAutoVotes(
+				poolSnapshots, txn,
+			); err != nil {
+				return fmt.Errorf(
+					"resolving reward-account auto-votes for "+
+						"%s snapshot epoch %d: %w",
+					st.name,
+					st.targetEpoch,
+					err,
+				)
+			}
 		}
 		if err := store.SavePoolStakeSnapshots(
 			poolSnapshots, metaTxn,

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/stretchr/testify/require"
 )
@@ -303,6 +304,117 @@ func TestPersistImportedSnapshotClearsEpochWhenEmpty(t *testing.T) {
 	require.True(t, summary.SnapshotReady)
 	require.Equal(t, existingSummary.BoundarySlot, summary.BoundarySlot)
 	require.True(t, bytes.Equal(existingSummary.EpochNonce, summary.EpochNonce))
+}
+
+// TestPersistImportedSnapshotResolvesAutoVoteOnlyForMark verifies the
+// CIP-1694 reward-account auto-vote resolver runs against live Pool /
+// Account state for the "mark" rotation (whose target epoch equals
+// the import-time epoch and therefore matches the live state) but is
+// SKIPPED for "set" and "go" rotations (whose target epochs are
+// older than the live state). The set/go rows are still written but
+// must carry RewardAccountAutoVoteResolved=false so the tally
+// fallback treats them as implicit no rather than freezing today's
+// delegation map into a historical boundary.
+func TestPersistImportedSnapshotResolvesAutoVoteOnlyForMark(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	poolKeyHash := make([]byte, 28)
+	poolKeyHash[0] = 0x42
+	rewardAccount := make([]byte, 28)
+	rewardAccount[0] = 0x43
+
+	// Seed Pool + Account state so the resolver, if called, would
+	// produce a non-default outcome (Abstain). Set/go must NOT pick
+	// this up — that's the regression we're guarding against.
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test requires the sqlite metadata backend")
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash:   poolKeyHash,
+		RewardAccount: rewardAccount,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardAccount,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+
+	mkSnapshot := func(epoch uint64) []*models.PoolStakeSnapshot {
+		return []*models.PoolStakeSnapshot{
+			{
+				Epoch:          epoch,
+				SnapshotType:   "mark",
+				PoolKeyHash:    poolKeyHash,
+				TotalStake:     100,
+				DelegatorCount: 1,
+				CapturedSlot:   55,
+			},
+		}
+	}
+
+	cases := []struct {
+		name           string
+		targetEpoch    uint64
+		wantResolved   bool
+		wantAutoVote   uint8
+	}{
+		{
+			name:         "mark",
+			targetEpoch:  102,
+			wantResolved: true,
+			wantAutoVote: models.PoolRewardAccountAutoVoteAbstain,
+		},
+		{
+			name:         "set",
+			targetEpoch:  101,
+			wantResolved: false,
+			wantAutoVote: models.PoolRewardAccountAutoVoteNone,
+		},
+		{
+			name:         "go",
+			targetEpoch:  100,
+			wantResolved: false,
+			wantAutoVote: models.PoolRewardAccountAutoVoteNone,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := persistImportedSnapshot(
+				ImportConfig{
+					Database: db,
+					State: &RawLedgerState{
+						Epoch:      102,
+						EpochNonce: []byte{0x01},
+					},
+				},
+				999,
+				snapshotImportTarget{
+					name:        tc.name,
+					targetEpoch: tc.targetEpoch,
+				},
+				mkSnapshot(tc.targetEpoch),
+			)
+			require.NoError(t, err)
+
+			stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+				tc.targetEpoch, "mark", nil,
+			)
+			require.NoError(t, err)
+			require.Len(t, stored, 1)
+			require.Equal(
+				t, tc.wantResolved, stored[0].RewardAccountAutoVoteResolved,
+				"RewardAccountAutoVoteResolved mismatch for %s", tc.name,
+			)
+			require.Equal(
+				t, tc.wantAutoVote, stored[0].RewardAccountAutoVote,
+				"RewardAccountAutoVote mismatch for %s", tc.name,
+			)
+		})
+	}
 }
 
 func TestImportPParamsAnchorsAddedSlotToCurrentEpochStart(t *testing.T) {


### PR DESCRIPTION
Closes #2369 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CIP-1694 SPO reward-account delegation with snapshot-frozen auto-votes and explicit-vote precedence. Auto-votes are used only when the snapshot row is resolved; otherwise the pool counts toward total stake (implicit no). Post-Mithril bootstrap now skips resolving epoch 0 so live-state delegation isn’t frozen onto historical rows.

- **New Features**
  - Added `RewardAccountAutoVote` and `RewardAccountAutoVoteResolved` to pool snapshots, plus `database.ResolvePoolRewardAccountAutoVotes` to classify active reward accounts at the snapshot boundary.
  - `tallySPOVotes`: explicit votes win; `AlwaysAbstain` → Abstain; `AlwaysNoConfidence` → Yes on NoConfidence actions, No otherwise; unresolved rows are treated as None (implicit no).
  - Snapshot capture/import resolves auto-votes only when live state matches the target boundary: normal epoch transitions and current-epoch import resolve; N-1/N-2 remain unresolved; post-Mithril genesis leaves epoch 0 unresolved, while fresh-sync genesis resolves epoch 0.
  - Persistence: all backends upsert `reward_account_auto_vote{,_resolved}` so resolved values survive re-saves. Tests cover precedence, action mapping, deregistered accounts (active-only), unresolved fallback, snapshot immutability, and import/genesis gating (including post-Mithril epoch 0).

<sup>Written for commit 52c50da74ecaa1f735bf7efa56aa513efea8ec40. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stake pool voting now includes all pools' snapshot stake in totals and applies reward-account delegation auto-votes; explicit pool votes still override auto-votes.
* **Bug Fixes**
  * Snapshotting and import now freeze and persist resolved auto-vote decisions, preventing later account changes or failed resolutions from altering past tallies.
* **Tests**
  * Added extensive tests covering explicit vs. auto-votes, action-specific mappings, unresolved snapshot behavior, upsert persistence, and snapshot freeze semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->