### PR TITLE
fix(blockfrost): compute network locked supply and align network eras…

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -174,7 +174,7 @@ erDiagram
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
 | `transaction` | `id`, `hash`, `block_hash`, `slot`, `block_index`, `type`, `fee`, `ttl`, `valid`, `metadata` | PK `id`; unique `hash`; indexes `block_hash`, `slot` | One row per transaction. `block_hash` and `slot` point to the blob block. `metadata` is populated only in API mode. |
-| `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes address keys, spend/reference/collateral tx hashes, `added_slot`, `deleted_slot`, `amount`; composite `(deleted_slot, staking_key, amount)` | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. |
+| `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount`, `payment_script` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes address keys, spend/reference/collateral tx hashes, `added_slot`, `deleted_slot`, `amount`; composite `(deleted_slot, staking_key, amount)` and `(deleted_slot, payment_script, amount)` | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. `payment_script` is a bool set at index time from the output address type (true when the payment credential is a script hash); the `(deleted_slot, payment_script, amount)` composite backs the network script-locked supply sum (blockfrost `/network` `supply.locked`). It is derived only at write time, so a database synced before this column existed reports script-locked supply only for UTxOs created after the upgrade until it is rebuilt from chain data. |
 | `asset` | `id`, `utxo_id`, `policy_id`, `name`, `name_hex`, `fingerprint`, `amount` | PK `id`; unique `(name, policy_id, utxo_id)`; named index `idx_asset_policy_id` on `policy_id`; indexes `name_hex`, `fingerprint`, `amount` | Multi-asset quantities attached to `utxo.id`. The unique key backs ledger-state import `ON CONFLICT`; the policy-id query index can be deferred during bulk load. Use `utxo.deleted_slot = 0` for live balances. |
 | `address_transaction` | `id`, `payment_key`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key`, `staking_key`, `transaction_id`, `slot` | API-mode address-to-transaction index. Join to `transaction.id`. |
 | `transaction_metadata_label` | `id`, `transaction_id`, `label`, `slot`, `cbor_value`, `json_value` | PK `id`; unique `(transaction_id, label)`; indexes `label`, `slot` | API-mode per-label metadata index. Join to `transaction.id`. |
@@ -497,6 +497,18 @@ Controlled amount by staking key:
 SELECT COALESCE(SUM(amount), 0) AS controlled_amount
 FROM utxo
 WHERE staking_key = decode($1, 'hex')
+  AND deleted_slot = 0;
+```
+
+### `GetScriptLockedSupply`
+
+Network script-locked supply (sum of lovelace in live UTxOs whose payment
+credential is a script), backing blockfrost `/network` `supply.locked`:
+
+```sql
+SELECT COALESCE(SUM(amount), 0) AS locked_supply
+FROM utxo
+WHERE payment_script = true
   AND deleted_slot = 0;
 ```
 

--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -516,9 +516,16 @@ func (a *NodeAdapter) Network() (NetworkInfo, error) {
 		treasury = uint64(state.Treasury)
 		reserves = uint64(state.Reserves)
 	}
-	// TODO: Wire locked supply from script-address UTxOs and ledger deposits,
-	// then subtract it from circulating supply.
-	locked := uint64(0)
+	// Script-locked supply: lovelace held in live UTxOs whose payment
+	// credential is a script. Subtracted from circulating supply below.
+	locked, err := a.ledgerState.Database().Metadata().
+		GetScriptLockedSupply(nil)
+	if err != nil {
+		return NetworkInfo{}, fmt.Errorf(
+			"get script-locked supply: %w",
+			err,
+		)
+	}
 	total := uint64(0)
 	if reserves <= maxSupply {
 		total = maxSupply - reserves

--- a/blockfrost/blockfrost_test.go
+++ b/blockfrost/blockfrost_test.go
@@ -1935,7 +1935,7 @@ func TestHandleNetwork(t *testing.T) {
 				Max:         "45000000000000000",
 				Total:       "33000000000000000",
 				Circulating: "32000000000000000",
-				Locked:      "0",
+				Locked:      "1000000000000",
 				Treasury:    "500000000000",
 				Reserves:    "12000000000000000",
 			},
@@ -1969,6 +1969,7 @@ func TestHandleNetwork(t *testing.T) {
 	assert.NotEmpty(t, resp.Stake.Active)
 	assert.Equal(t, "500000000000", resp.Supply.Treasury)
 	assert.Equal(t, "12000000000000000", resp.Supply.Reserves)
+	assert.Equal(t, "1000000000000", resp.Supply.Locked)
 }
 
 func TestHandleNetworkEras(t *testing.T) {
@@ -2006,11 +2007,14 @@ func TestHandleNetworkEras(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
+	// Per OpenAPI 0.1.88, era items carry only start, end, and
+	// parameters; the era name must not appear in the response.
+	assert.NotContains(t, w.Body.String(), "\"era\"")
+
 	var resp []NetworkEraResponse
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 	require.Len(t, resp, 1)
-	assert.Equal(t, "Byron", resp[0].Era)
 	assert.Equal(t, uint64(0), resp[0].Start.Epoch)
 	require.NotNil(t, resp[0].End)
 	assert.Equal(t, uint64(208), resp[0].End.Epoch)

--- a/blockfrost/handlers.go
+++ b/blockfrost/handlers.go
@@ -368,7 +368,6 @@ func (b *Blockfrost) handleNetworkEras(
 			}
 		}
 		resp = append(resp, NetworkEraResponse{
-			Era: era.Era,
 			Start: NetworkEraBound{
 				Time:  era.Start.Time,
 				Slot:  era.Start.Slot,

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -153,9 +153,11 @@ type NetworkStake struct {
 	Active string `json:"active"`
 }
 
-// NetworkEraResponse represents a Blockfrost era summary.
+// NetworkEraResponse represents a Blockfrost era summary. Per Blockfrost
+// OpenAPI 0.1.88 (schema network-eras) each item carries only start, end,
+// and parameters; the human-readable era name is intentionally omitted to
+// keep the response shape compatible with the published schema.
 type NetworkEraResponse struct {
-	Era        string               `json:"era,omitempty"`
 	Start      NetworkEraBound      `json:"start"`
 	End        *NetworkEraBound     `json:"end"`
 	Parameters NetworkEraParameters `json:"parameters"`

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -76,9 +76,16 @@ type Utxo struct {
 	CollateralByTxId        []byte       `gorm:"index;size:32"`
 	ID                      uint         `gorm:"primarykey"`
 	AddedSlot               uint64       `gorm:"index"`
-	DeletedSlot             uint64       `gorm:"index:idx_utxo_deleted_staking_amount,priority:1"`
-	Amount                  types.Uint64 `gorm:"index:idx_utxo_deleted_staking_amount,priority:3"`
+	DeletedSlot             uint64       `gorm:"index:idx_utxo_deleted_staking_amount,priority:1;index:idx_utxo_deleted_payment_script,priority:1"`
+	Amount                  types.Uint64 `gorm:"index:idx_utxo_deleted_staking_amount,priority:3;index:idx_utxo_deleted_payment_script,priority:3"`
 	OutputIdx               uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
+	// PaymentScript is true when the output's payment credential is a
+	// script hash (as opposed to a key hash). It is derived from the
+	// address type at index time and used to compute the network's
+	// script-locked supply (see GetScriptLockedSupply). The composite
+	// index (deleted_slot, payment_script, amount) lets the supply sum
+	// scan only live script UTxOs.
+	PaymentScript bool `gorm:"index:idx_utxo_deleted_payment_script,priority:2"`
 }
 
 // UtxoWithOrdering includes UTxO with transaction ordering metadata
@@ -149,6 +156,13 @@ func UtxoLedgerToModel(
 	pkh := outAddr.PaymentKeyHash()
 	if pkh != zeroHash {
 		ret.PaymentKey = pkh.Bytes()
+	}
+	// The low bit of the address type distinguishes a script payment
+	// credential from a key-hash credential. Byron addresses (type
+	// 0b1000) never have this bit set, so they are correctly treated
+	// as non-script.
+	if outAddr.Type()&lcommon.AddressTypeScriptBit == lcommon.AddressTypeScriptBit {
+		ret.PaymentScript = true
 	}
 	skh := outAddr.StakeKeyHash()
 	if skh != zeroHash {

--- a/database/models/utxo_test.go
+++ b/database/models/utxo_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUtxoLedgerToModelPaymentScript verifies that PaymentScript is set
+// only when the output's payment credential is a script hash.
+func TestUtxoLedgerToModelPaymentScript(t *testing.T) {
+	payHash := bytes.Repeat([]byte{0xAB}, lcommon.AddressHashSize)
+
+	tests := []struct {
+		name       string
+		addrType   uint8
+		wantScript bool
+	}{
+		{
+			name:       "enterprise key payment credential",
+			addrType:   lcommon.AddressTypeKeyNone,
+			wantScript: false,
+		},
+		{
+			name:       "enterprise script payment credential",
+			addrType:   lcommon.AddressTypeScriptNone,
+			wantScript: true,
+		},
+		{
+			name:       "key payment, script staking",
+			addrType:   lcommon.AddressTypeKeyScript,
+			wantScript: false,
+		},
+		{
+			name:       "script payment, key staking",
+			addrType:   lcommon.AddressTypeScriptKey,
+			wantScript: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stakingHash []byte
+			switch tc.addrType {
+			case lcommon.AddressTypeKeyScript,
+				lcommon.AddressTypeScriptKey:
+				stakingHash = bytes.Repeat(
+					[]byte{0xCD},
+					lcommon.AddressHashSize,
+				)
+			}
+			addr, err := lcommon.NewAddressFromParts(
+				tc.addrType,
+				lcommon.AddressNetworkMainnet,
+				payHash,
+				stakingHash,
+			)
+			require.NoError(t, err)
+
+			utxo := ledger.Utxo{
+				Id: shelley.NewShelleyTransactionInput(
+					"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+					0,
+				),
+				Output: &shelley.ShelleyTransactionOutput{
+					OutputAddress: addr,
+					OutputAmount:  1_000_000,
+				},
+			}
+
+			model := UtxoLedgerToModel(utxo, 42)
+			assert.Equal(t, tc.wantScript, model.PaymentScript)
+			// Payment hash is recorded regardless of credential type.
+			assert.Equal(t, payHash, model.PaymentKey)
+		})
+	}
+}

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -195,6 +195,10 @@ var Manifest = []Index{
 		Notes:    "Composite SearchUtxos index; primary utxorpc query path",
 		Critical: true,
 	},
+	{
+		Model: &models.Utxo{}, Name: "idx_utxo_deleted_payment_script", Table: "utxo",
+		Notes: "Script-locked supply sum (blockfrost /network); low-frequency, lazy",
+	},
 
 	// transaction: BlockHash/Slot are query indexes; the
 	// uniqueIndex on Hash carries the ON CONFLICT target and

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -197,7 +197,8 @@ var Manifest = []Index{
 	},
 	{
 		Model: &models.Utxo{}, Name: "idx_utxo_deleted_payment_script", Table: "utxo",
-		Notes: "Script-locked supply sum (blockfrost /network); low-frequency, lazy",
+		Notes:    "Script-locked supply SUM (blockfrost /network); live query path",
+		Critical: true,
 	},
 
 	// transaction: BlockHash/Slot are query indexes; the

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -70,7 +70,7 @@ func TestCriticalManifestNotEmpty(t *testing.T) {
 		t.Fatal("CriticalManifest returned empty slice")
 	}
 	// Pin the expected count so accidental de-classification is caught.
-	const wantCritical = 11
+	const wantCritical = 12
 	if len(critical) != wantCritical {
 		t.Errorf("CriticalManifest: got %d entries, want %d — update this constant if the classification changed intentionally", len(critical), wantCritical)
 	}

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -420,7 +420,11 @@ func (d *MetadataStoreMysql) Close() error {
 	if d.db == nil {
 		return nil
 	}
-	// get DB handle from gorm.DB
+	// Stop the PreparedStmtDB LRU goroutine before closing the underlying pool
+	// so it cannot access the pool after it is closed.
+	if ps, ok := d.db.ConnPool.(*gorm.PreparedStmtDB); ok {
+		ps.Close()
+	}
 	db, err := d.DB().DB()
 	if err != nil {
 		return err

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -264,6 +264,28 @@ func (d *MetadataStoreMysql) GetControlledAmountByStakingKey(
 	return total, nil
 }
 
+// GetScriptLockedSupply returns the sum of lovelace held in live UTxOs
+// whose payment credential is a script.
+func (d *MetadataStoreMysql) GetScriptLockedSupply(
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for script-locked supply: %w",
+			err,
+		)
+	}
+	var total uint64
+	if err := db.Model(&models.Utxo{}).
+		Where("payment_script = ? AND deleted_slot = 0", true).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf("get script-locked supply: %w", err)
+	}
+	return total, nil
+}
+
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -316,7 +316,11 @@ func (d *MetadataStorePostgres) Close() error {
 	if d.db == nil {
 		return nil
 	}
-	// get DB handle from gorm.DB
+	// Stop the PreparedStmtDB LRU goroutine before closing the underlying pool
+	// so it cannot access the pool after it is closed.
+	if ps, ok := d.db.ConnPool.(*gorm.PreparedStmtDB); ok {
+		ps.Close()
+	}
 	db, err := d.DB().DB()
 	if err != nil {
 		return err

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -105,6 +105,28 @@ func (d *MetadataStorePostgres) GetControlledAmountByStakingKey(
 	return total, nil
 }
 
+// GetScriptLockedSupply returns the sum of lovelace held in live UTxOs
+// whose payment credential is a script.
+func (d *MetadataStorePostgres) GetScriptLockedSupply(
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for script-locked supply: %w",
+			err,
+		)
+	}
+	var total uint64
+	if err := db.Model(&models.Utxo{}).
+		Where("payment_script = ? AND deleted_slot = 0", true).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf("get script-locked supply: %w", err)
+	}
+	return total, nil
+}
+
 // GetUtxosAddedAfterSlot returns a list of Utxos added after a given slot
 func (d *MetadataStorePostgres) GetUtxosAddedAfterSlot(
 	slot uint64,

--- a/database/plugin/metadata/sqlite/bulk_sql.go
+++ b/database/plugin/metadata/sqlite/bulk_sql.go
@@ -53,7 +53,7 @@ var (
 		"transaction_id", "collateral_return_for_tx_id", "tx_id",
 		"payment_key", "staking_key", "datum_hash", "spent_at_tx_id",
 		"referenced_by_tx_id", "collateral_by_tx_id", "added_slot",
-		"deleted_slot", "amount", "output_idx",
+		"deleted_slot", "amount", "output_idx", "payment_script",
 	}
 	assetCols = []string{
 		"name", "name_hex", "policy_id", "fingerprint", "utxo_id", "amount",
@@ -77,7 +77,7 @@ func appendUtxoRow(dst []any, u *models.Utxo) []any {
 		u.TransactionID, u.CollateralReturnForTxID, u.TxId,
 		u.PaymentKey, u.StakingKey, u.DatumHash, u.SpentAtTxId,
 		u.ReferencedByTxId, u.CollateralByTxId, u.AddedSlot,
-		u.DeletedSlot, u.Amount, u.OutputIdx,
+		u.DeletedSlot, u.Amount, u.OutputIdx, u.PaymentScript,
 	)
 }
 

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -521,8 +521,13 @@ func (d *MetadataStoreSqlite) Close() error {
 	d.timerMutex.Unlock()
 
 	var errs []error
-	// Close read pool first (if separate from write pool)
+	// Close read pool first (if separate from write pool). Stop the
+	// PreparedStmtDB LRU goroutine first so it does not access the pool
+	// after the underlying sql.DB is closed.
 	if d.readDB != nil && d.readDB != d.db {
+		if ps, ok := d.readDB.ConnPool.(*gorm.PreparedStmtDB); ok {
+			ps.Close()
+		}
 		if readSqlDB, err := d.readDB.DB(); err != nil {
 			errs = append(errs, err)
 		} else {
@@ -533,6 +538,9 @@ func (d *MetadataStoreSqlite) Close() error {
 	}
 	// Close write pool
 	if d.db != nil {
+		if ps, ok := d.db.ConnPool.(*gorm.PreparedStmtDB); ok {
+			ps.Close()
+		}
 		if db, err := d.DB().DB(); err != nil {
 			errs = append(errs, err)
 		} else {

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -384,6 +384,28 @@ func (d *MetadataStoreSqlite) GetControlledAmountByStakingKey(
 	return total, nil
 }
 
+// GetScriptLockedSupply returns the sum of lovelace held in live UTxOs
+// whose payment credential is a script.
+func (d *MetadataStoreSqlite) GetScriptLockedSupply(
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for script-locked supply: %w",
+			err,
+		)
+	}
+	var total uint64
+	if err := db.Model(&models.Utxo{}).
+		Where("payment_script = ? AND deleted_slot = 0", true).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf("get script-locked supply: %w", err)
+	}
+	return total, nil
+}
+
 // GetUtxosByAddressWithOrdering returns UTxOs matching q (OR of addresses, optional asset).
 func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -401,3 +401,55 @@ func sortUtxoIds(ids []models.UtxoId) {
 		return ids[i].Idx < ids[j].Idx
 	})
 }
+
+func TestGetScriptLockedSupply(t *testing.T) {
+	store := setupTestDB(t)
+
+	rows := []models.Utxo{
+		// Live key-hash UTxO: excluded.
+		{
+			TxId:      bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx: 0,
+			AddedSlot: 100,
+			Amount:    types.Uint64(1_000_000),
+		},
+		// Live script UTxOs: counted.
+		{
+			TxId:          bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:     0,
+			AddedSlot:     100,
+			Amount:        types.Uint64(2_000_000),
+			PaymentScript: true,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:     0,
+			AddedSlot:     200,
+			Amount:        types.Uint64(3_000_000),
+			PaymentScript: true,
+		},
+		// Spent script UTxO: excluded (deleted_slot != 0).
+		{
+			TxId:          bytes.Repeat([]byte{0x04}, 32),
+			OutputIdx:     0,
+			AddedSlot:     100,
+			DeletedSlot:   150,
+			Amount:        types.Uint64(9_000_000),
+			PaymentScript: true,
+		},
+	}
+	for i := range rows {
+		require.NoError(t, store.DB().Create(&rows[i]).Error)
+	}
+
+	got, err := store.GetScriptLockedSupply(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5_000_000), got)
+}
+
+func TestGetScriptLockedSupplyEmpty(t *testing.T) {
+	store := setupTestDB(t)
+	got, err := store.GetScriptLockedSupply(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), got)
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -682,6 +682,11 @@ type MetadataStore interface {
 	// amounts controlled by the given staking key.
 	GetControlledAmountByStakingKey([]byte, types.Txn) (uint64, error)
 
+	// GetScriptLockedSupply returns the sum of lovelace held in live
+	// UTxOs whose payment credential is a script. This is the network's
+	// script-locked supply (blockfrost /network supply.locked).
+	GetScriptLockedSupply(types.Txn) (uint64, error)
+
 	// GetUtxosByAddressWithOrdering runs q against live UTxOs with ordering metadata.
 	// See models.UtxoWithOrderingQuery. q must be non-nil.
 	GetUtxosByAddressWithOrdering(

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -120,16 +120,17 @@ type EraBound struct {
 // ParsedUTxO represents a parsed unspent transaction output ready
 // for conversion to Dingo's database model.
 type ParsedUTxO struct {
-	TxHash      []byte // 32 bytes
-	OutputIndex uint32
-	Address     []byte // raw address bytes
-	PaymentKey  []byte // 28 bytes, extracted from address
-	StakingKey  []byte // 28 bytes, extracted from address
-	Amount      uint64 // lovelace
-	Assets      []ParsedAsset
-	DatumHash   []byte // optional
-	Datum       []byte // optional inline datum CBOR
-	ScriptRef   []byte // optional reference script CBOR
+	TxHash        []byte // 32 bytes
+	OutputIndex   uint32
+	Address       []byte // raw address bytes
+	PaymentKey    []byte // 28 bytes, extracted from address
+	StakingKey    []byte // 28 bytes, extracted from address
+	PaymentScript bool   // true when payment credential is a script hash
+	Amount        uint64 // lovelace
+	Assets        []ParsedAsset
+	DatumHash     []byte // optional
+	Datum         []byte // optional inline datum CBOR
+	ScriptRef     []byte // optional reference script CBOR
 }
 
 // ParsedAsset represents a native asset within a UTxO.

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -435,6 +435,8 @@ func extractAddressKeys(addr []byte, result *ParsedUTxO) {
 		// Base address: 1 header + 28 payment + 28 staking
 		if paymentIsKey {
 			result.PaymentKey = bytes.Clone(addr[1:29])
+		} else {
+			result.PaymentScript = true
 		}
 		if addrType <= 1 { // staking is key for types 0,1
 			result.StakingKey = bytes.Clone(addr[29:57])
@@ -443,11 +445,15 @@ func extractAddressKeys(addr []byte, result *ParsedUTxO) {
 		// Pointer address: 1 header + 28 payment + pointer
 		if paymentIsKey {
 			result.PaymentKey = bytes.Clone(addr[1:29])
+		} else {
+			result.PaymentScript = true
 		}
 	case (addrType == 6 || addrType == 7) && len(addr) >= 29:
 		// Enterprise address: 1 header + 28 payment
 		if paymentIsKey {
 			result.PaymentKey = bytes.Clone(addr[1:29])
+		} else {
+			result.PaymentScript = true
 		}
 	}
 }
@@ -499,6 +505,9 @@ func parseCborTxOut(
 	skh := addr.StakeKeyHash()
 	if skh != zeroBlake2b224 {
 		result.StakingKey = skh.Bytes()
+	}
+	if addr.Type()&lcommon.AddressTypeScriptBit == lcommon.AddressTypeScriptBit {
+		result.PaymentScript = true
 	}
 
 	if dh := txOut.DatumHash(); dh != nil {
@@ -698,15 +707,16 @@ func parseIndefiniteUTxOMapWithProgress(
 // UTxOToModel converts a ParsedUTxO to a Dingo database Utxo model.
 func UTxOToModel(u *ParsedUTxO, slot uint64) models.Utxo {
 	utxo := models.Utxo{
-		TxId:       u.TxHash,
-		OutputIdx:  u.OutputIndex,
-		PaymentKey: u.PaymentKey,
-		StakingKey: u.StakingKey,
-		Amount:     types.Uint64(u.Amount),
-		AddedSlot:  slot,
-		DatumHash:  u.DatumHash,
-		Datum:      u.Datum,
-		ScriptRef:  u.ScriptRef,
+		TxId:          u.TxHash,
+		OutputIdx:     u.OutputIndex,
+		PaymentKey:    u.PaymentKey,
+		StakingKey:    u.StakingKey,
+		PaymentScript: u.PaymentScript,
+		Amount:        types.Uint64(u.Amount),
+		AddedSlot:     slot,
+		DatumHash:     u.DatumHash,
+		Datum:         u.Datum,
+		ScriptRef:     u.ScriptRef,
 	}
 
 	// Convert assets

--- a/ledgerstate/utxo_test.go
+++ b/ledgerstate/utxo_test.go
@@ -98,6 +98,8 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			}
 			if tc.wantStakeKey {
 				require.Equal(t, stakeHash, result.StakingKey, "StakingKey")
+			} else {
+				require.Empty(t, result.StakingKey, "StakingKey should be empty for non-staking-key address types")
 			}
 		})
 	}

--- a/ledgerstate/utxo_test.go
+++ b/ledgerstate/utxo_test.go
@@ -21,3 +21,101 @@ func TestDecodeTxIn_BinaryKeyUsesBigEndianOutputIndex(t *testing.T) {
 	require.Equal(t, txHash, decodedHash)
 	require.Equal(t, uint32(1), outputIndex)
 }
+
+// buildShelleyAddr constructs a minimal Shelley address byte slice:
+// header (addrType<<4 | networkId), 28-byte payment hash, 28-byte staking hash (for base addrs).
+func buildShelleyAddr(addrType, networkID byte, paymentHash, stakingHash []byte) []byte {
+	addr := []byte{(addrType << 4) | networkID}
+	addr = append(addr, paymentHash...)
+	if stakingHash != nil {
+		addr = append(addr, stakingHash...)
+	}
+	return addr
+}
+
+func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
+	t.Parallel()
+
+	payHash := bytes.Repeat([]byte{0x11}, 28)
+	stakeHash := bytes.Repeat([]byte{0x22}, 28)
+
+	tests := []struct {
+		name          string
+		addr          []byte
+		wantScript    bool
+		wantPayKey    bool
+		wantStakeKey  bool
+	}{
+		{
+			// Type 0: key payment + key staking — NOT script
+			name:         "type0_key_payment",
+			addr:         buildShelleyAddr(0, 1, payHash, stakeHash),
+			wantScript:   false,
+			wantPayKey:   true,
+			wantStakeKey: true,
+		},
+		{
+			// Type 1: script payment + key staking
+			name:         "type1_script_payment_key_staking",
+			addr:         buildShelleyAddr(1, 1, payHash, stakeHash),
+			wantScript:   true,
+			wantPayKey:   false,
+			wantStakeKey: true,
+		},
+		{
+			// Type 5: script payment + pointer staking (enterprise-like min length)
+			name:        "type5_script_payment_pointer",
+			addr:        buildShelleyAddr(5, 1, payHash, nil),
+			wantScript:  true,
+			wantPayKey:  false,
+		},
+		{
+			// Type 6: enterprise key payment — NOT script
+			name:       "type6_enterprise_key",
+			addr:       buildShelleyAddr(6, 1, payHash, nil),
+			wantScript: false,
+			wantPayKey: true,
+		},
+		{
+			// Type 7: enterprise script payment
+			name:       "type7_enterprise_script",
+			addr:       buildShelleyAddr(7, 1, payHash, nil),
+			wantScript: true,
+			wantPayKey: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := &ParsedUTxO{}
+			extractAddressKeys(tc.addr, result)
+			require.Equal(t, tc.wantScript, result.PaymentScript, "PaymentScript")
+			if tc.wantPayKey {
+				require.Equal(t, payHash, result.PaymentKey, "PaymentKey")
+			} else {
+				require.Empty(t, result.PaymentKey, "PaymentKey should be empty for script payment")
+			}
+			if tc.wantStakeKey {
+				require.Equal(t, stakeHash, result.StakingKey, "StakingKey")
+			}
+		})
+	}
+}
+
+func TestUTxOToModel_PropagatesPaymentScript(t *testing.T) {
+	t.Parallel()
+
+	txHash := bytes.Repeat([]byte{0xab}, 32)
+
+	for _, wantScript := range []bool{false, true} {
+		u := &ParsedUTxO{
+			TxHash:        txHash,
+			OutputIndex:   0,
+			Amount:        1_000_000,
+			PaymentScript: wantScript,
+		}
+		m := UTxOToModel(u, 100)
+		require.Equal(t, wantScript, m.PaymentScript)
+	}
+}


### PR DESCRIPTION
Closes #2490 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute `supply.locked` in `blockfrost` `/network` by summing lovelace in live script-payment UTxOs, and subtract it from `supply.circulating`. Align `/network/eras` with OpenAPI 0.1.88 by omitting the era name.

- **New Features**
  - Add `payment_script` to `utxo` with composite index `(deleted_slot, payment_script, amount)`; set from address type during indexing and ledger import.
  - Implement `GetScriptLockedSupply` for SQLite, Postgres, and MySQL; wire into `/network`.
  - Close `gorm.PreparedStmtDB` on shutdown (SQLite read/write, Postgres, MySQL).

- **Migration**
  - Run DB migrations to add `payment_script` and index `idx_utxo_deleted_payment_script`.
  - After upgrade, `supply.locked` counts only UTxOs created post-upgrade until you rebuild from immutable data (`dingo load` or Mithril import). Clients: `/network/eras` items no longer include the `era` field.

<sup>Written for commit 851a88ae16f436d997a7a0b39dc79b3fca03e1e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network API endpoint now returns accurate script-locked supply information instead of a placeholder value.

* **Updates**
  * Network eras endpoint response structure updated; era name field removed.
  * Database infrastructure enhanced to track and query script-locked supply metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->