### PR TITLE
fix: use slices.Backward for reverse iteration

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -648,8 +648,8 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 	// Check headers for rollback point without mutating them
 	if len(c.headers) > 0 {
 		var header queuedHeader
-		for i := len(c.headers) - 1; i >= 0; i-- {
-			header = c.headers[i]
+		for _, v := range slices.Backward(c.headers) {
+			header = v
 			if header.point.Slot > point.Slot {
 				continue
 			}
@@ -715,8 +715,8 @@ func (c *Chain) rollbackLocked(
 	if len(c.headers) > 0 {
 		// Iterate backwards to make deletion safe
 		var header queuedHeader
-		for i := len(c.headers) - 1; i >= 0; i-- {
-			header = c.headers[i]
+		for i, v := range slices.Backward(c.headers) {
+			header = v
 			// Remove headers after rollback slot
 			if header.point.Slot > point.Slot {
 				c.headers = slices.Delete(c.headers, i, i+1)
@@ -1287,27 +1287,24 @@ func (c *Chain) reconcile() error {
 	if primaryChain == nil {
 		return models.ErrBlockNotFound
 	}
-	for i := len(c.blocks) - 1; i >= 0; i-- {
-		tmpBlock, err := primaryChain.blockByIndex(
-			// Add 1 to prevent off-by-one error
-			c.lastCommonBlockIndex + uint64(i) + 1,
-		)
-		if err != nil {
-			if errors.Is(err, models.ErrBlockNotFound) {
-				continue
-			}
+	blockIndex := c.tipBlockIndex
+	for i, v := range slices.Backward(c.blocks) {
+		tmpBlock, err := primaryChain.blockByIndex(blockIndex)
+		if err != nil && !errors.Is(err, models.ErrBlockNotFound) {
 			return err
 		}
-		if c.blocks[i].Slot != tmpBlock.Slot {
-			continue
+		if err == nil &&
+			v.Slot == tmpBlock.Slot &&
+			bytes.Equal(v.Hash, tmpBlock.Hash) {
+			// Adjust our chain-local blocks and offset point from primary chain
+			c.blocks = slices.Delete(c.blocks, 0, i+1)
+			c.lastCommonBlockIndex = tmpBlock.ID
+			return nil
 		}
-		if !bytes.Equal(c.blocks[i].Hash, tmpBlock.Hash) {
-			continue
+		if blockIndex == 0 {
+			break
 		}
-		// Adjust our chain-local blocks and offset point from primary chain
-		c.blocks = slices.Delete(c.blocks, 0, i+1)
-		c.lastCommonBlockIndex = tmpBlock.ID
-		return nil
+		blockIndex--
 	}
 	// Determine prev-hash from earliest known good block
 	knownPoint := c.currentTip.Point

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -1774,21 +1775,21 @@ func gapBlockEpoch(
 	epochs []models.Epoch,
 	slot uint64,
 ) (models.Epoch, error) {
-	for i := len(epochs) - 1; i >= 0; i-- {
-		if slot < epochs[i].StartSlot {
+	for _, epoch := range slices.Backward(epochs) {
+		if slot < epoch.StartSlot {
 			continue
 		}
-		end := epochs[i].StartSlot + uint64(epochs[i].LengthInSlots)
-		if epochs[i].LengthInSlots > 0 && slot >= end {
+		end := epoch.StartSlot + uint64(epoch.LengthInSlots)
+		if epoch.LengthInSlots > 0 && slot >= end {
 			return models.Epoch{}, fmt.Errorf(
 				"slot %d is past the end of the last known epoch %d (slots %d..%d)",
 				slot,
-				epochs[i].EpochId,
-				epochs[i].StartSlot,
+				epoch.EpochId,
+				epoch.StartSlot,
 				end,
 			)
 		}
-		return epochs[i], nil
+		return epoch, nil
 	}
 	return models.Epoch{}, fmt.Errorf("no epoch found for slot %d", slot)
 }

--- a/database/hot_cache.go
+++ b/database/hot_cache.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"maps"
+	"slices"
 	"sort"
 	"sync/atomic"
 )
@@ -249,9 +250,7 @@ func (c *HotCache) maybeEvict() {
 		keptSize := 0
 		var keptBytes int64
 
-		for i := len(entriesList) - 1; i >= 0; i-- {
-			e := entriesList[i]
-
+		for _, e := range slices.Backward(entriesList) {
 			wouldExceedSize := c.maxSize > 0 && keptSize >= targetSize
 			wouldExceedBytes := c.maxBytes > 0 && keptBytes+e.size > targetBytes
 

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"encoding/hex"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -99,13 +100,13 @@ func (ls *LedgerState) emitTransactionRollbackEvents(
 		if len(txs) == 0 {
 			continue
 		}
-		for i := len(txs) - 1; i >= 0; i-- {
+		for i, tx := range slices.Backward(txs) {
 			ls.config.EventBus.PublishAsync(
 				TransactionEventType,
 				event.NewEvent(
 					TransactionEventType,
 					TransactionEvent{
-						Transaction: txs[i],
+						Transaction: tx,
 						Point:       blockPoint,
 						BlockNumber: block.Number,
 						TxIndex:     uint32(i), //nolint:gosec

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1461,8 +1461,8 @@ func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 	if history == nil || len(history.order) == 0 {
 		return 0, nil
 	}
-	for i := len(history.order) - 1; i >= 0; i-- {
-		record, ok := history.byHash[history.order[i]]
+	for _, v := range slices.Backward(history.order) {
+		record, ok := history.byHash[v]
 		if !ok || record.event.Point.Slot <= point.Slot {
 			continue
 		}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log/slog"
 	"math/big"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -4014,8 +4015,7 @@ func (ls *LedgerState) computePParams(
 	if len(epochCache) == 0 {
 		return pparams, prevEraPParams, nil
 	}
-	for i := len(epochCache) - 1; i >= 0; i-- {
-		ep := epochCache[i]
+	for _, ep := range slices.Backward(epochCache) {
 		if ep.EraId != era.Id {
 			prevEra := eras.GetEraById(ep.EraId)
 			if prevEra != nil &&

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2853,9 +2854,9 @@ func TestDensityWindow(t *testing.T) {
 	// Test rollback: roll back to slot 199000
 	rollbackSlot := uint64(199000)
 	rollbackBlock := uint64(0)
-	for i := len(ls.densityWindow) - 1; i >= 0; i-- {
-		if ls.densityWindow[i].slot <= rollbackSlot {
-			rollbackBlock = ls.densityWindow[i].blockNum
+	for _, v := range slices.Backward(ls.densityWindow) {
+		if v.slot <= rollbackSlot {
+			rollbackBlock = v.blockNum
 			break
 		}
 	}

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -231,8 +232,7 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 
 	// Search newest-to-oldest so that if cache entries overlap
 	// (e.g., after rollback/rebuild), we use the most recent epoch data.
-	for i := len(ls.epochCache) - 1; i >= 0; i-- {
-		ep := ls.epochCache[i]
+	for _, ep := range slices.Backward(ls.epochCache) {
 		if ep.LengthInSlots == 0 {
 			continue
 		}
@@ -246,10 +246,10 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 	// meaningful error message.
 	var lastValidEnd uint64
 	var hasValidEpoch bool
-	for i := len(ls.epochCache) - 1; i >= 0; i-- {
-		if ls.epochCache[i].LengthInSlots > 0 {
-			lastValidEnd = ls.epochCache[i].StartSlot +
-				uint64(ls.epochCache[i].LengthInSlots)
+	for _, v := range slices.Backward(ls.epochCache) {
+		if v.LengthInSlots > 0 {
+			lastValidEnd = v.StartSlot +
+				uint64(v.LengthInSlots)
 			hasValidEpoch = true
 			break
 		}

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -2300,8 +2300,7 @@ func snapshotEpochAnchorSlot(
 		)
 		return 0
 	}
-	for eraIndex := len(cfg.State.EraBounds) - 1; eraIndex >= 0; eraIndex-- {
-		bound := cfg.State.EraBounds[eraIndex]
+	for eraIndex, bound := range slices.Backward(cfg.State.EraBounds) {
 		if epoch < bound.Epoch {
 			continue
 		}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -566,8 +566,8 @@ func (m *Mempool) rebuildOverlay() error {
 			hashSet[h] = struct{}{}
 		}
 		m.consumersMutex.Lock()
-		for i := len(m.transactions) - 1; i >= 0; i-- {
-			h := m.transactions[i].Hash
+		for i, v := range slices.Backward(m.transactions) {
+			h := v.Hash
 			if _, found := hashSet[h]; found {
 				evt := m.removeTransactionByIndexLocked(i)
 				if evt != nil {
@@ -644,8 +644,8 @@ func (m *Mempool) removeExpiredTransactions() {
 			expiredHashes[h] = struct{}{}
 		}
 		// Remove all from transactions list (backward for safe index handling)
-		for i := len(m.transactions) - 1; i >= 0; i-- {
-			if _, ok := expiredHashes[m.transactions[i].Hash]; ok {
+		for i, v := range slices.Backward(m.transactions) {
+			if _, ok := expiredHashes[v.Hash]; ok {
 				evt := m.removeTransactionByIndexLocked(i)
 				removedCount++
 				if evt != nil {
@@ -868,8 +868,8 @@ func (m *Mempool) RemoveTransaction(txHash string) {
 	}
 	// Remove all from transactions list (backward for safe index handling)
 	var removed bool
-	for i := len(m.transactions) - 1; i >= 0; i-- {
-		if _, ok := toRemove[m.transactions[i].Hash]; ok {
+	for i, v := range slices.Backward(m.transactions) {
+		if _, ok := toRemove[v.Hash]; ok {
 			evt := m.removeTransactionByIndexLocked(i)
 			removed = true
 			if evt != nil {
@@ -1015,8 +1015,8 @@ func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
 		for _, h := range pruned {
 			prunedSet[h] = struct{}{}
 		}
-		for i := len(m.transactions) - 1; i >= 0; i-- {
-			if _, ok := prunedSet[m.transactions[i].Hash]; ok {
+		for i, v := range slices.Backward(m.transactions) {
+			if _, ok := prunedSet[v.Hash]; ok {
 				evt := m.removeTransactionByIndexLocked(i)
 				if evt != nil {
 					events = append(events, *evt)

--- a/node.go
+++ b/node.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -121,8 +122,8 @@ func (n *Node) Run(ctx context.Context) error {
 				n.cancel()
 			}
 			// Cleanup on panic, then re-panic
-			for i := len(started) - 1; i >= 0; i-- {
-				started[i]()
+			for _, s := range slices.Backward(started) {
+				s()
 			}
 			panic(r)
 		} else if !success {
@@ -130,8 +131,8 @@ func (n *Node) Run(ctx context.Context) error {
 				n.cancel()
 			}
 			// Cleanup on failure (non-panic)
-			for i := len(started) - 1; i >= 0; i-- {
-				started[i]()
+			for _, s := range slices.Backward(started) {
+				s()
 			}
 		}
 	}()

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -52,8 +52,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 	var coldPromotions, warmPromotions, warmDemotions, knownRemoved, activeIncreased, activeDecreased int
 
 	// Demotion/Promotion Logic
-	for i := len(p.peers) - 1; i >= 0; i-- {
-		peer := p.peers[i]
+	for i, peer := range slices.Backward(p.peers) {
 		if peer == nil {
 			continue
 		}
@@ -67,8 +66,8 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 				(peer.Source != PeerSourceTopologyLocalRoot &&
 					now.Sub(peer.LastActivity) > p.config.InactivityTimeout)
 			if demoteForInactivity {
-				p.recordPeerStateChange(p.peers[i].State, PeerStateWarm)
-				p.peers[i].State = PeerStateWarm
+				p.recordPeerStateChange(peer.State, PeerStateWarm)
+				peer.State = PeerStateWarm
 				warmDemotions++
 				activeDecreased++
 				p.config.Logger.Debug(
@@ -120,9 +119,9 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 						peer,
 					)
 				} else {
-					p.recordPeerStateChange(p.peers[i].State, PeerStateWarm)
-					p.peers[i].State = PeerStateWarm
-					if p.peers[i].Source == PeerSourceInboundConn {
+					p.recordPeerStateChange(peer.State, PeerStateWarm)
+					peer.State = PeerStateWarm
+					if peer.Source == PeerSourceInboundConn {
 						p.recordInboundLifecycle("warmed")
 					}
 					coldPromotions++
@@ -665,8 +664,7 @@ func (p *PeerGovernor) pruneInboundWarmPeersLocked(
 	removedCount *int,
 ) []pendingEvent {
 	var events []pendingEvent
-	for i := len(p.peers) - 1; i >= 0; i-- {
-		peer := p.peers[i]
+	for i, peer := range slices.Backward(p.peers) {
 		if peer == nil || peer.Source != PeerSourceInboundConn || peer.State != PeerStateWarm {
 			continue
 		}

--- a/utxorpc/watch.go
+++ b/utxorpc/watch.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 
 	"connectrpc.com/connect"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -102,10 +103,10 @@ func watchTxBuildRollbackMessages(
 			found = true
 			break
 		}
-		for i := len(last.appliedTxs) - 1; i >= 0; i-- {
+		for _, v := range slices.Backward(last.appliedTxs) {
 			out = append(out, &watch.WatchTxResponse{
 				Action: &watch.WatchTxResponse_Undo{
-					Undo: last.appliedTxs[i],
+					Undo: v,
 				},
 			})
 		}
@@ -163,14 +164,10 @@ func (s *watchServiceServer) watchTxFetchRollbackUndoFromBlocks(
 		if err != nil {
 			return nil, err
 		}
-		if len(appliedTxs) == 0 {
-			hash = append([]byte(nil), block.PrevHash...)
-			continue
-		}
-		for j := len(appliedTxs) - 1; j >= 0; j-- {
+		for _, appliedTx := range slices.Backward(appliedTxs) {
 			out = append(out, &watch.WatchTxResponse{
 				Action: &watch.WatchTxResponse_Undo{
-					Undo: appliedTxs[j],
+					Undo: appliedTx,
 				},
 			})
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use `slices.Backward` for all reverse iteration to make deletions safe and the code clearer. Also fixes block reconciliation and rollback paths that could mis-handle off-by-one or missing data.

- **Bug Fixes**
  - Chain reconcile: iterate from tip with `slices.Backward`, handle `ErrBlockNotFound`, and update `lastCommonBlockIndex` correctly.
  - Rollback and undo flows: headers, density window, epoch lookups, mempool removals, and watch undo events now reverse-iterate safely to avoid skipped or duplicated items.

- **Refactors**
  - Replace manual i-- loops with `slices.Backward` across `chain`, `ledger`, `mempool`, `node`, `peergov`, `database`, and `utxorpc`.
  - Small loop variable cleanups for readability.

<sup>Written for commit 98552646f7e7110fefb7d39d37cda81cc894281e. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2402?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal iteration patterns across multiple components for enhanced code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->