### PR TITLE
fix(config): update devnet min protocol to 11

### DIFF
--- a/config/cardano/devnet/shelley-genesis.json
+++ b/config/cardano/devnet/shelley-genesis.json
@@ -30,7 +30,7 @@
         "nOpt": 100,
         "poolDeposit": 0,
         "protocolVersion": {
-            "major": 9,
+            "major": 11,
             "minor": 0
         },
         "rho": 0.1,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the Cardano devnet minimum protocol to v11 to align the network with the latest protocol and ensure node compatibility.
Updates `config/cardano/devnet/shelley-genesis.json` to set `protocolVersion.major` from 9 to 11.

<sup>Written for commit ff676f471248feeeadcd7b18acc029bda187cae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cardano protocol version to 11 in the development network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->