### PR TITLE
fix(chain): iterator race near tip

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1241,15 +1241,18 @@ func (c *Chain) iterNext(
 			c.manager.mutex.RUnlock()
 			return nil, ErrIteratorChainTip
 		}
-		c.mutex.Unlock()
-		c.manager.mutex.RUnlock()
-		// Wait for chain update
+		// Register the wait channel before releasing c.mutex. Otherwise
+		// a concurrent AddBlock can commit and notify in the gap between
+		// the at-tip check above and this iterator joining the waiter set,
+		// stranding ChainSync peers until a later chain event.
 		c.waitingChanMutex.Lock()
 		if c.waitingChan == nil {
 			c.waitingChan = make(chan struct{})
 		}
 		waitChan := c.waitingChan
 		c.waitingChanMutex.Unlock()
+		c.mutex.Unlock()
+		c.manager.mutex.RUnlock()
 
 		select {
 		case <-waitChan:

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	mockfixtures "github.com/blinklabs-io/ouroboros-mock/fixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 func TestIteratorCancelRemovesFromChain(t *testing.T) {
@@ -221,4 +223,89 @@ func TestIterNextSpuriousWakeups(t *testing.T) {
 	require.Error(t, r.err,
 		"cancelled iterator should return an error",
 	)
+}
+
+func TestIterNextRegistersWaitBeforeChainUpdateCanCommit(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := NewManager(nil, eventBus)
+	require.NoError(t, err)
+
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	iter, err := c.FromPoint(ocommon.Point{}, true)
+	require.NoError(t, err)
+	defer iter.Cancel()
+
+	type iterResult struct {
+		result *ChainIteratorResult
+		err    error
+	}
+	resultCh := make(chan iterResult, 1)
+	addDone := make(chan error, 1)
+
+	c.waitingChanMutex.Lock()
+	waitMutexLocked := true
+	defer func() {
+		if waitMutexLocked {
+			c.waitingChanMutex.Unlock()
+		}
+	}()
+
+	go func() {
+		res, err := iter.Next(true)
+		resultCh <- iterResult{result: res, err: err}
+	}()
+
+	testutil.WaitForCondition(t, func() bool {
+		if c.mutex.TryLock() {
+			c.mutex.Unlock()
+			return false
+		}
+		return true
+	}, 2*time.Second, "iterator should hold chain lock at tip")
+
+	blockFixture, err := mockfixtures.NewHarness(
+		mockfixtures.HarnessConfig{},
+	).Fixture(
+		"ouroboros-consensus/ouroboros-consensus-cardano/" +
+			"golden/cardano/CardanoNodeToNodeVersion2/Block_Conway",
+	)
+	require.NoError(t, err)
+	block, err := blockFixture.DecodeLedgerBlock()
+	require.NoError(t, err)
+	blockHash := block.Hash().Bytes()
+
+	go func() {
+		addDone <- c.AddBlock(block, nil)
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		addDone,
+		50*time.Millisecond,
+		"chain update committed before iterator registered wait channel",
+	)
+
+	c.waitingChanMutex.Unlock()
+	waitMutexLocked = false
+
+	addErr := testutil.RequireReceive(
+		t,
+		addDone,
+		2*time.Second,
+		"chain update should complete after wait registration",
+	)
+	require.NoError(t, addErr)
+
+	r := testutil.RequireReceive(
+		t,
+		resultCh,
+		2*time.Second,
+		"iterator should receive newly added block",
+	)
+	require.NoError(t, r.err)
+	require.NotNil(t, r.result)
+	assert.Equal(t, block.BlockNumber(), r.result.Block.Number)
+	assert.Equal(t, blockHash, r.result.Point.Hash)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race at the chain tip where iterators could miss a block notification and stall. We now register the wait channel before releasing locks so new blocks are delivered reliably.

- **Bug Fixes**
  - Register iterator wait channel before unlocking `c.mutex` and `c.manager.mutex` to close the gap with concurrent `AddBlock`.
  - Added `TestIterNextRegistersWaitBeforeChainUpdateCanCommit` using `ouroboros-mock` fixtures to reproduce and prevent regressions.

<sup>Written for commit 5937dd1234ec1eb8263dbfee399efc642e58eebf. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2422?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

