### PR TITLE
fix(ledger): chain density calculation

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -488,8 +488,7 @@ type LedgerState struct {
 	batchBlocksReceived           int                 // total blocks received in current blockfetch batch (including mid-batch flushes)
 	checkpointWrittenForEpoch     bool
 	closed                        atomic.Bool
-	inRecovery                    bool           // guards against recursive recovery in SubmitAsyncDBTxn
-	densityWindow                 []densityEntry // sliding window for chain density metric
+	inRecovery                    bool // guards against recursive recovery in SubmitAsyncDBTxn
 	lastAtTipRecovery             *atTipRecoveryAttempt
 	mithrilLedgerSlot             uint64 // blocks at or below this slot are Mithril-verified; skip validation
 	lastLocalRollbackSeq          uint64
@@ -1822,6 +1821,10 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 			newPrevPParams = prevPP
 		}
 	}
+	newTipDensity := ls.chainFragmentDensity(
+		newTip,
+		ls.securityParamForEraOrDefault(newCurrentEra.Id),
+	)
 	// Transaction committed successfully - now update all
 	// in-memory state atomically so readers see a consistent
 	// snapshot.
@@ -1894,7 +1897,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	// Allow the nonce-ready event to be emitted again if replay crosses
 	// the cutoff on a different fork after rollback.
 	ls.resetNextEpochNonceReady()
-	ls.updateTipMetrics()
+	ls.updateTipMetrics(newTipDensity)
 	ls.Unlock()
 	if ls.config.EventBus != nil {
 		ls.config.EventBus.Publish(
@@ -2252,10 +2255,21 @@ func (ls *LedgerState) securityParamForEra(eraId uint) (uint64, bool) {
 
 // SecurityParam returns the security parameter for the current era
 func (ls *LedgerState) SecurityParam() int {
-	if k, ok := ls.securityParamForEra(ls.currentEra.Id); ok {
+	return ls.securityParamForEraOrDefault(ls.currentEra.Id)
+}
+
+func (ls *LedgerState) securityParamForEraOrDefault(eraId uint) int {
+	if k, ok := ls.securityParamForEra(eraId); ok {
 		return int(k) // #nosec G115 -- k came from a non-negative int genesis field
 	}
 	return blockfetchBatchSlotThresholdDefault
+}
+
+func (ls *LedgerState) securityParamForCurrentEraSnapshot() int {
+	ls.RLock()
+	eraId := ls.currentEra.Id
+	ls.RUnlock()
+	return ls.securityParamForEraOrDefault(eraId)
 }
 
 // shouldSkipPhase2ValidationForBlock reports whether a block is deep enough
@@ -3322,6 +3336,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// Transaction committed successfully - now update in-memory state.
 			// Only update if blocks were actually processed to avoid resetting tip to zero.
 			if blocksProcessed > 0 {
+				tipDensity := ls.chainFragmentDensity(
+					pendingTip,
+					ls.securityParamForCurrentEraSnapshot(),
+				)
 				// Brief lock to ensure readers see consistent state.
 				ls.Lock()
 				ls.currentTip = pendingTip
@@ -3333,7 +3351,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					ls.validationEnabled = true
 					ls.reachedTip = true
 				}
-				ls.updateTipMetrics()
+				ls.updateTipMetrics(tipDensity)
 				// After advancing the tip, first honor any TestXHardForkAtEpoch
 				// override so queries surface the pinned epoch ahead of time;
 				// then check whether the stability window reaches or exceeds
@@ -3630,71 +3648,78 @@ func opCertSequenceNumber(block ledger.Block) (uint32, bool) {
 	}
 }
 
-// densityEntry records a block's slot and block number for the chain density
-// sliding window calculation.
-type densityEntry struct {
-	slot     uint64
-	blockNum uint64
-}
-
-func (ls *LedgerState) updateTipMetrics() {
+// updateTipMetrics updates gauges from in-memory state. Call under ls.Lock().
+// The density value must be computed before taking the lock because fragment
+// density can require database lookups.
+func (ls *LedgerState) updateTipMetrics(density float64) {
 	ls.metrics.blockNum.Set(float64(ls.currentTip.BlockNumber))
 	ls.metrics.slotNum.Set(float64(ls.currentTip.Point.Slot))
 	ls.metrics.slotInEpoch.Set(
 		float64(ls.currentTip.Point.Slot - ls.currentEpoch.StartSlot),
 	)
-	tipSlot := ls.currentTip.Point.Slot
-	tipBlockNum := ls.currentTip.BlockNumber
+	ls.metrics.density.Set(density)
+}
 
-	// Trim entries beyond current tip (rollbacks)
-	for len(ls.densityWindow) > 0 &&
-		ls.densityWindow[len(ls.densityWindow)-1].slot > tipSlot {
-		ls.densityWindow = ls.densityWindow[:len(ls.densityWindow)-1]
+// chainFragmentDensity matches cardano-node's ChainDB fragment density:
+// block delta divided by slot delta over the selected chain fragment.
+func (ls *LedgerState) chainFragmentDensity(
+	tip ochainsync.Tip,
+	securityParam int,
+) float64 {
+	tipSlot := tip.Point.Slot
+	tipBlockNum := tip.BlockNumber
+	if tipSlot == 0 || tipBlockNum == 0 {
+		return 0
 	}
-	// Append current tip if new
-	if len(ls.densityWindow) == 0 ||
-		ls.densityWindow[len(ls.densityWindow)-1].slot < tipSlot {
-		ls.densityWindow = append(ls.densityWindow, densityEntry{
-			slot:     tipSlot,
-			blockNum: tipBlockNum,
-		})
+	if ls.db == nil {
+		return totalChainDensity(tipSlot, tipBlockNum)
 	}
+	if securityParam <= 0 {
+		return totalChainDensity(tipSlot, tipBlockNum)
+	}
+	tipBlock, err := database.BlockByPoint(ls.db, tip.Point)
+	if err != nil {
+		return totalChainDensity(tipSlot, tipBlockNum)
+	}
+	oldestIndex := database.BlockInitialIndex
+	if tipBlock.ID > uint64(securityParam) {
+		oldestIndex = tipBlock.ID - uint64(securityParam)
+	}
+	oldestBlock, err := ls.db.BlockByIndex(oldestIndex, nil)
+	if err != nil {
+		return totalChainDensity(tipSlot, tipBlockNum)
+	}
+	return fragmentDensity(
+		tipBlock.Slot,
+		tipBlock.Number,
+		oldestBlock.Slot,
+		oldestBlock.Number,
+	)
+}
 
-	// Chain density over a 3k/f sliding window (matches cardano-node)
-	k := ls.SecurityParam()
-	f := ls.ActiveSlotCoeff()
-	if k > 0 && f > 0 && tipSlot > 0 {
-		windowSize := uint64(float64(3*k) / f)
-		cutoff := uint64(0)
-		if tipSlot > windowSize {
-			cutoff = tipSlot - windowSize
-		}
-		// Prune entries outside the window
-		pruneIdx := 0
-		for pruneIdx < len(ls.densityWindow) &&
-			ls.densityWindow[pruneIdx].slot < cutoff {
-			pruneIdx++
-		}
-		if pruneIdx > 0 {
-			ls.densityWindow = ls.densityWindow[pruneIdx:]
-		}
-		if len(ls.densityWindow) > 0 {
-			blocksInWindow := tipBlockNum -
-				ls.densityWindow[0].blockNum + 1
-			ls.metrics.density.Set(
-				float64(blocksInWindow) / float64(windowSize),
-			)
-		} else {
-			ls.metrics.density.Set(0)
-		}
-	} else if tipSlot > 0 {
-		// Fallback before protocol params are available
-		ls.metrics.density.Set(
-			float64(tipBlockNum) / float64(tipSlot),
-		)
-	} else {
-		ls.metrics.density.Set(0)
+func totalChainDensity(tipSlot, tipBlockNum uint64) float64 {
+	if tipSlot == 0 {
+		return 0
 	}
+	return float64(tipBlockNum) / float64(tipSlot)
+}
+
+func fragmentDensity(
+	tipSlot, tipBlockNum, oldestSlot, oldestBlockNum uint64,
+) float64 {
+	if tipSlot <= oldestSlot {
+		return 0
+	}
+	firstBlockNum := oldestBlockNum
+	if firstBlockNum == 0 {
+		// cardano-node ignores Byron EBB block number 0 in this metric.
+		firstBlockNum = 1
+	}
+	if tipBlockNum <= firstBlockNum {
+		return 0
+	}
+	return float64(tipBlockNum-firstBlockNum) /
+		float64(tipSlot-oldestSlot)
 }
 
 // loadPParams reads currentEpoch, currentEra, and epochCache and writes
@@ -4267,13 +4292,17 @@ func (ls *LedgerState) loadTip() error {
 			return err
 		}
 	}
+	tipDensity := ls.chainFragmentDensity(
+		tmpTip,
+		ls.securityParamForCurrentEraSnapshot(),
+	)
 	// Lock only for in-memory state updates
 	ls.Lock()
 	ls.currentTip = tmpTip
 	if tmpTip.Point.Slot > 0 {
 		ls.currentTipBlockNonce = tipNonce
 	}
-	ls.updateTipMetrics()
+	ls.updateTipMetrics(tipDensity)
 	ls.Unlock()
 	return nil
 }

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -34,6 +33,7 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -2904,10 +2904,10 @@ func TestIntersectPointsSkipsMissingDenseBlockIndex(t *testing.T) {
 	assert.True(t, hasPreviousDenseSlot)
 }
 
-func TestDensityWindow(t *testing.T) {
+func TestChainDensityUsesCardanoNodeFragment(t *testing.T) {
 	shelleyGenesisJSON := `{
 		"activeSlotsCoeff": 0.05,
-		"securityParam": 2160
+		"securityParam": 3
 	}`
 	cfg := &cardano.CardanoNodeConfig{}
 	require.NoError(
@@ -2915,60 +2915,113 @@ func TestDensityWindow(t *testing.T) {
 		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
 	)
 
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := []models.Block{
+		makeTestBlock(10, 1),
+		makeTestBlock(20, 2),
+		makeTestBlock(100, 3),
+		makeTestBlock(190, 4),
+		makeTestBlock(210, 5),
+	}
+	for _, block := range blocks {
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+	tipBlock := blocks[len(blocks)-1]
 	ls := &LedgerState{
+		db:         db,
+		currentEra: eras.ShelleyEraDesc,
+		currentTip: ochainsync.Tip{
+			Point:       makeTestPoint(tipBlock),
+			BlockNumber: tipBlock.Number,
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+
+	density := ls.chainFragmentDensity(ls.currentTip, ls.SecurityParam())
+	ls.Lock()
+	ls.updateTipMetrics(density)
+	ls.Unlock()
+
+	// cardano-node computes density over the ChainDB fragment as:
+	// (tip block - oldest fragment block) / (tip slot - oldest fragment slot).
+	// With k=3 and tip block index 5, the oldest fragment block is index 2.
+	assert.InDelta(
+		t,
+		3.0/190.0,
+		promtestutil.ToFloat64(ls.metrics.density),
+		1e-12,
+	)
+}
+
+func TestLoadTipSeedsChainDensityFromPersistedFragment(t *testing.T) {
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 3
+	}`
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	blocks := []models.Block{
+		makeTestBlock(10, 1),
+		makeTestBlock(20, 2),
+		makeTestBlock(100, 3),
+		makeTestBlock(190, 4),
+		makeTestBlock(210, 5),
+	}
+	for _, block := range blocks {
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+	tipBlock := blocks[len(blocks)-1]
+	require.NoError(t, db.SetBlockNonce(tipBlock.Hash, tipBlock.Slot, []byte{1}, false, nil))
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point:       makeTestPoint(tipBlock),
+		BlockNumber: tipBlock.Number,
+	}, nil))
+
+	ls := &LedgerState{
+		db:         db,
 		currentEra: eras.ShelleyEraDesc,
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
-	reg := prometheus.NewRegistry()
-	ls.metrics.init(reg)
+	ls.metrics.init(prometheus.NewRegistry())
 
-	// Window size = 3*2160/0.05 = 129600
+	require.NoError(t, ls.loadTip())
 
-	// Simulate extending to slot 200000, block 6000
-	// with blocks every ~33 slots (approx 3% density)
-	slot := uint64(70000)
-	blockNum := uint64(2100)
-	for slot <= 200000 {
-		ls.currentTip = ochainsync.Tip{
-			Point:       ocommon.Point{Slot: slot},
-			BlockNumber: blockNum,
-		}
-		ls.updateTipMetrics()
-		slot += 33
-		blockNum++
-	}
+	assert.InDelta(
+		t,
+		3.0/190.0,
+		promtestutil.ToFloat64(ls.metrics.density),
+		1e-12,
+	)
+}
 
-	// The window covers slots [200000-129600, 200000] = [70400, 200000]
-	// First entry in window should be around slot 70400
-	require.Greater(t, len(ls.densityWindow), 0)
-	assert.GreaterOrEqual(t, ls.densityWindow[0].slot, uint64(70390))
-
-	// Verify density is in a reasonable range for ~3% active slots
-	blocksInWindow := ls.currentTip.BlockNumber - ls.densityWindow[0].blockNum + 1
-	calculatedDensity := float64(blocksInWindow) / 129600.0
-	assert.InDelta(t, 0.03, calculatedDensity, 0.005)
-
-	// Test rollback: roll back to slot 199000
-	rollbackSlot := uint64(199000)
-	rollbackBlock := uint64(0)
-	for _, v := range slices.Backward(ls.densityWindow) {
-		if v.slot <= rollbackSlot {
-			rollbackBlock = v.blockNum
-			break
-		}
-	}
-	ls.currentTip = ochainsync.Tip{
-		Point:       ocommon.Point{Slot: rollbackSlot},
-		BlockNumber: rollbackBlock,
-	}
-	ls.updateTipMetrics()
-
-	// Window should have trimmed entries past rollback slot
-	lastEntry := ls.densityWindow[len(ls.densityWindow)-1]
-	assert.LessOrEqual(t, lastEntry.slot, rollbackSlot)
+func TestFragmentDensityIgnoresByronEbbBlockNumber(t *testing.T) {
+	assert.InDelta(t, 9.0/100.0, fragmentDensity(100, 10, 0, 0), 1e-12)
 }
 
 func TestReconcilePrimaryChainTipWithLedgerTipPreservesSelectedChain(


### PR DESCRIPTION
Closes #2476 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chain density metric in `ledger` to match cardano-node by computing density over the ChainDB fragment (last k blocks). Resolves #2476 and stabilizes the `density` gauge across rollbacks, restarts, and during normal sync.

- **Bug Fixes**
  - Compute density as (tip block − oldest fragment block) / (tip slot − oldest fragment slot) using the DB-backed fragment for k.
  - Fallback to total chain density when the DB, k, or lookups are unavailable.
  - Ignore Byron EBB block number 0 to match cardano-node.
  - Remove the in-memory 3k/f sliding window; compute fragment density before locking and pass it to `updateTipMetrics`.
  - Add tests for fragment density, seeding via `loadTip`, and Byron EBB handling.

<sup>Written for commit 9fcefd7fdec8c865344c2e7dad13e63823d91b3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain density metric calculations with refined algorithm for better accuracy.
  * Enhanced recovery state tracking for more reliable ledger state management.

* **Tests**
  * Updated test coverage to validate chain density metric computation and recovery state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->