### PR TITLE
docs: archive and pruning modes and usage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last reviewed: 2026-05-22
+Last reviewed: 2026-05-29
 
 Dingo is a high-performance Cardano blockchain node implementation in Go. This document describes its architecture, core components, and design patterns.
 
@@ -96,10 +96,14 @@ graph TB
         Bark["Bark<br/><i>bark/</i>"]
     end
 
+    subgraph "Archive Support"
+        BPruner["Bark Pruner<br/><i>bark/pruner.go</i>"]
+    end
+
     EB["EventBus<br/><i>event/</i>"]
 
     Node --> CM & PG & OB & ChM & LS & MP & DB & EB
-    Node -.->|"optional"| BF & LE & URPC & BFA & Mesh & Bark
+    Node -.->|"optional"| BF & LE & URPC & BFA & Mesh & Bark & BPruner
 
     PG -->|"outbound conn requests"| CM
     CM -->|"connections"| OB
@@ -109,6 +113,7 @@ graph TB
     LS -->|"validate txs"| MP
     ChM --> DB
     DB --> Blob & Meta
+    BPruner --> LS & DB
     BF --> LE & MP & ChM
     SM -->|"stake snapshots"| DB
     CSel -->|"switch active peer"| CS
@@ -521,7 +526,8 @@ dingo/
 ├── bark/                # Bark Dingo-to-Dingo C2 and archive protocol
 │   ├── bark.go          # Bark server lifecycle and transport setup
 │   ├── archive.go       # Archive service interface
-│   └── blob.go          # Remote archive blob adapter with security window
+│   ├── blob.go          # Remote archive blob adapter
+│   └── pruner.go        # Ledger-window-based local block pruning
 ├── mithril/             # Mithril snapshot bootstrap
 │   ├── bootstrap.go     # Bootstrap orchestration
 │   ├── client.go        # Mithril aggregator client
@@ -718,6 +724,25 @@ Dingo supports two storage modes, configured via `storageMode`:
 
 - `core` (default): Minimal storage for chain following and block production.
 - `api`: Extended storage with transaction indexes, address lookups, and asset tracking. Required when any client-facing API server (Blockfrost, Mesh, UTxO RPC) is enabled. Bark is a separate Dingo-to-Dingo protocol and is not part of that API surface.
+
+### Archive And Pruning Topology
+
+Dingo's blob-store abstraction supports an archive/pruning deployment pattern:
+
+- An archive node uses a signed-URL-capable object-storage blob plugin (`s3` or
+  `gcs`) and enables the Bark server with `barkPort`. Bark's archive service
+  maps a requested `(slot, hash)` to the blob store's `GetBlockURL`, returning
+  a signed object URL plus compact block metadata.
+- A pruning node keeps its local blob plugin, configures `barkBaseUrl`, and is
+  wired by `node.go` with a `bark.BlobStoreBark` wrapper plus
+  `bark.Pruner`. Normal block writes still go to the local blob plugin. Reads
+  first check local storage; tombstoned or missing historical blocks fall back
+  to the remote Bark archive and download the signed URL response.
+- The pruner derives its safety window from `LedgerState.StabilityWindow()` and
+  scans only blocks older than that window. `Database.PruneBlock` materializes
+  any UTxO CBOR still stored as block offsets before replacing the block CBOR
+  value with a tombstone, leaving block indexes and metadata intact for archive
+  resolution.
 
 ### Tiered CBOR Cache
 
@@ -1052,7 +1077,23 @@ A gRPC server implementing the UTxO RPC specification with query, submit, sync, 
 
 ### Bark (`bark/`)
 
-Bark is Dingo's own protocol for Dingo-to-Dingo control-plane and archive services. It exposes archive access over Connect/gRPC and also supplies a remote archive adapter with a configurable security window, allowing Dingo to fetch historical blocks from a remote Bark instance instead of storing them locally.
+Bark is Dingo's own protocol for Dingo-to-Dingo control-plane and archive
+services. It exposes archive access over Connect/gRPC and supplies the remote
+archive adapter used by pruning nodes.
+
+The server side (`bark.Bark`) registers the archive service, health endpoint,
+and gRPC reflection. Archive fetches validate the requested block hash, ask the
+active blob plugin for a signed block URL, and return that URL with block type,
+height, and previous-hash metadata. In practice this makes `s3` and `gcs` the
+archive-node blob backends because they can sign object-storage URLs.
+
+The client side (`bark.BlobStoreBark`) wraps the configured local blob store.
+`GetBlock` and block iterators pass through local values, but resolve
+`types.ErrBlockTombstoned` or missing historical block CBOR by calling the
+remote Bark archive and downloading the signed URL. `bark.Pruner` runs only
+when `barkBaseUrl` is configured; it uses the ledger-derived stability window,
+not a separate operator-supplied security-window value, to decide which local
+blocks are safe to tombstone.
 
 ## Architectural Boundaries
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -291,7 +291,30 @@ magic "DTXP" (4) + block_slot (8) + block_hash (32)
 + metadata_offset/metadata_length (8) + is_valid (1)
 ```
 
-Pruning can replace a block's `bp...` value with `DBT1`. The SQL metadata rows remain, and the blob store returns `types.ErrBlockTombstoned` with the slot/hash so an archive proxy can fetch the CBOR elsewhere.
+### Archive And Pruning Contract
+
+Archive nodes and pruning nodes use the same logical blob keys. The difference
+is where immutable block CBOR is expected to live after the block is older than
+the ledger stability window:
+
+- Archive nodes keep block CBOR in a signed-URL-capable blob backend. The `s3`
+  and `gcs` plugins implement `GetBlockURL` by reading the block's
+  `bp..._metadata` value and generating a one-hour signed URL for the `bp...`
+  object. Bark's archive service exposes that URL and metadata to other Dingo
+  nodes. The local Badger plugin does not implement `GetBlockURL`, so it is not
+  suitable as the backing store for a Bark archive node.
+- Pruning nodes keep their normal local blob plugin, wrap it with the Bark
+  archive adapter, and run the Bark pruner when `barkBaseUrl` is configured.
+  The pruner calls `Database.PruneBlock` for blocks below
+  `current_slot - ledger.StabilityWindow()`. `PruneBlock` first materializes
+  UTxO CBOR entries that still point into the block by `DOFF` offset, then
+  replaces the block's `bp...` value with tombstone marker `DBT1` in the same
+  blob transaction.
+- Tombstoned blocks keep their `bi...`, `bh...`, and `bp..._metadata` entries.
+  SQL metadata rows also remain. Blob readers return
+  `types.ErrBlockTombstoned` with the slot/hash, allowing the Bark wrapper to
+  fetch the CBOR from the archive while preserving local block indexes and
+  iteration semantics.
 
 ## SQL Examples Mirroring the Go API
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ The following environment variables modify Dingo's behavior:
   - TCP port for the Mesh (Coinbase Rosetta) API (default: `0`, disabled)
 - `DINGO_BARK_PORT`
   - TCP port for the Bark block archive API (default: `0`, disabled)
+- `DINGO_BARK_BASE_URL`
+  - Base URL of a remote Bark archive node used for archive-backed local pruning
+    (default: empty, disabled)
+- `DINGO_BARK_PRUNER_FREQUENCY`
+  - How often an archive-backed pruning node scans for old local blocks to
+    prune (default: `1h`)
 - `DINGO_STORAGE_MODE`
   - Storage mode: `core` (default) or `api`
   - `core` stores only consensus data (UTxOs, certs, pools, protocol params)
@@ -192,6 +198,51 @@ blockfrostPort: 3100
 utxorpcPort: 9090
 ```
 
+### Archive And Pruning Nodes
+
+Dingo can be deployed as an archive node that keeps immutable block CBOR in
+cloud-native object storage, and paired pruning nodes can then remove old block
+CBOR from their own local blob stores while still serving historical block
+requests through the archive.
+
+An archive node uses a signed-URL-capable blob plugin (`s3` or `gcs`) and
+enables Bark with `barkPort`. Bark answers Dingo-to-Dingo archive requests by
+returning a signed object-storage URL plus block metadata. Badger is valid for a
+normal local blob store, but it does not provide signed URLs and should not be
+used as the Bark archive backend.
+
+```yaml
+storageMode: "core"
+database:
+  blob:
+    plugin: "s3"
+    s3:
+      bucket: "dingo-archive"
+      region: "us-east-1"
+      prefix: "preview"
+barkPort: 9091
+```
+
+A pruning node keeps its normal local blob store, sets `barkBaseUrl` to the
+archive node, and optionally tunes `barkPrunerFrequency`. Dingo wraps the local
+blob store with the Bark archive adapter, starts a background pruner, and prunes
+blocks older than the ledger-derived stability window. Pruned blocks keep their
+local indexes and a tombstone marker, so block fetches and block iterators can
+transparently retrieve the CBOR from the archive when needed.
+
+```yaml
+storageMode: "core"
+database:
+  blob:
+    plugin: "badger"
+barkBaseUrl: "http://archive.example.internal:9091"
+barkPrunerFrequency: 1h
+```
+
+The runnable demonstration in `internal/test/archive-demo/` brings up an S3
+compatible Minio archive node, a local Badger pruning node, and an end-to-end
+BlockFetch check through Bark.
+
 ### Deployment Patterns
 
 **Relay node** (consensus only, no APIs):
@@ -202,6 +253,16 @@ utxorpcPort: 9090
 **API / data node** (full indexing, one or more APIs):
 ```bash
 DINGO_STORAGE_MODE=api DINGO_BLOCKFROST_PORT=3100 ./dingo
+```
+
+**Archive node** (cloud object storage plus Bark archive service):
+```bash
+DINGO_DATABASE_BLOB_PLUGIN=s3 DINGO_BARK_PORT=9091 ./dingo
+```
+
+**Pruning node** (local storage plus a remote Bark archive):
+```bash
+DINGO_BARK_BASE_URL=http://archive.example.internal:9091 ./dingo
 ```
 
 **Block producer** (consensus only, with SPO keys):

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -182,13 +182,23 @@ blockfrostPort: 3000
 # CLI: --mesh-port
 meshPort: 8080
 
-# base url of bark archive server
+# Base URL of a remote Bark archive server. When set, this node keeps using
+# its configured local blob plugin but wraps it with Bark archive fallback and
+# starts the background pruner.
+# Can be overridden with DINGO_BARK_BASE_URL
 # CLI: --bark-url
 barkBaseUrl: ""
 
-# TCP port bind for listening for bark RPC calls
+# TCP port bind for listening for Bark RPC calls. Enable this on archive nodes.
+# Can be overridden with DINGO_BARK_PORT
 # CLI: --bark-port
 barkPort: 0
+
+# How often a Bark-backed pruning node scans for blocks older than the
+# ledger-derived stability window. Default: 1h.
+# Can be overridden with DINGO_BARK_PRUNER_FREQUENCY
+# CLI: --bark-pruner-frequency
+barkPrunerFrequency: 1h
 
 # ---
 # Deployment pattern examples (uncomment one block):
@@ -221,6 +231,25 @@ barkPort: 0
 #   # Optional forging tolerances (0 = defaults)
 #   forgeSyncToleranceSlots: 0
 #   forgeStaleGapThresholdSlots: 0
+#
+# Archive node (full immutable block history in object storage, Bark enabled):
+#   storageMode: "core"
+#   database:
+#     blob:
+#       plugin: "s3" # or "gcs"
+#       s3:
+#         bucket: "dingo-archive"
+#         region: "us-east-1"
+#         prefix: "preview"
+#   barkPort: 9091
+#
+# Pruning node (local blobs plus remote archive fallback):
+#   storageMode: "core"
+#   database:
+#     blob:
+#       plugin: "badger"
+#   barkBaseUrl: "http://archive.example.internal:9091"
+#   barkPrunerFrequency: 1h
 #
 # Dev mode (isolated, forge blocks, no outbound):
 #   runMode: "dev"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documents how to run archive and pruning nodes with Bark, including config, deployment examples, and the archive/pruning contract. Updates architecture and database docs to cover `bark.Pruner`, signed-URL backends (`s3`/`gcs`), and tombstone behavior.

- **New Features**
  - Added archive/pruning topology to `ARCHITECTURE.md` and included `bark.Pruner` in the diagram and file tree.
  - Defined the archive/pruning contract in `DATABASE.md` (stability window pruning, `DBT1` tombstones, `GetBlockURL` for `s3`/`gcs`).
  - Updated `README.md` with `DINGO_BARK_BASE_URL`, `DINGO_BARK_PRUNER_FREQUENCY`, `DINGO_BARK_PORT`, plus minimal configs for archive and pruning nodes.
  - Expanded `dingo.yaml.example` with Bark settings and commented presets for archive/pruning deployments.

<sup>Written for commit 83431a1afadbeabe66d55dd68253fac856cd7439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

