### PR TITLE
fix(backfill): use in-flight produced outputs for same-batch provenance lookups

### DIFF
--- a/database/batch.go
+++ b/database/batch.go
@@ -79,6 +79,14 @@ type batchStatsSetter interface {
 	SetBackfillStats(*types.BackfillHotPathStats)
 }
 
+// inFlightProducerLookup is implemented by accumulators that index the
+// outputs produced earlier in the current batch but not yet flushed. When
+// available, consumed-input recovery can skip blob/metadata recovery for a
+// producer that will be created (and spent) by the pending FlushBatch.
+type inFlightProducerLookup interface {
+	HasInFlightProducer(txId []byte, outputIdx uint32) bool
+}
+
 // SetTransactionBatched stores transaction blob offsets and immediate
 // metadata, while accumulating bulk metadata rows into acc for a later
 // FlushBatch.
@@ -228,7 +236,7 @@ func (d *Database) SetTransactionBatchedWithOpts(
 	}
 
 	recoverStart := time.Now()
-	if err := d.ensureTransactionConsumedUtxos(tx, point, txn); err != nil {
+	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, acc); err != nil {
 		return err
 	}
 	if opts.Stats != nil {

--- a/database/inflight_provenance_test.go
+++ b/database/inflight_provenance_test.go
@@ -17,6 +17,8 @@ package database
 import (
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/stretchr/testify/require"
 )
 
@@ -188,5 +190,98 @@ func TestSetTransactionBatched_MissingProducerNotFabricated(t *testing.T) {
 		t,
 		utxo,
 		"genuinely missing producer must not be hidden or fabricated",
+	)
+}
+
+// ingestSameBatchProducerConsumer ingests the producer and consumer of the
+// candidate through the batched path into one accumulator and flushes.
+func ingestSameBatchProducerConsumer(
+	t *testing.T,
+	db *Database,
+	candidate batchedCrossBlockSpendCandidate,
+) {
+	t.Helper()
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0, nil, nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc, txn, BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.consumerTx,
+		candidate.consumerPoint,
+		candidate.consumerIdx,
+		0, nil, nil,
+		mustBlockOffsets(t, candidate.consumerBlock),
+		acc, txn, BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+}
+
+// TestSetTransactionBatched_InFlightDoesNotSkipExistingRowRepair guards the
+// resumed-backfill case: when the consumed output already exists in metadata
+// as a partially-written spent row (DeletedSlot == consumer slot, SpentAtTxId
+// == nil from a prior partial run) and the producer is re-ingested into the
+// same batch (so it is also "in-flight"), the consumer must still backfill the
+// spender link. The in-flight short-circuit must run after the existing-row
+// repair: the flush's batchSpendUtxos only updates rows where deleted_slot = 0
+// and could not fix this row later.
+//
+// Two passes make the simulation faithful: the first pass ingests normally
+// (creating the consumer transaction row that spent_at_tx_id references), then
+// spent_at_tx_id is cleared to mimic the partial-write state, and the second
+// pass must repair it.
+func TestSetTransactionBatched_InFlightDoesNotSkipExistingRowRepair(
+	t *testing.T,
+) {
+	db := openTestDB(t)
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+
+	// Pass 1: ingest normally so the output is spent and the consumer tx row
+	// exists.
+	ingestSameBatchProducerConsumer(t, db, candidate)
+
+	store, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok)
+
+	// Mimic a partial prior run: the row stays deleted at the consumer slot
+	// but loses its spender hash.
+	require.NoError(t, store.DB().
+		Model(&models.Utxo{}).
+		Where("tx_id = ? AND output_idx = ?",
+			candidate.input.Id().Bytes(), candidate.input.Index()).
+		Update("spent_at_tx_id", nil).Error)
+
+	pre, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(), candidate.input.Index(), nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, pre)
+	require.Equal(t, candidate.consumerPoint.Slot, pre.DeletedSlot)
+	require.Nil(t, pre.SpentAtTxId, "precondition: spender hash cleared")
+
+	// Pass 2: re-ingest. The producer is in-flight again, but because the row
+	// already exists the consumer must repair the spender link rather than
+	// short-circuit on the in-flight lookup.
+	ingestSameBatchProducerConsumer(t, db, candidate)
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(), candidate.input.Index(), nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, post)
+	require.Equal(t, candidate.consumerPoint.Slot, post.DeletedSlot)
+	require.Equal(
+		t,
+		candidate.consumerTx.Hash().Bytes(),
+		post.SpentAtTxId,
+		"spender link must be backfilled for a pre-existing same-slot row",
 	)
 }

--- a/database/inflight_provenance_test.go
+++ b/database/inflight_provenance_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetTransactionBatched_SameBatchProducerSpentViaInFlight ingests a
+// producer and the transaction that spends its output into the SAME batch
+// accumulator before any flush. When the consumer is processed the output it
+// spends exists only in the in-flight accumulator — it has never been written
+// to the metadata store. Correct provenance (the produced row ends up present
+// and marked spent) proves the in-flight lookup carries same-batch provenance
+// without depending on blob/metadata recovery.
+func TestSetTransactionBatched_SameBatchProducerSpentViaInFlight(t *testing.T) {
+	db := openTestDB(t)
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.consumerTx,
+		candidate.consumerPoint,
+		candidate.consumerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.consumerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+
+	utxo, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(),
+		candidate.input.Index(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(
+		t,
+		utxo,
+		"same-batch produced output must be created at flush",
+	)
+	require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
+	require.Equal(t, candidate.consumerTx.Hash().Bytes(), utxo.SpentAtTxId)
+}
+
+// TestSetTransactionBatched_CrossBatchProducerResolvesFromDB flushes the
+// producer in one batch, then ingests the consumer in a second batch whose
+// accumulator does not contain the producer. The spend must resolve through
+// the metadata-store fallthrough, exactly as before this optimisation.
+func TestSetTransactionBatched_CrossBatchProducerResolvesFromDB(t *testing.T) {
+	db := openTestDB(t)
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+
+	// Batch 1: ingest and flush the producer so its output is committed.
+	acc1 := db.NewBatchAccumulator()
+	txn1 := db.Transaction(true)
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc1,
+		txn1,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc1, txn1))
+	require.NoError(t, txn1.Commit())
+	txn1.Release()
+
+	// The producer output is now a committed, live row — not in-flight.
+	pre, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(),
+		candidate.input.Index(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, pre)
+	require.Zero(
+		t,
+		pre.DeletedSlot,
+		"producer output must be live before the consumer batch",
+	)
+
+	// Batch 2: a fresh accumulator (empty in-flight index) ingests the
+	// consumer; the spend must resolve via the metadata store.
+	acc2 := db.NewBatchAccumulator()
+	txn2 := db.Transaction(true)
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.consumerTx,
+		candidate.consumerPoint,
+		candidate.consumerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.consumerBlock),
+		acc2,
+		txn2,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc2, txn2))
+	require.NoError(t, txn2.Commit())
+	txn2.Release()
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(),
+		candidate.input.Index(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, post)
+	require.Equal(t, candidate.consumerPoint.Slot, post.DeletedSlot)
+	require.Equal(t, candidate.consumerTx.Hash().Bytes(), post.SpentAtTxId)
+}
+
+// TestSetTransactionBatched_MissingProducerNotFabricated ingests only the
+// consumer, with no producer either in-flight or committed. A genuinely
+// missing historical producer must not be hidden or fabricated: the in-flight
+// optimisation only short-circuits real same-batch producers.
+func TestSetTransactionBatched_MissingProducerNotFabricated(t *testing.T) {
+	db := openTestDB(t)
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	defer txn.Release()
+	defer txn.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.consumerTx,
+		candidate.consumerPoint,
+		candidate.consumerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.consumerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+
+	utxo, err := db.Metadata().GetUtxoIncludingSpent(
+		candidate.input.Id().Bytes(),
+		candidate.input.Index(),
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t,
+		utxo,
+		"genuinely missing producer must not be hidden or fabricated",
+	)
+}

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -52,11 +53,25 @@ type BatchAccumulator struct {
 	CollateralRets []models.Utxo
 	DeleteTxIDs    []uint
 	stats          *types.BackfillHotPathStats
+	// producedByRef indexes produced outputs and collateral returns by their
+	// "%x:%d" tx-id/output-index ref so a later transaction in the same batch
+	// can resolve provenance and address keys for an output that has not yet
+	// been flushed to the database. Eagerly allocated so the Add/lookup
+	// methods never need a nil check.
+	producedByRef map[string]models.Utxo
+}
+
+// utxoRefKey builds the "%x:%d" lookup key shared by the in-flight index,
+// GetUtxoAddressKeysBatch's result map, and the consumed-input dedup loops.
+func utxoRefKey(txId []byte, outputIdx uint32) string {
+	return fmt.Sprintf("%x:%d", txId, outputIdx)
 }
 
 // NewBatchAccumulator returns an empty BatchAccumulator ready for use.
 func NewBatchAccumulator() *BatchAccumulator {
-	return &BatchAccumulator{}
+	return &BatchAccumulator{
+		producedByRef: make(map[string]models.Utxo),
+	}
 }
 
 // NewBatchAccumulator creates an accumulator for this metadata store.
@@ -97,6 +112,7 @@ func (b *BatchAccumulator) AddAddressTx(at models.AddressTransaction) {
 // AddUtxoOutput appends a produced UTxO record to the batch.
 func (b *BatchAccumulator) AddUtxoOutput(u models.Utxo) {
 	b.UtxoOutputs = append(b.UtxoOutputs, u)
+	b.producedByRef[utxoRefKey(u.TxId, u.OutputIdx)] = u
 }
 
 // AddUtxoSpend appends a consumed UTxO record to the batch.
@@ -107,6 +123,32 @@ func (b *BatchAccumulator) AddUtxoSpend(s utxoSpend) {
 // AddCollateralReturn appends a collateral return UTxO to the batch.
 func (b *BatchAccumulator) AddCollateralReturn(u models.Utxo) {
 	b.CollateralRets = append(b.CollateralRets, u)
+	b.producedByRef[utxoRefKey(u.TxId, u.OutputIdx)] = u
+}
+
+// InFlightAddressKeys returns the address-key projection for an output
+// produced earlier in the current batch (and not yet flushed), so a later
+// transaction can resolve it without a database round trip.
+func (b *BatchAccumulator) InFlightAddressKeys(
+	txId []byte,
+	outputIdx uint32,
+) (UtxoAddressKeys, bool) {
+	u, ok := b.producedByRef[utxoRefKey(txId, outputIdx)]
+	if !ok {
+		return UtxoAddressKeys{}, false
+	}
+	return utxoAddressKeysFromUtxo(u), true
+}
+
+// HasInFlightProducer reports whether an output produced earlier in the
+// current batch (and not yet flushed) matches the given ref. The database
+// layer uses this to skip blob recovery for same-batch provenance.
+func (b *BatchAccumulator) HasInFlightProducer(
+	txId []byte,
+	outputIdx uint32,
+) bool {
+	_, ok := b.producedByRef[utxoRefKey(txId, outputIdx)]
+	return ok
 }
 
 // AddDeleteTxID appends a transaction ID scheduled for idempotent
@@ -128,6 +170,7 @@ func (b *BatchAccumulator) Reset() {
 	b.UtxoSpends = b.UtxoSpends[:0]
 	b.CollateralRets = b.CollateralRets[:0]
 	b.DeleteTxIDs = b.DeleteTxIDs[:0]
+	clear(b.producedByRef)
 	b.stats = nil
 }
 
@@ -174,6 +217,7 @@ func (b *BatchAccumulator) MergeFrom(other *BatchAccumulator) {
 	b.UtxoSpends = append(b.UtxoSpends, other.UtxoSpends...)
 	b.CollateralRets = append(b.CollateralRets, other.CollateralRets...)
 	b.DeleteTxIDs = append(b.DeleteTxIDs, other.DeleteTxIDs...)
+	maps.Copy(b.producedByRef, other.producedByRef)
 }
 
 // addPendingCountsToStats reports rows buffered for the next batch flush.

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -149,6 +149,81 @@ func TestBatchAccumulator_AddAndReset(t *testing.T) {
 	assert.Equal(t, []byte{0xff}, ba.KeyWitnesses[0].Vkey)
 }
 
+func TestBatchAccumulator_InFlightProducerIndex(t *testing.T) {
+	ba := NewBatchAccumulator()
+
+	producerTx := bytes.Repeat([]byte{0xaa}, 32)
+	paymentKey := []byte{0x11}
+	stakingKey := []byte{0x22}
+	ba.AddUtxoOutput(models.Utxo{
+		TxId:       producerTx,
+		OutputIdx:  3,
+		PaymentKey: paymentKey,
+		StakingKey: stakingKey,
+		AddedSlot:  100,
+	})
+
+	colRetTx := bytes.Repeat([]byte{0xcc}, 32)
+	ba.AddCollateralReturn(models.Utxo{
+		TxId:       colRetTx,
+		OutputIdx:  0,
+		PaymentKey: []byte{0x33},
+		StakingKey: []byte{0x44},
+		AddedSlot:  100,
+	})
+
+	// Produced output is resolvable with its address keys.
+	assert.True(t, ba.HasInFlightProducer(producerTx, 3))
+	keys, ok := ba.InFlightAddressKeys(producerTx, 3)
+	require.True(t, ok)
+	assert.Equal(t, producerTx, keys.TxId)
+	assert.Equal(t, uint32(3), keys.OutputIdx)
+	assert.Equal(t, paymentKey, keys.PaymentKey)
+	assert.Equal(t, stakingKey, keys.StakingKey)
+
+	// Collateral returns are indexed too.
+	assert.True(t, ba.HasInFlightProducer(colRetTx, 0))
+
+	// Misses: wrong index, wrong tx id.
+	assert.False(t, ba.HasInFlightProducer(producerTx, 4))
+	assert.False(t, ba.HasInFlightProducer(bytes.Repeat([]byte{0x99}, 32), 3))
+	_, ok = ba.InFlightAddressKeys(producerTx, 4)
+	assert.False(t, ok)
+
+	// Reset clears the index along with the slices.
+	ba.Reset()
+	assert.False(t, ba.HasInFlightProducer(producerTx, 3))
+	assert.False(t, ba.HasInFlightProducer(colRetTx, 0))
+
+	// The index is reusable after reset.
+	ba.AddUtxoOutput(models.Utxo{TxId: producerTx, OutputIdx: 3})
+	assert.True(t, ba.HasInFlightProducer(producerTx, 3))
+}
+
+func TestBatchAccumulator_MergeFromIndex(t *testing.T) {
+	dst := NewBatchAccumulator()
+	src := NewBatchAccumulator()
+
+	dstTx := bytes.Repeat([]byte{0x01}, 32)
+	dst.AddUtxoOutput(
+		models.Utxo{TxId: dstTx, OutputIdx: 0, PaymentKey: []byte{0x10}},
+	)
+
+	srcTx := bytes.Repeat([]byte{0x02}, 32)
+	src.AddUtxoOutput(
+		models.Utxo{TxId: srcTx, OutputIdx: 1, PaymentKey: []byte{0x20}},
+	)
+
+	dst.MergeFrom(src)
+
+	// Both the destination's own and the merged-in producers resolve.
+	assert.True(t, dst.HasInFlightProducer(dstTx, 0))
+	assert.True(t, dst.HasInFlightProducer(srcTx, 1))
+	keys, ok := dst.InFlightAddressKeys(srcTx, 1)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0x20}, keys.PaymentKey)
+}
+
 func TestFlushBatch_Witnesses(t *testing.T) {
 	store := setupTestDBWithMode(t, "api")
 	batch := NewBatchAccumulator()

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"strings"
 	"time"
@@ -2733,25 +2734,38 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			local.AddDeleteTxID(tmpTx.ID)
 		}
 
-		// Fetch input address keys for address-indexing below.
+		// Fetch input address keys for address-indexing below. Outputs
+		// produced earlier in this same batch are not yet in the database,
+		// so resolve those from the in-flight accumulator and only query the
+		// store for the remaining (cross-batch) refs.
+		inputAddressKeys := make(map[string]UtxoAddressKeys, len(tx.Inputs()))
 		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
 		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			if keys, ok := batch.InFlightAddressKeys(inTxId, inIdx); ok {
+				inputAddressKeys[fmt.Sprintf("%x:%d", inTxId, inIdx)] = keys
+				continue
+			}
 			inputRefs = append(inputRefs, UtxoRef{
-				TxId:      input.Id().Bytes(),
-				OutputIdx: input.Index(),
+				TxId:      inTxId,
+				OutputIdx: inIdx,
 			})
 		}
-		lookupStart := time.Now()
-		inputAddressKeys, err := d.GetUtxoAddressKeysBatch(inputRefs, txn)
-		if batch.stats != nil {
-			// Track regular input address-key lookup for address indexing.
-			batch.stats.UtxoAddressLookup += time.Since(lookupStart)
-		}
-		if err != nil {
-			return fmt.Errorf(
-				"failed to batch fetch input UTXO address keys (batched): %w",
-				err,
-			)
+		if len(inputRefs) > 0 {
+			lookupStart := time.Now()
+			dbKeys, err := d.GetUtxoAddressKeysBatch(inputRefs, txn)
+			if batch.stats != nil {
+				// Track regular input address-key lookup for address indexing.
+				batch.stats.UtxoAddressLookup += time.Since(lookupStart)
+			}
+			if err != nil {
+				return fmt.Errorf(
+					"failed to batch fetch input UTXO address keys (batched): %w",
+					err,
+				)
+			}
+			maps.Copy(inputAddressKeys, dbKeys)
 		}
 
 		// Address-transaction index.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -291,15 +291,6 @@ func (d *Database) ensureTransactionConsumedUtxos(
 			continue
 		}
 		seen[inputKey] = struct{}{}
-		// An output produced earlier in this same batch has not been
-		// flushed yet, so the metadata lookup below would miss and fall
-		// through to expensive blob recovery. FlushBatch creates the
-		// producer row before applying spends, and SetTransactionBatched
-		// records the spend independently, so we can skip recovery here.
-		if inFlight != nil &&
-			inFlight.HasInFlightProducer(inputTxId, input.Index()) {
-			continue
-		}
 		existingUtxo, err := d.metadata.GetUtxoIncludingSpent(
 			inputTxId,
 			input.Index(),
@@ -337,6 +328,20 @@ func (d *Database) ensureTransactionConsumedUtxos(
 					)
 				}
 			}
+			continue
+		}
+		// The row is absent from the store. If it was produced earlier in
+		// this same batch it has not been flushed yet: FlushBatch creates the
+		// producer row before applying spends, and SetTransactionBatched
+		// records the spend independently, so skip the expensive blob
+		// recovery rather than reconstructing a row the flush will write.
+		// This check is deliberately after the existing-row repair above so a
+		// partially-written row from a resumed backfill (DeletedSlot ==
+		// point.Slot, SpentAtTxId == nil) still gets its spender link
+		// backfilled — batchSpendUtxos only updates rows where deleted_slot
+		// = 0 and would not fix it later.
+		if inFlight != nil &&
+			inFlight.HasInFlightProducer(inputTxId, input.Index()) {
 			continue
 		}
 		recoveredUtxo, err := d.recoverConsumedUtxo(

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -143,7 +143,7 @@ func (d *Database) SetTransaction(
 		}
 	}
 
-	if err := d.ensureTransactionConsumedUtxos(tx, point, txn); err != nil {
+	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, nil); err != nil {
 		return err
 	}
 	if err := d.metadata.SetTransaction(tx, point, idx, certDeposits, txn.Metadata()); err != nil {
@@ -274,11 +274,13 @@ func (d *Database) ensureTransactionConsumedUtxos(
 	tx lcommon.Transaction,
 	point ocommon.Point,
 	txn *Txn,
+	acc BatchAccumulator,
 ) error {
 	consumed := tx.Consumed()
 	if len(consumed) == 0 {
 		return nil
 	}
+	inFlight, _ := acc.(inFlightProducerLookup)
 	spenderTxHash := ledgerHashBytes(tx.Hash())
 	recoveredUtxos := make([]models.Utxo, 0, len(consumed))
 	seen := make(map[string]struct{}, len(consumed))
@@ -289,6 +291,15 @@ func (d *Database) ensureTransactionConsumedUtxos(
 			continue
 		}
 		seen[inputKey] = struct{}{}
+		// An output produced earlier in this same batch has not been
+		// flushed yet, so the metadata lookup below would miss and fall
+		// through to expensive blob recovery. FlushBatch creates the
+		// producer row before applying spends, and SetTransactionBatched
+		// records the spend independently, so we can skip recovery here.
+		if inFlight != nil &&
+			inFlight.HasInFlightProducer(inputTxId, input.Index()) {
+			continue
+		}
 		existingUtxo, err := d.metadata.GetUtxoIncludingSpent(
 			inputTxId,
 			input.Index(),


### PR DESCRIPTION
## Summary

During API-mode Mithril backfill, transactions in dense history frequently spend or reference outputs produced **earlier in the same batch window** (the `BatchAccumulator` buffers 50–100 blocks before flushing). Those producers are not yet flushed, so the current code goes to the metadata store / blob recovery anyway. The May 30, 2026 backfill rerun showed this dominating the hot path:

- `consumed_input_recovery_ms`: ~2.6–3.3s per 10s interval (the costly blob hot-cache → block-LRU → cold-extraction → `ImportUtxos` chain in `recoverConsumedUtxo`)
- `utxo_address_lookup_ms`: ~0.88–1.04s per 10s interval (`GetUtxoAddressKeysBatch` round trips)

The produced rows already sit in `acc.UtxoOutputs` / `acc.CollateralRets` carrying `TxId`, `OutputIdx`, `PaymentKey`, and `StakingKey`. This change adds a ref-indexed lookup over those in-flight rows and consults it before falling back.

Closes #2459.

## Changes

- **`sqlite/batch_accumulator.go`** — new `producedByRef` map (eagerly allocated in `NewBatchAccumulator`, populated in `AddUtxoOutput`/`AddCollateralReturn`, `clear()`-ed in `Reset`, merged in `MergeFrom`); new `InFlightAddressKeys` and `HasInFlightProducer` methods.
- **`database/batch.go` + `database/transaction.go`** — new optional `inFlightProducerLookup` interface (mirrors `batchStatsSetter`); `ensureTransactionConsumedUtxos` skips `GetUtxoIncludingSpent` + blob recovery for same-batch producers. `FlushBatch` creates the producer row before applying spends and the spend is recorded independently, so final state is unchanged. `ensureGapConsumedUtxos` (gap repair) is left untouched.
- **`sqlite/transaction.go`** — the regular-input address-key lookup resolves same-batch producers from the in-flight index and only queries `GetUtxoAddressKeysBatch` for cross-batch misses.

Scope is deliberately limited to consumed-input recovery and **regular-input** address keys. Collateral/reference address-key sites (which also drive immediate marker-UPDATEs) and the gap path are unchanged.

## Invariants preserved

- **Cross-batch inputs**: producer already flushed → not in the index → DB path runs as before.
- **Missing producers**: neither in-flight nor in store → recovery still runs and surfaces/logs exactly as today; nothing is fabricated or hidden.
- **Resumed backfill**: `batchCreateUtxos` is `ON CONFLICT (tx_id, output_idx) DO NOTHING` and `batchSpendUtxos` is guarded by `WHERE deleted_slot = 0`, so re-running is a no-op.
- **Postgres/MySQL**: the optional interface is only implemented by the sqlite accumulator, so other plugins are unaffected.

## Testing

- `go build ./...`
- `go test -race ./database/...` — all packages pass
- `golangci-lint run ./database/...` — no findings
- `modernize ./database/...` — clean
- conformance (`internal/test/conformance`) — pass
- New tests: accumulator index unit tests (populate/clear/merge + both lookups) and integration tests for same-batch resolution, cross-batch DB fallthrough, and missing-producer-not-fabricated.

Note: the timing evidence in #2459 was gathered with a local workaround for #2457, which is now closed and is not a prerequisite.

## Documentation

`DATABASE.md` / `ARCHITECTURE.md` checked, not affected — this is an internal lookup-ordering optimization with no schema, external query/API surface, blob layout, CBOR, pruning, or component/lifecycle change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve same-batch provenance and input address keys from in-flight produced outputs during Mithril API-mode backfill, avoiding blob/metadata recovery and unnecessary DB lookups. Also fixes resumed-backfill edge cases by repairing existing spent rows before skipping recovery. Closes #2459.

- **New Features**
  - `sqlite` batch accumulator: added an in-flight `producedByRef` index. Populated in produced outputs and collateral returns. Cleared on reset and merged on batch merge. Exposes `InFlightAddressKeys` and `HasInFlightProducer`.
  - Database: new optional `inFlightProducerLookup`; `ensureTransactionConsumedUtxos` accepts the accumulator and skips recovery for same-batch producers. Gap repair and non-`sqlite` plugins unchanged.
  - Address keys: `sqlite` resolves same-batch inputs from the accumulator and only calls `GetUtxoAddressKeysBatch` for cross-batch misses.

- **Bug Fixes**
  - On resumed backfill, repair partially written spent rows (same-slot delete with missing `SpentAtTxId`) before the in-flight short-circuit. Adds a two-pass regression test alongside tests for same-batch resolution, cross-batch fallthrough, and missing-producer behavior.

<sup>Written for commit 8e0d1790695db5857cb7e437292020b1b3243759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transaction dependencies within the same batch, ensuring correct provenance tracking when multiple transactions are processed together.
  * Enhanced transaction metadata resolution to prevent missing producer information in batched operations.

* **Performance**
  * Optimized address key lookups by checking in-flight batch data first before querying the database, reducing unnecessary database calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->