### PR TITLE
perf(ledger): use binary search for leader slot lookup

### DIFF
--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -47,10 +47,19 @@ type Schedule struct {
 	PoolStake     uint64              // Pool's stake from Go snapshot
 	TotalStake    uint64              // Total active stake from Go snapshot
 	EpochNonce    []byte              // Epoch nonce for VRF
-	LeaderSlots   []uint64            // Slots where pool is leader
+	LeaderSlots   []uint64            // Slots where pool is leader, ascending-sorted
 
 	mu sync.RWMutex
 }
+
+// LeaderSlots is maintained in ascending-sorted order so that
+// IsLeaderForSlot can do an O(log n) binary search instead of an O(n)
+// scan — relevant for high-stake pools with many leader slots per epoch.
+// The invariant is upheld at every entry point that populates the slice:
+//   - CalculateSchedule iterates slots in ascending order, so AddLeaderSlot
+//     only ever appends a value greater than the last.
+//   - syncStateScheduleStore.LoadSchedule re-sorts after rebuilding from a
+//     persisted record, guarding against a tampered or legacy unsorted list.
 
 // NewSchedule creates a new empty schedule for an epoch.
 func NewSchedule(
@@ -79,11 +88,14 @@ func (s *Schedule) AddLeaderSlot(slot uint64) {
 }
 
 // IsLeaderForSlot returns true if the pool is leader for the given slot.
+// LeaderSlots is kept ascending-sorted (see the type doc), so this is an
+// O(log n) binary search rather than an O(n) scan.
 func (s *Schedule) IsLeaderForSlot(slot uint64) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return slices.Contains(s.LeaderSlots, slot)
+	_, found := slices.BinarySearch(s.LeaderSlots, slot)
+	return found
 }
 
 // SlotCount returns the number of slots where this pool is leader.

--- a/ledger/leader/schedule_test.go
+++ b/ledger/leader/schedule_test.go
@@ -16,6 +16,7 @@ package leader
 
 import (
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/consensus"
@@ -500,4 +501,71 @@ func TestScheduleConcurrentAccess(t *testing.T) {
 	}
 
 	assert.Equal(t, 10, schedule.SlotCount())
+}
+
+// TestCalculateScheduleProducesSortedSlots guards the invariant that
+// IsLeaderForSlot's binary search depends on: CalculateSchedule must emit
+// leader slots in ascending order.
+func TestCalculateScheduleProducesSortedSlots(t *testing.T) {
+	calc := NewCalculator(0.9, 30)
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	schedule, err := calc.CalculateSchedule(
+		7,
+		poolId,
+		testVRFSeed,
+		1_000_000,
+		1_000_000,
+		testEpochNonce,
+		consensus.ConsensusModeCPraos,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, schedule)
+
+	slots := schedule.LeaderSlotsSnapshot()
+	require.NotEmpty(t, slots, "high-stake pool should win some slots")
+	assert.True(t, slices.IsSorted(slots),
+		"CalculateSchedule must produce ascending-sorted leader slots, got %v",
+		slots)
+}
+
+// TestScheduleIsLeaderForSlotBinarySearch cross-checks the binary-search
+// lookup against a linear scan over a wide, sparse slot set so a regression
+// in either ordering or search would be caught.
+func TestScheduleIsLeaderForSlotBinarySearch(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	schedule := NewSchedule(10, poolId, 1000, 10000, nil)
+
+	want := []uint64{1, 5, 9, 42, 100, 1_000, 50_000, 1_000_000}
+	for _, slot := range want {
+		schedule.AddLeaderSlot(slot)
+	}
+
+	for probe := range uint64(60) {
+		assert.Equal(t,
+			slices.Contains(want, probe),
+			schedule.IsLeaderForSlot(probe),
+			"binary search disagrees with linear scan for slot %d", probe)
+	}
+	// Spot-check the large boundary values too.
+	assert.True(t, schedule.IsLeaderForSlot(1_000_000))
+	assert.False(t, schedule.IsLeaderForSlot(1_000_001))
+}
+
+// BenchmarkIsLeaderForSlot exercises lookups against a large schedule,
+// approximating a high-stake pool with many leader slots per epoch.
+func BenchmarkIsLeaderForSlot(b *testing.B) {
+	poolId := lcommon.PoolKeyHash{}
+	schedule := NewSchedule(10, poolId, 1000, 10000, nil)
+	const n = 20_000
+	for i := range uint64(n) {
+		schedule.AddLeaderSlot(i * 3) // ascending, sparse
+	}
+
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		// Miss on odd offset, exercising the not-found path too.
+		_ = schedule.IsLeaderForSlot(uint64(i%n)*3 + uint64(i&1))
+	}
 }

--- a/ledger/leader/store.go
+++ b/ledger/leader/store.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -109,6 +110,11 @@ func (s *syncStateScheduleStore) LoadSchedule(
 	for _, slot := range record.LeaderSlots {
 		schedule.AddLeaderSlot(slot)
 	}
+	// IsLeaderForSlot relies on LeaderSlots being ascending-sorted for its
+	// binary search. Persisted records written by CalculateSchedule already
+	// satisfy this, but sort defensively so a tampered or legacy unsorted
+	// payload can never silently break leader lookups.
+	slices.Sort(schedule.LeaderSlots)
 	return schedule, nil
 }
 

--- a/ledger/leader/store_test.go
+++ b/ledger/leader/store_test.go
@@ -112,6 +112,37 @@ func TestSyncStateScheduleStoreLoadsZeroFormatVersionFromOldRecord(t *testing.T)
 		"missing format_version must decode to 0 so validation rejects it")
 }
 
+// TestSyncStateScheduleStoreSortsUnsortedRecord verifies that a persisted
+// payload whose leader_slots are out of order is re-sorted on load, so
+// IsLeaderForSlot's binary search stays correct even against a tampered or
+// legacy record.
+func TestSyncStateScheduleStoreSortsUnsortedRecord(t *testing.T) {
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	backingStore := newMockSyncStateStore()
+	key := syncStateScheduleKey(42, poolId)
+	backingStore.values[key] = `{"format_version":1,"epoch":42,"pool_id":"` +
+		hexEncode(poolId[:]) + `","pool_stake":1,"total_stake":1,` +
+		`"epoch_nonce":"","leader_slots":[300,100,200,50]}`
+
+	store := NewSyncStateScheduleStore(backingStore)
+	loaded, err := store.LoadSchedule(42, poolId)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(
+		t,
+		[]uint64{50, 100, 200, 300},
+		loaded.LeaderSlotsSnapshot(),
+		"persisted leader slots must be sorted ascending on load",
+	)
+	// Binary search must find every slot regardless of stored order.
+	for _, slot := range []uint64{50, 100, 200, 300} {
+		assert.True(t, loaded.IsLeaderForSlot(slot))
+	}
+	assert.False(t, loaded.IsLeaderForSlot(150))
+}
+
 func hexEncode(b []byte) string {
 	const hexChars = "0123456789abcdef"
 	out := make([]byte, len(b)*2)


### PR DESCRIPTION
Closes #2288 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use binary search for leader slot lookups to reduce `IsLeaderForSlot` from O(n) to O(log n), and enforce that `LeaderSlots` stays ascending-sorted. Adds tests and defensive sorting on load to preserve the invariant.

- **New Features**
  - Replace linear scan with `slices.BinarySearch` in `IsLeaderForSlot`.
  - Ensure `LeaderSlots` is always ascending-sorted: `CalculateSchedule` appends in order; `LoadSchedule` sorts defensively.
  - Add tests for sorted output, binary search correctness, and a benchmark for large schedules.

<sup>Written for commit 998c2637230d45f1870323c3f38d63a87adab485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added data validation to ensure persisted schedules are properly formatted on load.

* **Refactor**
  * Optimized leader slot eligibility checks for faster performance.

* **Tests**
  * Enhanced test coverage for schedule validation and leader slot lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->