### PR TITLE
fix: use max to get maximum value

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1668,10 +1668,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 		// the trust anchor — we never rewind below it — so the
 		// authoritative deletion slot is the rollback target or the
 		// Mithril boundary, whichever is later.
-		deleteSlot := point.Slot
-		if ls.mithrilLedgerSlot > deleteSlot {
-			deleteSlot = ls.mithrilLedgerSlot
-		}
+		deleteSlot := max(ls.mithrilLedgerSlot, point.Slot)
 		err := ls.db.UtxosDeleteRolledback(deleteSlot, txn)
 		if err != nil {
 			return fmt.Errorf("remove rolled-back UTxOs: %w", err)

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -746,11 +746,9 @@ func (p *PeerGovernor) inboundPruneDecisionLocked(
 		return false, "", "", 0, false
 	}
 	if flapping, multiplier := p.inboundFlappingStateLocked(peer, now); flapping {
-		cooldownDuration = p.config.InboundCooldown * time.Duration(multiplier)
-		// Keep cooldown at least as long as the normal deny duration.
-		if cooldownDuration < p.config.DenyDuration {
-			cooldownDuration = p.config.DenyDuration
-		}
+		cooldownDuration = max(
+			// Keep cooldown at least as long as the normal deny duration.
+			p.config.InboundCooldown*time.Duration(multiplier), p.config.DenyDuration)
 		reason = "inbound flapping cooldown"
 		reasonLabel = "flapping_cooldown"
 		applyCooldown = true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use max() to pick the later slot during rollback and the longer inbound cooldown during flapping, replacing manual if-logic. This clarifies intent and guarantees we don’t delete before the Mithril boundary and don’t cool down for less than the deny duration.

<sup>Written for commit 8d5f5e0cc87a27a54a0241dccf77643362d1e9b7. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2399?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

