### PR TITLE
fix(ouroboros/blockfetch): rate-limit or close peers stuck on missing point

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -39,6 +39,17 @@ const blockfetchMetricsCdfUpdateInterval = 32
 // corresponds to the stability window (3k/f) on mainnet (k=2160, f=0.05).
 const MaxBlockFetchRange = 129600
 
+// blockfetchMaxConsecutiveNoBlocks is the number of consecutive NoBlocks
+// responses for the same (connId, start) tuple before closing the connection.
+const blockfetchMaxConsecutiveNoBlocks = 5
+
+// blockfetchNoBlocksPoint is the map key for tracking consecutive NoBlocks
+// responses per (slot, hash) start-point tuple.
+type blockfetchNoBlocksPoint struct {
+	Slot uint64
+	Hash string
+}
+
 type blockfetchRangeIterator interface {
 	Next(bool) (*chain.ChainIteratorResult, error)
 	Cancel()
@@ -114,6 +125,23 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 				err,
 			)
 		}
+		if o.blockfetchRecordNoBlocks(ctx.ConnectionId, start) {
+			o.config.Logger.Warn(
+				"blockfetch: closing stuck peer after repeated oversized range requests",
+				"connection_id", ctx.ConnectionId.String(),
+				"start_slot", start.Slot,
+			)
+			if o.ConnManager != nil {
+				conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
+				if conn != nil {
+					o.closeBlockfetchConnection(
+						conn,
+						ctx.ConnectionId.String(),
+						"blockfetch: peer stuck on oversized range",
+					)
+				}
+			}
+		}
 		return nil
 	}
 	// Validate that the start point exists in our chain (#397)
@@ -131,8 +159,26 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 				err,
 			)
 		}
+		if o.blockfetchRecordNoBlocks(ctx.ConnectionId, start) {
+			o.config.Logger.Warn(
+				"blockfetch: closing stuck peer after repeated missing-point requests",
+				"connection_id", ctx.ConnectionId.String(),
+				"start_slot", start.Slot,
+			)
+			if o.ConnManager != nil {
+				conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
+				if conn != nil {
+					o.closeBlockfetchConnection(
+						conn,
+						ctx.ConnectionId.String(),
+						"blockfetch: peer stuck on missing point",
+					)
+				}
+			}
+		}
 		return nil
 	}
+	o.blockfetchResetNoBlocks(ctx.ConnectionId)
 	// Start async process to send requested block range
 	go func() {
 		conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
@@ -309,6 +355,28 @@ func (o *Ouroboros) closeBlockfetchConnection(
 			"error", err,
 		)
 	}
+}
+
+// blockfetchRecordNoBlocks increments the consecutive NoBlocks counter for
+// (connId, start) and returns true when blockfetchMaxConsecutiveNoBlocks is reached.
+func (o *Ouroboros) blockfetchRecordNoBlocks(
+	connId ouroboros.ConnectionId,
+	start ocommon.Point,
+) bool {
+	key := blockfetchNoBlocksPoint{Slot: start.Slot, Hash: string(start.Hash)}
+	o.blockFetchMutex.Lock()
+	defer o.blockFetchMutex.Unlock()
+	if o.blockfetchNoBlocksCounts[connId] == nil {
+		o.blockfetchNoBlocksCounts[connId] = make(map[blockfetchNoBlocksPoint]int)
+	}
+	o.blockfetchNoBlocksCounts[connId][key]++
+	return o.blockfetchNoBlocksCounts[connId][key] >= blockfetchMaxConsecutiveNoBlocks
+}
+
+func (o *Ouroboros) blockfetchResetNoBlocks(connId ouroboros.ConnectionId) {
+	o.blockFetchMutex.Lock()
+	delete(o.blockfetchNoBlocksCounts, connId)
+	o.blockFetchMutex.Unlock()
 }
 
 // BlockfetchClientRequestRange is called by the ledger when it needs to request a range of block bodies

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -43,11 +43,16 @@ const MaxBlockFetchRange = 129600
 // responses for the same (connId, start) tuple before closing the connection.
 const blockfetchMaxConsecutiveNoBlocks = 5
 
-// blockfetchNoBlocksPoint is the map key for tracking consecutive NoBlocks
-// responses per (slot, hash) start-point tuple.
+// blockfetchNoBlocksPoint identifies the start point used by the last
+// NoBlocks response tracked for a connection.
 type blockfetchNoBlocksPoint struct {
 	Slot uint64
 	Hash string
+}
+
+type blockfetchNoBlocksState struct {
+	Point blockfetchNoBlocksPoint
+	Count int
 }
 
 type blockfetchRangeIterator interface {
@@ -125,23 +130,12 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 				err,
 			)
 		}
-		if o.blockfetchRecordNoBlocks(ctx.ConnectionId, start) {
-			o.config.Logger.Warn(
-				"blockfetch: closing stuck peer after repeated oversized range requests",
-				"connection_id", ctx.ConnectionId.String(),
-				"start_slot", start.Slot,
-			)
-			if o.ConnManager != nil {
-				conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
-				if conn != nil {
-					o.closeBlockfetchConnection(
-						conn,
-						ctx.ConnectionId.String(),
-						"blockfetch: peer stuck on oversized range",
-					)
-				}
-			}
-		}
+		o.blockfetchRecordNoBlocksAndMaybeClose(
+			ctx.ConnectionId,
+			start,
+			"blockfetch: closing stuck peer after repeated oversized range requests",
+			"blockfetch: peer stuck on oversized range",
+		)
 		return nil
 	}
 	// Validate that the start point exists in our chain (#397)
@@ -159,23 +153,12 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 				err,
 			)
 		}
-		if o.blockfetchRecordNoBlocks(ctx.ConnectionId, start) {
-			o.config.Logger.Warn(
-				"blockfetch: closing stuck peer after repeated missing-point requests",
-				"connection_id", ctx.ConnectionId.String(),
-				"start_slot", start.Slot,
-			)
-			if o.ConnManager != nil {
-				conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
-				if conn != nil {
-					o.closeBlockfetchConnection(
-						conn,
-						ctx.ConnectionId.String(),
-						"blockfetch: peer stuck on missing point",
-					)
-				}
-			}
-		}
+		o.blockfetchRecordNoBlocksAndMaybeClose(
+			ctx.ConnectionId,
+			start,
+			"blockfetch: closing stuck peer after repeated missing-point requests",
+			"blockfetch: peer stuck on missing point",
+		)
 		return nil
 	}
 	o.blockfetchResetNoBlocks(ctx.ConnectionId)
@@ -357,6 +340,30 @@ func (o *Ouroboros) closeBlockfetchConnection(
 	}
 }
 
+func (o *Ouroboros) blockfetchRecordNoBlocksAndMaybeClose(
+	connId ouroboros.ConnectionId,
+	start ocommon.Point,
+	logMessage string,
+	closeReason string,
+) {
+	if !o.blockfetchRecordNoBlocks(connId, start) {
+		return
+	}
+	o.config.Logger.Warn(
+		logMessage,
+		"connection_id", connId.String(),
+		"start_slot", start.Slot,
+	)
+	if o.ConnManager == nil {
+		return
+	}
+	conn := o.ConnManager.GetConnectionById(connId)
+	if conn == nil {
+		return
+	}
+	o.closeBlockfetchConnection(conn, connId.String(), closeReason)
+}
+
 // blockfetchRecordNoBlocks increments the consecutive NoBlocks counter for
 // (connId, start) and returns true when blockfetchMaxConsecutiveNoBlocks is reached.
 func (o *Ouroboros) blockfetchRecordNoBlocks(
@@ -366,11 +373,17 @@ func (o *Ouroboros) blockfetchRecordNoBlocks(
 	key := blockfetchNoBlocksPoint{Slot: start.Slot, Hash: string(start.Hash)}
 	o.blockFetchMutex.Lock()
 	defer o.blockFetchMutex.Unlock()
-	if o.blockfetchNoBlocksCounts[connId] == nil {
-		o.blockfetchNoBlocksCounts[connId] = make(map[blockfetchNoBlocksPoint]int)
+	state, ok := o.blockfetchNoBlocksCounts[connId]
+	if !ok || state.Point != key {
+		o.blockfetchNoBlocksCounts[connId] = blockfetchNoBlocksState{
+			Point: key,
+			Count: 1,
+		}
+		return false
 	}
-	o.blockfetchNoBlocksCounts[connId][key]++
-	return o.blockfetchNoBlocksCounts[connId][key] >= blockfetchMaxConsecutiveNoBlocks
+	state.Count++
+	o.blockfetchNoBlocksCounts[connId] = state
+	return state.Count >= blockfetchMaxConsecutiveNoBlocks
 }
 
 func (o *Ouroboros) blockfetchResetNoBlocks(connId ouroboros.ConnectionId) {

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -448,10 +448,10 @@ func TestBlockfetchRecordNoBlocks_ProgressResetsCounter(t *testing.T) {
 	assert.True(t, o.blockfetchRecordNoBlocks(connId, start), "should need another full sequence after progress")
 }
 
-// TestBlockfetchRecordNoBlocks_IndependentPoints verifies NoBlocks counts are
-// tracked separately for each requested start point on the same connection.
+// TestBlockfetchRecordNoBlocks_IndependentPoints verifies changing start
+// points resets the consecutive NoBlocks count on the same connection.
 func TestBlockfetchRecordNoBlocks_IndependentPoints(t *testing.T) {
-	// Tracks counters independently per start point for the same connection.
+	// Only consecutive NoBlocks for the same start point should accumulate.
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	o := NewOuroboros(OuroborosConfig{
 		Logger:   logger,
@@ -465,6 +465,7 @@ func TestBlockfetchRecordNoBlocks_IndependentPoints(t *testing.T) {
 		assert.False(t, o.blockfetchRecordNoBlocks(connId, startA))
 	}
 	assert.False(t, o.blockfetchRecordNoBlocks(connId, startB), "different start point should not inherit count")
+	assert.False(t, o.blockfetchRecordNoBlocks(connId, startA), "interleaved start point should reset consecutive count")
 }
 
 // TestBlockfetchRecordNoBlocks_IndependentConns verifies NoBlocks counts are

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -389,6 +389,139 @@ func TestReportBlockfetchServerAsyncError_ClosedErrorChan_NoPanic(
 	})
 }
 
+// TestBlockfetchRecordNoBlocks_BelowThreshold verifies repeated NoBlocks stay
+// below the close threshold until the configured limit is reached.
+func TestBlockfetchRecordNoBlocks_BelowThreshold(t *testing.T) {
+	// Returns false for each of the first four identical NoBlocks requests.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	connId := testConnId()
+	start := ocommon.NewPoint(100, []byte{0x01})
+
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		assert.False(t, o.blockfetchRecordNoBlocks(connId, start), "should not trigger before threshold")
+	}
+}
+
+// TestBlockfetchRecordNoBlocks_ReachesThreshold verifies the stuck-peer
+// detector triggers on the configured consecutive NoBlocks threshold.
+func TestBlockfetchRecordNoBlocks_ReachesThreshold(t *testing.T) {
+	// Returns true on the fifth consecutive NoBlocks for the same start point.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	connId := testConnId()
+	start := ocommon.NewPoint(100, []byte{0x01})
+
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		o.blockfetchRecordNoBlocks(connId, start)
+	}
+	assert.True(t, o.blockfetchRecordNoBlocks(connId, start), "should trigger on 5th consecutive request")
+}
+
+// TestBlockfetchRecordNoBlocks_ProgressResetsCounter verifies valid progress
+// clears prior NoBlocks counts for the connection.
+func TestBlockfetchRecordNoBlocks_ProgressResetsCounter(t *testing.T) {
+	// Valid blockfetch progress clears prior NoBlocks counts for the connection.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	connId := testConnId()
+	start := ocommon.NewPoint(100, []byte{0x01})
+
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		assert.False(t, o.blockfetchRecordNoBlocks(connId, start))
+	}
+
+	o.blockfetchResetNoBlocks(connId)
+
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		assert.False(t, o.blockfetchRecordNoBlocks(connId, start), "counter should reset after progress")
+	}
+	assert.True(t, o.blockfetchRecordNoBlocks(connId, start), "should need another full sequence after progress")
+}
+
+// TestBlockfetchRecordNoBlocks_IndependentPoints verifies NoBlocks counts are
+// tracked separately for each requested start point on the same connection.
+func TestBlockfetchRecordNoBlocks_IndependentPoints(t *testing.T) {
+	// Tracks counters independently per start point for the same connection.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	connId := testConnId()
+	startA := ocommon.NewPoint(100, []byte{0x01})
+	startB := ocommon.NewPoint(200, []byte{0x02})
+
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		assert.False(t, o.blockfetchRecordNoBlocks(connId, startA))
+	}
+	assert.False(t, o.blockfetchRecordNoBlocks(connId, startB), "different start point should not inherit count")
+}
+
+// TestBlockfetchRecordNoBlocks_IndependentConns verifies NoBlocks counts are
+// tracked separately for each connection.
+func TestBlockfetchRecordNoBlocks_IndependentConns(t *testing.T) {
+	// Tracks counters independently per connection for the same start point.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	connA := ouroboros_conn.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
+	}
+	connB := ouroboros_conn.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3003},
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		o.blockfetchRecordNoBlocks(connA, start)
+	}
+	// Different connId at the same point must have its own independent counter
+	assert.False(t, o.blockfetchRecordNoBlocks(connB, start), "different connId should not inherit count")
+}
+
+// TestBlockfetchRecordNoBlocks_CleanupResetsCounter verifies connection-close
+// cleanup clears stuck-peer state before a reconnect starts fresh.
+func TestBlockfetchRecordNoBlocks_CleanupResetsCounter(t *testing.T) {
+	// Resets the counter after connection close so the peer gets a fresh count on reconnect.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	connId := testConnId()
+	start := ocommon.NewPoint(100, []byte{0x01})
+
+	// Drive counter to threshold
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks; i++ {
+		o.blockfetchRecordNoBlocks(connId, start)
+	}
+
+	// Simulate connection close cleanup
+	o.blockFetchMutex.Lock()
+	delete(o.blockfetchNoBlocksCounts, connId)
+	o.blockFetchMutex.Unlock()
+
+	// Counter should be reset — needs another full sequence to trigger
+	for i := 0; i < blockfetchMaxConsecutiveNoBlocks-1; i++ {
+		assert.False(t, o.blockfetchRecordNoBlocks(connId, start), "counter should reset after cleanup")
+	}
+	assert.True(t, o.blockfetchRecordNoBlocks(connId, start), "should trigger again after reset")
+}
+
 func BenchmarkBlockfetchClientBlockMetrics(b *testing.B) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	eventBus := event.NewEventBus(nil, logger)

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -63,7 +63,7 @@ type Ouroboros struct {
 	protocolMetrics          *protocolMetrics
 	blockFetchStarts         map[ouroboros.ConnectionId]time.Time
 	blockFetchMutex          sync.Mutex
-	blockfetchNoBlocksCounts map[ouroboros.ConnectionId]map[blockfetchNoBlocksPoint]int
+	blockfetchNoBlocksCounts map[ouroboros.ConnectionId]blockfetchNoBlocksState
 	// ChainSync measurement tracking for peer scoring
 	chainsyncStats map[ouroboros.ConnectionId]*chainsyncPeerStats
 	chainsyncMutex sync.Mutex
@@ -139,7 +139,7 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		EventBus:                 cfg.EventBus,
 		ConnManager:              cfg.ConnManager,
 		blockFetchStarts:         make(map[ouroboros.ConnectionId]time.Time),
-		blockfetchNoBlocksCounts: make(map[ouroboros.ConnectionId]map[blockfetchNoBlocksPoint]int),
+		blockfetchNoBlocksCounts: make(map[ouroboros.ConnectionId]blockfetchNoBlocksState),
 		chainsyncStats:           make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
 		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
 	}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -52,17 +52,18 @@ import (
 const defaultMaxChainsyncClients = chainsync.DefaultMaxClients
 
 type Ouroboros struct {
-	ConnManager       *connmanager.ConnectionManager
-	PeerGov           *peergov.PeerGovernor
-	ChainsyncState    *chainsync.State
-	EventBus          *event.EventBus
-	Mempool           *mempool.Mempool
-	LedgerState       *ledger.LedgerState
-	config            OuroborosConfig
-	blockfetchMetrics *blockfetchMetrics
-	protocolMetrics   *protocolMetrics
-	blockFetchStarts  map[ouroboros.ConnectionId]time.Time
-	blockFetchMutex   sync.Mutex
+	ConnManager              *connmanager.ConnectionManager
+	PeerGov                  *peergov.PeerGovernor
+	ChainsyncState           *chainsync.State
+	EventBus                 *event.EventBus
+	Mempool                  *mempool.Mempool
+	LedgerState              *ledger.LedgerState
+	config                   OuroborosConfig
+	blockfetchMetrics        *blockfetchMetrics
+	protocolMetrics          *protocolMetrics
+	blockFetchStarts         map[ouroboros.ConnectionId]time.Time
+	blockFetchMutex          sync.Mutex
+	blockfetchNoBlocksCounts map[ouroboros.ConnectionId]map[blockfetchNoBlocksPoint]int
 	// ChainSync measurement tracking for peer scoring
 	chainsyncStats map[ouroboros.ConnectionId]*chainsyncPeerStats
 	chainsyncMutex sync.Mutex
@@ -134,12 +135,13 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		cfg.ChainsyncBlockTimeout,
 	)
 	o := &Ouroboros{
-		config:              cfg,
-		EventBus:            cfg.EventBus,
-		ConnManager:         cfg.ConnManager,
-		blockFetchStarts:    make(map[ouroboros.ConnectionId]time.Time),
-		chainsyncStats:      make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
-		leiosEndorserBlocks: make(map[string]*leiosEndorserBlockData),
+		config:                   cfg,
+		EventBus:                 cfg.EventBus,
+		ConnManager:              cfg.ConnManager,
+		blockFetchStarts:         make(map[ouroboros.ConnectionId]time.Time),
+		blockfetchNoBlocksCounts: make(map[ouroboros.ConnectionId]map[blockfetchNoBlocksPoint]int),
+		chainsyncStats:           make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
+		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond
@@ -381,9 +383,10 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	if o.Mempool != nil {
 		o.Mempool.RemoveConsumer(connId)
 	}
-	// Clean up any pending block fetch start times
+	// Clean up any pending block fetch start times and NoBlocks counters
 	o.blockFetchMutex.Lock()
 	delete(o.blockFetchStarts, connId)
+	delete(o.blockfetchNoBlocksCounts, connId)
 	o.blockFetchMutex.Unlock()
 	// Clean up chainsync stats
 	o.chainsyncMutex.Lock()


### PR DESCRIPTION
1. Made changes to track consecutive blockfetch NoBlocks responses per connection for the current start point.
2. Made changes to close a peer after 5 consecutive NoBlocks responses for the same start point.
3. Reset NoBlocks tracking when a valid range is accepted or the connection closes.
4. Added tests for threshold behavior, reset behavior, and per-connection/per-point isolation.

Closes #2248 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close blockfetch peers that get stuck on repeated NoBlocks by tracking per-connection/per-start-point requests and closing after 5 consecutive failures. This addresses #2248 and prevents wasted cycles on missing points or oversized ranges.

- **Bug Fixes**
  - Track consecutive NoBlocks per `(connId, start)` in `ouroboros/blockfetch`; close the connection on the 5th repeat.
  - Reset counters when a valid range is accepted and when the connection closes (`HandleConnClosedEvent`).
  - Apply the same handling for oversized range and missing start point cases.
  - Add tests for threshold triggering, reset on progress and cleanup, and isolation per connection and start point.

<sup>Written for commit ab7adf0a79ad3b57b799e98b30691f0919593bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The system now detects peers that repeatedly respond with "no blocks" for the same block range and automatically disconnects them after reaching a configured threshold, improving synchronization reliability.

* **Tests**
  * Added comprehensive test suite covering peer detection thresholds, counter resets on progress, per-connection tracking, and cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->