### PR TITLE
docs(examples): wait for mithril in gov lens compose

### DIFF
--- a/examples/dingo-gov-lens/README.md
+++ b/examples/dingo-gov-lens/README.md
@@ -55,9 +55,11 @@ cp .env.example .env
 
 # This is the full bootstrap path; Mithril gets to tip quickly, then API-mode
 # historical metadata backfill continues from the snapshot/checkpoint.
-docker compose up -d postgres
-docker compose --profile sync run --rm dingo-sync
-docker compose up -d dingo app
+#
+# dingo-sync is a one-shot `dingo mithril sync` job. The dingo service waits
+# for it to complete successfully (depends_on service_completed_successfully)
+# before running `dingo serve`, so a single `up` orchestrates the full order.
+docker compose up -d
 ```
 
 Open `http://127.0.0.1:8088`.

--- a/examples/dingo-gov-lens/docker-compose.yml
+++ b/examples/dingo-gov-lens/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       dockerfile: Dockerfile
       target: final
     image: ${DINGO_IMAGE:-dingo-gov-lens-dingo:local}
-    profiles:
-      - sync
     restart: "no"
     depends_on:
       postgres:
@@ -60,6 +58,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      dingo-sync:
+        condition: service_completed_successfully
     command: ["-n", "preview", "serve"]
     environment:
       <<: *dingo-env
@@ -78,6 +78,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      dingo-sync:
+        condition: service_completed_successfully
     environment:
       ADDR: 0.0.0.0:8088
       GOVTOOL_BASE_URL: ${GOVTOOL_BASE_URL:-https://preview.gov.tools}

--- a/examples/dingo-gov-lens/scripts/e2e-compose.sh
+++ b/examples/dingo-gov-lens/scripts/e2e-compose.sh
@@ -8,9 +8,9 @@ POSTGRES_DB="${POSTGRES_DB:-dingo_metadata}"
 POSTGRES_USER="${POSTGRES_USER:-dingo}"
 APP_PORT="${APP_PORT:-8088}"
 
-docker compose up -d postgres
-docker compose --profile sync run --rm dingo-sync
-docker compose up -d dingo app
+# dingo waits for the one-shot dingo-sync job to complete successfully before
+# starting `dingo serve`, so a single `up` brings the whole stack up in order.
+docker compose up -d
 
 for _ in $(seq 1 60); do
   if curl -fsS "http://127.0.0.1:${APP_PORT}/api/status" >/tmp/dingo-gov-lens-status.json; then


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the gov-lens example wait for the Mithril sync job and start the stack with one `docker compose up`. `dingo` and `app` now start only after `dingo mithril sync` completes successfully.

- **Refactors**
  - docker-compose: removed `profiles: sync` from `dingo-sync`; added `depends_on` with `service_completed_successfully` for both `dingo` and `app`.
  - README and e2e: replaced multi-step bootstrap with a single `docker compose up -d` and explained the wait behavior.

<sup>Written for commit 469f449a5335914c245131375b75df9a8e56d302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Docker Compose startup instructions for the dingo-gov-lens example—users can now start the application with a single `docker compose up -d` command instead of multiple sequential steps.

* **Chores**
  * Updated configuration to automatically orchestrate service startup order with proper dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/dingo/pull/2454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->