### PR TITLE
fix(database/sqlite): Made changes to reduce deferred index rebuild cost after API backfill

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1054,6 +1054,18 @@ ledger-state import, ImmutableDB loading, and API-mode metadata backfill are
 orchestrated by `cmd/dingo` and `internal/node`. This is exposed via the
 `dingo mithril` CLI subcommand and the `dingo load` command.
 
+In API storage mode, the SQLite metadata plugin can defer selected query indexes
+during bulk load. Deferred indexes are classified as critical or lazy in
+`database/plugin/metadata/deferred`: critical indexes cover startup API queries
+and rollback predicates, while lazy indexes cover secondary query paths. The
+metadata plugin exposes `BuildCriticalDeferredIndexes` for the critical subset
+and `BuildDeferredIndexes` for the full manifest. Mithril sync rebuilds the
+critical subset before clearing `sync_status`, then leaves the pending
+sync-state marker set. API-mode `serve` verifies the critical subset before
+startup and runs the full lazy rebuild as background maintenance; the marker is
+cleared only after the full manifest has been rebuilt. Core-mode startup still
+repairs the full manifest synchronously before serving.
+
 ## External Interfaces
 
 Dingo provides three client-facing APIs plus Bark. All are optional and gated by port configuration. UTxO RPC, Blockfrost, and Mesh are general-purpose external APIs and require `storageMode: api`. Bark is different: it is Dingo's own protocol for Dingo-to-Dingo C2/archive services, not a general-purpose application API.

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -538,7 +538,7 @@ func runMithrilSync(
 	// clears sync_status — so a crash between drop and rebuild
 	// leaves sync_status set and triggers the recovery path on
 	// the next startup.
-	rebuildDeferredIndexes := node.WithDeferredIndexes(db, logger)
+	deferredIndexes := node.WithDeferredIndexes(db, logger)
 
 	// Import ledger state and copy blocks in parallel.
 	// Ledger state goes to metadata (SQLite), blocks go to the blob
@@ -856,13 +856,24 @@ func runMithrilSync(
 		metrics.setPhaseActive(mithrilSyncPhaseBackfill, false)
 	}
 
-	// Rebuild deferred indexes BEFORE clearing sync_status so a
+	// Rebuild critical deferred indexes BEFORE clearing sync_status so a
 	// crash here leaves sync_status set (serve refuses to start)
 	// and metadata_indexes_pending set (next mithril sync rebuilds
 	// before re-running anything else).
-	if err := rebuildDeferredIndexes(); err != nil {
+	metrics.setPhaseActive(mithrilSyncPhaseIndexRebuild, true)
+	indexRebuildStart := time.Now()
+	if err := deferredIndexes.BuildCritical(); err != nil {
+		metrics.setPhaseActive(mithrilSyncPhaseIndexRebuild, false)
 		return err
 	}
+	indexRebuildElapsed := time.Since(indexRebuildStart)
+	metrics.recordIndexRebuildDuration(indexRebuildElapsed)
+	metrics.setPhaseActive(mithrilSyncPhaseIndexRebuild, false)
+	logger.Info(
+		"critical deferred metadata indexes rebuilt; lazy indexes deferred to maintenance",
+		"component", "mithril",
+		"duration", indexRebuildElapsed,
+	)
 
 	if err := updateMithrilReadyState(
 		db, logger, loadResult, ledgerStateSlot,
@@ -883,6 +894,8 @@ func runMithrilSync(
 		"component", "mithril",
 		"epoch", result.Snapshot.Beacon.Epoch,
 		"immutable_file_number", result.Snapshot.Beacon.ImmutableFileNumber,
+		"index_rebuild_elapsed", indexRebuildElapsed,
+		"lazy_index_rebuild_mode", "maintenance",
 	)
 
 	return nil

--- a/cmd/dingo/mithril_metrics.go
+++ b/cmd/dingo/mithril_metrics.go
@@ -39,6 +39,7 @@ const (
 	mithrilSyncPhaseGapBlocks     = "gap_blocks"
 	mithrilSyncPhasePostLedger    = "post_ledger_state"
 	mithrilSyncPhaseBackfill      = "backfill"
+	mithrilSyncPhaseIndexRebuild  = "index_rebuild"
 	mithrilSyncPhaseComplete      = "complete"
 )
 
@@ -139,6 +140,8 @@ type mithrilSyncMetrics struct {
 	backfillPercent        prometheus.Gauge
 	backfillStageDuration  *prometheus.GaugeVec
 	backfillIntervalCounts *prometheus.GaugeVec
+
+	indexRebuildDuration prometheus.Gauge
 }
 
 func newMithrilSyncMetrics(reg prometheus.Registerer) *mithrilSyncMetrics {
@@ -277,6 +280,10 @@ func newMithrilSyncMetrics(reg prometheus.Registerer) *mithrilSyncMetrics {
 			},
 			[]string{"kind"},
 		),
+		indexRebuildDuration: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "dingo_mithril_sync_index_rebuild_duration_seconds",
+			Help: "Duration spent rebuilding critical deferred metadata indexes during Mithril sync.",
+		}),
 	}
 	m.startedAt.SetToCurrentTime()
 	return m
@@ -432,6 +439,13 @@ func (m *mithrilSyncMetrics) recordBackfillProgress(
 		Set(float64(stats.BlobUtxoOffsetWrites))
 	m.backfillIntervalCounts.WithLabelValues("skipped_utxo_offsets").
 		Set(float64(stats.SkippedUtxoOffsets))
+}
+
+func (m *mithrilSyncMetrics) recordIndexRebuildDuration(duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.indexRebuildDuration.Set(duration.Seconds())
 }
 
 func (m *mithrilSyncMetrics) markComplete() {

--- a/cmd/dingo/mithril_metrics_test.go
+++ b/cmd/dingo/mithril_metrics_test.go
@@ -96,6 +96,7 @@ func TestMithrilSyncMetricsRecordProgress(t *testing.T) {
 			CheckpointWrites:      900 * time.Millisecond,
 		},
 	})
+	metrics.recordIndexRebuildDuration(1500 * time.Millisecond)
 	metrics.markComplete()
 	metrics.recordError()
 
@@ -198,6 +199,11 @@ func TestMithrilSyncMetricsRecordProgress(t *testing.T) {
 				"skipped_utxo_offsets",
 			),
 		),
+	)
+	require.Equal(
+		t,
+		float64(1.5),
+		promtestutil.ToFloat64(metrics.indexRebuildDuration),
 	)
 	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.completed))
 	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.errors))

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -57,7 +57,6 @@ func serveRun(
 			)
 			os.Exit(1)
 		}
-		startDeferredIndexMaintenance(cfg, logger)
 	} else {
 		// Core mode: if a Mithril sync interrupted between drop
 		// and rebuild, repair before exposing the node so
@@ -155,27 +154,6 @@ func repairDeferredIndexes(
 	}
 	defer db.Close()
 	return node.RepairDeferredIndexes(db, logger)
-}
-
-// startDeferredIndexMaintenance finishes lazy deferred-index rebuilds
-// in the background for API mode. The critical subset has already
-// been rebuilt by resumeBackfill, so API traffic can start while this
-// maintenance step restores secondary query indexes and clears the
-// pending marker. If the process exits mid-rebuild, the marker remains
-// and the next serve run retries the same maintenance path.
-func startDeferredIndexMaintenance(
-	cfg *config.Config, logger *slog.Logger,
-) {
-	go func() {
-		if err := repairDeferredIndexes(cfg, logger); err != nil {
-			logger.Error(
-				"deferred-index maintenance failed",
-				"error", err,
-			)
-			return
-		}
-		logger.Info("deferred-index maintenance complete")
-	}()
 }
 
 // resumeBackfill checks whether metadata backfill is needed and

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -57,6 +57,7 @@ func serveRun(
 			)
 			os.Exit(1)
 		}
+		startDeferredIndexMaintenance(cfg, logger)
 	} else {
 		// Core mode: if a Mithril sync interrupted between drop
 		// and rebuild, repair before exposing the node so
@@ -132,10 +133,7 @@ func checkSyncState(
 }
 
 // repairDeferredIndexes rebuilds any deferred metadata indexes left
-// outstanding by a prior interrupted bulk-load run. This is the
-// "repair" path the issue references: API/query paths cannot be
-// exposed with a partial index set, so serve waits for the rebuild
-// instead of immediately exposing the node.
+// outstanding by a prior interrupted bulk-load run.
 func repairDeferredIndexes(
 	cfg *config.Config, logger *slog.Logger,
 ) error {
@@ -157,6 +155,27 @@ func repairDeferredIndexes(
 	}
 	defer db.Close()
 	return node.RepairDeferredIndexes(db, logger)
+}
+
+// startDeferredIndexMaintenance finishes lazy deferred-index rebuilds
+// in the background for API mode. The critical subset has already
+// been rebuilt by resumeBackfill, so API traffic can start while this
+// maintenance step restores secondary query indexes and clears the
+// pending marker. If the process exits mid-rebuild, the marker remains
+// and the next serve run retries the same maintenance path.
+func startDeferredIndexMaintenance(
+	cfg *config.Config, logger *slog.Logger,
+) {
+	go func() {
+		if err := repairDeferredIndexes(cfg, logger); err != nil {
+			logger.Error(
+				"deferred-index maintenance failed",
+				"error", err,
+			)
+			return
+		}
+		logger.Info("deferred-index maintenance complete")
+	}()
 }
 
 // resumeBackfill checks whether metadata backfill is needed and
@@ -236,9 +255,10 @@ func resumeBackfill(
 	if !needed {
 		// Still rebuild deferred indexes if a prior bulk-load
 		// run left them pending — the previous backfill may
-		// have completed but crashed before BuildDeferredIndexes
-		// ran.
-		if err := node.RepairDeferredIndexes(db, logger); err != nil {
+		// have completed but crashed before the critical rebuild
+		// ran. The lazy remainder is handled by background
+		// maintenance after the API starts.
+		if err := node.RepairCriticalDeferredIndexes(db, logger); err != nil {
 			return err
 		}
 		return clearBackfillSyncStatus(db)
@@ -259,10 +279,10 @@ func resumeBackfill(
 	if err := bf.Run(ctx); err != nil {
 		return fmt.Errorf("backfill: %w", err)
 	}
-	// Rebuild deferred indexes before clearing sync_status so a
+	// Rebuild critical deferred indexes before clearing sync_status so a
 	// crash between the two leaves both markers set and the next
 	// startup re-runs the rebuild.
-	if err := node.RepairDeferredIndexes(db, logger); err != nil {
+	if err := node.RepairCriticalDeferredIndexes(db, logger); err != nil {
 		return err
 	}
 	if err := clearBackfillSyncStatus(db); err != nil {

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -87,6 +87,23 @@ type Index struct {
 	// in the manifest test failure message when the
 	// classification is questioned.
 	Notes string
+	// Critical marks indexes that must be present before the API
+	// can serve traffic. Critical indexes are rebuilt first so
+	// that the node can accept queries while the remaining lazy
+	// indexes finish in the background.
+	//
+	// Criteria for Critical=true:
+	//   - Any WHERE predicate on the index column used by a live
+	//     API query path (blockfrost, utxorpc, ledger queries).
+	//   - Any WHERE predicate used by the rollback path
+	//     (DeleteXAfterSlot), since rollbacks can occur as soon
+	//     as live sync resumes.
+	//
+	// Everything else is lazy: FK reverse-lookups, consumer-tx
+	// back-references (SpentAtTxId, ReferencedByTxId,
+	// CollateralByTxId), witness/redeemer secondary indexes, and
+	// any column that is only SELECTed or SET but never filtered.
+	Critical bool
 }
 
 // ResolvedName returns the GORM-visible name for the index — the
@@ -97,6 +114,19 @@ func (i Index) ResolvedName() string {
 		return i.Name
 	}
 	return i.Field
+}
+
+// CriticalManifest returns the subset of Manifest entries that are
+// marked Critical=true. These are the indexes that must be present
+// before the API can serve traffic.
+func CriticalManifest() []Index {
+	var out []Index
+	for _, idx := range Manifest {
+		if idx.Critical {
+			out = append(out, idx)
+		}
+	}
+	return out
 }
 
 // SyncStateKey is the sync_state row that marks an in-flight (or
@@ -129,11 +159,13 @@ var Manifest = []Index{
 	// spend predicate, which uses tx_id_output_idx exclusively.
 	{
 		Model: &models.Utxo{}, Field: "PaymentKey", Table: "utxo",
-		Notes: "API address lookup; not touched by UTxO insert or spend",
+		Notes:    "API address lookup; not touched by UTxO insert or spend",
+		Critical: true,
 	},
 	{
 		Model: &models.Utxo{}, Field: "StakingKey", Table: "utxo",
-		Notes: "API stake lookup; not touched by UTxO insert or spend",
+		Notes:    "API stake lookup; not touched by UTxO insert or spend",
+		Critical: true,
 	},
 	{
 		Model: &models.Utxo{}, Field: "SpentAtTxId", Table: "utxo",
@@ -149,7 +181,8 @@ var Manifest = []Index{
 	},
 	{
 		Model: &models.Utxo{}, Field: "AddedSlot", Table: "utxo",
-		Notes: "Range scan; not used by insert or spend",
+		Notes:    "Rollback range scan (DeleteUtxosAfterSlot); not used by insert or spend",
+		Critical: true,
 	},
 	{
 		Model: &models.Utxo{}, Field: "TransactionID", Table: "utxo",
@@ -157,7 +190,8 @@ var Manifest = []Index{
 	},
 	{
 		Model: &models.Utxo{}, Name: "idx_utxo_deleted_staking_amount", Table: "utxo",
-		Notes: "Composite SearchUtxos index; query-only path",
+		Notes:    "Composite SearchUtxos index; primary utxorpc query path",
+		Critical: true,
 	},
 
 	// transaction: BlockHash/Slot are query indexes; the
@@ -165,11 +199,13 @@ var Manifest = []Index{
 	// stays.
 	{
 		Model: &models.Transaction{}, Field: "BlockHash", Table: "transaction",
-		Notes: "Block-tx grouping query; not used by tx upsert",
+		Notes:    "Block-tx grouping query (blockfrost /blocks/{id}/txs); not used by tx upsert",
+		Critical: true,
 	},
 	{
 		Model: &models.Transaction{}, Field: "Slot", Table: "transaction",
-		Notes: "Slot range scan; not used by tx upsert",
+		Notes:    "Rollback range scan (DeleteTransactionsAfterSlot) and tx history ordering; not used by tx upsert",
+		Critical: true,
 	},
 
 	// asset: idx_asset_unique (Name + PolicyId + UtxoID) is the
@@ -177,15 +213,16 @@ var Manifest = []Index{
 	// per-column indexes are deferable.
 	{
 		Model: &models.Asset{}, Field: "NameHex", Table: "asset",
-		Notes: "Hex name lookup; query-only",
+		Notes: "Hex name lookup; query-only; no current WHERE name_hex=? path in API",
 	},
 	{
 		Model: &models.Asset{}, Name: "idx_asset_policy_id", Table: "asset",
-		Notes: "Policy-id lookup; query-only; idx_asset_unique still covers import",
+		Notes:    "Policy-id lookup (GetAssetsByPolicy); query-only; idx_asset_unique still covers import",
+		Critical: true,
 	},
 	{
 		Model: &models.Asset{}, Field: "Fingerprint", Table: "asset",
-		Notes: "Fingerprint lookup; query-only",
+		Notes: "Fingerprint lookup; query-only; returned as response field, not a WHERE predicate",
 	},
 	{
 		Model: &models.Asset{}, Field: "Amount", Table: "asset",
@@ -212,7 +249,8 @@ var Manifest = []Index{
 	},
 	{
 		Model: &models.Certificate{}, Field: "Slot", Table: "certs",
-		Notes: "Slot range scan; not used by cert insert",
+		Notes:    "Rollback range scan (DeleteCertificatesAfterSlot); not used by cert insert",
+		Critical: true,
 	},
 	{
 		Model: &models.Certificate{}, Field: "CertType", Table: "certs",

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -99,10 +99,9 @@ type Index struct {
 	//     (DeleteXAfterSlot), since rollbacks can occur as soon
 	//     as live sync resumes.
 	//
-	// Everything else is lazy: FK reverse-lookups, consumer-tx
-	// back-references (SpentAtTxId, ReferencedByTxId,
-	// CollateralByTxId), witness/redeemer secondary indexes, and
-	// any column that is only SELECTed or SET but never filtered.
+	// Everything else is lazy: FK reverse-lookups,
+	// witness/redeemer secondary indexes, and any column that is
+	// only SELECTed or SET but never filtered.
 	Critical bool
 }
 
@@ -169,15 +168,18 @@ var Manifest = []Index{
 	},
 	{
 		Model: &models.Utxo{}, Field: "SpentAtTxId", Table: "utxo",
-		Notes: "Consumer-tx query; rollback only — not used by spend predicate",
+		Notes:    "Consumer-tx query and rollback repair (DeleteTransactionsAfterSlot); not used by spend predicate",
+		Critical: true,
 	},
 	{
 		Model: &models.Utxo{}, Field: "ReferencedByTxId", Table: "utxo",
-		Notes: "Reference-input query; not used by insert path",
+		Notes:    "Reference-input query and rollback repair (DeleteTransactionsAfterSlot); not used by insert path",
+		Critical: true,
 	},
 	{
 		Model: &models.Utxo{}, Field: "CollateralByTxId", Table: "utxo",
-		Notes: "Collateral query; not used by insert path",
+		Notes:    "Collateral query and rollback repair (DeleteTransactionsAfterSlot); not used by insert path",
+		Critical: true,
 	},
 	{
 		Model: &models.Utxo{}, Field: "AddedSlot", Table: "utxo",

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -62,6 +62,31 @@ func TestManifestEntriesHaveResolvableName(t *testing.T) {
 	}
 }
 
+// TestCriticalManifestNotEmpty ensures CriticalManifest returns a
+// non-empty slice and that every entry in it also appears in Manifest.
+func TestCriticalManifestNotEmpty(t *testing.T) {
+	critical := CriticalManifest()
+	if len(critical) == 0 {
+		t.Fatal("CriticalManifest returned empty slice")
+	}
+	// Pin the expected count so accidental de-classification is caught.
+	const wantCritical = 8
+	if len(critical) != wantCritical {
+		t.Errorf("CriticalManifest: got %d entries, want %d — update this constant if the classification changed intentionally", len(critical), wantCritical)
+	}
+	// Every critical entry must exist in the full manifest.
+	full := map[string]bool{}
+	for _, idx := range Manifest {
+		full[fmt.Sprintf("%T:%s:%s", idx.Model, idx.Field, idx.Name)] = true
+	}
+	for _, idx := range critical {
+		key := fmt.Sprintf("%T:%s:%s", idx.Model, idx.Field, idx.Name)
+		if !full[key] {
+			t.Errorf("critical entry %q not found in full Manifest", key)
+		}
+	}
+}
+
 // TestSyncStateConstants pins the marker key/value strings. Any
 // change must be a deliberate migration: changing the key would
 // orphan markers written by older binaries during a partial

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -70,7 +70,7 @@ func TestCriticalManifestNotEmpty(t *testing.T) {
 		t.Fatal("CriticalManifest returned empty slice")
 	}
 	// Pin the expected count so accidental de-classification is caught.
-	const wantCritical = 8
+	const wantCritical = 11
 	if len(critical) != wantCritical {
 		t.Errorf("CriticalManifest: got %d entries, want %d — update this constant if the classification changed intentionally", len(critical), wantCritical)
 	}

--- a/database/plugin/metadata/deferred_indexes.go
+++ b/database/plugin/metadata/deferred_indexes.go
@@ -40,6 +40,11 @@ package metadata
 //     decide whether to refuse startup or auto-repair.
 type DeferredIndexManager interface {
 	DropDeferredIndexes() error
+	// BuildCriticalDeferredIndexes rebuilds only the manifest
+	// entries marked Critical=true. Call this before marking the
+	// API ready so queries and rollbacks work immediately; follow
+	// up with BuildDeferredIndexes to finish the lazy remainder.
+	BuildCriticalDeferredIndexes() error
 	BuildDeferredIndexes() error
 	HasDeferredIndexesPending() (bool, error)
 }

--- a/database/plugin/metadata/sqlite/deferred_indexes.go
+++ b/database/plugin/metadata/sqlite/deferred_indexes.go
@@ -65,6 +65,15 @@ func (d *MetadataStoreSqlite) DropDeferredIndexes() error {
 	return nil
 }
 
+// BuildCriticalDeferredIndexes recreates only the manifest entries
+// marked Critical=true. It does NOT clear the sync_state marker,
+// because the lazy remainder still needs to be built.
+// Call this before marking the API ready; follow up with
+// BuildDeferredIndexes to finish the remaining lazy indexes.
+func (d *MetadataStoreSqlite) BuildCriticalDeferredIndexes() error {
+	return d.buildIndexSubset(deferred.CriticalManifest(), false)
+}
+
 // BuildDeferredIndexes recreates every index in deferred.Manifest
 // that is missing from the schema and, once every manifest entry is
 // present, clears the sync_state marker. The operation is
@@ -74,10 +83,14 @@ func (d *MetadataStoreSqlite) DropDeferredIndexes() error {
 // slow builds with specific indexes (the utxo composite index, in
 // particular, can take several minutes on mainnet).
 func (d *MetadataStoreSqlite) BuildDeferredIndexes() error {
+	return d.buildIndexSubset(deferred.Manifest, true)
+}
+
+func (d *MetadataStoreSqlite) buildIndexSubset(subset []deferred.Index, clearMarker bool) error {
 	migrator := d.DB().Migrator()
 	overallStart := time.Now()
 	built := 0
-	for _, idx := range deferred.Manifest {
+	for _, idx := range subset {
 		name := idx.ResolvedName()
 		if migrator.HasIndex(idx.Model, name) {
 			continue
@@ -104,11 +117,7 @@ func (d *MetadataStoreSqlite) BuildDeferredIndexes() error {
 			"duration", time.Since(entryStart),
 		)
 	}
-	// Sanity check: every manifest entry must now exist before we
-	// declare the database ready. A missing index here would mean
-	// either a stale manifest entry (the index no longer maps to
-	// a real field) or a CREATE that silently no-op'd.
-	for _, idx := range deferred.Manifest {
+	for _, idx := range subset {
 		name := idx.ResolvedName()
 		if !migrator.HasIndex(idx.Model, name) {
 			return fmt.Errorf(
@@ -118,13 +127,16 @@ func (d *MetadataStoreSqlite) BuildDeferredIndexes() error {
 			)
 		}
 	}
-	if err := d.clearIndexesPending(); err != nil {
-		return fmt.Errorf("clearing indexes-pending marker: %w", err)
+	if clearMarker {
+		if err := d.clearIndexesPending(); err != nil {
+			return fmt.Errorf("clearing indexes-pending marker: %w", err)
+		}
 	}
 	d.logger.Info(
 		"rebuilt deferred metadata indexes",
 		"component", "database",
 		"built", built,
+		"subset_size", len(subset),
 		"manifest_size", len(deferred.Manifest),
 		"duration", time.Since(overallStart),
 	)

--- a/database/plugin/metadata/sqlite/deferred_indexes_test.go
+++ b/database/plugin/metadata/sqlite/deferred_indexes_test.go
@@ -113,6 +113,57 @@ func TestDropAndBuildDeferredIndexesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestBuildCriticalDeferredIndexesOnlyRebuildsCriticalSubset verifies the
+// split rebuild contract: critical indexes are restored first, lazy indexes
+// remain missing, and the pending marker is not cleared until the full rebuild.
+func TestBuildCriticalDeferredIndexesOnlyRebuildsCriticalSubset(t *testing.T) {
+	d := setupTestDB(t)
+	if err := d.DropDeferredIndexes(); err != nil {
+		t.Fatalf("DropDeferredIndexes: %v", err)
+	}
+
+	if err := d.BuildCriticalDeferredIndexes(); err != nil {
+		t.Fatalf("BuildCriticalDeferredIndexes: %v", err)
+	}
+
+	pending, err := d.HasDeferredIndexesPending()
+	if err != nil {
+		t.Fatalf("HasDeferredIndexesPending after critical build: %v", err)
+	}
+	if !pending {
+		t.Fatal("indexes_pending should remain true after critical-only build")
+	}
+
+	critical := map[string]bool{}
+	for _, idx := range deferred.CriticalManifest() {
+		critical[idx.Table+"\x00"+idx.ResolvedName()] = true
+	}
+
+	migrator := d.DB().Migrator()
+	for _, idx := range deferred.Manifest {
+		name := idx.ResolvedName()
+		hasIndex := migrator.HasIndex(idx.Model, name)
+		isCritical := critical[idx.Table+"\x00"+name]
+		switch {
+		case isCritical && !hasIndex:
+			t.Errorf("critical index %q on %q missing after critical rebuild", name, idx.Table)
+		case !isCritical && hasIndex:
+			t.Errorf("lazy index %q on %q rebuilt during critical rebuild", name, idx.Table)
+		}
+	}
+
+	if err := d.BuildDeferredIndexes(); err != nil {
+		t.Fatalf("BuildDeferredIndexes after critical build: %v", err)
+	}
+	pending, err = d.HasDeferredIndexesPending()
+	if err != nil {
+		t.Fatalf("HasDeferredIndexesPending after full build: %v", err)
+	}
+	if pending {
+		t.Fatal("indexes_pending should be false after full rebuild")
+	}
+}
+
 // TestDropDeferredIndexesPreservesAssetImportConflictTarget covers the
 // #2457 failure mode: dropping the asset policy-id query index must not drop
 // idx_asset_unique, because ledger-state UTxO import uses it as the

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -135,22 +135,51 @@ func RunPlannerStats(db *database.Database, logger *slog.Logger) error {
 	return nil
 }
 
+// DeferredIndexRebuilder owns the drop/rebuild pairing for a single
+// bulk-load run. The critical subset can be rebuilt before API
+// readiness; the full rebuild finishes the lazy maintenance work
+// and clears the pending marker.
+type DeferredIndexRebuilder struct {
+	manager metadata.DeferredIndexManager
+}
+
+func (r *DeferredIndexRebuilder) BuildCritical() error {
+	if r == nil || r.manager == nil {
+		return nil
+	}
+	if err := r.manager.BuildCriticalDeferredIndexes(); err != nil {
+		return fmt.Errorf("rebuilding critical deferred indexes: %w", err)
+	}
+	return nil
+}
+
+func (r *DeferredIndexRebuilder) BuildAll() error {
+	if r == nil || r.manager == nil {
+		return nil
+	}
+	if err := r.manager.BuildDeferredIndexes(); err != nil {
+		return fmt.Errorf("rebuilding deferred indexes: %w", err)
+	}
+	return nil
+}
+
 // WithDeferredIndexes drops the deferred-index manifest before bulk
-// load and rebuilds it on the returned cleanup. Stores that do not
-// implement metadata.DeferredIndexManager are silently skipped — the
-// orchestrator behaves as if every index stayed in place.
+// load and returns a rebuilder for the critical and full rebuild
+// phases. Stores that do not implement metadata.DeferredIndexManager
+// are silently skipped — the orchestrator behaves as if every index
+// stayed in place.
 //
-// The cleanup must be called before the database is marked ready
-// (i.e. before sync_status is cleared). The orchestrator is the
-// authority on that ordering; this helper just owns the
-// drop/rebuild pairing.
+// BuildCritical must be called before the database is marked ready
+// (i.e. before sync_status is cleared). BuildAll may run later as
+// maintenance; it clears the pending marker once the full manifest
+// exists.
 func WithDeferredIndexes(
 	db *database.Database,
 	logger *slog.Logger,
-) func() error {
+) *DeferredIndexRebuilder {
 	manager, ok := db.Metadata().(metadata.DeferredIndexManager)
 	if !ok {
-		return func() error { return nil }
+		return &DeferredIndexRebuilder{}
 	}
 	if err := manager.DropDeferredIndexes(); err != nil {
 		logger.Warn(
@@ -158,14 +187,35 @@ func WithDeferredIndexes(
 				"continuing with full schema",
 			"error", err,
 		)
-		return func() error { return nil }
+		return &DeferredIndexRebuilder{}
 	}
-	return func() error {
-		if err := manager.BuildDeferredIndexes(); err != nil {
-			return fmt.Errorf("rebuilding deferred indexes: %w", err)
-		}
+	return &DeferredIndexRebuilder{manager: manager}
+}
+
+// RepairCriticalDeferredIndexes rebuilds the API/rollback-critical
+// subset if a prior run left deferred indexes pending. It leaves the
+// pending marker in place so RepairDeferredIndexes can finish the
+// lazy remainder later.
+func RepairCriticalDeferredIndexes(
+	db *database.Database,
+	logger *slog.Logger,
+) error {
+	manager, ok := db.Metadata().(metadata.DeferredIndexManager)
+	if !ok {
 		return nil
 	}
+	pending, err := manager.HasDeferredIndexesPending()
+	if err != nil {
+		return err
+	}
+	if !pending {
+		return nil
+	}
+	logger.Warn(
+		"critical deferred metadata indexes pending from a prior run; " +
+			"rebuilding before serving API traffic",
+	)
+	return manager.BuildCriticalDeferredIndexes()
 }
 
 // RepairDeferredIndexes rebuilds any deferred indexes that were

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -184,10 +184,10 @@ func WithDeferredIndexes(
 	if err := manager.DropDeferredIndexes(); err != nil {
 		logger.Warn(
 			"failed to drop deferred metadata indexes; "+
-				"continuing with full schema",
+				"continuing and repairing during rebuild phases",
 			"error", err,
 		)
-		return &DeferredIndexRebuilder{}
+		return &DeferredIndexRebuilder{manager: manager}
 	}
 	return &DeferredIndexRebuilder{manager: manager}
 }

--- a/node.go
+++ b/node.go
@@ -943,8 +943,10 @@ func (n *Node) startDeferredIndexMaintenance() {
 		return
 	}
 	if !pending {
+		n.config.logger.Info("deferred-index maintenance not needed")
 		return
 	}
+	n.config.logger.Info("deferred-index maintenance starting")
 	go func() {
 		if err := manager.BuildDeferredIndexes(); err != nil {
 			n.config.logger.Error(

--- a/node.go
+++ b/node.go
@@ -68,6 +68,7 @@ type Node struct {
 	leaderElection                   *leader.Election
 	rtsMetrics                       *rtsMetrics
 	shutdownFuncs                    []func(context.Context) error
+	deferredIndexMaintenanceDone     chan struct{}
 	config                           Config
 	ctx                              context.Context
 	cancel                           context.CancelFunc
@@ -874,7 +875,7 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 
 	if n.config.storageMode.IsAPI() {
-		n.startDeferredIndexMaintenance()
+		started = append(started, n.startDeferredIndexMaintenance())
 	}
 
 	// Initialize block forger if production mode is enabled
@@ -929,10 +930,10 @@ func (n *Node) Run(ctx context.Context) error {
 // rebuilt before API readiness, so this background repair can restore
 // secondary query indexes and clear the pending marker without opening a
 // second Badger handle during serve startup.
-func (n *Node) startDeferredIndexMaintenance() {
+func (n *Node) startDeferredIndexMaintenance() func() {
 	manager, ok := n.db.Metadata().(metadata.DeferredIndexManager)
 	if !ok {
-		return
+		return func() {}
 	}
 	pending, err := manager.HasDeferredIndexesPending()
 	if err != nil {
@@ -940,14 +941,17 @@ func (n *Node) startDeferredIndexMaintenance() {
 			"checking deferred-index maintenance state failed",
 			"error", err,
 		)
-		return
+		return func() {}
 	}
 	if !pending {
 		n.config.logger.Info("deferred-index maintenance not needed")
-		return
+		return func() {}
 	}
+	done := make(chan struct{})
+	n.deferredIndexMaintenanceDone = done
 	n.config.logger.Info("deferred-index maintenance starting")
 	go func() {
+		defer close(done)
 		if err := manager.BuildDeferredIndexes(); err != nil {
 			n.config.logger.Error(
 				"deferred-index maintenance failed",
@@ -957,4 +961,7 @@ func (n *Node) startDeferredIndexMaintenance() {
 		}
 		n.config.logger.Info("deferred-index maintenance complete")
 	}()
+	return func() {
+		<-done
+	}
 }

--- a/node.go
+++ b/node.go
@@ -32,6 +32,7 @@ import (
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
@@ -872,6 +873,10 @@ func (n *Node) Run(ctx context.Context) error {
 		})
 	}
 
+	if n.config.storageMode.IsAPI() {
+		n.startDeferredIndexMaintenance()
+	}
+
 	// Initialize block forger if production mode is enabled
 	if n.config.blockProducer {
 		creds, err := n.validateBlockProducerStartup()
@@ -917,4 +922,37 @@ func (n *Node) Run(ctx context.Context) error {
 	// Wait for shutdown signal
 	<-n.ctx.Done()
 	return nil
+}
+
+// startDeferredIndexMaintenance finishes lazy deferred-index rebuilds
+// using the node's already-open database handle. The critical subset is
+// rebuilt before API readiness, so this background repair can restore
+// secondary query indexes and clear the pending marker without opening a
+// second Badger handle during serve startup.
+func (n *Node) startDeferredIndexMaintenance() {
+	manager, ok := n.db.Metadata().(metadata.DeferredIndexManager)
+	if !ok {
+		return
+	}
+	pending, err := manager.HasDeferredIndexesPending()
+	if err != nil {
+		n.config.logger.Error(
+			"checking deferred-index maintenance state failed",
+			"error", err,
+		)
+		return
+	}
+	if !pending {
+		return
+	}
+	go func() {
+		if err := manager.BuildDeferredIndexes(); err != nil {
+			n.config.logger.Error(
+				"deferred-index maintenance failed",
+				"error", err,
+			)
+			return
+		}
+		n.config.logger.Info("deferred-index maintenance complete")
+	}()
 }

--- a/node.go
+++ b/node.go
@@ -962,6 +962,16 @@ func (n *Node) startDeferredIndexMaintenance() func() {
 		n.config.logger.Info("deferred-index maintenance complete")
 	}()
 	return func() {
-		<-done
+		timeout := n.configuredShutdownTimeout()
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case <-done:
+		case <-timer.C:
+			n.config.logger.Warn(
+				"timed out waiting for deferred-index maintenance; continuing cleanup",
+				"timeout", timeout,
+			)
+		}
 	}
 }

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -214,6 +214,12 @@ func (n *Node) shutdown() error {
 		}
 	}
 
+	if n.deferredIndexMaintenanceDone != nil {
+		n.config.logger.Info("waiting for deferred-index maintenance")
+		<-n.deferredIndexMaintenanceDone
+		n.config.logger.Info("deferred-index maintenance stopped")
+	}
+
 	if n.db != nil {
 		n.config.logger.Info("closing database")
 		if closeErr := n.closeWithShutdownTimeout(

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -73,13 +73,16 @@ func (n *Node) closeWithShutdownTimeout(
 	}
 }
 
+func (n *Node) configuredShutdownTimeout() time.Duration {
+	if n.config.shutdownTimeout > 0 {
+		return n.config.shutdownTimeout
+	}
+	return 30 * time.Second
+}
+
 func (n *Node) shutdown() error {
 	shutdownStart := time.Now()
-	// Create shutdown context with timeout (default 30s if not configured)
-	shutdownTimeout := 30 * time.Second
-	if n.config.shutdownTimeout > 0 {
-		shutdownTimeout = n.config.shutdownTimeout
-	}
+	shutdownTimeout := n.configuredShutdownTimeout()
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	if n.cancel != nil {
@@ -216,8 +219,23 @@ func (n *Node) shutdown() error {
 
 	if n.deferredIndexMaintenanceDone != nil {
 		n.config.logger.Info("waiting for deferred-index maintenance")
-		<-n.deferredIndexMaintenanceDone
-		n.config.logger.Info("deferred-index maintenance stopped")
+		select {
+		case <-n.deferredIndexMaintenanceDone:
+			n.config.logger.Info("deferred-index maintenance stopped")
+		case <-ctx.Done():
+			n.config.logger.Warn(
+				"timed out waiting for deferred-index maintenance; continuing shutdown",
+				"timeout", shutdownTimeout,
+				"error", ctx.Err(),
+			)
+			err = errors.Join(
+				err,
+				fmt.Errorf(
+					"deferred-index maintenance shutdown: %w",
+					ctx.Err(),
+				),
+			)
+		}
 	}
 
 	if n.db != nil {


### PR DESCRIPTION
1. Added a top-level timing around Mithril deferred index rebuild and index_rebuild_elapsed to the final mithril bootstrap complete log.
2. Added dingo_mithril_sync_index_rebuild_duration_seconds prometheus metric and index_rebuild phase tracking as well.
3. I have analyzed all 27 deferred indexes and split sqlite deferred metadata index rebuild into critical and lazy phases.
4. Made changes for deferred index manifest entries where it supports Critical=true classification.
5. I have marked 11 deferred indexes as critical added a CriticalManifest() helper as well.
6. Here, critical indexes are the ones needed for immediate API queries or rollback safety where I have added CriticalManifest() and BuildCriticalDeferredIndexes() so sqlite can rebuild only that startup-critical subset instead of always rebuilding all 27 indexes.
7. I have changed mithril sync to rebuild only the critical indexes before clearing sync_status and marking bootstrap complete. 
8. So, api mode serve now ensures the critical indexes exist before startup, then rebuilds the remaining lazy indexes in background maintenanc where it reduces the post-backfill wait before the API can become available while still eventually restoring the full index set.
9. Added regression test coverage for critical manifest classification.
10. Added regression coverage proving BuildCriticalDeferredIndexes() rebuilds only critical indexes.
11. Updated ARCHITECTURE.md for the critical/lazy deferred-index lifecycle.

Closes #2460 





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split SQLite deferred-index rebuild into critical and lazy phases to cut API startup time after backfill while preserving rollback safety. Critical indexes rebuild during Mithril; the node finishes lazy indexes in background maintenance using its existing DB handle and now waits for that maintenance at shutdown using the configured timeout.

- **New Features**
  - Added `Critical` classification and `CriticalManifest()`; SQLite exposes `BuildCriticalDeferredIndexes()` for the critical subset.
  - Mithril rebuilds critical indexes before clearing `sync_status`, tracks an `index_rebuild` phase, and records `dingo_mithril_sync_index_rebuild_duration_seconds`.
  - Moved lazy rebuild to the node lifecycle so API-mode `serve` starts immediately, avoids a second Badger handle, and waits for maintenance completion on shutdown honoring `shutdownTimeout`.
  - Added `RepairCriticalDeferredIndexes` to ensure the critical subset exists if a previous run left indexes pending.

- **Migration**
  - No action needed. API starts faster post-backfill; background maintenance restores remaining indexes and clears the marker.
  - Monitor `dingo_mithril_sync_index_rebuild_duration_seconds`; failures keep the pending marker and retry on next start.

<sup>Written for commit fedf857c83bea606a8a518ec889bcd286c1fec13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Mithril synchronization startup time by prioritizing critical database index rebuilds before API availability, with remaining indexes rebuilt in the background.
  * Added metrics tracking for index rebuild duration during Mithril synchronization.

* **Documentation**
  * Updated architecture documentation with details on deferred index handling and synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->