### PR TITLE
fix: new expression vs pointer

### DIFF
--- a/bark/archive.go
+++ b/bark/archive.go
@@ -25,7 +25,6 @@ import (
 	archiveconnect "github.com/blinklabs-io/bark/proto/v1alpha1/archive/archivev1alpha1connect"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/protocol/common"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -67,13 +66,13 @@ func (a *archiveServiceHandler) FetchBlock(
 			Block: &archive.BlockRef{
 				Hash:   b.Hash,
 				Slot:   b.Slot,
-				Height: proto.Uint64(metadata.Height),
+				Height: new(metadata.Height),
 			},
 			Url:       signedURL.URL.String(),
 			ExpiresAt: timestamppb.New(signedURL.Expires),
 			Meta: &archive.BlockMeta{
 				Type:     (archive.BlockType)(blockType).Enum(),
-				PrevHash: proto.String(hex.EncodeToString(metadata.PrevHash)),
+				PrevHash: new(hex.EncodeToString(metadata.PrevHash)),
 			},
 		})
 	}

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -31,7 +31,6 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
-	"google.golang.org/protobuf/proto"
 )
 
 // archiveFetchTimeout bounds a single archive round-trip (signed-URL request
@@ -259,8 +258,8 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 			&archivev1alpha1.FetchBlockRequest{
 				Blocks: []*archivev1alpha1.BlockRef{
 					{
-						Slot: proto.Uint64(slot),
-						Hash: proto.String(hex.EncodeToString(hash)),
+						Slot: new(slot),
+						Hash: new(hex.EncodeToString(hash)),
 					},
 				},
 			},

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"google.golang.org/protobuf/proto"
 )
 
 // fakeArchive serves FetchBlock responses pointing at downloadURL, where
@@ -64,12 +63,12 @@ func (a *fakeArchive) FetchBlock(
 			Block: &archive.BlockRef{
 				Hash:   b.Hash,
 				Slot:   b.Slot,
-				Height: proto.Uint64(a.height),
+				Height: new(a.height),
 			},
 			Url: a.downloadURL + "?hash=" + hashHex,
 			Meta: &archive.BlockMeta{
 				Type:     a.blockType.Enum(),
-				PrevHash: proto.String(hex.EncodeToString(a.prevHash)),
+				PrevHash: new(hex.EncodeToString(a.prevHash)),
 			},
 		})
 	}

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -29,8 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//go:fix inline
 func intPtr(v int) *int {
-	return &v
+	return new(v)
 }
 
 // mockNode implements BlockfrostNode for testing.
@@ -826,7 +827,7 @@ func TestHandlePoolsExtended(t *testing.T) {
 					{
 						IPv4: "192.168.0.1",
 						DNS:  "relay-two.example",
-						Port: intPtr(3002),
+						Port: new(3002),
 					},
 				},
 			},
@@ -843,7 +844,7 @@ func TestHandlePoolsExtended(t *testing.T) {
 					{
 						IPv6: "2001:db8::1",
 						DNS:  "relay-one.example",
-						Port: intPtr(3001),
+						Port: new(3001),
 					},
 					{
 						DNS: "relay-no-port.example",

--- a/config/cardano/node_test.go
+++ b/config/cardano/node_test.go
@@ -30,8 +30,11 @@ const (
 	testDataDir = "testdata"
 )
 
-func ptrBool(v bool) *bool       { return &v }
-func ptrUint64(v uint64) *uint64 { return &v }
+//go:fix inline
+func ptrBool(v bool) *bool { return new(v) }
+
+//go:fix inline
+func ptrUint64(v uint64) *uint64 { return new(v) }
 
 var expectedCardanoNodeConfig = &CardanoNodeConfig{
 	path:                                       testDataDir,
@@ -47,7 +50,7 @@ var expectedCardanoNodeConfig = &CardanoNodeConfig{
 	MithrilGenesisAncillaryVerificationKeyFile: "ancillary.vkey",
 	ShelleyGenesisFile:                         "shelley-genesis.json",
 	ShelleyGenesisHash:                         "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d",
-	ExperimentalHardForksEnabled:               ptrBool(false),
+	ExperimentalHardForksEnabled:               new(false),
 	TestShelleyHardForkAtEpoch:                 ptrUint64(0),
 	TestAllegraHardForkAtEpoch:                 ptrUint64(0),
 	TestMaryHardForkAtEpoch:                    ptrUint64(0),
@@ -265,8 +268,8 @@ func TestCardanoNodeConfigPeerSharing(t *testing.T) {
 		want *bool
 	}{
 		{name: "absent", body: `{}`, want: nil},
-		{name: "true", body: `{"PeerSharing": true}`, want: ptrBool(true)},
-		{name: "false", body: `{"PeerSharing": false}`, want: ptrBool(false)},
+		{name: "true", body: `{"PeerSharing": true}`, want: new(true)},
+		{name: "false", body: `{"PeerSharing": false}`, want: new(false)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -343,7 +346,7 @@ func TestGenesisHashMismatchConway(t *testing.T) {
 func TestHardForkEpoch(t *testing.T) {
 	t.Run("enabled with all eras at epoch 0", func(t *testing.T) {
 		cfg := &CardanoNodeConfig{
-			ExperimentalHardForksEnabled: ptrBool(true),
+			ExperimentalHardForksEnabled: new(true),
 			TestShelleyHardForkAtEpoch:   ptrUint64(0),
 			TestAllegraHardForkAtEpoch:   ptrUint64(0),
 			TestMaryHardForkAtEpoch:      ptrUint64(0),
@@ -366,7 +369,7 @@ func TestHardForkEpoch(t *testing.T) {
 
 	t.Run("disabled ignores all epochs", func(t *testing.T) {
 		cfg := &CardanoNodeConfig{
-			ExperimentalHardForksEnabled: ptrBool(false),
+			ExperimentalHardForksEnabled: new(false),
 			TestShelleyHardForkAtEpoch:   ptrUint64(0),
 			TestConwayHardForkAtEpoch:    ptrUint64(0),
 		}
@@ -386,7 +389,7 @@ func TestHardForkEpoch(t *testing.T) {
 
 	t.Run("partial configuration", func(t *testing.T) {
 		cfg := &CardanoNodeConfig{
-			ExperimentalHardForksEnabled: ptrBool(true),
+			ExperimentalHardForksEnabled: new(true),
 			TestShelleyHardForkAtEpoch:   ptrUint64(0),
 			// Conway not set
 		}
@@ -399,7 +402,7 @@ func TestHardForkEpoch(t *testing.T) {
 
 	t.Run("unknown era", func(t *testing.T) {
 		cfg := &CardanoNodeConfig{
-			ExperimentalHardForksEnabled: ptrBool(true),
+			ExperimentalHardForksEnabled: new(true),
 		}
 		_, ok := cfg.HardForkEpoch("unknown")
 		assert.False(t, ok, "unknown era should not be configured")
@@ -407,7 +410,7 @@ func TestHardForkEpoch(t *testing.T) {
 
 	t.Run("non-zero epoch", func(t *testing.T) {
 		cfg := &CardanoNodeConfig{
-			ExperimentalHardForksEnabled: ptrBool(true),
+			ExperimentalHardForksEnabled: new(true),
 			TestConwayHardForkAtEpoch:    ptrUint64(5),
 		}
 		epoch, ok := cfg.HardForkEpoch("conway")

--- a/database/blob_iterator_test.go
+++ b/database/blob_iterator_test.go
@@ -129,7 +129,7 @@ func TestBlobBlockIterator_SlotRanges(t *testing.T) {
 		{
 			name:     "BlocksInRange/inclusive",
 			start:    20,
-			end:      ptr(uint64(40)),
+			end:      new(uint64(40)),
 			expected: []uint64{20, 30, 40},
 		},
 	}
@@ -159,7 +159,9 @@ func TestBlobBlockIterator_SlotRanges(t *testing.T) {
 }
 
 // ptr returns a pointer to the given value.
-func ptr[T any](v T) *T { return &v }
+//
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
 
 func TestBlobBlockIterator_Progress(t *testing.T) {
 	db := newTestDB(t)

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -213,7 +213,7 @@ func (d *BlobStoreS3) Delete(txn types.Txn, key []byte) error {
 	defer cancel()
 	_, err = d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(key))),
+		Key:    new(d.fullKey(string(key))),
 	})
 	if err != nil {
 		if isS3NotFound(err) {
@@ -364,28 +364,28 @@ func (d *BlobStoreS3) DeleteBlock(
 	key := types.BlockBlobKey(slot, hash)
 	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(key))),
+		Key:    new(d.fullKey(string(key))),
 	}); err != nil && !isS3NotFound(err) {
 		return err
 	}
 	indexKey := types.BlockBlobIndexKey(id)
 	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(indexKey))),
+		Key:    new(d.fullKey(string(indexKey))),
 	}); err != nil && !isS3NotFound(err) {
 		return err
 	}
 	metadataKey := types.BlockBlobMetadataKey(key)
 	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(metadataKey))),
+		Key:    new(d.fullKey(string(metadataKey))),
 	}); err != nil && !isS3NotFound(err) {
 		return err
 	}
 	hashIndexKey := types.BlockHashIndexKey(hash)
 	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(hashIndexKey))),
+		Key:    new(d.fullKey(string(hashIndexKey))),
 	}); err != nil && !isS3NotFound(err) {
 		return err
 	}
@@ -429,7 +429,7 @@ func (d *BlobStoreS3) TombstoneBlock(
 	metadataKey := types.BlockBlobMetadataKey(key)
 	if _, err := d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(metadataKey))),
+		Key:    new(d.fullKey(string(metadataKey))),
 	}); err != nil && !isS3NotFound(err) {
 		return err
 	}
@@ -496,7 +496,7 @@ func (d *BlobStoreS3) DeleteUtxo(
 	key := types.UtxoBlobKey(txId, outputIdx)
 	_, err = d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(key))),
+		Key:    new(d.fullKey(string(key))),
 	})
 	if err != nil && !isS3NotFound(err) {
 		d.logger.Errorf("s3 delete %q failed: %v", string(key), err)
@@ -565,7 +565,7 @@ func (d *BlobStoreS3) DeleteTx(
 	key := types.TxBlobKey(txHash)
 	_, err = d.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(d.bucket),
-		Key:    awsString(d.fullKey(string(key))),
+		Key:    new(d.fullKey(string(key))),
 	})
 	if err != nil && !isS3NotFound(err) {
 		d.logger.Errorf("s3 delete %q failed: %v", string(key), err)
@@ -778,10 +778,6 @@ func (d *BlobStoreS3) fullKey(key string) string {
 	return d.prefix + hex.EncodeToString([]byte(key))
 }
 
-func awsString(s string) *string {
-	return &s
-}
-
 // getInternal reads the value at key.
 func (d *BlobStoreS3) getInternal(
 	ctx context.Context,
@@ -789,7 +785,7 @@ func (d *BlobStoreS3) getInternal(
 ) ([]byte, error) {
 	out, err := d.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &d.bucket,
-		Key:    awsString(d.fullKey(key)),
+		Key:    new(d.fullKey(key)),
 	})
 	if err != nil {
 		if !isS3NotFound(err) {
@@ -812,7 +808,7 @@ func (d *BlobStoreS3) getInternal(
 func (d *BlobStoreS3) Put(ctx context.Context, key string, value []byte) error {
 	_, err := d.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: &d.bucket,
-		Key:    awsString(d.fullKey(key)),
+		Key:    new(d.fullKey(key)),
 		Body:   bytes.NewReader(value),
 	})
 	if err != nil {
@@ -915,7 +911,7 @@ func (d *BlobStoreS3) GetBlockURL(
 		ctx,
 		&s3.HeadObjectInput{
 			Bucket: &d.bucket,
-			Key:    awsString(d.fullKey(string(key))),
+			Key:    new(d.fullKey(string(key))),
 		})
 	if isS3NotFound(err) {
 		return types.SignedURL{}, types.BlockMetadata{},
@@ -934,7 +930,7 @@ func (d *BlobStoreS3) GetBlockURL(
 		ctx,
 		&s3.GetObjectInput{
 			Bucket: &d.bucket,
-			Key:    awsString(d.fullKey(string(key))),
+			Key:    new(d.fullKey(string(key))),
 		},
 		s3.WithPresignExpires(time.Hour))
 	if err != nil {

--- a/internal/node/peersharing_test.go
+++ b/internal/node/peersharing_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 )
 
-func boolPtr(v bool) *bool { return &v }
+//go:fix inline
+func boolPtr(v bool) *bool { return new(v) }
 
 func TestResolvePeerSharing(t *testing.T) {
 	tests := []struct {
@@ -34,7 +35,7 @@ func TestResolvePeerSharing(t *testing.T) {
 	}{
 		{
 			name:            "explicit true on BP warns and stays true",
-			dingoNative:     boolPtr(true),
+			dingoNative:     new(true),
 			blockProducer:   true,
 			cardanoNode:     nil,
 			want:            true,
@@ -42,30 +43,30 @@ func TestResolvePeerSharing(t *testing.T) {
 		},
 		{
 			name:          "explicit true off BP stays true",
-			dingoNative:   boolPtr(true),
+			dingoNative:   new(true),
 			blockProducer: false,
 			cardanoNode:   nil,
 			want:          true,
 		},
 		{
 			name:          "explicit false on BP stays false",
-			dingoNative:   boolPtr(false),
+			dingoNative:   new(false),
 			blockProducer: true,
-			cardanoNode:   boolPtr(true),
+			cardanoNode:   new(true),
 			want:          false,
 		},
 		{
 			name:          "explicit false off BP stays false",
-			dingoNative:   boolPtr(false),
+			dingoNative:   new(false),
 			blockProducer: false,
-			cardanoNode:   boolPtr(true),
+			cardanoNode:   new(true),
 			want:          false,
 		},
 		{
 			name:            "unset on BP defaults off, ignores cardano-node",
 			dingoNative:     nil,
 			blockProducer:   true,
-			cardanoNode:     boolPtr(true),
+			cardanoNode:     new(true),
 			want:            false,
 			wantLogContains: "disabled by default on block producer",
 		},
@@ -73,7 +74,7 @@ func TestResolvePeerSharing(t *testing.T) {
 			name:            "unset off BP, cardano-node true falls through",
 			dingoNative:     nil,
 			blockProducer:   false,
-			cardanoNode:     boolPtr(true),
+			cardanoNode:     new(true),
 			want:            true,
 			wantLogContains: "cardano-node config.json PeerSharing",
 		},
@@ -81,7 +82,7 @@ func TestResolvePeerSharing(t *testing.T) {
 			name:          "unset off BP, cardano-node false falls through",
 			dingoNative:   nil,
 			blockProducer: false,
-			cardanoNode:   boolPtr(false),
+			cardanoNode:   new(false),
 			want:          false,
 		},
 		{
@@ -124,9 +125,9 @@ func TestResolvePeerSharingNilLogger(t *testing.T) {
 		blockProducer bool
 		cardanoNode   *bool
 	}{
-		{boolPtr(true), true, nil},
+		{new(true), true, nil},
 		{nil, true, nil},
-		{nil, false, boolPtr(true)},
+		{nil, false, new(true)},
 		{nil, false, nil},
 	}
 	for _, tc := range cases {

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -46,8 +46,10 @@ func newMockEventBus() *event.EventBus {
 
 // boolPtr returns a pointer to the given bool value.
 // Used for config fields that use *bool to distinguish nil from explicit false.
+//
+//go:fix inline
 func boolPtr(v bool) *bool {
-	return &v
+	return new(v)
 }
 
 func requirePendingEventData[T any](
@@ -6518,7 +6520,7 @@ func TestPeerGovernor_BootstrapRecovery(t *testing.T) {
 		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:              eventBus,
 		MinHotPeers:           3,
-		AutoBootstrapRecovery: boolPtr(true), // Explicitly enable
+		AutoBootstrapRecovery: new(true), // Explicitly enable
 	})
 
 	// Start with bootstrap exited
@@ -6556,7 +6558,7 @@ func TestPeerGovernor_BootstrapRecoveryPublishesChainSelectionUpgrade(
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		MinHotPeers:           3,
-		AutoBootstrapRecovery: boolPtr(true),
+		AutoBootstrapRecovery: new(true),
 	})
 	connId := ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
@@ -6609,7 +6611,7 @@ func TestPeerGovernor_BootstrapRecovery_NotNeededWithWarmCandidates(
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		MinHotPeers:           3,
-		AutoBootstrapRecovery: boolPtr(true),
+		AutoBootstrapRecovery: new(true),
 	})
 
 	// Start with bootstrap exited
@@ -6648,7 +6650,7 @@ func TestPeerGovernor_BootstrapRecovery_IgnoresResponderOnlyWarmCandidates(
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		MinHotPeers:           3,
-		AutoBootstrapRecovery: boolPtr(true),
+		AutoBootstrapRecovery: new(true),
 	})
 
 	pg.mu.Lock()
@@ -6681,7 +6683,7 @@ func TestPeerGovernor_BootstrapRecovery_NotNeededWithEnoughHotPeers(
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		MinHotPeers:           2,
-		AutoBootstrapRecovery: boolPtr(true),
+		AutoBootstrapRecovery: new(true),
 	})
 
 	// Start with bootstrap exited
@@ -6729,8 +6731,8 @@ func TestPeerGovernor_Reconcile_ExitsBootstrap(t *testing.T) {
 		Logger:                slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		SyncProgressProvider:  mockSync,
 		SyncProgressForExit:   0.95,
-		AutoBootstrapRecovery: boolPtr(false), // Disable recovery for this test
-		MinHotPeers:           1,              // Low threshold to avoid recovery
+		AutoBootstrapRecovery: new(false), // Disable recovery for this test
+		MinHotPeers:           1,          // Low threshold to avoid recovery
 	})
 
 	// Add bootstrap peer


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes pointer creation across the codebase using small `new(...)` helpers, replacing `proto.*` and address-of patterns, and removing redundant helpers like `awsString`; drops several `google.golang.org/protobuf/proto` imports. No functional behavior changes.

- **Refactors**
  - Archive/blob: replace `proto.String`/`proto.Uint64` with `new(...)`; remove `proto` import.
  - S3: set `Key` via `new(...)`; remove `awsString`.
  - Tests: use concise `new(...)` helpers for bool/int/uint64 and generics; add `//go:fix inline`.

<sup>Written for commit 1d6497eb90c3ec2260ae7504f819116bb4023b8f. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2400?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

