### PR TITLE
fix(chainsync): cap FindIntersect point count

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -36,6 +36,15 @@ import (
 const (
 	chainsyncIntersectPointCount = 100
 
+	// chainsyncMaxFindIntersectPoints bounds how many points a peer may
+	// send in a single FindIntersect request. Honest clients send a small,
+	// bounded bisection list (our own client sends at most
+	// chainsyncIntersectPointCount). This generous cap protects against a
+	// malicious or buggy peer forcing avoidable intersection lookups against
+	// the ledger until the protocol timeout fires, while leaving ample
+	// headroom so legitimate sync is never rejected.
+	chainsyncMaxFindIntersectPoints = 1000
+
 	// chainsyncRestartTimeout bounds how long the restart of a
 	// chainsync client can take before we give up and close the
 	// connection. Increase this for slow or congested networks.
@@ -364,6 +373,22 @@ func (o *Ouroboros) chainsyncServerFindIntersect(
 		"component", "ouroboros",
 		"tip_slot", tip.Point.Slot,
 	)
+	// Reject oversized point lists before performing any intersection
+	// lookup. Without this cap a peer could send an arbitrarily large list
+	// and force avoidable CPU/database work until the protocol timeout. We
+	// respond with IntersectNotFound (via ErrIntersectNotFound) rather than
+	// tearing down the connection, which keeps the failure cheap and avoids
+	// reconnect churn.
+	if len(points) > chainsyncMaxFindIntersectPoints {
+		o.config.Logger.Warn(
+			"chainsync server: rejecting FindIntersect with too many points",
+			"component", "ouroboros",
+			"connection_id", ctx.ConnectionId.String(),
+			"num_points", len(points),
+			"max_points", chainsyncMaxFindIntersectPoints,
+		)
+		return retPoint, tip, ochainsync.ErrIntersectNotFound
+	}
 	intersectPoint, err := o.LedgerState.GetIntersectPoint(points)
 	if err != nil {
 		o.config.Logger.Error(

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1524,3 +1524,76 @@ func TestChainsyncClientRollBackward_InboundUpstreamProcessesRollback(
 		)
 	}
 }
+
+// newFindIntersectTestOuroboros builds an Ouroboros wired with a fresh,
+// empty LedgerState (tip at origin) and ChainsyncState. With the chain at
+// origin, GetIntersectPoint returns the origin point for any in-bounds point
+// list, so a successful FindIntersect proves the cap did not reject the
+// request.
+func newFindIntersectTestOuroboros(t *testing.T) *Ouroboros {
+	t.Helper()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	t.Cleanup(bus.Close)
+	ledgerState := newTestLedgerState(t)
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		Logger:   logger,
+	})
+	o.LedgerState = ledgerState
+	o.ChainsyncState = dchainsync.NewState(bus, ledgerState)
+	return o
+}
+
+func makeFindIntersectPoints(n int) []ocommon.Point {
+	points := make([]ocommon.Point, n)
+	for i := range points {
+		points[i] = ocommon.NewPoint(
+			uint64(i+1),
+			[]byte{byte(i), byte(i >> 8)},
+		)
+	}
+	return points
+}
+
+func TestChainsyncServerFindIntersect_AtLimitAccepted(t *testing.T) {
+	o := newFindIntersectTestOuroboros(t)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	points := makeFindIntersectPoints(chainsyncMaxFindIntersectPoints)
+
+	_, _, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		points,
+	)
+	// An empty chain intersects every in-bounds request at origin, so a
+	// point list at the limit must be accepted (no error).
+	require.NoError(t, err)
+}
+
+func TestChainsyncServerFindIntersect_OverLimitRejected(t *testing.T) {
+	o := newFindIntersectTestOuroboros(t)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	points := makeFindIntersectPoints(chainsyncMaxFindIntersectPoints + 1)
+
+	_, _, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		points,
+	)
+	// Over-limit lists are rejected before any intersection lookup. On an
+	// empty chain the lookup would otherwise return origin, so receiving
+	// ErrIntersectNotFound here proves the cap short-circuited the request.
+	require.ErrorIs(t, err, ochainsync.ErrIntersectNotFound)
+}
+
+func TestChainsyncServerFindIntersect_NormalPointListAccepted(t *testing.T) {
+	o := newFindIntersectTestOuroboros(t)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	// A typical client sends at most chainsyncIntersectPointCount points.
+	points := makeFindIntersectPoints(chainsyncIntersectPointCount)
+
+	_, _, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		points,
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Closes #2283 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `chainsync` FindIntersect point lists at 1000 to prevent oversized requests from wasting CPU/DB work; over-limit requests now return IntersectNotFound and are logged. Adds tests to confirm at-limit acceptance, over-limit rejection, and normal behavior.

- **Bug Fixes**
  - Added `chainsyncMaxFindIntersectPoints = 1000` and early reject in server FindIntersect handler.
  - Return IntersectNotFound (no disconnect) and warn-log with connection_id and counts.
  - Tests: AtLimitAccepted, OverLimitRejected, NormalPointListAccepted.

<sup>Written for commit c5f9434935c47e1fc7c41bd73d5113c0c5e6b54b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to limit the maximum number of intersection points accepted in peer requests. Oversized requests are now rejected to prevent resource exhaustion.

* **Tests**
  * Added comprehensive test coverage for intersection point request validation, including edge cases at and above the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->