### PR TITLE
 fix(mempool): LocalTxSubmission rejection CBOR is a bare text string; cardano-cli 10.x expects HardFork list format

### DIFF
--- a/ouroboros/localtxsubmission.go
+++ b/ouroboros/localtxsubmission.go
@@ -15,9 +15,12 @@
 package ouroboros
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	olocaltxsubmission "github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
 )
 
@@ -63,7 +66,106 @@ func (o *Ouroboros) localtxsubmissionServerSubmitTx(
 			"role", "server",
 			"connection_id", ctx.ConnectionId.String(),
 		)
-		return err
+		return newLocalTxSubmissionRejectReason(tx.EraId, err)
 	}
 	return nil
+}
+
+type cborRejectReason interface {
+	error
+	MarshalCBOR() ([]byte, error)
+}
+
+type hardForkApplyTxError struct {
+	era uint8
+	err error
+}
+
+func newLocalTxSubmissionRejectReason(
+	eraId uint16,
+	err error,
+) error {
+	var typed cborRejectReason
+	if errors.As(err, &typed) {
+		return err
+	}
+	return &hardForkApplyTxError{
+		era: uint8(eraId), //nolint:gosec // Cardano era IDs fit in uint8
+		err: err,
+	}
+}
+
+func (e *hardForkApplyTxError) Error() string {
+	return e.err.Error()
+}
+
+func (e *hardForkApplyTxError) Unwrap() error {
+	return e.err
+}
+
+func (e *hardForkApplyTxError) MarshalCBOR() ([]byte, error) {
+	return cbor.Encode([]any{
+		[]any{
+			e.era,
+			[]any{
+				[]any{
+					gledger.ApplyTxErrorUtxowFailure,
+					e.utxowFailure(),
+				},
+			},
+		},
+	})
+}
+
+func (e *hardForkApplyTxError) utxowFailure() []any {
+	utxoFailure := []any{
+		e.era,
+		e.inputSetEmptyFailure(),
+	}
+
+	switch e.era {
+	case gledger.EraIdShelley, gledger.EraIdAllegra, gledger.EraIdMary:
+		return []any{
+			gledger.ShelleyUtxowUtxoFailure,
+			utxoFailure,
+		}
+	case gledger.EraIdAlonzo:
+		return []any{
+			gledger.AlonzoUtxowShelleyInAlonzo,
+			[]any{
+				gledger.ShelleyUtxowUtxoFailure,
+				utxoFailure,
+			},
+		}
+	case gledger.EraIdBabbage:
+		return []any{
+			gledger.BabbageUtxowUtxoFailure,
+			[]any{
+				gledger.BabbageUtxoAlonzoInBabbage,
+				utxoFailure,
+			},
+		}
+	case gledger.EraIdConway:
+		return []any{
+			gledger.ConwayUtxowUtxoFailure,
+			utxoFailure,
+		}
+	default:
+		return []any{
+			gledger.ConwayUtxowUtxoFailure,
+			[]any{
+				gledger.EraIdConway,
+				[]any{gledger.ConwayUtxoInputSetEmptyUTxO},
+			},
+		}
+	}
+}
+
+func (e *hardForkApplyTxError) inputSetEmptyFailure() []any {
+	switch e.era {
+	case gledger.EraIdConway:
+		return []any{gledger.ConwayUtxoInputSetEmptyUTxO}
+	default:
+		return []any{gledger.UtxoFailureInputSetEmpty}
+	}
 }

--- a/ouroboros/localtxsubmission_test.go
+++ b/ouroboros/localtxsubmission_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalTxSubmissionRejectReason_FallbackIsHardForkApplyTxErr(t *testing.T) {
+	for _, era := range []uint16{
+		gledger.EraIdShelley,
+		gledger.EraIdAllegra,
+		gledger.EraIdMary,
+		gledger.EraIdAlonzo,
+		gledger.EraIdBabbage,
+		gledger.EraIdConway,
+	} {
+		t.Run(gledger.GetEraById(uint8(era)).Name, func(t *testing.T) {
+			err := newLocalTxSubmissionRejectReason(
+				era,
+				errors.New("plain validation failure"),
+			)
+			reason, ok := err.(cborRejectReason)
+			require.True(t, ok)
+
+			wireBytes, marshalErr := reason.MarshalCBOR()
+			require.NoError(t, marshalErr)
+
+			decoded, decodeErr := gledger.NewTxSubmitErrorFromCbor(wireBytes)
+			require.NoError(t, decodeErr)
+
+			var validationErr *gledger.ShelleyTxValidationError
+			require.ErrorAs(t, decoded, &validationErr)
+			assert.Equal(t, uint8(era), validationErr.Era)
+		})
+	}
+}
+
+func TestLocalTxSubmissionRejectReason_PreservesTypedReason(t *testing.T) {
+	typed := &gledger.EraMismatch{
+		OtherEra: gledger.EraInfo{
+			Index: gledger.EraIdShelley,
+			Name:  "Shelley",
+		},
+		LedgerEra: gledger.EraInfo{
+			Index: gledger.EraIdByron,
+			Name:  "Byron",
+		},
+	}
+	wrapped := fmt.Errorf("validate transaction: %w", typed)
+
+	err := newLocalTxSubmissionRejectReason(gledger.EraIdShelley, wrapped)
+	assert.Same(t, wrapped, err)
+
+	var reason cborRejectReason
+	require.ErrorAs(t, err, &reason)
+
+	wireBytes, marshalErr := reason.MarshalCBOR()
+	require.NoError(t, marshalErr)
+
+	decoded, decodeErr := gledger.NewTxSubmitErrorFromCbor(wireBytes)
+	require.NoError(t, decodeErr)
+
+	var eraMismatch *gledger.EraMismatch
+	require.ErrorAs(t, decoded, &eraMismatch)
+	assert.Equal(t, typed.OtherEra, eraMismatch.OtherEra)
+	assert.Equal(t, typed.LedgerEra, eraMismatch.LedgerEra)
+}


### PR DESCRIPTION
1. Made changes to wrap untyped errors with hardForkApplyTxError that implements cborRejectReason and CBOR encoding; typed CBOR errors pass through unchanged.
2. Added unit-tests to validate this part.

Closes #2214 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix LocalTxSubmission reject reasons to encode as the HardFork ApplyTxError list expected by `cardano-cli` 10.x. Previously we returned a bare text string.

- **Bug Fixes**
  - Wrap untyped errors with `hardForkApplyTxError` that implements `cborRejectReason` and CBOR encoding; typed CBOR errors pass through unchanged.
  - Encode era-specific UTXOW failures per `gouroboros/ledger` for Shelley, Allegra, Mary, Alonzo, Babbage, and Conway (with sensible defaults).
  - Add tests for fallback encoding and typed error preservation.

<sup>Written for commit 532dc7fc6787b42410aae8cbf37ea82655dece75. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2427?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for transaction mempool insertion failures with better error conversion and era-specific formatting.

* **Tests**
  * Added test coverage for transaction rejection error handling across different Cardano eras.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->