### PR TITLE
fix(database): improved badger recovery

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -537,8 +537,24 @@ func (d *BlobStoreBadger) NewIterator(
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			err, ok := r.(error)
-			if ok && errors.Is(err, badger.ErrDBClosed) {
+			var err error
+			switch v := r.(type) {
+			case error:
+				err = v
+			case string:
+				err = errors.New(v)
+				if v == badger.ErrDBClosed.Error() {
+					err = fmt.Errorf("%w: %s", badger.ErrDBClosed, v)
+				}
+			default:
+				panic(r)
+			}
+			d.logger.Warn(
+				"iterator creation failed during shutdown",
+				"panic", r,
+				"error", err,
+			)
+			if errors.Is(err, badger.ErrDBClosed) {
 				iter = &errorIterator{
 					err: fmt.Errorf("%w: %w", types.ErrBlobStoreUnavailable, err),
 				}

--- a/database/plugin/blob/badger/database_test.go
+++ b/database/plugin/blob/badger/database_test.go
@@ -16,10 +16,12 @@ package badger
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
+	badger "github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,6 +100,7 @@ func TestBlobStoreBadger_NewIteratorAfterCloseDoesNotPanic(t *testing.T) {
 
 	// Create a transaction from that store.
 	txn := store.NewTransaction(false)
+	defer func() { require.NoError(t, txn.Rollback()) }()
 
 	// Close the store.
 	require.NoError(t, store.Close())
@@ -112,5 +115,6 @@ func TestBlobStoreBadger_NewIteratorAfterCloseDoesNotPanic(t *testing.T) {
 
 	// Expect an iterator object and to contain an error.
 	require.NotNil(t, iter)
-	require.Error(t, iter.Err())
+	require.ErrorIs(t, iter.Err(), types.ErrBlobStoreUnavailable)
+	require.True(t, errors.Is(iter.Err(), badger.ErrDBClosed))
 }

--- a/database/plugin/metadata/sqlite/reward_state_test.go
+++ b/database/plugin/metadata/sqlite/reward_state_test.go
@@ -386,6 +386,108 @@ func TestGetPoolRegistrationsAtSlot(t *testing.T) {
 	require.Equal(t, "1/10", registrations[0].Margin.String())
 }
 
+func TestGetPoolRegistrationsAtSlotTieBreaksSameAddedSlot(t *testing.T) {
+	store := setupTestDB(t)
+	poolKeyHash := rewardStateTestHash(0xcc)
+	poolHash := rewardStateTestPoolKeyHash(0xcc)
+
+	pools := []*models.Pool{
+		{PoolKeyHash: rewardStateTestHash(0xc1)},
+		{PoolKeyHash: rewardStateTestHash(0xc2)},
+		{PoolKeyHash: rewardStateTestHash(0xc3)},
+	}
+	for _, pool := range pools {
+		require.NoError(t, store.DB().Create(pool).Error)
+	}
+
+	txLowBlock := &models.Transaction{
+		Hash:       rewardStateTestHash(0x11),
+		Slot:       50,
+		BlockIndex: 1,
+		Valid:      true,
+	}
+	txHighBlock := &models.Transaction{
+		Hash:       rewardStateTestHash(0x22),
+		Slot:       50,
+		BlockIndex: 2,
+		Valid:      true,
+	}
+	txHighCert := &models.Transaction{
+		Hash:       rewardStateTestHash(0x33),
+		Slot:       50,
+		BlockIndex: 2,
+		Valid:      true,
+	}
+	require.NoError(t, store.DB().Create(txLowBlock).Error)
+	require.NoError(t, store.DB().Create(txHighBlock).Error)
+	require.NoError(t, store.DB().Create(txHighCert).Error)
+
+	certLowBlock := &models.Certificate{
+		TransactionID: txLowBlock.ID,
+		Slot:          50,
+		CertIndex:     99,
+		CertType:      uint(lcommon.CertificateTypePoolRegistration),
+	}
+	certHighBlockLowCert := &models.Certificate{
+		TransactionID: txHighBlock.ID,
+		Slot:          50,
+		CertIndex:     1,
+		CertType:      uint(lcommon.CertificateTypePoolRegistration),
+	}
+	certHighBlockHighCert := &models.Certificate{
+		TransactionID: txHighCert.ID,
+		Slot:          50,
+		CertIndex:     2,
+		CertType:      uint(lcommon.CertificateTypePoolRegistration),
+	}
+	require.NoError(t, store.DB().Create(certLowBlock).Error)
+	require.NoError(t, store.DB().Create(certHighBlockLowCert).Error)
+	require.NoError(t, store.DB().Create(certHighBlockHighCert).Error)
+
+	for _, reg := range []*models.PoolRegistration{
+		{
+			PoolID:        pools[0].ID,
+			PoolKeyHash:   poolKeyHash,
+			CertificateID: certLowBlock.ID,
+			AddedSlot:     50,
+			Pledge:        1_000,
+			Cost:          100,
+			Margin:        &types.Rat{Rat: big.NewRat(1, 100)},
+		},
+		{
+			PoolID:        pools[1].ID,
+			PoolKeyHash:   poolKeyHash,
+			CertificateID: certHighBlockHighCert.ID,
+			AddedSlot:     50,
+			Pledge:        3_000,
+			Cost:          300,
+			Margin:        &types.Rat{Rat: big.NewRat(3, 100)},
+		},
+		{
+			PoolID:        pools[2].ID,
+			PoolKeyHash:   poolKeyHash,
+			CertificateID: certHighBlockLowCert.ID,
+			AddedSlot:     50,
+			Pledge:        2_000,
+			Cost:          200,
+			Margin:        &types.Rat{Rat: big.NewRat(2, 100)},
+		},
+	} {
+		require.NoError(t, store.DB().Create(reg).Error)
+	}
+
+	registrations, err := store.GetPoolRegistrationsAtSlot(
+		[]lcommon.PoolKeyHash{poolHash},
+		50,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, registrations, 1)
+	require.Equal(t, uint64(3_000), uint64(registrations[0].Pledge))
+	require.Equal(t, uint64(300), uint64(registrations[0].Cost))
+	require.Equal(t, "3/100", registrations[0].Margin.String())
+}
+
 func rewardStateTestHash(fill byte) []byte {
 	hash := make([]byte, 28)
 	for i := range hash {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -178,6 +178,11 @@ func (m *mockBlobTxn) Rollback() error {
 	return nil
 }
 
+// alwaysValidIterator is a test-only helper whose Valid() and
+// ValidForPrefix() methods always return true. That would normally cause
+// infinite iteration; it is safe here only because the test uses an
+// expired/negative deadline to force an immediate timeout. Do not use it where
+// Valid() must eventually transition to false.
 type alwaysValidIterator struct{}
 
 func (it *alwaysValidIterator) Rewind()                    {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves `badger` blob store iterator recovery during shutdown to avoid panics and return a clear, consistent error. Adds tests to lock in behavior and a tie-break rule for pool registrations at the same slot.

- **Bug Fixes**
  - Safely handles panics in iterator creation by converting panic values to errors, logging a warning, and returning an error iterator when the DB is closed; surfaces `types.ErrBlobStoreUnavailable` wrapping `badger.ErrDBClosed`.
  - Adds tests to ensure no panic after `Close()` and that errors are correctly reported.
  - Adds a test to confirm reward-state selection tie-breaks same `AddedSlot` by block and certificate order.

<sup>Written for commit 07219a41b2e8965ffd3101c0dbf2329e37929c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

