### PR TITLE
test: replace time.After waits

### DIFF
--- a/ledger/chainsync_replay_shutdown_test.go
+++ b/ledger/chainsync_replay_shutdown_test.go
@@ -17,6 +17,8 @@ package ledger
 import (
 	"testing"
 	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // Regression for #2107: replayBufferedHeadersAsync must be a no-op once
@@ -37,11 +39,12 @@ func TestReplayBufferedHeadersAsyncSkippedAfterClose(t *testing.T) {
 		ls.replayWG.Wait()
 		close(done)
 	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("replayWG did not complete: a worker was spawned despite ls.closed=true")
-	}
+	testutil.RequireReceive(
+		t,
+		done,
+		2*time.Second,
+		"replayWG did not complete: a worker was spawned despite ls.closed=true",
+	)
 }
 
 // Regression for #2107: Close must drain in-flight replay goroutines
@@ -54,6 +57,12 @@ func TestCloseWaitsForInFlightReplay(t *testing.T) {
 	// Hold the chainsync mutex so the goroutine spawned by
 	// replayBufferedHeadersAsync blocks before touching the DB.
 	ls.chainsyncMutex.Lock()
+	chainsyncMutexLocked := true
+	defer func() {
+		if chainsyncMutexLocked {
+			ls.chainsyncMutex.Unlock()
+		}
+	}()
 	ls.replayBufferedHeadersAsync(fixture.connId)
 
 	// (The goroutine ran replayWG.Add(1) synchronously before launching,
@@ -65,35 +74,35 @@ func TestCloseWaitsForInFlightReplay(t *testing.T) {
 
 	// Wait until Close has set closed=true and is therefore committed
 	// to draining the replay worker before it can return.
-	deadline := time.Now().Add(2 * time.Second)
-	for !ls.closed.Load() {
-		if time.Now().After(deadline) {
-			ls.chainsyncMutex.Unlock()
-			t.Fatal("Close did not set ls.closed within 2s")
-		}
-		time.Sleep(time.Millisecond)
-	}
+	testutil.WaitForCondition(
+		t,
+		ls.closed.Load,
+		2*time.Second,
+		"Close did not set ls.closed within 2s",
+	)
 
 	// With closed=true and the worker blocked on chainsyncMutex, Close
 	// must not return: doing so would close the DB while the worker is
 	// still alive (the original #2107 panic).
-	select {
-	case err := <-closeReturned:
-		ls.chainsyncMutex.Unlock()
-		t.Fatalf("Close returned (err=%v) before replay drained", err)
-	default:
-	}
+	testutil.RequireNoReceive(
+		t,
+		closeReturned,
+		50*time.Millisecond,
+		"Close returned before replay drained",
+	)
 
 	// Releasing the mutex lets the worker observe ls.closed=true and exit
 	// without issuing any DB reads; Close can then finish draining.
 	ls.chainsyncMutex.Unlock()
+	chainsyncMutexLocked = false
 
-	select {
-	case err := <-closeReturned:
-		if err != nil {
-			t.Fatalf("Close returned error: %v", err)
-		}
-	case <-time.After(15 * time.Second):
-		t.Fatal("Close did not return after replay worker exited")
+	err := testutil.RequireReceive(
+		t,
+		closeReturned,
+		15*time.Second,
+		"Close did not return after replay worker exited",
+	)
+	if err != nil {
+		t.Fatalf("Close returned error: %v", err)
 	}
 }

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -137,17 +138,18 @@ func TestHandleEventChainsyncRollbackRejectsBelowMithrilBoundary(
 	require.NoError(t, err)
 	assert.Equal(t, "20", storedBoundary)
 
-	select {
-	case e := <-resyncCh:
-		assert.Equal(
-			t,
-			event.ChainsyncResyncReasonRollbackExceedsMithril,
-			e.Reason,
-		)
-		assert.Equal(t, fixture.connId, e.ConnectionId)
-	case <-time.After(time.Second):
-		t.Fatal("expected Mithril rollback-boundary resync event")
-	}
+	e := testutil.RequireReceive(
+		t,
+		resyncCh,
+		time.Second,
+		"expected Mithril rollback-boundary resync event",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonRollbackExceedsMithril,
+		e.Reason,
+	)
+	assert.Equal(t, fixture.connId, e.ConnectionId)
 	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.activeBlockfetchConnId)
 	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.selectedBlockfetchConnId)
 	assert.Equal(t, ouroboros.ConnectionId{}, fixture.ls.shadowBlockfetchConnId)
@@ -624,11 +626,12 @@ func TestTryResolveForkDoesNotAdvanceLaggingLedgerTip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 
-	select {
-	case resync := <-resyncCh:
-		t.Fatalf("expected no local rollback resync event, got: %#v", resync)
-	case <-time.After(200 * time.Millisecond):
-	}
+	testutil.RequireNoReceive(
+		t,
+		resyncCh,
+		200*time.Millisecond,
+		"expected no local rollback resync event",
+	)
 }
 
 func TestTryResolveForkQueuesKnownPeerForkSegment(t *testing.T) {
@@ -851,17 +854,18 @@ func TestHandleEventChainsyncBlockHeaderMissingAncestorRequestsResync(
 	})
 	require.NoError(t, err)
 
-	select {
-	case resync := <-resyncCh:
-		assert.Equal(t, fixture.connId, resync.ConnectionId)
-		assert.Equal(
-			t,
-			event.ChainsyncResyncReasonRollbackNotFound,
-			resync.Reason,
-		)
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected chainsync resync event")
-	}
+	resync := testutil.RequireReceive(
+		t,
+		resyncCh,
+		2*time.Second,
+		"expected chainsync resync event",
+	)
+	assert.Equal(t, fixture.connId, resync.ConnectionId)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonRollbackNotFound,
+		resync.Reason,
+	)
 
 	assert.Zero(t, fixture.ls.headerMismatchCount)
 	_, ok := fixture.ls.bufferedHeaderEvents[connIdKey(fixture.connId)]
@@ -894,18 +898,19 @@ func TestRollbackPublishesChainsyncResyncAtRollbackPoint(t *testing.T) {
 
 	require.NoError(t, fixture.ls.rollback(fixture.ancestorTip.Point))
 
-	select {
-	case resync := <-resyncCh:
-		assert.Equal(
-			t,
-			event.ChainsyncResyncReasonLocalLedgerRollback,
-			resync.Reason,
-		)
-		assert.Equal(t, fixture.ancestorTip.Point, resync.Point)
-		assert.Equal(t, ouroboros.ConnectionId{}, resync.ConnectionId)
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected chainsync resync event")
-	}
+	resync := testutil.RequireReceive(
+		t,
+		resyncCh,
+		2*time.Second,
+		"expected chainsync resync event",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonLocalLedgerRollback,
+		resync.Reason,
+	)
+	assert.Equal(t, fixture.ancestorTip.Point, resync.Point)
+	assert.Equal(t, ouroboros.ConnectionId{}, resync.ConnectionId)
 }
 
 func TestRecoverAfterLocalRollbackReplaysPeerHeaderHistory(
@@ -1269,11 +1274,12 @@ func TestHandleEventChainsyncBlockHeaderIgnoresStaleRollForwardBehindTip(
 	assert.Zero(t, fixture.ls.headerMismatchCount)
 	assert.Zero(t, fixture.ls.chain.HeaderCount())
 
-	select {
-	case resync := <-resyncCh:
-		t.Fatalf("expected no chainsync resync event, got: %#v", resync)
-	case <-time.After(200 * time.Millisecond):
-	}
+	testutil.RequireNoReceive(
+		t,
+		resyncCh,
+		200*time.Millisecond,
+		"expected no chainsync resync event",
+	)
 }
 
 func TestReconcilePrimaryChainTipWithLedgerTipRollsBackMetadata(t *testing.T) {

--- a/ledger/slot_battle_test.go
+++ b/ledger/slot_battle_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger/forging"
 )
 
@@ -77,18 +78,19 @@ func TestCheckSlotBattle_DetectsConflict(t *testing.T) {
 	ls.checkSlotBattle(e, errors.New("block rejected"))
 
 	// Verify the event was emitted
-	select {
-	case evt := <-evtCh:
-		battle, ok := evt.Data.(forging.SlotBattleEvent)
-		require.True(t, ok, "event data should be SlotBattleEvent")
-		assert.Equal(t, uint64(1000), battle.Slot)
-		assert.Equal(t, localHash, battle.LocalBlockHash)
-		assert.Equal(t, remoteHash, battle.RemoteBlockHash)
-		assert.True(t, battle.Won,
-			"local should win when remote block is rejected")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for SlotBattleEvent")
-	}
+	evt := testutil.RequireReceive(
+		t,
+		evtCh,
+		2*time.Second,
+		"timeout waiting for SlotBattleEvent",
+	)
+	battle, ok := evt.Data.(forging.SlotBattleEvent)
+	require.True(t, ok, "event data should be SlotBattleEvent")
+	assert.Equal(t, uint64(1000), battle.Slot)
+	assert.Equal(t, localHash, battle.LocalBlockHash)
+	assert.Equal(t, remoteHash, battle.RemoteBlockHash)
+	assert.True(t, battle.Won,
+		"local should win when remote block is rejected")
 }
 
 func TestCheckSlotBattle_RemoteWinsWhenAccepted(t *testing.T) {
@@ -124,16 +126,17 @@ func TestCheckSlotBattle_RemoteWinsWhenAccepted(t *testing.T) {
 	}
 	ls.checkSlotBattle(e, nil)
 
-	select {
-	case evt := <-evtCh:
-		battle, ok := evt.Data.(forging.SlotBattleEvent)
-		require.True(t, ok)
-		assert.Equal(t, uint64(1000), battle.Slot)
-		assert.False(t, battle.Won,
-			"local should lose when remote block is accepted")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for SlotBattleEvent")
-	}
+	evt := testutil.RequireReceive(
+		t,
+		evtCh,
+		2*time.Second,
+		"timeout waiting for SlotBattleEvent",
+	)
+	battle, ok := evt.Data.(forging.SlotBattleEvent)
+	require.True(t, ok)
+	assert.Equal(t, uint64(1000), battle.Slot)
+	assert.False(t, battle.Won,
+		"local should lose when remote block is accepted")
 }
 
 func TestCheckSlotBattle_NoConflictDifferentSlot(t *testing.T) {
@@ -166,12 +169,12 @@ func TestCheckSlotBattle_NoConflictDifferentSlot(t *testing.T) {
 	ls.checkSlotBattle(e, nil)
 
 	// Verify no event was emitted
-	select {
-	case evt := <-evtCh:
-		t.Fatalf("unexpected SlotBattleEvent: %+v", evt)
-	case <-time.After(50 * time.Millisecond):
-		// Expected: no event emitted
-	}
+	testutil.RequireNoReceive(
+		t,
+		evtCh,
+		50*time.Millisecond,
+		"unexpected SlotBattleEvent",
+	)
 }
 
 func TestCheckSlotBattle_SameHashIsNotBattle(t *testing.T) {
@@ -205,12 +208,12 @@ func TestCheckSlotBattle_SameHashIsNotBattle(t *testing.T) {
 	}
 	ls.checkSlotBattle(e, nil)
 
-	select {
-	case evt := <-evtCh:
-		t.Fatalf("same-hash block should not trigger slot battle: %+v", evt)
-	case <-time.After(50 * time.Millisecond):
-		// Expected: no event for same-hash block
-	}
+	testutil.RequireNoReceive(
+		t,
+		evtCh,
+		50*time.Millisecond,
+		"same-hash block should not trigger slot battle",
+	)
 }
 
 func TestCheckSlotBattle_NilCheckerSkips(t *testing.T) {
@@ -235,12 +238,12 @@ func TestCheckSlotBattle_NilCheckerSkips(t *testing.T) {
 	}
 	ls.checkSlotBattle(e, nil)
 
-	select {
-	case evt := <-evtCh:
-		t.Fatalf("nil checker should not emit events: %+v", evt)
-	case <-time.After(50 * time.Millisecond):
-		// Expected: no event when checker is nil
-	}
+	testutil.RequireNoReceive(
+		t,
+		evtCh,
+		50*time.Millisecond,
+		"nil checker should not emit events",
+	)
 }
 
 func TestCheckSlotBattle_NilEventBus(t *testing.T) {
@@ -315,22 +318,23 @@ func TestCheckSlotBattle_UnderWriteLock(t *testing.T) {
 		ls.Unlock()
 	}()
 
-	select {
-	case <-done:
-		// OK — no deadlock
-	case <-time.After(2 * time.Second):
-		t.Fatal("checkSlotBattle deadlocked under write lock")
-	}
+	testutil.RequireReceive(
+		t,
+		done,
+		2*time.Second,
+		"checkSlotBattle deadlocked under write lock",
+	)
 
-	select {
-	case evt := <-evtCh:
-		battle, ok := evt.Data.(forging.SlotBattleEvent)
-		require.True(t, ok)
-		assert.Equal(t, uint64(1000), battle.Slot)
-		assert.True(t, battle.Won)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for SlotBattleEvent")
-	}
+	evt := testutil.RequireReceive(
+		t,
+		evtCh,
+		2*time.Second,
+		"timeout waiting for SlotBattleEvent",
+	)
+	battle, ok := evt.Data.(forging.SlotBattleEvent)
+	require.True(t, ok)
+	assert.Equal(t, uint64(1000), battle.Slot)
+	assert.True(t, battle.Won)
 }
 
 func TestSetForgedBlockChecker(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced time.After-based waits in ledger tests with `internal/test/testutil` helpers to reduce flakiness and make concurrency assertions clearer. Improves reliability in chainsync and slot battle test cases without changing behavior.

- **Refactors**
  - Swapped select/time.After patterns for `testutil.RequireReceive`, `testutil.RequireNoReceive`, and `testutil.WaitForCondition` across `ledger/chainsync_replay_shutdown_test.go`, `ledger/chainsync_rollback_test.go`, and `ledger/slot_battle_test.go`.
  - Added a defer-guarded unlock for `chainsyncMutex` to avoid leaks if a test fails early.
  - Simplified event and channel assertions with explicit timeouts.

<sup>Written for commit 8d421263b2f7ae27449edec7d8b06c56ce9e79ba. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2421?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

