### PR TITLE
feat(backfill): Add API backfill hot-path timing counters

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -838,6 +838,7 @@ func runMithrilSync(
 			)
 		}
 		bf.DisableNonceComputation()
+		bf.SetProgressFunc(metrics.recordBackfillProgress)
 		if err := bf.Run(ctx); err != nil {
 			return fmt.Errorf("backfill: %w", err)
 		}

--- a/cmd/dingo/mithril_metrics.go
+++ b/cmd/dingo/mithril_metrics.go
@@ -132,6 +132,13 @@ type mithrilSyncMetrics struct {
 	immutableBlocksPerSec prometheus.Gauge
 
 	gapBlocks prometheus.Gauge
+
+	backfillCurrentSlot    prometheus.Gauge
+	backfillTipSlot        prometheus.Gauge
+	backfillBlocksPerSec   prometheus.Gauge
+	backfillPercent        prometheus.Gauge
+	backfillStageDuration  *prometheus.GaugeVec
+	backfillIntervalCounts *prometheus.GaugeVec
 }
 
 func newMithrilSyncMetrics(reg prometheus.Registerer) *mithrilSyncMetrics {
@@ -240,6 +247,36 @@ func newMithrilSyncMetrics(reg prometheus.Registerer) *mithrilSyncMetrics {
 			Name: "dingo_mithril_sync_gap_blocks",
 			Help: "Volatile gap blocks fetched or reused during Mithril sync.",
 		}),
+		backfillCurrentSlot: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_backfill_current_slot",
+			Help: "Current slot processed by API-mode Mithril metadata backfill.",
+		}),
+		backfillTipSlot: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_backfill_tip_slot",
+			Help: "Target tip slot for API-mode Mithril metadata backfill.",
+		}),
+		backfillBlocksPerSec: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_backfill_blocks_per_second",
+			Help: "Current API-mode Mithril metadata backfill block rate.",
+		}),
+		backfillPercent: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_backfill_percent",
+			Help: "Completion percentage for API-mode Mithril metadata backfill.",
+		}),
+		backfillStageDuration: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_backfill_stage_duration_seconds",
+				Help: "Interval duration spent in an API-mode Mithril backfill hot-path stage.",
+			},
+			[]string{"stage"},
+		),
+		backfillIntervalCounts: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dingo_mithril_sync_backfill_interval_count",
+				Help: "Interval row and item counts for API-mode Mithril metadata backfill.",
+			},
+			[]string{"kind"},
+		),
 	}
 	m.startedAt.SetToCurrentTime()
 	return m
@@ -340,6 +377,61 @@ func (m *mithrilSyncMetrics) recordGapBlocks(count int) {
 		return
 	}
 	m.gapBlocks.Set(float64(count))
+}
+
+// recordBackfillProgress publishes the latest backfill interval snapshot.
+func (m *mithrilSyncMetrics) recordBackfillProgress(
+	p node.BackfillProgress,
+) {
+	if m == nil {
+		return
+	}
+	m.backfillCurrentSlot.Set(float64(p.Slot))
+	m.backfillTipSlot.Set(float64(p.TipSlot))
+	m.backfillBlocksPerSec.Set(p.BlocksPerSecond)
+	m.backfillPercent.Set(p.ProgressPercent)
+
+	stats := p.Stats
+	m.backfillStageDuration.WithLabelValues("block_read_decode").
+		Set(stats.BlockReadDecode.Seconds())
+	m.backfillStageDuration.WithLabelValues("offset_compute").
+		Set(stats.OffsetComputation.Seconds())
+	m.backfillStageDuration.WithLabelValues("blob_offset_write").
+		Set(stats.BlobOffsetWrites.Seconds())
+	m.backfillStageDuration.WithLabelValues("set_transaction_batched").
+		Set(stats.SetTransactionBatched.Seconds())
+	m.backfillStageDuration.WithLabelValues("consumed_input_recovery").
+		Set(stats.ConsumedInputRecovery.Seconds())
+	m.backfillStageDuration.WithLabelValues("utxo_address_lookup").
+		Set(stats.UtxoAddressLookup.Seconds())
+	m.backfillStageDuration.WithLabelValues("address_index").
+		Set(stats.AddressIndex.Seconds())
+	m.backfillStageDuration.WithLabelValues("flush_batch").
+		Set(stats.FlushBatch.Seconds())
+	m.backfillStageDuration.WithLabelValues("checkpoint_write").
+		Set(stats.CheckpointWrites.Seconds())
+
+	m.backfillIntervalCounts.WithLabelValues("blocks").Set(float64(stats.Blocks))
+	m.backfillIntervalCounts.WithLabelValues("txs").Set(float64(stats.Txs))
+	m.backfillIntervalCounts.WithLabelValues("utxos").Set(float64(stats.Utxos))
+	m.backfillIntervalCounts.WithLabelValues("input_refs").Set(float64(stats.InputRefs))
+	m.backfillIntervalCounts.WithLabelValues("address_txs").Set(float64(stats.AddressTxs))
+	m.backfillIntervalCounts.WithLabelValues("witnesses").Set(float64(stats.Witnesses))
+	m.backfillIntervalCounts.WithLabelValues("witness_scripts").Set(float64(stats.WitnessScripts))
+	m.backfillIntervalCounts.WithLabelValues("scripts").Set(float64(stats.Scripts))
+	m.backfillIntervalCounts.WithLabelValues("plutus_data").Set(float64(stats.PlutusData))
+	m.backfillIntervalCounts.WithLabelValues("redeemers").Set(float64(stats.Redeemers))
+	m.backfillIntervalCounts.WithLabelValues("utxo_spends").Set(float64(stats.UtxoSpends))
+	m.backfillIntervalCounts.WithLabelValues("collateral_returns").Set(float64(stats.CollateralRets))
+	m.backfillIntervalCounts.WithLabelValues("certificates").Set(float64(stats.Certificates))
+	m.backfillIntervalCounts.WithLabelValues("metadata_labels").Set(float64(stats.MetadataLabels))
+	m.backfillIntervalCounts.WithLabelValues("pparam_updates").Set(float64(stats.PParamUpdates))
+	m.backfillIntervalCounts.WithLabelValues("blob_tx_offset_writes").
+		Set(float64(stats.BlobTxOffsetWrites))
+	m.backfillIntervalCounts.WithLabelValues("blob_utxo_offset_writes").
+		Set(float64(stats.BlobUtxoOffsetWrites))
+	m.backfillIntervalCounts.WithLabelValues("skipped_utxo_offsets").
+		Set(float64(stats.SkippedUtxoOffsets))
 }
 
 func (m *mithrilSyncMetrics) markComplete() {

--- a/cmd/dingo/mithril_metrics_test.go
+++ b/cmd/dingo/mithril_metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/blinklabs-io/dingo/ledgerstate"
 	"github.com/blinklabs-io/dingo/mithril"
@@ -67,6 +68,34 @@ func TestMithrilSyncMetricsRecordProgress(t *testing.T) {
 		Percent:         97.2,
 	})
 	metrics.recordGapBlocks(3)
+	metrics.recordBackfillProgress(node.BackfillProgress{
+		Slot:            1200,
+		TipSlot:         2400,
+		BlocksPerSecond: 25,
+		ProgressPercent: 50,
+		Stats: dbtypes.BackfillHotPathStats{
+			Blocks:                10,
+			Txs:                   20,
+			Utxos:                 30,
+			InputRefs:             40,
+			AddressTxs:            50,
+			Witnesses:             60,
+			Scripts:               70,
+			Redeemers:             80,
+			BlobTxOffsetWrites:    20,
+			BlobUtxoOffsetWrites:  30,
+			SkippedUtxoOffsets:    5,
+			BlockReadDecode:       100 * time.Millisecond,
+			OffsetComputation:     200 * time.Millisecond,
+			BlobOffsetWrites:      300 * time.Millisecond,
+			SetTransactionBatched: 400 * time.Millisecond,
+			ConsumedInputRecovery: 500 * time.Millisecond,
+			UtxoAddressLookup:     600 * time.Millisecond,
+			AddressIndex:          700 * time.Millisecond,
+			FlushBatch:            800 * time.Millisecond,
+			CheckpointWrites:      900 * time.Millisecond,
+		},
+	})
 	metrics.markComplete()
 	metrics.recordError()
 
@@ -141,6 +170,35 @@ func TestMithrilSyncMetricsRecordProgress(t *testing.T) {
 		promtestutil.ToFloat64(metrics.immutableBlocksPerSec),
 	)
 	require.Equal(t, float64(3), promtestutil.ToFloat64(metrics.gapBlocks))
+	require.Equal(t, float64(1200), promtestutil.ToFloat64(metrics.backfillCurrentSlot))
+	require.Equal(t, float64(2400), promtestutil.ToFloat64(metrics.backfillTipSlot))
+	require.Equal(t, float64(25), promtestutil.ToFloat64(metrics.backfillBlocksPerSec))
+	require.Equal(t, float64(50), promtestutil.ToFloat64(metrics.backfillPercent))
+	require.Equal(
+		t,
+		float64(0.4),
+		promtestutil.ToFloat64(
+			metrics.backfillStageDuration.WithLabelValues(
+				"set_transaction_batched",
+			),
+		),
+	)
+	require.Equal(
+		t,
+		float64(50),
+		promtestutil.ToFloat64(
+			metrics.backfillIntervalCounts.WithLabelValues("address_txs"),
+		),
+	)
+	require.Equal(
+		t,
+		float64(5),
+		promtestutil.ToFloat64(
+			metrics.backfillIntervalCounts.WithLabelValues(
+				"skipped_utxo_offsets",
+			),
+		),
+	)
 	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.completed))
 	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.errors))
 }

--- a/database/batch.go
+++ b/database/batch.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -67,6 +68,15 @@ type BatchedTxIngestOpts struct {
 	// TX offset writes, metadata writes, and consumed-input handling are
 	// unaffected.
 	SkipProducedUtxoOffsetWrites bool
+
+	// Stats receives hot-path timings and row-ish counts for operator
+	// visibility during API-mode Mithril backfill. It is optional and is
+	// intentionally updated only at coarse stage boundaries.
+	Stats *types.BackfillHotPathStats
+}
+
+type batchStatsSetter interface {
+	SetBackfillStats(*types.BackfillHotPathStats)
 }
 
 // SetTransactionBatched stores transaction blob offsets and immediate
@@ -151,12 +161,27 @@ func (d *Database) SetTransactionBatchedWithOpts(
 			point.Slot,
 		)
 	}
+
+	produced := tx.Produced()
+	if opts.Stats != nil {
+		// Record interval density so timings can be compared across eras.
+		opts.Stats.Txs++
+		opts.Stats.Utxos += uint64(len(produced))
+		opts.Stats.InputRefs += uint64(len(tx.Inputs()) +
+			len(tx.Collateral()) + len(tx.ReferenceInputs()))
+	}
+
+	blobStart := time.Now()
 	offsetData := EncodeTxOffset(&txOffset)
 	if err := blob.SetTx(blobTxn, txHashBytes, offsetData); err != nil {
 		return fmt.Errorf("set tx offset: %w", err)
 	}
+	if opts.Stats != nil {
+		// Count tx offset writes separately from produced UTxO offset writes.
+		opts.Stats.BlobTxOffsetWrites++
+	}
 
-	for _, utxo := range tx.Produced() {
+	for _, utxo := range produced {
 		txID := ledgerInputIDBytes(utxo.Id)
 		outputIdx := utxo.Id.Index()
 		ref := UtxoRef{
@@ -188,14 +213,34 @@ func (d *Database) SetTransactionBatchedWithOpts(
 				err,
 			)
 		}
+		if opts.Stats != nil {
+			// Count produced UTxO offset writes that were not elided.
+			opts.Stats.BlobUtxoOffsetWrites++
+		}
+	}
+	if opts.Stats != nil {
+		if opts.SkipProducedUtxoOffsetWrites {
+			// Count saved blob writes from the Mithril immutable-copy phase.
+			opts.Stats.SkippedUtxoOffsets += uint64(len(produced))
+		}
+		// Time spent writing offset refs to the blob plugin.
+		opts.Stats.BlobOffsetWrites += time.Since(blobStart)
 	}
 
+	recoverStart := time.Now()
 	if err := d.ensureTransactionConsumedUtxos(tx, point, txn); err != nil {
 		return err
+	}
+	if opts.Stats != nil {
+		// Time consumed-input lookup/recovery before metadata batching.
+		opts.Stats.ConsumedInputRecovery += time.Since(recoverStart)
 	}
 	metadataTxn := txn.Metadata()
 	if metadataTxn == nil {
 		return types.ErrNilTxn
+	}
+	if setter, ok := acc.(batchStatsSetter); ok {
+		setter.SetBackfillStats(opts.Stats)
 	}
 	if err := d.metadata.SetTransactionBatched(
 		tx, point, idx, certDeposits, acc, metadataTxn,
@@ -214,6 +259,10 @@ func (d *Database) SetTransactionBatchedWithOpts(
 			); err != nil {
 				return fmt.Errorf("set pparam update: %w", err)
 			}
+		}
+		if opts.Stats != nil {
+			// Count pparam updates written from valid update transactions.
+			opts.Stats.PParamUpdates += uint64(len(pparamUpdates))
 		}
 	}
 

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -51,6 +51,7 @@ type BatchAccumulator struct {
 	UtxoSpends     []utxoSpend
 	CollateralRets []models.Utxo
 	DeleteTxIDs    []uint
+	stats          *types.BackfillHotPathStats
 }
 
 // NewBatchAccumulator returns an empty BatchAccumulator ready for use.
@@ -127,6 +128,16 @@ func (b *BatchAccumulator) Reset() {
 	b.UtxoSpends = b.UtxoSpends[:0]
 	b.CollateralRets = b.CollateralRets[:0]
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
+	b.stats = nil
+}
+
+// SetBackfillStats attaches the current backfill interval stats collector.
+func (b *BatchAccumulator) SetBackfillStats(
+	stats *types.BackfillHotPathStats,
+) {
+	if b != nil {
+		b.stats = stats
+	}
 }
 
 // Len returns the number of accumulated metadata rows. It is intentionally a
@@ -163,6 +174,23 @@ func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
 	b.UtxoSpends = append(b.UtxoSpends, other.UtxoSpends...)
 	b.CollateralRets = append(b.CollateralRets, other.CollateralRets...)
 	b.DeleteTxIDs = append(b.DeleteTxIDs, other.DeleteTxIDs...)
+}
+
+// addPendingCountsToStats reports rows buffered for the next batch flush.
+func (b *BatchAccumulator) addPendingCountsToStats() {
+	if b == nil || b.stats == nil {
+		return
+	}
+	// Count deferred metadata rows accumulated for the next FlushBatch.
+	b.stats.Witnesses += uint64(len(b.KeyWitnesses))
+	b.stats.WitnessScripts += uint64(len(b.WitnessScripts))
+	b.stats.Scripts += uint64(len(b.Scripts))
+	b.stats.PlutusData += uint64(len(b.PlutusData))
+	b.stats.Redeemers += uint64(len(b.Redeemers))
+	b.stats.AddressTxs += uint64(len(b.AddressTxs))
+	b.stats.UtxoSpends += uint64(len(b.UtxoSpends))
+	b.stats.CollateralRets += uint64(len(b.CollateralRets))
+	b.stats.DeleteTxIDs += uint64(len(b.DeleteTxIDs))
 }
 
 // FlushBatch writes all accumulated records in a deterministic order.

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -369,6 +370,8 @@ func TestSetTransactionBatched_AccumulatesCorrectly(t *testing.T) {
 		Slot: 999,
 	}
 	acc := NewBatchAccumulator()
+	var stats dbtypes.BackfillHotPathStats
+	acc.SetBackfillStats(&stats)
 
 	require.NoError(
 		t,
@@ -390,6 +393,7 @@ func TestSetTransactionBatched_AccumulatesCorrectly(t *testing.T) {
 	// ------------------------------------------------------------------ //
 	assert.Len(t, acc.KeyWitnesses, 1, "one vkey witness expected in accumulator")
 	assert.Equal(t, models.KeyWitnessTypeVkey, acc.KeyWitnesses[0].Type)
+	assert.Equal(t, uint64(1), stats.Witnesses)
 
 	var witnessCount int64
 	require.NoError(

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
@@ -2423,6 +2424,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		return errors.New("SetTransactionBatched: acc must not be nil")
 	}
 	local := NewBatchAccumulator()
+	local.stats = batch.stats
 	txHash := tx.Hash().Bytes()
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -2517,6 +2519,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 
 	// metadata labels – small, write immediately just like SetTransaction.
 	if len(metadataLabels) > 0 {
+		if batch.stats != nil {
+			// Count metadata label rows written immediately for this tx.
+			batch.stats.MetadataLabels += uint64(len(metadataLabels))
+		}
 		labelRecords := make(
 			[]models.TransactionMetadataLabel,
 			0,
@@ -2577,10 +2583,15 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			})
 		}
 		var err error
+		lookupStart := time.Now()
 		collateralAddressKeys, err = d.GetUtxoAddressKeysBatch(
 			collateralRefs,
 			txn,
 		)
+		if batch.stats != nil {
+			// Track collateral input address-key lookup for address indexing.
+			batch.stats.UtxoAddressLookup += time.Since(lookupStart)
+		}
 		if err != nil {
 			return fmt.Errorf(
 				"failed to batch fetch collateral UTXO address keys (batched): %w",
@@ -2636,10 +2647,15 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			})
 		}
 		var err error
+		lookupStart := time.Now()
 		refInputAddressKeys, err = d.GetUtxoAddressKeysBatch(
 			refInputRefs,
 			txn,
 		)
+		if batch.stats != nil {
+			// Track reference input address-key lookup for address indexing.
+			batch.stats.UtxoAddressLookup += time.Since(lookupStart)
+		}
 		if err != nil {
 			return fmt.Errorf(
 				"failed to batch fetch reference input UTXO address keys (batched): %w",
@@ -2725,7 +2741,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				OutputIdx: input.Index(),
 			})
 		}
+		lookupStart := time.Now()
 		inputAddressKeys, err := d.GetUtxoAddressKeysBatch(inputRefs, txn)
+		if batch.stats != nil {
+			// Track regular input address-key lookup for address indexing.
+			batch.stats.UtxoAddressLookup += time.Since(lookupStart)
+		}
 		if err != nil {
 			return fmt.Errorf(
 				"failed to batch fetch input UTXO address keys (batched): %w",
@@ -2734,6 +2755,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		}
 
 		// Address-transaction index.
+		addressIndexStart := time.Now()
 		addressKeys := make(
 			[]UtxoAddressKeys,
 			0,
@@ -2773,6 +2795,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			addressKeys,
 		) {
 			local.AddAddressTx(atx)
+		}
+		if batch.stats != nil {
+			// Track address_transaction row generation from collected keys.
+			batch.stats.AddressIndex += time.Since(addressIndexStart)
 		}
 
 		// Witnesses.
@@ -2884,6 +2910,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	if tx.IsValid() {
 		certs := tx.Certificates()
 		if len(certs) > 0 {
+			if batch.stats != nil {
+				// Count certificate rows handled by immediate metadata writes.
+				batch.stats.Certificates += uint64(len(certs))
+			}
 			unifiedIDs := []uint{}
 			if result := db.Model(&models.Certificate{}).
 				Where("transaction_id = ?", tmpTx.ID).
@@ -3689,6 +3719,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 		}
 	}
 
+	local.addPendingCountsToStats()
 	batch.MergeFrom(local)
 	return nil
 }

--- a/database/types/backfill_stats.go
+++ b/database/types/backfill_stats.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "time"
+
+// BackfillHotPathStats captures low-overhead interval counters for API-mode
+// Mithril metadata backfill. Callers aggregate these per progress interval so
+// dense and sparse historical ranges can be compared without pprof.
+type BackfillHotPathStats struct {
+	Blocks    uint64
+	Txs       uint64
+	Utxos     uint64
+	InputRefs uint64
+
+	BlobTxOffsetWrites   uint64
+	BlobUtxoOffsetWrites uint64
+	SkippedUtxoOffsets   uint64
+
+	AddressTxs      uint64
+	Witnesses       uint64
+	Scripts         uint64
+	WitnessScripts  uint64
+	PlutusData      uint64
+	Redeemers       uint64
+	UtxoSpends      uint64
+	CollateralRets  uint64
+	DeleteTxIDs     uint64
+	Certificates    uint64
+	MetadataLabels  uint64
+	PParamUpdates   uint64
+	RecoveredInputs uint64
+
+	BlockReadDecode       time.Duration
+	OffsetComputation     time.Duration
+	BlobOffsetWrites      time.Duration
+	SetTransactionBatched time.Duration
+	ConsumedInputRecovery time.Duration
+	UtxoAddressLookup     time.Duration
+	AddressIndex          time.Duration
+	FlushBatch            time.Duration
+	CheckpointWrites      time.Duration
+}
+
+// Add folds another stats snapshot into s.
+func (s *BackfillHotPathStats) Add(other BackfillHotPathStats) {
+	s.Blocks += other.Blocks
+	s.Txs += other.Txs
+	s.Utxos += other.Utxos
+	s.InputRefs += other.InputRefs
+	s.BlobTxOffsetWrites += other.BlobTxOffsetWrites
+	s.BlobUtxoOffsetWrites += other.BlobUtxoOffsetWrites
+	s.SkippedUtxoOffsets += other.SkippedUtxoOffsets
+	s.AddressTxs += other.AddressTxs
+	s.Witnesses += other.Witnesses
+	s.Scripts += other.Scripts
+	s.WitnessScripts += other.WitnessScripts
+	s.PlutusData += other.PlutusData
+	s.Redeemers += other.Redeemers
+	s.UtxoSpends += other.UtxoSpends
+	s.CollateralRets += other.CollateralRets
+	s.DeleteTxIDs += other.DeleteTxIDs
+	s.Certificates += other.Certificates
+	s.MetadataLabels += other.MetadataLabels
+	s.PParamUpdates += other.PParamUpdates
+	s.RecoveredInputs += other.RecoveredInputs
+	s.BlockReadDecode += other.BlockReadDecode
+	s.OffsetComputation += other.OffsetComputation
+	s.BlobOffsetWrites += other.BlobOffsetWrites
+	s.SetTransactionBatched += other.SetTransactionBatched
+	s.ConsumedInputRecovery += other.ConsumedInputRecovery
+	s.UtxoAddressLookup += other.UtxoAddressLookup
+	s.AddressIndex += other.AddressIndex
+	s.FlushBatch += other.FlushBatch
+	s.CheckpointWrites += other.CheckpointWrites
+}
+
+// Reset clears the interval counters while preserving the allocation.
+func (s *BackfillHotPathStats) Reset() {
+	*s = BackfillHotPathStats{}
+}

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -989,7 +989,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 		b.maybeLogProgress(
 			cp, processedBlocks, processedTxs,
 			tipSlot, startSlot, startTime, &lastLogTime,
-			&intervalStats,
+			&intervalStats, false,
 		)
 	}
 
@@ -998,6 +998,11 @@ func (b *Backfill) Run(ctx context.Context) error {
 		saveCommittedCheckpoint()
 		return fmt.Errorf("flushing final backfill batch: %w", err)
 	}
+	b.maybeLogProgress(
+		cp, processedBlocks, processedTxs,
+		tipSlot, startSlot, startTime, &lastLogTime,
+		&intervalStats, true,
+	)
 
 	cp.Completed = true
 	cp.UpdatedAt = time.Now()
@@ -1096,7 +1101,7 @@ func (b *Backfill) saveCheckpoint(cp *models.BackfillCheckpoint) {
 }
 
 // maybeLogProgress logs backfill progress with rate and ETA,
-// throttled to at most once every 10 seconds.
+// throttled to at most once every 10 seconds unless force is true.
 func (b *Backfill) maybeLogProgress(
 	cp *models.BackfillCheckpoint,
 	processedBlocks int,
@@ -1106,9 +1111,10 @@ func (b *Backfill) maybeLogProgress(
 	startTime time.Time,
 	lastLogTime *time.Time,
 	stats *dbtypes.BackfillHotPathStats,
+	force bool,
 ) {
 	now := time.Now()
-	if now.Sub(*lastLogTime) < 10*time.Second {
+	if !force && now.Sub(*lastLogTime) < 10*time.Second {
 		return
 	}
 	*lastLogTime = now

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/governance"
 	ouroboros_cbor "github.com/blinklabs-io/gouroboros/cbor"
@@ -47,6 +48,17 @@ const DefaultBackfillBatchRows = 5000
 
 type backfillBatchSizer interface {
 	Len() int
+}
+
+// BackfillProgress is emitted with interval counters during metadata backfill.
+type BackfillProgress struct {
+	Slot            uint64
+	TipSlot         uint64
+	ProcessedBlocks int
+	ProcessedTxs    int
+	BlocksPerSecond float64
+	ProgressPercent float64
+	Stats           dbtypes.BackfillHotPathStats
 }
 
 // Backfill replays stored blocks to populate historical metadata.
@@ -84,6 +96,8 @@ type Backfill struct {
 	// observable.
 	skippedBlocks   uint64
 	skippedUtxoRefs uint64
+
+	onProgress func(BackfillProgress)
 }
 
 // NewBackfill creates a new Backfill instance.
@@ -117,6 +131,11 @@ func (b *Backfill) SetBatchSize(size int) error {
 // nonce rows.
 func (b *Backfill) DisableNonceComputation() {
 	b.computeNonces = false
+}
+
+// SetProgressFunc registers a callback for interval backfill counters.
+func (b *Backfill) SetProgressFunc(onProgress func(BackfillProgress)) {
+	b.onProgress = onProgress
 }
 
 // SetImmutableUtxoOffsetsTipSlot informs the backfill that produced-UTxO
@@ -756,6 +775,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 	var (
 		processedBlocks int
 		processedTxs    int
+		intervalStats   dbtypes.BackfillHotPathStats
 		// batchBlockCount tracks blocks accumulated since the last flush.
 		batchBlockCount int
 		// committedSlot is the latest slot durably committed by a batch.
@@ -788,9 +808,12 @@ func (b *Backfill) Run(ctx context.Context) error {
 			return errors.New("missing backfill batch transaction")
 		}
 		oldTxn := batchTxn
+		flushStart := time.Now()
 		if err := b.db.FlushBatch(acc, oldTxn); err != nil {
 			return err
 		}
+		// Track deferred metadata batch write cost.
+		intervalStats.FlushBatch += time.Since(flushStart)
 		if err := oldTxn.Commit(); err != nil {
 			return err
 		}
@@ -826,6 +849,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 			return fmt.Errorf("cancelled: %w", err)
 		}
 
+		readDecodeStart := time.Now()
 		blk, err := it.NextRaw()
 		if err != nil {
 			saveCommittedCheckpoint()
@@ -859,6 +883,9 @@ func (b *Backfill) Run(ctx context.Context) error {
 			blk.Cbor,
 			lcommon.VerifyConfig{SkipBodyHashValidation: true},
 		)
+		// Track raw block read plus ledger block decode cost.
+		intervalStats.BlockReadDecode += time.Since(readDecodeStart)
+		intervalStats.Blocks++
 		if parseErr != nil {
 			b.logger.Warn(
 				"skipping unparseable block",
@@ -888,9 +915,12 @@ func (b *Backfill) Run(ctx context.Context) error {
 				indexer := database.NewBlockIndexer(
 					blk.Slot, blk.Hash,
 				)
+				offsetStart := time.Now()
 				offsets, oErr := indexer.ComputeOffsets(
 					blk.Cbor, parsedBlock,
 				)
+				// Track CBOR offset discovery for txs and produced UTxOs.
+				intervalStats.OffsetComputation += time.Since(offsetStart)
 				if oErr != nil {
 					b.logger.Warn(
 						"skipping block with offset error",
@@ -904,6 +934,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 					if pErr := b.processBlockTxsBatched(
 						txs, point, epochId, eraId,
 						pp, offsets, acc, batchTxn,
+						&intervalStats,
 					); pErr != nil {
 						saveCommittedCheckpoint()
 						return fmt.Errorf(
@@ -950,11 +981,15 @@ func (b *Backfill) Run(ctx context.Context) error {
 					err,
 				)
 			}
+			checkpointStart := time.Now()
 			b.saveCheckpoint(cp)
+			// Track checkpoint writes that make backfill resumable.
+			intervalStats.CheckpointWrites += time.Since(checkpointStart)
 		}
 		b.maybeLogProgress(
 			cp, processedBlocks, processedTxs,
 			tipSlot, startSlot, startTime, &lastLogTime,
+			&intervalStats,
 		)
 	}
 
@@ -1000,6 +1035,7 @@ func (b *Backfill) processBlockTxsBatched(
 	offsets *database.BlockIngestionResult,
 	acc database.BatchAccumulator,
 	txn *database.Txn,
+	stats *dbtypes.BackfillHotPathStats,
 ) error {
 	opts := database.BatchedTxIngestOpts{
 		SkipProducedUtxoOffsetWrites: b.immutableUtxoOffsetsTipSlot > 0 &&
@@ -1017,12 +1053,21 @@ func (b *Backfill) processBlockTxsBatched(
 			// Counter is informational; Produced() is cheap (slice length).
 			b.skippedUtxoRefs += uint64(len(tx.Produced()))
 		}
+		setTxStart := time.Now()
 		if err := b.db.SetTransactionBatchedWithOpts(
 			tx, point, uint32(i), // #nosec G115
 			updateEpoch, paramUpdates,
-			certDeposits, offsets, acc, txn, opts,
+			certDeposits, offsets, acc, txn,
+			database.BatchedTxIngestOpts{
+				SkipProducedUtxoOffsetWrites: opts.SkipProducedUtxoOffsetWrites,
+				Stats:                        stats,
+			},
 		); err != nil {
 			return fmt.Errorf("storing TX: %w", err)
+		}
+		if stats != nil {
+			// Track end-to-end batched transaction ingestion.
+			stats.SetTransactionBatched += time.Since(setTxStart)
 		}
 		if err := b.processBlockGovernance(
 			tx, point, epochId, pp, txn,
@@ -1060,6 +1105,7 @@ func (b *Backfill) maybeLogProgress(
 	startSlot uint64,
 	startTime time.Time,
 	lastLogTime *time.Time,
+	stats *dbtypes.BackfillHotPathStats,
 ) {
 	now := time.Now()
 	if now.Sub(*lastLogTime) < 10*time.Second {
@@ -1082,6 +1128,21 @@ func (b *Backfill) maybeLogProgress(
 		"blocks_per_sec", fmt.Sprintf("%.0f", blocksPerSec),
 		"progress", fmt.Sprintf("%.1f%%", pct),
 	}
+	if stats != nil {
+		attrs = appendBackfillStatsAttrs(attrs, *stats)
+		if b.onProgress != nil {
+			b.onProgress(BackfillProgress{
+				Slot:            cp.LastSlot,
+				TipSlot:         tipSlot,
+				ProcessedBlocks: processedBlocks,
+				ProcessedTxs:    processedTxs,
+				BlocksPerSecond: blocksPerSec,
+				ProgressPercent: pct,
+				Stats:           *stats,
+			})
+		}
+		stats.Reset()
+	}
 
 	slotsProcessed := cp.LastSlot - startSlot
 	if blocksPerSec > 0 && slotsProcessed > 0 &&
@@ -1100,4 +1161,41 @@ func (b *Backfill) maybeLogProgress(
 	}
 
 	b.logger.Info("backfill progress", attrs...)
+}
+
+// appendBackfillStatsAttrs adds interval hot-path counters to progress logs.
+func appendBackfillStatsAttrs(
+	attrs []any,
+	stats dbtypes.BackfillHotPathStats,
+) []any {
+	return append(
+		attrs,
+		"interval_blocks", stats.Blocks,
+		"interval_txs", stats.Txs,
+		"interval_utxos", stats.Utxos,
+		"interval_input_refs", stats.InputRefs,
+		"blob_tx_offset_writes", stats.BlobTxOffsetWrites,
+		"blob_utxo_offset_writes", stats.BlobUtxoOffsetWrites,
+		"skipped_utxo_offsets", stats.SkippedUtxoOffsets,
+		"address_txs", stats.AddressTxs,
+		"witnesses", stats.Witnesses,
+		"witness_scripts", stats.WitnessScripts,
+		"scripts", stats.Scripts,
+		"plutus_data", stats.PlutusData,
+		"redeemers", stats.Redeemers,
+		"utxo_spends", stats.UtxoSpends,
+		"collateral_returns", stats.CollateralRets,
+		"certificates", stats.Certificates,
+		"metadata_labels", stats.MetadataLabels,
+		"pparam_updates", stats.PParamUpdates,
+		"block_read_decode_ms", stats.BlockReadDecode.Milliseconds(),
+		"offset_compute_ms", stats.OffsetComputation.Milliseconds(),
+		"blob_offset_write_ms", stats.BlobOffsetWrites.Milliseconds(),
+		"set_transaction_batched_ms", stats.SetTransactionBatched.Milliseconds(),
+		"consumed_input_recovery_ms", stats.ConsumedInputRecovery.Milliseconds(),
+		"utxo_address_lookup_ms", stats.UtxoAddressLookup.Milliseconds(),
+		"address_index_ms", stats.AddressIndex.Milliseconds(),
+		"flush_batch_ms", stats.FlushBatch.Milliseconds(),
+		"checkpoint_write_ms", stats.CheckpointWrites.Milliseconds(),
+	)
 }

--- a/internal/node/backfill_test.go
+++ b/internal/node/backfill_test.go
@@ -241,6 +241,46 @@ func TestRun_IncompleteCheckpointAtZeroStartsAtSlotZero(t *testing.T) {
 	require.Equal(t, uint64(1), got.LastSlot)
 }
 
+// TestRun_EmitsFinalProgressForShortRun ensures final interval metrics are
+// published even when the run finishes before the normal 10s progress tick.
+func TestRun_EmitsFinalProgressForShortRun(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now()
+	cp := &models.BackfillCheckpoint{
+		Phase:      BackfillPhase,
+		LastSlot:   0,
+		TotalSlots: 1,
+		StartedAt:  now,
+		UpdatedAt:  now,
+		Completed:  false,
+	}
+	require.NoError(t, db.Metadata().SetBackfillCheckpoint(cp, nil))
+
+	for _, slot := range []uint64{0, 1} {
+		hash := make([]byte, 32)
+		hash[0] = byte(slot + 1)
+		require.NoError(t, db.BlockCreate(models.Block{
+			Slot: slot,
+			Hash: hash,
+			Cbor: []byte{0x82, 0x01},
+			Type: 1,
+		}, nil))
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bf := NewBackfill(db, nil, logger)
+	var progress []BackfillProgress
+	bf.SetProgressFunc(func(p BackfillProgress) {
+		progress = append(progress, p)
+	})
+
+	require.NoError(t, bf.Run(context.Background()))
+	require.Len(t, progress, 1)
+	assert.Equal(t, uint64(1), progress[0].Slot)
+	assert.Equal(t, uint64(2), progress[0].Stats.Blocks)
+}
+
 // TestRun_IncompleteCheckpointAtZeroVisitsSlotZero proves the iterator
 // actually starts at slot 0 (rather than LastSlot+1 = 1). Asserting only
 // the final cp.LastSlot is too weak: it's left at 1 in both the correct


### PR DESCRIPTION
1. Added BackfillHotPathStats as the shared interval stats for api mode mithril backfill timings and counters.
2. Made changes to create and reset interval stats during backfill progress logging.
3. Collected interval stats during block read/decode, offset computation, tx batching, flush, checkpoint, and progress logging. Added these new stats fields to structured backfill progress logs.
4. Added mithril sync Pprometheus gauges for backfill slot, tip slot, percent, and blocks/sec.
5. Add labeled metrics for backfill stage durations and interval row/item counts.
6. Add BackfillProgress and SetProgressFunc where we can publish the same interval stats to defined pometheus metrics.
7. Modified the existing metrics tests to cover the new backfill progress gauges, stage duration metrics, and interval count metrics.
8. Modified the BatchedTxIngestOpts with an optional stats collector to record tx, utxo, input-ref counts. tx/utxo blob offset write counts, skipped utxo offset writes, blob write timing, consumed-input recovery timing, and pparam update counts.
9. Recorded the metadata label, certificate counts along with utxo address-key lookups for inputs, collateral, and reference inputs and address_transaction row generation for the address index.
10. Added the current stats collector to the sqlite batch accumulator to count deferred batch rows for witnesses, witness scripts, scripts, plutus data, redeemers, address txs, utxo spends, collateral returns, and retry deletes.


Closes #2355 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-interval hot-path timing counters for API-mode Mithril metadata backfill and exposes them via structured logs and Prometheus gauges to monitor progress and throughput. Also ensures final progress metrics are emitted for short runs. Addresses Linear #2355.

- **New Features**
  - Interval timings for block read/decode, offset compute, blob offset writes, batched tx ingest, input recovery, address lookups/index, batch flush, and checkpoint writes.
  - Interval counters for blocks/txs/utxos/input refs, address_txs, witnesses/witness_scripts/scripts/plutus data/redeemers, utxo spends/collateral returns, certificates/metadata labels/pparam updates, and blob offset writes (tx/utxo, skipped).
  - Added `BackfillProgress` and a progress callback; wired into Mithril sync to publish gauges for current slot, tip slot, percent, blocks/sec, labeled stage durations, and interval counts. Updated tests for gauges and counters.

- **Bug Fixes**
  - Emit a final progress update (and metrics) even when the backfill finishes before the 10s tick. Added a unit test to cover short runs.

<sup>Written for commit 76174ee0e826a171c434c784b7f05d86273c42d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2449?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Prometheus metrics for tracking Mithril backfill progress, including current/target slots, processing speed, completion percentage, stage durations, and row counts.
  
* **Tests**
  * Extended test coverage to validate backfill progress metrics and statistics collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->