### PR TITLE
fix(mithril): defensiveness during download

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -357,6 +357,12 @@ func runMithrilSync(
 	if err != nil {
 		return err
 	}
+	if cfg.Mithril.DownloadMaxIdleRetries < 0 {
+		return fmt.Errorf(
+			"invalid Mithril download max idle retries %d: must be >= 0",
+			cfg.Mithril.DownloadMaxIdleRetries,
+		)
+	}
 
 	metrics.setPhaseActive(mithrilSyncPhaseBootstrap, true)
 	result, err := mithril.Bootstrap(

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -86,6 +86,20 @@ func resolveAggregatorURL(
 	return url, nil
 }
 
+func parseOptionalDuration(
+	name string,
+	value string,
+) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", name, value, err)
+	}
+	return duration, nil
+}
+
 func mithrilListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -336,6 +350,13 @@ func runMithrilSync(
 			cfg.DatabasePath, ".mithril-cache",
 		)
 	}
+	downloadIdleTimeout, err := parseOptionalDuration(
+		"Mithril download idle timeout",
+		cfg.Mithril.DownloadIdleTimeout,
+	)
+	if err != nil {
+		return err
+	}
 
 	metrics.setPhaseActive(mithrilSyncPhaseBootstrap, true)
 	result, err := mithril.Bootstrap(
@@ -349,7 +370,9 @@ func runMithrilSync(
 			GenesisVerificationKey: nodeCfg.MithrilGenesisVerificationKey,
 			AncillaryVerificationKey: nodeCfg.
 				MithrilGenesisAncillaryVerificationKey,
-			Logger: logger,
+			Logger:                 logger,
+			DownloadIdleTimeout:    downloadIdleTimeout,
+			DownloadMaxIdleRetries: cfg.Mithril.DownloadMaxIdleRetries,
 			OnProgress: func() func(mithril.DownloadProgress) {
 				const progressLogInterval = 10 * time.Second
 				const progressLogPercentStep = 5.0

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -368,6 +368,14 @@ mithril:
   # Directory for downloading snapshot archives
   # If empty, a randomized temporary directory is created automatically
   # downloadDir: ""
+  # Maximum idle time waiting for snapshot headers or body bytes before retrying
+  # Empty uses the built-in default. A negative duration disables idle detection.
+  # CLI: --mithril-download-idle-timeout
+  # downloadIdleTimeout: ""
+  # Consecutive idle retries allowed without additional downloaded bytes
+  # 0 uses the built-in default
+  # CLI: --mithril-download-max-idle-retries
+  # downloadMaxIdleRetries: 0
   # Remove temporary files after loading completes
   # Default: true
   cleanupAfterLoad: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -325,6 +325,13 @@ type MithrilConfig struct {
 	// DownloadDir is the directory where snapshot archives are downloaded.
 	// If empty, a randomized temporary directory is created automatically.
 	DownloadDir string `yaml:"downloadDir"        envconfig:"DINGO_MITHRIL_DOWNLOAD_DIR"`
+	// DownloadIdleTimeout is the maximum idle time to wait for snapshot
+	// response headers or body bytes before retrying. Empty uses the
+	// downloader default; a negative duration disables idle detection.
+	DownloadIdleTimeout string `yaml:"downloadIdleTimeout" envconfig:"DINGO_MITHRIL_DOWNLOAD_IDLE_TIMEOUT"`
+	// DownloadMaxIdleRetries is the number of consecutive idle retries
+	// allowed without additional bytes. Zero uses the downloader default.
+	DownloadMaxIdleRetries int `yaml:"downloadMaxIdleRetries" envconfig:"DINGO_MITHRIL_DOWNLOAD_MAX_IDLE_RETRIES"`
 	// CleanupAfterLoad controls whether temporary files are removed
 	// after the ImmutableDB has been loaded.
 	CleanupAfterLoad bool `yaml:"cleanupAfterLoad"   envconfig:"DINGO_MITHRIL_CLEANUP"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,8 @@ mithril:
   enabled: false
   aggregatorUrl: "https://mithril.example.net"
   downloadDir: "/tmp/mithril"
+  downloadIdleTimeout: "5m"
+  downloadMaxIdleRetries: 9
   cleanupAfterLoad: false
   verifyCertificates: false
 `
@@ -150,11 +152,13 @@ mithril:
 		ForgeSyncToleranceSlots:     321,
 		ForgeStaleGapThresholdSlots: 654,
 		Mithril: MithrilConfig{
-			Enabled:            false,
-			AggregatorURL:      "https://mithril.example.net",
-			DownloadDir:        "/tmp/mithril",
-			CleanupAfterLoad:   false,
-			VerifyCertificates: false,
+			Enabled:                false,
+			AggregatorURL:          "https://mithril.example.net",
+			DownloadDir:            "/tmp/mithril",
+			DownloadIdleTimeout:    "5m",
+			DownloadMaxIdleRetries: 9,
+			CleanupAfterLoad:       false,
+			VerifyCertificates:     false,
 		},
 	}
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -141,6 +141,8 @@ var flagSpecs = []flagSpec{
 	boolFlag("Mithril.Enabled", "mithril-enabled", "enable Mithril integration"),
 	stringFlag("Mithril.AggregatorURL", "mithril-aggregator-url", "", "Mithril aggregator URL override"),
 	stringFlag("Mithril.DownloadDir", "mithril-download-dir", "", "Mithril snapshot download directory"),
+	stringFlag("Mithril.DownloadIdleTimeout", "mithril-download-idle-timeout", "", "Mithril snapshot download idle timeout"),
+	intFlag("Mithril.DownloadMaxIdleRetries", "mithril-download-max-idle-retries", "Mithril snapshot download idle retries without progress"),
 	boolFlag("Mithril.CleanupAfterLoad", "mithril-cleanup-after-load", "cleanup Mithril files after load"),
 	boolFlag("Mithril.VerifyCertificates", "mithril-verify-certs", "verify Mithril certificate chains"),
 }

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
 )
 
 // BootstrapConfig holds configuration for the Mithril bootstrap
@@ -57,6 +58,13 @@ type BootstrapConfig struct {
 	Logger *slog.Logger
 	// OnProgress is called during download with progress updates.
 	OnProgress ProgressFunc
+	// DownloadIdleTimeout is the maximum time to wait for download
+	// response headers or body bytes before retrying. Zero uses the
+	// downloader default; negative disables idle detection.
+	DownloadIdleTimeout time.Duration
+	// DownloadMaxIdleRetries is the number of consecutive idle retries
+	// allowed without additional bytes. Zero uses the downloader default.
+	DownloadMaxIdleRetries int
 }
 
 // VerificationMode selects the level of Mithril certificate verification.
@@ -330,12 +338,14 @@ func Bootstrap(
 		for i, loc := range snapshot.Locations {
 			archivePath, dlErr = DownloadSnapshot(
 				ctx, DownloadConfig{
-					URL:          loc,
-					DestDir:      downloadDir,
-					Filename:     archiveFilename,
-					ExpectedSize: snapshot.Size,
-					Logger:       cfg.Logger,
-					OnProgress:   cfg.OnProgress,
+					URL:            loc,
+					DestDir:        downloadDir,
+					Filename:       archiveFilename,
+					ExpectedSize:   snapshot.Size,
+					Logger:         cfg.Logger,
+					OnProgress:     cfg.OnProgress,
+					IdleTimeout:    cfg.DownloadIdleTimeout,
+					MaxIdleRetries: cfg.DownloadMaxIdleRetries,
 				},
 			)
 			if dlErr == nil {
@@ -514,12 +524,14 @@ func downloadAncillary(
 	for i, loc := range snapshot.AncillaryLocations {
 		ancillaryPath, err = DownloadSnapshot(
 			ctx, DownloadConfig{
-				URL:          loc,
-				DestDir:      downloadDir,
-				Filename:     ancillaryFilename,
-				ExpectedSize: snapshot.AncillarySize,
-				Logger:       cfg.Logger,
-				OnProgress:   cfg.OnProgress,
+				URL:            loc,
+				DestDir:        downloadDir,
+				Filename:       ancillaryFilename,
+				ExpectedSize:   snapshot.AncillarySize,
+				Logger:         cfg.Logger,
+				OnProgress:     cfg.OnProgress,
+				IdleTimeout:    cfg.DownloadIdleTimeout,
+				MaxIdleRetries: cfg.DownloadMaxIdleRetries,
 			},
 		)
 		if err == nil {

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -49,7 +49,7 @@ type ProgressFunc func(DownloadProgress)
 
 const (
 	defaultDownloadIdleTimeout = 2 * time.Minute
-	defaultDownloadIdleRetries = 3
+	defaultDownloadIdleRetries = 12
 )
 
 var errDownloadIdleTimeout = errors.New("download idle timeout")
@@ -87,8 +87,9 @@ type DownloadConfig struct {
 	// or body bytes before retrying. If zero, a conservative default
 	// is used. If negative, idle detection is disabled.
 	IdleTimeout time.Duration
-	// MaxIdleRetries is the number of retry attempts after an idle
-	// timeout. If zero, a conservative default is used.
+	// MaxIdleRetries is the number of consecutive retry attempts
+	// after idle timeouts that make no additional download progress.
+	// If zero, a conservative default is used.
 	MaxIdleRetries int
 }
 
@@ -233,6 +234,34 @@ func downloadIdleTimeoutCause(timeout time.Duration) error {
 	return fmt.Errorf("%w after %s without data", errDownloadIdleTimeout, timeout)
 }
 
+func downloadDestinationPath(cfg DownloadConfig) string {
+	filename := filepath.Base(cfg.Filename)
+	if filename == "." || filename == "/" {
+		filename = "snapshot.tar.zst"
+	}
+	return filepath.Join(cfg.DestDir, filename)
+}
+
+func downloadFileSize(filename string) int64 {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+func newDownloadTransport() *http.Transport {
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport := base.Clone()
+		transport.DisableKeepAlives = true
+		return transport
+	}
+	return &http.Transport{
+		Proxy:             http.ProxyFromEnvironment,
+		DisableKeepAlives: true,
+	}
+}
+
 // progressWriter wraps an io.Writer to track bytes written and
 // report download progress.
 type progressWriter struct {
@@ -333,27 +362,43 @@ func DownloadSnapshot(
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
-	maxAttempts := cfg.maxIdleRetries() + 1
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
+	maxIdleRetries := cfg.maxIdleRetries()
+	destPath := downloadDestinationPath(cfg)
+	lastObservedSize := downloadFileSize(destPath)
+	consecutiveIdleRetries := 0
+	for attempt := 1; ; attempt++ {
+		startSize := downloadFileSize(destPath)
 		path, err := downloadSnapshotOnce(ctx, cfg)
 		if err == nil {
 			return path, nil
 		}
-		if !errors.Is(err, errDownloadIdleTimeout) ||
-			attempt == maxAttempts ||
-			ctx.Err() != nil {
+		if !errors.Is(err, errDownloadIdleTimeout) || ctx.Err() != nil {
+			return "", err
+		}
+		currentSize := downloadFileSize(destPath)
+		madeProgress := currentSize > startSize ||
+			currentSize > lastObservedSize
+		if madeProgress {
+			consecutiveIdleRetries = 0
+			lastObservedSize = currentSize
+		} else {
+			consecutiveIdleRetries++
+		}
+		if consecutiveIdleRetries > maxIdleRetries {
 			return "", err
 		}
 		cfg.Logger.Warn(
 			"snapshot download stalled, retrying",
 			"component", "mithril",
 			"attempt", attempt,
-			"max_attempts", maxAttempts,
+			"consecutive_idle_retries", consecutiveIdleRetries,
+			"max_idle_retries", maxIdleRetries,
 			"idle_timeout", cfg.idleTimeout(),
+			"partial_bytes", currentSize,
+			"made_progress", madeProgress,
 			"error", err,
 		)
 	}
-	return "", errors.New("download retry loop exhausted")
 }
 
 func downloadSnapshotOnce(
@@ -378,11 +423,7 @@ func downloadSnapshotOnce(
 		)
 	}
 
-	filename := filepath.Base(cfg.Filename)
-	if filename == "." || filename == "/" {
-		filename = "snapshot.tar.zst"
-	}
-	destPath := filepath.Join(cfg.DestDir, filename)
+	destPath := downloadDestinationPath(cfg)
 
 	// Check for partial download to support resume
 	var existingSize int64
@@ -408,8 +449,11 @@ func downloadSnapshotOnce(
 		)
 	}
 
+	transport := newDownloadTransport()
+	defer transport.CloseIdleConnections()
 	client := &http.Client{
 		Timeout:       0, // No timeout for large downloads
+		Transport:     transport,
 		CheckRedirect: httpsOnlyRedirect,
 	}
 	var headerTimer *idleTimer

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -200,6 +200,99 @@ func TestDownloadSnapshotIdleTimeoutRetriesAndResumes(t *testing.T) {
 	require.Equal(t, fullContent, data)
 }
 
+func TestDownloadSnapshotIdleRetriesResetAfterProgress(t *testing.T) {
+	fullContent := []byte("AAABBBCCC")
+	var requestCount atomic.Int32
+	rangeCh := make(chan string, 2)
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch requestCount.Add(1) {
+			case 1:
+				w.Header().Set(
+					"Content-Length",
+					fmt.Sprintf("%d", len(fullContent)),
+				)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(fullContent[:3])
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				<-r.Context().Done()
+			case 2:
+				select {
+				case rangeCh <- r.Header.Get("Range"):
+				default:
+				}
+				w.Header().Set("Content-Range", "bytes 3-8/9")
+				w.Header().Set("Content-Length", "6")
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write(fullContent[3:6])
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				<-r.Context().Done()
+			default:
+				select {
+				case rangeCh <- r.Header.Get("Range"):
+				default:
+				}
+				w.Header().Set("Content-Range", "bytes 6-8/9")
+				w.Header().Set("Content-Length", "3")
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write(fullContent[6:])
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	destDir := t.TempDir()
+	cfg := DownloadConfig{
+		URL:            server.URL + "/snapshot.tar.zst",
+		DestDir:        destDir,
+		Filename:       "idle-progress-reset.tar.zst",
+		ExpectedSize:   int64(len(fullContent)),
+		IdleTimeout:    50 * time.Millisecond,
+		MaxIdleRetries: 1,
+	}
+	timeout := 3*cfg.IdleTimeout + 500*time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	path, err := DownloadSnapshot(ctx, cfg)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		filepath.Join(destDir, "idle-progress-reset.tar.zst"),
+		path,
+	)
+	require.Equal(t, int32(3), requestCount.Load())
+	require.Equal(
+		t,
+		"bytes=3-",
+		testutil.RequireReceive(
+			t,
+			rangeCh,
+			time.Second,
+			"first retry resume range",
+		),
+	)
+	require.Equal(
+		t,
+		"bytes=6-",
+		testutil.RequireReceive(
+			t,
+			rangeCh,
+			time.Second,
+			"second retry resume range",
+		),
+	)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, fullContent, data)
+}
+
 func TestDownloadSnapshotRejectsNegativeMaxIdleRetries(t *testing.T) {
 	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
 		URL:            "http://example.invalid/snapshot.tar.zst",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `mithril` snapshot downloads more resilient by detecting stalls, counting retries only when no new bytes are observed, and resuming across attempts. Adds configurable idle timeout and max idle retries with validation, and tightens HTTP connection handling.

- **Bug Fixes**
  - Detect stalls on headers/body; count idle retries only without progress; reset after any byte progress; cap consecutive idle retries.
  - Resume partial downloads based on on‑disk size; log partial bytes and made_progress.
  - Disable HTTP keep‑alives and close idle connections per attempt.
  - Validate config: reject negative `downloadMaxIdleRetries`; parse `downloadIdleTimeout` with clear errors.

- **New Features**
  - New options: `mithril.downloadIdleTimeout` (`--mithril-download-idle-timeout`) and `mithril.downloadMaxIdleRetries` (`--mithril-download-max-idle-retries`). Empty/zero use defaults; negative timeout disables idle detection.
  - Defaults: idle timeout 2m; max idle retries increased to 12.
  - Add examples to `dingo.yaml.example`.

<sup>Written for commit e59be96a0f2bfc2fd839d672b093c630ceed80fd. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Mithril download idle timeout and maximum retry parameters, settable via YAML config, environment variables, or CLI flags (`--mithril-download-idle-timeout` and `--mithril-download-max-idle-retries`).

* **Bug Fixes**
  * Improved download retry logic to better detect progress and reset retries accordingly during idle conditions.
  * Enhanced HTTP connection handling for snapshot downloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->