### PR TITLE
fix: remove redundant for var assignment

### DIFF
--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -761,7 +761,6 @@ func TestSubscribeChainsyncResyncClosesConnectionForFreshSyncReasons(
 		event.ChainsyncResyncReasonRollbackLoop,
 	}
 	for _, reason := range reasons {
-		reason := reason
 		t.Run(reason, func(t *testing.T) {
 			logBuf := &lockedBuffer{}
 			logger := slog.New(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a redundant loop variable assignment in ouroboros/chainsync_test.go when iterating resync reasons for t.Run. No behavior change; cleans up the test and avoids unnecessary shadowing.

<sup>Written for commit bba9043de0c776ecd20df74778db514b74ebc3f0. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2397?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

