### PR TITLE
fix(database): transaction import gap utxos

### DIFF
--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -745,12 +745,18 @@ func (d *MetadataStoreMysql) SetGapBlockTransaction(
 		m := models.UtxoLedgerToModel(utxo, point.Slot)
 		tmpTx.Outputs = append(tmpTx.Outputs, m)
 	}
+	outputsToCreate := tmpTx.Outputs
+	collateralReturnToCreate := tmpTx.CollateralReturn
+	tmpTx.Outputs = nil
+	tmpTx.CollateralReturn = nil
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"block_hash", "block_index", "slot"},
 		),
 	}).Create(tmpTx)
+	tmpTx.Outputs = outputsToCreate
+	tmpTx.CollateralReturn = collateralReturnToCreate
 	if result.Error != nil {
 		return fmt.Errorf(
 			"create gap block transaction at slot %d: %w",
@@ -772,6 +778,31 @@ func (d *MetadataStoreMysql) SetGapBlockTransaction(
 			)
 		}
 		tmpTx.ID = existingTx.ID
+	}
+	for i := range tmpTx.Outputs {
+		tmpTx.Outputs[i].ID = 0
+		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
+	}
+	if len(tmpTx.Outputs) > 0 {
+		if err := d.ImportUtxos(tmpTx.Outputs, txn); err != nil {
+			return fmt.Errorf(
+				"create gap block utxo outputs for tx %x: %w",
+				txHash, err,
+			)
+		}
+	}
+	if tmpTx.CollateralReturn != nil {
+		tmpTx.CollateralReturn.ID = 0
+		tmpTx.CollateralReturn.CollateralReturnForTxID = &tmpTx.ID
+		if err := d.ImportUtxos(
+			[]models.Utxo{*tmpTx.CollateralReturn},
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"create gap block collateral return for tx %x: %w",
+				txHash, err,
+			)
+		}
 	}
 	return nil
 }

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
 
@@ -40,6 +41,8 @@ type mockTransaction struct {
 	hash         lcommon.Blake2b256
 	certificates []lcommon.Certificate
 	isValid      bool
+	produced     []lcommon.Utxo
+	collReturn   lcommon.TransactionOutput
 }
 
 func (m *mockTransaction) Hash() lcommon.Blake2b256 {
@@ -79,11 +82,11 @@ func (m *mockTransaction) RawAuxiliaryData() []byte {
 }
 
 func (m *mockTransaction) CollateralReturn() lcommon.TransactionOutput {
-	return nil
+	return m.collReturn
 }
 
 func (m *mockTransaction) Produced() []lcommon.Utxo {
-	return nil
+	return m.produced
 }
 
 func (m *mockTransaction) Outputs() []lcommon.TransactionOutput {
@@ -172,6 +175,75 @@ func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
 
 func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
 	return lcommon.Blake2b256{}
+}
+
+type mockTransactionInput struct {
+	hash  lcommon.Blake2b256
+	index uint32
+}
+
+func (m mockTransactionInput) Id() lcommon.Blake2b256 {
+	return m.hash
+}
+
+func (m mockTransactionInput) Index() uint32 {
+	return m.index
+}
+
+func (m mockTransactionInput) String() string {
+	return m.hash.String()
+}
+
+func (m mockTransactionInput) Utxorpc() (*cardano.TxInput, error) {
+	return nil, nil
+}
+
+func (m mockTransactionInput) ToPlutusData() data.PlutusData {
+	return nil
+}
+
+type mockTransactionOutput struct {
+	amount *big.Int
+}
+
+func (m *mockTransactionOutput) Address() lcommon.Address {
+	return lcommon.Address{}
+}
+
+func (m *mockTransactionOutput) Amount() *big.Int {
+	return m.amount
+}
+
+func (m *mockTransactionOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return nil
+}
+
+func (m *mockTransactionOutput) Datum() *lcommon.Datum {
+	return nil
+}
+
+func (m *mockTransactionOutput) DatumHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+func (m *mockTransactionOutput) Cbor() []byte {
+	return nil
+}
+
+func (m *mockTransactionOutput) Utxorpc() (*cardano.TxOutput, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionOutput) ScriptRef() lcommon.Script {
+	return nil
+}
+
+func (m *mockTransactionOutput) ToPlutusData() data.PlutusData {
+	return nil
+}
+
+func (m *mockTransactionOutput) String() string {
+	return ""
 }
 
 // isPostgresConfigured checks if postgres is configured via cmdlineOptions or environment variables.

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -747,12 +747,18 @@ func (d *MetadataStorePostgres) SetGapBlockTransaction(
 		m := models.UtxoLedgerToModel(utxo, point.Slot)
 		tmpTx.Outputs = append(tmpTx.Outputs, m)
 	}
+	outputsToCreate := tmpTx.Outputs
+	collateralReturnToCreate := tmpTx.CollateralReturn
+	tmpTx.Outputs = nil
+	tmpTx.CollateralReturn = nil
 	result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "hash"}},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"block_hash", "block_index", "slot"},
 		),
 	}).Create(tmpTx)
+	tmpTx.Outputs = outputsToCreate
+	tmpTx.CollateralReturn = collateralReturnToCreate
 	if result.Error != nil {
 		return fmt.Errorf(
 			"create gap block transaction at slot %d: %w",
@@ -774,6 +780,31 @@ func (d *MetadataStorePostgres) SetGapBlockTransaction(
 			)
 		}
 		tmpTx.ID = existingTx.ID
+	}
+	for i := range tmpTx.Outputs {
+		tmpTx.Outputs[i].ID = 0
+		tmpTx.Outputs[i].TransactionID = &tmpTx.ID
+	}
+	if len(tmpTx.Outputs) > 0 {
+		if err := d.ImportUtxos(tmpTx.Outputs, txn); err != nil {
+			return fmt.Errorf(
+				"create gap block utxo outputs for tx %x: %w",
+				txHash, err,
+			)
+		}
+	}
+	if tmpTx.CollateralReturn != nil {
+		tmpTx.CollateralReturn.ID = 0
+		tmpTx.CollateralReturn.CollateralReturnForTxID = &tmpTx.ID
+		if err := d.ImportUtxos(
+			[]models.Utxo{*tmpTx.CollateralReturn},
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"create gap block collateral return for tx %x: %w",
+				txHash, err,
+			)
+		}
 	}
 	return nil
 }

--- a/database/plugin/metadata/postgres/transaction_gap_test.go
+++ b/database/plugin/metadata/postgres/transaction_gap_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGapBlockTransactionHydratesSnapshotUtxoPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+
+	txHash := lcommon.NewBlake2b256(
+		[]byte("pg-gap-hydrate-snapshot-utxo-1"),
+	)
+	point := ocommon.Point{
+		Hash: []byte("pg-gap-hydrate-block-hash-1"),
+		Slot: 700001,
+	}
+	output := &mockTransactionOutput{amount: big.NewInt(1_241_280)}
+	tx := &mockTransaction{
+		hash:    txHash,
+		isValid: true,
+		produced: []lcommon.Utxo{
+			{
+				Id: mockTransactionInput{
+					hash:  txHash,
+					index: 0,
+				},
+				Output: output,
+			},
+		},
+	}
+
+	cleanup := func() {
+		_ = store.DB().
+			Where("tx_id = ?", txHash.Bytes()).
+			Delete(&models.Utxo{}).Error
+		_ = store.DB().
+			Where("hash = ?", txHash.Bytes()).
+			Delete(&models.Transaction{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:      txHash.Bytes(),
+		OutputIdx: 0,
+		AddedSlot: point.Slot + 100,
+		Amount:    types.Uint64(1_241_280),
+	}).Error)
+
+	require.NoError(t, store.SetGapBlockTransaction(tx, point, 0, nil))
+	require.NoError(t, store.SetGapBlockTransaction(tx, point, 0, nil))
+
+	var persistedTx models.Transaction
+	require.NoError(t, store.DB().
+		Where("hash = ?", txHash.Bytes()).
+		Take(&persistedTx).Error)
+
+	var persistedUtxo models.Utxo
+	require.NoError(t, store.DB().
+		Where("tx_id = ? AND output_idx = ?", txHash.Bytes(), 0).
+		Take(&persistedUtxo).Error)
+	require.NotNil(t, persistedUtxo.TransactionID)
+	require.Equal(t, persistedTx.ID, *persistedUtxo.TransactionID)
+	require.Equal(t, point.Slot, persistedUtxo.AddedSlot)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes gap block transaction import so produced outputs and collateral-return UTXOs are saved and linked to their transaction in both Postgres and MySQL. Prevents missing UTXOs during gap reconciliation and sets the correct slot.

- **Bug Fixes**
  - Temporarily detach outputs and collateral return during transaction upsert, then import via `ImportUtxos` with proper `TransactionID`/`CollateralReturnForTxID`.
  - Reset UTXO IDs to avoid conflicts and ensure fresh inserts.
  - Added Postgres tests to confirm snapshot UTXOs are hydrated, linked to the transaction, and `AddedSlot` is set to the block slot.

<sup>Written for commit 27949c34012768e985a15ffbcb68b1dad26147dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2446?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

