### PR TITLE
fix: use maps copy instead of loop iteration

### DIFF
--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"strings"
 	"sync"
@@ -199,9 +200,7 @@ func TestNewOuroborosDoesNotMutateChainsyncNtNTimeouts(t *testing.T) {
 	originalStateMap := ochainsync.StateMapNtN.Copy()
 	t.Cleanup(func() {
 		clear(ochainsync.StateMapNtN)
-		for state, entry := range originalStateMap {
-			ochainsync.StateMapNtN[state] = entry
-		}
+		maps.Copy(ochainsync.StateMapNtN, originalStateMap)
 	})
 
 	before := snapshotChainsyncNtNTimeouts()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace manual map iteration with `maps.Copy` in `ouroboros/chainsync_test.go` to restore `ochainsync.StateMapNtN` during test cleanup. This reduces boilerplate and ensures a safe, accurate map restore.

<sup>Written for commit 55301be23b23dd7b717f58155f66116602b1c6fd. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2398?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup logic for more efficient state restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->