### PR TITLE
feat(database): skip consumed-input recovery checks during Mithril backfill 

### DIFF
--- a/database/batch.go
+++ b/database/batch.go
@@ -69,6 +69,16 @@ type BatchedTxIngestOpts struct {
 	// unaffected.
 	SkipProducedUtxoOffsetWrites bool
 
+	// SkipConsumedInputRecovery elides the per-input GetUtxoIncludingSpent
+	// recovery checks in ensureTransactionConsumedUtxos. Use when replaying
+	// immutable blocks in slot order during Mithril historical backfill,
+	// where consumed inputs are guaranteed to already exist in the metadata
+	// store from earlier producer transactions. The in-flight producer lookup
+	// optimization (same-batch provenance) remains active. Do NOT enable for
+	// gap blocks, resumed backfill with potential missing rows, or normal
+	// replay paths where producer rows may be absent.
+	SkipConsumedInputRecovery bool
+
 	// Stats receives hot-path timings and row-ish counts for operator
 	// visibility during API-mode Mithril backfill. It is optional and is
 	// intentionally updated only at coarse stage boundaries.
@@ -236,7 +246,7 @@ func (d *Database) SetTransactionBatchedWithOpts(
 	}
 
 	recoverStart := time.Now()
-	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, acc); err != nil {
+	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, acc, opts); err != nil {
 		return err
 	}
 	if opts.Stats != nil {

--- a/database/batch_skip_test.go
+++ b/database/batch_skip_test.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -320,4 +321,133 @@ func TestSetTransactionBatchedWithOpts_RequiresOffsetsEvenWhenSkipping(
 	)
 	require.Error(t, err, "missing offset must still error even with skip enabled")
 	require.Contains(t, err.Error(), "missing UTxO offset")
+}
+
+// TestSetTransactionBatchedWithOpts_SkipConsumedInputRecovery verifies that
+// enabling SkipConsumedInputRecovery elides the per-input GetUtxoIncludingSpent
+// checks. During Mithril backfill, immutable blocks are replayed in slot order
+// against a metadata store being populated from the same history, so consumed
+// inputs are guaranteed to already exist from earlier producer transactions.
+// This test ensures the skip path counts inputs that would have been checked.
+func TestSetTransactionBatchedWithOpts_SkipConsumedInputRecovery(t *testing.T) {
+	db := openTestDB(t)
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+
+	// Store producer block first so consumed inputs exist in metadata
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+	txn.Release()
+
+	// Now ingest the consumer with skip enabled
+	storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+	var stats types.BackfillHotPathStats
+	acc2 := db.NewBatchAccumulator()
+	txn2 := db.Transaction(true)
+	defer txn2.Release()
+	defer txn2.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.consumerTx,
+		candidate.consumerPoint,
+		candidate.consumerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.consumerBlock),
+		acc2,
+		txn2,
+		BatchedTxIngestOpts{
+			SkipConsumedInputRecovery: true,
+			Stats:                     &stats,
+		},
+	))
+	require.NoError(t, db.FlushBatch(acc2, txn2))
+	require.NoError(t, txn2.Commit())
+
+	// Verify the counter shows skipped inputs
+	consumed := candidate.consumerTx.Consumed()
+	require.Greater(t, len(consumed), 0, "consumer tx must have at least one input")
+	require.Equal(
+		t, uint64(len(consumed)), stats.SkippedInputRecovery,
+		"SkippedInputRecovery must count all consumed inputs when skip is enabled",
+	)
+}
+
+// TestSetTransactionBatchedWithOpts_DefaultDoesNotSkipInputRecovery confirms
+// that when SkipConsumedInputRecovery is false (default), the recovery path
+// is still executed and the counter remains zero.
+func TestSetTransactionBatchedWithOpts_DefaultDoesNotSkipInputRecovery(
+	t *testing.T,
+) {
+	db := openTestDB(t)
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+
+	// Store producer block first
+	storeBlockOffsetsOnly(t, db, candidate.producerBlock)
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+		BatchedTxIngestOpts{},
+	))
+	require.NoError(t, db.FlushBatch(acc, txn))
+	require.NoError(t, txn.Commit())
+	txn.Release()
+
+	// Ingest consumer with default options (skip disabled)
+	storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+	var stats types.BackfillHotPathStats
+	acc2 := db.NewBatchAccumulator()
+	txn2 := db.Transaction(true)
+	defer txn2.Release()
+	defer txn2.Rollback() //nolint:errcheck
+
+	require.NoError(t, db.SetTransactionBatchedWithOpts(
+		candidate.consumerTx,
+		candidate.consumerPoint,
+		candidate.consumerIdx,
+		0,
+		nil,
+		nil,
+		mustBlockOffsets(t, candidate.consumerBlock),
+		acc2,
+		txn2,
+		BatchedTxIngestOpts{
+			SkipConsumedInputRecovery: false, // explicit default
+			Stats:                     &stats,
+		},
+	))
+	require.NoError(t, db.FlushBatch(acc2, txn2))
+	require.NoError(t, txn2.Commit())
+
+	// Verify the skip counter is zero when recovery is not skipped
+	require.Equal(
+		t, uint64(0), stats.SkippedInputRecovery,
+		"SkippedInputRecovery must be zero when skip is disabled",
+	)
 }

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -275,11 +275,32 @@ func (d *Database) ensureTransactionConsumedUtxos(
 	point ocommon.Point,
 	txn *Txn,
 	acc BatchAccumulator,
+	opts BatchedTxIngestOpts,
 ) error {
 	consumed := tx.Consumed()
 	if len(consumed) == 0 {
 		return nil
 	}
+
+	// During Mithril historical backfill, immutable blocks are replayed in
+	// slot order against a metadata store being populated from the same
+	// history. Consumed inputs are guaranteed to already exist in the store
+	// from earlier producer transactions, so the per-input recovery checks
+	// are redundant. The in-flight producer lookup optimization (same-batch
+	// provenance) remains valuable and is preserved below.
+	if opts.SkipConsumedInputRecovery {
+		if opts.Stats != nil {
+			// Count inputs that would have triggered GetUtxoIncludingSpent
+			// lookups. The in-flight check below is cheap and would have
+			// avoided recovery anyway, so count the full consumed set.
+			opts.Stats.SkippedInputRecovery += uint64(len(consumed))
+		}
+		// Return early: skip GetUtxoIncludingSpent, SetUtxoDeletedAtSlot,
+		// recoverConsumedUtxo, and ImportUtxos. The in-flight producer
+		// optimization is moot when the recovery path is disabled.
+		return nil
+	}
+
 	inFlight, _ := acc.(inFlightProducerLookup)
 	spenderTxHash := ledgerHashBytes(tx.Hash())
 	recoveredUtxos := make([]models.Utxo, 0, len(consumed))

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -143,7 +143,7 @@ func (d *Database) SetTransaction(
 		}
 	}
 
-	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, nil); err != nil {
+	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, nil, BatchedTxIngestOpts{}); err != nil {
 		return err
 	}
 	if err := d.metadata.SetTransaction(tx, point, idx, certDeposits, txn.Metadata()); err != nil {

--- a/database/types/backfill_stats.go
+++ b/database/types/backfill_stats.go
@@ -28,6 +28,7 @@ type BackfillHotPathStats struct {
 	BlobTxOffsetWrites   uint64
 	BlobUtxoOffsetWrites uint64
 	SkippedUtxoOffsets   uint64
+	SkippedInputRecovery uint64
 
 	AddressTxs      uint64
 	Witnesses       uint64
@@ -63,6 +64,7 @@ func (s *BackfillHotPathStats) Add(other BackfillHotPathStats) {
 	s.BlobTxOffsetWrites += other.BlobTxOffsetWrites
 	s.BlobUtxoOffsetWrites += other.BlobUtxoOffsetWrites
 	s.SkippedUtxoOffsets += other.SkippedUtxoOffsets
+	s.SkippedInputRecovery += other.SkippedInputRecovery
 	s.AddressTxs += other.AddressTxs
 	s.Witnesses += other.Witnesses
 	s.Scripts += other.Scripts

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -689,6 +689,11 @@ func (b *Backfill) Run(ctx context.Context) error {
 
 	var startSlot uint64
 	now := time.Now()
+	// Track whether this is a fresh backfill start (not resumed). The
+	// consumed-input recovery optimization is only safe when the metadata
+	// store is in a pristine, monotonic state. Resumed runs may have
+	// inconsistencies from interrupted batches that need repair.
+	isFreshStart := cp == nil
 	if cp == nil {
 		cp = &models.BackfillCheckpoint{
 			Phase:      BackfillPhase,
@@ -934,7 +939,7 @@ func (b *Backfill) Run(ctx context.Context) error {
 					if pErr := b.processBlockTxsBatched(
 						txs, point, epochId, eraId,
 						pp, offsets, acc, batchTxn,
-						&intervalStats,
+						&intervalStats, isFreshStart,
 					); pErr != nil {
 						saveCommittedCheckpoint()
 						return fmt.Errorf(
@@ -1041,6 +1046,7 @@ func (b *Backfill) processBlockTxsBatched(
 	acc database.BatchAccumulator,
 	txn *database.Txn,
 	stats *dbtypes.BackfillHotPathStats,
+	isFreshStart bool,
 ) error {
 	opts := database.BatchedTxIngestOpts{
 		SkipProducedUtxoOffsetWrites: b.immutableUtxoOffsetsTipSlot > 0 &&
@@ -1065,8 +1071,11 @@ func (b *Backfill) processBlockTxsBatched(
 			certDeposits, offsets, acc, txn,
 			database.BatchedTxIngestOpts{
 				SkipProducedUtxoOffsetWrites: opts.SkipProducedUtxoOffsetWrites,
-				SkipConsumedInputRecovery:    true, // Mithril backfill: immutable blocks in slot order
-				Stats:                        stats,
+				// Only skip consumed-input recovery on fresh backfill starts.
+				// Resumed runs may have inconsistencies from interrupted batches
+				// that need repair via the recovery path.
+				SkipConsumedInputRecovery: isFreshStart,
+				Stats:                     stats,
 			},
 		); err != nil {
 			return fmt.Errorf("storing TX: %w", err)

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -1065,6 +1065,7 @@ func (b *Backfill) processBlockTxsBatched(
 			certDeposits, offsets, acc, txn,
 			database.BatchedTxIngestOpts{
 				SkipProducedUtxoOffsetWrites: opts.SkipProducedUtxoOffsetWrites,
+				SkipConsumedInputRecovery:    true, // Mithril backfill: immutable blocks in slot order
 				Stats:                        stats,
 			},
 		); err != nil {


### PR DESCRIPTION
closes #2353 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up Mithril historical backfill by skipping per-input `GetUtxoIncludingSpent` recovery when replaying immutable blocks in slot order. The skip is gated to fresh backfill starts and tracked via a new metric.

- **New Features**
  - Add `SkipConsumedInputRecovery` to `BatchedTxIngestOpts` and wire it into `ensureTransactionConsumedUtxos`; default-off via `SetTransaction`.
  - Enable the flag in `internal/node/backfill` only for fresh Mithril backfill runs; resumed runs keep recovery checks.
  - Add `SkippedInputRecovery` to backfill stats and aggregate it; tests verify skip counts all inputs and default keeps the counter at 0.

<sup>Written for commit e7eaf9ebdacbd2e5de8ccf445a9120c77f5ac3a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `SkipConsumedInputRecovery` option to batch ingestion for optimized processing of immutable blocks, reducing unnecessary recovery checks.
  * Introduced `SkippedInputRecovery` metric to track when input recovery is bypassed.

* **Tests**
  * Added test cases validating skip and default behaviors for consumed input recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->