### PR TITLE
feat: configurable backfill batch size

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -788,6 +788,13 @@ func runMithrilSync(
 			return fmt.Errorf("running planner statistics before backfill: %w", err)
 		}
 		bf := node.NewBackfill(db, nodeCfg, logger)
+		if err := bf.SetBatchSize(cfg.BackfillBatchSize); err != nil {
+			return fmt.Errorf(
+				"invalid backfill batch size %d in SetBatchSize: %w",
+				cfg.BackfillBatchSize,
+				err,
+			)
+		}
 		bf.DisableNonceComputation()
 		if err := bf.Run(ctx); err != nil {
 			return fmt.Errorf("backfill: %w", err)

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -170,6 +170,13 @@ func resumeBackfill(
 	defer db.Close()
 
 	bf := node.NewBackfill(db, nodeCfg, logger)
+	if err := bf.SetBatchSize(cfg.BackfillBatchSize); err != nil {
+		return fmt.Errorf(
+			"invalid BackfillBatchSize %d in SetBatchSize: %w",
+			cfg.BackfillBatchSize,
+			err,
+		)
+	}
 	bf.DisableNonceComputation()
 	needed, err := bf.NeedsBackfill()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,6 +235,7 @@ type Config struct {
 	// Database worker pool tuning (worker count and task queue size)
 	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
 	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
+	BackfillBatchSize int `yaml:"backfillBatchSize" envconfig:"DINGO_BACKFILL_BATCH_SIZE"`
 
 	// Peer targets (0 = use default, -1 = unlimited)
 	TargetNumberOfKnownPeers       int `yaml:"targetNumberOfKnownPeers"       envconfig:"DINGO_TARGET_KNOWN_PEERS"`
@@ -434,9 +435,10 @@ var globalConfig = &Config{
 	ImmutableDbPath:      "",
 	ShutdownTimeout:      DefaultShutdownTimeout,
 	LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
-	// Defaults for database worker pool tuning
+	// Defaults for database worker pool and API backfill tuning
 	DatabaseWorkers:   5,
 	DatabaseQueueSize: 50,
+	BackfillBatchSize: 100,
 	// Cache configuration defaults
 	Cache: DefaultCacheConfig(),
 	// Chainsync configuration defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,7 @@ func resetGlobalConfig() {
 		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
 		DatabaseWorkers:             5,
 		DatabaseQueueSize:           50,
+		BackfillBatchSize:           100,
 		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
@@ -83,6 +84,7 @@ relayPort: 4000
 utxorpcPort: 9940
 databaseWorkers: 11
 databaseQueueSize: 77
+backfillBatchSize: 200
 immutableDbPath: "/tmp/immutable"
 shutdownTimeout: "45s"
 ledgerCatchupTimeout: "90m"
@@ -144,6 +146,7 @@ mithril:
 		LedgerCatchupTimeout: "90m",
 		DatabaseWorkers:      11,
 		DatabaseQueueSize:    77,
+		BackfillBatchSize:    200,
 		GenesisBootstrap: GenesisBootstrapConfig{
 			Enabled:                     false,
 			WindowSlots:                 4321,
@@ -214,6 +217,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
 		DatabaseWorkers:             5,
 		DatabaseQueueSize:           50,
+		BackfillBatchSize:           100,
 		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -123,9 +123,10 @@ var flagSpecs = []flagSpec{
 	uint64Flag("GenesisBootstrap.WindowSlots", "genesis-bootstrap-window-slots", "Genesis density comparison window in slots (0 derives from Shelley genesis 3k/f)"),
 	intFlag("GenesisBootstrap.PromotionMinDiversityGroups", "genesis-bootstrap-promotion-min-diversity-groups", "minimum diversity groups preferred during Genesis bootstrap peer promotion"),
 
-	// Database workers
+	// Database workers and API backfill
 	intFlag("DatabaseWorkers", "db-workers", "database worker pool worker count"),
 	intFlag("DatabaseQueueSize", "db-queue-size", "database worker pool task queue size"),
+	intFlag("BackfillBatchSize", "backfill-batch-size", "API-mode metadata backfill block batch size"),
 
 	// Block production
 	boolFlag("BlockProducer", "block-producer", "enable block production mode"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -71,6 +71,7 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CARDANO_MEMPOOL_CAPACITY", "123456")
 	t.Setenv("DINGO_DATABASE_WORKERS", "9")
+	t.Setenv("DINGO_BACKFILL_BATCH_SIZE", "50")
 
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")
@@ -94,12 +95,19 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 			cfg.DatabaseWorkers,
 		)
 	}
+	if cfg.BackfillBatchSize != 50 {
+		t.Fatalf(
+			"expected env var to set backfillBatchSize=50, got %d",
+			cfg.BackfillBatchSize,
+		)
+	}
 
 	cmd := &cobra.Command{Use: "dingo"}
 	RegisterFlags(cmd)
 	if err := cmd.ParseFlags([]string{
 		"--mempool-capacity=7890",
 		"--data-dir=/tmp/override",
+		"--backfill-batch-size=200",
 	}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -124,6 +132,12 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		t.Fatalf(
 			"expected --data-dir to set databasePath, got %q",
 			cfg.DatabasePath,
+		)
+	}
+	if cfg.BackfillBatchSize != 200 {
+		t.Fatalf(
+			"expected --backfill-batch-size to set backfillBatchSize=200, got %d",
+			cfg.BackfillBatchSize,
 		)
 	}
 }

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -37,9 +37,9 @@ import (
 // backfill checkpoint.
 const BackfillPhase = "metadata"
 
-// backfillBatchSize controls how many processed blocks are accumulated
+// DefaultBackfillBatchSize controls how many processed blocks are accumulated
 // before deferred metadata rows are flushed.
-const backfillBatchSize = 100
+const DefaultBackfillBatchSize = 100
 
 // Backfill replays stored blocks to populate historical metadata.
 // It is triggered automatically during Mithril sync when
@@ -50,6 +50,7 @@ type Backfill struct {
 	logger       *slog.Logger
 	epochs       []models.Epoch
 	pparamsCache map[uint64]lcommon.ProtocolParameters
+	batchSize    int
 
 	// Running state tracked across blocks.
 	currentPParams lcommon.ProtocolParameters
@@ -87,8 +88,19 @@ func NewBackfill(
 		db:            db,
 		nodeCfg:       nodeCfg,
 		logger:        logger,
+		batchSize:     DefaultBackfillBatchSize,
 		computeNonces: nodeCfg != nil,
 	}
+}
+
+// SetBatchSize overrides the number of processed blocks accumulated before
+// deferred metadata rows are flushed.
+func (b *Backfill) SetBatchSize(size int) error {
+	if size <= 0 {
+		return fmt.Errorf("backfill batch size must be positive: %d", size)
+	}
+	b.batchSize = size
+	return nil
 }
 
 // DisableNonceComputation skips historical block nonce reconstruction.
@@ -669,6 +681,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 			"starting metadata backfill",
 			"component", "backfill",
 			"tip_slot", tipSlot,
+			"batch_size", b.batchSize,
 		)
 		// Fresh start: reset epoch/era tracking to the
 		// first epoch so processEpochBoundary doesn't
@@ -688,6 +701,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 				"component", "backfill",
 				"tip_slot", tipSlot,
 				"restart_from_first_block", true,
+				"batch_size", b.batchSize,
 			)
 			b.initializeFromFirstEpoch()
 		} else {
@@ -696,6 +710,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 				"component", "backfill",
 				"resume_from_slot", cp.LastSlot,
 				"tip_slot", tipSlot,
+				"batch_size", b.batchSize,
 			)
 			// Recover running nonce from the last processed
 			// block so nonce computation can continue.
@@ -896,9 +911,8 @@ func (b *Backfill) Run(ctx context.Context) error {
 		processedBlocks++
 		batchBlockCount++
 
-		// Flush once the current batch reaches the configured block
-		// window.
-		if batchBlockCount >= backfillBatchSize {
+		// Flush once the current batch reaches the configured block window.
+		if batchBlockCount >= b.batchSize {
 			if err := flushBatch(); err != nil {
 				saveCommittedCheckpoint()
 				return fmt.Errorf(
@@ -910,7 +924,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 		if processedBlocks%1000 == 0 {
 			// Periodic checkpoints must only record durable progress.
 			// Flush any partial batch first so checkpoint safety does
-			// not depend on backfillBatchSize dividing 1000.
+			// not depend on the configured batch size dividing 1000.
 			if err := flushBatch(); err != nil {
 				saveCommittedCheckpoint()
 				return fmt.Errorf(
@@ -949,6 +963,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 		"blocks_processed", processedBlocks,
 		"transactions_stored", processedTxs,
 		"elapsed", elapsed.Round(time.Second),
+		"batch_size", b.batchSize,
 		"skipped_utxo_offset_block_writes", b.skippedBlocks,
 		"skipped_utxo_offset_refs", b.skippedUtxoRefs,
 	)

--- a/internal/node/backfill_test.go
+++ b/internal/node/backfill_test.go
@@ -44,6 +44,24 @@ func newTestDB(t *testing.T) *database.Database {
 	return db
 }
 
+func TestBackfillBatchSizeDefaultAndOverride(t *testing.T) {
+	db := newTestDB(t)
+	bf := NewBackfill(db, nil, slog.Default())
+
+	require.Equal(t, DefaultBackfillBatchSize, bf.batchSize)
+	require.NoError(t, bf.SetBatchSize(200))
+	require.Equal(t, 200, bf.batchSize)
+}
+
+func TestBackfillSetBatchSizeRejectsInvalid(t *testing.T) {
+	db := newTestDB(t)
+	bf := NewBackfill(db, nil, slog.Default())
+
+	require.Error(t, bf.SetBatchSize(0))
+	require.Error(t, bf.SetBatchSize(-1))
+	require.Equal(t, DefaultBackfillBatchSize, bf.batchSize)
+}
+
 func TestNeedsBackfill_NoCheckpoint(t *testing.T) {
 	db := newTestDB(t)
 	bf := NewBackfill(db, nil, slog.Default())


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the metadata backfill batch size configurable to tune flush cadence and memory use during API-mode backfills. Addresses Linear 1802.

- **New Features**
  - Added `backfillBatchSize` config with env `DINGO_BACKFILL_BATCH_SIZE` and CLI flag `--backfill-batch-size`; default is 100.
  - Validates positive values via `SetBatchSize`; logs include `batch_size` on start, resume, and completion.
  - Applies batch size in both Mithril sync and backfill resume paths.

<sup>Written for commit 0abfd2ac8de7c94afc04453bf335531def39f84a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2389?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable batch size for API-mode metadata backfill operations. Default is 100; configure via `--backfill-batch-size` CLI flag, environment variable, or config file.

* **Tests**
  * Added validation tests for batch size configuration and invalid value handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->