### PR TITLE
fix: use errors as type

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -1757,8 +1757,7 @@ func (a *NodeAdapter) TransactionSubmit(
 		)
 	}
 	if err := a.submitter.AddTransaction(txType, txCbor); err != nil {
-		var mempoolFull *mempool.MempoolFullError
-		if errors.As(err, &mempoolFull) {
+		if _, ok := errors.AsType[*mempool.MempoolFullError](err); ok {
 			return "", fmt.Errorf("submit transaction to mempool: %w: %w", err, ErrMempoolFull)
 		}
 		return "", fmt.Errorf("submit transaction to mempool: %w: %w", err, ErrInvalidTransaction)

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -852,8 +852,7 @@ func (b *Blockfrost) handleTransactionSubmit(
 	r.Body = http.MaxBytesReader(w, r.Body, maxTxBodySize)
 	txCbor, err := io.ReadAll(r.Body)
 	if err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			writeError(
 				w,
 				http.StatusRequestEntityTooLarge,

--- a/database/database.go
+++ b/database/database.go
@@ -331,14 +331,12 @@ func New(
 			ConstLabels: prometheus.Labels{"store": "metadata"},
 		})
 		if err := configCopy.PromRegistry.Register(blobSizeGauge); err != nil {
-			var are prometheus.AlreadyRegisteredError
-			if errors.As(err, &are) {
+			if are, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 				blobSizeGauge = are.ExistingCollector.(prometheus.Gauge)
 			}
 		}
 		if err := configCopy.PromRegistry.Register(metadataSizeGauge); err != nil {
-			var are prometheus.AlreadyRegisteredError
-			if errors.As(err, &are) {
+			if are, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 				metadataSizeGauge = are.ExistingCollector.(prometheus.Gauge)
 			}
 		}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1708,8 +1708,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		"connection_id", e.ConnectionId.String(),
 	)
 	if err := ls.chain.AddBlockHeader(e.BlockHeader); err != nil {
-		var notFitErr chain.BlockNotFitChainTipError
-		if errors.As(err, &notFitErr) {
+		if notFitErr, ok := errors.AsType[chain.BlockNotFitChainTipError](err); ok {
 			localTip := ls.chain.Tip()
 			// A header behind the local tip is stale only if the
 			// Praos comparison also says it cannot beat the local


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched error matching to the generic `errors.AsType` helper for clearer, more reliable checks. Fixes edge cases in transaction submission, request size handling, Prometheus gauge registration, and chain sync tip validation.

- **Bug Fixes**
  - `blockfrost/adapter`: use `errors.AsType` to detect `*mempool.MempoolFullError` and return `ErrMempoolFull`.
  - `blockfrost/handlers`: use `errors.AsType` to detect `*http.MaxBytesError` and respond with 413.
  - `database`: use `errors.AsType` to handle `prometheus.AlreadyRegisteredError` and reuse existing gauges.
  - `ledger/chainsync`: use `errors.AsType` to detect `chain.BlockNotFitChainTipError` for correct stale header handling.

<sup>Written for commit 79d0cf1b03f149f03d65d241de102c5e66f3064b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2396?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

