### PR TITLE
fix(config): sync peer snapshot and topology 20260605

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -501,7 +501,7 @@ dingo/
 │   ├── ledger.go        # Ledger-based peer discovery
 │   └── event.go         # Peer events
 ├── topology/            # Network topology handling
-│   └── topology.go      # Topology configuration
+│   └── topology.go      # Topology and peer-snapshot configuration
 ├── blockfrost/          # Blockfrost-compatible REST API
 │   ├── blockfrost.go    # Server lifecycle
 │   ├── adapter.go       # Node state adapter
@@ -1001,6 +1001,22 @@ The `PeerGovernor` (`peergov/peergov.go`) manages peer selection and topology:
     |   (30 min timeout)                             |
     -------------------------------------------------
 ```
+
+Topology configuration is loaded from an explicit topology file when provided,
+otherwise from the embedded `network/topology.json` for built-in networks,
+falling back to the legacy network bootstrap-peer list only when no embedded
+topology exists. A topology `peerSnapshotFile` is resolved relative to the
+topology file or embedded network directory and parsed as a cardano-node ledger
+peer snapshot.
+
+When Genesis chain selection is active and a peer snapshot contains relays, the
+node loads topology local/public roots without topology bootstrap peers, then
+seeds the snapshot relays as `PeerSourceP2PLedger` peers before outbound
+connection startup. This avoids relying on bootstrap peers for Ouroboros
+Genesis initial sync while preserving the existing `UseLedgerAfterSlot` path:
+later ledger peer refreshes still query the live ledger/database provider.
+If the snapshot produces no usable peers, startup falls back to topology
+bootstrap peers.
 
 ## Transaction Mempool
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /antithesis/customer
 RUN make build
 
 FROM ghcr.io/blinklabs-io/cardano-cli:11.0.0.0-1 AS cardano-cli
-FROM ghcr.io/blinklabs-io/cardano-configs:20260430-1 AS cardano-configs
+FROM ghcr.io/blinklabs-io/cardano-configs:20260605-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/nview:0.14.0 AS nview
 FROM ghcr.io/blinklabs-io/txtop:0.15.0 AS txtop
 

--- a/config/cardano/mainnet/peer-snapshot.json
+++ b/config/cardano/mainnet/peer-snapshot.json
@@ -2,23 +2,13 @@
   "NetworkMagic": 764824073,
   "NodeToClientVersion": 23,
   "Point": {
-    "blockPointHash": "1bcdeadabab1074b2fc7ea615bc34351939ce9525090a4bd2e5db06d42e973bc",
-    "blockPointSlot": 182396915
+    "blockPointHash": "1a7f1af3e52ba8810247f7c82431113a61c2efc5435a8fe6f76c5ae6618cc92a",
+    "blockPointSlot": 185831188
   },
   "bigLedgerPools": [
     {
-      "accumulatedStake": 0.005624384116166084,
-      "relativeStake": 0.005624384116166084,
-      "relays": [
-        {
-          "address": "92a8429c.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.01106492483626304,
-      "relativeStake": 0.005440540720096956,
+      "accumulatedStake": 0.005374442898178548,
+      "relativeStake": 0.005374442898178548,
       "relays": [
         {
           "address": "relay-trustwallet-5-0.cardano.mainnet.kiln.fi",
@@ -35,8 +25,35 @@
       ]
     },
     {
-      "accumulatedStake": 0.016034919651443075,
-      "relativeStake": 0.0049699948151800365,
+      "accumulatedStake": 0.009708426606565979,
+      "relativeStake": 0.00433398370838743,
+      "relays": [
+        {
+          "address": "relay-pool-2-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.013940148674896902,
+      "relativeStake": 0.004231722068330924,
+      "relays": [
+        {
+          "address": "relay-pool-ledger-2-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.017802972691128915,
+      "relativeStake": 0.0038628240162320118,
+      "relays": [
+        {
+          "address": "relay-pool-3-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.021629299907305704,
+      "relativeStake": 0.0038263272161767905,
       "relays": [
         {
           "address": "relay-kiln-9-0.cardano.mainnet.kiln.fi",
@@ -53,35 +70,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.020550315817728794,
-      "relativeStake": 0.004515396166285717,
-      "relays": [
-        {
-          "address": "relay-pool-3-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.02488697695537983,
-      "relativeStake": 0.004336661137651035,
-      "relays": [
-        {
-          "address": "relay-pool-ledger-2-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.028937056180075006,
-      "relativeStake": 0.004050079224695179,
-      "relays": [
-        {
-          "address": "relay-pool-2-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.03257854928892488,
-      "relativeStake": 0.0036414931088498735,
+      "accumulatedStake": 0.02544330760311462,
+      "relativeStake": 0.0038140076958089134,
       "relays": [
         {
           "address": "Relay1.NordicPool.org",
@@ -98,96 +88,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.036194949107623116,
-      "relativeStake": 0.003616399818698232,
-      "relays": [
-        {
-          "address": "Relay1.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay2.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay3.NordicPool.org",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.039800466825486436,
-      "relativeStake": 0.0036055177178633217,
-      "relays": [
-        {
-          "address": "gateway.adavault.com",
-          "port": 4021
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4022
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4026
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4027
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.04338824604102516,
-      "relativeStake": 0.003587779215538729,
-      "relays": [
-        {
-          "address": "cardanosuisse.com",
-          "port": 170
-        },
-        {
-          "address": "cardanosuisse.com",
-          "port": 171
-        },
-        {
-          "address": "cardanosuisse.com",
-          "port": 172
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.04696715454056126,
-      "relativeStake": 0.003578908499536093,
-      "relays": [
-        {
-          "address": "48.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.050545918205633714,
-      "relativeStake": 0.0035787636650724563,
-      "relays": [
-        {
-          "address": "27.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.054124575123092655,
-      "relativeStake": 0.0035786569174589434,
-      "relays": [
-        {
-          "address": "26.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.05770296092091576,
-      "relativeStake": 0.003578385797823104,
+      "accumulatedStake": 0.029072349871612557,
+      "relativeStake": 0.0036290422684979377,
       "relays": [
         {
           "address": "relay-kiln-4-0.cardano.mainnet.kiln.fi",
@@ -204,1267 +106,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.06128106276939354,
-      "relativeStake": 0.0035781018484777783,
-      "relays": [
-        {
-          "address": "cf1r1.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        },
-        {
-          "address": "cf1r2.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.06485856384252382,
-      "relativeStake": 0.0035775010731302773,
-      "relays": [
-        {
-          "address": "cf4r1.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        },
-        {
-          "address": "cf4r2.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.06843606489505297,
-      "relativeStake": 0.0035775010525291528,
-      "relays": [
-        {
-          "address": "cf2r1.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        },
-        {
-          "address": "cf2r2.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.07201356594034797,
-      "relativeStake": 0.0035775010452950063,
-      "relays": [
-        {
-          "address": "cf3r1.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        },
-        {
-          "address": "cf3r2.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.07559104733611886,
-      "relativeStake": 0.003577481395770893,
-      "relays": [
-        {
-          "address": "13.236.12.204",
-          "port": 8332
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.07916720647986882,
-      "relativeStake": 0.003576159143749945,
-      "relays": [
-        {
-          "address": "28.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.08274240275255344,
-      "relativeStake": 0.003575196272684625,
-      "relays": [
-        {
-          "address": "13.211.73.179",
-          "port": 8332
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.086312631041465,
-      "relativeStake": 0.003570228288911561,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.08987432377110156,
-      "relativeStake": 0.0035616927296365686,
-      "relays": [
-        {
-          "address": "relay-kiln-3-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-3-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-3-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.09343350608564953,
-      "relativeStake": 0.003559182314547962,
-      "relays": [
-        {
-          "address": "relay-kiln-2-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-2-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-2-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.09697918800462044,
-      "relativeStake": 0.0035456819189709095,
-      "relays": [
-        {
-          "address": "162.120.71.180",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.10052069775702885,
-      "relativeStake": 0.003541509752408406,
-      "relays": [
-        {
-          "address": "50.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.10406062059160943,
-      "relativeStake": 0.0035399228345805935,
-      "relays": [
-        {
-          "address": "cf5r1.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        },
-        {
-          "address": "cf5r2.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1076005422906462,
-      "relativeStake": 0.003539921699036752,
-      "relays": [
-        {
-          "address": "cf6r1.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        },
-        {
-          "address": "cf6r2.mainnet.pool.cardanofoundation.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.11113046925205745,
-      "relativeStake": 0.0035299269614112597,
-      "relays": [
-        {
-          "address": "r1.spirestaking.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.11465004878991707,
-      "relativeStake": 0.003519579537859622,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.11816507359163282,
-      "relativeStake": 0.003515024801715747,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.12166666643850171,
-      "relativeStake": 0.0035015928468689,
-      "relays": [
-        {
-          "address": "178.128.79.219",
-          "port": 3001
-        },
-        {
-          "address": "104.131.122.73",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1251509307901025,
-      "relativeStake": 0.0034842643516007723,
-      "relays": [
-        {
-          "address": "r1.1percentpool.eu",
-          "port": 19001
-        },
-        {
-          "address": "r2.1percentpool.eu",
-          "port": 19002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.12862765529631218,
-      "relativeStake": 0.003476724506209674,
-      "relays": [
-        {
-          "address": "Relay1.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay2.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay3.NordicPool.org",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1320989591290814,
-      "relativeStake": 0.0034713038327692414,
-      "relays": [
-        {
-          "address": "relays.bladepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.13557002699436385,
-      "relativeStake": 0.003471067865282442,
-      "relays": [
-        {
-          "address": "47.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.13904107616838862,
-      "relativeStake": 0.0034710491740247715,
-      "relays": [
-        {
-          "address": "42.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1425119759035131,
-      "relativeStake": 0.0034708997351244994,
-      "relays": [
-        {
-          "address": "44.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1459828009573176,
-      "relativeStake": 0.0034708250538044764,
-      "relays": [
-        {
-          "address": "45.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1494535885694131,
-      "relativeStake": 0.0034707876120955035,
-      "relays": [
-        {
-          "address": "41.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1529241333769774,
-      "relativeStake": 0.0034705448075643174,
-      "relays": [
-        {
-          "address": "46.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.15639305734827177,
-      "relativeStake": 0.0034689239712943653,
-      "relays": [
-        {
-          "address": "bd-cardano-main-relay-12-a.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "address": "bd-cardano-main-relay-12-b.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.15985710093835995,
-      "relativeStake": 0.0034640435900881667,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.16330947172094296,
-      "relativeStake": 0.0034523707825830042,
-      "relays": [
-        {
-          "address": "gateway.adavault.com",
-          "port": 4021
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4022
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4026
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4027
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.16675344091532693,
-      "relativeStake": 0.003443969194383975,
-      "relays": [
-        {
-          "address": "Relay1.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay2.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay3.NordicPool.org",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.17018501137735717,
-      "relativeStake": 0.0034315704620302475,
-      "relays": [
-        {
-          "address": "relay1.mainnet.pool.cardano.services",
-          "port": 3001
-        },
-        {
-          "address": "relay2.mainnet.pool.cardano.services",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.17360037251356633,
-      "relativeStake": 0.0034153611362091533,
-      "relays": [
-        {
-          "address": "olive-geonosis-edffc.cardano.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "address": "violet-kingston-8d67e.cardano.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.17700780940107058,
-      "relativeStake": 0.0034074368875042535,
-      "relays": [
-        {
-          "address": "95.154.235.142",
-          "port": 6000
-        },
-        {
-          "address": "217.155.18.115",
-          "port": 6003
-        },
-        {
-          "address": "217.155.18.115",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.18040514155841397,
-      "relativeStake": 0.003397332157343391,
-      "relays": [
-        {
-          "address": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "address": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.18379625445679793,
-      "relativeStake": 0.0033911128983839466,
-      "relays": [
-        {
-          "address": "r-eu-0.titanstaking.io",
-          "port": 4321
-        },
-        {
-          "address": "r-eu-1.titanstaking.io",
-          "port": 4321
-        },
-        {
-          "address": "r-eu-2.titanstaking.io",
-          "port": 4321
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.18716899530586173,
-      "relativeStake": 0.003372740849063801,
-      "relays": [
-        {
-          "address": "relay01.ca.lovelace.community",
-          "port": 3001
-        },
-        {
-          "address": "relay02.ca.lovelace.community",
-          "port": 3001
-        },
-        {
-          "address": "relay01.fr.lovelace.community",
-          "port": 3001
-        },
-        {
-          "address": "relay01.de.lovelace.community",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1905173960545174,
-      "relativeStake": 0.0033484007486556835,
-      "relays": [
-        {
-          "address": "gateway.adavault.com",
-          "port": 4021
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4022
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4026
-        },
-        {
-          "address": "gateway.adavault.com",
-          "port": 4027
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.19386481885254717,
-      "relativeStake": 0.003347422798029769,
-      "relays": [
-        {
-          "address": "40.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.19719678911313354,
-      "relativeStake": 0.003331970260586354,
-      "relays": [
-        {
-          "address": "relay1.nihaocardano.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2.nihaocardano.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.20052837613980612,
-      "relativeStake": 0.0033315870266725804,
-      "relays": [
-        {
-          "address": "46.101.9.225",
-          "port": 3001
-        },
-        {
-          "address": "64.227.46.95",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.20385728866077066,
-      "relativeStake": 0.003328912520964552,
-      "relays": [
-        {
-          "address": "26e894b1.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.20717875864580632,
-      "relativeStake": 0.003321469985035645,
-      "relays": [
-        {
-          "address": "relay1.cardanotech.io",
-          "port": 6000
-        },
-        {
-          "address": "relay2.cardanotech.io",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.21049553812720598,
-      "relativeStake": 0.0033167794813996833,
-      "relays": [
-        {
-          "address": "relay-kiln-6-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-6-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-6-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.21380278995206206,
-      "relativeStake": 0.003307251824856066,
-      "relays": [
-        {
-          "address": "7ddb9c28.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.21710076933681843,
-      "relativeStake": 0.00329797938475638,
-      "relays": [
-        {
-          "address": "b3e201f4.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.22039854760573588,
-      "relativeStake": 0.0032977782689174403,
-      "relays": [
-        {
-          "address": "8d6f8de4.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.22369468552988767,
-      "relativeStake": 0.0032961379241517896,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.22698614354512048,
-      "relativeStake": 0.0032914580152328273,
-      "relays": [
-        {
-          "address": "b3bbbcac.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.23027723951914958,
-      "relativeStake": 0.0032910959740290982,
-      "relays": [
-        {
-          "address": "ddbb5a06.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.23356292898779013,
-      "relativeStake": 0.0032856894686405405,
-      "relays": [
-        {
-          "address": "e4527900.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2368476707541861,
-      "relativeStake": 0.003284741766395994,
-      "relays": [
-        {
-          "address": "50809bee.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.24013218371576628,
-      "relativeStake": 0.003284512961580141,
-      "relays": [
-        {
-          "address": "9a956262.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.24341658555395723,
-      "relativeStake": 0.0032844018381909725,
-      "relays": [
-        {
-          "address": "35.75.32.253",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2467009088822046,
-      "relativeStake": 0.003284323328247383,
-      "relays": [
-        {
-          "address": "a94da6a8.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.24998502800137634,
-      "relativeStake": 0.003284119119171711,
-      "relays": [
-        {
-          "address": "9dc533bf.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2532687831378998,
-      "relativeStake": 0.0032837551365234724,
-      "relays": [
-        {
-          "address": "f84db19f.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.25655205954774923,
-      "relativeStake": 0.003283276409849445,
-      "relays": [
-        {
-          "address": "72e508af.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2598353013763964,
-      "relativeStake": 0.0032832418286471436,
-      "relays": [
-        {
-          "address": "dbe22510.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.263118521551285,
-      "relativeStake": 0.0032832201748886104,
-      "relays": [
-        {
-          "address": "778cb679.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2664016375873957,
-      "relativeStake": 0.0032831160361106895,
-      "relays": [
-        {
-          "address": "a5f2af9f.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.26968469738502304,
-      "relativeStake": 0.003283059797627328,
-      "relays": [
-        {
-          "address": "d489c136.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2729677339377178,
-      "relativeStake": 0.003283036552694748,
-      "relays": [
-        {
-          "address": "d89eeea0.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2762506908229386,
-      "relativeStake": 0.0032829568852208394,
-      "relays": [
-        {
-          "address": "d699483e.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.27953360058135496,
-      "relativeStake": 0.003282909758416363,
-      "relays": [
-        {
-          "address": "94cc7304.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.28281637950599664,
-      "relativeStake": 0.003282778924641654,
-      "relays": [
-        {
-          "address": "bb78d57d.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.28609842655734435,
-      "relativeStake": 0.003282047051347706,
-      "relays": [
-        {
-          "address": "35.75.32.253",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2893568264527578,
-      "relativeStake": 0.0032583998954134755,
-      "relays": [
-        {
-          "address": "lucerne.datadyne.earth",
-          "port": 3001
-        },
-        {
-          "address": "g5.datadyne.earth",
-          "port": 3002
-        },
-        {
-          "address": "drcaroll.datadyne.earth",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2926150825676592,
-      "relativeStake": 0.0032582561149014405,
-      "relays": [
-        {
-          "address": "relay-pool-figment-19-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2958509504720694,
-      "relativeStake": 0.0032358679044101474,
-      "relays": [
-        {
-          "address": "ada-relay01.biglazycat.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.29904745619019385,
-      "relativeStake": 0.00319650571812443,
-      "relays": [
-        {
-          "address": "relays.stakepool.at",
-          "port": 3001
-        },
-        {
-          "address": "relay-1.stakepool.at",
-          "port": 3001
-        },
-        {
-          "address": "relay-2.stakepool.at",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3022416091547415,
-      "relativeStake": 0.003194152964547723,
-      "relays": [
-        {
-          "address": "relay.cardano.securestaking.io",
-          "port": 3000
-        },
-        {
-          "address": "secur2.cardano.securestaking.io",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3054160566294121,
-      "relativeStake": 0.00317444747467059,
-      "relays": [
-        {
-          "address": "relay1-dl.aichi-stakepool.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2-jp.aichi-stakepool.com",
-          "port": 6000
-        },
-        {
-          "address": "relay3-li.aichi-stakepool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3085791408173079,
-      "relativeStake": 0.0031630841878957663,
-      "relays": [
-        {
-          "address": "94c3c6d3.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.31171967793074645,
-      "relativeStake": 0.00314053711343854,
-      "relays": [
-        {
-          "address": "cof-1.cardanocafe.org",
-          "port": 3005
-        },
-        {
-          "address": "cof-2.cardanocafe.org",
-          "port": 3010
-        },
-        {
-          "address": "cap-1.cardanocafe.org",
-          "port": 4000
-        },
-        {
-          "address": "cap-2.cardanocafe.org",
-          "port": 4005
-        },
-        {
-          "address": "lat-1.cardanocafe.org",
-          "port": 5001
-        },
-        {
-          "address": "lat-2.cardanocafe.org",
-          "port": 5002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3148587446057767,
-      "relativeStake": 0.0031390666750302524,
-      "relays": [
-        {
-          "address": "11.relays.happystaking.io",
-          "port": 3001
-        },
-        {
-          "address": "12.relays.happystaking.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3179361183766701,
-      "relativeStake": 0.0030773737708933726,
-      "relays": [
-        {
-          "address": "relay1.clovernodes.io",
-          "port": 6000
-        },
-        {
-          "address": "relay2.clovernodes.io",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3209790999345109,
-      "relativeStake": 0.0030429815578408184,
-      "relays": [
-        {
-          "address": "r-eu-0.titanstaking.io",
-          "port": 4321
-        },
-        {
-          "address": "r-eu-1.titanstaking.io",
-          "port": 4321
-        },
-        {
-          "address": "r-eu-2.titanstaking.io",
-          "port": 4321
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3240045767015962,
-      "relativeStake": 0.003025476767085335,
-      "relays": [
-        {
-          "address": "170.23.181.50",
-          "port": 6001
-        },
-        {
-          "address": "170.23.181.50",
-          "port": 6002
-        },
-        {
-          "address": "170.23.181.50",
-          "port": 6003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3270294544783557,
-      "relativeStake": 0.0030248777767594897,
-      "relays": [
-        {
-          "address": "octaluso.dyndns.org",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.33004274588989,
-      "relativeStake": 0.0030132914115343296,
-      "relays": [
-        {
-          "address": "157.173.120.233",
-          "port": 3001
-        },
-        {
-          "address": "157.173.120.233",
-          "port": 3002
-        },
-        {
-          "address": "5.252.53.68",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.33305486748942686,
-      "relativeStake": 0.0030121215995368425,
-      "relays": [
-        {
-          "address": "Relay1.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay2.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "address": "Relay3.NordicPool.org",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3360632065642291,
-      "relativeStake": 0.0030083390748022417,
-      "relays": [
-        {
-          "address": "rel01.fairpool.eu",
-          "port": 55001
-        },
-        {
-          "address": "rel02.fairpool.eu",
-          "port": 55002
-        },
-        {
-          "address": "rel03.fairpool.eu",
-          "port": 55003
-        },
-        {
-          "address": "rel04.fairpool.eu",
-          "port": 55004
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3390674374767554,
-      "relativeStake": 0.0030042309125262673,
-      "relays": [
-        {
-          "address": "c2504518.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3420381444761067,
-      "relativeStake": 0.002970706999351332,
-      "relays": [
-        {
-          "address": "91.242.214.33",
-          "port": 3001
-        },
-        {
-          "address": "186.233.187.33",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3449737981902648,
-      "relativeStake": 0.0029356537141580577,
-      "relays": [
-        {
-          "address": "cardano-relays.autostake.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3479075923937727,
-      "relativeStake": 0.002933794203507963,
-      "relays": [
-        {
-          "address": "173.15.110.154",
-          "port": 6000
-        },
-        {
-          "address": "173.15.110.155",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.35082220006730663,
-      "relativeStake": 0.0029146076735338997,
-      "relays": [
-        {
-          "address": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.35373254100949597,
-      "relativeStake": 0.0029103409421893122,
-      "relays": [
-        {
-          "address": "relay1.snakepool.link",
-          "port": 3001
-        },
-        {
-          "address": "relay2.snakepool.link",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3566369690000247,
-      "relativeStake": 0.002904427990528695,
-      "relays": [
-        {
-          "address": "57.129.24.185",
-          "port": 3001
-        },
-        {
-          "address": "57.129.28.178",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.35952435252437503,
-      "relativeStake": 0.0028873835243503868,
-      "relays": [
-        {
-          "address": "52.6.109.221",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3624033796068719,
-      "relativeStake": 0.002879027082496888,
-      "relays": [
-        {
-          "address": "relays.stakepool.at",
-          "port": 3001
-        },
-        {
-          "address": "relay-1.stakepool.at",
-          "port": 3001
-        },
-        {
-          "address": "relay-2.stakepool.at",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.36526145585608305,
-      "relativeStake": 0.002858076249211119,
-      "relays": [
-        {
-          "address": "6398a55d.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.368107680022731,
-      "relativeStake": 0.002846224166647955,
-      "relays": [
-        {
-          "address": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3709511616321207,
-      "relativeStake": 0.002843481609389736,
-      "relays": [
-        {
-          "address": "85.215.129.208",
-          "port": 3001
-        },
-        {
-          "address": "154.26.158.189",
-          "port": 3001
-        },
-        {
-          "address": "5.104.83.174",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3737922027586682,
-      "relativeStake": 0.002841041126547493,
-      "relays": [
-        {
-          "address": "77cb3f75.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3766256274161481,
-      "relativeStake": 0.0028334246574798286,
+      "accumulatedStake": 0.03270005853686575,
+      "relativeStake": 0.0036277086652531936,
       "relays": [
         {
           "address": "relay-kiln-0-0.cardano.mainnet.kiln.fi",
@@ -1481,214 +124,30 @@
       ]
     },
     {
-      "accumulatedStake": 0.37942946023090585,
-      "relativeStake": 0.0028038328147577695,
+      "accumulatedStake": 0.036312797031401535,
+      "relativeStake": 0.0036127384945357824,
       "relays": [
         {
-          "address": "cardano-main.everstake.one",
-          "port": 3001
+          "address": "gateway.adavault.com",
+          "port": 4021
         },
         {
-          "address": "cardano-main2.everstake.one",
-          "port": 3001
+          "address": "gateway.adavault.com",
+          "port": 4022
         },
         {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
+          "address": "gateway.adavault.com",
+          "port": 4026
         },
         {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
-          "port": 3001
+          "address": "gateway.adavault.com",
+          "port": 4027
         }
       ]
     },
     {
-      "accumulatedStake": 0.3822326954808714,
-      "relativeStake": 0.002803235249965583,
-      "relays": [
-        {
-          "address": "129.80.153.243",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.38501922279216483,
-      "relativeStake": 0.0027865273112933973,
-      "relays": [
-        {
-          "address": "35.211.17.86",
-          "port": 3000
-        },
-        {
-          "address": "34.23.88.7",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3878041387754049,
-      "relativeStake": 0.0027849159832401306,
-      "relays": [
-        {
-          "address": "rockyrelay1.ddns.net",
-          "port": 3001
-        },
-        {
-          "address": "rockyrelay2.ddns.net",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3905651835140288,
-      "relativeStake": 0.0027610447386238685,
-      "relays": [
-        {
-          "address": "148.113.17.23",
-          "port": 6000
-        },
-        {
-          "address": "158.69.25.103",
-          "port": 6000
-        },
-        {
-          "address": "46.4.53.238",
-          "port": 6000
-        },
-        {
-          "address": "149.102.140.164",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.39332084896407665,
-      "relativeStake": 0.002755665450047866,
-      "relays": [
-        {
-          "address": "76cf1dd1.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3960737043172269,
-      "relativeStake": 0.002752855353150195,
-      "relays": [
-        {
-          "address": "relay-kiln-7-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-7-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "address": "relay-kiln-7-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3988262066246909,
-      "relativeStake": 0.002752502307464065,
-      "relays": [
-        {
-          "address": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4015622373245946,
-      "relativeStake": 0.002736030699903695,
-      "relays": [
-        {
-          "address": "57.128.184.33",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.31",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.40429758746283956,
-      "relativeStake": 0.002735350138244913,
-      "relays": [
-        {
-          "address": "bd-cardano-main-relay-5-a.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "address": "bd-cardano-main-relay-5-b.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4070297167304597,
-      "relativeStake": 0.002732129267620131,
-      "relays": [
-        {
-          "address": "relays.cardanowithpaul.com",
-          "port": 1069
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.40975759495669134,
-      "relativeStake": 0.0027278782262316692,
-      "relays": [
-        {
-          "address": "r-eu-1.polypool.io",
-          "port": 4001
-        },
-        {
-          "address": "r-sg-1.polypool.io",
-          "port": 4001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4124796920828253,
-      "relativeStake": 0.0027220971261339454,
-      "relays": [
-        {
-          "address": "rev-cardano-main-relay-01-a.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "address": "rev-cardano-main-relay-01-b.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.41519530076754774,
-      "relativeStake": 0.002715608684722465,
+      "accumulatedStake": 0.03992463359434855,
+      "relativeStake": 0.003611836562947021,
       "relays": [
         {
           "address": "relay-kiln-8-0.cardano.mainnet.kiln.fi",
@@ -1705,8 +164,569 @@
       ]
     },
     {
-      "accumulatedStake": 0.4179101992805863,
-      "relativeStake": 0.002714898513038538,
+      "accumulatedStake": 0.043534993858084924,
+      "relativeStake": 0.003610360263736371,
+      "relays": [
+        {
+          "address": "cardanosuisse.com",
+          "port": 170
+        },
+        {
+          "address": "cardanosuisse.com",
+          "port": 171
+        },
+        {
+          "address": "cardanosuisse.com",
+          "port": 172
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.04714340447381351,
+      "relativeStake": 0.0036084106157285825,
+      "relays": [
+        {
+          "address": "13.236.12.204",
+          "port": 8332
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.050749101364542935,
+      "relativeStake": 0.0036056968907294306,
+      "relays": [
+        {
+          "address": "13.211.73.179",
+          "port": 8332
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.05434746790206477,
+      "relativeStake": 0.0035983665375218287,
+      "relays": [
+        {
+          "address": "48.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.05794512044484381,
+      "relativeStake": 0.003597652542779045,
+      "relays": [
+        {
+          "address": "27.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.0615424193035904,
+      "relativeStake": 0.003597298858746587,
+      "relays": [
+        {
+          "address": "cf1r1.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        },
+        {
+          "address": "cf1r2.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.0651391753342143,
+      "relativeStake": 0.0035967560306238992,
+      "relays": [
+        {
+          "address": "cf4r1.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        },
+        {
+          "address": "cf4r2.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.06873593134412619,
+      "relativeStake": 0.0035967560099118942,
+      "relays": [
+        {
+          "address": "cf2r1.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        },
+        {
+          "address": "cf2r2.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.072332687346765,
+      "relativeStake": 0.003596756002638812,
+      "relays": [
+        {
+          "address": "cf3r1.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        },
+        {
+          "address": "cf3r2.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.07592793071620275,
+      "relativeStake": 0.003595243369437755,
+      "relays": [
+        {
+          "address": "28.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.07952035828949579,
+      "relativeStake": 0.0035924275732930255,
+      "relays": [
+        {
+          "address": "gateway.adavault.com",
+          "port": 4021
+        },
+        {
+          "address": "gateway.adavault.com",
+          "port": 4022
+        },
+        {
+          "address": "gateway.adavault.com",
+          "port": 4026
+        },
+        {
+          "address": "gateway.adavault.com",
+          "port": 4027
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.08310439515938065,
+      "relativeStake": 0.0035840368698848643,
+      "relays": [
+        {
+          "address": "30.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.08668333625688798,
+      "relativeStake": 0.0035789410975073373,
+      "relays": [
+        {
+          "address": "162.120.71.180",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.09024818219196967,
+      "relativeStake": 0.003564845935081683,
+      "relays": [
+        {
+          "address": "relays.bladepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.09380926669458656,
+      "relativeStake": 0.003561084502616894,
+      "relays": [
+        {
+          "address": "relay-kiln-2-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "address": "relay-kiln-2-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "address": "relay-kiln-2-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.09736937170611602,
+      "relativeStake": 0.0035601050115294675,
+      "relays": [
+        {
+          "address": "50.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1009283472432164,
+      "relativeStake": 0.0035589755371003753,
+      "relays": [
+        {
+          "address": "cf5r1.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        },
+        {
+          "address": "cf5r2.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.10448732156446405,
+      "relativeStake": 0.0035589743212476477,
+      "relays": [
+        {
+          "address": "49.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.10803606905879032,
+      "relativeStake": 0.0035487474943262654,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1115793581385967,
+      "relativeStake": 0.003543289079806376,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.11511648386057985,
+      "relativeStake": 0.0035371257219831602,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1186316891474176,
+      "relativeStake": 0.0035152052868377445,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.12214446755130515,
+      "relativeStake": 0.003512778403887549,
+      "relays": [
+        {
+          "address": "r1.spirestaking.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1256401776217798,
+      "relativeStake": 0.0034957100704746634,
+      "relays": [
+        {
+          "address": "bd-cardano-main-relay-12-a.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "address": "bd-cardano-main-relay-12-b.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.12913002711459814,
+      "relativeStake": 0.003489849492818339,
+      "relays": [
+        {
+          "address": "42.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1326198020980895,
+      "relativeStake": 0.003489774983491336,
+      "relays": [
+        {
+          "address": "41.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1361094861667491,
+      "relativeStake": 0.003489684068659594,
+      "relays": [
+        {
+          "address": "46.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.13959911214388226,
+      "relativeStake": 0.0034896259771331857,
+      "relays": [
+        {
+          "address": "45.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1430887380921154,
+      "relativeStake": 0.0034896259482331358,
+      "relays": [
+        {
+          "address": "44.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1465783268264004,
+      "relativeStake": 0.003489588734285008,
+      "relays": [
+        {
+          "address": "47.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.150064031921081,
+      "relativeStake": 0.003485705094680595,
+      "relays": [
+        {
+          "address": "r1.1percentpool.eu",
+          "port": 19001
+        },
+        {
+          "address": "r2.1percentpool.eu",
+          "port": 19002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.153538811711978,
+      "relativeStake": 0.0034747797908969923,
+      "relays": [
+        {
+          "address": "r-eu-0.titanstaking.io",
+          "port": 4321
+        },
+        {
+          "address": "r-eu-1.titanstaking.io",
+          "port": 4321
+        },
+        {
+          "address": "r-eu-2.titanstaking.io",
+          "port": 4321
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.15698307896039274,
+      "relativeStake": 0.003444267248414735,
+      "relays": [
+        {
+          "address": "relay1.mainnet.pool.cardano.services",
+          "port": 3001
+        },
+        {
+          "address": "relay2.mainnet.pool.cardano.services",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1604262366074174,
+      "relativeStake": 0.003443157647024659,
+      "relays": [
+        {
+          "address": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "address": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1638684010409817,
+      "relativeStake": 0.0034421644335643057,
+      "relays": [
+        {
+          "address": "olive-geonosis-edffc.cardano.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "address": "violet-kingston-8d67e.cardano.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.16729413564799103,
+      "relativeStake": 0.0034257346070093453,
+      "relays": [
+        {
+          "address": "relay-pool-figment-21-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.17071496333720293,
+      "relativeStake": 0.0034208276892118846,
+      "relays": [
+        {
+          "address": "170.23.181.50",
+          "port": 6001
+        },
+        {
+          "address": "170.23.181.50",
+          "port": 6002
+        },
+        {
+          "address": "170.23.181.50",
+          "port": 6003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.174125564114978,
+      "relativeStake": 0.0034106007777750915,
+      "relays": [
+        {
+          "address": "178.128.79.219",
+          "port": 3001
+        },
+        {
+          "address": "104.131.122.73",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.17750485455088452,
+      "relativeStake": 0.0033792904359065015,
+      "relays": [
+        {
+          "address": "relay.de.fikapool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay.sg.fikapool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay.ca.fikapool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.18088156140741551,
+      "relativeStake": 0.003376706856531004,
+      "relays": [
+        {
+          "address": "95.154.235.142",
+          "port": 6000
+        },
+        {
+          "address": "217.155.18.115",
+          "port": 6003
+        },
+        {
+          "address": "217.155.18.115",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.18424074119056127,
+      "relativeStake": 0.0033591797831457426,
+      "relays": [
+        {
+          "address": "cardano-relays.autostake.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.18759600878851534,
+      "relativeStake": 0.00335526759795409,
+      "relays": [
+        {
+          "address": "26e894b1.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.19093565792956324,
+      "relativeStake": 0.003339649141047875,
+      "relays": [
+        {
+          "address": "ada-relay01.biglazycat.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.19427160795428933,
+      "relativeStake": 0.0033359500247260887,
+      "relays": [
+        {
+          "address": "relay.cardano.securestaking.io",
+          "port": 3000
+        },
+        {
+          "address": "secur2.cardano.securestaking.io",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1976068867998066,
+      "relativeStake": 0.003335278845517267,
+      "relays": [
+        {
+          "address": "46.101.9.225",
+          "port": 3001
+        },
+        {
+          "address": "64.227.46.95",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.20093662442713522,
+      "relativeStake": 0.0033297376273286497,
       "relays": [
         {
           "address": "180.150.102.25",
@@ -1735,26 +755,555 @@
       ]
     },
     {
-      "accumulatedStake": 0.4206203480321787,
-      "relativeStake": 0.002710148751592389,
+      "accumulatedStake": 0.20426180896286147,
+      "relativeStake": 0.0033251845357262395,
       "relays": [
         {
-          "address": "relaynode1.bravostakepool.nl",
-          "port": 3001
-        },
+          "address": "7ddb9c28.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2075850095396342,
+      "relativeStake": 0.0033232005767727404,
+      "relays": [
         {
-          "address": "relaynode2.bravostakepool.nl",
-          "port": 3001
-        },
-        {
-          "address": "relaynode3.bravostakepool.nl",
+          "address": "relays.wavepool.digital",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.4233285901203706,
-      "relativeStake": 0.002708242088191927,
+      "accumulatedStake": 0.21090068888850746,
+      "relativeStake": 0.0033156793488732534,
+      "relays": [
+        {
+          "address": "8d6f8de4.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.21421636232933938,
+      "relativeStake": 0.0033156734408319186,
+      "relays": [
+        {
+          "address": "b3e201f4.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.21753103296490847,
+      "relativeStake": 0.003314670635569077,
+      "relays": [
+        {
+          "address": "relay-kiln-6-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "address": "relay-kiln-6-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "address": "relay-kiln-6-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.22084278026612894,
+      "relativeStake": 0.003311747301220469,
+      "relays": [
+        {
+          "address": "relay1.cardanotech.io",
+          "port": 6000
+        },
+        {
+          "address": "relay2.cardanotech.io",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.22415322682988933,
+      "relativeStake": 0.0033104465637604106,
+      "relays": [
+        {
+          "address": "Relay1.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay2.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay3.NordicPool.org",
+          "port": 3005
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.22746225925200822,
+      "relativeStake": 0.0033090324221188685,
+      "relays": [
+        {
+          "address": "b3bbbcac.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.23077101021326482,
+      "relativeStake": 0.003308750961256621,
+      "relays": [
+        {
+          "address": "ddbb5a06.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.23407540492923293,
+      "relativeStake": 0.0033043947159681064,
+      "relays": [
+        {
+          "address": "35.75.32.253",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2373787210676444,
+      "relativeStake": 0.0033033161384114556,
+      "relays": [
+        {
+          "address": "e4527900.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2406816511056443,
+      "relativeStake": 0.0033029300379999052,
+      "relays": [
+        {
+          "address": "50809bee.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.24398377237679114,
+      "relativeStake": 0.0033021212711468345,
+      "relays": [
+        {
+          "address": "a94da6a8.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.24728579113764354,
+      "relativeStake": 0.0033020187608523923,
+      "relays": [
+        {
+          "address": "9a956262.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.25058748374767575,
+      "relativeStake": 0.003301692610032227,
+      "relays": [
+        {
+          "address": "9dc533bf.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2538889644248383,
+      "relativeStake": 0.0033014806771625464,
+      "relays": [
+        {
+          "address": "f84db19f.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2571900850908579,
+      "relativeStake": 0.0033011206660195744,
+      "relays": [
+        {
+          "address": "c2504518.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.26049107460263743,
+      "relativeStake": 0.003300989511779533,
+      "relays": [
+        {
+          "address": "dbe22510.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2637919734743998,
+      "relativeStake": 0.0033008988717624075,
+      "relays": [
+        {
+          "address": "778cb679.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2670927542116305,
+      "relativeStake": 0.0033007807372306837,
+      "relays": [
+        {
+          "address": "94cc7304.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2703935300668164,
+      "relativeStake": 0.00330077585518588,
+      "relays": [
+        {
+          "address": "bb78d57d.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2736942472061372,
+      "relativeStake": 0.003300717139320816,
+      "relays": [
+        {
+          "address": "72e508af.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.27699489083623985,
+      "relativeStake": 0.0033006436301026482,
+      "relays": [
+        {
+          "address": "d89eeea0.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.28029546895066365,
+      "relativeStake": 0.0033005781144238174,
+      "relays": [
+        {
+          "address": "d699483e.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2835960255532317,
+      "relativeStake": 0.0033005566025680567,
+      "relays": [
+        {
+          "address": "a5f2af9f.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.28689656727497403,
+      "relativeStake": 0.0033005417217423414,
+      "relays": [
+        {
+          "address": "d489c136.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2901962790803425,
+      "relativeStake": 0.0032997118053684424,
+      "relays": [
+        {
+          "address": "35.75.32.253",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2934808704970831,
+      "relativeStake": 0.00328459141674062,
+      "relays": [
+        {
+          "address": "Relay1.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay2.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay3.NordicPool.org",
+          "port": 3005
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.29676352969386877,
+      "relativeStake": 0.0032826591967856215,
+      "relays": [
+        {
+          "address": "relay-pool-figment-19-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3000108380817497,
+      "relativeStake": 0.0032473083878810003,
+      "relays": [
+        {
+          "address": "92a8429c.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3032445665449438,
+      "relativeStake": 0.0032337284631940473,
+      "relays": [
+        {
+          "address": "relays.stakepool.at",
+          "port": 3001
+        },
+        {
+          "address": "relay-1.stakepool.at",
+          "port": 3001
+        },
+        {
+          "address": "relay-2.stakepool.at",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.30647450076952526,
+      "relativeStake": 0.00322993422458148,
+      "relays": [
+        {
+          "address": "Relay1.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay2.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay3.NordicPool.org",
+          "port": 3005
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.30969966684260447,
+      "relativeStake": 0.0032251660730792026,
+      "relays": [
+        {
+          "address": "lucerne.datadyne.earth",
+          "port": 3001
+        },
+        {
+          "address": "g5.datadyne.earth",
+          "port": 3002
+        },
+        {
+          "address": "drcaroll.datadyne.earth",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.31289491758416743,
+      "relativeStake": 0.0031952507415629705,
+      "relays": [
+        {
+          "address": "relay01.ca.lovelace.community",
+          "port": 3001
+        },
+        {
+          "address": "relay02.ca.lovelace.community",
+          "port": 3001
+        },
+        {
+          "address": "relay01.fr.lovelace.community",
+          "port": 3001
+        },
+        {
+          "address": "relay01.de.lovelace.community",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.31608446138738877,
+      "relativeStake": 0.003189543803221323,
+      "relays": [
+        {
+          "address": "94c3c6d3.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3192519609710251,
+      "relativeStake": 0.00316749958363634,
+      "relays": [
+        {
+          "address": "11.relays.happystaking.io",
+          "port": 3001
+        },
+        {
+          "address": "12.relays.happystaking.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3224120238329085,
+      "relativeStake": 0.00316006286188342,
+      "relays": [
+        {
+          "address": "cof-1.cardanocafe.org",
+          "port": 3005
+        },
+        {
+          "address": "cof-2.cardanocafe.org",
+          "port": 3010
+        },
+        {
+          "address": "cap-1.cardanocafe.org",
+          "port": 4000
+        },
+        {
+          "address": "cap-2.cardanocafe.org",
+          "port": 4005
+        },
+        {
+          "address": "lat-1.cardanocafe.org",
+          "port": 5001
+        },
+        {
+          "address": "lat-2.cardanocafe.org",
+          "port": 5002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3255500605512152,
+      "relativeStake": 0.0031380367183066705,
+      "relays": [
+        {
+          "address": "relay1-dl.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay2-jp.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay3-li.aichi-stakepool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3286550118516534,
+      "relativeStake": 0.003104951300438186,
+      "relays": [
+        {
+          "address": "relay1.clovernodes.io",
+          "port": 6000
+        },
+        {
+          "address": "relay2.clovernodes.io",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.33173395010023077,
+      "relativeStake": 0.0030789382485773968,
+      "relays": [
+        {
+          "address": "gateway.adavault.com",
+          "port": 4021
+        },
+        {
+          "address": "gateway.adavault.com",
+          "port": 4022
+        },
+        {
+          "address": "gateway.adavault.com",
+          "port": 4026
+        },
+        {
+          "address": "gateway.adavault.com",
+          "port": 4027
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3347950471339347,
+      "relativeStake": 0.0030610970337039286,
+      "relays": [
+        {
+          "address": "173.15.110.154",
+          "port": 6000
+        },
+        {
+          "address": "173.15.110.155",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3378299087349564,
+      "relativeStake": 0.0030348616010216567,
+      "relays": [
+        {
+          "address": "rel01.fairpool.eu",
+          "port": 55001
+        },
+        {
+          "address": "rel02.fairpool.eu",
+          "port": 55002
+        },
+        {
+          "address": "rel03.fairpool.eu",
+          "port": 55003
+        },
+        {
+          "address": "rel04.fairpool.eu",
+          "port": 55004
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.34085499176656525,
+      "relativeStake": 0.0030250830316088852,
       "relays": [
         {
           "address": "relay.cardano.securestaking.io",
@@ -1767,8 +1316,186 @@
       ]
     },
     {
-      "accumulatedStake": 0.42603420141848,
-      "relativeStake": 0.0027056112981093863,
+      "accumulatedStake": 0.3438770973680805,
+      "relativeStake": 0.0030221056015152506,
+      "relays": [
+        {
+          "address": "157.173.120.233",
+          "port": 3001
+        },
+        {
+          "address": "157.173.120.233",
+          "port": 3002
+        },
+        {
+          "address": "5.252.53.68",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.346891603387648,
+      "relativeStake": 0.0030145060195675027,
+      "relays": [
+        {
+          "address": "octaluso.dyndns.org",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3498859230581036,
+      "relativeStake": 0.0029943196704556013,
+      "relays": [
+        {
+          "address": "91.242.214.33",
+          "port": 3001
+        },
+        {
+          "address": "186.233.187.33",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3528424190823353,
+      "relativeStake": 0.0029564960242317298,
+      "relays": [
+        {
+          "address": "r-eu-0.titanstaking.io",
+          "port": 4321
+        },
+        {
+          "address": "r-eu-1.titanstaking.io",
+          "port": 4321
+        },
+        {
+          "address": "r-eu-2.titanstaking.io",
+          "port": 4321
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.35579819946448704,
+      "relativeStake": 0.0029557803821516873,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3587435495330062,
+      "relativeStake": 0.0029453500685191905,
+      "relays": [
+        {
+          "address": "644dd09c.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3616683071792176,
+      "relativeStake": 0.0029247576462113995,
+      "relays": [
+        {
+          "address": "bd-cardano-main-relay-5-a.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "address": "bd-cardano-main-relay-5-b.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.36459111375790265,
+      "relativeStake": 0.002922806578685019,
+      "relays": [
+        {
+          "address": "rockyrelay1.ddns.net",
+          "port": 3001
+        },
+        {
+          "address": "rockyrelay2.ddns.net",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3675062381847631,
+      "relativeStake": 0.002915124426860442,
+      "relays": [
+        {
+          "address": "77cb3f75.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.37041689491577684,
+      "relativeStake": 0.0029106567310137393,
+      "relays": [
+        {
+          "address": "st3ak.1337.cx",
+          "port": 6000
+        },
+        {
+          "address": "st3ak.mooo.com",
+          "port": 6000
+        },
+        {
+          "address": "st3ak.root.sx",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3733211557271872,
+      "relativeStake": 0.0029042608114104086,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3762157830199588,
+      "relativeStake": 0.0028946272927715356,
       "relays": [
         {
           "address": "f9395b98.cardano-relay.herd.run",
@@ -1777,8 +1504,60 @@
       ]
     },
     {
-      "accumulatedStake": 0.42873186628427434,
-      "relativeStake": 0.0026976648657943765,
+      "accumulatedStake": 0.37909997977240006,
+      "relativeStake": 0.002884196752441284,
+      "relays": [
+        {
+          "address": "relays.stakepool.at",
+          "port": 3001
+        },
+        {
+          "address": "relay-1.stakepool.at",
+          "port": 3001
+        },
+        {
+          "address": "relay-2.stakepool.at",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.38198350293534566,
+      "relativeStake": 0.0028835231629456225,
+      "relays": [
+        {
+          "address": "57.129.24.185",
+          "port": 3001
+        },
+        {
+          "address": "57.129.28.178",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.38486439599821165,
+      "relativeStake": 0.0028808930628660117,
+      "relays": [
+        {
+          "address": "6398a55d.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3877301827215599,
+      "relativeStake": 0.002865786723348199,
+      "relays": [
+        {
+          "address": "relays.digi.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.39058171693656657,
+      "relativeStake": 0.0028515342150066784,
       "relays": [
         {
           "address": "sydney.cardanode.com.au",
@@ -1799,82 +1578,137 @@
       ]
     },
     {
-      "accumulatedStake": 0.43140439375335043,
-      "relativeStake": 0.002672527469076086,
+      "accumulatedStake": 0.39341528870556497,
+      "relativeStake": 0.0028335717689984084,
       "relays": [
         {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
+          "address": "129.80.153.243",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.434075207960416,
-      "relativeStake": 0.002670814207065531,
+      "accumulatedStake": 0.3962217583094921,
+      "relativeStake": 0.0028064696039271295,
       "relays": [
         {
-          "address": "cork.queenada.com",
-          "port": 7500
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4367323959114714,
-      "relativeStake": 0.00265718795105539,
-      "relays": [
-        {
-          "address": "relay.anonaf.com",
-          "port": 3333
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.43938683646372284,
-      "relativeStake": 0.0026544405522514747,
-      "relays": [
-        {
-          "address": "st3ak.1337.cx",
-          "port": 6000
+          "address": "relay1.snakepool.link",
+          "port": 3001
         },
         {
-          "address": "st3ak.mooo.com",
-          "port": 6000
-        },
-        {
-          "address": "st3ak.root.sx",
-          "port": 6000
+          "address": "relay2.snakepool.link",
+          "port": 3002
         }
       ]
     },
     {
-      "accumulatedStake": 0.4420409758525711,
-      "relativeStake": 0.0026541393888483015,
+      "accumulatedStake": 0.39902351851020645,
+      "relativeStake": 0.002801760200714388,
       "relays": [
         {
-          "address": "relay1.str8pool.com",
-          "port": 7421
+          "address": "Relay1.NordicPool.org",
+          "port": 3005
         },
         {
-          "address": "relay2.str8pool.com",
-          "port": 3611
+          "address": "Relay2.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "address": "Relay3.NordicPool.org",
+          "port": 3005
         }
       ]
     },
     {
-      "accumulatedStake": 0.4446744567271612,
-      "relativeStake": 0.002633480874590054,
+      "accumulatedStake": 0.4018212003507588,
+      "relativeStake": 0.0027976818405523033,
+      "relays": [
+        {
+          "address": "relay-pool-figment-10-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.40461670729215843,
+      "relativeStake": 0.0027955069413996363,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.40741136157583135,
+      "relativeStake": 0.002794654283672943,
+      "relays": [
+        {
+          "address": "relay-kiln-7-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "address": "relay-kiln-7-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "address": "relay-kiln-7-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.41018876230544665,
+      "relativeStake": 0.0027774007296152677,
+      "relays": [
+        {
+          "address": "76cf1dd1.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.41295327874534166,
+      "relativeStake": 0.0027645164398950473,
+      "relays": [
+        {
+          "address": "a0e18895.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.41571248113722503,
+      "relativeStake": 0.0027592023918833536,
+      "relays": [
+        {
+          "address": "57.128.184.33",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.31",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.41846261748300534,
+      "relativeStake": 0.0027501363457803217,
       "relays": [
         {
           "address": "relay.cardano.securestaking.io",
@@ -1887,107 +1721,82 @@
       ]
     },
     {
-      "accumulatedStake": 0.4472992488548879,
-      "relativeStake": 0.0026247921277267315,
+      "accumulatedStake": 0.4212077964344027,
+      "relativeStake": 0.0027451789513973338,
       "relays": [
         {
-          "address": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4499127967123031,
-      "relativeStake": 0.0026135478574151635,
-      "relays": [
-        {
-          "address": "relay1.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay2.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay3.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay4.nedscave.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.45252358969318374,
-      "relativeStake": 0.0026107929808806196,
-      "relays": [
-        {
-          "address": "relay1-dl.aichi-stakepool.com",
+          "address": "148.113.17.23",
           "port": 6000
         },
         {
-          "address": "relay2-jp.aichi-stakepool.com",
+          "address": "158.69.25.103",
           "port": 6000
         },
         {
-          "address": "relay3-li.aichi-stakepool.com",
+          "address": "46.4.53.238",
+          "port": 6000
+        },
+        {
+          "address": "149.102.140.164",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.4550992087208691,
-      "relativeStake": 0.0025756190276854237,
+      "accumulatedStake": 0.4239408062823674,
+      "relativeStake": 0.0027330098479647355,
       "relays": [
         {
-          "address": "54.37.87.63",
-          "port": 6000
+          "address": "relays.cardanowithpaul.com",
+          "port": 1069
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.42664033671180945,
+      "relativeStake": 0.0026995304294420135,
+      "relays": [
+        {
+          "address": "52.6.109.221",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4293354414626648,
+      "relativeStake": 0.0026951047508553395,
+      "relays": [
+        {
+          "address": "relaynode1.bravostakepool.nl",
+          "port": 3001
         },
         {
-          "address": "54.36.178.85",
-          "port": 6000
+          "address": "relaynode2.bravostakepool.nl",
+          "port": 3001
+        },
+        {
+          "address": "relaynode3.bravostakepool.nl",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.45766899256467397,
-      "relativeStake": 0.0025697838438048385,
+      "accumulatedStake": 0.43202433052580813,
+      "relativeStake": 0.002688889063143339,
       "relays": [
         {
-          "address": "relay-pool-ledger-3-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4602371204260182,
-      "relativeStake": 0.002568127861344214,
-      "relays": [
+          "address": "r-eu-1.polypool.io",
+          "port": 4001
+        },
         {
-          "address": "644dd09c.cardano-relay.herd.run",
-          "port": 1338
+          "address": "r-sg-1.polypool.io",
+          "port": 4001
         }
       ]
     },
     {
-      "accumulatedStake": 0.46279848833835785,
-      "relativeStake": 0.002561367912339629,
+      "accumulatedStake": 0.4347112421702529,
+      "relativeStake": 0.00268691164444478,
       "relays": [
         {
           "address": "20.61.229.103",
@@ -2008,185 +1817,64 @@
       ]
     },
     {
-      "accumulatedStake": 0.46531841133700746,
-      "relativeStake": 0.002519922998649633,
+      "accumulatedStake": 0.4373730658920572,
+      "relativeStake": 0.002661823721804297,
       "relays": [
         {
-          "address": "fr.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "address": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.467803814453146,
-      "relativeStake": 0.002485403116138525,
-      "relays": [
-        {
-          "address": "a0e18895.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.47028043592594915,
-      "relativeStake": 0.0024766214728031365,
-      "relays": [
-        {
-          "address": "norway.adanorthpool.com",
-          "port": 9011
-        },
-        {
-          "address": "norway.adanorthpool.com",
-          "port": 9012
-        },
-        {
-          "address": "norway.adanorthpool.com",
-          "port": 9014
-        },
-        {
-          "address": "norway2.adanorthpool.com",
-          "port": 9014
-        },
-        {
-          "address": "norway2.adanorthpool.com",
-          "port": 9013
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.47275620635229443,
-      "relativeStake": 0.002475770426345324,
-      "relays": [
-        {
-          "address": "relay1.able-pool.io",
-          "port": 4555
-        },
-        {
-          "address": "relay2.able-pool.io",
-          "port": 4419
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.47522604882645125,
-      "relativeStake": 0.0024698424741568244,
-      "relays": [
-        {
-          "address": "c61ace08.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4776952455433105,
-      "relativeStake": 0.0024691967168592537,
-      "relays": [
-        {
-          "address": "r1.adastat.net",
-          "port": 3333
-        },
-        {
-          "address": "r2.adastat.net",
-          "port": 3333
-        },
-        {
-          "address": "r3.adastat.net",
+          "address": "relay.anonaf.com",
           "port": 3333
         }
       ]
     },
     {
-      "accumulatedStake": 0.4801630395397893,
-      "relativeStake": 0.0024677939964787435,
+      "accumulatedStake": 0.44002677354802155,
+      "relativeStake": 0.002653707655964343,
       "relays": [
         {
-          "address": "r1.1percentpool.eu",
-          "port": 19001
+          "address": "relay1.str8pool.com",
+          "port": 7421
         },
         {
-          "address": "r2.1percentpool.eu",
-          "port": 19002
+          "address": "relay2.str8pool.com",
+          "port": 3611
         }
       ]
     },
     {
-      "accumulatedStake": 0.48260385111903215,
-      "relativeStake": 0.0024408115792428704,
+      "accumulatedStake": 0.4426651740874086,
+      "relativeStake": 0.0026384005393870545,
       "relays": [
         {
-          "address": "cardano-main.everstake.one",
-          "port": 3001
+          "address": "54.37.87.63",
+          "port": 6000
         },
         {
-          "address": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
-          "port": 3001
+          "address": "54.36.178.85",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.48501218858278106,
-      "relativeStake": 0.0024083374637488978,
+      "accumulatedStake": 0.44530217500070596,
+      "relativeStake": 0.002637000913297383,
       "relays": [
         {
-          "address": "relays.onyxstakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4873753240105113,
-      "relativeStake": 0.0023631354277302884,
-      "relays": [
-        {
-          "address": "cardano-main.everstake.one",
+          "address": "31.220.91.105",
           "port": 3001
         },
         {
-          "address": "cardano-main2.everstake.one",
+          "address": "154.26.158.189",
           "port": 3001
         },
         {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
+          "address": "5.104.83.174",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.48973727829241853,
-      "relativeStake": 0.0023619542819072197,
-      "relays": [
-        {
-          "address": "relay-pool-figment-6-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.49209847736707246,
-      "relativeStake": 0.0023611990746539133,
+      "accumulatedStake": 0.4479329124726364,
+      "relativeStake": 0.002630737471930427,
       "relays": [
         {
           "address": "ACLrelay1.cardanoland.com",
@@ -2215,474 +1903,39 @@
       ]
     },
     {
-      "accumulatedStake": 0.494455657294716,
-      "relativeStake": 0.0023571799276435514,
+      "accumulatedStake": 0.4505324668820946,
+      "relativeStake": 0.0025995544094581688,
       "relays": [
         {
-          "address": "3.217.90.52",
-          "port": 6000
-        },
-        {
-          "address": "3.219.254.127",
-          "port": 6000
+          "address": "relay-pool-ledger-3-mainnet.cardano.aeq5f.com"
         }
       ]
     },
     {
-      "accumulatedStake": 0.49681049895830043,
-      "relativeStake": 0.002354841663584441,
+      "accumulatedStake": 0.45311890520368375,
+      "relativeStake": 0.0025864383215891823,
       "relays": [
         {
-          "address": "ada-relay02.biglazycat.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.49916351514528895,
-      "relativeStake": 0.0023530161869884983,
-      "relays": [
-        {
-          "address": "152.53.21.151",
-          "port": 6000
-        },
-        {
-          "address": "149.102.152.63",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5015130382059434,
-      "relativeStake": 0.0023495230606544065,
-      "relays": [
-        {
-          "address": "178.156.128.18",
-          "port": 6001
-        },
-        {
-          "address": "65.21.7.149",
-          "port": 6001
-        },
-        {
-          "address": "137.220.49.160",
-          "port": 6001
-        },
-        {
-          "address": "149.28.106.237",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5038579295468899,
-      "relativeStake": 0.0023448913409465444,
-      "relays": [
-        {
-          "address": "49.12.198.221",
-          "port": 6000
-        },
-        {
-          "address": "89.58.18.51",
-          "port": 6000
-        },
-        {
-          "address": "131.153.199.82",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5062025760002355,
-      "relativeStake": 0.002344646453345665,
-      "relays": [
-        {
-          "address": "20.61.229.103",
+          "address": "relay1.nedscave.io",
           "port": 3001
         },
         {
-          "address": "20.61.228.218",
+          "address": "relay2.nedscave.io",
           "port": 3001
         },
         {
-          "address": "108.142.42.221",
+          "address": "relay3.nedscave.io",
           "port": 3001
         },
         {
-          "address": "108.142.42.161",
+          "address": "relay4.nedscave.io",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5085469129981557,
-      "relativeStake": 0.002344336997920081,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5108912423729653,
-      "relativeStake": 0.0023443293748097475,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5132355704287384,
-      "relativeStake": 0.002344328055773013,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5155798929324923,
-      "relativeStake": 0.0023443225037539346,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5179242106994834,
-      "relativeStake": 0.002344317766990997,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5202513851321492,
-      "relativeStake": 0.0023271744326658047,
-      "relays": [
-        {
-          "address": "35.156.192.95",
-          "port": 6000
-        },
-        {
-          "address": "18.197.51.215",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5225661781107586,
-      "relativeStake": 0.002314792978609375,
-      "relays": [
-        {
-          "address": "188.165.236.202",
-          "port": 3001
-        },
-        {
-          "address": "195.201.107.114",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5248729353595707,
-      "relativeStake": 0.0023067572488121345,
-      "relays": [
-        {
-          "address": "relay0.fimi.vn",
-          "port": 3000
-        },
-        {
-          "address": "relay1.fimi.vn",
-          "port": 3000
-        },
-        {
-          "address": "relay2.fimi.vn",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5271723731551283,
-      "relativeStake": 0.0022994377955577274,
-      "relays": [
-        {
-          "address": "eu1.stakecool.io",
-          "port": 4001
-        },
-        {
-          "address": "eu2.stakecool.io",
-          "port": 4001
-        },
-        {
-          "address": "ca1.stakecool.io",
-          "port": 4001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5294446773307174,
-      "relativeStake": 0.0022723041755890534,
-      "relays": [
-        {
-          "address": "57.128.184.27",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.86",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5317122504848985,
-      "relativeStake": 0.002267573154181023,
-      "relays": [
-        {
-          "address": "relay1.apexfusionhosting.com",
-          "port": 3001
-        },
-        {
-          "address": "relay2.apexfusionhosting.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5339627919019266,
-      "relativeStake": 0.0022505414170281564,
-      "relays": [
-        {
-          "address": "150.136.111.193",
-          "port": 6001
-        },
-        {
-          "address": "150.136.84.82",
-          "port": 6001
-        },
-        {
-          "address": "158.101.99.150",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.536202836611862,
-      "relativeStake": 0.0022400447099353423,
-      "relays": [
-        {
-          "address": "35.211.17.86",
-          "port": 3000
-        },
-        {
-          "address": "34.23.88.7",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5384370244092833,
-      "relativeStake": 0.0022341877974213485,
-      "relays": [
-        {
-          "address": "relay0.viperstaking.com",
-          "port": 4444
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5406374778941677,
-      "relativeStake": 0.0022004534848843833,
-      "relays": [
-        {
-          "address": "86.80.128.65",
-          "port": 3001
-        },
-        {
-          "address": "86.80.128.65",
-          "port": 3002
-        },
-        {
-          "address": "86.80.128.65",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.542829563688235,
-      "relativeStake": 0.0021920857940673044,
-      "relays": [
-        {
-          "address": "relay-pool-bitvavo-1-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.545017385735282,
-      "relativeStake": 0.002187822047047032,
-      "relays": [
-        {
-          "address": "germany.cardanode.io",
-          "port": 6000
-        },
-        {
-          "address": "missouri.cardanode.io",
-          "port": 6000
-        },
-        {
-          "address": "la.cardanode.io",
-          "port": 6000
-        },
-        {
-          "address": "perth.cardanode.io",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5471989129097393,
-      "relativeStake": 0.002181527174457328,
-      "relays": [
-        {
-          "address": "relay1.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay3.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay4.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay5.adaocean.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5493794384924475,
-      "relativeStake": 0.002180525582708133,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5515475259093724,
-      "relativeStake": 0.0021680874169249403,
-      "relays": [
-        {
-          "address": "relay.azureada.com",
-          "port": 3001
-        },
-        {
-          "address": "relay.azureada.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5537110675740752,
-      "relativeStake": 0.0021635416647027253,
-      "relays": [
-        {
-          "address": "relay1.0aaaa.org",
-          "port": 3001
-        },
-        {
-          "address": "relay2.0aaaa.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5558384006867865,
-      "relativeStake": 0.0021273331127113085,
-      "relays": [
-        {
-          "address": "relay-pool-bitvavo-2-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5579557593684276,
-      "relativeStake": 0.002117358681641092,
+      "accumulatedStake": 0.4557047292835245,
+      "relativeStake": 0.0025858240798407586,
       "relays": [
         {
           "address": "cardano-main.everstake.one",
@@ -2707,17 +1960,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.5600717746319206,
-      "relativeStake": 0.0021160152634930817,
+      "accumulatedStake": 0.4582846939829833,
+      "relativeStake": 0.0025799646994587966,
       "relays": [
         {
-          "address": "relay-pool-bitvavo-3-mainnet.cardano.aeq5f.com"
+          "address": "cork.queenada.com",
+          "port": 7500
         }
       ]
     },
     {
-      "accumulatedStake": 0.5621862580417112,
-      "relativeStake": 0.0021144834097905564,
+      "accumulatedStake": 0.46085984874250274,
+      "relativeStake": 0.0025751547595194483,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.46342822006714185,
+      "relativeStake": 0.0025683713246390867,
       "relays": [
         {
           "address": "relays.wavepool.digital",
@@ -2726,64 +2002,534 @@
       ]
     },
     {
-      "accumulatedStake": 0.5642982017388849,
-      "relativeStake": 0.0021119436971737257,
+      "accumulatedStake": 0.4659531766833514,
+      "relativeStake": 0.002524956616209537,
       "relays": [
         {
-          "address": "57.128.184.28",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.30",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5663910833035803,
-      "relativeStake": 0.0020928815646953894,
-      "relays": [
-        {
-          "address": "109.123.231.213",
+          "address": "relay1-dl.aichi-stakepool.com",
           "port": 6000
         },
         {
-          "address": "89.58.45.244",
+          "address": "relay2-jp.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay3-li.aichi-stakepool.com",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5684592703652375,
-      "relativeStake": 0.0020681870616571915,
+      "accumulatedStake": 0.4684780560320951,
+      "relativeStake": 0.002524879348743712,
       "relays": [
         {
-          "address": "relay.cardano.securestaking.io",
+          "address": "norway.adanorthpool.com",
+          "port": 9011
+        },
+        {
+          "address": "norway.adanorthpool.com",
+          "port": 9012
+        },
+        {
+          "address": "norway.adanorthpool.com",
+          "port": 9014
+        },
+        {
+          "address": "norway2.adanorthpool.com",
+          "port": 9014
+        },
+        {
+          "address": "norway2.adanorthpool.com",
+          "port": 9013
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4709678599219869,
+      "relativeStake": 0.0024898038898918486,
+      "relays": [
+        {
+          "address": "c61ace08.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4734513977010985,
+      "relativeStake": 0.002483537779111584,
+      "relays": [
+        {
+          "address": "25.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.47592336554563625,
+      "relativeStake": 0.0024719678445377087,
+      "relays": [
+        {
+          "address": "fr.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "address": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.47839233549016624,
+      "relativeStake": 0.00246896994453004,
+      "relays": [
+        {
+          "address": "r1.adastat.net",
+          "port": 3333
+        },
+        {
+          "address": "r2.adastat.net",
+          "port": 3333
+        },
+        {
+          "address": "r3.adastat.net",
+          "port": 3333
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4808221922276984,
+      "relativeStake": 0.0024298567375321267,
+      "relays": [
+        {
+          "address": "r1.1percentpool.eu",
+          "port": 19001
+        },
+        {
+          "address": "r2.1percentpool.eu",
+          "port": 19002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.48324966241598577,
+      "relativeStake": 0.0024274701882874006,
+      "relays": [
+        {
+          "address": "relays.onyxstakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.48567312568748355,
+      "relativeStake": 0.0024234632714977607,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4880864400256466,
+      "relativeStake": 0.0024133143381630333,
+      "relays": [
+        {
+          "address": "relay-pool-figment-8-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.490476315357572,
+      "relativeStake": 0.0023898753319254243,
+      "relays": [
+        {
+          "address": "35.156.192.95",
+          "port": 6000
+        },
+        {
+          "address": "18.197.51.215",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4928576821690409,
+      "relativeStake": 0.0023813668114689105,
+      "relays": [
+        {
+          "address": "fdd5329e.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4952376719612856,
+      "relativeStake": 0.0023799897922446634,
+      "relays": [
+        {
+          "address": "relay-pool-figment-6-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4976100023657637,
+      "relativeStake": 0.0023723304044780996,
+      "relays": [
+        {
+          "address": "178.156.128.18",
+          "port": 6001
+        },
+        {
+          "address": "65.21.7.149",
+          "port": 6001
+        },
+        {
+          "address": "137.220.49.160",
+          "port": 6001
+        },
+        {
+          "address": "149.28.106.237",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4999817053637754,
+      "relativeStake": 0.0023717029980116805,
+      "relays": [
+        {
+          "address": "152.53.21.151",
+          "port": 6000
+        },
+        {
+          "address": "149.102.152.63",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.502344812543146,
+      "relativeStake": 0.0023631071793706188,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5047033580082712,
+      "relativeStake": 0.002358545465125197,
+      "relays": [
+        {
+          "address": "188.165.236.202",
+          "port": 3001
+        },
+        {
+          "address": "195.201.107.114",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5070606239037565,
+      "relativeStake": 0.0023572658954852696,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5094175795807052,
+      "relativeStake": 0.0023569556769487254,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5117745276355762,
+      "relativeStake": 0.00235694805487104,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5141314743786524,
+      "relativeStake": 0.002356946743076096,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5164884145809725,
+      "relativeStake": 0.0023569402023201646,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5188453500210354,
+      "relativeStake": 0.002356935440062848,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5212016424679966,
+      "relativeStake": 0.0023562924469612426,
+      "relays": [
+        {
+          "address": "3.217.90.52",
+          "port": 6000
+        },
+        {
+          "address": "3.219.254.127",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5235522138998014,
+      "relativeStake": 0.002350571431804833,
+      "relays": [
+        {
+          "address": "ada-relay02.biglazycat.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5258815868560779,
+      "relativeStake": 0.0023293729562765216,
+      "relays": [
+        {
+          "address": "relay1.able-pool.io",
+          "port": 4555
+        },
+        {
+          "address": "relay2.able-pool.io",
+          "port": 4419
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5282045386881936,
+      "relativeStake": 0.0023229518321156617,
+      "relays": [
+        {
+          "address": "relay0.fimi.vn",
           "port": 3000
         },
         {
-          "address": "secur2.cardano.securestaking.io",
+          "address": "relay1.fimi.vn",
+          "port": 3000
+        },
+        {
+          "address": "relay2.fimi.vn",
           "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5705273639022838,
-      "relativeStake": 0.0020680935370462877,
+      "accumulatedStake": 0.5305194904630778,
+      "relativeStake": 0.002314951774884148,
       "relays": [
         {
-          "address": "eu-relay.hermes-stakepool.com",
-          "port": 1000
-        },
-        {
-          "address": "us-relay.hermes-stakepool.com",
-          "port": 1000
+          "address": "relay0.viperstaking.com",
+          "port": 4444
         }
       ]
     },
     {
-      "accumulatedStake": 0.5725600079323763,
-      "relativeStake": 0.002032644030092499,
+      "accumulatedStake": 0.5328231846361834,
+      "relativeStake": 0.0023036941731056216,
+      "relays": [
+        {
+          "address": "49.12.198.221",
+          "port": 6000
+        },
+        {
+          "address": "89.58.18.51",
+          "port": 6000
+        },
+        {
+          "address": "131.153.199.82",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5351164422990041,
+      "relativeStake": 0.0022932576628207977,
+      "relays": [
+        {
+          "address": "relay.azureada.com",
+          "port": 3001
+        },
+        {
+          "address": "relay.azureada.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5373849910096721,
+      "relativeStake": 0.0022685487106679104,
+      "relays": [
+        {
+          "address": "150.136.111.193",
+          "port": 6001
+        },
+        {
+          "address": "150.136.84.82",
+          "port": 6001
+        },
+        {
+          "address": "158.101.99.150",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5396423655976568,
+      "relativeStake": 0.0022573745879847368,
+      "relays": [
+        {
+          "address": "35.211.17.86",
+          "port": 3000
+        },
+        {
+          "address": "34.23.88.7",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5418544093557837,
+      "relativeStake": 0.002212043758126846,
       "relays": [
         {
           "address": "ada10753.allnodes.me",
@@ -2804,8 +2550,290 @@
       ]
     },
     {
-      "accumulatedStake": 0.5745459019311394,
-      "relativeStake": 0.0019858939987631554,
+      "accumulatedStake": 0.544063220021817,
+      "relativeStake": 0.0022088106660332714,
+      "relays": [
+        {
+          "address": "relay-pool-bitvavo-1-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5462585717881371,
+      "relativeStake": 0.002195351766320109,
+      "relays": [
+        {
+          "address": "relay1.apexfusionhosting.com",
+          "port": 3001
+        },
+        {
+          "address": "relay2.apexfusionhosting.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5484361190542453,
+      "relativeStake": 0.002177547266108194,
+      "relays": [
+        {
+          "address": "86.80.128.65",
+          "port": 3001
+        },
+        {
+          "address": "86.80.128.65",
+          "port": 3002
+        },
+        {
+          "address": "86.80.128.65",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5506069629916355,
+      "relativeStake": 0.0021708439373902635,
+      "relays": [
+        {
+          "address": "germany.cardanode.io",
+          "port": 6000
+        },
+        {
+          "address": "missouri.cardanode.io",
+          "port": 6000
+        },
+        {
+          "address": "la.cardanode.io",
+          "port": 6000
+        },
+        {
+          "address": "perth.cardanode.io",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5527700505906009,
+      "relativeStake": 0.0021630875989654377,
+      "relays": [
+        {
+          "address": "57.128.184.27",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.86",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5549141647792237,
+      "relativeStake": 0.002144114188622757,
+      "relays": [
+        {
+          "address": "relay-pool-bitvavo-2-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5570533235651313,
+      "relativeStake": 0.002139158785907605,
+      "relays": [
+        {
+          "address": "eu1.stakecool.io",
+          "port": 4001
+        },
+        {
+          "address": "eu2.stakecool.io",
+          "port": 4001
+        },
+        {
+          "address": "eu3.stakecool.io",
+          "port": 4002
+        },
+        {
+          "address": "eu4.stakecool.io",
+          "port": 4002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5591862241930684,
+      "relativeStake": 0.0021329006279371147,
+      "relays": [
+        {
+          "address": "relay1.0aaaa.org",
+          "port": 3001
+        },
+        {
+          "address": "relay2.0aaaa.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5613186405839753,
+      "relativeStake": 0.0021324163909069425,
+      "relays": [
+        {
+          "address": "217.160.14.223",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5634508179919976,
+      "relativeStake": 0.002132177408022246,
+      "relays": [
+        {
+          "address": "relay-pool-bitvavo-3-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5655786196709736,
+      "relativeStake": 0.002127801678975986,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5676931444025295,
+      "relativeStake": 0.0021145247315558823,
+      "relays": [
+        {
+          "address": "35.211.17.86",
+          "port": 3000
+        },
+        {
+          "address": "34.23.88.7",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5698012574754914,
+      "relativeStake": 0.0021081130729618696,
+      "relays": [
+        {
+          "address": "relay-pool-ledger-1-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5718980620605204,
+      "relativeStake": 0.0020968045850291183,
+      "relays": [
+        {
+          "address": "109.123.231.213",
+          "port": 6000
+        },
+        {
+          "address": "89.58.45.244",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5739867721843978,
+      "relativeStake": 0.0020887101238773525,
+      "relays": [
+        {
+          "address": "57.128.184.28",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.30",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5760746805884916,
+      "relativeStake": 0.0020879084040938997,
+      "relays": [
+        {
+          "address": "relay1.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay2.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay3.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay4.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay5.adaocean.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5781499416645924,
+      "relativeStake": 0.0020752610761007846,
+      "relays": [
+        {
+          "address": "18.157.253.103",
+          "port": 8381
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5802216608981194,
+      "relativeStake": 0.002071719233526926,
+      "relays": [
+        {
+          "address": "eu-relay.hermes-stakepool.com",
+          "port": 1000
+        },
+        {
+          "address": "us-relay.hermes-stakepool.com",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.582212347624437,
+      "relativeStake": 0.0019906867263175736,
+      "relays": [
+        {
+          "address": "relay-1.minswap.org",
+          "port": 3001
+        },
+        {
+          "address": "relay-2.minswap.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.584193955009649,
+      "relativeStake": 0.0019816073852120183,
       "relays": [
         {
           "address": "relay1-us.xstakepool.com",
@@ -2826,17 +2854,100 @@
       ]
     },
     {
-      "accumulatedStake": 0.5765242966819681,
-      "relativeStake": 0.001978394750828746,
+      "accumulatedStake": 0.5861570530944576,
+      "relativeStake": 0.00196309808480865,
       "relays": [
         {
-          "address": "relay-pool-figment-8-mainnet.cardano.aeq5f.com"
+          "address": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "address": "cardano-relays-2.nu.fi",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5784878073678886,
-      "relativeStake": 0.0019635106859204397,
+      "accumulatedStake": 0.5881180408136072,
+      "relativeStake": 0.0019609877191495385,
+      "relays": [
+        {
+          "address": "cardano-relay1.nodes.lgns.xyz",
+          "port": 6000
+        },
+        {
+          "address": "cardano-relay2.nodes.lgns.xyz",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.590050066658488,
+      "relativeStake": 0.001932025844880846,
+      "relays": [
+        {
+          "address": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "address": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5919751025136544,
+      "relativeStake": 0.0019250358551663365,
+      "relays": [
+        {
+          "address": "1339aecb.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5938945994163727,
+      "relativeStake": 0.0019194969027183017,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5958073212422521,
+      "relativeStake": 0.0019127218258794137,
+      "relays": [
+        {
+          "address": "relay1.blueocean.sg",
+          "port": 3001
+        },
+        {
+          "address": "relay2.blueocean.sg",
+          "port": 3001
+        },
+        {
+          "address": "hcm07xw90vx.sn.mynetname.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5977136121128878,
+      "relativeStake": 0.0019062908706357104,
       "relays": [
         {
           "address": "gateway.adavault.com",
@@ -2865,88 +2976,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5804401707483577,
-      "relativeStake": 0.0019523633804691169,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5823881066833779,
-      "relativeStake": 0.0019479359350201527,
-      "relays": [
-        {
-          "address": "relay1.blueocean.sg",
-          "port": 3001
-        },
-        {
-          "address": "relay2.blueocean.sg",
-          "port": 3001
-        },
-        {
-          "address": "hcm07xw90vx.sn.mynetname.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5843339141454863,
-      "relativeStake": 0.0019458074621083678,
-      "relays": [
-        {
-          "address": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "address": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5862755192690736,
-      "relativeStake": 0.0019416051235873247,
-      "relays": [
-        {
-          "address": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "address": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.588215845239637,
-      "relativeStake": 0.001940325970563445,
-      "relays": [
-        {
-          "address": "cardano-relay1.nodes.lgns.xyz",
-          "port": 6000
-        },
-        {
-          "address": "cardano-relay2.nodes.lgns.xyz",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5901531233722824,
-      "relativeStake": 0.00193727813264542,
-      "relays": [
-        {
-          "address": "18.157.253.103",
-          "port": 8381
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5920878607012943,
-      "relativeStake": 0.0019347373290118039,
+      "accumulatedStake": 0.5996190051063393,
+      "relativeStake": 0.0019053929934514252,
       "relays": [
         {
           "address": "cardano-main.everstake.one",
@@ -2971,96 +3002,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5940132691552562,
-      "relativeStake": 0.0019254084539619336,
-      "relays": [
-        {
-          "address": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "address": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5959224901785553,
-      "relativeStake": 0.0019092210232990996,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5978036347192763,
-      "relativeStake": 0.001881144540721049,
-      "relays": [
-        {
-          "address": "relay1.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay3.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay4.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay5.adaocean.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5996727793047445,
-      "relativeStake": 0.0018691445854681792,
-      "relays": [
-        {
-          "address": "66.160.158.69",
-          "port": 6000
-        },
-        {
-          "address": "66.160.158.70",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.601520469740498,
-      "relativeStake": 0.0018476904357534356,
+      "accumulatedStake": 0.6015133599307139,
+      "relativeStake": 0.001894354824374587,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -3081,57 +3024,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.603346089963336,
-      "relativeStake": 0.0018256202228380917,
-      "relays": [
-        {
-          "address": "relay-pool-ledger-1-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6051676930610724,
-      "relativeStake": 0.0018216030977363923,
-      "relays": [
-        {
-          "address": "relay-1.minswap.org",
-          "port": 3001
-        },
-        {
-          "address": "relay-2.minswap.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6069841407878498,
-      "relativeStake": 0.0018164477267773732,
-      "relays": [
-        {
-          "address": "relay1.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay3.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay4.adaocean.com",
-          "port": 6000
-        },
-        {
-          "address": "relay5.adaocean.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6087644759586577,
-      "relativeStake": 0.001780335170807912,
+      "accumulatedStake": 0.6034000980153355,
+      "relativeStake": 0.0018867380846216296,
       "relays": [
         {
           "address": "relay1.zetetic.tech",
@@ -3152,124 +3046,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.6105421647277266,
-      "relativeStake": 0.001777688769068936,
+      "accumulatedStake": 0.6052630442199183,
+      "relativeStake": 0.0018629462045828484,
       "relays": [
         {
-          "address": "adar1.stakit.io",
-          "port": 30500
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6123175641882551,
-      "relativeStake": 0.001775399460528437,
-      "relays": [
-        {
-          "address": "170.187.203.117",
-          "port": 6000
+          "address": "relay.cardano.securestaking.io",
+          "port": 3000
         },
         {
-          "address": "173.255.203.8",
-          "port": 6000
+          "address": "secur2.cardano.securestaking.io",
+          "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.6140867149360767,
-      "relativeStake": 0.0017691507478216357,
-      "relays": [
-        {
-          "address": "64.176.49.224",
-          "port": 6000
-        },
-        {
-          "address": "149.28.161.63",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6158553574910489,
-      "relativeStake": 0.0017686425549722194,
-      "relays": [
-        {
-          "address": "europe-2.katanapool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6176200577878549,
-      "relativeStake": 0.0017647002968059346,
-      "relays": [
-        {
-          "address": "217.160.14.223",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6193620958621975,
-      "relativeStake": 0.001742038074342562,
-      "relays": [
-        {
-          "address": "relay.sunnyada.com",
-          "port": 5001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.621091650861335,
-      "relativeStake": 0.0017295549991375584,
-      "relays": [
-        {
-          "address": "north-america-relay.jpn-sp.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6228210278826258,
-      "relativeStake": 0.0017293770212908697,
-      "relays": [
-        {
-          "address": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "address": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.624524673109576,
-      "relativeStake": 0.0017036452269501932,
-      "relays": [
-        {
-          "address": "32.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6262259520776995,
-      "relativeStake": 0.0017012789681234083,
-      "relays": [
-        {
-          "address": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "address": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6279106628348828,
-      "relativeStake": 0.0016847107571834137,
+      "accumulatedStake": 0.6070926762399448,
+      "relativeStake": 0.0018296320200265294,
       "relays": [
         {
           "address": "relay1.adaocean.com",
@@ -3294,288 +3086,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6295945627025578,
-      "relativeStake": 0.0016838998676748183,
-      "relays": [
-        {
-          "address": "1339aecb.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6312703422088141,
-      "relativeStake": 0.0016757795062563743,
-      "relays": [
-        {
-          "address": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6329461095139719,
-      "relativeStake": 0.0016757673051578715,
-      "relays": [
-        {
-          "address": "20.69.213.207",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.634621450992894,
-      "relativeStake": 0.0016753414789220595,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6362944620066422,
-      "relativeStake": 0.0016730110137481615,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6379670153535618,
-      "relativeStake": 0.0016725533469196677,
-      "relays": [
-        {
-          "address": "25.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6396390126601265,
-      "relativeStake": 0.0016719973065646445,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6413097005571066,
-      "relativeStake": 0.0016706878969800683,
-      "relays": [
-        {
-          "address": "150.136.84.82",
-          "port": 6001
-        },
-        {
-          "address": "158.101.99.150",
-          "port": 6001
-        },
-        {
-          "address": "150.136.111.193",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6429800638019684,
-      "relativeStake": 0.001670363244861775,
-      "relays": [
-        {
-          "address": "157.245.228.134",
-          "port": 3001
-        },
-        {
-          "address": "159.89.120.164",
-          "port": 3001
-        },
-        {
-          "address": "209.97.186.44",
-          "port": 3001
-        },
-        {
-          "address": "eu.bloompool.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6446503487797992,
-      "relativeStake": 0.0016702849778308891,
-      "relays": [
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6463199385856379,
-      "relativeStake": 0.0016695898058386265,
-      "relays": [
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6479887163528796,
-      "relativeStake": 0.0016687777672417456,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6496564092068314,
-      "relativeStake": 0.0016676928539518924,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6513240715571031,
-      "relativeStake": 0.0016676623502716581,
-      "relays": [
-        {
-          "address": "139.180.198.13",
-          "port": 6000
-        },
-        {
-          "address": "207.148.77.122",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6529913314890687,
-      "relativeStake": 0.001667259931965641,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6546578385151776,
-      "relativeStake": 0.0016665070261087343,
-      "relays": [
-        {
-          "address": "35.154.118.137",
-          "port": 6000
-        },
-        {
-          "address": "3.6.81.137",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6563237670411108,
-      "relativeStake": 0.0016659285259333625,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6579739203186702,
-      "relativeStake": 0.001650153277559273,
-      "relays": [
-        {
-          "address": "13.235.131.115",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.659620026635378,
-      "relativeStake": 0.0016461063167078967,
+      "accumulatedStake": 0.6089219243154441,
+      "relativeStake": 0.001829248075499264,
       "relays": [
         {
           "address": "cardano-main.everstake.one",
@@ -3600,8 +3112,438 @@
       ]
     },
     {
-      "accumulatedStake": 0.6612633166816051,
-      "relativeStake": 0.0016432900462270928,
+      "accumulatedStake": 0.6107401620430193,
+      "relativeStake": 0.0018182377275752096,
+      "relays": [
+        {
+          "address": "66.160.158.69",
+          "port": 6000
+        },
+        {
+          "address": "66.160.158.70",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.612543846392066,
+      "relativeStake": 0.0018036843490467922,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6143334384467719,
+      "relativeStake": 0.0017895920547057742,
+      "relays": [
+        {
+          "address": "170.187.203.117",
+          "port": 6000
+        },
+        {
+          "address": "173.255.203.8",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.616121367446658,
+      "relativeStake": 0.0017879289998862051,
+      "relays": [
+        {
+          "address": "157.245.228.134",
+          "port": 3001
+        },
+        {
+          "address": "159.89.120.164",
+          "port": 3001
+        },
+        {
+          "address": "209.97.186.44",
+          "port": 3001
+        },
+        {
+          "address": "eu.bloompool.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.617902473809324,
+      "relativeStake": 0.0017811063626658804,
+      "relays": [
+        {
+          "address": "europe-2.katanapool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6196755082760637,
+      "relativeStake": 0.001773034466739681,
+      "relays": [
+        {
+          "address": "32.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6214420340890052,
+      "relativeStake": 0.0017665258129415868,
+      "relays": [
+        {
+          "address": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "address": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.623201212913736,
+      "relativeStake": 0.001759178824730743,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6249534064619596,
+      "relativeStake": 0.001752193548223672,
+      "relays": [
+        {
+          "address": "adar1.stakit.io",
+          "port": 30500
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6266941531879563,
+      "relativeStake": 0.0017407467259967205,
+      "relays": [
+        {
+          "address": "relay1.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay2.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay3.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay4.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay5.adaocean.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6284333100286028,
+      "relativeStake": 0.001739156840646438,
+      "relays": [
+        {
+          "address": "north-america-relay.jpn-sp.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6301549899704401,
+      "relativeStake": 0.0017216799418373282,
+      "relays": [
+        {
+          "address": "relay1.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay2.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay3.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay4.adaocean.com",
+          "port": 6000
+        },
+        {
+          "address": "relay5.adaocean.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6318687941519752,
+      "relativeStake": 0.0017138041815350918,
+      "relays": [
+        {
+          "address": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "address": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6335607403638951,
+      "relativeStake": 0.001691946211919943,
+      "relays": [
+        {
+          "address": "150.136.84.82",
+          "port": 6001
+        },
+        {
+          "address": "158.101.99.150",
+          "port": 6001
+        },
+        {
+          "address": "150.136.111.193",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6352493652079293,
+      "relativeStake": 0.0016886248440341873,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6369356478887626,
+      "relativeStake": 0.0016862826808332681,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6386214123268102,
+      "relativeStake": 0.001685764438047588,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6403044291427815,
+      "relativeStake": 0.0016830168159713233,
+      "relays": [
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6419869712183479,
+      "relativeStake": 0.0016825420755664368,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6436678007952883,
+      "relativeStake": 0.0016808295769402874,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6453486097433196,
+      "relativeStake": 0.0016808089480313613,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6470278605385517,
+      "relativeStake": 0.0016792507952321043,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6486873458436666,
+      "relativeStake": 0.001659485305114931,
+      "relays": [
+        {
+          "address": "relays.cardanowithpaul.com",
+          "port": 1069
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6503428122278245,
+      "relativeStake": 0.0016554663841579463,
+      "relays": [
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.651997434467022,
+      "relativeStake": 0.0016546222391974144,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6536518754633575,
+      "relativeStake": 0.001654440996335495,
+      "relays": [
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6553060423603467,
+      "relativeStake": 0.0016541668969892306,
+      "relays": [
+        {
+          "address": "35.154.118.137",
+          "port": 6000
+        },
+        {
+          "address": "3.6.81.137",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6569582318718463,
+      "relativeStake": 0.0016521895114995791,
       "relays": [
         {
           "address": "3ef2283d.cardano-relay.bison.run",
@@ -3610,56 +3552,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6629061614292528,
-      "relativeStake": 0.001642844747647747,
-      "relays": [
-        {
-          "address": "53e378bf.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.664548392746531,
-      "relativeStake": 0.0016422313172780618,
-      "relays": [
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6661905916891434,
-      "relativeStake": 0.0016421989426124812,
-      "relays": [
-        {
-          "address": "fdd5329e.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6678325625396374,
-      "relativeStake": 0.001641970850493925,
-      "relays": [
-        {
-          "address": "a1666f4c.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6694744552783704,
-      "relativeStake": 0.001641892738732957,
+      "accumulatedStake": 0.6586098576574367,
+      "relativeStake": 0.001651625785590425,
       "relays": [
         {
           "address": "0b2a2fd4.cardano-relay.bison.run",
@@ -3668,8 +3562,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6711162820953072,
-      "relativeStake": 0.0016418268169368993,
+      "accumulatedStake": 0.6602609778193886,
+      "relativeStake": 0.001651120161951869,
       "relays": [
         {
           "address": "e646e266.cardano-relay.bison.run",
@@ -3678,8 +3572,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.6727580936950337,
-      "relativeStake": 0.0016418115997265225,
+      "accumulatedStake": 0.6619119230226697,
+      "relativeStake": 0.0016509452032810723,
+      "relays": [
+        {
+          "address": "a1666f4c.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6635624844451515,
+      "relativeStake": 0.0016505614224818987,
       "relays": [
         {
           "address": "07f6ea55.cardano-relay.herd.run",
@@ -3688,8 +3592,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.674399757672749,
-      "relativeStake": 0.0016416639777152649,
+      "accumulatedStake": 0.665213013734454,
+      "relativeStake": 0.0016505292893024136,
+      "relays": [
+        {
+          "address": "53e378bf.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6668634670015037,
+      "relativeStake": 0.0016504532670496759,
       "relays": [
         {
           "address": "84cbba68.cardano-relay.herd.run",
@@ -3698,44 +3612,54 @@
       ]
     },
     {
-      "accumulatedStake": 0.6760412592732798,
-      "relativeStake": 0.0016415016005309057,
+      "accumulatedStake": 0.6685125361311269,
+      "relativeStake": 0.0016490691296232268,
       "relays": [
         {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
+          "address": "cardano-main.everstake.one",
+          "port": 3001
         },
         {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
         },
         {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.6776827486744375,
-      "relativeStake": 0.0016414894011574932,
+      "accumulatedStake": 0.670143994182182,
+      "relativeStake": 0.0016314580510550284,
       "relays": [
         {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
+          "address": "52.6.109.221",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.6793180409536981,
-      "relativeStake": 0.0016352922792607217,
+      "accumulatedStake": 0.6717667604564161,
+      "relativeStake": 0.0016227662742342873,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6733888587747704,
+      "relativeStake": 0.0016220983183542388,
       "relays": [
         {
           "address": "195.201.143.213",
@@ -3752,38 +3676,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6809523749363431,
-      "relativeStake": 0.0016343339826450094,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6825775910248615,
-      "relativeStake": 0.0016252160885183275,
-      "relays": [
-        {
-          "address": "relays.cardanowithpaul.com",
-          "port": 1069
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6841966962129706,
-      "relativeStake": 0.001619105188109192,
-      "relays": [
-        {
-          "address": "52.6.109.221",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6857979650940152,
-      "relativeStake": 0.0016012688810446124,
+      "accumulatedStake": 0.6750014524400212,
+      "relativeStake": 0.0016125936652507192,
       "relays": [
         {
           "address": "relay-pool-figment-3-mainnet.cardano.aeq5f.com"
@@ -3791,8 +3685,66 @@
       ]
     },
     {
-      "accumulatedStake": 0.6873875516359903,
-      "relativeStake": 0.0015895865419750354,
+      "accumulatedStake": 0.6765947735861101,
+      "relativeStake": 0.0015933211460889274,
+      "relays": [
+        {
+          "address": "20.69.213.207",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6781860061086691,
+      "relativeStake": 0.0015912325225589934,
+      "relays": [
+        {
+          "address": "relays.digi.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6797733674583004,
+      "relativeStake": 0.0015873613496313794,
+      "relays": [
+        {
+          "address": "64.176.49.224",
+          "port": 6000
+        },
+        {
+          "address": "149.28.161.63",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6813606682607499,
+      "relativeStake": 0.0015873008024495049,
+      "relays": [
+        {
+          "address": "relays.smaug.pool.pm",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6829465426077412,
+      "relativeStake": 0.001585874346991232,
+      "relays": [
+        {
+          "address": "139.180.198.13",
+          "port": 6000
+        },
+        {
+          "address": "207.148.77.122",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6845307568966208,
+      "relativeStake": 0.001584214288879611,
       "relays": [
         {
           "address": "202.61.246.91",
@@ -3801,44 +3753,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.6889761130156862,
-      "relativeStake": 0.001588561379695911,
+      "accumulatedStake": 0.6861119617541765,
+      "relativeStake": 0.0015812048575557709,
       "relays": [
         {
-          "address": "relay1.ada-stake.com",
-          "port": 3001
-        },
-        {
-          "address": "relay2.ada-stake.com",
+          "address": "relays.digi.pro",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.6905550145204441,
-      "relativeStake": 0.0015789015047578715,
-      "relays": [
-        {
-          "address": "rho.relay.easy1staking.com",
-          "port": 30020
-        },
-        {
-          "address": "pi.relay.easy1staking.com",
-          "port": 30021
-        },
-        {
-          "address": "eu-central-1.relay.easy1staking.com",
-          "port": 30000
-        },
-        {
-          "address": "us-east-1.relay.easy1staking.com",
-          "port": 30000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6921281777105447,
-      "relativeStake": 0.0015731631901006642,
+      "accumulatedStake": 0.6876894834993339,
+      "relativeStake": 0.0015775217451573073,
       "relays": [
         {
           "address": "truth.kiwipool.org",
@@ -3867,28 +3793,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.6937001972302053,
-      "relativeStake": 0.0015720195196605538,
+      "accumulatedStake": 0.6892669107015574,
+      "relativeStake": 0.001577427202223518,
       "relays": [
         {
-          "address": "relays.smaug.pool.pm",
+          "address": "13.235.131.115",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.695268161256444,
-      "relativeStake": 0.0015679640262386838,
-      "relays": [
-        {
-          "address": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6968320402336844,
-      "relativeStake": 0.0015638789772404464,
+      "accumulatedStake": 0.6908432188490322,
+      "relativeStake": 0.00157630814747482,
       "relays": [
         {
           "address": "3.234.66.234",
@@ -3897,18 +3813,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6983934749536242,
-      "relativeStake": 0.0015614347199397974,
-      "relays": [
-        {
-          "address": "3.234.66.234",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6999519607028227,
-      "relativeStake": 0.0015584857491985305,
+      "accumulatedStake": 0.6924182336254293,
+      "relativeStake": 0.0015750147763970645,
       "relays": [
         {
           "address": "cardano-main.everstake.one",
@@ -3933,8 +3839,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7015087823583013,
-      "relativeStake": 0.0015568216554785225,
+      "accumulatedStake": 0.6939916261918598,
+      "relativeStake": 0.001573392566430587,
+      "relays": [
+        {
+          "address": "3.234.66.234",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6955606178955724,
+      "relativeStake": 0.001568991703712563,
       "relays": [
         {
           "address": "34.192.61.190",
@@ -3943,8 +3859,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7030634691306413,
-      "relativeStake": 0.0015546867723400786,
+      "accumulatedStake": 0.6971274422783479,
+      "relativeStake": 0.0015668243827754145,
       "relays": [
         {
           "address": "3.234.185.23",
@@ -3953,8 +3869,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7046179625186462,
-      "relativeStake": 0.0015544933880048573,
+      "accumulatedStake": 0.6986931484171648,
+      "relativeStake": 0.001565706138816926,
       "relays": [
         {
           "address": "3.234.185.23",
@@ -3963,8 +3879,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.706162555625103,
-      "relativeStake": 0.0015445931064568324,
+      "accumulatedStake": 0.700257200585263,
+      "relativeStake": 0.0015640521680982521,
       "relays": [
         {
           "address": "cardano-main.everstake.one",
@@ -3989,8 +3905,173 @@
       ]
     },
     {
-      "accumulatedStake": 0.7077033016863388,
-      "relativeStake": 0.0015407460612357506,
+      "accumulatedStake": 0.7018049211216697,
+      "relativeStake": 0.0015477205364066264,
+      "relays": [
+        {
+          "address": "relay.sunnyada.com",
+          "port": 5001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7033318141227112,
+      "relativeStake": 0.0015268930010414864,
+      "relays": [
+        {
+          "address": "198.71.57.191",
+          "port": 6000
+        },
+        {
+          "address": "154.12.240.223",
+          "port": 6000
+        },
+        {
+          "address": "94.16.113.130",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7048533247882857,
+      "relativeStake": 0.0015215106655745278,
+      "relays": [
+        {
+          "address": "18.207.62.97",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7063723416936925,
+      "relativeStake": 0.00151901690540675,
+      "relays": [
+        {
+          "address": "23.21.195.62",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7078886894943422,
+      "relativeStake": 0.0015163478006497812,
+      "relays": [
+        {
+          "address": "23.23.190.5",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7094049595106533,
+      "relativeStake": 0.001516270016311099,
+      "relays": [
+        {
+          "address": "23.23.190.5",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7109202114347891,
+      "relativeStake": 0.001515251924135794,
+      "relays": [
+        {
+          "address": "3.221.94.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7124350633716882,
+      "relativeStake": 0.0015148519368990325,
+      "relays": [
+        {
+          "address": "3.221.94.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7139497646522234,
+      "relativeStake": 0.0015147012805352884,
+      "relays": [
+        {
+          "address": "3.231.140.4",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7154631928530591,
+      "relativeStake": 0.0015134282008356912,
+      "relays": [
+        {
+          "address": "18.207.62.97",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7169764942360813,
+      "relativeStake": 0.001513301383022255,
+      "relays": [
+        {
+          "address": "relay-pool-figment-9-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7184895238716726,
+      "relativeStake": 0.001513029635591268,
+      "relays": [
+        {
+          "address": "3.231.140.4",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7200008183691088,
+      "relativeStake": 0.0015112944974361349,
+      "relays": [
+        {
+          "address": "3.221.184.134",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7215120093364755,
+      "relativeStake": 0.0015111909673668138,
+      "relays": [
+        {
+          "address": "3.221.184.134",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7230207452594221,
+      "relativeStake": 0.001508735922946461,
+      "relays": [
+        {
+          "address": "104.131.47.170",
+          "port": 6000
+        },
+        {
+          "address": "128.199.64.13",
+          "port": 6000
+        },
+        {
+          "address": "165.232.180.100",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7245224879654725,
+      "relativeStake": 0.0015017427060504828,
       "relays": [
         {
           "address": "185.161.193.91",
@@ -4015,182 +4096,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.7092230141672969,
-      "relativeStake": 0.0015197124809581079,
+      "accumulatedStake": 0.7260002190612425,
+      "relativeStake": 0.0014777310957699548,
       "relays": [
         {
-          "address": "198.71.57.191",
-          "port": 6000
+          "address": "52.8.37.3",
+          "port": 3001
         },
         {
-          "address": "154.12.240.223",
-          "port": 6000
+          "address": "3.125.252.182",
+          "port": 3001
         },
         {
-          "address": "94.16.113.130",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7107374546747671,
-      "relativeStake": 0.0015144405074701858,
-      "relays": [
-        {
-          "address": "18.207.62.97",
+          "address": "52.63.225.190",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.712250417725277,
-      "relativeStake": 0.0015129630505099293,
+      "accumulatedStake": 0.7274717052648344,
+      "relativeStake": 0.001471486203591906,
       "relays": [
         {
-          "address": "23.21.195.62",
+          "address": "asia-pacific-zzzrelay.zzzpool.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.7137631279136731,
-      "relativeStake": 0.0015127101883961353,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7152705732956584,
-      "relativeStake": 0.001507445381985213,
-      "relays": [
-        {
-          "address": "23.23.190.5",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7167778775117531,
-      "relativeStake": 0.0015073042160947837,
-      "relays": [
-        {
-          "address": "23.23.190.5",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7182839576800469,
-      "relativeStake": 0.0015060801682938371,
-      "relays": [
-        {
-          "address": "18.207.62.97",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7197893089096696,
-      "relativeStake": 0.0015053512296226263,
-      "relays": [
-        {
-          "address": "3.231.140.4",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7212939455900499,
-      "relativeStake": 0.0015046366803802835,
-      "relays": [
-        {
-          "address": "3.221.94.137",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7227977469143688,
-      "relativeStake": 0.001503801324318907,
-      "relays": [
-        {
-          "address": "3.221.94.137",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.724300133470892,
-      "relativeStake": 0.00150238655652313,
-      "relays": [
-        {
-          "address": "3.231.140.4",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7258023209807051,
-      "relativeStake": 0.0015021875098131098,
-      "relays": [
-        {
-          "address": "3.221.184.134",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.727304264948581,
-      "relativeStake": 0.0015019439678760208,
-      "relays": [
-        {
-          "address": "3.221.184.134",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7287958666732369,
-      "relativeStake": 0.0014916017246559107,
-      "relays": [
-        {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.730286161140597,
-      "relativeStake": 0.001490294467359952,
-      "relays": [
-        {
-          "address": "104.131.47.170",
-          "port": 6000
-        },
-        {
-          "address": "128.199.64.13",
-          "port": 6000
-        },
-        {
-          "address": "165.232.180.100",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7317705098455068,
-      "relativeStake": 0.0014843487049099238,
+      "accumulatedStake": 0.7289426513978793,
+      "relativeStake": 0.0014709461330449209,
       "relays": [
         {
           "address": "148.113.17.23",
@@ -4211,17 +4146,104 @@
       ]
     },
     {
-      "accumulatedStake": 0.7332376887548759,
-      "relativeStake": 0.0014671789093690568,
+      "accumulatedStake": 0.7303943413398137,
+      "relativeStake": 0.0014516899419344052,
       "relays": [
         {
-          "address": "relay-pool-figment-9-mainnet.cardano.aeq5f.com"
+          "address": "35.211.17.86",
+          "port": 3000
+        },
+        {
+          "address": "34.23.88.7",
+          "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.7347001223136951,
-      "relativeStake": 0.0014624335588192274,
+      "accumulatedStake": 0.7318413704047482,
+      "relativeStake": 0.0014470290649344875,
+      "relays": [
+        {
+          "address": "rho.relay.easy1staking.com",
+          "port": 30020
+        },
+        {
+          "address": "pi.relay.easy1staking.com",
+          "port": 30021
+        },
+        {
+          "address": "eu-central-1.relay.easy1staking.com",
+          "port": 30000
+        },
+        {
+          "address": "us-east-1.relay.easy1staking.com",
+          "port": 30000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7332788938769459,
+      "relativeStake": 0.0014375234721976855,
+      "relays": [
+        {
+          "address": "relay.pasklab.com",
+          "port": 3001
+        },
+        {
+          "address": "relay.pasklab.com",
+          "port": 3002
+        },
+        {
+          "address": "relay.pasklab.com",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7347130191671213,
+      "relativeStake": 0.0014341252901754324,
+      "relays": [
+        {
+          "address": "relays.mainnet.fortepool.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7361410972034781,
+      "relativeStake": 0.001428078036356772,
+      "relays": [
+        {
+          "address": "158.101.99.150",
+          "port": 6001
+        },
+        {
+          "address": "150.136.111.193",
+          "port": 6001
+        },
+        {
+          "address": "150.136.84.82",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7375639814661292,
+      "relativeStake": 0.0014228842626511427,
+      "relays": [
+        {
+          "address": "r1.1percentpool.eu",
+          "port": 19001
+        },
+        {
+          "address": "r2.1percentpool.eu",
+          "port": 19002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7389813370342005,
+      "relativeStake": 0.00141735556807127,
       "relays": [
         {
           "address": "148.113.17.23",
@@ -4242,54 +4264,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7361619993704461,
-      "relativeStake": 0.0014618770567510076,
-      "relays": [
-        {
-          "address": "a-r1.elitestakepool.com",
-          "port": 7011
-        },
-        {
-          "address": "a-r2.elitestakepool.com",
-          "port": 7012
-        },
-        {
-          "address": "b-r3.elitestakepool.com",
-          "port": 7013
-        },
-        {
-          "address": "b-r4.elitestakepool.com",
-          "port": 7014
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.737621974817746,
-      "relativeStake": 0.0014599754472998851,
-      "relays": [
-        {
-          "address": "asia-pacific-zzzrelay.zzzpool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7390644959091505,
-      "relativeStake": 0.0014425210914044183,
-      "relays": [
-        {
-          "address": "35.211.17.86",
-          "port": 3000
-        },
-        {
-          "address": "34.23.88.7",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7405063468379972,
-      "relativeStake": 0.0014418509288468015,
+      "accumulatedStake": 0.7403921046334544,
+      "relativeStake": 0.0014107675992539078,
       "relays": [
         {
           "address": "52.8.37.3",
@@ -4306,96 +4282,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.741944533701984,
-      "relativeStake": 0.0014381868639867334,
-      "relays": [
-        {
-          "address": "relay.pasklab.com",
-          "port": 3001
-        },
-        {
-          "address": "relay.pasklab.com",
-          "port": 3002
-        },
-        {
-          "address": "relay.pasklab.com",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7433797693374719,
-      "relativeStake": 0.0014352356354879082,
-      "relays": [
-        {
-          "address": "158.101.99.150",
-          "port": 6001
-        },
-        {
-          "address": "150.136.111.193",
-          "port": 6001
-        },
-        {
-          "address": "150.136.84.82",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7448004228207765,
-      "relativeStake": 0.001420653483304617,
-      "relays": [
-        {
-          "address": "relays.staking4ada.org",
-          "port": 1818
-        },
-        {
-          "address": "globecast.staking4ada.org",
-          "port": 6061
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7462157045245867,
-      "relativeStake": 0.0014152817038102427,
-      "relays": [
-        {
-          "address": "relays.mainnet.fortepool.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7476247015315195,
-      "relativeStake": 0.0014089970069327696,
-      "relays": [
-        {
-          "address": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "address": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7490296902813058,
-      "relativeStake": 0.0014049887497863043,
-      "relays": [
-        {
-          "address": "89.58.38.12",
-          "port": 6001
-        },
-        {
-          "address": "37.120.189.7",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7504330497943363,
-      "relativeStake": 0.0014033595130305556,
+      "accumulatedStake": 0.7417985083191783,
+      "relativeStake": 0.0014064036857238517,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -4416,44 +4304,72 @@
       ]
     },
     {
-      "accumulatedStake": 0.7518285261520552,
-      "relativeStake": 0.0013954763577188475,
+      "accumulatedStake": 0.7431981049473858,
+      "relativeStake": 0.001399596628207528,
       "relays": [
         {
-          "address": "52.8.37.3",
-          "port": 3001
+          "address": "a-r1.elitestakepool.com",
+          "port": 7011
         },
         {
-          "address": "3.125.252.182",
-          "port": 3001
+          "address": "a-r2.elitestakepool.com",
+          "port": 7012
         },
         {
-          "address": "52.63.225.190",
-          "port": 3001
+          "address": "b-r3.elitestakepool.com",
+          "port": 7013
+        },
+        {
+          "address": "b-r4.elitestakepool.com",
+          "port": 7014
         }
       ]
     },
     {
-      "accumulatedStake": 0.7531976280674301,
-      "relativeStake": 0.0013691019153748859,
+      "accumulatedStake": 0.744597216018768,
+      "relativeStake": 0.0013991110713822616,
       "relays": [
         {
-          "address": "relay1.hyperlinkpool.kr",
-          "port": 3002
-        },
-        {
-          "address": "relay2.hyperlinkpool.kr",
+          "address": "cardano-relays-1.nu.fi",
           "port": 3003
         },
         {
-          "address": "relay3.hyperlinkpool.kr",
-          "port": 3004
+          "address": "cardano-relays-2.nu.fi",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.7545459627768972,
-      "relativeStake": 0.0013483347094670657,
+      "accumulatedStake": 0.7459605503087353,
+      "relativeStake": 0.0013633342899673218,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7473119931079608,
+      "relativeStake": 0.0013514427992254402,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7486624045322869,
+      "relativeStake": 0.0013504114243261206,
       "relays": [
         {
           "address": "relay1-us.xstakepool.com",
@@ -4474,36 +4390,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.7558868962984265,
-      "relativeStake": 0.001340933521529312,
+      "accumulatedStake": 0.7499947003851116,
+      "relativeStake": 0.0013322958528247406,
       "relays": [
         {
-          "address": "cardano-relay-1.upbit.com",
-          "port": 30800
+          "address": "rev-cardano-main-relay-01-a.bdnodes.net",
+          "port": 6000
         },
         {
-          "address": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "address": "cardano-relay-3.upbit.com",
-          "port": 30800
+          "address": "rev-cardano-main-relay-01-b.bdnodes.net",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.757214746023954,
-      "relativeStake": 0.0013278497255274685,
+      "accumulatedStake": 0.7513219236460204,
+      "relativeStake": 0.0013272232609086638,
       "relays": [
         {
-          "address": "private-pools.fivebinaries.com",
-          "port": 3001
+          "address": "relay1.hyperlinkpool.kr",
+          "port": 3002
+        },
+        {
+          "address": "relay2.hyperlinkpool.kr",
+          "port": 3003
+        },
+        {
+          "address": "relay3.hyperlinkpool.kr",
+          "port": 3004
         }
       ]
     },
     {
-      "accumulatedStake": 0.7585310542993202,
-      "relativeStake": 0.0013163082753662857,
+      "accumulatedStake": 0.7526440842805215,
+      "relativeStake": 0.0013221606345012375,
       "relays": [
         {
           "address": "relay1.cardanesia.com",
@@ -4516,22 +4436,128 @@
       ]
     },
     {
-      "accumulatedStake": 0.7598387025418954,
-      "relativeStake": 0.0013076482425752572,
+      "accumulatedStake": 0.7539517582258343,
+      "relativeStake": 0.001307673945312667,
       "relays": [
         {
-          "address": "r1.1percentpool.eu",
-          "port": 19001
+          "address": "65.109.12.161",
+          "port": 6001
         },
         {
-          "address": "r2.1percentpool.eu",
-          "port": 19002
+          "address": "116.203.131.106",
+          "port": 6002
         }
       ]
     },
     {
-      "accumulatedStake": 0.7611423809458638,
-      "relativeStake": 0.0013036784039683067,
+      "accumulatedStake": 0.7552571363425743,
+      "relativeStake": 0.0013053781167400504,
+      "relays": [
+        {
+          "address": "relays.digi.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7565477214399801,
+      "relativeStake": 0.0012905850974057516,
+      "relays": [
+        {
+          "address": "3.139.50.19",
+          "port": 6000
+        },
+        {
+          "address": "3.137.129.218",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7578352273326621,
+      "relativeStake": 0.0012875058926819904,
+      "relays": [
+        {
+          "address": "btc-cardano-main-relay-00-a.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "address": "btc-cardano-main-relay-00-b.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7591019440946158,
+      "relativeStake": 0.0012667167619537776,
+      "relays": [
+        {
+          "address": "89.58.38.12",
+          "port": 6001
+        },
+        {
+          "address": "37.120.189.7",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7603661002643566,
+      "relativeStake": 0.0012641561697408047,
+      "relays": [
+        {
+          "address": "ipclub29-1.relay.my-ip.at",
+          "port": 3001
+        },
+        {
+          "address": "ipclub29-1.relay.my-ip.at",
+          "port": 3002
+        },
+        {
+          "address": "ipclub29-2.relay.my-ip.at",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7616265463791896,
+      "relativeStake": 0.0012604461148330035,
+      "relays": [
+        {
+          "address": "132.145.98.48",
+          "port": 6000
+        },
+        {
+          "address": "82.165.230.141",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.762881183143731,
+      "relativeStake": 0.0012546367645414151,
+      "relays": [
+        {
+          "address": "relay1.nedscave.io",
+          "port": 3001
+        },
+        {
+          "address": "relay2.nedscave.io",
+          "port": 3001
+        },
+        {
+          "address": "relay3.nedscave.io",
+          "port": 3001
+        },
+        {
+          "address": "relay4.nedscave.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7641326066914177,
+      "relativeStake": 0.00125142354768668,
       "relays": [
         {
           "address": "148.113.17.23",
@@ -4552,132 +4578,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7624431188387898,
-      "relativeStake": 0.0013007378929260195,
-      "relays": [
-        {
-          "address": "65.109.12.161",
-          "port": 6001
-        },
-        {
-          "address": "116.203.131.106",
-          "port": 6002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7637329020885809,
-      "relativeStake": 0.001289783249791046,
-      "relays": [
-        {
-          "address": "relay1.angelstakepool.net",
-          "port": 5001
-        },
-        {
-          "address": "relay2.angelstakepool.net",
-          "port": 5002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7650201878234272,
-      "relativeStake": 0.0012872857348463329,
-      "relays": [
-        {
-          "address": "btc-cardano-main-relay-00-a.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "address": "btc-cardano-main-relay-00-b.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7663073870019743,
-      "relativeStake": 0.0012871991785471425,
-      "relays": [
-        {
-          "address": "eu-de-blue-cdn-relays.cardano.fans",
-          "port": 3001
-        },
-        {
-          "address": "us-us-blue-cdn-relays.cardano.fans",
-          "port": 3001
-        },
-        {
-          "address": "eu-fr-blue-cdn-relays.cardano.fans",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7675836114089347,
-      "relativeStake": 0.0012762244069603375,
-      "relays": [
-        {
-          "address": "3.139.50.19",
-          "port": 6000
-        },
-        {
-          "address": "3.137.129.218",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7688581599863797,
-      "relativeStake": 0.0012745485774450194,
-      "relays": [
-        {
-          "address": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7701254154599034,
-      "relativeStake": 0.0012672554735237121,
-      "relays": [
-        {
-          "address": "ipclub29-1.relay.my-ip.at",
-          "port": 3001
-        },
-        {
-          "address": "ipclub29-1.relay.my-ip.at",
-          "port": 3002
-        },
-        {
-          "address": "ipclub29-2.relay.my-ip.at",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7713738961559374,
-      "relativeStake": 0.0012484806960340032,
-      "relays": [
-        {
-          "address": "relay1.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay2.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay3.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay4.nedscave.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7726169932731277,
-      "relativeStake": 0.0012430971171903476,
+      "accumulatedStake": 0.7653825035845474,
+      "relativeStake": 0.0012498968931296736,
       "relays": [
         {
           "address": "34.146.212.90",
@@ -4690,8 +4592,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.7738586466837956,
-      "relativeStake": 0.0012416534106677382,
+      "accumulatedStake": 0.7666244741935794,
+      "relativeStake": 0.0012419706090319978,
+      "relays": [
+        {
+          "address": "relay1.angelstakepool.net",
+          "port": 5001
+        },
+        {
+          "address": "relay2.angelstakepool.net",
+          "port": 5002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7678555300225995,
+      "relativeStake": 0.0012310558290201618,
       "relays": [
         {
           "address": "cardano-relays-1.nu.fi",
@@ -4704,32 +4620,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.7750940024215712,
-      "relativeStake": 0.0012353557377756774,
+      "accumulatedStake": 0.7690865670134721,
+      "relativeStake": 0.0012310369908725672,
       "relays": [
         {
-          "address": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7763071141751364,
-      "relativeStake": 0.0012131117535652458,
-      "relays": [
-        {
-          "address": "benitoite-rohan-d68b9.cardano.bdnodes.net",
-          "port": 6000
+          "address": "relays.staking4ada.org",
+          "port": 1818
         },
         {
-          "address": "brown-lagos-6a470.cardano.bdnodes.net",
-          "port": 6000
+          "address": "globecast.staking4ada.org",
+          "port": 6061
         }
       ]
     },
     {
-      "accumulatedStake": 0.7775199527799337,
-      "relativeStake": 0.0012128386047972409,
+      "accumulatedStake": 0.7703076763658518,
+      "relativeStake": 0.001221109352379696,
+      "relays": [
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.771518427614977,
+      "relativeStake": 0.0012107512491252306,
       "relays": [
         {
           "address": "89.58.11.57",
@@ -4742,74 +4666,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7787231739260179,
-      "relativeStake": 0.0012032211460841576,
-      "relays": [
-        {
-          "address": "132.145.98.48",
-          "port": 6000
-        },
-        {
-          "address": "82.165.230.141",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7799232639534962,
-      "relativeStake": 0.0012000900274783735,
-      "relays": [
-        {
-          "address": "asia.jazzstakepool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7811171796030892,
-      "relativeStake": 0.001193915649593001,
-      "relays": [
-        {
-          "address": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "address": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7823107350050861,
-      "relativeStake": 0.0011935554019969015,
-      "relays": [
-        {
-          "address": "20.42.119.172",
-          "port": 6000
-        },
-        {
-          "address": "160.251.196.40",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7834898330403242,
-      "relativeStake": 0.0011790980352380956,
-      "relays": [
-        {
-          "address": "relaynode1.kaldano.work",
-          "port": 3001
-        },
-        {
-          "address": "relaynode2.kaldano.work",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7846606135698613,
-      "relativeStake": 0.001170780529537031,
+      "accumulatedStake": 0.7727290604938732,
+      "relativeStake": 0.0012106328788961658,
       "relays": [
         {
           "address": "cardano-relay-1.upbit.com",
@@ -4826,32 +4684,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.7858244737114545,
-      "relativeStake": 0.0011638601415932099,
+      "accumulatedStake": 0.7739301452836453,
+      "relativeStake": 0.0012010847897721579,
       "relays": [
         {
-          "address": "relay1.kaizn.kaizencrypto.com",
+          "address": "20.42.119.172",
           "port": 6000
         },
         {
-          "address": "relay2.kaizn.kaizencrypto.com",
+          "address": "160.251.196.40",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.7869838449051492,
-      "relativeStake": 0.0011593711936946994,
-      "relays": [
-        {
-          "address": "3.111.14.60",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7881177431202667,
-      "relativeStake": 0.0011338982151175413,
+      "accumulatedStake": 0.7751305530193997,
+      "relativeStake": 0.0012004077357543838,
       "relays": [
         {
           "address": "cardano-relays-1.nu.fi",
@@ -4864,8 +4712,116 @@
       ]
     },
     {
-      "accumulatedStake": 0.7892507593125041,
-      "relativeStake": 0.0011330161922374498,
+      "accumulatedStake": 0.7763272837813623,
+      "relativeStake": 0.0011967307619625547,
+      "relays": [
+        {
+          "address": "private-pools.fivebinaries.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7775238214846781,
+      "relativeStake": 0.0011965377033158824,
+      "relays": [
+        {
+          "address": "asia.jazzstakepool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7787038290987413,
+      "relativeStake": 0.0011800076140630346,
+      "relays": [
+        {
+          "address": "49.0.82.230",
+          "port": 6000
+        },
+        {
+          "address": "46.250.239.144",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7798838051869307,
+      "relativeStake": 0.0011799760881894734,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7810584090045185,
+      "relativeStake": 0.001174603817587782,
+      "relays": [
+        {
+          "address": "eu-de-blue-cdn-relays.cardano.fans",
+          "port": 3001
+        },
+        {
+          "address": "us-us-blue-cdn-relays.cardano.fans",
+          "port": 3001
+        },
+        {
+          "address": "eu-fr-blue-cdn-relays.cardano.fans",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.782231003127814,
+      "relativeStake": 0.0011725941232955187,
+      "relays": [
+        {
+          "address": "relaynode1.kaldano.work",
+          "port": 3001
+        },
+        {
+          "address": "relaynode2.kaldano.work",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7834021770630633,
+      "relativeStake": 0.0011711739352492888,
+      "relays": [
+        {
+          "address": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "address": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7845589599401468,
+      "relativeStake": 0.0011567828770834977,
+      "relays": [
+        {
+          "address": "43.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7857009868613496,
+      "relativeStake": 0.0011420269212028215,
       "relays": [
         {
           "address": "r1.isp-r1.wjg.jp",
@@ -4878,8 +4834,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.790383413531752,
-      "relativeStake": 0.0011326542192478697,
+      "accumulatedStake": 0.7868416712356765,
+      "relativeStake": 0.0011406843743269291,
       "relays": [
         {
           "address": "152.53.121.193",
@@ -4892,22 +4848,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7915054361583694,
-      "relativeStake": 0.0011220226266174685,
-      "relays": [
-        {
-          "address": "relays.planetstake.com",
-          "port": 3001
-        },
-        {
-          "address": "161.97.90.20",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7926215052559584,
-      "relativeStake": 0.001116069097589006,
+      "accumulatedStake": 0.7879663724740666,
+      "relativeStake": 0.0011247012383901404,
       "relays": [
         {
           "address": "asia.jazzstakepool.net",
@@ -4916,547 +4858,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7937303817074872,
-      "relativeStake": 0.0011088764515287284,
-      "relays": [
-        {
-          "address": "relays.liqwid.finance",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7948375564104727,
-      "relativeStake": 0.001107174702985494,
-      "relays": [
-        {
-          "address": "relays.liqwid.finance",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7959419390311377,
-      "relativeStake": 0.0011043826206650472,
-      "relays": [
-        {
-          "address": "asia.jazzstakepool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7970462314513641,
-      "relativeStake": 0.0011042924202263136,
-      "relays": [
-        {
-          "address": "202.61.246.91",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7981471641274794,
-      "relativeStake": 0.0011009326761153974,
-      "relays": [
-        {
-          "address": "europe1-zzz3relay.zzzpool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7992403348970045,
-      "relativeStake": 0.0010931707695250644,
-      "relays": [
-        {
-          "address": "3.6.124.226",
-          "port": 3001
-        },
-        {
-          "address": "18.193.92.87",
-          "port": 3001
-        },
-        {
-          "address": "54.219.241.10",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8003292502163932,
-      "relativeStake": 0.0010889153193887106,
-      "relays": [
-        {
-          "address": "89.58.57.185",
-          "port": 4000
-        },
-        {
-          "address": "5.250.178.133",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8014053272565285,
-      "relativeStake": 0.001076077040135204,
-      "relays": [
-        {
-          "address": "161.35.209.217",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8024711039461423,
-      "relativeStake": 0.0010657766896138671,
-      "relays": [
-        {
-          "address": "europe-de.popsp.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8035266146461709,
-      "relativeStake": 0.0010555107000286715,
-      "relays": [
-        {
-          "address": "102.130.127.242",
-          "port": 6000
-        },
-        {
-          "address": "94.16.106.16",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8045660478776575,
-      "relativeStake": 0.0010394332314865298,
-      "relays": [
-        {
-          "address": "135.181.194.233",
-          "port": 6000
-        },
-        {
-          "address": "168.119.101.200",
-          "port": 6000
-        },
-        {
-          "address": "5.161.59.12",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8056027731684823,
-      "relativeStake": 0.0010367252908248118,
-      "relays": [
-        {
-          "address": "relay1.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay2.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay3.nedscave.io",
-          "port": 3001
-        },
-        {
-          "address": "relay4.nedscave.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.806635795722039,
-      "relativeStake": 0.0010330225535567256,
-      "relays": [
-        {
-          "address": "43.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8076652215631651,
-      "relativeStake": 0.0010294258411260651,
-      "relays": [
-        {
-          "address": "20.69.213.207",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8086901352019924,
-      "relativeStake": 0.0010249136388273017,
-      "relays": [
-        {
-          "address": "20.91.236.57",
-          "port": 6000
-        },
-        {
-          "address": "160.251.204.162",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8097146598956924,
-      "relativeStake": 0.001024524693700001,
-      "relays": [
-        {
-          "address": "relay-pool-figment-10-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8107323444270654,
-      "relativeStake": 0.001017684531373001,
-      "relays": [
-        {
-          "address": "relay.azureada.com",
-          "port": 3001
-        },
-        {
-          "address": "relay.azureada.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8117441883215332,
-      "relativeStake": 0.0010118438944677842,
-      "relays": [
-        {
-          "address": "relay1.bluecheesestakehouse.com",
-          "port": 5001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8127401330887197,
-      "relativeStake": 0.0009959447671864994,
-      "relays": [
-        {
-          "address": "52.167.20.127",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8137355954715615,
-      "relativeStake": 0.0009954623828418007,
-      "relays": [
-        {
-          "address": "relay1.cerostakepool.com",
-          "port": 3001
-        },
-        {
-          "address": "relay2.cerostakepool.com",
-          "port": 3001
-        },
-        {
-          "address": "relay3.cerostakepool.com",
-          "port": 3001
-        },
-        {
-          "address": "relay4.cerostakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8147246138479882,
-      "relativeStake": 0.0009890183764267244,
-      "relays": [
-        {
-          "address": "europe3-zzz5relay.zzzpool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8157117451407783,
-      "relativeStake": 0.0009871312927900544,
-      "relays": [
-        {
-          "address": "private-pools.fivebinaries.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8166930299823046,
-      "relativeStake": 0.0009812848415263874,
-      "relays": [
-        {
-          "address": "relay0.bluecheesestakehouse.com",
-          "port": 5000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.817672188360478,
-      "relativeStake": 0.000979158378173252,
-      "relays": [
-        {
-          "address": "20.69.213.207",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8186433384263827,
-      "relativeStake": 0.0009711500659047956,
-      "relays": [
-        {
-          "address": "109.123.231.213",
-          "port": 6000
-        },
-        {
-          "address": "89.58.45.244",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.819602275851924,
-      "relativeStake": 0.0009589374255412625,
-      "relays": [
-        {
-          "address": "adaboy-mainnet-2a.gleeze.com",
-          "port": 6000
-        },
-        {
-          "address": "adaboy-mainnet-3a.gleeze.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8205533012164307,
-      "relativeStake": 0.0009510253645066538,
-      "relays": [
-        {
-          "address": "relay1.viperstaking.com",
-          "port": 4444
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8214995692135476,
-      "relativeStake": 0.0009462679971170091,
-      "relays": [
-        {
-          "address": "cardano-relays.autostake.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8224424729880954,
-      "relativeStake": 0.0009429037745477667,
-      "relays": [
-        {
-          "address": "35.154.123.251",
-          "port": 3001
-        },
-        {
-          "address": "15.206.230.107",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8233769481097518,
-      "relativeStake": 0.0009344751216563667,
-      "relays": [
-        {
-          "address": "relay.azureada.com",
-          "port": 3001
-        },
-        {
-          "address": "relay.azureada.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8242977686438321,
-      "relativeStake": 0.000920820534080327,
-      "relays": [
-        {
-          "address": "154.38.174.71",
-          "port": 6000
-        },
-        {
-          "address": "118.153.253.133",
-          "port": 57413
-        },
-        {
-          "address": "118.153.253.133",
-          "port": 57414
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8252181326601427,
-      "relativeStake": 0.0009203640163105332,
-      "relays": [
-        {
-          "address": "125.250.255.197",
-          "port": 8000
-        },
-        {
-          "address": "75.119.158.164",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8261335217521255,
-      "relativeStake": 0.0009153890919828674,
-      "relays": [
-        {
-          "address": "relay0.crimsonpool.com",
-          "port": 5100
-        },
-        {
-          "address": "relay1.crimsonpool.com",
-          "port": 5101
-        },
-        {
-          "address": "relay2.crimsonpool.com",
-          "port": 5102
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8270476859805773,
-      "relativeStake": 0.0009141642284518056,
-      "relays": [
-        {
-          "address": "relay-ca.ada.psiloblox.io",
-          "port": 3002
-        },
-        {
-          "address": "2600:ac02:7c06:0:20c:29ff:fe01:4ff9",
-          "port": 3002
-        },
-        {
-          "address": "208.118.69.126",
-          "port": 3003
-        },
-        {
-          "address": "relay-jp.ada.psiloblox.io",
-          "port": 3001
-        },
-        {
-          "address": "relay-de.ada.psiloblox.io",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8279518487954441,
-      "relativeStake": 0.0009041628148668343,
-      "relays": [
-        {
-          "address": "relay1.alfa-pool.gr",
-          "port": 6001
-        },
-        {
-          "address": "relay2.alfa-pool.gr",
-          "port": 6000
-        },
-        {
-          "address": "relay3.alfa-pool.gr",
-          "port": 6000
-        },
-        {
-          "address": "relay4.alfa-pool.gr",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8288534175543489,
-      "relativeStake": 0.0009015687589047565,
-      "relays": [
-        {
-          "address": "relays.xray.app",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8297524871599838,
-      "relativeStake": 0.0008990696056349906,
-      "relays": [
-        {
-          "address": "194.233.70.42",
-          "port": 57997
-        },
-        {
-          "address": "194.233.71.183",
-          "port": 51180
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8306472099874058,
-      "relativeStake": 0.0008947228274219014,
-      "relays": [
-        {
-          "address": "75.119.157.236",
-          "port": 6000
-        },
-        {
-          "address": "149.102.144.126",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8315392232211808,
-      "relativeStake": 0.0008920132337749792,
-      "relays": [
-        {
-          "address": "143.110.217.207",
-          "port": 6000
-        },
-        {
-          "address": "167.99.88.198",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8324287529909317,
-      "relativeStake": 0.0008895297697508698,
-      "relays": [
-        {
-          "address": "relay01.nekota.work",
-          "port": 3001
-        },
-        {
-          "address": "relay02.nekota.work",
-          "port": 3001
-        },
-        {
-          "address": "relay03.nekota.work",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8333109365207326,
-      "relativeStake": 0.0008821835298009825,
+      "accumulatedStake": 0.7890885981310028,
+      "relativeStake": 0.0011222256569361373,
       "relays": [
         {
           "address": "relay1.adaocean.com",
@@ -5481,136 +4884,156 @@
       ]
     },
     {
-      "accumulatedStake": 0.8341925909451167,
-      "relativeStake": 0.0008816544243840736,
+      "accumulatedStake": 0.7902007924525716,
+      "relativeStake": 0.0011121943215687312,
       "relays": [
         {
-          "address": "144.126.145.189",
-          "port": 6000
-        },
-        {
-          "address": "144.126.145.190",
-          "port": 7001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8350740081109559,
-      "relativeStake": 0.0008814171658392364,
-      "relays": [
-        {
-          "address": "relay1.mazza.vc",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8359537015105147,
-      "relativeStake": 0.0008796933995588361,
-      "relays": [
-        {
-          "address": "57.129.28.179",
-          "port": 3001
-        },
-        {
-          "address": "57.129.28.180",
+          "address": "asia.jazzstakepool.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8368296327011965,
-      "relativeStake": 0.0008759311906817679,
+      "accumulatedStake": 0.791311987602705,
+      "relativeStake": 0.0011111951501335015,
       "relays": [
         {
-          "address": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "address": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8376988449921292,
-      "relativeStake": 0.0008692122909327091,
-      "relays": [
-        {
-          "address": "ram-relay1.irota.xyz",
+          "address": "relay1.kaizn.kaizencrypto.com",
           "port": 6000
         },
         {
-          "address": "kyu-relay2.irota.xyz",
+          "address": "relay2.kaizn.kaizencrypto.com",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8385655594351753,
-      "relativeStake": 0.0008667144430460358,
+      "accumulatedStake": 0.7924174661465144,
+      "relativeStake": 0.001105478543809356,
       "relays": [
         {
-          "address": "private-pools.fivebinaries.com",
+          "address": "europe1-zzz3relay.zzzpool.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8394318996326311,
-      "relativeStake": 0.0008663401974558026,
+      "accumulatedStake": 0.7935228756142924,
+      "relativeStake": 0.0011054094677779619,
       "relays": [
         {
-          "address": "ipclub29-1.relay.my-ip.at",
-          "port": 3001
+          "address": "benitoite-rohan-d68b9.cardano.bdnodes.net",
+          "port": 6000
         },
         {
-          "address": "ipclub29-1.relay.my-ip.at",
-          "port": 3002
-        },
-        {
-          "address": "ipclub29-2.relay.my-ip.at",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8402973270561428,
-      "relativeStake": 0.0008654274235117347,
-      "relays": [
-        {
-          "address": "104.236.24.187",
-          "port": 5281
-        },
-        {
-          "address": "23.24.140.149",
-          "port": 5282
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8411609207100412,
-      "relativeStake": 0.0008635936538984055,
-      "relays": [
-        {
-          "address": "13.208.79.46",
+          "address": "brown-lagos-6a470.cardano.bdnodes.net",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8420185391092674,
-      "relativeStake": 0.0008576183992261982,
+      "accumulatedStake": 0.7946228163888817,
+      "relativeStake": 0.0010999407745892846,
       "relays": [
         {
-          "address": "52.167.20.127",
+          "address": "202.61.246.91",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7957212491549697,
+      "relativeStake": 0.0010984327660880757,
+      "relays": [
+        {
+          "address": "relays.planetstake.com",
+          "port": 3001
+        },
+        {
+          "address": "161.97.90.20",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7968180601291609,
+      "relativeStake": 0.0010968109741912005,
+      "relays": [
+        {
+          "address": "3.6.124.226",
+          "port": 3001
+        },
+        {
+          "address": "18.193.92.87",
+          "port": 3001
+        },
+        {
+          "address": "54.219.241.10",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7978998334443127,
+      "relativeStake": 0.0010817733151517967,
+      "relays": [
+        {
+          "address": "89.58.57.185",
+          "port": 4000
+        },
+        {
+          "address": "5.250.178.133",
           "port": 4000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8428716213706673,
-      "relativeStake": 0.0008530822613998441,
+      "accumulatedStake": 0.7989760887302824,
+      "relativeStake": 0.001076255285969609,
+      "relays": [
+        {
+          "address": "161.35.209.217",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8000341975366483,
+      "relativeStake": 0.0010581088063660025,
+      "relays": [
+        {
+          "address": "europe-de.popsp.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8010920283027103,
+      "relativeStake": 0.001057830766062023,
+      "relays": [
+        {
+          "address": "102.130.127.242",
+          "port": 6000
+        },
+        {
+          "address": "94.16.106.16",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8021420275277314,
+      "relativeStake": 0.0010499992250211007,
+      "relays": [
+        {
+          "address": "20.69.213.207",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8031858614318781,
+      "relativeStake": 0.0010438339041466064,
       "relays": [
         {
           "address": "relay1.nedscave.io",
@@ -5631,28 +5054,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8437181502738306,
-      "relativeStake": 0.000846528903163302,
-      "relays": [
-        {
-          "address": "cardano-relays.atomicwallet.io",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8445555949696387,
-      "relativeStake": 0.0008374446958081908,
-      "relays": [
-        {
-          "address": "77.110.114.135",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8453923274506314,
-      "relativeStake": 0.000836732480992623,
+      "accumulatedStake": 0.8042288373765908,
+      "relativeStake": 0.0010429759447127369,
       "relays": [
         {
           "address": "135.181.194.233",
@@ -5661,16 +5064,598 @@
         {
           "address": "168.119.101.200",
           "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8052488852606581,
+      "relativeStake": 0.0010200478840673229,
+      "relays": [
+        {
+          "address": "3.111.14.60",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8062675550944346,
+      "relativeStake": 0.0010186698337764433,
+      "relays": [
+        {
+          "address": "relay.azureada.com",
+          "port": 3001
         },
         {
-          "address": "5.161.59.12",
+          "address": "relay.azureada.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8072858640848488,
+      "relativeStake": 0.0010183089904142292,
+      "relays": [
+        {
+          "address": "77.110.114.135",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.846227754768476,
-      "relativeStake": 0.0008354273178446716,
+      "accumulatedStake": 0.8082870225336672,
+      "relativeStake": 0.0010011584488185017,
+      "relays": [
+        {
+          "address": "relay1.cerostakepool.com",
+          "port": 3001
+        },
+        {
+          "address": "relay2.cerostakepool.com",
+          "port": 3001
+        },
+        {
+          "address": "relay3.cerostakepool.com",
+          "port": 3001
+        },
+        {
+          "address": "relay4.cerostakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8092818446822414,
+      "relativeStake": 0.0009948221485740897,
+      "relays": [
+        {
+          "address": "relay1.bluecheesestakehouse.com",
+          "port": 5001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8102760557225224,
+      "relativeStake": 0.0009942110402810036,
+      "relays": [
+        {
+          "address": "52.167.20.127",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8112664826276421,
+      "relativeStake": 0.0009904269051197732,
+      "relays": [
+        {
+          "address": "europe3-zzz5relay.zzzpool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8122498830802934,
+      "relativeStake": 0.0009834004526513066,
+      "relays": [
+        {
+          "address": "relay0.bluecheesestakehouse.com",
+          "port": 5000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8132283817226138,
+      "relativeStake": 0.0009784986423203115,
+      "relays": [
+        {
+          "address": "109.123.231.213",
+          "port": 6000
+        },
+        {
+          "address": "89.58.45.244",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.814197954760518,
+      "relativeStake": 0.0009695730379042441,
+      "relays": [
+        {
+          "address": "20.69.213.207",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8151593434279255,
+      "relativeStake": 0.0009613886674074412,
+      "relays": [
+        {
+          "address": "adaboy-mainnet-2a.gleeze.com",
+          "port": 6000
+        },
+        {
+          "address": "adaboy-mainnet-3a.gleeze.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.816119160474873,
+      "relativeStake": 0.0009598170469475138,
+      "relays": [
+        {
+          "address": "cardano-relays.autostake.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8170744943663502,
+      "relativeStake": 0.0009553338914771692,
+      "relays": [
+        {
+          "address": "relay1.viperstaking.com",
+          "port": 4444
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8180231286421358,
+      "relativeStake": 0.0009486342757856727,
+      "relays": [
+        {
+          "address": "35.154.123.251",
+          "port": 3001
+        },
+        {
+          "address": "15.206.230.107",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8189503999832747,
+      "relativeStake": 0.0009272713411388273,
+      "relays": [
+        {
+          "address": "private-pools.fivebinaries.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8198762704004404,
+      "relativeStake": 0.0009258704171657942,
+      "relays": [
+        {
+          "address": "154.38.174.71",
+          "port": 6000
+        },
+        {
+          "address": "118.153.253.133",
+          "port": 57413
+        },
+        {
+          "address": "118.153.253.133",
+          "port": 57414
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8207991204178662,
+      "relativeStake": 0.0009228500174257473,
+      "relays": [
+        {
+          "address": "125.250.255.197",
+          "port": 8000
+        },
+        {
+          "address": "75.119.158.164",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.821711629937068,
+      "relativeStake": 0.0009125095192018712,
+      "relays": [
+        {
+          "address": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8226178134325651,
+      "relativeStake": 0.0009061834954970374,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8235239395914457,
+      "relativeStake": 0.000906126158880511,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.824430019994917,
+      "relativeStake": 0.0009060804034714137,
+      "relays": [
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8253323253543384,
+      "relativeStake": 0.0009023053594214094,
+      "relays": [
+        {
+          "address": "relay.azureada.com",
+          "port": 3001
+        },
+        {
+          "address": "relay.azureada.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8262338973747414,
+      "relativeStake": 0.0009015720204030234,
+      "relays": [
+        {
+          "address": "relay0.crimsonpool.com",
+          "port": 5100
+        },
+        {
+          "address": "relay1.crimsonpool.com",
+          "port": 5101
+        },
+        {
+          "address": "relay2.crimsonpool.com",
+          "port": 5102
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8271335806774097,
+      "relativeStake": 0.0008996833026682164,
+      "relays": [
+        {
+          "address": "75.119.157.236",
+          "port": 6000
+        },
+        {
+          "address": "149.102.144.126",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8280308569801463,
+      "relativeStake": 0.0008972763027366847,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8289274793627974,
+      "relativeStake": 0.0008966223826510377,
+      "relays": [
+        {
+          "address": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "address": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8298213472807767,
+      "relativeStake": 0.0008938679179793544,
+      "relays": [
+        {
+          "address": "relay-ca.ada.psiloblox.io",
+          "port": 3002
+        },
+        {
+          "address": "2600:ac02:7c06:0:20c:29ff:fe01:4ff9",
+          "port": 3002
+        },
+        {
+          "address": "208.118.69.126",
+          "port": 3003
+        },
+        {
+          "address": "relay-jp.ada.psiloblox.io",
+          "port": 3001
+        },
+        {
+          "address": "relay-de.ada.psiloblox.io",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8307105431058251,
+      "relativeStake": 0.0008891958250483979,
+      "relays": [
+        {
+          "address": "104.236.24.187",
+          "port": 5281
+        },
+        {
+          "address": "23.24.140.149",
+          "port": 5282
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8315984732776543,
+      "relativeStake": 0.0008879301718292169,
+      "relays": [
+        {
+          "address": "57.129.28.179",
+          "port": 3001
+        },
+        {
+          "address": "57.129.28.180",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8324861190699833,
+      "relativeStake": 0.0008876457923288704,
+      "relays": [
+        {
+          "address": "144.126.145.189",
+          "port": 6000
+        },
+        {
+          "address": "144.126.145.190",
+          "port": 7001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8333728350343669,
+      "relativeStake": 0.0008867159643836523,
+      "relays": [
+        {
+          "address": "relay1.mazza.vc",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8342551728499854,
+      "relativeStake": 0.000882337815618516,
+      "relays": [
+        {
+          "address": "eu1.stakecool.io",
+          "port": 4001
+        },
+        {
+          "address": "eu2.stakecool.io",
+          "port": 4001
+        },
+        {
+          "address": "eu3.stakecool.io",
+          "port": 4002
+        },
+        {
+          "address": "eu4.stakecool.io",
+          "port": 4002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8351369407668173,
+      "relativeStake": 0.000881767916831879,
+      "relays": [
+        {
+          "address": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "address": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8360098723976417,
+      "relativeStake": 0.0008729316308243685,
+      "relays": [
+        {
+          "address": "relay01.nekota.work",
+          "port": 3001
+        },
+        {
+          "address": "relay02.nekota.work",
+          "port": 3001
+        },
+        {
+          "address": "relay03.nekota.work",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.836878101250302,
+      "relativeStake": 0.0008682288526604273,
+      "relays": [
+        {
+          "address": "13.208.79.46",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8377455917188795,
+      "relativeStake": 0.0008674904685775001,
+      "relays": [
+        {
+          "address": "ram-relay1.irota.xyz",
+          "port": 6000
+        },
+        {
+          "address": "kyu-relay2.irota.xyz",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8386116536264203,
+      "relativeStake": 0.0008660619075407379,
+      "relays": [
+        {
+          "address": "143.110.217.207",
+          "port": 6000
+        },
+        {
+          "address": "167.99.88.198",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8394754306906393,
+      "relativeStake": 0.000863777064219078,
+      "relays": [
+        {
+          "address": "ipclub29-1.relay.my-ip.at",
+          "port": 3001
+        },
+        {
+          "address": "ipclub29-1.relay.my-ip.at",
+          "port": 3002
+        },
+        {
+          "address": "ipclub29-2.relay.my-ip.at",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8403369512119392,
+      "relativeStake": 0.0008615205212997511,
+      "relays": [
+        {
+          "address": "cardano-relays.atomicwallet.io",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8411839449436413,
+      "relativeStake": 0.0008469937317021823,
+      "relays": [
+        {
+          "address": "52.167.20.127",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8420297464869356,
+      "relativeStake": 0.0008458015432943613,
+      "relays": [
+        {
+          "address": "relay1.alfa-pool.gr",
+          "port": 6001
+        },
+        {
+          "address": "relay2.alfa-pool.gr",
+          "port": 6000
+        },
+        {
+          "address": "relay3.alfa-pool.gr",
+          "port": 6000
+        },
+        {
+          "address": "relay4.alfa-pool.gr",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8428713299696712,
+      "relativeStake": 0.0008415834827354471,
       "relays": [
         {
           "address": "34.84.0.241",
@@ -5683,8 +5668,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8470623723622231,
-      "relativeStake": 0.0008346175937470577,
+      "accumulatedStake": 0.8437045264948537,
+      "relativeStake": 0.0008331965251825946,
       "relays": [
         {
           "address": "206.81.3.194",
@@ -5693,8 +5678,50 @@
       ]
     },
     {
-      "accumulatedStake": 0.8478909836129518,
-      "relativeStake": 0.0008286112507286418,
+      "accumulatedStake": 0.8445353158592313,
+      "relativeStake": 0.0008307893643775043,
+      "relays": [
+        {
+          "address": "relay1.toiro.love",
+          "port": 6000
+        },
+        {
+          "address": "relay2.toiro.love",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8453623800469156,
+      "relativeStake": 0.0008270641876843146,
+      "relays": [
+        {
+          "address": "85.215.147.174",
+          "port": 6000
+        },
+        {
+          "address": "85.215.187.104",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8461810533988751,
+      "relativeStake": 0.0008186733519594747,
+      "relays": [
+        {
+          "address": "relay1.cashflowpool.com",
+          "port": 3001
+        },
+        {
+          "address": "relay2.cashflowpool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8469955892391946,
+      "relativeStake": 0.0008145358403195726,
       "relays": [
         {
           "address": "cpr1.sargatxet.cloud",
@@ -5711,64 +5738,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.8487183867904875,
-      "relativeStake": 0.0008274031775357175,
+      "accumulatedStake": 0.8478063216146212,
+      "relativeStake": 0.0008107323754265945,
       "relays": [
         {
-          "address": "178.128.79.219",
+          "address": "1f018fdb.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8486161079363498,
+      "relativeStake": 0.0008097863217285512,
+      "relays": [
+        {
+          "address": "private-pools.fivebinaries.com",
           "port": 3001
-        },
-        {
-          "address": "104.131.122.73",
-          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8495428064953148,
-      "relativeStake": 0.0008244197048273633,
-      "relays": [
-        {
-          "address": "relay1.toiro.love",
-          "port": 6000
-        },
-        {
-          "address": "relay2.toiro.love",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.850363996653932,
-      "relativeStake": 0.000821190158617238,
-      "relays": [
-        {
-          "address": "85.215.147.174",
-          "port": 6000
-        },
-        {
-          "address": "85.215.187.104",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.85118212320122,
-      "relativeStake": 0.000818126547287911,
-      "relays": [
-        {
-          "address": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "address": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8519965415551772,
-      "relativeStake": 0.0008144183539572845,
+      "accumulatedStake": 0.8494255185639406,
+      "relativeStake": 0.0008094106275908568,
       "relays": [
         {
           "address": "ACLrelay1.cardanoland.com",
@@ -5797,22 +5788,66 @@
       ]
     },
     {
-      "accumulatedStake": 0.8528069451330912,
-      "relativeStake": 0.0008104035779139112,
+      "accumulatedStake": 0.8502337880302093,
+      "relativeStake": 0.000808269466268684,
       "relays": [
         {
-          "address": "relay1.cashflowpool.com",
-          "port": 3001
+          "address": "eu.relays.cardanians.io",
+          "port": 1000
         },
         {
-          "address": "relay2.cashflowpool.com",
+          "address": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8510394777545834,
+      "relativeStake": 0.0008056897243742184,
+      "relays": [
+        {
+          "address": "202.61.246.91",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8536156791119288,
-      "relativeStake": 0.0008087339788376497,
+      "accumulatedStake": 0.8518429202851121,
+      "relativeStake": 0.0008034425305286372,
+      "relays": [
+        {
+          "address": "178.128.79.219",
+          "port": 3001
+        },
+        {
+          "address": "104.131.122.73",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8526447290265909,
+      "relativeStake": 0.0008018087414788021,
+      "relays": [
+        {
+          "address": "relays.xray.app",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.853445491114125,
+      "relativeStake": 0.0008007620875340966,
+      "relays": [
+        {
+          "address": "cardano-relays.atomicwallet.io",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.854244470635223,
+      "relativeStake": 0.0007989795210979802,
       "relays": [
         {
           "address": "LANDrelay1.cardanoland.com",
@@ -5841,72 +5876,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.8544218373209725,
-      "relativeStake": 0.0008061582090436945,
+      "accumulatedStake": 0.8550276330727926,
+      "relativeStake": 0.0007831624375696461,
       "relays": [
         {
-          "address": "cardano-relays.atomicwallet.io",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8552261895118938,
-      "relativeStake": 0.0008043521909212164,
-      "relays": [
-        {
-          "address": "1f018fdb.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8560238452430919,
-      "relativeStake": 0.0007976557311982022,
-      "relays": [
-        {
-          "address": "202.61.246.91",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8568144922676356,
-      "relativeStake": 0.0007906470245436949,
-      "relays": [
-        {
-          "address": "europe1-relay.jpn-sp.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8575888229228082,
-      "relativeStake": 0.0007743306551726713,
-      "relays": [
-        {
-          "address": "45.77.67.30",
-          "port": 3000
+          "address": "20.91.236.57",
+          "port": 6000
         },
         {
-          "address": "45.32.153.230",
-          "port": 3000
+          "address": "160.251.204.162",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8583624341986797,
-      "relativeStake": 0.0007736112758714668,
-      "relays": [
-        {
-          "address": "relays.banderini.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8591308579949659,
-      "relativeStake": 0.0007684237962861838,
+      "accumulatedStake": 0.8558009743389028,
+      "relativeStake": 0.0007733412661100845,
       "relays": [
         {
           "address": "cardano-relays-1.nu.fi",
@@ -5919,8 +5904,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8598975582074256,
-      "relativeStake": 0.0007667002124597204,
+      "accumulatedStake": 0.8565739249831432,
+      "relativeStake": 0.00077295064424043,
       "relays": [
         {
           "address": "r1.1percentpool.eu",
@@ -5933,8 +5918,32 @@
       ]
     },
     {
-      "accumulatedStake": 0.8606515250860334,
-      "relativeStake": 0.0007539668786076959,
+      "accumulatedStake": 0.8573442723015531,
+      "relativeStake": 0.000770347318409912,
+      "relays": [
+        {
+          "address": "45.77.67.30",
+          "port": 3000
+        },
+        {
+          "address": "45.32.153.230",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8581122019291069,
+      "relativeStake": 0.0007679296275537987,
+      "relays": [
+        {
+          "address": "relays.liqwid.finance",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.85887642578392,
+      "relativeStake": 0.0007642238548131399,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -5955,18 +5964,42 @@
       ]
     },
     {
-      "accumulatedStake": 0.8614026705672106,
-      "relativeStake": 0.0007511454811772888,
+      "accumulatedStake": 0.8596401337698061,
+      "relativeStake": 0.0007637079858860529,
       "relays": [
         {
-          "address": "private-pools.fivebinaries.com",
+          "address": "relays.liqwid.finance",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8621509221279966,
-      "relativeStake": 0.0007482515607859499,
+      "accumulatedStake": 0.8604004507388093,
+      "relativeStake": 0.000760316969003216,
+      "relays": [
+        {
+          "address": "r1.spirestaking.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8611530654948933,
+      "relativeStake": 0.0007526147560840317,
+      "relays": [
+        {
+          "address": "135.181.194.233",
+          "port": 6000
+        },
+        {
+          "address": "168.119.101.200",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8618987355577531,
+      "relativeStake": 0.0007456700628598168,
       "relays": [
         {
           "address": "csn.relay1.cardanoscan.io",
@@ -5979,30 +6012,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8628905797523294,
-      "relativeStake": 0.0007396576243327929,
-      "relays": [
-        {
-          "address": "148.113.17.23",
-          "port": 6000
-        },
-        {
-          "address": "158.69.25.103",
-          "port": 6000
-        },
-        {
-          "address": "95.216.70.238",
-          "port": 6000
-        },
-        {
-          "address": "149.102.140.234",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8636243475687287,
-      "relativeStake": 0.0007337678163993805,
+      "accumulatedStake": 0.862637982816408,
+      "relativeStake": 0.0007392472586548657,
       "relays": [
         {
           "address": "r1.1percentpool.eu",
@@ -6015,8 +6026,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8643571888933576,
-      "relativeStake": 0.000732841324628815,
+      "accumulatedStake": 0.863376390175281,
+      "relativeStake": 0.0007384073588730325,
       "relays": [
         {
           "address": "cardano1.vampyre.fund",
@@ -6037,8 +6048,31 @@
       ]
     },
     {
-      "accumulatedStake": 0.8650842960430492,
-      "relativeStake": 0.0007271071496915514,
+      "accumulatedStake": 0.8641089315372706,
+      "relativeStake": 0.0007325413619896069,
+      "relays": [
+        {
+          "address": "relay1.adaverse.com",
+          "port": 5000
+        },
+        {
+          "address": "relay2.adaverse.com",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8648404122546046,
+      "relativeStake": 0.0007314807173339368,
+      "relays": [
+        {
+          "address": "relay-pool-1-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8655714328670665,
+      "relativeStake": 0.0007310206124619118,
       "relays": [
         {
           "address": "20.61.229.103",
@@ -6059,8 +6093,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8658106233548666,
-      "relativeStake": 0.000726327311817411,
+      "accumulatedStake": 0.8662981487771658,
+      "relativeStake": 0.000726715910099282,
       "relays": [
         {
           "address": "adar2.stakit.io",
@@ -6069,17 +6103,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8665365503044483,
-      "relativeStake": 0.0007259269495818007,
-      "relays": [
-        {
-          "address": "relay-pool-1-mainnet.cardano.aeq5f.com"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8672556154393306,
-      "relativeStake": 0.0007190651348822756,
+      "accumulatedStake": 0.8670198323713676,
+      "relativeStake": 0.0007216835942018014,
       "relays": [
         {
           "address": "149.28.106.59",
@@ -6088,22 +6113,30 @@
       ]
     },
     {
-      "accumulatedStake": 0.8679710677978387,
-      "relativeStake": 0.0007154523585080676,
+      "accumulatedStake": 0.8677384265407809,
+      "relativeStake": 0.0007185941694133036,
       "relays": [
         {
-          "address": "116.80.93.53",
+          "address": "148.113.17.23",
           "port": 6000
         },
         {
-          "address": "5.104.85.79",
+          "address": "158.69.25.103",
+          "port": 6000
+        },
+        {
+          "address": "95.216.70.238",
+          "port": 6000
+        },
+        {
+          "address": "149.102.140.234",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8686845936175166,
-      "relativeStake": 0.0007135258196778847,
+      "accumulatedStake": 0.8684422458890244,
+      "relativeStake": 0.0007038193482434933,
       "relays": [
         {
           "address": "34.175.101.127",
@@ -6116,22 +6149,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8693855363077436,
-      "relativeStake": 0.0007009426902270571,
-      "relays": [
-        {
-          "address": "relay1.thevikingpool.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2.thevikingpool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8700855901806929,
-      "relativeStake": 0.0007000538729492572,
+      "accumulatedStake": 0.8691424472699345,
+      "relativeStake": 0.0007002013809101404,
       "relays": [
         {
           "address": "54.150.77.128",
@@ -6144,60 +6163,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.8707848501047212,
-      "relativeStake": 0.0006992599240282642,
+      "accumulatedStake": 0.8698377776476993,
+      "relativeStake": 0.0006953303777647926,
       "relays": [
         {
-          "address": "relay1.adaverse.com",
-          "port": 5000
-        },
-        {
-          "address": "relay2.adaverse.com",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8714769664327201,
-      "relativeStake": 0.0006921163279989886,
-      "relays": [
-        {
-          "address": "51.195.91.118",
-          "port": 3001
-        },
-        {
-          "address": "51.161.35.246",
-          "port": 3001
-        },
-        {
-          "address": "49.12.123.178",
-          "port": 3001
-        },
-        {
-          "address": "95.217.58.124",
-          "port": 3001
-        },
-        {
-          "address": "51.195.91.118",
-          "port": 3001
-        },
-        {
-          "address": "51.161.35.246",
-          "port": 3001
-        },
-        {
-          "address": "49.12.123.178",
-          "port": 3001
-        },
-        {
-          "address": "95.217.58.124",
+          "address": "private-pools.fivebinaries.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8721649987034145,
-      "relativeStake": 0.0006880322706943222,
+      "accumulatedStake": 0.8705330740274401,
+      "relativeStake": 0.000695296379740791,
+      "relays": [
+        {
+          "address": "cf6r1.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        },
+        {
+          "address": "cf6r2.mainnet.pool.cardanofoundation.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.871223519615106,
+      "relativeStake": 0.0006904455876658882,
+      "relays": [
+        {
+          "address": "relay1.powerstakepool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay2.powerstakepool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8719125424518231,
+      "relativeStake": 0.0006890228367171643,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -6218,22 +6223,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8728465372292654,
-      "relativeStake": 0.0006815385258509849,
-      "relays": [
-        {
-          "address": "relay1.powerstakepool.com",
-          "port": 6000
-        },
-        {
-          "address": "relay2.powerstakepool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8735269466285409,
-      "relativeStake": 0.0006804093992755044,
+      "accumulatedStake": 0.8725981042901032,
+      "relativeStake": 0.0006855618382800864,
       "relays": [
         {
           "address": "asia-pacific-japan.popsp.net",
@@ -6242,8 +6233,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.8742051157300589,
-      "relativeStake": 0.0006781691015179352,
+      "accumulatedStake": 0.8732806669171672,
+      "relativeStake": 0.0006825626270639732,
+      "relays": [
+        {
+          "address": "r1.adaism.uk",
+          "port": 8081
+        },
+        {
+          "address": "r2.adaism.uk",
+          "port": 8081
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8739611963682078,
+      "relativeStake": 0.0006805294510406321,
       "relays": [
         {
           "address": "r1.relaypool.online",
@@ -6252,8 +6257,31 @@
       ]
     },
     {
-      "accumulatedStake": 0.8748764607797828,
-      "relativeStake": 0.0006713450497238363,
+      "accumulatedStake": 0.8746406621324305,
+      "relativeStake": 0.0006794657642226421,
+      "relays": [
+        {
+          "address": "relay-pool-figment-7-mainnet.cardano.aeq5f.com"
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8753181014622012,
+      "relativeStake": 0.0006774393297707118,
+      "relays": [
+        {
+          "address": "116.80.93.53",
+          "port": 6000
+        },
+        {
+          "address": "5.104.85.79",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8759882476121118,
+      "relativeStake": 0.0006701461499106475,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -6274,8 +6302,64 @@
       ]
     },
     {
-      "accumulatedStake": 0.8755407744814095,
-      "relativeStake": 0.0006643137016268544,
+      "accumulatedStake": 0.8766573780989739,
+      "relativeStake": 0.0006691304868621199,
+      "relays": [
+        {
+          "address": "34.192.61.190",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8773264660542184,
+      "relativeStake": 0.0006690879552444623,
+      "relays": [
+        {
+          "address": "1e5c4061.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8779947002090775,
+      "relativeStake": 0.0006682341548591432,
+      "relays": [
+        {
+          "address": "relay-1.banderini.net",
+          "port": 3001
+        },
+        {
+          "address": "relay-2.banderini.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8786620838947601,
+      "relativeStake": 0.0006673836856825095,
+      "relays": [
+        {
+          "address": "51.195.91.118",
+          "port": 3001
+        },
+        {
+          "address": "51.161.35.246",
+          "port": 3001
+        },
+        {
+          "address": "49.12.123.178",
+          "port": 3001
+        },
+        {
+          "address": "95.217.58.124",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8793247193536917,
+      "relativeStake": 0.0006626354589316641,
       "relays": [
         {
           "address": "137.117.180.0",
@@ -6292,32 +6376,48 @@
       ]
     },
     {
-      "accumulatedStake": 0.8762048709920652,
-      "relativeStake": 0.0006640965106556832,
+      "accumulatedStake": 0.879987024523362,
+      "relativeStake": 0.0006623051696702111,
       "relays": [
         {
-          "address": "34.192.61.190",
+          "address": "40.160.1.159",
+          "port": 6000
+        },
+        {
+          "address": "15.204.108.52",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.880641721598379,
+      "relativeStake": 0.0006546970750169694,
+      "relays": [
+        {
+          "address": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "address": "cardano-relay2.everstake.one",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8768676994756336,
-      "relativeStake": 0.0006628284835682907,
-      "relays": [
-        {
-          "address": "r1.adaism.uk",
-          "port": 8081
-        },
-        {
-          "address": "r2.adaism.uk",
-          "port": 8081
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8775278020882246,
-      "relativeStake": 0.0006601026125910174,
+      "accumulatedStake": 0.8812943274113928,
+      "relativeStake": 0.0006526058130138462,
       "relays": [
         {
           "address": "germany.cardanode.io",
@@ -6338,36 +6438,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8781858596421002,
-      "relativeStake": 0.0006580575538755809,
-      "relays": [
-        {
-          "address": "223.25.73.249",
-          "port": 6452
-        },
-        {
-          "address": "128.199.147.30",
-          "port": 6001
-        },
-        {
-          "address": "158.140.141.199",
-          "port": 8082
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8788330189426898,
-      "relativeStake": 0.0006471593005897048,
-      "relays": [
-        {
-          "address": "78.47.119.91",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8794795721111512,
-      "relativeStake": 0.000646553168461384,
+      "accumulatedStake": 0.8819452529719731,
+      "relativeStake": 0.0006509255605803138,
       "relays": [
         {
           "address": "r1.cosd.com",
@@ -6380,8 +6452,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8801253104550608,
-      "relativeStake": 0.000645738343909519,
+      "accumulatedStake": 0.8825957649780541,
+      "relativeStake": 0.0006505120060810492,
       "relays": [
         {
           "address": "relay1.pudim.cat",
@@ -6394,8 +6466,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8807698519948719,
-      "relativeStake": 0.0006445415398111695,
+      "accumulatedStake": 0.8832416727476259,
+      "relativeStake": 0.0006459077695717085,
       "relays": [
         {
           "address": "relay1.squidpool.com",
@@ -6408,8 +6480,32 @@
       ]
     },
     {
-      "accumulatedStake": 0.8814019712113352,
-      "relativeStake": 0.0006321192164632496,
+      "accumulatedStake": 0.8838856148595768,
+      "relativeStake": 0.0006439421119509522,
+      "relays": [
+        {
+          "address": "78.47.119.91",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8845231037207099,
+      "relativeStake": 0.0006374888611330525,
+      "relays": [
+        {
+          "address": "relay1.thevikingpool.com",
+          "port": 6000
+        },
+        {
+          "address": "relay2.thevikingpool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8851598947632959,
+      "relativeStake": 0.00063679104258605,
       "relays": [
         {
           "address": "relay1-ada.cex.io",
@@ -6426,22 +6522,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8820333442427105,
-      "relativeStake": 0.0006313730313753691,
-      "relays": [
-        {
-          "address": "re1.reservoir.network",
-          "port": 3001
-        },
-        {
-          "address": "re2.reservoir.network",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8826643808386406,
-      "relativeStake": 0.0006310365959300425,
+      "accumulatedStake": 0.8857918249471275,
+      "relativeStake": 0.0006319301838316043,
       "relays": [
         {
           "address": "relays.onyxstakepool.com",
@@ -6450,26 +6532,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8832913964369937,
-      "relativeStake": 0.000627015598353071,
-      "relays": [
-        {
-          "address": "eu1.stakecool.io",
-          "port": 4001
-        },
-        {
-          "address": "eu2.stakecool.io",
-          "port": 4001
-        },
-        {
-          "address": "ca1.stakecool.io",
-          "port": 4001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8839115709512115,
-      "relativeStake": 0.000620174514217867,
+      "accumulatedStake": 0.8864218614639224,
+      "relativeStake": 0.0006300365167949216,
       "relays": [
         {
           "address": "cardano-relays-1.nu.fi",
@@ -6482,8 +6546,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.8845278989187342,
-      "relativeStake": 0.0006163279675226348,
+      "accumulatedStake": 0.8870506596772845,
+      "relativeStake": 0.0006287982133620322,
+      "relays": [
+        {
+          "address": "223.25.73.249",
+          "port": 6452
+        },
+        {
+          "address": "128.199.147.30",
+          "port": 6001
+        },
+        {
+          "address": "158.140.141.199",
+          "port": 8082
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8876790135741269,
+      "relativeStake": 0.0006283538968424842,
+      "relays": [
+        {
+          "address": "re1.reservoir.network",
+          "port": 3001
+        },
+        {
+          "address": "re2.reservoir.network",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8883025192607364,
+      "relativeStake": 0.0006235056866095227,
       "relays": [
         {
           "address": "r1.isp-r1.wjg.jp",
@@ -6496,32 +6592,78 @@
       ]
     },
     {
-      "accumulatedStake": 0.8851396666454671,
-      "relativeStake": 0.0006117677267328818,
+      "accumulatedStake": 0.8889180442339519,
+      "relativeStake": 0.000615524973215457,
       "relays": [
         {
-          "address": "relay.armadastakepool.com",
-          "port": 5100
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8857499434875613,
-      "relativeStake": 0.00061027684209428,
-      "relays": [
-        {
-          "address": "40.160.1.159",
+          "address": "108.174.196.172",
           "port": 6000
         },
         {
-          "address": "15.204.108.52",
+          "address": "142.11.241.195",
           "port": 6000
+        },
+        {
+          "address": "142.11.241.198",
+          "port": 6000
+        },
+        {
+          "address": "104.168.174.247",
+          "port": 6000
+        },
+        {
+          "address": "104.168.204.201",
+          "port": 6001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8863587854610916,
-      "relativeStake": 0.0006088419735302651,
+      "accumulatedStake": 0.8895211707326439,
+      "relativeStake": 0.0006031264986919512,
+      "relays": [
+        {
+          "address": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "address": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8901211189772648,
+      "relativeStake": 0.0005999482446209061,
+      "relays": [
+        {
+          "address": "cof-1.cardanocafe.org",
+          "port": 3005
+        },
+        {
+          "address": "cof-2.cardanocafe.org",
+          "port": 3010
+        },
+        {
+          "address": "cap-1.cardanocafe.org",
+          "port": 4000
+        },
+        {
+          "address": "cap-2.cardanocafe.org",
+          "port": 4005
+        },
+        {
+          "address": "lat-1.cardanocafe.org",
+          "port": 5001
+        },
+        {
+          "address": "lat-2.cardanocafe.org",
+          "port": 5002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8907202096117809,
+      "relativeStake": 0.0005990906345160633,
       "relays": [
         {
           "address": "bra-relay.cardanistas.io",
@@ -6538,116 +6680,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8869653499925783,
-      "relativeStake": 0.0006065645314866251,
+      "accumulatedStake": 0.8913183508822952,
+      "relativeStake": 0.0005981412705142785,
       "relays": [
         {
-          "address": "r1-1.cardanocafe.org",
-          "port": 3000
-        },
-        {
-          "address": "r1-2.cardanocafe.org",
-          "port": 3005
-        },
-        {
-          "address": "r1-3.cardanocafe.org",
-          "port": 3010
-        },
-        {
-          "address": "r2-1.cardanocafe.org",
-          "port": 4000
-        },
-        {
-          "address": "r2-2.cardanocafe.org",
-          "port": 4005
-        },
-        {
-          "address": "r2-3.cardanocafe.org",
-          "port": 4008
-        },
-        {
-          "address": "r3-1.cardanocafe.org",
-          "port": 5000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8875710106178578,
-      "relativeStake": 0.0006056606252796287,
-      "relays": [
-        {
-          "address": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "address": "cardano-relays-2.nu.fi",
+          "address": "europe1-relay.jpn-sp.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8881755439520491,
-      "relativeStake": 0.0006045333341912545,
-      "relays": [
-        {
-          "address": "57.128.184.29",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.32",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8887751145924825,
-      "relativeStake": 0.0005995706404333223,
-      "relays": [
-        {
-          "address": "135.181.194.233",
-          "port": 6000
-        },
-        {
-          "address": "168.119.101.200",
-          "port": 6000
-        },
-        {
-          "address": "5.161.59.12",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8893740347337954,
-      "relativeStake": 0.0005989201413129765,
-      "relays": [
-        {
-          "address": "white-denver-a41cf.cardano.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "address": "cinnabar-prague-71400.cardano.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8899695261930107,
-      "relativeStake": 0.0005954914592153131,
-      "relays": [
-        {
-          "address": "otg-relay-1.adamantium.online",
-          "port": 6001
-        },
-        {
-          "address": "otg-relay-2.adamantium.online",
-          "port": 6002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8905605343539847,
-      "relativeStake": 0.0005910081609740461,
+      "accumulatedStake": 0.8919138993355925,
+      "relativeStake": 0.0005955484532974075,
       "relays": [
         {
           "address": "202.61.225.111",
@@ -6660,8 +6704,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.8911436331574114,
-      "relativeStake": 0.0005830988034266726,
+      "accumulatedStake": 0.8925083975686573,
+      "relativeStake": 0.0005944982330647594,
+      "relays": [
+        {
+          "address": "57.128.184.29",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.32",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8930964300812169,
+      "relativeStake": 0.0005880325125595455,
       "relays": [
         {
           "address": "relay-pool-figment-20-mainnet.cardano.aeq5f.com"
@@ -6669,18 +6727,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8917250121170454,
-      "relativeStake": 0.0005813789596339322,
-      "relays": [
-        {
-          "address": "private-pools.fivebinaries.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8923016933285998,
-      "relativeStake": 0.0005766812115544127,
+      "accumulatedStake": 0.8936784936927645,
+      "relativeStake": 0.0005820636115477006,
       "relays": [
         {
           "address": "cardano-relays-1.nu.fi",
@@ -6693,18 +6741,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.8928756626565895,
-      "relativeStake": 0.0005739693279896269,
+      "accumulatedStake": 0.8942585898612556,
+      "relativeStake": 0.0005800961684910642,
       "relays": [
         {
-          "address": "relays.wavepool.digital",
-          "port": 3001
+          "address": "135.181.194.233",
+          "port": 6000
+        },
+        {
+          "address": "168.119.101.200",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8934492985112303,
-      "relativeStake": 0.0005736358546409553,
+      "accumulatedStake": 0.8948379523212129,
+      "relativeStake": 0.0005793624599573376,
+      "relays": [
+        {
+          "address": "white-denver-a41cf.cardano.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "address": "cinnabar-prague-71400.cardano.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.895414302883865,
+      "relativeStake": 0.0005763505626520559,
       "relays": [
         {
           "address": "cardano-relays.atomicwallet.io",
@@ -6713,8 +6779,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8940225783214181,
-      "relativeStake": 0.0005732798101876767,
+      "accumulatedStake": 0.8959903990069797,
+      "relativeStake": 0.0005760961231147303,
       "relays": [
         {
           "address": "15.237.92.158",
@@ -6723,18 +6789,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8945954230479142,
-      "relativeStake": 0.0005728447264961475,
-      "relays": [
-        {
-          "address": "r1.spirestaking.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8951681360136513,
-      "relativeStake": 0.0005727129657371665,
+      "accumulatedStake": 0.8965620543429192,
+      "relativeStake": 0.0005716553359395335,
       "relays": [
         {
           "address": "r1.1percentpool.eu",
@@ -6747,26 +6803,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8957359437943629,
-      "relativeStake": 0.0005678077807115678,
-      "relays": [
-        {
-          "address": "mound.adastack.net",
-          "port": 3001
-        },
-        {
-          "address": "pack.adastack.net",
-          "port": 3001
-        },
-        {
-          "address": "heap.adastack.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.896303487748306,
-      "relativeStake": 0.0005675439539431166,
+      "accumulatedStake": 0.8971331081224474,
+      "relativeStake": 0.0005710537795281797,
       "relays": [
         {
           "address": "133.167.33.31",
@@ -6779,8 +6817,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.8968684828134537,
-      "relativeStake": 0.000564995065147591,
+      "accumulatedStake": 0.8977018448326373,
+      "relativeStake": 0.0005687367101898461,
+      "relays": [
+        {
+          "address": "relay.armadastakepool.com",
+          "port": 5100
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8982675706453946,
+      "relativeStake": 0.000565725812757376,
+      "relays": [
+        {
+          "address": "85.25.93.176",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.898832809445944,
+      "relativeStake": 0.00056523880054938,
       "relays": [
         {
           "address": "54.228.75.154",
@@ -6801,18 +6859,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8974303529801412,
-      "relativeStake": 0.0005618701666875684,
-      "relays": [
-        {
-          "address": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8979872731855907,
-      "relativeStake": 0.0005569202054495193,
+      "accumulatedStake": 0.899393842615942,
+      "relativeStake": 0.0005610331699979974,
       "relays": [
         {
           "address": "202.61.246.91",
@@ -6821,54 +6869,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.8985353580402337,
-      "relativeStake": 0.0005480848546428952,
+      "accumulatedStake": 0.8999548412752059,
+      "relativeStake": 0.0005609986592638654,
       "relays": [
         {
-          "address": "relay.cardano.stakepools.info",
-          "port": 30001
-        },
-        {
-          "address": "relay-2.cardano.stakepools.info",
-          "port": 30001
+          "address": "ada-relay03.biglazycat.com",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8990808009014679,
-      "relativeStake": 0.0005454428612342884,
+      "accumulatedStake": 0.9005075826505399,
+      "relativeStake": 0.0005527413753339238,
       "relays": [
         {
-          "address": "relays.cardaspians.io",
+          "address": "relays.digi.pro",
           "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8996260656383023,
-      "relativeStake": 0.0005452647368344223,
-      "relays": [
-        {
-          "address": "relays.xray.app",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.9001687280539324,
-      "relativeStake": 0.0005426624156300743,
-      "relays": [
-        {
-          "address": "170.23.181.50",
-          "port": 6001
-        },
-        {
-          "address": "170.23.181.50",
-          "port": 6002
-        },
-        {
-          "address": "170.23.181.50",
-          "port": 6003
         }
       ]
     }

--- a/config/cardano/mainnet/topology-non-bootstrap-peers.json
+++ b/config/cardano/mainnet/topology-non-bootstrap-peers.json
@@ -26,5 +26,5 @@
       "advertise": false
     }
   ],
-  "useLedgerAfterSlot": 182044807
+  "useLedgerAfterSlot": 185500763
 }

--- a/config/cardano/mainnet/topology.json
+++ b/config/cardano/mainnet/topology.json
@@ -28,5 +28,5 @@
       "advertise": false
     }
   ],
-  "useLedgerAfterSlot": 182044807
+  "useLedgerAfterSlot": 185500763
 }

--- a/config/cardano/preprod/peer-snapshot.json
+++ b/config/cardano/preprod/peer-snapshot.json
@@ -2,13 +2,13 @@
   "NetworkMagic": 1,
   "NodeToClientVersion": 23,
   "Point": {
-    "blockPointHash": "5ea50d4d362e8aea9852dc246bdcac134846499ec608ae65abf2dbd98ff26154",
-    "blockPointSlot": 118280038
+    "blockPointHash": "1c8eee89ecbd6f48f69f879ffb9c299191c3ccd6971dce7ae66add61fea805fc",
+    "blockPointSlot": 121713740
   },
   "bigLedgerPools": [
     {
-      "accumulatedStake": 0.1193656264788864,
-      "relativeStake": 0.1193656264788864,
+      "accumulatedStake": 0.12350320003929828,
+      "relativeStake": 0.12350320003929828,
       "relays": [
         {
           "address": "relay.preprod.staging.wingriders.com",
@@ -21,8 +21,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.18873975151690667,
-      "relativeStake": 0.06937412503802028,
+      "accumulatedStake": 0.19480661169334237,
+      "relativeStake": 0.0713034116540441,
       "relays": [
         {
           "address": "132.226.203.38",
@@ -31,8 +31,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.25140842063036184,
-      "relativeStake": 0.06266866911345517,
+      "accumulatedStake": 0.25852298913385646,
+      "relativeStake": 0.06371637744051409,
       "relays": [
         {
           "address": "preprod-node.pool.milkomeda.com",
@@ -41,8 +41,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.30840510673971655,
-      "relativeStake": 0.05699668610935471,
+      "accumulatedStake": 0.31692192192262314,
+      "relativeStake": 0.05839893278876668,
       "relays": [
         {
           "address": "preprod1-node.play.dev.cardano.org",
@@ -51,8 +51,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.36481970241557043,
-      "relativeStake": 0.05641459567585385,
+      "accumulatedStake": 0.3747168428417586,
+      "relativeStake": 0.05779492091913546,
       "relays": [
         {
           "address": "preprod2-node.play.dev.cardano.org",
@@ -61,8 +61,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.42122119657082757,
-      "relativeStake": 0.056401494155257186,
+      "accumulatedStake": 0.4325054016779095,
+      "relativeStake": 0.05778855883615095,
       "relays": [
         {
           "address": "preprod3-node.play.dev.cardano.org",
@@ -71,8 +71,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4745986177926452,
-      "relativeStake": 0.05337742122181765,
+      "accumulatedStake": 0.48688593483850406,
+      "relativeStake": 0.054380533160594505,
       "relays": [
         {
           "address": "73.222.122.247",
@@ -81,8 +81,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5229213413980791,
-      "relativeStake": 0.048322723605433875,
+      "accumulatedStake": 0.5364569084052639,
+      "relativeStake": 0.04957097356675984,
       "relays": [
         {
           "address": "144.24.168.10",
@@ -95,8 +95,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5699446877633036,
-      "relativeStake": 0.047023346365224525,
+      "accumulatedStake": 0.5857920477078614,
+      "relativeStake": 0.0493351393025975,
       "relays": [
         {
           "address": "node1.cardano.gratis",
@@ -113,8 +113,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6071345484950862,
-      "relativeStake": 0.03718986073178259,
+      "accumulatedStake": 0.6236067489790599,
+      "relativeStake": 0.037814701271198466,
       "relays": [
         {
           "address": "relay1.preprod.pool.cardano.services",
@@ -127,8 +127,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6377490124780831,
-      "relativeStake": 0.03061446398299685,
+      "accumulatedStake": 0.6546201109051201,
+      "relativeStake": 0.031013361926060173,
       "relays": [
         {
           "address": "logicalmechanism.asuscomm.com",
@@ -141,8 +141,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6604779212875624,
-      "relativeStake": 0.02272890880947936,
+      "accumulatedStake": 0.6786493077851653,
+      "relativeStake": 0.024029196880045272,
       "relays": [
         {
           "address": "adact.preprod.relay1.adacapital.io",
@@ -151,8 +151,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6824849814960178,
-      "relativeStake": 0.02200706020845535,
+      "accumulatedStake": 0.701577026791224,
+      "relativeStake": 0.022927719006058722,
       "relays": [
         {
           "address": "tn-preprod.psilobyte.io",
@@ -161,8 +161,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6982697421436838,
-      "relativeStake": 0.015784760647665933,
+      "accumulatedStake": 0.7179119536687949,
+      "relativeStake": 0.016334926877570904,
       "relays": [
         {
           "address": "adaboy-preprod-2b.gleeze.com",
@@ -175,8 +175,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.71236739628196,
-      "relativeStake": 0.014097654138276253,
+      "accumulatedStake": 0.7323648704259433,
+      "relativeStake": 0.014452916757148406,
       "relays": [
         {
           "address": "161.97.136.104",
@@ -185,8 +185,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7262800380729858,
-      "relativeStake": 0.013912641791025849,
+      "accumulatedStake": 0.7466350580556536,
+      "relativeStake": 0.014270187629710256,
       "relays": [
         {
           "address": "pp-relay1.apexpool.info",
@@ -195,8 +195,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7380285127756174,
-      "relativeStake": 0.011748474702631628,
+      "accumulatedStake": 0.7590359079660914,
+      "relativeStake": 0.012400849910437836,
       "relays": [
         {
           "address": "preprod.canadastakes.ca",
@@ -205,18 +205,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7478938112935654,
-      "relativeStake": 0.009865298517947863,
-      "relays": [
-        {
-          "address": "node1.testnet.epiknode.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7571870230296901,
-      "relativeStake": 0.009293211736124754,
+      "accumulatedStake": 0.7685629868609879,
+      "relativeStake": 0.009527078894896512,
       "relays": [
         {
           "address": "preprod1.volcyada.com",
@@ -233,8 +223,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7664207112526631,
-      "relativeStake": 0.00923368822297307,
+      "accumulatedStake": 0.7779714302925651,
+      "relativeStake": 0.009408443431577155,
       "relays": [
         {
           "address": "cf1r1.preprod.pool.cardanofoundation.org",
@@ -247,8 +237,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7745468128306773,
-      "relativeStake": 0.008126101578014182,
+      "accumulatedStake": 0.7862993627701755,
+      "relativeStake": 0.008327932477610406,
       "relays": [
         {
           "address": "preprod.happystaking.io",
@@ -257,8 +247,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.781943014453597,
-      "relativeStake": 0.007396201622919756,
+      "accumulatedStake": 0.7944601201493823,
+      "relativeStake": 0.008160757379206721,
+      "relays": [
+        {
+          "address": "node1.testnet.epiknode.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.801999396351018,
+      "relativeStake": 0.0075392762016358375,
       "relays": [
         {
           "address": "18.222.164.102",
@@ -267,8 +267,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7890831794335362,
-      "relativeStake": 0.007140164979939183,
+      "accumulatedStake": 0.8093553888045176,
+      "relativeStake": 0.007355992453499579,
       "relays": [
         {
           "address": "r1.pp.mrbee.io",
@@ -277,8 +277,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.794822369516844,
-      "relativeStake": 0.005739190083307808,
+      "accumulatedStake": 0.815238294727069,
+      "relativeStake": 0.0058829059225513165,
       "relays": [
         {
           "address": "test.smaug.pool.pm",
@@ -287,8 +287,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8001099344924952,
-      "relativeStake": 0.0052875649756511265,
+      "accumulatedStake": 0.8206299272118519,
+      "relativeStake": 0.005391632484782917,
       "relays": [
         {
           "address": "66.42.94.80",
@@ -301,8 +301,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8044307746891947,
-      "relativeStake": 0.004320840196699443,
+      "accumulatedStake": 0.8250319681538786,
+      "relativeStake": 0.004402040942026655,
       "relays": [
         {
           "address": "dyn.derksen-it.nl",
@@ -311,18 +311,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8087373673529119,
-      "relativeStake": 0.004306592663717312,
-      "relays": [
-        {
-          "address": "157.173.126.241",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8129207323228647,
-      "relativeStake": 0.004183364969952673,
+      "accumulatedStake": 0.8293195973716657,
+      "relativeStake": 0.0042876292177871315,
       "relays": [
         {
           "address": "152.53.81.245",
@@ -335,18 +325,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8168618155113234,
-      "relativeStake": 0.0039410831884587475,
-      "relays": [
-        {
-          "address": "preprod-r1.panl.org",
-          "port": 3012
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8203064067246322,
-      "relativeStake": 0.0034445912133088275,
+      "accumulatedStake": 0.8328289232053228,
+      "relativeStake": 0.0035093258336571474,
       "relays": [
         {
           "address": "relay.preprod.cardanostakehouse.com",
@@ -355,8 +335,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8236969821907208,
-      "relativeStake": 0.003390575466088635,
+      "accumulatedStake": 0.8362832182515002,
+      "relativeStake": 0.00345429504617734,
       "relays": [
         {
           "address": "relay.preprod.cardanostakehouse.com",
@@ -365,8 +345,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8270323870804261,
-      "relativeStake": 0.003335404889705262,
+      "accumulatedStake": 0.8396813058197535,
+      "relativeStake": 0.00339808756825333,
       "relays": [
         {
           "address": "relay.preprod.cardanostakehouse.com",
@@ -375,8 +355,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.830305150704251,
-      "relativeStake": 0.003272763623824952,
+      "accumulatedStake": 0.8430777317135651,
+      "relativeStake": 0.003396425893811662,
       "relays": [
         {
           "address": "preprod-relay1.angelstakepool.net",
@@ -385,8 +365,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8335698989214808,
-      "relativeStake": 0.0032647482172298045,
+      "accumulatedStake": 0.8464250205795479,
+      "relativeStake": 0.0033472888659828205,
       "relays": [
         {
           "address": "relay1.hunadapool.com",
@@ -395,8 +375,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8366840800339969,
-      "relativeStake": 0.0031141811125160197,
+      "accumulatedStake": 0.8495977268834047,
+      "relativeStake": 0.0031727063038567184,
       "relays": [
         {
           "address": "relay.preprod.cardanostakehouse.com",
@@ -405,8 +385,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8397619095658945,
-      "relativeStake": 0.003077829531897599,
+      "accumulatedStake": 0.8527703738782614,
+      "relativeStake": 0.0031726469948566527,
       "relays": [
         {
           "address": "relay0-preprod.adanet.io",
@@ -415,8 +395,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8427638085054945,
-      "relativeStake": 0.0030018989396000052,
+      "accumulatedStake": 0.855828687809512,
+      "relativeStake": 0.0030583139312507046,
       "relays": [
         {
           "address": "relay.preprod.cardanostakehouse.com",
@@ -425,8 +405,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8456839018294191,
-      "relativeStake": 0.0029200933239246093,
+      "accumulatedStake": 0.8588218740329102,
+      "relativeStake": 0.0029931862233982046,
       "relays": [
         {
           "address": "d.fluxpool.cc",
@@ -435,18 +415,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8485436844142834,
-      "relativeStake": 0.0028597825848643297,
-      "relays": [
-        {
-          "address": "73.54.73.48",
-          "port": 7000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8513999771295109,
-      "relativeStake": 0.0028562927152275155,
+      "accumulatedStake": 0.8617499445321803,
+      "relativeStake": 0.0029280704992701175,
       "relays": [
         {
           "address": "168.138.37.117",
@@ -455,18 +425,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8541640342332004,
-      "relativeStake": 0.00276405710368948,
+      "accumulatedStake": 0.8646667961781053,
+      "relativeStake": 0.002916851645924863,
       "relays": [
         {
-          "address": "flightrelay1.intertreecryptoconsultants.com",
-          "port": 6000
+          "address": "73.54.73.48",
+          "port": 7000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8569212284983541,
-      "relativeStake": 0.002757194265153676,
+      "accumulatedStake": 0.8674913296042872,
+      "relativeStake": 0.002824533426182035,
       "relays": [
         {
           "address": "8.tcp.eu.ngrok.io",
@@ -475,8 +445,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8596760006911386,
-      "relativeStake": 0.002754772192784476,
+      "accumulatedStake": 0.8703131616801308,
+      "relativeStake": 0.0028218320758436138,
       "relays": [
         {
           "address": "204.216.213.96",
@@ -485,8 +455,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8622113212857934,
-      "relativeStake": 0.002535320594654846,
+      "accumulatedStake": 0.8729071322397249,
+      "relativeStake": 0.002593970559594101,
       "relays": [
         {
           "address": "relay1.preprod.stakepool.quebec",
@@ -495,8 +465,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8647387542815499,
-      "relativeStake": 0.002527432995756483,
+      "accumulatedStake": 0.875497511273764,
+      "relativeStake": 0.002590379034038982,
       "relays": [
         {
           "address": "pre-prod1.xstakepool.com",
@@ -505,8 +475,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.867262957881345,
-      "relativeStake": 0.002524203599795055,
+      "accumulatedStake": 0.878084349522625,
+      "relativeStake": 0.002586838248861128,
       "relays": [
         {
           "address": "preprod.altzpool.com",
@@ -515,18 +485,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8697591060933414,
-      "relativeStake": 0.0024961482119964236,
+      "accumulatedStake": 0.8806521190295092,
+      "relativeStake": 0.002567769506884192,
       "relays": [
         {
-          "address": "gateway.adavault.com",
-          "port": 4050
+          "address": "gateway2.adavault.com",
+          "port": 4062
         }
       ]
     },
     {
-      "accumulatedStake": 0.8722402051249636,
-      "relativeStake": 0.0024810990316222487,
+      "accumulatedStake": 0.8831961681701809,
+      "relativeStake": 0.002544049140671588,
       "relays": [
         {
           "address": "62.169.19.81",
@@ -535,8 +505,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8747140004034907,
-      "relativeStake": 0.0024737952785270456,
+      "accumulatedStake": 0.8857311388330895,
+      "relativeStake": 0.0025349706629086088,
       "relays": [
         {
           "address": "81.174.170.134",
@@ -545,8 +515,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8771802644700778,
-      "relativeStake": 0.0024662640665871764,
+      "accumulatedStake": 0.8882519072179472,
+      "relativeStake": 0.002520768384857727,
       "relays": [
         {
           "address": "alpha.stake-cardano-pool.com",
@@ -555,18 +525,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8796388118574309,
-      "relativeStake": 0.0024585473873529914,
+      "accumulatedStake": 0.890757122641649,
+      "relativeStake": 0.002505215423701724,
       "relays": [
         {
-          "address": "preprod.frcan.com",
-          "port": 6011
+          "address": "157.173.126.241",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8820466938320446,
-      "relativeStake": 0.0024078819746137688,
+      "accumulatedStake": 0.8932270724241782,
+      "relativeStake": 0.0024699497825292774,
       "relays": [
         {
           "address": "preprod-relay1.angelstakepool.net",
@@ -575,8 +545,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8844385050652271,
-      "relativeStake": 0.002391811233182546,
+      "accumulatedStake": 0.895674519847032,
+      "relativeStake": 0.0024474474228537947,
       "relays": [
         {
           "address": "preprod-relays.onyxstakepool.com",
@@ -585,8 +555,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8868233938931211,
-      "relativeStake": 0.0023848888278940523,
+      "accumulatedStake": 0.8981184035465078,
+      "relativeStake": 0.0024438836994758713,
       "relays": [
         {
           "address": "c-pp-rn01.liv.io",
@@ -599,74 +569,12 @@
       ]
     },
     {
-      "accumulatedStake": 0.8891902321726045,
-      "relativeStake": 0.0023668382794833453,
+      "accumulatedStake": 0.900542999406095,
+      "relativeStake": 0.0024245958595870637,
       "relays": [
         {
           "address": "pp-relays.digitalfortress.online",
           "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8915362763012269,
-      "relativeStake": 0.002346044128622378,
-      "relays": [
-        {
-          "address": "74.122.122.121",
-          "port": 6100
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8938779833159768,
-      "relativeStake": 0.00234170701474987,
-      "relays": [
-        {
-          "address": "relay1.amapools.ir",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.89621937211142,
-      "relativeStake": 0.0023413887954431686,
-      "relays": [
-        {
-          "address": "preprod.weebl.me",
-          "port": 3123
-        },
-        {
-          "address": "77.174.62.158",
-          "port": 3124
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8985553415237665,
-      "relativeStake": 0.002335969412346516,
-      "relays": [
-        {
-          "address": "PreProd1.cardanoland.com",
-          "port": 6660
-        },
-        {
-          "address": "PreProd2.cardanoland.com",
-          "port": 7770
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.9008707907109827,
-      "relativeStake": 0.0023154491872162905,
-      "relays": [
-        {
-          "address": "preprod.leadstakepool.com",
-          "port": 3001
-        },
-        {
-          "address": "preprod.leadstakepool.com",
-          "port": 3002
         }
       ]
     }

--- a/config/cardano/preprod/topology.json
+++ b/config/cardano/preprod/topology.json
@@ -20,5 +20,5 @@
       "advertise": false
     }
   ],
-  "useLedgerAfterSlot": 118022427
+  "useLedgerAfterSlot": 121478354
 }

--- a/config/cardano/preview/peer-snapshot.json
+++ b/config/cardano/preview/peer-snapshot.json
@@ -2,13 +2,23 @@
   "NetworkMagic": 2,
   "NodeToClientVersion": 23,
   "Point": {
-    "blockPointHash": "c6fb280328118c7accdfb3ed2a4069fdf0ea111c787055417f2e7a7e3ea776ba",
-    "blockPointSlot": 107307232
+    "blockPointHash": "d6792f8031323804b7ac44a67747de78ed70fd307bb5ffddc5147844d9363b30",
+    "blockPointSlot": 110741160
   },
   "bigLedgerPools": [
     {
-      "accumulatedStake": 0.058838652444400515,
-      "relativeStake": 0.058838652444400515,
+      "accumulatedStake": 0.05242807080100503,
+      "relativeStake": 0.05242807080100503,
+      "relays": [
+        {
+          "address": "preview1-node.play.dev.cardano.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.0982336349002027,
+      "relativeStake": 0.04580556409919767,
       "relays": [
         {
           "address": "node1.cardano.gratis",
@@ -25,18 +35,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.11180587216784509,
-      "relativeStake": 0.05296721972344457,
-      "relays": [
-        {
-          "address": "preview1-node.play.dev.cardano.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1630940123797963,
-      "relativeStake": 0.05128814021195121,
+      "accumulatedStake": 0.1379841210518655,
+      "relativeStake": 0.039750486151662795,
       "relays": [
         {
           "address": "preview2-node.play.dev.cardano.org",
@@ -45,8 +45,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.21435710040663677,
-      "relativeStake": 0.05126308802684048,
+      "accumulatedStake": 0.1777066205916202,
+      "relativeStake": 0.039722499539754694,
       "relays": [
         {
           "address": "preview3-node.play.dev.cardano.org",
@@ -55,22 +55,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.2585057922016948,
-      "relativeStake": 0.044148691795057995,
-      "relays": [
-        {
-          "address": "73.54.73.48",
-          "port": 6000
-        },
-        {
-          "address": "144.126.157.225",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3008792892720755,
-      "relativeStake": 0.04237349707038073,
+      "accumulatedStake": 0.21089610723700583,
+      "relativeStake": 0.033189486645385624,
       "relays": [
         {
           "address": "adaboy-preview-1c.gleeze.com",
@@ -83,8 +69,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.34287928628972497,
-      "relativeStake": 0.04199999701764948,
+      "accumulatedStake": 0.24367905871282317,
+      "relativeStake": 0.03278295147581733,
       "relays": [
         {
           "address": "preview1.volcyada.com",
@@ -101,8 +87,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.3797120811998089,
-      "relativeStake": 0.03683279491008391,
+      "accumulatedStake": 0.2747071967363724,
+      "relativeStake": 0.031028138023549236,
+      "relays": [
+        {
+          "address": "73.54.73.48",
+          "port": 6000
+        },
+        {
+          "address": "144.126.157.225",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.30277733271146495,
+      "relativeStake": 0.028070135975092576,
       "relays": [
         {
           "address": "tn-preview.psilobyte.io",
@@ -115,8 +115,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.41349554662933125,
-      "relativeStake": 0.033783465429522354,
+      "accumulatedStake": 0.32894976640054235,
+      "relativeStake": 0.02617243368907739,
       "relays": [
         {
           "address": "adact.preview.relay1.adacapital.io",
@@ -125,8 +125,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.444384299740847,
-      "relativeStake": 0.030888753111515718,
+      "accumulatedStake": 0.3524899702340541,
+      "relativeStake": 0.023540203833511766,
       "relays": [
         {
           "address": "73.222.122.247",
@@ -135,8 +135,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4638629247974206,
-      "relativeStake": 0.01947862505657363,
+      "accumulatedStake": 0.3675638693042061,
+      "relativeStake": 0.015073899070151968,
       "relays": [
         {
           "address": "preview.world.bbhmm.net",
@@ -145,8 +145,204 @@
       ]
     },
     {
-      "accumulatedStake": 0.48096311057344615,
-      "relativeStake": 0.017100185776025543,
+      "accumulatedStake": 0.38159844209517685,
+      "relativeStake": 0.014034572790970758,
+      "relays": [
+        {
+          "address": "preview.happystaking.io",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.39494009207254527,
+      "relativeStake": 0.013341649977368428,
+      "relays": [
+        {
+          "address": "159.195.26.127",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4082722271631674,
+      "relativeStake": 0.01333213509062213,
+      "relays": [
+        {
+          "address": "pvrelay.cardano8964.net",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.42160070650078657,
+      "relativeStake": 0.01332847933761915,
+      "relays": [
+        {
+          "address": "preview.cardano-dev.securestaking.io",
+          "port": 3000
+        },
+        {
+          "address": "relay.cardano-dev.securestaking.io",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4349264893595214,
+      "relativeStake": 0.013325782858734833,
+      "relays": [
+        {
+          "address": "preview.str8pool.com",
+          "port": 3503
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4482520127345661,
+      "relativeStake": 0.01332552337504471,
+      "relays": [
+        {
+          "address": "81.174.170.134",
+          "port": 6004
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4615714397723417,
+      "relativeStake": 0.01331942703777562,
+      "relays": [
+        {
+          "address": "silemfoundation.org",
+          "port": 4550
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.47488666053190276,
+      "relativeStake": 0.01331522075956102,
+      "relays": [
+        {
+          "address": "preview.cardano-dev.securestaking.io",
+          "port": 3000
+        },
+        {
+          "address": "relay.cardano-dev.securestaking.io",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4881974060570967,
+      "relativeStake": 0.013310745525193972,
+      "relays": [
+        {
+          "address": "85.215.201.40",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5015062365302753,
+      "relativeStake": 0.013308830473178573,
+      "relays": [
+        {
+          "address": "cf2r1.preview.pool.cardanofoundation.org",
+          "port": 30002
+        },
+        {
+          "address": "cf2r1.preview.pool.cardanofoundation.org",
+          "port": 30002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5148135150122446,
+      "relativeStake": 0.013307278481969288,
+      "relays": [
+        {
+          "address": "adar1prev.stakit.io",
+          "port": 31000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5281109830036113,
+      "relativeStake": 0.013297467991366722,
+      "relays": [
+        {
+          "address": "mithril-signer-1.testing-preview.api.mithril.network",
+          "port": 9091
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5414074855253803,
+      "relativeStake": 0.013296502521769076,
+      "relays": [
+        {
+          "address": "mithril-signer-3.testing-preview.api.mithril.network",
+          "port": 9092
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5547011532184903,
+      "relativeStake": 0.013293667693110025,
+      "relays": [
+        {
+          "address": "mithril-signer-2.testing-preview.api.mithril.network",
+          "port": 9092
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5679800866902903,
+      "relativeStake": 0.013278933471799887,
+      "relays": [
+        {
+          "address": "172.24.135.93",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5812550766801624,
+      "relativeStake": 0.013274989989872095,
+      "relays": [
+        {
+          "address": "relay1.preview.blinklabs.cloud",
+          "port": 3001
+        },
+        {
+          "address": "relay2.preview.blinklabs.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.594506202362839,
+      "relativeStake": 0.013251125682676633,
+      "relays": [
+        {
+          "address": "relay.preview.cardanostakehouse.com",
+          "port": 11000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6077573246185959,
+      "relativeStake": 0.013251122255756826,
+      "relays": [
+        {
+          "address": "pre.adanaut.com",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.621005423623324,
+      "relativeStake": 0.01324809900472815,
       "relays": [
         {
           "address": "204.216.214.226",
@@ -155,8 +351,38 @@
       ]
     },
     {
-      "accumulatedStake": 0.4961173436373309,
-      "relativeStake": 0.015154233063884753,
+      "accumulatedStake": 0.6340882038048322,
+      "relativeStake": 0.013082780181508236,
+      "relays": [
+        {
+          "address": "129.152.11.126",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6467518158993875,
+      "relativeStake": 0.012663612094555216,
+      "relays": [
+        {
+          "address": "195.252.217.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6594120721364468,
+      "relativeStake": 0.012660256237059419,
+      "relays": [
+        {
+          "address": "91.134.92.108",
+          "port": 6200
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6711566686042022,
+      "relativeStake": 0.011744596467755341,
       "relays": [
         {
           "address": "sully.crabdance.com",
@@ -165,8 +391,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5087358252067299,
-      "relativeStake": 0.01261848156939898,
+      "accumulatedStake": 0.6809295087570649,
+      "relativeStake": 0.0097728401528627,
       "relays": [
         {
           "address": "relay-m.fluxpool.cc",
@@ -175,8 +401,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.520231651429843,
-      "relativeStake": 0.011495826223113039,
+      "accumulatedStake": 0.6898353281745165,
+      "relativeStake": 0.008905819417451614,
       "relays": [
         {
           "address": "75.119.130.108",
@@ -185,8 +411,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5308955525949078,
-      "relativeStake": 0.010663901165064967,
+      "accumulatedStake": 0.6980894780442672,
+      "relativeStake": 0.00825414986975075,
       "relays": [
         {
           "address": "preview.leadstakepool.com",
@@ -199,8 +425,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5412061857727606,
-      "relativeStake": 0.010310633177852661,
+      "accumulatedStake": 0.705947171565332,
+      "relativeStake": 0.00785769352106481,
       "relays": [
         {
           "address": "161.97.167.41",
@@ -209,8 +435,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5510573290883817,
-      "relativeStake": 0.009851143315621133,
+      "accumulatedStake": 0.7135768985413145,
+      "relativeStake": 0.007629726975982346,
       "relays": [
         {
           "address": "90.248.37.47",
@@ -219,8 +445,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5606635261740677,
-      "relativeStake": 0.009606197085686016,
+      "accumulatedStake": 0.7210243680088233,
+      "relativeStake": 0.007447469467508942,
       "relays": [
         {
           "address": "test.smaug.pool.pm",
@@ -229,8 +455,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5699102531307909,
-      "relativeStake": 0.009246726956723194,
+      "accumulatedStake": 0.7281944530220101,
+      "relativeStake": 0.007170085013186741,
       "relays": [
         {
           "address": "relay1.preview.stakepool.quebec",
@@ -239,18 +465,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5779174781083863,
-      "relativeStake": 0.00800722497759541,
-      "relays": [
-        {
-          "address": "preview.frcan.com",
-          "port": 6010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5856218350748764,
-      "relativeStake": 0.007704356966490155,
+      "accumulatedStake": 0.7340659148043149,
+      "relativeStake": 0.0058714617823048525,
       "relays": [
         {
           "address": "adar-monitor.freeddns.org",
@@ -259,8 +475,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5932878412387173,
-      "relativeStake": 0.007666006163840788,
+      "accumulatedStake": 0.7399081495825939,
+      "relativeStake": 0.0058422347782789655,
       "relays": [
         {
           "address": "82.208.22.91",
@@ -269,8 +485,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6003465863311481,
-      "relativeStake": 0.007058745092430829,
+      "accumulatedStake": 0.7453761149438809,
+      "relativeStake": 0.005467965361286996,
       "relays": [
         {
           "address": "r1.pv.mrbee.io",
@@ -279,8 +495,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6073868945332833,
-      "relativeStake": 0.0070403082021352845,
+      "accumulatedStake": 0.7507415076332745,
+      "relativeStake": 0.005365392689393571,
       "relays": [
         {
           "address": "beadapool.ddns.net",
@@ -289,8 +505,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6142629766994437,
-      "relativeStake": 0.006876082166160427,
+      "accumulatedStake": 0.755989546256885,
+      "relativeStake": 0.005248038623610491,
       "relays": [
         {
           "address": "preview-r1.panl.org",
@@ -299,58 +515,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6208457172171036,
-      "relativeStake": 0.006582740517659816,
-      "relays": [
-        {
-          "address": "preview.adastack.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6272921636134242,
-      "relativeStake": 0.00644644639632061,
-      "relays": [
-        {
-          "address": "relay.test.lidonation.com",
-          "port": 3010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6336758855880813,
-      "relativeStake": 0.006383721974657104,
-      "relays": [
-        {
-          "address": "5.252.53.68",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6400556183032448,
-      "relativeStake": 0.00637973271516348,
-      "relays": [
-        {
-          "address": "beta.stake-cardano-pool.com",
-          "port": 7002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6463442295733329,
-      "relativeStake": 0.006288611270088189,
-      "relays": [
-        {
-          "address": "1.tcp.au.ngrok.io",
-          "port": 25432
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6526258219908868,
-      "relativeStake": 0.006281592417553839,
+      "accumulatedStake": 0.7612059090757893,
+      "relativeStake": 0.005216362818904316,
       "relays": [
         {
           "address": "preview.canadastakes.ca",
@@ -359,18 +525,58 @@
       ]
     },
     {
-      "accumulatedStake": 0.6588709760034563,
-      "relativeStake": 0.006245154012569574,
+      "accumulatedStake": 0.7663490243462427,
+      "relativeStake": 0.005143115270453447,
       "relays": [
         {
-          "address": "207.180.211.199",
-          "port": 6007
+          "address": "preview.frcan.com",
+          "port": 6010
         }
       ]
     },
     {
-      "accumulatedStake": 0.66509852248398,
-      "relativeStake": 0.006227546480523642,
+      "accumulatedStake": 0.7714485166376437,
+      "relativeStake": 0.005099492291401001,
+      "relays": [
+        {
+          "address": "preview.adastack.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7763968783365329,
+      "relativeStake": 0.004948361698889241,
+      "relays": [
+        {
+          "address": "5.252.53.68",
+          "port": 3005
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.781335005874178,
+      "relativeStake": 0.004938127537645067,
+      "relays": [
+        {
+          "address": "relay.test.lidonation.com",
+          "port": 3010
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7862613957582661,
+      "relativeStake": 0.0049263898840880916,
+      "relays": [
+        {
+          "address": "beta.stake-cardano-pool.com",
+          "port": 7002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7910737670996547,
+      "relativeStake": 0.004812371341388559,
       "relays": [
         {
           "address": "testnet.valhallapool.net",
@@ -379,8 +585,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.6713111755530906,
-      "relativeStake": 0.006212653069110608,
+      "accumulatedStake": 0.7958662943536087,
+      "relativeStake": 0.004792527253953994,
+      "relays": [
+        {
+          "address": "1.tcp.au.ngrok.io",
+          "port": 25432
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8006257029932781,
+      "relativeStake": 0.004759408639669359,
+      "relays": [
+        {
+          "address": "207.180.211.199",
+          "port": 6007
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.805362140747363,
+      "relativeStake": 0.004736437754084989,
       "relays": [
         {
           "address": "relay01.preview.junglestakepool.com",
@@ -389,8 +615,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6773766321193273,
-      "relativeStake": 0.006065456566236634,
+      "accumulatedStake": 0.809984602631695,
+      "relativeStake": 0.004622461884331996,
       "relays": [
         {
           "address": "88.198.86.62",
@@ -399,8 +625,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6834011818595787,
-      "relativeStake": 0.006024549740251325,
+      "accumulatedStake": 0.8145758895761258,
+      "relativeStake": 0.004591286944430742,
       "relays": [
         {
           "address": "142.132.229.15",
@@ -409,18 +635,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6892413019670665,
-      "relativeStake": 0.005840120107487853,
-      "relays": [
-        {
-          "address": "preview-testnet-relay.cardanistas.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6949743317939046,
-      "relativeStake": 0.005733029826838123,
+      "accumulatedStake": 0.81904271543317,
+      "relativeStake": 0.004466825857044215,
       "relays": [
         {
           "address": "preview-relay.sparkcube.xyz",
@@ -429,8 +645,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7006969816373583,
-      "relativeStake": 0.005722649843453703,
+      "accumulatedStake": 0.8234934492405894,
+      "relativeStake": 0.004450733807419417,
+      "relays": [
+        {
+          "address": "preview-testnet-relay.cardanistas.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8279269265158435,
+      "relativeStake": 0.00443347727525413,
       "relays": [
         {
           "address": "bbotest.duckdns.org",
@@ -443,8 +669,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7063550227095325,
-      "relativeStake": 0.005658041072174216,
+      "accumulatedStake": 0.832312395749156,
+      "relativeStake": 0.004385469233312467,
       "relays": [
         {
           "address": "preview-testnet-relay.junostakepool.com",
@@ -457,8 +683,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7119057185291155,
-      "relativeStake": 0.005550695819583015,
+      "accumulatedStake": 0.8365435686156475,
+      "relativeStake": 0.00423117286649151,
       "relays": [
         {
           "address": "relay1.afica.io",
@@ -467,8 +693,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7173690616256853,
-      "relativeStake": 0.005463343096569776,
+      "accumulatedStake": 0.8407071620647374,
+      "relativeStake": 0.004163593449089893,
       "relays": [
         {
           "address": "preview-node.world.dev.cardano.org",
@@ -477,18 +703,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.722729917232762,
-      "relativeStake": 0.0053608556070767685,
-      "relays": [
-        {
-          "address": "preview.testnet.cryptobounty.org",
-          "port": 6161
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7280886687062148,
-      "relativeStake": 0.0053587514734527684,
+      "accumulatedStake": 0.8448588036532678,
+      "relativeStake": 0.004151641588530403,
       "relays": [
         {
           "address": "130.162.231.122",
@@ -497,8 +713,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7334088018494099,
-      "relativeStake": 0.005320133143195084,
+      "accumulatedStake": 0.848988130187367,
+      "relativeStake": 0.004129326534099174,
       "relays": [
         {
           "address": "194.60.201.143",
@@ -507,8 +723,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7385979035794915,
-      "relativeStake": 0.00518910173008155,
+      "accumulatedStake": 0.8530736183019897,
+      "relativeStake": 0.004085488114622673,
+      "relays": [
+        {
+          "address": "preview.testnet.cryptobounty.org",
+          "port": 6161
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8570282134259155,
+      "relativeStake": 0.00395459512392581,
       "relays": [
         {
           "address": "52.166.113.150",
@@ -517,8 +743,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7437574758299408,
-      "relativeStake": 0.005159572250449353,
+      "accumulatedStake": 0.8609603042432695,
+      "relativeStake": 0.003932090817354099,
       "relays": [
         {
           "address": "adrelay.hawak.cloud",
@@ -527,8 +753,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7489157875707219,
-      "relativeStake": 0.0051583117407810975,
+      "accumulatedStake": 0.8648914344308949,
+      "relativeStake": 0.0039311301876252865,
       "relays": [
         {
           "address": "184.174.32.106",
@@ -537,8 +763,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.754051039729456,
-      "relativeStake": 0.005135252158734099,
+      "accumulatedStake": 0.8688049909968287,
+      "relativeStake": 0.0039135565659338505,
       "relays": [
         {
           "address": "esq.ddns.net",
@@ -551,8 +777,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.759123808350655,
-      "relativeStake": 0.005072768621198963,
+      "accumulatedStake": 0.8726709290912592,
+      "relativeStake": 0.00386593809443046,
       "relays": [
         {
           "address": "194.163.149.210",
@@ -561,28 +787,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7641091638571735,
-      "relativeStake": 0.00498535550651853,
-      "relays": [
-        {
-          "address": "128.140.96.209",
-          "port": 8000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7690919815506243,
-      "relativeStake": 0.004982817693450753,
-      "relays": [
-        {
-          "address": "alpha.relays.preview.mochipool.com",
-          "port": 31111
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.77406350380887,
-      "relativeStake": 0.004971522258245751,
+      "accumulatedStake": 0.8765222758777435,
+      "relativeStake": 0.0038513467864842695,
       "relays": [
         {
           "address": "104.238.148.18",
@@ -595,8 +801,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.77900928565081,
-      "relativeStake": 0.00494578184193998,
+      "accumulatedStake": 0.8803215967626714,
+      "relativeStake": 0.003799320884928003,
+      "relays": [
+        {
+          "address": "128.140.96.209",
+          "port": 8000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8841189835897016,
+      "relativeStake": 0.0037973868270302575,
+      "relays": [
+        {
+          "address": "alpha.relays.preview.mochipool.com",
+          "port": 31111
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8878881455320768,
+      "relativeStake": 0.003769161942375195,
       "relays": [
         {
           "address": "5.161.75.212",
@@ -613,8 +839,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7839422177784459,
-      "relativeStake": 0.004932932127635831,
+      "accumulatedStake": 0.8916475147549846,
+      "relativeStake": 0.0037593692229076904,
       "relays": [
         {
           "address": "scarborough1.ddns.net",
@@ -631,8 +857,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7888373438725398,
-      "relativeStake": 0.004895126094094001,
+      "accumulatedStake": 0.8953780721403766,
+      "relativeStake": 0.0037305573853920002,
       "relays": [
         {
           "address": "194.60.201.143",
@@ -641,8 +867,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7930564490536407,
-      "relativeStake": 0.004219105181100914,
+      "accumulatedStake": 0.898593437524681,
+      "relativeStake": 0.003215365384304461,
       "relays": [
         {
           "address": "relay.preview.cardanostakehouse.com",
@@ -651,653 +877,12 @@
       ]
     },
     {
-      "accumulatedStake": 0.7969919693513685,
-      "relativeStake": 0.003935520297727803,
+      "accumulatedStake": 0.9017544600415627,
+      "relativeStake": 0.0031610225168815847,
       "relays": [
         {
-          "address": "prv-relay1.apexpool.info",
+          "address": "73.54.73.48",
           "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8005119716426062,
-      "relativeStake": 0.0035200022912377387,
-      "relays": [
-        {
-          "address": "preview.relay.hyperlinkpool.kr",
-          "port": 9001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8036217952918968,
-      "relativeStake": 0.0031098236492905296,
-      "relays": [
-        {
-          "address": "101100.dyndns.org",
-          "port": 6008
-        },
-        {
-          "address": "101100.dyndns.org",
-          "port": 6005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8064630389782615,
-      "relativeStake": 0.002841243686364713,
-      "relays": [
-        {
-          "address": "18.219.254.123",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8092215989297087,
-      "relativeStake": 0.0027585599514471783,
-      "relays": [
-        {
-          "address": "relay0-testnet.zeropercentstaking.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8119333077983327,
-      "relativeStake": 0.00271170886862407,
-      "relays": [
-        {
-          "address": "d8bdbfbe.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8146289472401894,
-      "relativeStake": 0.0026956394418566547,
-      "relays": [
-        {
-          "address": "test.stakepool.at",
-          "port": 9001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8173122576202736,
-      "relativeStake": 0.0026833103800841343,
-      "relays": [
-        {
-          "address": "010011.dyndns.org",
-          "port": 5026
-        },
-        {
-          "address": "010011.dyndns.org",
-          "port": 5034
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8224080100575973,
-      "relativeStake": 0.0024761085004084784,
-      "relays": [
-        {
-          "address": "topo-test.topopool.com",
-          "port": 3010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8248520527278979,
-      "relativeStake": 0.002444042670300531,
-      "relays": [
-        {
-          "address": "preview-relays.onyxstakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.827237487684828,
-      "relativeStake": 0.0023854349569301467,
-      "relays": [
-        {
-          "address": "testnet-relay.xstakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8293804405919155,
-      "relativeStake": 0.002142952907087547,
-      "relays": [
-        {
-          "address": "preview.relays.liqwid.finance",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8315019936216306,
-      "relativeStake": 0.0021215530297150607,
-      "relays": [
-        {
-          "address": "midnight-testnet.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.833421331204982,
-      "relativeStake": 0.0019193375833513808,
-      "relays": [
-        {
-          "address": "pn1.powerfulpools.com",
-          "port": 6030
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8353362368669646,
-      "relativeStake": 0.0019149056619826171,
-      "relays": [
-        {
-          "address": "preview-test.ahlnet.nu",
-          "port": 2102
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8372466291051835,
-      "relativeStake": 0.0019103922382189644,
-      "relays": [
-        {
-          "address": "preview-node.play.dev.cardano.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8391252856308303,
-      "relativeStake": 0.0018786565256467545,
-      "relays": [
-        {
-          "address": "ava1.sytes.net",
-          "port": 6010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8409754286781138,
-      "relativeStake": 0.0018501430472834901,
-      "relays": [
-        {
-          "address": "pv-relays.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8427652689955777,
-      "relativeStake": 0.0017898403174639364,
-      "relays": [
-        {
-          "address": "157.173.103.26",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8445549427633543,
-      "relativeStake": 0.0017896737677765323,
-      "relays": [
-        {
-          "address": "previewrelay1.intertreecryptoconsultants.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8463181661255075,
-      "relativeStake": 0.0017632233621531883,
-      "relays": [
-        {
-          "address": "relay.test.lidonation.com",
-          "port": 3010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8480789176261719,
-      "relativeStake": 0.0017607515006644904,
-      "relays": [
-        {
-          "address": "preview.planetstake.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8498248729761319,
-      "relativeStake": 0.0017459553499598636,
-      "relays": [
-        {
-          "address": "2001:861:4000:2b80:216:3eff:fe05:9009",
-          "port": 6006
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8514712953977353,
-      "relativeStake": 0.0016464224216033968,
-      "relays": [
-        {
-          "address": "95.216.173.194",
-          "port": 16000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8530524217950497,
-      "relativeStake": 0.0015811263973144907,
-      "relays": [
-        {
-          "address": "spec2-staging.spirestaking2.com",
-          "port": 3006
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8546210178380925,
-      "relativeStake": 0.001568596043042841,
-      "relays": [
-        {
-          "address": "preview.happystaking.io",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8561879613575881,
-      "relativeStake": 0.0015669435194955261,
-      "relays": [
-        {
-          "address": "2001:861:4000:2b80:216:3eff:feb6:d700",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8577395349838167,
-      "relativeStake": 0.0015515736262286567,
-      "relays": [
-        {
-          "address": "1.tcp.ap.ngrok.io",
-          "port": 25317
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8592140902885466,
-      "relativeStake": 0.001474555304729801,
-      "relays": [
-        {
-          "address": "84.32.59.203",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.860677197924016,
-      "relativeStake": 0.001463107635469493,
-      "relays": [
-        {
-          "address": "168.138.37.117",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8621227577153533,
-      "relativeStake": 0.0014455597913373187,
-      "relays": [
-        {
-          "address": "relay1.cakraspo.xyz",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8635585120153376,
-      "relativeStake": 0.00143575429998423,
-      "relays": [
-        {
-          "address": "65.21.198.152",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8649932992081628,
-      "relativeStake": 0.001434787192825208,
-      "relays": [
-        {
-          "address": "spec1-staging.spirestaking2.com",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8664259748240414,
-      "relativeStake": 0.0014326756158786454,
-      "relays": [
-        {
-          "address": "testicles.kiwipool.org",
-          "port": 9720
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8678284086109007,
-      "relativeStake": 0.0014024337868592698,
-      "relays": [
-        {
-          "address": "relay.preview.crimsonpool.com",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8691838088496275,
-      "relativeStake": 0.0013554002387267969,
-      "relays": [
-        {
-          "address": "pv-relays.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.870522859069743,
-      "relativeStake": 0.0013390502201154942,
-      "relays": [
-        {
-          "address": "pv-relays.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8718399717406868,
-      "relativeStake": 0.0013171126709438778,
-      "relays": [
-        {
-          "address": "152.53.146.246",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8731539067733936,
-      "relativeStake": 0.0013139350327066467,
-      "relays": [
-        {
-          "address": "f7ca89d1.cardano-relay.stagebison.net",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8744471486751833,
-      "relativeStake": 0.001293241901789728,
-      "relays": [
-        {
-          "address": "185.43.205.110",
-          "port": 3003
-        },
-        {
-          "address": "cardano.illusion.hu"
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8757371887006701,
-      "relativeStake": 0.0012900400254868692,
-      "relays": [
-        {
-          "address": "51.77.24.220",
-          "port": 4003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8770035713119965,
-      "relativeStake": 0.001266382611326391,
-      "relays": [
-        {
-          "address": "157.173.126.241",
-          "port": 6123
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8782415818063751,
-      "relativeStake": 0.0012380104943786208,
-      "relays": [
-        {
-          "address": "88.198.86.61",
-          "port": 8888
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8794535476916331,
-      "relativeStake": 0.0012119658852580136,
-      "relays": [
-        {
-          "address": "trustpool.asuscomm.com",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.880596497029179,
-      "relativeStake": 0.0011429493375458843,
-      "relays": [
-        {
-          "address": "preview.ada.chicando.net",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.881725097954267,
-      "relativeStake": 0.001128600925087952,
-      "relays": [
-        {
-          "address": "preview.vampyre.fund",
-          "port": 3201
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.882846805013477,
-      "relativeStake": 0.0011217070592100698,
-      "relays": [
-        {
-          "address": "preview.cr0ss0ver.com",
-          "port": 5000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8839284155209921,
-      "relativeStake": 0.001081610507515043,
-      "relays": [
-        {
-          "address": "109.205.181.113",
-          "port": 7900
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8850020985610554,
-      "relativeStake": 0.0010736830400632608,
-      "relays": [
-        {
-          "address": "hida.duckdns.org",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8860741331292674,
-      "relativeStake": 0.0010720345682120591,
-      "relays": [
-        {
-          "address": "test.paradoxicalsphere.com",
-          "port": 6080
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8871407153523705,
-      "relativeStake": 0.0010665822231031403,
-      "relays": [
-        {
-          "address": "gateway.adavault.com",
-          "port": 4051
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.888201091671936,
-      "relativeStake": 0.0010603763195654338,
-      "relays": [
-        {
-          "address": "173.67.34.66",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8892608604703044,
-      "relativeStake": 0.0010597687983683744,
-      "relays": [
-        {
-          "address": "167.86.86.234",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8903203417281077,
-      "relativeStake": 0.0010594812578033342,
-      "relays": [
-        {
-          "address": "85.215.249.201",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.891376441027653,
-      "relativeStake": 0.00105609929954537,
-      "relays": [
-        {
-          "address": "preview-relay.adaseal.eu",
-          "port": 6002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.892415764413431,
-      "relativeStake": 0.0010393233857779426,
-      "relays": [
-        {
-          "address": "65.109.33.28",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8934452308555746,
-      "relativeStake": 0.0010294664421436272,
-      "relays": [
-        {
-          "address": "152.53.38.172",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8944696671490097,
-      "relativeStake": 0.0010244362934349876,
-      "relays": [
-        {
-          "address": "188.68.34.2",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8954818204282616,
-      "relativeStake": 0.001012153279252067,
-      "relays": [
-        {
-          "address": "ss-staging.spirestaking2.com",
-          "port": 3008
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8964868377370064,
-      "relativeStake": 0.001005017308744798,
-      "relays": [
-        {
-          "address": "preview1.fluid7.com",
-          "port": 6011
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8974889168680088,
-      "relativeStake": 0.0010020791310023597,
-      "relays": [
-        {
-          "address": "relay404.rspo.dev",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8984903804119281,
-      "relativeStake": 0.0010014635439192332,
-      "relays": [
-        {
-          "address": "206.253.67.154",
-          "port": 4001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8994879793818779,
-      "relativeStake": 0.0009975989699497906,
-      "relays": [
-        {
-          "address": "77.23.179.21",
-          "port": 4444
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.900483386847109,
-      "relativeStake": 0.000995407465231161,
-      "relays": [
-        {
-          "address": "preprod.altzpool.com",
-          "port": 5001
         }
       ]
     }

--- a/config/cardano/preview/topology.json
+++ b/config/cardano/preview/topology.json
@@ -20,5 +20,5 @@
       "advertise": false
     }
   ],
-  "useLedgerAfterSlot": 107222465
+  "useLedgerAfterSlot": 110678393
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,12 +19,15 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"maps"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"time"
 
+	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -776,39 +779,73 @@ func GetConfig() *Config {
 var globalTopologyConfig = &topology.TopologyConfig{}
 
 func LoadTopologyConfig() (*topology.TopologyConfig, error) {
-	if globalConfig.RunMode.IsDevMode() {
-		return globalTopologyConfig, nil
+	tc, err := LoadTopologyConfigFor(globalConfig)
+	if err != nil {
+		return nil, err
 	}
-	if globalConfig.Topology == "" {
-		// Use default bootstrap peers for specified network
-		network, ok := ouroboros.NetworkByName(globalConfig.Network)
+	globalTopologyConfig = tc
+	return globalTopologyConfig, nil
+}
+
+func LoadTopologyConfigFor(cfg *Config) (*topology.TopologyConfig, error) {
+	if cfg == nil {
+		return nil, errors.New("nil config")
+	}
+	if cfg.RunMode.IsDevMode() {
+		return &topology.TopologyConfig{}, nil
+	}
+	if cfg.Topology == "" {
+		embeddedTopologyPath := path.Join(cfg.Network, "topology.json")
+		tc, err := topology.NewTopologyConfigFromFS(
+			cardano.EmbeddedConfigFS,
+			embeddedTopologyPath,
+		)
+		if err == nil {
+			return tc, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) ||
+			!embeddedTopologyFileMissing(embeddedTopologyPath) {
+			return nil, fmt.Errorf(
+				"failed to load embedded topology file: %w",
+				err,
+			)
+		}
+		network, ok := ouroboros.NetworkByName(cfg.Network)
 		if !ok {
-			return nil, fmt.Errorf("unknown network: %s", globalConfig.Network)
+			return nil, fmt.Errorf("unknown network: %s", cfg.Network)
 		}
 		if len(network.BootstrapPeers) == 0 {
 			return nil, fmt.Errorf(
 				"no known bootstrap peers for network %s",
-				globalConfig.Network,
+				cfg.Network,
 			)
 		}
+		ret := &topology.TopologyConfig{}
 		for _, peer := range network.BootstrapPeers {
-			globalTopologyConfig.BootstrapPeers = append(
-				globalTopologyConfig.BootstrapPeers,
+			ret.BootstrapPeers = append(
+				ret.BootstrapPeers,
 				topology.TopologyConfigP2PAccessPoint{
 					Address: peer.Address,
 					Port:    peer.Port,
 				},
 			)
 		}
-		return globalTopologyConfig, nil
+		return ret, nil
 	}
-	tc, err := topology.NewTopologyConfigFromFile(globalConfig.Topology)
+	tc, err := topology.NewTopologyConfigFromFile(cfg.Topology)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load topology file: %+w", err)
 	}
-	// update globalTopologyConfig
-	globalTopologyConfig = tc
-	return globalTopologyConfig, nil
+	return tc, nil
+}
+
+func embeddedTopologyFileMissing(file string) bool {
+	topologyFile, err := cardano.EmbeddedConfigFS.Open(file)
+	if err == nil {
+		_ = topologyFile.Close()
+		return false
+	}
+	return errors.Is(err, fs.ErrNotExist)
 }
 
 func GetTopologyConfig() *topology.TopologyConfig {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/blinklabs-io/dingo/topology"
 )
 
 func resetGlobalConfig() {
@@ -66,6 +68,7 @@ func resetGlobalConfig() {
 			VerifyCertificates: true,
 		},
 	}
+	globalTopologyConfig = &topology.TopologyConfig{}
 }
 
 func TestLoad_CompareFullStruct(t *testing.T) {
@@ -463,6 +466,20 @@ func TestLoadConfig_EmbeddedDefaults(t *testing.T) {
 
 	if cfg.RelayPort != 3001 {
 		t.Errorf("expected RelayPort to be 3001, got %d", cfg.RelayPort)
+	}
+
+	topologyConfig := GetTopologyConfig()
+	if topologyConfig.PeerSnapshotFile != "peer-snapshot.json" {
+		t.Fatalf(
+			"expected embedded topology to reference peer-snapshot.json, got %q",
+			topologyConfig.PeerSnapshotFile,
+		)
+	}
+	if topologyConfig.PeerSnapshot == nil {
+		t.Fatal("expected embedded topology to load peer snapshot")
+	}
+	if !topologyConfig.PeerSnapshot.HasRelays() {
+		t.Fatal("expected embedded peer snapshot to contain relays")
 	}
 }
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -172,6 +172,10 @@ func ApplyFlags(cmd *cobra.Command, cfg *Config) error {
 			return err
 		}
 	}
+	globalConfig = cfg
+	if _, err := LoadTopologyConfig(); err != nil {
+		return fmt.Errorf("loading topology after flags: %w", err)
+	}
 	return nil
 }
 

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -161,6 +161,42 @@ func TestApplyFlags_NetworkMagicRejectsOverflow(t *testing.T) {
 	}
 }
 
+func TestApplyFlags_ReloadsTopologyForNetworkFlag(t *testing.T) {
+	resetGlobalConfig()
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.Network != "preview" {
+		t.Fatalf("expected default network preview, got %q", cfg.Network)
+	}
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	if err := cmd.ParseFlags([]string{"--network=preprod"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := ApplyFlags(cmd, cfg); err != nil {
+		t.Fatalf("failed to apply flags: %v", err)
+	}
+
+	if cfg.Network != "preprod" {
+		t.Fatalf("expected network preprod, got %q", cfg.Network)
+	}
+	topologyConfig := GetTopologyConfig()
+	if topologyConfig.PeerSnapshot == nil {
+		t.Fatal("expected topology reload to load preprod peer snapshot")
+	}
+	if topologyConfig.PeerSnapshot.NetworkMagic != 1 {
+		t.Fatalf(
+			"expected preprod peer snapshot network magic 1, got %d",
+			topologyConfig.PeerSnapshot.NetworkMagic,
+		)
+	}
+}
+
 func collectExportedLeafFields(
 	t reflect.Type,
 	prefix string,

--- a/node.go
+++ b/node.go
@@ -644,7 +644,37 @@ func (n *Node) Run(ctx context.Context) error {
 		n.ouroboros.HandleOutboundConnEvent,
 	)
 	if n.config.topologyConfig != nil {
-		n.peerGov.LoadTopologyConfig(n.config.topologyConfig)
+		topologyConfig := n.config.topologyConfig
+		usePeerSnapshot := genesisSelectionMode &&
+			topologyConfig.PeerSnapshot != nil &&
+			topologyConfig.PeerSnapshot.HasRelays()
+		if usePeerSnapshot {
+			topologyConfig = topologyConfig.WithoutBootstrapPeers()
+		}
+		n.peerGov.LoadTopologyConfig(topologyConfig)
+		if usePeerSnapshot {
+			added := n.peerGov.LoadPeerSnapshot(
+				n.config.topologyConfig.PeerSnapshot,
+			)
+			if added > 0 {
+				n.config.logger.Info(
+					"using peer snapshot for Genesis bootstrap",
+					"snapshot_slot",
+					n.config.topologyConfig.PeerSnapshot.Point.BlockPointSlot,
+					"snapshot_peers_added",
+					added,
+					"bootstrap_peers_omitted",
+					len(n.config.topologyConfig.BootstrapPeers),
+				)
+			} else {
+				n.config.logger.Warn(
+					"peer snapshot produced no usable peers; falling back to topology bootstrap peers",
+					"snapshot_slot",
+					n.config.topologyConfig.PeerSnapshot.Point.BlockPointSlot,
+				)
+				n.peerGov.LoadTopologyConfig(n.config.topologyConfig)
+			}
+		}
 	}
 	if err := n.peerGov.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("peer governor start failed: %w", err)

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -15,7 +15,6 @@
 package peergov
 
 import (
-	"math/rand/v2"
 	"time"
 )
 
@@ -93,24 +92,8 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 		return
 	}
 
-	// Flatten relays into candidate addresses, deduplicate them, and
-	// shuffle so we do not always pick the same relays in provider-returned
-	// order.
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
-	rand.Shuffle(len(candidates), func(i, j int) {
-		candidates[i], candidates[j] = candidates[j], candidates[i]
-	})
-
-	// Add candidates until we reach the target or exhaust the list.
-	addedCount := 0
-	for _, addr := range candidates {
-		if p.ledgerPeerDeficit() <= 0 {
-			break
-		}
-		if p.addLedgerPeer(addr) {
-			addedCount++
-		}
-	}
+	addedCount := p.addLedgerRelays(relays)
 
 	if addedCount > 0 {
 		p.config.Logger.Info(

--- a/peergov/ledger_discovery_test.go
+++ b/peergov/ledger_discovery_test.go
@@ -22,9 +22,68 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/topology"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoadPeerSnapshotSeedsLedgerPeers(t *testing.T) {
+	snapshot := &topology.PeerSnapshotConfig{
+		Point: topology.PeerSnapshotPoint{BlockPointSlot: 42},
+		BigLedgerPools: []topology.PeerSnapshotLedgerPool{
+			{
+				Relays: []topology.TopologyConfigP2PAccessPoint{
+					{Address: "44.0.0.1", Port: 3001},
+					{Address: "44.0.0.2", Port: 3001},
+					{Address: "44.0.0.3", Port: 3001},
+				},
+			},
+		},
+	}
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:         newMockEventBus(),
+		LedgerPeerTarget: 2,
+	})
+
+	added := pg.LoadPeerSnapshot(snapshot)
+
+	require.Equal(t, 2, added)
+	require.Len(t, pg.peers, 2)
+	for _, peer := range pg.peers {
+		require.NotNil(t, peer)
+		assert.Equal(t, PeerSource(PeerSourceP2PLedger), peer.Source)
+		assert.Equal(t, PeerStateCold, peer.State)
+		_, known := pg.ledgerKnownAddrs[peer.NormalizedAddress]
+		assert.True(t, known)
+	}
+}
+
+func TestLoadPeerSnapshotConvertsRelayShapes(t *testing.T) {
+	snapshot := &topology.PeerSnapshotConfig{
+		BigLedgerPools: []topology.PeerSnapshotLedgerPool{
+			{
+				Relays: []topology.TopologyConfigP2PAccessPoint{
+					{Address: "relay.example.com", Port: 3002},
+					{Address: "44.0.1.1", Port: 3003},
+					{Address: "2001:db8::1", Port: 3004},
+				},
+			},
+		},
+	}
+
+	relays := PoolRelaysFromPeerSnapshot(snapshot)
+
+	require.Len(t, relays, 3)
+	assert.Equal(t, "relay.example.com", relays[0].Hostname)
+	assert.Equal(t, uint(3002), relays[0].Port)
+	require.NotNil(t, relays[1].IPv4)
+	assert.Equal(t, "44.0.1.1", relays[1].IPv4.String())
+	assert.Equal(t, uint(3003), relays[1].Port)
+	require.NotNil(t, relays[2].IPv6)
+	assert.Equal(t, "2001:db8::1", relays[2].IPv6.String())
+	assert.Equal(t, uint(3004), relays[2].Port)
+}
 
 func TestDiscoverLedgerPeers_BoundedByTarget(t *testing.T) {
 	// Provide 50 relays but set target to 5

--- a/peergov/peer_snapshot.go
+++ b/peergov/peer_snapshot.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"math/rand/v2"
+	"net"
+
+	"github.com/blinklabs-io/dingo/topology"
+)
+
+// LoadPeerSnapshot seeds ledger peers from cardano-node's peer-snapshot.json.
+// It is intended for Ouroboros Genesis startup, where the snapshot provides
+// historical ledger peers before the local ledger can answer relay queries.
+func (p *PeerGovernor) LoadPeerSnapshot(
+	snapshot *topology.PeerSnapshotConfig,
+) int {
+	if p == nil || snapshot == nil || !snapshot.HasRelays() ||
+		p.config.DisableOutbound {
+		return 0
+	}
+	relays := PoolRelaysFromPeerSnapshot(snapshot)
+	added := p.addLedgerRelays(relays)
+	p.config.Logger.Info(
+		"loaded peer snapshot",
+		"snapshot_slot", snapshot.Point.BlockPointSlot,
+		"relay_candidates", len(relays),
+		"added", added,
+	)
+	return added
+}
+
+func PoolRelaysFromPeerSnapshot(
+	snapshot *topology.PeerSnapshotConfig,
+) []PoolRelay {
+	if snapshot == nil {
+		return nil
+	}
+	accessPoints := snapshot.RelayAccessPoints()
+	relays := make([]PoolRelay, 0, len(accessPoints))
+	for _, accessPoint := range accessPoints {
+		if relay, ok := poolRelayFromSnapshotAccessPoint(accessPoint); ok {
+			relays = append(relays, relay)
+		}
+	}
+	return relays
+}
+
+func poolRelayFromSnapshotAccessPoint(
+	accessPoint topology.TopologyConfigP2PAccessPoint,
+) (PoolRelay, bool) {
+	if accessPoint.Address == "" {
+		return PoolRelay{}, false
+	}
+	ip := net.ParseIP(accessPoint.Address)
+	if ip == nil {
+		return PoolRelay{
+			Hostname: accessPoint.Address,
+			Port:     accessPoint.Port,
+		}, true
+	}
+	if ipv4 := ip.To4(); ipv4 != nil {
+		ipCopy := append(net.IP(nil), ipv4...)
+		return PoolRelay{
+			IPv4: &ipCopy,
+			Port: accessPoint.Port,
+		}, true
+	}
+	ipCopy := append(net.IP(nil), ip...)
+	return PoolRelay{
+		IPv6: &ipCopy,
+		Port: accessPoint.Port,
+	}, true
+}
+
+func (p *PeerGovernor) addLedgerRelays(relays []PoolRelay) int {
+	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
+	rand.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+
+	added := 0
+	for _, addr := range candidates {
+		if p.ledgerPeerDeficit() <= 0 {
+			break
+		}
+		if p.addLedgerPeer(addr) {
+			added++
+		}
+	}
+	return added
+}

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -18,7 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path"
+	"path/filepath"
 )
 
 // TopologyConfig represents a cardano-node topology config
@@ -27,6 +30,8 @@ type TopologyConfig struct {
 	PublicRoots        []TopologyConfigP2PPublicRoot    `json:"publicRoots"`
 	BootstrapPeers     []TopologyConfigP2PBootstrapPeer `json:"bootstrapPeers"`
 	UseLedgerAfterSlot int64                            `json:"useLedgerAfterSlot"`
+	PeerSnapshotFile   string                           `json:"peerSnapshotFile"`
+	PeerSnapshot       *PeerSnapshotConfig              `json:"-"`
 }
 
 type TopologyConfigP2PAccessPoint struct {
@@ -51,13 +56,59 @@ type TopologyConfigP2PPublicRoot struct {
 
 type TopologyConfigP2PBootstrapPeer = TopologyConfigP2PAccessPoint
 
+// PeerSnapshotConfig represents cardano-node's peer-snapshot.json format.
+type PeerSnapshotConfig struct {
+	NetworkMagic        uint32                   `json:"NetworkMagic"`
+	NodeToClientVersion uint16                   `json:"NodeToClientVersion"`
+	Point               PeerSnapshotPoint        `json:"Point"`
+	BigLedgerPools      []PeerSnapshotLedgerPool `json:"bigLedgerPools"`
+	LedgerPools         []PeerSnapshotLedgerPool `json:"ledgerPools"`
+}
+
+type PeerSnapshotPoint struct {
+	BlockPointHash string `json:"blockPointHash"`
+	BlockPointSlot uint64 `json:"blockPointSlot"`
+}
+
+type PeerSnapshotLedgerPool struct {
+	AccumulatedStake float64                        `json:"accumulatedStake"`
+	RelativeStake    float64                        `json:"relativeStake"`
+	Relays           []TopologyConfigP2PAccessPoint `json:"relays"`
+}
+
 func NewTopologyConfigFromFile(path string) (*TopologyConfig, error) {
 	dataFile, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer dataFile.Close()
-	return NewTopologyConfigFromReader(dataFile)
+	ret, err := NewTopologyConfigFromReader(dataFile)
+	if err != nil {
+		return nil, err
+	}
+	if err := ret.loadPeerSnapshotFromDisk(filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func NewTopologyConfigFromFS(
+	fsys fs.FS,
+	file string,
+) (*TopologyConfig, error) {
+	dataFile, err := fsys.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer dataFile.Close()
+	ret, err := NewTopologyConfigFromReader(dataFile)
+	if err != nil {
+		return nil, err
+	}
+	if err := ret.loadPeerSnapshotFromFS(fsys, path.Dir(file)); err != nil {
+		return nil, err
+	}
+	return ret, nil
 }
 
 // maxTopologySize is the maximum allowed size for a topology config file
@@ -80,4 +131,124 @@ func NewTopologyConfigFromReader(r io.Reader) (*TopologyConfig, error) {
 		return nil, err
 	}
 	return t, nil
+}
+
+// maxPeerSnapshotSize is the maximum allowed size for peer-snapshot.json
+// (10 MB). This matches topology config's defensive read limit.
+const maxPeerSnapshotSize = 10 * 1024 * 1024
+
+func NewPeerSnapshotConfigFromReader(
+	r io.Reader,
+) (*PeerSnapshotConfig, error) {
+	s := &PeerSnapshotConfig{}
+	data, err := io.ReadAll(io.LimitReader(r, maxPeerSnapshotSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxPeerSnapshotSize {
+		return nil, fmt.Errorf(
+			"peer snapshot file exceeds maximum size of %d bytes",
+			maxPeerSnapshotSize,
+		)
+	}
+	if err := json.Unmarshal(data, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func NewPeerSnapshotConfigFromFile(
+	file string,
+) (*PeerSnapshotConfig, error) {
+	dataFile, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer dataFile.Close()
+	return NewPeerSnapshotConfigFromReader(dataFile)
+}
+
+func (t *TopologyConfig) loadPeerSnapshotFromDisk(baseDir string) error {
+	if t == nil || t.PeerSnapshotFile == "" {
+		return nil
+	}
+	snapshotPath := t.PeerSnapshotFile
+	if !filepath.IsAbs(snapshotPath) {
+		snapshotPath = filepath.Join(baseDir, snapshotPath)
+	}
+	snapshot, err := NewPeerSnapshotConfigFromFile(snapshotPath)
+	if err != nil {
+		return fmt.Errorf("failed to load peer snapshot file: %w", err)
+	}
+	t.PeerSnapshot = snapshot
+	return nil
+}
+
+func (t *TopologyConfig) loadPeerSnapshotFromFS(
+	fsys fs.FS,
+	baseDir string,
+) error {
+	if t == nil || t.PeerSnapshotFile == "" {
+		return nil
+	}
+	snapshotPath := t.PeerSnapshotFile
+	if !path.IsAbs(snapshotPath) {
+		snapshotPath = path.Join(baseDir, snapshotPath)
+	}
+	dataFile, err := fsys.Open(snapshotPath)
+	if err != nil {
+		return fmt.Errorf("failed to load peer snapshot file: %w", err)
+	}
+	defer dataFile.Close()
+	snapshot, err := NewPeerSnapshotConfigFromReader(dataFile)
+	if err != nil {
+		return err
+	}
+	t.PeerSnapshot = snapshot
+	return nil
+}
+
+func (t *TopologyConfig) WithoutBootstrapPeers() *TopologyConfig {
+	if t == nil {
+		return nil
+	}
+	ret := *t
+	ret.BootstrapPeers = nil
+	return &ret
+}
+
+func (s *PeerSnapshotConfig) RelayAccessPoints() []TopologyConfigP2PAccessPoint {
+	if s == nil {
+		return nil
+	}
+	ret := make(
+		[]TopologyConfigP2PAccessPoint,
+		0,
+		s.peerSnapshotRelayCount(),
+	)
+	for _, pool := range s.BigLedgerPools {
+		ret = append(ret, pool.Relays...)
+	}
+	for _, pool := range s.LedgerPools {
+		ret = append(ret, pool.Relays...)
+	}
+	return ret
+}
+
+func (s *PeerSnapshotConfig) HasRelays() bool {
+	return s != nil && s.peerSnapshotRelayCount() > 0
+}
+
+func (s *PeerSnapshotConfig) peerSnapshotRelayCount() int {
+	if s == nil {
+		return 0
+	}
+	count := 0
+	for _, pool := range s.BigLedgerPools {
+		count += len(pool.Relays)
+	}
+	for _, pool := range s.LedgerPools {
+		count += len(pool.Relays)
+	}
+	return count
 }

--- a/topology/topology_test.go
+++ b/topology/topology_test.go
@@ -202,6 +202,102 @@ func TestNewTopologyConfigFromFile_ClosesFile(t *testing.T) {
 	)
 }
 
+func TestNewTopologyConfigFromFile_LoadsPeerSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	topologyPath := filepath.Join(dir, "topology.json")
+	snapshotPath := filepath.Join(dir, "peer-snapshot.json")
+
+	require.NoError(
+		t,
+		os.WriteFile(
+			topologyPath,
+			[]byte(`{"peerSnapshotFile":"peer-snapshot.json"}`),
+			0o600,
+		),
+	)
+	require.NoError(
+		t,
+		os.WriteFile(
+			snapshotPath,
+			[]byte(`{
+  "NetworkMagic": 1,
+  "NodeToClientVersion": 23,
+  "Point": {
+    "blockPointHash": "abc",
+    "blockPointSlot": 42
+  },
+  "bigLedgerPools": [
+    {
+      "relativeStake": 0.5,
+      "accumulatedStake": 0.5,
+      "relays": [
+        {"address": "relay.example.com", "port": 3001}
+      ]
+    }
+  ]
+}`),
+			0o600,
+		),
+	)
+
+	cfg, err := topology.NewTopologyConfigFromFile(topologyPath)
+	require.NoError(t, err)
+	require.Equal(t, "peer-snapshot.json", cfg.PeerSnapshotFile)
+	require.NotNil(t, cfg.PeerSnapshot)
+	require.Equal(t, uint64(42), cfg.PeerSnapshot.Point.BlockPointSlot)
+	require.Equal(
+		t,
+		[]topology.TopologyConfigP2PAccessPoint{
+			{Address: "relay.example.com", Port: 3001},
+		},
+		cfg.PeerSnapshot.RelayAccessPoints(),
+	)
+}
+
+func TestNewTopologyConfigFromFS_LoadsPeerSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "preview"), 0o700))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(dir, "preview", "topology.json"),
+			[]byte(`{"peerSnapshotFile":"peer-snapshot.json"}`),
+			0o600,
+		),
+	)
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(dir, "preview", "peer-snapshot.json"),
+			[]byte(`{
+  "NetworkMagic": 2,
+  "NodeToClientVersion": 23,
+  "Point": {
+    "blockPointHash": "def",
+    "blockPointSlot": 77
+  },
+  "bigLedgerPools": [
+    {
+      "relays": [
+        {"address": "44.0.0.1", "port": 3001}
+      ]
+    }
+  ]
+}`),
+			0o600,
+		),
+	)
+
+	cfg, err := topology.NewTopologyConfigFromFS(
+		os.DirFS(dir),
+		"preview/topology.json",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.PeerSnapshot)
+	require.Equal(t, uint64(77), cfg.PeerSnapshot.Point.BlockPointSlot)
+	require.True(t, cfg.PeerSnapshot.HasRelays())
+}
+
 func TestNewTopologyConfigFromFile_NotFound(t *testing.T) {
 	_, err := topology.NewTopologyConfigFromFile(
 		"/nonexistent/topology.json",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sync Cardano configs to the latest peer snapshots and enable embedded topology/peer-snapshot loading to seed peers for Genesis bootstrap, reducing bootstrap-peer dependence and speeding startup. Also refreshed slot cutovers and pruned stale relays for mainnet, preprod, and preview.

- New Features
  - `topology`: parse `peerSnapshotFile`, load snapshot from disk or embedded FS (`NewTopologyConfigFromFS`), expose relay access points, and add `WithoutBootstrapPeers`.
  - `Node`: in Genesis selection mode, seed `PeerSourceP2PLedger` peers from the snapshot and omit bootstrap peers, with automatic fallback and logging.
  - `config`: auto-load embedded topology by network when no file is provided and reload topology after `--network`; added tests and docs.
  - `peergov`: add `LoadPeerSnapshot` and helpers to convert/add relays for snapshot seeding.

- Bug Fixes
  - Refreshed `peer-snapshot.json` for mainnet, preprod, and preview with new Point and pool data; removed stale/duplicate relays.
  - Updated `useLedgerAfterSlot`: mainnet 185500763, preprod 121478354, preview 110678393.
  - Docker: bump `ghcr.io/blinklabs-io/cardano-configs` to `20260605-1`.

<sup>Written for commit 8f4bfa09221237e35cc1b9167cdd0b177b76729d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

