### PR TITLE
fix(ledgerstate): mmap ledger utxo table parsing

### DIFF
--- a/ledgerstate/mmap_test.go
+++ b/ledgerstate/mmap_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMmapReadOnlyRejectsEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(path, nil, 0o640); err != nil {
+		t.Fatalf("writing empty file: %v", err)
+	}
+
+	data, cleanup, err := mmapReadOnly(path)
+	if err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatalf("expected error, got data len %d", len(data))
+	}
+	if !strings.Contains(err.Error(), "empty file") {
+		t.Fatalf("expected empty file error, got %v", err)
+	}
+}
+
+func TestMmapReadOnlyReturnsFileData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data")
+	want := []byte("dingo mmap test")
+	if err := os.WriteFile(path, want, 0o640); err != nil {
+		t.Fatalf("writing data file: %v", err)
+	}
+
+	data, cleanup, err := mmapReadOnly(path)
+	if err != nil {
+		t.Fatalf("mmap read-only: %v", err)
+	}
+	defer cleanup()
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("mapped data = %q, want %q", data, want)
+	}
+}

--- a/ledgerstate/mmap_unix.go
+++ b/ledgerstate/mmap_unix.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func mmapReadOnly(path string) ([]byte, func(), error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return nil, nil, errors.New("empty file")
+	}
+	maxInt := int64(int(^uint(0) >> 1))
+	if size > maxInt {
+		return nil, nil, fmt.Errorf(
+			"file too large to map into memory: %d bytes",
+			size,
+		)
+	}
+	data, err := unix.Mmap(
+		int(file.Fd()),
+		0,
+		int(size),
+		unix.PROT_READ,
+		unix.MAP_PRIVATE,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if data == nil {
+		return nil, nil, errors.New("mmap returned nil data")
+	}
+	mappedFile := file
+	file = nil
+	if err := mappedFile.Close(); err != nil {
+		_ = unix.Munmap(data)
+		return nil, nil, err
+	}
+	return data, func() {
+		_ = unix.Munmap(data)
+	}, nil
+}

--- a/ledgerstate/mmap_windows.go
+++ b/ledgerstate/mmap_windows.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerstate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func mmapReadOnly(path string) ([]byte, func(), error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return nil, nil, errors.New("empty file")
+	}
+	maxInt := int64(int(^uint(0) >> 1))
+	if size > maxInt {
+		return nil, nil, fmt.Errorf(
+			"file too large to map into memory: %d bytes",
+			size,
+		)
+	}
+	length := int(size) //nolint:gosec // size <= maxInt checked above
+
+	mapping, err := windows.CreateFileMapping(
+		windows.Handle(file.Fd()),
+		nil,
+		windows.PAGE_READONLY,
+		0,
+		0,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer windows.CloseHandle(mapping) //nolint:errcheck
+
+	addr, err := windows.MapViewOfFile(
+		mapping,
+		windows.FILE_MAP_READ,
+		0,
+		0,
+		uintptr(length),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	data := unsafe.Slice( //nolint:gosec // Windows mmap view as []byte
+		(*byte)(unsafe.Pointer(addr)),
+		length,
+	)
+	if data == nil {
+		_ = windows.UnmapViewOfFile(addr)
+		return nil, nil, errors.New("mmap returned nil data")
+	}
+
+	mappedFile := file
+	file = nil
+	if err := mappedFile.Close(); err != nil {
+		_ = windows.UnmapViewOfFile(addr)
+		return nil, nil, err
+	}
+
+	return data, func() {
+		_ = windows.UnmapViewOfFile(addr)
+	}, nil
+}

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -543,11 +542,8 @@ func convertMultiAsset(
 // file. The tvar format is array(1) containing a map of TxIn->TxOut
 // entries. The map may use indefinite-length encoding (0xbf...0xff).
 //
-// Note: The entire file is read into memory because the CBOR stream
-// decoder (gouroboros) requires a contiguous byte slice and does not
-// support io.Reader streaming. Mainnet tvar files can be multi-GB.
-// A future optimization could use mmap to avoid copying the file
-// contents into Go heap memory.
+// Note: The CBOR stream decoder requires a contiguous byte slice, so the file
+// is mmap'd read-only to avoid copying large UTxO-HD tables into Go heap.
 func ParseUTxOsFromFile(
 	path string,
 	callback UTxOCallback,
@@ -560,10 +556,11 @@ func parseUTxOsFromFileWithProgress(
 	callback UTxOCallback,
 	progress func(UTxOParseProgress),
 ) (int, error) {
-	data, err := os.ReadFile(path)
+	data, cleanup, err := mmapReadOnly(path)
 	if err != nil {
 		return 0, fmt.Errorf("reading tvar file: %w", err)
 	}
+	defer cleanup()
 
 	// Parse outer array header using StreamDecoder
 	decoder, err := cbor.NewStreamDecoder(data)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memory-map the ledger UTxO-HD tvar file during parsing to avoid copying large files into the Go heap. This reduces peak memory and speeds up parsing on Unix and Windows.

- **Bug Fixes**
  - Cross-platform read-only mmap with cleanup; checks for empty/too-large files; unit tests (`golang.org/x/sys/unix`, `golang.org/x/sys/windows`).
  - Parser now uses `mmapReadOnly` in `utxo.go` (replaces `os.ReadFile`) and defers unmap.

<sup>Written for commit 5502ceecb3fa5b45307c98ce93d9211c285ce036. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2414?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized UTxO file reading to use memory-mapped I/O instead of loading entire files into memory, reducing memory overhead and improving performance for large files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->