### PR TITLE
fix(ledger): range over int

### DIFF
--- a/ledger/leader/schedule_consensus_mode_test.go
+++ b/ledger/leader/schedule_consensus_mode_test.go
@@ -104,7 +104,7 @@ func TestCalculateSchedule_TPraosErasMatchGouroborosTPraos(t *testing.T) {
 	tpraosLeaders := map[uint64]struct{}{}
 	signer, err := consensus.NewSimpleVRFSigner(vrfSeed)
 	require.NoError(t, err)
-	for slot := epoch * slotsPerEpoch; slot < (epoch+1)*slotsPerEpoch; slot++ {
+	for slot := range (epoch + 1) * slotsPerEpoch {
 		res, err := consensus.IsSlotLeaderWithMode(
 			slot,
 			epochNonce,

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -86,7 +86,7 @@ func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-start
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			ls.Lock()
 			if i%2 == 0 {
 				ls.currentEra = eras.BabbageEraDesc
@@ -98,7 +98,7 @@ func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 		close(done)
 	}()
 
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced index-based loops in ledger tests with Go 1.22 range-over-int syntax to simplify code. Changes are test-only and keep behavior the same.

<sup>Written for commit 2a2e9076917566ae9c2874e5a20d8bd00e43f429. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2401?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

