### PR TITLE
fix: streamed invalid tx index extraction

### DIFF
--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -915,15 +915,24 @@ func storeRawBlockUtxoOffsets(
 }
 
 func extractInvalidTxIndices(blockCbor []byte) (map[int]struct{}, error) {
-	var blockArray []gcbor.RawMessage
-	if _, err := gcbor.Decode(blockCbor, &blockArray); err != nil {
+	decoder, err := gcbor.NewStreamDecoder(blockCbor)
+	if err != nil {
 		return nil, err
 	}
-	if len(blockArray) < 5 {
+	blockLen, _, _, err := decoder.DecodeArrayHeader()
+	if err != nil {
+		return nil, err
+	}
+	if blockLen < 5 {
 		return nil, nil
 	}
+	for i := 0; i < 4; i++ {
+		if _, _, err := decoder.Skip(); err != nil {
+			return nil, err
+		}
+	}
 	var invalidTxs []uint
-	if _, err := gcbor.Decode([]byte(blockArray[4]), &invalidTxs); err != nil {
+	if _, _, err := decoder.Decode(&invalidTxs); err != nil {
 		return nil, err
 	}
 	if len(invalidTxs) == 0 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes invalid transaction index extraction by switching to streamed CBOR decoding. This avoids full-block decoding and properly handles short blocks to prevent read errors.

- **Bug Fixes**
  - Use `gcbor.NewStreamDecoder` to read the array header, skip the first 4 items, and decode invalid-tx indices in place.
  - Return nil for blocks with fewer than 5 items; propagate decoder errors.

<sup>Written for commit cccb57629a7cfa6361715c33d0144727b7b9a86b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2416?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

