### PR TITLE
fix: plutus budget accounting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -816,6 +816,8 @@ The `LedgerState` (`ledger/state.go`) manages UTXO tracking and validation:
 
 The `ledger/eras/` package provides era-specific validation rules for each Cardano era (Byron through Conway). Each era implements protocol parameter extraction, fee calculation, and era-specific transaction rules.
 
+During accepted block replay, Alonzo-and-newer validation runs the UTXO/Phase 1 rule set and keeps declared ExUnit limit checks. Plutus Phase 2 execution is skipped only for blocks at or before the immutable tip (`tipBlockNo - securityParam`), where the block producer's `isValid` flag is treated as authoritative until the local Plutus VM is consensus-equivalent. Volatile block replay, local transaction validation for mempool submission, and forging continue to run Plutus execution.
+
 ### Block Header Validation
 
 `ledger/verify_header.go` performs cryptographic validation of block headers:

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -178,8 +178,8 @@ func ValidateTxAlonzo(
 	}
 	tx = normalizedTx
 	errs := []error{}
-	for _, validationFunc := range alonzo.UtxoValidationRules {
-		err = validationFunc(tx, slot, ls, pp)
+	for _, validationRule := range alonzoUtxoValidationRules {
+		err = validationRule.validationFunc(tx, slot, ls, pp)
 		if err != nil {
 			errs = append(
 				errs,
@@ -213,6 +213,9 @@ func ValidateTxAlonzo(
 	}
 	// Skip script evaluation if TX is marked as not valid
 	if !tx.IsValid() {
+		return nil
+	}
+	if shouldSkipPhase2Validation(ls) {
 		return nil
 	}
 	// Resolve inputs
@@ -343,6 +346,17 @@ func ValidateTxAlonzo(
 		}
 	}
 	return nil
+}
+
+var alonzoUtxoValidationRules = buildAlonzoValidationRules()
+
+func buildAlonzoValidationRules() []indexedUtxoValidationRule {
+	return buildIndexedUtxoValidationRules(
+		alonzo.UtxoValidationRules,
+		alonzoUtxoValidatePlutusScriptsRuleIndex,
+		alonzo.UtxoValidatePlutusScripts,
+		"alonzo.UtxoValidatePlutusScripts",
+	)
 }
 
 func EvaluateTxAlonzo(

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -209,8 +209,8 @@ func ValidateTxBabbage(
 	}
 	tx = normalizedTx
 	errs := []error{}
-	for _, validationFunc := range babbage.UtxoValidationRules {
-		err = validationFunc(tx, slot, ls, pp)
+	for _, validationRule := range babbageUtxoValidationRules {
+		err = validationRule.validationFunc(tx, slot, ls, pp)
 		if err != nil {
 			errs = append(
 				errs,
@@ -226,6 +226,9 @@ func ValidateTxBabbage(
 	// to script execution compatibility.
 	// Skip script evaluation if TX is marked as not valid
 	if !tx.IsValid() {
+		return nil
+	}
+	if shouldSkipPhase2Validation(ls) {
 		return nil
 	}
 	// Resolve inputs
@@ -433,6 +436,17 @@ func ValidateTxBabbage(
 		}
 	}
 	return nil
+}
+
+var babbageUtxoValidationRules = buildBabbageValidationRules()
+
+func buildBabbageValidationRules() []indexedUtxoValidationRule {
+	return buildIndexedUtxoValidationRules(
+		babbage.UtxoValidationRules,
+		babbageUtxoValidatePlutusScriptsRuleIndex,
+		babbage.UtxoValidatePlutusScripts,
+		"babbage.UtxoValidatePlutusScripts",
+	)
 }
 
 func EvaluateTxBabbage(

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -188,12 +188,16 @@ func ValidateTxConway(
 	// These must run even for isValid=false transactions, which still
 	// require valid structure, fees, and UTxO references for collateral.
 	errs := []error{}
-	for idx, validationFunc := range conway.UtxoValidationRules {
-		err = validationFunc(tx, slot, ls, pp)
+	for _, validationRule := range conwayValidationRules(ls) {
+		err = validationRule.validationFunc(tx, slot, ls, pp)
 		if err != nil {
 			errs = append(
 				errs,
-				fmt.Errorf("conway utxo validation rule %d: %w", idx, err),
+				fmt.Errorf(
+					"conway utxo validation rule %d: %w",
+					validationRule.index,
+					err,
+				),
 			)
 		}
 	}
@@ -207,6 +211,39 @@ func ValidateTxConway(
 		return nil
 	}
 	return nil
+}
+
+var (
+	conwayUtxoValidationRules       = buildConwayValidationRules(false)
+	conwayPhase1UtxoValidationRules = buildConwayValidationRules(true)
+)
+
+func conwayValidationRules(
+	ls lcommon.LedgerState,
+) []indexedUtxoValidationRule {
+	if shouldSkipPhase2Validation(ls) {
+		return conwayPhase1UtxoValidationRules
+	}
+	return conwayUtxoValidationRules
+}
+
+func buildConwayValidationRules(
+	skipPhase2 bool,
+) []indexedUtxoValidationRule {
+	if skipPhase2 {
+		return buildIndexedUtxoValidationRules(
+			conway.UtxoValidationRules,
+			conwayUtxoValidatePlutusScriptsRuleIndex,
+			conway.UtxoValidatePlutusScripts,
+			"conway.UtxoValidatePlutusScripts",
+		)
+	}
+	return buildIndexedUtxoValidationRules(
+		conway.UtxoValidationRules,
+		noUtxoValidationRuleIndex,
+		nil,
+		"",
+	)
 }
 
 func EvaluateTxConway(

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -31,6 +32,105 @@ import (
 var ErrExUnitsOverflow = errors.New(
 	"execution units overflow int64",
 )
+
+type phase2ValidationSkipper interface {
+	SkipPhase2Validation() bool
+}
+
+type indexedUtxoValidationRule struct {
+	index          int
+	validationFunc lcommon.UtxoValidationRuleFunc
+}
+
+const (
+	noUtxoValidationRuleIndex = -1
+
+	// Positions in gouroboros v0.179.0 UtxoValidationRules. Function
+	// values are not directly comparable in Go, so setup guards compare
+	// function pointers before filtering by index.
+	alonzoUtxoValidatePlutusScriptsRuleIndex  = 26
+	babbageUtxoValidatePlutusScriptsRuleIndex = 30
+	conwayUtxoValidateExUnitsTooBigRuleIndex  = 34
+	conwayUtxoValidatePlutusScriptsRuleIndex  = 38
+)
+
+func shouldSkipPhase2Validation(
+	ls lcommon.LedgerState,
+) bool {
+	skipper, ok := ls.(phase2ValidationSkipper)
+	return ok && skipper.SkipPhase2Validation()
+}
+
+func buildIndexedUtxoValidationRules(
+	rules []lcommon.UtxoValidationRuleFunc,
+	skipIndex int,
+	skipValidationFunc lcommon.UtxoValidationRuleFunc,
+	skipRuleName string,
+) []indexedUtxoValidationRule {
+	if skipIndex != noUtxoValidationRuleIndex {
+		validateUtxoValidationSkipIndex(
+			rules,
+			skipIndex,
+			skipValidationFunc,
+			skipRuleName,
+		)
+	}
+
+	ret := make([]indexedUtxoValidationRule, 0, len(rules))
+	for idx, validationFunc := range rules {
+		if idx == skipIndex {
+			continue
+		}
+		ret = append(ret, indexedUtxoValidationRule{
+			index:          idx,
+			validationFunc: validationFunc,
+		})
+	}
+	return ret
+}
+
+func validateUtxoValidationSkipIndex(
+	rules []lcommon.UtxoValidationRuleFunc,
+	skipIndex int,
+	skipValidationFunc lcommon.UtxoValidationRuleFunc,
+	skipRuleName string,
+) {
+	if skipRuleName == "" {
+		skipRuleName = "UTxO validation skip rule"
+	}
+	if skipIndex < 0 {
+		panic(fmt.Sprintf(
+			"%s has invalid negative hardcoded rule index %d",
+			skipRuleName,
+			skipIndex,
+		))
+	}
+	if skipIndex >= len(rules) {
+		panic(fmt.Sprintf(
+			"%s hardcoded rule index %d is outside upstream rules length %d",
+			skipRuleName,
+			skipIndex,
+			len(rules),
+		))
+	}
+	if skipValidationFunc == nil {
+		panic(skipRuleName + " expected validation function is nil")
+	}
+	if utxoValidationRulePtr(rules[skipIndex]) != utxoValidationRulePtr(skipValidationFunc) {
+		panic(fmt.Sprintf(
+			"%s hardcoded rule index %d no longer resolves to the expected function",
+			skipRuleName,
+			skipIndex,
+		))
+	}
+}
+
+func utxoValidationRulePtr(fn lcommon.UtxoValidationRuleFunc) uintptr {
+	if fn == nil {
+		return 0
+	}
+	return reflect.ValueOf(fn).Pointer()
+}
 
 // SafeAddExUnits adds two ExUnits values with
 // overflow detection. Returns an error if either

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -21,6 +21,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/assert"
@@ -138,6 +140,154 @@ func (m *mockRedeemers) Iter() iter.Seq2[lcommon.RedeemerKey, lcommon.RedeemerVa
 				return
 			}
 		}
+	}
+}
+
+func TestAlonzoValidationRulesUseLocalPlutusExecution(t *testing.T) {
+	requireRuleIndexResolvesToFunc(
+		t,
+		alonzo.UtxoValidationRules,
+		alonzoUtxoValidatePlutusScriptsRuleIndex,
+		alonzo.UtxoValidatePlutusScripts,
+		"alonzo.UtxoValidatePlutusScripts",
+	)
+	require.Len(t, alonzoUtxoValidationRules, len(alonzo.UtxoValidationRules)-1)
+	requireIndexedRulesExcludeFunc(
+		t,
+		alonzoUtxoValidationRules,
+		alonzo.UtxoValidatePlutusScripts,
+		"Alonzo validation must use Dingo's local Plutus execution path",
+	)
+}
+
+func TestBabbageValidationRulesUseLocalPlutusExecution(t *testing.T) {
+	requireRuleIndexResolvesToFunc(
+		t,
+		babbage.UtxoValidationRules,
+		babbageUtxoValidatePlutusScriptsRuleIndex,
+		babbage.UtxoValidatePlutusScripts,
+		"babbage.UtxoValidatePlutusScripts",
+	)
+	require.Len(t, babbageUtxoValidationRules, len(babbage.UtxoValidationRules)-1)
+	requireIndexedRulesExcludeFunc(
+		t,
+		babbageUtxoValidationRules,
+		babbage.UtxoValidatePlutusScripts,
+		"Babbage validation must use Dingo's local Plutus execution path",
+	)
+}
+
+func TestConwayValidationRulesIncludePlutusExecutionByDefault(t *testing.T) {
+	requireRuleIndexResolvesToFunc(
+		t,
+		conway.UtxoValidationRules,
+		conwayUtxoValidatePlutusScriptsRuleIndex,
+		conway.UtxoValidatePlutusScripts,
+		"conway.UtxoValidatePlutusScripts",
+	)
+	require.Len(t, conwayUtxoValidationRules, len(conway.UtxoValidationRules))
+	requireIndexedRulesIncludeFunc(
+		t,
+		conwayUtxoValidationRules,
+		conway.UtxoValidatePlutusScripts,
+		"Conway validation should include gouroboros Plutus execution by default",
+	)
+}
+
+func TestConwayPhase1ValidationRulesSkipPlutusExecution(t *testing.T) {
+	requireRuleIndexResolvesToFunc(
+		t,
+		conway.UtxoValidationRules,
+		conwayUtxoValidateExUnitsTooBigRuleIndex,
+		conway.UtxoValidateExUnitsTooBigUtxo,
+		"conway.UtxoValidateExUnitsTooBigUtxo",
+	)
+	requireRuleIndexResolvesToFunc(
+		t,
+		conway.UtxoValidationRules,
+		conwayUtxoValidatePlutusScriptsRuleIndex,
+		conway.UtxoValidatePlutusScripts,
+		"conway.UtxoValidatePlutusScripts",
+	)
+	require.Len(
+		t,
+		conwayPhase1UtxoValidationRules,
+		len(conway.UtxoValidationRules)-1,
+	)
+	requireIndexedRulesIncludeFunc(
+		t,
+		conwayPhase1UtxoValidationRules,
+		conway.UtxoValidateExUnitsTooBigUtxo,
+		"Conway phase-1 replay must still enforce ExUnits limits",
+	)
+	requireIndexedRulesExcludeFunc(
+		t,
+		conwayPhase1UtxoValidationRules,
+		conway.UtxoValidatePlutusScripts,
+		"Conway phase-1 replay must not execute Plutus scripts",
+	)
+}
+
+func TestBuildIndexedUtxoValidationRulesPanicsForStaleSkipIndex(t *testing.T) {
+	require.PanicsWithValue(
+		t,
+		"test.UtxoValidatePlutusScripts hardcoded rule index 25 no longer resolves to the expected function",
+		func() {
+			buildIndexedUtxoValidationRules(
+				alonzo.UtxoValidationRules,
+				alonzoUtxoValidatePlutusScriptsRuleIndex-1,
+				alonzo.UtxoValidatePlutusScripts,
+				"test.UtxoValidatePlutusScripts",
+			)
+		},
+	)
+}
+
+func requireRuleIndexResolvesToFunc(
+	t *testing.T,
+	rules []lcommon.UtxoValidationRuleFunc,
+	index int,
+	want lcommon.UtxoValidationRuleFunc,
+	name string,
+) {
+	t.Helper()
+	require.GreaterOrEqual(t, index, 0, "%s rule index must be non-negative", name)
+	require.Less(t, index, len(rules), "%s rule index must be within upstream rules", name)
+	require.Equal(
+		t,
+		utxoValidationRulePtr(want),
+		utxoValidationRulePtr(rules[index]),
+		"%s hardcoded rule index no longer resolves to the expected function",
+		name,
+	)
+}
+
+func requireIndexedRulesIncludeFunc(
+	t *testing.T,
+	rules []indexedUtxoValidationRule,
+	want lcommon.UtxoValidationRuleFunc,
+	message string,
+) {
+	t.Helper()
+	wantPtr := utxoValidationRulePtr(want)
+	for _, rule := range rules {
+		if utxoValidationRulePtr(rule.validationFunc) == wantPtr {
+			return
+		}
+	}
+	require.Fail(t, message)
+}
+
+func requireIndexedRulesExcludeFunc(
+	t *testing.T,
+	rules []indexedUtxoValidationRule,
+	want lcommon.UtxoValidationRuleFunc,
+	message string,
+) {
+	t.Helper()
+	wantPtr := utxoValidationRulePtr(want)
+	for _, rule := range rules {
+		require.NotEqual(t, wantPtr, utxoValidationRulePtr(rule.validationFunc), message)
 	}
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2193,46 +2193,101 @@ func (ls *LedgerState) CurrentTransitionInfo() hardfork.TransitionInfo {
 	return ti
 }
 
-// SecurityParam returns the security parameter for the current era
-func (ls *LedgerState) SecurityParam() int {
+func (ls *LedgerState) securityParamForEra(eraId uint) (uint64, bool) {
 	if ls.config.CardanoNodeConfig == nil {
-		ls.config.Logger.Warn(
-			"CardanoNodeConfig is nil, using default security parameter",
-		)
-		return blockfetchBatchSlotThresholdDefault
+		if ls.config.Logger != nil {
+			ls.config.Logger.Warn(
+				"CardanoNodeConfig is nil, security parameter unavailable",
+			)
+		}
+		return 0, false
 	}
 	// Byron era only needs Byron genesis
-	if ls.currentEra.Id == 0 {
+	if eraId == 0 {
 		byronGenesis := ls.config.CardanoNodeConfig.ByronGenesis()
 		if byronGenesis == nil {
-			return blockfetchBatchSlotThresholdDefault
+			return 0, false
 		}
 		k := byronGenesis.ProtocolConsts.K
 		if k < 0 {
-			ls.config.Logger.Warn("invalid negative security parameter", "k", k)
-			return blockfetchBatchSlotThresholdDefault
+			if ls.config.Logger != nil {
+				ls.config.Logger.Warn(
+					"invalid negative security parameter",
+					"k", k,
+				)
+			}
+			return 0, false
 		}
 		if k == 0 {
-			ls.config.Logger.Warn("security parameter is zero", "k", k)
-			return blockfetchBatchSlotThresholdDefault
+			if ls.config.Logger != nil {
+				ls.config.Logger.Warn("security parameter is zero", "k", k)
+			}
+			return 0, false
 		}
-		return int(k) // #nosec G115
+		return uint64(k), true // #nosec G115
 	}
 	// Shelley+ eras only need Shelley genesis
 	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil {
-		return blockfetchBatchSlotThresholdDefault
+		return 0, false
 	}
 	k := shelleyGenesis.SecurityParam
 	if k < 0 {
-		ls.config.Logger.Warn("invalid negative security parameter", "k", k)
-		return blockfetchBatchSlotThresholdDefault
+		if ls.config.Logger != nil {
+			ls.config.Logger.Warn(
+				"invalid negative security parameter",
+				"k", k,
+			)
+		}
+		return 0, false
 	}
 	if k == 0 {
-		ls.config.Logger.Warn("security parameter is zero", "k", k)
-		return blockfetchBatchSlotThresholdDefault
+		if ls.config.Logger != nil {
+			ls.config.Logger.Warn("security parameter is zero", "k", k)
+		}
+		return 0, false
 	}
-	return int(k)
+	return uint64(k), true
+}
+
+// SecurityParam returns the security parameter for the current era
+func (ls *LedgerState) SecurityParam() int {
+	if k, ok := ls.securityParamForEra(ls.currentEra.Id); ok {
+		return int(k) // #nosec G115 -- k came from a non-negative int genesis field
+	}
+	return blockfetchBatchSlotThresholdDefault
+}
+
+// shouldSkipPhase2ValidationForBlock reports whether a block is deep enough
+// behind the reference tip that its producer-supplied isValid flag can be
+// trusted for replay-only Plutus Phase 2 results.
+func (ls *LedgerState) shouldSkipPhase2ValidationForBlock(
+	blockNumber uint64,
+	referenceBlockNumber uint64,
+	eraId uint,
+) bool {
+	securityParam, ok := ls.securityParamForEra(eraId)
+	if !ok || referenceBlockNumber < securityParam {
+		return false
+	}
+	immutableBlockNumber := referenceBlockNumber - securityParam
+	return blockNumber <= immutableBlockNumber
+}
+
+// shouldSkipPhase2ValidationForBlockAtCurrentTip samples the primary chain tip
+// for this specific block. The chain can advance or roll back while ledger
+// processing drains a read batch, so callers must not reuse a sub-batch-start
+// reference tip for all blocks in the transaction.
+func (ls *LedgerState) shouldSkipPhase2ValidationForBlockAtCurrentTip(
+	blockNumber uint64,
+	eraId uint,
+) bool {
+	referenceTip := ls.chain.Tip()
+	return ls.shouldSkipPhase2ValidationForBlock(
+		blockNumber,
+		referenceTip.BlockNumber,
+		eraId,
+	)
 }
 
 // StabilityWindow returns the Ouroboros security stability window for the
@@ -2981,7 +3036,8 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			localCheckpointWritten := ls.checkpointWrittenForEpoch
 			snapshotValidationEnabled := ls.validationEnabled
 			snapshotChainsyncState := ls.chainsyncState
-			chainTipSlot := ls.chain.Tip().Point.Slot
+			chainTip := ls.chain.Tip()
+			chainTipSlot := chainTip.Point.Slot
 			snapshotMithrilSlot := ls.mithrilLedgerSlot
 			ls.RUnlock()
 
@@ -3135,11 +3191,17 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 						continue
 					}
 					// Process block
+					skipPhase2Validation := shouldValidateBlock &&
+						ls.shouldSkipPhase2ValidationForBlockAtCurrentTip(
+							next.BlockNumber(),
+							snapshotEra.Id,
+						)
 					delta, err = ls.ledgerProcessBlock(
 						txn,
 						tmpPoint,
 						next,
 						shouldValidateBlock,
+						skipPhase2Validation,
 						expectedPrevHash,
 						blockOffsets,
 						snapshotEra,
@@ -3337,6 +3399,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 	point ocommon.Point,
 	block ledger.Block,
 	shouldValidate bool,
+	skipPhase2Validation bool,
 	expectedPrevHash []byte,
 	offsets *database.BlockIngestionResult,
 	currentEra eras.EraDesc,
@@ -3408,9 +3471,10 @@ func (ls *LedgerState) ledgerProcessBlock(
 					pp = prevEraPParams
 				}
 				lv := &LedgerView{
-					txn:             txn,
-					ls:              ls,
-					intraBlockUtxos: intraBlockUtxos,
+					txn:                  txn,
+					ls:                   ls,
+					intraBlockUtxos:      intraBlockUtxos,
+					skipPhase2Validation: skipPhase2Validation,
 				}
 				err := validationEra.ValidateTxFunc(
 					tx,

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -115,6 +115,110 @@ func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {
 	wg.Wait()
 }
 
+func TestShouldSkipPhase2ValidationForBlockUsesSecurityParam(t *testing.T) {
+	const securityParam uint64 = 37
+	cfg := newTestShelleyGenesisCfg(t)
+	cfg.ShelleyGenesis().SecurityParam = int(securityParam)
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	const referenceBlockNumber uint64 = 1000
+	immutableTipBlockNumber := referenceBlockNumber - securityParam
+
+	require.True(t, ls.shouldSkipPhase2ValidationForBlock(
+		immutableTipBlockNumber,
+		referenceBlockNumber,
+		eras.ShelleyEraDesc.Id,
+	))
+	require.False(t, ls.shouldSkipPhase2ValidationForBlock(
+		immutableTipBlockNumber+1,
+		referenceBlockNumber,
+		eras.ShelleyEraDesc.Id,
+	))
+	require.False(t, ls.shouldSkipPhase2ValidationForBlock(
+		0,
+		securityParam-1,
+		eras.ShelleyEraDesc.Id,
+	))
+}
+
+func TestShouldSkipPhase2ValidationForBlockRequiresSecurityParam(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	require.False(t, ls.shouldSkipPhase2ValidationForBlock(
+		0,
+		1000,
+		eras.ShelleyEraDesc.Id,
+	))
+}
+
+func TestShouldSkipPhase2ValidationForBlockAtCurrentTipRefreshesChainTip(
+	t *testing.T,
+) {
+	const securityParam uint64 = 2
+	cfg := newTestShelleyGenesisCfg(t)
+	cfg.ShelleyGenesis().SecurityParam = int(securityParam)
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{
+			securityParam: int(securityParam),
+		}),
+	)
+
+	rawBlocks := make([]chain.RawBlock, 0, 5)
+	var prevHash []byte
+	for blockNumber := uint64(1); blockNumber <= 5; blockNumber++ {
+		block := makeTestBlock(blockNumber*10, blockNumber)
+		block.PrevHash = prevHash
+		rawBlocks = append(rawBlocks, chain.RawBlock{
+			Slot:        block.Slot,
+			Hash:        block.Hash,
+			BlockNumber: block.Number,
+			Type:        block.Type,
+			PrevHash:    block.PrevHash,
+			Cbor:        block.Cbor,
+		})
+		prevHash = block.Hash
+	}
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(rawBlocks))
+
+	ls := &LedgerState{
+		chain: cm.PrimaryChain(),
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	require.True(t, ls.shouldSkipPhase2ValidationForBlockAtCurrentTip(
+		3,
+		eras.ShelleyEraDesc.Id,
+	))
+
+	rollbackPoint := ocommon.NewPoint(
+		rawBlocks[3].Slot,
+		rawBlocks[3].Hash,
+	)
+	require.NoError(t, cm.PrimaryChain().Rollback(rollbackPoint))
+
+	require.False(t, ls.shouldSkipPhase2ValidationForBlockAtCurrentTip(
+		3,
+		eras.ShelleyEraDesc.Id,
+	))
+}
+
 // TestCalculateStabilityWindow_ByronEra tests the stability window calculation for Byron era
 func TestCalculateStabilityWindow_ByronEra(t *testing.T) {
 	testCases := []struct {
@@ -3646,6 +3750,7 @@ func TestLedgerProcessBlockTracksOpCertSequenceByIssuerVkeyHash(t *testing.T) {
 			txn,
 			ocommon.Point{Slot: 10},
 			block,
+			false,
 			false,
 			nil,
 			nil,

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -48,6 +48,13 @@ type LedgerView struct {
 	// consumedUtxos tracks inputs consumed by pending mempool transactions.
 	// Key format: hex(txId) + ":" + outputIdx
 	consumedUtxos map[string]struct{}
+	// skipPhase2Validation is set for accepted block replay, where
+	// the producer's isValid flag is authoritative for Phase-2 results.
+	skipPhase2Validation bool
+}
+
+func (lv *LedgerView) SkipPhase2Validation() bool {
+	return lv.skipPhase2Validation
 }
 
 func (lv *LedgerView) NetworkId() uint {

--- a/ledger/view_test.go
+++ b/ledger/view_test.go
@@ -59,6 +59,14 @@ func TestLedgerViewUnimplementedMethodsReturnSentinelError(t *testing.T) {
 	require.Zero(t, treasury)
 }
 
+func TestLedgerViewSkipPhase2Validation(t *testing.T) {
+	lv := &LedgerView{}
+	require.False(t, lv.SkipPhase2Validation())
+
+	lv.skipPhase2Validation = true
+	require.True(t, lv.SkipPhase2Validation())
+}
+
 func TestExtractCostModelsFromPParams_Nil(t *testing.T) {
 	result := extractCostModelsFromPParams(nil)
 	require.Empty(t, result)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Plutus budget accounting by running Phase 2 only when needed. During accepted block replay, we skip Plutus execution at or before the immutable tip, decided per block using the current tip, while still enforcing UTxO and ExUnits limits.

- Bug Fixes
  - Skip Phase 2 for accepted blocks at or before the immutable tip (era-aware security parameter, per-block tip sampling).
  - Trust the producer’s isValid only on that replay path; still enforce declared ExUnits limits (keeps Conway ExUnitsTooBig).
  - Keep Plutus execution for volatile replay, mempool validation, and forging; Alonzo/Babbage use our local execution path and honor the skip flag; Conway includes full rules by default and switches to phase-1-only on replay.

- Refactors
  - Added indexed UTxO rule sets per era to include or omit the Plutus scripts rule.
  - Added runtime guards that verify hardcoded rule indices match upstream function pointers; tests cover stale-index panics.
  - Introduced phase2ValidationSkipper and LedgerView.SkipPhase2Validation; compute immutability via securityParamForEra and pass the flag through block processing.

<sup>Written for commit b07d0f10e4608eec51f2ae2e143d643101b7385e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented conditional skipping of Plutus Phase 2 validation during historical block replay, while maintaining full Phase 1 validation and ExUnit checks. Local mempool validation and block forging continue with full Plutus execution.

* **Documentation**
  * Updated architecture documentation to describe Phase 2 validation skipping behavior for accepted blocks.

* **Tests**
  * Added comprehensive test coverage for validation rules across eras and phase-skipping scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->