### PR TITLE
feat(forging): log CBOR diagnostics when a forged block fails to re-decode

### DIFF
--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -661,6 +661,22 @@ func (b *DefaultBlockBuilder) BuildBlock(
 	// matching era's block decoder.
 	ledgerBlock, err := decodeBlockFromCbor(limits.era, blockCbor)
 	if err != nil {
+		// The forged block failed to round-trip through its own era
+		// decoder, so this winning slot would be silently dropped. Dump
+		// the generated block in Cardano-aware CBOR diagnostic notation
+		// so the encoder/decoder wire-shape mismatch is diagnosable from
+		// the logs rather than only via the opaque unmarshal error
+		// (issue #2063).
+		b.logger.Error(
+			"forged block failed to re-decode; dumping CBOR diagnostics",
+			"component", "forging",
+			"era", limits.era,
+			"proto_major", limits.protoMajor,
+			"tx_count", len(transactionBodies),
+			"block_cbor_len", len(blockCbor),
+			"error", err,
+			"diagnostics", forgedBlockDiagnostics(blockCbor),
+		)
 		return nil, nil, fmt.Errorf(
 			"failed to unmarshal forged block from generated CBOR: %w",
 			err,

--- a/ledger/forging/diagnostics_test.go
+++ b/ledger/forging/diagnostics_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// corruptBlock mirrors the Conway block envelope but encodes
+// transaction_bodies as a CBOR map instead of an array — the structural
+// defect behind issue #2063. Used only to exercise forgedBlockDiagnostics.
+type corruptBlock struct {
+	cbor.StructAsArray
+	Header                 cbor.RawMessage
+	TransactionBodies      map[uint]cbor.RawMessage
+	TransactionWitnessSets []cbor.RawMessage
+	TransactionMetadataSet cbor.RawMessage
+	InvalidTransactions    []uint
+}
+
+// TestForgedBlockDiagnosticsPinpointsBadBodiesField verifies that the
+// diagnostic dump labels the offending block field. When the bodies slot
+// holds a map instead of an array (issue #2063), the notation must show
+// "transaction_bodies" rendered as a map so the mismatch is obvious.
+func TestForgedBlockDiagnosticsPinpointsBadBodiesField(t *testing.T) {
+	// A minimal but structurally valid Conway header: [header_body, sig].
+	header, err := cbor.Encode([]any{[]any{uint64(0)}, []byte{0x00}})
+	require.NoError(t, err)
+
+	bad, err := cbor.Encode(corruptBlock{
+		Header:                 cbor.RawMessage(header),
+		TransactionBodies:      map[uint]cbor.RawMessage{0: {0xa0}},
+		TransactionWitnessSets: []cbor.RawMessage{{0xa0}},
+		TransactionMetadataSet: cbor.RawMessage{0xa0},
+		InvalidTransactions:    []uint{},
+	})
+	require.NoError(t, err)
+
+	diag := forgedBlockDiagnostics(bad)
+	t.Logf("diagnostics:\n%s", diag)
+
+	assert.Contains(
+		t,
+		diag,
+		"transaction_bodies",
+		"diagnostics must label the bodies field",
+	)
+	// The bodies field should render as a map ("{ ... }"), which is the
+	// shape mismatch the decoder rejects.
+	idx := strings.Index(diag, "transaction_bodies")
+	require.GreaterOrEqual(t, idx, 0)
+	rest := diag[idx:]
+	assert.True(
+		t,
+		strings.HasPrefix(
+			strings.TrimSpace(rest[len("transaction_bodies:"):]),
+			"{",
+		),
+		"transaction_bodies should render as a map in the diagnostics",
+	)
+}
+
+// TestForgedBlockDiagnosticsNeverPanics ensures the helper degrades
+// gracefully (returns a marker, never panics or errors) on garbage input.
+func TestForgedBlockDiagnosticsNeverPanics(t *testing.T) {
+	for _, in := range [][]byte{
+		nil,
+		{},
+		{0xff, 0xff, 0xff}, // malformed
+		{0x01},             // a bare uint, not a block
+		[]byte("not cbor at all..."),
+	} {
+		out := forgedBlockDiagnostics(in)
+		assert.NotEmpty(t, out, "should always return some diagnostic text")
+	}
+}
+
+// TestForgedBlockDiagnosticsLabelsValidBlock confirms a well-formed forged
+// block dumps with the bodies field as an array (the correct shape).
+func TestForgedBlockDiagnosticsLabelsValidBlock(t *testing.T) {
+	creds := setupTestCredentials(t)
+	pp := &mockPParamsProvider{pparams: &conway.ConwayProtocolParameters{
+		MaxTxSize:        1 << 20,
+		MaxBlockBodySize: 1 << 22,
+		MaxBlockExUnits:  lcommon.ExUnits{Memory: 1 << 40, Steps: 1 << 40},
+	}}
+	ct := &mockChainTip{tip: ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 1000, Hash: make([]byte, 32)},
+		BlockNumber: 100,
+	}}
+	en := &mockEpochNonceProvider{epoch: 1, nonce: make([]byte, 32)}
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool:         &mockMempool{},
+		PParamsProvider: pp,
+		ChainTip:        ct,
+		EpochNonce:      en,
+		Credentials:     creds,
+	})
+	require.NoError(t, err)
+	_, blockCbor, err := builder.BuildBlock(1001, 0)
+	require.NoError(t, err)
+
+	diag := forgedBlockDiagnostics(blockCbor)
+	assert.Contains(t, diag, "header")
+	assert.Contains(t, diag, "transaction_bodies")
+	idx := strings.Index(diag, "transaction_bodies")
+	require.GreaterOrEqual(t, idx, 0)
+	rest := strings.TrimSpace(diag[idx+len("transaction_bodies:"):])
+	assert.True(
+		t,
+		strings.HasPrefix(rest, "["),
+		"a valid block must render transaction_bodies as an array",
+	)
+}

--- a/ledger/forging/eras.go
+++ b/ledger/forging/eras.go
@@ -200,3 +200,35 @@ func decodeBlockFromCbor(era eraKind, blockCbor []byte) (ledger.Block, error) {
 		return nil, fmt.Errorf("unknown era kind: %d", era)
 	}
 }
+
+// forgedBlockDiagnostics renders a freshly-encoded block in Cardano-aware
+// CBOR diagnostic notation, for logging when the re-decode in BuildBlock
+// fails. The notation labels each top-level block field — header,
+// transaction_bodies, transaction_witnesses, auxiliary_data_set,
+// invalid_transactions — and shows its CBOR shape, so a structural
+// encoder/decoder mismatch (e.g. a field serialized as a map where the
+// decoder expects an array, the failure mode in issue #2063) is visible
+// at a glance instead of hidden behind a generic unmarshal error.
+//
+// Array fan-out and nesting depth are capped to keep the dump bounded;
+// this runs only on the (expected-never) decode-failure path. Any error
+// from the formatter is folded into the returned string so logging the
+// diagnostics can never itself fail the forge.
+func forgedBlockDiagnostics(blockCbor []byte) string {
+	opts := cbor.DiagnosticOptions{
+		CardanoAware:  true,
+		MaxArrayItems: 8,
+		MaxDepth:      6,
+		MaxByteLength: 64,
+	}
+	if diag, err := cbor.FormatBlockDiagnostic(blockCbor, opts); err == nil {
+		return diag
+	}
+	// The block-aware formatter rejects a malformed envelope outright;
+	// fall back to a generic diagnostic so we still learn the shape.
+	if res, err := cbor.Diagnose(blockCbor, opts); err == nil &&
+		res.Root != nil {
+		return res.Root.FormatDiagnosticPretty(opts)
+	}
+	return fmt.Sprintf("<diagnostics unavailable for %d-byte block>", len(blockCbor))
+}


### PR DESCRIPTION
Closes #2463 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log Cardano-aware CBOR diagnostics when a freshly forged block fails to re-decode, making structural mismatches visible instead of silently dropping the slot. Helps debug the transaction_bodies map-vs-array issue and addresses #2463.

- **New Features**
  - Builder logs diagnostics on re-decode failure with era, proto_major, tx_count, block size, error, and a formatted CBOR dump.
  - Added forgedBlockDiagnostics: bounded, Cardano-aware CBOR formatter with safe fallback; always returns text.
  - Tests cover corrupt bodies field, valid blocks, and garbage input.

<sup>Written for commit ebd79f127c4bec679b1008b59ba6791c414d9e87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging for block forging failures, now providing detailed diagnostic output including block metrics and CBOR analysis to aid troubleshooting.

* **Tests**
  * Added comprehensive test coverage for block diagnostic output, including validation of corruption detection and formatting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->