### PR TITLE
fix: use atomic counters

### DIFF
--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestScheduler_RegistersAndRunsTask(t *testing.T) {
-	var counter int32
+	var counter atomic.Int32
 
 	// Create a Scheduler with 10ms tick interval
 	timer := NewScheduler(10 * time.Millisecond)
@@ -32,19 +32,19 @@ func TestScheduler_RegistersAndRunsTask(t *testing.T) {
 
 	// Registering task to execute every 3 ticks
 	timer.Register(3, func() {
-		atomic.AddInt32(&counter, 1)
+		counter.Add(1)
 	}, nil)
 
 	// Wait for task to run at least 2 times (polls instead of fixed sleep)
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&counter) >= 2
+		return counter.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond,
 		"expected task to run at least 2 times",
 	)
 }
 
 func TestScheduler_ChangeInterval(t *testing.T) {
-	var counter int32
+	var counter atomic.Int32
 
 	// Create a Scheduler with 50ms tick interval
 	timer := NewScheduler(50 * time.Millisecond)
@@ -53,16 +53,16 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 
 	// Registering task with 50ms tick interval to execute for every 1 tick
 	timer.Register(1, func() {
-		atomic.AddInt32(&counter, 1)
+		counter.Add(1)
 	}, nil)
 
 	// Wait for at least 2 executions before changing interval
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&counter) >= 2
+		return counter.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond,
 		"expected at least 2 executions before interval change",
 	)
-	beforeChange := atomic.LoadInt32(&counter)
+	beforeChange := counter.Load()
 
 	// Change interval to 200ms
 	err := timer.ChangeInterval(200 * time.Millisecond)
@@ -70,7 +70,7 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 
 	// Wait for at least 1 execution after interval change
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&counter)-beforeChange >= 1
+		return counter.Load()-beforeChange >= 1
 	}, 2*time.Second, 10*time.Millisecond,
 		"expected at least 1 execution after interval change",
 	)
@@ -78,7 +78,7 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 	// Allow enough time for potential additional ticks
 	time.Sleep(500 * time.Millisecond)
 
-	secondCount := atomic.LoadInt32(&counter)
+	secondCount := counter.Load()
 	afterChange := secondCount - beforeChange
 
 	if afterChange < 1 || afterChange > 3 {
@@ -90,7 +90,7 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 }
 
 func TestSchedulerRunFailFunc(t *testing.T) {
-	var failCounter int32
+	var failCounter atomic.Int32
 
 	// Create a Scheduler with 50ms tick interval
 	timer := NewScheduler(50 * time.Millisecond)
@@ -109,13 +109,13 @@ func TestSchedulerRunFailFunc(t *testing.T) {
 		},
 		// Run fail func
 		func() {
-			atomic.AddInt32(&failCounter, 1)
+			failCounter.Add(1)
 		},
 	)
 
 	// Wait for the fail function to be called at least 3 times
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&failCounter) >= 3
+		return failCounter.Load() >= 3
 	}, 10*time.Second, 50*time.Millisecond,
 		"expected failure to run task at least 3 times",
 	)

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -17,7 +17,6 @@ package ouroboros
 import (
 	"errors"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -374,26 +373,26 @@ func (o *Ouroboros) blockfetchClientBlock(
 			}
 
 			o.blockfetchMetrics.blockDelay.Set(delaySeconds)
-			total := atomic.AddInt64(&o.blockfetchMetrics.totalBlocksFetched, 1)
+			total := o.blockfetchMetrics.totalBlocksFetched.Add(1)
 			// Cumulative CDF buckets: each counter includes all
 			// blocks at or below its threshold.
 			if delaySeconds < 1.0 {
-				atomic.AddInt64(&o.blockfetchMetrics.blocksUnder1s, 1)
+				o.blockfetchMetrics.blocksUnder1s.Add(1)
 			}
 			if delaySeconds < 3.0 {
-				atomic.AddInt64(&o.blockfetchMetrics.blocksUnder3s, 1)
+				o.blockfetchMetrics.blocksUnder3s.Add(1)
 			}
 			if delaySeconds < 5.0 {
-				atomic.AddInt64(&o.blockfetchMetrics.blocksUnder5s, 1)
+				o.blockfetchMetrics.blocksUnder5s.Add(1)
 			} else {
 				o.blockfetchMetrics.lateBlocks.Inc()
 			}
 			if total == 1 ||
 				total%blockfetchMetricsCdfUpdateInterval == 0 ||
 				delaySeconds >= 5.0 {
-				under1 := atomic.LoadInt64(&o.blockfetchMetrics.blocksUnder1s)
-				under3 := atomic.LoadInt64(&o.blockfetchMetrics.blocksUnder3s)
-				under5 := atomic.LoadInt64(&o.blockfetchMetrics.blocksUnder5s)
+				under1 := o.blockfetchMetrics.blocksUnder1s.Load()
+				under3 := o.blockfetchMetrics.blocksUnder3s.Load()
+				under5 := o.blockfetchMetrics.blocksUnder5s.Load()
 				o.blockfetchMetrics.blockDelayCdfOne.Set(
 					float64(under1) / float64(total) * 100,
 				)

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chainsync"
@@ -113,10 +114,10 @@ type blockfetchMetrics struct {
 	blockDelayCdfOne   prometheus.Gauge
 	blockDelayCdfThree prometheus.Gauge
 	blockDelayCdfFive  prometheus.Gauge
-	totalBlocksFetched int64
-	blocksUnder1s      int64
-	blocksUnder3s      int64
-	blocksUnder5s      int64
+	totalBlocksFetched atomic.Int64
+	blocksUnder1s      atomic.Int64
+	blocksUnder3s      atomic.Int64
+	blocksUnder5s      atomic.Int64
 }
 
 func NewOuroboros(cfg OuroborosConfig) *Ouroboros {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched metrics and test counters to Go’s typed atomics. This improves thread-safety and keeps blockfetch delay metrics and scheduler tests reliable under concurrency.

- **Refactors**
  - Migrated `blockfetchMetrics` counters to `atomic.Int64` and updated `blockfetch.go` to use Add/Load methods (removed direct `sync/atomic` function calls).
  - Updated `ledger/timer_test.go` to use `atomic.Int32` with Add/Load for the scheduler counters.

<sup>Written for commit cf073fb5869c2f043782da3c81f51b7fc9b739b1. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

