### PR TITLE
perf(database): Make badger compression level configurable

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -271,6 +271,7 @@ type BlobStoreBadger struct {
 	valueThreshold       int64
 	compactBlockMetadata bool
 	compressionEnabled   bool
+	compressionLevel     int
 	gcEnabled            bool
 	deferOpen            bool // when true, Badger is opened in Start() not New()
 }
@@ -282,7 +283,8 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 	db := &BlobStoreBadger{
 		// Set defaults
 		gcEnabled:          true, // Enable GC by default for disk-backed stores
-		compressionEnabled: true, // Snappy compression by default
+		compressionEnabled: true, // ZSTD compression by default
+		compressionLevel:   DefaultCompressionLevel,
 		blockCacheSize:     DefaultBlockCacheSize,
 		indexCacheSize:     DefaultIndexCacheSize,
 		valueLogFileSize:   int64(DefaultValueLogFileSize),
@@ -315,7 +317,8 @@ func (db *BlobStoreBadger) open() error {
 			WithLoggingLevel(badger.WARNING).
 			WithInMemory(true).
 			WithValueThreshold(db.valueThreshold).
-			WithCompression(db.badgerCompression())
+			WithCompression(db.badgerCompression()).
+			WithZSTDCompressionLevel(db.compressionLevel)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
 			return fmt.Errorf("badger open in-memory: %w", err)
@@ -343,7 +346,8 @@ func (db *BlobStoreBadger) open() error {
 			WithValueLogFileSize(db.valueLogFileSize).
 			WithMemTableSize(db.memTableSize).
 			WithValueThreshold(db.valueThreshold).
-			WithCompression(db.badgerCompression())
+			WithCompression(db.badgerCompression()).
+			WithZSTDCompressionLevel(db.compressionLevel)
 		blobDb, err = badger.Open(badgerOpts)
 		if err != nil {
 			return fmt.Errorf("badger open on-disk: %w", err)
@@ -367,7 +371,7 @@ func (db *BlobStoreBadger) open() error {
 
 func (db *BlobStoreBadger) badgerCompression() options.CompressionType {
 	if db.compressionEnabled {
-		return options.Snappy
+		return options.ZSTD
 	}
 	return options.None
 }

--- a/database/plugin/blob/badger/options.go
+++ b/database/plugin/blob/badger/options.go
@@ -94,11 +94,20 @@ func WithCompactBlockMetadata(enabled bool) BlobStoreBadgerOptionFunc {
 	}
 }
 
-// WithCompressionEnabled controls Snappy compression of SSTable blocks.
+// WithCompressionEnabled controls ZSTD compression of SSTable blocks.
 // Disabling compression allows block cache size 0 (pure mmap).
 func WithCompressionEnabled(enabled bool) BlobStoreBadgerOptionFunc {
 	return func(b *BlobStoreBadger) {
 		b.compressionEnabled = enabled
+	}
+}
+
+// WithCompressionLevel sets the ZSTD compression level used when compression
+// is enabled. Higher levels yield better compression ratios at the cost of
+// throughput. Has no effect when compression is disabled.
+func WithCompressionLevel(level int) BlobStoreBadgerOptionFunc {
+	return func(b *BlobStoreBadger) {
+		b.compressionLevel = level
 	}
 }
 

--- a/database/plugin/blob/badger/options_test.go
+++ b/database/plugin/blob/badger/options_test.go
@@ -358,6 +358,62 @@ func TestNewFromCmdlineOptionsPreservesExplicitCompressionDisableInAPIStorageMod
 	}
 }
 
+func TestNewFromCmdlineOptionsCompressionLevelDefault(t *testing.T) {
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+
+	p := NewFromCmdlineOptions()
+	b, ok := p.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if b.compressionLevel != DefaultCompressionLevel {
+		t.Fatalf(
+			"compressionLevel: want default %d, got %d",
+			DefaultCompressionLevel,
+			b.compressionLevel,
+		)
+	}
+}
+
+func TestNewFromCmdlineOptionsCompressionLevelOverride(t *testing.T) {
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+
+	if err := plugin.ProcessConfig(map[string]map[string]map[string]any{
+		"blob": {
+			"badger": {
+				"compression-level": uint64(7),
+			},
+		},
+	}); err != nil {
+		t.Fatalf("process plugin config: %v", err)
+	}
+
+	p := NewFromCmdlineOptions()
+	b, ok := p.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if b.compressionLevel != 7 {
+		t.Fatalf("compressionLevel: want explicit override 7, got %d", b.compressionLevel)
+	}
+}
+
 func TestNewFromCmdlineOptionsDoesNotMutateGlobals(t *testing.T) {
 	cmdlineOptionsMutex.Lock()
 	saved := cmdlineOptions

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -43,6 +43,10 @@ const (
 	DefaultAPIBlockCacheSize      = DefaultBlockCacheSize
 	DefaultAPIIndexCacheSize      = DefaultIndexCacheSize
 	DefaultAPICompressionEnabled  = true
+	// DefaultCompressionLevel is the ZSTD compression level used when
+	// compression is enabled. Badger recommends level 1, which gives a good
+	// compression ratio without the throughput penalty of higher levels.
+	DefaultCompressionLevel = 1
 )
 
 var (
@@ -57,6 +61,7 @@ var (
 		valueThreshold        uint64
 		gcEnabled             bool
 		compressionEnabled    bool
+		compressionLevel      uint64
 		blockCacheSizeSet     bool
 		indexCacheSizeSet     bool
 		compressionEnabledSet bool
@@ -115,6 +120,7 @@ func initCmdlineOptions() {
 	cmdlineOptions.storageMode = "core"
 	cmdlineOptions.gcEnabled = true
 	cmdlineOptions.compressionEnabled = DefaultCoreCompressionEnabled
+	cmdlineOptions.compressionLevel = DefaultCompressionLevel
 	cmdlineOptions.blockCacheSizeSet = false
 	cmdlineOptions.indexCacheSizeSet = false
 	cmdlineOptions.compressionEnabledSet = false
@@ -199,10 +205,17 @@ func init() {
 				{
 					Name:         "compression",
 					Type:         plugin.PluginOptionTypeBool,
-					Description:  "Enable Snappy compression (runtime default: false in core mode, true in api mode)",
+					Description:  "Enable ZSTD compression (runtime default: false in core mode, true in api mode)",
 					DefaultValue: DefaultCoreCompressionEnabled,
 					Dest:         &(cmdlineOptions.compressionEnabled),
 					SetIndicator: &(cmdlineOptions.compressionEnabledSet),
+				},
+				{
+					Name:         "compression-level",
+					Type:         plugin.PluginOptionTypeUint,
+					Description:  "ZSTD compression level used when compression is enabled (higher = better ratio, slower)",
+					DefaultValue: uint64(DefaultCompressionLevel),
+					Dest:         &(cmdlineOptions.compressionLevel),
 				},
 			},
 		},
@@ -237,6 +250,10 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		cmdlineOptions.valueThreshold,
 		uint64(math.MaxInt64),
 	)
+	compressionLevel := min(
+		cmdlineOptions.compressionLevel,
+		uint64(math.MaxInt),
+	)
 	// #nosec G115
 	opts := []BlobStoreBadgerOptionFunc{
 		WithDataDir(cmdlineOptions.dataDir),
@@ -253,6 +270,7 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		WithValueThreshold(int64(valueThreshold)),
 		WithGc(cmdlineOptions.gcEnabled),
 		WithCompressionEnabled(compressionEnabled),
+		WithCompressionLevel(int(compressionLevel)),
 		WithDeferOpen(),
 	}
 	cmdlineOptionsMutex.Unlock()

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -38,11 +38,15 @@ database:
       # index-cache-size: 0
       # Enable garbage collection (default: true)
       gc: true
-      # Enable Snappy compression.
+      # Enable ZSTD compression.
       # Leave unset to use the storage-mode default:
       # - false when storageMode: "core"
       # - true when storageMode: "api"
       # compression: false
+      # ZSTD compression level used when compression is enabled.
+      # Higher levels give a better compression ratio at the cost of
+      # throughput. Badger recommends level 1 (default).
+      # compression-level: 1
     gcs:
       # Google Cloud Storage bucket name
       bucket: ""


### PR DESCRIPTION
Closes #565 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `badger` SSTable compression level configurable and switch the default compression to ZSTD (level 1). This gives better control over throughput vs. disk usage.

- **New Features**
  - Adds `compression-level` option for the `blob/badger` plugin (config/CLI); ignored if compression is disabled.
  - Sets ZSTD as the default compression type and default level to 1; compression defaults remain false in core mode and true in api mode.
  - Passes level through to `badger` via `WithZSTDCompressionLevel`; replaces Snappy with ZSTD in `options`.
  - Updates `dingo.yaml.example` and adds tests for default and override behavior.

<sup>Written for commit 43a0aa819a56d1c6aed71e3caa6e9031ecd280f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable compression level option for blob storage, allowing users to balance compression efficiency against performance.

* **Improvements**
  * Blob storage compression now uses updated compression algorithms with a default compression level of 1.

* **Documentation**
  * Updated configuration examples to document the new compression level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->