### PR TITLE
build(make): exclude worktrees from GO_FILES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Determine root directory
 ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-# Gather all .go files for use in dependencies below
-GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
+# Gather all .go files for use in dependencies below. Exclude local git
+# worktrees so sibling checkouts do not affect formatting or rebuild inputs.
+GO_FILES=$(shell find $(ROOT_DIR) -path '$(ROOT_DIR)/.worktrees' -prune -o -name '*.go' -print)
 
 # Gather list of expected binaries
 BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)


### PR DESCRIPTION
Closes #2294 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude local git worktrees from `GO_FILES` in the `Makefile` so files under `.worktrees` aren’t considered build or formatting inputs. This prevents unnecessary formatting and rebuilds caused by sibling checkouts.

<sup>Written for commit 222269b7fa4b3da9907e3e4a9e2f66909ffd2dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system efficiency by refining file discovery logic to exclude development-specific directories from rebuild triggers and formatting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->