### PR TITLE
fix(utxorpc): Add server-side timeout for WaitForTx streams

### DIFF
--- a/utxorpc/rpc_connect_test.go
+++ b/utxorpc/rpc_connect_test.go
@@ -28,7 +28,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"testing"
 	"time"
 
@@ -644,6 +643,9 @@ func waitForEventSubscriber(
 	eventType event.EventType,
 ) {
 	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
 	for {
 		if eb.HasSubscribers(eventType) {
 			return
@@ -651,8 +653,7 @@ func waitForEventSubscriber(
 		select {
 		case <-ctx.Done():
 			t.Fatalf("event subscriber was not registered: %v", ctx.Err())
-		default:
-			runtime.Gosched()
+		case <-ticker.C:
 		}
 	}
 }

--- a/utxorpc/rpc_connect_test.go
+++ b/utxorpc/rpc_connect_test.go
@@ -22,11 +22,13 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -86,8 +88,9 @@ type utxorpcConnectHarness struct {
 }
 
 type utxorpcHarnessOptions struct {
-	numBlocks       int
-	maxHistoryItems int
+	numBlocks        int
+	maxHistoryItems  int
+	waitForTxTimeout time.Duration
 }
 
 func newConnectH2CClient() *http.Client {
@@ -207,11 +210,12 @@ func newUtxorpcConnectHarness(t *testing.T, opts utxorpcHarnessOptions) *utxorpc
 		maxHist = DefaultMaxHistoryItems
 	}
 	u := NewUtxorpc(UtxorpcConfig{
-		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:        apiBus,
-		LedgerState:     ls,
-		Mempool:         mp,
-		MaxHistoryItems: maxHist,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:         apiBus,
+		LedgerState:      ls,
+		Mempool:          mp,
+		MaxHistoryItems:  maxHist,
+		WaitForTxTimeout: opts.waitForTxTimeout,
 	})
 
 	srv := httptest.NewServer(testUtxorpcHTTPHandler(u))
@@ -629,6 +633,122 @@ func TestConnect_WaitForTx_EmptyRefsClosesStream(t *testing.T) {
 	require.False(t, stream.Receive(), "no refs means the handler returns without frames")
 	require.NoError(t, stream.Err())
 	cancel()
+}
+
+// Wait until WaitForTx is listening on the fake event bus before the test
+// publishes events.
+func waitForEventSubscriber(
+	t *testing.T,
+	ctx context.Context,
+	eb *event.EventBus,
+	eventType event.EventType,
+) {
+	t.Helper()
+	for {
+		if eb.HasSubscribers(eventType) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("event subscriber was not registered: %v", ctx.Err())
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+type waitForTxResult struct {
+	resp *submit.WaitForTxResponse
+	err  error
+}
+
+// Run WaitForTx in the background so the test can cancel the request while
+// the stream is still open.
+func receiveWaitForTx(
+	ctx context.Context,
+	cli submitconnect.SubmitServiceClient,
+	req *submit.WaitForTxRequest,
+) <-chan waitForTxResult {
+	resultCh := make(chan waitForTxResult, 1)
+	go func() {
+		stream, err := cli.WaitForTx(ctx, connect.NewRequest(req))
+		if err != nil {
+			resultCh <- waitForTxResult{err: err}
+			return
+		}
+		if !stream.Receive() {
+			resultCh <- waitForTxResult{err: stream.Err()}
+			return
+		}
+		resp := stream.Msg()
+		if stream.Receive() {
+			resultCh <- waitForTxResult{
+				err: fmt.Errorf("unexpected extra WaitForTx frame"),
+			}
+			return
+		}
+		resultCh <- waitForTxResult{resp: resp, err: stream.Err()}
+	}()
+	return resultCh
+}
+
+// Test that WaitForTx times out when the transaction is never seen.
+func TestConnect_WaitForTx_ServerTimeout(t *testing.T) {
+	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{
+		numBlocks:        5,
+		waitForTxTimeout: 25 * time.Millisecond,
+	})
+	cli := submitconnect.NewSubmitServiceClient(h.Client, h.Server.URL, connect.WithGRPC())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resultCh := receiveWaitForTx(
+		ctx,
+		cli,
+		&submit.WaitForTxRequest{
+			Ref: [][]byte{bytes.Repeat([]byte{0xaa}, 32)},
+		},
+	)
+	select {
+	case result := <-resultCh:
+		require.Nil(t, result.resp)
+		require.Equal(t, connect.CodeDeadlineExceeded, connect.CodeOf(result.err))
+		require.ErrorContains(t, result.err, "wait for tx timed out")
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}
+
+// Test that WaitForTx stops when the client cancels first.
+func TestConnect_WaitForTx_ClientCancellation(t *testing.T) {
+	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{
+		numBlocks:        5,
+		waitForTxTimeout: time.Hour,
+	})
+	cli := submitconnect.NewSubmitServiceClient(h.Client, h.Server.URL, connect.WithGRPC())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := receiveWaitForTx(
+		ctx,
+		cli,
+		&submit.WaitForTxRequest{
+			Ref: [][]byte{bytes.Repeat([]byte{0xbb}, 32)},
+		},
+	)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer waitCancel()
+	waitForEventSubscriber(t, waitCtx, h.EB, ledger.BlockfetchEventType)
+
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		require.Nil(t, result.resp)
+		require.Equal(t, connect.CodeCanceled, connect.CodeOf(result.err))
+	case <-waitCtx.Done():
+		t.Fatal(waitCtx.Err())
+	}
 }
 
 func TestConnect_EvalTx(t *testing.T) {

--- a/utxorpc/rpc_connect_test.go
+++ b/utxorpc/rpc_connect_test.go
@@ -88,9 +88,9 @@ type utxorpcConnectHarness struct {
 }
 
 type utxorpcHarnessOptions struct {
-	numBlocks        int
-	maxHistoryItems  int
-	waitForTxTimeout time.Duration
+	numBlocks       int
+	maxHistoryItems int
+	serverTimeout   time.Duration
 }
 
 func newConnectH2CClient() *http.Client {
@@ -210,12 +210,12 @@ func newUtxorpcConnectHarness(t *testing.T, opts utxorpcHarnessOptions) *utxorpc
 		maxHist = DefaultMaxHistoryItems
 	}
 	u := NewUtxorpc(UtxorpcConfig{
-		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:         apiBus,
-		LedgerState:      ls,
-		Mempool:          mp,
-		MaxHistoryItems:  maxHist,
-		WaitForTxTimeout: opts.waitForTxTimeout,
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:        apiBus,
+		LedgerState:     ls,
+		Mempool:         mp,
+		MaxHistoryItems: maxHist,
+		ServerTimeout:   opts.serverTimeout,
 	})
 
 	srv := httptest.NewServer(testUtxorpcHTTPHandler(u))
@@ -695,8 +695,8 @@ func receiveWaitForTx(
 // Test that WaitForTx times out when the transaction is never seen.
 func TestConnect_WaitForTx_ServerTimeout(t *testing.T) {
 	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{
-		numBlocks:        5,
-		waitForTxTimeout: 25 * time.Millisecond,
+		numBlocks:     5,
+		serverTimeout: 25 * time.Millisecond,
 	})
 	cli := submitconnect.NewSubmitServiceClient(h.Client, h.Server.URL, connect.WithGRPC())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -722,8 +722,8 @@ func TestConnect_WaitForTx_ServerTimeout(t *testing.T) {
 // Test that WaitForTx stops when the client cancels first.
 func TestConnect_WaitForTx_ClientCancellation(t *testing.T) {
 	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{
-		numBlocks:        5,
-		waitForTxTimeout: time.Hour,
+		numBlocks:     5,
+		serverTimeout: time.Hour,
 	})
 	cli := submitconnect.NewSubmitServiceClient(h.Client, h.Server.URL, connect.WithGRPC())
 	ctx, cancel := context.WithCancel(context.Background())

--- a/utxorpc/submit.go
+++ b/utxorpc/submit.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/blinklabs-io/dingo/event"
@@ -78,7 +79,8 @@ func (s *submitServiceServer) SubmitTx(
 
 // WaitForTx subscribes to block events and streams confirmation responses
 // for the requested transaction hashes. It blocks until all requested
-// transactions are confirmed or the client disconnects.
+// transactions are confirmed, the server-side timeout expires, or the client
+// disconnects.
 func (s *submitServiceServer) WaitForTx(
 	ctx context.Context,
 	req *connect.Request[submit.WaitForTxRequest],
@@ -200,8 +202,12 @@ func (s *submitServiceServer) WaitForTx(
 		streamMu.Unlock()
 	}()
 
+	waitTimeout := s.utxorpc.config.WaitForTxTimeout
+	timeout := time.NewTimer(waitTimeout)
+	defer timeout.Stop()
+
 	// Block until all transactions are confirmed, an error
-	// occurs, or the client disconnects
+	// occurs, the server-side timeout expires, or the client disconnects
 	select {
 	case <-doneCh:
 		return nil
@@ -219,6 +225,19 @@ func (s *submitServiceServer) WaitForTx(
 			"WaitForTx client disconnected",
 		)
 		return ctx.Err()
+	case <-timeout.C:
+		mu.Lock()
+		remaining := len(pending)
+		mu.Unlock()
+		s.utxorpc.config.Logger.Warn(
+			"WaitForTx timed out",
+			"timeout", waitTimeout,
+			"pending", remaining,
+		)
+		return connect.NewError(
+			connect.CodeDeadlineExceeded,
+			fmt.Errorf("wait for tx timed out after %s", waitTimeout),
+		)
 	}
 }
 

--- a/utxorpc/submit.go
+++ b/utxorpc/submit.go
@@ -202,8 +202,8 @@ func (s *submitServiceServer) WaitForTx(
 		streamMu.Unlock()
 	}()
 
-	waitTimeout := s.utxorpc.config.WaitForTxTimeout
-	timeout := time.NewTimer(waitTimeout)
+	serverTimeout := s.utxorpc.config.ServerTimeout
+	timeout := time.NewTimer(serverTimeout)
 	defer timeout.Stop()
 
 	// Block until all transactions are confirmed, an error
@@ -231,12 +231,12 @@ func (s *submitServiceServer) WaitForTx(
 		mu.Unlock()
 		s.utxorpc.config.Logger.Warn(
 			"WaitForTx timed out",
-			"timeout", waitTimeout,
+			"timeout", serverTimeout,
 			"pending", remaining,
 		)
 		return connect.NewError(
 			connect.CodeDeadlineExceeded,
-			fmt.Errorf("wait for tx timed out after %s", waitTimeout),
+			fmt.Errorf("wait for tx timed out after %s", serverTimeout),
 		)
 	}
 }

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -43,10 +43,11 @@ import (
 // Default request size limits to prevent denial-of-service via
 // unbounded request arrays.
 const (
-	DefaultMaxBlockRefs    = 100
-	DefaultMaxUtxoKeys     = 1000
-	DefaultMaxHistoryItems = 10000
-	DefaultMaxDataKeys     = 1000
+	DefaultMaxBlockRefs     = 100
+	DefaultMaxUtxoKeys      = 1000
+	DefaultMaxHistoryItems  = 10000
+	DefaultMaxDataKeys      = 1000
+	DefaultWaitForTxTimeout = time.Hour
 )
 
 type Utxorpc struct {
@@ -72,6 +73,8 @@ type UtxorpcConfig struct {
 	// max_items uses this cap.
 	MaxHistoryItems int
 	MaxDataKeys     int
+	// WaitForTxTimeout bounds WaitForTx streams server-side (0 = use default).
+	WaitForTxTimeout time.Duration
 }
 
 func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
@@ -96,6 +99,9 @@ func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
 	}
 	if cfg.MaxDataKeys <= 0 {
 		cfg.MaxDataKeys = DefaultMaxDataKeys
+	}
+	if cfg.WaitForTxTimeout <= 0 {
+		cfg.WaitForTxTimeout = DefaultWaitForTxTimeout
 	}
 	return &Utxorpc{
 		config: cfg,

--- a/utxorpc/utxorpc.go
+++ b/utxorpc/utxorpc.go
@@ -43,11 +43,11 @@ import (
 // Default request size limits to prevent denial-of-service via
 // unbounded request arrays.
 const (
-	DefaultMaxBlockRefs     = 100
-	DefaultMaxUtxoKeys      = 1000
-	DefaultMaxHistoryItems  = 10000
-	DefaultMaxDataKeys      = 1000
-	DefaultWaitForTxTimeout = time.Hour
+	DefaultMaxBlockRefs    = 100
+	DefaultMaxUtxoKeys     = 1000
+	DefaultMaxHistoryItems = 10000
+	DefaultMaxDataKeys     = 1000
+	DefaultServerTimeout   = time.Hour
 )
 
 type Utxorpc struct {
@@ -73,8 +73,9 @@ type UtxorpcConfig struct {
 	// max_items uses this cap.
 	MaxHistoryItems int
 	MaxDataKeys     int
-	// WaitForTxTimeout bounds WaitForTx streams server-side (0 = use default).
-	WaitForTxTimeout time.Duration
+	// ServerTimeout bounds long-running UTxO RPC handlers server-side
+	// (0 = use default).
+	ServerTimeout time.Duration
 }
 
 func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
@@ -100,8 +101,8 @@ func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
 	if cfg.MaxDataKeys <= 0 {
 		cfg.MaxDataKeys = DefaultMaxDataKeys
 	}
-	if cfg.WaitForTxTimeout <= 0 {
-		cfg.WaitForTxTimeout = DefaultWaitForTxTimeout
+	if cfg.ServerTimeout <= 0 {
+		cfg.ServerTimeout = DefaultServerTimeout
 	}
 	return &Utxorpc{
 		config: cfg,

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -59,27 +59,27 @@ func TestNewUtxorpc_DefaultLimits(t *testing.T) {
 	)
 	require.Equal(
 		t,
-		DefaultWaitForTxTimeout,
-		u.config.WaitForTxTimeout,
-		"WaitForTxTimeout should default",
+		DefaultServerTimeout,
+		u.config.ServerTimeout,
+		"ServerTimeout should default",
 	)
 }
 
 func TestNewUtxorpc_CustomLimits(t *testing.T) {
 	u := NewUtxorpc(UtxorpcConfig{
-		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:         event.NewEventBus(nil, nil),
-		MaxBlockRefs:     50,
-		MaxUtxoKeys:      500,
-		MaxHistoryItems:  5000,
-		MaxDataKeys:      200,
-		WaitForTxTimeout: 10 * time.Second,
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:        event.NewEventBus(nil, nil),
+		MaxBlockRefs:    50,
+		MaxUtxoKeys:     500,
+		MaxHistoryItems: 5000,
+		MaxDataKeys:     200,
+		ServerTimeout:   10 * time.Second,
 	})
 	require.Equal(t, 50, u.config.MaxBlockRefs)
 	require.Equal(t, 500, u.config.MaxUtxoKeys)
 	require.Equal(t, 5000, u.config.MaxHistoryItems)
 	require.Equal(t, 200, u.config.MaxDataKeys)
-	require.Equal(t, 10*time.Second, u.config.WaitForTxTimeout)
+	require.Equal(t, 10*time.Second, u.config.ServerTimeout)
 }
 
 // TestRequestLimitConstants verifies that the default limit constants
@@ -89,7 +89,7 @@ func TestRequestLimitConstants(t *testing.T) {
 	require.Equal(t, 1000, DefaultMaxUtxoKeys)
 	require.Equal(t, 10000, DefaultMaxHistoryItems)
 	require.Equal(t, 1000, DefaultMaxDataKeys)
-	require.Equal(t, time.Hour, DefaultWaitForTxTimeout)
+	require.Equal(t, time.Hour, DefaultServerTimeout)
 }
 
 // TestRequestLimitEnforcement_Pattern verifies the limit enforcement

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -57,21 +57,29 @@ func TestNewUtxorpc_DefaultLimits(t *testing.T) {
 		u.config.MaxDataKeys,
 		"MaxDataKeys should default",
 	)
+	require.Equal(
+		t,
+		DefaultWaitForTxTimeout,
+		u.config.WaitForTxTimeout,
+		"WaitForTxTimeout should default",
+	)
 }
 
 func TestNewUtxorpc_CustomLimits(t *testing.T) {
 	u := NewUtxorpc(UtxorpcConfig{
-		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:        event.NewEventBus(nil, nil),
-		MaxBlockRefs:    50,
-		MaxUtxoKeys:     500,
-		MaxHistoryItems: 5000,
-		MaxDataKeys:     200,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:         event.NewEventBus(nil, nil),
+		MaxBlockRefs:     50,
+		MaxUtxoKeys:      500,
+		MaxHistoryItems:  5000,
+		MaxDataKeys:      200,
+		WaitForTxTimeout: 10 * time.Second,
 	})
 	require.Equal(t, 50, u.config.MaxBlockRefs)
 	require.Equal(t, 500, u.config.MaxUtxoKeys)
 	require.Equal(t, 5000, u.config.MaxHistoryItems)
 	require.Equal(t, 200, u.config.MaxDataKeys)
+	require.Equal(t, 10*time.Second, u.config.WaitForTxTimeout)
 }
 
 // TestRequestLimitConstants verifies that the default limit constants
@@ -81,6 +89,7 @@ func TestRequestLimitConstants(t *testing.T) {
 	require.Equal(t, 1000, DefaultMaxUtxoKeys)
 	require.Equal(t, 10000, DefaultMaxHistoryItems)
 	require.Equal(t, 1000, DefaultMaxDataKeys)
+	require.Equal(t, time.Hour, DefaultWaitForTxTimeout)
 }
 
 // TestRequestLimitEnforcement_Pattern verifies the limit enforcement


### PR DESCRIPTION
1. Added a shared ServerTimeout in UtxorpcConfig with a default of 1 hour.
2. Made changes to return DeadlineExceeded when the server-side request exceed the WaitForTx timeout value.
3. Added TestConnect_WaitForTx_ServerTimeout to verify the stream returns DeadlineExceeded when no requested transaction is observed before the server timeout.
4. Added TestConnect_WaitForTx_ClientCancellation to verify client cancellation still closes the stream normally before the server timeout.

Closes #2282 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a general, configurable server-side timeout to `utxorpc` and applies it to `WaitForTx` so streams don’t hang; timed-out requests return `connect.CodeDeadlineExceeded`. Tests were hardened by replacing busy waits with an explicit subscriber wait.

- **Bug Fixes**
  - `WaitForTx` stops on server timeout and returns `connect.CodeDeadlineExceeded` with a clear message.
  - Client cancellation remains unchanged and returns `connect.CodeCanceled`.
  - Replaced busy-wait in `WaitForTx` tests with a subscriber wait to reduce flakiness.

- **Migration**
  - Configure `UtxorpcConfig.ServerTimeout` (default 1h) to bound long-running handlers like `WaitForTx`.

<sup>Written for commit f92e5c81b53e86c50d472db363d6a037e6644c3f. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2379?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added configurable timeout for transaction confirmation operations with a 1-hour default
* Improved error reporting for timeout expiration and client cancellation scenarios during transaction waiting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->