### PR TITLE
fix(ledger): avoid repeated next-epoch nonce recomputation on slot ticks

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1355,10 +1355,10 @@ func (ls *LedgerState) emitNextEpochNonceReady(
 	}
 
 	readyEpoch := currentEpoch.EpochId + 1
-	if len(ls.EpochNonce(readyEpoch)) == 0 {
+	if ls.nextNonceReadyEpoch.Load() == readyEpoch {
 		return
 	}
-	if ls.nextNonceReadyEpoch.Load() == readyEpoch {
+	if len(ls.EpochNonce(readyEpoch)) == 0 {
 		return
 	}
 	ls.nextNonceReadyEpoch.Store(readyEpoch)


### PR DESCRIPTION
closes #2359 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop recomputing the next-epoch nonce on slot ticks. We now bail out early if the next nonce is already marked ready, before touching `EpochNonce`.

- **Bug Fixes**
  - Reordered checks in `ledger/state.go` to test `nextNonceReadyEpoch == readyEpoch` first, avoiding unnecessary `EpochNonce` calls and extra work.

<sup>Written for commit 7a5f3a20ed98da059045add10b44f0581aaa0337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where nonce readiness notifications could be emitted multiple times for the same epoch, improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->