### PR TITLE
perf(backfill): fixed-shape SQL for SQLite API-backfill write hot paths

### DIFF
--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 const (
@@ -306,22 +305,22 @@ func (d *MetadataStoreSqlite) FlushBatch(
 			return fmt.Errorf("flush batch: spend utxos: %w", err)
 		}
 
-		if err := batchCreate(db, batch.KeyWitnesses); err != nil {
+		if err := insertKeyWitnesses(db, batch.KeyWitnesses); err != nil {
 			return fmt.Errorf("flush batch: create key witnesses: %w", err)
 		}
-		if err := batchCreate(db, batch.WitnessScripts); err != nil {
+		if err := insertWitnessScripts(db, batch.WitnessScripts); err != nil {
 			return fmt.Errorf("flush batch: create witness scripts: %w", err)
 		}
-		if err := batchCreateScripts(db, batch.Scripts); err != nil {
+		if err := insertScripts(db, batch.Scripts); err != nil {
 			return fmt.Errorf("flush batch: create scripts: %w", err)
 		}
-		if err := batchCreate(db, batch.PlutusData); err != nil {
+		if err := insertPlutusData(db, batch.PlutusData); err != nil {
 			return fmt.Errorf("flush batch: create plutus data: %w", err)
 		}
-		if err := batchCreate(db, batch.Redeemers); err != nil {
+		if err := insertRedeemers(db, batch.Redeemers); err != nil {
 			return fmt.Errorf("flush batch: create redeemers: %w", err)
 		}
-		if err := batchCreate(db, batch.AddressTxs); err != nil {
+		if err := insertAddressTxs(db, batch.AddressTxs); err != nil {
 			return fmt.Errorf("flush batch: create address txs: %w", err)
 		}
 		return nil
@@ -338,34 +337,11 @@ func (d *MetadataStoreSqlite) FlushBatch(
 	return nil
 }
 
-func batchCreate[T any](db *gorm.DB, items []T) error {
-	if len(items) == 0 {
-		return nil
-	}
-	if result := db.CreateInBatches(items, batchChunkRows); result.Error != nil {
-		return result.Error
-	}
-	return nil
-}
-
 func batchCreateUtxos(db *gorm.DB, items []models.Utxo) error {
 	if len(items) == 0 {
 		return nil
 	}
 	return importUtxosWithDB(db, items)
-}
-
-func batchCreateScripts(db *gorm.DB, items []models.Script) error {
-	if len(items) == 0 {
-		return nil
-	}
-	if result := db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "hash"}},
-		DoNothing: true,
-	}).CreateInBatches(items, batchChunkRows); result.Error != nil {
-		return result.Error
-	}
-	return nil
 }
 
 func batchDeleteByTxIDs(db *gorm.DB, table string, ids []uint) error {

--- a/database/plugin/metadata/sqlite/batch_accumulator.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator.go
@@ -17,7 +17,6 @@ package sqlite
 import (
 	"fmt"
 	"maps"
-	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -363,60 +362,20 @@ func batchSpendUtxos(db *gorm.DB, spends []utxoSpend) error {
 	if len(spends) == 0 {
 		return nil
 	}
-	for i := 0; i < len(spends); i += batchChunkRows {
-		end := min(i+batchChunkRows, len(spends))
-		chunk := spends[i:end]
-		var deletedSlotCases []string
-		var spentAtCases []string
-		var whereConditions []string
-		var deletedSlotArgs []any
-		var spentAtArgs []any
-		var whereArgs []any
-		for _, spend := range chunk {
-			deletedSlotCases = append(
-				deletedSlotCases,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
-			)
-			deletedSlotArgs = append(
-				deletedSlotArgs,
-				spend.TxId,
-				spend.OutputIdx,
-				spend.Slot,
-			)
-
-			spentAtCases = append(
-				spentAtCases,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
-			)
-			spentAtArgs = append(
-				spentAtArgs,
-				spend.TxId,
-				spend.OutputIdx,
-				spend.SpentByTxHash,
-			)
-
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, spend.TxId, spend.OutputIdx)
-		}
-
-		args := make([]any, 0, len(deletedSlotArgs)+len(spentAtArgs)+len(whereArgs))
-		args = append(args, deletedSlotArgs...)
-		args = append(args, spentAtArgs...)
-		args = append(args, whereArgs...)
-		sql := fmt.Sprintf(
-			"UPDATE "+utxoRefIndexedTable()+
-				" SET deleted_slot = CASE %s ELSE deleted_slot END, "+
-				"spent_at_tx_id = CASE %s ELSE spent_at_tx_id END "+
-				"WHERE deleted_slot = 0 AND (%s)",
-			strings.Join(deletedSlotCases, " "),
-			strings.Join(spentAtCases, " "),
-			strings.Join(whereConditions, " OR "),
-		)
-		if result := db.Exec(sql, args...); result.Error != nil {
-			return result.Error
+	// Stable per-row UPDATE reused for every spend (one prepared statement),
+	// replacing the prior dynamic CASE whose shape changed per chunk and so
+	// could not be reused. The deleted_slot = 0 guard keeps re-application
+	// idempotent: an already-spent row is skipped, which resumed backfill and
+	// the #2459 create-before-spend flush ordering rely on.
+	query := "UPDATE " + utxoRefIndexedTable() +
+		" SET deleted_slot = ?, spent_at_tx_id = ?" +
+		" WHERE deleted_slot = 0 AND tx_id = ? AND output_idx = ?"
+	for i := range spends {
+		s := &spends[i]
+		if _, err := execRawOnConn(db, query, []any{
+			s.Slot, s.SpentByTxHash, s.TxId, s.OutputIdx,
+		}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/database/plugin/metadata/sqlite/bulk_sql.go
+++ b/database/plugin/metadata/sqlite/bulk_sql.go
@@ -49,7 +49,39 @@ var (
 	addressTxCols = []string{
 		"payment_key", "staking_key", "transaction_id", "slot", "tx_index",
 	}
+	utxoCols = []string{
+		"transaction_id", "collateral_return_for_tx_id", "tx_id",
+		"payment_key", "staking_key", "datum_hash", "spent_at_tx_id",
+		"referenced_by_tx_id", "collateral_by_tx_id", "added_slot",
+		"deleted_slot", "amount", "output_idx",
+	}
+	assetCols = []string{
+		"name", "name_hex", "policy_id", "fingerprint", "utxo_id", "amount",
+	}
 )
+
+// Conflict clauses preserved verbatim from the prior GORM clause.OnConflict
+// targets; their unique indexes are the idempotency contract for resumed
+// backfill.
+const (
+	utxoConflictClause  = `ON CONFLICT ("tx_id","output_idx") DO NOTHING`
+	assetConflictClause = `ON CONFLICT ("utxo_id","policy_id","name") DO NOTHING`
+)
+
+func appendUtxoRow(dst []any, u *models.Utxo) []any {
+	return append(dst,
+		u.TransactionID, u.CollateralReturnForTxID, u.TxId,
+		u.PaymentKey, u.StakingKey, u.DatumHash, u.SpentAtTxId,
+		u.ReferencedByTxId, u.CollateralByTxId, u.AddedSlot,
+		u.DeletedSlot, u.Amount, u.OutputIdx,
+	)
+}
+
+func appendAssetRow(dst []any, a *models.Asset) []any {
+	return append(dst,
+		a.Name, a.NameHex, a.PolicyId, a.Fingerprint, a.UtxoID, a.Amount,
+	)
+}
 
 // buildBulkInsertSQL returns a multi-row INSERT for nRows rows. For a given
 // (table, cols, conflict, nRows) the result is byte-identical on every call,
@@ -99,17 +131,26 @@ func buildBulkInsertSQL(
 }
 
 // execRawOnConn runs query on the transaction's underlying connection pool,
-// bypassing GORM's clause builder. GORM's positional-var path expands a []byte
-// argument into one bound value per byte; database/sql binds it as a single
-// blob. The conn pool is the active transaction's, and (with PrepareStmt on)
-// caches the compiled statement keyed by the stable query string.
-func execRawOnConn(db *gorm.DB, query string, args []any) error {
+// bypassing GORM's clause builder, and returns the affected-row count. GORM's
+// positional-var path expands a []byte argument into one bound value per byte;
+// database/sql binds it as a single blob. The conn pool is the active
+// transaction's, and (with PrepareStmt on) caches the compiled statement keyed
+// by the stable query string. For INSERT ... ON CONFLICT DO NOTHING the count
+// is the number of rows actually inserted (skipped conflicts are not counted).
+func execRawOnConn(db *gorm.DB, query string, args []any) (int64, error) {
 	ctx := db.Statement.Context
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	_, err := db.Statement.ConnPool.ExecContext(ctx, query, args...)
-	return err
+	res, err := db.Statement.ConnPool.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // execBulkInsert writes nRows rows to table in fixed-size chunks. Full chunks
@@ -139,7 +180,7 @@ func execBulkInsert(
 		for j := i; j < i+chunkRows; j++ {
 			args = appendRow(args, j)
 		}
-		if err := execRawOnConn(db, fullSQL, args); err != nil {
+		if _, err := execRawOnConn(db, fullSQL, args); err != nil {
 			return err
 		}
 	}
@@ -149,7 +190,7 @@ func execBulkInsert(
 		for j := i; j < nRows; j++ {
 			args = appendRow(args, j)
 		}
-		if err := execRawOnConn(db, remSQL, args); err != nil {
+		if _, err := execRawOnConn(db, remSQL, args); err != nil {
 			return err
 		}
 	}

--- a/database/plugin/metadata/sqlite/bulk_sql.go
+++ b/database/plugin/metadata/sqlite/bulk_sql.go
@@ -58,6 +58,10 @@ var (
 	assetCols = []string{
 		"name", "name_hex", "policy_id", "fingerprint", "utxo_id", "amount",
 	}
+	transactionCols = []string{
+		"hash", "block_hash", "metadata", "slot", "type",
+		"fee", "ttl", "block_index", "valid",
+	}
 )
 
 // Conflict clauses preserved verbatim from the prior GORM clause.OnConflict
@@ -81,6 +85,37 @@ func appendAssetRow(dst []any, a *models.Asset) []any {
 	return append(dst,
 		a.Name, a.NameHex, a.PolicyId, a.Fingerprint, a.UtxoID, a.Amount,
 	)
+}
+
+func appendTransactionRow(dst []any, t *models.Transaction) []any {
+	return append(dst,
+		t.Hash, t.BlockHash, t.Metadata, t.Slot, t.Type,
+		t.Fee, t.TTL, t.BlockIndex, t.Valid,
+	)
+}
+
+// insertReturningID runs an INSERT ... RETURNING id on the transaction's conn
+// pool. It returns (id, true) for a row that was actually inserted, or
+// (0, false) when an ON CONFLICT DO NOTHING skipped the insert (RETURNING
+// yields no row). []byte args bind as blobs, like execRawOnConn.
+func insertReturningID(db *gorm.DB, query string, args []any) (uint, bool, error) {
+	ctx := db.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rows, err := db.Statement.ConnPool.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, false, err
+	}
+	defer rows.Close() //nolint:errcheck
+	if !rows.Next() {
+		return 0, false, rows.Err()
+	}
+	var id uint
+	if err := rows.Scan(&id); err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
 }
 
 // buildBulkInsertSQL returns a multi-row INSERT for nRows rows. For a given

--- a/database/plugin/metadata/sqlite/bulk_sql.go
+++ b/database/plugin/metadata/sqlite/bulk_sql.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"context"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"gorm.io/gorm"
+)
+
+// Fixed-shape SQL bulk writers for the hottest API-backfill flush paths.
+//
+// These replace GORM's reflection-based CreateInBatches on the dominant child
+// tables. Each writer emits a multi-row INSERT whose statement string is stable
+// for a given row count, so GORM's PrepareStmt cache (enabled on the write pool)
+// compiles it once and reuses it, and no per-row model reflection happens.
+// Conflict/idempotency semantics are kept identical to the GORM path.
+
+// Column lists exclude the autoincrement primary key. They are asserted to
+// match the GORM-migrated schema by TestBulkInsertColumnsMatchSchema, so a
+// model change that drifts from these lists fails a test rather than silently
+// writing the wrong columns.
+var (
+	keyWitnessCols = []string{
+		"vkey", "signature", "public_key", "chain_code",
+		"attributes", "transaction_id", "type",
+	}
+	witnessScriptCols = []string{"script_hash", "transaction_id", "type"}
+	scriptCols        = []string{"hash", "content", "created_slot", "type"}
+	plutusDataCols    = []string{"data", "transaction_id"}
+	redeemerCols      = []string{
+		"data", "transaction_id", "ex_units_memory",
+		"ex_units_cpu", "index", "tag",
+	}
+	addressTxCols = []string{
+		"payment_key", "staking_key", "transaction_id", "slot", "tx_index",
+	}
+)
+
+// buildBulkInsertSQL returns a multi-row INSERT for nRows rows. For a given
+// (table, cols, conflict, nRows) the result is byte-identical on every call,
+// so GORM's PrepareStmt cache can reuse the compiled statement. Identifiers are
+// double-quoted so reserved words (e.g. "index") are safe.
+func buildBulkInsertSQL(
+	table string,
+	cols []string,
+	conflict string,
+	nRows int,
+) string {
+	var b strings.Builder
+	b.WriteString(`INSERT INTO "`)
+	b.WriteString(table)
+	b.WriteString(`" (`)
+	for i, c := range cols {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte('"')
+		b.WriteString(c)
+		b.WriteByte('"')
+	}
+	b.WriteString(") VALUES ")
+	// Single placeholder tuple, e.g. "(?,?,?)".
+	var tuple strings.Builder
+	tuple.WriteByte('(')
+	for i := range cols {
+		if i > 0 {
+			tuple.WriteByte(',')
+		}
+		tuple.WriteByte('?')
+	}
+	tuple.WriteByte(')')
+	t := tuple.String()
+	for i := range nRows {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(t)
+	}
+	if conflict != "" {
+		b.WriteByte(' ')
+		b.WriteString(conflict)
+	}
+	return b.String()
+}
+
+// execRawOnConn runs query on the transaction's underlying connection pool,
+// bypassing GORM's clause builder. GORM's positional-var path expands a []byte
+// argument into one bound value per byte; database/sql binds it as a single
+// blob. The conn pool is the active transaction's, and (with PrepareStmt on)
+// caches the compiled statement keyed by the stable query string.
+func execRawOnConn(db *gorm.DB, query string, args []any) error {
+	ctx := db.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := db.Statement.ConnPool.ExecContext(ctx, query, args...)
+	return err
+}
+
+// execBulkInsert writes nRows rows to table in fixed-size chunks. Full chunks
+// share one stable SQL string; a final partial chunk uses a statement built for
+// its exact size. appendRow appends row i's column values, in cols order, to
+// dst. conflict is an optional fixed clause (e.g. ON CONFLICT (...) DO NOTHING).
+func execBulkInsert(
+	db *gorm.DB,
+	table string,
+	cols []string,
+	conflict string,
+	nRows int,
+	appendRow func(dst []any, i int) []any,
+) error {
+	if nRows == 0 {
+		return nil
+	}
+	chunkRows := batchChunkRows
+	args := make([]any, 0, chunkRows*len(cols))
+	var fullSQL string
+	i := 0
+	for ; i+chunkRows <= nRows; i += chunkRows {
+		if fullSQL == "" {
+			fullSQL = buildBulkInsertSQL(table, cols, conflict, chunkRows)
+		}
+		args = args[:0]
+		for j := i; j < i+chunkRows; j++ {
+			args = appendRow(args, j)
+		}
+		if err := execRawOnConn(db, fullSQL, args); err != nil {
+			return err
+		}
+	}
+	if rem := nRows - i; rem > 0 {
+		remSQL := buildBulkInsertSQL(table, cols, conflict, rem)
+		args = args[:0]
+		for j := i; j < nRows; j++ {
+			args = appendRow(args, j)
+		}
+		if err := execRawOnConn(db, remSQL, args); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertKeyWitnesses(db *gorm.DB, items []models.KeyWitness) error {
+	return execBulkInsert(
+		db, "key_witness", keyWitnessCols, "", len(items),
+		func(dst []any, i int) []any {
+			w := &items[i]
+			return append(dst,
+				w.Vkey, w.Signature, w.PublicKey, w.ChainCode,
+				w.Attributes, w.TransactionID, w.Type,
+			)
+		},
+	)
+}
+
+func insertWitnessScripts(db *gorm.DB, items []models.WitnessScripts) error {
+	return execBulkInsert(
+		db, "witness_scripts", witnessScriptCols, "", len(items),
+		func(dst []any, i int) []any {
+			w := &items[i]
+			return append(dst, w.ScriptHash, w.TransactionID, w.Type)
+		},
+	)
+}
+
+func insertScripts(db *gorm.DB, items []models.Script) error {
+	return execBulkInsert(
+		db, "script", scriptCols, `ON CONFLICT ("hash") DO NOTHING`,
+		len(items),
+		func(dst []any, i int) []any {
+			s := &items[i]
+			return append(dst, s.Hash, s.Content, s.CreatedSlot, s.Type)
+		},
+	)
+}
+
+func insertPlutusData(db *gorm.DB, items []models.PlutusData) error {
+	return execBulkInsert(
+		db, "plutus_data", plutusDataCols, "", len(items),
+		func(dst []any, i int) []any {
+			p := &items[i]
+			return append(dst, p.Data, p.TransactionID)
+		},
+	)
+}
+
+func insertRedeemers(db *gorm.DB, items []models.Redeemer) error {
+	return execBulkInsert(
+		db, "redeemer", redeemerCols, "", len(items),
+		func(dst []any, i int) []any {
+			r := &items[i]
+			return append(dst,
+				r.Data, r.TransactionID, r.ExUnitsMemory,
+				r.ExUnitsCPU, r.Index, r.Tag,
+			)
+		},
+	)
+}
+
+func insertAddressTxs(db *gorm.DB, items []models.AddressTransaction) error {
+	return execBulkInsert(
+		db, "address_transaction", addressTxCols, "", len(items),
+		func(dst []any, i int) []any {
+			a := &items[i]
+			return append(dst,
+				a.PaymentKey, a.StakingKey, a.TransactionID, a.Slot, a.TxIndex,
+			)
+		},
+	)
+}

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -198,6 +198,43 @@ func TestImportUtxos_ConflictDoNothingIdempotent(t *testing.T) {
 	assert.Equal(t, types.Uint64(10), got[0].Amount)
 }
 
+// TestBatchSpendUtxos_GuardSkipsAlreadySpent confirms the per-row UPDATE keeps
+// the deleted_slot = 0 idempotency guard: a second spend of an already-spent
+// row (e.g. on retry, or a different tx) is a no-op and leaves the first
+// spender's slot/hash intact.
+func TestBatchSpendUtxos_GuardSkipsAlreadySpent(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	txid := bytes.Repeat([]byte{0x55}, 32)
+	spender1 := bytes.Repeat([]byte{0x66}, 32)
+	spender2 := bytes.Repeat([]byte{0x77}, 32)
+
+	// spent_at_tx_id has an FK to transactions.hash; create the spenders.
+	require.NoError(t, store.DB().Create(
+		&models.Transaction{Hash: spender1, Slot: 100, Valid: true},
+	).Error)
+	require.NoError(t, store.DB().Create(
+		&models.Transaction{Hash: spender2, Slot: 200, Valid: true},
+	).Error)
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId: txid, OutputIdx: 0, AddedSlot: 1, Amount: types.Uint64(5),
+	}}, nil))
+
+	require.NoError(t, batchSpendUtxos(store.DB(), []utxoSpend{{
+		TxId: txid, OutputIdx: 0, Slot: 100, SpentByTxHash: spender1,
+	}}))
+	// Second spend must be skipped (deleted_slot != 0).
+	require.NoError(t, batchSpendUtxos(store.DB(), []utxoSpend{{
+		TxId: txid, OutputIdx: 0, Slot: 200, SpentByTxHash: spender2,
+	}}))
+
+	var got models.Utxo
+	require.NoError(t, store.DB().
+		Where("tx_id = ? AND output_idx = ?", txid, uint32(0)).
+		First(&got).Error)
+	assert.Equal(t, uint64(100), got.DeletedSlot)
+	assert.Equal(t, spender1, got.SpentAtTxId)
+}
+
 func newBenchStore(b *testing.B) *MetadataStoreSqlite {
 	b.Helper()
 	store, err := NewWithOptions(WithStorageMode("api"))

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm/schema"
@@ -44,6 +45,8 @@ func TestBulkInsertColumnsMatchSchema(t *testing.T) {
 		{"plutus_data", &models.PlutusData{}, plutusDataCols},
 		{"redeemer", &models.Redeemer{}, redeemerCols},
 		{"address_transaction", &models.AddressTransaction{}, addressTxCols},
+		{"utxo", &models.Utxo{}, utxoCols},
+		{"asset", &models.Asset{}, assetCols},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -128,6 +131,71 @@ func TestInsertScripts_ConflictDoNothing(t *testing.T) {
 	require.NoError(t, store.DB().Where("hash = ?", hash).Find(&got).Error)
 	require.Len(t, got, 1)
 	assert.Equal(t, []byte{0x01}, got[0].Content)
+}
+
+// TestImportUtxos_FixedShapeRoundTrip inserts a fully-populated UTxO with an
+// asset through the fixed-shape path and reads every column back. A swapped
+// column in utxoCols/assetCols (which the set-based schema guard would miss)
+// corrupts a value here. It also exercises asset linking, which depends on
+// BatchRefetchUtxoIDs recovering the utxo ID after a raw INSERT.
+func TestImportUtxos_FixedShapeRoundTrip(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	txid := bytes.Repeat([]byte{0x11}, 32)
+	in := models.Utxo{
+		TxId:       txid,
+		OutputIdx:  2,
+		PaymentKey: bytes.Repeat([]byte{0x22}, 28),
+		StakingKey: bytes.Repeat([]byte{0x33}, 28),
+		AddedSlot:  42,
+		Amount:     types.Uint64(1234567),
+		Assets: []models.Asset{{
+			Name:        []byte("TOKEN"),
+			NameHex:     []byte("544f4b454e"),
+			PolicyId:    bytes.Repeat([]byte{0x44}, 28),
+			Fingerprint: []byte("asset1xyz"),
+			Amount:      types.Uint64(999),
+		}},
+	}
+	require.NoError(t, store.ImportUtxos([]models.Utxo{in}, nil))
+
+	var got models.Utxo
+	require.NoError(t, store.DB().
+		Where("tx_id = ? AND output_idx = ?", txid, uint32(2)).
+		First(&got).Error)
+	assert.Equal(t, in.PaymentKey, got.PaymentKey)
+	assert.Equal(t, in.StakingKey, got.StakingKey)
+	assert.Equal(t, uint64(42), got.AddedSlot)
+	assert.Equal(t, types.Uint64(1234567), got.Amount)
+	assert.Equal(t, uint32(2), got.OutputIdx)
+
+	var assets []models.Asset
+	require.NoError(t, store.DB().Where("utxo_id = ?", got.ID).Find(&assets).Error)
+	require.Len(t, assets, 1)
+	assert.Equal(t, []byte("TOKEN"), assets[0].Name)
+	assert.Equal(t, bytes.Repeat([]byte{0x44}, 28), assets[0].PolicyId)
+	assert.Equal(t, []byte("asset1xyz"), assets[0].Fingerprint)
+	assert.Equal(t, types.Uint64(999), assets[0].Amount)
+}
+
+// TestImportUtxos_ConflictDoNothingIdempotent confirms the
+// ON CONFLICT(tx_id,output_idx) DO NOTHING semantics survive the conversion:
+// re-importing the same ref keeps the original row.
+func TestImportUtxos_ConflictDoNothingIdempotent(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	txid := bytes.Repeat([]byte{0xAA}, 32)
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId: txid, OutputIdx: 0, AddedSlot: 1, Amount: types.Uint64(10),
+	}}, nil))
+	// Same ref, different payload: must be ignored, not overwritten or errored.
+	require.NoError(t, store.ImportUtxos([]models.Utxo{{
+		TxId: txid, OutputIdx: 0, AddedSlot: 2, Amount: types.Uint64(20),
+	}}, nil))
+
+	var got []models.Utxo
+	require.NoError(t, store.DB().Where("tx_id = ?", txid).Find(&got).Error)
+	require.Len(t, got, 1)
+	assert.Equal(t, uint64(1), got[0].AddedSlot)
+	assert.Equal(t, types.Uint64(10), got[0].Amount)
 }
 
 func newBenchStore(b *testing.B) *MetadataStoreSqlite {

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"bytes"
+	"encoding/binary"
 	"sync"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 )
 
@@ -285,6 +287,67 @@ func BenchmarkInsertKeyWitnessesGORM(b *testing.B) {
 		b.StartTimer()
 		if err := store.DB().
 			CreateInBatches(rows, batchChunkRows).Error; err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchHash builds a deterministic 32-byte key unique to (prefix, a, b) so a
+// benchmark's repeated flushes insert fresh rows instead of hitting
+// ON CONFLICT DO NOTHING.
+func benchHash(prefix byte, a, b int) []byte {
+	h := make([]byte, 32)
+	h[0] = prefix
+	binary.BigEndian.PutUint32(h[1:5], uint32(a))
+	binary.BigEndian.PutUint32(h[5:9], uint32(b))
+	return h
+}
+
+func benchUtxos(iter, n int) []models.Utxo {
+	utxos := make([]models.Utxo, n)
+	for i := range utxos {
+		utxos[i] = models.Utxo{
+			TxId:       benchHash(0x01, iter, i),
+			OutputIdx:  0,
+			PaymentKey: benchHash(0x02, iter, i)[:28],
+			StakingKey: benchHash(0x03, iter, i)[:28],
+			AddedSlot:  uint64(iter),
+			Amount:     types.Uint64(1_000_000),
+		}
+	}
+	return utxos
+}
+
+// BenchmarkImportUtxos and BenchmarkImportUtxosGORM compare the fixed-shape
+// utxo writer against the prior GORM CreateInBatches path on the heaviest flush
+// table. Both rebuild rows per iteration (untimed) with keys unique to the
+// iteration, so each insert is fresh; utxos carry no assets and a nil
+// TransactionID, so neither path touches the asset refetch or any FK.
+func BenchmarkImportUtxos(b *testing.B) {
+	store := newBenchStore(b)
+	for n := range b.N {
+		b.StopTimer()
+		utxos := benchUtxos(n, 500)
+		b.StartTimer()
+		if err := importUtxosWithDB(store.DB(), utxos); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkImportUtxosGORM(b *testing.B) {
+	store := newBenchStore(b)
+	for n := range b.N {
+		b.StopTimer()
+		utxos := benchUtxos(n, 500)
+		b.StartTimer()
+		if err := store.DB().Omit("Assets").Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "tx_id"},
+				{Name: "output_idx"},
+			},
+			DoNothing: true,
+		}).CreateInBatches(utxos, importUtxoBatchSize).Error; err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -47,6 +47,7 @@ func TestBulkInsertColumnsMatchSchema(t *testing.T) {
 		{"address_transaction", &models.AddressTransaction{}, addressTxCols},
 		{"utxo", &models.Utxo{}, utxoCols},
 		{"asset", &models.Asset{}, assetCols},
+		{"transaction", &models.Transaction{}, transactionCols},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm/schema"
+)
+
+// TestBulkInsertColumnsMatchSchema guards the hand-written column lists in
+// bulk_sql.go against the GORM-migrated schema. If a model gains/renames a
+// column (or GORM names one differently than expected, e.g. ex_units_cpu),
+// this fails instead of silently writing the wrong columns.
+func TestBulkInsertColumnsMatchSchema(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	ns := store.DB().NamingStrategy
+
+	cases := []struct {
+		name  string
+		model any
+		cols  []string
+	}{
+		{"key_witness", &models.KeyWitness{}, keyWitnessCols},
+		{"witness_scripts", &models.WitnessScripts{}, witnessScriptCols},
+		{"script", &models.Script{}, scriptCols},
+		{"plutus_data", &models.PlutusData{}, plutusDataCols},
+		{"redeemer", &models.Redeemer{}, redeemerCols},
+		{"address_transaction", &models.AddressTransaction{}, addressTxCols},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := schema.Parse(tc.model, &sync.Map{}, ns)
+			require.NoError(t, err)
+			// Expected = every real column except the autoincrement PK,
+			// which the bulk INSERT lets SQLite assign.
+			want := map[string]struct{}{}
+			for _, name := range s.DBNames {
+				f := s.FieldsByDBName[name]
+				if f.AutoIncrement && f.PrimaryKey {
+					continue
+				}
+				want[name] = struct{}{}
+			}
+			got := map[string]struct{}{}
+			for _, c := range tc.cols {
+				got[c] = struct{}{}
+			}
+			assert.Equal(
+				t, want, got,
+				"bulk insert columns for %s drifted from the schema",
+				tc.name,
+			)
+		})
+	}
+}
+
+// TestExecBulkInsert_PartialChunkWritesAllRows exercises the remainder path:
+// a row count that is not a multiple of batchChunkRows must still write every
+// row (full chunks via the stable statement, the tail via a one-off statement).
+func TestExecBulkInsert_PartialChunkWritesAllRows(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	// 2 full chunks of batchChunkRows + a partial remainder.
+	n := 2*batchChunkRows + batchChunkRows/2
+	items := make([]models.KeyWitness, n)
+	for i := range items {
+		items[i] = models.KeyWitness{
+			Vkey:          []byte{byte(i), byte(i >> 8)},
+			Signature:     []byte{0xFF},
+			TransactionID: uint(i + 1),
+			Type:          models.KeyWitnessTypeVkey,
+		}
+	}
+	require.NoError(t, insertKeyWitnesses(store.DB(), items))
+
+	var count int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.KeyWitness{}).Count(&count).Error,
+	)
+	assert.Equal(t, int64(n), count)
+
+	// Spot-check a row from the trailing remainder chunk round-trips intact.
+	last := n - 1
+	var row models.KeyWitness
+	require.NoError(
+		t,
+		store.DB().
+			Where("transaction_id = ?", uint(last+1)).
+			First(&row).Error,
+	)
+	assert.Equal(t, []byte{byte(last), byte(last >> 8)}, row.Vkey)
+}
+
+// TestInsertScripts_ConflictDoNothing confirms the ON CONFLICT(hash) DO NOTHING
+// semantics survive the GORM->fixed-shape conversion: re-inserting an existing
+// hash is a no-op that keeps the original row.
+func TestInsertScripts_ConflictDoNothing(t *testing.T) {
+	store := setupTestDBWithMode(t, "api")
+	hash := bytes.Repeat([]byte{0xAB}, 28)
+
+	require.NoError(t, insertScripts(store.DB(), []models.Script{{
+		Hash: hash, Content: []byte{0x01}, CreatedSlot: 10, Type: 1,
+	}}))
+	// Same hash, different content: must be ignored, not error or overwrite.
+	require.NoError(t, insertScripts(store.DB(), []models.Script{{
+		Hash: hash, Content: []byte{0x02}, CreatedSlot: 20, Type: 2,
+	}}))
+
+	var got []models.Script
+	require.NoError(t, store.DB().Where("hash = ?", hash).Find(&got).Error)
+	require.Len(t, got, 1)
+	assert.Equal(t, []byte{0x01}, got[0].Content)
+}
+
+func newBenchStore(b *testing.B) *MetadataStoreSqlite {
+	b.Helper()
+	store, err := NewWithOptions(WithStorageMode("api"))
+	require.NoError(b, err)
+	require.NoError(b, store.Start())
+	b.Cleanup(func() {
+		store.Close() //nolint:errcheck
+	})
+	return store
+}
+
+func benchKeyWitnessRows(n int) []models.KeyWitness {
+	items := make([]models.KeyWitness, n)
+	for i := range items {
+		items[i] = models.KeyWitness{
+			Vkey:          []byte{byte(i), byte(i >> 8), byte(i >> 16)},
+			Signature:     []byte{0x01, 0x02, 0x03, 0x04},
+			TransactionID: uint(i + 1),
+			Type:          models.KeyWitnessTypeVkey,
+		}
+	}
+	return items
+}
+
+// BenchmarkInsertKeyWitnesses measures the fixed-shape writer; pair with
+// BenchmarkInsertKeyWitnessesGORM to see the delta vs the prior CreateInBatches
+// path. key_witness has no unique constraint, so repeated inserts just append.
+func BenchmarkInsertKeyWitnesses(b *testing.B) {
+	store := newBenchStore(b)
+	rows := benchKeyWitnessRows(1000)
+	b.ResetTimer()
+	for range b.N {
+		if err := insertKeyWitnesses(store.DB(), rows); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkInsertKeyWitnessesGORM(b *testing.B) {
+	store := newBenchStore(b)
+	b.ResetTimer()
+	for range b.N {
+		// GORM mutates the slice's PKs on Create, so rebuild per iteration
+		// (untimed) to avoid re-inserting populated IDs.
+		b.StopTimer()
+		rows := benchKeyWitnessRows(1000)
+		b.StartTimer()
+		if err := store.DB().
+			CreateInBatches(rows, batchChunkRows).Error; err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -78,24 +78,27 @@ func importUtxosWithDB(
 		stripped[i].Assets = nil
 	}
 
-	// Insert UTxOs (without assets)
+	// Insert UTxOs (without assets) via fixed-shape SQL. A raw INSERT does
+	// not write back autoincrement IDs, so utxo IDs for asset linking are
+	// recovered below by BatchRefetchUtxoIDs (which handles all-zero IDs).
 	var hydrationCandidates []models.Utxo
 	for i := 0; i < len(stripped); i += importUtxoBatchSize {
 		end := min(i+importUtxoBatchSize, len(stripped))
 		batch := stripped[i:end]
-		result := db.Omit("Assets").Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "tx_id"},
-				{Name: "output_idx"},
-			},
-			DoNothing: true,
-		}).Create(&batch)
-		if result.Error != nil {
-			return fmt.Errorf("import utxos: %w", result.Error)
+		args := make([]any, 0, len(batch)*len(utxoCols))
+		for j := range batch {
+			args = appendUtxoRow(args, &batch[j])
+		}
+		sqlStr := buildBulkInsertSQL(
+			"utxo", utxoCols, utxoConflictClause, len(batch),
+		)
+		n, err := execRawOnConn(db, sqlStr, args)
+		if err != nil {
+			return fmt.Errorf("import utxos: %w", err)
 		}
 		// Only skipped inserts can correspond to snapshot-imported
 		// rows that still need provenance hydration.
-		if result.RowsAffected != int64(len(batch)) {
+		if n != int64(len(batch)) {
 			hydrationCandidates = append(
 				hydrationCandidates,
 				batch...,
@@ -142,18 +145,17 @@ func importUtxosWithDB(
 		for i := 0; i < len(assets); i += importAssetBatchSize {
 			end := min(i+importAssetBatchSize, len(assets))
 			batch := assets[i:end]
-			result := db.Clauses(clause.OnConflict{
-				Columns: []clause.Column{
-					{Name: "utxo_id"},
-					{Name: "policy_id"},
-					{Name: "name"},
-				},
-				DoNothing: true,
-			}).Create(&batch)
-			if result.Error != nil {
+			args := make([]any, 0, len(batch)*len(assetCols))
+			for j := range batch {
+				args = appendAssetRow(args, &batch[j])
+			}
+			sqlStr := buildBulkInsertSQL(
+				"asset", assetCols, assetConflictClause, len(batch),
+			)
+			if _, err := execRawOnConn(db, sqlStr, args); err != nil {
 				return fmt.Errorf(
 					"import utxo assets: %w",
-					result.Error,
+					err,
 				)
 			}
 		}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2486,25 +2486,47 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 	// Clear Outputs on tmpTx so the upsert doesn't try to create them.
 	tmpTx.Outputs = nil
 
-	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "hash"}},
-		DoUpdates: clause.AssignmentColumns(
-			[]string{"block_hash", "block_index", "slot"},
-		),
-	}).Create(tmpTx)
-	needsIdFetch := tmpTx.ID == 0
-
-	if result.Error != nil {
+	// Fixed-shape upsert. The common path is a single INSERT ... ON CONFLICT
+	// DO NOTHING RETURNING id: a returned id means a fresh insert. On conflict
+	// the row already exists (a retry), so preserve the prior DO UPDATE
+	// behavior on the mutable columns, refetch the id, and flag needsIdFetch so
+	// previously flushed child rows are deleted before re-insert.
+	insertSQL := buildBulkInsertSQL(
+		"transaction",
+		transactionCols,
+		`ON CONFLICT ("hash") DO NOTHING RETURNING id`,
+		1,
+	)
+	id, inserted, err := insertReturningID(
+		db, insertSQL, appendTransactionRow(nil, tmpTx),
+	)
+	if err != nil {
 		return fmt.Errorf(
 			"create transaction (batched) at slot %d, block %x, txHash %x, txIndex %d: %w",
 			point.Slot,
 			point.Hash,
 			txHash,
 			idx,
-			result.Error,
+			err,
 		)
 	}
-	if needsIdFetch {
+	needsIdFetch := !inserted
+	if inserted {
+		tmpTx.ID = id
+	} else {
+		if _, err := execRawOnConn(
+			db,
+			`UPDATE "transaction" SET "block_hash" = ?, "block_index" = ?, `+
+				`"slot" = ? WHERE "hash" = ?`,
+			[]any{tmpTx.BlockHash, tmpTx.BlockIndex, tmpTx.Slot, txHash},
+		); err != nil {
+			return fmt.Errorf(
+				"update existing transaction (batched) at slot %d, txHash %x: %w",
+				point.Slot,
+				txHash,
+				err,
+			)
+		}
 		var existing struct{ ID uint }
 		if err := db.Model(&models.Transaction{}).
 			Select("id").


### PR DESCRIPTION
## Summary

API-mode Mithril backfill is bottlenecked on the SQLite metadata **write** path, not block decode or CBOR offset extraction. The May 30 2026 profile around slot 11.6M showed `set_transaction_batched_ms` at 5.2–5.9s and `flush_batch_ms` at 3.6–5.0s per 10s interval — both dominated by GORM, which rebuilds statements (reflection, callback pipeline, dynamic clause construction) on every flush/tx.

This PR replaces the hottest write paths in the **sqlite** plugin with **fixed-shape SQL** (stable statement strings) executed on the transaction's raw `database/sql` conn pool, preserving every conflict/idempotency clause byte-for-byte. It continues the backfill hot-path work from #2459, reusing its `BackfillHotPathStats` counters as the success metric.

Closes #2458.

## Changes (phased, each independently testable)

1. **FlushBatch child-table writers** (`bulk_sql.go`, `batch_accumulator.go`): `key_witness`, `witness_scripts`, `script`, `plutus_data`, `redeemer`, `address_transaction` use a shared `execBulkInsert` (stable multi-row INSERT per chunk + a remainder statement) instead of GORM `CreateInBatches`.
2. **`importUtxosWithDB`** (`import.go`): utxo + asset inserts converted, preserving the asset-stripping and post-insert ID re-hydration (`BatchRefetchUtxoIDs` handles the all-zero IDs a raw INSERT leaves) and the hydration-candidate detection via rows-affected.
3. **`batchSpendUtxos`**: the per-chunk dynamic CASE UPDATE (whose shape changed with chunk size, defeating statement reuse) → a single stable per-row UPDATE, keeping the `deleted_slot = 0` idempotency guard.
4. **Per-tx transaction upsert** (`transaction.go`): `INSERT … ON CONFLICT(hash) DO NOTHING RETURNING id` on the common new-row path (one statement, no follow-up SELECT); the conflict/retry path keeps the prior DO UPDATE + refetch + `needsIdFetch` (stale-child delete) behavior.
5. **Benchmarks** quantifying the win.

## Why the raw conn pool

GORM's positional-var path (`db.Exec(sql, args...)`) expands a `[]byte` argument into **one bound value per byte** (e.g. a 28-byte hash → 28 values → "31 values for 4 columns"). Executing on `db.Statement.ConnPool` (the active transaction's pool) uses `database/sql`, which binds `[]byte` as a single blob — and, because the write pool runs with `PrepareStmt: true`, the stable statement strings are compiled once and reused. So no per-call model reflection *and* prepared-statement reuse.

## Invariants preserved

- All `ON CONFLICT … DO NOTHING` targets kept verbatim; delete-first retry semantics for the no-conflict child tables kept; `deleted_slot = 0` spend guard kept (relied on by resumed backfill and #2459's create-before-spend flush ordering).
- Asset ID re-hydration and provenance hydration unchanged. `types.Uint64`'s `Value()` (decimal string) keeps `amount`/`fee`/`ttl` storage byte-identical to GORM.
- A schema-guard test pins every hand-written column list to the GORM-migrated schema, so a model change or naming surprise (e.g. `ex_units_cpu`) fails a test rather than silently writing the wrong columns.
- Non-SQLite backends (postgres/mysql) untouched.

## Benchmarks (fixed-shape vs prior GORM `CreateInBatches`, `-benchmem`)

| Writer | Fixed-shape | GORM | Delta |
|---|---|---|---|
| key_witness (1000 rows) | 13.8ms · 3.6k allocs/op | 20.3ms · 17.4k allocs/op | ~32% faster, 4.8× fewer allocs |
| utxo (500 rows) | 50.7ms · 3.8k allocs/op | 54.6ms · 13.4k allocs/op | ~7% faster, 3.5× fewer allocs |

Wall-clock win scales inversely with row width (SQLite I/O dominates the heavy utxo rows); the 3.5–4.8× allocation reduction is the consistent signal and compounds under real-backfill GC pressure. Real-world before/after is the #2449 `set_transaction_batched_ms` / `flush_batch_ms` counters.

## Testing

- `go test ./database/plugin/metadata/sqlite/...` and `go test -race ./database/plugin/metadata/sqlite/` — pass (race run per phase).
- `go test ./database/...` integration (mithril/gap/import/flush/inflight/rollback) — pass; the #2459 two-pass test exercises the transaction-upsert retry path.
- conformance (`internal/test/conformance`) — pass.
- golangci-lint 0 issues; modernize clean.
- New focused tests: schema guard (all converted tables), utxo round-trip (catches column-order drift the set-based guard can't), conflict-idempotency for utxo/script, and the spend `deleted_slot = 0` guard.

## Documentation

`DATABASE.md` / `ARCHITECTURE.md` checked — **not affected**. This is an internal write-mechanics optimization: schema, the documented `ON CONFLICT` unique keys, the `MetadataStore` API surface, blob layout, CBOR/offset encodings, and pruning are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up API-mode backfill on SQLite by replacing GORM-built writes with fixed-shape SQL executed on the transaction’s raw connection pool, reducing allocations 3.5–4.8x and improving hot-path latency up to ~32%. Preserves all conflict/idempotency behavior and adds guards/tests; addresses #2458.

- **Refactors**
  - Replaced GORM batch inserts with shared fixed-shape multi-row INSERTs for key child tables: key_witness, witness_scripts, script, plutus_data, redeemer, address_transaction.
  - Converted UTxO and asset inserts in importUtxosWithDB to fixed-shape INSERTs; keeps ON CONFLICT targets, asset ID re-hydration, and hydration-candidate detection.
  - Switched batchSpendUtxos to a stable per-row UPDATE with the deleted_slot = 0 guard.
  - Updated transaction upsert to INSERT … ON CONFLICT(hash) DO NOTHING RETURNING id; conflict path performs targeted UPDATE and id refetch.
  - Added schema-guard and round-trip tests plus benchmarks; no schema or API changes, and non-SQLite backends are untouched.

<sup>Written for commit 40dd684e36486409e6c9e7ef7643afaeabf59a99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance & Optimization**
  * Refactored database bulk insert operations to improve transaction and UTxO processing performance.
  * Enhanced conflict-handling mechanisms to prevent duplicate data insertion.

* **Tests**
  * Added comprehensive test suite and benchmarks validating bulk insert operations and data integrity across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->