### PR TITLE
test: use any instead of interface{}

### DIFF
--- a/database/plugin/metadata/sqlite/import_test.go
+++ b/database/plugin/metadata/sqlite/import_test.go
@@ -43,21 +43,21 @@ func (r *importSQLRecorder) LogMode(
 func (*importSQLRecorder) Info(
 	context.Context,
 	string,
-	...interface{},
+	...any,
 ) {
 }
 
 func (*importSQLRecorder) Warn(
 	context.Context,
 	string,
-	...interface{},
+	...any,
 ) {
 }
 
 func (*importSQLRecorder) Error(
 	context.Context,
 	string,
-	...interface{},
+	...any,
 ) {
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced interface{} with any in test logger methods to modernize types and align with Go 1.18+. No behavior change; improves readability and consistency in the sqlite import tests.

<sup>Written for commit af96db9da7542f8ae7cb2e35642455de3bb2d231. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2394?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

