### PR TITLE
feat(ouroboros): leios vote diffusion mini-protocol and RB integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last reviewed: 2026-05-29
+Last reviewed: 2026-06-04
 
 Dingo is a high-performance Cardano blockchain node implementation in Go. This document describes its architecture, core components, and design patterns.
 
@@ -843,7 +843,7 @@ The `ledger/eras/` package provides era-specific validation rules for each Carda
 
 Era transitions run the target era's `HardForkFunc` to translate protocol parameters before persisting the new pparams. Transitions can also rewrite ratified-but-not-yet-enacted governance action payloads into the target era's CBOR shape; the Conway to Dijkstra path translates parameter-change proposals so the Dijkstra enactment update function receives `DijkstraProtocolParameterUpdate` rather than a stale Conway update.
 
-When the Dijkstra/Leios gate is active, `node.go` also enables the experimental N2N Leios protocols. `ouroboros/` registers LeiosFetch, LeiosNotify, and the scaffolded LeiosVotes mini-protocol; vote generation/storage is not implemented yet, so LeiosVotes can receive/log votes but returns an explicit unavailable error when peers request locally generated votes.
+When the Dijkstra/Leios gate is active, `node.go` also enables the experimental N2N Leios protocols. `ouroboros/` registers LeiosFetch, LeiosNotify, and LeiosVotes. LeiosNotify/LeiosFetch cache endorser-block material in-memory, and LeiosVotes caches received vote messages in-memory with TTL/dedupe so peers can pull vote diffusion data through LeiosVotes or targeted LeiosFetch vote requests. LeiosVotes pull requests remain outstanding while the in-memory vote cache is empty and complete when new vote material arrives or the protocol shuts down, so an empty relay cache is not treated as a mini-protocol error. Local vote generation, durable vote storage, EB certificate aggregation, and RB certificate embedding are still gated by the current gouroboros/Dijkstra certificate shape, where the generated Leios certificate slot remains a placeholder.
 
 During accepted block replay, Alonzo-and-newer validation runs the UTXO/Phase 1 rule set and keeps declared ExUnit limit checks. Plutus Phase 2 execution is skipped only for blocks at or before the immutable tip (`tipBlockNo - securityParam`), where the block producer's `isValid` flag is treated as authoritative until the local Plutus VM is consensus-equivalent. Volatile block replay, local transaction validation for mempool submission, and forging continue to run Plutus execution.
 
@@ -930,6 +930,10 @@ The `Ouroboros` struct (`ouroboros/ouroboros.go`) manages all protocol handlers:
     |                     |                     |
     | PeerSharing         | LocalStateQuery     |
     |   Peer discovery    |   Ledger queries    |
+    |                     |                     |
+    | LeiosFetch/Notify/  |                     |
+    | Votes (experimental)|                     |
+    |   EB + vote relay   |                     |
     -------------------------------------------
 ```
 

--- a/ouroboros/leiosfetch.go
+++ b/ouroboros/leiosfetch.go
@@ -154,8 +154,12 @@ func (o *Ouroboros) leiosfetchServerVotesRequest(
 	ctx oleiosfetch.CallbackContext,
 	voteIds []oleiosfetch.MsgVotesRequestVoteId,
 ) (protocol.Message, error) {
-	// TODO
-	return nil, nil
+	votes := o.leiosVotesForIds(voteIds)
+	msg, err := oleiosfetch.NewMsgVotesFromVotes(votes)
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
 }
 
 func (o *Ouroboros) leiosfetchServerBlockRangeRequest(

--- a/ouroboros/leiosvotes.go
+++ b/ouroboros/leiosvotes.go
@@ -16,12 +16,28 @@ package ouroboros
 
 import (
 	"errors"
+	"fmt"
+	"slices"
 	"time"
 
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol"
 	oleiosvotes "github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
 )
 
+const (
+	leiosVoteCacheMaxEntries = 4096
+	leiosVoteCacheTTL        = 10 * time.Minute
+)
+
 var errLeiosVotesUnavailable = errors.New("leios votes unavailable")
+
+type leiosVoteData struct {
+	vote       oleiosvotes.Vote
+	insertedAt time.Time
+	sequence   uint64
+}
 
 func (o *Ouroboros) leiosvotesServerConnOpts() []oleiosvotes.LeiosVotesOptionFunc {
 	return []oleiosvotes.LeiosVotesOptionFunc{
@@ -33,10 +49,25 @@ func (o *Ouroboros) leiosvotesServerConnOpts() []oleiosvotes.LeiosVotesOptionFun
 
 func (o *Ouroboros) leiosvotesClientConnOpts() []oleiosvotes.LeiosVotesOptionFunc {
 	return []oleiosvotes.LeiosVotesOptionFunc{
+		oleiosvotes.WithRequestNextCount(1),
 		oleiosvotes.WithVoteFunc(
 			o.instrumentLeiosvotesVote(o.leiosvotesClientVote),
 		),
 	}
+}
+
+func (o *Ouroboros) leiosvotesClientStart(connId ouroboros.ConnectionId) error {
+	conn := o.ConnManager.GetConnectionById(connId)
+	if conn == nil {
+		return fmt.Errorf(
+			"failed to lookup connection ID: %s",
+			leiosConnectionIdString(connId),
+		)
+	}
+	if conn.LeiosVotes() == nil || conn.LeiosVotes().Client == nil {
+		return nil
+	}
+	return conn.LeiosVotes().Client.Sync()
 }
 
 func (o *Ouroboros) instrumentLeiosvotesRequestNext(
@@ -71,19 +102,41 @@ func (o *Ouroboros) leiosvotesServerRequestNext(
 	ctx oleiosvotes.CallbackContext,
 	count uint64,
 ) ([]oleiosvotes.Vote, error) {
+	done := (<-chan struct{})(nil)
+	if ctx.Server != nil {
+		done = ctx.Server.DoneChan()
+	}
+	votes, err := o.waitLeiosVotesForRequestNext(
+		ctx.ConnectionId,
+		count,
+		done,
+	)
+	if err == nil {
+		o.config.Logger.Debug(
+			"serving leios votes",
+			"protocol", "leios-votes",
+			"connection_id", leiosConnectionIdString(ctx.ConnectionId),
+			"count", count,
+		)
+		return votes, nil
+	}
 	o.config.Logger.Debug(
-		"leios votes requested but vote store is not implemented",
+		"leios votes requested but unavailable",
 		"protocol", "leios-votes",
 		"connection_id", leiosConnectionIdString(ctx.ConnectionId),
 		"count", count,
+		"error", err,
 	)
-	return nil, errLeiosVotesUnavailable
+	return nil, err
 }
 
 func (o *Ouroboros) leiosvotesClientVote(
 	ctx oleiosvotes.CallbackContext,
 	vote oleiosvotes.Vote,
 ) error {
+	if err := o.storeLeiosVote(vote); err != nil {
+		return err
+	}
 	o.config.Logger.Debug(
 		"received leios vote",
 		"protocol", "leios-votes",
@@ -93,4 +146,208 @@ func (o *Ouroboros) leiosvotesClientVote(
 		"endorser_block_hash", vote.EndorserBlockHash.String(),
 	)
 	return nil
+}
+
+func cloneLeiosVote(vote oleiosvotes.Vote) oleiosvotes.Vote {
+	ret := vote
+	ret.VoteSignature = slices.Clone(vote.VoteSignature)
+	if raw := vote.Cbor(); len(raw) > 0 {
+		ret.SetCbor(slices.Clone(raw))
+	} else {
+		ret.SetCbor(nil)
+	}
+	return ret
+}
+
+func leiosVoteKey(vote oleiosvotes.Vote) string {
+	return fmt.Sprintf(
+		"%d:%s:%d",
+		vote.SlotNo,
+		vote.EndorserBlockHash.String(),
+		vote.VoterId,
+	)
+}
+
+func (data *leiosVoteData) expired(now time.Time) bool {
+	return data != nil &&
+		data.insertedAt.Before(now.Add(-leiosVoteCacheTTL))
+}
+
+func (o *Ouroboros) storeLeiosVote(vote oleiosvotes.Vote) error {
+	if err := vote.Validate(); err != nil {
+		return err
+	}
+	key := leiosVoteKey(vote)
+	now := time.Now()
+	o.leiosMu.Lock()
+	defer o.leiosMu.Unlock()
+	if o.leiosVotes == nil {
+		o.leiosVotes = make(map[string]*leiosVoteData)
+	}
+	if o.leiosVoteCursors == nil {
+		o.leiosVoteCursors = make(map[string]uint64)
+	}
+	if data, ok := o.leiosVotes[key]; ok {
+		data.vote = cloneLeiosVote(vote)
+		data.insertedAt = now
+		return nil
+	}
+	o.leiosVoteSeq++
+	o.leiosVotes[key] = &leiosVoteData{
+		vote:       cloneLeiosVote(vote),
+		insertedAt: now,
+		sequence:   o.leiosVoteSeq,
+	}
+	o.leiosVoteOrder = append(o.leiosVoteOrder, key)
+	o.pruneLeiosVoteCacheLocked(now)
+	o.notifyLeiosVoteWaitersLocked()
+	return nil
+}
+
+func (o *Ouroboros) notifyLeiosVoteWaitersLocked() {
+	if o.leiosVoteNotify == nil {
+		o.leiosVoteNotify = make(chan struct{})
+		return
+	}
+	close(o.leiosVoteNotify)
+	o.leiosVoteNotify = make(chan struct{})
+}
+
+func (o *Ouroboros) pruneLeiosVoteCacheLocked(now time.Time) {
+	if len(o.leiosVotes) == 0 {
+		o.leiosVoteOrder = nil
+		return
+	}
+	liveOrder := o.leiosVoteOrder[:0]
+	for _, key := range o.leiosVoteOrder {
+		data, ok := o.leiosVotes[key]
+		if !ok || data == nil {
+			continue
+		}
+		if data.expired(now) {
+			delete(o.leiosVotes, key)
+			continue
+		}
+		liveOrder = append(liveOrder, key)
+	}
+	o.leiosVoteOrder = liveOrder
+	if len(o.leiosVoteOrder) <= leiosVoteCacheMaxEntries {
+		return
+	}
+	evictCount := len(o.leiosVoteOrder) - leiosVoteCacheMaxEntries
+	for _, key := range o.leiosVoteOrder[:evictCount] {
+		delete(o.leiosVotes, key)
+	}
+	o.leiosVoteOrder = o.leiosVoteOrder[evictCount:]
+}
+
+func (o *Ouroboros) leiosVotesForRequestNext(
+	connId ouroboros.ConnectionId,
+	count uint64,
+) ([]oleiosvotes.Vote, error) {
+	if count == 0 {
+		return nil, errors.New("leios votes request count must be positive")
+	}
+	cursorKey := leiosConnectionIdString(connId)
+	now := time.Now()
+	o.leiosMu.Lock()
+	defer o.leiosMu.Unlock()
+	o.pruneLeiosVoteCacheLocked(now)
+	return o.leiosVotesForRequestNextLocked(cursorKey, count)
+}
+
+func (o *Ouroboros) waitLeiosVotesForRequestNext(
+	connId ouroboros.ConnectionId,
+	count uint64,
+	done <-chan struct{},
+) ([]oleiosvotes.Vote, error) {
+	if done == nil {
+		return o.leiosVotesForRequestNext(connId, count)
+	}
+	if count == 0 {
+		return nil, errors.New("leios votes request count must be positive")
+	}
+	cursorKey := leiosConnectionIdString(connId)
+	for {
+		now := time.Now()
+		o.leiosMu.Lock()
+		o.pruneLeiosVoteCacheLocked(now)
+		votes, err := o.leiosVotesForRequestNextLocked(cursorKey, count)
+		if err == nil || !errors.Is(err, errLeiosVotesUnavailable) {
+			o.leiosMu.Unlock()
+			return votes, err
+		}
+		notify := o.leiosVoteNotify
+		if notify == nil {
+			notify = make(chan struct{})
+			o.leiosVoteNotify = notify
+		}
+		o.leiosMu.Unlock()
+		select {
+		case <-notify:
+		case <-done:
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+	}
+}
+
+func (o *Ouroboros) leiosVotesForRequestNextLocked(
+	cursorKey string,
+	count uint64,
+) ([]oleiosvotes.Vote, error) {
+	cursor := o.leiosVoteCursors[cursorKey]
+	votes := make([]oleiosvotes.Vote, 0, count)
+	var lastSequence uint64
+	for _, key := range o.leiosVoteOrder {
+		data := o.leiosVotes[key]
+		if data == nil || data.sequence <= cursor {
+			continue
+		}
+		votes = append(votes, cloneLeiosVote(data.vote))
+		lastSequence = data.sequence
+		if uint64(len(votes)) == count {
+			break
+		}
+	}
+	if uint64(len(votes)) != count {
+		return nil, fmt.Errorf(
+			"%w: requested %d, available %d",
+			errLeiosVotesUnavailable,
+			count,
+			len(votes),
+		)
+	}
+	if o.leiosVoteCursors == nil {
+		o.leiosVoteCursors = make(map[string]uint64)
+	}
+	o.leiosVoteCursors[cursorKey] = lastSequence
+	return votes, nil
+}
+
+func (o *Ouroboros) leiosVotesForIds(
+	voteIds []lcommon.LeiosVoteId,
+) []oleiosvotes.Vote {
+	if len(voteIds) == 0 {
+		return nil
+	}
+	now := time.Now()
+	o.leiosMu.Lock()
+	defer o.leiosMu.Unlock()
+	o.pruneLeiosVoteCacheLocked(now)
+	ret := make([]oleiosvotes.Vote, 0, len(voteIds))
+	for _, voteId := range voteIds {
+		// gouroboros v0.180.0 vote IDs omit the EB hash. Preserve all
+		// cached votes for the requested slot/voter pair instead of
+		// collapsing competing EB votes here.
+		for _, key := range o.leiosVoteOrder {
+			data := o.leiosVotes[key]
+			if data == nil ||
+				data.vote.SlotNo != voteId.SlotNo ||
+				data.vote.VoterId != voteId.VoterId {
+				continue
+			}
+			ret = append(ret, cloneLeiosVote(data.vote))
+		}
+	}
+	return ret
 }

--- a/ouroboros/leiosvotes_test.go
+++ b/ouroboros/leiosvotes_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
+	oleiosvotes "github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
+	"github.com/stretchr/testify/require"
+)
+
+func testLeiosVote(slot uint64, hashFill byte, voterId uint64) oleiosvotes.Vote {
+	signature := make([]byte, lcommon.LeiosBlsSignatureSize)
+	for idx := range signature {
+		signature[idx] = byte(idx) ^ hashFill
+	}
+	return oleiosvotes.Vote{
+		SlotNo:            slot,
+		EndorserBlockHash: lcommon.NewBlake2b256([]byte{hashFill}),
+		VoterId:           voterId,
+		VoteSignature:     signature,
+	}
+}
+
+type leiosVoteWaitResult struct {
+	votes []oleiosvotes.Vote
+	err   error
+}
+
+func TestLeiosVotesClientRequestSizeIsIncremental(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	cfg := oleiosvotes.NewConfig(o.leiosvotesClientConnOpts()...)
+	require.Equal(t, uint64(1), cfg.RequestNextCount)
+}
+
+func TestLeiosVotesServerRequestNextUsesCursor(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	vote1 := testLeiosVote(10, 0xaa, 1)
+	vote2 := testLeiosVote(11, 0xbb, 2)
+	require.NoError(t, o.storeLeiosVote(vote1))
+	require.NoError(t, o.storeLeiosVote(vote2))
+
+	got, err := o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []oleiosvotes.Vote{vote1}, got)
+
+	got, err = o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []oleiosvotes.Vote{vote2}, got)
+
+	got, err = o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		1,
+	)
+	require.ErrorIs(t, err, errLeiosVotesUnavailable)
+	require.Nil(t, got)
+}
+
+func TestLeiosVotesRequestNextDoesNotAdvanceCursorOnShortRead(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	vote1 := testLeiosVote(10, 0xaa, 1)
+	vote2 := testLeiosVote(11, 0xbb, 2)
+	require.NoError(t, o.storeLeiosVote(vote1))
+
+	got, err := o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		2,
+	)
+	require.ErrorIs(t, err, errLeiosVotesUnavailable)
+	require.Nil(t, got)
+
+	require.NoError(t, o.storeLeiosVote(vote2))
+	got, err = o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		2,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []oleiosvotes.Vote{vote1, vote2}, got)
+}
+
+func TestLeiosVotesRequestNextWaitsForCachedVote(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	done := make(chan struct{})
+	resultCh := make(chan leiosVoteWaitResult, 1)
+	connId := oleiosvotes.CallbackContext{}.ConnectionId
+
+	go func() {
+		got, err := o.waitLeiosVotesForRequestNext(connId, 1, done)
+		resultCh <- leiosVoteWaitResult{votes: got, err: err}
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		resultCh,
+		50*time.Millisecond,
+		"empty cache should leave the leios-votes pull outstanding",
+	)
+	vote := testLeiosVote(10, 0xaa, 1)
+	require.NoError(t, o.storeLeiosVote(vote))
+	result := testutil.RequireReceive(
+		t,
+		resultCh,
+		2*time.Second,
+		"leios-votes waiter should wake when a vote is cached",
+	)
+	require.NoError(t, result.err)
+	require.Equal(t, []oleiosvotes.Vote{vote}, result.votes)
+}
+
+func TestLeiosVotesRequestNextWaitStopsOnDone(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	done := make(chan struct{})
+	resultCh := make(chan leiosVoteWaitResult, 1)
+	connId := oleiosvotes.CallbackContext{}.ConnectionId
+
+	go func() {
+		got, err := o.waitLeiosVotesForRequestNext(connId, 1, done)
+		resultCh <- leiosVoteWaitResult{votes: got, err: err}
+	}()
+
+	close(done)
+	result := testutil.RequireReceive(
+		t,
+		resultCh,
+		2*time.Second,
+		"leios-votes waiter should stop when the protocol is done",
+	)
+	require.ErrorIs(t, result.err, protocol.ErrProtocolShuttingDown)
+	require.Nil(t, result.votes)
+}
+
+func TestLeiosVoteCacheDedupesFullVoteIdentity(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	vote := testLeiosVote(10, 0xaa, 1)
+	require.NoError(t, o.storeLeiosVote(vote))
+	require.NoError(t, o.storeLeiosVote(vote))
+
+	got, err := o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		2,
+	)
+	require.ErrorIs(t, err, errLeiosVotesUnavailable)
+	require.Nil(t, got)
+
+	got, err = o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []oleiosvotes.Vote{vote}, got)
+}
+
+func TestLeiosVoteCacheAllowsSameVoterDifferentEndorserBlock(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	vote1 := testLeiosVote(10, 0xaa, 1)
+	vote2 := testLeiosVote(10, 0xbb, 1)
+	require.NoError(t, o.storeLeiosVote(vote1))
+	require.NoError(t, o.storeLeiosVote(vote2))
+
+	got, err := o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		2,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []oleiosvotes.Vote{vote1, vote2}, got)
+}
+
+func TestLeiosVoteCacheRejectsInvalidVote(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	err := o.storeLeiosVote(oleiosvotes.Vote{
+		SlotNo:            10,
+		EndorserBlockHash: lcommon.NewBlake2b256([]byte{0xaa}),
+		VoterId:           1,
+		VoteSignature:     []byte{0x01},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "VoteSignature")
+}
+
+func TestLeiosFetchServerVotesRequestReturnsCachedVotes(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	matching := testLeiosVote(10, 0xaa, 1)
+	other := testLeiosVote(10, 0xbb, 2)
+	require.NoError(t, o.storeLeiosVote(matching))
+	require.NoError(t, o.storeLeiosVote(other))
+
+	msg, err := o.leiosfetchServerVotesRequest(
+		oleiosfetch.CallbackContext{},
+		[]oleiosfetch.MsgVotesRequestVoteId{{
+			SlotNo:  matching.SlotNo,
+			VoterId: matching.VoterId,
+		}},
+	)
+	require.NoError(t, err)
+	resp, ok := msg.(*oleiosfetch.MsgVotes)
+	require.True(t, ok)
+	votes, err := resp.DecodeVotes()
+	require.NoError(t, err)
+	require.Len(t, votes, 1)
+	require.Equal(t, matching.SlotNo, votes[0].SlotNo)
+	require.Equal(t, matching.EndorserBlockHash, votes[0].EndorserBlockHash)
+	require.Equal(t, matching.VoterId, votes[0].VoterId)
+	require.Equal(t, matching.VoteSignature, votes[0].VoteSignature)
+}
+
+func TestLeiosVoteLookupExpiresStaleEntries(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	vote := testLeiosVote(10, 0xaa, 1)
+	require.NoError(t, o.storeLeiosVote(vote))
+
+	o.leiosMu.Lock()
+	cached := o.leiosVotes[leiosVoteKey(vote)]
+	if cached != nil {
+		cached.insertedAt = time.Now().
+			Add(-leiosVoteCacheTTL - time.Second)
+	}
+	o.leiosMu.Unlock()
+	require.NotNil(t, cached)
+
+	got, err := o.leiosvotesServerRequestNext(
+		oleiosvotes.CallbackContext{},
+		1,
+	)
+	require.True(t, errors.Is(err, errLeiosVotesUnavailable))
+	require.Nil(t, got)
+
+	o.leiosMu.RLock()
+	cacheEntries := len(o.leiosVotes)
+	o.leiosMu.RUnlock()
+	require.Zero(t, cacheEntries)
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -86,6 +86,11 @@ type Ouroboros struct {
 	// ChainSync serve merged RB+EB blocks without coupling the chain
 	// package to Leios prototype protocols.
 	leiosEndorserBlocks map[string]*leiosEndorserBlockData
+	leiosVotes          map[string]*leiosVoteData
+	leiosVoteOrder      []string
+	leiosVoteCursors    map[string]uint64
+	leiosVoteNotify     chan struct{}
+	leiosVoteSeq        uint64
 	leiosMu             sync.RWMutex
 }
 
@@ -153,6 +158,9 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		blockfetchNoBlocksCounts: make(map[ouroboros.ConnectionId]blockfetchNoBlocksState),
 		chainsyncStats:           make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
 		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
+		leiosVotes:               make(map[string]*leiosVoteData),
+		leiosVoteCursors:         make(map[string]uint64),
+		leiosVoteNotify:          make(chan struct{}),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond
@@ -425,6 +433,9 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	if o.txSubmissionRateLimiter != nil {
 		o.txSubmissionRateLimiter.RemovePeer(connId)
 	}
+	o.leiosMu.Lock()
+	delete(o.leiosVoteCursors, leiosConnectionIdString(connId))
+	o.leiosMu.Unlock()
 }
 
 func (o *Ouroboros) HandlePeerEligibilityChangedEvent(evt event.Event) {
@@ -519,6 +530,14 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 		if err := o.leiosnotifyClientStart(connId); err != nil {
 			o.config.Logger.Error(
 				"failed to start leiosnotify client",
+				"error",
+				err,
+			)
+			return
+		}
+		if err := o.leiosvotesClientStart(connId); err != nil {
+			o.config.Logger.Error(
+				"failed to start leiosvotes client",
 				"error",
 				err,
 			)
@@ -634,6 +653,32 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 		} else {
 			o.config.Logger.Debug(
 				"started txsubmission client on inbound connection",
+				"connection_id", connId.String(),
+			)
+		}
+	}
+	if o.config.EnableLeios {
+		if err := o.leiosnotifyClientStart(connId); err != nil {
+			o.config.Logger.Warn(
+				"leiosnotify client failed on inbound connection",
+				"error", err,
+				"connection_id", connId.String(),
+			)
+		} else {
+			o.config.Logger.Debug(
+				"started leiosnotify client on inbound connection",
+				"connection_id", connId.String(),
+			)
+		}
+		if err := o.leiosvotesClientStart(connId); err != nil {
+			o.config.Logger.Warn(
+				"leiosvotes client failed on inbound connection",
+				"error", err,
+				"connection_id", connId.String(),
+			)
+		} else {
+			o.config.Logger.Debug(
+				"started leiosvotes client on inbound connection",
 				"connection_id", connId.String(),
 			)
 		}


### PR DESCRIPTION
Closes #1865 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `LeiosVotes` mini-protocol with an in-memory vote cache and integrates vote retrieval via `LeiosFetch`, enabling incremental vote diffusion for Leios/RB. Addresses #1865.

- **New Features**
  - Added `LeiosVotes` client/server with an in-memory vote cache (TTL 10m, max 4096, deduped by slot+EB hash+voter).
  - `RequestNext` uses per-connection cursors and waits until votes arrive or shutdown; empty cache is not treated as an error.
  - Client starts with `RequestNextCount(1)` and stores received votes; `Ouroboros` starts `LeiosVotes` on inbound/outbound peers and clears cursors on close.
  - `LeiosFetch` now serves `MsgVotes` from the local cache for requested vote IDs.
  - Updated `ARCHITECTURE.md` to document Leios vote relay behavior.
  - Added unit tests for caching, waiting semantics, dedupe, fetch integration, and expiry.

<sup>Written for commit a213ca7379665a5f3fa069d44d3a4fc0b0c16f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented Leios protocol votes caching with TTL-based expiration and automatic deduplication.
  * Added vote request coordination and retrieval mechanisms with pagination support.

* **Tests**
  * Added comprehensive test coverage for votes caching, request pagination, protocol shutdown, and vote validation scenarios.

* **Documentation**
  * Updated architecture documentation to reflect Leios experimental protocol details and in-memory caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->