### PR TITLE
fix(ledger): fee calculation and min-fee handling

### DIFF
--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -1,5 +1,12 @@
 # Dingo Ledger & Database Benchmark Results
 
+Focused Mithril API-mode metadata backfill results are tracked separately in
+[`benchmark_results_api_backfill.md`](benchmark_results_api_backfill.md).
+The latest local Kubernetes rerun on May 29-30, 2026 measured current `main`
+with a local #2457 workaround at 87.1 blocks/sec for API backfill
+(13h45m16s for 4,312,604 blocks), plus 32m28s to rebuild deferred metadata
+indexes.
+
 ## Latest Results
 
 ### Test Environment

--- a/benchmark_results_api_backfill.md
+++ b/benchmark_results_api_backfill.md
@@ -1,0 +1,24 @@
+# Dingo Mithril API Backfill Benchmark Results
+
+Focused Mithril API-mode metadata backfill results are tracked here separately
+from the broader ledger and database benchmark table.
+
+## May 29-30, 2026 Preview Backfill
+
+The latest local Kubernetes preview run measured `origin/main` commit
+`d73407b6`. Clean current `main` failed during Mithril ledger-state UTxO asset
+import because deferred SQLite index handling drops the asset uniqueness needed
+by `ON CONFLICT (utxo_id, policy_id, name) DO NOTHING`; that blocker is tracked
+as #2457. The completed measurement used only a local diagnostic workaround for
+#2457, keeping `asset.policy_id` out of the deferred-index manifest.
+
+| Metric | Value |
+|--------|-------|
+| Blocks processed | 4,312,604 |
+| Transactions stored | 6,567,610 |
+| Backfill elapsed time | 13h45m16s |
+| Average backfill throughput | 87.1 blocks/sec |
+| Throughput needed for same range under 6h | 199.7 blocks/sec |
+| Remaining gap | about 2.3x |
+| Deferred metadata index rebuild | 26 indexes in 32m28s |
+| Whole pod command wall time | about 14h32m33s |

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.26.0
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.180.0
+	github.com/blinklabs-io/gouroboros v0.180.1
 	github.com/blinklabs-io/ouroboros-mock v0.12.0
 	github.com/blinklabs-io/plutigo v0.1.14
 	github.com/blockfrost/blockfrost-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.180.0 h1:OkQwC2UN8NdfFkvO9ydj29+DIHzRqZyMLJRz4rfwtsw=
-github.com/blinklabs-io/gouroboros v0.180.0/go.mod h1:xjA3SxWqNzlZlmaZ1aJSRctIYryGa/o1W2pivaS4J3w=
+github.com/blinklabs-io/gouroboros v0.180.1 h1:rwZhXOTOzKNvkqTjK5AaT9pEEiJ3bsTbbX8m/yDnUiQ=
+github.com/blinklabs-io/gouroboros v0.180.1/go.mod h1:xjA3SxWqNzlZlmaZ1aJSRctIYryGa/o1W2pivaS4J3w=
 github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
 github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
 github.com/blinklabs-io/plutigo v0.1.14 h1:SUwrQQPVZkbAz1MumCC0O2qn7N7aLnz95/syW2tLl+4=

--- a/ledger/candidate_nonce.go
+++ b/ledger/candidate_nonce.go
@@ -305,7 +305,7 @@ func (ls *LedgerState) computeCandidateNonceSlow(
 		}
 		eraId := uint(parsedBlock.Era().Id)
 		era, ok := ls.eraById(eraId)
-		if !ok {
+		if !ok || era == nil {
 			return fmt.Errorf(
 				"recompute candidate nonce at slot %d block %x: unknown era ID %d",
 				block.Slot,

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -260,7 +260,7 @@ func ValidateTxAlonzo(
 		}
 	}
 	// Evaluate scripts
-	var txInfoV1 script.TxInfo
+	var txInfoV1 script.TxInfoV1
 	txInfoV1, err = script.NewTxInfoV1FromTransaction(
 		ls,
 		tx,
@@ -269,7 +269,7 @@ func ValidateTxAlonzo(
 	if err != nil {
 		return err
 	}
-	for _, redeemerPair := range txInfoV1.(script.TxInfoV1).Redeemers {
+	for _, redeemerPair := range txInfoV1.Redeemers {
 		purpose := redeemerPair.Key
 		if purpose == nil {
 			return errors.New("script purpose is nil")
@@ -302,6 +302,7 @@ func ValidateTxAlonzo(
 			if err != nil {
 				return fmt.Errorf("build evaluation context: %w", err)
 			}
+			evalContext.SkipFinalSlippageFlush = true
 			_, err = s.Evaluate(
 				datum,
 				redeemer.Data,
@@ -412,9 +413,8 @@ func EvaluateTxAlonzo(
 	// Evaluate scripts
 	var retTotalExUnits lcommon.ExUnits
 	retRedeemerExUnits := make(map[lcommon.RedeemerKey]lcommon.ExUnits)
-	var txInfoV1 script.TxInfo
 	var err error
-	txInfoV1, err = script.NewTxInfoV1FromTransaction(
+	txInfoV1, err := script.NewTxInfoV1FromTransaction(
 		ls,
 		tx,
 		slices.Concat(resolvedInputs, resolvedRefInputs),
@@ -422,7 +422,7 @@ func EvaluateTxAlonzo(
 	if err != nil {
 		return 0, lcommon.ExUnits{}, nil, err
 	}
-	for _, redeemerPair := range txInfoV1.(script.TxInfoV1).Redeemers {
+	for _, redeemerPair := range txInfoV1.Redeemers {
 		purpose := redeemerPair.Key
 		if purpose == nil {
 			return 0, lcommon.ExUnits{}, nil, errors.New(

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -277,7 +277,7 @@ func ValidateTxBabbage(
 		}
 	}
 	// Evaluate scripts
-	var txInfoV2 script.TxInfo
+	var txInfoV2 script.TxInfoV2
 	txInfoV2, err = script.NewTxInfoV2FromTransaction(
 		ls,
 		tx,
@@ -286,7 +286,7 @@ func ValidateTxBabbage(
 	if err != nil {
 		return err
 	}
-	for _, redeemerPair := range txInfoV2.(script.TxInfoV2).Redeemers {
+	for _, redeemerPair := range txInfoV2.Redeemers {
 		purpose := redeemerPair.Key
 		if purpose == nil {
 			return errors.New("script purpose is nil")
@@ -327,6 +327,7 @@ func ValidateTxBabbage(
 			if err != nil {
 				return fmt.Errorf("build evaluation context: %w", err)
 			}
+			evalContext.SkipFinalSlippageFlush = true
 			_, err = s.Evaluate(
 				datum,
 				redeemer.Data,
@@ -392,6 +393,7 @@ func ValidateTxBabbage(
 			if err != nil {
 				return fmt.Errorf("build evaluation context: %w", err)
 			}
+			evalContext.SkipFinalSlippageFlush = true
 			_, err = s.Evaluate(
 				datum,
 				redeemer.Data,
@@ -506,9 +508,8 @@ func EvaluateTxBabbage(
 	// Evaluate scripts
 	var retTotalExUnits lcommon.ExUnits
 	retRedeemerExUnits := make(map[lcommon.RedeemerKey]lcommon.ExUnits)
-	var txInfoV2 script.TxInfo
 	var err error
-	txInfoV2, err = script.NewTxInfoV2FromTransaction(
+	txInfoV2, err := script.NewTxInfoV2FromTransaction(
 		ls,
 		tx,
 		slices.Concat(resolvedInputs, resolvedRefInputs),
@@ -516,7 +517,7 @@ func EvaluateTxBabbage(
 	if err != nil {
 		return 0, lcommon.ExUnits{}, nil, err
 	}
-	for _, redeemerPair := range txInfoV2.(script.TxInfoV2).Redeemers {
+	for _, redeemerPair := range txInfoV2.Redeemers {
 		purpose := redeemerPair.Key
 		if purpose == nil {
 			return 0, lcommon.ExUnits{}, nil, errors.New(

--- a/ledger/eras/byron_test.go
+++ b/ledger/eras/byron_test.go
@@ -285,8 +285,10 @@ var errUtxoNotFound = errors.New("UTxO not found")
 // mockLedgerState implements lcommon.LedgerState for testing
 // UTxO-aware Byron validation rules.
 type mockLedgerState struct {
-	utxos     map[string]lcommon.Utxo
-	networkId uint
+	utxos                map[string]lcommon.Utxo
+	networkId            uint
+	skipPhase2Validation bool
+	utxoLookups          int
 }
 
 func newMockLedgerState() *mockLedgerState {
@@ -309,6 +311,7 @@ func (m *mockLedgerState) addUtxo(
 func (m *mockLedgerState) UtxoById(
 	input lcommon.TransactionInput,
 ) (lcommon.Utxo, error) {
+	m.utxoLookups++
 	key := fmt.Sprintf("%s#%d", input.Id(), input.Index())
 	utxo, ok := m.utxos[key]
 	if !ok {
@@ -318,6 +321,10 @@ func (m *mockLedgerState) UtxoById(
 }
 
 func (m *mockLedgerState) NetworkId() uint { return m.networkId }
+
+func (m *mockLedgerState) SkipPhase2Validation() bool {
+	return m.skipPhase2Validation
+}
 
 // Stub implementations for the remaining LedgerState
 // interface methods. These are unused by Byron validation.

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -15,11 +15,13 @@
 package eras
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
 	"slices"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -176,7 +178,8 @@ func ValidateTxConway(
 	ls lcommon.LedgerState,
 	pp lcommon.ProtocolParameters,
 ) error {
-	if _, ok := pp.(*conway.ConwayProtocolParameters); !ok {
+	tmpPparams, ok := pp.(*conway.ConwayProtocolParameters)
+	if !ok {
 		return ErrIncompatibleProtocolParams
 	}
 	normalizedTx, err := normalizeScriptDataHashCbor(tx)
@@ -201,8 +204,30 @@ func ValidateTxConway(
 			)
 		}
 	}
+	if err := ValidateTxFeeConway(tx, ls, tmpPparams); err != nil &&
+		(!isInputResolutionError(err) || len(errs) == 0) {
+		errs = append(
+			errs,
+			fmt.Errorf("conway fee validation: %w", err),
+		)
+	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
+	}
+	plutusCtx, err := newConwayPlutusValidationContext(tx, ls)
+	if err != nil {
+		return fmt.Errorf("conway plutus redeemer validation: %w", err)
+	}
+	// Required redeemers are a Conway UTXOW/phase-1 condition, so this stays
+	// before phase-2 skips.
+	if err := validateConwayRequiredPlutusRedeemers(
+		tx,
+		plutusCtx.scriptInputs,
+		plutusCtx.inputs,
+		plutusCtx.assetMint,
+		plutusCtx.redeemers,
+	); err != nil {
+		return fmt.Errorf("conway plutus redeemer validation: %w", err)
 	}
 	// Skip script evaluation (Phase-2) if TX is marked as not valid.
 	// These transactions failed script validation on-chain; collateral
@@ -210,12 +235,24 @@ func ValidateTxConway(
 	if !tx.IsValid() {
 		return nil
 	}
+	if shouldSkipPhase2Validation(ls) {
+		return nil
+	}
+	if err := validateTxPlutusConwayWithContext(
+		tx,
+		ls,
+		tmpPparams,
+		plutusCtx,
+		false,
+	); err != nil {
+		return fmt.Errorf("conway plutus validation: %w", err)
+	}
 	return nil
 }
 
 var (
-	conwayUtxoValidationRules       = buildConwayValidationRules(false)
-	conwayPhase1UtxoValidationRules = buildConwayValidationRules(true)
+	conwayUtxoValidationRules       = buildConwayValidationRules()
+	conwayPhase1UtxoValidationRules = conwayUtxoValidationRules
 )
 
 func conwayValidationRules(
@@ -227,22 +264,867 @@ func conwayValidationRules(
 	return conwayUtxoValidationRules
 }
 
-func buildConwayValidationRules(
-	skipPhase2 bool,
-) []indexedUtxoValidationRule {
-	if skipPhase2 {
-		return buildIndexedUtxoValidationRules(
-			conway.UtxoValidationRules,
-			conwayUtxoValidatePlutusScriptsRuleIndex,
-			conway.UtxoValidatePlutusScripts,
-			"conway.UtxoValidatePlutusScripts",
+func buildConwayValidationRules() []indexedUtxoValidationRule {
+	skips := []utxoValidationRuleSkip{
+		{
+			index:          conwayUtxoValidateFeeTooSmallRuleIndex,
+			validationFunc: conway.UtxoValidateFeeTooSmallUtxo,
+			name:           "conway.UtxoValidateFeeTooSmallUtxo",
+		},
+		{
+			index:          conwayUtxoValidatePlutusScriptsRuleIndex,
+			validationFunc: conway.UtxoValidatePlutusScripts,
+			name:           "conway.UtxoValidatePlutusScripts",
+		},
+	}
+	return buildIndexedUtxoValidationRulesWithSkips(
+		conway.UtxoValidationRules,
+		skips,
+	)
+}
+
+func isInputResolutionError(err error) bool {
+	return errors.Is(err, lcommon.ErrInputResolution) ||
+		errors.Is(err, lcommon.ErrReferenceInputResolution)
+}
+
+type conwayPlutusValidationContext struct {
+	scriptInputs  conwayScriptInputs
+	inputs        []lcommon.TransactionInput
+	assetMint     lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
+	redeemers     lcommon.TransactionWitnessRedeemers
+	witnessDatums map[lcommon.Blake2b256]*lcommon.Datum
+}
+
+func newConwayPlutusValidationContext(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) (conwayPlutusValidationContext, error) {
+	var ret conwayPlutusValidationContext
+	scriptInputs, err := resolveConwayScriptInputs(tx, ls, true)
+	if err != nil {
+		return ret, err
+	}
+	ret.scriptInputs = scriptInputs
+	witnesses := tx.Witnesses()
+	ret.witnessDatums = make(map[lcommon.Blake2b256]*lcommon.Datum)
+	if witnesses != nil {
+		ret.redeemers = witnesses.Redeemers()
+		plutusData := witnesses.PlutusData()
+		ret.witnessDatums = make(
+			map[lcommon.Blake2b256]*lcommon.Datum,
+			len(plutusData),
+		)
+		for i := range plutusData {
+			datum := plutusData[i]
+			ret.witnessDatums[datum.Hash()] = &datum
+		}
+	}
+	ret.inputs = script.SortInputs(tx.Inputs())
+	assetMint := tx.AssetMint()
+	if assetMint != nil {
+		ret.assetMint = *assetMint
+	}
+	return ret, nil
+}
+
+func ValidateTxPlutusConway(
+	tx lcommon.Transaction,
+	_ uint64,
+	ls lcommon.LedgerState,
+	pp *conway.ConwayProtocolParameters,
+) error {
+	return validateTxPlutusConway(tx, ls, pp, true)
+}
+
+func validateTxPlutusConway(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+	pp *conway.ConwayProtocolParameters,
+	validateRequiredRedeemers bool,
+) error {
+	if !tx.IsValid() {
+		return nil
+	}
+	plutusCtx, err := newConwayPlutusValidationContext(tx, ls)
+	if err != nil {
+		return err
+	}
+	return validateTxPlutusConwayWithContext(
+		tx,
+		ls,
+		pp,
+		plutusCtx,
+		validateRequiredRedeemers,
+	)
+}
+
+func validateTxPlutusConwayWithContext(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+	pp *conway.ConwayProtocolParameters,
+	plutusCtx conwayPlutusValidationContext,
+	validateRequiredRedeemers bool,
+) error {
+	if validateRequiredRedeemers {
+		if err := validateConwayRequiredPlutusRedeemers(
+			tx,
+			plutusCtx.scriptInputs,
+			plutusCtx.inputs,
+			plutusCtx.assetMint,
+			plutusCtx.redeemers,
+		); err != nil {
+			return err
+		}
+	}
+	if plutusCtx.redeemers == nil {
+		return nil
+	}
+	hasRedeemers := false
+	for range plutusCtx.redeemers.Iter() {
+		hasRedeemers = true
+		break
+	}
+	if !hasRedeemers {
+		return nil
+	}
+	txInfos := newConwayTxInfoCache(
+		ls,
+		tx,
+		plutusCtx.scriptInputs.resolvedAllInputs,
+	)
+	for redeemerKey, redeemerValue := range plutusCtx.redeemers.Iter() {
+		purpose, ok := buildConwayScriptPurpose(
+			redeemerKey,
+			plutusCtx.scriptInputs.resolvedInputsMap,
+			plutusCtx.inputs,
+			plutusCtx.assetMint,
+			tx.Certificates(),
+			tx.Withdrawals(),
+			tx.VotingProcedures(),
+			tx.ProposalProcedures(),
+			plutusCtx.witnessDatums,
+		)
+		if !ok {
+			return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+		}
+		if purpose == nil {
+			return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+		}
+		switch p := purpose.(type) {
+		case script.ScriptPurposeSpending:
+			if p.Input.Output != nil {
+				addr := p.Input.Output.Address()
+				if (addr.Type() & lcommon.AddressTypeScriptBit) == 0 {
+					return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+				}
+			}
+		case script.ScriptPurposeCertifying:
+			if p.ScriptHash() == (lcommon.ScriptHash{}) {
+				return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+			}
+		case script.ScriptPurposeRewarding:
+			if p.StakeCredential.CredType != lcommon.CredentialTypeScriptHash {
+				return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+			}
+		case script.ScriptPurposeProposing:
+			if p.ScriptHash() == (lcommon.ScriptHash{}) {
+				return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+			}
+		case script.ScriptPurposeVoting:
+			// ScriptPurposeVoting.ScriptHash() returns the voter hash even for
+			// key-hash voters, so an empty-hash check (as used for the other
+			// purposes above) cannot distinguish them. A redeemer pointing at a
+			// key-hash voter requires no script and is therefore extraneous.
+			if !conwayVoterRequiresScriptRedeemer(&p.Voter) {
+				return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+			}
+		}
+		scriptHash := purpose.ScriptHash()
+		plutusScript, ok := plutusCtx.scriptInputs.scripts[scriptHash]
+		if !ok {
+			return lcommon.MissingScriptWitnessesError{
+				ScriptHash: scriptHash,
+			}
+		}
+		if !isConwayPlutusScript(plutusScript) {
+			return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
+		}
+		var datum data.PlutusData
+		var spendInput lcommon.TransactionInput
+		if spendPurpose, ok := purpose.(script.ScriptPurposeSpending); ok {
+			datum = spendPurpose.Datum
+			spendInput = spendPurpose.Input.Id
+		}
+		switch plutusScript.(type) {
+		case lcommon.PlutusV1Script, lcommon.PlutusV2Script:
+			if _, isSpend := purpose.(script.ScriptPurposeSpending); isSpend && datum == nil {
+				return conway.MissingDatumForSpendingScriptError{
+					ScriptHash: scriptHash,
+					Input:      spendInput,
+				}
+			}
+		}
+		redeemer := script.Redeemer{
+			Tag:     redeemerKey.Tag,
+			Index:   redeemerKey.Index,
+			Data:    redeemerValue.Data.Data,
+			ExUnits: redeemerValue.ExUnits,
+		}
+		_, execErr, err := evaluateConwayPlutusScript(
+			plutusScript,
+			purpose,
+			redeemer,
+			datum,
+			redeemerValue.ExUnits,
+			pp,
+			txInfos,
+			true,
+		)
+		if err != nil {
+			return err
+		}
+		if execErr != nil {
+			return conway.PlutusScriptFailedError{
+				ScriptHash: scriptHash,
+				Tag:        redeemerKey.Tag,
+				Index:      redeemerKey.Index,
+				Err:        execErr,
+			}
+		}
+	}
+	return nil
+}
+
+func validateConwayRequiredPlutusRedeemers(
+	tx lcommon.Transaction,
+	scriptInputs conwayScriptInputs,
+	inputs []lcommon.TransactionInput,
+	assetMint lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
+	redeemers lcommon.TransactionWitnessRedeemers,
+) error {
+	present := make(map[lcommon.RedeemerKey]struct{})
+	if redeemers != nil {
+		for redeemerKey := range redeemers.Iter() {
+			present[redeemerKey] = struct{}{}
+		}
+	}
+	checkRequired := func(
+		key lcommon.RedeemerKey,
+		purpose script.ScriptPurpose,
+	) error {
+		if purpose == nil {
+			return nil
+		}
+		scriptHash := purpose.ScriptHash()
+		if scriptHash == (lcommon.ScriptHash{}) {
+			return nil
+		}
+		availableScript, ok := scriptInputs.scripts[scriptHash]
+		if !ok {
+			return lcommon.MissingScriptWitnessesError{
+				ScriptHash: scriptHash,
+			}
+		}
+		if !isConwayPlutusScript(availableScript) {
+			return nil
+		}
+		if _, ok := present[key]; ok {
+			return nil
+		}
+		return conway.MissingRedeemerForScriptError{
+			ScriptHash: scriptHash,
+			Tag:        key.Tag,
+			Index:      key.Index,
+		}
+	}
+	for idx, input := range inputs {
+		utxo, ok := scriptInputs.resolvedInputsMap[input.String()]
+		if !ok || utxo.Output == nil {
+			continue
+		}
+		addr := utxo.Output.Address()
+		if (addr.Type() & lcommon.AddressTypeScriptBit) == 0 {
+			continue
+		}
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTagSpend,
+			Index: uint32(idx),
+		}
+		if err := checkRequired(
+			key,
+			script.ScriptPurposeSpending{Input: utxo},
+		); err != nil {
+			return err
+		}
+	}
+	policies := assetMint.Policies()
+	slices.SortFunc(policies, func(a, b lcommon.Blake2b224) int {
+		return bytes.Compare(a.Bytes(), b.Bytes())
+	})
+	for idx, policy := range policies {
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTagMint,
+			Index: uint32(idx),
+		}
+		if err := checkRequired(
+			key,
+			script.ScriptPurposeMinting{PolicyId: policy},
+		); err != nil {
+			return err
+		}
+	}
+	for idx, cert := range tx.Certificates() {
+		if !conwayCertificateRequiresScriptRedeemer(cert) {
+			continue
+		}
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTagCert,
+			Index: uint32(idx),
+		}
+		if err := checkRequired(
+			key,
+			script.ScriptPurposeCertifying{
+				Index:       uint32(idx),
+				Certificate: cert,
+			},
+		); err != nil {
+			return err
+		}
+	}
+	withdrawalAddrs := sortedConwayWithdrawalAddresses(tx.Withdrawals())
+	for idx, addr := range withdrawalAddrs {
+		if (addr.Type() & lcommon.AddressTypeScriptBit) == 0 {
+			continue
+		}
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTagReward,
+			Index: uint32(idx),
+		}
+		if err := checkRequired(
+			key,
+			script.ScriptPurposeRewarding{
+				StakeCredential: lcommon.Credential{
+					CredType:   lcommon.CredentialTypeScriptHash,
+					Credential: addr.StakeKeyHash(),
+				},
+			},
+		); err != nil {
+			return err
+		}
+	}
+	voters := sortedConwayVoters(tx.VotingProcedures())
+	for idx, voter := range voters {
+		if !conwayVoterRequiresScriptRedeemer(voter) {
+			continue
+		}
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTagVoting,
+			Index: uint32(idx),
+		}
+		if err := checkRequired(
+			key,
+			script.ScriptPurposeVoting{Voter: *voter},
+		); err != nil {
+			return err
+		}
+	}
+	for idx, proposal := range tx.ProposalProcedures() {
+		if proposal == nil || proposal.GovAction() == nil {
+			continue
+		}
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTagProposing,
+			Index: uint32(idx),
+		}
+		if err := checkRequired(
+			key,
+			script.ScriptPurposeProposing{
+				Index:             uint32(idx),
+				ProposalProcedure: proposal,
+			},
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func conwayCertificateRequiresScriptRedeemer(
+	cert lcommon.Certificate,
+) bool {
+	var cred *lcommon.Credential
+	switch c := cert.(type) {
+	case *lcommon.StakeDeregistrationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.StakeDelegationCertificate:
+		cred = c.StakeCredential
+	case *lcommon.RegistrationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.DeregistrationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.VoteDelegationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.StakeVoteDelegationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.StakeRegistrationDelegationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.VoteRegistrationDelegationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.StakeVoteRegistrationDelegationCertificate:
+		cred = &c.StakeCredential
+	case *lcommon.AuthCommitteeHotCertificate:
+		cred = &c.ColdCredential
+	case *lcommon.ResignCommitteeColdCertificate:
+		cred = &c.ColdCredential
+	case *lcommon.RegistrationDrepCertificate:
+		cred = &c.DrepCredential
+	case *lcommon.DeregistrationDrepCertificate:
+		cred = &c.DrepCredential
+	case *lcommon.UpdateDrepCertificate:
+		cred = &c.DrepCredential
+	default:
+		return false
+	}
+	return cred != nil && cred.CredType == lcommon.CredentialTypeScriptHash
+}
+
+func isConwayPlutusScript(script lcommon.Script) bool {
+	switch script.(type) {
+	case lcommon.PlutusV1Script,
+		lcommon.PlutusV2Script,
+		lcommon.PlutusV3Script:
+		return true
+	default:
+		return false
+	}
+}
+
+func sortedConwayWithdrawalAddresses(
+	withdrawals map[*lcommon.Address]*big.Int,
+) []*lcommon.Address {
+	ret := make([]*lcommon.Address, 0, len(withdrawals))
+	for addr := range withdrawals {
+		ret = append(ret, addr)
+	}
+	slices.SortFunc(ret, func(a, b *lcommon.Address) int {
+		aBytes, aErr := a.Bytes()
+		bBytes, bErr := b.Bytes()
+		if aErr != nil || bErr != nil {
+			return strings.Compare(a.String(), b.String())
+		}
+		return bytes.Compare(aBytes, bBytes)
+	})
+	return ret
+}
+
+func sortedConwayVoters(
+	votingProcedures lcommon.VotingProcedures,
+) []*lcommon.Voter {
+	ret := make([]*lcommon.Voter, 0, len(votingProcedures))
+	for voter := range votingProcedures {
+		ret = append(ret, voter)
+	}
+	slices.SortFunc(ret, func(a, b *lcommon.Voter) int {
+		tagA := conwayVoterRedeemerOrder(a)
+		tagB := conwayVoterRedeemerOrder(b)
+		if tagA == tagB {
+			return bytes.Compare(a.Hash[:], b.Hash[:])
+		}
+		return tagA - tagB
+	})
+	return ret
+}
+
+func conwayVoterRedeemerOrder(voter *lcommon.Voter) int {
+	switch voter.Type {
+	case lcommon.VoterTypeConstitutionalCommitteeHotScriptHash:
+		return 0
+	case lcommon.VoterTypeConstitutionalCommitteeHotKeyHash:
+		return 1
+	case lcommon.VoterTypeDRepScriptHash:
+		return 2
+	case lcommon.VoterTypeDRepKeyHash:
+		return 3
+	case lcommon.VoterTypeStakingPoolKeyHash:
+		return 4
+	default:
+		return -1
+	}
+}
+
+func conwayVoterRequiresScriptRedeemer(voter *lcommon.Voter) bool {
+	return voter.Type == lcommon.VoterTypeConstitutionalCommitteeHotScriptHash ||
+		voter.Type == lcommon.VoterTypeDRepScriptHash
+}
+
+type conwayScriptInputs struct {
+	resolvedInputs          []lcommon.Utxo
+	resolvedReferenceInputs []lcommon.Utxo
+	resolvedAllInputs       []lcommon.Utxo
+	resolvedInputsMap       map[string]lcommon.Utxo
+	scripts                 map[lcommon.ScriptHash]lcommon.Script
+}
+
+func resolveConwayScriptInputs(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+	includeNativeScripts bool,
+) (conwayScriptInputs, error) {
+	ret := conwayScriptInputs{
+		resolvedInputs: make([]lcommon.Utxo, 0, len(tx.Inputs())),
+		resolvedReferenceInputs: make(
+			[]lcommon.Utxo,
+			0,
+			len(tx.ReferenceInputs()),
+		),
+		resolvedInputsMap: make(
+			map[string]lcommon.Utxo,
+			len(tx.Inputs())+len(tx.ReferenceInputs()),
+		),
+	}
+	for _, input := range tx.Inputs() {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return ret, lcommon.InputResolutionError{
+				Input: input,
+				Err:   err,
+			}
+		}
+		ret.resolvedInputs = append(ret.resolvedInputs, utxo)
+		ret.resolvedInputsMap[input.String()] = utxo
+	}
+	for _, input := range tx.ReferenceInputs() {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return ret, lcommon.ReferenceInputResolutionError{
+				Input: input,
+				Err:   err,
+			}
+		}
+		ret.resolvedReferenceInputs = append(ret.resolvedReferenceInputs, utxo)
+		ret.resolvedInputsMap[input.String()] = utxo
+	}
+	ret.resolvedAllInputs = make(
+		[]lcommon.Utxo,
+		0,
+		len(ret.resolvedInputs)+len(ret.resolvedReferenceInputs),
+	)
+	ret.resolvedAllInputs = append(ret.resolvedAllInputs, ret.resolvedInputs...)
+	ret.resolvedAllInputs = append(
+		ret.resolvedAllInputs,
+		ret.resolvedReferenceInputs...,
+	)
+	ret.scripts = collectConwayAvailableScripts(
+		tx.Witnesses(),
+		ret.resolvedAllInputs,
+		includeNativeScripts,
+	)
+	return ret, nil
+}
+
+func collectConwayAvailableScripts(
+	witnesses lcommon.TransactionWitnessSet,
+	resolvedInputs []lcommon.Utxo,
+	includeNativeScripts bool,
+) map[lcommon.ScriptHash]lcommon.Script {
+	ret := make(map[lcommon.ScriptHash]lcommon.Script)
+	if witnesses != nil {
+		for _, tmpScript := range witnesses.PlutusV1Scripts() {
+			ret[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.PlutusV2Scripts() {
+			ret[tmpScript.Hash()] = tmpScript
+		}
+		for _, tmpScript := range witnesses.PlutusV3Scripts() {
+			ret[tmpScript.Hash()] = tmpScript
+		}
+		if includeNativeScripts {
+			for _, tmpScript := range witnesses.NativeScripts() {
+				ret[tmpScript.Hash()] = tmpScript
+			}
+		}
+	}
+	for _, utxo := range resolvedInputs {
+		if utxo.Output == nil {
+			continue
+		}
+		scriptRef := utxo.Output.ScriptRef()
+		if scriptRef == nil {
+			continue
+		}
+		ret[scriptRef.Hash()] = scriptRef
+	}
+	return ret
+}
+
+type conwayTxInfoCache struct {
+	ls             lcommon.LedgerState
+	tx             lcommon.Transaction
+	resolvedInputs []lcommon.Utxo
+	txInfoV1       script.TxInfoV1
+	txInfoV2       script.TxInfoV2
+	txInfoV3       script.TxInfoV3
+	txInfoV1Built  bool
+	txInfoV2Built  bool
+	txInfoV3Built  bool
+}
+
+func newConwayTxInfoCache(
+	ls lcommon.LedgerState,
+	tx lcommon.Transaction,
+	resolvedInputs []lcommon.Utxo,
+) *conwayTxInfoCache {
+	return &conwayTxInfoCache{
+		ls:             ls,
+		tx:             tx,
+		resolvedInputs: resolvedInputs,
+	}
+}
+
+func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
+	if !c.txInfoV1Built {
+		txInfo, err := script.NewTxInfoV1FromTransaction(
+			c.ls,
+			c.tx,
+			c.resolvedInputs,
+		)
+		if err != nil {
+			return script.TxInfoV1{}, conway.ScriptContextConstructionError{
+				Err: err,
+			}
+		}
+		c.txInfoV1 = txInfo
+		c.txInfoV1Built = true
+	}
+	return c.txInfoV1, nil
+}
+
+func (c *conwayTxInfoCache) v2() (script.TxInfoV2, error) {
+	if !c.txInfoV2Built {
+		txInfo, err := script.NewTxInfoV2FromTransaction(
+			c.ls,
+			c.tx,
+			c.resolvedInputs,
+		)
+		if err != nil {
+			return script.TxInfoV2{}, conway.ScriptContextConstructionError{
+				Err: err,
+			}
+		}
+		c.txInfoV2 = txInfo
+		c.txInfoV2Built = true
+	}
+	return c.txInfoV2, nil
+}
+
+func (c *conwayTxInfoCache) v3() (script.TxInfoV3, error) {
+	if !c.txInfoV3Built {
+		txInfo, err := script.NewTxInfoV3FromTransaction(
+			c.ls,
+			c.tx,
+			c.resolvedInputs,
+		)
+		if err != nil {
+			return script.TxInfoV3{}, conway.ScriptContextConstructionError{
+				Err: err,
+			}
+		}
+		c.txInfoV3 = txInfo
+		c.txInfoV3Built = true
+	}
+	return c.txInfoV3, nil
+}
+
+func evaluateConwayPlutusScript(
+	plutusScript lcommon.Script,
+	purpose script.ScriptPurpose,
+	redeemer script.Redeemer,
+	datum data.PlutusData,
+	budget lcommon.ExUnits,
+	pp *conway.ConwayProtocolParameters,
+	txInfos *conwayTxInfoCache,
+	skipFinalSlippageFlush bool,
+) (lcommon.ExUnits, error, error) {
+	switch s := plutusScript.(type) {
+	case lcommon.PlutusV3Script:
+		txInfoV3, err := txInfos.v3()
+		if err != nil {
+			return lcommon.ExUnits{}, nil, err
+		}
+		ctx := script.NewScriptContextV3(txInfoV3, redeemer, purpose)
+		evalContext, err := cek.NewEvalContext(
+			lang.LanguageVersionV3,
+			cek.ProtoVersion{
+				Major: pp.ProtocolVersion.Major,
+				Minor: pp.ProtocolVersion.Minor,
+			},
+			pp.CostModels[2],
+		)
+		if err != nil {
+			return lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
+		}
+		evalContext.SkipFinalSlippageFlush = skipFinalSlippageFlush
+		usedBudget, err := s.Evaluate(
+			ctx.ToPlutusData(),
+			budget,
+			evalContext,
+		)
+		if err != nil {
+			return lcommon.ExUnits{}, err, nil
+		}
+		return usedBudget, nil, nil
+	case lcommon.PlutusV2Script:
+		txInfoV2, err := txInfos.v2()
+		if err != nil {
+			return lcommon.ExUnits{}, nil, err
+		}
+		ctx := script.NewScriptContextV1V2(txInfoV2, purpose)
+		evalContext, err := cek.NewEvalContext(
+			lang.LanguageVersionV2,
+			cek.ProtoVersion{
+				Major: pp.ProtocolVersion.Major,
+				Minor: pp.ProtocolVersion.Minor,
+			},
+			pp.CostModels[1],
+		)
+		if err != nil {
+			return lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
+		}
+		evalContext.SkipFinalSlippageFlush = skipFinalSlippageFlush
+		usedBudget, err := s.Evaluate(
+			datum,
+			redeemer.Data,
+			ctx.ToPlutusData(),
+			budget,
+			evalContext,
+		)
+		if err != nil {
+			return lcommon.ExUnits{}, err, nil
+		}
+		return usedBudget, nil, nil
+	case lcommon.PlutusV1Script:
+		txInfoV1, err := txInfos.v1()
+		if err != nil {
+			return lcommon.ExUnits{}, nil, err
+		}
+		ctx := script.NewScriptContextV1V2(txInfoV1, purpose)
+		evalContext, err := cek.NewEvalContext(
+			lang.LanguageVersionV1,
+			cek.ProtoVersion{
+				Major: pp.ProtocolVersion.Major,
+				Minor: pp.ProtocolVersion.Minor,
+			},
+			pp.CostModels[0],
+		)
+		if err != nil {
+			return lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
+		}
+		evalContext.SkipFinalSlippageFlush = skipFinalSlippageFlush
+		usedBudget, err := s.Evaluate(
+			datum,
+			redeemer.Data,
+			ctx.ToPlutusData(),
+			budget,
+			evalContext,
+		)
+		if err != nil {
+			return lcommon.ExUnits{}, err, nil
+		}
+		return usedBudget, nil, nil
+	default:
+		return lcommon.ExUnits{}, nil, fmt.Errorf(
+			"unimplemented script type: %T",
+			plutusScript,
 		)
 	}
-	return buildIndexedUtxoValidationRules(
-		conway.UtxoValidationRules,
-		noUtxoValidationRuleIndex,
-		nil,
-		"",
+}
+
+func buildConwayScriptPurpose(
+	redeemerKey lcommon.RedeemerKey,
+	resolvedInputs map[string]lcommon.Utxo,
+	inputs []lcommon.TransactionInput,
+	mint lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
+	certificates []lcommon.Certificate,
+	withdrawals map[*lcommon.Address]*big.Int,
+	votes lcommon.VotingProcedures,
+	proposalProcedures []lcommon.ProposalProcedure,
+	witnessDatums map[lcommon.Blake2b256]*lcommon.Datum,
+) (purpose script.ScriptPurpose, ok bool) {
+	defer func() {
+		if recover() != nil {
+			purpose = nil
+			ok = false
+		}
+	}()
+	purpose = script.BuildScriptPurpose(
+		redeemerKey,
+		resolvedInputs,
+		inputs,
+		mint,
+		certificates,
+		withdrawals,
+		votes,
+		proposalProcedures,
+		witnessDatums,
+	)
+	return purpose, purpose != nil
+}
+
+func ValidateTxFeeConway(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+	pp *conway.ConwayProtocolParameters,
+) error {
+	txSize := TxSizeForFee(tx)
+	declaredEU, err := DeclaredExUnits(tx)
+	if err != nil {
+		return fmt.Errorf(
+			"calculating declared execution units: %w",
+			err,
+		)
+	}
+	refScriptSize, err := ReferencedScriptSize(tx, ls)
+	if err != nil {
+		return fmt.Errorf(
+			"calculating reference script size: %w",
+			err,
+		)
+	}
+	var pricesMem, pricesSteps *big.Rat
+	if pp.ExecutionCosts.MemPrice != nil {
+		pricesMem = pp.ExecutionCosts.MemPrice.ToBigRat()
+	}
+	if pp.ExecutionCosts.StepPrice != nil {
+		pricesSteps = pp.ExecutionCosts.StepPrice.ToBigRat()
+	}
+	var refScriptCostPerByte *big.Rat
+	if pp.MinFeeRefScriptCostPerByte != nil {
+		refScriptCostPerByte = pp.MinFeeRefScriptCostPerByte.ToBigRat()
+	}
+	minFee := CalculateConwayMinFee(
+		txSize,
+		declaredEU,
+		pp.MinFeeA,
+		pp.MinFeeB,
+		pricesMem,
+		pricesSteps,
+		refScriptSize,
+		refScriptCostPerByte,
+	)
+	txFee := tx.Fee()
+	if txFee == nil {
+		txFee = new(big.Int)
+	}
+	minFeeBig := new(big.Int).SetUint64(minFee)
+	if txFee.Cmp(minFeeBig) >= 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"transaction fee %d is less than the calculated "+
+			"minimum fee %d",
+		txFee,
+		minFeeBig,
 	)
 }
 
@@ -255,68 +1137,23 @@ func EvaluateTxConway(
 	if !ok {
 		return 0, lcommon.ExUnits{}, nil, ErrIncompatibleProtocolParams
 	}
-	// Resolve inputs
-	resolvedInputs := []lcommon.Utxo{}
-	for _, tmpInput := range tx.Inputs() {
-		tmpUtxo, err := ls.UtxoById(tmpInput)
-		if err != nil {
-			return 0, lcommon.ExUnits{}, nil, err
-		}
-		resolvedInputs = append(
-			resolvedInputs,
-			tmpUtxo,
-		)
-	}
-	// Resolve reference inputs
-	resolvedRefInputs := []lcommon.Utxo{}
-	for _, tmpRefInput := range tx.ReferenceInputs() {
-		tmpUtxo, err := ls.UtxoById(tmpRefInput)
-		if err != nil {
-			return 0, lcommon.ExUnits{}, nil, err
-		}
-		resolvedRefInputs = append(
-			resolvedRefInputs,
-			tmpUtxo,
-		)
-	}
-	// Build TX script map
-	scripts := make(map[lcommon.ScriptHash]lcommon.Script)
-	// Add script refs from all resolved UTxOs (both inputs and reference inputs)
-	for _, utxo := range slices.Concat(resolvedInputs, resolvedRefInputs) {
-		tmpScript := utxo.Output.ScriptRef()
-		if tmpScript == nil {
-			continue
-		}
-		scripts[tmpScript.Hash()] = tmpScript
-	}
-	if witnesses := tx.Witnesses(); witnesses != nil {
-		for _, tmpScript := range witnesses.PlutusV1Scripts() {
-			scripts[tmpScript.Hash()] = tmpScript
-		}
-		for _, tmpScript := range witnesses.PlutusV2Scripts() {
-			scripts[tmpScript.Hash()] = tmpScript
-		}
-		for _, tmpScript := range witnesses.PlutusV3Scripts() {
-			scripts[tmpScript.Hash()] = tmpScript
-		}
-		for _, tmpScript := range witnesses.NativeScripts() {
-			scripts[tmpScript.Hash()] = tmpScript
-		}
+	scriptInputs, err := resolveConwayScriptInputs(tx, ls, true)
+	if err != nil {
+		return 0, lcommon.ExUnits{}, nil, err
 	}
 	// Evaluate scripts
 	var retTotalExUnits lcommon.ExUnits
 	retRedeemerExUnits := make(map[lcommon.RedeemerKey]lcommon.ExUnits)
-	var txInfoV3 script.TxInfo
-	var err error
-	txInfoV3, err = script.NewTxInfoV3FromTransaction(
+	txInfos := newConwayTxInfoCache(
 		ls,
 		tx,
-		slices.Concat(resolvedInputs, resolvedRefInputs),
+		scriptInputs.resolvedAllInputs,
 	)
+	txInfoV3, err := txInfos.v3()
 	if err != nil {
 		return 0, lcommon.ExUnits{}, nil, err
 	}
-	for _, redeemerPair := range txInfoV3.(script.TxInfoV3).Redeemers {
+	for _, redeemerPair := range txInfoV3.Redeemers {
 		purpose := redeemerPair.Key
 		if purpose == nil {
 			return 0, lcommon.ExUnits{}, nil, errors.New(
@@ -325,127 +1162,38 @@ func EvaluateTxConway(
 		}
 		redeemer := redeemerPair.Value
 		// Lookup script from redeemer purpose
-		tmpScript := scripts[purpose.ScriptHash()]
+		tmpScript := scriptInputs.scripts[purpose.ScriptHash()]
 		if tmpScript == nil {
 			return 0, lcommon.ExUnits{}, nil, errors.New(
 				"could not find needed script",
 			)
 		}
-		switch s := tmpScript.(type) {
-		case lcommon.PlutusV1Script:
-			txInfoV1, err := script.NewTxInfoV1FromTransaction(
-				ls,
-				tx,
-				slices.Concat(resolvedInputs, resolvedRefInputs),
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, err
-			}
-			// Get spent UTxO datum
-			var datum data.PlutusData
-			if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
-				datum = tmp.Datum
-			}
-			sc := script.NewScriptContextV1V2(txInfoV1, purpose)
-			evalContext, err := cek.NewEvalContext(
-				lang.LanguageVersionV1,
-				cek.ProtoVersion{
-					Major: tmpPparams.ProtocolVersion.Major,
-					Minor: tmpPparams.ProtocolVersion.Minor,
-				},
-				tmpPparams.CostModels[0],
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
-			}
-			usedBudget, err := s.Evaluate(
-				datum,
-				redeemer.Data,
-				sc.ToPlutusData(),
-				tmpPparams.MaxTxExUnits,
-				evalContext,
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, err
-			}
-			retTotalExUnits.Steps += usedBudget.Steps
-			retTotalExUnits.Memory += usedBudget.Memory
-			retRedeemerExUnits[lcommon.RedeemerKey{
-				Tag:   redeemer.Tag,
-				Index: redeemer.Index,
-			}] = usedBudget
-		case lcommon.PlutusV2Script:
-			txInfoV2, err := script.NewTxInfoV2FromTransaction(
-				ls,
-				tx,
-				slices.Concat(resolvedInputs, resolvedRefInputs),
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, err
-			}
-			// Get spent UTxO datum
-			var datum data.PlutusData
-			if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
-				datum = tmp.Datum
-			}
-			sc := script.NewScriptContextV1V2(txInfoV2, purpose)
-			evalContext, err := cek.NewEvalContext(
-				lang.LanguageVersionV2,
-				cek.ProtoVersion{
-					Major: tmpPparams.ProtocolVersion.Major,
-					Minor: tmpPparams.ProtocolVersion.Minor,
-				},
-				tmpPparams.CostModels[1],
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
-			}
-			usedBudget, err := s.Evaluate(
-				datum,
-				redeemer.Data,
-				sc.ToPlutusData(),
-				tmpPparams.MaxTxExUnits,
-				evalContext,
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, err
-			}
-			retTotalExUnits.Steps += usedBudget.Steps
-			retTotalExUnits.Memory += usedBudget.Memory
-			retRedeemerExUnits[lcommon.RedeemerKey{
-				Tag:   redeemer.Tag,
-				Index: redeemer.Index,
-			}] = usedBudget
-		case lcommon.PlutusV3Script:
-			sc := script.NewScriptContextV3(txInfoV3, redeemer, purpose)
-			evalContext, err := cek.NewEvalContext(
-				lang.LanguageVersionV3,
-				cek.ProtoVersion{
-					Major: tmpPparams.ProtocolVersion.Major,
-					Minor: tmpPparams.ProtocolVersion.Minor,
-				},
-				tmpPparams.CostModels[2],
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("build evaluation context: %w", err)
-			}
-			usedBudget, err := s.Evaluate(
-				sc.ToPlutusData(),
-				tmpPparams.MaxTxExUnits,
-				evalContext,
-			)
-			if err != nil {
-				return 0, lcommon.ExUnits{}, nil, err
-			}
-			retTotalExUnits.Steps += usedBudget.Steps
-			retTotalExUnits.Memory += usedBudget.Memory
-			retRedeemerExUnits[lcommon.RedeemerKey{
-				Tag:   redeemer.Tag,
-				Index: redeemer.Index,
-			}] = usedBudget
-		default:
-			return 0, lcommon.ExUnits{}, nil, fmt.Errorf("unimplemented script type: %T", tmpScript)
+		var datum data.PlutusData
+		if tmp, ok := purpose.(script.ScriptPurposeSpending); ok {
+			datum = tmp.Datum
 		}
+		usedBudget, execErr, err := evaluateConwayPlutusScript(
+			tmpScript,
+			purpose,
+			redeemer,
+			datum,
+			tmpPparams.MaxTxExUnits,
+			tmpPparams,
+			txInfos,
+			false,
+		)
+		if err != nil {
+			return 0, lcommon.ExUnits{}, nil, err
+		}
+		if execErr != nil {
+			return 0, lcommon.ExUnits{}, nil, execErr
+		}
+		retTotalExUnits.Steps += usedBudget.Steps
+		retTotalExUnits.Memory += usedBudget.Memory
+		retRedeemerExUnits[lcommon.RedeemerKey{
+			Tag:   redeemer.Tag,
+			Index: redeemer.Index,
+		}] = usedBudget
 	}
 	// Calculate fee based on TX size and calculated ExUnits
 	txSize := TxSizeForFee(tx)
@@ -463,6 +1211,23 @@ func EvaluateTxConway(
 		tmpPparams.MinFeeB,
 		pricesMem,
 		pricesSteps,
+	)
+	refScriptSize, err := ReferenceScriptSizeFromUtxos(
+		scriptInputs.resolvedAllInputs,
+	)
+	if err != nil {
+		return 0, lcommon.ExUnits{}, nil, err
+	}
+	var refScriptCostPerByte *big.Rat
+	if tmpPparams.MinFeeRefScriptCostPerByte != nil {
+		refScriptCostPerByte = tmpPparams.MinFeeRefScriptCostPerByte.ToBigRat()
+	}
+	fee = saturatedAddUint64(
+		fee,
+		CalculateConwayRefScriptFee(
+			refScriptSize,
+			refScriptCostPerByte,
+		),
 	)
 	return fee, retTotalExUnits, retRedeemerExUnits, nil
 }

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -42,17 +42,26 @@ type indexedUtxoValidationRule struct {
 	validationFunc lcommon.UtxoValidationRuleFunc
 }
 
+type utxoValidationRuleSkip struct {
+	index          int
+	validationFunc lcommon.UtxoValidationRuleFunc
+	name           string
+}
+
 const (
 	noUtxoValidationRuleIndex = -1
 
-	// Positions in gouroboros v0.179.0 UtxoValidationRules. Function
+	// Positions in gouroboros v0.180.1 UtxoValidationRules. Function
 	// values are not directly comparable in Go, so setup guards compare
 	// function pointers before filtering by index.
 	alonzoUtxoValidatePlutusScriptsRuleIndex   = 26
 	babbageUtxoValidatePlutusScriptsRuleIndex  = 30
+	conwayUtxoValidateFeeTooSmallRuleIndex     = 19
 	conwayUtxoValidateExUnitsTooBigRuleIndex   = 34
 	conwayUtxoValidatePlutusScriptsRuleIndex   = 38
 	dijkstraUtxoValidatePlutusScriptsRuleIndex = 38
+
+	conwayRefScriptCostStride = 25_600
 )
 
 func shouldSkipPhase2Validation(
@@ -69,17 +78,40 @@ func buildIndexedUtxoValidationRules(
 	skipRuleName string,
 ) []indexedUtxoValidationRule {
 	if skipIndex != noUtxoValidationRuleIndex {
-		validateUtxoValidationSkipIndex(
+		return buildIndexedUtxoValidationRulesWithSkips(
 			rules,
-			skipIndex,
-			skipValidationFunc,
-			skipRuleName,
+			[]utxoValidationRuleSkip{
+				{
+					index:          skipIndex,
+					validationFunc: skipValidationFunc,
+					name:           skipRuleName,
+				},
+			},
 		)
 	}
+	return buildIndexedUtxoValidationRulesWithSkips(rules, nil)
+}
 
+func buildIndexedUtxoValidationRulesWithSkips(
+	rules []lcommon.UtxoValidationRuleFunc,
+	skips []utxoValidationRuleSkip,
+) []indexedUtxoValidationRule {
+	skipIndexes := map[int]struct{}{}
+	for _, skip := range skips {
+		if skip.index == noUtxoValidationRuleIndex {
+			continue
+		}
+		validateUtxoValidationSkipIndex(
+			rules,
+			skip.index,
+			skip.validationFunc,
+			skip.name,
+		)
+		skipIndexes[skip.index] = struct{}{}
+	}
 	ret := make([]indexedUtxoValidationRule, 0, len(rules))
 	for idx, validationFunc := range rules {
-		if idx == skipIndex {
+		if _, ok := skipIndexes[idx]; ok {
 			continue
 		}
 		ret = append(ret, indexedUtxoValidationRule{
@@ -346,29 +378,199 @@ func CalculateMinFee(
 			new(big.Rat).SetInt64(exUnits.Steps),
 		)
 		sum := new(big.Rat).Add(memCost, stepCost)
-		// ceil(sum) using integer arithmetic
-		num := sum.Num()
-		denom := sum.Denom()
-		q, r := new(big.Int).DivMod(
-			num,
-			denom,
-			new(big.Int),
-		)
-		if r.Sign() > 0 {
-			q.Add(q, big.NewInt(1))
-		}
-		if !q.IsUint64() {
-			scriptFee = math.MaxUint64
-		} else {
-			scriptFee = q.Uint64()
-		}
+		scriptFee = ceilRatToUint64(sum)
 	}
 
-	total := baseFee + scriptFee
-	if total < baseFee {
+	return saturatedAddUint64(baseFee, scriptFee)
+}
+
+func saturatedAddUint64(a, b uint64) uint64 {
+	if b > math.MaxUint64-a {
 		return math.MaxUint64
 	}
-	return total
+	return a + b
+}
+
+func ceilRatToUint64(val *big.Rat) uint64 {
+	if val == nil {
+		return 0
+	}
+	num := val.Num()
+	denom := val.Denom()
+	q, r := new(big.Int).DivMod(
+		num,
+		denom,
+		new(big.Int),
+	)
+	if r.Sign() > 0 {
+		q.Add(q, big.NewInt(1))
+	}
+	if !q.IsUint64() {
+		return math.MaxUint64
+	}
+	return q.Uint64()
+}
+
+func floorRatToUint64(val *big.Rat) uint64 {
+	if val == nil {
+		return 0
+	}
+	q := new(big.Int).Div(val.Num(), val.Denom())
+	if q.Sign() < 0 {
+		return 0
+	}
+	if !q.IsUint64() {
+		return math.MaxUint64
+	}
+	return q.Uint64()
+}
+
+func calculateTieredRefScriptFee(
+	refScriptSize uint64,
+	costPerByte *big.Rat,
+	stride uint64,
+	multiplier *big.Rat,
+) uint64 {
+	if refScriptSize == 0 || costPerByte == nil || stride == 0 {
+		return 0
+	}
+	if multiplier == nil {
+		multiplier = big.NewRat(1, 1)
+	}
+	remaining := refScriptSize
+	currentCostPerByte := new(big.Rat).Set(costPerByte)
+	total := new(big.Rat)
+	for remaining > 0 {
+		chunkSize := stride
+		if remaining < chunkSize {
+			chunkSize = remaining
+		}
+		chunkFee := new(big.Rat).Mul(
+			currentCostPerByte,
+			new(big.Rat).SetInt(
+				new(big.Int).SetUint64(chunkSize),
+			),
+		)
+		total.Add(total, chunkFee)
+		remaining -= chunkSize
+		currentCostPerByte.Mul(currentCostPerByte, multiplier)
+	}
+	return floorRatToUint64(total)
+}
+
+func CalculateConwayRefScriptFee(
+	refScriptSize uint64,
+	costPerByte *big.Rat,
+) uint64 {
+	return calculateTieredRefScriptFee(
+		refScriptSize,
+		costPerByte,
+		conwayRefScriptCostStride,
+		big.NewRat(6, 5),
+	)
+}
+
+func CalculateConwayMinFee(
+	txSize uint64,
+	exUnits lcommon.ExUnits,
+	minFeeA uint,
+	minFeeB uint,
+	pricesMem *big.Rat,
+	pricesSteps *big.Rat,
+	refScriptSize uint64,
+	refScriptCostPerByte *big.Rat,
+) uint64 {
+	baseAndExecutionFee := CalculateMinFee(
+		txSize,
+		exUnits,
+		minFeeA,
+		minFeeB,
+		pricesMem,
+		pricesSteps,
+	)
+	refScriptFee := CalculateConwayRefScriptFee(
+		refScriptSize,
+		refScriptCostPerByte,
+	)
+	return saturatedAddUint64(baseAndExecutionFee, refScriptFee)
+}
+
+func ReferencedScriptSize(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) (uint64, error) {
+	utxos, err := referencedScriptUtxos(tx, ls)
+	if err != nil {
+		return 0, err
+	}
+	return ReferenceScriptSizeFromUtxos(utxos)
+}
+
+func ReferenceScriptSizeFromUtxos(
+	utxos []lcommon.Utxo,
+) (uint64, error) {
+	var total uint64
+	seen := make(map[string]struct{}, len(utxos))
+	for _, utxo := range utxos {
+		if utxo.Output == nil {
+			continue
+		}
+		scriptRef := utxo.Output.ScriptRef()
+		if scriptRef == nil {
+			continue
+		}
+		if utxo.Id != nil {
+			key := utxo.Id.String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		size := uint64(len(scriptRef.RawScriptBytes()))
+		if size > math.MaxUint64-total {
+			return 0, errors.New("reference script size overflow")
+		}
+		total += size
+	}
+	return total, nil
+}
+
+func referencedScriptUtxos(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) ([]lcommon.Utxo, error) {
+	inputs := tx.Inputs()
+	refInputs := tx.ReferenceInputs()
+	if len(inputs) == 0 && len(refInputs) == 0 {
+		return nil, nil
+	}
+	if ls == nil {
+		return nil, errors.New(
+			"ledger state unavailable for reference script fee calculation",
+		)
+	}
+	utxos := make([]lcommon.Utxo, 0, len(inputs)+len(refInputs))
+	for _, input := range inputs {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return nil, lcommon.InputResolutionError{
+				Input: input,
+				Err:   err,
+			}
+		}
+		utxos = append(utxos, utxo)
+	}
+	for _, input := range refInputs {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return nil, lcommon.ReferenceInputResolutionError{
+				Input: input,
+				Err:   err,
+			}
+		}
+		utxos = append(utxos, utxo)
+	}
+	return utxos, nil
 }
 
 // DeclaredExUnits returns the total execution units

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -21,10 +21,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,10 +74,117 @@ func (m *mockFeeTx) Witnesses() lcommon.TransactionWitnessSet {
 	return m.witnesses
 }
 
+func (m *mockFeeTx) ScriptDataHash() *lcommon.Blake2b256 {
+	return nil
+}
+
+type mockConwayFeeTx struct {
+	mockFeeTx
+	inputs             []lcommon.TransactionInput
+	referenceInputs    []lcommon.TransactionInput
+	certificates       []lcommon.Certificate
+	withdrawals        map[*lcommon.Address]*big.Int
+	assetMint          *lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
+	votingProcedures   lcommon.VotingProcedures
+	proposalProcedures []lcommon.ProposalProcedure
+}
+
+func (m *mockConwayFeeTx) Inputs() []lcommon.TransactionInput {
+	return m.inputs
+}
+
+func (m *mockConwayFeeTx) ReferenceInputs() []lcommon.TransactionInput {
+	return m.referenceInputs
+}
+
+func (m *mockConwayFeeTx) Id() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func (m *mockConwayFeeTx) Produced() []lcommon.Utxo {
+	return nil
+}
+
+func (m *mockConwayFeeTx) Outputs() []lcommon.TransactionOutput {
+	return nil
+}
+
+func (m *mockConwayFeeTx) TTL() uint64 {
+	return 0
+}
+
+func (m *mockConwayFeeTx) ValidityIntervalStart() uint64 {
+	return 0
+}
+
+func (m *mockConwayFeeTx) Certificates() []lcommon.Certificate {
+	return m.certificates
+}
+
+func (m *mockConwayFeeTx) Withdrawals() map[*lcommon.Address]*big.Int {
+	return m.withdrawals
+}
+
+func (m *mockConwayFeeTx) RequiredSigners() []lcommon.Blake2b224 {
+	return nil
+}
+
+func (m *mockConwayFeeTx) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	return m.assetMint
+}
+
+func (m *mockConwayFeeTx) IsValid() bool {
+	return true
+}
+
+func (m *mockConwayFeeTx) VotingProcedures() lcommon.VotingProcedures {
+	return m.votingProcedures
+}
+
+func (m *mockConwayFeeTx) ProposalProcedures() []lcommon.ProposalProcedure {
+	return m.proposalProcedures
+}
+
+type testScriptOutput struct {
+	testOutput
+	scriptRef lcommon.Script
+}
+
+func (o testScriptOutput) ScriptRef() lcommon.Script {
+	return o.scriptRef
+}
+
+type testAddressOutput struct {
+	testOutput
+	addr lcommon.Address
+}
+
+func (o testAddressOutput) Address() lcommon.Address {
+	return o.addr
+}
+
+type testAddressScriptOutput struct {
+	testOutput
+	addr      lcommon.Address
+	scriptRef lcommon.Script
+}
+
+func (o testAddressScriptOutput) Address() lcommon.Address {
+	return o.addr
+}
+
+func (o testAddressScriptOutput) ScriptRef() lcommon.Script {
+	return o.scriptRef
+}
+
 // mockWitnessSet implements TransactionWitnessSet for
 // testing, returning only redeemers.
 type mockWitnessSet struct {
-	redeemers lcommon.TransactionWitnessRedeemers
+	redeemers       lcommon.TransactionWitnessRedeemers
+	nativeScripts   []lcommon.NativeScript
+	plutusV1Scripts []lcommon.PlutusV1Script
+	plutusV2Scripts []lcommon.PlutusV2Script
+	plutusV3Scripts []lcommon.PlutusV3Script
 }
 
 func (m *mockWitnessSet) Vkey() []lcommon.VkeyWitness {
@@ -82,7 +192,7 @@ func (m *mockWitnessSet) Vkey() []lcommon.VkeyWitness {
 }
 
 func (m *mockWitnessSet) NativeScripts() []lcommon.NativeScript {
-	return nil
+	return m.nativeScripts
 }
 
 func (m *mockWitnessSet) Bootstrap() []lcommon.BootstrapWitness {
@@ -94,15 +204,15 @@ func (m *mockWitnessSet) PlutusData() []lcommon.Datum {
 }
 
 func (m *mockWitnessSet) PlutusV1Scripts() []lcommon.PlutusV1Script {
-	return nil
+	return m.plutusV1Scripts
 }
 
 func (m *mockWitnessSet) PlutusV2Scripts() []lcommon.PlutusV2Script {
-	return nil
+	return m.plutusV2Scripts
 }
 
 func (m *mockWitnessSet) PlutusV3Scripts() []lcommon.PlutusV3Script {
-	return nil
+	return m.plutusV3Scripts
 }
 
 func (m *mockWitnessSet) Redeemers() lcommon.TransactionWitnessRedeemers {
@@ -177,7 +287,14 @@ func TestBabbageValidationRulesUseLocalPlutusExecution(t *testing.T) {
 	)
 }
 
-func TestConwayValidationRulesIncludePlutusExecutionByDefault(t *testing.T) {
+func TestConwayValidationRulesUseLocalPlutusExecution(t *testing.T) {
+	requireRuleIndexResolvesToFunc(
+		t,
+		conway.UtxoValidationRules,
+		conwayUtxoValidateFeeTooSmallRuleIndex,
+		conway.UtxoValidateFeeTooSmallUtxo,
+		"conway.UtxoValidateFeeTooSmallUtxo",
+	)
 	requireRuleIndexResolvesToFunc(
 		t,
 		conway.UtxoValidationRules,
@@ -185,16 +302,29 @@ func TestConwayValidationRulesIncludePlutusExecutionByDefault(t *testing.T) {
 		conway.UtxoValidatePlutusScripts,
 		"conway.UtxoValidatePlutusScripts",
 	)
-	require.Len(t, conwayUtxoValidationRules, len(conway.UtxoValidationRules))
-	requireIndexedRulesIncludeFunc(
+	require.Len(t, conwayUtxoValidationRules, len(conway.UtxoValidationRules)-2)
+	requireIndexedRulesExcludeFunc(
+		t,
+		conwayUtxoValidationRules,
+		conway.UtxoValidateFeeTooSmallUtxo,
+		"Conway validation must use Dingo's reference-script-aware fee rule",
+	)
+	requireIndexedRulesExcludeFunc(
 		t,
 		conwayUtxoValidationRules,
 		conway.UtxoValidatePlutusScripts,
-		"Conway validation should include gouroboros Plutus execution by default",
+		"Conway validation must use Dingo's local Plutus execution path",
 	)
 }
 
 func TestConwayPhase1ValidationRulesSkipPlutusExecution(t *testing.T) {
+	requireRuleIndexResolvesToFunc(
+		t,
+		conway.UtxoValidationRules,
+		conwayUtxoValidateFeeTooSmallRuleIndex,
+		conway.UtxoValidateFeeTooSmallUtxo,
+		"conway.UtxoValidateFeeTooSmallUtxo",
+	)
 	requireRuleIndexResolvesToFunc(
 		t,
 		conway.UtxoValidationRules,
@@ -212,7 +342,13 @@ func TestConwayPhase1ValidationRulesSkipPlutusExecution(t *testing.T) {
 	require.Len(
 		t,
 		conwayPhase1UtxoValidationRules,
-		len(conway.UtxoValidationRules)-1,
+		len(conway.UtxoValidationRules)-2,
+	)
+	requireIndexedRulesExcludeFunc(
+		t,
+		conwayPhase1UtxoValidationRules,
+		conway.UtxoValidateFeeTooSmallUtxo,
+		"Conway phase-1 validation must use Dingo's reference-script-aware fee rule",
 	)
 	requireIndexedRulesIncludeFunc(
 		t,
@@ -225,6 +361,459 @@ func TestConwayPhase1ValidationRulesSkipPlutusExecution(t *testing.T) {
 		conwayPhase1UtxoValidationRules,
 		conway.UtxoValidatePlutusScripts,
 		"Conway phase-1 replay must not execute Plutus scripts",
+	)
+}
+
+func TestValidateTxPlutusConwayMissingScriptWitnessFails(t *testing.T) {
+	var scriptHash lcommon.ScriptHash
+	scriptHash[0] = 0xaa
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	spendInput := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			witnesses: &mockWitnessSet{
+				redeemers: &mockRedeemers{
+					entries: []struct {
+						key lcommon.RedeemerKey
+						val lcommon.RedeemerValue
+					}{
+						{
+							key: lcommon.RedeemerKey{
+								Tag:   lcommon.RedeemerTagSpend,
+								Index: 0,
+							},
+							val: lcommon.RedeemerValue{},
+						},
+					},
+				},
+			},
+		},
+		inputs: []lcommon.TransactionInput{spendInput},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		spendInput,
+		testAddressOutput{
+			testOutput: newTestOutput(1_000_000),
+			addr:       addr,
+		},
+	)
+
+	err = ValidateTxPlutusConway(
+		tx,
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	)
+	require.Error(t, err)
+	var missing lcommon.MissingScriptWitnessesError
+	require.ErrorAs(t, err, &missing)
+	assert.Equal(t, scriptHash, missing.ScriptHash)
+}
+
+func TestValidateTxPlutusConwayMissingScriptWitnessWithoutRedeemerFails(t *testing.T) {
+	var scriptHash lcommon.ScriptHash
+	scriptHash[0] = 0xaa
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	spendInput := newTestInput(0x01, 0)
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		spendInput,
+		testAddressOutput{
+			testOutput: newTestOutput(1_000_000),
+			addr:       addr,
+		},
+	)
+
+	tests := []struct {
+		name      string
+		witnesses lcommon.TransactionWitnessSet
+	}{
+		{
+			name: "nil witnesses",
+		},
+		{
+			name:      "nil redeemers",
+			witnesses: &mockWitnessSet{},
+		},
+		{
+			name: "empty redeemers",
+			witnesses: &mockWitnessSet{
+				redeemers: &mockRedeemers{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &mockConwayFeeTx{
+				mockFeeTx: mockFeeTx{
+					txType:    txTypeAlonzo,
+					witnesses: tt.witnesses,
+				},
+				inputs: []lcommon.TransactionInput{spendInput},
+			}
+
+			err := ValidateTxPlutusConway(
+				tx,
+				0,
+				ls,
+				&conway.ConwayProtocolParameters{},
+			)
+			require.Error(t, err)
+			var missing lcommon.MissingScriptWitnessesError
+			require.ErrorAs(t, err, &missing)
+			assert.Equal(t, scriptHash, missing.ScriptHash)
+		})
+	}
+}
+
+func TestValidateTxPlutusConwayNativeScriptWitnessWithoutRedeemerPasses(t *testing.T) {
+	nativeScript := lcommon.NativeScript{}
+	scriptHash := nativeScript.Hash()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	spendInput := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			witnesses: &mockWitnessSet{
+				nativeScripts: []lcommon.NativeScript{
+					nativeScript,
+				},
+			},
+		},
+		inputs: []lcommon.TransactionInput{spendInput},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		spendInput,
+		testAddressOutput{
+			testOutput: newTestOutput(1_000_000),
+			addr:       addr,
+		},
+	)
+
+	require.NoError(t, ValidateTxPlutusConway(
+		tx,
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	))
+}
+
+func TestValidateTxPlutusConwayMissingRedeemerForScriptRefFails(t *testing.T) {
+	plutusScript := lcommon.PlutusV2Script([]byte{0x01, 0x02})
+	scriptHash := plutusScript.Hash()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	spendInput := newTestInput(0x01, 0)
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		spendInput,
+		testAddressScriptOutput{
+			testOutput: newTestOutput(1_000_000),
+			addr:       addr,
+			scriptRef:  plutusScript,
+		},
+	)
+
+	tests := []struct {
+		name      string
+		witnesses lcommon.TransactionWitnessSet
+	}{
+		{
+			name: "nil witnesses",
+		},
+		{
+			name:      "nil redeemers",
+			witnesses: &mockWitnessSet{},
+		},
+		{
+			name: "empty redeemers",
+			witnesses: &mockWitnessSet{
+				redeemers: &mockRedeemers{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &mockConwayFeeTx{
+				mockFeeTx: mockFeeTx{
+					txType:    txTypeAlonzo,
+					witnesses: tt.witnesses,
+				},
+				inputs: []lcommon.TransactionInput{spendInput},
+			}
+
+			err := ValidateTxPlutusConway(
+				tx,
+				0,
+				ls,
+				&conway.ConwayProtocolParameters{},
+			)
+			require.Error(t, err)
+			var missing conway.MissingRedeemerForScriptError
+			require.ErrorAs(t, err, &missing)
+			assert.Equal(t, scriptHash, missing.ScriptHash)
+			assert.Equal(t, lcommon.RedeemerTagSpend, missing.Tag)
+			assert.Equal(t, uint32(0), missing.Index)
+		})
+	}
+}
+
+func TestValidateTxPlutusConwayRegistrationCertificateMissingRedeemerFails(t *testing.T) {
+	plutusScript := lcommon.PlutusV2Script([]byte{0x03, 0x04})
+	scriptHash := plutusScript.Hash()
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			witnesses: &mockWitnessSet{
+				plutusV2Scripts: []lcommon.PlutusV2Script{
+					plutusScript,
+				},
+				redeemers: &mockRedeemers{},
+			},
+		},
+		certificates: []lcommon.Certificate{
+			&lcommon.RegistrationCertificate{
+				StakeCredential: lcommon.Credential{
+					CredType:   lcommon.CredentialTypeScriptHash,
+					Credential: scriptHash,
+				},
+				Amount: 2_000_000,
+			},
+		},
+	}
+
+	err := ValidateTxPlutusConway(
+		tx,
+		0,
+		newMockLedgerState(),
+		&conway.ConwayProtocolParameters{},
+	)
+	require.Error(t, err)
+	var missing conway.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missing)
+	assert.Equal(t, scriptHash, missing.ScriptHash)
+	assert.Equal(t, lcommon.RedeemerTagCert, missing.Tag)
+	assert.Equal(t, uint32(0), missing.Index)
+}
+
+func TestValidateTxPlutusConwayNonSpendMissingScriptWitnessFails(t *testing.T) {
+	var scriptHash lcommon.ScriptHash
+	scriptHash[0] = 0xaa
+
+	scriptCred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeScriptHash,
+		Credential: scriptHash,
+	}
+	withdrawalAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneScript,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		scriptHash.Bytes(),
+	)
+	require.NoError(t, err)
+	voter := &lcommon.Voter{
+		Type: lcommon.VoterTypeDRepScriptHash,
+		Hash: [28]byte(scriptHash),
+	}
+	assetMint := lcommon.NewMultiAsset[lcommon.MultiAssetTypeMint](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeMint{
+			lcommon.Blake2b224(scriptHash): {
+				cbor.NewByteString([]byte("asset")): big.NewInt(1),
+			},
+		},
+	)
+	proposal := conway.ConwayProposalProcedure{
+		PPGovAction: conway.ConwayGovAction{
+			Action: &lcommon.TreasuryWithdrawalGovAction{
+				PolicyHash: scriptHash.Bytes(),
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		tx   *mockConwayFeeTx
+	}{
+		{
+			name: "mint",
+			tx: &mockConwayFeeTx{
+				assetMint: &assetMint,
+			},
+		},
+		{
+			name: "cert",
+			tx: &mockConwayFeeTx{
+				certificates: []lcommon.Certificate{
+					&lcommon.RegistrationCertificate{
+						StakeCredential: scriptCred,
+						Amount:          2_000_000,
+					},
+				},
+			},
+		},
+		{
+			name: "withdraw",
+			tx: &mockConwayFeeTx{
+				withdrawals: map[*lcommon.Address]*big.Int{
+					&withdrawalAddr: big.NewInt(1_000_000),
+				},
+			},
+		},
+		{
+			name: "vote",
+			tx: &mockConwayFeeTx{
+				votingProcedures: lcommon.VotingProcedures{
+					voter: {
+						&lcommon.GovActionId{}: lcommon.VotingProcedure{
+							Vote: lcommon.GovVoteYes,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "propose",
+			tx: &mockConwayFeeTx{
+				proposalProcedures: []lcommon.ProposalProcedure{
+					proposal,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.tx.mockFeeTx = mockFeeTx{
+				txType:    txTypeAlonzo,
+				witnesses: &mockWitnessSet{},
+			}
+
+			err := ValidateTxPlutusConway(
+				tt.tx,
+				0,
+				newMockLedgerState(),
+				&conway.ConwayProtocolParameters{},
+			)
+			require.Error(t, err)
+			var missing lcommon.MissingScriptWitnessesError
+			require.ErrorAs(t, err, &missing)
+			assert.Equal(t, scriptHash, missing.ScriptHash)
+		})
+	}
+}
+
+func TestValidateTxPlutusConwayUnusedReferenceScriptWithoutRedeemerPasses(t *testing.T) {
+	plutusScript := lcommon.PlutusV2Script([]byte{0x01, 0x02})
+	scriptHash := plutusScript.Hash()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	refInput := newTestInput(0x02, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			witnesses: &mockWitnessSet{
+				redeemers: &mockRedeemers{},
+			},
+		},
+		referenceInputs: []lcommon.TransactionInput{refInput},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		refInput,
+		testAddressScriptOutput{
+			testOutput: newTestOutput(1_000_000),
+			addr:       addr,
+			scriptRef:  plutusScript,
+		},
+	)
+
+	require.NoError(t, ValidateTxPlutusConway(
+		tx,
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	))
+}
+
+// TestTxInfoV2ContextSortsInputs guards the canonical Plutus requirement that
+// the script context lists transaction inputs sorted by TxOutRef, not in
+// transaction-body order. Building the context in body order (as the reverted
+// txInfoV2WithTxInputOrder wrapper did) makes validators traverse a mis-ordered
+// input list and over-compute the execution budget relative to cardano-node,
+// producing phase-2 "Plutus evaluation disagrees with block producer" failures.
+func TestTxInfoV2ContextSortsInputs(t *testing.T) {
+	// Body order is intentionally unsorted: 0x02 before 0x01.
+	bodyFirst := newTestInput(0x02, 0)
+	bodySecond := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			fee:       big.NewInt(0),
+			witnesses: &mockWitnessSet{},
+		},
+		inputs: []lcommon.TransactionInput{
+			bodyFirst,
+			bodySecond,
+		},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(bodyFirst, newTestOutput(1_000_000))
+	ls.addUtxo(bodySecond, newTestOutput(1_000_000))
+	resolved := []lcommon.Utxo{
+		{Id: bodyFirst, Output: newTestOutput(1_000_000)},
+		{Id: bodySecond, Output: newTestOutput(1_000_000)},
+	}
+
+	txInfo, err := script.NewTxInfoV2FromTransaction(ls, tx, resolved)
+
+	require.NoError(t, err)
+	require.Len(t, txInfo.Inputs, 2)
+	// Canonical order sorts by TxOutRef, so 0x01 must come before 0x02
+	// regardless of the body order or resolved-input order.
+	assert.Equal(
+		t,
+		bodySecond.String(),
+		lcommon.Utxo(txInfo.Inputs[0]).Id.String(),
+	)
+	assert.Equal(
+		t,
+		bodyFirst.String(),
+		lcommon.Utxo(txInfo.Inputs[1]).Id.String(),
 	)
 }
 
@@ -910,6 +1499,264 @@ func TestCalculateMinFee_MultipleScriptsSum(t *testing.T) {
 	// stepFee = ceil(721*200000000/10000000) = 14420
 	// total = 172981 + 34620 + 14420 = 222021
 	assert.Equal(t, uint64(222021), fee)
+}
+
+func TestCalculateConwayRefScriptFee_Tiered(t *testing.T) {
+	fee := CalculateConwayRefScriptFee(
+		30_000,
+		big.NewRat(15, 1),
+	)
+	// First 25,600 bytes cost 15/byte. The remaining 4,400 bytes
+	// cost 18/byte after Conway's 1.2 multiplier.
+	assert.Equal(t, uint64(463_200), fee)
+}
+
+func TestCalculateConwayRefScriptFee_FloorsTieredTotal(t *testing.T) {
+	fee := CalculateConwayRefScriptFee(
+		25_601,
+		big.NewRat(1, 3),
+	)
+	// floor(25,600 / 3 + 1 * 2 / 5) = floor(8,533.733...)
+	assert.Equal(t, uint64(8_533), fee)
+}
+
+func TestValidateTxFeeConwayIncludesReferenceScripts(t *testing.T) {
+	spendInput := newTestInput(0x01, 0)
+	refInput := newTestInput(0x02, 1)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			cbor:   make([]byte, 101),
+			txType: txTypeAlonzo,
+			fee:    big.NewInt(450),
+		},
+		inputs:          []lcommon.TransactionInput{spendInput},
+		referenceInputs: []lcommon.TransactionInput{refInput},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		spendInput,
+		testScriptOutput{
+			testOutput: newTestOutput(1_000_000),
+			scriptRef:  lcommon.PlutusV2Script(make([]byte, 10)),
+		},
+	)
+	ls.addUtxo(
+		refInput,
+		testScriptOutput{
+			testOutput: newTestOutput(1_000_000),
+			scriptRef:  lcommon.PlutusV3Script(make([]byte, 20)),
+		},
+	)
+	pp := &conway.ConwayProtocolParameters{
+		MinFeeRefScriptCostPerByte: &cbor.Rat{
+			Rat: big.NewRat(15, 1),
+		},
+	}
+
+	require.NoError(t, ValidateTxFeeConway(tx, ls, pp))
+
+	tx.fee = big.NewInt(449)
+	err := ValidateTxFeeConway(tx, ls, pp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "minimum fee 450")
+}
+
+func TestValidateTxFeeConwayDeduplicatesOverlappingReferenceScriptInput(
+	t *testing.T,
+) {
+	spendInput := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			cbor:   make([]byte, 101),
+			txType: txTypeAlonzo,
+			fee:    big.NewInt(150),
+		},
+		inputs:          []lcommon.TransactionInput{spendInput},
+		referenceInputs: []lcommon.TransactionInput{spendInput},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(
+		spendInput,
+		testScriptOutput{
+			testOutput: newTestOutput(1_000_000),
+			scriptRef:  lcommon.PlutusV2Script(make([]byte, 10)),
+		},
+	)
+	pp := &conway.ConwayProtocolParameters{
+		MinFeeRefScriptCostPerByte: &cbor.Rat{
+			Rat: big.NewRat(15, 1),
+		},
+	}
+
+	require.NoError(t, ValidateTxFeeConway(tx, ls, pp))
+
+	tx.fee = big.NewInt(149)
+	err := ValidateTxFeeConway(tx, ls, pp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "minimum fee 150")
+}
+
+func TestValidateTxConwaySkipPhase2StillValidatesRequiredRedeemers(
+	t *testing.T,
+) {
+	withoutConwayUtxoValidationRules(t)
+
+	plutusScript := lcommon.PlutusV2Script([]byte{0x01, 0x02})
+	scriptHash := plutusScript.Hash()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	spendInput := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			fee:    big.NewInt(0),
+		},
+		inputs: []lcommon.TransactionInput{spendInput},
+	}
+	ls := newMockLedgerState()
+	ls.skipPhase2Validation = true
+	ls.addUtxo(
+		spendInput,
+		testAddressScriptOutput{
+			testOutput: newTestOutput(1_000_000),
+			addr:       addr,
+			scriptRef:  plutusScript,
+		},
+	)
+
+	err = ValidateTxConway(
+		tx,
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	)
+	require.Error(t, err)
+	var missing conway.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missing)
+	assert.Equal(t, scriptHash, missing.ScriptHash)
+}
+
+func TestValidateTxConwaySkipPhase2StillValidatesRequiredScriptWitnesses(
+	t *testing.T,
+) {
+	withoutConwayUtxoValidationRules(t)
+
+	var scriptHash lcommon.ScriptHash
+	scriptHash[0] = 0xaa
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			fee:    big.NewInt(0),
+		},
+		certificates: []lcommon.Certificate{
+			&lcommon.RegistrationCertificate{
+				StakeCredential: lcommon.Credential{
+					CredType:   lcommon.CredentialTypeScriptHash,
+					Credential: scriptHash,
+				},
+				Amount: 2_000_000,
+			},
+		},
+	}
+	ls := newMockLedgerState()
+	ls.skipPhase2Validation = true
+
+	err := ValidateTxConway(
+		tx,
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	)
+	require.Error(t, err)
+	var missing lcommon.MissingScriptWitnessesError
+	require.ErrorAs(t, err, &missing)
+	assert.Equal(t, scriptHash, missing.ScriptHash)
+}
+
+func TestValidateTxConwayReusesResolvedPlutusContext(t *testing.T) {
+	withoutConwayUtxoValidationRules(t)
+
+	spendInput := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			fee:    big.NewInt(0),
+		},
+		inputs: []lcommon.TransactionInput{spendInput},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(spendInput, newTestOutput(1_000_000))
+
+	err := ValidateTxConway(
+		tx,
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, ls.utxoLookups)
+}
+
+func TestValidateTxConwayMissingInputReportsBadInputNotFeeResolution(
+	t *testing.T,
+) {
+	inputHash := make([]byte, 32)
+	inputHash[0] = 0xaa
+	bodyMap := map[uint]any{
+		0: cbor.Tag{
+			Number: 258,
+			Content: []any{
+				[]any{inputHash, uint64(0)},
+			},
+		},
+		2: uint64(200_000),
+	}
+	txCbor, err := cbor.Encode([]any{bodyMap, map[uint]any{}, true, nil})
+	require.NoError(t, err)
+
+	tx, err := conway.NewConwayTransactionFromCbor(txCbor)
+	require.NoError(t, err)
+
+	err = ValidateTxConway(
+		tx,
+		0,
+		newMockLedgerState(),
+		&conway.ConwayProtocolParameters{
+			ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+				Major: conway.MinProtocolVersionConway,
+			},
+			MaxTxSize:            16_384,
+			MaxValueSize:         5_000,
+			CollateralPercentage: 150,
+			MaxCollateralInputs:  3,
+		},
+	)
+	require.Error(t, err)
+
+	var badInputs shelley.BadInputsUtxoError
+	require.ErrorAs(t, err, &badInputs)
+	require.Len(t, badInputs.Inputs, 1)
+	assert.Equal(t, tx.Inputs()[0].String(), badInputs.Inputs[0].String())
+	assert.NotContains(t, err.Error(), "conway fee validation")
+	assert.NotContains(t, err.Error(), "calculating reference script size")
+}
+
+func withoutConwayUtxoValidationRules(t *testing.T) {
+	t.Helper()
+
+	origRules := conwayUtxoValidationRules
+	origPhase1Rules := conwayPhase1UtxoValidationRules
+	conwayUtxoValidationRules = nil
+	conwayPhase1UtxoValidationRules = nil
+	t.Cleanup(func() {
+		conwayUtxoValidationRules = origRules
+		conwayPhase1UtxoValidationRules = origPhase1Rules
+	})
 }
 
 func TestCalculateMinFee_NilPricesIgnoresExUnits(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2040,7 +2040,7 @@ func (ls *LedgerState) transitionToEra(
 	currentPParams lcommon.ProtocolParameters,
 ) (*EraTransitionResult, error) {
 	nextEraPtr, ok := ls.eraById(nextEraId)
-	if !ok {
+	if !ok || nextEraPtr == nil {
 		return nil, fmt.Errorf("unknown era ID %d", nextEraId)
 	}
 	nextEra := *nextEraPtr
@@ -3291,7 +3291,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					var blockNonce []byte
 					if snapshotEra.CalculateEtaVFunc != nil {
 						tmpEra, ok := ls.eraById(uint(next.Era().Id))
-						if ok && tmpEra.CalculateEtaVFunc != nil {
+						if ok && tmpEra != nil && tmpEra.CalculateEtaVFunc != nil {
 							tmpNonce, err := tmpEra.CalculateEtaVFunc(
 								ls.config.CardanoNodeConfig,
 								runningNonce,
@@ -5107,7 +5107,7 @@ func (ls *LedgerState) ProtocolParamsForSlot(
 		}
 		nextID := eraID + 1
 		nextEraPtr, ok := ls.eraById(nextID)
-		if !ok {
+		if !ok || nextEraPtr == nil {
 			break
 		}
 		nextEra := *nextEraPtr


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Conway min-fee and phase-2 validation by moving fee checks and Plutus execution to local logic. Adds tiered reference-script fees and canonical ordering (inputs/withdrawals/voters), and enables SkipFinalSlippageFlush for V1/V2; updates `github.com/blinklabs-io/gouroboros` to `v0.180.1`.

- **New Features**
  - Local Conway fee validation via ValidateTxFeeConway and new CalculateConwayMinFee/CalculateConwayRefScriptFee; fees include reference-script bytes from inputs and reference inputs with 25,600-byte tiers (6/5 multiplier) and de-duplicate overlapping inputs.
  - Local Conway Plutus execution via ValidateTxPlutusConway with required-redeemer checks (spend/mint/cert/withdraw/vote/propose), extra-redeemer detection, per-tx TxInfo cache, and canonical sorting of inputs, withdrawals, and voters; SkipFinalSlippageFlush for V1/V2 (also applied to Alonzo/Babbage); phase-2 can still be skipped, but required redeemers are enforced.

- **Bug Fixes**
  - Correct min-fee math: ceil ex-unit totals, floor tiered ref-script totals, saturating uint64 addition; EvaluateTxConway now adds ref-script fees.
  - Replaced Conway UTxO rules FeeTooSmallUtxo and PlutusScripts with local logic; unresolved inputs report BadInputsUtxo; clearer errors for missing/extra redeemers and missing script witnesses/datums.
  - Guard nil era descriptors in nonce, chain sync, and state transitions to prevent panics.

<sup>Written for commit 5ace889f93469e20edaeb7454f09c8d8ad6a5c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reference script fee calculation for Conway-era transactions

* **Improvements**
  * Enhanced transaction validation with support for reference script fees in Conway era
  * Refined script evaluation logic for improved transaction processing
  * Strengthened fee validation mechanisms

* **Tests**
  * Expanded test coverage for Conway-era validation and reference script fee computation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->