### PR TITLE
fix: set network in database

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -472,6 +472,7 @@ func runMithrilSync(
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: cfg.DatabaseWorkers,
 		StorageMode:    cfg.StorageMode,
+		Network:        cfg.Network,
 	})
 	if err != nil {
 		// Tolerate a recoverable commit-timestamp mismatch carried

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -75,6 +75,7 @@ func checkSyncState(
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: 1,
 		StorageMode:    cfg.StorageMode,
+		Network:        cfg.Network,
 	})
 	if err != nil {
 		// A commit-timestamp mismatch is recoverable downstream in
@@ -149,6 +150,7 @@ func resumeBackfill(
 		MetadataPlugin: cfg.MetadataPlugin,
 		MaxConnections: cfg.DatabaseWorkers,
 		StorageMode:    cfg.StorageMode,
+		Network:        cfg.Network,
 	})
 	if err != nil {
 		// Backfill writes through full transactions which heal a


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the database network from config so all sync paths open the DB with the correct network, preventing cross-network state issues during sync, state checks, and backfill.

- **Bug Fixes**
  - Pass `Network: cfg.Network` to DB options in `runMithrilSync`, `checkSyncState`, and `resumeBackfill`.

<sup>Written for commit f88b709ecdcba352d51c67ae63cfbb0b9fffa93f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2444?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network configuration is now consistently passed to the database during initialization across all critical paths, including snapshot bootstrap, synchronization state verification, and metadata backfill resume operations. This ensures the database is configured with the correct network settings in all startup scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->