### PR TITLE
fix(database): reduce backfill memory

### DIFF
--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -126,6 +126,24 @@ func (b *BatchAccumulator) Reset() {
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
 }
 
+// Len returns the number of accumulated metadata rows. It is intentionally a
+// simple row-count estimate used by backfill to bound batch memory.
+func (b *BatchAccumulator) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.KeyWitnesses) +
+		len(b.WitnessScripts) +
+		len(b.Scripts) +
+		len(b.PlutusData) +
+		len(b.Redeemers) +
+		len(b.AddressTxs) +
+		len(b.UtxoOutputs) +
+		len(b.UtxoSpends) +
+		len(b.CollateralRets) +
+		len(b.DeleteTxIDs)
+}
+
 // MergeFrom appends all records from other into b.
 // It is a no-op when other is nil or other == b.
 func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -126,6 +126,24 @@ func (b *BatchAccumulator) Reset() {
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
 }
 
+// Len returns the number of accumulated metadata rows. It is intentionally a
+// simple row-count estimate used by backfill to bound batch memory.
+func (b *BatchAccumulator) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.KeyWitnesses) +
+		len(b.WitnessScripts) +
+		len(b.Scripts) +
+		len(b.PlutusData) +
+		len(b.Redeemers) +
+		len(b.AddressTxs) +
+		len(b.UtxoOutputs) +
+		len(b.UtxoSpends) +
+		len(b.CollateralRets) +
+		len(b.DeleteTxIDs)
+}
+
 // MergeFrom appends all records from other into b.
 // It is a no-op when other is nil or other == b.
 func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -55,18 +55,7 @@ type BatchAccumulator struct {
 
 // NewBatchAccumulator returns an empty BatchAccumulator ready for use.
 func NewBatchAccumulator() *BatchAccumulator {
-	return &BatchAccumulator{
-		KeyWitnesses:   make([]models.KeyWitness, 0, batchChunkRows),
-		WitnessScripts: make([]models.WitnessScripts, 0, batchChunkRows),
-		Scripts:        make([]models.Script, 0, batchChunkRows),
-		PlutusData:     make([]models.PlutusData, 0, batchChunkRows),
-		Redeemers:      make([]models.Redeemer, 0, batchChunkRows),
-		AddressTxs:     make([]models.AddressTransaction, 0, batchChunkRows),
-		UtxoOutputs:    make([]models.Utxo, 0, batchChunkRows),
-		UtxoSpends:     make([]utxoSpend, 0, batchChunkRows),
-		CollateralRets: make([]models.Utxo, 0, batchChunkRows),
-		DeleteTxIDs:    make([]uint, 0, batchChunkRows),
-	}
+	return &BatchAccumulator{}
 }
 
 // NewBatchAccumulator creates an accumulator for this metadata store.
@@ -138,6 +127,24 @@ func (b *BatchAccumulator) Reset() {
 	b.UtxoSpends = b.UtxoSpends[:0]
 	b.CollateralRets = b.CollateralRets[:0]
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
+}
+
+// Len returns the number of accumulated metadata rows. It is intentionally a
+// simple row-count estimate used by backfill to bound batch memory.
+func (b *BatchAccumulator) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.KeyWitnesses) +
+		len(b.WitnessScripts) +
+		len(b.Scripts) +
+		len(b.PlutusData) +
+		len(b.Redeemers) +
+		len(b.AddressTxs) +
+		len(b.UtxoOutputs) +
+		len(b.UtxoSpends) +
+		len(b.CollateralRets) +
+		len(b.DeleteTxIDs)
 }
 
 // MergeFrom appends all records from other into b.

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -39,6 +39,11 @@ import (
 // exceeding SQLite's max bind variable limit (default 999).
 const sqliteBindVarLimit = 400
 
+// sqlitePrepareStmtMaxSize bounds GORM's prepared statement cache. The default
+// is effectively unbounded, which performs poorly for API backfill because many
+// bulk INSERT/UPDATE statements have batch-dependent SQL text.
+const sqlitePrepareStmtMaxSize = 1024
+
 // sqliteTxn wraps a gorm transaction and implements types.Txn
 type sqliteTxn struct {
 	beginErr error
@@ -262,6 +267,7 @@ func (d *MetadataStoreSqlite) Start() error {
 				Logger:                 d.gormLogger(),
 				SkipDefaultTransaction: true,
 				PrepareStmt:            true,
+				PrepareStmtMaxSize:     sqlitePrepareStmtMaxSize,
 			},
 		)
 		if err != nil {
@@ -341,6 +347,7 @@ func (d *MetadataStoreSqlite) Start() error {
 				Logger:                 d.gormLogger(),
 				SkipDefaultTransaction: true,
 				PrepareStmt:            true,
+				PrepareStmtMaxSize:     sqlitePrepareStmtMaxSize,
 			},
 		)
 		if err != nil {
@@ -360,6 +367,7 @@ func (d *MetadataStoreSqlite) Start() error {
 				Logger:                 gormlogger.Discard,
 				SkipDefaultTransaction: true,
 				PrepareStmt:            true,
+				PrepareStmtMaxSize:     sqlitePrepareStmtMaxSize,
 			},
 		)
 		if err != nil {

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -41,6 +41,14 @@ const BackfillPhase = "metadata"
 // before deferred metadata rows are flushed.
 const DefaultBackfillBatchSize = 100
 
+// DefaultBackfillBatchRows caps the accumulated metadata row count before a
+// flush so dense eras do not hold oversized batches in memory.
+const DefaultBackfillBatchRows = 5000
+
+type backfillBatchSizer interface {
+	Len() int
+}
+
 // Backfill replays stored blocks to populate historical metadata.
 // It is triggered automatically during Mithril sync when
 // storageMode is "api".
@@ -682,6 +690,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 			"component", "backfill",
 			"tip_slot", tipSlot,
 			"batch_size", b.batchSize,
+			"batch_row_limit", DefaultBackfillBatchRows,
 		)
 		// Fresh start: reset epoch/era tracking to the
 		// first epoch so processEpochBoundary doesn't
@@ -702,6 +711,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 				"tip_slot", tipSlot,
 				"restart_from_first_block", true,
 				"batch_size", b.batchSize,
+				"batch_row_limit", DefaultBackfillBatchRows,
 			)
 			b.initializeFromFirstEpoch()
 		} else {
@@ -711,6 +721,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 				"resume_from_slot", cp.LastSlot,
 				"tip_slot", tipSlot,
 				"batch_size", b.batchSize,
+				"batch_row_limit", DefaultBackfillBatchRows,
 			)
 			// Recover running nonce from the last processed
 			// block so nonce computation can continue.
@@ -911,8 +922,15 @@ func (b *Backfill) Run(ctx context.Context) error {
 		processedBlocks++
 		batchBlockCount++
 
-		// Flush once the current batch reaches the configured block window.
-		if batchBlockCount >= b.batchSize {
+		batchRows := 0
+		if sizer, ok := acc.(backfillBatchSizer); ok {
+			batchRows = sizer.Len()
+		}
+		// Flush once the current batch reaches the configured block window
+		// or the plugin reports enough accumulated rows to fill efficient
+		// bulk SQL batches.
+		if batchBlockCount >= b.batchSize ||
+			batchRows >= DefaultBackfillBatchRows {
 			if err := flushBatch(); err != nil {
 				saveCommittedCheckpoint()
 				return fmt.Errorf(
@@ -964,6 +982,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 		"transactions_stored", processedTxs,
 		"elapsed", elapsed.Round(time.Second),
 		"batch_size", b.batchSize,
+		"batch_row_limit", DefaultBackfillBatchRows,
 		"skipped_utxo_offset_block_writes", b.skippedBlocks,
 		"skipped_utxo_offset_refs", b.skippedUtxoRefs,
 	)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce memory during metadata backfill by capping batch row counts and tightening `gorm` prepared statement caching in SQLite. Adds a simple row counter to accumulators so backfill flushes earlier in dense eras.

- **Bug Fixes**
  - Backfill now flushes when either the block window is reached or accumulated rows >= 5000 (`DefaultBackfillBatchRows`), using a new `Len()` on batch accumulators for MySQL/Postgres/SQLite.
  - SQLite: stop preallocating accumulator slices and cap `gorm` prepared statement cache via `PrepareStmtMaxSize = 1024` to prevent unbounded growth during bulk writes.
  - Added `batch_row_limit` to logs for visibility.

<sup>Written for commit 695ee2aabe7d5dde38a4c8ad89e16c7e72a49940. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

