### PR TITLE
feat(ledger): LocalStateQuery implement GetLedgerPeerSnapshot

### DIFF
--- a/ledger/peer_snapshot_query.go
+++ b/ledger/peer_snapshot_query.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -23,17 +24,19 @@ import (
 	"sort"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
 // bigLedgerPeerQuota is the cumulative relative-stake threshold that
 // delimits the "big" ledger peers: walking pools from highest to lowest
 // stake, a pool belongs to the big set while the stake accumulated by the
-// pools before it has not yet exceeded this quota (so the first pool that
-// crosses the quota is still included). The value mirrors the
-// bigLedgerPeerQuota default (0.9) used by ouroboros-network's
+// pools before it has not yet reached this quota (so the first pool that
+// reaches or crosses the quota is the last one included). The value mirrors
+// the bigLedgerPeerQuota default (0.9) used by ouroboros-network's
 // PeerSelection.LedgerPeers. It is applied only when a client requests
 // LedgerPeerKindBig; LedgerPeerKindAll returns every relay-advertising pool.
 //
@@ -56,13 +59,25 @@ var bigLedgerPeerQuota = big.NewRat(9, 10)
 func (ls *LedgerState) queryLedgerPeerSnapshot(
 	peerKind olocalstatequery.LedgerPeerKind,
 ) (any, error) {
-	slot := ls.ChainTipSlot()
-
 	txn := ls.db.Transaction(false)
 	defer txn.Release()
 
+	// Read the tip from the same read transaction as the pool/stake data so
+	// the reported snapshot slot describes the exact point the relays and
+	// stake were observed at, even under a concurrent block apply or rollback.
+	tip, err := ls.db.GetTip(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetLedgerPeerSnapshot: get tip: %w", err)
+	}
+	slot := withOriginSlot(tip.Point)
+
 	pkhBytes, err := ls.db.Metadata().GetActivePoolKeyHashes(txn.Metadata())
 	if err != nil {
+		// Epoch data may not be synced yet for the current tip (early sync);
+		// there are simply no ledger peers to report at that point.
+		if errors.Is(err, types.ErrNoEpochData) {
+			return emptyLedgerPeerSnapshot(slot), nil
+		}
 		return nil, fmt.Errorf(
 			"GetLedgerPeerSnapshot: get active pools: %w",
 			err,
@@ -95,22 +110,25 @@ func (ls *LedgerState) queryLedgerPeerSnapshot(
 	return assembleLedgerPeerSnapshot(slot, stakeByPool, pools, peerKind), nil
 }
 
-// emptyLedgerPeerSnapshot builds a well-formed empty (V1) snapshot for the
-// given tip slot. A node with no active pools still returns a valid result.
-func emptyLedgerPeerSnapshot(slot uint64) olocalstatequery.LedgerPeerSnapshotResult {
+// emptyLedgerPeerSnapshot builds a well-formed empty (V1) snapshot at the
+// given point. A node with no active pools still returns a valid result.
+func emptyLedgerPeerSnapshot(
+	slot olocalstatequery.WithOriginSlot,
+) olocalstatequery.LedgerPeerSnapshotResult {
 	return olocalstatequery.LedgerPeerSnapshotResult{
 		Version: 0, // LedgerPeerSnapshotV1
-		Slot:    withOriginSlot(slot),
+		Slot:    slot,
 		Pools:   []olocalstatequery.PoolLedgerPeers{},
 	}
 }
 
-// withOriginSlot encodes a tip slot as a WithOrigin SlotNo. Slot 0 means the
-// chain is still at origin (no block applied), which maps to Origin.
-func withOriginSlot(slot uint64) olocalstatequery.WithOriginSlot {
+// withOriginSlot encodes a chain point as a WithOrigin SlotNo. The origin
+// point (slot 0 with an empty hash) maps to Origin; a real slot-0 block
+// (slot 0 with a non-empty hash) is reported as At slot 0.
+func withOriginSlot(point ocommon.Point) olocalstatequery.WithOriginSlot {
 	return olocalstatequery.WithOriginSlot{
-		HasSlot: slot > 0,
-		Slot:    slot,
+		HasSlot: point.Slot != 0 || len(point.Hash) > 0,
+		Slot:    point.Slot,
 	}
 }
 
@@ -138,7 +156,7 @@ type poolLedgerPeer struct {
 // still contribute to the total-stake denominator, matching the Cardano
 // ledger's pool-distribution semantics.
 func assembleLedgerPeerSnapshot(
-	slot uint64,
+	slot olocalstatequery.WithOriginSlot,
 	stakeByPool map[string]uint64,
 	pools []models.Pool,
 	peerKind olocalstatequery.LedgerPeerKind,
@@ -180,10 +198,12 @@ func assembleLedgerPeerSnapshot(
 	acc := new(big.Rat)
 	for _, e := range entries {
 		// For the big-peer set, stop once the stake accumulated by the
-		// preceding pools has exceeded the quota. The pool that first crosses
-		// the quota is still included (takeWhilePrev semantics).
+		// preceding pools has reached the quota. The pool that first reaches
+		// or crosses the quota is the last one included; pools after it
+		// (including zero-stake relayed pools sitting exactly on a 0.9
+		// boundary) are excluded.
 		if peerKind == olocalstatequery.LedgerPeerKindBig &&
-			acc.Cmp(bigLedgerPeerQuota) > 0 {
+			acc.Cmp(bigLedgerPeerQuota) >= 0 {
 			break
 		}
 		poolStake := new(big.Rat).SetFrac(

--- a/ledger/peer_snapshot_query.go
+++ b/ledger/peer_snapshot_query.go
@@ -268,7 +268,10 @@ func relayAccessPoints(
 		return nil
 	}
 	host := relay.Hostname
-	if relay.Port != 0 {
+	// Branch on the validated port, not relay.Port: a malformed out-of-range
+	// port narrows to 0 above, so such a row falls through to MultiHostName
+	// rather than emitting a SingleHostName with a bogus port 0.
+	if port != 0 {
 		// SingleHostName: a domain resolved directly, with an explicit port.
 		p := port
 		return []olocalstatequery.RelayAccessPoint{{

--- a/ledger/peer_snapshot_query.go
+++ b/ledger/peer_snapshot_query.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"sort"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// bigLedgerPeerQuota is the cumulative relative-stake threshold that
+// delimits the "big" ledger peers: walking pools from highest to lowest
+// stake, a pool belongs to the big set while the stake accumulated by the
+// pools before it has not yet exceeded this quota (so the first pool that
+// crosses the quota is still included). The value mirrors the
+// bigLedgerPeerQuota default (0.9) used by ouroboros-network's
+// PeerSelection.LedgerPeers. It is applied only when a client requests
+// LedgerPeerKindBig; LedgerPeerKindAll returns every relay-advertising pool.
+//
+// Tuning the big-peer quota is part of the broader peer-governance roadmap
+// (#1787-#1796) and intentionally out of scope here; this constant only
+// shapes the GetLedgerPeerSnapshot query result.
+var bigLedgerPeerQuota = big.NewRat(9, 10)
+
+// queryLedgerPeerSnapshot answers the LocalStateQuery GetLedgerPeerSnapshot
+// query (NtC v19+). It returns the relay endpoints advertised by currently
+// active stake pools together with each pool's relative and cumulative stake,
+// which is exactly the data a dmq-node-compatible client needs for ledger
+// peer discovery.
+//
+// Point-in-time behavior: LocalStateQuery Acquire/Release are still no-ops
+// pending ViewManager snapshot isolation (#382), so the snapshot reflects the
+// current chain tip rather than the acquired point. The reported slot is the
+// current tip slot. When that isolation lands, only the data-sourcing here
+// needs to observe the acquired view; the query surface stays the same.
+func (ls *LedgerState) queryLedgerPeerSnapshot(
+	peerKind olocalstatequery.LedgerPeerKind,
+) (any, error) {
+	slot := ls.ChainTipSlot()
+
+	txn := ls.db.Transaction(false)
+	defer txn.Release()
+
+	pkhBytes, err := ls.db.Metadata().GetActivePoolKeyHashes(txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetLedgerPeerSnapshot: get active pools: %w",
+			err,
+		)
+	}
+	if len(pkhBytes) == 0 {
+		return emptyLedgerPeerSnapshot(slot), nil
+	}
+
+	stakeByPool, _, err := ls.db.Metadata().GetStakeByPools(
+		pkhBytes,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetLedgerPeerSnapshot: get stake by pools: %w",
+			err,
+		)
+	}
+
+	pkhs := make([]lcommon.PoolKeyHash, 0, len(pkhBytes))
+	for _, b := range pkhBytes {
+		pkhs = append(pkhs, lcommon.PoolKeyHash(lcommon.NewBlake2b224(b)))
+	}
+	pools, err := ls.db.GetPools(pkhs, txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetLedgerPeerSnapshot: get pools: %w", err)
+	}
+
+	return assembleLedgerPeerSnapshot(slot, stakeByPool, pools, peerKind), nil
+}
+
+// emptyLedgerPeerSnapshot builds a well-formed empty (V1) snapshot for the
+// given tip slot. A node with no active pools still returns a valid result.
+func emptyLedgerPeerSnapshot(slot uint64) olocalstatequery.LedgerPeerSnapshotResult {
+	return olocalstatequery.LedgerPeerSnapshotResult{
+		Version: 0, // LedgerPeerSnapshotV1
+		Slot:    withOriginSlot(slot),
+		Pools:   []olocalstatequery.PoolLedgerPeers{},
+	}
+}
+
+// withOriginSlot encodes a tip slot as a WithOrigin SlotNo. Slot 0 means the
+// chain is still at origin (no block applied), which maps to Origin.
+func withOriginSlot(slot uint64) olocalstatequery.WithOriginSlot {
+	return olocalstatequery.WithOriginSlot{
+		HasSlot: slot > 0,
+		Slot:    slot,
+	}
+}
+
+// poolLedgerPeer is an intermediate, sortable view of a single pool's
+// contribution to the snapshot.
+type poolLedgerPeer struct {
+	keyHash []byte
+	stake   uint64
+	relays  []olocalstatequery.RelayAccessPoint
+}
+
+// assembleLedgerPeerSnapshot is the pure mapping from ledger/database state to
+// a LedgerPeerSnapshot result. It is split out from queryLedgerPeerSnapshot so
+// the stake math, ordering, big-peer selection, and relay mapping can be
+// tested without a live database.
+//
+//   - stakeByPool is keyed by string(poolKeyHash) and holds the delegated
+//     stake of every active pool (including pools without relays). Its sum is
+//     the denominator for relative stake; pools missing from the map are
+//     treated as zero stake.
+//   - pools carries the per-pool registration detail (including relays) for
+//     the same active pools.
+//
+// Pools that advertise no usable relay are omitted from the result list but
+// still contribute to the total-stake denominator, matching the Cardano
+// ledger's pool-distribution semantics.
+func assembleLedgerPeerSnapshot(
+	slot uint64,
+	stakeByPool map[string]uint64,
+	pools []models.Pool,
+	peerKind olocalstatequery.LedgerPeerKind,
+) olocalstatequery.LedgerPeerSnapshotResult {
+	result := emptyLedgerPeerSnapshot(slot)
+
+	// Total stake across all active pools is the relative-stake denominator.
+	totalStake := new(big.Int)
+	for _, s := range stakeByPool {
+		totalStake.Add(totalStake, new(big.Int).SetUint64(s))
+	}
+	if totalStake.Sign() == 0 {
+		// No measurable stake yet (e.g. early chain); nothing to weight.
+		return result
+	}
+
+	entries := make([]poolLedgerPeer, 0, len(pools))
+	for _, pool := range pools {
+		relays := relayAccessPointsFromPool(pool)
+		if len(relays) == 0 {
+			continue
+		}
+		entries = append(entries, poolLedgerPeer{
+			keyHash: pool.PoolKeyHash,
+			stake:   stakeByPool[string(pool.PoolKeyHash)],
+			relays:  relays,
+		})
+	}
+
+	// Order by descending stake (the big-peer accumulation order), with the
+	// pool key hash as a deterministic tie-breaker.
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].stake != entries[j].stake {
+			return entries[i].stake > entries[j].stake
+		}
+		return bytes.Compare(entries[i].keyHash, entries[j].keyHash) < 0
+	})
+
+	acc := new(big.Rat)
+	for _, e := range entries {
+		// For the big-peer set, stop once the stake accumulated by the
+		// preceding pools has exceeded the quota. The pool that first crosses
+		// the quota is still included (takeWhilePrev semantics).
+		if peerKind == olocalstatequery.LedgerPeerKindBig &&
+			acc.Cmp(bigLedgerPeerQuota) > 0 {
+			break
+		}
+		poolStake := new(big.Rat).SetFrac(
+			new(big.Int).SetUint64(e.stake),
+			totalStake,
+		)
+		acc = new(big.Rat).Add(acc, poolStake)
+		result.Pools = append(result.Pools, olocalstatequery.PoolLedgerPeers{
+			AccumulatedStake: &cbor.Rat{Rat: new(big.Rat).Set(acc)},
+			Detail: olocalstatequery.PoolLedgerPeersDetail{
+				PoolStake: &cbor.Rat{Rat: poolStake},
+				Relays:    e.relays,
+			},
+		})
+	}
+	return result
+}
+
+// relayAccessPointsFromPool extracts the relays of a pool's most recent
+// registration and maps each stored relay row to one or more
+// RelayAccessPoint values. GetPools orders Registration newest-first, so
+// Registration[0] is the active registration.
+func relayAccessPointsFromPool(
+	pool models.Pool,
+) []olocalstatequery.RelayAccessPoint {
+	if len(pool.Registration) == 0 {
+		return nil
+	}
+	stored := pool.Registration[0].Relays
+	out := make([]olocalstatequery.RelayAccessPoint, 0, len(stored))
+	for _, relay := range stored {
+		out = append(out, relayAccessPoints(relay)...)
+	}
+	return out
+}
+
+// relayAccessPoints maps a single stored relay row to RelayAccessPoint(s).
+//
+// Dingo normalises each on-chain PoolRelay into one row carrying optional
+// IPv4/IPv6 addresses, an optional hostname, and a port:
+//
+//   - SingleHostAddr  -> IPv4 and/or IPv6 set, port set (a dual-stack relay
+//     yields one access point per address family).
+//   - SingleHostName  -> hostname + port, no IP (an A/AAAA-record domain).
+//   - MultiHostName   -> hostname only, no port (an SRV record; the resolver
+//     supplies the port).
+//
+// Rows that carry no usable endpoint are dropped.
+func relayAccessPoints(
+	relay models.PoolRegistrationRelay,
+) []olocalstatequery.RelayAccessPoint {
+	var out []olocalstatequery.RelayAccessPoint
+	// On-chain relay ports are Word16; the column is a wider uint, so guard
+	// the narrowing conversion. An out-of-range value is malformed data and
+	// is treated as no port.
+	port := uint16(0)
+	if relay.Port <= math.MaxUint16 {
+		port = uint16(relay.Port)
+	}
+	if relay.Ipv4 != nil {
+		ip := append(net.IP(nil), *relay.Ipv4...)
+		p := port
+		out = append(out, olocalstatequery.RelayAccessPoint{
+			Kind: olocalstatequery.RelayKindIPv4,
+			IPv4: &ip,
+			Port: &p,
+		})
+	}
+	if relay.Ipv6 != nil {
+		ip := append(net.IP(nil), *relay.Ipv6...)
+		p := port
+		out = append(out, olocalstatequery.RelayAccessPoint{
+			Kind: olocalstatequery.RelayKindIPv6,
+			IPv6: &ip,
+			Port: &p,
+		})
+	}
+	if len(out) > 0 {
+		return out
+	}
+	if relay.Hostname == "" {
+		return nil
+	}
+	host := relay.Hostname
+	if relay.Port != 0 {
+		// SingleHostName: a domain resolved directly, with an explicit port.
+		p := port
+		return []olocalstatequery.RelayAccessPoint{{
+			Kind:   olocalstatequery.RelayKindDomain,
+			Domain: &host,
+			Port:   &p,
+		}}
+	}
+	// MultiHostName: an SRV record; the port comes from the SRV lookup.
+	return []olocalstatequery.RelayAccessPoint{{
+		Kind:   olocalstatequery.RelayKindSRV,
+		Domain: &host,
+	}}
+}

--- a/ledger/peer_snapshot_query_test.go
+++ b/ledger/peer_snapshot_query_test.go
@@ -287,6 +287,30 @@ func TestAssembleLedgerPeerSnapshotRelayKinds(t *testing.T) {
 	assert.Equal(t, uint16(3004), *relays[5].Port)
 }
 
+// TestAssembleLedgerPeerSnapshotMalformedPort proves a hostname relay with an
+// out-of-range (malformed) port narrows to no port and is treated as an SRV
+// (MultiHostName) record rather than a SingleHostName with a bogus port 0.
+func TestAssembleLedgerPeerSnapshotMalformedPort(t *testing.T) {
+	host := "bad-port.example.com"
+	kh := poolKeyHash28(0x01)
+	pool := poolWithRelays(
+		kh,
+		models.PoolRegistrationRelay{Hostname: host, Port: 70000},
+	)
+	stake := map[string]uint64{string(kh): 1}
+
+	snapshot := assembleLedgerPeerSnapshot(
+		1, stake, []models.Pool{pool}, olocalstatequery.LedgerPeerKindAll,
+	)
+	require.Len(t, snapshot.Pools, 1)
+	relays := snapshot.Pools[0].Detail.Relays
+	require.Len(t, relays, 1)
+	assert.Equal(t, olocalstatequery.RelayKindSRV, relays[0].Kind)
+	require.NotNil(t, relays[0].Domain)
+	assert.Equal(t, host, *relays[0].Domain)
+	assert.Nil(t, relays[0].Port, "malformed port must not be emitted")
+}
+
 // TestAssembleLedgerPeerSnapshotResultEncodes proves the assembled result
 // round-trips through the gouroboros CBOR marshaller, i.e. it is a valid
 // wire-format GetLedgerPeerSnapshot response.

--- a/ledger/peer_snapshot_query_test.go
+++ b/ledger/peer_snapshot_query_test.go
@@ -59,6 +59,11 @@ func ipv6Relay(ip string, port uint) models.PoolRegistrationRelay {
 	return models.PoolRegistrationRelay{Ipv6: &parsed, Port: port}
 }
 
+// atSlot builds a WithOrigin SlotNo for a real (non-origin) slot.
+func atSlot(slot uint64) olocalstatequery.WithOriginSlot {
+	return olocalstatequery.WithOriginSlot{HasSlot: true, Slot: slot}
+}
+
 // --- dispatch + empty snapshot --------------------------------------------
 
 // TestQueryLedgerPeerSnapshotDispatch proves the query routes through
@@ -66,12 +71,13 @@ func ipv6Relay(ip string, port uint) models.PoolRegistrationRelay {
 // a well-formed empty (V1) result against an empty database, with the slot
 // taken from the current tip.
 func TestQueryLedgerPeerSnapshotDispatch(t *testing.T) {
-	ls := &LedgerState{
-		db: newTestDB(t),
-		currentTip: ochainsync.Tip{
-			Point: ocommon.NewPoint(4242, []byte("tip")),
-		},
-	}
+	ls := &LedgerState{db: newTestDB(t)}
+	// The handler reads the snapshot slot from the same DB transaction as the
+	// pool data, so seed the tip in the database rather than in-memory state.
+	require.NoError(t, ls.db.SetTip(
+		ochainsync.Tip{Point: ocommon.NewPoint(4242, []byte("tip"))},
+		nil,
+	))
 
 	query := &olocalstatequery.BlockQuery{
 		Query: &olocalstatequery.ShelleyQuery{
@@ -105,13 +111,30 @@ func TestQueryLedgerPeerSnapshotEmptyAtOrigin(t *testing.T) {
 	assert.Empty(t, snapshot.Pools)
 }
 
+// TestQueryLedgerPeerSnapshotRealSlotZero proves a real slot-0 block (slot 0
+// with a non-empty hash) is reported as At slot 0, not collapsed to Origin.
+func TestQueryLedgerPeerSnapshotRealSlotZero(t *testing.T) {
+	ls := &LedgerState{db: newTestDB(t)}
+	require.NoError(t, ls.db.SetTip(
+		ochainsync.Tip{Point: ocommon.NewPoint(0, []byte("genesis-block"))},
+		nil,
+	))
+
+	result, err := ls.queryLedgerPeerSnapshot(olocalstatequery.LedgerPeerKindAll)
+	require.NoError(t, err)
+
+	snapshot := result.(olocalstatequery.LedgerPeerSnapshotResult)
+	assert.True(t, snapshot.Slot.HasSlot, "slot 0 with a hash is a real point")
+	assert.Equal(t, uint64(0), snapshot.Slot.Slot)
+}
+
 func TestAssembleLedgerPeerSnapshotNoStake(t *testing.T) {
 	// Pools exist with relays but no delegated stake -> empty weighted set.
 	pools := []models.Pool{
 		poolWithRelays(poolKeyHash28(0x01), ipv4Relay("1.2.3.4", 3001)),
 	}
 	snapshot := assembleLedgerPeerSnapshot(
-		100,
+		atSlot(100),
 		map[string]uint64{},
 		pools,
 		olocalstatequery.LedgerPeerKindAll,
@@ -140,7 +163,7 @@ func TestAssembleLedgerPeerSnapshotStakeAndOrdering(t *testing.T) {
 	} // total = 40
 
 	snapshot := assembleLedgerPeerSnapshot(
-		500,
+		atSlot(500),
 		stake,
 		pools,
 		olocalstatequery.LedgerPeerKindAll,
@@ -177,7 +200,7 @@ func TestAssembleLedgerPeerSnapshotRelaylessPoolCounted(t *testing.T) {
 	} // total = 100
 
 	snapshot := assembleLedgerPeerSnapshot(
-		1,
+		atSlot(1),
 		stake,
 		pools,
 		olocalstatequery.LedgerPeerKindAll,
@@ -209,16 +232,49 @@ func TestAssembleLedgerPeerSnapshotBigPeerQuota(t *testing.T) {
 	} // total = 100
 
 	all := assembleLedgerPeerSnapshot(
-		1, stake, pools, olocalstatequery.LedgerPeerKindAll,
+		atSlot(1), stake, pools, olocalstatequery.LedgerPeerKindAll,
 	)
 	require.Len(t, all.Pools, 3, "All returns every relay-advertising pool")
 
 	big := assembleLedgerPeerSnapshot(
-		1, stake, pools, olocalstatequery.LedgerPeerKindBig,
+		atSlot(1), stake, pools, olocalstatequery.LedgerPeerKindBig,
 	)
 	// 0.95 already exceeds the 0.9 quota, so only the top pool is big.
 	require.Len(t, big.Pools, 1)
 	assert.Equal(t, "19/20", big.Pools[0].Detail.PoolStake.String())
+}
+
+// TestAssembleLedgerPeerSnapshotBigPeerExactThreshold proves that a pool which
+// lands the cumulative stake exactly on the 0.9 quota terminates the big set:
+// pools after it (including same-stake or zero-stake relayed pools) are
+// excluded rather than admitted by an off-by-one boundary.
+func TestAssembleLedgerPeerSnapshotBigPeerExactThreshold(t *testing.T) {
+	khA := poolKeyHash28(0xA0) // 80%
+	khB := poolKeyHash28(0xB0) // 10% -> cumulative exactly 0.9
+	khC := poolKeyHash28(0xC0) // 10% -> must be excluded
+	pools := []models.Pool{
+		poolWithRelays(khA, ipv4Relay("10.0.0.1", 3001)),
+		poolWithRelays(khB, ipv4Relay("10.0.0.2", 3001)),
+		poolWithRelays(khC, ipv4Relay("10.0.0.3", 3001)),
+	}
+	stake := map[string]uint64{
+		string(khA): 80,
+		string(khB): 10,
+		string(khC): 10,
+	} // total = 100
+
+	big := assembleLedgerPeerSnapshot(
+		atSlot(1), stake, pools, olocalstatequery.LedgerPeerKindBig,
+	)
+	require.Len(t, big.Pools, 2, "exact 0.9 boundary terminates the big set")
+	// The second (boundary) pool's cumulative stake is exactly 9/10.
+	assert.Equal(t, "9/10", big.Pools[1].AccumulatedStake.String())
+
+	// LedgerPeerKindAll still returns all three relay-advertising pools.
+	all := assembleLedgerPeerSnapshot(
+		atSlot(1), stake, pools, olocalstatequery.LedgerPeerKindAll,
+	)
+	require.Len(t, all.Pools, 3)
 }
 
 // --- relay-kind mapping ----------------------------------------------------
@@ -245,7 +301,7 @@ func TestAssembleLedgerPeerSnapshotRelayKinds(t *testing.T) {
 	stake := map[string]uint64{string(kh): 1}
 
 	snapshot := assembleLedgerPeerSnapshot(
-		1, stake, []models.Pool{pool}, olocalstatequery.LedgerPeerKindAll,
+		atSlot(1), stake, []models.Pool{pool}, olocalstatequery.LedgerPeerKindAll,
 	)
 	require.Len(t, snapshot.Pools, 1)
 	relays := snapshot.Pools[0].Detail.Relays
@@ -300,7 +356,7 @@ func TestAssembleLedgerPeerSnapshotMalformedPort(t *testing.T) {
 	stake := map[string]uint64{string(kh): 1}
 
 	snapshot := assembleLedgerPeerSnapshot(
-		1, stake, []models.Pool{pool}, olocalstatequery.LedgerPeerKindAll,
+		atSlot(1), stake, []models.Pool{pool}, olocalstatequery.LedgerPeerKindAll,
 	)
 	require.Len(t, snapshot.Pools, 1)
 	relays := snapshot.Pools[0].Detail.Relays
@@ -318,7 +374,7 @@ func TestAssembleLedgerPeerSnapshotResultEncodes(t *testing.T) {
 	kh := poolKeyHash28(0x01)
 	pool := poolWithRelays(kh, ipv4Relay("1.2.3.4", 3001))
 	snapshot := assembleLedgerPeerSnapshot(
-		7, map[string]uint64{string(kh): 1}, []models.Pool{pool},
+		atSlot(7), map[string]uint64{string(kh): 1}, []models.Pool{pool},
 		olocalstatequery.LedgerPeerKindAll,
 	)
 

--- a/ledger/peer_snapshot_query_test.go
+++ b/ledger/peer_snapshot_query_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// poolKeyHash28 builds a readable 28-byte pool key hash from a byte pattern.
+func poolKeyHash28(b byte) []byte {
+	out := make([]byte, 28)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+// poolWithRelays builds a models.Pool whose latest registration carries the
+// given relays, mirroring what GetPools returns (Registration newest-first).
+func poolWithRelays(
+	keyHash []byte,
+	relays ...models.PoolRegistrationRelay,
+) models.Pool {
+	return models.Pool{
+		PoolKeyHash: keyHash,
+		Registration: []models.PoolRegistration{
+			{Relays: relays},
+		},
+	}
+}
+
+func ipv4Relay(ip string, port uint) models.PoolRegistrationRelay {
+	parsed := net.ParseIP(ip).To4()
+	return models.PoolRegistrationRelay{Ipv4: &parsed, Port: port}
+}
+
+func ipv6Relay(ip string, port uint) models.PoolRegistrationRelay {
+	parsed := net.ParseIP(ip)
+	return models.PoolRegistrationRelay{Ipv6: &parsed, Port: port}
+}
+
+// --- dispatch + empty snapshot --------------------------------------------
+
+// TestQueryLedgerPeerSnapshotDispatch proves the query routes through
+// ls.Query -> queryBlock -> queryShelley to the snapshot handler and returns
+// a well-formed empty (V1) result against an empty database, with the slot
+// taken from the current tip.
+func TestQueryLedgerPeerSnapshotDispatch(t *testing.T) {
+	ls := &LedgerState{
+		db: newTestDB(t),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(4242, []byte("tip")),
+		},
+	}
+
+	query := &olocalstatequery.BlockQuery{
+		Query: &olocalstatequery.ShelleyQuery{
+			Query: &olocalstatequery.ShelleyGetLedgerPeerSnapshotQuery{
+				PeerKind: olocalstatequery.LedgerPeerKindAll,
+			},
+		},
+	}
+
+	result, err := ls.Query(query)
+	require.NoError(t, err)
+
+	snapshot, ok := result.(olocalstatequery.LedgerPeerSnapshotResult)
+	require.True(t, ok, "expected LedgerPeerSnapshotResult, got %T", result)
+	assert.Equal(t, uint64(0), snapshot.Version, "snapshot is V1 (version 0)")
+	assert.True(t, snapshot.Slot.HasSlot)
+	assert.Equal(t, uint64(4242), snapshot.Slot.Slot)
+	assert.Empty(t, snapshot.Pools, "empty DB yields no pools")
+}
+
+// TestQueryLedgerPeerSnapshotEmptyAtOrigin proves a node still at chain origin
+// (tip slot 0) reports a WithOrigin/Origin slot and no pools.
+func TestQueryLedgerPeerSnapshotEmptyAtOrigin(t *testing.T) {
+	ls := &LedgerState{db: newTestDB(t)}
+
+	result, err := ls.queryLedgerPeerSnapshot(olocalstatequery.LedgerPeerKindAll)
+	require.NoError(t, err)
+
+	snapshot := result.(olocalstatequery.LedgerPeerSnapshotResult)
+	assert.False(t, snapshot.Slot.HasSlot, "tip slot 0 maps to Origin")
+	assert.Empty(t, snapshot.Pools)
+}
+
+func TestAssembleLedgerPeerSnapshotNoStake(t *testing.T) {
+	// Pools exist with relays but no delegated stake -> empty weighted set.
+	pools := []models.Pool{
+		poolWithRelays(poolKeyHash28(0x01), ipv4Relay("1.2.3.4", 3001)),
+	}
+	snapshot := assembleLedgerPeerSnapshot(
+		100,
+		map[string]uint64{},
+		pools,
+		olocalstatequery.LedgerPeerKindAll,
+	)
+	assert.True(t, snapshot.Slot.HasSlot)
+	assert.Equal(t, uint64(100), snapshot.Slot.Slot)
+	assert.Empty(t, snapshot.Pools)
+}
+
+// --- stake population + ordering ------------------------------------------
+
+// TestAssembleLedgerPeerSnapshotStakeAndOrdering proves relative stake is
+// pool/total, that pools are emitted highest-stake-first, and that the
+// accumulated stake is the running cumulative sum.
+func TestAssembleLedgerPeerSnapshotStakeAndOrdering(t *testing.T) {
+	khSmall := poolKeyHash28(0x0A)
+	khBig := poolKeyHash28(0x0B)
+	pools := []models.Pool{
+		// Deliberately list the smaller-stake pool first to prove sorting.
+		poolWithRelays(khSmall, ipv4Relay("10.0.0.1", 3001)),
+		poolWithRelays(khBig, ipv4Relay("10.0.0.2", 3001)),
+	}
+	stake := map[string]uint64{
+		string(khSmall): 10,
+		string(khBig):   30,
+	} // total = 40
+
+	snapshot := assembleLedgerPeerSnapshot(
+		500,
+		stake,
+		pools,
+		olocalstatequery.LedgerPeerKindAll,
+	)
+
+	require.Len(t, snapshot.Pools, 2)
+
+	// First entry must be the larger pool: 30/40 = 3/4.
+	first := snapshot.Pools[0]
+	assert.Equal(t, "3/4", first.Detail.PoolStake.String())
+	assert.Equal(t, "3/4", first.AccumulatedStake.String())
+	require.Len(t, first.Detail.Relays, 1)
+	assert.Equal(t, olocalstatequery.RelayKindIPv4, first.Detail.Relays[0].Kind)
+
+	// Second entry: 10/40 = 1/4, cumulative 3/4 + 1/4 = 1/1.
+	second := snapshot.Pools[1]
+	assert.Equal(t, "1/4", second.Detail.PoolStake.String())
+	assert.Equal(t, "1/1", second.AccumulatedStake.String())
+}
+
+// TestAssembleLedgerPeerSnapshotRelaylessPoolCounted proves a pool without
+// relays is excluded from the result list yet still counts toward the
+// total-stake denominator.
+func TestAssembleLedgerPeerSnapshotRelaylessPoolCounted(t *testing.T) {
+	khRelay := poolKeyHash28(0x01)
+	khNoRelay := poolKeyHash28(0x02)
+	pools := []models.Pool{
+		poolWithRelays(khRelay, ipv4Relay("1.2.3.4", 3001)),
+		poolWithRelays(khNoRelay), // no relays
+	}
+	stake := map[string]uint64{
+		string(khRelay):   10,
+		string(khNoRelay): 90,
+	} // total = 100
+
+	snapshot := assembleLedgerPeerSnapshot(
+		1,
+		stake,
+		pools,
+		olocalstatequery.LedgerPeerKindAll,
+	)
+
+	require.Len(t, snapshot.Pools, 1, "relayless pool is not listed")
+	// 10/100 = 1/10 proves the relayless pool's 90 stayed in the denominator.
+	assert.Equal(t, "1/10", snapshot.Pools[0].Detail.PoolStake.String())
+}
+
+// --- big-peer selection ----------------------------------------------------
+
+// TestAssembleLedgerPeerSnapshotBigPeerQuota proves LedgerPeerKindBig trims
+// the set at the cumulative-stake quota (0.9) while LedgerPeerKindAll keeps
+// every relay-advertising pool.
+func TestAssembleLedgerPeerSnapshotBigPeerQuota(t *testing.T) {
+	khA := poolKeyHash28(0xA0) // 95%
+	khB := poolKeyHash28(0xB0) // 4%
+	khC := poolKeyHash28(0xC0) // 1%
+	pools := []models.Pool{
+		poolWithRelays(khA, ipv4Relay("10.0.0.1", 3001)),
+		poolWithRelays(khB, ipv4Relay("10.0.0.2", 3001)),
+		poolWithRelays(khC, ipv4Relay("10.0.0.3", 3001)),
+	}
+	stake := map[string]uint64{
+		string(khA): 95,
+		string(khB): 4,
+		string(khC): 1,
+	} // total = 100
+
+	all := assembleLedgerPeerSnapshot(
+		1, stake, pools, olocalstatequery.LedgerPeerKindAll,
+	)
+	require.Len(t, all.Pools, 3, "All returns every relay-advertising pool")
+
+	big := assembleLedgerPeerSnapshot(
+		1, stake, pools, olocalstatequery.LedgerPeerKindBig,
+	)
+	// 0.95 already exceeds the 0.9 quota, so only the top pool is big.
+	require.Len(t, big.Pools, 1)
+	assert.Equal(t, "19/20", big.Pools[0].Detail.PoolStake.String())
+}
+
+// --- relay-kind mapping ----------------------------------------------------
+
+// TestAssembleLedgerPeerSnapshotRelayKinds proves every stored relay shape is
+// mapped to the correct RelayAccessPoint kind, including multi-host (SRV) and
+// dual-stack single-host-address relays.
+func TestAssembleLedgerPeerSnapshotRelayKinds(t *testing.T) {
+	hostPort := "named.example.com"
+	srvHost := "srv.example.com"
+	dualV4 := net.ParseIP("9.9.9.9").To4()
+	dualV6 := net.ParseIP("2001:db8::99")
+
+	kh := poolKeyHash28(0x01)
+	pool := poolWithRelays(
+		kh,
+		ipv4Relay("1.2.3.4", 3001),
+		ipv6Relay("2001:db8::1", 3002),
+		models.PoolRegistrationRelay{Hostname: hostPort, Port: 3003},
+		models.PoolRegistrationRelay{Hostname: srvHost}, // port 0 -> SRV
+		// dual-stack single-host-address row -> two access points
+		models.PoolRegistrationRelay{Ipv4: &dualV4, Ipv6: &dualV6, Port: 3004},
+	)
+	stake := map[string]uint64{string(kh): 1}
+
+	snapshot := assembleLedgerPeerSnapshot(
+		1, stake, []models.Pool{pool}, olocalstatequery.LedgerPeerKindAll,
+	)
+	require.Len(t, snapshot.Pools, 1)
+	relays := snapshot.Pools[0].Detail.Relays
+	require.Len(t, relays, 6, "dual-stack row expands to two access points")
+
+	// IPv4
+	assert.Equal(t, olocalstatequery.RelayKindIPv4, relays[0].Kind)
+	require.NotNil(t, relays[0].IPv4)
+	assert.Equal(t, "1.2.3.4", relays[0].IPv4.String())
+	require.NotNil(t, relays[0].Port)
+	assert.Equal(t, uint16(3001), *relays[0].Port)
+
+	// IPv6
+	assert.Equal(t, olocalstatequery.RelayKindIPv6, relays[1].Kind)
+	require.NotNil(t, relays[1].IPv6)
+	assert.Equal(t, "2001:db8::1", relays[1].IPv6.String())
+	require.NotNil(t, relays[1].Port)
+	assert.Equal(t, uint16(3002), *relays[1].Port)
+
+	// SingleHostName (domain + port)
+	assert.Equal(t, olocalstatequery.RelayKindDomain, relays[2].Kind)
+	require.NotNil(t, relays[2].Domain)
+	assert.Equal(t, hostPort, *relays[2].Domain)
+	require.NotNil(t, relays[2].Port)
+	assert.Equal(t, uint16(3003), *relays[2].Port)
+
+	// MultiHostName (SRV, no port)
+	assert.Equal(t, olocalstatequery.RelayKindSRV, relays[3].Kind)
+	require.NotNil(t, relays[3].Domain)
+	assert.Equal(t, srvHost, *relays[3].Domain)
+	assert.Nil(t, relays[3].Port, "SRV relay carries no port")
+
+	// Dual-stack expansion: IPv4 then IPv6, both with the row's port.
+	assert.Equal(t, olocalstatequery.RelayKindIPv4, relays[4].Kind)
+	assert.Equal(t, "9.9.9.9", relays[4].IPv4.String())
+	assert.Equal(t, uint16(3004), *relays[4].Port)
+	assert.Equal(t, olocalstatequery.RelayKindIPv6, relays[5].Kind)
+	assert.Equal(t, "2001:db8::99", relays[5].IPv6.String())
+	assert.Equal(t, uint16(3004), *relays[5].Port)
+}
+
+// TestAssembleLedgerPeerSnapshotResultEncodes proves the assembled result
+// round-trips through the gouroboros CBOR marshaller, i.e. it is a valid
+// wire-format GetLedgerPeerSnapshot response.
+func TestAssembleLedgerPeerSnapshotResultEncodes(t *testing.T) {
+	kh := poolKeyHash28(0x01)
+	pool := poolWithRelays(kh, ipv4Relay("1.2.3.4", 3001))
+	snapshot := assembleLedgerPeerSnapshot(
+		7, map[string]uint64{string(kh): 1}, []models.Pool{pool},
+		olocalstatequery.LedgerPeerKindAll,
+	)
+
+	encoded, err := snapshot.MarshalCBOR()
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	var decoded olocalstatequery.LedgerPeerSnapshotResult
+	require.NoError(t, decoded.UnmarshalCBOR(encoded))
+	assert.Equal(t, uint64(7), decoded.Slot.Slot)
+	require.Len(t, decoded.Pools, 1)
+	assert.Equal(t, "1/1", decoded.Pools[0].Detail.PoolStake.String())
+	require.Len(t, decoded.Pools[0].Detail.Relays, 1)
+	assert.Equal(
+		t,
+		olocalstatequery.RelayKindIPv4,
+		decoded.Pools[0].Detail.Relays[0].Kind,
+	)
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -443,6 +443,8 @@ func (ls *LedgerState) queryShelley(
 		return ls.queryShelleyFilteredDelegationAndRewardAccounts(
 			q.Creds.Items(),
 		)
+	case *olocalstatequery.ShelleyGetLedgerPeerSnapshotQuery:
+		return ls.queryLedgerPeerSnapshot(q.PeerKind)
 	// TODO (#394)
 	/*
 		case *olocalstatequery.ShelleyLedgerTipQuery:


### PR DESCRIPTION
Closes #2492 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `GetLedgerPeerSnapshot` for `LocalStateQuery` (NtC v19+) to return a stake‑weighted snapshot of active pools’ relay endpoints for peer discovery, with correct big‑peer quota handling, wired into the ledger query path.

- **New Features**
  - Returns V1 snapshot with a WithOrigin slot sourced from the current tip in the same read transaction; Origin at genesis, At 0 for a real slot‑0 block.
  - Loads active pools and delegated stake; orders by stake desc with key‑hash tie‑break.
  - Excludes pools without relays but includes their stake in the total.
  - Maps relays to access points: IPv4/IPv6+port, domain+port, SRV; dual‑stack expands to two entries; malformed hostname ports fall back to SRV (no port).
  - Supports `LedgerPeerKindAll` and `LedgerPeerKindBig` with a 0.9 cumulative‑stake quota and correct boundary semantics (the quota‑crossing pool is included; later pools are excluded).
  - Adds tests for dispatch, slot/origin handling, ordering and stake math, big‑peer boundary, relay‑kind mapping, malformed port, and CBOR round‑trip.

<sup>Written for commit d6122eea058e4964abf69da5f1e4ed6aa898a33d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented peer snapshot querying for ledger peer discovery supporting protocol v19+, enabling nodes to efficiently discover and select peers based on stake-weighted distribution.

* **Tests**
  * Added comprehensive test coverage for peer snapshot querying, stake calculations, peer filtering, quota-based peer selection, relay endpoint handling, and serialization compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->