### PR TITLE
fix: appease nilaway scanner

### DIFF
--- a/bark/blob.go
+++ b/bark/blob.go
@@ -294,6 +294,10 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("failed downloading block from bark supplied url: %w", err)
 	}
+	if blockResp == nil {
+		return nil, types.BlockMetadata{},
+			errors.New("bark supplied url returned nil response")
+	}
 	defer blockResp.Body.Close()
 
 	if blockResp.StatusCode != http.StatusOK {

--- a/chain/blockcache_test.go
+++ b/chain/blockcache_test.go
@@ -351,6 +351,7 @@ func TestBlockCache_PrometheusMetric(t *testing.T) {
 	require.NoError(t, err)
 	for _, mf := range metrics {
 		if mf.GetName() == "dingo_chain_manager_cached_blocks" {
+			require.NotEmpty(t, mf.GetMetric())
 			assert.Equal(
 				t,
 				float64(1),

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -311,6 +311,9 @@ func TestChainIteratorReverseFromTipNonInclusive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error from reverse iterator: %s", err)
 	}
+	if next == nil {
+		t.Fatal("reverse iterator returned nil result")
+	}
 	want := testBlocks[len(testBlocks)-2].MockHash
 	got := hex.EncodeToString(next.Block.Hash)
 	if got != want {
@@ -1364,7 +1367,7 @@ func generateTestChain(
 ) []ledger.Block {
 	t.Helper()
 	if count <= 0 {
-		return nil
+		return []ledger.Block{}
 	}
 	// All generated blocks have identical empty bodies, so the four
 	// component CBORs and the resulting block body hash are constant.
@@ -1947,6 +1950,9 @@ func TestChainIterateNonPrimaryAfterPrimaryRollbackPastFork(t *testing.T) {
 	}
 
 	const forkIdx = 2 // primary block 3 (0-based index 2)
+	if len(primaryBlocks) <= forkIdx {
+		t.Fatalf("expected at least %d primary blocks, got %d", forkIdx+1, len(primaryBlocks))
+	}
 	forkPoint := ocommon.Point{
 		Slot: primaryBlocks[forkIdx].SlotNumber(),
 		Hash: primaryBlocks[forkIdx].Hash().Bytes(),
@@ -2053,6 +2059,9 @@ func TestChainRollbackNonPrimaryAfterPrimaryRollback(t *testing.T) {
 	}
 
 	const forkIdx = 2 // primary block 3
+	if len(primaryBlocks) <= forkIdx {
+		t.Fatalf("expected at least %d primary blocks, got %d", forkIdx+1, len(primaryBlocks))
+	}
 	forkPoint := ocommon.Point{
 		Slot: primaryBlocks[forkIdx].SlotNumber(),
 		Hash: primaryBlocks[forkIdx].Hash().Bytes(),

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -84,7 +84,11 @@ func newChainIterator(
 }
 
 func (ci *ChainIterator) Next(blocking bool) (*ChainIteratorResult, error) {
-	return ci.chain.iterNext(ci, blocking)
+	ret, err := ci.chain.iterNext(ci, blocking)
+	if ret == nil && err == nil {
+		return nil, ErrIteratorChainTip
+	}
+	return ret, err
 }
 
 func (ci *ChainIterator) Cancel() {

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -97,7 +97,11 @@ func (cm *ChainManager) SetLedger(
 func (cm *ChainManager) PrimaryChain() *Chain {
 	cm.mutex.RLock()
 	defer cm.mutex.RUnlock()
-	return cm.primaryChainLocked()
+	chain := cm.primaryChainLocked()
+	if chain == nil {
+		panic("chain manager primary chain is not initialized")
+	}
+	return chain
 }
 
 // primaryChainLocked returns the primary chain without acquiring the mutex.

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -280,7 +280,7 @@ func (s *State) RemoveClientConnId(
 	tc, exists := s.trackedClients[connId]
 	wasPrimary := s.activeClientConnId != nil &&
 		*s.activeClientConnId == connId
-	wasEligible := exists && !tc.ObservabilityOnly
+	wasEligible := exists && tc != nil && !tc.ObservabilityOnly
 	delete(s.trackedClients, connId)
 	s.clearObservedHeaderHistory(connId)
 	if wasPrimary {

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -1428,11 +1428,11 @@ func loadGapBlocksFromBlob(
 	endSlot uint64,
 ) ([]models.Block, error) {
 	if startSlot > endSlot {
-		return nil, nil
+		return []models.Block{}, nil
 	}
 	iter := db.BlocksInRange(startSlot, endSlot)
 	defer iter.Close()
-	var ret []models.Block
+	ret := make([]models.Block, 0)
 	for {
 		next, err := iter.NextRaw()
 		if err != nil {
@@ -1503,6 +1503,12 @@ func validateStoredGapBlocks(
 ) error {
 	if err := validateStoredGapContinuity(blocks, immutableTip); err != nil {
 		return err
+	}
+	if len(blocks) == 0 {
+		return fmt.Errorf(
+			"stored volatile gap is empty after immutable tip slot %d",
+			immutableTip.Slot,
+		)
 	}
 	last := blocks[len(blocks)-1]
 	if !bytes.Equal(last.Hash, ledgerStateHash) {

--- a/cmd/dingo/mithril_gap_governance_test.go
+++ b/cmd/dingo/mithril_gap_governance_test.go
@@ -456,6 +456,7 @@ func TestProcessGapBlocksNoOpWithoutUint64Overflow(t *testing.T) {
 				i+1,
 			)
 		}
+		require.NotNil(t, next)
 		if next.IsEbb {
 			continue
 		}
@@ -605,6 +606,7 @@ func TestLoadGapBlocksFromBlob(t *testing.T) {
 				i+1,
 			)
 		}
+		require.NotNil(t, next)
 		if next.IsEbb {
 			continue
 		}

--- a/cmd/dingo/mithril_metrics_test.go
+++ b/cmd/dingo/mithril_metrics_test.go
@@ -172,6 +172,7 @@ func TestStartPrometheusMetricsServerWithHandlerServesMetrics(t *testing.T) {
 	client := http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get("http://" + server.addr + "/metrics")
 	require.NoError(t, err)
+	require.NotNil(t, resp)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/database/batch.go
+++ b/database/batch.go
@@ -132,13 +132,14 @@ func (d *Database) SetTransactionBatchedWithOpts(
 	}
 
 	txHash := tx.Hash()
+	txHashBytes := ledgerHashBytes(txHash)
 	var txHashArray [32]byte
-	copy(txHashArray[:], txHash.Bytes())
+	copy(txHashArray[:], txHashBytes)
 
 	if offsets == nil {
 		return fmt.Errorf(
 			"missing offsets for transaction %s at slot %d: offsets must be computed",
-			hex.EncodeToString(txHash.Bytes()[:8]),
+			hex.EncodeToString(ledgerHashPrefix(txHash)),
 			point.Slot,
 		)
 	}
@@ -146,17 +147,17 @@ func (d *Database) SetTransactionBatchedWithOpts(
 	if !ok {
 		return fmt.Errorf(
 			"missing TX offset for %s at slot %d: offset must be computed by block indexer",
-			hex.EncodeToString(txHash.Bytes()[:8]),
+			hex.EncodeToString(ledgerHashPrefix(txHash)),
 			point.Slot,
 		)
 	}
 	offsetData := EncodeTxOffset(&txOffset)
-	if err := blob.SetTx(blobTxn, txHash.Bytes(), offsetData); err != nil {
+	if err := blob.SetTx(blobTxn, txHashBytes, offsetData); err != nil {
 		return fmt.Errorf("set tx offset: %w", err)
 	}
 
 	for _, utxo := range tx.Produced() {
-		txID := utxo.Id.Id().Bytes()
+		txID := ledgerInputIDBytes(utxo.Id)
 		outputIdx := utxo.Id.Index()
 		ref := UtxoRef{
 			TxId:      txHashArray,
@@ -166,7 +167,7 @@ func (d *Database) SetTransactionBatchedWithOpts(
 		if !ok {
 			return fmt.Errorf(
 				"missing UTxO offset for %s#%d at slot %d: offset must be computed by block indexer",
-				hex.EncodeToString(txID[:8]),
+				hex.EncodeToString(bytePrefix(txID)),
 				outputIdx,
 				point.Slot,
 			)
@@ -182,7 +183,7 @@ func (d *Database) SetTransactionBatchedWithOpts(
 		if err := blob.SetUtxo(blobTxn, txID, outputIdx, offsetData); err != nil {
 			return fmt.Errorf(
 				"set utxo offset %x#%d: %w",
-				txID[:8],
+				bytePrefix(txID),
 				outputIdx,
 				err,
 			)

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -174,7 +174,7 @@ func DelegationTableCertTypes(table string) []uint {
 			uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
 		}
 	default:
-		return nil
+		return []uint{}
 	}
 }
 
@@ -279,7 +279,7 @@ func RegistrationTableCertTypes(
 			uint(lcommon.CertificateTypeDeregistration),
 		}
 	default:
-		return nil
+		return []uint{}
 	}
 }
 

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -28,6 +28,27 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
+func ledgerHashBytes(hash lcommon.Blake2b256) []byte {
+	return hash[:]
+}
+
+func ledgerHashPrefix(hash lcommon.Blake2b256) []byte {
+	return hash[:8]
+}
+
+func ledgerInputIDBytes(input lcommon.TransactionInput) []byte {
+	id := input.Id()
+	return id[:]
+}
+
+func bytePrefix(data []byte) []byte {
+	const count = 8
+	if len(data) < count {
+		return data
+	}
+	return data[:count]
+}
+
 func (d *Database) SetTransaction(
 	tx lcommon.Transaction,
 	point ocommon.Point,
@@ -56,13 +77,14 @@ func (d *Database) SetTransaction(
 
 	// Store transaction CBOR offset - offsets MUST be available
 	txHash := tx.Hash()
+	txHashBytes := ledgerHashBytes(txHash)
 	var txHashArray [32]byte
-	copy(txHashArray[:], txHash.Bytes())
+	copy(txHashArray[:], txHashBytes)
 
 	if offsets == nil {
 		return fmt.Errorf(
 			"missing offsets for transaction %s at slot %d: offsets must be computed",
-			hex.EncodeToString(txHash.Bytes()[:8]),
+			hex.EncodeToString(ledgerHashPrefix(txHash)),
 			point.Slot,
 		)
 	}
@@ -70,13 +92,13 @@ func (d *Database) SetTransaction(
 	if !ok {
 		return fmt.Errorf(
 			"missing TX offset for %s at slot %d: offset must be computed by block indexer",
-			hex.EncodeToString(txHash.Bytes()[:8]),
+			hex.EncodeToString(ledgerHashPrefix(txHash)),
 			point.Slot,
 		)
 	}
 	// Store offset reference
 	offsetData := EncodeTxOffset(&txOffset)
-	if err := blob.SetTx(blobTxn, txHash.Bytes(), offsetData); err != nil {
+	if err := blob.SetTx(blobTxn, txHashBytes, offsetData); err != nil {
 		return fmt.Errorf("set tx offset: %w", err)
 	}
 
@@ -88,12 +110,12 @@ func (d *Database) SetTransaction(
 	if len(produced) == 0 {
 		d.logger.Warn(
 			"transaction has no produced outputs",
-			"txHash", hex.EncodeToString(txHash.Bytes()[:8]),
+			"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
 			"slot", point.Slot,
 		)
 	}
 	for _, utxo := range produced {
-		txId := utxo.Id.Id().Bytes()
+		txId := ledgerInputIDBytes(utxo.Id)
 		outputIdx := utxo.Id.Index()
 
 		ref := UtxoRef{
@@ -104,7 +126,7 @@ func (d *Database) SetTransaction(
 		if !ok {
 			return fmt.Errorf(
 				"missing UTxO offset for %s#%d at slot %d: offset must be computed by block indexer",
-				hex.EncodeToString(txId[:8]),
+				hex.EncodeToString(bytePrefix(txId)),
 				outputIdx,
 				point.Slot,
 			)
@@ -114,7 +136,7 @@ func (d *Database) SetTransaction(
 		if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
 			return fmt.Errorf(
 				"set utxo offset %x#%d: %w",
-				txId[:8],
+				bytePrefix(txId),
 				outputIdx,
 				err,
 			)
@@ -174,13 +196,14 @@ func (d *Database) SetGapBlockTransaction(
 	}
 
 	txHash := tx.Hash()
+	txHashBytes := ledgerHashBytes(txHash)
 	var txHashArray [32]byte
-	copy(txHashArray[:], txHash.Bytes())
+	copy(txHashArray[:], txHashBytes)
 
 	if offsets == nil {
 		return fmt.Errorf(
 			"missing offsets for gap block transaction %s at slot %d",
-			hex.EncodeToString(txHash.Bytes()[:8]),
+			hex.EncodeToString(ledgerHashPrefix(txHash)),
 			point.Slot,
 		)
 	}
@@ -188,18 +211,18 @@ func (d *Database) SetGapBlockTransaction(
 	if !ok {
 		return fmt.Errorf(
 			"missing TX offset for gap block %s at slot %d",
-			hex.EncodeToString(txHash.Bytes()[:8]),
+			hex.EncodeToString(ledgerHashPrefix(txHash)),
 			point.Slot,
 		)
 	}
 	offsetData := EncodeTxOffset(&txOffset)
-	if err := blob.SetTx(blobTxn, txHash.Bytes(), offsetData); err != nil {
+	if err := blob.SetTx(blobTxn, txHashBytes, offsetData); err != nil {
 		return fmt.Errorf("set gap block tx offset: %w", err)
 	}
 
 	// Store UTxO offsets for produced outputs
 	for _, utxo := range tx.Produced() {
-		txId := utxo.Id.Id().Bytes()
+		txId := ledgerInputIDBytes(utxo.Id)
 		outputIdx := utxo.Id.Index()
 		ref := UtxoRef{
 			TxId:      txHashArray,
@@ -209,7 +232,7 @@ func (d *Database) SetGapBlockTransaction(
 		if !ok {
 			return fmt.Errorf(
 				"missing UTxO offset for gap block %s#%d at slot %d",
-				hex.EncodeToString(txId[:8]),
+				hex.EncodeToString(bytePrefix(txId)),
 				outputIdx,
 				point.Slot,
 			)
@@ -218,7 +241,7 @@ func (d *Database) SetGapBlockTransaction(
 		if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
 			return fmt.Errorf(
 				"set gap block utxo offset %x#%d: %w",
-				txId[:8], outputIdx, err,
+				bytePrefix(txId), outputIdx, err,
 			)
 		}
 	}
@@ -256,11 +279,11 @@ func (d *Database) ensureTransactionConsumedUtxos(
 	if len(consumed) == 0 {
 		return nil
 	}
-	spenderTxHash := tx.Hash().Bytes()
+	spenderTxHash := ledgerHashBytes(tx.Hash())
 	recoveredUtxos := make([]models.Utxo, 0, len(consumed))
 	seen := make(map[string]struct{}, len(consumed))
 	for _, input := range consumed {
-		inputTxId := input.Id().Bytes()
+		inputTxId := ledgerInputIDBytes(input)
 		inputKey := fmt.Sprintf("%x:%d", inputTxId, input.Index())
 		if _, ok := seen[inputKey]; ok {
 			continue
@@ -345,11 +368,11 @@ func (d *Database) ensureGapConsumedUtxos(
 	if len(consumed) == 0 {
 		return nil
 	}
-	spenderTxHash := tx.Hash().Bytes()
+	spenderTxHash := ledgerHashBytes(tx.Hash())
 	recoveredUtxos := make([]models.Utxo, 0, len(consumed))
 	seen := make(map[string]struct{}, len(consumed))
 	for _, input := range consumed {
-		inputTxId := input.Id().Bytes()
+		inputTxId := ledgerInputIDBytes(input)
 		inputKey := fmt.Sprintf("%x:%d", inputTxId, input.Index())
 		if _, ok := seen[inputKey]; ok {
 			continue
@@ -462,7 +485,7 @@ func (d *Database) recoverConsumedUtxo(
 	}
 	utxoData, err := blob.GetUtxo(
 		blobTxn,
-		input.Id().Bytes(),
+		ledgerInputIDBytes(input),
 		input.Index(),
 	)
 	if err != nil && !errors.Is(err, types.ErrBlobKeyNotFound) {
@@ -506,7 +529,7 @@ func (d *Database) recoverConsumedUtxo(
 		slot, found, slotErr := utxoRecoverySlotForTx(
 			txn.DB(),
 			txn,
-			input.Id().Bytes(),
+			ledgerInputIDBytes(input),
 		)
 		if slotErr != nil {
 			return nil, fmt.Errorf(
@@ -522,7 +545,7 @@ func (d *Database) recoverConsumedUtxo(
 		block, err := utxoRecoveryBlockForTx(
 			txn.DB(),
 			txn,
-			input.Id().Bytes(),
+			ledgerInputIDBytes(input),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("lookup producer block: %w", err)
@@ -540,7 +563,7 @@ func (d *Database) recoverConsumedUtxo(
 		}
 		outputCbor, err = utxoCborFromDecodedBlock(
 			decodedBlock,
-			input.Id().Bytes(),
+			ledgerInputIDBytes(input),
 			input.Index(),
 		)
 		if err != nil {
@@ -551,13 +574,13 @@ func (d *Database) recoverConsumedUtxo(
 		offsets, indexErr := indexer.ComputeOffsets(block.Cbor, decodedBlock)
 		if indexErr == nil {
 			var txHashArray [32]byte
-			copy(txHashArray[:], input.Id().Bytes())
+			copy(txHashArray[:], ledgerInputIDBytes(input))
 			ref := UtxoRef{TxId: txHashArray, OutputIdx: input.Index()}
 			if offset, ok := offsets.UtxoOffsets[ref]; ok {
 				if repairErr := repairUtxoBlob(
 					txn.DB(),
 					txn,
-					input.Id().Bytes(),
+					ledgerInputIDBytes(input),
 					input.Index(),
 					&offset,
 				); repairErr != nil {
@@ -591,7 +614,7 @@ func (d *Database) recoverConsumedUtxo(
 	// the FK nil and the row stays unjoinable until backfilled by a
 	// later path that has the producer.
 	producerID, found, lookupErr := d.metadata.GetTransactionIDByHash(
-		input.Id().Bytes(),
+		ledgerInputIDBytes(input),
 		txn.Metadata(),
 	)
 	if lookupErr != nil {
@@ -640,7 +663,7 @@ func (d *Database) SetGenesisTransaction(
 
 	utxoModels := make([]models.Utxo, len(outputs))
 	for i, utxo := range outputs {
-		txId := utxo.Id.Id().Bytes()
+		txId := ledgerInputIDBytes(utxo.Id)
 		outputIdx := utxo.Id.Index()
 
 		ref := UtxoRef{
@@ -652,7 +675,7 @@ func (d *Database) SetGenesisTransaction(
 		if !ok {
 			return fmt.Errorf(
 				"missing offset for genesis utxo %x:%d",
-				txId[:8],
+				bytePrefix(txId),
 				outputIdx,
 			)
 		}
@@ -662,7 +685,7 @@ func (d *Database) SetGenesisTransaction(
 		if err := blob.SetUtxo(blobTxn, txId, outputIdx, offsetData); err != nil {
 			return fmt.Errorf(
 				"set genesis utxo offset %x#%d: %w",
-				txId[:8],
+				bytePrefix(txId),
 				outputIdx,
 				err,
 			)

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -306,6 +306,5 @@ func BlockTombstone() []byte {
 // treated as a tombstone — a partial or unexpectedly extended marker
 // must never be misread as block CBOR.
 func IsBlockTombstone(data []byte) bool {
-	return len(data) >= len(BlockTombstoneMagic) &&
-		bytes.Equal(data[:len(BlockTombstoneMagic)], BlockTombstoneMagic[:])
+	return bytes.HasPrefix(data, BlockTombstoneMagic[:])
 }

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -263,7 +263,7 @@ func utxoRecoverySlotForTx(
 	if err != nil {
 		return 0, false, fmt.Errorf(
 			"lookup producer tx metadata for utxo recovery %x: %w",
-			txId[:8],
+			bytePrefix(txId),
 			err,
 		)
 	}
@@ -294,7 +294,7 @@ func fetchTxBlobSlotAndHash(
 		}
 		return 0, blockHash, false, fmt.Errorf(
 			"lookup tx blob for utxo recovery %x: %w",
-			txId[:8],
+			bytePrefix(txId),
 			err,
 		)
 	}
@@ -304,7 +304,7 @@ func fetchTxBlobSlotAndHash(
 		if err != nil {
 			return 0, blockHash, false, fmt.Errorf(
 				"decode tx offset for utxo recovery %x: %w",
-				txId[:8],
+				bytePrefix(txId),
 				err,
 			)
 		}
@@ -314,7 +314,7 @@ func fetchTxBlobSlotAndHash(
 		if err != nil {
 			return 0, blockHash, false, fmt.Errorf(
 				"decode tx parts for utxo recovery %x: %w",
-				txId[:8],
+				bytePrefix(txId),
 				err,
 			)
 		}
@@ -344,7 +344,7 @@ func utxoRecoveryBlockForTx(
 		if err != nil {
 			return nil, fmt.Errorf(
 				"lookup producer block from tx blob %x: %w",
-				txId[:8],
+				bytePrefix(txId),
 				err,
 			)
 		}
@@ -354,7 +354,7 @@ func utxoRecoveryBlockForTx(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"lookup producer tx metadata for utxo recovery %x: %w",
-			txId[:8],
+			bytePrefix(txId),
 			err,
 		)
 	}
@@ -368,7 +368,7 @@ func utxoRecoveryBlockForTx(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"lookup producer block from tx metadata %x: %w",
-			txId[:8],
+			bytePrefix(txId),
 			err,
 		)
 	}

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -240,6 +240,7 @@ func TestCopyBlocksRawWithCallback_StoresUtxoOffsets(t *testing.T) {
 				i+1,
 			)
 		}
+		require.NotNil(t, next)
 		if next.IsEbb {
 			continue
 		}

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -690,11 +690,12 @@ func TestHandleEventChainsyncBlockHeaderBuffersIncompatibleNonOwnerConnection(
 	require.NoError(t, err)
 	assert.Equal(t, connId1, ls.headerPipelineConnId)
 	assert.Equal(t, 1, ls.chain.HeaderCount())
-	require.Len(t, ls.bufferedHeaderEvents[connIdKey(connId2)], 1)
+	events := ls.bufferedHeaderEvents[connIdKey(connId2)]
+	require.Len(t, events, 1)
 	assert.Equal(
 		t,
 		header2.slot,
-		ls.bufferedHeaderEvents[connIdKey(connId2)][0].Point.Slot,
+		events[0].Point.Slot,
 	)
 }
 

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -248,11 +248,13 @@ func ValidateTxAlonzo(
 		}
 		scripts[tmpScript.Hash()] = tmpScript
 	}
-	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().NativeScripts() {
-		scripts[tmpScript.Hash()] = tmpScript
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, tmpScript := range witnesses.PlutusV1Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.NativeScripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
 	}
 	// Evaluate scripts
 	var txInfoV1 script.TxInfo
@@ -385,11 +387,13 @@ func EvaluateTxAlonzo(
 		}
 		scripts[tmpScript.Hash()] = tmpScript
 	}
-	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().NativeScripts() {
-		scripts[tmpScript.Hash()] = tmpScript
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, tmpScript := range witnesses.PlutusV1Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.NativeScripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
 	}
 	// Evaluate scripts
 	var retTotalExUnits lcommon.ExUnits

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -262,14 +262,16 @@ func ValidateTxBabbage(
 		}
 		scripts[tmpScript.Hash()] = tmpScript
 	}
-	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV2Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().NativeScripts() {
-		scripts[tmpScript.Hash()] = tmpScript
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, tmpScript := range witnesses.PlutusV1Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.PlutusV2Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.NativeScripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
 	}
 	// Evaluate scripts
 	var txInfoV2 script.TxInfo
@@ -476,14 +478,16 @@ func EvaluateTxBabbage(
 		}
 		scripts[tmpScript.Hash()] = tmpScript
 	}
-	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV2Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().NativeScripts() {
-		scripts[tmpScript.Hash()] = tmpScript
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, tmpScript := range witnesses.PlutusV1Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.PlutusV2Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.NativeScripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
 	}
 	// Evaluate scripts
 	var retTotalExUnits lcommon.ExUnits

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -252,17 +252,19 @@ func EvaluateTxConway(
 		}
 		scripts[tmpScript.Hash()] = tmpScript
 	}
-	for _, tmpScript := range tx.Witnesses().PlutusV1Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV2Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().PlutusV3Scripts() {
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	for _, tmpScript := range tx.Witnesses().NativeScripts() {
-		scripts[tmpScript.Hash()] = tmpScript
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, tmpScript := range witnesses.PlutusV1Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.PlutusV2Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.PlutusV3Scripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.NativeScripts() {
+			scripts[tmpScript.Hash()] = tmpScript
+		}
 	}
 	// Evaluate scripts
 	var retTotalExUnits lcommon.ExUnits

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -306,18 +306,22 @@ func (b *DefaultBlockBuilder) BuildBlock(
 		// Pull ExUnits from redeemers in the witness set
 		var estimatedTxExUnits lcommon.ExUnits
 		var exUnitsErr error
-		for _, redeemer := range fullTx.Witnesses().Redeemers().Iter() {
-			estimatedTxExUnits, exUnitsErr = eras.SafeAddExUnits(
-				estimatedTxExUnits,
-				redeemer.ExUnits,
-			)
-			if exUnitsErr != nil {
-				b.logger.Debug(
-					"skipping transaction - ExUnits overflow",
-					"component", "forging",
-					"error", exUnitsErr,
-				)
-				break
+		if witnesses := fullTx.Witnesses(); witnesses != nil {
+			if redeemers := witnesses.Redeemers(); redeemers != nil {
+				for _, redeemer := range redeemers.Iter() {
+					estimatedTxExUnits, exUnitsErr = eras.SafeAddExUnits(
+						estimatedTxExUnits,
+						redeemer.ExUnits,
+					)
+					if exUnitsErr != nil {
+						b.logger.Debug(
+							"skipping transaction - ExUnits overflow",
+							"component", "forging",
+							"error", exUnitsErr,
+						)
+						break
+					}
+				}
 			}
 		}
 		if exUnitsErr != nil {

--- a/ledger/genesis_utxo_test.go
+++ b/ledger/genesis_utxo_test.go
@@ -93,8 +93,9 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 		default:
 			t.Fatalf("Unexpected output type: %T", utxo.Output)
 		}
+		utxoTxID := utxo.Id.Id()
 		t.Logf("Encoded UTxO %x#%d: %d bytes",
-			utxo.Id.Id().Bytes()[:8], utxo.Id.Index(), len(cborData))
+			utxoTxID[:8], utxo.Id.Index(), len(cborData))
 	}
 
 	// Get the Byron genesis hash to use as the synthetic block hash
@@ -203,7 +204,9 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 	// Now try to retrieve each genesis UTxO
 	t.Log("Retrieving genesis UTxOs...")
 	for _, utxo := range byronGenesisUtxos {
-		txId := utxo.Id.Id().Bytes()
+		txIDHash := utxo.Id.Id()
+		txId := txIDHash[:]
+		txIDPrefix := txIDHash[:8]
 		outputIdx := utxo.Id.Index()
 
 		// Try to get the UTxO from blob store
@@ -216,14 +219,14 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 		data, err := blob.GetUtxo(blobTxn, txId, outputIdx)
 		if err != nil {
 			t.Errorf("Failed to get UTxO %s#%d from blob: %v",
-				hex.EncodeToString(txId[:8]), outputIdx, err)
+				hex.EncodeToString(txIDPrefix), outputIdx, err)
 			readTxn.Rollback() //nolint:errcheck
 			continue
 		}
 
 		t.Logf(
 			"Retrieved data for %x#%d: %d bytes, first bytes: %s",
-			txId[:8],
+			txIDPrefix,
 			outputIdx,
 			len(data),
 			hex.EncodeToString(data[:min(20, len(data))]),
@@ -239,7 +242,7 @@ func TestGenesisUtxoStorageAndRetrieval(t *testing.T) {
 				t,
 				err,
 				"Failed to decode offset for %x#%d",
-				txId[:8],
+				txIDPrefix,
 				outputIdx,
 			)
 

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -232,6 +232,7 @@ func waitForSchedule(
 		schedule = election.CurrentSchedule()
 		return schedule != nil
 	}, timeout, 50*time.Millisecond, "schedule should be computed")
+	require.NotNil(t, schedule)
 	return schedule
 }
 
@@ -452,6 +453,7 @@ func TestElectionPersistsComputedSchedule(t *testing.T) {
 		require.NoError(t, err)
 		return persisted != nil
 	}, 2*time.Second, 50*time.Millisecond)
+	require.NotNil(t, persisted)
 	assert.Equal(
 		t,
 		schedule.LeaderSlotsSnapshot(),
@@ -977,6 +979,7 @@ func TestElectionRollbackKeepsPrecomputedNextSchedule(t *testing.T) {
 		nextBefore = election.ScheduleForEpoch(11)
 		return nextBefore != nil
 	}, 30*time.Second, 100*time.Millisecond)
+	require.NotNil(t, nextBefore)
 	expectedSlots := nextBefore.LeaderSlotsSnapshot()
 	expectedNonce := append([]byte(nil), nextBefore.EpochNonce...)
 

--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -88,6 +88,9 @@ func (s *Schedule) IsLeaderForSlot(slot uint64) bool {
 
 // SlotCount returns the number of slots where this pool is leader.
 func (s *Schedule) SlotCount() int {
+	if s == nil {
+		return 0
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.LeaderSlots)
@@ -95,6 +98,9 @@ func (s *Schedule) SlotCount() int {
 
 // LeaderSlotsSnapshot returns a copy of the leader slot list.
 func (s *Schedule) LeaderSlotsSnapshot() []uint64 {
+	if s == nil {
+		return nil
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return append([]uint64(nil), s.LeaderSlots...)

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -63,6 +63,13 @@ func newTestEraHistoryCfg(t testing.TB) *cardano.CardanoNodeConfig {
 	return cfg
 }
 
+func requireEraDesc(t testing.TB, eraId uint) eras.EraDesc {
+	t.Helper()
+	era := eras.GetEraById(eraId)
+	require.NotNil(t, era)
+	return *era
+}
+
 // TestQueryHardForkEraHistory_OpenEraEndBoundedBySafeZone proves that the
 // current era's EraEnd is snapped to the end of the epoch that contains
 // ledgerTip + safeZone.  Within a single epoch slot↔time is linear (constant
@@ -917,6 +924,10 @@ func TestCheckedSlotAdd(t *testing.T) {
 // stopped in the window between an epoch-rollover version bump and the first
 // block of the new era.
 func TestReconstructTransitionInfo(t *testing.T) {
+	babbageEra := eras.GetEraById(eras.BabbageEraDesc.Id)
+	require.NotNil(t, babbageEra)
+	conwayEra := eras.GetEraById(eras.ConwayEraDesc.Id)
+	require.NotNil(t, conwayEra)
 	tests := []struct {
 		name           string
 		currentEra     eras.EraDesc
@@ -929,7 +940,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 			// Babbage pparams with Conway major version (9): TransitionKnown.
 			// This is the pre-Conway restart window scenario.
 			name:       "babbage era pparams with conway version → TransitionKnown",
-			currentEra: *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEra: *babbageEra,
 			currentEpoch: models.Epoch{
 				EpochId: 500,
 				EraId:   eras.BabbageEraDesc.Id,
@@ -943,7 +954,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 		{
 			// Babbage pparams with normal Babbage version: no transition.
 			name:       "babbage era pparams with babbage version → TransitionUnknown",
-			currentEra: *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEra: *babbageEra,
 			currentEpoch: models.Epoch{
 				EpochId: 499,
 				EraId:   eras.BabbageEraDesc.Id,
@@ -956,7 +967,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 		{
 			// Conway pparams in Conway era: pparamsEra == currentEra, no transition.
 			name:       "conway era pparams with conway version → TransitionUnknown",
-			currentEra: *eras.GetEraById(eras.ConwayEraDesc.Id),
+			currentEra: *conwayEra,
 			currentEpoch: models.Epoch{
 				EpochId: 600,
 				EraId:   eras.ConwayEraDesc.Id,
@@ -971,7 +982,7 @@ func TestReconstructTransitionInfo(t *testing.T) {
 		{
 			// Nil pparams: must not panic, leave TransitionUnknown.
 			name:           "nil pparams → TransitionUnknown",
-			currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+			currentEra:     *babbageEra,
 			currentEpoch:   models.Epoch{EpochId: 400, EraId: eras.BabbageEraDesc.Id},
 			currentPParams: nil,
 			expectedState:  hardfork.TransitionUnknown,

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -768,7 +768,9 @@ func TestTryRecoverFromTxValidationErrorFallsBackToChainScan(t *testing.T) {
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
 
-	producerTx := producerBlock.block.Transactions()[0]
+	producerTxs := producerBlock.block.Transactions()
+	require.NotEmpty(t, producerTxs)
+	producerTx := producerTxs[0]
 	recovered, err := ls.tryRecoverFromTxValidationError(
 		&txValidationError{
 			BlockPoint: currentTip.Point,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3364,10 +3364,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 	var delta *LedgerDelta
 	// Track outputs from earlier transactions in this block for intra-block
 	// dependencies only when TX validation is enabled.
-	var intraBlockUtxos map[string]lcommon.Utxo
-	if shouldValidate {
-		intraBlockUtxos = make(map[string]lcommon.Utxo)
-	}
+	intraBlockUtxos := make(map[string]lcommon.Utxo)
 	for i, tx := range block.Transactions() {
 		if delta == nil {
 			delta = NewLedgerDelta(
@@ -4619,7 +4616,7 @@ func (ls *LedgerState) withMithrilTrustBoundaryIntersectPoint(
 	points []ocommon.Point,
 	count int,
 ) []ocommon.Point {
-	if count <= 0 {
+	if count <= 0 || len(points) == 0 {
 		return points
 	}
 	point, ok := ls.mithrilTrustBoundaryPoint()

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2409,6 +2409,7 @@ func TestIntersectPointsUsesSparseLedgerTipSamples(t *testing.T) {
 		require.NoError(t, db.BlockCreate(block, nil))
 	}
 
+	require.NotEmpty(t, blocks)
 	ledgerTipBlock := blocks[len(blocks)-1]
 	ls := &LedgerState{
 		db: db,
@@ -2453,6 +2454,7 @@ func TestIntersectPointsIncludesMithrilTrustBoundary(t *testing.T) {
 		require.NoError(t, db.BlockCreate(block, nil))
 	}
 
+	require.NotEmpty(t, blocks)
 	ledgerTipBlock := blocks[len(blocks)-1]
 	ls := &LedgerState{
 		db: db,
@@ -2556,6 +2558,7 @@ func TestIntersectPointsSkipsMissingMithrilTrustBoundaryBlock(
 		require.NoError(t, db.BlockCreate(block, nil))
 	}
 
+	require.NotEmpty(t, blocks)
 	ledgerTipBlock := blocks[len(blocks)-1]
 	boundarySlot := uint64(5)
 	ls := &LedgerState{
@@ -2968,7 +2971,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneReachesEpochEnd(t *testing.
 
 	cfg := newTestEraHistoryCfg(t)
 	ls := &LedgerState{
-		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:   requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentEpoch: newTestEpoch(500, epochStart, epochLen, eras.ConwayEraDesc.Id),
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
@@ -2999,7 +3002,7 @@ func TestEvaluateTransitionImpossible_SetWhenSafeZoneExceedsEpochEnd(t *testing.
 
 	cfg := newTestEraHistoryCfg(t)
 	ls := &LedgerState{
-		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:   requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentEpoch: newTestEpoch(500, epochStart, epochLen, eras.ConwayEraDesc.Id),
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
@@ -3028,7 +3031,7 @@ func TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch(t *testing.T
 
 	cfg := newTestEraHistoryCfg(t)
 	ls := &LedgerState{
-		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:   requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentEpoch: newTestEpoch(500, epochStart, epochLen, eras.ConwayEraDesc.Id),
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(tipSlot, []byte("tip")),
@@ -3051,7 +3054,7 @@ func TestEvaluateTransitionImpossible_NotSetWhenSafeZoneInsideEpoch(t *testing.T
 func TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown(t *testing.T) {
 	cfg := newTestEraHistoryCfg(t)
 	ls := &LedgerState{
-		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:   requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentEpoch: newTestEpoch(500, 100_000, 432_000, eras.ConwayEraDesc.Id),
 		currentTip: ochainsync.Tip{
 			// tipSlot past the safe-zone boundary → would normally trigger Impossible
@@ -3076,7 +3079,7 @@ func TestEvaluateTransitionImpossible_NoOpWhenTransitionKnown(t *testing.T) {
 func TestEvaluateTransitionImpossible_NoOpAlreadyImpossible(t *testing.T) {
 	cfg := newTestEraHistoryCfg(t)
 	ls := &LedgerState{
-		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:   requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentEpoch: newTestEpoch(500, 100_000, 432_000, eras.ConwayEraDesc.Id),
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(520_000, []byte("tip")),
@@ -3098,7 +3101,7 @@ func TestEvaluateTransitionImpossible_NoOpAlreadyImpossible(t *testing.T) {
 func TestEvaluateTransitionImpossible_NoOpWhenEpochLengthZero(t *testing.T) {
 	cfg := newTestEraHistoryCfg(t)
 	ls := &LedgerState{
-		currentEra:   *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:   requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentEpoch: models.Epoch{EpochId: 0, LengthInSlots: 0},
 		currentTip: ochainsync.Tip{
 			Point: ocommon.NewPoint(999_999, []byte("tip")),
@@ -3154,7 +3157,7 @@ func newTestLedgerStateWithTrigger(
 		cfg.TestConwayHardForkAtEpoch = overrideEpoch
 	}
 	return &LedgerState{
-		currentEra:     *eras.GetEraById(currentEraId),
+		currentEra:     requireEraDesc(t, currentEraId),
 		currentEpoch:   newTestEpoch(currentEpochId, 0, 432_000, currentEraId),
 		transitionInfo: initialTI,
 		config: LedgerStateConfig{
@@ -3288,7 +3291,7 @@ func TestEvaluateTriggerAtEpoch_NoOpWithoutOverride(t *testing.T) {
 // TransitionUnknown so the new epoch starts fresh.
 func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentPParams: babbagePParams(9),
 		// Simulate state at end of epoch 500: TransitionImpossible was set
 		// because the tip's safe zone reached the epoch end.
@@ -3298,7 +3301,7 @@ func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 	var eraTransitions []*EraTransitionResult
 	rolloverResult := &EpochRolloverResult{
 		NewCurrentEpoch:   models.Epoch{EpochId: 501, StartSlot: 532_000, LengthInSlots: 432_000},
-		NewCurrentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewCurrentEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		NewCurrentPParams: babbagePParams(9),
 		NewEpochCache:     []models.Epoch{{EpochId: 501}},
 		HardFork:          nil,
@@ -3332,13 +3335,13 @@ func TestRolloverCommit_ResetsTransitionImpossible(t *testing.T) {
 // era-transition block" case).
 func TestApplyEraTransition_ClearsTransitionKnown(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
 		transitionInfo: hardfork.NewTransitionKnown(500),
 	}
 
 	result := &EraTransitionResult{
-		NewEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		NewPParams: babbagePParams(9),
 	}
 
@@ -3358,13 +3361,13 @@ func TestApplyEraTransition_ClearsTransitionKnown(t *testing.T) {
 // no-op for the State field (still TransitionUnknown).
 func TestApplyEraTransition_ClearsTransitionUnknown(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
 		transitionInfo: hardfork.NewTransitionUnknown(),
 	}
 
 	result := &EraTransitionResult{
-		NewEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		NewPParams: babbagePParams(9),
 	}
 
@@ -3383,13 +3386,13 @@ func TestApplyEraTransition_PreservesAndUpdatesFields(t *testing.T) {
 	newPParams := babbagePParams(9)
 
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 		currentPParams: lcommon.ProtocolParameters(oldPParams),
 		transitionInfo: hardfork.NewTransitionKnown(500),
 	}
 
 	result := &EraTransitionResult{
-		NewEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		NewPParams: lcommon.ProtocolParameters(newPParams),
 	}
 
@@ -3412,18 +3415,18 @@ func TestApplyEraTransition_PreservesAndUpdatesFields(t *testing.T) {
 // transitionInfo, and the final state is TransitionUnknown.
 func TestApplyEraTransition_MultipleSteps_AllCleared(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.AlonzoEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.AlonzoEraDesc.Id),
 		currentPParams: babbagePParams(6),
 		transitionInfo: hardfork.NewTransitionKnown(300),
 	}
 
 	steps := []*EraTransitionResult{
 		{
-			NewEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+			NewEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 			NewPParams: babbagePParams(8),
 		},
 		{
-			NewEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+			NewEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 			NewPParams: babbagePParams(9),
 		},
 	}
@@ -3445,20 +3448,20 @@ func TestApplyEraTransition_MultipleSteps_AllCleared(t *testing.T) {
 // is also set (should not happen in practice, but the logic must be safe).
 func TestRolloverCommit_EraTransitionClearsTransitionInfo(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
 		transitionInfo: hardfork.NewTransitionKnown(499),
 	}
 
 	eraTransitions := []*EraTransitionResult{
 		{
-			NewEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+			NewEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 			NewPParams: babbagePParams(9),
 		},
 	}
 	rolloverResult := &EpochRolloverResult{
 		NewCurrentEpoch:   models.Epoch{EpochId: 500},
-		NewCurrentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewCurrentEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		NewCurrentPParams: babbagePParams(9),
 		NewEpochCache:     []models.Epoch{{EpochId: 500}},
 		HardFork: &HardForkInfo{
@@ -3490,7 +3493,7 @@ func TestRolloverCommit_EraTransitionClearsTransitionInfo(t *testing.T) {
 // transition happened (the normal epoch-boundary version-bump window).
 func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 		currentPParams: babbagePParams(8),
 		transitionInfo: hardfork.NewTransitionUnknown(),
 	}
@@ -3498,7 +3501,7 @@ func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 	var eraTransitions []*EraTransitionResult // empty — no standalone transition
 	rolloverResult := &EpochRolloverResult{
 		NewCurrentEpoch:   models.Epoch{EpochId: 500},
-		NewCurrentEra:     *eras.GetEraById(eras.BabbageEraDesc.Id),
+		NewCurrentEra:     requireEraDesc(t, eras.BabbageEraDesc.Id),
 		NewCurrentPParams: babbagePParams(9),
 		NewEpochCache:     []models.Epoch{{EpochId: 500}},
 		HardFork: &HardForkInfo{
@@ -3529,7 +3532,7 @@ func TestRolloverCommit_HardForkWithoutEraTransition(t *testing.T) {
 // epoch rollover (no HardFork, no era transition) leaves transitionInfo alone.
 func TestRolloverCommit_NoHardFork_TransitionInfoUnchanged(t *testing.T) {
 	ls := &LedgerState{
-		currentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		currentEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		currentPParams: babbagePParams(9),
 		transitionInfo: hardfork.NewTransitionUnknown(),
 	}
@@ -3537,7 +3540,7 @@ func TestRolloverCommit_NoHardFork_TransitionInfoUnchanged(t *testing.T) {
 	var eraTransitions []*EraTransitionResult
 	rolloverResult := &EpochRolloverResult{
 		NewCurrentEpoch:   models.Epoch{EpochId: 501},
-		NewCurrentEra:     *eras.GetEraById(eras.ConwayEraDesc.Id),
+		NewCurrentEra:     requireEraDesc(t, eras.ConwayEraDesc.Id),
 		NewCurrentPParams: babbagePParams(9),
 		NewEpochCache:     []models.Epoch{{EpochId: 501}},
 		HardFork:          nil,

--- a/mesh/convert.go
+++ b/mesh/convert.go
@@ -401,18 +401,20 @@ func convertParsedTransaction(
 	var signers []*AccountIdentifier
 	if signed {
 		witnesses := tx.Witnesses()
-		for _, vkw := range witnesses.Vkey() {
-			keyHash := lcommon.Blake2b224Hash(
-				vkw.Vkey,
-			)
-			signers = append(
-				signers,
-				&AccountIdentifier{
-					Address: hex.EncodeToString(
-						keyHash[:],
-					),
-				},
-			)
+		if witnesses != nil {
+			for _, vkw := range witnesses.Vkey() {
+				keyHash := lcommon.Blake2b224Hash(
+					vkw.Vkey,
+				)
+				signers = append(
+					signers,
+					&AccountIdentifier{
+						Address: hex.EncodeToString(
+							keyHash[:],
+						),
+					},
+				)
+			}
 		}
 	}
 

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -80,6 +80,7 @@ func createChunkArchive(t *testing.T) []byte {
 
 func finalizeTestCertificate(t *testing.T, cert *Certificate) {
 	t.Helper()
+	require.NotNil(t, cert)
 	if cert.ProtocolMessage.MessageParts == nil {
 		cert.ProtocolMessage.MessageParts = map[string]string{}
 	}

--- a/node.go
+++ b/node.go
@@ -199,9 +199,10 @@ func (n *Node) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to load chain manager: %w", err)
 	}
 	n.chainManager = cm
+	primaryChain := n.chainManager.PrimaryChain()
 	n.eventBus.SubscribeFunc(
 		chain.BlockProposedEventType,
-		n.chainManager.PrimaryChain().HandleBlockProposedEvent,
+		primaryChain.HandleBlockProposedEvent,
 	)
 	n.chainsyncIngressEligibilityCache = make(
 		map[ouroboros.ConnectionId]bool,

--- a/node_forging.go
+++ b/node_forging.go
@@ -68,6 +68,9 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 		return nil, fmt.Errorf("compute current KES period: %w", err)
 	}
 	opCert := creds.GetOpCert()
+	if opCert == nil {
+		return nil, errors.New("block producer operational certificate is nil")
+	}
 	n.config.logger.Info(
 		"block producer credentials validated",
 		"component", "node",

--- a/node_test.go
+++ b/node_test.go
@@ -89,11 +89,15 @@ func TestHandleChainSwitchEventUpdatesActiveConnection(t *testing.T) {
 
 	active := state.GetClientConnId()
 	require.NotNil(t, active)
+	clientA := state.GetTrackedClient(connA)
+	clientB := state.GetTrackedClient(connB)
+	require.NotNil(t, clientA)
+	require.NotNil(t, clientB)
 	assert.Equal(t, connB, *active)
-	assert.Equal(t, pointA, state.GetTrackedClient(connA).Cursor)
-	assert.Equal(t, pointB, state.GetTrackedClient(connB).Cursor)
-	assert.Equal(t, uint64(1), state.GetTrackedClient(connA).HeadersRecv)
-	assert.Equal(t, uint64(1), state.GetTrackedClient(connB).HeadersRecv)
+	assert.Equal(t, pointA, clientA.Cursor)
+	assert.Equal(t, pointB, clientB.Cursor)
+	assert.Equal(t, uint64(1), clientA.HeadersRecv)
+	assert.Equal(t, uint64(1), clientB.HeadersRecv)
 }
 
 func TestChainsyncIngressEligibilityCacheDefaultsAndUpdates(t *testing.T) {

--- a/utxorpc/query_test.go
+++ b/utxorpc/query_test.go
@@ -85,6 +85,7 @@ func TestParseSearchUtxosStartToken_Valid(t *testing.T) {
 	t.Parallel()
 	cur, err := parseSearchUtxosStartToken("1:2:3")
 	require.NoError(t, err)
+	require.NotNil(t, cur)
 	require.Equal(t, uint64(1), cur.Slot)
 	require.Equal(t, uint32(2), cur.BlockIndex)
 	require.Equal(t, uint32(3), cur.OutputIdx)

--- a/utxorpc/rpc_connect_test.go
+++ b/utxorpc/rpc_connect_test.go
@@ -150,6 +150,7 @@ func newUtxorpcConnectHarness(t *testing.T, opts utxorpcHarnessOptions) *utxorpc
 	t.Cleanup(func() { _ = db.Close() })
 
 	blocks := loadTestChainBlocks(t, opts.numBlocks)
+	require.NotEmpty(t, blocks)
 	for i := range blocks {
 		require.NoError(t, db.BlockCreate(blocks[i], nil))
 	}
@@ -381,6 +382,7 @@ func TestConnect_DumpHistory(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	blocks := loadTestChainBlocks(t, 25)
+	require.NotEmpty(t, blocks)
 	out, err := cli.DumpHistory(
 		ctx,
 		connect.NewRequest(&sync.DumpHistoryRequest{
@@ -788,6 +790,7 @@ func TestConnect_FollowTip_RollbackEmitsReset(t *testing.T) {
 	const n = 8
 	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{numBlocks: n})
 	blocks := loadTestChainBlocks(t, n)
+	require.Len(t, blocks, n)
 	inter := blocks[5]
 	roll := ocommon.NewPoint(inter.Slot, inter.Hash)
 	require.NoError(t, h.LS.Chain().ValidateRollback(roll))
@@ -861,8 +864,14 @@ func TestConnect_WatchTx_IdleEmptyForwardBlock(t *testing.T) {
 		break
 	}
 	require.True(t, found, "no suitable empty block in fixture scan")
+	if cut < 2 {
+		t.Fatalf("empty block cut must include a parent, got %d", cut)
+	}
 	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{numBlocks: cut})
 	blocks := loadTestChainBlocks(t, cut)
+	if len(blocks) < cut {
+		t.Fatalf("expected at least %d blocks, got %d", cut, len(blocks))
+	}
 	parent := blocks[cut-2]
 	emptyChild := blocks[cut-1]
 	require.Equal(t, emptyChild.Slot, h.LS.Tip().Point.Slot)

--- a/utxorpc/sync_dump_history_test.go
+++ b/utxorpc/sync_dump_history_test.go
@@ -47,7 +47,7 @@ func loadTestChainBlocks(t *testing.T, n int) []models.Block {
 	it, err := imm.BlocksFromPoint(ocommon.Point{})
 	require.NoError(t, err)
 	defer it.Close()
-	var out []models.Block
+	out := make([]models.Block, 0, n)
 	for range n {
 		b, err := it.Next()
 		require.NoError(t, err)
@@ -211,5 +211,6 @@ func TestSyncBlockRefFromModel_CopiesHash(t *testing.T) {
 	}
 	ref := syncBlockRefFromModel(b)
 	b.Hash[0] = 0xff
+	require.NotEmpty(t, ref.GetHash())
 	require.Equal(t, byte(1), ref.GetHash()[0])
 }

--- a/utxorpc/sync_test.go
+++ b/utxorpc/sync_test.go
@@ -264,6 +264,7 @@ func TestFollowTip_RollbackToOrigin(t *testing.T) {
 	}
 
 	// Verify Reset action for origin
+	require.NotNil(t, resp)
 	reset, ok := resp.Action.(*sync.FollowTipResponse_Reset_)
 	require.True(t, ok, "should be Reset action")
 	require.NotNil(t, reset.Reset_, "Reset_ should not be nil")

--- a/utxorpc/tx_predicate_test.go
+++ b/utxorpc/tx_predicate_test.go
@@ -275,6 +275,7 @@ func TestTxPredicateFromSubmit_nonCardanoMatchSetsUnevaluable(t *testing.T) {
 	node := txPredicateFromSubmit(&submit.TxPredicate{
 		Match: &submit.AnyChainTxPattern{},
 	})
+	require.NotNil(t, node)
 	require.True(t, node.matchNonCardano)
 	require.Nil(t, node.match)
 }

--- a/utxorpc/watch.go
+++ b/utxorpc/watch.go
@@ -163,6 +163,10 @@ func (s *watchServiceServer) watchTxFetchRollbackUndoFromBlocks(
 		if err != nil {
 			return nil, err
 		}
+		if len(appliedTxs) == 0 {
+			hash = append([]byte(nil), block.PrevHash...)
+			continue
+		}
 		for j := len(appliedTxs) - 1; j >= 0; j-- {
 			out = append(out, &watch.WatchTxResponse{
 				Action: &watch.WatchTxResponse_Undo{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves nil-safety across the codebase to satisfy NilAway and prevent nil dereferences. Adds defensive checks, safe defaults, and clearer errors; small behavior tweaks include returning empty slices instead of nil and explicit panics/errors for uninitialized state.

- **Bug Fixes**
  - Guard nil HTTP responses when fetching blocks from `bark` archive.
  - `chain` iterator returns `ErrIteratorChainTip`; `ChainManager.PrimaryChain()` panics if uninitialized; `Node.Run()` uses the resolved chain for event subscription.
  - Safer `chainsync` client removal by checking tracked client entry before access.
  - Ledger: era validation/evaluation, forging, and mesh signer extraction now guard nil `witnesses`/`redeemers`; block producer startup fails if opCert is nil.
  - `utxorpc` watch undo path skips empty blocks and walks via `PrevHash`.
  - Leader `Schedule` methods handle a nil receiver; intersect-point helper no-ops on empty input.
  - Mithril gap: `loadGapBlocksFromBlob` returns an empty slice; `validateStoredGapBlocks` now errors when the stored gap is empty.

- **Refactors**
  - Introduced helpers (`ledgerHashBytes`, `ledgerInputIDBytes`, `bytePrefix`) and standardized error prefixes in `database`; simplified tombstone check using `bytes.HasPrefix`.
  - Return empty slices instead of nil in loaders/metadata (e.g., `accounthistory`) and utilities; updated tests to assert non-nil/non-empty as needed.

<sup>Written for commit a3e42841ce9706be96968d42e7e0f0cefe12dab7. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2393?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Resolved nil-pointer dereference risks in block downloads, transaction processing, witness validation, and iterator operations across multiple components
- Added defensive bounds and nil checks to prevent out-of-range panics and crashes during array/slice access
- Improved error handling and validation in transaction, UTxO recovery, and chain state management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->