### PR TITLE
test: iterate fields directly

### DIFF
--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -152,8 +152,8 @@ func collectExportedLeafFields(
 	prefix string,
 	out map[string]struct{},
 ) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
+		field := field
 		if !field.IsExported() {
 			continue
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactor tests to iterate struct fields directly with `t.Fields()` instead of using `t.NumField()`/`t.Field(i)`. This modernizes `collectExportedLeafFields` to use the standard iterator pattern while keeping behavior the same.

<sup>Written for commit b7f53260f59620fa1e17132be88385576abfef9a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2403?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

