### PR TITLE
feat(leios): serve merged RB+EB over N2C

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -461,7 +461,7 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 		} else {
 			err = ctx.Server.RollForward(
 				next.Block.Type,
-				next.Block.Cbor,
+				o.chainsyncServerBlockCbor(ctx, next.Block),
 				tip,
 			)
 		}
@@ -531,7 +531,7 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 		} else {
 			if err := ctx.Server.RollForward(
 				next.Block.Type,
-				next.Block.Cbor,
+				o.chainsyncServerBlockCbor(ctx, next.Block),
 				tip,
 			); err != nil {
 				o.config.Logger.Error(

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -1,0 +1,442 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	leiosEndorserBlockCacheMaxEntries = 1024
+	leiosEndorserBlockCacheTTL        = 10 * time.Minute
+)
+
+var errLeiosEndorserBlockNotCached = errors.New("leios endorser block not cached")
+
+type leiosEndorserBlockData struct {
+	point      ocommon.Point
+	blockRaw   []byte
+	refs       []gleios.TxReference
+	txsRaw     []cbor.RawMessage
+	cacheKeys  []string
+	insertedAt time.Time
+}
+
+func leiosBlockKey(hash []byte) string {
+	return string(hash)
+}
+
+func cloneRawMessages(in []cbor.RawMessage) []cbor.RawMessage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]cbor.RawMessage, len(in))
+	for i := range in {
+		out[i] = slices.Clone(in[i])
+	}
+	return out
+}
+
+func (o *Ouroboros) storeLeiosEndorserBlock(
+	point ocommon.Point,
+	blockRaw []byte,
+	txsRaw []cbor.RawMessage,
+) error {
+	if len(blockRaw) == 0 {
+		return errors.New("leios endorser block cache: empty block")
+	}
+	block, err := gleios.NewLeiosEndorserBlockFromCbor(blockRaw)
+	if err != nil {
+		return fmt.Errorf("decode leios endorser block: %w", err)
+	}
+	var refs []gleios.TxReference
+	if block.Body != nil {
+		refs = slices.Clone(block.Body.TxReferences)
+	}
+	blockHash := block.Hash()
+	cacheKeys := []string{leiosBlockKey(blockHash.Bytes())}
+	if len(point.Hash) > 0 {
+		pointKey := leiosBlockKey(point.Hash)
+		if pointKey != cacheKeys[0] {
+			cacheKeys = append(cacheKeys, pointKey)
+		}
+	}
+	data := &leiosEndorserBlockData{
+		point:      point,
+		blockRaw:   slices.Clone(blockRaw),
+		refs:       refs,
+		txsRaw:     cloneRawMessages(txsRaw),
+		cacheKeys:  cacheKeys,
+		insertedAt: time.Now(),
+	}
+	o.leiosMu.Lock()
+	defer o.leiosMu.Unlock()
+	if o.leiosEndorserBlocks == nil {
+		o.leiosEndorserBlocks = make(map[string]*leiosEndorserBlockData)
+	}
+	for _, key := range cacheKeys {
+		o.leiosEndorserBlocks[key] = data
+	}
+	o.pruneLeiosEndorserBlockCacheLocked(time.Now())
+	return nil
+}
+
+func (data *leiosEndorserBlockData) completeTxCache() bool {
+	return data != nil && len(data.txsRaw) == len(data.refs)
+}
+
+func (data *leiosEndorserBlockData) expired(now time.Time) bool {
+	return data != nil &&
+		data.insertedAt.Before(now.Add(-leiosEndorserBlockCacheTTL))
+}
+
+func (o *Ouroboros) pruneLeiosEndorserBlockCacheLocked(now time.Time) {
+	if len(o.leiosEndorserBlocks) == 0 {
+		return
+	}
+	uniqueBlocks := make(
+		map[*leiosEndorserBlockData]struct{},
+		len(o.leiosEndorserBlocks),
+	)
+	for key, data := range o.leiosEndorserBlocks {
+		if data == nil {
+			delete(o.leiosEndorserBlocks, key)
+			continue
+		}
+		uniqueBlocks[data] = struct{}{}
+	}
+	for data := range uniqueBlocks {
+		if data.expired(now) {
+			o.deleteLeiosEndorserBlockDataLocked(data)
+			delete(uniqueBlocks, data)
+		}
+	}
+	if len(uniqueBlocks) <= leiosEndorserBlockCacheMaxEntries {
+		return
+	}
+	blocks := make([]*leiosEndorserBlockData, 0, len(uniqueBlocks))
+	for data := range uniqueBlocks {
+		blocks = append(blocks, data)
+	}
+	slices.SortFunc(blocks, func(a, b *leiosEndorserBlockData) int {
+		return a.insertedAt.Compare(b.insertedAt)
+	})
+	for _, data := range blocks[:len(blocks)-leiosEndorserBlockCacheMaxEntries] {
+		o.deleteLeiosEndorserBlockDataLocked(data)
+	}
+}
+
+func (o *Ouroboros) deleteLeiosEndorserBlockDataLocked(
+	data *leiosEndorserBlockData,
+) {
+	if len(data.cacheKeys) > 0 {
+		for _, key := range data.cacheKeys {
+			if o.leiosEndorserBlocks[key] == data {
+				delete(o.leiosEndorserBlocks, key)
+			}
+		}
+		return
+	}
+	for key, cached := range o.leiosEndorserBlocks {
+		if cached == data {
+			delete(o.leiosEndorserBlocks, key)
+		}
+	}
+}
+
+func (o *Ouroboros) lookupLeiosEndorserBlock(
+	hash []byte,
+) (*leiosEndorserBlockData, bool) {
+	key := leiosBlockKey(hash)
+	now := time.Now()
+	o.leiosMu.RLock()
+	data, ok := o.leiosEndorserBlocks[key]
+	if !ok || data == nil {
+		o.leiosMu.RUnlock()
+		return nil, false
+	}
+	if !data.expired(now) {
+		o.leiosMu.RUnlock()
+		return data, true
+	}
+	o.leiosMu.RUnlock()
+
+	o.leiosMu.Lock()
+	defer o.leiosMu.Unlock()
+	data, ok = o.leiosEndorserBlocks[key]
+	if !ok || data == nil {
+		return nil, false
+	}
+	if data.expired(now) {
+		o.deleteLeiosEndorserBlockDataLocked(data)
+		return nil, false
+	}
+	return data, true
+}
+
+func leiosAllTxBitmap(count int) (map[uint16]uint64, error) {
+	if count <= 0 {
+		return nil, nil
+	}
+	if count > (math.MaxUint16+1)*64 {
+		return nil, fmt.Errorf("too many leios txs for bitmap: %d", count)
+	}
+	ret := make(map[uint16]uint64, (count+63)/64)
+	for idx := range count {
+		bucket := uint16(idx / 64) // #nosec G115 -- bounded above
+		ret[bucket] |= 1 << uint(idx%64)
+	}
+	return ret, nil
+}
+
+func leiosTxsFromBitmap(
+	txs []cbor.RawMessage,
+	bitmaps map[uint16]uint64,
+) []cbor.RawMessage {
+	if len(txs) == 0 || len(bitmaps) == 0 {
+		return nil
+	}
+	ret := make([]cbor.RawMessage, 0, len(txs))
+	for idx, tx := range txs {
+		bucket := idx / 64
+		if bucket > math.MaxUint16 {
+			break
+		}
+		mask := bitmaps[uint16(bucket)] // #nosec G115 -- checked above
+		if mask&(1<<uint(idx%64)) == 0 {
+			continue
+		}
+		ret = append(ret, slices.Clone(tx))
+	}
+	return ret
+}
+
+func validateLeiosTxBitmap(count int, bitmaps map[uint16]uint64) error {
+	for bucket, mask := range bitmaps {
+		if mask == 0 {
+			continue
+		}
+		baseIdx := int(bucket) * 64
+		for offset := range 64 {
+			if mask&(1<<uint(offset)) == 0 {
+				continue
+			}
+			idx := baseIdx + offset
+			if idx >= count {
+				return fmt.Errorf(
+					"leios tx bitmap references tx index %d beyond %d cached txs",
+					idx,
+					count,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func cborRawIsNull(raw cbor.RawMessage) bool {
+	return len(raw) == 1 && raw[0] == 0xf6
+}
+
+func decodeRawArray(raw cbor.RawMessage, name string) ([]cbor.RawMessage, error) {
+	var ret []cbor.RawMessage
+	if _, err := cbor.Decode(raw, &ret); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", name, err)
+	}
+	return ret, nil
+}
+
+func decodeUintArray(raw cbor.RawMessage, name string) ([]uint64, error) {
+	items, err := decodeRawArray(raw, name)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]uint64, 0, len(items))
+	for _, item := range items {
+		var idx uint64
+		if _, err := cbor.Decode(item, &idx); err != nil {
+			return nil, fmt.Errorf("decode %s item: %w", name, err)
+		}
+		ret = append(ret, idx)
+	}
+	return ret, nil
+}
+
+func encodeRaw(value any, name string) (cbor.RawMessage, error) {
+	encoded, err := cbor.Encode(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode %s: %w", name, err)
+	}
+	return cbor.RawMessage(encoded), nil
+}
+
+func mergeLeiosTransactionArrays(
+	blockCbor []byte,
+	txsRaw []cbor.RawMessage,
+) ([]byte, error) {
+	blockItems, err := decodeRawArray(blockCbor, "leios ranking block")
+	if err != nil {
+		return nil, err
+	}
+	if len(blockItems) < 5 {
+		return nil, fmt.Errorf(
+			"leios ranking block: expected at least 5 fields, got %d",
+			len(blockItems),
+		)
+	}
+	bodies, err := decodeRawArray(blockItems[1], "transaction bodies")
+	if err != nil {
+		return nil, err
+	}
+	witnesses, err := decodeRawArray(blockItems[2], "transaction witness sets")
+	if err != nil {
+		return nil, err
+	}
+	if len(bodies) != len(witnesses) {
+		return nil, fmt.Errorf(
+			"leios ranking block: body/witness count mismatch: %d != %d",
+			len(bodies),
+			len(witnesses),
+		)
+	}
+	metadata := map[uint64]cbor.RawMessage{}
+	if !cborRawIsNull(blockItems[3]) {
+		if _, err := cbor.Decode(blockItems[3], &metadata); err != nil {
+			return nil, fmt.Errorf("decode transaction metadata set: %w", err)
+		}
+	}
+	invalid, err := decodeUintArray(blockItems[4], "invalid transactions")
+	if err != nil {
+		return nil, err
+	}
+	baseTxCount := len(bodies)
+	for idx, txRaw := range txsRaw {
+		txItems, err := decodeRawArray(txRaw, "leios endorser transaction")
+		if err != nil {
+			return nil, err
+		}
+		if len(txItems) != 4 {
+			return nil, fmt.Errorf(
+				"leios endorser transaction: expected 4 fields, got %d",
+				len(txItems),
+			)
+		}
+		bodies = append(bodies, txItems[0])
+		witnesses = append(witnesses, txItems[1])
+		var isValid bool
+		if _, err := cbor.Decode(txItems[2], &isValid); err != nil {
+			return nil, fmt.Errorf("decode leios tx validity flag: %w", err)
+		}
+		mergedTxIndex := uint64(baseTxCount + idx) // #nosec G115 -- slice length fits uint64
+		if !isValid {
+			invalid = append(invalid, mergedTxIndex)
+		}
+		if !cborRawIsNull(txItems[3]) {
+			metadata[mergedTxIndex] = slices.Clone(txItems[3])
+		}
+	}
+	blockItems[1], err = encodeRaw(bodies, "merged transaction bodies")
+	if err != nil {
+		return nil, err
+	}
+	blockItems[2], err = encodeRaw(witnesses, "merged transaction witness sets")
+	if err != nil {
+		return nil, err
+	}
+	blockItems[3], err = encodeRaw(metadata, "merged transaction metadata set")
+	if err != nil {
+		return nil, err
+	}
+	blockItems[4], err = encodeRaw(invalid, "merged invalid transactions")
+	if err != nil {
+		return nil, err
+	}
+	merged, err := cbor.Encode(blockItems)
+	if err != nil {
+		return nil, fmt.Errorf("encode merged leios block: %w", err)
+	}
+	return merged, nil
+}
+
+func (o *Ouroboros) mergedLeiosRankingBlockCbor(
+	blockCbor []byte,
+) ([]byte, bool, error) {
+	blockItems, err := decodeRawArray(blockCbor, "leios ranking block")
+	if err != nil {
+		return nil, false, err
+	}
+	if len(blockItems) < 6 || cborRawIsNull(blockItems[5]) {
+		return blockCbor, false, nil
+	}
+	var cert lcommon.LeiosEbCertificate
+	if _, err := cbor.Decode(blockItems[5], &cert); err != nil {
+		return nil, false, fmt.Errorf("decode leios EB certificate: %w", err)
+	}
+	data, ok := o.lookupLeiosEndorserBlock(cert.EndorserBlockHash.Bytes())
+	if !ok || !data.completeTxCache() || len(data.txsRaw) == 0 {
+		return blockCbor, false, nil
+	}
+	merged, err := mergeLeiosTransactionArrays(blockCbor, data.txsRaw)
+	if err != nil {
+		return nil, false, err
+	}
+	return merged, true, nil
+}
+
+func (o *Ouroboros) chainsyncServerBlockCbor(
+	ctx ochainsync.CallbackContext,
+	block models.Block,
+) []byte {
+	if !o.config.EnableLeios ||
+		block.Type != uint(gleios.BlockTypeLeiosRanking) ||
+		ctx.Server == nil {
+		return block.Cbor
+	}
+	p := ctx.Server.ProtocolInstance()
+	if p == nil || p.Mode() != protocol.ProtocolModeNodeToClient {
+		return block.Cbor
+	}
+	merged, ok, err := o.mergedLeiosRankingBlockCbor(block.Cbor)
+	if err != nil {
+		o.config.Logger.Warn(
+			"failed to build merged Leios block for NtC chainsync",
+			"error", err,
+			"slot", block.Slot,
+		)
+		return block.Cbor
+	}
+	if !ok {
+		return block.Cbor
+	}
+	o.config.Logger.Debug(
+		"serving merged Leios block over NtC chainsync",
+		"slot", block.Slot,
+		"hash", hex.EncodeToString(block.Hash),
+	)
+	return merged
+}

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -1,0 +1,382 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	gouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
+	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/stretchr/testify/require"
+)
+
+func mustCbor(t *testing.T, value any) cbor.RawMessage {
+	t.Helper()
+	data, err := cbor.Encode(value)
+	require.NoError(t, err)
+	return cbor.RawMessage(data)
+}
+
+func testTxRaw(
+	t *testing.T,
+	body cbor.RawMessage,
+	witness cbor.RawMessage,
+	valid bool,
+	metadata cbor.RawMessage,
+) cbor.RawMessage {
+	t.Helper()
+	return mustCbor(t, []any{
+		body,
+		witness,
+		valid,
+		metadata,
+	})
+}
+
+func testEndorserBlockRaw(
+	t *testing.T,
+	refs []gleios.TxReference,
+) cbor.RawMessage {
+	t.Helper()
+	block := &gleios.LeiosEndorserBlock{
+		Body: &gleios.LeiosEndorserBlockBody{
+			TxReferences: refs,
+		},
+	}
+	data, err := block.MarshalCBOR()
+	require.NoError(t, err)
+	return cbor.RawMessage(data)
+}
+
+func testIndexedEndorserBlock(
+	t *testing.T,
+	idx int,
+) (ocommon.Point, cbor.RawMessage) {
+	t.Helper()
+	var txHash lcommon.Blake2b256
+	txHash[0] = byte(idx)
+	txHash[1] = byte(idx >> 8)
+	ebRaw := testEndorserBlockRaw(t, []gleios.TxReference{
+		{TxHash: txHash, TxSize: uint16(idx + 1)},
+	})
+	ebHash := lcommon.Blake2b256Hash(ebRaw)
+	return ocommon.NewPoint(uint64(idx), ebHash.Bytes()), ebRaw
+}
+
+func testCertifiedRankingBlockRaw(
+	t *testing.T,
+	ebHash lcommon.Blake2b256,
+	baseBody cbor.RawMessage,
+	baseWitness cbor.RawMessage,
+	baseMetadata cbor.RawMessage,
+) cbor.RawMessage {
+	t.Helper()
+	cert := lcommon.LeiosEbCertificate{
+		ElectionId:        lcommon.Blake2b256{0x01},
+		EndorserBlockHash: ebHash,
+		AggregatedVoteSig: make([]byte, 48),
+	}
+	certRaw := mustCbor(t, cert)
+	return mustCbor(t, []any{
+		cbor.RawMessage{0x80}, // header, not inspected by merge logic
+		[]cbor.RawMessage{baseBody},
+		[]cbor.RawMessage{baseWitness},
+		map[uint64]cbor.RawMessage{0: baseMetadata},
+		[]uint64{},
+		certRaw,
+	})
+}
+
+func TestMergedLeiosRankingBlockCborAppendsEndorserTransactions(
+	t *testing.T,
+) {
+	baseBody := mustCbor(t, map[uint64]uint64{0: 1})
+	baseWitness := mustCbor(t, map[uint64]uint64{})
+	baseMetadata := mustCbor(t, map[uint64]string{1: "base"})
+
+	ebRefHash1 := lcommon.Blake2b256{0x11}
+	ebRefHash2 := lcommon.Blake2b256{0x22}
+	ebRaw := testEndorserBlockRaw(t, []gleios.TxReference{
+		{TxHash: ebRefHash1, TxSize: 123},
+		{TxHash: ebRefHash2, TxSize: 456},
+	})
+	ebHash := lcommon.Blake2b256Hash(ebRaw)
+	blockRaw := testCertifiedRankingBlockRaw(
+		t,
+		ebHash,
+		baseBody,
+		baseWitness,
+		baseMetadata,
+	)
+
+	ebBody1 := mustCbor(t, map[uint64]uint64{0: 2})
+	ebWitness1 := mustCbor(t, map[uint64]uint64{1: 1})
+	ebMetadata1 := mustCbor(t, map[uint64]string{2: "endorser"})
+	ebBody2 := mustCbor(t, map[uint64]uint64{0: 3})
+	ebWitness2 := mustCbor(t, map[uint64]uint64{2: 1})
+	ebTxs := []cbor.RawMessage{
+		testTxRaw(t, ebBody1, ebWitness1, true, ebMetadata1),
+		testTxRaw(t, ebBody2, ebWitness2, false, cbor.RawMessage{0xf6}),
+	}
+
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	require.NoError(
+		t,
+		o.storeLeiosEndorserBlock(
+			ocommon.NewPoint(10, ebHash.Bytes()),
+			ebRaw,
+			ebTxs,
+		),
+	)
+
+	mergedRaw, ok, err := o.mergedLeiosRankingBlockCbor(blockRaw)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var mergedItems []cbor.RawMessage
+	_, err = cbor.Decode(mergedRaw, &mergedItems)
+	require.NoError(t, err)
+	require.Len(t, mergedItems, 6)
+
+	var bodies []cbor.RawMessage
+	_, err = cbor.Decode(mergedItems[1], &bodies)
+	require.NoError(t, err)
+	require.Equal(t, []cbor.RawMessage{baseBody, ebBody1, ebBody2}, bodies)
+
+	var witnesses []cbor.RawMessage
+	_, err = cbor.Decode(mergedItems[2], &witnesses)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]cbor.RawMessage{baseWitness, ebWitness1, ebWitness2},
+		witnesses,
+	)
+
+	var metadata map[uint64]cbor.RawMessage
+	_, err = cbor.Decode(mergedItems[3], &metadata)
+	require.NoError(t, err)
+	require.Equal(t, baseMetadata, metadata[0])
+	require.Equal(t, ebMetadata1, metadata[1])
+	require.NotContains(t, metadata, uint64(2))
+
+	var invalid []uint64
+	_, err = cbor.Decode(mergedItems[4], &invalid)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{2}, invalid)
+}
+
+func TestMergedLeiosRankingBlockCborFallsBackWithoutCachedTxs(t *testing.T) {
+	ebHash := lcommon.Blake2b256{0xaa}
+	blockRaw := testCertifiedRankingBlockRaw(
+		t,
+		ebHash,
+		mustCbor(t, map[uint64]uint64{}),
+		mustCbor(t, map[uint64]uint64{}),
+		mustCbor(t, map[uint64]uint64{}),
+	)
+
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	got, ok, err := o.mergedLeiosRankingBlockCbor(blockRaw)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, []byte(blockRaw), got)
+}
+
+func TestLeiosTxsFromBitmapPreservesRequestedOrder(t *testing.T) {
+	txs := []cbor.RawMessage{
+		mustCbor(t, "tx0"),
+		mustCbor(t, "tx1"),
+		mustCbor(t, "tx2"),
+		mustCbor(t, "tx3"),
+	}
+
+	got := leiosTxsFromBitmap(txs, map[uint16]uint64{0: 0b1010})
+	require.Equal(t, []cbor.RawMessage{txs[1], txs[3]}, got)
+}
+
+func TestLeiosFetchServerBlockTxsRejectsIncompleteCache(t *testing.T) {
+	txRefHash1 := lcommon.Blake2b256{0x11}
+	txRefHash2 := lcommon.Blake2b256{0x22}
+	ebRaw := testEndorserBlockRaw(t, []gleios.TxReference{
+		{TxHash: txRefHash1, TxSize: 123},
+		{TxHash: txRefHash2, TxSize: 456},
+	})
+	ebHash := lcommon.Blake2b256Hash(ebRaw)
+	point := ocommon.NewPoint(10, ebHash.Bytes())
+
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	require.NoError(
+		t,
+		o.storeLeiosEndorserBlock(
+			point,
+			ebRaw,
+			[]cbor.RawMessage{mustCbor(t, "tx0")},
+		),
+	)
+
+	msg, err := o.leiosfetchServerBlockTxsRequest(
+		oleiosfetch.CallbackContext{},
+		point,
+		map[uint16]uint64{0: 0b11},
+	)
+	require.Error(t, err)
+	require.Nil(t, msg)
+	require.Contains(t, err.Error(), "tx cache incomplete")
+}
+
+func TestLeiosFetchServerBlockTxsRejectsOutOfRangeBitmap(t *testing.T) {
+	txRefHash1 := lcommon.Blake2b256{0x11}
+	txRefHash2 := lcommon.Blake2b256{0x22}
+	ebRaw := testEndorserBlockRaw(t, []gleios.TxReference{
+		{TxHash: txRefHash1, TxSize: 123},
+		{TxHash: txRefHash2, TxSize: 456},
+	})
+	ebHash := lcommon.Blake2b256Hash(ebRaw)
+	point := ocommon.NewPoint(10, ebHash.Bytes())
+
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	require.NoError(
+		t,
+		o.storeLeiosEndorserBlock(
+			point,
+			ebRaw,
+			[]cbor.RawMessage{mustCbor(t, "tx0"), mustCbor(t, "tx1")},
+		),
+	)
+
+	msg, err := o.leiosfetchServerBlockTxsRequest(
+		oleiosfetch.CallbackContext{},
+		point,
+		map[uint16]uint64{0: 0b100},
+	)
+	require.Error(t, err)
+	require.Nil(t, msg)
+	require.Contains(t, err.Error(), "beyond")
+}
+
+func TestLeiosNotifyBlockTxsOfferCacheMissIsNonFatal(t *testing.T) {
+	cm := connmanager.NewConnectionManager(connmanager.ConnectionManagerConfig{})
+	conn, err := gouroboros.New()
+	require.NoError(t, err)
+	require.True(t, cm.AddConnection(conn, false, "127.0.0.1:1234"))
+	defer func() {
+		conn.ErrorChan() <- errors.New("test connection closed")
+	}()
+
+	o := NewOuroboros(OuroborosConfig{ConnManager: cm, EnableLeios: true})
+	err = o.leiosnotifyClientNotification(
+		oleiosnotify.CallbackContext{ConnectionId: conn.Id()},
+		oleiosnotify.NewMsgBlockTxsOffer(
+			ocommon.NewPoint(99, []byte{0xaa}),
+		),
+	)
+	require.NoError(t, err)
+}
+
+func TestFetchCachedLeiosEndorserBlockTxsReturnsCompleteCacheWithoutFetch(
+	t *testing.T,
+) {
+	txRefHash := lcommon.Blake2b256{0x11}
+	ebRaw := testEndorserBlockRaw(t, []gleios.TxReference{
+		{TxHash: txRefHash, TxSize: 123},
+	})
+	ebHash := lcommon.Blake2b256Hash(ebRaw)
+	point := ocommon.NewPoint(10, ebHash.Bytes())
+	txRaw := mustCbor(t, "tx0")
+
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	require.NoError(
+		t,
+		o.storeLeiosEndorserBlock(
+			point,
+			ebRaw,
+			[]cbor.RawMessage{txRaw},
+		),
+	)
+
+	got, err := o.fetchCachedLeiosEndorserBlockTxs(nil, point)
+	require.NoError(t, err)
+	require.Equal(t, []cbor.RawMessage{txRaw}, got)
+
+	got[0][0] ^= 0xff
+	cached, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	require.True(t, ok)
+	require.Equal(t, txRaw, cached.txsRaw[0])
+}
+
+func TestLeiosEndorserBlockLookupExpiresStaleEntries(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	point, raw := testIndexedEndorserBlock(t, 1)
+	require.NoError(t, o.storeLeiosEndorserBlock(point, raw, nil))
+	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	require.True(t, ok)
+
+	o.leiosMu.Lock()
+	data.insertedAt = time.Now().Add(-leiosEndorserBlockCacheTTL - time.Second)
+	o.leiosMu.Unlock()
+
+	_, ok = o.lookupLeiosEndorserBlock(point.Hash)
+	require.False(t, ok)
+
+	o.leiosMu.RLock()
+	cacheEntries := len(o.leiosEndorserBlocks)
+	o.leiosMu.RUnlock()
+	require.Zero(t, cacheEntries)
+}
+
+func TestLeiosEndorserBlockCachePrunesExpiredEntries(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	oldPoint, oldRaw := testIndexedEndorserBlock(t, 1)
+	require.NoError(t, o.storeLeiosEndorserBlock(oldPoint, oldRaw, nil))
+	oldData, ok := o.lookupLeiosEndorserBlock(oldPoint.Hash)
+	require.True(t, ok)
+
+	o.leiosMu.Lock()
+	oldData.insertedAt = time.Now().Add(-leiosEndorserBlockCacheTTL - time.Second)
+	o.leiosMu.Unlock()
+
+	newPoint, newRaw := testIndexedEndorserBlock(t, 2)
+	require.NoError(t, o.storeLeiosEndorserBlock(newPoint, newRaw, nil))
+
+	_, ok = o.lookupLeiosEndorserBlock(oldPoint.Hash)
+	require.False(t, ok)
+	_, ok = o.lookupLeiosEndorserBlock(newPoint.Hash)
+	require.True(t, ok)
+}
+
+func TestLeiosEndorserBlockCachePrunesBySize(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	var lastPoint ocommon.Point
+	for idx := 0; idx < leiosEndorserBlockCacheMaxEntries+1; idx++ {
+		point, raw := testIndexedEndorserBlock(t, idx)
+		require.NoError(t, o.storeLeiosEndorserBlock(point, raw, nil))
+		lastPoint = point
+	}
+
+	o.leiosMu.RLock()
+	cacheEntries := len(o.leiosEndorserBlocks)
+	o.leiosMu.RUnlock()
+	require.LessOrEqual(t, cacheEntries, leiosEndorserBlockCacheMaxEntries)
+	_, ok := o.lookupLeiosEndorserBlock(lastPoint.Hash)
+	require.True(t, ok)
+}

--- a/ouroboros/leiosfetch.go
+++ b/ouroboros/leiosfetch.go
@@ -15,8 +15,10 @@
 package ouroboros
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
@@ -107,8 +109,15 @@ func (o *Ouroboros) leiosfetchServerBlockRequest(
 	ctx oleiosfetch.CallbackContext,
 	point ocommon.Point,
 ) (protocol.Message, error) {
-	// TODO
-	return nil, nil
+	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	if !ok {
+		return nil, fmt.Errorf(
+			"leios endorser block not found: %d.%x",
+			point.Slot,
+			point.Hash,
+		)
+	}
+	return oleiosfetch.NewMsgBlock(cbor.RawMessage(data.blockRaw)), nil
 }
 
 func (o *Ouroboros) leiosfetchServerBlockTxsRequest(
@@ -116,8 +125,29 @@ func (o *Ouroboros) leiosfetchServerBlockTxsRequest(
 	point ocommon.Point,
 	txBitmap map[uint16]uint64,
 ) (protocol.Message, error) {
-	// TODO
-	return nil, nil
+	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	if !ok {
+		return nil, fmt.Errorf(
+			"leios endorser block txs not found: %d.%x",
+			point.Slot,
+			point.Hash,
+		)
+	}
+	if !data.completeTxCache() {
+		return nil, fmt.Errorf(
+			"leios endorser block tx cache incomplete: %d.%x: have %d txs for %d refs",
+			point.Slot,
+			point.Hash,
+			len(data.txsRaw),
+			len(data.refs),
+		)
+	}
+	if err := validateLeiosTxBitmap(len(data.txsRaw), txBitmap); err != nil {
+		return nil, err
+	}
+	return oleiosfetch.NewMsgBlockTxs(
+		leiosTxsFromBitmap(data.txsRaw, txBitmap),
+	), nil
 }
 
 func (o *Ouroboros) leiosfetchServerVotesRequest(

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -15,11 +15,18 @@
 package ouroboros
 
 import (
+	"context"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
 )
@@ -48,7 +55,10 @@ func (o *Ouroboros) leiosnotifyClientConnOpts() []oleiosnotify.LeiosNotifyOption
 func (o *Ouroboros) leiosnotifyClientStart(connId ouroboros.ConnectionId) error {
 	conn := o.ConnManager.GetConnectionById(connId)
 	if conn == nil {
-		return fmt.Errorf("failed to lookup connection ID: %s", connId.String())
+		return fmt.Errorf(
+			"failed to lookup connection ID: %s",
+			leiosConnectionIdString(connId),
+		)
 	}
 	if conn.LeiosNotify() == nil {
 		// Return silently if LeiosNotify protocol is not supported by peer
@@ -58,6 +68,13 @@ func (o *Ouroboros) leiosnotifyClientStart(connId ouroboros.ConnectionId) error 
 		return err
 	}
 	return nil
+}
+
+func leiosConnectionIdString(connId ouroboros.ConnectionId) string {
+	if connId.LocalAddr == nil || connId.RemoteAddr == nil {
+		return "<unknown>"
+	}
+	return connId.String()
 }
 
 func (o *Ouroboros) instrumentLeiosnotifyNotification(
@@ -87,30 +104,168 @@ func (o *Ouroboros) leiosnotifyClientNotification(
 	msg protocol.Message,
 ) error {
 	conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
+	connId := leiosConnectionIdString(ctx.ConnectionId)
 	if conn == nil {
-		return fmt.Errorf("failed to lookup connection ID: %s", ctx.ConnectionId.String())
+		return fmt.Errorf("failed to lookup connection ID: %s", connId)
 	}
 	switch m := msg.(type) {
 	case *oleiosnotify.MsgBlockOffer:
+		if conn.LeiosFetch() == nil || conn.LeiosFetch().Client == nil {
+			return errors.New("leios-fetch client unavailable")
+		}
 		resp, err := conn.LeiosFetch().Client.BlockRequest(m.Point)
 		if err != nil {
 			return err
 		}
-		respBlock := resp.(*leiosfetch.MsgBlock)
+		respBlock, ok := resp.(*leiosfetch.MsgBlock)
+		if !ok {
+			return fmt.Errorf(
+				"unexpected leios-fetch Block response type %T",
+				resp,
+			)
+		}
+		txsRaw, err := o.fetchLeiosEndorserBlockTxs(
+			conn,
+			m.Point,
+			respBlock.BlockRaw,
+		)
+		if err != nil {
+			o.config.Logger.Warn(
+				"failed to fetch Leios EB transactions",
+				"component", "network",
+				"protocol", "leios-fetch",
+				"role", "client",
+				"connection_id", connId,
+				"slot", m.Point.Slot,
+				"hash", hex.EncodeToString(m.Point.Hash),
+				"error", err,
+			)
+		}
+		if err := o.storeLeiosEndorserBlock(
+			m.Point,
+			respBlock.BlockRaw,
+			txsRaw,
+		); err != nil {
+			return err
+		}
 		o.config.Logger.Info(
 			fmt.Sprintf(
-				"fetched EB %d.%x with size %d",
+				"fetched EB %d.%x with size %d and %d txs",
 				m.Point.Slot,
 				m.Point.Hash,
 				len(respBlock.BlockRaw),
+				len(txsRaw),
 			),
 			"component", "network",
 			"protocol", "leios-fetch",
 			"role", "client",
-			"connection_id", ctx.ConnectionId.String(),
+			"connection_id", connId,
+		)
+	case *oleiosnotify.MsgBlockTxsOffer:
+		txsRaw, err := o.fetchCachedLeiosEndorserBlockTxs(conn, m.Point)
+		if err != nil {
+			level := slog.LevelWarn
+			msg := "failed to fetch Leios EB transactions"
+			if errors.Is(err, errLeiosEndorserBlockNotCached) {
+				level = slog.LevelDebug
+				msg = "skipping Leios EB transactions offer for uncached block"
+			}
+			o.config.Logger.Log(
+				context.Background(),
+				level,
+				msg,
+				"component", "network",
+				"protocol", "leios-fetch",
+				"role", "client",
+				"connection_id", connId,
+				"slot", m.Point.Slot,
+				"hash", hex.EncodeToString(m.Point.Hash),
+				"error", err,
+			)
+			return nil
+		}
+		o.config.Logger.Debug(
+			"fetched Leios EB transactions",
+			"component", "network",
+			"protocol", "leios-fetch",
+			"role", "client",
+			"connection_id", connId,
+			"slot", m.Point.Slot,
+			"hash", hex.EncodeToString(m.Point.Hash),
+			"tx_count", len(txsRaw),
 		)
 	}
 	return nil
+}
+
+func (o *Ouroboros) fetchCachedLeiosEndorserBlockTxs(
+	conn *ouroboros.Connection,
+	point ocommon.Point,
+) ([]cbor.RawMessage, error) {
+	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: %d.%x",
+			errLeiosEndorserBlockNotCached,
+			point.Slot,
+			point.Hash,
+		)
+	}
+	if data.completeTxCache() {
+		return cloneRawMessages(data.txsRaw), nil
+	}
+	txsRaw, err := o.fetchLeiosEndorserBlockTxs(
+		conn,
+		point,
+		cbor.RawMessage(data.blockRaw),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := o.storeLeiosEndorserBlock(point, data.blockRaw, txsRaw); err != nil {
+		return nil, err
+	}
+	return txsRaw, nil
+}
+
+func (o *Ouroboros) fetchLeiosEndorserBlockTxs(
+	conn *ouroboros.Connection,
+	point ocommon.Point,
+	blockRaw cbor.RawMessage,
+) ([]cbor.RawMessage, error) {
+	if conn.LeiosFetch() == nil || conn.LeiosFetch().Client == nil {
+		return nil, errors.New("leios-fetch client unavailable")
+	}
+	block, err := gleios.NewLeiosEndorserBlockFromCbor(blockRaw)
+	if err != nil {
+		return nil, err
+	}
+	if block.Body == nil || len(block.Body.TxReferences) == 0 {
+		return nil, nil
+	}
+	bitmaps, err := leiosAllTxBitmap(len(block.Body.TxReferences))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := conn.LeiosFetch().Client.BlockTxsRequest(point, bitmaps)
+	if err != nil {
+		return nil, err
+	}
+	respTxs, ok := resp.(*leiosfetch.MsgBlockTxs)
+	if !ok {
+		return nil, fmt.Errorf(
+			"unexpected leios-fetch BlockTxs response type %T",
+			resp,
+		)
+	}
+	if len(respTxs.TxsRaw) != len(block.Body.TxReferences) {
+		return nil, fmt.Errorf(
+			"leios-fetch BlockTxs returned %d txs for %d references",
+			len(respTxs.TxsRaw),
+			len(block.Body.TxReferences),
+		)
+	}
+	return cloneRawMessages(respTxs.TxsRaw), nil
 }
 
 func (o *Ouroboros) leiosnotifyServerRequestNext(

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -69,6 +69,11 @@ type Ouroboros struct {
 	restartMu sync.Map // ouroboros.ConnectionId → *sync.Mutex
 	// Per-peer rate limiter for TxSubmission server
 	txSubmissionRateLimiter *txSubmissionRateLimiter
+	// Cached Leios EB material fetched from peers. This lets NtC
+	// ChainSync serve merged RB+EB blocks without coupling the chain
+	// package to Leios prototype protocols.
+	leiosEndorserBlocks map[string]*leiosEndorserBlockData
+	leiosMu             sync.RWMutex
 }
 
 // chainsyncPeerStats tracks ChainSync performance metrics per peer connection.
@@ -128,11 +133,12 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		cfg.ChainsyncBlockTimeout,
 	)
 	o := &Ouroboros{
-		config:           cfg,
-		EventBus:         cfg.EventBus,
-		ConnManager:      cfg.ConnManager,
-		blockFetchStarts: make(map[ouroboros.ConnectionId]time.Time),
-		chainsyncStats:   make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
+		config:              cfg,
+		EventBus:            cfg.EventBus,
+		ConnManager:         cfg.ConnManager,
+		blockFetchStarts:    make(map[ouroboros.ConnectionId]time.Time),
+		chainsyncStats:      make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
+		leiosEndorserBlocks: make(map[string]*leiosEndorserBlockData),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond


### PR DESCRIPTION
Closes #1930 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve merged Leios Ranking Blocks with embedded Endorser Block transactions over Node-to-Client ChainSync. Adds a TTL/size-bounded EB cache and wires `leios-notify`/`leios-fetch` to populate and serve EB blocks/txs, addressing #1930.

- New Features
  - NtC `ChainSync` serves merged RB+EB via `chainsyncServerBlockCbor`, with safe fallback when EB txs are missing or errors occur.
  - In-memory EB cache in `Ouroboros` with TTL and max-entries pruning; keyed by EB hash and point.
  - `leios-notify` client fetches EB via `leios-fetch` on `MsgBlockOffer`, then requests all txs; handles `MsgBlockTxsOffer` and skips uncached offers without error.
  - `leios-fetch` server returns EB and selected txs from cache; validates tx bitmaps and rejects incomplete or out-of-range requests.
  - `leios_merged.go` merges CBOR arrays (bodies, witnesses, metadata, invalid) when an EB certificate is present; tests cover merge, bitmap selection, server validation, fallback, and cache pruning.

<sup>Written for commit 6aca1f8baf49c7e0585e2e12525e77529275da51. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2392?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

