### PR TITLE
feat(logging): selectable text/json log output via logging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ The following environment variables modify Dingo's behavior:
   - API servers (Blockfrost, UTxO RPC, Mesh) require `api` mode
 - `DINGO_RUN_MODE`
   - Run mode: `serve` (full node, default), `load` (batch import), `dev` (development mode), or `leios` (experimental Leios protocol support)
+- `DINGO_LOGGING_FORMAT`
+  - Log output format: `text` (default, human-readable) or `json` (machine-parseable, for ELK/Loki ingestion)
+- `DINGO_LOGGING_LEVEL`
+  - Minimum log level: `debug`, `info` (default), `warn`, or `error` (the `--debug` flag overrides this to `debug`)
 - `TLS_CERT_FILE_PATH` - SSL certificate to use, requires `TLS_KEY_FILE_PATH`
     (default: empty)
 - `TLS_KEY_FILE_PATH` - SSL certificate key to use (default: empty)

--- a/cmd/dingo/load.go
+++ b/cmd/dingo/load.go
@@ -39,7 +39,7 @@ func loadRun(ctx context.Context, args []string, cfg *config.Config) {
 		os.Exit(1)
 	}
 
-	logger := commonRun()
+	logger := commonRun(cfg)
 	if err := node.Load(ctx, cfg, logger, immutablePath); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)

--- a/cmd/dingo/logging_test.go
+++ b/cmd/dingo/logging_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLogger_JSONFormatProducesValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	logger, levelOK, formatOK := newLogger(&buf, "json", "info", false)
+	require.True(t, levelOK)
+	require.True(t, formatOK)
+
+	logger.Info("hello", "component", "test", "k", "v")
+
+	line := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, line)
+	require.True(t, json.Valid([]byte(line)), "expected valid JSON, got: %s", line)
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &rec))
+	assert.Equal(t, "hello", rec["msg"])
+	assert.Equal(t, "test", rec["component"])
+}
+
+func TestNewLogger_TextFormatIsNotJSON(t *testing.T) {
+	var buf bytes.Buffer
+	logger, _, formatOK := newLogger(&buf, "text", "info", false)
+	require.True(t, formatOK)
+
+	logger.Info("hello", "component", "test")
+
+	line := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, line)
+	assert.False(
+		t, json.Valid([]byte(line)),
+		"text output should not be valid JSON: %s", line,
+	)
+	assert.Contains(t, line, "component=test")
+}
+
+func TestNewLogger_EmptyFormatDefaultsToText(t *testing.T) {
+	var buf bytes.Buffer
+	logger, _, formatOK := newLogger(&buf, "", "info", false)
+	require.True(t, formatOK)
+
+	logger.Info("hello")
+	assert.False(t, json.Valid(bytes.TrimSpace(buf.Bytes())))
+}
+
+func TestNewLogger_UnknownFormatFallsBackToTextAndReportsNotOK(t *testing.T) {
+	var buf bytes.Buffer
+	logger, _, formatOK := newLogger(&buf, "xml", "info", false)
+	assert.False(t, formatOK)
+
+	logger.Info("hello")
+	assert.False(t, json.Valid(bytes.TrimSpace(buf.Bytes())))
+}
+
+func TestNewLogger_LevelFiltersBelowThreshold(t *testing.T) {
+	var buf bytes.Buffer
+	logger, levelOK, _ := newLogger(&buf, "text", "warn", false)
+	require.True(t, levelOK)
+
+	logger.Info("info-msg")
+	logger.Warn("warn-msg")
+
+	out := buf.String()
+	assert.NotContains(t, out, "info-msg")
+	assert.Contains(t, out, "warn-msg")
+}
+
+func TestNewLogger_UnknownLevelReportsNotOKAndUsesInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger, levelOK, _ := newLogger(&buf, "text", "bogus", false)
+	assert.False(t, levelOK)
+
+	logger.Debug("debug-msg") // below info => suppressed
+	logger.Info("info-msg")
+	out := buf.String()
+	assert.NotContains(t, out, "debug-msg")
+	assert.Contains(t, out, "info-msg")
+}
+
+func TestNewLogger_DebugFlagOverridesLevel(t *testing.T) {
+	var buf bytes.Buffer
+	// level=error, but --debug must force debug level.
+	logger, _, _ := newLogger(&buf, "text", "error", true)
+
+	logger.Debug("debug-msg")
+	assert.Contains(t, buf.String(), "debug-msg")
+}
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   slog.Level
+		wantOK bool
+	}{
+		{"debug", slog.LevelDebug, true},
+		{"info", slog.LevelInfo, true},
+		{"", slog.LevelInfo, true},
+		{"WARN", slog.LevelWarn, true},
+		{"warning", slog.LevelWarn, true},
+		{"error", slog.LevelError, true},
+		{"bogus", slog.LevelInfo, false},
+	}
+	for _, c := range cases {
+		got, ok := parseLogLevel(c.in)
+		assert.Equalf(t, c.want, got, "level %q", c.in)
+		assert.Equalf(t, c.wantOK, ok, "ok %q", c.in)
+	}
+}

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -46,21 +47,31 @@ var (
 	configFile string
 )
 
-func commonRun() *slog.Logger {
-	// Configure logger
-	logLevel := slog.LevelInfo
-	addSource := false
-	if globalFlags.debug {
-		logLevel = slog.LevelDebug
-		addSource = true
-	}
-	logger := slog.New(
-		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-			AddSource: addSource,
-			Level:     logLevel,
-		}),
+func commonRun(cfg *config.Config) *slog.Logger {
+	// Configure logger from config. The --debug flag is the highest-precedence
+	// override (CLI > env > YAML > defaults): it forces debug level and source
+	// locations regardless of the configured level.
+	logger, levelOK, formatOK := newLogger(
+		os.Stdout,
+		cfg.Logging.Format,
+		cfg.Logging.Level,
+		globalFlags.debug,
 	)
 	slog.SetDefault(logger)
+	if !levelOK {
+		logger.Warn(
+			"unknown logging level, using info",
+			"component", programName,
+			"level", cfg.Logging.Level,
+		)
+	}
+	if !formatOK {
+		logger.Warn(
+			"unknown logging format, using text",
+			"component", programName,
+			"format", cfg.Logging.Format,
+		)
+	}
 	// Configure max processes with our logger wrapper, toss undo func
 	_, err := maxprocs.Set(maxprocs.Logger(slogPrintf))
 	if err != nil {
@@ -73,6 +84,54 @@ func commonRun() *slog.Logger {
 		"component", programName,
 	)
 	return logger
+}
+
+// newLogger builds a slog.Logger writing to w. format selects the handler
+// ("json" for JSON, anything else for text); level sets the minimum level;
+// debug forces debug level and source locations. The two bools report whether
+// level/format were recognized so the caller can warn on unknown values.
+func newLogger(
+	w io.Writer,
+	format, level string,
+	debug bool,
+) (*slog.Logger, bool, bool) {
+	logLevel, levelOK := parseLogLevel(level)
+	addSource := false
+	if debug {
+		logLevel = slog.LevelDebug
+		addSource = true
+	}
+	opts := &slog.HandlerOptions{
+		AddSource: addSource,
+		Level:     logLevel,
+	}
+	f := strings.ToLower(strings.TrimSpace(format))
+	formatOK := f == "" || f == "text" || f == "json"
+	var handler slog.Handler
+	if f == "json" {
+		handler = slog.NewJSONHandler(w, opts)
+	} else {
+		handler = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(handler), levelOK, formatOK
+}
+
+// parseLogLevel maps a config level string to a slog.Level. It returns
+// ok=false for an unrecognized value so the caller can warn; an empty value
+// is treated as the default ("info").
+func parseLogLevel(level string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug, true
+	case "", "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
 }
 
 func listPlugins(

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -58,18 +58,21 @@ func commonRun(cfg *config.Config) *slog.Logger {
 		globalFlags.debug,
 	)
 	slog.SetDefault(logger)
+	// Config-validation warnings go to stderr, not the logger: a high
+	// configured level (e.g. error) would otherwise suppress them, leaving the
+	// operator with no feedback that their value was ignored.
 	if !levelOK {
-		logger.Warn(
-			"unknown logging level, using info",
-			"component", programName,
-			"level", cfg.Logging.Level,
+		fmt.Fprintf(
+			os.Stderr,
+			"%s: unknown logging level %q, using info\n",
+			programName, cfg.Logging.Level,
 		)
 	}
 	if !formatOK {
-		logger.Warn(
-			"unknown logging format, using text",
-			"component", programName,
-			"format", cfg.Logging.Format,
+		fmt.Fprintf(
+			os.Stderr,
+			"%s: unknown logging format %q, using text\n",
+			programName, cfg.Logging.Format,
 		)
 	}
 	// Configure max processes with our logger wrapper, toss undo func

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -258,7 +258,7 @@ func mithrilSyncRunE(
 	if cfg == nil {
 		return errors.New("no config found in context")
 	}
-	logger := commonRun()
+	logger := commonRun(cfg)
 	network := cfg.Network
 	if network == "" {
 		network = "preview"

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -32,7 +32,7 @@ import (
 func serveRun(
 	cmd *cobra.Command, _ []string, cfg *config.Config,
 ) {
-	logger := commonRun()
+	logger := commonRun(cfg)
 
 	// Check for an in-progress sync. If the "sync_status" key in
 	// the sync_state table holds a non-empty value, a previous sync

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -119,6 +119,16 @@ socketPath: "dingo.socket"
 # CLI: --network
 network: "preview"
 
+# Logging output configuration
+# format: "text" (default, human-readable) or "json" (machine-parseable,
+#         for ELK/Loki ingestion)
+# level:  "debug", "info" (default), "warn", or "error".
+#         The --debug flag overrides this to "debug".
+# Env: DINGO_LOGGING_FORMAT, DINGO_LOGGING_LEVEL
+logging:
+  format: text
+  level: info
+
 # TLS certificate file path (for HTTPS)
 #
 # Can be overridden with the TLS_CERT_FILE_PATH environment variable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,6 +202,24 @@ func DefaultCacheConfig() CacheConfig {
 	}
 }
 
+// LoggingConfig holds log output configuration.
+type LoggingConfig struct {
+	// Format selects the log output handler: "text" (default) or "json".
+	// JSON is intended for machine-parseable ingestion (ELK/Loki).
+	Format string `yaml:"format" envconfig:"DINGO_LOGGING_FORMAT"`
+	// Level is the minimum log level: "debug", "info" (default), "warn",
+	// or "error". The --debug flag, when set, overrides this to "debug".
+	Level string `yaml:"level"  envconfig:"DINGO_LOGGING_LEVEL"`
+}
+
+// DefaultLoggingConfig returns the default logging configuration.
+func DefaultLoggingConfig() LoggingConfig {
+	return LoggingConfig{
+		Format: "text",
+		Level:  "info",
+	}
+}
+
 type Config struct {
 	MetadataPlugin       string        `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
 	TlsKeyFilePath       string        `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
@@ -270,6 +288,9 @@ type Config struct {
 
 	// Genesis bootstrap configuration for from-origin chain selection.
 	GenesisBootstrap GenesisBootstrapConfig `yaml:"genesisBootstrap"`
+
+	// Logging configuration (output format and level)
+	Logging LoggingConfig `yaml:"logging"`
 
 	// KES (Key Evolving Signature) configuration for block production
 	// SlotsPerKESPeriod is the number of slots in a KES period.
@@ -447,6 +468,8 @@ var globalConfig = &Config{
 	Chainsync: DefaultChainsyncConfig(),
 	// Genesis bootstrap defaults
 	GenesisBootstrap: DefaultGenesisBootstrapConfig(),
+	// Logging defaults (text output at info level)
+	Logging: DefaultLoggingConfig(),
 	// KES configuration defaults (mainnet values)
 	SlotsPerKESPeriod: 129600, // 1.5 days at 1 second per slot
 	MaxKESEvolutions:  62,     // 2^6 - 2 for KES depth 6

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -49,8 +49,8 @@ var flagSpecs = []flagSpec{
 	stringFlag("DatabasePath", "data-dir", "", "data directory for all storage plugins (overrides CARDANO_DATABASE_PATH)"),
 	stringFlag("BindAddr", "bind-addr", "", "public bind address"),
 	stringFlag("SocketPath", "socket-path", "", "path to UNIX socket file"),
-	transformStringFlag("RunMode", "run-mode", "", "run mode: serve, load, dev, or leios", normalizeRunMode),
-	transformStringFlag("StorageMode", "storage-mode", "", `storage mode: "core" (minimal) or "api" (full indexing)`, normalizeStorageMode),
+	transformStringFlag("RunMode", "run-mode", "run mode: serve, load, dev, or leios", normalizeRunMode),
+	transformStringFlag("StorageMode", "storage-mode", `storage mode: "core" (minimal) or "api" (full indexing)`, normalizeStorageMode),
 	stringFlag("CardanoConfig", "cardano-config", "", "path to Cardano config file"),
 	stringFlag("Topology", "topology", "", "path to topology file"),
 	stringFlag("ShutdownTimeout", "shutdown-timeout", "", "graceful shutdown timeout"),
@@ -125,8 +125,8 @@ var flagSpecs = []flagSpec{
 	intFlag("GenesisBootstrap.PromotionMinDiversityGroups", "genesis-bootstrap-promotion-min-diversity-groups", "minimum diversity groups preferred during Genesis bootstrap peer promotion"),
 
 	// Logging
-	stringFlag("Logging.Format", "logging-format", "", "log output format: text (default) or json"),
-	stringFlag("Logging.Level", "logging-level", "", "log level: debug, info (default), warn, or error"),
+	transformStringFlag("Logging.Format", "logging-format", "log output format: text (default) or json", normalizeLoggingValue),
+	transformStringFlag("Logging.Level", "logging-level", "log level: debug, info (default), warn, or error", normalizeLoggingValue),
 
 	// Database workers and API backfill
 	intFlag("DatabaseWorkers", "db-workers", "database worker pool worker count"),
@@ -264,10 +264,10 @@ func validatedStringFlag(
 // transformStringFlag normalizes the parsed value (e.g. lowercasing)
 // and may reject it; the transformed value is stored.
 func transformStringFlag(
-	field, name, shorthand, help string,
+	field, name, help string,
 	transform func(string) (string, error),
 ) flagSpec {
-	s := stringFlag(field, name, shorthand, help)
+	s := stringFlag(field, name, "", help)
 	s.apply = func(f *pflag.FlagSet, cfg *Config) error {
 		if !f.Changed(name) {
 			return nil
@@ -509,4 +509,12 @@ func normalizeStorageMode(v string) (string, error) {
 			v, storageModeCore, storageModeAPI,
 		)
 	}
+}
+
+// normalizeLoggingValue lower-cases a logging format/level flag so values are
+// accepted case-insensitively (e.g. --logging-format=JSON). It does not
+// validate: unknown values are handled by the logger's warn-and-fallback path,
+// keeping flag, env, and YAML behavior identical.
+func normalizeLoggingValue(v string) (string, error) {
+	return strings.ToLower(strings.TrimSpace(v)), nil
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -124,6 +124,10 @@ var flagSpecs = []flagSpec{
 	uint64Flag("GenesisBootstrap.WindowSlots", "genesis-bootstrap-window-slots", "Genesis density comparison window in slots (0 derives from Shelley genesis 3k/f)"),
 	intFlag("GenesisBootstrap.PromotionMinDiversityGroups", "genesis-bootstrap-promotion-min-diversity-groups", "minimum diversity groups preferred during Genesis bootstrap peer promotion"),
 
+	// Logging
+	stringFlag("Logging.Format", "logging-format", "", "log output format: text (default) or json"),
+	stringFlag("Logging.Level", "logging-level", "", "log level: debug, info (default), warn, or error"),
+
 	// Database workers and API backfill
 	intFlag("DatabaseWorkers", "db-workers", "database worker pool worker count"),
 	intFlag("DatabaseQueueSize", "db-queue-size", "database worker pool task queue size"),

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -52,6 +52,13 @@ func TestLoad_LoggingEnvVars(t *testing.T) {
 func TestLoad_LoggingFromYAML(t *testing.T) {
 	resetGlobalConfig()
 	t.Setenv("HOME", t.TempDir())
+	// Ensure a developer's exported DINGO_LOGGING_* env vars cannot override
+	// the YAML values under test. t.Setenv records the originals for restore;
+	// os.Unsetenv then removes them for the duration of the test.
+	t.Setenv("DINGO_LOGGING_FORMAT", "")
+	os.Unsetenv("DINGO_LOGGING_FORMAT")
+	t.Setenv("DINGO_LOGGING_LEVEL", "")
+	os.Unsetenv("DINGO_LOGGING_LEVEL")
 
 	yamlContent := "logging:\n  format: json\n  level: error\n"
 	tmpFile := filepath.Join(t.TempDir(), "dingo.yaml")

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultLoggingConfig(t *testing.T) {
+	d := DefaultLoggingConfig()
+	if d.Format != "text" {
+		t.Errorf("default Format = %q, want text", d.Format)
+	}
+	if d.Level != "info" {
+		t.Errorf("default Level = %q, want info", d.Level)
+	}
+}
+
+func TestLoad_LoggingEnvVars(t *testing.T) {
+	resetGlobalConfig()
+	// Avoid picking up a real ~/.dingo/dingo.yaml on the dev machine.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_LOGGING_FORMAT", "json")
+	t.Setenv("DINGO_LOGGING_LEVEL", "warn")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Logging.Format != "json" {
+		t.Errorf("Logging.Format = %q, want json", cfg.Logging.Format)
+	}
+	if cfg.Logging.Level != "warn" {
+		t.Errorf("Logging.Level = %q, want warn", cfg.Logging.Level)
+	}
+}
+
+func TestLoad_LoggingFromYAML(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+
+	yamlContent := "logging:\n  format: json\n  level: error\n"
+	tmpFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Logging.Format != "json" {
+		t.Errorf("Logging.Format = %q, want json", cfg.Logging.Format)
+	}
+	if cfg.Logging.Level != "error" {
+		t.Errorf("Logging.Level = %q, want error", cfg.Logging.Level)
+	}
+}


### PR DESCRIPTION
## Summary

SPOs running ELK/Loki need machine-parseable logs. Dingo already uses `slog` throughout, but `cmd/dingo/main.go:commonRun()` hardcoded a JSON handler with the level driven only by the `--debug` flag — no way to pick a format and no config-driven level. This adds `logging.format` (`text` | `json`) and `logging.level` (`debug|info|warn|error`) config, with matching env vars and CLI flags, and wires `commonRun` to honor them.

Closes #1647.

## ⚠️ Behavior change

The default output format is now **text**. Previously `commonRun` always used `slog.NewJSONHandler`, so JSON was the de-facto default. **Anything parsing dingo's stdout as JSON must now set `logging.format: json`** (or `DINGO_LOGGING_FORMAT=json`, or `--logging-format json`). This was a deliberate choice to match the issue; flagging it here for release notes.

## Changes

- **`internal/config`**: new `LoggingConfig{Format, Level}` sub-struct (mirrors `CacheConfig`/`ChainsyncConfig`) with yaml tag `logging` and `envconfig:"DINGO_LOGGING_FORMAT"` / `DINGO_LOGGING_LEVEL`; `DefaultLoggingConfig()` → `text`/`info`; wired into `Config` and the `globalConfig` defaults.
- **CLI flags**: `--logging-format` / `--logging-level` added to `flagSpecs` (also required by the flag-coverage test), giving full CLI > env > YAML > defaults precedence.
- **`cmd/dingo`**: `commonRun(cfg)` now builds the handler from config via a testable `newLogger(io.Writer, format, level, debug)` helper + `parseLogLevel`. Text vs JSON is selected by format; unknown values warn and fall back (text / info). `--debug` remains the highest-precedence override (forces debug level + `AddSource`). Updated the three call sites (`serve.go`, `load.go`, `mithril.go`).
- **Component keys**: the issue's "add `component` to all loggers" is already satisfied (~500 existing `slog.With("component", …)` sites; `node.go` tags subsystem loggers; the only production `slog.New` is `commonRun`). No churn.
- **Docs**: documented `logging:` block in `dingo.yaml.example`; `DINGO_LOGGING_FORMAT` / `DINGO_LOGGING_LEVEL` added to the README env-var list.

## Testing

- `go test ./internal/config/... ./cmd/dingo/...` — pass. New tests: `newLogger` JSON output passes `encoding/json.Valid`, text output does not; level filtering; `--debug` overrides level; `parseLogLevel` table; config load of `logging` from env and YAML; `DefaultLoggingConfig`. Existing flag-coverage and full-struct config tests still pass.
- `go build ./...`, conformance (`internal/test/conformance`) — pass.
- golangci-lint 0 issues; modernize clean for the changed files.

## Documentation

`DATABASE.md` / `ARCHITECTURE.md` checked — **not affected** (logger construction + a config field; no schema, component-boundary, EventBus, or lifecycle change). `dingo.yaml.example` and README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable logging output and level with support for both text and JSON, and switches the default format to text. This fulfills #1647 and improves CLI consistency and warning visibility.

- **New Features**
  - Added `logging.format` (`text` | `json`) and `logging.level` (`debug|info|warn|error`) config, env vars `DINGO_LOGGING_FORMAT`/`DINGO_LOGGING_LEVEL`, and CLI flags `--logging-format`/`--logging-level` (case-insensitive).
  - `commonRun(cfg)` now builds the logger via `newLogger(...)`; CLI > env > YAML > defaults. `--debug` still forces debug level and adds source.
  - Unknown format/level now warn to stderr and fall back to `text`/`info`.
  - Tests cover JSON vs text output, level filtering, `--debug` override, and config loading. Docs and `dingo.yaml.example` updated.

- **Migration**
  - Default logs are now text. If you ingest JSON, set one of:
    - YAML: `logging.format: json`
    - Env: `DINGO_LOGGING_FORMAT=json`
    - CLI: `--logging-format json`

<sup>Written for commit 6edeb2ca3d79861ecc82a86508d74ec407624e50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable logging system with format (text/json) and level (debug/info/warn/error) options
  * Settings can be configured via environment variables, YAML config file, or CLI flags (--logging-format, --logging-level)
  * Debug flag overrides the configured logging level

<!-- end of auto-generated comment: release notes by coderabbit.ai -->