### PR TITLE
fix(database): postgres epoch summary persistence

### DIFF
--- a/database/plugin/metadata/postgres/stake_snapshot.go
+++ b/database/plugin/metadata/postgres/stake_snapshot.go
@@ -200,7 +200,9 @@ func (d *MetadataStorePostgres) SaveEpochSummary(
 				}),
 				clause.Assignment{
 					Column: clause.Column{Name: "snapshot_ready"},
-					Value:  clause.Expr{SQL: "snapshot_ready OR excluded.snapshot_ready"},
+					Value: clause.Expr{
+						SQL: `"epoch_summary"."snapshot_ready" OR excluded.snapshot_ready`,
+					},
 				},
 			),
 		},

--- a/database/plugin/metadata/postgres/stake_snapshot_test.go
+++ b/database/plugin/metadata/postgres/stake_snapshot_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveEpochSummaryUpsertSnapshotReadyPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const epoch = uint64(424242)
+	require.NoError(t, store.DB().Where("epoch = ?", epoch).Delete(&models.EpochSummary{}).Error)
+	t.Cleanup(func() {
+		_ = store.DB().Where("epoch = ?", epoch).Delete(&models.EpochSummary{}).Error
+	})
+
+	initial := &models.EpochSummary{
+		Epoch:            epoch,
+		TotalActiveStake: types.Uint64(1000),
+		TotalPoolCount:   10,
+		TotalDelegators:  100,
+		BoundarySlot:     1,
+		SnapshotReady:    false,
+	}
+	require.NoError(t, store.SaveEpochSummary(initial, nil))
+
+	updated := &models.EpochSummary{
+		Epoch:            epoch,
+		TotalActiveStake: types.Uint64(2000),
+		TotalPoolCount:   20,
+		TotalDelegators:  200,
+		BoundarySlot:     2,
+		SnapshotReady:    true,
+	}
+	require.NoError(t, store.SaveEpochSummary(updated, nil))
+
+	again := &models.EpochSummary{
+		Epoch:            epoch,
+		TotalActiveStake: types.Uint64(3000),
+		TotalPoolCount:   30,
+		TotalDelegators:  300,
+		BoundarySlot:     3,
+		SnapshotReady:    false,
+	}
+	require.NoError(t, store.SaveEpochSummary(again, nil))
+
+	retrieved, err := store.GetEpochSummary(epoch, nil)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, types.Uint64(3000), retrieved.TotalActiveStake)
+	require.True(t, retrieved.SnapshotReady)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Postgres epoch summary upsert so `snapshot_ready` stays true once set and isn’t overwritten by later updates. Prevents lost snapshot flags during `SaveEpochSummary`.

- **Bug Fixes**
  - Qualifies the conflict update to use `"epoch_summary"."snapshot_ready" OR excluded.snapshot_ready"`.
  - Adds `TestSaveEpochSummaryUpsertSnapshotReadyPostgres` to confirm the flag remains true while other fields continue updating.

<sup>Written for commit ccb5d58dce7a1fea7db119ea6922891995e7d52d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2445?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

