### PR TITLE
fix: prevent near-tip stall

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -908,6 +908,11 @@ The selector tracks tips from all connected peers, honors peer eligibility and
 priority updates from peer governance, and switches the active chainsync
 connection when a better chain is found.
 
+Bootstrap topology peers remain chain-selection eligible after bootstrap exit
+as a fallback ingress source, but peer governance lowers their priority to zero.
+This lets non-bootstrap peers win same-tip transport selection without
+stranding ChainSync when the bootstrap peer is still the only usable upstream.
+
 ## Network and Protocol Handling
 
 ### Ouroboros Protocol Stack
@@ -1017,6 +1022,13 @@ Genesis initial sync while preserving the existing `UseLedgerAfterSlot` path:
 later ledger peer refreshes still query the live ledger/database provider.
 If the snapshot produces no usable peers, startup falls back to topology
 bootstrap peers.
+
+Bootstrap peers are used during initial sync and recovery. Bootstrap exit can
+be triggered by enough connected ledger peers, or by the configured slot/progress
+thresholds once at least one non-bootstrap client-capable successor is
+available. Exiting bootstrap preserves bootstrap peer identity for recovery and
+lowers bootstrap chain-selection priority instead of making connected bootstrap
+ChainSync streams ineligible.
 
 ## Transaction Mempool
 
@@ -1311,6 +1323,11 @@ type EpochTransitionEvent struct {
     SnapshotSlot      uint64  // Typically boundary - 1
 }
 ```
+
+Epoch transition events may come from block processing or the slot clock. The
+slot clock only emits proactive epoch transitions when the ledger tip is within
+the current era's stability window of the upstream tip; while farther behind,
+block processing owns historical epoch transitions during catch-up.
 
 ### Rollback Support
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1281,8 +1281,8 @@ func (ls *LedgerState) handleSlotTicks() {
 
 		// During catch up, don't emit slot-based epoch events. Block
 		// processing handles epoch transitions for historical data. We
-		// consider the node "near tip" when the ledger tip is within 95%
-		// of the upstream peer's tip slot.
+		// consider the node "near tip" when the ledger tip is inside the
+		// current era's stability window from the upstream peer's tip.
 		if !ls.isNearTip(tipSlot) {
 			if tick.IsEpochStart {
 				logger.Debug(
@@ -1428,19 +1428,21 @@ func (ls *LedgerState) resetNextEpochNonceReady() {
 	ls.nextNonceReadyEpoch.Store(0)
 }
 
-// isNearTip returns true when the given slot is within 95% of the
-// upstream peer's tip. This is used to decide whether to emit
-// slot-clock epoch events. During initial catch-up the node is far
-// behind the tip and these checks are skipped; once the node is close
-// to the tip they are always on. Returns false when no upstream tip is
-// known yet (no peer connected), since we can't determine proximity.
+// isNearTip returns true when the given slot is inside the current era's
+// stability window from the upstream peer's tip. This is used to decide
+// whether to emit slot-clock epoch events. During initial catch-up the node is
+// far behind the tip and these checks are skipped; once the node is close to
+// the tip they are always on. Returns false when no upstream tip is known yet
+// (no peer connected), since we can't determine proximity.
 func (ls *LedgerState) isNearTip(slot uint64) bool {
 	upstreamTip := ls.syncUpstreamTipSlot.Load()
 	if upstreamTip == 0 {
 		return false
 	}
-	// 95% threshold using division to avoid uint64 overflow.
-	return slot >= upstreamTip-upstreamTip/20
+	if slot >= upstreamTip {
+		return true
+	}
+	return upstreamTip-slot <= ls.calculateStabilityWindow()
 }
 
 func (ls *LedgerState) scheduleCleanupConsumedUtxos() {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -954,6 +954,20 @@ func newNonceReadyTestLedgerState(
 	}
 }
 
+func TestLedgerStateIsNearTipUsesStabilityWindow(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newNonceReadyTestConfig(t),
+		},
+		currentEra: eras.ShelleyEraDesc,
+	}
+	ls.syncUpstreamTipSlot.Store(1000)
+
+	assert.False(t, ls.isNearTip(993), "gap above 3k/f should be catch-up")
+	assert.True(t, ls.isNearTip(994), "gap equal to 3k/f should be near tip")
+	assert.True(t, ls.isNearTip(1001), "local tip beyond upstream is near tip")
+}
+
 func TestNextEpochNonceReadyCutoffSlot(t *testing.T) {
 	byronGenesisJSON := `{
 		"protocolConsts": {

--- a/peergov/bootstrap.go
+++ b/peergov/bootstrap.go
@@ -20,10 +20,10 @@ import (
 )
 
 // shouldExitBootstrap checks if conditions are met to exit bootstrap mode.
-// Returns true if ANY of these conditions are met:
-// 1. Current slot > UseLedgerAfterSlot (ledger peers are enabled)
-// 2. Ledger peer count >= MinLedgerPeersForExit
-// 3. Sync progress >= SyncProgressForExit
+// Returns true if any of these conditions are met:
+// 1. Ledger peer count >= MinLedgerPeersForExit
+// 2. Current slot > UseLedgerAfterSlot and a non-bootstrap successor exists
+// 3. Sync progress >= SyncProgressForExit and a non-bootstrap successor exists
 // Must be called with p.mu held.
 func (p *PeerGovernor) shouldExitBootstrap() (bool, string) {
 	// Already exited
@@ -43,17 +43,7 @@ func (p *PeerGovernor) shouldExitBootstrap() (bool, string) {
 		return false, ""
 	}
 
-	// Condition 1: Current slot > UseLedgerAfterSlot
-	if p.config.UseLedgerAfterSlot > 0 && p.config.LedgerPeerProvider != nil {
-		currentSlot := p.config.LedgerPeerProvider.CurrentSlot()
-		// Safe conversion: UseLedgerAfterSlot is already checked to be > 0
-		useLedgerAfterSlot := uint64(p.config.UseLedgerAfterSlot) // #nosec G115
-		if currentSlot > useLedgerAfterSlot {
-			return true, "slot threshold reached"
-		}
-	}
-
-	// Condition 2: Ledger peer count >= MinLedgerPeersForExit
+	// Condition 1: Ledger peer count >= MinLedgerPeersForExit
 	if p.config.MinLedgerPeersForExit > 0 {
 		ledgerPeerCount := 0
 		for _, peer := range p.peers {
@@ -72,20 +62,73 @@ func (p *PeerGovernor) shouldExitBootstrap() (bool, string) {
 		}
 	}
 
-	// Condition 3: Sync progress >= SyncProgressForExit
+	successorCount := p.bootstrapExitSuccessorCountLocked()
+
+	// Condition 2: Current slot > UseLedgerAfterSlot. The slot threshold
+	// only means ledger peers may be discovered; do not disable the
+	// bootstrap source until some non-bootstrap client-capable peer can
+	// carry ChainSync/BlockFetch forward.
+	if p.config.UseLedgerAfterSlot > 0 && p.config.LedgerPeerProvider != nil {
+		currentSlot := p.config.LedgerPeerProvider.CurrentSlot()
+		// Safe conversion: UseLedgerAfterSlot is already checked to be > 0
+		useLedgerAfterSlot := uint64(p.config.UseLedgerAfterSlot) // #nosec G115
+		if currentSlot > useLedgerAfterSlot {
+			if successorCount > 0 {
+				return true, "slot threshold reached"
+			}
+			p.config.Logger.Debug(
+				"bootstrap exit delayed: no non-bootstrap successor peers",
+				"reason", "slot threshold reached",
+				"successor_count", successorCount,
+			)
+		}
+	}
+
+	// Condition 3: Sync progress >= SyncProgressForExit. Absolute slot
+	// ratios can report 99%+ while still tens of thousands of slots behind;
+	// use the threshold only after another trusted client-capable source is
+	// available so bootstrap exit cannot strand chain sync.
 	if p.config.SyncProgressForExit > 0 &&
 		p.config.SyncProgressProvider != nil {
 		syncProgress := p.config.SyncProgressProvider.SyncProgress()
 		if syncProgress >= p.config.SyncProgressForExit {
-			return true, fmt.Sprintf(
-				"sync progress (%.2f%%) >= threshold (%.2f%%)",
-				syncProgress*100,
-				p.config.SyncProgressForExit*100,
+			if successorCount > 0 {
+				return true, fmt.Sprintf(
+					"sync progress (%.2f%%) >= threshold (%.2f%%)",
+					syncProgress*100,
+					p.config.SyncProgressForExit*100,
+				)
+			}
+			p.config.Logger.Debug(
+				"bootstrap exit delayed: no non-bootstrap successor peers",
+				"reason", "sync progress threshold reached",
+				"sync_progress", syncProgress,
+				"sync_progress_threshold", p.config.SyncProgressForExit,
+				"successor_count", successorCount,
 			)
 		}
 	}
 
 	return false, ""
+}
+
+// bootstrapExitSuccessorCountLocked returns the number of connected,
+// non-bootstrap peers that can continue feeding ChainSync/BlockFetch after
+// bootstrap priority is lowered. Must be called with p.mu held.
+func (p *PeerGovernor) bootstrapExitSuccessorCountLocked() int {
+	successorCount := 0
+	for _, peer := range p.peers {
+		if peer == nil ||
+			peer.Source == PeerSourceTopologyBootstrapPeer ||
+			chainSelectionPriority(peer.Source) == 0 ||
+			(peer.State != PeerStateHot && peer.State != PeerStateWarm) {
+			continue
+		}
+		if chainSelectionEligible(peer.Source, peer.Connection) {
+			successorCount++
+		}
+	}
+	return successorCount
 }
 
 // exitBootstrap marks bootstrap as exited while preserving bootstrap-source

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -6033,12 +6033,49 @@ func TestPeerGovernor_ShouldExitBootstrap_SlotThreshold(t *testing.T) {
 		Source:  PeerSourceTopologyBootstrapPeer,
 		State:   PeerStateWarm,
 	})
+	pg.peers = append(pg.peers, &Peer{
+		Address:    "192.168.1.1:3001",
+		Source:     PeerSourceP2PGossip,
+		State:      PeerStateWarm,
+		Connection: &PeerConnection{IsClient: true},
+	})
 
 	shouldExit, reason := pg.shouldExitBootstrap()
 	pg.mu.Unlock()
 
 	assert.True(t, shouldExit, "should exit bootstrap when slot > threshold")
 	assert.Equal(t, "slot threshold reached", reason)
+}
+
+func TestPeerGovernor_ShouldExitBootstrap_SlotThreshold_NoSuccessor(
+	t *testing.T,
+) {
+	mockProvider := &mockLedgerPeerProvider{
+		currentSlot: 5001, // Above threshold
+	}
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		LedgerPeerProvider: mockProvider,
+		UseLedgerAfterSlot: 5000, // Threshold
+	})
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:    "44.0.0.1:3001",
+		Source:     PeerSourceTopologyBootstrapPeer,
+		State:      PeerStateHot,
+		Connection: &PeerConnection{IsClient: true},
+	})
+
+	shouldExit, _ := pg.shouldExitBootstrap()
+	pg.mu.Unlock()
+
+	assert.False(
+		t,
+		shouldExit,
+		"should keep bootstrap when no non-bootstrap peer can carry chainsync",
+	)
 }
 
 func TestPeerGovernor_ShouldExitBootstrap_SlotThreshold_NotReached(
@@ -6228,6 +6265,12 @@ func TestPeerGovernor_ShouldExitBootstrap_SyncProgress(t *testing.T) {
 		Source:  PeerSourceTopologyBootstrapPeer,
 		State:   PeerStateWarm,
 	})
+	pg.peers = append(pg.peers, &Peer{
+		Address:    "192.168.1.1:3001",
+		Source:     PeerSourceP2PGossip,
+		State:      PeerStateWarm,
+		Connection: &PeerConnection{IsClient: true},
+	})
 
 	shouldExit, reason := pg.shouldExitBootstrap()
 	pg.mu.Unlock()
@@ -6238,6 +6281,37 @@ func TestPeerGovernor_ShouldExitBootstrap_SyncProgress(t *testing.T) {
 		"should exit bootstrap when sync progress >= threshold",
 	)
 	assert.Contains(t, reason, "sync progress")
+}
+
+func TestPeerGovernor_ShouldExitBootstrap_SyncProgress_NoSuccessor(
+	t *testing.T,
+) {
+	mockSync := &mockSyncProgressProvider{
+		progress: 0.9995,
+	}
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		SyncProgressProvider: mockSync,
+		SyncProgressForExit:  0.95,
+	})
+
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:    "44.0.0.1:3001",
+		Source:     PeerSourceTopologyBootstrapPeer,
+		State:      PeerStateHot,
+		Connection: &PeerConnection{IsClient: true},
+	})
+
+	shouldExit, _ := pg.shouldExitBootstrap()
+	pg.mu.Unlock()
+
+	assert.False(
+		t,
+		shouldExit,
+		"should keep bootstrap when high absolute-slot progress has no successor",
+	)
 }
 
 func TestPeerGovernor_ShouldExitBootstrap_SyncProgress_NotReached(
@@ -6432,7 +6506,7 @@ func TestPeerGovernor_ExitBootstrapDoesNotReportDemotions(t *testing.T) {
 	)
 }
 
-func TestPeerGovernor_ExitBootstrapPublishesChainSelectionDowngrade(
+func TestPeerGovernor_ExitBootstrapLowersBootstrapPriority(
 	t *testing.T,
 ) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
@@ -6458,18 +6532,6 @@ func TestPeerGovernor_ExitBootstrapPublishesChainSelectionDowngrade(
 
 	assert.Equal(
 		t,
-		PeerEligibilityChangedEvent{
-			ConnectionId: connId,
-			Eligible:     false,
-		},
-		requirePendingEventData[PeerEligibilityChangedEvent](
-			t,
-			events,
-			PeerEligibilityChangedEventType,
-		),
-	)
-	assert.Equal(
-		t,
 		PeerPriorityChangedEvent{
 			ConnectionId: connId,
 			Priority:     0,
@@ -6480,6 +6542,13 @@ func TestPeerGovernor_ExitBootstrapPublishesChainSelectionDowngrade(
 			PeerPriorityChangedEventType,
 		),
 	)
+	for _, evt := range events {
+		require.NotEqual(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			evt.eventType,
+		)
+	}
 }
 
 func TestPeerGovernor_ExitBootstrap_PreventsPromotion(t *testing.T) {
@@ -6581,18 +6650,6 @@ func TestPeerGovernor_BootstrapRecoveryPublishesChainSelectionUpgrade(
 
 	assert.Equal(
 		t,
-		PeerEligibilityChangedEvent{
-			ConnectionId: connId,
-			Eligible:     true,
-		},
-		requirePendingEventData[PeerEligibilityChangedEvent](
-			t,
-			events,
-			PeerEligibilityChangedEventType,
-		),
-	)
-	assert.Equal(
-		t,
 		PeerPriorityChangedEvent{
 			ConnectionId: connId,
 			Priority:     40,
@@ -6603,6 +6660,13 @@ func TestPeerGovernor_BootstrapRecoveryPublishesChainSelectionUpgrade(
 			PeerPriorityChangedEventType,
 		),
 	)
+	for _, evt := range events {
+		require.NotEqual(
+			t,
+			event.EventType(PeerEligibilityChangedEventType),
+			evt.eventType,
+		)
+	}
 }
 
 func TestPeerGovernor_BootstrapRecovery_NotNeededWithWarmCandidates(

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -493,7 +493,10 @@ func chainSelectionState(
 	eligible := chainSelectionEligible(source, conn)
 	priority := chainSelectionPriority(source)
 	if source == PeerSourceTopologyBootstrapPeer && bootstrapExited {
-		eligible = false
+		// Bootstrap peers remain eligible as a fallback ingress source after
+		// bootstrap exit. Lowering priority lets ledger/gossip/topology peers
+		// win same-tip transport selection without stranding ChainSync when no
+		// replacement peer is actually usable yet.
 		priority = 0
 	}
 	return chainSelectionPeerState{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent near-tip stalls by using the era stability window for tip proximity and by delaying bootstrap exit until a non-bootstrap successor is available. Bootstrap peers now stay eligible with priority 0 so ChainSync isn’t stranded.

- **Bug Fixes**
  - `ledger`: Replace 95% rule with stability-window check in `isNearTip`; emit slot-clock epoch events only when near tip; add tests.
  - `peergov`: Require at least one non-bootstrap client-capable successor before exiting on slot/progress thresholds; lower bootstrap priority to 0 instead of toggling eligibility; add successor-count helper and tests.
  - Chain selection: Keep bootstrap peers eligible after exit but at priority 0 so non-bootstrap peers win when ready.
  - Docs: Update ARCHITECTURE on bootstrap exit behavior and epoch transition handling.

<sup>Written for commit 3668ca733bcd8fcadddcc5088bff90e1c890c9de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

