### PR TITLE
fix(leios): Wire leios endorser block and ranking block correctly

### DIFF
--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -248,10 +249,9 @@ func validateLeiosTxBitmap(count int, bitmaps map[uint16]uint64) error {
 func (o *Ouroboros) mergedLeiosRankingBlockCbor(
 	blockCbor []byte,
 ) ([]byte, bool, error) {
-	// gouroboros v0.180.0 maps the old Leios block aliases onto the
-	// Dijkstra block CDDL. Dijkstra carries nullable Leios/Peras certificate
-	// slots, but the current Leios certificate placeholder is an empty list
-	// and does not contain an endorser-block hash to drive the old merge path.
+	// Dijkstra carries nullable Leios/Peras certificate slots, but the current
+	// Leios certificate placeholder is an empty list and does not contain an
+	// endorser-block hash to drive the old merge path.
 	return blockCbor, false, nil
 }
 
@@ -260,7 +260,7 @@ func (o *Ouroboros) chainsyncServerBlockCbor(
 	block models.Block,
 ) []byte {
 	if !o.config.EnableLeios ||
-		block.Type != uint(gleios.BlockTypeLeiosRanking) ||
+		block.Type != uint(gdijkstra.BlockTypeDijkstra) ||
 		ctx.Server == nil {
 		return block.Cbor
 	}

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -103,7 +103,7 @@ func (o *Ouroboros) storeLeiosEndorserBlock(
 	// Trigger local vote emission for the stored block, outside the
 	// cache lock
 	if o.LeiosVotes != nil {
-		o.LeiosVotes.HandleEndorserBlock(block.SlotNumber(), blockHash)
+		o.LeiosVotes.HandleEndorserBlock(point.Slot, blockHash)
 	}
 	return nil
 }

--- a/ouroboros/leiosvotes_test.go
+++ b/ouroboros/leiosvotes_test.go
@@ -195,7 +195,7 @@ func TestLeiosFetchServerVotesRequestWithoutHandler(t *testing.T) {
 }
 
 func TestStoreLeiosEndorserBlockNotifiesVoteHandler(t *testing.T) {
-	point, blockRaw := testDijkstraBlockRaw(t, 10)
+	point, blockRaw := testLeiosEndorserBlockRaw(t, 10)
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
 	handler := &fakeLeiosVoteHandler{}
 	o.LeiosVotes = handler
@@ -207,7 +207,7 @@ func TestStoreLeiosEndorserBlockNotifiesVoteHandler(t *testing.T) {
 }
 
 func TestStoreLeiosEndorserBlockWithoutHandler(t *testing.T) {
-	point, blockRaw := testDijkstraBlockRaw(t, 11)
+	point, blockRaw := testLeiosEndorserBlockRaw(t, 11)
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
 	require.NoError(t, o.storeLeiosEndorserBlock(point, blockRaw, nil))
 }


### PR DESCRIPTION
1. Made changes to use gouroboros new LeiosEndorserBlock type for Leios EB fetch/cache handling.
2. Changed EB decoding from `NewDijkstraBlockFromCbor` to `NewLeiosEndorserBlockFromCbor`.
3. Changed EB cache key calculation to hash the raw EB CBOR bytes.
4. Changed cached EB transaction count to use `len(block.TransactionReferences)`.
5. Changed ranking block type checks to use `dijkstra.BlockTypeDijkstra`.
6. Updated tests to build real `LeiosEndorserBlock` fixtures for EB cache paths.

Closes #1859 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Leios EB handling to `gouroboros` `LeiosEndorserBlock`, fix cache hashing and tx counts, and gate ChainSync on `gdijkstra.BlockTypeDijkstra` so merged ranking blocks remain a no-op. Also send the correct slot to the EB vote handler and fix rebase-related SQLite test failures; aligns with #1859 by stabilizing EB fetch/notify and ranking-block routing.

- **Bug Fixes**
  - Decode EB with `NewLeiosEndorserBlockFromCbor`.
  - Derive cache keys from `Blake2b256` of raw EB CBOR.
  - Use `len(block.TransactionReferences)` for tx count.
  - In ChainSync, treat ranking blocks as `gdijkstra.BlockTypeDijkstra`.
  - Notify vote handler with `point.Slot` when storing EB.
  - Fix SQLite test failures after rebase.

<sup>Written for commit 3a4eec550dc0d07a8f5387ad2cfbcb3fcd811867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed endorser-block caching to correctly derive cache keys from raw block bytes and use accurate transaction metadata sources, improving overall cache consistency and reliability in block handling.
  * Enhanced merged-block routing logic to properly classify incoming blocks and ensure correct block synchronization across the network, improving protocol performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->