### PR TITLE
refactor(bark): move pruning out of bark

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,14 +96,14 @@ graph TB
         Bark["Bark<br/><i>bark/</i>"]
     end
 
-    subgraph "Archive Support"
-        BPruner["Bark Pruner<br/><i>bark/pruner.go</i>"]
+    subgraph "History Expiry"
+        HExpiry["History Expiry<br/><i>internal/historyexpiry/</i>"]
     end
 
     EB["EventBus<br/><i>event/</i>"]
 
     Node --> CM & PG & OB & ChM & LS & MP & DB & EB
-    Node -.->|"optional"| BF & LE & URPC & BFA & Mesh & Bark & BPruner
+    Node -.->|"optional"| BF & LE & URPC & BFA & Mesh & Bark & HExpiry
 
     PG -->|"outbound conn requests"| CM
     CM -->|"connections"| OB
@@ -113,7 +113,7 @@ graph TB
     LS -->|"validate txs"| MP
     ChM --> DB
     DB --> Blob & Meta
-    BPruner --> LS & DB
+    HExpiry --> LS & DB
     BF --> LE & MP & ChM
     SM -->|"stake snapshots"| DB
     CSel -->|"switch active peer"| CS
@@ -221,7 +221,7 @@ graph LR
     utxorpc --> ledger & ledger_eras & mempool
     mesh --> chain & db & db_models & ev & ledger & mempool
     blockfrost --> db & db_models & db_meta_util & ledger & ledger_eras & mempool
-    bark --> db & db_blob & db_types & ledger
+    bark --> db & db_blob & db_types
 ```
 
 ### Data Flow
@@ -526,8 +526,7 @@ dingo/
 ├── bark/                # Bark Dingo-to-Dingo C2 and archive protocol
 │   ├── bark.go          # Bark server lifecycle and transport setup
 │   ├── archive.go       # Archive service interface
-│   ├── blob.go          # Remote archive blob adapter
-│   └── pruner.go        # Ledger-window-based local block pruning
+│   └── blob.go          # Remote archive blob adapter
 ├── mithril/             # Mithril snapshot bootstrap
 │   ├── bootstrap.go     # Bootstrap orchestration
 │   ├── client.go        # Mithril aggregator client
@@ -545,6 +544,8 @@ dingo/
 │   ├── node/            # Node orchestration (CLI wiring)
 │   │   ├── node.go      # Run(), signal handling, metrics server
 │   │   └── load.go      # Block loading implementation
+│   ├── historyexpiry/   # Ledger-window-based local block history expiry
+│   │   └── pruner.go    # Background expiry scanner
 │   ├── test/            # Test utilities
 │   │   ├── conformance/ # Amaru conformance tests
 │   │   ├── devnet/      # DevNet end-to-end tests
@@ -573,7 +574,7 @@ type Node struct {
     snapshotMgr    *snapshot.Manager              // Stake snapshot capture
     utxorpc        *utxorpc.Utxorpc               // UTxO RPC server
     bark           *bark.Bark                     // Bark C2/archive server
-    barkPruner     *bark.Pruner                   // Archive-backed local pruning
+    historyExpiry  *historyexpiry.Pruner          // Local block history expiry
     blockfrostAPI  *blockfrost.Blockfrost         // Blockfrost REST API
     meshAPI        *mesh.Server                   // Mesh (Rosetta) API
     ouroboros      *ouroboros.Ouroboros            // Protocol handlers
@@ -593,7 +594,7 @@ When `Node.Run()` is called, components are initialized in this order:
  3. ChainManager initialization and block-proposed event subscription
  4. Ouroboros protocol handler creation
  5. LedgerState creation (UTXO tracking, validation)
- 6. Bark remote archive adapter and pruner (if configured)
+ 6. Bark remote archive adapter and History Expiry worker (if configured)
  7. Database recovery, if startup detects a recoverable timestamp conflict
  8. LedgerState start
  9. Snapshot manager start (captures genesis snapshot)
@@ -725,24 +726,26 @@ Dingo supports two storage modes, configured via `storageMode`:
 - `core` (default): Minimal storage for chain following and block production.
 - `api`: Extended storage with transaction indexes, address lookups, and asset tracking. Required when any client-facing API server (Blockfrost, Mesh, UTxO RPC) is enabled. Bark is a separate Dingo-to-Dingo protocol and is not part of that API surface.
 
-### Archive And Pruning Topology
+### Archive And History Expiry Topology
 
-Dingo's blob-store abstraction supports an archive/pruning deployment pattern:
+Dingo's blob-store abstraction supports independent history expiry and archive
+fallback:
 
 - An archive node uses a signed-URL-capable object-storage blob plugin (`s3` or
   `gcs`) and enables the Bark server with `barkPort`. Bark's archive service
   maps a requested `(slot, hash)` to the blob store's `GetBlockURL`, returning
   a signed object URL plus compact block metadata.
-- A pruning node keeps its local blob plugin, configures `barkBaseUrl`, and is
-  wired by `node.go` with a `bark.BlobStoreBark` wrapper plus
-  `bark.Pruner`. Normal block writes still go to the local blob plugin. Reads
-  first check local storage; tombstoned or missing historical blocks fall back
-  to the remote Bark archive and download the signed URL response.
-- The pruner derives its safety window from `LedgerState.StabilityWindow()` and
-  scans only blocks older than that window. `Database.PruneBlock` materializes
-  any UTxO CBOR still stored as block offsets before replacing the block CBOR
-  value with a tombstone, leaving block indexes and metadata intact for archive
-  resolution.
+- A node with `historyExpiry.enabled` keeps its local blob plugin and starts
+  `internal/historyexpiry.Pruner`. The worker derives its safety window from
+  `LedgerState.StabilityWindow()` and scans only blocks older than that window.
+  `Database.PruneBlock` materializes any UTxO CBOR still stored as block
+  offsets before replacing the block CBOR value with an expired-history marker,
+  leaving block indexes and metadata intact.
+- A node with `barkBaseUrl` is wired by `node.go` with a `bark.BlobStoreBark`
+  wrapper. Normal block writes still go to the local blob plugin. Reads first
+  check local storage; expired or missing historical blocks fall back to the
+  remote Bark archive and download the signed URL response. This wrapper can be
+  used with or without local History Expiry.
 
 ### Tiered CBOR Cache
 
@@ -1129,7 +1132,7 @@ A gRPC server implementing the UTxO RPC specification with query, submit, sync, 
 
 Bark is Dingo's own protocol for Dingo-to-Dingo control-plane and archive
 services. It exposes archive access over Connect/gRPC and supplies the remote
-archive adapter used by pruning nodes.
+archive adapter used by nodes that want historical fallback.
 
 The server side (`bark.Bark`) registers the archive service, health endpoint,
 and gRPC reflection. Archive fetches validate the requested block hash, ask the
@@ -1139,11 +1142,10 @@ archive-node blob backends because they can sign object-storage URLs.
 
 The client side (`bark.BlobStoreBark`) wraps the configured local blob store.
 `GetBlock` and block iterators pass through local values, but resolve
-`types.ErrBlockTombstoned` or missing historical block CBOR by calling the
-remote Bark archive and downloading the signed URL. `bark.Pruner` runs only
-when `barkBaseUrl` is configured; it uses the ledger-derived stability window,
-not a separate operator-supplied security-window value, to decide which local
-blocks are safe to tombstone.
+`types.ErrHistoryExpired` or missing historical block CBOR by calling the
+remote Bark archive and downloading the signed URL. Bark does not decide which
+local blocks expire; `internal/historyexpiry.Pruner` owns that lifecycle when
+`historyExpiry.enabled` is configured.
 
 ## Architectural Boundaries
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -269,11 +269,11 @@ flowchart LR
 
 | Logical key | Value | Used by |
 |---|---|---|
-| `bp` + big-endian slot `uint64` + block hash bytes | Raw block CBOR, or tombstone marker `DBT1` | `BlobStore.SetBlock`, `GetBlock`, `TombstoneBlock`, block iterators |
-| `bp..._metadata` | `types.BlockMetadata`: `id`, `type`, `height`, `prev_hash` encoded as CBOR; Badger can use compact `DBM1` binary metadata | `GetBlock` and archive-proxy/tombstone paths |
+| `bp` + big-endian slot `uint64` + block hash bytes | Raw block CBOR, or expired-history marker `DBT1` | `BlobStore.SetBlock`, `GetBlock`, `TombstoneBlock`, block iterators |
+| `bp..._metadata` | `types.BlockMetadata`: `id`, `type`, `height`, `prev_hash` encoded as CBOR; Badger can use compact `DBM1` binary metadata | `GetBlock` and archive-proxy/history-expiry paths |
 | `bi` + big-endian internal block ID `uint64` | The corresponding `bp...` block key | Block iteration and block-by-index lookup |
 | `bh` + block hash bytes | The corresponding `bp...` block key | Fast block-by-hash lookup |
-| `u` + tx hash bytes + big-endian output index `uint32` | UTxO CBOR or a 52-byte `DOFF` CBOR-offset reference into a block | UTxO resolution and pruning |
+| `u` + tx hash bytes + big-endian output index `uint32` | UTxO CBOR or a 52-byte `DOFF` CBOR-offset reference into a block | UTxO resolution and history expiry |
 | `t` + tx hash bytes | Transaction CBOR offset bytes. Current writers store 52-byte `DOFF`; readers also support 69-byte `DTXP` tx-part offsets. | Transaction CBOR lookup |
 | `metadata_commit_timestamp` | Big-endian timestamp integer bytes | Commit consistency check with SQL `commit_timestamp` |
 
@@ -291,11 +291,11 @@ magic "DTXP" (4) + block_slot (8) + block_hash (32)
 + metadata_offset/metadata_length (8) + is_valid (1)
 ```
 
-### Archive And Pruning Contract
+### Archive And History Expiry Contract
 
-Archive nodes and pruning nodes use the same logical blob keys. The difference
-is where immutable block CBOR is expected to live after the block is older than
-the ledger stability window:
+Archive nodes and history-expiry nodes use the same logical blob keys. The
+difference is where immutable block CBOR is expected to live after the block is
+older than the ledger stability window:
 
 - Archive nodes keep block CBOR in a signed-URL-capable blob backend. The `s3`
   and `gcs` plugins implement `GetBlockURL` by reading the block's
@@ -303,18 +303,18 @@ the ledger stability window:
   object. Bark's archive service exposes that URL and metadata to other Dingo
   nodes. The local Badger plugin does not implement `GetBlockURL`, so it is not
   suitable as the backing store for a Bark archive node.
-- Pruning nodes keep their normal local blob plugin, wrap it with the Bark
-  archive adapter, and run the Bark pruner when `barkBaseUrl` is configured.
-  The pruner calls `Database.PruneBlock` for blocks below
+- History-expiry nodes keep their normal local blob plugin and run
+  `internal/historyexpiry.Pruner` when `historyExpiry.enabled` is configured. The pruner
+  calls `Database.PruneBlock` for blocks below
   `current_slot - ledger.StabilityWindow()`. `PruneBlock` first materializes
   UTxO CBOR entries that still point into the block by `DOFF` offset, then
-  replaces the block's `bp...` value with tombstone marker `DBT1` in the same
-  blob transaction.
-- Tombstoned blocks keep their `bi...`, `bh...`, and `bp..._metadata` entries.
-  SQL metadata rows also remain. Blob readers return
-  `types.ErrBlockTombstoned` with the slot/hash, allowing the Bark wrapper to
-  fetch the CBOR from the archive while preserving local block indexes and
-  iteration semantics.
+  replaces the block's `bp...` value with marker `DBT1` in the same blob
+  transaction.
+- Expired blocks keep their `bi...`, `bh...`, and `bp..._metadata` entries.
+  SQL metadata rows also remain. Blob readers return `types.ErrHistoryExpired`
+  with the slot/hash. Without an archive wrapper this is the final read error;
+  with `barkBaseUrl` configured, Bark fetches the CBOR from the archive while
+  preserving local block indexes and iteration semantics.
 
 ## SQL Examples Mirroring the Go API
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ The following environment variables modify Dingo's behavior:
 - `DINGO_BARK_PORT`
   - TCP port for the Bark block archive API (default: `0`, disabled)
 - `DINGO_BARK_BASE_URL`
-  - Base URL of a remote Bark archive node used for archive-backed local pruning
+  - Base URL of a remote Bark archive node used for archive fallback
     (default: empty, disabled)
-- `DINGO_BARK_PRUNER_FREQUENCY`
-  - How often an archive-backed pruning node scans for old local blocks to
-    prune (default: `1h`)
+- `DINGO_HISTORY_EXPIRY_ENABLED`
+  - Enable local expiry of immutable block CBOR older than the ledger stability
+    window (default: `false`)
+- `DINGO_HISTORY_EXPIRY_FREQUENCY`
+  - How often a history-expiry node scans for old local blocks (default: `1h`)
 - `DINGO_STORAGE_MODE`
   - Storage mode: `core` (default) or `api`
   - `core` stores only consensus data (UTxOs, certs, pools, protocol params)
@@ -204,12 +206,14 @@ blockfrostPort: 3100
 utxorpcPort: 9090
 ```
 
-### Archive And Pruning Nodes
+### Archive And History Expiry Nodes
 
-Dingo can be deployed as an archive node that keeps immutable block CBOR in
-cloud-native object storage, and paired pruning nodes can then remove old block
-CBOR from their own local blob stores while still serving historical block
-requests through the archive.
+Dingo can expire immutable block CBOR from a local blob store once blocks are
+older than the ledger-derived stability window. This History Expiry mode is a
+valid standalone operational mode: without an archive fallback, reads for
+expired blocks return a clear history-expired error. When paired with Bark,
+expired or missing historical block reads can be transparently served from a
+remote archive node.
 
 An archive node uses a signed-URL-capable blob plugin (`s3` or `gcs`) and
 enables Bark with `barkPort`. Bark answers Dingo-to-Dingo archive requests by
@@ -229,24 +233,30 @@ database:
 barkPort: 9091
 ```
 
-A pruning node keeps its normal local blob store, sets `barkBaseUrl` to the
-archive node, and optionally tunes `barkPrunerFrequency`. Dingo wraps the local
-blob store with the Bark archive adapter, starts a background pruner, and prunes
-blocks older than the ledger-derived stability window. Pruned blocks keep their
-local indexes and a tombstone marker, so block fetches and block iterators can
-transparently retrieve the CBOR from the archive when needed.
+A history-expiry node keeps its normal local blob store and enables
+`historyExpiry`. Dingo expires blocks older than the ledger-derived stability
+window while keeping local indexes and metadata, so reads fail explicitly as
+expired history unless an archive wrapper can serve them.
 
 ```yaml
 storageMode: "core"
 database:
   blob:
     plugin: "badger"
+historyExpiry:
+  enabled: true
+  frequency: 1h
+```
+
+Add `barkBaseUrl` when expired historical reads should fall back to a Bark
+archive:
+
+```yaml
 barkBaseUrl: "http://archive.example.internal:9091"
-barkPrunerFrequency: 1h
 ```
 
 The runnable demonstration in `internal/test/archive-demo/` brings up an S3
-compatible Minio archive node, a local Badger pruning node, and an end-to-end
+compatible Minio archive node, a local Badger history-expiry node, and an end-to-end
 BlockFetch check through Bark.
 
 ### Deployment Patterns
@@ -266,8 +276,9 @@ DINGO_STORAGE_MODE=api DINGO_BLOCKFROST_PORT=3100 ./dingo
 DINGO_DATABASE_BLOB_PLUGIN=s3 DINGO_BARK_PORT=9091 ./dingo
 ```
 
-**Pruning node** (local storage plus a remote Bark archive):
+**History-expiry node** (local storage plus a remote Bark archive):
 ```bash
+DINGO_HISTORY_EXPIRY_ENABLED=true \
 DINGO_BARK_BASE_URL=http://archive.example.internal:9091 ./dingo
 ```
 

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -29,20 +28,17 @@ import (
 	archiveconnect "github.com/blinklabs-io/bark/proto/v1alpha1/archive/archivev1alpha1connect"
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
-	"github.com/blinklabs-io/dingo/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // archiveFetchTimeout bounds a single archive round-trip (signed-URL request
 // plus the follow-up download). Used by both GetBlock and the iterator's
-// per-item tombstone resolution.
+// per-item expired-history resolution.
 const archiveFetchTimeout = 20 * time.Second
 
 type BlobStoreBarkConfig struct {
-	BaseUrl     string
-	HTTPClient  *http.Client
-	LedgerState *ledger.LedgerState
-	Logger      *slog.Logger
+	BaseUrl    string
+	HTTPClient *http.Client
 }
 
 type BlobStoreBark struct {
@@ -56,8 +52,8 @@ func NewBarkBlobStore(
 	config BlobStoreBarkConfig,
 	upstream blob.BlobStore,
 ) (*BlobStoreBark, error) {
-	if config.LedgerState == nil {
-		return nil, errors.New("bark: ledger state is required")
+	if upstream == nil {
+		return nil, errors.New("bark: upstream blob store is required")
 	}
 
 	httpClient := config.HTTPClient
@@ -113,10 +109,10 @@ func (b *BlobStoreBark) NewIterator(
 }
 
 // barkIterator wraps an upstream blob iterator so that values returned via
-// Item().ValueCopy() transparently resolve archive tombstones. Tombstones
-// only appear at "bp"+slot+hash keys; values at any other key (bi/bh,
-// bp_metadata, …) pass through unchanged, so wrapping is zero-cost for
-// non-block-CBOR iterations.
+// Item().ValueCopy() transparently resolve expired history from the archive.
+// Expiry markers only appear at "bp"+slot+hash keys; values at any other key
+// (bi/bh, bp_metadata, …) pass through unchanged, so wrapping is zero-cost
+// for non-block-CBOR iterations.
 type barkIterator struct {
 	upstream types.BlobIterator
 	store    *BlobStoreBark
@@ -139,7 +135,7 @@ func (it *barkIterator) Item() types.BlobItem {
 }
 
 // barkItem wraps an upstream blob item. Key() passes through. ValueCopy()
-// catches the typed *types.BlockTombstonedError surfaced by the upstream
+// catches the typed *types.HistoryExpiredError surfaced by the upstream
 // plugin's iterator and resolves the block via the archive using the
 // (slot, hash) carried by the error — keeping the wrapper transparent to
 // callers without coupling it to any blob-key format.
@@ -155,8 +151,8 @@ func (i *barkItem) ValueCopy(dst []byte) ([]byte, error) {
 	if err == nil {
 		return val, nil
 	}
-	var tombErr *types.BlockTombstonedError
-	if !errors.As(err, &tombErr) {
+	var historyErr *types.HistoryExpiredError
+	if !errors.As(err, &historyErr) {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(
@@ -164,12 +160,12 @@ func (i *barkItem) ValueCopy(dst []byte) ([]byte, error) {
 	)
 	defer cancel()
 	cbor, _, fetchErr := i.store.fetchBlockFromArchive(
-		ctx, tombErr.Slot, tombErr.Hash,
+		ctx, historyErr.Slot, historyErr.Hash,
 	)
 	if fetchErr != nil {
 		return nil, fmt.Errorf(
-			"bark iterator: resolving tombstoned block at slot=%d: %w",
-			tombErr.Slot, fetchErr,
+			"bark iterator: resolving expired history at slot=%d: %w",
+			historyErr.Slot, fetchErr,
 		)
 	}
 	return cbor, nil
@@ -205,16 +201,16 @@ func (b *BlobStoreBark) GetBlock(
 	// Always consult the upstream first so we can pick up the local
 	// BlockMetadata (most importantly the block ID, which the chain
 	// iterator's BlockByIndex path depends on). Upstream reports
-	// ErrBlockTombstoned for archive-only blocks while still returning
+	// ErrHistoryExpired for locally expired blocks while still returning
 	// the metadata it kept around for exactly this purpose. Fall through
-	// to the archive on ErrBlobKeyNotFound too: blocks pruned before the
-	// tombstone-on-prune fix (or never indexed locally, e.g. snapshot
-	// bootstrap) have no bp entry, but the archive can still serve them.
+	// to the archive on ErrBlobKeyNotFound too: blocks expired before the
+	// marker-preserving fix (or never indexed locally, e.g. snapshot bootstrap)
+	// have no bp entry, but the archive can still serve them.
 	upstreamCbor, upstreamMeta, err := b.upstream.GetBlock(txn, slot, hash)
 	if err == nil {
 		return upstreamCbor, upstreamMeta, nil
 	}
-	if !errors.Is(err, types.ErrBlockTombstoned) &&
+	if !errors.Is(err, types.ErrHistoryExpired) &&
 		!errors.Is(err, types.ErrBlobKeyNotFound) {
 		return nil, types.BlockMetadata{}, err
 	}
@@ -230,7 +226,7 @@ func (b *BlobStoreBark) GetBlock(
 	// Prefer the local metadata for ID (the archive does not know our
 	// local block IDs), but trust the archive for Type/Height/PrevHash
 	// in case upstream returned a zero metadata struct alongside the
-	// tombstone error.
+	// expired-history error.
 	merged := upstreamMeta
 	if merged.Type == 0 {
 		merged.Type = archiveMeta.Type

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -131,9 +131,8 @@ func newTestDB(t *testing.T) *database.Database {
 }
 
 // newBarkBlobStoreForTest builds a BlobStoreBark wrapping db's blob store
-// and pointed at baseURL. The constructor's panic on a nil LedgerState is
-// bypassed via direct struct construction — these tests exercise the
-// iterator path, which does not consult ledger state.
+// and pointed at baseURL. Direct struct construction lets the tests inject
+// a fake archive client while focusing on the iterator path.
 func newBarkBlobStoreForTest(
 	db *database.Database, baseURL string,
 ) *BlobStoreBark {
@@ -147,12 +146,10 @@ func newBarkBlobStoreForTest(
 	}
 }
 
-// TestBarkIterator_ResolvesTombstoneViaArchive seeds the database with a
-// block, tombstones it via the same path the pruner uses, then iterates
-// through the bark wrapper. ValueCopy must surface the archive's CBOR,
-// not the tombstone marker — issue #2104: callers iterating bp keys
-// must never observe tombstone bytes through the wrapper.
-func TestBarkIterator_ResolvesTombstoneViaArchive(t *testing.T) {
+// TestBarkIterator_ResolvesExpiredHistoryViaArchive seeds the database with a
+// block, marks it expired locally, then iterates through the bark wrapper.
+// ValueCopy must surface the archive's CBOR, not the local expiry marker.
+func TestBarkIterator_ResolvesExpiredHistoryViaArchive(t *testing.T) {
 	db := newTestDB(t)
 
 	const slot uint64 = 100
@@ -196,8 +193,8 @@ func TestBarkIterator_ResolvesTombstoneViaArchive(t *testing.T) {
 		require.NotNil(t, item)
 		k := item.Key()
 		// Skip the metadata key — TombstoneBlock removes it, but a fresh
-		// fixture might still see it before commit; either way, tombstones
-		// never live there so it's not interesting for this assertion.
+		// fixture might still see it before commit; either way, expiry
+		// markers never live there so it's not interesting for this assertion.
 		if bytes.HasSuffix(k, []byte(types.BlockBlobMetadataKeySuffix)) {
 			continue
 		}
@@ -212,20 +209,20 @@ func TestBarkIterator_ResolvesTombstoneViaArchive(t *testing.T) {
 	require.True(t, seenBp, "iterator did not visit the bp key")
 
 	assert.False(t, types.IsBlockTombstone(gotValue),
-		"ValueCopy must not surface the raw tombstone marker — the wrapper "+
+		"ValueCopy must not surface the raw expiry marker — the wrapper "+
 			"is supposed to resolve it via the archive")
 	assert.Equal(t, cbor, gotValue,
-		"ValueCopy must return the archive-served CBOR for a tombstoned block")
+		"ValueCopy must return the archive-served CBOR for expired history")
 	assert.Equal(t, 1, archiveSrv.fetchCalls,
-		"exactly one archive FetchBlock call expected for one tombstoned block")
+		"exactly one archive FetchBlock call expected for one expired block")
 }
 
-// TestUpstreamIterator_SurfacesTypedTombstoneError proves the contract
+// TestUpstreamIterator_SurfacesTypedHistoryExpiredError proves the contract
 // bark relies on: the underlying plugin iterator returns a typed
-// *types.BlockTombstonedError (carrying slot+hash) from ValueCopy when
-// it encounters a tombstone, so the bark wrapper can resolve via
+// *types.HistoryExpiredError (carrying slot+hash) from ValueCopy when
+// it encounters an expiry marker, so the bark wrapper can resolve via
 // errors.As without parsing any blob keys.
-func TestUpstreamIterator_SurfacesTypedTombstoneError(t *testing.T) {
+func TestUpstreamIterator_SurfacesTypedHistoryExpiredError(t *testing.T) {
 	db := newTestDB(t)
 
 	const slot uint64 = 300
@@ -263,23 +260,23 @@ func TestUpstreamIterator_SurfacesTypedTombstoneError(t *testing.T) {
 		}
 		_, err := item.ValueCopy(nil)
 		require.Error(t, err,
-			"upstream ValueCopy on a tombstone must surface an error")
-		var tombErr *types.BlockTombstonedError
-		require.True(t, errors.As(err, &tombErr),
-			"upstream error must be (or wrap) *BlockTombstonedError so "+
+			"upstream ValueCopy on expired history must surface an error")
+		var historyErr *types.HistoryExpiredError
+		require.True(t, errors.As(err, &historyErr),
+			"upstream error must be (or wrap) *HistoryExpiredError so "+
 				"bark can extract slot/hash with errors.As")
-		assert.Equal(t, slot, tombErr.Slot)
-		assert.Equal(t, hash, tombErr.Hash)
-		require.True(t, errors.Is(err, types.ErrBlockTombstoned),
-			"typed error must still satisfy errors.Is(ErrBlockTombstoned)")
+		assert.Equal(t, slot, historyErr.Slot)
+		assert.Equal(t, hash, historyErr.Hash)
+		require.True(t, errors.Is(err, types.ErrHistoryExpired),
+			"typed error must still satisfy errors.Is(ErrHistoryExpired)")
 		typedErrSeen = true
 	}
 	require.True(t, typedErrSeen,
-		"iterator did not surface the tombstone we just wrote")
+		"iterator did not surface the expiry marker we just wrote")
 }
 
 // TestBarkIterator_PassesThroughLiveValues checks that values at non-bp
-// keys (here: bi index pointers) and at non-tombstoned bp keys go
+// keys (here: bi index pointers) and at non-expired bp keys go
 // straight through without any archive call.
 func TestBarkIterator_PassesThroughLiveValues(t *testing.T) {
 	db := newTestDB(t)
@@ -326,7 +323,7 @@ func TestBarkIterator_PassesThroughLiveValues(t *testing.T) {
 	require.True(t, found)
 
 	// Iterate bi prefix: the value is the bp key reference (not a CBOR
-	// payload); it must pass through unchanged regardless of tombstones
+	// payload); it must pass through unchanged regardless of expiry markers
 	// elsewhere.
 	itBi := store.NewIterator(rTxn, types.BlobIteratorOptions{
 		Prefix: []byte(types.BlockBlobIndexKeyPrefix),

--- a/bark/constructor_test.go
+++ b/bark/constructor_test.go
@@ -30,12 +30,11 @@ func TestNewBark_RejectsNilDB(t *testing.T) {
 	assert.Contains(t, err.Error(), "db is required")
 }
 
-// TestNewBarkBlobStore_RejectsNilLedgerState pins that the constructor
-// returns an error rather than panicking when the required ledger state
-// dependency is nil.
-func TestNewBarkBlobStore_RejectsNilLedgerState(t *testing.T) {
-	bs, err := NewBarkBlobStore(BlobStoreBarkConfig{LedgerState: nil}, nil)
+// TestNewBarkBlobStore_RejectsNilUpstream pins that the constructor returns an
+// error rather than panicking when the required upstream blob store is nil.
+func TestNewBarkBlobStore_RejectsNilUpstream(t *testing.T) {
+	bs, err := NewBarkBlobStore(BlobStoreBarkConfig{}, nil)
 	require.Error(t, err)
 	assert.Nil(t, bs)
-	assert.Contains(t, err.Error(), "ledger state is required")
+	assert.Contains(t, err.Error(), "upstream blob store is required")
 }

--- a/config.go
+++ b/config.go
@@ -75,6 +75,12 @@ func (m StorageMode) IsAPI() bool {
 	return m == StorageModeAPI
 }
 
+// HistoryExpiryConfig controls local expiry of immutable block history.
+type HistoryExpiryConfig struct {
+	Enabled   bool
+	Frequency time.Duration
+}
+
 type Config struct {
 	promRegistry             prometheus.Registerer
 	topologyConfig           *topology.TopologyConfig
@@ -96,7 +102,7 @@ type Config struct {
 	utxorpcPort              uint
 	barkBaseUrl              string
 	barkPort                 uint
-	barkPrunerFrequency      time.Duration
+	historyExpiry            HistoryExpiryConfig
 	corsAllowedOrigins       []string
 	networkMagic             uint32
 	intersectTip             bool
@@ -390,6 +396,9 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 		// We do this so we don't have to add guards around every log operation
 		logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		genesisBootstrap: true,
+		historyExpiry: HistoryExpiryConfig{
+			Frequency: time.Hour,
+		},
 		corsAllowedOrigins: []string{
 			"*",
 		},
@@ -836,12 +845,10 @@ func WithBarkPort(port uint) ConfigOptionFunc {
 	}
 }
 
-// WithBarkPrunerFrequency specifies how often the Bark pruner runs
-// (deleting blob entries older than the ledger stability window).
-// Default is 1 hour. Values <= 0 fall back to the default.
-func WithBarkPrunerFrequency(freq time.Duration) ConfigOptionFunc {
+// WithHistoryExpiry configures local immutable block history expiry.
+func WithHistoryExpiry(cfg HistoryExpiryConfig) ConfigOptionFunc {
 	return func(c *Config) {
-		c.barkPrunerFrequency = freq
+		c.historyExpiry = cfg
 	}
 }
 

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -328,7 +328,7 @@ func (d *BlobStoreS3) GetBlock(
 	}
 	if types.IsBlockTombstone(cborData) {
 		return nil, types.BlockMetadata{},
-			&types.BlockTombstonedError{Slot: slot, Hash: hash}
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	metadataKey := types.BlockBlobMetadataKey(key)
 	metadataBytes, err := d.getInternal(ctx, string(metadataKey))
@@ -392,10 +392,9 @@ func (d *BlobStoreS3) DeleteBlock(
 	return nil
 }
 
-// TombstoneBlock replaces a block's CBOR with a tombstone marker so a
-// wrapping archive proxy can resolve the block via GetBlock(slot, hash):
+// TombstoneBlock replaces a block's CBOR with an expired-history marker.
 // GetBlock reads the bp object, sees the marker, and returns
-// types.ErrBlockTombstoned for the proxy to intercept.
+// types.ErrHistoryExpired so an archive proxy can intercept it.
 //
 // What stays:
 //   - bi<id>: required by BlockByIndex (the chain iterator translates
@@ -405,9 +404,9 @@ func (d *BlobStoreS3) DeleteBlock(
 //     preserves the fast path.
 //
 // What goes:
-//   - bp_metadata: GetBlock short-circuits on the tombstone before reading
-//     metadata, and no other caller asks for metadata of a tombstoned
-//     block — bark's archive response carries its own.
+//   - bp_metadata: GetBlock short-circuits on the expiry marker before
+//     reading metadata, and no other caller asks for local metadata of an
+//     expired block — bark's archive response carries its own.
 func (d *BlobStoreS3) TombstoneBlock(
 	txn types.Txn,
 	slot uint64,
@@ -689,10 +688,11 @@ func (i *s3Item) ValueCopy(dst []byte) ([]byte, error) {
 		slot, hash, parseErr := types.ParseBlockBlobKey([]byte(i.key))
 		if parseErr != nil {
 			return nil, fmt.Errorf(
-				"tombstone at unexpected key shape: %w", parseErr,
+				"history expiry marker at unexpected key shape: %w",
+				parseErr,
 			)
 		}
-		return nil, &types.BlockTombstonedError{Slot: slot, Hash: hash}
+		return nil, &types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	if dst != nil {
 		return append(dst[:0], data...), nil

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -242,17 +242,17 @@ func (i *badgerItem) ValueCopy(dst []byte) ([]byte, error) {
 	if !types.IsBlockTombstone(val) {
 		return val, nil
 	}
-	// The tombstone marker only appears at fully-formed bp keys; parse
-	// the key we just emitted to attach (slot, hash) to the typed
-	// error. The plugin owns this key format end-to-end so the parse
-	// is internally safe.
+	// The expiry marker only appears at fully-formed bp keys; parse the
+	// key we just emitted to attach (slot, hash) to the typed error.
+	// The plugin owns this key format end-to-end so the parse is safe.
 	slot, hash, parseErr := types.ParseBlockBlobKey(i.item.KeyCopy(nil))
 	if parseErr != nil {
 		return nil, fmt.Errorf(
-			"tombstone at unexpected key shape: %w", parseErr,
+			"history expiry marker at unexpected key shape: %w",
+			parseErr,
 		)
 	}
-	return nil, &types.BlockTombstonedError{Slot: slot, Hash: hash}
+	return nil, &types.HistoryExpiredError{Slot: slot, Hash: hash}
 }
 
 // BlobStoreBadger stores all data in badger. Data may not be persisted
@@ -667,8 +667,8 @@ func (d *BlobStoreBadger) GetBlock(
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
-	// Read the metadata key whether or not the bp value is a tombstone.
-	// Tombstoned blocks keep their metadata so a wrapping archive proxy
+	// Read the metadata key whether or not the bp value is an expiry marker.
+	// Expired blocks keep their metadata so a wrapping archive proxy
 	// can populate models.Block.ID from the local node's bi index when
 	// fetching the CBOR remotely.
 	metadataKey := types.BlockBlobMetadataKey(key)
@@ -677,7 +677,7 @@ func (d *BlobStoreBadger) GetBlock(
 		if errors.Is(err, badger.ErrKeyNotFound) {
 			if types.IsBlockTombstone(cborData) {
 				return nil, types.BlockMetadata{},
-					&types.BlockTombstonedError{Slot: slot, Hash: hash}
+					&types.HistoryExpiredError{Slot: slot, Hash: hash}
 			}
 			return nil, types.BlockMetadata{}, types.ErrBlobKeyNotFound
 		}
@@ -693,7 +693,7 @@ func (d *BlobStoreBadger) GetBlock(
 	}
 	if types.IsBlockTombstone(cborData) {
 		return nil, tmpMetadata,
-			&types.BlockTombstonedError{Slot: slot, Hash: hash}
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	return cborData, tmpMetadata, nil
 }
@@ -729,10 +729,9 @@ func (d *BlobStoreBadger) DeleteBlock(
 	return nil
 }
 
-// TombstoneBlock overwrites a block's CBOR with a tombstone marker so a
-// wrapping archive proxy can resolve the block via GetBlock(slot, hash):
+// TombstoneBlock overwrites a block's CBOR with an expired-history marker.
 // GetBlock reads the bp value, sees the marker, and returns
-// types.ErrBlockTombstoned for the proxy to intercept.
+// types.ErrHistoryExpired so an archive proxy can intercept it.
 //
 // What stays:
 //

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -461,7 +461,7 @@ func (d *BlobStoreGCS) GetBlock(
 	}
 	if types.IsBlockTombstone(cborData) {
 		return nil, types.BlockMetadata{},
-			&types.BlockTombstonedError{Slot: slot, Hash: hash}
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	metadataKey := types.BlockBlobMetadataKey(key)
 	r, err = d.object(metadataKey).NewReader(ctx)
@@ -546,10 +546,9 @@ func (d *BlobStoreGCS) DeleteBlock(
 	return nil
 }
 
-// TombstoneBlock replaces a block's CBOR with a tombstone marker so a
-// wrapping archive proxy can resolve the block via GetBlock(slot, hash):
+// TombstoneBlock replaces a block's CBOR with an expired-history marker.
 // GetBlock reads the bp object, sees the marker, and returns
-// types.ErrBlockTombstoned for the proxy to intercept.
+// types.ErrHistoryExpired so an archive proxy can intercept it.
 //
 // What stays:
 //   - bi<id>: required by BlockByIndex (the chain iterator translates
@@ -559,9 +558,9 @@ func (d *BlobStoreGCS) DeleteBlock(
 //     preserves the fast path.
 //
 // What goes:
-//   - bp_metadata: GetBlock short-circuits on the tombstone before reading
-//     metadata, and no other caller asks for metadata of a tombstoned
-//     block — bark's archive response carries its own.
+//   - bp_metadata: GetBlock short-circuits on the expiry marker before
+//     reading metadata, and no other caller asks for local metadata of an
+//     expired block — bark's archive response carries its own.
 func (d *BlobStoreGCS) TombstoneBlock(
 	txn types.Txn,
 	slot uint64,
@@ -915,10 +914,11 @@ func (i *gcsItem) ValueCopy(dst []byte) ([]byte, error) {
 		slot, hash, parseErr := types.ParseBlockBlobKey([]byte(i.key))
 		if parseErr != nil {
 			return nil, fmt.Errorf(
-				"tombstone at unexpected key shape: %w", parseErr,
+				"history expiry marker at unexpected key shape: %w",
+				parseErr,
 			)
 		}
-		return nil, &types.BlockTombstonedError{Slot: slot, Hash: hash}
+		return nil, &types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	if dst != nil {
 		return append(dst[:0], data...), nil

--- a/database/plugin/blob/store.go
+++ b/database/plugin/blob/store.go
@@ -71,13 +71,12 @@ type BlobStore interface {
 		hash []byte,
 	) ([]byte, types.BlockMetadata, error)
 	DeleteBlock(txn types.Txn, slot uint64, hash []byte, id uint64) error
-	// TombstoneBlock replaces the block's CBOR with a tombstone marker
-	// while leaving index pointers (bi, bh) and metadata in place. Used by
-	// the prune-for-archive path so a wrapping proxy (e.g. bark) can still
-	// resolve the block via GetBlock(slot, hash) — the upstream returns
-	// types.ErrBlockTombstoned for the block, which the wrapper intercepts
-	// and proxies to the archive. DeleteBlock continues to fully remove a
-	// block (used for orphan rollbacks where there is no archive copy).
+	// TombstoneBlock replaces the block's CBOR with an expired-history
+	// marker while leaving index pointers (bi, bh) and metadata in place.
+	// GetBlock and iterator ValueCopy must return types.ErrHistoryExpired
+	// for the block so archive wrappers can proxy it if configured.
+	// DeleteBlock continues to fully remove a block for orphan rollbacks
+	// where there is no retained history entry.
 	TombstoneBlock(txn types.Txn, slot uint64, hash []byte) error
 	GetBlockURL(ctx context.Context, txn types.Txn, point ocommon.Point) (types.SignedURL, types.BlockMetadata, error)
 	// UTxO operations

--- a/database/prune.go
+++ b/database/prune.go
@@ -24,13 +24,11 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
-// PruneBlock tombstones the given block in the blob store after
+// PruneBlock expires the given block's local CBOR in the blob store after
 // materializing any active UTxOs that still reference it. The block's CBOR
-// is replaced with a small tombstone marker; index pointers (bi, bh) and
-// metadata are kept so a wrapping archive proxy (e.g. bark) can still
-// resolve the block by (slot, hash) — without the tombstone the chain
-// iterator would hit ErrBlobKeyNotFound at the bi lookup before ever
-// reaching the proxy's GetBlock.
+// is replaced with a small expired-history marker; index pointers (bi, bh)
+// and metadata are kept so local reads can return ErrHistoryExpired and an
+// optional archive proxy can still resolve the block by (slot, hash).
 //
 // UTxO blob entries are stored as 52-byte CborOffset references that point
 // into a source block's CBOR. Tombstoning a block while live UTxOs still
@@ -38,9 +36,9 @@ import (
 // PruneBlock first finds every UTxO with added_slot equal to the pruned
 // block's slot, decodes its offset, slices the underlying CBOR out of the
 // block, and rewrites the UTxO blob entry as raw CBOR (which the resolver
-// treats as the legacy non-offset format). The block tombstone and all
+// treats as the legacy non-offset format). The block expiry marker and all
 // UTxO rewrites happen in a single blob transaction, so the block is
-// never tombstoned while live UTxOs still depend on it.
+// never expired while live UTxOs still depend on it.
 //
 // In core storage mode only live (deleted_slot = 0) UTxOs at the slot are
 // considered, because spent UTxOs are hard-deleted by the periodic
@@ -49,7 +47,7 @@ import (
 // indefinitely for historical transaction queries; in that mode every
 // UTxO at the slot (including spent rows whose blob entries still hold
 // offset references) is materialized so CBOR resolution survives the
-// block tombstone without requiring a wrapping archive proxy.
+// expired block without requiring a wrapping archive proxy.
 //
 // Returns the number of UTxOs that were materialized.
 func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
@@ -99,7 +97,7 @@ func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
 		}
 		if err := d.blob.TombstoneBlock(txn.Blob(), slot, hash); err != nil {
 			return fmt.Errorf(
-				"prune block (slot=%d): tombstone block: %w",
+				"prune block (slot=%d): expire block: %w",
 				slot,
 				err,
 			)

--- a/database/prune_test.go
+++ b/database/prune_test.go
@@ -152,21 +152,21 @@ func TestPruneBlock_MaterializesLiveUtxoAndTombstonesBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, n, "exactly one live UTxO should be materialized")
 
-	// Block CBOR has been replaced with a tombstone marker; GetBlock
-	// signals this with ErrBlockTombstoned so a wrapping archive proxy
+	// Block CBOR has been replaced with an expiry marker; GetBlock
+	// signals this with ErrHistoryExpired so a wrapping archive proxy
 	// can intercept and resolve from the archive. The bp key still
-	// exists (carrying just the tombstone bytes), and the bi/bh index
+	// exists (carrying just the marker bytes), and the bi/bh index
 	// pointers and metadata remain so chain-iterator lookups still
 	// translate id/hash into a block key.
 	blobTxn = db.BlobTxn(false)
 	defer blobTxn.Release()
 	_, _, err = db.Blob().GetBlock(blobTxn.Blob(), slot, hash)
-	assert.ErrorIs(t, err, types.ErrBlockTombstoned)
+	assert.ErrorIs(t, err, types.ErrHistoryExpired)
 	rawBp, err := db.Blob().Get(blobTxn.Blob(), types.BlockBlobKey(slot, hash))
 	require.NoError(t, err,
 		"bp key must still exist post-prune so bi/bh references stay valid")
 	assert.True(t, types.IsBlockTombstone(rawBp),
-		"bp value must be the tombstone marker after prune")
+		"bp value must be the expiry marker after prune")
 
 	// Live UTxO entry is now raw CBOR matching the in-block slice.
 	postLive, err := db.Blob().GetUtxo(blobTxn.Blob(), txId, 0)
@@ -220,16 +220,16 @@ func TestPruneBlock_ResolverReadsMaterializedUtxoAfterPrune(t *testing.T) {
 	)
 }
 
-// TestPruneBlock_LeavesChainIteratorAtTombstone exercises the post-fix
+// TestPruneBlock_LeavesChainIteratorAtHistoryExpired exercises the post-fix
 // behavior for issue #2104. After prune the chain-iterator path resolves
 // the (id|hash) → block-key mapping locally (bi/bh and metadata are kept)
 // and reaches the GetBlock call inside blockByKey, which now surfaces
-// ErrBlockTombstoned. That sentinel is the explicit handoff point for a
+// ErrHistoryExpired. That sentinel is the explicit handoff point for a
 // wrapping archive proxy (bark) to fetch from the archive. Without a
 // proxy installed, the error propagates so the operator sees a clear
-// "block was archived; no proxy configured" signal — not the silent
-// chain-tip closure that BlockFetch produced before the fix.
-func TestPruneBlock_LeavesChainIteratorAtTombstone(t *testing.T) {
+// "history expired" signal — not the silent chain-tip closure that
+// BlockFetch produced before the fix.
+func TestPruneBlock_LeavesChainIteratorAtHistoryExpired(t *testing.T) {
 	db := newTestDB(t)
 
 	const slot uint64 = 100
@@ -252,13 +252,13 @@ func TestPruneBlock_LeavesChainIteratorAtTombstone(t *testing.T) {
 
 	// BlockByIndex is the path the chain iterator walks. After prune the
 	// id→key indirection still resolves (bi is preserved), so the lookup
-	// reaches blob.GetBlock; that now returns ErrBlockTombstoned, which
+	// reaches blob.GetBlock; that now returns ErrHistoryExpired, which
 	// blockByKey propagates verbatim. A bark wrapper would intercept this
 	// error and proxy to the archive. Without a wrapper the error reaches
 	// the iterator as a clear, actionable signal.
 	_, err = db.BlockByIndex(blockID, nil)
-	assert.ErrorIs(t, err, types.ErrBlockTombstoned,
-		"BlockByIndex must reach the GetBlock handoff (tombstone) so a "+
+	assert.ErrorIs(t, err, types.ErrHistoryExpired,
+		"BlockByIndex must reach the GetBlock handoff (history expired) so a "+
 			"bark archive proxy can intercept and resolve")
 	assert.NotErrorIs(t, err, models.ErrBlockNotFound,
 		"the lookup must not collapse to ErrBlockNotFound — that is the "+
@@ -266,8 +266,8 @@ func TestPruneBlock_LeavesChainIteratorAtTombstone(t *testing.T) {
 
 	// BlockByHash exercises the parallel hash-keyed path; same handoff.
 	_, err = BlockByHash(db, hash)
-	assert.ErrorIs(t, err, types.ErrBlockTombstoned,
-		"BlockByHash must also reach the tombstone handoff post-prune")
+	assert.ErrorIs(t, err, types.ErrHistoryExpired,
+		"BlockByHash must also reach the history-expired handoff post-prune")
 	assert.NotErrorIs(t, err, models.ErrBlockNotFound)
 }
 
@@ -276,8 +276,8 @@ func TestPruneBlock_LeavesChainIteratorAtTombstone(t *testing.T) {
 // UTxOs at the slot as well as live ones. This is the counterpart fix
 // to skipping cleanupConsumedUtxos in API mode: with spent rows
 // retained for historical transaction queries, the source block can
-// still be tombstoned, but the spent UTxO blob entries — which hold
-// offset references into the (now-tombstoned) block — must be rewritten
+// still be expired, but the spent UTxO blob entries — which hold
+// offset references into the expired block — must be rewritten
 // to raw CBOR up front so resolution does not require a wrapping
 // archive proxy to fetch the source block.
 func TestPruneBlock_APIModeMaterializesSpentUtxos(t *testing.T) {
@@ -296,7 +296,7 @@ func TestPruneBlock_APIModeMaterializesSpentUtxos(t *testing.T) {
 	// Live UTxO at slot 100; spent UTxO consumed at slot 150. In API mode
 	// the spent row is retained past the stability window, and its blob
 	// entry — still an offset reference to slot 100 — must be materialized
-	// before the block is tombstoned.
+	// before the block is expired.
 	seedUtxoMetadata(t, db, txId, 0, slot, 0)
 	seedUtxoMetadata(t, db, txId, 1, slot, 150)
 

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -143,39 +143,42 @@ type NodeSettings struct {
 // ErrBlobKeyNotFound is returned by blob operations when a key is missing
 var ErrBlobKeyNotFound = errors.New("blob key not found")
 
-// ErrBlockTombstoned is the sentinel for tombstoned-block errors. Callers
-// can use errors.Is(err, ErrBlockTombstoned) for existence checks. To get
-// the (slot, hash) of the tombstoned block, use errors.As to extract a
-// *BlockTombstonedError. The block was pruned for archival and is expected
-// to be available via an archive proxy; wrappers (notably bark) intercept
-// the typed error and resolve the block from the archive. Unwrapped
-// consumers should treat it as a configuration error (the block is no
-// longer local but no proxy is wired up).
-var ErrBlockTombstoned = errors.New("block tombstoned (archived)")
+// ErrHistoryExpired is returned when a block's local CBOR has expired from
+// history storage. Callers can use errors.Is(err, ErrHistoryExpired) for
+// existence checks. To get the (slot, hash), use errors.As to extract a
+// *HistoryExpiredError. Archive-proxy wrappers can intercept this typed
+// error and resolve the block from remote history; unwrapped consumers should
+// surface the condition as unavailable expired history.
+var ErrHistoryExpired = errors.New("history expired")
 
-// BlockTombstonedError is the typed form of ErrBlockTombstoned, returned
-// by blob plugins on every tombstone observation (GetBlock and iterator
-// ValueCopy). It carries the (slot, hash) of the tombstoned block so an
-// archive-proxy wrapper can resolve it without having to parse the blob
-// key — the wrapper extracts it via:
+// HistoryExpiredError is the typed form of ErrHistoryExpired, returned by
+// blob plugins when GetBlock or iterator ValueCopy observe an expired block.
+// It carries the (slot, hash) so archive-proxy wrappers can resolve it without
+// parsing blob keys — the wrapper extracts it via:
 //
-//	var t *types.BlockTombstonedError
-//	if errors.As(err, &t) { fetchFromArchive(t.Slot, t.Hash) }
-type BlockTombstonedError struct {
+//	var h *types.HistoryExpiredError
+//	if errors.As(err, &h) { fetchFromArchive(h.Slot, h.Hash) }
+type HistoryExpiredError struct {
 	Slot uint64
 	Hash []byte
 }
 
-func (e *BlockTombstonedError) Error() string {
+func (e *HistoryExpiredError) Error() string {
 	return fmt.Sprintf(
 		"%s: slot=%d hash=%s",
-		ErrBlockTombstoned, e.Slot, hex.EncodeToString(e.Hash),
+		ErrHistoryExpired, e.Slot, hex.EncodeToString(e.Hash),
 	)
 }
 
-// Unwrap returns ErrBlockTombstoned so errors.Is(err, ErrBlockTombstoned)
-// keeps working for callers that only need to detect the condition.
-func (e *BlockTombstonedError) Unwrap() error { return ErrBlockTombstoned }
+// Unwrap returns ErrHistoryExpired so errors.Is(err, ErrHistoryExpired) keeps
+// working for callers that only need to detect the condition.
+func (e *HistoryExpiredError) Unwrap() error { return ErrHistoryExpired }
+
+// ErrBlockTombstoned and BlockTombstonedError are retained as aliases for
+// older callers. New code should use ErrHistoryExpired and HistoryExpiredError.
+var ErrBlockTombstoned = ErrHistoryExpired
+
+type BlockTombstonedError = HistoryExpiredError
 
 // ErrTxnWrongType is returned when a transaction has the wrong type
 var ErrTxnWrongType = errors.New("invalid transaction type")
@@ -284,16 +287,16 @@ type SignedURL struct {
 	Expires time.Time
 }
 
-// BlockTombstoneMagic is the four-byte prefix that identifies a tombstone
-// record stored at a block's bp key. The bytes "DBT1" do not appear at the
-// start of any valid Cardano block CBOR (blocks begin with a CBOR array
-// header byte such as 0x82/0x83), so detection is unambiguous.
+// BlockTombstoneMagic is the four-byte prefix that identifies an expired
+// history marker stored at a block's bp key. The bytes "DBT1" do not appear
+// at the start of any valid Cardano block CBOR (blocks begin with a CBOR
+// array header byte such as 0x82/0x83), so detection is unambiguous.
 var BlockTombstoneMagic = [4]byte{'D', 'B', 'T', '1'}
 
 // BlockTombstone returns a fresh copy of the tombstone marker that
-// replaces a block's CBOR when the block has been pruned for archival.
+// replaces a block's CBOR when the block has expired from local history.
 // The marker carries no embedded (slot, hash) — the bp key already does,
-// and surfacing the typed BlockTombstonedError is the responsibility of
+// and surfacing the typed HistoryExpiredError is the responsibility of
 // each blob plugin (which knows its own key format).
 func BlockTombstone() []byte {
 	out := make([]byte, len(BlockTombstoneMagic))

--- a/database/types/types_test.go
+++ b/database/types/types_test.go
@@ -141,19 +141,19 @@ func TestParseBlockBlobKeyRejectsMalformed(t *testing.T) {
 	}
 }
 
-// TestBlockTombstonedErrorWraps ensures the typed error keeps satisfying
-// errors.Is(err, ErrBlockTombstoned) for callers that just want to detect
+// TestHistoryExpiredErrorWraps ensures the typed error keeps satisfying
+// errors.Is(err, ErrHistoryExpired) for callers that just want to detect
 // the condition, while errors.As lets archive-proxy wrappers extract the
 // (slot, hash).
-func TestBlockTombstonedErrorWraps(t *testing.T) {
+func TestHistoryExpiredErrorWraps(t *testing.T) {
 	hash := bytes.Repeat([]byte{0xCD}, 32)
-	original := &types.BlockTombstonedError{Slot: 42, Hash: hash}
+	original := &types.HistoryExpiredError{Slot: 42, Hash: hash}
 
-	if !errors.Is(original, types.ErrBlockTombstoned) {
-		t.Fatal("typed error must satisfy errors.Is(..., ErrBlockTombstoned)")
+	if !errors.Is(original, types.ErrHistoryExpired) {
+		t.Fatal("typed error must satisfy errors.Is(..., ErrHistoryExpired)")
 	}
 
-	var extracted *types.BlockTombstonedError
+	var extracted *types.HistoryExpiredError
 	if !errors.As(original, &extracted) {
 		t.Fatal("errors.As did not extract the typed error")
 	}

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -197,8 +197,8 @@ blockfrostPort: 3000
 meshPort: 8080
 
 # Base URL of a remote Bark archive server. When set, this node keeps using
-# its configured local blob plugin but wraps it with Bark archive fallback and
-# starts the background pruner.
+# its configured local blob plugin but wraps it with Bark archive fallback for
+# expired or missing historical blocks.
 # Can be overridden with DINGO_BARK_BASE_URL
 # CLI: --bark-url
 barkBaseUrl: ""
@@ -208,11 +208,16 @@ barkBaseUrl: ""
 # CLI: --bark-port
 barkPort: 0
 
-# How often a Bark-backed pruning node scans for blocks older than the
-# ledger-derived stability window. Default: 1h.
-# Can be overridden with DINGO_BARK_PRUNER_FREQUENCY
-# CLI: --bark-pruner-frequency
-barkPrunerFrequency: 1h
+# Local immutable block history expiry. When enabled, Dingo replaces block CBOR
+# older than the ledger-derived stability window with an expired-history marker
+# while retaining local indexes and metadata. Bark fallback is optional.
+historyExpiry:
+  # Can be overridden with DINGO_HISTORY_EXPIRY_ENABLED
+  # CLI: --history-expiry-enabled
+  enabled: false
+  # Can be overridden with DINGO_HISTORY_EXPIRY_FREQUENCY
+  # CLI: --history-expiry-frequency
+  frequency: 1h
 
 # ---
 # Deployment pattern examples (uncomment one block):
@@ -257,13 +262,15 @@ barkPrunerFrequency: 1h
 #         prefix: "preview"
 #   barkPort: 9091
 #
-# Pruning node (local blobs plus remote archive fallback):
+# History-expiry node (local blobs plus remote archive fallback):
 #   storageMode: "core"
 #   database:
 #     blob:
 #       plugin: "badger"
+#   historyExpiry:
+#     enabled: true
+#     frequency: 1h
 #   barkBaseUrl: "http://archive.example.internal:9091"
-#   barkPrunerFrequency: 1h
 #
 # Dev mode (isolated, forge blocks, no outbound):
 #   runMode: "dev"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,6 +177,14 @@ type GenesisBootstrapConfig struct {
 	PromotionMinDiversityGroups int `yaml:"promotionMinDiversityGroups" envconfig:"DINGO_GENESIS_BOOTSTRAP_PROMOTION_MIN_DIVERSITY_GROUPS"`
 }
 
+// HistoryExpiryConfig controls local expiry of immutable block history.
+type HistoryExpiryConfig struct {
+	// Enabled starts the background expiry worker when true.
+	Enabled bool `yaml:"enabled" envconfig:"DINGO_HISTORY_EXPIRY_ENABLED"`
+	// Frequency controls how often the worker scans for expired block CBOR.
+	Frequency time.Duration `yaml:"frequency" envconfig:"DINGO_HISTORY_EXPIRY_FREQUENCY"`
+}
+
 // DefaultChainsyncConfig returns the default chainsync configuration.
 // StallTimeout must match chainsync.DefaultStallTimeout and the
 // fallback in internal/node/node.go.
@@ -192,6 +200,13 @@ func DefaultChainsyncConfig() ChainsyncConfig {
 func DefaultGenesisBootstrapConfig() GenesisBootstrapConfig {
 	return GenesisBootstrapConfig{
 		Enabled: true,
+	}
+}
+
+// DefaultHistoryExpiryConfig returns the default history expiry settings.
+func DefaultHistoryExpiryConfig() HistoryExpiryConfig {
+	return HistoryExpiryConfig{
+		Frequency: time.Hour,
 	}
 }
 
@@ -245,37 +260,36 @@ func DefaultLoggingConfig() LoggingConfig {
 }
 
 type Config struct {
-	MetadataPlugin       string        `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
-	TlsKeyFilePath       string        `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
-	Topology             string        `yaml:"topology"`
-	CardanoConfig        string        `yaml:"cardanoConfig"      envconfig:"config"`
-	DatabasePath         string        `yaml:"databasePath"                                                     split_words:"true"`
-	SocketPath           string        `yaml:"socketPath"                                                       split_words:"true"`
-	TlsCertFilePath      string        `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr             string        `yaml:"bindAddr"                                                         split_words:"true"`
-	BlobPlugin           string        `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
-	PrivateBindAddr      string        `yaml:"privateBindAddr"                                                  split_words:"true"`
-	ShutdownTimeout      string        `yaml:"shutdownTimeout"                                                  split_words:"true"`
-	LedgerCatchupTimeout string        `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
-	Network              string        `yaml:"network"`
-	NetworkMagic         uint32        `yaml:"networkMagic"                                                     split_words:"true"`
-	MempoolCapacity      int64         `yaml:"mempoolCapacity"                                                  split_words:"true"`
-	EvictionWatermark    float64       `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
-	RejectionWatermark   float64       `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
-	PrivatePort          uint          `yaml:"privatePort"                                                      split_words:"true"`
-	RelayPort            uint          `yaml:"relayPort"          envconfig:"port"`
-	BarkBaseUrl          string        `yaml:"barkBaseUrl"        envconfig:"DINGO_BARK_BASE_URL"`
-	BarkPort             uint          `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
-	BarkPrunerFrequency  time.Duration `yaml:"barkPrunerFrequency" envconfig:"DINGO_BARK_PRUNER_FREQUENCY"`
-	UtxorpcPort          uint          `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
-	CORSAllowedOrigins   []string      `yaml:"corsAllowedOrigins" envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
-	MetricsPort          uint          `yaml:"metricsPort"                                                      split_words:"true"`
-	DebugPort            uint          `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
-	IntersectTip         bool          `yaml:"intersectTip"                                                     split_words:"true"`
-	ValidateHistorical   bool          `yaml:"validateHistorical"                                               split_words:"true"`
-	RunMode              RunMode       `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
-	StartEra             StartEra      `yaml:"startEra"           envconfig:"DINGO_START_ERA"`
-	ImmutableDbPath      string        `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
+	MetadataPlugin       string   `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
+	TlsKeyFilePath       string   `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
+	Topology             string   `yaml:"topology"`
+	CardanoConfig        string   `yaml:"cardanoConfig"      envconfig:"config"`
+	DatabasePath         string   `yaml:"databasePath"                                                     split_words:"true"`
+	SocketPath           string   `yaml:"socketPath"                                                       split_words:"true"`
+	TlsCertFilePath      string   `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
+	BindAddr             string   `yaml:"bindAddr"                                                         split_words:"true"`
+	BlobPlugin           string   `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
+	PrivateBindAddr      string   `yaml:"privateBindAddr"                                                  split_words:"true"`
+	ShutdownTimeout      string   `yaml:"shutdownTimeout"                                                  split_words:"true"`
+	LedgerCatchupTimeout string   `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
+	Network              string   `yaml:"network"`
+	NetworkMagic         uint32   `yaml:"networkMagic"                                                     split_words:"true"`
+	MempoolCapacity      int64    `yaml:"mempoolCapacity"                                                  split_words:"true"`
+	EvictionWatermark    float64  `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
+	RejectionWatermark   float64  `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
+	PrivatePort          uint     `yaml:"privatePort"                                                      split_words:"true"`
+	RelayPort            uint     `yaml:"relayPort"          envconfig:"port"`
+	BarkBaseUrl          string   `yaml:"barkBaseUrl"        envconfig:"DINGO_BARK_BASE_URL"`
+	BarkPort             uint     `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
+	UtxorpcPort          uint     `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
+	CORSAllowedOrigins   []string `yaml:"corsAllowedOrigins" envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
+	MetricsPort          uint     `yaml:"metricsPort"                                                      split_words:"true"`
+	DebugPort            uint     `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
+	IntersectTip         bool     `yaml:"intersectTip"                                                     split_words:"true"`
+	ValidateHistorical   bool     `yaml:"validateHistorical"                                               split_words:"true"`
+	RunMode              RunMode  `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
+	StartEra             StartEra `yaml:"startEra"           envconfig:"DINGO_START_ERA"`
+	ImmutableDbPath      string   `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
 	// Database worker pool tuning (worker count and task queue size)
 	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
 	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
@@ -313,6 +327,9 @@ type Config struct {
 
 	// Genesis bootstrap configuration for from-origin chain selection.
 	GenesisBootstrap GenesisBootstrapConfig `yaml:"genesisBootstrap"`
+
+	// History expiry configuration for local immutable block CBOR expiry.
+	HistoryExpiry HistoryExpiryConfig `yaml:"historyExpiry"`
 
 	// Logging configuration (output format and level)
 	Logging LoggingConfig `yaml:"logging"`
@@ -468,7 +485,6 @@ var globalConfig = &Config{
 	RelayPort:            3001,
 	BarkBaseUrl:          "",
 	BarkPort:             0,
-	BarkPrunerFrequency:  time.Hour,
 	UtxorpcPort:          9090,
 	CORSAllowedOrigins:   []string{"*"},
 	BlockfrostPort:       3000,
@@ -494,6 +510,8 @@ var globalConfig = &Config{
 	Chainsync: DefaultChainsyncConfig(),
 	// Genesis bootstrap defaults
 	GenesisBootstrap: DefaultGenesisBootstrapConfig(),
+	// History expiry defaults
+	HistoryExpiry: DefaultHistoryExpiryConfig(),
 	// Logging defaults (text output at info level)
 	Logging: DefaultLoggingConfig(),
 	// KES configuration defaults (mainnet values)
@@ -753,6 +771,9 @@ func LoadConfig(configFile string) (*Config, error) {
 	}
 	if globalConfig.ForgeStaleGapThresholdSlots == 0 {
 		globalConfig.ForgeStaleGapThresholdSlots = DefaultForgeStaleGapThresholdSlots
+	}
+	if globalConfig.HistoryExpiry.Frequency <= 0 {
+		globalConfig.HistoryExpiry.Frequency = time.Hour
 	}
 
 	// Validate network name to prevent path traversal (INT-03).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/topology"
 )
@@ -60,6 +61,7 @@ func resetGlobalConfig() {
 		DatabaseQueueSize:           50,
 		BackfillBatchSize:           100,
 		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
+		HistoryExpiry:               DefaultHistoryExpiryConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
@@ -159,6 +161,7 @@ mithril:
 			WindowSlots:                 4321,
 			PromotionMinDiversityGroups: 4,
 		},
+		HistoryExpiry:               DefaultHistoryExpiryConfig(),
 		ForgeSyncToleranceSlots:     321,
 		ForgeStaleGapThresholdSlots: 654,
 		Mithril: MithrilConfig{
@@ -228,6 +231,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 		DatabaseQueueSize:           50,
 		BackfillBatchSize:           100,
 		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
+		HistoryExpiry:               DefaultHistoryExpiryConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
@@ -305,6 +309,58 @@ func TestLoad_GenesisBootstrapEnvVars(t *testing.T) {
 		t.Fatalf(
 			"expected GenesisBootstrap.PromotionMinDiversityGroups to be 6, got %d",
 			cfg.GenesisBootstrap.PromotionMinDiversityGroups,
+		)
+	}
+}
+
+func TestLoad_HistoryExpiryConfig(t *testing.T) {
+	resetGlobalConfig()
+	globalConfig.RunMode = RunModeDev
+
+	yamlContent := `
+historyExpiry:
+  enabled: true
+  frequency: 15m
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "history-expiry.yaml")
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !cfg.HistoryExpiry.Enabled {
+		t.Fatal("expected HistoryExpiry.Enabled to be true")
+	}
+	if cfg.HistoryExpiry.Frequency != 15*time.Minute {
+		t.Fatalf(
+			"expected HistoryExpiry.Frequency to be 15m, got %s",
+			cfg.HistoryExpiry.Frequency,
+		)
+	}
+}
+
+func TestLoad_HistoryExpiryEnvVars(t *testing.T) {
+	resetGlobalConfig()
+	globalConfig.RunMode = RunModeDev
+
+	t.Setenv("DINGO_HISTORY_EXPIRY_ENABLED", "true")
+	t.Setenv("DINGO_HISTORY_EXPIRY_FREQUENCY", "45m")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !cfg.HistoryExpiry.Enabled {
+		t.Fatal("expected HistoryExpiry.Enabled to be true")
+	}
+	if cfg.HistoryExpiry.Frequency != 45*time.Minute {
+		t.Fatalf(
+			"expected HistoryExpiry.Frequency to be 45m, got %s",
+			cfg.HistoryExpiry.Frequency,
 		)
 	}
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -79,9 +79,12 @@ var flagSpecs = []flagSpec{
 	stringSliceFlag("CORSAllowedOrigins", "cors-allowed-origins", "CORS allowed origins for API servers"),
 
 	// Bark
-	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive base URL"),
+	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive fallback base URL"),
 	uintFlag("BarkPort", "bark-port", "Bark RPC port"),
-	durationFlag("BarkPrunerFrequency", "bark-pruner-frequency", "Bark pruner run frequency"),
+
+	// History expiry
+	boolFlag("HistoryExpiry.Enabled", "history-expiry-enabled", "enable local immutable block history expiry"),
+	durationFlag("HistoryExpiry.Frequency", "history-expiry-frequency", "history expiry scan frequency"),
 
 	// Mempool
 	int64Flag("MempoolCapacity", "mempool-capacity", "mempool max bytes"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -72,6 +72,7 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 	t.Setenv("CARDANO_MEMPOOL_CAPACITY", "123456")
 	t.Setenv("DINGO_DATABASE_WORKERS", "9")
 	t.Setenv("DINGO_BACKFILL_BATCH_SIZE", "50")
+	t.Setenv("DINGO_HISTORY_EXPIRY_FREQUENCY", "15m")
 
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")
@@ -101,6 +102,12 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 			cfg.BackfillBatchSize,
 		)
 	}
+	if cfg.HistoryExpiry.Frequency.String() != "15m0s" {
+		t.Fatalf(
+			"expected env var to set history expiry frequency=15m, got %s",
+			cfg.HistoryExpiry.Frequency,
+		)
+	}
 
 	cmd := &cobra.Command{Use: "dingo"}
 	RegisterFlags(cmd)
@@ -108,6 +115,8 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		"--mempool-capacity=7890",
 		"--data-dir=/tmp/override",
 		"--backfill-batch-size=200",
+		"--history-expiry-enabled=true",
+		"--history-expiry-frequency=30m",
 	}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -138,6 +147,15 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		t.Fatalf(
 			"expected --backfill-batch-size to set backfillBatchSize=200, got %d",
 			cfg.BackfillBatchSize,
+		)
+	}
+	if !cfg.HistoryExpiry.Enabled {
+		t.Fatal("expected --history-expiry-enabled to enable history expiry")
+	}
+	if cfg.HistoryExpiry.Frequency.String() != "30m0s" {
+		t.Fatalf(
+			"expected --history-expiry-frequency to set 30m, got %s",
+			cfg.HistoryExpiry.Frequency,
 		)
 	}
 }

--- a/internal/historyexpiry/pruner.go
+++ b/internal/historyexpiry/pruner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bark
+package historyexpiry
 
 import (
 	"context"
@@ -24,11 +24,18 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/database"
-	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
+// LedgerWindow exposes the ledger-derived slot horizon used to decide when
+// immutable block history can be expired locally.
+type LedgerWindow interface {
+	CurrentSlot() (uint64, error)
+	StabilityWindow() uint64
+}
+
 type PrunerConfig struct {
-	LedgerState *ledger.LedgerState
+	LedgerState LedgerWindow
 	DB          *database.Database
 	Logger      *slog.Logger
 	Frequency   time.Duration
@@ -37,7 +44,7 @@ type PrunerConfig struct {
 type Pruner struct {
 	config      PrunerConfig
 	logger      *slog.Logger
-	ledgerState *ledger.LedgerState
+	ledgerState LedgerWindow
 	db          *database.Database
 
 	wg     sync.WaitGroup
@@ -58,7 +65,7 @@ func NewPruner(cfg PrunerConfig) *Pruner {
 
 func (p *Pruner) pruneBlock(next *database.BlobBlockResult) error {
 	if _, err := p.db.PruneBlock(next.Slot, next.Hash); err != nil {
-		return fmt.Errorf("pruner: %w", err)
+		return fmt.Errorf("history expiry: %w", err)
 	}
 	return nil
 }
@@ -67,22 +74,22 @@ func (p *Pruner) prune(ctx context.Context) {
 	currentSlot, err := p.ledgerState.CurrentSlot()
 	if err != nil {
 		p.logger.Error(
-			"pruner: failed to get current slot",
+			"history expiry: failed to get current slot",
 			"error",
 			err,
 		)
 		return
 	}
 
-	securityWindow := p.ledgerState.StabilityWindow()
-	if currentSlot <= securityWindow {
+	stabilityWindow := p.ledgerState.StabilityWindow()
+	if currentSlot <= stabilityWindow {
 		p.logger.Debug(
-			"pruner: skipped because current slot is not high enough")
+			"history expiry: skipped because current slot is not high enough")
 		return
 	}
 	iter := p.db.BlocksInRange(
 		0,
-		currentSlot-securityWindow-1,
+		currentSlot-stabilityWindow-1,
 	)
 	defer iter.Close()
 
@@ -93,21 +100,24 @@ func (p *Pruner) prune(ctx context.Context) {
 		default:
 			next, err := iter.NextRaw()
 			if err != nil {
+				if errors.Is(err, types.ErrHistoryExpired) {
+					continue
+				}
 				p.logger.Error(
-					"pruner: failed to prune block",
+					"history expiry: failed to expire block",
 					"error",
 					err,
 				)
 				return
 			}
 			if next == nil {
-				p.logger.Debug("pruner: completed round of pruning")
+				p.logger.Debug("history expiry: completed round")
 				return
 			}
 
 			if err := p.pruneBlock(next); err != nil {
 				p.logger.Error(
-					"pruner: failed to prune block",
+					"history expiry: failed to expire block",
 					"error",
 					err,
 				)
@@ -132,15 +142,15 @@ func (p *Pruner) run(ctx context.Context) {
 func (p *Pruner) Start(ctx context.Context) error {
 	if p.config.Frequency <= 0 {
 		return fmt.Errorf(
-			"pruner: invalid frequency %d (must be > 0)",
+			"history expiry: invalid frequency %d (must be > 0)",
 			p.config.Frequency,
 		)
 	}
 	if p.ledgerState == nil {
-		return errors.New("pruner: ledger state must not be nil")
+		return errors.New("history expiry: ledger state must not be nil")
 	}
 	if p.db == nil {
-		return errors.New("pruner: database must not be nil")
+		return errors.New("history expiry: database must not be nil")
 	}
 
 	ctx, p.cancel = context.WithCancel(ctx) //nolint:gosec
@@ -166,7 +176,7 @@ func (p *Pruner) Stop(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf(
-			"pruner: failed to stop before context cancellation: %w",
+			"history expiry: failed to stop before context cancellation: %w",
 			ctx.Err(),
 		)
 	}

--- a/internal/historyexpiry/pruner_test.go
+++ b/internal/historyexpiry/pruner_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package historyexpiry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testLedgerWindow struct {
+	currentSlot     uint64
+	stabilityWindow uint64
+	err             error
+}
+
+func (w testLedgerWindow) CurrentSlot() (uint64, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	return w.currentSlot, nil
+}
+
+func (w testLedgerWindow) StabilityWindow() uint64 {
+	return w.stabilityWindow
+}
+
+func newTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		DataDir: "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db
+}
+
+func insertTestBlock(
+	t *testing.T,
+	db *database.Database,
+	slot uint64,
+	hashByte byte,
+) []byte {
+	t.Helper()
+	hash := bytes.Repeat([]byte{hashByte}, 32)
+	err := db.BlockCreate(models.Block{
+		Slot:   slot,
+		Hash:   hash,
+		Cbor:   []byte{0x82, hashByte},
+		Type:   1,
+		Number: slot,
+	}, nil)
+	require.NoError(t, err)
+	return hash
+}
+
+func TestPrunerExpiresBlocksOlderThanStabilityWindow(t *testing.T) {
+	db := newTestDB(t)
+	oldHash := insertTestBlock(t, db, 9, 0x09)
+	boundaryHash := insertTestBlock(t, db, 10, 0x0a)
+	recentHash := insertTestBlock(t, db, 11, 0x0b)
+
+	pruner := NewPruner(PrunerConfig{
+		LedgerState: testLedgerWindow{
+			currentSlot:     15,
+			stabilityWindow: 5,
+		},
+		DB:        db,
+		Frequency: time.Hour,
+	})
+	pruner.prune(context.Background())
+
+	txn := db.BlobTxn(false)
+	defer txn.Release()
+	_, _, err := db.Blob().GetBlock(txn.Blob(), 9, oldHash)
+	assert.ErrorIs(t, err, types.ErrHistoryExpired)
+	_, _, err = db.Blob().GetBlock(txn.Blob(), 10, boundaryHash)
+	assert.NoError(t, err)
+	_, _, err = db.Blob().GetBlock(txn.Blob(), 11, recentHash)
+	assert.NoError(t, err)
+}
+
+func TestPrunerSkipsWhenCurrentSlotWithinStabilityWindow(t *testing.T) {
+	db := newTestDB(t)
+	hash := insertTestBlock(t, db, 1, 0x01)
+
+	pruner := NewPruner(PrunerConfig{
+		LedgerState: testLedgerWindow{
+			currentSlot:     5,
+			stabilityWindow: 5,
+		},
+		DB:        db,
+		Frequency: time.Hour,
+	})
+	pruner.prune(context.Background())
+
+	txn := db.BlobTxn(false)
+	defer txn.Release()
+	_, _, err := db.Blob().GetBlock(txn.Blob(), 1, hash)
+	assert.NoError(t, err)
+}
+
+func TestPrunerSkipsAlreadyExpiredBlocks(t *testing.T) {
+	db := newTestDB(t)
+	firstHash := insertTestBlock(t, db, 1, 0x01)
+	secondHash := insertTestBlock(t, db, 2, 0x02)
+
+	_, err := db.PruneBlock(1, firstHash)
+	require.NoError(t, err)
+
+	pruner := NewPruner(PrunerConfig{
+		LedgerState: testLedgerWindow{
+			currentSlot:     10,
+			stabilityWindow: 5,
+		},
+		DB:        db,
+		Frequency: time.Hour,
+	})
+	pruner.prune(context.Background())
+
+	txn := db.BlobTxn(false)
+	defer txn.Release()
+	_, _, err = db.Blob().GetBlock(txn.Blob(), 2, secondHash)
+	assert.ErrorIs(t, err, types.ErrHistoryExpired)
+}
+
+func TestPrunerStartValidation(t *testing.T) {
+	db := newTestDB(t)
+	tests := []struct {
+		name string
+		cfg  PrunerConfig
+	}{
+		{
+			name: "invalid frequency",
+			cfg: PrunerConfig{
+				LedgerState: testLedgerWindow{},
+				DB:          db,
+			},
+		},
+		{
+			name: "missing ledger",
+			cfg: PrunerConfig{
+				DB:        db,
+				Frequency: time.Hour,
+			},
+		},
+		{
+			name: "missing database",
+			cfg: PrunerConfig{
+				LedgerState: testLedgerWindow{},
+				Frequency:   time.Hour,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewPruner(tt.cfg).Start(context.Background())
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestPrunerStartStop(t *testing.T) {
+	db := newTestDB(t)
+	pruner := NewPruner(PrunerConfig{
+		LedgerState: testLedgerWindow{},
+		DB:          db,
+		Frequency:   time.Hour,
+	})
+	require.NoError(t, pruner.Start(context.Background()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, pruner.Stop(ctx))
+}
+
+func TestPrunerHandlesCurrentSlotError(t *testing.T) {
+	db := newTestDB(t)
+	hash := insertTestBlock(t, db, 1, 0x01)
+
+	pruner := NewPruner(PrunerConfig{
+		LedgerState: testLedgerWindow{
+			err: errors.New("slot clock unavailable"),
+		},
+		DB:        db,
+		Frequency: time.Hour,
+	})
+	pruner.prune(context.Background())
+
+	txn := db.BlobTxn(false)
+	defer txn.Release()
+	_, _, err := db.Blob().GetBlock(txn.Blob(), 1, hash)
+	assert.NoError(t, err)
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -299,7 +299,10 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
 			dingo.WithBarkBaseUrl(cfg.BarkBaseUrl),
 			dingo.WithBarkPort(cfg.BarkPort),
-			dingo.WithBarkPrunerFrequency(cfg.BarkPrunerFrequency),
+			dingo.WithHistoryExpiry(dingo.HistoryExpiryConfig{
+				Enabled:   cfg.HistoryExpiry.Enabled,
+				Frequency: cfg.HistoryExpiry.Frequency,
+			}),
 			dingo.WithCORSAllowedOrigins(cfg.CORSAllowedOrigins),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
 			dingo.WithRunMode(string(cfg.RunMode)),

--- a/internal/test/archive-demo/README.md
+++ b/internal/test/archive-demo/README.md
@@ -1,8 +1,8 @@
 # Archive Node Demo
 
-Runnable demonstration of Dingo's archive-node + pruning-node + Bark
-proxy. Mirrors `internal/test/devnet/` in shape but adds Minio (S3) and
-shows the S3 blob plugin and Bark proxy working end to end.
+Runnable demonstration of Dingo's archive-node + history-expiry node + Bark
+proxy. Mirrors `internal/test/devnet/` in shape but adds Minio (S3) and shows
+the S3 blob plugin, local History Expiry, and Bark proxy working end to end.
 
 ## Stack
 
@@ -10,8 +10,9 @@ shows the S3 blob plugin and Bark proxy working end to end.
 - `dingo-archive` - Dingo with `blobPlugin: s3`, Bark server on port 3003
 - `dingo-pruning` - Dingo with `blobPlugin: badger`,
   `barkBaseUrl` pointing at `dingo-archive`,
-  `barkPrunerFrequency: 5s`. The security window is derived from the
-  ledger's stability window (3k/f = 300 slots for testnet.yaml).
+  `historyExpiry.enabled: true`, and `historyExpiry.frequency: 5s`. The
+  security window is derived from the ledger's stability window (3k/f = 300
+  slots for testnet.yaml).
 - `minio` - S3-compatible blob storage; bucket `dingo-archive`
 
 ## Usage
@@ -25,10 +26,10 @@ shows the S3 blob plugin and Bark proxy working end to end.
 
 `demo.sh` is the right entry point for showing this off. It builds the
 helper binary, brings the stack up, prints a stats line every 10 seconds
-(chain tip, Minio object count, local Badger size, pruner activity), and
+(chain tip, Minio object count, local Badger size, expiry activity), and
 once the chain has crossed the security window it runs a scripted
 BlockFetch from outside the stack against a pre-window block on the
-pruning node and prints the byte count and timing.
+history-expiry node and prints the byte count and timing.
 
 ## What it shows
 
@@ -37,8 +38,8 @@ block at slot ~50, well behind the 300-slot stability window:
 
 1. Returned successfully when BlockFetched from `dingo-pruning` (the
    bark proxy fetches it from the archive on the fly).
-2. Absent from `dingo-pruning`'s local Badger blob store (the pruner
-   really did delete it).
+2. Absent from `dingo-pruning`'s local Badger blob store (History Expiry
+   really did expire it locally).
 3. Present in the Minio `dingo-archive` bucket (the archive holds the
    only copy).
 
@@ -70,6 +71,6 @@ Minio credentials: `demo` / `demodemo`.
 - `cmd/inspect-blob/` is a small Go binary that imports Dingo's blob
   plugin and reports whether a (slot, hash) pair is present in a Badger
   store. `run-tests.sh` builds it on demand.
-- The pruner's run frequency is configurable via `barkPrunerFrequency`
-  in `dingo.yaml` or the `DINGO_BARK_PRUNER_FREQUENCY` env var. Default
-  is 1 hour; the demo uses 5 seconds.
+- The expiry run frequency is configurable via `historyExpiry.frequency`
+  in `dingo.yaml` or the `DINGO_HISTORY_EXPIRY_FREQUENCY` env var. Default is
+  1 hour; the demo uses 5 seconds.

--- a/internal/test/archive-demo/cmd/inspect-blob/main.go
+++ b/internal/test/archive-demo/cmd/inspect-blob/main.go
@@ -94,11 +94,11 @@ func main() {
 	}
 }
 
-// isNotFound treats both "not found" and "tombstoned" errors as the
-// locally-absent case. A tombstone means the bp value has been replaced
-// with a small marker so the bark proxy can resolve the block remotely;
-// from the perspective of "is the real CBOR stored locally?" the answer
-// is no, same as a hard delete.
+// isNotFound treats both "not found" and "history expired" errors as the
+// locally-absent case. Expired history means the bp value has been replaced
+// with a small marker so the bark proxy can resolve the block remotely; from
+// the perspective of "is the real CBOR stored locally?" the answer is no,
+// same as a hard delete.
 func isNotFound(err error) bool {
 	if err == nil {
 		return false
@@ -106,5 +106,5 @@ func isNotFound(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "not found") ||
 		strings.Contains(msg, "errkeynotfound") ||
-		strings.Contains(msg, "tombstoned")
+		strings.Contains(msg, "history expired")
 }

--- a/internal/test/archive-demo/configs/dingo-pruning.yaml
+++ b/internal/test/archive-demo/configs/dingo-pruning.yaml
@@ -1,7 +1,9 @@
-# Pruning node config: local Badger blob store. The pruner runs every 5s
-# and deletes blocks beyond the chain stability window (derived by Dingo
-# from genesis: 3k/f, which is 300 slots for testnet.yaml). When asked
-# for a pre-window block, the BarkBlobStore wrapper transparently fetches
-# it from the archive node.
+# History-expiry node config: local Badger blob store. The expiry worker runs
+# every 5s and expires blocks beyond the chain stability window (derived by
+# Dingo from genesis: 3k/f, which is 300 slots for testnet.yaml). When asked
+# for a pre-window block, the BarkBlobStore wrapper transparently fetches it
+# from the archive node.
 barkBaseUrl: http://dingo-archive:3003
-barkPrunerFrequency: 5s
+historyExpiry:
+  enabled: true
+  frequency: 5s

--- a/internal/test/archive-demo/demo.sh
+++ b/internal/test/archive-demo/demo.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Operator-facing guided demo of the archive-node + pruning-node + bark
-# proxy story. Stands the stack up, narrates chain growth and pruner
+# Operator-facing guided demo of the archive-node + history-expiry-node + bark
+# proxy story. Stands the stack up, narrates chain growth and expiry
 # activity, then shows a live BlockFetch from outside the stack against
-# a block that has already been pruned locally.
+# a block whose local history has already expired.
 #
 # Usage:
 #   ./demo.sh             # full guided demo
@@ -27,9 +27,9 @@
 #   1. Stack comes up (Minio + cardano-producer + dingo-archive + dingo-pruning).
 #   2. Chain advances; both Dingo nodes track it.
 #   3. Minio bucket fills with block CBOR objects as the archive node writes.
-#   4. Pruner kicks in once tip is past the stability window (3k/f = 300
+#   4. History Expiry kicks in once tip is past the stability window (3k/f = 300
 #      slots for testnet.yaml); local Badger blob count drops.
-#   5. demo-fetch BlockFetches a block at slot ~50 from the pruning node
+#   5. demo-fetch BlockFetches a block at slot ~50 from the expiry node
 #      and prints "OK: fetched X bytes from dingo-pruning in Yms" once the
 #      bark proxy returns the block from the archive.
 
@@ -160,34 +160,34 @@ badger_blob_size() {
     | awk '{print $1}' || echo "?"
 }
 
-pruner_rounds() {
-  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'completed round of pruning' || true
+expiry_rounds() {
+  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'history expiry: completed round' || true
 }
 
-pruner_skipped() {
-  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'skipped because current slot is not high enough' || true
+expiry_skipped() {
+  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'history expiry: skipped because current slot is not high enough' || true
 }
 
 # ---------------------------------------------------------------------------
 # Watch the system grow: print a stats line every 10s until tip clears the
-# security window and the pruner has had time to act on slot ~50.
+# security window and History Expiry has had time to act on slot ~50.
 # ---------------------------------------------------------------------------
-say "Watching chain grow and pruner act..."
-note "Stability window: 300 slots (3k/f from testnet.yaml). Target: tip >= 400 (pruner will have removed slots 0..99)."
+say "Watching chain grow and History Expiry act..."
+note "Stability window: 300 slots (3k/f from testnet.yaml). Target: tip >= 400 (History Expiry will have expired slots 0..99)."
 TARGET_TIP=400
 deadline=$(( $(date +%s) + 600 ))
-prev_pruner=0
+prev_expiry=0
 while true; do
   tip="$(last_tip_slot 2>/dev/null || true)"
   tip="${tip:-0}"
   obj_total=$(minio_object_count)
   obj_bp=$(minio_block_objects)
   badger=$(badger_blob_size)
-  rounds=$(pruner_rounds)
-  delta=$(( rounds - prev_pruner ))
-  prev_pruner=${rounds}
+  rounds=$(expiry_rounds)
+  delta=$(( rounds - prev_expiry ))
+  prev_expiry=${rounds}
 
-  printf '   tip=%-4s  minio_objects=%-5s  minio_block_cbor=%-4s  pruning_node_blob=%-7s  pruner_rounds=%s (+%d)\n' \
+  printf '   tip=%-4s  minio_objects=%-5s  minio_block_cbor=%-4s  expiry_node_blob=%-7s  expiry_rounds=%s (+%d)\n' \
     "${tip}" "${obj_total}" "${obj_bp}" "${badger}" "${rounds}" "${delta}"
 
   if [[ ${tip} -ge ${TARGET_TIP} ]]; then
@@ -199,14 +199,14 @@ while true; do
   sleep 10
 done
 
-note "Tip is past the security window. Pruner has run $(pruner_rounds) rounds."
+note "Tip is past the security window. History Expiry has run $(expiry_rounds) rounds."
 
 # ---------------------------------------------------------------------------
 # BlockFetch a block well behind the security window. Show timing.
 # ---------------------------------------------------------------------------
 say "BlockFetch test: requesting a block at slot ~50 from dingo-pruning"
 note "  slot 50 is ~350 slots behind the current tip (well past the 300-slot window)"
-note "  it has been deleted from dingo-pruning's local Badger"
+note "  it has expired from dingo-pruning's local Badger"
 note "  if the bark proxy is wired correctly, dingo-pruning fetches it from the archive"
 note ""
 note "Running demo-fetch (timeout 60s)..."

--- a/internal/test/archive-demo/docker-compose.yml
+++ b/internal/test/archive-demo/docker-compose.yml
@@ -15,7 +15,7 @@
 # Archive node demo Docker Compose configuration.
 #
 # Mirrors internal/test/devnet/ in shape but exercises the S3 blob plugin,
-# Bark archive server, and Bark client + pruner together.
+# Bark archive server, Bark client fallback, and History Expiry together.
 #
 # Services:
 #   configurator     - one-shot, generates pool keys and genesis files
@@ -23,8 +23,8 @@
 #   minio-init       - one-shot, creates the "dingo-archive" bucket
 #   cardano-producer - sole block producer (cardano-node 11.0.1)
 #   dingo-archive    - non-producer; S3 blob plugin + Bark server :3002
-#   dingo-pruning    - non-producer; Badger blob plugin + Bark client
-#                      pointed at dingo-archive
+#   dingo-pruning    - non-producer; Badger blob plugin + History Expiry
+#                      plus Bark client pointed at dingo-archive
 #
 # Usage:
 #   ./start.sh         # bring up

--- a/internal/test/archive-demo/internal/archivedemo/harness.go
+++ b/internal/test/archive-demo/internal/archivedemo/harness.go
@@ -42,7 +42,7 @@ type Endpoint struct {
 	Address string
 }
 
-// DefaultEndpoints returns the archive and pruning Dingo endpoints,
+// DefaultEndpoints returns the archive and history-expiry Dingo endpoints,
 // honoring env overrides for CI flexibility.
 func DefaultEndpoints() (archive, pruning Endpoint) {
 	arch := os.Getenv("ARCHIVEDEMO_DINGO_ARCHIVE_ADDR")

--- a/internal/test/archive-demo/internal/archivedemo/scenarios/archive_demo_test.go
+++ b/internal/test/archive-demo/internal/archivedemo/scenarios/archive_demo_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestArchiveProxy exercises the full archive-node + pruning-node + bark
+// TestArchiveProxy exercises the full archive-node + history-expiry-node + bark
 // proxy story end to end:
 //
 //  1. wait for chain to advance well past the security window on both nodes
@@ -52,9 +52,9 @@ func TestArchiveProxy(t *testing.T) {
 	archive, pruning := archivedemo.DefaultEndpoints()
 
 	// Step 1: wait for both nodes to advance past the stability window.
-	// Dingo derives the bark security window from LedgerState.StabilityWindow(),
+	// Dingo derives the expiry window from LedgerState.StabilityWindow(),
 	// which is 3k/f. With testnet.yaml's k=40 and f=0.4 that's 300 slots.
-	// We wait for tip >= 400 to give the pruner some cycles past the window.
+	// We wait for tip >= 400 to give History Expiry some cycles past the window.
 	const stabilityWindow = uint64(300) // 3 * k(40) / f(0.4)
 	const targetTip = uint64(400)
 	_, err := archivedemo.WaitForSlot(archive, archivedemo.DefaultNetworkMagic, targetTip, 10*time.Minute, t.Logf)
@@ -62,9 +62,9 @@ func TestArchiveProxy(t *testing.T) {
 	_, err = archivedemo.WaitForSlot(pruning, archivedemo.DefaultNetworkMagic, targetTip, 10*time.Minute, t.Logf)
 	require.NoError(t, err)
 
-	// Step 1b: poll until the pruner has had time to act on candidateSlot.
+	// Step 1b: poll until History Expiry has had time to act on candidateSlot.
 	// inspect-blob can't run while the container holds the badger lockfile,
-	// so we wait until the pruner's tick frequency (5s) has had several
+	// so we wait until the expiry tick frequency (5s) has had several
 	// cycles past candidateSlot+stabilityWindow.
 	const candidateSlot = uint64(50)
 	require.Eventually(t, func() bool {
@@ -73,7 +73,7 @@ func TestArchiveProxy(t *testing.T) {
 			return false
 		}
 		return tip.Slot >= candidateSlot+stabilityWindow+30
-	}, 3*time.Minute, 5*time.Second, "chain did not advance far enough for pruner to act")
+	}, 3*time.Minute, 5*time.Second, "chain did not advance far enough for history expiry to act")
 
 	// Step 2: resolve (slot, hash) of the first block at or after candidateSlot
 	// using dingo-archive, which has the full chain.
@@ -88,7 +88,7 @@ func TestArchiveProxy(t *testing.T) {
 	cbor, err := archivedemo.FetchBlock(
 		pruning, archivedemo.DefaultNetworkMagic, point, 60*time.Second,
 	)
-	require.NoError(t, err, "BlockFetch on pruning node should transparently proxy via bark")
+	require.NoError(t, err, "BlockFetch on history-expiry node should transparently proxy via bark")
 	require.NotEmpty(t, cbor, "block CBOR should be non-empty")
 
 	// Step 4 (assertion 3): object present in Minio bucket.

--- a/internal/test/archive-demo/start.sh
+++ b/internal/test/archive-demo/start.sh
@@ -16,7 +16,7 @@
 
 # Start the archive-node demo for manual exploration.
 # The bind-mount tmp/dingo-pruning-data is created up front so the
-# pruning node has a stable host path the integration test can later
+# history-expiry node has a stable host path the integration test can later
 # open with Badger.
 #
 # Usage: ./start.sh
@@ -37,7 +37,7 @@ echo "Archive demo started."
 echo "  Cardano producer: localhost:${ARCHIVEDEMO_CARDANO_PORT:-3110}"
 echo "  Dingo archive:    localhost:${ARCHIVEDEMO_DINGO_ARCHIVE_PORT:-3111}"
 echo "  Bark gRPC:        localhost:${ARCHIVEDEMO_BARK_PORT:-3112}"
-echo "  Dingo pruning:    localhost:${ARCHIVEDEMO_DINGO_PRUNING_PORT:-3113}"
+echo "  Dingo expiry:     localhost:${ARCHIVEDEMO_DINGO_PRUNING_PORT:-3113}"
 echo "  Minio S3:         localhost:${ARCHIVEDEMO_MINIO_PORT:-9100}"
 echo "  Minio console:    localhost:${ARCHIVEDEMO_MINIO_CONSOLE_PORT:-9101} (demo/demodemo)"
 echo ""

--- a/node.go
+++ b/node.go
@@ -34,6 +34,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/historyexpiry"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	"github.com/blinklabs-io/dingo/ledger/leader"
@@ -60,7 +61,7 @@ type Node struct {
 	snapshotMgr                      *snapshot.Manager
 	utxorpc                          *utxorpc.Utxorpc
 	bark                             *bark.Bark
-	barkPruner                       *bark.Pruner
+	historyExpiry                    *historyexpiry.Pruner
 	blockfrostAPI                    *blockfrost.Blockfrost
 	meshAPI                          *mesh.Server
 	ouroboros                        *ouroborosPkg.Ouroboros
@@ -336,31 +337,31 @@ func (n *Node) Run(ctx context.Context) error {
 			HTTPClient: &http.Client{
 				Timeout: 30 * time.Second,
 			},
-			LedgerState: state,
-			Logger:      n.config.logger,
 		}, n.db.Blob())
 		if err != nil {
 			return fmt.Errorf("failed to create bark blob store: %w", err)
 		}
 		n.db.SetBlobStore(barkBlobStore)
+	}
 
-		prunerFreq := n.config.barkPrunerFrequency
+	if n.config.historyExpiry.Enabled {
+		prunerFreq := n.config.historyExpiry.Frequency
 		if prunerFreq <= 0 {
 			prunerFreq = time.Hour
 		}
-		n.barkPruner = bark.NewPruner(bark.PrunerConfig{
+		n.historyExpiry = historyexpiry.NewPruner(historyexpiry.PrunerConfig{
 			LedgerState: state,
 			DB:          n.db,
 			Logger:      n.config.logger,
 			Frequency:   prunerFreq,
 		})
 
-		if err := n.barkPruner.Start(n.ctx); err != nil {
-			return fmt.Errorf("failed to start pruner: %w", err)
+		if err := n.historyExpiry.Start(n.ctx); err != nil {
+			return fmt.Errorf("failed to start history expiry: %w", err)
 		}
 
 		started = append(started, func() {
-			_ = n.barkPruner.Stop(context.Background())
+			_ = n.historyExpiry.Stop(context.Background())
 		})
 	}
 

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -143,11 +143,11 @@ func (n *Node) shutdown() error {
 		}
 	}
 
-	if n.barkPruner != nil {
-		if stopErr := n.barkPruner.Stop(ctx); stopErr != nil {
+	if n.historyExpiry != nil {
+		if stopErr := n.historyExpiry.Stop(ctx); stopErr != nil {
 			err = errors.Join(
 				err,
-				fmt.Errorf("bark pruner shutdown: %w", stopErr))
+				fmt.Errorf("history expiry shutdown: %w", stopErr))
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved ledger-window pruning into a standalone History Expiry worker and kept Bark focused on archive fallback. This adds `internal/historyexpiry` with a simple on/off config and switches tombstone handling to “history expired” across blob plugins and Bark.

- **Refactors**
  - Added `internal/historyexpiry.Pruner` that expires old block CBOR using the ledger’s stability window.
  - Bark now only provides archive fallback; `bark.BlobStoreBark` resolves `types.ErrHistoryExpired` or missing blocks from a remote archive.
  - Removed Bark pruner wiring; node starts History Expiry only when `historyExpiry.enabled` is true.
  - Replaced tombstone errors with `types.ErrHistoryExpired` and `types.HistoryExpiredError` (kept `ErrBlockTombstoned` as an alias).
  - Updated blob plugins (`badger`, `s3`, `gcs`) and iterators to emit `HistoryExpiredError`.
  - Simplified `bark.BlobStoreBark` constructor (no `LedgerState`); requires an upstream blob store.
  - Docs and archive demo updated to reflect History Expiry + optional Bark fallback.

- **Migration**
  - Config: add `historyExpiry.enabled` and `historyExpiry.frequency`; remove `barkPrunerFrequency`.
  - Env/flags:
    - New: `DINGO_HISTORY_EXPIRY_ENABLED`, `DINGO_HISTORY_EXPIRY_FREQUENCY`, `--history-expiry-enabled`, `--history-expiry-frequency`.
    - Removed: `DINGO_BARK_PRUNER_FREQUENCY`, `--bark-pruner-frequency`.
  - Keep previous behavior by enabling `historyExpiry.enabled: true` and setting `barkBaseUrl` for archive fallback.
  - Update code to check `types.ErrHistoryExpired` (aliases keep older checks working).

<sup>Written for commit e3f186c60a09d46284f0e321d88e18cc58d2acf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture, deployment, and configuration documentation to reflect archive and history expiry behavior.

* **Configuration**
  * Added new `historyExpiry` configuration options (`enabled`, `frequency`) for controlling local block history retention.
  * Updated environment variable support and YAML configuration examples.

* **Improvements**
  * Enhanced error messaging for expired historical blocks with clearer semantics.
  * Updated archive fallback behavior documentation for handling locally-expired blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->