### PR TITLE
fix(chain): let ChainIterator inherit caller context

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -16,6 +16,7 @@ package chain
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1055,12 +1056,23 @@ func (c *Chain) FromPoint(
 	point ocommon.Point,
 	inclusive bool,
 ) (*ChainIterator, error) {
+	return c.FromPointContext(context.Background(), point, inclusive)
+}
+
+// FromPointContext returns a ChainIterator that inherits cancellation from
+// ctx.
+func (c *Chain) FromPointContext(
+	ctx context.Context,
+	point ocommon.Point,
+	inclusive bool,
+) (*ChainIterator, error) {
 	if c == nil {
 		return nil, errors.New("chain is nil")
 	}
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	iter, err := newChainIterator(
+	iter, err := newChainIteratorWithContext(
+		ctx,
 		c,
 		point,
 		inclusive,
@@ -1070,6 +1082,7 @@ func (c *Chain) FromPoint(
 		return nil, err
 	}
 	c.iterators = append(c.iterators, iter)
+	iter.startCancelWatcher()
 	return iter, nil
 }
 
@@ -1082,12 +1095,23 @@ func (c *Chain) FromPointReverse(
 	point ocommon.Point,
 	inclusive bool,
 ) (*ChainIterator, error) {
+	return c.FromPointReverseContext(context.Background(), point, inclusive)
+}
+
+// FromPointReverseContext returns a reverse ChainIterator that inherits
+// cancellation from ctx.
+func (c *Chain) FromPointReverseContext(
+	ctx context.Context,
+	point ocommon.Point,
+	inclusive bool,
+) (*ChainIterator, error) {
 	if c == nil {
 		return nil, errors.New("chain is nil")
 	}
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	iter, err := newChainIterator(
+	iter, err := newChainIteratorWithContext(
+		ctx,
 		c,
 		point,
 		inclusive,
@@ -1097,6 +1121,7 @@ func (c *Chain) FromPointReverse(
 		return nil, err
 	}
 	c.iterators = append(c.iterators, iter)
+	iter.startCancelWatcher()
 	return iter, nil
 }
 

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1059,8 +1059,7 @@ func (c *Chain) FromPoint(
 	return c.FromPointContext(context.Background(), point, inclusive)
 }
 
-// FromPointContext returns a ChainIterator that inherits cancellation from
-// ctx.
+// FromPointContext returns a ChainIterator that inherits cancellation from ctx.
 func (c *Chain) FromPointContext(
 	ctx context.Context,
 	point ocommon.Point,
@@ -1098,8 +1097,7 @@ func (c *Chain) FromPointReverse(
 	return c.FromPointReverseContext(context.Background(), point, inclusive)
 }
 
-// FromPointReverseContext returns a reverse ChainIterator that inherits
-// cancellation from ctx.
+// FromPointReverseContext returns a reverse ChainIterator that inherits cancellation from ctx.
 func (c *Chain) FromPointReverseContext(
 	ctx context.Context,
 	point ocommon.Point,

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -48,6 +48,9 @@ func newChainIteratorWithContext(
 	inclusive bool,
 	reverse bool,
 ) (*ChainIterator, error) {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
 	iterCtx, cancel := context.WithCancel(parentCtx)
 	ci := &ChainIterator{
 		chain:          chain,

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -16,6 +16,7 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -49,7 +50,7 @@ func newChainIteratorWithContext(
 	reverse bool,
 ) (*ChainIterator, error) {
 	if parentCtx == nil {
-		parentCtx = context.Background()
+		return nil, errors.New("chain iterator context is nil")
 	}
 	iterCtx, cancel := context.WithCancel(parentCtx)
 	ci := &ChainIterator{

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -41,38 +41,23 @@ type ChainIteratorResult struct {
 	Rollback bool
 }
 
-func newChainIterator(
-	chain *Chain,
-	startPoint ocommon.Point,
-	inclusive bool,
-	reverse bool,
-) (*ChainIterator, error) {
-	return newChainIteratorWithContext(
-		context.Background(),
-		chain,
-		startPoint,
-		inclusive,
-		reverse,
-	)
-}
-
 func newChainIteratorWithContext(
-	ctx context.Context,
+	parentCtx context.Context,
 	chain *Chain,
 	startPoint ocommon.Point,
 	inclusive bool,
 	reverse bool,
 ) (*ChainIterator, error) {
-	if ctx == nil {
-		ctx = context.Background()
+	if parentCtx == nil {
+		parentCtx = context.Background()
 	}
-	ctx, cancel := context.WithCancel(ctx)
+	iterCtx, cancel := context.WithCancel(parentCtx)
 	ci := &ChainIterator{
 		chain:          chain,
 		startPoint:     startPoint,
 		nextBlockIndex: initialBlockIndex,
 		reverse:        reverse,
-		ctx:            ctx,
+		ctx:            iterCtx,
 		cancel:         cancel,
 	}
 	// Lookup start block in metadata DB if not origin

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -16,6 +16,7 @@ package chain
 
 import (
 	"context"
+	"sync"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -31,6 +32,7 @@ type ChainIterator struct {
 	reverse        bool
 	ctx            context.Context
 	cancel         context.CancelFunc
+	cancelOnce     sync.Once
 }
 
 type ChainIteratorResult struct {
@@ -45,7 +47,26 @@ func newChainIterator(
 	inclusive bool,
 	reverse bool,
 ) (*ChainIterator, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	return newChainIteratorWithContext(
+		context.Background(),
+		chain,
+		startPoint,
+		inclusive,
+		reverse,
+	)
+}
+
+func newChainIteratorWithContext(
+	ctx context.Context,
+	chain *Chain,
+	startPoint ocommon.Point,
+	inclusive bool,
+	reverse bool,
+) (*ChainIterator, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
 	ci := &ChainIterator{
 		chain:          chain,
 		startPoint:     startPoint,
@@ -83,6 +104,13 @@ func newChainIterator(
 	return ci, nil
 }
 
+func (ci *ChainIterator) startCancelWatcher() {
+	go func() {
+		<-ci.ctx.Done()
+		ci.Cancel()
+	}()
+}
+
 func (ci *ChainIterator) Next(blocking bool) (*ChainIteratorResult, error) {
 	ret, err := ci.chain.iterNext(ci, blocking)
 	if ret == nil && err == nil {
@@ -92,11 +120,13 @@ func (ci *ChainIterator) Next(blocking bool) (*ChainIteratorResult, error) {
 }
 
 func (ci *ChainIterator) Cancel() {
-	if ci.cancel != nil {
-		ci.cancel()
-	}
-	// Remove from chain's iterator list to prevent memory leak
-	if ci.chain != nil {
-		ci.chain.removeIterator(ci)
-	}
+	ci.cancelOnce.Do(func() {
+		if ci.cancel != nil {
+			ci.cancel()
+		}
+		// Remove from chain's iterator list to prevent memory leak
+		if ci.chain != nil {
+			ci.chain.removeIterator(ci)
+		}
+	})
 }

--- a/chain/iter.go
+++ b/chain/iter.go
@@ -48,9 +48,6 @@ func newChainIteratorWithContext(
 	inclusive bool,
 	reverse bool,
 ) (*ChainIterator, error) {
-	if parentCtx == nil {
-		parentCtx = context.Background()
-	}
 	iterCtx, cancel := context.WithCancel(parentCtx)
 	ci := &ChainIterator{
 		chain:          chain,

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -131,6 +131,8 @@ func TestIteratorCancelIdempotent(t *testing.T) {
 	c.mutex.RUnlock()
 }
 
+// TestIteratorParentContextCancelUnblocksNext verifies that a blocking
+// iterator created with a parent context exits when that parent is canceled.
 func TestIteratorParentContextCancelUnblocksNext(t *testing.T) {
 	eventBus := event.NewEventBus(nil, nil)
 	cm, err := NewManager(nil, eventBus)

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -15,6 +15,8 @@
 package chain
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -127,6 +129,55 @@ func TestIteratorCancelIdempotent(t *testing.T) {
 	c.mutex.RLock()
 	assert.Equal(t, 0, len(c.iterators))
 	c.mutex.RUnlock()
+}
+
+func TestIteratorParentContextCancelUnblocksNext(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := NewManager(nil, eventBus)
+	require.NoError(t, err)
+
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	iter, err := c.FromPointContext(ctx, ocommon.Point{}, true)
+	require.NoError(t, err)
+	defer iter.Cancel()
+
+	type iterResult struct {
+		result *ChainIteratorResult
+		err    error
+	}
+	resultCh := make(chan iterResult, 1)
+
+	go func() {
+		res, err := iter.Next(true)
+		resultCh <- iterResult{result: res, err: err}
+	}()
+
+	testutil.WaitForCondition(t, func() bool {
+		c.waitingChanMutex.Lock()
+		defer c.waitingChanMutex.Unlock()
+		return c.waitingChan != nil
+	}, 2*time.Second, "iterator should block waiting for a chain update")
+
+	cancel()
+
+	r := testutil.RequireReceive(
+		t,
+		resultCh,
+		2*time.Second,
+		"parent context cancellation should unblock iterator",
+	)
+	require.Nil(t, r.result)
+	require.Error(t, r.err)
+	require.True(t, errors.Is(r.err, context.Canceled))
+
+	testutil.WaitForCondition(t, func() bool {
+		c.mutex.RLock()
+		defer c.mutex.RUnlock()
+		return len(c.iterators) == 0
+	}, 2*time.Second, "parent context cancellation should remove iterator")
 }
 
 // TestIterNextSpuriousWakeups verifies that the blocking

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -95,7 +95,7 @@ func TestIteratorCancelMultiple(t *testing.T) {
 	c.mutex.RLock()
 	assert.Equal(t, 2, len(c.iterators))
 	for _, it := range c.iterators {
-		assert.NotEqual(t, iter2, it)
+		assert.False(t, it == iter2)
 	}
 	c.mutex.RUnlock()
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2276,7 +2276,7 @@ func (ls *LedgerState) ledgerReadChain(
 		startPoint := ls.currentTip.Point
 		ls.RUnlock()
 		// Create chain iterator
-		iter, err := ls.chain.FromPoint(startPoint, false)
+		iter, err := ls.chain.FromPointContext(ctx, startPoint, false)
 		if err != nil {
 			if !errors.Is(err, models.ErrBlockNotFound) {
 				ls.config.Logger.Warn(
@@ -4812,6 +4812,16 @@ func (ls *LedgerState) GetChainFromPoint(
 	return ls.chain.FromPoint(point, inclusive)
 }
 
+// GetChainFromPointContext returns a ChainIterator that inherits cancellation
+// from ctx.
+func (ls *LedgerState) GetChainFromPointContext(
+	ctx context.Context,
+	point ocommon.Point,
+	inclusive bool,
+) (*chain.ChainIterator, error) {
+	return ls.chain.FromPointContext(ctx, point, inclusive)
+}
+
 // GetChainFromPointReverse returns a ChainIterator that walks backward from
 // the specified point toward chain origin. If inclusive is true the iterator
 // yields the start point first; otherwise it yields the preceding block.
@@ -4820,6 +4830,16 @@ func (ls *LedgerState) GetChainFromPointReverse(
 	inclusive bool,
 ) (*chain.ChainIterator, error) {
 	return ls.chain.FromPointReverse(point, inclusive)
+}
+
+// GetChainFromPointReverseContext returns a reverse ChainIterator that
+// inherits cancellation from ctx.
+func (ls *LedgerState) GetChainFromPointReverseContext(
+	ctx context.Context,
+	point ocommon.Point,
+	inclusive bool,
+) (*chain.ChainIterator, error) {
+	return ls.chain.FromPointReverseContext(ctx, point, inclusive)
 }
 
 // Tip returns the current chain tip

--- a/utxorpc/sync.go
+++ b/utxorpc/sync.go
@@ -138,7 +138,8 @@ func (s *syncServiceServer) DumpHistory(
 		inclusive = false
 	}
 
-	chainIter, err := s.utxorpc.config.LedgerState.GetChainFromPoint(
+	chainIter, err := s.utxorpc.config.LedgerState.GetChainFromPointContext(
+		ctx,
 		startPoint,
 		inclusive,
 	)
@@ -218,7 +219,8 @@ func (s *syncServiceServer) FollowTip(
 	}
 
 	// Create our chain iterator
-	chainIter, err := s.utxorpc.config.LedgerState.GetChainFromPoint(
+	chainIter, err := s.utxorpc.config.LedgerState.GetChainFromPointContext(
+		ctx,
 		*point,
 		false,
 	)
@@ -231,13 +233,6 @@ func (s *syncServiceServer) FollowTip(
 	}
 
 	defer chainIter.Cancel()
-
-	// Cancel the chain iterator when the gRPC stream context is
-	// done so that blocking Next() calls unblock immediately.
-	go func() {
-		<-ctx.Done()
-		chainIter.Cancel()
-	}()
 
 	for {
 		// Check for available block

--- a/utxorpc/watch.go
+++ b/utxorpc/watch.go
@@ -238,7 +238,8 @@ func (s *watchServiceServer) WatchTx(
 	}
 
 	// Create our chain iterator
-	chainIter, err := s.utxorpc.config.LedgerState.GetChainFromPoint(
+	chainIter, err := s.utxorpc.config.LedgerState.GetChainFromPointContext(
+		ctx,
 		*point,
 		false,
 	)
@@ -251,13 +252,6 @@ func (s *watchServiceServer) WatchTx(
 	}
 
 	defer chainIter.Cancel()
-
-	// Cancel the chain iterator when the gRPC stream context is
-	// done so that blocking Next() calls unblock immediately.
-	go func() {
-		<-ctx.Done()
-		chainIter.Cancel()
-	}()
 
 	shouldSend := func(tx ledger.Transaction) bool {
 		if predicate == nil {


### PR DESCRIPTION
1. Added context-aware chain iterator constructors such as Chain.FromPointContext, Chain.FromPointReverseContext, LedgerState.GetChainFromPointContext, LedgerState.GetChainFromPointReverseContext.
2. Preserved explicit ChainIterator.Cancel() for early termination and Updated ledger, utxo rpc call sites to pass request/shutdown contexts into iterators.
3. Made iterator cancellation idempotent with sync.Once and removed rpc goroutines that manually canceled iterators on ctx.Done().
4. Added a regression test proving parent context cancellation unblocks Next(true).

Closes #2291 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chain iterators now inherit the caller’s context, so blocked `Next(true)` exits on cancellation and iterators are cleaned up promptly. Closes #2291.

- **Bug Fixes**
  - Added context-aware constructors: `chain.FromPointContext`, `chain.FromPointReverseContext`, `ledger.GetChainFromPointContext`, `ledger.GetChainFromPointReverseContext`.
  - Iterators inherit and watch parent ctx; Cancel is idempotent via `sync.Once`.
  - `ledger` and `utxorpc` pass request ctx to iterators; removed manual `ctx.Done` goroutines.
  - Nil parent ctx now returns an error (no `context.Background()` fallback); regression test proves cancellation unblocks `Next(true)` and removes the iterator.

<sup>Written for commit 692b57b079ead8b1cf78faef0494362a9fedc7d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2429?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync operations (history dumps, tip following, transaction watching) now properly respond to context cancellation requests, enabling users to cleanly interrupt and stop long-running operations.
  * Iterator cancellation is now fully idempotent and more robust, significantly improving the reliability of resource cleanup and preventing issues from duplicate cancellation attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->