### PR TITLE
test: use wg.Go

### DIFF
--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -82,9 +82,7 @@ func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		for i := 0; i < 100; i++ {
 			ls.Lock()
@@ -96,12 +94,10 @@ func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 			ls.Unlock()
 		}
 		close(done)
-	}()
+	})
 
 	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for {
 				select {
@@ -111,7 +107,7 @@ func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 					_ = ls.calculateStabilityWindow()
 				}
 			}
-		}()
+		})
 	}
 
 	close(start)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the concurrency test in `ledger/state_test.go` to use `wg.Go` for all goroutines. Simplifies `sync.WaitGroup`, avoids missed Done calls, and stays aligned with `main`.

<sup>Written for commit 697be43863832945a5949b32f75202266965516f. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2404?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved concurrency handling in stability window tests through updated goroutine synchronization patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->