### PR TITLE
feat: debug/pprof port during mithril sync

### DIFF
--- a/cmd/dingo/debug_pprof.go
+++ b/cmd/dingo/debug_pprof.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"strconv"
+	"time"
+)
+
+type debugPprofServer struct {
+	server *http.Server
+	errCh  <-chan error
+	addr   string
+}
+
+func startDebugPprofServer(
+	logger *slog.Logger,
+	bindAddr string,
+	port uint,
+	component string,
+) (*debugPprofServer, error) {
+	if port == 0 {
+		return nil, nil
+	}
+	addr := net.JoinHostPort(bindAddr, strconv.FormatUint(uint64(port), 10))
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("starting debug listener on %s: %w", addr, err)
+	}
+	debugMux := http.NewServeMux()
+	debugMux.HandleFunc("/debug/pprof/", pprof.Index)
+	debugMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	debugMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	debugMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	debugMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	actualAddr := listener.Addr().String()
+	logger.Info(
+		"serving pprof debug endpoints on "+actualAddr,
+		"component", component,
+	)
+	server := &http.Server{
+		Addr:              actualAddr,
+		Handler:           debugMux,
+		ReadHeaderTimeout: 60 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		if err := server.Serve(listener); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("debug server: %w", err)
+		}
+	}()
+	return &debugPprofServer{
+		server: server,
+		errCh:  errCh,
+		addr:   actualAddr,
+	}, nil
+}
+
+func (s *debugPprofServer) Shutdown(ctx context.Context) error {
+	if s == nil || s.server == nil {
+		return nil
+	}
+	return s.server.Shutdown(ctx)
+}
+
+func (s *debugPprofServer) Err() <-chan error {
+	if s == nil {
+		errCh := make(chan error)
+		close(errCh)
+		return errCh
+	}
+	return s.errCh
+}

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -320,6 +320,48 @@ func runMithrilSync(
 			}
 		}()
 	}
+	debugServer, debugErr := startDebugPprofServer(
+		logger,
+		cfg.BindAddr,
+		cfg.DebugPort,
+		"mithril",
+	)
+	if debugErr != nil {
+		logger.Warn(
+			"failed to start pprof debug server; continuing",
+			"component", "mithril",
+			"port", cfg.DebugPort,
+			"error", debugErr,
+		)
+	}
+	defer func() {
+		if debugServer == nil {
+			return
+		}
+		shutdownCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			5*time.Second,
+		)
+		defer cancel()
+		if shutdownErr := debugServer.Shutdown(shutdownCtx); shutdownErr != nil {
+			logger.Warn(
+				"failed to stop pprof debug server",
+				"component", "mithril",
+				"error", shutdownErr,
+			)
+		}
+	}()
+	if debugServer != nil {
+		go func() {
+			if serverErr := <-debugServer.Err(); serverErr != nil {
+				logger.Error(
+					"pprof debug server stopped",
+					"component", "mithril",
+					"error", serverErr,
+				)
+			}
+		}()
+	}
 
 	cardanoConfigPath := cfg.CardanoConfig
 	if cardanoConfigPath == "" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional `net/http/pprof` server during mithril sync to enable runtime profiling. It listens on `cfg.BindAddr:cfg.DebugPort`, shuts down gracefully, and won’t block sync if it fails to start.

- New Features
  - Exposes `/debug/pprof/*` endpoints for `mithril` when `DebugPort` > 0.
  - Logs the bound address on start; continues on startup errors.
  - Graceful shutdown with timeout; error channel monitored and logged.

<sup>Written for commit e43be952ceb6e6cc6391ebabb758c66c5cd51a68. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2413?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

