### PR TITLE
fix(ouroboros/chainsync): propagate async server RollForward/RollBackward failures

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -523,9 +523,11 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 				next.Point,
 				tip,
 			); err != nil {
-				o.config.Logger.Error(
-					"failed to roll backward",
-					"error", err,
+				o.reportChainsyncServerAsyncError(
+					conn,
+					ctx.ConnectionId.String(),
+					"RollBackward",
+					err,
 				)
 			}
 		} else {
@@ -534,14 +536,54 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 				next.Block.Cbor,
 				tip,
 			); err != nil {
-				o.config.Logger.Error(
-					"failed to roll forward",
-					"error", err,
+				o.reportChainsyncServerAsyncError(
+					conn,
+					ctx.ConnectionId.String(),
+					"RollForward",
+					err,
 				)
 			}
 		}
 	}()
 	return nil
+}
+
+func (o *Ouroboros) reportChainsyncServerAsyncError(
+	conn *ouroboros.Connection,
+	connectionID string,
+	operation string,
+	err error,
+) {
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	o.config.Logger.Error(
+		"chainsync server: async send failed",
+		"connection_id", connectionID,
+		"operation", operation,
+		"error", err,
+	)
+	if !sendChainsyncConnError(conn.ErrorChan(), err) {
+		o.config.Logger.Debug(
+			"chainsync server: failed to forward async send error to connection error channel",
+			"connection_id", connectionID,
+			"operation", operation,
+		)
+	}
+}
+
+func sendChainsyncConnError(errCh chan error, err error) (sent bool) {
+	defer func() {
+		if recover() != nil {
+			sent = false
+		}
+	}()
+	select {
+	case errCh <- err:
+		return true
+	default:
+		return false
+	}
 }
 
 func (o *Ouroboros) chainsyncClientRollBackward(

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -453,8 +453,6 @@ func TestChainsyncServerRequestNext_AsyncRollBackwardErrorClosesConnection(
 	}
 	require.NoError(t, h.ledgerState.Chain().AddBlock(block, nil))
 	requestNextIntoAsyncAwait(t, h)
-	// The existing block is delivered synchronously; this extra request parks
-	// the server back in AwaitReply before the rollback arrives.
 	ctx := ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/peergov"
-	"github.com/blinklabs-io/gouroboros"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -395,7 +395,7 @@ func requireChainsyncClosedEvent(
 	evt := testutil.RequireReceive(
 		t,
 		h.closedCh,
-		500*time.Millisecond,
+		5*time.Second,
 		msg,
 	)
 	closed, ok := evt.Data.(connmanager.ConnectionClosedEvent)

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/peergov"
 	"github.com/blinklabs-io/gouroboros"
@@ -41,6 +42,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"github.com/stretchr/testify/require"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 type lockedBuffer struct {
@@ -87,6 +89,14 @@ type testBlockHeader struct {
 	bodyHash    gledger.Blake2b256
 }
 
+// testBlock is the smallest block implementation needed to wake a server-side
+// ChainIterator and drive the async RollForward path.
+type testBlock struct {
+	*testBlockHeader
+	blockType int
+	cbor      []byte
+}
+
 func (h *testBlockHeader) Hash() gledger.Blake2b256 {
 	return h.hash
 }
@@ -123,6 +133,26 @@ func (h *testBlockHeader) BlockBodyHash() gledger.Blake2b256 {
 	return h.bodyHash
 }
 
+func (b *testBlock) Header() gledger.BlockHeader {
+	return b.testBlockHeader
+}
+
+func (b *testBlock) Type() int {
+	return b.blockType
+}
+
+func (b *testBlock) Transactions() []gledger.Transaction {
+	return nil
+}
+
+func (b *testBlock) Utxorpc() (*utxorpc.Block, error) {
+	return nil, nil
+}
+
+func (b *testBlock) Cbor() []byte {
+	return b.cbor
+}
+
 func newTestBlockHeader(slot, block uint64, hashByte byte) gledger.BlockHeader {
 	var hash gledger.Blake2b256
 	hash[0] = hashByte
@@ -148,6 +178,14 @@ func newTestConnId(local, remote string) ouroboros.ConnectionId {
 	}
 }
 
+type testSecurityParamLedger struct {
+	securityParam int
+}
+
+func (l testSecurityParamLedger) SecurityParam() int {
+	return l.securityParam
+}
+
 func newTestLedgerState(t *testing.T) *ledger.LedgerState {
 	t.Helper()
 
@@ -161,6 +199,7 @@ func newTestLedgerState(t *testing.T) *ledger.LedgerState {
 
 	cm, err := chain.NewManager(db, nil)
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 2160}))
 
 	ls, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
 		Database:     db,
@@ -228,6 +267,211 @@ func TestChainsyncConnOptsUseConfiguredBlockTimeout(t *testing.T) {
 
 	require.Equal(t, blockTimeout, clientCfg.BlockTimeout)
 	require.Equal(t, blockTimeout, serverCfg.BlockTimeout)
+}
+
+type chainsyncAsyncSendFailureHarness struct {
+	o           *Ouroboros
+	conn        *ouroboros.Connection
+	server      *ochainsync.Server
+	ledgerState *ledger.LedgerState
+	closedCh    <-chan event.Event
+}
+
+// newChainsyncAsyncSendFailureHarness creates a real in-memory Ouroboros
+// connection registered with connmanager, so async send errors must flow
+// through conn.ErrorChan() to produce connmanager.conn_closed.
+func newChainsyncAsyncSendFailureHarness(
+	t *testing.T,
+) chainsyncAsyncSendFailureHarness {
+	t.Helper()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	t.Cleanup(bus.Close)
+
+	_, closedCh := bus.Subscribe(connmanager.ConnectionClosedEventType)
+	ledgerState := newTestLedgerState(t)
+	chainsyncState := dchainsync.NewState(bus, ledgerState)
+	connManager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{
+			EventBus: bus,
+			Logger:   logger,
+		},
+	)
+	serverPipe, clientPipe := net.Pipe()
+	t.Cleanup(func() {
+		_ = serverPipe.Close()
+		_ = clientPipe.Close()
+	})
+
+	serverConnCh := make(chan *ouroboros.Connection, 1)
+	serverErrCh := make(chan error, 1)
+	go func() {
+		conn, err := ouroboros.New(
+			ouroboros.WithConnection(serverPipe),
+			ouroboros.WithServer(true),
+			ouroboros.WithNetworkMagic(42),
+			ouroboros.WithDelayProtocolStart(true),
+			ouroboros.WithLogger(logger),
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		serverConnCh <- conn
+	}()
+	clientConn, err := ouroboros.New(
+		ouroboros.WithConnection(clientPipe),
+		ouroboros.WithNetworkMagic(42),
+		ouroboros.WithDelayProtocolStart(true),
+		ouroboros.WithLogger(logger),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientConn.Close() })
+	var conn *ouroboros.Connection
+	select {
+	case err := <-serverErrCh:
+		t.Fatalf("server connection setup failed: %v", err)
+	case conn = <-serverConnCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for server connection setup")
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	require.True(
+		t,
+		connManager.AddConnection(conn, false, conn.Id().RemoteAddr.String()),
+	)
+	t.Cleanup(func() {
+		select {
+		case conn.ErrorChan() <- context.Canceled:
+		default:
+		}
+	})
+
+	server := conn.ChainSync().Server
+	server.Start()
+	t.Cleanup(server.Stop)
+
+	o := NewOuroboros(OuroborosConfig{
+		ConnManager: connManager,
+		EventBus:    bus,
+		Logger:      logger,
+	})
+	o.LedgerState = ledgerState
+	o.ChainsyncState = chainsyncState
+
+	return chainsyncAsyncSendFailureHarness{
+		o:           o,
+		conn:        conn,
+		server:      server,
+		ledgerState: ledgerState,
+		closedCh:    closedCh,
+	}
+}
+
+// requireChainsyncClosedEvent verifies that the async send failure reached
+// connmanager's lifecycle path instead of being logged and dropped.
+func requireChainsyncClosedEvent(
+	t *testing.T,
+	h chainsyncAsyncSendFailureHarness,
+	msg string,
+) {
+	t.Helper()
+	evt := testutil.RequireReceive(
+		t,
+		h.closedCh,
+		500*time.Millisecond,
+		msg,
+	)
+	closed, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+	require.True(t, ok)
+	require.Equal(t, h.conn.Id(), closed.ConnectionId)
+	require.Error(t, closed.Error)
+}
+
+// requestNextIntoAsyncAwait performs the initial rollback handshake and then
+// parks the server in AwaitReply, which is the async path covered by H6.
+func requestNextIntoAsyncAwait(
+	t *testing.T,
+	h chainsyncAsyncSendFailureHarness,
+) {
+	t.Helper()
+	ctx := ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	}
+	require.NoError(t, h.o.chainsyncServerRequestNext(ctx))
+	require.NoError(t, h.o.chainsyncServerRequestNext(ctx))
+}
+
+// TestChainsyncServerRequestNext_AsyncRollForwardErrorClosesConnection
+// reproduces H6 for the async RollForward path: once AwaitReply has returned,
+// a later send failure must still close through connmanager lifecycle handling.
+func TestChainsyncServerRequestNext_AsyncRollForwardErrorClosesConnection(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	requestNextIntoAsyncAwait(t, h)
+
+	// Stop the protocol before waking the iterator so the goroutine's
+	// RollForward send fails after chainsyncServerRequestNext has returned.
+	h.server.Stop()
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  1,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, h.ledgerState.Chain().AddBlock(block, nil))
+
+	// The failure must be observable as normal connection lifecycle handling.
+	requireChainsyncClosedEvent(
+		t,
+		h,
+		"async RollForward send failure should close the connection",
+	)
+}
+
+// TestChainsyncServerRequestNext_AsyncRollBackwardErrorClosesConnection
+// reproduces H6 for the async RollBackward path: rollback send failures after
+// AwaitReply must not leave the downstream peer connection silently open.
+func TestChainsyncServerRequestNext_AsyncRollBackwardErrorClosesConnection(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  1,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, h.ledgerState.Chain().AddBlock(block, nil))
+	requestNextIntoAsyncAwait(t, h)
+	// The existing block is delivered synchronously; this extra request parks
+	// the server back in AwaitReply before the rollback arrives.
+	ctx := ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	}
+	require.NoError(t, h.o.chainsyncServerRequestNext(ctx))
+
+	// Stop the protocol before rolling back so the goroutine's RollBackward
+	// send fails after chainsyncServerRequestNext has returned.
+	h.server.Stop()
+	require.NoError(t, h.ledgerState.Chain().Rollback(ocommon.NewPointOrigin()))
+
+	// The failure must be observable as normal connection lifecycle handling.
+	requireChainsyncClosedEvent(
+		t,
+		h,
+		"async RollBackward send failure should close the connection",
+	)
 }
 
 func TestNormalizeIntersectPoints(t *testing.T) {

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -297,6 +297,14 @@ func newChainsyncAsyncSendFailureHarness(
 			Logger:   logger,
 		},
 	)
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer stopCancel()
+		_ = connManager.Stop(stopCtx)
+	})
 	serverPipe, clientPipe := net.Pipe()
 	t.Cleanup(func() {
 		_ = serverPipe.Close()
@@ -342,10 +350,7 @@ func newChainsyncAsyncSendFailureHarness(
 		connManager.AddConnection(conn, false, conn.Id().RemoteAddr.String()),
 	)
 	t.Cleanup(func() {
-		select {
-		case conn.ErrorChan() <- context.Canceled:
-		default:
-		}
+		sendChainsyncTestConnError(conn.ErrorChan(), context.Canceled)
 	})
 
 	server := conn.ChainSync().Server
@@ -366,6 +371,16 @@ func newChainsyncAsyncSendFailureHarness(
 		server:      server,
 		ledgerState: ledgerState,
 		closedCh:    closedCh,
+	}
+}
+
+func sendChainsyncTestConnError(errCh chan error, err error) {
+	defer func() {
+		_ = recover()
+	}()
+	select {
+	case errCh <- err:
+	default:
 	}
 }
 


### PR DESCRIPTION
1. Made changes in ouroboros/chainsync.go so async RollForward and RollBackward errors after AwaitReply are sent to conn.ErrorChan().
2. Added tests for async RollForward and RollBackward failures.
3. Verified failed async sends now produce connmanager.conn_closed instead of silently leaving the connection open.

Closes #2259 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates async ChainSync server send failures (RollForward/RollBackward after AwaitReply) to `conn.ErrorChan()` so `connmanager` closes the connection instead of leaving it open. Closes #2259.

- **Bug Fixes**
  - In `ouroboros/chainsync.go`, added `reportChainsyncServerAsyncError` and panic-safe, non-blocking `sendChainsyncConnError` to forward async send errors; logs `connection_id` and operation, ignores `context.Canceled`, and logs debug if forwarding fails.
  - Expanded tests with a real in-memory connection registered with `connmanager`; reproduce async `RollForward`/`RollBackward` failures after `AwaitReply` and assert `connmanager.ConnectionClosed` is emitted.

<sup>Written for commit d5e822d33711a23c559ee0e8eece158f1d55df1a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2419?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Async failures during chain synchronization are now reported and propagated to the connection lifecycle (no longer only logged), improving error visibility and ensuring connections close predictably on send errors.

* **Tests**
  * Added tests covering async error paths in chain synchronization to verify errors propagate and trigger connection-close events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->