### PR TITLE
ci(publish): disable npm packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -429,31 +429,3 @@ jobs:
       #- name: Pull new module version
       #  if: startsWith(github.ref, 'refs/tags/')
       #  uses: andrewslotin/go-proxy-pull-action@e5aea3b8b3478fc5b76befda4390513868ed2dc8 # v1.4.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.4.0
-
-  npm-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    needs: [finalize-release]
-    steps:
-      - run: |
-          RELEASE_TAG=${GITHUB_REF#refs/tags/}
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=${RELEASE_TAG:1}" >> $GITHUB_ENV
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout/releases/tag/v6.0.0
-        if: startsWith(github.ref, 'refs/tags/')
-      - name: setup nodejs
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 https://github.com/actions/setup-node/releases/tag/v6.4.0
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Update package.json
-        run: sed -e "s/0.999.0/${RELEASE_VERSION}/" .github/package.json > package.json
-        if: startsWith(github.ref, 'refs/tags/')
-      - name: Publish to NPM
-        run: npm publish --provenance --access public
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #2448 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `npm` packaging and publish job from `.github/workflows/publish.yml` to stop publishing releases to `npm` and simplify CI. This prevents accidental publishes and aligns the release flow with non-`npm` targets.

<sup>Written for commit fc1117d6db8bcaeba845315ad3716ee2ba48987a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2452?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

