### PR TITLE
fix(database): make stake and DRep credential identity tag-aware

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -766,7 +766,8 @@ quoting (`"transaction"` on SQLite/Postgres, `` `transaction` `` on MySQL).
 
 ```sql
 WITH latest_reg AS (
-  SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+  SELECT pr.pool_id, pr.added_slot, pr.reward_account,
+    pr.reward_account_credential_tag, pr.deposit_amount,
     COALESCE(t.block_index, 0) AS blk_idx,
     COALESCE(c.cert_index, 0)  AS cert_idx,
     ROW_NUMBER() OVER (
@@ -791,7 +792,8 @@ latest_ret AS (
   LEFT JOIN "transaction" t ON t.id = c.transaction_id
   WHERE rt.added_slot < $boundarySlot
 )
-SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+SELECT p.pool_key_hash, lr.reward_account, lr.reward_account_credential_tag,
+  lr.deposit_amount
 FROM pool p
 INNER JOIN latest_reg lr  ON lr.pool_id = p.id  AND lr.rn = 1
 INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
@@ -804,7 +806,8 @@ WHERE lrt.epoch = $epoch
 ```
 
 The `reward_account` is the 28-byte stake credential stored on the registration,
-used directly to look up the reward account (see `AddAccountReward`). Deposit
+and `reward_account_credential_tag` distinguishes key-hash vs script-hash reward
+credentials when looking up the reward account. Deposit
 refunds are applied in `applyPoolRetirements` (ledger): the deposit is credited
 to the registered, active reward account, or added to `network_state.treasury`
 when that account is missing or inactive. Both writes are slot-keyed (the

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -523,6 +523,7 @@ FROM utxo u
 LEFT JOIN asset a ON a.utxo_id = u.id
 WHERE u.deleted_slot = 0
   AND u.payment_key = decode($1, 'hex')
+  AND u.payment_script = $2
 ORDER BY u.added_slot DESC, u.output_idx DESC;
 ```
 
@@ -531,9 +532,10 @@ Historical UTxOs at a slot:
 ```sql
 SELECT u.*
 FROM utxo u
-WHERE u.added_slot <= $2
-  AND (u.deleted_slot = 0 OR u.deleted_slot > $2)
-  AND u.payment_key = decode($1, 'hex');
+WHERE u.added_slot <= $3
+  AND (u.deleted_slot = 0 OR u.deleted_slot > $3)
+  AND u.payment_key = decode($1, 'hex')
+  AND u.payment_script = $2;
 ```
 
 Controlled amount by stake credential:

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -47,7 +47,7 @@ flowchart LR
 - Byte columns store raw bytes, not hex strings. In Postgres use `encode(col, 'hex')` and `decode($1, 'hex')`. In MySQL use `HEX(col)` and `UNHEX(?)`.
 - `types.Uint64` values such as `amount`, `reward`, `pledge`, `cost`, treasury/reserves, and stake totals are persisted as unsigned decimal values through the Go SQL driver. Use numeric casts if your SQL client reports them as text in a specific backend.
 - Quote the `transaction` table in SQL examples because it is a keyword-adjacent identifier: `"transaction"` in Postgres, `` `transaction` `` in MySQL.
-- `id` is the normal auto-increment primary key. Tables with ledger identifiers also have unique indexes such as `hash`, `staking_key`, `(tx_id, output_idx)`, or `(epoch, snapshot_type, pool_key_hash)`.
+- `id` is the normal auto-increment primary key. Tables with ledger identifiers also have unique indexes such as `hash`, `(credential_tag, staking_key)`, `(tx_id, output_idx)`, or `(epoch, snapshot_type, pool_key_hash)`.
 - Many relations are logical joins rather than explicit foreign keys. Certificate rows have two logical pointers: each specialized certificate table has `certificate_id -> certs.id`, and `certs.certificate_id` is the polymorphic back-pointer to that specialized row chosen by `certs.cert_type`.
 - Live UTxOs have `utxo.deleted_slot = 0`. Governance/committee/constitution soft deletes use nullable `deleted_slot`; `NULL` means active.
 - Certificate history ordering must use `added_slot DESC`, the producing transaction's `block_index DESC`, and `cert_index DESC`. `cert_index` resets per transaction.
@@ -94,17 +94,17 @@ erDiagram
     POOL_REGISTRATION ||..|| CERTS : "certificate_id -> certs.id"
     POOL_RETIREMENT ||..|| CERTS : "certificate_id -> certs.id"
 
-    ACCOUNT ||..o{ REGISTRATION : "staking_key"
-    ACCOUNT ||..o{ DEREGISTRATION : "staking_key"
-    ACCOUNT ||..o{ STAKE_REGISTRATION : "staking_key"
-    ACCOUNT ||..o{ STAKE_DEREGISTRATION : "staking_key"
-    ACCOUNT ||..o{ STAKE_DELEGATION : "staking_key"
-    ACCOUNT ||..o{ STAKE_REGISTRATION_DELEGATION : "staking_key"
-    ACCOUNT ||..o{ STAKE_VOTE_DELEGATION : "staking_key"
-    ACCOUNT ||..o{ STAKE_VOTE_REGISTRATION_DELEGATION : "staking_key"
-    ACCOUNT ||..o{ VOTE_DELEGATION : "staking_key"
-    ACCOUNT ||..o{ VOTE_REGISTRATION_DELEGATION : "staking_key"
-    ACCOUNT ||..o{ ACCOUNT_REWARD_DELTA : "staking_key"
+    ACCOUNT ||..o{ REGISTRATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ DEREGISTRATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ STAKE_REGISTRATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ STAKE_DEREGISTRATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ STAKE_DELEGATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ STAKE_REGISTRATION_DELEGATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ STAKE_VOTE_DELEGATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ STAKE_VOTE_REGISTRATION_DELEGATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ VOTE_DELEGATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ VOTE_REGISTRATION_DELEGATION : "credential_tag + staking_key"
+    ACCOUNT ||..o{ ACCOUNT_REWARD_DELTA : "credential_tag + staking_key"
     POOL ||--o{ POOL_REGISTRATION : "pool_id"
     POOL ||--o{ POOL_RETIREMENT : "pool_id"
     POOL_REGISTRATION ||--o{ POOL_REGISTRATION_OWNER : "pool_registration_id"
@@ -203,18 +203,18 @@ erDiagram
 
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
-| `account` | `id`, `staking_key`, `pool`, `drep`, `added_slot`, `certificate_id`, `reward`, `drep_type`, `active` | PK `id`; unique `staking_key`; indexes pool/DRep/active lookup combinations | Current stake account state. Historical changes are in certificate-specific tables. `drep_type`: 0 key hash, 1 script hash, 2 AlwaysAbstain, 3 AlwaysNoConfidence. |
-| `account_reward_delta` | `id`, `staking_key`, `tx_hash`, `amount`, `previous_reward`, `added_slot`, `withdrawal` | PK `id`; indexes `staking_key`, `tx_hash`, `added_slot`, `withdrawal`; unique `(withdrawal, tx_hash, staking_key)` | Rollback-aware reward-account change journal. Credit rows add `amount`; withdrawal rows clear `account.reward`, store `previous_reward`, and use `tx_hash` to keep transaction re-ingest idempotent. For withdrawal rows, `amount` is the ledger-valid withdrawal amount and may exceed the projected `account.reward`; rollback restores `previous_reward`. Logical join to `account.staking_key`. |
-| `registration` | `id`, `staking_key`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `certificate_id`, `added_slot` | Conway-era stake registration certificate. Join `certificate_id -> certs.id`. |
-| `deregistration` | `id`, `staking_key`, `certificate_id`, `added_slot`, `amount` | PK `id`; indexes `staking_key`, `certificate_id`, `added_slot` | Conway-era stake deregistration certificate. |
-| `stake_registration` | `id`, `staking_key`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `certificate_id`, `added_slot` | Shelley-era stake registration certificate. |
-| `stake_deregistration` | `id`, `staking_key`, `certificate_id`, `added_slot` | PK `id`; indexes `staking_key`, `certificate_id`, `added_slot` | Shelley-era stake deregistration certificate. |
-| `stake_delegation` | `id`, `staking_key`, `pool_key_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `staking_key`, `pool_key_hash`, `certificate_id`, `added_slot` | Stake delegation to pool. Logical joins to `account.staking_key` and `pool.pool_key_hash`. |
-| `stake_registration_delegation` | `id`, `staking_key`, `pool_key_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `pool_key_hash`, `certificate_id`, `added_slot` | Combined registration and pool delegation. |
-| `stake_vote_delegation` | `id`, `staking_key`, `pool_key_hash`, `drep`, `drep_type`, `certificate_id`, `added_slot` | PK `id`; indexes `staking_key`, `pool_key_hash`, `drep`, `certificate_id`, `added_slot` | Combined pool and DRep delegation. |
-| `stake_vote_registration_delegation` | `id`, `staking_key`, `pool_key_hash`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `pool_key_hash`, `drep`, `certificate_id`, `added_slot` | Combined registration, pool delegation, and DRep delegation. |
-| `vote_delegation` | `id`, `staking_key`, `drep`, `drep_type`, `certificate_id`, `added_slot` | PK `id`; indexes `staking_key`, `drep`, `certificate_id`, `added_slot` | DRep-only vote delegation. |
-| `vote_registration_delegation` | `id`, `staking_key`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `drep`, `certificate_id`, `added_slot` | Combined registration and DRep delegation. |
+| `account` | `id`, `staking_key`, `credential_tag`, `pool`, `drep`, `added_slot`, `certificate_id`, `reward`, `drep_type`, `active` | PK `id`; unique `(credential_tag, staking_key)`; indexes pool/DRep/active lookup combinations | Current stake account state. `credential_tag`: 0 key hash, 1 script hash. Historical changes are in certificate-specific tables. `drep_type`: 0 key hash, 1 script hash, 2 AlwaysAbstain, 3 AlwaysNoConfidence. |
+| `account_reward_delta` | `id`, `staking_key`, `credential_tag`, `tx_hash`, `amount`, `previous_reward`, `added_slot`, `withdrawal` | PK `id`; indexes `(credential_tag, staking_key)`, `tx_hash`, `added_slot`, `withdrawal`; unique `(withdrawal, tx_hash, credential_tag, staking_key)` | Rollback-aware reward-account change journal. Credit rows add `amount`; withdrawal rows clear `account.reward`, store `previous_reward`, and use `tx_hash` plus the full stake credential identity to keep transaction re-ingest idempotent. Logical join to `account.(credential_tag, staking_key)`. |
+| `registration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Conway-era stake registration certificate. Join `certificate_id -> certs.id`. |
+| `deregistration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot`, `amount` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Conway-era stake deregistration certificate. |
+| `stake_registration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Shelley-era stake registration certificate. |
+| `stake_deregistration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Shelley-era stake deregistration certificate. |
+| `stake_delegation` | `id`, `staking_key`, `credential_tag`, `pool_key_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, staking_key)`, `pool_key_hash`, `certificate_id`, `added_slot` | Stake delegation to pool. Logical joins to `account.(credential_tag, staking_key)` and `pool.pool_key_hash`. |
+| `stake_registration_delegation` | `id`, `staking_key`, `credential_tag`, `pool_key_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `pool_key_hash`, `certificate_id`, `added_slot` | Combined registration and pool delegation. |
+| `stake_vote_delegation` | `id`, `staking_key`, `credential_tag`, `pool_key_hash`, `drep`, `drep_type`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, staking_key)`, `pool_key_hash`, `drep`, `certificate_id`, `added_slot` | Combined pool and DRep delegation. |
+| `stake_vote_registration_delegation` | `id`, `staking_key`, `credential_tag`, `pool_key_hash`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `pool_key_hash`, `drep`, `certificate_id`, `added_slot` | Combined registration, pool delegation, and DRep delegation. |
+| `vote_delegation` | `id`, `staking_key`, `credential_tag`, `drep`, `drep_type`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, staking_key)`, `drep`, `certificate_id`, `added_slot` | DRep-only vote delegation. |
+| `vote_registration_delegation` | `id`, `staking_key`, `credential_tag`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `drep`, `certificate_id`, `added_slot` | Combined registration and DRep delegation. |
 | `move_instantaneous_rewards` | `id`, `pot`, `certificate_id`, `added_slot`, `other_pot` | PK `id`; indexes `pot`, `certificate_id`, `added_slot` | MIR certificate header. `pot`: 0 = Reserves, 1 = Treasury. `other_pot` is non-zero for pot-to-pot transfer certs (no child rows); zero for credential distribution certs (child rows in `move_instantaneous_rewards_reward`). Applied at each epoch boundary by the Shelley INSTANT rule. |
 | `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `amount` | PK `id`; index `mir_id` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. |
 
@@ -599,6 +599,7 @@ Latest delegation state for an account:
 ```sql
 -- Postgres
 SELECT
+  a.credential_tag,
   encode(a.staking_key, 'hex') AS staking_key,
   encode(a.pool, 'hex') AS pool_key_hash,
   encode(a.drep, 'hex') AS drep,
@@ -606,7 +607,8 @@ SELECT
   a.reward,
   a.active
 FROM account a
-WHERE a.staking_key = decode($1, 'hex');
+WHERE a.credential_tag = $1
+  AND a.staking_key = decode($2, 'hex');
 ```
 
 To match `includeInactive = false`, add:

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -121,13 +121,13 @@ erDiagram
 
 ```mermaid
 erDiagram
-    DREP ||..o{ REGISTRATION_DREP : "credential = drep_credential"
-    DREP ||..o{ DEREGISTRATION_DREP : "credential = drep_credential"
-    DREP ||..o{ UPDATE_DREP : "credential"
-    DREP ||..o{ VOTE_DELEGATION : "credential = drep"
-    DREP ||..o{ VOTE_REGISTRATION_DELEGATION : "credential = drep"
-    DREP ||..o{ STAKE_VOTE_DELEGATION : "credential = drep"
-    DREP ||..o{ STAKE_VOTE_REGISTRATION_DELEGATION : "credential = drep"
+    DREP ||..o{ REGISTRATION_DREP : "credential_tag + credential"
+    DREP ||..o{ DEREGISTRATION_DREP : "credential_tag + credential"
+    DREP ||..o{ UPDATE_DREP : "credential_tag + credential"
+    DREP ||..o{ VOTE_DELEGATION : "drep_type + drep"
+    DREP ||..o{ VOTE_REGISTRATION_DELEGATION : "drep_type + drep"
+    DREP ||..o{ STAKE_VOTE_DELEGATION : "drep_type + drep"
+    DREP ||..o{ STAKE_VOTE_REGISTRATION_DELEGATION : "drep_type + drep"
     REGISTRATION_DREP ||..|| CERTS : "certificate_id -> certs.id"
     DEREGISTRATION_DREP ||..|| CERTS : "certificate_id -> certs.id"
     UPDATE_DREP ||..|| CERTS : "certificate_id -> certs.id"
@@ -234,12 +234,12 @@ erDiagram
 
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
-| `drep` | `id`, `credential`, `anchor_url`, `anchor_hash`, `added_slot`, `last_activity_epoch`, `expiry_epoch`, `active` | PK `id`; unique `credential`; indexes `added_slot`, `last_activity_epoch`, `expiry_epoch` | Current DRep state. |
-| `registration_drep` | `id`, `drep_credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; unique `(drep_credential, added_slot)`; index `certificate_id` | DRep registration certificate. |
-| `deregistration_drep` | `id`, `drep_credential`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `drep_credential`, `certificate_id`, `added_slot` | DRep deregistration certificate. |
-| `update_drep` | `id`, `credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `credential`, `certificate_id`, `added_slot` | DRep update certificate. |
+| `drep` | `id`, `credential_tag`, `credential`, `anchor_url`, `anchor_hash`, `added_slot`, `last_activity_epoch`, `expiry_epoch`, `active` | PK `id`; unique `(credential_tag, credential)`; indexes `added_slot`, `last_activity_epoch`, `expiry_epoch` | Current DRep state. `credential_tag`: 0 key-hash, 1 script-hash. The composite unique key distinguishes same-hash key and script DReps. |
+| `registration_drep` | `id`, `credential_tag`, `drep_credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; unique `(credential_tag, drep_credential, added_slot)`; index `certificate_id` | DRep registration certificate. `credential_tag` mirrors `drep.credential_tag` for the registered DRep. |
+| `deregistration_drep` | `id`, `credential_tag`, `drep_credential`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, drep_credential)`, `certificate_id`, `added_slot` | DRep deregistration certificate. |
+| `update_drep` | `id`, `credential_tag`, `credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, credential)`, `certificate_id`, `added_slot` | DRep update certificate. |
 | `governance_proposal` | `id`, `tx_hash`, `action_index`, `action_type`, `proposed_epoch`, `expires_epoch`, `parent_tx_hash`, `parent_action_idx`, `enacted_epoch`, `enacted_slot`, `ratified_epoch`, `ratified_slot`, `policy_hash`, `anchor_url`, `anchor_hash`, `deposit`, `return_address`, `gov_action_cbor`, `expired_epoch`, `expired_slot`, `added_slot`, `deleted_slot` | PK `id`; unique `(tx_hash, action_index)`; composite `(parent_tx_hash, parent_action_idx)` (`idx_gov_proposal_parent`); indexes action type, epochs, lifecycle slots, `added_slot`, `deleted_slot` | Governance action lifecycle. Votes join by `governance_vote.proposal_id`. `gov_action_cbor` stores the era-specific GovAction CBOR used for enactment; replay may rewrite ratified parameter-change actions at an era boundary, such as Conway to Dijkstra, so old databases should be rebuilt from chain data when this encoding changes. |
-| `governance_vote` | `id`, `proposal_id`, `voter_type`, `voter_credential`, `vote`, `anchor_url`, `anchor_hash`, `added_slot`, `vote_updated_slot`, `deleted_slot` | PK `id`; unique `(proposal_id, voter_type, voter_credential)`; indexes proposal/voter/lifecycle slots | Vote on a governance proposal. `voter_type`: 0 committee, 1 DRep, 2 SPO. `vote`: 0 No, 1 Yes, 2 Abstain. |
+| `governance_vote` | `id`, `proposal_id`, `voter_type`, `voter_credential_tag`, `voter_credential`, `vote`, `anchor_url`, `anchor_hash`, `added_slot`, `vote_updated_slot`, `deleted_slot` | PK `id`; unique `(proposal_id, voter_type, voter_credential_tag, voter_credential)`; indexes proposal/voter/lifecycle slots | Vote on a governance proposal. `voter_type`: 0 committee, 1 DRep, 2 SPO. `voter_credential_tag`: 0 key hash, 1 script hash for committee/DRep voters; 0 for SPO key hashes. `vote`: 0 No, 1 Yes, 2 Abstain. |
 | `constitution` | `id`, `anchor_url`, `anchor_hash`, `policy_hash`, `added_slot`, `deleted_slot` | PK `id`; unique `added_slot`; index `deleted_slot` | Current or historical constitution references. |
 | `committee_member` | `id`, `cold_cred_hash`, `expires_epoch`, `added_slot`, `deleted_slot` | PK `id`; unique `cold_cred_hash`; indexes `added_slot`, `deleted_slot` | Snapshot-imported committee state. |
 | `committee_quorum` | `id`, `quorum`, `added_slot` | PK `id`; unique `added_slot` | Enacted committee quorum threshold. `quorum` is stored through `types.Rat`. |
@@ -834,6 +834,7 @@ SELECT
   gp.action_index,
   gp.action_type,
   gv.voter_type,
+  gv.voter_credential_tag,
   encode(gv.voter_credential, 'hex') AS voter,
   gv.vote
 FROM governance_proposal gp

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -175,9 +175,9 @@ erDiagram
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
 | `transaction` | `id`, `hash`, `block_hash`, `slot`, `block_index`, `type`, `fee`, `ttl`, `valid`, `metadata` | PK `id`; unique `hash`; indexes `block_hash`, `slot` | One row per transaction. `block_hash` and `slot` point to the blob block. `metadata` is populated only in API mode. |
-| `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount`, `payment_script` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes address keys, spend/reference/collateral tx hashes, `added_slot`, `deleted_slot`, `amount`; composite `(deleted_slot, staking_key, amount)` and `(deleted_slot, payment_script, amount)` | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. `payment_script` is a bool set at index time from the output address type (true when the payment credential is a script hash); the `(deleted_slot, payment_script, amount)` composite backs the network script-locked supply sum (blockfrost `/network` `supply.locked`). It is derived only at write time, so a database synced before this column existed reports script-locked supply only for UTxOs created after the upgrade until it is rebuilt from chain data. |
+| `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `credential_tag`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount`, `payment_script` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes address keys, spend/reference/collateral tx hashes, `added_slot`, `deleted_slot`, `amount`; composite `(deleted_slot, credential_tag, staking_key, amount)` and `(deleted_slot, payment_script, amount)` | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. `credential_tag`: 0 key hash, 1 script hash for stake-bearing outputs. `payment_script` is a bool set at index time from the output address type (true when the payment credential is a script hash); the `(deleted_slot, payment_script, amount)` composite backs the network script-locked supply sum (blockfrost `/network` `supply.locked`). It is derived only at write time, so a database synced before this column existed reports script-locked supply only for UTxOs created after the upgrade until it is rebuilt from chain data. |
 | `asset` | `id`, `utxo_id`, `policy_id`, `name`, `name_hex`, `fingerprint`, `amount` | PK `id`; unique `(name, policy_id, utxo_id)`; named index `idx_asset_policy_id` on `policy_id`; indexes `name_hex`, `fingerprint`, `amount` | Multi-asset quantities attached to `utxo.id`. The unique key backs ledger-state import `ON CONFLICT`; the policy-id query index can be deferred during bulk load. Use `utxo.deleted_slot = 0` for live balances. |
-| `address_transaction` | `id`, `payment_key`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key`, `staking_key`, `transaction_id`, `slot` | API-mode address-to-transaction index. Join to `transaction.id`. |
+| `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key`, `(credential_tag, staking_key)`, `transaction_id`, `slot` | API-mode address-to-transaction index. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. |
 | `transaction_metadata_label` | `id`, `transaction_id`, `label`, `slot`, `cbor_value`, `json_value` | PK `id`; unique `(transaction_id, label)`; indexes `label`, `slot` | API-mode per-label metadata index. Join to `transaction.id`. |
 | `key_witness` | `id`, `transaction_id`, `type`, `vkey`, `signature`, `public_key`, `chain_code`, `attributes` | PK `id`; indexes `transaction_id`, `type` | API-mode vkey/bootstrap witnesses. Join to `transaction.id`. |
 | `witness_scripts` | `id`, `transaction_id`, `script_hash`, `type` | PK `id`; indexes `transaction_id`, `script_hash`, `type` | API-mode witness-script references. Join `script_hash = script.hash`. |
@@ -215,6 +215,7 @@ erDiagram
 | `stake_vote_registration_delegation` | `id`, `staking_key`, `credential_tag`, `pool_key_hash`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `pool_key_hash`, `drep`, `certificate_id`, `added_slot` | Combined registration, pool delegation, and DRep delegation. |
 | `vote_delegation` | `id`, `staking_key`, `credential_tag`, `drep`, `drep_type`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, staking_key)`, `drep`, `certificate_id`, `added_slot` | DRep-only vote delegation. |
 | `vote_registration_delegation` | `id`, `staking_key`, `credential_tag`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `drep`, `certificate_id`, `added_slot` | Combined registration and DRep delegation. |
+
 | `move_instantaneous_rewards` | `id`, `pot`, `certificate_id`, `added_slot`, `other_pot` | PK `id`; indexes `pot`, `certificate_id`, `added_slot` | MIR certificate header. `pot`: 0 = Reserves, 1 = Treasury. `other_pot` is non-zero for pot-to-pot transfer certs (no child rows); zero for credential distribution certs (child rows in `move_instantaneous_rewards_reward`). Applied at each epoch boundary by the Shelley INSTANT rule. |
 | `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `amount` | PK `id`; index `mir_id` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. |
 
@@ -222,8 +223,8 @@ erDiagram
 
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
-| `pool` | `id`, `pool_key_hash`, `vrf_key_hash`, `reward_account`, `latest_op_cert_sequence`, `pledge`, `cost`, `margin` | PK `id`; unique `pool_key_hash` | Current pool state. Historical registrations and retirements are separate rows. |
-| `pool_registration` | `id`, `pool_id`, `pool_key_hash`, `vrf_key_hash`, `reward_account`, `pledge`, `cost`, `margin`, `metadata_url`, `metadata_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; unique `(pool_id, added_slot)`; indexes `pool_key_hash`, `certificate_id` | Pool registration certificate. Join `pool_id -> pool.id` and `certificate_id -> certs.id`. |
+| `pool` | `id`, `pool_key_hash`, `vrf_key_hash`, `reward_account`, `reward_account_credential_tag`, `latest_op_cert_sequence`, `pledge`, `cost`, `margin` | PK `id`; unique `pool_key_hash` | Current pool state. Historical registrations and retirements are separate rows. `reward_account_credential_tag`: 0 key hash, 1 script hash for the pool reward account. |
+| `pool_registration` | `id`, `pool_id`, `pool_key_hash`, `vrf_key_hash`, `reward_account`, `reward_account_credential_tag`, `pledge`, `cost`, `margin`, `metadata_url`, `metadata_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; unique `(pool_id, added_slot)`; indexes `pool_key_hash`, `certificate_id` | Pool registration certificate. Join `pool_id -> pool.id` and `certificate_id -> certs.id`. `reward_account_credential_tag`: 0 key hash, 1 script hash. |
 | `pool_registration_owner` | `id`, `pool_registration_id`, `pool_id`, `key_hash` | PK `id`; indexes `pool_registration_id`, `pool_id` | Owners for a pool registration. Join `pool_registration_id -> pool_registration.id`; `pool_id -> pool.id`. |
 | `pool_registration_relay` | `id`, `pool_registration_id`, `pool_id`, `ipv4`, `ipv6`, `hostname`, `port` | PK `id`; indexes `pool_registration_id`, `pool_id` | Relay addresses for a pool registration. |
 | `pool_retirement` | `id`, `pool_id`, `pool_key_hash`, `certificate_id`, `epoch`, `added_slot` | PK `id`; indexes `pool_id`, `pool_key_hash`, `certificate_id`, `added_slot` | Pool retirement certificate. |
@@ -469,7 +470,8 @@ SELECT t.slot, t.block_index, encode(t.hash, 'hex') AS tx_hash
 FROM address_transaction atx
 JOIN "transaction" t ON t.id = atx.transaction_id
 WHERE atx.payment_key = decode($1, 'hex')
-  AND atx.staking_key = decode($2, 'hex')
+  AND atx.credential_tag = $2
+  AND atx.staking_key = decode($3, 'hex')
 ORDER BY t.slot DESC, t.block_index DESC, t.id DESC
 LIMIT 50;
 ```
@@ -480,7 +482,8 @@ Count the same address index:
 SELECT COUNT(DISTINCT atx.transaction_id) AS tx_count
 FROM address_transaction atx
 WHERE atx.payment_key = decode($1, 'hex')
-  AND atx.staking_key = decode($2, 'hex');
+  AND atx.credential_tag = $2
+  AND atx.staking_key = decode($3, 'hex');
 ```
 
 Payment-only Byron-style or enterprise-style lookups use the same condition Dingo uses:
@@ -490,19 +493,20 @@ WHERE atx.payment_key = decode($1, 'hex')
   AND (atx.staking_key IS NULL OR length(atx.staking_key) = 0)
 ```
 
-### `GetAddressesByStakingKey`
+### `GetAddressesByCredential`
 
 ```sql
-SELECT MIN(id) AS id, payment_key, staking_key
+SELECT MIN(id) AS id, payment_key, credential_tag, staking_key
 FROM address_transaction
-WHERE staking_key = decode($1, 'hex')
+WHERE credential_tag = $1
+  AND staking_key = decode($2, 'hex')
   AND length(payment_key) > 0
-GROUP BY payment_key, staking_key
+GROUP BY payment_key, credential_tag, staking_key
 ORDER BY payment_key ASC
 LIMIT 100;
 ```
 
-### `GetUtxosByAddress`, `GetUtxosByAddressAtSlot`, and `GetControlledAmountByStakingKey`
+### `GetUtxosByAddress`, `GetUtxosByAddressAtSlot`, and `GetControlledAmountByCredential`
 
 Live UTxOs for a payment key with assets:
 
@@ -532,12 +536,13 @@ WHERE u.added_slot <= $2
   AND u.payment_key = decode($1, 'hex');
 ```
 
-Controlled amount by staking key:
+Controlled amount by stake credential:
 
 ```sql
 SELECT COALESCE(SUM(amount), 0) AS controlled_amount
 FROM utxo
-WHERE staking_key = decode($1, 'hex')
+WHERE credential_tag = $1
+  AND staking_key = decode($2, 'hex')
   AND deleted_slot = 0;
 ```
 
@@ -657,6 +662,24 @@ FROM (
 ) h
 ORDER BY added_slot DESC, block_index DESC, cert_index DESC, tx_hash DESC
 LIMIT 50;
+```
+
+### `GetStakeRegistrationsByCredential`
+
+Stake registration certificate reconstruction uses the full stake credential
+identity. `credential_tag` is restored into the returned certificate's
+`StakeCredential.CredType`.
+
+```sql
+-- Postgres
+SELECT
+  sr.credential_tag,
+  encode(sr.staking_key, 'hex') AS staking_key,
+  sr.added_slot
+FROM stake_registration sr
+WHERE sr.credential_tag = $1
+  AND sr.staking_key = decode($2, 'hex')
+ORDER BY sr.id DESC;
 ```
 
 ### `GetPool`, `GetPoolRegistrationsAtSlot`, and Pool History
@@ -914,6 +937,7 @@ SELECT HEX(t.hash) AS tx_hash, t.slot, t.block_index
 FROM address_transaction atx
 JOIN `transaction` t ON t.id = atx.transaction_id
 WHERE atx.payment_key = UNHEX(?)
+  AND atx.credential_tag = ?
   AND atx.staking_key = UNHEX(?)
 ORDER BY t.slot DESC, t.block_index DESC, t.id DESC
 LIMIT 50;

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -628,28 +628,32 @@ FROM (
   FROM stake_delegation sd
   JOIN certs c ON c.id = sd.certificate_id
   JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE sd.staking_key = decode($1, 'hex')
+  WHERE sd.credential_tag = $1
+    AND sd.staking_key = decode($2, 'hex')
 
   UNION ALL
   SELECT srd.added_slot, tx.block_index, c.cert_index, tx.hash, srd.pool_key_hash
   FROM stake_registration_delegation srd
   JOIN certs c ON c.id = srd.certificate_id
   JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE srd.staking_key = decode($1, 'hex')
+  WHERE srd.credential_tag = $1
+    AND srd.staking_key = decode($2, 'hex')
 
   UNION ALL
   SELECT svd.added_slot, tx.block_index, c.cert_index, tx.hash, svd.pool_key_hash
   FROM stake_vote_delegation svd
   JOIN certs c ON c.id = svd.certificate_id
   JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE svd.staking_key = decode($1, 'hex')
+  WHERE svd.credential_tag = $1
+    AND svd.staking_key = decode($2, 'hex')
 
   UNION ALL
   SELECT svrd.added_slot, tx.block_index, c.cert_index, tx.hash, svrd.pool_key_hash
   FROM stake_vote_registration_delegation svrd
   JOIN certs c ON c.id = svrd.certificate_id
   JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE svrd.staking_key = decode($1, 'hex')
+  WHERE svrd.credential_tag = $1
+    AND svrd.staking_key = decode($2, 'hex')
 ) h
 ORDER BY added_slot DESC, block_index DESC, cert_index DESC, tx_hash DESC
 LIMIT 50;

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -995,7 +995,7 @@ func (a *NodeAdapter) Account(
 		return AccountInfo{}, err
 	}
 	controlledAmount, err := a.ledgerState.Database().
-		GetControlledAmountByStakingKey(stakeKey, nil)
+		GetControlledAmountByCredential(credentialTag, stakeKey, nil)
 	if err != nil {
 		return AccountInfo{}, fmt.Errorf(
 			"get controlled amount: %w",
@@ -1075,7 +1075,7 @@ func (a *NodeAdapter) AccountAssociatedAddresses(
 		return nil, 0, err
 	}
 	total, err := a.ledgerState.Database().
-		CountAddressesByStakingKey(stakeKey, nil)
+		CountAddressesByCredential(credentialTag, stakeKey, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"count associated addresses: %w",
@@ -1085,7 +1085,8 @@ func (a *NodeAdapter) AccountAssociatedAddresses(
 	offset := (params.Page - 1) * params.Count
 
 	rows, err := a.ledgerState.Database().
-		GetAddressesByStakingKey(
+		GetAddressesByCredential(
+			credentialTag,
 			stakeKey,
 			params.Count,
 			offset,
@@ -2387,11 +2388,9 @@ func (a *NodeAdapter) TransactionPoolUpdates(
 			owners = append(owners, address)
 		}
 
+		rewardAccountCredential := poolRewardAccountCredential(c)
 		rewardAccount, err := stakeAddressFromCredential(
-			lcommon.Credential{
-				CredType:   lcommon.CredentialTypeAddrKeyHash,
-				Credential: lcommon.CredentialHash(c.RewardAccount),
-			},
+			rewardAccountCredential,
 			networkID,
 		)
 		if err != nil {
@@ -2942,6 +2941,31 @@ func stakeAddressFromCredential(
 		return "", err
 	}
 	return addr.String(), nil
+}
+
+func poolRewardAccountCredential(
+	cert *lcommon.PoolRegistrationCertificate,
+) lcommon.Credential {
+	credType := uint(lcommon.CredentialTypeAddrKeyHash)
+	hash := cert.RewardAccount[:]
+	rawCbor := cert.Cbor()
+	if len(rawCbor) > 0 {
+		var raw []cbor.RawMessage
+		if _, err := cbor.Decode(rawCbor, &raw); err == nil && len(raw) > 6 {
+			var rewardAddrBytes []byte
+			if _, err := cbor.Decode(raw[6], &rewardAddrBytes); err == nil &&
+				len(rewardAddrBytes) == 29 {
+				if (rewardAddrBytes[0] & 0xF0) == 0xF0 {
+					credType = lcommon.CredentialTypeScriptHash
+				}
+				hash = rewardAddrBytes[1:]
+			}
+		}
+	}
+	return lcommon.Credential{
+		CredType:   credType,
+		Credential: lcommon.CredentialHash(lcommon.NewBlake2b224(hash)),
+	}
 }
 
 func redeemerPurpose(tag lcommon.RedeemerTag) string {

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -747,7 +747,11 @@ func (a *NodeAdapter) DRep(
 	credential DRepCredential,
 ) (DRepInfo, error) {
 	db := a.ledgerState.Database()
-	drep, err := db.GetDrep(credential.Hash, true, nil)
+	var credentialTag uint8
+	if credential.HasScript {
+		credentialTag = 1
+	}
+	drep, err := db.GetDrepByCredential(credentialTag, credential.Hash, true, nil)
 	if err != nil {
 		if errors.Is(err, models.ErrDrepNotFound) {
 			return DRepInfo{}, fmt.Errorf(
@@ -762,7 +766,7 @@ func (a *NodeAdapter) DRep(
 			err,
 		)
 	}
-	power, err := db.GetDRepVotingPower(credential.Hash, nil)
+	power, err := db.GetDRepVotingPower(credentialTag, credential.Hash, nil)
 	if err != nil {
 		return DRepInfo{}, fmt.Errorf(
 			"get drep voting power %x: %w",

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -1104,9 +1104,13 @@ func (a *NodeAdapter) AccountAssociatedAddresses(
 		0,
 		len(rows),
 	)
+	addressType := uint8(lcommon.AddressTypeKeyKey)
+	if credentialTag == 1 {
+		addressType = lcommon.AddressTypeKeyScript
+	}
 	for _, row := range rows {
 		addr, err := lcommon.NewAddressFromParts(
-			lcommon.AddressTypeKeyKey,
+			addressType,
 			networkID,
 			row.PaymentKey,
 			stakeKey,
@@ -1146,7 +1150,11 @@ func (a *NodeAdapter) AccountDelegationHistory(
 	}
 	offset := (params.Page - 1) * params.Count
 	total, err := a.ledgerState.Database().
-		CountAccountDelegationHistory(stakeKey, nil)
+		CountAccountDelegationHistoryByCredential(
+			credentialTag,
+			stakeKey,
+			nil,
+		)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"count account delegation history: %w",
@@ -1157,7 +1165,8 @@ func (a *NodeAdapter) AccountDelegationHistory(
 		return []AccountDelegationHistoryInfo{}, total, nil
 	}
 	rows, err := a.ledgerState.Database().
-		GetAccountDelegationHistory(
+		GetAccountDelegationHistoryByCredential(
+			credentialTag,
 			stakeKey,
 			params.Count,
 			offset,
@@ -1218,7 +1227,11 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 	}
 	offset := (params.Page - 1) * params.Count
 	total, err := a.ledgerState.Database().
-		CountAccountRegistrationHistory(stakeKey, nil)
+		CountAccountRegistrationHistoryByCredential(
+			credentialTag,
+			stakeKey,
+			nil,
+		)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"count account registration history: %w",
@@ -1229,7 +1242,8 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 		return []AccountRegistrationHistoryInfo{}, total, nil
 	}
 	rows, err := a.ledgerState.Database().
-		GetAccountRegistrationHistory(
+		GetAccountRegistrationHistoryByCredential(
+			credentialTag,
 			stakeKey,
 			params.Count,
 			offset,

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -746,11 +746,29 @@ func (a *NodeAdapter) Asset(
 func (a *NodeAdapter) DRep(
 	credential DRepCredential,
 ) (DRepInfo, error) {
-	db := a.ledgerState.Database()
-	var credentialTag uint8
-	if credential.HasScript {
-		credentialTag = 1
+	if credential.CredentialTagKnown {
+		var credentialTag uint8
+		if credential.HasScript {
+			credentialTag = 1
+		}
+		return a.drepByCredentialTag(credential, credentialTag)
 	}
+
+	info, err := a.drepByCredentialTag(credential, 0)
+	if err == nil {
+		return info, nil
+	}
+	if !errors.Is(err, ErrDRepNotFound) {
+		return DRepInfo{}, err
+	}
+	return a.drepByCredentialTag(credential, 1)
+}
+
+func (a *NodeAdapter) drepByCredentialTag(
+	credential DRepCredential,
+	credentialTag uint8,
+) (DRepInfo, error) {
+	db := a.ledgerState.Database()
 	drep, err := db.GetDrepByCredential(credentialTag, credential.Hash, true, nil)
 	if err != nil {
 		if errors.Is(err, models.ErrDrepNotFound) {
@@ -766,6 +784,7 @@ func (a *NodeAdapter) DRep(
 			err,
 		)
 	}
+	hasScript := credentialTag == 1
 	power, err := db.GetDRepVotingPower(credentialTag, credential.Hash, nil)
 	if err != nil {
 		return DRepInfo{}, fmt.Errorf(
@@ -793,7 +812,7 @@ func (a *NodeAdapter) DRep(
 	return DRepInfo{
 		DRepID:      credential.ID,
 		Hex:         hex.EncodeToString(credential.Hash),
-		HasScript:   credential.HasScript,
+		HasScript:   hasScript,
 		Registered:  registered,
 		Epoch:       registrationEpoch.EpochId,
 		Amount:      amount,

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -977,7 +977,7 @@ func (a *NodeAdapter) PoolsExtended() (
 func (a *NodeAdapter) Account(
 	stakeAddress string,
 ) (AccountInfo, error) {
-	_, stakeKey, err := parseStakeAddress(
+	_, credentialTag, stakeKey, err := parseStakeAddress(
 		stakeAddress,
 	)
 	if err != nil {
@@ -985,7 +985,12 @@ func (a *NodeAdapter) Account(
 	}
 
 	db := a.ledgerState.Database()
-	account, err := db.GetAccount(stakeKey, true, nil)
+	account, err := db.GetAccountByCredential(
+		credentialTag,
+		stakeKey,
+		true,
+		nil,
+	)
 	if err != nil {
 		return AccountInfo{}, err
 	}
@@ -1047,7 +1052,7 @@ func (a *NodeAdapter) AccountAssociatedAddresses(
 	stakeAddress string,
 	params PaginationParams,
 ) ([]AccountAssociatedAddressInfo, int, error) {
-	stakeAddr, stakeKey, err := parseStakeAddress(
+	stakeAddr, credentialTag, stakeKey, err := parseStakeAddress(
 		stakeAddress,
 	)
 	if err != nil {
@@ -1061,7 +1066,12 @@ func (a *NodeAdapter) AccountAssociatedAddresses(
 		return nil, 0, err
 	}
 	if _, err := a.ledgerState.Database().
-		GetAccount(stakeKey, true, nil); err != nil {
+		GetAccountByCredential(
+			credentialTag,
+			stakeKey,
+			true,
+			nil,
+		); err != nil {
 		return nil, 0, err
 	}
 	total, err := a.ledgerState.Database().
@@ -1120,13 +1130,18 @@ func (a *NodeAdapter) AccountDelegationHistory(
 	stakeAddress string,
 	params PaginationParams,
 ) ([]AccountDelegationHistoryInfo, int, error) {
-	_, stakeKey, err := parseStakeAddress(stakeAddress)
+	_, credentialTag, stakeKey, err := parseStakeAddress(stakeAddress)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	if _, err := a.ledgerState.Database().
-		GetAccount(stakeKey, true, nil); err != nil {
+		GetAccountByCredential(
+			credentialTag,
+			stakeKey,
+			true,
+			nil,
+		); err != nil {
 		return nil, 0, err
 	}
 	offset := (params.Page - 1) * params.Count
@@ -1187,13 +1202,18 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 	stakeAddress string,
 	params PaginationParams,
 ) ([]AccountRegistrationHistoryInfo, int, error) {
-	_, stakeKey, err := parseStakeAddress(stakeAddress)
+	_, credentialTag, stakeKey, err := parseStakeAddress(stakeAddress)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	if _, err := a.ledgerState.Database().
-		GetAccount(stakeKey, true, nil); err != nil {
+		GetAccountByCredential(
+			credentialTag,
+			stakeKey,
+			true,
+			nil,
+		); err != nil {
 		return nil, 0, err
 	}
 	offset := (params.Page - 1) * params.Count
@@ -1243,12 +1263,17 @@ func (a *NodeAdapter) AccountRewardHistory(
 	stakeAddress string,
 	params PaginationParams,
 ) ([]AccountRewardHistoryInfo, int, error) {
-	_, stakeKey, err := parseStakeAddress(stakeAddress)
+	_, credentialTag, stakeKey, err := parseStakeAddress(stakeAddress)
 	if err != nil {
 		return nil, 0, err
 	}
 	if _, err := a.ledgerState.Database().
-		GetAccount(stakeKey, true, nil); err != nil {
+		GetAccountByCredential(
+			credentialTag,
+			stakeKey,
+			true,
+			nil,
+		); err != nil {
 		return nil, 0, err
 	}
 	// TODO(#1875): Implement reward history once Dingo persists
@@ -1267,18 +1292,27 @@ func blockIssuer(issuer lcommon.IssuerVkey) string {
 
 func parseStakeAddress(
 	stakeAddress string,
-) (lcommon.Address, []byte, error) {
+) (lcommon.Address, uint8, []byte, error) {
 	addr, err := lcommon.NewAddress(stakeAddress)
 	if err != nil {
-		return lcommon.Address{}, nil, ErrInvalidStakeAddress
+		return lcommon.Address{}, 0, nil, ErrInvalidStakeAddress
 	}
 	zeroHash := lcommon.NewBlake2b224(nil)
 	if addr.PaymentKeyHash() != zeroHash ||
 		addr.StakeKeyHash() == zeroHash {
-		return lcommon.Address{}, nil, ErrInvalidStakeAddress
+		return lcommon.Address{}, 0, nil, ErrInvalidStakeAddress
+	}
+	var credentialTag uint8
+	switch addr.StakingPayload().(type) {
+	case lcommon.AddressPayloadKeyHash:
+		credentialTag = 0
+	case lcommon.AddressPayloadScriptHash:
+		credentialTag = 1
+	default:
+		return lcommon.Address{}, 0, nil, ErrInvalidStakeAddress
 	}
 	stakeKey := addr.StakeKeyHash().Bytes()
-	return addr, stakeKey, nil
+	return addr, credentialTag, stakeKey, nil
 }
 
 func blockHashString(hash []byte) string {

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -64,6 +64,7 @@ type mockNode struct {
 	pools                         []PoolExtendedInfo
 	asset                         AssetInfo
 	drep                          DRepInfo
+	drepCredential                DRepCredential
 	addressUTXOs                  []AddressUTXOInfo
 	addressTransactions           []AddressTransactionInfo
 	metadataJSON                  []MetadataTransactionJSONInfo
@@ -203,8 +204,9 @@ func (m *mockNode) Asset(
 }
 
 func (m *mockNode) DRep(
-	_ DRepCredential,
+	credential DRepCredential,
 ) (DRepInfo, error) {
+	m.drepCredential = credential
 	return m.drep, m.drepErr
 }
 
@@ -742,6 +744,81 @@ func TestHandleDRep(t *testing.T) {
 	assert.Equal(t, mock.drep.Active, resp.Active)
 	assert.Equal(t, mock.drep.ActiveEpoch, resp.ActiveEpoch)
 	assert.Equal(t, mock.drep.LiveStake, resp.LiveStake)
+}
+
+// TestHandleDRepCIP129ScriptIdentifier verifies script DRep IDs keep their
+// credential type when the HTTP handler passes them to the node adapter.
+func TestHandleDRepCIP129ScriptIdentifier(t *testing.T) {
+	const drepID = "drep1xvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhknfj5"
+	const drepHex = "00000000000000000000000000000000000000000000000000000000"
+
+	mock := &mockNode{
+		drep: DRepInfo{
+			DRepID:    drepID,
+			Hex:       drepHex,
+			HasScript: true,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/governance/dreps/"+drepID,
+		nil,
+	)
+	req.SetPathValue("drep_id", drepID)
+	w := httptest.NewRecorder()
+	b.handleDRep(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, mock.drepCredential.HasScript)
+	assert.True(t, mock.drepCredential.CredentialTagKnown)
+	assert.Equal(t, make([]byte, drepCredentialHashLen), mock.drepCredential.Hash)
+}
+
+// TestParseDRepIdentifierCIP129CredentialType verifies CIP-129 DRep IDs
+// decode the credential type from the bech32 payload header.
+func TestParseDRepIdentifierCIP129CredentialType(t *testing.T) {
+	cases := []struct {
+		name          string
+		id            string
+		wantHasScript bool
+	}{
+		{
+			name:          "key",
+			id:            "drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n",
+			wantHasScript: false,
+		},
+		{
+			name:          "script",
+			id:            "drep1xvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhknfj5",
+			wantHasScript: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			credential, err := parseDRepIdentifier(tc.id)
+			require.NoError(t, err)
+			assert.Equal(t, tc.id, credential.ID)
+			assert.Equal(t, make([]byte, drepCredentialHashLen), credential.Hash)
+			assert.Equal(t, tc.wantHasScript, credential.HasScript)
+			assert.True(t, credential.CredentialTagKnown)
+		})
+	}
+}
+
+// TestParseDRepIdentifierHexIsAmbiguous verifies raw hash identifiers remain
+// untyped so lookup can deliberately fall back across key/script tags.
+func TestParseDRepIdentifierHexIsAmbiguous(t *testing.T) {
+	const drepHex = "00000000000000000000000000000000000000000000000000000000"
+
+	credential, err := parseDRepIdentifier(drepHex)
+	require.NoError(t, err)
+	assert.Equal(t, drepHex, credential.ID)
+	assert.Equal(t, make([]byte, drepCredentialHashLen), credential.Hash)
+	assert.False(t, credential.HasScript)
+	assert.False(t, credential.CredentialTagKnown)
 }
 
 func TestHandleDRepInvalidIdentifier(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -36,6 +36,9 @@ const (
 
 	// DRep credentials are Blake2b-224 hashes: 224 bits = 28 bytes.
 	drepCredentialHashLen = 28
+	// CIP-129 DRep identifiers include a one-byte voter header followed
+	// by the 28-byte credential hash.
+	drepCIP129PayloadLen = drepCredentialHashLen + 1
 	// Hex encodes each byte as two characters, so a 28-byte credential
 	// hash is represented by 56 hex characters.
 	drepCredentialHexLen = drepCredentialHashLen * 2
@@ -1533,17 +1536,55 @@ func parseDRepIdentifier(
 		return DRepCredential{}, fmt.Errorf("decode DRep payload: %w", err)
 	}
 
-	if len(payload) != drepCredentialHashLen {
+	switch len(payload) {
+	case drepCredentialHashLen:
+		return DRepCredential{
+			ID:        id,
+			Hash:      payload,
+			HasScript: false,
+		}, nil
+	case drepCIP129PayloadLen:
+		hasScript, err := parseCIP129DRepScriptFlag(payload[0])
+		if err != nil {
+			return DRepCredential{}, err
+		}
+		return DRepCredential{
+			ID:                 id,
+			Hash:               payload[1:],
+			HasScript:          hasScript,
+			CredentialTagKnown: true,
+		}, nil
+	default:
 		return DRepCredential{}, fmt.Errorf(
 			"invalid DRep credential length %d",
 			len(payload),
 		)
 	}
-	return DRepCredential{
-		ID:        id,
-		Hash:      payload,
-		HasScript: false,
-	}, nil
+}
+
+func parseCIP129DRepScriptFlag(header byte) (bool, error) {
+	voterType := header >> 4
+	credentialNibble := header & 0x0f
+	switch voterType {
+	case 2:
+		if credentialNibble != 0x2 {
+			return false, fmt.Errorf(
+				"invalid DRep key credential nibble 0x%x",
+				credentialNibble,
+			)
+		}
+		return false, nil
+	case 3:
+		if credentialNibble != 0x3 {
+			return false, fmt.Errorf(
+				"invalid DRep script credential nibble 0x%x",
+				credentialNibble,
+			)
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid DRep voter type %d", voterType)
+	}
 }
 
 func writeNodeQueryError(

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -562,9 +562,10 @@ type AssetInfo struct {
 
 // DRepCredential holds a parsed governance DRep identifier.
 type DRepCredential struct {
-	ID        string
-	Hash      []byte
-	HasScript bool
+	ID                 string
+	Hash               []byte
+	HasScript          bool
+	CredentialTagKnown bool
 }
 
 // DRepInfo holds DRep data needed by the governance API.

--- a/api/mesh/convert.go
+++ b/api/mesh/convert.go
@@ -178,12 +178,15 @@ func txStatus(valid bool) *string {
 
 // utxoAddress reconstructs a bech32 Cardano address from
 // the payment and staking key hashes stored in the
-// metadata DB. The address type depends on which keys
-// are present:
+// metadata DB. The address type is derived from the two
+// credential dimensions stored alongside the UTxO:
 //
-//   - PaymentKey + StakingKey → AddressTypeKeyKey
-//   - PaymentKey only        → AddressTypeKeyNone
-//   - Neither (Byron-era)    → "byron:<txId hex>"
+//   - PaymentScript (bool)   — payment credential is a script hash
+//   - CredentialTag (uint8)  — 0 = key-hash stake, 1 = script-hash stake
+//
+// Combined with staking key presence this gives the eight
+// Cardano Shelley address types (CIP-19).
+// Byron-era outputs (no PaymentKey) return "byron:<txId hex>".
 //
 // The networkID determines the address prefix
 // (addr / addr_test1).
@@ -203,10 +206,23 @@ func utxoAddress(
 	var addrType uint8
 	var stakingKey []byte
 	if len(utxo.StakingKey) > 0 {
-		addrType = lcommon.AddressTypeKeyKey
 		stakingKey = utxo.StakingKey
+		switch {
+		case !utxo.PaymentScript && utxo.CredentialTag == 0:
+			addrType = lcommon.AddressTypeKeyKey
+		case !utxo.PaymentScript && utxo.CredentialTag == 1:
+			addrType = lcommon.AddressTypeKeyScript
+		case utxo.PaymentScript && utxo.CredentialTag == 0:
+			addrType = lcommon.AddressTypeScriptKey
+		default: // PaymentScript && CredentialTag == 1
+			addrType = lcommon.AddressTypeScriptScript
+		}
 	} else {
-		addrType = lcommon.AddressTypeKeyNone
+		if utxo.PaymentScript {
+			addrType = lcommon.AddressTypeScriptNone
+		} else {
+			addrType = lcommon.AddressTypeKeyNone
+		}
 	}
 
 	addr, err := lcommon.NewAddressFromParts(

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -170,8 +170,10 @@ func searchUtxoModelToAnyData(utxo *models.UtxoWithOrdering) (*query.AnyUtxoData
 	return &aud, nil
 }
 
-// dedupeSearchAddresses drops duplicate ledger addresses with the same payment
-// credential and full stake credential identity.
+// dedupeSearchAddresses drops duplicate ledger addresses with the same full
+// payment credential identity (type + hash) and full stake credential identity
+// (type + hash). A key-hash payment and a script-hash payment that share the
+// same 28-byte hash are distinct addresses and must not be collapsed.
 func dedupeSearchAddresses(addrs []ledger.Address) []ledger.Address {
 	if len(addrs) < 2 {
 		return addrs
@@ -181,13 +183,13 @@ func dedupeSearchAddresses(addrs []ledger.Address) []ledger.Address {
 	for _, a := range addrs {
 		pkb := a.PaymentKeyHash().Bytes()
 		skb := a.StakeKeyHash().Bytes()
+		paymentTag := byte(a.Type() & lcommon.AddressTypeScriptBit)
 		stakeTag := byte(0)
 		if _, ok := a.StakingPayload().(lcommon.AddressPayloadScriptHash); ok {
 			stakeTag = 1
 		}
-		key := string(pkb) + "\x00" +
-			string([]byte{stakeTag}) + "\x00" +
-			string(skb)
+		key := string([]byte{paymentTag}) + string(pkb) + "\x00" +
+			string([]byte{stakeTag}) + string(skb)
 		if _, ok := seen[key]; ok {
 			continue
 		}

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -170,7 +170,8 @@ func searchUtxoModelToAnyData(utxo *models.UtxoWithOrdering) (*query.AnyUtxoData
 	return &aud, nil
 }
 
-// dedupeSearchAddresses drops duplicate ledger addresses (same payment + stake keys).
+// dedupeSearchAddresses drops duplicate ledger addresses with the same payment
+// credential and full stake credential identity.
 func dedupeSearchAddresses(addrs []ledger.Address) []ledger.Address {
 	if len(addrs) < 2 {
 		return addrs
@@ -180,7 +181,13 @@ func dedupeSearchAddresses(addrs []ledger.Address) []ledger.Address {
 	for _, a := range addrs {
 		pkb := a.PaymentKeyHash().Bytes()
 		skb := a.StakeKeyHash().Bytes()
-		key := string(pkb) + "\x00" + string(skb)
+		stakeTag := byte(0)
+		if _, ok := a.StakingPayload().(lcommon.AddressPayloadScriptHash); ok {
+			stakeTag = 1
+		}
+		key := string(pkb) + "\x00" +
+			string([]byte{stakeTag}) + "\x00" +
+			string(skb)
 		if _, ok := seen[key]; ok {
 			continue
 		}

--- a/database/account.go
+++ b/database/account.go
@@ -117,15 +117,6 @@ func (d *Database) RestoreAccountStateAtSlot(
 	return nil
 }
 
-// GetAccount returns an account by staking key
-func (d *Database) GetAccount(
-	stakeKey []byte,
-	includeInactive bool,
-	txn *Txn,
-) (*models.Account, error) {
-	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
-}
-
 // GetAccountByCredential returns an account by staking credential tag and key.
 func (d *Database) GetAccountByCredential(
 	credentialTag uint8,
@@ -152,22 +143,6 @@ func (d *Database) GetAccountByCredential(
 	return account, nil
 }
 
-// GetAccounts returns accounts for the given staking keys in a single
-// query, keyed by string(StakingKey). Stake keys with no matching row
-// are omitted (callers detect "not found" by absence). An empty input
-// returns an empty (non-nil) map and no error.
-func (d *Database) GetAccounts(
-	stakeKeys [][]byte,
-	includeInactive bool,
-	txn *Txn,
-) (map[string]*models.Account, error) {
-	if txn == nil {
-		txn = d.Transaction(false)
-		defer txn.Release()
-	}
-	return d.metadata.GetAccounts(stakeKeys, includeInactive, txn.Metadata())
-}
-
 // GetAccountsByCredential returns accounts for the given staking credentials in
 // a single query, keyed by StakeCredentialRef.MapKey().
 func (d *Database) GetAccountsByCredential(
@@ -184,16 +159,6 @@ func (d *Database) GetAccountsByCredential(
 		includeInactive,
 		txn.Metadata(),
 	)
-}
-
-// AddAccountReward credits the reward balance for a registered account.
-func (d *Database) AddAccountReward(
-	stakeKey []byte,
-	amount uint64,
-	slot uint64,
-	txn *Txn,
-) error {
-	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
 }
 
 // AddAccountRewardByCredential credits the reward balance for a registered

--- a/database/account.go
+++ b/database/account.go
@@ -123,11 +123,22 @@ func (d *Database) GetAccount(
 	includeInactive bool,
 	txn *Txn,
 ) (*models.Account, error) {
+	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
+}
+
+// GetAccountByCredential returns an account by staking credential tag and key.
+func (d *Database) GetAccountByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	includeInactive bool,
+	txn *Txn,
+) (*models.Account, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	account, err := d.metadata.GetAccount(
+	account, err := d.metadata.GetAccountByCredential(
+		credentialTag,
 		stakeKey,
 		includeInactive,
 		txn.Metadata(),
@@ -157,8 +168,38 @@ func (d *Database) GetAccounts(
 	return d.metadata.GetAccounts(stakeKeys, includeInactive, txn.Metadata())
 }
 
+// GetAccountsByCredential returns accounts for the given staking credentials in
+// a single query, keyed by StakeCredentialRef.MapKey().
+func (d *Database) GetAccountsByCredential(
+	refs []models.StakeCredentialRef,
+	includeInactive bool,
+	txn *Txn,
+) (map[string]*models.Account, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetAccountsByCredential(
+		refs,
+		includeInactive,
+		txn.Metadata(),
+	)
+}
+
 // AddAccountReward credits the reward balance for a registered account.
 func (d *Database) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn *Txn,
+) error {
+	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
+}
+
+// AddAccountRewardByCredential credits the reward balance for a registered
+// account identified by stake credential tag and key.
+func (d *Database) AddAccountRewardByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -177,7 +218,8 @@ func (d *Database) AddAccountReward(
 			}
 		}()
 	}
-	if err := d.metadata.AddAccountReward(
+	if err := d.metadata.AddAccountRewardByCredential(
+		credentialTag,
 		stakeKey,
 		amount,
 		slot,

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -20,24 +20,6 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 )
 
-// GetAccountDelegationHistory returns delegation history rows for a staking key.
-func (d *Database) GetAccountDelegationHistory(
-	stakeKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn *Txn,
-) ([]models.AccountDelegationHistoryRow, error) {
-	return d.GetAccountDelegationHistoryByCredential(
-		0,
-		stakeKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
-}
-
 // GetAccountDelegationHistoryByCredential returns delegation history rows for
 // a stake credential.
 func (d *Database) GetAccountDelegationHistoryByCredential(
@@ -69,15 +51,6 @@ func (d *Database) GetAccountDelegationHistoryByCredential(
 	return rows, nil
 }
 
-// CountAccountDelegationHistory returns the total number of delegation
-// history rows for a staking key.
-func (d *Database) CountAccountDelegationHistory(
-	stakeKey []byte,
-	txn *Txn,
-) (int, error) {
-	return d.CountAccountDelegationHistoryByCredential(0, stakeKey, txn)
-}
-
 // CountAccountDelegationHistoryByCredential returns the total number of
 // delegation history rows for a stake credential.
 func (d *Database) CountAccountDelegationHistoryByCredential(
@@ -101,24 +74,6 @@ func (d *Database) CountAccountDelegationHistoryByCredential(
 		)
 	}
 	return count, nil
-}
-
-// GetAccountRegistrationHistory returns registration history rows for a staking key.
-func (d *Database) GetAccountRegistrationHistory(
-	stakeKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn *Txn,
-) ([]models.AccountRegistrationHistoryRow, error) {
-	return d.GetAccountRegistrationHistoryByCredential(
-		0,
-		stakeKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
 }
 
 // GetAccountRegistrationHistoryByCredential returns registration history rows
@@ -150,15 +105,6 @@ func (d *Database) GetAccountRegistrationHistoryByCredential(
 		)
 	}
 	return rows, nil
-}
-
-// CountAccountRegistrationHistory returns the total number of
-// registration history rows for a staking key.
-func (d *Database) CountAccountRegistrationHistory(
-	stakeKey []byte,
-	txn *Txn,
-) (int, error) {
-	return d.CountAccountRegistrationHistoryByCredential(0, stakeKey, txn)
 }
 
 // CountAccountRegistrationHistoryByCredential returns the total number of

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -28,11 +28,32 @@ func (d *Database) GetAccountDelegationHistory(
 	order string,
 	txn *Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
+	return d.GetAccountDelegationHistoryByCredential(
+		0,
+		stakeKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+// GetAccountDelegationHistoryByCredential returns delegation history rows for
+// a stake credential.
+func (d *Database) GetAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn *Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	rows, err := d.metadata.GetAccountDelegationHistory(
+	rows, err := d.metadata.GetAccountDelegationHistoryByCredential(
+		credentialTag,
 		stakeKey,
 		limit,
 		offset,
@@ -54,11 +75,22 @@ func (d *Database) CountAccountDelegationHistory(
 	stakeKey []byte,
 	txn *Txn,
 ) (int, error) {
+	return d.CountAccountDelegationHistoryByCredential(0, stakeKey, txn)
+}
+
+// CountAccountDelegationHistoryByCredential returns the total number of
+// delegation history rows for a stake credential.
+func (d *Database) CountAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	txn *Txn,
+) (int, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	count, err := d.metadata.CountAccountDelegationHistory(
+	count, err := d.metadata.CountAccountDelegationHistoryByCredential(
+		credentialTag,
 		stakeKey,
 		txn.Metadata(),
 	)
@@ -79,11 +111,32 @@ func (d *Database) GetAccountRegistrationHistory(
 	order string,
 	txn *Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
+	return d.GetAccountRegistrationHistoryByCredential(
+		0,
+		stakeKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+// GetAccountRegistrationHistoryByCredential returns registration history rows
+// for a stake credential.
+func (d *Database) GetAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn *Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	rows, err := d.metadata.GetAccountRegistrationHistory(
+	rows, err := d.metadata.GetAccountRegistrationHistoryByCredential(
+		credentialTag,
 		stakeKey,
 		limit,
 		offset,
@@ -105,11 +158,22 @@ func (d *Database) CountAccountRegistrationHistory(
 	stakeKey []byte,
 	txn *Txn,
 ) (int, error) {
+	return d.CountAccountRegistrationHistoryByCredential(0, stakeKey, txn)
+}
+
+// CountAccountRegistrationHistoryByCredential returns the total number of
+// registration history rows for a stake credential.
+func (d *Database) CountAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	txn *Txn,
+) (int, error) {
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	count, err := d.metadata.CountAccountRegistrationHistory(
+	count, err := d.metadata.CountAccountRegistrationHistoryByCredential(
+		credentialTag,
 		stakeKey,
 		txn.Metadata(),
 	)

--- a/database/certs.go
+++ b/database/certs.go
@@ -64,10 +64,16 @@ func (d *Database) GetPoolRegistrations(
 	return d.metadata.GetPoolRegistrations(poolKeyHash, txn.Metadata())
 }
 
-// GetStakeRegistrations returns a list of stake registration certificates
-func (d *Database) GetStakeRegistrations(
+// GetStakeRegistrationsByCredential returns stake registration certificates
+// for the full stake credential identity.
+func (d *Database) GetStakeRegistrationsByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn *Txn,
 ) ([]lcommon.StakeRegistrationCertificate, error) {
-	return d.metadata.GetStakeRegistrations(stakingKey, txn.Metadata())
+	return d.metadata.GetStakeRegistrationsByCredential(
+		credentialTag,
+		stakingKey,
+		txn.Metadata(),
+	)
 }

--- a/database/drep.go
+++ b/database/drep.go
@@ -70,7 +70,8 @@ func (d *Database) RestoreDrepStateAtSlot(
 	return nil
 }
 
-// GetDrep returns a drep by credential
+// GetDrep returns a drep by credential hash only (no tag filter).
+// Use for the protocol validation path where only a hash is available.
 func (d *Database) GetDrep(
 	cred []byte,
 	includeInactive bool,
@@ -81,6 +82,29 @@ func (d *Database) GetDrep(
 		defer txn.Release()
 	}
 	ret, err := d.metadata.GetDrep(cred, includeInactive, txn.Metadata())
+	if err != nil {
+		return nil, err
+	}
+	if ret == nil {
+		return nil, models.ErrDrepNotFound
+	}
+	return ret, nil
+}
+
+// GetDrepByCredential returns a drep by the full credential identity (tag + hash).
+func (d *Database) GetDrepByCredential(
+	credentialTag uint8,
+	cred []byte,
+	includeInactive bool,
+	txn *Txn,
+) (*models.Drep, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	ret, err := d.metadata.GetDrepByCredential(
+		credentialTag, cred, includeInactive, txn.Metadata(),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -106,6 +130,7 @@ func (d *Database) GetActiveDreps(
 // registration metadata (added_slot, anchor_url, anchor_hash, active)
 // is never overwritten by the vote-replay recovery path.
 func (d *Database) InsertDrepIfAbsent(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -124,6 +149,7 @@ func (d *Database) InsertDrepIfAbsent(
 		}()
 	}
 	if err := d.metadata.InsertDrepIfAbsent(
+		credentialTag,
 		cred,
 		slot,
 		url,
@@ -144,8 +170,10 @@ func (d *Database) InsertDrepIfAbsent(
 
 // GetDRepVotingPower calculates the voting power for a DRep by summing
 // the current stake of all delegated accounts, approximated from live
-// UTxO balance plus reward-account balance.
+// UTxO balance plus reward-account balance. credentialTag distinguishes
+// key (0) from script (1) DRep credentials sharing the same 28-byte hash.
 func (d *Database) GetDRepVotingPower(
+	credentialTag uint8,
 	drepCredential []byte,
 	txn *Txn,
 ) (uint64, error) {
@@ -154,6 +182,7 @@ func (d *Database) GetDRepVotingPower(
 		defer txn.Release()
 	}
 	return d.metadata.GetDRepVotingPower(
+		credentialTag,
 		drepCredential,
 		txn.Metadata(),
 	)
@@ -162,7 +191,7 @@ func (d *Database) GetDRepVotingPower(
 // GetDRepVotingPowerBatch is the batch form of GetDRepVotingPower; see
 // the metadata-store interface for the contract.
 func (d *Database) GetDRepVotingPowerBatch(
-	drepCredentials [][]byte,
+	drepCredentials []models.StakeCredentialRef,
 	txn *Txn,
 ) (map[string]uint64, error) {
 	if txn == nil {
@@ -212,6 +241,7 @@ func (d *Database) GetDRepVotingPowerByType(
 // UpdateDRepActivity updates the DRep's last activity epoch and
 // recalculates the expiry epoch.
 func (d *Database) UpdateDRepActivity(
+	credentialTag uint8,
 	drepCredential []byte,
 	activityEpoch uint64,
 	inactivityPeriod uint64,
@@ -228,6 +258,7 @@ func (d *Database) UpdateDRepActivity(
 		}()
 	}
 	if err := d.metadata.UpdateDRepActivity(
+		credentialTag,
 		drepCredential,
 		activityEpoch,
 		inactivityPeriod,

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -49,14 +49,7 @@ func DrepTypeFromInt(drepType int) (uint64, error) {
 }
 
 func CredentialTagFromUint(tag uint) (uint8, error) {
-	switch tag {
-	case 0:
-		return 0, nil
-	case 1:
-		return 1, nil
-	default:
-		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
-	}
+	return CredentialTagFromUint64(uint64(tag))
 }
 
 func CredentialTagFromUint64(tag uint64) (uint8, error) {
@@ -133,6 +126,37 @@ func MigrateAccountCredentialTagIndex(db *gorm.DB, logger *slog.Logger) error {
 		"idx_account_staking_key",
 	); err != nil {
 		return fmt.Errorf("drop account staking_key index: %w", err)
+	}
+	return nil
+}
+
+// MigrateAccountRewardDeltaCredentialTagIndex drops the legacy unique index on
+// account_reward_delta before AutoMigrate adds credential_tag to it. The old
+// index covers (withdrawal, tx_hash, staking_key); the new one adds
+// credential_tag so key and script reward accounts with the same hash are
+// tracked independently.
+func MigrateAccountRewardDeltaCredentialTagIndex(db *gorm.DB, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&AccountRewardDelta{}) {
+		return nil
+	}
+	// If credential_tag is already present the index has already been migrated.
+	if db.Migrator().HasColumn(&AccountRewardDelta{}, "credential_tag") {
+		return nil
+	}
+	if !db.Migrator().HasIndex(&AccountRewardDelta{}, "idx_account_reward_delta_w_tx_s") {
+		return nil
+	}
+	logger.Info(
+		"dropping legacy account_reward_delta unique index before tag-aware migration",
+	)
+	if err := db.Migrator().DropIndex(
+		&AccountRewardDelta{},
+		"idx_account_reward_delta_w_tx_s",
+	); err != nil {
+		return fmt.Errorf("drop account_reward_delta unique index: %w", err)
 	}
 	return nil
 }

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -149,28 +149,6 @@ func NewStakeCredentialRef(tag uint8, key []byte) StakeCredentialRef {
 	}
 }
 
-func CredentialTagFromUint(tag uint) (uint8, error) {
-	switch tag {
-	case 0:
-		return 0, nil
-	case 1:
-		return 1, nil
-	default:
-		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
-	}
-}
-
-func CredentialTagFromUint64(tag uint64) (uint8, error) {
-	switch tag {
-	case 0:
-		return 0, nil
-	case 1:
-		return 1, nil
-	default:
-		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
-	}
-}
-
 func (r StakeCredentialRef) MapKey() string {
 	return string([]byte{r.Tag}) + string(r.Key)
 }

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -17,9 +17,11 @@ package models
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/btcsuite/btcd/btcutil/bech32"
+	"gorm.io/gorm"
 )
 
 var ErrAccountNotFound = errors.New("account not found")
@@ -46,6 +48,28 @@ func DrepTypeFromInt(drepType int) (uint64, error) {
 	}
 }
 
+func CredentialTagFromUint(tag uint) (uint8, error) {
+	switch tag {
+	case 0:
+		return 0, nil
+	case 1:
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
+	}
+}
+
+func CredentialTagFromUint64(tag uint64) (uint8, error) {
+	switch tag {
+	case 0:
+		return 0, nil
+	case 1:
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
+	}
+}
+
 // ValidatePredefinedDrepTypes rejects credential-backed DRep delegation
 // types. GetDRepVotingPowerByType is only for predefined, credentialless
 // DRep options.
@@ -67,7 +91,8 @@ func ValidatePredefinedDrepTypes(drepTypes []uint64) error {
 }
 
 type Account struct {
-	StakingKey    []byte `gorm:"uniqueIndex;size:28;index:idx_account_drep_active_staking_key,priority:3;index:idx_account_drep_type_active_staking_key,priority:3;index:idx_account_active_pool_staking_key,priority:3"`
+	StakingKey    []byte `gorm:"uniqueIndex:idx_account_credential,priority:2;size:28;index:idx_account_drep_active_staking_key,priority:4;index:idx_account_drep_type_active_staking_key,priority:4;index:idx_account_active_pool_staking_key,priority:4"`
+	CredentialTag uint8  `gorm:"uniqueIndex:idx_account_credential,priority:1;not null;default:0;index:idx_account_drep_active_staking_key,priority:3;index:idx_account_drep_type_active_staking_key,priority:3;index:idx_account_active_pool_staking_key,priority:3"`
 	Pool          []byte `gorm:"index;size:28;index:idx_account_active_pool_staking_key,priority:2"`
 	Drep          []byte `gorm:"index;size:28;index:idx_account_drep_active_staking_key,priority:1"`
 	ID            uint   `gorm:"primarykey"`
@@ -88,12 +113,53 @@ func (a *Account) TableName() string {
 	return "account"
 }
 
+// MigrateAccountCredentialTagIndex drops the legacy hash-only account
+// uniqueness so AutoMigrate can create the tag-aware composite unique index.
+func MigrateAccountCredentialTagIndex(db *gorm.DB, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&Account{}) {
+		return nil
+	}
+	if !db.Migrator().HasIndex(&Account{}, "idx_account_staking_key") {
+		return nil
+	}
+	logger.Info(
+		"dropping legacy account staking_key unique index before tag-aware migration",
+	)
+	if err := db.Migrator().DropIndex(
+		&Account{},
+		"idx_account_staking_key",
+	); err != nil {
+		return fmt.Errorf("drop account staking_key index: %w", err)
+	}
+	return nil
+}
+
+type StakeCredentialRef struct {
+	Tag uint8
+	Key []byte
+}
+
+func NewStakeCredentialRef(tag uint, key []byte) StakeCredentialRef {
+	return StakeCredentialRef{
+		Tag: uint8(tag),
+		Key: key,
+	}
+}
+
+func (r StakeCredentialRef) MapKey() string {
+	return string([]byte{r.Tag}) + string(r.Key)
+}
+
 // AccountRewardDelta records reward-account balance changes that are not
 // otherwise represented by a rollback-aware certificate row. Credits store the
 // credited Amount. Withdrawals store the withdrawal Amount, PreviousReward, and
 // TxHash so rollback can restore the cleared reward balance.
 type AccountRewardDelta struct {
-	StakingKey     []byte       `gorm:"index;size:28;not null;uniqueIndex:idx_account_reward_delta_w_tx_s,priority:3"`
+	StakingKey     []byte       `gorm:"index:idx_account_reward_delta_credential,priority:2;size:28;not null;uniqueIndex:idx_account_reward_delta_w_tx_s,priority:4"`
+	CredentialTag  uint8        `gorm:"index:idx_account_reward_delta_credential,priority:1;not null;default:0;uniqueIndex:idx_account_reward_delta_w_tx_s,priority:3"`
 	TxHash         []byte       `gorm:"index;size:32;uniqueIndex:idx_account_reward_delta_w_tx_s,priority:2"`
 	Amount         types.Uint64 `gorm:"not null"`
 	PreviousReward types.Uint64
@@ -126,7 +192,8 @@ func (a *Account) String() (string, error) {
 }
 
 type Deregistration struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_deregistration_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_deregistration_credential,priority:1;not null;default:0"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -138,7 +205,8 @@ func (Deregistration) TableName() string {
 }
 
 type Registration struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_registration_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_registration_credential,priority:1;not null;default:0"`
 	ID            uint   `gorm:"primarykey"`
 	CertificateID uint   `gorm:"index"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -150,7 +218,8 @@ func (Registration) TableName() string {
 }
 
 type StakeDelegation struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_stake_delegation_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_stake_delegation_credential,priority:1;not null;default:0"`
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
@@ -162,7 +231,8 @@ func (StakeDelegation) TableName() string {
 }
 
 type StakeDeregistration struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_stake_deregistration_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_stake_deregistration_credential,priority:1;not null;default:0"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -173,7 +243,8 @@ func (StakeDeregistration) TableName() string {
 }
 
 type StakeRegistration struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_stake_registration_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_stake_registration_credential,priority:1;not null;default:0"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
@@ -185,7 +256,8 @@ func (StakeRegistration) TableName() string {
 }
 
 type StakeRegistrationDelegation struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_stake_registration_delegation_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_stake_registration_delegation_credential,priority:1;not null;default:0"`
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
@@ -198,7 +270,8 @@ func (StakeRegistrationDelegation) TableName() string {
 }
 
 type StakeVoteDelegation struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_stake_vote_delegation_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_stake_vote_delegation_credential,priority:1;not null;default:0"`
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	Drep          []byte `gorm:"index;size:28"`
 	DrepType      uint64 `gorm:"default:0"`
@@ -212,7 +285,8 @@ func (StakeVoteDelegation) TableName() string {
 }
 
 type StakeVoteRegistrationDelegation struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_stake_vote_registration_delegation_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_stake_vote_registration_delegation_credential,priority:1;not null;default:0"`
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	Drep          []byte `gorm:"index;size:28"`
 	DrepType      uint64 `gorm:"default:0"`
@@ -227,7 +301,8 @@ func (StakeVoteRegistrationDelegation) TableName() string {
 }
 
 type VoteDelegation struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_vote_delegation_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_vote_delegation_credential,priority:1;not null;default:0"`
 	Drep          []byte `gorm:"index;size:28"`
 	DrepType      uint64 `gorm:"default:0"`
 	CertificateID uint   `gorm:"index"`
@@ -240,7 +315,8 @@ func (VoteDelegation) TableName() string {
 }
 
 type VoteRegistrationDelegation struct {
-	StakingKey    []byte `gorm:"index;size:28"`
+	StakingKey    []byte `gorm:"index:idx_vote_registration_delegation_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_vote_registration_delegation_credential,priority:1;not null;default:0"`
 	Drep          []byte `gorm:"index;size:28"`
 	DrepType      uint64 `gorm:"default:0"`
 	CertificateID uint   `gorm:"index"`

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -142,10 +142,32 @@ type StakeCredentialRef struct {
 	Key []byte
 }
 
-func NewStakeCredentialRef(tag uint, key []byte) StakeCredentialRef {
+func NewStakeCredentialRef(tag uint8, key []byte) StakeCredentialRef {
 	return StakeCredentialRef{
-		Tag: uint8(tag),
+		Tag: tag,
 		Key: key,
+	}
+}
+
+func CredentialTagFromUint(tag uint) (uint8, error) {
+	switch tag {
+	case 0:
+		return 0, nil
+	case 1:
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
+	}
+}
+
+func CredentialTagFromUint64(tag uint64) (uint8, error) {
+	switch tag {
+	case 0:
+		return 0, nil
+	case 1:
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unsupported stake credential tag: %d", tag)
 	}
 }
 

--- a/database/models/address_transaction.go
+++ b/database/models/address_transaction.go
@@ -19,7 +19,8 @@ package models
 type AddressTransaction struct {
 	ID            uint   `gorm:"primaryKey"`
 	PaymentKey    []byte `gorm:"index:idx_addr_tx_payment;size:28"`
-	StakingKey    []byte `gorm:"index:idx_addr_tx_staking;size:28"`
+	StakingKey    []byte `gorm:"index:idx_addr_tx_staking,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"not null;default:0;index:idx_addr_tx_staking,priority:1"`
 	TransactionID uint   `gorm:"index"`
 	Slot          uint64 `gorm:"index"`
 	TxIndex       uint32

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -16,8 +16,11 @@ package models
 
 import (
 	"errors"
+	"fmt"
+	"log/slog"
 
 	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm"
 )
 
 var (
@@ -30,11 +33,12 @@ var (
 )
 
 type Drep struct {
-	AnchorURL  string `gorm:"column:anchor_url;size:128"`
-	Credential []byte `gorm:"uniqueIndex;size:28"`
-	AnchorHash []byte
-	ID         uint   `gorm:"primarykey"`
-	AddedSlot  uint64 `gorm:"index"`
+	AnchorURL     string `gorm:"column:anchor_url;size:128"`
+	Credential    []byte `gorm:"uniqueIndex:idx_drep_credential,priority:2;size:28"`
+	AnchorHash    []byte
+	ID            uint  `gorm:"primarykey"`
+	AddedSlot     uint64 `gorm:"index"`
+	CredentialTag uint8  `gorm:"uniqueIndex:idx_drep_credential,priority:1;not null;default:0"`
 	// Last activity epoch (vote, register, update).
 	LastActivityEpoch uint64 `gorm:"index;default:0"`
 	// Epoch when DRep expires (activity + inactivity).
@@ -42,14 +46,39 @@ type Drep struct {
 	Active      bool   `gorm:"default:true"`
 }
 
+// MigrateDrepCredentialTagIndex drops the legacy hash-only DRep uniqueness
+// constraint before AutoMigrate installs the tag-aware composite unique index.
+func MigrateDrepCredentialTagIndex(db *gorm.DB, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&Drep{}) {
+		return nil
+	}
+	if !db.Migrator().HasIndex(&Drep{}, "idx_drep_credential") {
+		return nil
+	}
+	if db.Migrator().HasColumn(&Drep{}, "credential_tag") {
+		return nil
+	}
+	logger.Info(
+		"dropping legacy drep credential unique index before tag-aware migration",
+	)
+	if err := db.Migrator().DropIndex(&Drep{}, "idx_drep_credential"); err != nil {
+		return fmt.Errorf("drop drep credential index: %w", err)
+	}
+	return nil
+}
+
 func (d *Drep) TableName() string {
 	return "drep"
 }
 
 type DeregistrationDrep struct {
-	DrepCredential []byte `gorm:"index;size:28"`
+	DrepCredential []byte `gorm:"index:idx_dereg_drep_credential,priority:2;size:28"`
 	CertificateID  uint   `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
+	CredentialTag  uint8  `gorm:"index:idx_dereg_drep_credential,priority:1;not null;default:0"`
 	AddedSlot      uint64 `gorm:"index"`
 	DepositAmount  types.Uint64
 }
@@ -60,11 +89,12 @@ func (DeregistrationDrep) TableName() string {
 
 type RegistrationDrep struct {
 	AnchorURL      string `gorm:"column:anchor_url;size:128"`
-	DrepCredential []byte `gorm:"uniqueIndex:idx_drep_reg_cred_slot;size:28"`
+	DrepCredential []byte `gorm:"uniqueIndex:idx_drep_reg_cred_slot,priority:2;size:28"`
 	AnchorHash     []byte
 	CertificateID  uint   `gorm:"index"`
 	ID             uint   `gorm:"primarykey"`
-	AddedSlot      uint64 `gorm:"uniqueIndex:idx_drep_reg_cred_slot"`
+	CredentialTag  uint8  `gorm:"uniqueIndex:idx_drep_reg_cred_slot,priority:1;not null;default:0"`
+	AddedSlot      uint64 `gorm:"uniqueIndex:idx_drep_reg_cred_slot,priority:3"`
 	DepositAmount  types.Uint64
 }
 
@@ -74,10 +104,11 @@ func (RegistrationDrep) TableName() string {
 
 type UpdateDrep struct {
 	AnchorURL     string `gorm:"column:anchor_url;size:128"`
-	Credential    []byte `gorm:"index;size:28"`
+	Credential    []byte `gorm:"index:idx_update_drep_credential,priority:2;size:28"`
 	AnchorHash    []byte
 	CertificateID uint   `gorm:"index"`
 	ID            uint   `gorm:"primarykey"`
+	CredentialTag uint8  `gorm:"index:idx_update_drep_credential,priority:1;not null;default:0"`
 	AddedSlot     uint64 `gorm:"index"`
 }
 

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -36,7 +36,7 @@ type Drep struct {
 	AnchorURL     string `gorm:"column:anchor_url;size:128"`
 	Credential    []byte `gorm:"uniqueIndex:idx_drep_credential,priority:2;size:28"`
 	AnchorHash    []byte
-	ID            uint  `gorm:"primarykey"`
+	ID            uint   `gorm:"primarykey"`
 	AddedSlot     uint64 `gorm:"index"`
 	CredentialTag uint8  `gorm:"uniqueIndex:idx_drep_credential,priority:1;not null;default:0"`
 	// Last activity epoch (vote, register, update).

--- a/database/models/governance.go
+++ b/database/models/governance.go
@@ -14,7 +14,13 @@
 
 package models
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
 
 var ErrGovernanceProposalNotFound = errors.New("governance proposal not found")
 
@@ -88,21 +94,53 @@ func (GovernanceProposal) TableName() string {
 // GovernanceVote represents a vote cast by a Constitutional Committee member,
 // DRep, or Stake Pool Operator on a governance proposal.
 type GovernanceVote struct {
-	ID              uint    `gorm:"primarykey"`
-	ProposalID      uint    `gorm:"index:idx_vote_proposal;uniqueIndex:idx_vote_unique,priority:1;not null"`
-	VoterType       uint8   `gorm:"index:idx_vote_voter,priority:1;uniqueIndex:idx_vote_unique,priority:2;not null"` // 0=CC, 1=DRep, 2=SPO
-	VoterCredential []byte  `gorm:"index:idx_vote_voter,priority:2;uniqueIndex:idx_vote_unique,priority:3;size:28;not null"`
-	Vote            uint8   `gorm:"not null"` // 0=No, 1=Yes, 2=Abstain
-	AnchorURL       string  `gorm:"column:anchor_url;size:128"`
-	AnchorHash      []byte  `gorm:"size:32"`
-	AddedSlot       uint64  `gorm:"index;not null"`
-	VoteUpdatedSlot *uint64 `gorm:"index"` // Slot when vote was last changed (for rollback safety)
+	ID                 uint   `gorm:"primarykey"`
+	ProposalID         uint   `gorm:"index:idx_vote_proposal;uniqueIndex:idx_vote_unique,priority:1;not null"`
+	VoterType          uint8  `gorm:"index:idx_vote_voter,priority:1;uniqueIndex:idx_vote_unique,priority:2;not null"` // 0=CC, 1=DRep, 2=SPO
+	VoterCredentialTag uint8  `gorm:"index:idx_vote_voter,priority:2;uniqueIndex:idx_vote_unique,priority:3;not null;default:0"`
+	VoterCredential    []byte `gorm:"index:idx_vote_voter,priority:3;uniqueIndex:idx_vote_unique,priority:4;size:28;not null"`
+	Vote               uint8  `gorm:"not null"` // 0=No, 1=Yes, 2=Abstain
+	AnchorURL          string `gorm:"column:anchor_url;size:128"`
+	AnchorHash         []byte `gorm:"size:32"`
+	AddedSlot          uint64 `gorm:"index;not null"`
+	// Slot when vote was last changed (for rollback safety).
+	VoteUpdatedSlot *uint64 `gorm:"index"`
 	DeletedSlot     *uint64 `gorm:"index"`
 }
 
 // TableName returns the table name
 func (GovernanceVote) TableName() string {
 	return "governance_vote"
+}
+
+// MigrateGovernanceVoteCredentialTagIndex drops the legacy vote uniqueness
+// constraint before AutoMigrate installs the tag-aware composite unique index.
+func MigrateGovernanceVoteCredentialTagIndex(
+	db *gorm.DB,
+	logger *slog.Logger,
+) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&GovernanceVote{}) {
+		return nil
+	}
+	if !db.Migrator().HasIndex(&GovernanceVote{}, "idx_vote_unique") {
+		return nil
+	}
+	if db.Migrator().HasColumn(&GovernanceVote{}, "voter_credential_tag") {
+		return nil
+	}
+	logger.Info(
+		"dropping legacy governance vote unique index before tag-aware migration",
+	)
+	if err := db.Migrator().DropIndex(
+		&GovernanceVote{},
+		"idx_vote_unique",
+	); err != nil {
+		return fmt.Errorf("drop governance vote unique index: %w", err)
+	}
+	return nil
 }
 
 // ResignCommitteeCold represents a resignation certificate for a

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -42,8 +42,9 @@ type MIREffect struct {
 
 // MIRReward is a single credential→amount entry from a distribution MIR cert.
 type MIRReward struct {
-	Credential []byte
-	Amount     uint64
+	Credential    []byte
+	CredentialTag uint8
+	Amount        uint64
 }
 
 func (MoveInstantaneousRewards) TableName() string {

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -51,10 +51,11 @@ func (MoveInstantaneousRewards) TableName() string {
 }
 
 type MoveInstantaneousRewardsReward struct {
-	Credential []byte
-	Amount     types.Uint64
-	ID         uint `gorm:"primarykey"`
-	MIRID      uint `gorm:"index"`
+	Credential    []byte `gorm:"index:idx_mir_reward_credential,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"index:idx_mir_reward_credential,priority:1;not null;default:0"`
+	Amount        types.Uint64
+	ID            uint `gorm:"primarykey"`
+	MIRID         uint `gorm:"index"`
 }
 
 func (MoveInstantaneousRewardsReward) TableName() string {

--- a/database/models/pool.go
+++ b/database/models/pool.go
@@ -30,6 +30,13 @@ type Pool struct {
 	VrfKeyHash           []byte
 	RewardAccount        []byte
 	LatestOpCertSequence uint64
+	// RewardAccountCredentialTag is the stake credential type of the pool's
+	// reward account: 0 = key hash, 1 = script hash. The on-chain pool cert
+	// encodes the reward_account as a 29-byte reward address (header + 28-byte
+	// hash). The gouroboros library stores only the first 28 bytes in
+	// RewardAccount (AddrKeyHash), discarding the header. We decode the raw
+	// cert CBOR to preserve the credential type here.
+	RewardAccountCredentialTag uint8 `gorm:"not null;default:0"`
 	// Owners and Relays are query-only associations (no CASCADE).
 	// The actual parent-child relationship is PoolRegistration -> Owners/Relays.
 	// When Pool is deleted, PoolRegistrations cascade, which then cascade to Owners/Relays.
@@ -58,22 +65,23 @@ func (PoolOpCertSequence) TableName() string {
 }
 
 type PoolRegistration struct {
-	Margin        *types.Rat
-	Pool          *Pool // Belongs-to relationship; CASCADE is defined on Pool.Registration
-	MetadataUrl   string
-	VrfKeyHash    []byte
-	PoolKeyHash   []byte `gorm:"index;size:28"`
-	RewardAccount []byte
-	MetadataHash  []byte
-	Owners        []PoolRegistrationOwner `gorm:"foreignKey:PoolRegistrationID;constraint:OnDelete:CASCADE"`
-	Relays        []PoolRegistrationRelay `gorm:"foreignKey:PoolRegistrationID;constraint:OnDelete:CASCADE"`
-	Pledge        types.Uint64
-	Cost          types.Uint64
-	CertificateID uint   `gorm:"index"`
-	ID            uint   `gorm:"primarykey"`
-	PoolID        uint   `gorm:"uniqueIndex:idx_pool_reg_pool_slot"`
-	AddedSlot     uint64 `gorm:"uniqueIndex:idx_pool_reg_pool_slot"`
-	DepositAmount types.Uint64
+	Margin                     *types.Rat
+	Pool                       *Pool // Belongs-to relationship; CASCADE is defined on Pool.Registration
+	MetadataUrl                string
+	VrfKeyHash                 []byte
+	PoolKeyHash                []byte `gorm:"index;size:28"`
+	RewardAccount              []byte
+	RewardAccountCredentialTag uint8 `gorm:"not null;default:0"`
+	MetadataHash               []byte
+	Owners                     []PoolRegistrationOwner `gorm:"foreignKey:PoolRegistrationID;constraint:OnDelete:CASCADE"`
+	Relays                     []PoolRegistrationRelay `gorm:"foreignKey:PoolRegistrationID;constraint:OnDelete:CASCADE"`
+	Pledge                     types.Uint64
+	Cost                       types.Uint64
+	CertificateID              uint   `gorm:"index"`
+	ID                         uint   `gorm:"primarykey"`
+	PoolID                     uint   `gorm:"uniqueIndex:idx_pool_reg_pool_slot"`
+	AddedSlot                  uint64 `gorm:"uniqueIndex:idx_pool_reg_pool_slot"`
+	DepositAmount              types.Uint64
 }
 
 func (PoolRegistration) TableName() string {

--- a/database/models/pool.go
+++ b/database/models/pool.go
@@ -126,9 +126,10 @@ type PoolRetirement struct {
 // with the reward account and deposit needed to refund its POOLREAP deposit.
 // It is a query result, not a persisted table.
 type PoolRetirementRefund struct {
-	PoolKeyHash   []byte
-	RewardAccount []byte
-	DepositAmount types.Uint64
+	PoolKeyHash                []byte
+	RewardAccount              []byte
+	RewardAccountCredentialTag uint8
+	DepositAmount              types.Uint64
 }
 
 func (PoolRetirement) TableName() string {

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -43,19 +43,20 @@ func AppendUtxoAddressOrBranch(
 	sk := addr.StakeKeyHash()
 	hasPayment := pk != zeroHash
 	hasStake := sk != zeroHash
+	credentialTag, _ := StakeCredentialTagFromAddress(addr)
 	switch {
 	case hasPayment && hasStake:
 		*ors = append(
 			*ors,
-			"(utxo.payment_key = ? AND utxo.staking_key = ?)",
+			"(utxo.payment_key = ? AND utxo.credential_tag = ? AND utxo.staking_key = ?)",
 		)
-		*args = append(*args, pk.Bytes(), sk.Bytes())
+		*args = append(*args, pk.Bytes(), credentialTag, sk.Bytes())
 	case hasPayment:
 		*ors = append(*ors, "(utxo.payment_key = ?)")
 		*args = append(*args, pk.Bytes())
 	case hasStake:
-		*ors = append(*ors, "(utxo.staking_key = ?)")
-		*args = append(*args, sk.Bytes())
+		*ors = append(*ors, "(utxo.credential_tag = ? AND utxo.staking_key = ?)")
+		*args = append(*args, credentialTag, sk.Bytes())
 	}
 }
 
@@ -65,7 +66,8 @@ type Utxo struct {
 	CollateralReturnForTxID *uint        `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
 	TxId                    []byte       `gorm:"uniqueIndex:tx_id_output_idx;size:32"`
 	PaymentKey              []byte       `gorm:"index;size:28"`
-	StakingKey              []byte       `gorm:"index;size:28;index:idx_utxo_deleted_staking_amount,priority:2"`
+	StakingKey              []byte       `gorm:"index;size:28;index:idx_utxo_deleted_staking_amount,priority:3"`
+	CredentialTag           uint8        `gorm:"not null;default:0;index:idx_utxo_deleted_staking_amount,priority:2"`
 	Assets                  []Asset      `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
 	Cbor                    []byte       `gorm:"-"`       // This is here for convenience but not represented in the metadata DB
 	DatumHash               []byte       `gorm:"size:32"` // Optional datum hash (32 bytes)
@@ -167,6 +169,10 @@ func UtxoLedgerToModel(
 	skh := outAddr.StakeKeyHash()
 	if skh != zeroHash {
 		ret.StakingKey = skh.Bytes()
+		credentialTag, ok := StakeCredentialTagFromAddress(outAddr)
+		if ok {
+			ret.CredentialTag = credentialTag
+		}
 	}
 	if dh := utxo.Output.DatumHash(); dh != nil {
 		ret.DatumHash = append([]byte(nil), dh[:]...)
@@ -176,6 +182,21 @@ func UtxoLedgerToModel(
 	}
 
 	return ret
+}
+
+func StakeCredentialTagFromAddress(addr ledger.Address) (uint8, bool) {
+	zeroHash := lcommon.NewBlake2b224(nil)
+	if addr.StakeKeyHash() == zeroHash {
+		return 0, false
+	}
+	switch addr.StakingPayload().(type) {
+	case lcommon.AddressPayloadKeyHash:
+		return 0, true
+	case lcommon.AddressPayloadScriptHash:
+		return 1, true
+	default:
+		return 0, false
+	}
 }
 
 // UtxoSlot allows providing a slot number with a ledger.Utxo object

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -37,27 +37,42 @@ func AppendUtxoAddressOrBranch(
 	ors *[]string,
 	args *[]any,
 	addr ledger.Address,
-) {
+) error {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	pk := addr.PaymentKeyHash()
 	sk := addr.StakeKeyHash()
 	hasPayment := pk != zeroHash
 	hasStake := sk != zeroHash
-	credentialTag, _ := StakeCredentialTagFromAddress(addr)
+	paymentScript := PaymentScriptFromAddress(addr)
 	switch {
 	case hasPayment && hasStake:
+		credentialTag, ok := StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return errors.New("derive stake credential tag from address")
+		}
 		*ors = append(
 			*ors,
-			"(utxo.payment_key = ? AND utxo.credential_tag = ? AND utxo.staking_key = ?)",
+			"(utxo.payment_script = ? AND utxo.payment_key = ? AND utxo.credential_tag = ? AND utxo.staking_key = ?)",
 		)
-		*args = append(*args, pk.Bytes(), credentialTag, sk.Bytes())
+		*args = append(
+			*args,
+			paymentScript,
+			pk.Bytes(),
+			credentialTag,
+			sk.Bytes(),
+		)
 	case hasPayment:
-		*ors = append(*ors, "(utxo.payment_key = ?)")
-		*args = append(*args, pk.Bytes())
+		*ors = append(*ors, "(utxo.payment_script = ? AND utxo.payment_key = ?)")
+		*args = append(*args, paymentScript, pk.Bytes())
 	case hasStake:
+		credentialTag, ok := StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return errors.New("derive stake credential tag from address")
+		}
 		*ors = append(*ors, "(utxo.credential_tag = ? AND utxo.staking_key = ?)")
 		*args = append(*args, credentialTag, sk.Bytes())
 	}
+	return nil
 }
 
 // Utxo represents an unspent transaction output
@@ -163,7 +178,7 @@ func UtxoLedgerToModel(
 	// credential from a key-hash credential. Byron addresses (type
 	// 0b1000) never have this bit set, so they are correctly treated
 	// as non-script.
-	if outAddr.Type()&lcommon.AddressTypeScriptBit == lcommon.AddressTypeScriptBit {
+	if PaymentScriptFromAddress(outAddr) {
 		ret.PaymentScript = true
 	}
 	skh := outAddr.StakeKeyHash()
@@ -197,6 +212,10 @@ func StakeCredentialTagFromAddress(addr ledger.Address) (uint8, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func PaymentScriptFromAddress(addr ledger.Address) bool {
+	return addr.Type()&lcommon.AddressTypeScriptBit == lcommon.AddressTypeScriptBit
 }
 
 // UtxoSlot allows providing a slot number with a ledger.Utxo object

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -31,12 +31,34 @@ func QueryDelegationHistory(
 	offset int,
 	order string,
 ) ([]models.AccountDelegationHistoryRow, error) {
+	return QueryDelegationHistoryByCredential(
+		db,
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+}
+
+func QueryDelegationHistoryByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+) ([]models.AccountDelegationHistoryRow, error) {
 	ret := make([]models.AccountDelegationHistoryRow, 0)
 	if len(stakingKey) == 0 {
 		return ret, nil
 	}
 
-	query, args := delegationHistoryUnionQuery(db, stakingKey)
+	query, args := delegationHistoryUnionQuery(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if strings.EqualFold(order, "asc") {
 		query += " ORDER BY added_slot ASC, block_index ASC, cert_index ASC, tx_hash ASC"
 	} else {
@@ -60,10 +82,22 @@ func CountDelegationHistory(
 	db *gorm.DB,
 	stakingKey []byte,
 ) (int, error) {
+	return CountDelegationHistoryByCredential(db, 0, stakingKey)
+}
+
+func CountDelegationHistoryByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (int, error) {
 	if len(stakingKey) == 0 {
 		return 0, nil
 	}
-	query, args := delegationHistoryUnionQuery(db, stakingKey)
+	query, args := delegationHistoryUnionQuery(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	var count int64
 	if err := db.Raw(
 		"SELECT COUNT(*) AS count FROM ("+query+") AS delegation_history",
@@ -76,6 +110,7 @@ func CountDelegationHistory(
 
 func delegationHistoryUnionQuery(
 	db *gorm.DB,
+	credentialTag uint8,
 	stakingKey []byte,
 ) (string, []any) {
 	tables := []string{
@@ -102,13 +137,15 @@ func delegationHistoryUnionQuery(
 				ON certs.id = %[1]s.certificate_id
 				AND certs.cert_type = ?
 			%[2]s
-			WHERE %[1]s.staking_key = ?`,
+				WHERE %[1]s.credential_tag = ?
+					AND %[1]s.staking_key = ?`,
 			table,
 			transactionJoinClause(db),
 		))
 		args = append(
 			args,
 			certType,
+			credentialTag,
 			stakingKey,
 		)
 	}
@@ -122,12 +159,34 @@ func QueryRegistrationHistory(
 	offset int,
 	order string,
 ) ([]models.AccountRegistrationHistoryRow, error) {
+	return QueryRegistrationHistoryByCredential(
+		db,
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+}
+
+func QueryRegistrationHistoryByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+) ([]models.AccountRegistrationHistoryRow, error) {
 	ret := make([]models.AccountRegistrationHistoryRow, 0)
 	if len(stakingKey) == 0 {
 		return ret, nil
 	}
 
-	query, args := registrationHistoryUnionQuery(db, stakingKey)
+	query, args := registrationHistoryUnionQuery(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if strings.EqualFold(order, "asc") {
 		query += " ORDER BY added_slot ASC, block_index ASC, cert_index ASC, tx_hash ASC, action ASC"
 	} else {
@@ -178,10 +237,22 @@ func CountRegistrationHistory(
 	db *gorm.DB,
 	stakingKey []byte,
 ) (int, error) {
+	return CountRegistrationHistoryByCredential(db, 0, stakingKey)
+}
+
+func CountRegistrationHistoryByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (int, error) {
 	if len(stakingKey) == 0 {
 		return 0, nil
 	}
-	query, args := registrationHistoryUnionQuery(db, stakingKey)
+	query, args := registrationHistoryUnionQuery(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	var count int64
 	if err := db.Raw(
 		"SELECT COUNT(*) AS count FROM ("+query+") AS registration_history",
@@ -199,6 +270,7 @@ type registrationHistorySource struct {
 
 func registrationHistoryUnionQuery(
 	db *gorm.DB,
+	credentialTag uint8,
 	stakingKey []byte,
 ) (string, []any) {
 	sources := registrationHistorySources()
@@ -220,7 +292,8 @@ func registrationHistoryUnionQuery(
 				ON certs.id = %[1]s.certificate_id
 				AND certs.cert_type = ?
 			%[2]s
-			WHERE %[1]s.staking_key = ?`,
+				WHERE %[1]s.credential_tag = ?
+					AND %[1]s.staking_key = ?`,
 			source.table,
 			transactionJoinClause(db),
 		))
@@ -228,6 +301,7 @@ func registrationHistoryUnionQuery(
 			args,
 			source.action,
 			certType,
+			credentialTag,
 			stakingKey,
 		)
 	}

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -24,23 +24,6 @@ import (
 	"gorm.io/gorm"
 )
 
-func QueryDelegationHistory(
-	db *gorm.DB,
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-) ([]models.AccountDelegationHistoryRow, error) {
-	return QueryDelegationHistoryByCredential(
-		db,
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-	)
-}
-
 func QueryDelegationHistoryByCredential(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -76,13 +59,6 @@ func QueryDelegationHistoryByCredential(
 		return nil, fmt.Errorf("get account delegation history: %w", err)
 	}
 	return ret, nil
-}
-
-func CountDelegationHistory(
-	db *gorm.DB,
-	stakingKey []byte,
-) (int, error) {
-	return CountDelegationHistoryByCredential(db, 0, stakingKey)
 }
 
 func CountDelegationHistoryByCredential(
@@ -152,23 +128,6 @@ func delegationHistoryUnionQuery(
 	return strings.Join(parts, " UNION ALL "), args
 }
 
-func QueryRegistrationHistory(
-	db *gorm.DB,
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-) ([]models.AccountRegistrationHistoryRow, error) {
-	return QueryRegistrationHistoryByCredential(
-		db,
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-	)
-}
-
 func QueryRegistrationHistoryByCredential(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -231,13 +190,6 @@ func DelegationTableCertType(table string) (uint, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func CountRegistrationHistory(
-	db *gorm.DB,
-	stakingKey []byte,
-) (int, error) {
-	return CountRegistrationHistoryByCredential(db, 0, stakingKey)
 }
 
 func CountRegistrationHistoryByCredential(

--- a/database/plugin/metadata/internal/certutil/pool.go
+++ b/database/plugin/metadata/internal/certutil/pool.go
@@ -65,9 +65,18 @@ func PoolRewardAccount(
 		if len(rewardAddrBytes) != 29 {
 			return 0, nil, fmt.Errorf("pool cert reward_account: got %d bytes, want 29", len(rewardAddrBytes))
 		}
-		// Header high nibble: 0xF = script credential, otherwise key.
-		if (rewardAddrBytes[0] & 0xF0) == 0xF0 {
+		// High nibble 0xE = key-hash reward address, 0xF = script-hash reward address.
+		// Any other value is invalid for a pool registration reward account.
+		switch rewardAddrBytes[0] & 0xF0 {
+		case 0xE0:
+			credentialTag = 0
+		case 0xF0:
 			credentialTag = 1
+		default:
+			return 0, nil, fmt.Errorf(
+				"pool cert reward_account: unexpected address header 0x%02X",
+				rewardAddrBytes[0],
+			)
 		}
 		return credentialTag, rewardAddrBytes[1:], nil // pure 28-byte hash
 	}

--- a/database/plugin/metadata/internal/certutil/pool.go
+++ b/database/plugin/metadata/internal/certutil/pool.go
@@ -15,6 +15,8 @@
 package certutil
 
 import (
+	"fmt"
+
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -37,9 +39,12 @@ import (
 // the cert was parsed via UnmarshalJSON which correctly stores the pure
 // 28-byte hash in RewardAccount, and only key-hash reward accounts appear in
 // genesis, so tag=0 and cert.RewardAccount[:] are returned.
+//
+// Returns an error if rawCbor is non-empty but cannot be decoded correctly,
+// to prevent storing a corrupted reward account hash.
 func PoolRewardAccount(
 	cert *lcommon.PoolRegistrationCertificate,
-) (credentialTag uint8, hash []byte) {
+) (credentialTag uint8, hash []byte, err error) {
 	rawCbor := cert.Cbor()
 	if len(rawCbor) > 0 {
 		// Pool cert CBOR is a flat array:
@@ -47,19 +52,26 @@ func PoolRewardAccount(
 		//    reward_account, pool_owners, relays, pool_metadata]
 		// reward_account is at index 6.
 		var raw []gcbor.RawMessage
-		if _, err := gcbor.Decode(rawCbor, &raw); err == nil && len(raw) > 6 {
-			var rewardAddrBytes []byte
-			if _, err := gcbor.Decode(raw[6], &rewardAddrBytes); err == nil &&
-				len(rewardAddrBytes) == 29 {
-				// Header high nibble: 0xF = script credential, otherwise key.
-				if (rewardAddrBytes[0] & 0xF0) == 0xF0 {
-					credentialTag = 1
-				}
-				return credentialTag, rewardAddrBytes[1:] // pure 28-byte hash
-			}
+		if _, decErr := gcbor.Decode(rawCbor, &raw); decErr != nil {
+			return 0, nil, fmt.Errorf("decode pool cert CBOR: %w", decErr)
 		}
+		if len(raw) <= 6 {
+			return 0, nil, fmt.Errorf("pool cert CBOR array too short: got %d fields, want >6", len(raw))
+		}
+		var rewardAddrBytes []byte
+		if _, decErr := gcbor.Decode(raw[6], &rewardAddrBytes); decErr != nil {
+			return 0, nil, fmt.Errorf("decode pool cert reward_account field: %w", decErr)
+		}
+		if len(rewardAddrBytes) != 29 {
+			return 0, nil, fmt.Errorf("pool cert reward_account: got %d bytes, want 29", len(rewardAddrBytes))
+		}
+		// Header high nibble: 0xF = script credential, otherwise key.
+		if (rewardAddrBytes[0] & 0xF0) == 0xF0 {
+			credentialTag = 1
+		}
+		return credentialTag, rewardAddrBytes[1:], nil // pure 28-byte hash
 	}
 	// JSON/genesis path: RewardAccount already holds the pure 28-byte hash
 	// and genesis pools always use key-hash reward accounts.
-	return 0, cert.RewardAccount[:]
+	return 0, cert.RewardAccount[:], nil
 }

--- a/database/plugin/metadata/internal/certutil/pool.go
+++ b/database/plugin/metadata/internal/certutil/pool.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certutil
+
+import (
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// PoolRewardAccount extracts the credential tag and pure 28-byte hash from a
+// pool registration certificate's reward account.
+//
+// Background: PoolRegistrationCertificate.RewardAccount is AddrKeyHash
+// ([28]byte), but the on-chain CBOR encodes the reward_account field as a
+// 29-byte reward address (1 header byte + 28 hash bytes). fxamacker/cbor
+// decodes a 29-byte bytestring into [28]byte by taking the first 28 bytes, so
+// the struct field contains [header, hash_0..hash_26] — the last hash byte is
+// lost and the header byte pollutes the stored value.
+//
+// This function decodes the raw cert CBOR (available via cert.Cbor()) to
+// recover the full 29-byte reward address and returns both the credential type
+// (0 = key hash, 1 = script hash) and the pure 28-byte stake credential hash.
+//
+// Fallback when raw CBOR is unavailable (e.g. genesis/JSON-sourced certs):
+// the cert was parsed via UnmarshalJSON which correctly stores the pure
+// 28-byte hash in RewardAccount, and only key-hash reward accounts appear in
+// genesis, so tag=0 and cert.RewardAccount[:] are returned.
+func PoolRewardAccount(
+	cert *lcommon.PoolRegistrationCertificate,
+) (credentialTag uint8, hash []byte) {
+	rawCbor := cert.Cbor()
+	if len(rawCbor) > 0 {
+		// Pool cert CBOR is a flat array:
+		//   [cert_type, operator, vrf_keyhash, pledge, cost, margin,
+		//    reward_account, pool_owners, relays, pool_metadata]
+		// reward_account is at index 6.
+		var raw []gcbor.RawMessage
+		if _, err := gcbor.Decode(rawCbor, &raw); err == nil && len(raw) > 6 {
+			var rewardAddrBytes []byte
+			if _, err := gcbor.Decode(raw[6], &rewardAddrBytes); err == nil &&
+				len(rewardAddrBytes) == 29 {
+				// Header high nibble: 0xF = script credential, otherwise key.
+				if (rewardAddrBytes[0] & 0xF0) == 0xF0 {
+					credentialTag = 1
+				}
+				return credentialTag, rewardAddrBytes[1:] // pure 28-byte hash
+			}
+		}
+	}
+	// JSON/genesis path: RewardAccount already holds the pure 28-byte hash
+	// and genesis pools always use key-hash reward accounts.
+	return 0, cert.RewardAccount[:]
+}

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -25,15 +25,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetAccount gets an account by key credential hash.
-func (d *MetadataStoreMysql) GetAccount(
-	stakeKey []byte,
-	includeInactive bool,
-	txn types.Txn,
-) (*models.Account, error) {
-	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
-}
-
 // GetAccountByCredential gets an account by credential tag and hash.
 func (d *MetadataStoreMysql) GetAccountByCredential(
 	credentialTag uint8,
@@ -61,27 +52,6 @@ func (d *MetadataStoreMysql) GetAccountByCredential(
 			return nil, nil
 		}
 		return nil, result.Error
-	}
-	return ret, nil
-}
-
-// GetAccounts fetches multiple key-credential accounts.
-func (d *MetadataStoreMysql) GetAccounts(
-	stakeKeys [][]byte,
-	includeInactive bool,
-	txn types.Txn,
-) (map[string]*models.Account, error) {
-	refs := make([]models.StakeCredentialRef, 0, len(stakeKeys))
-	for _, stakeKey := range stakeKeys {
-		refs = append(refs, models.StakeCredentialRef{Key: stakeKey})
-	}
-	accounts, err := d.GetAccountsByCredential(refs, includeInactive, txn)
-	if err != nil {
-		return nil, err
-	}
-	ret := make(map[string]*models.Account, len(accounts))
-	for _, account := range accounts {
-		ret[string(account.StakingKey)] = account
 	}
 	return ret, nil
 }
@@ -124,16 +94,6 @@ func (d *MetadataStoreMysql) GetAccountsByCredential(
 		}
 	}
 	return ret, nil
-}
-
-// AddAccountReward credits a registered key-credential reward account.
-func (d *MetadataStoreMysql) AddAccountReward(
-	stakeKey []byte,
-	amount uint64,
-	slot uint64,
-	txn types.Txn,
-) error {
-	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
 }
 
 // AddAccountRewardByCredential credits a registered reward account.

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -352,19 +352,21 @@ func (d *MetadataStoreMysql) DeleteAccountRewardsAfterSlot(
 	return db.Transaction(rollback)
 }
 
-// SetAccount saves an account
+// SetAccount saves an account by full stake credential identity.
 func (d *MetadataStoreMysql) SetAccount(
+	credentialTag uint8,
 	stakeKey, pkh, drep []byte,
 	slot uint64,
 	active bool,
 	txn types.Txn,
 ) error {
 	tmpItem := models.Account{
-		StakingKey: stakeKey,
-		AddedSlot:  slot,
-		Pool:       pkh,
-		Drep:       drep,
-		Active:     active,
+		StakingKey:    stakeKey,
+		CredentialTag: credentialTag,
+		AddedSlot:     slot,
+		Pool:          pkh,
+		Drep:          drep,
+		Active:        active,
 	}
 	onConflict := clause.OnConflict{
 		Columns: []clause.Column{

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -17,6 +17,7 @@ package mysql
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -100,28 +101,31 @@ func (d *MetadataStoreMysql) GetAccountsByCredential(
 	if err != nil {
 		return nil, err
 	}
-	query := db.Where("1 = 0")
+
+	wanted := make(map[string]struct{}, len(refs))
+	stakeKeys := make([][]byte, 0, len(refs))
 	for _, ref := range refs {
-		conditions := "credential_tag = ? AND staking_key = ?"
-		args := []any{ref.Tag, ref.Key}
+		wanted[ref.MapKey()] = struct{}{}
+		stakeKeys = append(stakeKeys, ref.Key)
+	}
+	for chunk := range slices.Chunk(stakeKeys, 400) {
+		query := db.Where("staking_key IN ?", chunk)
 		if !includeInactive {
-			conditions += " AND active = ?"
-			args = append(args, true)
+			query = query.Where("active = ?", true)
 		}
-		query = query.Or(
-			conditions,
-			args...,
-		)
-	}
-	var rows []*models.Account
-	if result := query.Find(&rows); result.Error != nil {
-		return nil, result.Error
-	}
-	for _, row := range rows {
-		ret[models.StakeCredentialRef{
-			Tag: row.CredentialTag,
-			Key: row.StakingKey,
-		}.MapKey()] = row
+		var rows []*models.Account
+		if result := query.Find(&rows); result.Error != nil {
+			return nil, result.Error
+		}
+		for _, row := range rows {
+			key := models.StakeCredentialRef{
+				Tag: row.CredentialTag,
+				Key: row.StakingKey,
+			}.MapKey()
+			if _, ok := wanted[key]; ok {
+				ret[key] = row
+			}
+		}
 	}
 	return ret, nil
 }

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -367,7 +367,10 @@ func (d *MetadataStoreMysql) SetAccount(
 		Active:     active,
 	}
 	onConflict := clause.OnConflict{
-		Columns: []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"added_slot", "pool", "drep", "active"},
 		),

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -166,6 +166,7 @@ func (d *MetadataStoreMysql) AddAccountRewardByCredential(
 // rollback. The ledger rule clears the reward account when a withdrawal for
 // the credential appears in a valid transaction.
 func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -182,7 +183,8 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 	withdraw := func(tx *gorm.DB) error {
 		var account models.Account
 		if err := tx.Where(
-			"staking_key = ? AND active = ?",
+			"credential_tag = ? AND staking_key = ? AND active = ?",
+			credentialTag,
 			stakeKey,
 			true,
 		).First(&account).Error; err != nil {
@@ -197,7 +199,7 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 				"withdrawal = ? AND tx_hash = ? AND credential_tag = ? AND staking_key = ?",
 				true,
 				txHash,
-				account.CredentialTag,
+				credentialTag,
 				stakeKey,
 			).First(&existing)
 			if result.Error == nil {
@@ -219,7 +221,7 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 		}
 		delta := &models.AccountRewardDelta{
 			StakingKey:     stakeKey,
-			CredentialTag:  account.CredentialTag,
+			CredentialTag:  credentialTag,
 			TxHash:         txHash,
 			Amount:         types.Uint64(amount),
 			PreviousReward: types.Uint64(current),

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -102,14 +102,16 @@ func (d *MetadataStoreMysql) GetAccountsByCredential(
 	}
 	query := db.Where("1 = 0")
 	for _, ref := range refs {
+		conditions := "credential_tag = ? AND staking_key = ?"
+		args := []any{ref.Tag, ref.Key}
+		if !includeInactive {
+			conditions += " AND active = ?"
+			args = append(args, true)
+		}
 		query = query.Or(
-			"credential_tag = ? AND staking_key = ?",
-			ref.Tag,
-			ref.Key,
+			conditions,
+			args...,
 		)
-	}
-	if !includeInactive {
-		query = query.Where("active = ?", true)
 	}
 	var rows []*models.Account
 	if result := query.Find(&rows); result.Error != nil {

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -1110,7 +1110,10 @@ func (d *MetadataStoreMysql) ClearDanglingDRepDelegations(
 	// surprising semantics around NULL values in the subquery result.
 	liveDrepExists := db.Model(&models.Drep{}).
 		Select("1").
-		Where("drep.credential = account.drep AND drep.active = ?", true)
+		Where(
+			"drep.credential_tag = account.drep_type AND drep.credential = account.drep AND drep.active = ?",
+			true,
+		)
 	result := db.Model(&models.Account{}).
 		Where("drep IS NOT NULL").
 		Where(

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -102,14 +102,12 @@ func (d *MetadataStoreMysql) GetAccountsByCredential(
 		return nil, err
 	}
 
-	wanted := make(map[string]struct{}, len(refs))
-	stakeKeys := make([][]byte, 0, len(refs))
+	pairs := make([][]any, 0, len(refs))
 	for _, ref := range refs {
-		wanted[ref.MapKey()] = struct{}{}
-		stakeKeys = append(stakeKeys, ref.Key)
+		pairs = append(pairs, []any{ref.Tag, ref.Key})
 	}
-	for chunk := range slices.Chunk(stakeKeys, 400) {
-		query := db.Where("staking_key IN ?", chunk)
+	for chunk := range slices.Chunk(pairs, 400) {
+		query := db.Where("(credential_tag, staking_key) IN ?", chunk)
 		if !includeInactive {
 			query = query.Where("active = ?", true)
 		}
@@ -122,9 +120,7 @@ func (d *MetadataStoreMysql) GetAccountsByCredential(
 				Tag: row.CredentialTag,
 				Key: row.StakingKey,
 			}.MapKey()
-			if _, ok := wanted[key]; ok {
-				ret[key] = row
-			}
+			ret[key] = row
 		}
 	}
 	return ret, nil

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -24,8 +24,18 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetAccount gets an account
+// GetAccount gets an account by key credential hash.
 func (d *MetadataStoreMysql) GetAccount(
+	stakeKey []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Account, error) {
+	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
+}
+
+// GetAccountByCredential gets an account by credential tag and hash.
+func (d *MetadataStoreMysql) GetAccountByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	includeInactive bool,
 	txn types.Txn,
@@ -39,7 +49,12 @@ func (d *MetadataStoreMysql) GetAccount(
 	if !includeInactive {
 		query = query.Where("active = ?", true)
 	}
-	result := query.First(ret, "staking_key = ?", stakeKey)
+	result := query.First(
+		ret,
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakeKey,
+	)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -49,22 +64,50 @@ func (d *MetadataStoreMysql) GetAccount(
 	return ret, nil
 }
 
-// GetAccounts fetches multiple accounts in one IN-list query, keyed by
-// string(StakingKey). Stake keys with no matching row are omitted.
+// GetAccounts fetches multiple key-credential accounts.
 func (d *MetadataStoreMysql) GetAccounts(
 	stakeKeys [][]byte,
 	includeInactive bool,
 	txn types.Txn,
 ) (map[string]*models.Account, error) {
-	ret := make(map[string]*models.Account, len(stakeKeys))
-	if len(stakeKeys) == 0 {
+	refs := make([]models.StakeCredentialRef, 0, len(stakeKeys))
+	for _, stakeKey := range stakeKeys {
+		refs = append(refs, models.StakeCredentialRef{Key: stakeKey})
+	}
+	accounts, err := d.GetAccountsByCredential(refs, includeInactive, txn)
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]*models.Account, len(accounts))
+	for _, account := range accounts {
+		ret[string(account.StakingKey)] = account
+	}
+	return ret, nil
+}
+
+// GetAccountsByCredential fetches multiple accounts in one query, keyed by
+// StakeCredentialRef.MapKey(). Credentials with no matching row are omitted.
+func (d *MetadataStoreMysql) GetAccountsByCredential(
+	refs []models.StakeCredentialRef,
+	includeInactive bool,
+	txn types.Txn,
+) (map[string]*models.Account, error) {
+	ret := make(map[string]*models.Account, len(refs))
+	if len(refs) == 0 {
 		return ret, nil
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, err
 	}
-	query := db.Where("staking_key IN ?", stakeKeys)
+	query := db.Where("1 = 0")
+	for _, ref := range refs {
+		query = query.Or(
+			"credential_tag = ? AND staking_key = ?",
+			ref.Tag,
+			ref.Key,
+		)
+	}
 	if !includeInactive {
 		query = query.Where("active = ?", true)
 	}
@@ -73,13 +116,27 @@ func (d *MetadataStoreMysql) GetAccounts(
 		return nil, result.Error
 	}
 	for _, row := range rows {
-		ret[string(row.StakingKey)] = row
+		ret[models.StakeCredentialRef{
+			Tag: row.CredentialTag,
+			Key: row.StakingKey,
+		}.MapKey()] = row
 	}
 	return ret, nil
 }
 
-// AddAccountReward credits a registered reward account.
+// AddAccountReward credits a registered key-credential reward account.
 func (d *MetadataStoreMysql) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn types.Txn,
+) error {
+	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
+}
+
+// AddAccountRewardByCredential credits a registered reward account.
+func (d *MetadataStoreMysql) AddAccountRewardByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -102,7 +159,8 @@ func (d *MetadataStoreMysql) AddAccountReward(
 	credit := func(tx *gorm.DB) error {
 		var account models.Account
 		if err := tx.Where(
-			"staking_key = ? AND active = ?",
+			"credential_tag = ? AND staking_key = ? AND active = ?",
+			credentialTag,
 			stakeKey,
 			true,
 		).First(&account).Error; err != nil {
@@ -128,9 +186,10 @@ func (d *MetadataStoreMysql) AddAccountReward(
 			return models.ErrAccountNotFound
 		}
 		delta := &models.AccountRewardDelta{
-			StakingKey: stakeKey,
-			Amount:     types.Uint64(amount),
-			AddedSlot:  slot,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
+			Amount:        types.Uint64(amount),
+			AddedSlot:     slot,
 		}
 		return tx.Create(delta).Error
 	}
@@ -159,21 +218,6 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 		return err
 	}
 	withdraw := func(tx *gorm.DB) error {
-		if len(txHash) > 0 {
-			var existing models.AccountRewardDelta
-			result := tx.Where(
-				"withdrawal = ? AND tx_hash = ? AND staking_key = ?",
-				true,
-				txHash,
-				stakeKey,
-			).First(&existing)
-			if result.Error == nil {
-				return nil
-			}
-			if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-				return result.Error
-			}
-		}
 		var account models.Account
 		if err := tx.Where(
 			"staking_key = ? AND active = ?",
@@ -184,6 +228,22 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 				return models.ErrAccountNotFound
 			}
 			return err
+		}
+		if len(txHash) > 0 {
+			var existing models.AccountRewardDelta
+			result := tx.Where(
+				"withdrawal = ? AND tx_hash = ? AND credential_tag = ? AND staking_key = ?",
+				true,
+				txHash,
+				account.CredentialTag,
+				stakeKey,
+			).First(&existing)
+			if result.Error == nil {
+				return nil
+			}
+			if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+				return result.Error
+			}
 		}
 		current := uint64(account.Reward)
 		// Transaction validation proves the on-chain withdrawal amount is
@@ -197,6 +257,7 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 		}
 		delta := &models.AccountRewardDelta{
 			StakingKey:     stakeKey,
+			CredentialTag:  account.CredentialTag,
 			TxHash:         txHash,
 			Amount:         types.Uint64(amount),
 			PreviousReward: types.Uint64(current),
@@ -207,6 +268,7 @@ func (d *MetadataStoreMysql) ApplyAccountRewardWithdrawal(
 			Columns: []clause.Column{
 				{Name: "withdrawal"},
 				{Name: "tx_hash"},
+				{Name: "credential_tag"},
 				{Name: "staking_key"},
 			},
 			DoNothing: true,
@@ -240,7 +302,8 @@ func (d *MetadataStoreMysql) DeleteAccountRewardsAfterSlot(
 		for _, delta := range deltas {
 			var account models.Account
 			if result := tx.Where(
-				"staking_key = ?",
+				"credential_tag = ? AND staking_key = ?",
+				delta.CredentialTag,
 				delta.StakingKey,
 			).First(&account); result.Error != nil {
 				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -376,6 +439,13 @@ func newAccountCertCache(capacity int) *accountCertCache {
 	}
 }
 
+func accountCertCacheKey(credentialTag uint8, stakingKey []byte) string {
+	return models.StakeCredentialRef{
+		Tag: credentialTag,
+		Key: stakingKey,
+	}.MapKey()
+}
+
 // updateReg updates the registration if this one is more recent.
 func (c *accountCertCache) updateReg(key string, rec certRecord) {
 	if !c.hasReg[key] || rec.isMoreRecent(c.latestReg[key]) {
@@ -466,18 +536,19 @@ func batchFetchStakeRegistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration t
@@ -485,14 +556,14 @@ func batchFetchStakeRegistration(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateReg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -506,18 +577,19 @@ func batchFetchStakeRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration_delegation t
@@ -525,13 +597,13 @@ func batchFetchStakeRegistrationDelegation(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			pool:       r.PoolKeyHash,
 			addedSlot:  r.AddedSlot,
@@ -551,20 +623,21 @@ func batchFetchStakeVoteRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		Drep        []byte
-		DrepType    uint64
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_registration_delegation t
@@ -572,13 +645,13 @@ func batchFetchStakeVoteRegistrationDelegation(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			pool:       r.PoolKeyHash,
 			drep:       r.Drep,
@@ -610,19 +683,20 @@ func batchFetchVoteRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		Drep       []byte
-		DrepType   uint64
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_registration_delegation t
@@ -630,13 +704,13 @@ func batchFetchVoteRegistrationDelegation(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			drep:       r.Drep,
 			drepType:   r.DrepType,
@@ -657,10 +731,11 @@ func batchFetchRegistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so synthetic genesis Registration rows (no certs row,
@@ -668,11 +743,11 @@ func batchFetchRegistration(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM registration t
@@ -680,14 +755,14 @@ func batchFetchRegistration(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateReg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -701,17 +776,18 @@ func batchFetchStakeDeregistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_deregistration t
@@ -719,14 +795,14 @@ func batchFetchStakeDeregistration(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDereg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -740,17 +816,18 @@ func batchFetchDeregistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM deregistration t
@@ -758,14 +835,14 @@ func batchFetchDeregistration(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDereg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -779,11 +856,12 @@ func batchFetchStakeDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so genesis stake_delegation rows (no certs row,
@@ -791,11 +869,11 @@ func batchFetchStakeDelegation(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_delegation t
@@ -803,14 +881,14 @@ func batchFetchStakeDelegation(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updatePoolDelegation(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{
 				pool:       r.PoolKeyHash,
 				addedSlot:  r.AddedSlot,
@@ -829,13 +907,14 @@ func batchFetchStakeVoteDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		Drep        []byte
-		DrepType    uint64
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so genesis stake_vote_delegation rows (no certs row,
@@ -843,11 +922,11 @@ func batchFetchStakeVoteDelegation(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_vote_delegation t
@@ -855,13 +934,13 @@ func batchFetchStakeVoteDelegation(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		cache.updatePoolDelegation(
 			key,
 			certRecord{
@@ -892,12 +971,13 @@ func batchFetchVoteDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		Drep       []byte
-		DrepType   uint64
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so genesis vote_delegation rows (no certs row,
@@ -905,11 +985,11 @@ func batchFetchVoteDelegation(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.drep, t.drep_type, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM vote_delegation t
@@ -917,14 +997,14 @@ func batchFetchVoteDelegation(
 			LEFT JOIN transaction tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDrepDelegation(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{
 				drep:       r.Drep,
 				drepType:   r.DrepType,
@@ -979,7 +1059,7 @@ func (d *MetadataStoreMysql) RestoreAccountStateAtSlot(
 
 	// Process each account using the cached certificate data
 	for _, account := range accountsToRestore {
-		key := string(account.StakingKey)
+		key := accountCertCacheKey(account.CredentialTag, account.StakingKey)
 
 		// Check if this account had any registration before the rollback slot
 		latestReg, hasReg := cache.latestReg[key], cache.hasReg[key]

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -447,14 +447,37 @@ func (c *accountCertCache) updateDrepDelegation(key string, rec certRecord) {
 	}
 }
 
-// batchFetchCerts fetches all relevant certificates for the given staking keys
+// batchFetchCerts fetches all relevant certificates for the given credential refs
 // at or before the given slot. Uses one query per certificate table.
+//
+// The SQL IN clause filters on staking_key hash only (not credential_tag) for
+// simplicity; the cache is post-filtered to entries whose composite (tag, hash)
+// key matches one of the input refs, so credentials sharing a 28-byte hash but
+// differing in tag are kept isolated.
 func batchFetchCerts(
 	db *gorm.DB,
-	stakingKeys [][]byte,
+	refs []models.StakeCredentialRef,
 	slot uint64,
 ) (*accountCertCache, error) {
-	cache := newAccountCertCache(len(stakingKeys))
+	cache := newAccountCertCache(len(refs))
+
+	// Build unique staking-key list for the SQL IN clause and a requested
+	// set (by composite cache key) for post-filtering.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var stakingKeys [][]byte
+	for _, ref := range refs {
+		requested[accountCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			stakingKeys = append(stakingKeys, ref.Key)
+		}
+	}
+
+	if len(stakingKeys) == 0 {
+		return cache, nil
+	}
 
 	// Registration certificates (5 types)
 	if err := batchFetchStakeRegistration(db, stakingKeys, slot, cache); err != nil {
@@ -493,6 +516,30 @@ func batchFetchCerts(
 	// DRep delegation certificates - VoteDelegation is DRep-only
 	if err := batchFetchVoteDelegation(db, stakingKeys, slot, cache); err != nil {
 		return nil, err
+	}
+
+	// Remove entries for credential variants not present in the input refs.
+	for key := range cache.latestReg {
+		if _, ok := requested[key]; !ok {
+			delete(cache.latestReg, key)
+			delete(cache.hasReg, key)
+		}
+	}
+	for key := range cache.latestDereg {
+		if _, ok := requested[key]; !ok {
+			delete(cache.latestDereg, key)
+			delete(cache.hasDereg, key)
+		}
+	}
+	for key := range cache.poolDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.poolDelegation, key)
+		}
+	}
+	for key := range cache.drepDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.drepDelegation, key)
+		}
 	}
 
 	return cache, nil
@@ -1014,14 +1061,14 @@ func (d *MetadataStoreMysql) RestoreAccountStateAtSlot(
 		return nil
 	}
 
-	// Extract staking keys for batch fetching
-	stakingKeys := make([][]byte, len(accountsToRestore))
+	// Extract credential refs for batch fetching
+	refs := make([]models.StakeCredentialRef, len(accountsToRestore))
 	for i, account := range accountsToRestore {
-		stakingKeys[i] = account.StakingKey
+		refs[i] = models.NewStakeCredentialRef(account.CredentialTag, account.StakingKey)
 	}
 
 	// Batch-fetch all certificates for all affected accounts
-	cache, err := batchFetchCerts(db, stakingKeys, slot)
+	cache, err := batchFetchCerts(db, refs, slot)
 	if err != nil {
 		return err
 	}

--- a/database/plugin/metadata/mysql/certs.go
+++ b/database/plugin/metadata/mysql/certs.go
@@ -39,7 +39,9 @@ func (d *MetadataStoreMysql) GetStakeRegistrationsByCredential(
 		credentialTag,
 		stakingKey,
 	).
-		Order("id DESC").
+		Joins("LEFT JOIN certs ON certs.id = stake_registration.certificate_id").
+		Joins("LEFT JOIN `transaction` ON `transaction`.id = certs.transaction_id").
+		Order("stake_registration.added_slot DESC, COALESCE(`transaction`.block_index, 0) DESC, COALESCE(certs.cert_index, 0) DESC").
 		Find(&certs)
 	if result.Error != nil {
 		return ret, result.Error

--- a/database/plugin/metadata/mysql/certs.go
+++ b/database/plugin/metadata/mysql/certs.go
@@ -21,8 +21,10 @@ import (
 	"gorm.io/gorm"
 )
 
-// GetStakeRegistrations returns stake registration certificates
-func (d *MetadataStoreMysql) GetStakeRegistrations(
+// GetStakeRegistrationsByCredential returns stake registration certificates
+// for a specific key/script credential tag and hash.
+func (d *MetadataStoreMysql) GetStakeRegistrationsByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) ([]lcommon.StakeRegistrationCertificate, error) {
@@ -32,7 +34,11 @@ func (d *MetadataStoreMysql) GetStakeRegistrations(
 	if err != nil {
 		return ret, err
 	}
-	result := db.Where("staking_key = ?", stakingKey).
+	result := db.Where(
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakingKey,
+	).
 		Order("id DESC").
 		Find(&certs)
 	if result.Error != nil {
@@ -43,14 +49,20 @@ func (d *MetadataStoreMysql) GetStakeRegistrations(
 		tmpCert = lcommon.StakeRegistrationCertificate{
 			CertType: uint(lcommon.CertificateTypeStakeRegistration),
 			StakeCredential: lcommon.Credential{
-				// TODO: determine correct type
-				// CredType: lcommon.CredentialTypeAddrKeyHash,
+				CredType:   stakeCredentialTypeFromTag(cert.CredentialTag),
 				Credential: lcommon.CredentialHash(cert.StakingKey),
 			},
 		}
 		ret = append(ret, tmpCert)
 	}
 	return ret, nil
+}
+
+func stakeCredentialTypeFromTag(tag uint8) uint {
+	if tag == 1 {
+		return lcommon.CredentialTypeScriptHash
+	}
+	return lcommon.CredentialTypeAddrKeyHash
 }
 
 // DeleteCertificatesAfterSlot removes all certificate records added after the given slot.

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -339,6 +339,13 @@ func (d *MetadataStoreMysql) Start() error {
 			"governance vote credential tag index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateAccountRewardDeltaCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"account reward delta credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -318,6 +318,13 @@ func (d *MetadataStoreMysql) Start() error {
 			"block_nonce unique index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateAccountCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"account credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -325,6 +325,20 @@ func (d *MetadataStoreMysql) Start() error {
 			"account credential tag index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateDrepCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"drep credential tag index migration failed: %w", err,
+		)
+	}
+	if err := models.MigrateGovernanceVoteCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"governance vote credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -240,20 +240,17 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.active = 1 AND ax.drep IN ?
-				    AND ax.drep_type = a.drep_type
-			  )
-			GROUP BY credential_tag, staking_key
+			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
+				   COALESCE(SUM(CAST(utxo.amount AS UNSIGNED)), 0) AS utxo_sum
+			FROM account ax
+			JOIN utxo ON utxo.credential_tag = ax.credential_tag
+			         AND utxo.staking_key = ax.staking_key
+			         AND utxo.deleted_slot = 0
+			WHERE ax.active = 1 AND ax.drep IN ?
+			GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
 		) u ON u.credential_tag = a.credential_tag
 			AND u.staking_key = a.staking_key
+			AND u.drep_type = a.drep_type
 		WHERE a.active = 1 AND a.drep IN ?
 		GROUP BY a.drep, a.drep_type
 	`, hashes, hashes).Scan(&rows).Error; err != nil {

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -24,7 +24,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetDrep gets a drep
+// GetDrep gets a drep by hash only (no tag filter).
 func (d *MetadataStoreMysql) GetDrep(
 	cred []byte,
 	includeInactive bool,
@@ -39,6 +39,34 @@ func (d *MetadataStoreMysql) GetDrep(
 		db = db.Where("active = ?", true)
 	}
 	if result := db.First(&drep, "credential = ?", cred); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &drep, nil
+}
+
+// GetDrepByCredential gets a drep by the full credential identity (tag + hash).
+func (d *MetadataStoreMysql) GetDrepByCredential(
+	credentialTag uint8,
+	cred []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Drep, error) {
+	var drep models.Drep
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if !includeInactive {
+		db = db.Where("active = ?", true)
+	}
+	if result := db.First(
+		&drep,
+		"credential_tag = ? AND credential = ?",
+		credentialTag, cred,
+	); result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -64,6 +92,7 @@ func (d *MetadataStoreMysql) GetActiveDreps(
 
 // SetDrep saves a drep
 func (d *MetadataStoreMysql) SetDrep(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -72,14 +101,18 @@ func (d *MetadataStoreMysql) SetDrep(
 	txn types.Txn,
 ) error {
 	tmpItem := models.Drep{
-		Credential: cred,
-		AddedSlot:  slot,
-		AnchorURL:  url,
-		AnchorHash: hash,
-		Active:     active,
+		CredentialTag: credentialTag,
+		Credential:    cred,
+		AddedSlot:     slot,
+		AnchorURL:     url,
+		AnchorHash:    hash,
+		Active:        active,
 	}
 	onConflict := clause.OnConflict{
-		Columns: []clause.Column{{Name: "credential"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "credential"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"added_slot",
 			"anchor_url",
@@ -101,6 +134,7 @@ func (d *MetadataStoreMysql) SetDrep(
 // the given credential. Existing rows are left untouched so the repair
 // path cannot clobber real registration metadata.
 func (d *MetadataStoreMysql) InsertDrepIfAbsent(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -109,11 +143,12 @@ func (d *MetadataStoreMysql) InsertDrepIfAbsent(
 	txn types.Txn,
 ) error {
 	tmpItem := models.Drep{
-		Credential: cred,
-		AddedSlot:  slot,
-		AnchorURL:  url,
-		AnchorHash: hash,
-		Active:     active,
+		CredentialTag: credentialTag,
+		Credential:    cred,
+		AddedSlot:     slot,
+		AnchorURL:     url,
+		AnchorHash:    hash,
+		Active:        active,
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -135,6 +170,7 @@ func (d *MetadataStoreMysql) InsertDrepIfAbsent(
 // parameter and use epoch-based stake snapshots for accurate
 // voting power at a specific point in time.
 func (d *MetadataStoreMysql) GetDRepVotingPower(
+	credentialTag uint8,
 	drepCredential []byte,
 	txn types.Txn,
 ) (uint64, error) {
@@ -156,12 +192,12 @@ func (d *MetadataStoreMysql) GetDRepVotingPower(
 			WHERE deleted_slot = 0
 			  AND staking_key IN (
 				  SELECT staking_key FROM account
-				  WHERE drep = ? AND active = 1
+				  WHERE drep = ? AND drep_type = ? AND active = 1
 			  )
 			GROUP BY staking_key
 		) u ON u.staking_key = a.staking_key
-		WHERE a.drep = ? AND a.active = 1
-	`, drepCredential, drepCredential).Scan(&totalStake).Error; err != nil {
+		WHERE a.drep = ? AND a.drep_type = ? AND a.active = 1
+	`, drepCredential, credentialTag, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 	return totalStake, nil
@@ -170,7 +206,7 @@ func (d *MetadataStoreMysql) GetDRepVotingPower(
 // GetDRepVotingPowerBatch returns voting power for each DRep credential
 // in a single query. See sqlite/drep.go for the documented contract.
 func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
-	drepCredentials [][]byte,
+	drepCredentials []models.StakeCredentialRef,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64, len(drepCredentials))
@@ -182,17 +218,17 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 		return nil, err
 	}
 	type row struct {
-		Drep  []byte
-		Stake uint64
+		Drep     []byte
+		DrepType uint64
+		Stake    uint64
+	}
+	hashes := make([][]byte, len(drepCredentials))
+	for i, ref := range drepCredentials {
+		hashes[i] = ref.Key
 	}
 	var rows []row
-	// Aggregate UTxO amounts per staking_key in a subquery before
-	// adding account.reward, otherwise the LEFT JOIN would multiply
-	// the per-account reward by the number of live UTxOs and inflate
-	// the totals. Each account contributes (utxo_sum + reward) once
-	// to its DRep bucket.
 	if err := db.Raw(`
-		SELECT a.drep AS drep,
+		SELECT a.drep AS drep, a.drep_type AS drep_type,
 			   COALESCE(SUM(
 				   COALESCE(u.utxo_sum, 0)
 				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
@@ -210,12 +246,13 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 			GROUP BY staking_key
 		) u ON u.staking_key = a.staking_key
 		WHERE a.active = 1 AND a.drep IN ?
-		GROUP BY a.drep
-	`, drepCredentials, drepCredentials).Scan(&rows).Error; err != nil {
+		GROUP BY a.drep, a.drep_type
+	`, hashes, hashes).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power batch: %w", err)
 	}
 	for _, r := range rows {
-		out[string(r.Drep)] = r.Stake
+		ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+		out[ref.MapKey()] = r.Stake
 	}
 	return out, nil
 }
@@ -287,6 +324,7 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerByType(
 // that checks the current values differ, then fall back to an
 // existence check when RowsAffected is 0.
 func (d *MetadataStoreMysql) UpdateDRepActivity(
+	credentialTag uint8,
 	drepCredential []byte,
 	activityEpoch uint64,
 	inactivityPeriod uint64,
@@ -299,7 +337,8 @@ func (d *MetadataStoreMysql) UpdateDRepActivity(
 	expiryEpoch := activityEpoch + inactivityPeriod
 	result := db.Model(&models.Drep{}).
 		Where(
-			"credential = ? AND (last_activity_epoch != ? OR expiry_epoch != ?)",
+			"credential_tag = ? AND credential = ? AND (last_activity_epoch != ? OR expiry_epoch != ?)",
+			credentialTag,
 			drepCredential,
 			activityEpoch,
 			expiryEpoch,
@@ -316,7 +355,7 @@ func (d *MetadataStoreMysql) UpdateDRepActivity(
 		// Check existence to distinguish the two cases.
 		var count int64
 		if err := db.Model(&models.Drep{}).
-			Where("credential = ?", drepCredential).
+			Where("credential_tag = ? AND credential = ?", credentialTag, drepCredential).
 			Count(&count).Error; err != nil {
 			return fmt.Errorf(
 				"check drep existence: %w",
@@ -420,6 +459,13 @@ type drepCertCache struct {
 	hasUpdate      map[string]bool
 }
 
+// drepCertCacheKey returns a composite cache key combining credential_tag and
+// credential so key-hash and script-hash DReps with the same hash are tracked
+// independently.
+func drepCertCacheKey(credentialTag uint8, credential []byte) string {
+	return string([]byte{credentialTag}) + string(credential)
+}
+
 // batchFetchDrepCerts fetches all relevant certificates for the given DRep credentials
 // at or before the given slot.
 func batchFetchDrepCerts(
@@ -440,6 +486,7 @@ func batchFetchDrepCerts(
 	{
 		type result struct {
 			DrepCredential []byte
+			CredentialTag  uint8
 			AnchorURL      string `gorm:"column:anchor_url"`
 			AnchorHash     []byte
 			AddedSlot      uint64
@@ -448,22 +495,22 @@ func batchFetchDrepCerts(
 		var records []result
 		query := `
 			WITH ranked AS (
-				SELECT t.drep_credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
+				SELECT t.credential_tag, t.drep_credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
 					ROW_NUMBER() OVER (
-						PARTITION BY t.drep_credential
+						PARTITION BY t.credential_tag, t.drep_credential
 						ORDER BY t.added_slot DESC, c.cert_index DESC
 					) as rn
 				FROM registration_drep t
 				INNER JOIN certs c ON c.id = t.certificate_id
 				WHERE t.drep_credential IN ? AND t.added_slot <= ?
 			)
-			SELECT drep_credential, anchor_url, anchor_hash, added_slot, cert_index
+			SELECT credential_tag, drep_credential, anchor_url, anchor_hash, added_slot, cert_index
 			FROM ranked WHERE rn = 1`
 		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
 			return nil, err
 		}
 		for _, r := range records {
-			key := string(r.DrepCredential)
+			key := drepCertCacheKey(r.CredentialTag, r.DrepCredential)
 			cache.registration[key] = drepCertRecord{
 				anchorURL:  r.AnchorURL,
 				anchorHash: r.AnchorHash,
@@ -478,28 +525,29 @@ func batchFetchDrepCerts(
 	{
 		type result struct {
 			DrepCredential []byte
+			CredentialTag  uint8
 			AddedSlot      uint64
 			CertIndex      uint32
 		}
 		var records []result
 		query := `
 			WITH ranked AS (
-				SELECT t.drep_credential, t.added_slot, c.cert_index,
+				SELECT t.credential_tag, t.drep_credential, t.added_slot, c.cert_index,
 					ROW_NUMBER() OVER (
-						PARTITION BY t.drep_credential
+						PARTITION BY t.credential_tag, t.drep_credential
 						ORDER BY t.added_slot DESC, c.cert_index DESC
 					) as rn
 				FROM deregistration_drep t
 				INNER JOIN certs c ON c.id = t.certificate_id
 				WHERE t.drep_credential IN ? AND t.added_slot <= ?
 			)
-			SELECT drep_credential, added_slot, cert_index
+			SELECT credential_tag, drep_credential, added_slot, cert_index
 			FROM ranked WHERE rn = 1`
 		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
 			return nil, err
 		}
 		for _, r := range records {
-			key := string(r.DrepCredential)
+			key := drepCertCacheKey(r.CredentialTag, r.DrepCredential)
 			cache.deregistration[key] = drepCertRecord{
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
@@ -511,31 +559,32 @@ func batchFetchDrepCerts(
 	// Fetch updates
 	{
 		type result struct {
-			Credential []byte
-			AnchorURL  string `gorm:"column:anchor_url"`
-			AnchorHash []byte
-			AddedSlot  uint64
-			CertIndex  uint32
+			Credential    []byte
+			CredentialTag uint8
+			AnchorURL     string `gorm:"column:anchor_url"`
+			AnchorHash    []byte
+			AddedSlot     uint64
+			CertIndex     uint32
 		}
 		var records []result
 		query := `
 			WITH ranked AS (
-				SELECT t.credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
+				SELECT t.credential_tag, t.credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
 					ROW_NUMBER() OVER (
-						PARTITION BY t.credential
+						PARTITION BY t.credential_tag, t.credential
 						ORDER BY t.added_slot DESC, c.cert_index DESC
 					) as rn
 				FROM update_drep t
 				INNER JOIN certs c ON c.id = t.certificate_id
 				WHERE t.credential IN ? AND t.added_slot <= ?
 			)
-			SELECT credential, anchor_url, anchor_hash, added_slot, cert_index
+			SELECT credential_tag, credential, anchor_url, anchor_hash, added_slot, cert_index
 			FROM ranked WHERE rn = 1`
 		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
 			return nil, err
 		}
 		for _, r := range records {
-			key := string(r.Credential)
+			key := drepCertCacheKey(r.CredentialTag, r.Credential)
 			cache.update[key] = drepCertRecord{
 				anchorURL:  r.AnchorURL,
 				anchorHash: r.AnchorHash,
@@ -580,7 +629,7 @@ func (d *MetadataStoreMysql) RestoreDrepStateAtSlot(
 			"NOT EXISTS (?)",
 			db.Model(&models.RegistrationDrep{}).
 				Select("1").
-				Where("registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
+				Where("registration_drep.credential_tag = drep.credential_tag AND registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
 		)
 	if result := drepsWithNoValidRegsSubquery.Pluck("id", &drepIDsToDelete); result.Error != nil {
 		return result.Error
@@ -617,7 +666,7 @@ func (d *MetadataStoreMysql) RestoreDrepStateAtSlot(
 
 	// Process each DRep using the cached certificate data
 	for _, drep := range drepsToRestore {
-		key := string(drep.Credential)
+		key := drepCertCacheKey(drep.CredentialTag, drep.Credential)
 
 		// Get registration from cache (must exist due to Phase 1 deletion)
 		lastReg, hasRegAtSlot := cache.registration[key], cache.hasReg[key]

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -186,16 +186,19 @@ func (d *MetadataStoreMysql) GetDRepVotingPower(
 			   ), 0)
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE drep = ? AND drep_type = ? AND active = 1
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.drep = ? AND ax.drep_type = ? AND ax.active = 1
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.drep = ? AND a.drep_type = ? AND a.active = 1
 	`, drepCredential, credentialTag, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
@@ -223,8 +226,10 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 		Stake    uint64
 	}
 	hashes := make([][]byte, len(drepCredentials))
+	requested := make(map[string]struct{}, len(drepCredentials))
 	for i, ref := range drepCredentials {
 		hashes[i] = ref.Key
+		requested[ref.MapKey()] = struct{}{}
 	}
 	var rows []row
 	if err := db.Raw(`
@@ -235,16 +240,19 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE active = 1 AND drep IN ?
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.active = 1 AND ax.drep IN ?
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.active = 1 AND a.drep IN ?
 		GROUP BY a.drep, a.drep_type
 	`, hashes, hashes).Scan(&rows).Error; err != nil {
@@ -252,6 +260,9 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 	}
 	for _, r := range rows {
 		ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+		if _, ok := requested[ref.MapKey()]; !ok {
+			continue
+		}
 		out[ref.MapKey()] = r.Stake
 	}
 	return out, nil
@@ -292,16 +303,19 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerByType(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE active = 1 AND drep_type IN ?
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.active = 1 AND ax.drep_type IN ?
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.active = 1 AND a.drep_type IN ?
 		GROUP BY a.drep_type
 	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -221,9 +221,9 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 		return nil, err
 	}
 	type row struct {
-		Drep     []byte
-		DrepType uint64
-		Stake    uint64
+		Drep          []byte
+		CredentialTag uint64
+		Stake         uint64
 	}
 	hashes := make([][]byte, len(drepCredentials))
 	requested := make(map[string]struct{}, len(drepCredentials))
@@ -233,7 +233,7 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 	}
 	var rows []row
 	if err := db.Raw(`
-		SELECT a.drep AS drep, a.drep_type AS drep_type,
+		SELECT a.drep AS drep, a.drep_type AS credential_tag,
 			   COALESCE(SUM(
 				   COALESCE(u.utxo_sum, 0)
 				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
@@ -259,7 +259,13 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 		return nil, fmt.Errorf("get drep voting power batch: %w", err)
 	}
 	for _, r := range rows {
-		ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+		// account.drep_type 0=key and 1=script align with credential_tag values
+		// by protocol spec; types ≥2 (ALWAYS_ABSTAIN, ALWAYS_NO_CONFIDENCE)
+		// carry no credential hash and are never in the requested map.
+		if r.CredentialTag > 1 {
+			continue
+		}
+		ref := models.StakeCredentialRef{Tag: uint8(r.CredentialTag), Key: r.Drep}
 		if _, ok := requested[ref.MapKey()]; !ok {
 			continue
 		}
@@ -480,20 +486,43 @@ func drepCertCacheKey(credentialTag uint8, credential []byte) string {
 	return string([]byte{credentialTag}) + string(credential)
 }
 
-// batchFetchDrepCerts fetches all relevant certificates for the given DRep credentials
+// batchFetchDrepCerts fetches all relevant certificates for the given DRep credential refs
 // at or before the given slot.
+//
+// The SQL IN clause filters on credential hash only (not credential_tag) for
+// simplicity; the cache is post-filtered to entries whose composite (tag, hash)
+// key matches one of the input refs, so credentials sharing a 28-byte hash but
+// differing in tag are kept isolated.
 func batchFetchDrepCerts(
 	db *gorm.DB,
-	credentials [][]byte,
+	refs []models.StakeCredentialRef,
 	slot uint64,
 ) (*drepCertCache, error) {
 	cache := &drepCertCache{
-		registration:   make(map[string]drepCertRecord, len(credentials)),
-		hasReg:         make(map[string]bool, len(credentials)),
-		deregistration: make(map[string]drepCertRecord, len(credentials)),
-		hasDereg:       make(map[string]bool, len(credentials)),
-		update:         make(map[string]drepCertRecord, len(credentials)),
-		hasUpdate:      make(map[string]bool, len(credentials)),
+		registration:   make(map[string]drepCertRecord, len(refs)),
+		hasReg:         make(map[string]bool, len(refs)),
+		deregistration: make(map[string]drepCertRecord, len(refs)),
+		hasDereg:       make(map[string]bool, len(refs)),
+		update:         make(map[string]drepCertRecord, len(refs)),
+		hasUpdate:      make(map[string]bool, len(refs)),
+	}
+
+	// Build unique credential list for the SQL IN clause and a requested
+	// set (by composite cache key) for post-filtering.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var credentials [][]byte
+	for _, ref := range refs {
+		requested[drepCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			credentials = append(credentials, ref.Key)
+		}
+	}
+
+	if len(credentials) == 0 {
+		return cache, nil
 	}
 
 	// Fetch registrations
@@ -609,6 +638,26 @@ func batchFetchDrepCerts(
 		}
 	}
 
+	// Remove entries for DRep credential variants not present in the input refs.
+	for key := range cache.registration {
+		if _, ok := requested[key]; !ok {
+			delete(cache.registration, key)
+			delete(cache.hasReg, key)
+		}
+	}
+	for key := range cache.deregistration {
+		if _, ok := requested[key]; !ok {
+			delete(cache.deregistration, key)
+			delete(cache.hasDereg, key)
+		}
+	}
+	for key := range cache.update {
+		if _, ok := requested[key]; !ok {
+			delete(cache.update, key)
+			delete(cache.hasUpdate, key)
+		}
+	}
+
 	return cache, nil
 }
 
@@ -666,14 +715,14 @@ func (d *MetadataStoreMysql) RestoreDrepStateAtSlot(
 		return nil
 	}
 
-	// Extract credentials for batch fetching
-	credentials := make([][]byte, len(drepsToRestore))
+	// Extract credential refs for batch fetching
+	drepRefs := make([]models.StakeCredentialRef, len(drepsToRestore))
 	for i, drep := range drepsToRestore {
-		credentials[i] = drep.Credential
+		drepRefs[i] = models.NewStakeCredentialRef(drep.CredentialTag, drep.Credential)
 	}
 
 	// Batch-fetch all certificates for all affected DReps
-	cache, err := batchFetchDrepCerts(db, credentials, slot)
+	cache, err := batchFetchDrepCerts(db, drepRefs, slot)
 	if err != nil {
 		return err
 	}

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -249,6 +249,7 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 				  WHERE ax.credential_tag = utxo.credential_tag
 				    AND ax.staking_key = utxo.staking_key
 				    AND ax.active = 1 AND ax.drep IN ?
+				    AND ax.drep_type = a.drep_type
 			  )
 			GROUP BY credential_tag, staking_key
 		) u ON u.credential_tag = a.credential_tag

--- a/database/plugin/metadata/mysql/drep_test.go
+++ b/database/plugin/metadata/mysql/drep_test.go
@@ -41,8 +41,8 @@ func TestMysqlGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	multiUtxoCred := testHash28("drep_multi_utxo")
 	multiUtxoStake := testHash28("stake_multi_utxo")
 
-	require.NoError(t, store.SetDrep(rewardOnlyCred, 1000, "", nil, true, nil))
-	require.NoError(t, store.SetDrep(multiUtxoCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(0, rewardOnlyCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(0, multiUtxoCred, 1000, "", nil, true, nil))
 	require.NoError(t, store.DB().Create(&models.Account{
 		StakingKey: rewardOnlyStake,
 		Drep:       rewardOnlyCred,
@@ -73,18 +73,21 @@ func TestMysqlGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	}).Error)
 
 	powers, err := store.GetDRepVotingPowerBatch(
-		[][]byte{rewardOnlyCred, multiUtxoCred},
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: rewardOnlyCred},
+			{Tag: 0, Key: multiUtxoCred},
+		},
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(700), powers[string(rewardOnlyCred)])
-	assert.Equal(t, uint64(1000), powers[string(multiUtxoCred)])
+	assert.Equal(t, uint64(700), powers[models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey()])
+	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
 
-	singlePower, err := store.GetDRepVotingPower(rewardOnlyCred, nil)
+	singlePower, err := store.GetDRepVotingPower(0, rewardOnlyCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), singlePower)
 
-	singlePower, err = store.GetDRepVotingPower(multiUtxoCred, nil)
+	singlePower, err = store.GetDRepVotingPower(0, multiUtxoCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1000), singlePower)
 }

--- a/database/plugin/metadata/mysql/drep_test.go
+++ b/database/plugin/metadata/mysql/drep_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -139,4 +140,114 @@ func TestMysqlGetDRepVotingPowerByTypeIncludesReward(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), powers[models.DrepTypeAlwaysAbstain])
 	assert.Equal(t, uint64(1000), powers[models.DrepTypeAlwaysNoConfidence])
+}
+
+// TestMysqlGetDRepVotingPowerCrossTagIsolation verifies that key-hash and
+// script-hash DReps sharing the same 28-byte credential hash are treated as
+// independent identities. GetDRepVotingPower and GetDRepVotingPowerBatch must
+// only aggregate stake delegated to the exact (tag, hash) pair requested.
+func TestMysqlGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	cleanupDRepVotingPowerTestData(t, store)
+
+	sharedHash := testHash28("shared_drep_cross_tag")
+
+	require.NoError(t, store.SetDrep(0, sharedHash, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(1, sharedHash, 1000, "", nil, true, nil))
+
+	keyStake := testHash28("key_stake_cross_tag")
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    keyStake,
+		CredentialTag: 0,
+		Drep:          sharedHash,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		Reward:        types.Uint64(100),
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+
+	scriptStake := testHash28("script_stake_cross_tag")
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    scriptStake,
+		CredentialTag: 1,
+		Drep:          sharedHash,
+		DrepType:      models.DrepTypeScriptHash,
+		Reward:        types.Uint64(200),
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+
+	keyPower, err := store.GetDRepVotingPower(0, sharedHash, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), keyPower, "key-hash DRep power should be 100")
+
+	scriptPower, err := store.GetDRepVotingPower(1, sharedHash, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(200), scriptPower, "script-hash DRep power should be 200")
+
+	powers, err := store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: sharedHash},
+			{Tag: 1, Key: sharedHash},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), powers[models.StakeCredentialRef{Tag: 0, Key: sharedHash}.MapKey()],
+		"batch: key-hash DRep power should be 100")
+	assert.Equal(t, uint64(200), powers[models.StakeCredentialRef{Tag: 1, Key: sharedHash}.MapKey()],
+		"batch: script-hash DRep power should be 200")
+}
+
+// TestMysqlRollbackRewardDeltaIsCredentialTagAware verifies that
+// DeleteAccountRewardsAfterSlot matches AccountRewardDelta rows to accounts
+// by the composite (credential_tag, staking_key) key. A credit delta for
+// tag=1 must adjust only the script-hash account, not the key-hash account
+// that shares the same 28-byte hash.
+func TestMysqlRollbackRewardDeltaIsCredentialTagAware(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+
+	stakeKey := testHash28("reward_rollback_cross_tag")
+	const baseReward = types.Uint64(1_000_000)
+	const creditAmount = uint64(500_000)
+	const slot = uint64(200)
+
+	keyAccount := &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+		AddedSlot:     10,
+		Reward:        baseReward,
+	}
+	scriptAccount := &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Active:        true,
+		AddedSlot:     10,
+		Reward:        baseReward,
+	}
+	require.NoError(t, store.DB().Create(keyAccount).Error)
+	require.NoError(t, store.DB().Create(scriptAccount).Error)
+
+	require.NoError(t, store.AddAccountRewardByCredential(1, stakeKey, creditAmount, slot, nil))
+
+	keyBefore, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward, keyBefore.Reward, "key-hash account must not be affected by script-hash credit")
+
+	scriptBefore, err := store.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward+types.Uint64(creditAmount), scriptBefore.Reward, "script-hash account must have received credit")
+
+	require.NoError(t, store.DeleteAccountRewardsAfterSlot(slot-1, nil))
+
+	keyAfter, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward, keyAfter.Reward, "key-hash account reward must be unchanged after rollback")
+
+	scriptAfter, err := store.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward, scriptAfter.Reward, "script-hash account reward must be restored to base after rollback")
 }

--- a/database/plugin/metadata/mysql/governance.go
+++ b/database/plugin/metadata/mysql/governance.go
@@ -298,6 +298,7 @@ func (d *MetadataStoreMysql) SetGovernanceVote(
 		Columns: []clause.Column{
 			{Name: "proposal_id"},
 			{Name: "voter_type"},
+			{Name: "voter_credential_tag"},
 			{Name: "voter_credential"},
 		},
 		// Note: added_slot is NOT updated on conflict to preserve rollback safety.

--- a/database/plugin/metadata/mysql/import.go
+++ b/database/plugin/metadata/mysql/import.go
@@ -169,7 +169,10 @@ func (d *MetadataStoreMysql) ImportAccount(
 		)
 	}
 	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"pool", "drep", "drep_type", "active", "reward"},
 		),

--- a/database/plugin/metadata/mysql/import.go
+++ b/database/plugin/metadata/mysql/import.go
@@ -345,7 +345,10 @@ func (d *MetadataStoreMysql) ImportDrep(
 
 	// Upsert the DRep record
 	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "credential"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "credential"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"anchor_url", "anchor_hash", "active",
 		}),
@@ -358,7 +361,9 @@ func (d *MetadataStoreMysql) ImportDrep(
 	if drep.ID == 0 {
 		var existing models.Drep
 		if err := db.Where(
-			"credential = ?", drep.Credential,
+			"credential_tag = ? AND credential = ?",
+			drep.CredentialTag,
+			drep.Credential,
 		).First(&existing).Error; err != nil {
 			return fmt.Errorf(
 				"fetching drep ID after upsert: %w", err,
@@ -370,6 +375,7 @@ func (d *MetadataStoreMysql) ImportDrep(
 	// Create registration record (ignore duplicates on retry).
 	if result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{
+			{Name: "credential_tag"},
 			{Name: "drep_credential"},
 			{Name: "added_slot"},
 		},

--- a/database/plugin/metadata/mysql/import.go
+++ b/database/plugin/metadata/mysql/import.go
@@ -201,7 +201,7 @@ func (d *MetadataStoreMysql) ImportPool(
 		Columns: []clause.Column{{Name: "pool_key_hash"}},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"vrf_key_hash", "pledge", "cost",
-			"margin", "reward_account",
+			"margin", "reward_account", "reward_account_credential_tag",
 		}),
 	}).Create(pool)
 	if result.Error != nil {

--- a/database/plugin/metadata/mysql/mir.go
+++ b/database/plugin/metadata/mysql/mir.go
@@ -48,8 +48,9 @@ func (d *MetadataStoreMysql) GetMIRCertsInSlotRange(
 		effects[i].Rewards = make([]models.MIRReward, len(m.Rewards))
 		for j, r := range m.Rewards {
 			effects[i].Rewards[j] = models.MIRReward{
-				Credential: r.Credential,
-				Amount:     uint64(r.Amount),
+				Credential:    r.Credential,
+				CredentialTag: r.CredentialTag,
+				Amount:        uint64(r.Amount),
 			}
 		}
 	}

--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -723,6 +723,7 @@ func TestMysqlSetAccountPreservesCertificateID(t *testing.T) {
 
 	// Now use SetAccount to update the account (this should NOT overwrite CertificateID)
 	err := pgStore.SetAccount(
+		0,
 		stakeKey,
 		[]byte("pool2"), // new pool
 		[]byte("drep2"), // new drep
@@ -736,7 +737,9 @@ func TestMysqlSetAccountPreservesCertificateID(t *testing.T) {
 
 	// Fetch the account and verify CertificateID was preserved
 	var updatedAccount models.Account
-	if result := pgStore.DB().Where("staking_key = ?", stakeKey).First(&updatedAccount); result.Error != nil {
+	if result := pgStore.DB().
+		Where("credential_tag = ? AND staking_key = ?", 0, stakeKey).
+		First(&updatedAccount); result.Error != nil {
 		t.Fatalf("failed to fetch updated account: %v", result.Error)
 	}
 

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -605,14 +605,15 @@ func (d *MetadataStoreMysql) GetActivePoolRelays(
 // during pool state restoration.
 // Includes blockIndex, certIndex for deterministic same-slot disambiguation.
 type poolRegRecord struct {
-	pledge        types.Uint64
-	cost          types.Uint64
-	margin        *types.Rat
-	vrfKeyHash    []byte
-	rewardAccount []byte
-	addedSlot     uint64
-	blockIndex    uint32
-	certIndex     uint32
+	pledge                     types.Uint64
+	cost                       types.Uint64
+	margin                     *types.Rat
+	vrfKeyHash                 []byte
+	rewardAccount              []byte
+	rewardAccountCredentialTag uint8
+	addedSlot                  uint64
+	blockIndex                 uint32
+	certIndex                  uint32
 }
 
 // poolRegCache holds batch-fetched registration data for all pools being restored.
@@ -635,15 +636,16 @@ func batchFetchPoolRegs(
 	}
 
 	type result struct {
-		PoolID        uint
-		Pledge        types.Uint64
-		Cost          types.Uint64
-		Margin        *types.Rat
-		VrfKeyHash    []byte
-		RewardAccount []byte
-		AddedSlot     uint64
-		BlockIndex    uint32
-		CertIndex     uint32
+		PoolID                     uint
+		Pledge                     types.Uint64
+		Cost                       types.Uint64
+		Margin                     *types.Rat
+		VrfKeyHash                 []byte
+		RewardAccount              []byte
+		RewardAccountCredentialTag uint8
+		AddedSlot                  uint64
+		BlockIndex                 uint32
+		CertIndex                  uint32
 	}
 	var records []result
 
@@ -651,8 +653,9 @@ func batchFetchPoolRegs(
 	// Join transaction to get block_index for proper ordering (cert_index resets per tx)
 	query := `
 		WITH ranked AS (
-			SELECT pr.pool_id, pr.pledge, pr.cost, pr.margin,
-				pr.vrf_key_hash, pr.reward_account, pr.added_slot,
+				SELECT pr.pool_id, pr.pledge, pr.cost, pr.margin,
+					pr.vrf_key_hash, pr.reward_account,
+					pr.reward_account_credential_tag, pr.added_slot,
 				COALESCE(t.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
@@ -664,22 +667,23 @@ func batchFetchPoolRegs(
 			LEFT JOIN transaction t ON t.id = c.transaction_id
 			WHERE pr.pool_id IN ? AND pr.added_slot <= ?
 		)
-		SELECT pool_id, pledge, cost, margin, vrf_key_hash, reward_account, added_slot, block_index, cert_index
-		FROM ranked WHERE rn = 1`
+			SELECT pool_id, pledge, cost, margin, vrf_key_hash, reward_account, reward_account_credential_tag, added_slot, block_index, cert_index
+			FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, poolIDs, slot).Scan(&records).Error; err != nil {
 		return nil, err
 	}
 
 	for _, r := range records {
 		cache.registration[r.PoolID] = poolRegRecord{
-			pledge:        r.Pledge,
-			cost:          r.Cost,
-			margin:        r.Margin,
-			vrfKeyHash:    r.VrfKeyHash,
-			rewardAccount: r.RewardAccount,
-			addedSlot:     r.AddedSlot,
-			blockIndex:    r.BlockIndex,
-			certIndex:     r.CertIndex,
+			pledge:                     r.Pledge,
+			cost:                       r.Cost,
+			margin:                     r.Margin,
+			vrfKeyHash:                 r.VrfKeyHash,
+			rewardAccount:              r.RewardAccount,
+			rewardAccountCredentialTag: r.RewardAccountCredentialTag,
+			addedSlot:                  r.AddedSlot,
+			blockIndex:                 r.BlockIndex,
+			certIndex:                  r.CertIndex,
 		}
 		cache.hasReg[r.PoolID] = true
 	}
@@ -783,11 +787,12 @@ func (d *MetadataStoreMysql) RestorePoolStateAtSlot(
 
 		// Update the Pool's denormalized fields from the registration
 		if result := db.Model(&pool).Updates(map[string]any{
-			"pledge":         latestReg.pledge,
-			"cost":           latestReg.cost,
-			"margin":         latestReg.margin,
-			"vrf_key_hash":   latestReg.vrfKeyHash,
-			"reward_account": latestReg.rewardAccount,
+			"pledge":                        latestReg.pledge,
+			"cost":                          latestReg.cost,
+			"margin":                        latestReg.margin,
+			"vrf_key_hash":                  latestReg.vrfKeyHash,
+			"reward_account":                latestReg.rewardAccount,
+			"reward_account_credential_tag": latestReg.rewardAccountCredentialTag,
 		}); result.Error != nil {
 			return result.Error
 		}

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -1042,7 +1042,7 @@ func (d *MetadataStoreMysql) GetStakeByPools(
 	var stakeResults []poolStakeResult
 	if err := db.Table("account").
 		Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
-		Joins("INNER JOIN utxo ON utxo.staking_key = account.staking_key").
+		Joins("INNER JOIN utxo ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 		Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", poolKeyHashes, true).
 		Group("account.pool").
 		Scan(&stakeResults).Error; err != nil {

--- a/database/plugin/metadata/mysql/poolreap.go
+++ b/database/plugin/metadata/mysql/poolreap.go
@@ -39,15 +39,16 @@ func (d *MetadataStoreMysql) GetPoolsRetiringAtEpoch(
 	}
 
 	type row struct {
-		PoolKeyHash   []byte
-		RewardAccount []byte
-		DepositAmount types.Uint64
+		PoolKeyHash                []byte
+		RewardAccount              []byte
+		RewardAccountCredentialTag uint8
+		DepositAmount              types.Uint64
 	}
 	var rows []row
 
 	query := `
 		WITH latest_reg AS (
-			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.reward_account_credential_tag, pr.deposit_amount,
 				COALESCE(t.block_index, 0) as blk_idx,
 				COALESCE(c.cert_index, 0) as cert_idx,
 				ROW_NUMBER() OVER (
@@ -72,7 +73,7 @@ func (d *MetadataStoreMysql) GetPoolsRetiringAtEpoch(
 			LEFT JOIN ` + "`transaction`" + ` t ON t.id = c.transaction_id
 			WHERE rt.added_slot < ?
 		)
-		SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+		SELECT p.pool_key_hash, lr.reward_account, lr.reward_account_credential_tag, lr.deposit_amount
 		FROM pool p
 		INNER JOIN latest_reg lr ON lr.pool_id = p.id AND lr.rn = 1
 		INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
@@ -94,9 +95,10 @@ func (d *MetadataStoreMysql) GetPoolsRetiringAtEpoch(
 	refunds := make([]models.PoolRetirementRefund, len(rows))
 	for i, r := range rows {
 		refunds[i] = models.PoolRetirementRefund{
-			PoolKeyHash:   r.PoolKeyHash,
-			RewardAccount: r.RewardAccount,
-			DepositAmount: r.DepositAmount,
+			PoolKeyHash:                r.PoolKeyHash,
+			RewardAccount:              r.RewardAccount,
+			RewardAccountCredentialTag: r.RewardAccountCredentialTag,
+			DepositAmount:              r.DepositAmount,
 		}
 	}
 	return refunds, nil

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -1537,7 +1537,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(c)
+					rewardAcctTag, rewardAcctHash, err := certutil.PoolRewardAccount(c)
+					if err != nil {
+						return fmt.Errorf("pool reward account: %w", err)
+					}
 					tmpPool.RewardAccount = rewardAcctHash
 					tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
@@ -3034,7 +3037,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					rewardAcctTag2, rewardAcctHash2 := certutil.PoolRewardAccount(c)
+					rewardAcctTag2, rewardAcctHash2, err := certutil.PoolRewardAccount(c)
+					if err != nil {
+						return fmt.Errorf("pool reward account: %w", err)
+					}
 					tmpPool.RewardAccount = rewardAcctHash2
 					tmpPool.RewardAccountCredentialTag = rewardAcctTag2
 					tmpReg := models.PoolRegistration{
@@ -4023,7 +4029,10 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 		tmpPool.Pledge = types.Uint64(cert.Pledge)
 		tmpPool.Cost = types.Uint64(cert.Cost)
 		tmpPool.Margin = &types.Rat{Rat: cert.Margin.Rat}
-		rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(&cert)
+		rewardAcctTag, rewardAcctHash, err := certutil.PoolRewardAccount(&cert)
+		if err != nil {
+			return fmt.Errorf("pool reward account: %w", err)
+		}
 		tmpPool.RewardAccount = rewardAcctHash
 		tmpPool.RewardAccountCredentialTag = rewardAcctTag
 

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -1973,10 +1973,15 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.RegistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					// Registration (re)creates/activates the DRep regardless of prior state.
 
 					tmpReg := models.RegistrationDrep{
+						CredentialTag:  drepCredTag,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -1988,7 +1993,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 					}
 
 					// Persist DRep anchor and active state
-					if err := d.SetDrep(drepCredential, point.Slot, tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -1997,6 +2002,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 					// the registration fields instead of failing on the unique index.
 					result := db.Clauses(clause.OnConflict{
 						Columns: []clause.Column{
+							{Name: "credential_tag"},
 							{Name: "drep_credential"},
 							{Name: "added_slot"},
 						},
@@ -2013,8 +2019,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if tmpReg.ID == 0 {
 						var existing models.RegistrationDrep
 						if err := db.Where(
-							"drep_credential = ? AND added_slot = ?",
-							tmpReg.DrepCredential, tmpReg.AddedSlot,
+							"credential_tag = ? AND drep_credential = ? AND added_slot = ?",
+							drepCredTag, tmpReg.DrepCredential, tmpReg.AddedSlot,
 						).First(&existing).Error; err != nil {
 							return fmt.Errorf(
 								"fetching drep registration ID after upsert: %w",
@@ -2028,8 +2034,13 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.DeregistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					tmpDereg := models.DeregistrationDrep{
+						CredentialTag:  drepCredTag,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -2038,7 +2049,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					// Mark DRep inactive
 					// Ensure we don't create a new DRep during deregistration. Check existence first.
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag, drepCredential, true, txn)
 					if err != nil {
 						if !errors.Is(err, models.ErrDrepNotFound) {
 							return fmt.Errorf("process certificate: %w", err)
@@ -2047,7 +2058,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if existingDrep == nil {
 						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
 					}
-					if err := d.SetDrep(drepCredential, point.Slot, "", nil, false, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, "", nil, false, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -2059,8 +2070,13 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpDereg.ID
 				case *lcommon.UpdateDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					tmpUpdate := models.UpdateDrep{
+						CredentialTag: drepCredTag,
 						Credential:    drepCredential,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -2072,7 +2088,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					// Update DRep anchor and mark active
 					// Require that the DRep already exists for updates.
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag, drepCredential, true, txn)
 					if err != nil {
 						if !errors.Is(err, models.ErrDrepNotFound) {
 							return fmt.Errorf("process certificate: %w", err)
@@ -2081,7 +2097,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 					if existingDrep == nil {
 						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
 					}
-					if err := d.SetDrep(drepCredential, point.Slot, tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -3414,7 +3430,12 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.RegistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpReg := models.RegistrationDrep{
+						CredentialTag:  drepCredTag2,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -3425,13 +3446,14 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						tmpReg.AnchorHash = c.Anchor.DataHash[:]
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot,
+						drepCredTag2, drepCredential, point.Slot,
 						tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					r2 := db.Clauses(clause.OnConflict{
 						Columns: []clause.Column{
+							{Name: "credential_tag"},
 							{Name: "drep_credential"},
 							{Name: "added_slot"},
 						},
@@ -3445,8 +3467,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					if tmpReg.ID == 0 {
 						var existing models.RegistrationDrep
 						if err := db.Where(
-							"drep_credential = ? AND added_slot = ?",
-							tmpReg.DrepCredential, tmpReg.AddedSlot,
+							"credential_tag = ? AND drep_credential = ? AND added_slot = ?",
+							drepCredTag2, tmpReg.DrepCredential, tmpReg.AddedSlot,
 						).First(&existing).Error; err != nil {
 							return fmt.Errorf(
 								"fetching drep registration ID after upsert (batched): %w",
@@ -3458,13 +3480,18 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.DeregistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpDereg := models.DeregistrationDrep{
+						CredentialTag:  drepCredTag2,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
 						CertificateID:  certIDMap[i],
 					}
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag2, drepCredential, true, txn)
 					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3475,7 +3502,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						)
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot, "", nil, false, txn,
+						drepCredTag2, drepCredential, point.Slot, "", nil, false, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3485,7 +3512,12 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpDereg.ID
 				case *lcommon.UpdateDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpUpdate := models.UpdateDrep{
+						CredentialTag: drepCredTag2,
 						Credential:    drepCredential,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -3494,7 +3526,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						tmpUpdate.AnchorURL = c.Anchor.Url
 						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
 					}
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag2, drepCredential, true, txn)
 					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3505,7 +3537,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						)
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot,
+						drepCredTag2, drepCredential, point.Slot,
 						tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -4133,19 +4165,27 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 		if cred == nil {
 			continue
 		}
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return fmt.Errorf("genesis drep credential type: %w", err)
+		}
 		drepCred := cred.Credential[:]
 		drep := &models.Drep{
-			Credential:  drepCred,
-			AddedSlot:   0,
-			ExpiryEpoch: state.Expiry,
-			Active:      true,
+			CredentialTag: credentialTag,
+			Credential:    drepCred,
+			AddedSlot:     0,
+			ExpiryEpoch:   state.Expiry,
+			Active:        true,
 		}
 		if state.Anchor != nil {
 			drep.AnchorURL = state.Anchor.Url
 			drep.AnchorHash = state.Anchor.DataHash[:]
 		}
 		if result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "credential"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "credential"},
+			},
 			DoUpdates: clause.AssignmentColumns([]string{
 				"added_slot",
 				"anchor_url",
@@ -4161,6 +4201,7 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 		}
 
 		reg := &models.RegistrationDrep{
+			CredentialTag:  credentialTag,
 			DrepCredential: drepCred,
 			AddedSlot:      0,
 			DepositAmount:  types.Uint64(state.Deposit),
@@ -4171,6 +4212,7 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 		}
 		if result := db.Clauses(clause.OnConflict{
 			Columns: []clause.Column{
+				{Name: "credential_tag"},
 				{Name: "drep_credential"},
 				{Name: "added_slot"},
 			},

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -207,7 +208,7 @@ func (d *MetadataStoreMysql) GetTransactionsByBlockHash(
 }
 
 // It builds AddressTransaction rows for a single transaction.
-// deduplication by (payment_key, staking_key) within the tx.
+// deduplication by (payment_key, credential_tag, staking_key) within the tx.
 func collectAddressTransactions(
 	transactionID uint,
 	slot uint64,
@@ -220,13 +221,19 @@ func collectAddressTransactions(
 		if len(utxo.PaymentKey) == 0 && len(utxo.StakingKey) == 0 {
 			continue
 		}
-		key := fmt.Sprintf("%x|%x", utxo.PaymentKey, utxo.StakingKey)
+		key := fmt.Sprintf(
+			"%x|%d|%x",
+			utxo.PaymentKey,
+			utxo.CredentialTag,
+			utxo.StakingKey,
+		)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
 		ret = append(ret, models.AddressTransaction{
 			PaymentKey:    append([]byte(nil), utxo.PaymentKey...),
+			CredentialTag: utxo.CredentialTag,
 			StakingKey:    append([]byte(nil), utxo.StakingKey...),
 			TransactionID: transactionID,
 			Slot:          slot,
@@ -240,6 +247,7 @@ func collectAddressTransactions(
 // the given payment/staking key with pagination support.
 func (d *MetadataStoreMysql) GetTransactionsByAddress(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -260,8 +268,9 @@ func (d *MetadataStoreMysql) GetTransactionsByAddress(
 	switch {
 	case len(paymentKey) > 0 && len(stakingKey) > 0:
 		addrQuery = addrQuery.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			paymentKey,
+			credentialTag,
 			stakingKey,
 		)
 	case len(paymentKey) > 0:
@@ -270,7 +279,11 @@ func (d *MetadataStoreMysql) GetTransactionsByAddress(
 			paymentKey,
 		)
 	default:
-		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+		addrQuery = addrQuery.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakingKey,
+		)
 	}
 
 	subQuery := addrQuery.Select("DISTINCT transaction_id")
@@ -308,6 +321,7 @@ func (d *MetadataStoreMysql) GetTransactionsByAddress(
 // payment/staking key.
 func (d *MetadataStoreMysql) CountTransactionsByAddress(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
@@ -324,8 +338,9 @@ func (d *MetadataStoreMysql) CountTransactionsByAddress(
 	switch {
 	case len(paymentKey) > 0 && len(stakingKey) > 0:
 		addrQuery = addrQuery.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			paymentKey,
+			credentialTag,
 			stakingKey,
 		)
 	case len(paymentKey) > 0:
@@ -334,7 +349,11 @@ func (d *MetadataStoreMysql) CountTransactionsByAddress(
 			paymentKey,
 		)
 	default:
-		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+		addrQuery = addrQuery.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakingKey,
+		)
 	}
 
 	var count int64
@@ -348,8 +367,9 @@ func (d *MetadataStoreMysql) CountTransactionsByAddress(
 	return int(count), nil
 }
 
-// GetAddressesByStakingKey returns distinct addresses mapped to a staking key.
-func (d *MetadataStoreMysql) GetAddressesByStakingKey(
+// GetAddressesByCredential returns distinct addresses mapped to a stake credential.
+func (d *MetadataStoreMysql) GetAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -365,9 +385,13 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 		return nil, err
 	}
 	query := db.Model(&models.AddressTransaction{}).
-		Select("MIN(id) AS id, payment_key, staking_key").
-		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
-		Group("payment_key, staking_key").
+		Select("MIN(id) AS id, payment_key, credential_tag, staking_key").
+		Where(
+			"credential_tag = ? AND staking_key = ? AND length(payment_key) > 0",
+			credentialTag,
+			stakingKey,
+		).
+		Group("payment_key, credential_tag, staking_key").
 		Order(addressOrderClause(order))
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -376,13 +400,14 @@ func (d *MetadataStoreMysql) GetAddressesByStakingKey(
 		query = query.Offset(offset)
 	}
 	if result := query.Find(&ret); result.Error != nil {
-		return nil, fmt.Errorf("get addresses by staking key: %w", result.Error)
+		return nil, fmt.Errorf("get addresses by stake credential: %w", result.Error)
 	}
 	return ret, nil
 }
 
-// CountAddressesByStakingKey returns the total number of distinct addresses mapped to a staking key.
-func (d *MetadataStoreMysql) CountAddressesByStakingKey(
+// CountAddressesByCredential returns the total number of distinct addresses mapped to a stake credential.
+func (d *MetadataStoreMysql) CountAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
@@ -392,16 +417,20 @@ func (d *MetadataStoreMysql) CountAddressesByStakingKey(
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"resolve DB for count addresses by staking key: %w",
+			"resolve DB for count addresses by stake credential: %w",
 			err,
 		)
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).
-		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
+		Where(
+			"credential_tag = ? AND staking_key = ? AND length(payment_key) > 0",
+			credentialTag,
+			stakingKey,
+		).
 		Distinct("payment_key").
 		Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("count addresses by staking key: %w", err)
+		return 0, fmt.Errorf("count addresses by stake credential: %w", err)
 	}
 	return int(count), nil
 }
@@ -1508,19 +1537,22 @@ func (d *MetadataStoreMysql) SetTransaction(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					tmpPool.RewardAccount = c.RewardAccount[:]
+					rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(c)
+					tmpPool.RewardAccount = rewardAcctHash
+					tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
 					// Create registration record
 					tmpReg := models.PoolRegistration{
-						PoolKeyHash:   c.Operator[:],
-						VrfKeyHash:    c.VrfKeyHash[:],
-						Pledge:        types.Uint64(c.Pledge),
-						Cost:          types.Uint64(c.Cost),
-						Margin:        &types.Rat{Rat: c.Margin.Rat},
-						RewardAccount: c.RewardAccount[:],
-						AddedSlot:     point.Slot,
-						DepositAmount: types.Uint64(deposit),
-						CertificateID: certIDMap[i],
+						PoolKeyHash:                c.Operator[:],
+						VrfKeyHash:                 c.VrfKeyHash[:],
+						Pledge:                     types.Uint64(c.Pledge),
+						Cost:                       types.Uint64(c.Cost),
+						Margin:                     &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount:              rewardAcctHash,
+						RewardAccountCredentialTag: rewardAcctTag,
+						AddedSlot:                  point.Slot,
+						DepositAmount:              types.Uint64(deposit),
+						CertificateID:              certIDMap[i],
 					}
 					if c.PoolMetadata != nil {
 						tmpReg.MetadataUrl = c.PoolMetadata.Url
@@ -1573,7 +1605,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 						},
 						DoUpdates: clause.AssignmentColumns([]string{
 							"vrf_key_hash", "pledge", "cost", "margin",
-							"reward_account", "certificate_id",
+							"reward_account", "reward_account_credential_tag", "certificate_id",
 							"metadata_url", "metadata_hash",
 							"deposit_amount",
 						}),
@@ -2247,10 +2279,15 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					// Save individual rewards
 					for credential, amount := range c.Reward.Rewards {
+						credentialTag, err := models.CredentialTagFromUint(credential.CredType)
+						if err != nil {
+							return fmt.Errorf("process certificate: %w", err)
+						}
 						tmpReward := models.MoveInstantaneousRewardsReward{
-							Credential: credential.Credential[:],
-							Amount:     types.Uint64(amount),
-							MIRID:      tmpMIR.ID,
+							Credential:    credential.Credential[:],
+							CredentialTag: credentialTag,
+							Amount:        types.Uint64(amount),
+							MIRID:         tmpMIR.ID,
 						}
 						result := db.Create(&tmpReward)
 						if result.Error != nil {
@@ -2981,17 +3018,20 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					tmpPool.RewardAccount = c.RewardAccount[:]
+					rewardAcctTag2, rewardAcctHash2 := certutil.PoolRewardAccount(c)
+					tmpPool.RewardAccount = rewardAcctHash2
+					tmpPool.RewardAccountCredentialTag = rewardAcctTag2
 					tmpReg := models.PoolRegistration{
-						PoolKeyHash:   c.Operator[:],
-						VrfKeyHash:    c.VrfKeyHash[:],
-						Pledge:        types.Uint64(c.Pledge),
-						Cost:          types.Uint64(c.Cost),
-						Margin:        &types.Rat{Rat: c.Margin.Rat},
-						RewardAccount: c.RewardAccount[:],
-						AddedSlot:     point.Slot,
-						DepositAmount: types.Uint64(deposit),
-						CertificateID: certIDMap[i],
+						PoolKeyHash:                c.Operator[:],
+						VrfKeyHash:                 c.VrfKeyHash[:],
+						Pledge:                     types.Uint64(c.Pledge),
+						Cost:                       types.Uint64(c.Cost),
+						Margin:                     &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount:              rewardAcctHash2,
+						RewardAccountCredentialTag: rewardAcctTag2,
+						AddedSlot:                  point.Slot,
+						DepositAmount:              types.Uint64(deposit),
+						CertificateID:              certIDMap[i],
 					}
 					if c.PoolMetadata != nil {
 						tmpReg.MetadataUrl = c.PoolMetadata.Url
@@ -3047,7 +3087,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 						},
 						DoUpdates: clause.AssignmentColumns([]string{
 							"vrf_key_hash", "pledge", "cost", "margin",
-							"reward_account", "certificate_id",
+							"reward_account", "reward_account_credential_tag", "certificate_id",
 							"metadata_url", "metadata_hash", "deposit_amount",
 						}),
 					}).Omit("Owners", "Relays").Create(&tmpReg)
@@ -3629,10 +3669,15 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					}
 					certIDUpdates[certIDMap[i]] = tmpMIR.ID
 					for credential, amount := range c.Reward.Rewards {
+						credentialTag, err := models.CredentialTagFromUint(credential.CredType)
+						if err != nil {
+							return fmt.Errorf("process certificate: %w", err)
+						}
 						tmpReward := models.MoveInstantaneousRewardsReward{
-							Credential: credential.Credential[:],
-							Amount:     types.Uint64(amount),
-							MIRID:      tmpMIR.ID,
+							Credential:    credential.Credential[:],
+							CredentialTag: credentialTag,
+							Amount:        types.Uint64(amount),
+							MIRID:         tmpMIR.ID,
 						}
 						if r := db.Create(&tmpReward); r.Error != nil {
 							return fmt.Errorf("process certificate (batched): %w", r.Error)
@@ -3946,16 +3991,19 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 		tmpPool.Pledge = types.Uint64(cert.Pledge)
 		tmpPool.Cost = types.Uint64(cert.Cost)
 		tmpPool.Margin = &types.Rat{Rat: cert.Margin.Rat}
-		tmpPool.RewardAccount = cert.RewardAccount[:]
+		rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(&cert)
+		tmpPool.RewardAccount = rewardAcctHash
+		tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
 		tmpReg := models.PoolRegistration{
-			PoolKeyHash:   cert.Operator[:],
-			VrfKeyHash:    cert.VrfKeyHash[:],
-			Pledge:        types.Uint64(cert.Pledge),
-			Cost:          types.Uint64(cert.Cost),
-			Margin:        &types.Rat{Rat: cert.Margin.Rat},
-			RewardAccount: cert.RewardAccount[:],
-			AddedSlot:     0,
+			PoolKeyHash:                cert.Operator[:],
+			VrfKeyHash:                 cert.VrfKeyHash[:],
+			Pledge:                     types.Uint64(cert.Pledge),
+			Cost:                       types.Uint64(cert.Cost),
+			Margin:                     &types.Rat{Rat: cert.Margin.Rat},
+			RewardAccount:              rewardAcctHash,
+			RewardAccountCredentialTag: rewardAcctTag,
+			AddedSlot:                  0,
 		}
 		if cert.PoolMetadata != nil {
 			tmpReg.MetadataUrl = cert.PoolMetadata.Url

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -413,24 +413,6 @@ func addressOrderClause(order string) string {
 	return "payment_key ASC"
 }
 
-// GetAccountDelegationHistory returns delegation history rows for a staking key.
-func (d *MetadataStoreMysql) GetAccountDelegationHistory(
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn types.Txn,
-) ([]models.AccountDelegationHistoryRow, error) {
-	return d.GetAccountDelegationHistoryByCredential(
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
-}
-
 func (d *MetadataStoreMysql) GetAccountDelegationHistoryByCredential(
 	credentialTag uint8,
 	stakingKey []byte,
@@ -463,15 +445,6 @@ func (d *MetadataStoreMysql) GetAccountDelegationHistoryByCredential(
 	return rows, nil
 }
 
-// CountAccountDelegationHistory returns the total number of
-// delegation history rows for a staking key.
-func (d *MetadataStoreMysql) CountAccountDelegationHistory(
-	stakingKey []byte,
-	txn types.Txn,
-) (int, error) {
-	return d.CountAccountDelegationHistoryByCredential(0, stakingKey, txn)
-}
-
 func (d *MetadataStoreMysql) CountAccountDelegationHistoryByCredential(
 	credentialTag uint8,
 	stakingKey []byte,
@@ -496,24 +469,6 @@ func (d *MetadataStoreMysql) CountAccountDelegationHistoryByCredential(
 		)
 	}
 	return count, nil
-}
-
-// GetAccountRegistrationHistory returns registration history rows for a staking key.
-func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn types.Txn,
-) ([]models.AccountRegistrationHistoryRow, error) {
-	return d.GetAccountRegistrationHistoryByCredential(
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
 }
 
 func (d *MetadataStoreMysql) GetAccountRegistrationHistoryByCredential(
@@ -546,15 +501,6 @@ func (d *MetadataStoreMysql) GetAccountRegistrationHistoryByCredential(
 		)
 	}
 	return rows, nil
-}
-
-// CountAccountRegistrationHistory returns the total number of
-// registration history rows for a staking key.
-func (d *MetadataStoreMysql) CountAccountRegistrationHistory(
-	stakingKey []byte,
-	txn types.Txn,
-) (int, error) {
-	return d.CountAccountRegistrationHistoryByCredential(0, stakingKey, txn)
 }
 
 func (d *MetadataStoreMysql) CountAccountRegistrationHistoryByCredential(

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2378,7 +2378,12 @@ func (d *MetadataStoreMysql) applyTransactionRewardWithdrawals(
 		if stakeKeyHash == zeroHash {
 			return errors.New("reward withdrawal missing stake credential")
 		}
+		credentialTag, ok := models.StakeCredentialTagFromAddress(*addr)
+		if !ok {
+			return errors.New("derive reward withdrawal credential tag")
+		}
 		if err := d.ApplyAccountRewardWithdrawal(
+			credentialTag,
 			stakeKeyHash.Bytes(),
 			amount.Uint64(),
 			slot,

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -4131,7 +4131,10 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 		}
 
 		account := &models.Account{
-			StakingKey:    stakerBytes,
+			StakingKey: stakerBytes,
+			// Shelley genesis staking section encodes stake credentials as
+			// raw 28-byte hashes with no type metadata. All Shelley-era
+			// genesis stake credentials are key-hash by protocol design.
 			CredentialTag: 0,
 			Pool:          poolBytes,
 			Active:        true,

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -1628,7 +1628,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1690,7 +1693,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1732,7 +1738,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1775,7 +1784,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1804,7 +1816,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1834,7 +1849,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1876,7 +1894,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2026,7 +2047,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2069,7 +2093,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2110,7 +2137,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -3069,7 +3099,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3124,7 +3157,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3159,7 +3195,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3195,7 +3234,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3218,7 +3260,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3242,7 +3287,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3278,7 +3326,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3405,7 +3456,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3442,7 +3496,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3477,7 +3534,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -4056,7 +4116,10 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 			continue
 		}
 		stakeKey := cred.Credential[:]
-		credentialTag := uint8(cred.CredType)
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return err
+		}
 
 		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
 		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -421,6 +421,24 @@ func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 	order string,
 	txn types.Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
+	return d.GetAccountDelegationHistoryByCredential(
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func (d *MetadataStoreMysql) GetAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -428,8 +446,9 @@ func (d *MetadataStoreMysql) GetAccountDelegationHistory(
 			err,
 		)
 	}
-	rows, err := accounthistory.QueryDelegationHistory(
+	rows, err := accounthistory.QueryDelegationHistoryByCredential(
 		db,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -450,6 +469,14 @@ func (d *MetadataStoreMysql) CountAccountDelegationHistory(
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
+	return d.CountAccountDelegationHistoryByCredential(0, stakingKey, txn)
+}
+
+func (d *MetadataStoreMysql) CountAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
@@ -457,7 +484,11 @@ func (d *MetadataStoreMysql) CountAccountDelegationHistory(
 			err,
 		)
 	}
-	count, err := accounthistory.CountDelegationHistory(db, stakingKey)
+	count, err := accounthistory.CountDelegationHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"count account delegation history: %w",
@@ -475,6 +506,24 @@ func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
 	order string,
 	txn types.Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
+	return d.GetAccountRegistrationHistoryByCredential(
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func (d *MetadataStoreMysql) GetAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -482,8 +531,9 @@ func (d *MetadataStoreMysql) GetAccountRegistrationHistory(
 			err,
 		)
 	}
-	rows, err := accounthistory.QueryRegistrationHistory(
+	rows, err := accounthistory.QueryRegistrationHistoryByCredential(
 		db,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -504,6 +554,14 @@ func (d *MetadataStoreMysql) CountAccountRegistrationHistory(
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
+	return d.CountAccountRegistrationHistoryByCredential(0, stakingKey, txn)
+}
+
+func (d *MetadataStoreMysql) CountAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
@@ -511,7 +569,11 @@ func (d *MetadataStoreMysql) CountAccountRegistrationHistory(
 			err,
 		)
 	}
-	count, err := accounthistory.CountRegistrationHistory(db, stakingKey)
+	count, err := accounthistory.CountRegistrationHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"count account registration history: %w",

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -1708,7 +1708,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if result.Error != nil {
@@ -1753,7 +1756,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if result.Error != nil {
@@ -3171,7 +3177,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 							CredentialTag: credentialTag,
 						}
 						r := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if r.Error != nil {
@@ -3209,7 +3218,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 							CredentialTag: credentialTag,
 						}
 						r := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if r.Error != nil {
@@ -4017,10 +4029,11 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 		}
 
 		account := &models.Account{
-			StakingKey: stakerBytes,
-			Pool:       poolBytes,
-			Active:     true,
-			AddedSlot:  0,
+			StakingKey:    stakerBytes,
+			CredentialTag: 0,
+			Pool:          poolBytes,
+			Active:        true,
+			AddedSlot:     0,
 		}
 		// DoUpdates intentionally omits added_slot: RestoreAccountStateAtSlot
 		// selects rows by `added_slot > rollback_slot`, so resetting a
@@ -4028,7 +4041,10 @@ func (d *MetadataStoreMysql) SetGenesisStaking(
 		// Mithril after partial sync) would make that row invisible to
 		// every future rollback.
 		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "staking_key"},
+			},
 			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
@@ -4164,10 +4180,10 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 		}
 
 		// Delegation history tables have no unique constraint that covers
-		// (staking_key, added_slot), so we use FirstOrCreate to keep the
-		// slot-0 row idempotent across retries (e.g., resumed Mithril
-		// bootstrap). Each staking key contributes at most one genesis
-		// delegation row of a given type, so matching on staking_key +
+		// (credential_tag, staking_key, added_slot), so we use FirstOrCreate
+		// to keep the slot-0 row idempotent across retries (e.g., resumed
+		// Mithril bootstrap). Each stake credential contributes at most one
+		// genesis delegation row of a given type, so matching on tag + key +
 		// added_slot is sufficient.
 		switch delegatee.Type {
 		case conway.ConwayGenesisDelegateeTypeStake:
@@ -4179,8 +4195,8 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 			}
 			var existing models.StakeDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.StakeDelegation{
 				StakingKey:    stakeKey,
 				CredentialTag: credentialTag,
@@ -4202,8 +4218,8 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 			}
 			var existing models.VoteDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.VoteDelegation{
 				StakingKey:    stakeKey,
 				CredentialTag: credentialTag,
@@ -4227,8 +4243,8 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 			}
 			var existing models.StakeVoteDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.StakeVoteDelegation{
 				StakingKey:    stakeKey,
 				CredentialTag: credentialTag,

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -647,11 +647,12 @@ func certRequiresDeposit(cert lcommon.Certificate) bool {
 
 // getOrCreateAccount retrieves an existing account or creates a new one
 func (d *MetadataStoreMysql) getOrCreateAccount(
+	credentialTag uint8,
 	stakeKey []byte,
 	txn types.Txn,
 ) (*models.Account, error) {
 	// Include inactive accounts to allow reactivation on registration.
-	tmpAccount, err := d.GetAccount(stakeKey, true, txn)
+	tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, true, txn)
 	if err != nil {
 		if !errors.Is(err, models.ErrAccountNotFound) {
 			return nil, err
@@ -659,7 +660,8 @@ func (d *MetadataStoreMysql) getOrCreateAccount(
 	}
 	if tmpAccount == nil {
 		tmpAccount = &models.Account{
-			StakingKey: stakeKey,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
 		}
 	} else if !tmpAccount.Active {
 		tmpAccount.Active = true
@@ -668,12 +670,15 @@ func (d *MetadataStoreMysql) getOrCreateAccount(
 }
 
 // saveAccount persists the account to the database. It creates a new
-// record when `account.ID == 0` (with an upsert on `staking_key`) or saves
+// record when `account.ID == 0` (with an upsert on credential tag + staking key) or saves
 // the existing record otherwise.
 func saveAccount(account *models.Account, db *gorm.DB) error {
 	if account.ID == 0 {
 		result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "staking_key"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "staking_key"},
+			},
 			DoUpdates: clause.AssignmentColumns(
 				[]string{
 					"added_slot",
@@ -1623,13 +1628,15 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
 					tmpReg := models.StakeRegistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1683,14 +1690,16 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 					if tmpAccount == nil {
 						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
 						tmpAccount = &models.Account{
-							StakingKey: stakeKey,
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
@@ -1706,6 +1715,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1722,14 +1732,16 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 					if tmpAccount == nil {
 						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
 						tmpAccount = &models.Account{
-							StakingKey: stakeKey,
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
@@ -1745,6 +1757,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 						Amount:        types.Uint64(deposit),
@@ -1762,7 +1775,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1772,6 +1786,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -1789,7 +1804,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1799,6 +1815,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
@@ -1817,7 +1834,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1838,6 +1856,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -1857,13 +1876,15 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
 					tmpReg := models.Registration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -2005,7 +2026,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2026,6 +2048,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -2046,7 +2069,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2066,6 +2090,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -2085,7 +2110,8 @@ func (d *MetadataStoreMysql) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2105,6 +2131,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -3042,12 +3069,14 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					tmpReg := models.StakeRegistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -3095,12 +3124,16 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					if tmpAccount == nil {
-						tmpAccount = &models.Account{StakingKey: stakeKey}
+						tmpAccount = &models.Account{
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
+						}
 						r := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
 							UpdateAll: true,
@@ -3113,6 +3146,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -3125,12 +3159,16 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					if tmpAccount == nil {
-						tmpAccount = &models.Account{StakingKey: stakeKey}
+						tmpAccount = &models.Account{
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
+						}
 						r := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
 							UpdateAll: true,
@@ -3143,6 +3181,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 						Amount:        types.Uint64(deposit),
@@ -3156,7 +3195,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3164,6 +3204,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -3177,7 +3218,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3185,6 +3227,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
@@ -3199,7 +3242,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3218,6 +3262,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -3233,12 +3278,14 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					tmpReg := models.Registration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -3358,7 +3405,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3377,6 +3425,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -3393,7 +3442,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3411,6 +3461,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -3426,7 +3477,8 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3444,6 +3496,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -4003,6 +4056,7 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 			continue
 		}
 		stakeKey := cred.Credential[:]
+		credentialTag := uint8(cred.CredType)
 
 		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
 		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {
@@ -4015,7 +4069,7 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 			drepCredential = delegatee.DRep.Credential
 		}
 
-		account, err := d.getOrCreateAccount(stakeKey, txn)
+		account, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 		if err != nil {
 			return fmt.Errorf(
 				"get or create genesis delegatee account: %w",
@@ -4033,11 +4087,12 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 		// would delete a genesis-rooted account.
 		var existingReg models.Registration
 		regResult := db.Where(
-			"staking_key = ? AND added_slot = ?",
-			stakeKey, uint64(0),
+			"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+			credentialTag, stakeKey, uint64(0),
 		).Attrs(models.Registration{
-			StakingKey: stakeKey,
-			AddedSlot:  0,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
+			AddedSlot:     0,
 		}).FirstOrCreate(&existingReg)
 		if regResult.Error != nil {
 			return fmt.Errorf(
@@ -4064,9 +4119,10 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 				"staking_key = ? AND added_slot = ?",
 				stakeKey, uint64(0),
 			).Attrs(models.StakeDelegation{
-				StakingKey:  stakeKey,
-				PoolKeyHash: delegatee.PoolId[:],
-				AddedSlot:   0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				PoolKeyHash:   delegatee.PoolId[:],
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -4086,10 +4142,11 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 				"staking_key = ? AND added_slot = ?",
 				stakeKey, uint64(0),
 			).Attrs(models.VoteDelegation{
-				StakingKey: stakeKey,
-				Drep:       drepCredential,
-				DrepType:   drepType,
-				AddedSlot:  0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				Drep:          drepCredential,
+				DrepType:      drepType,
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -4110,11 +4167,12 @@ func (d *MetadataStoreMysql) SetGenesisGovernance(
 				"staking_key = ? AND added_slot = ?",
 				stakeKey, uint64(0),
 			).Attrs(models.StakeVoteDelegation{
-				StakingKey:  stakeKey,
-				PoolKeyHash: delegatee.PoolId[:],
-				Drep:        drepCredential,
-				DrepType:    drepType,
-				AddedSlot:   0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				PoolKeyHash:   delegatee.PoolId[:],
+				Drep:          drepCredential,
+				DrepType:      drepType,
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -190,9 +190,11 @@ func addressWhereClause(
 
 	switch {
 	case hasPayment && hasStake:
+		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
 		return db.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			addr.PaymentKeyHash().Bytes(),
+			credentialTag,
 			addr.StakeKeyHash().Bytes(),
 		)
 	case hasPayment:
@@ -201,8 +203,10 @@ func addressWhereClause(
 			addr.PaymentKeyHash().Bytes(),
 		)
 	case hasStake:
+		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
 		return db.Where(
-			"staking_key = ?",
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
 			addr.StakeKeyHash().Bytes(),
 		)
 	default:
@@ -235,9 +239,10 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	return ret, nil
 }
 
-// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
-// controlled by the given staking key.
-func (d *MetadataStoreMysql) GetControlledAmountByStakingKey(
+// GetControlledAmountByCredential returns the sum of live UTxO amounts
+// controlled by the given stake credential.
+func (d *MetadataStoreMysql) GetControlledAmountByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (uint64, error) {
@@ -253,7 +258,11 @@ func (d *MetadataStoreMysql) GetControlledAmountByStakingKey(
 	}
 	var total uint64
 	if err := db.Model(&models.Utxo{}).
-		Where("staking_key = ? AND deleted_slot = 0", stakingKey).
+		Where(
+			"credential_tag = ? AND staking_key = ? AND deleted_slot = 0",
+			credentialTag,
+			stakingKey,
+		).
 		Select("COALESCE(SUM(amount), 0)").
 		Scan(&total).Error; err != nil {
 		return 0, fmt.Errorf(

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -183,34 +183,43 @@ func (d *MetadataStoreMysql) GetUtxosDeletedBeforeSlot(
 func addressWhereClause(
 	db *gorm.DB,
 	addr lcommon.Address,
-) *gorm.DB {
+) (*gorm.DB, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	hasPayment := addr.PaymentKeyHash() != zeroHash
 	hasStake := addr.StakeKeyHash() != zeroHash
+	paymentScript := models.PaymentScriptFromAddress(addr)
 
 	switch {
 	case hasPayment && hasStake:
-		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
+		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, fmt.Errorf("derive stake credential tag from address")
+		}
 		return db.Where(
-			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
+			"payment_script = ? AND payment_key = ? AND credential_tag = ? AND staking_key = ?",
+			paymentScript,
 			addr.PaymentKeyHash().Bytes(),
 			credentialTag,
 			addr.StakeKeyHash().Bytes(),
-		)
+		), nil
 	case hasPayment:
 		return db.Where(
-			"payment_key = ?",
+			"payment_script = ? AND payment_key = ?",
+			paymentScript,
 			addr.PaymentKeyHash().Bytes(),
-		)
+		), nil
 	case hasStake:
-		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
+		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, fmt.Errorf("derive stake credential tag from address")
+		}
 		return db.Where(
 			"credential_tag = ? AND staking_key = ?",
 			credentialTag,
 			addr.StakeKeyHash().Bytes(),
-		)
+		), nil
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
@@ -224,7 +233,10 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery := addressWhereClause(db, addr)
+	addrQuery, err := addressWhereClause(db, addr)
+	if err != nil {
+		return nil, err
+	}
 	if addrQuery == nil {
 		return ret, nil
 	}
@@ -325,7 +337,12 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 		var ors []string
 		var args []any
 		for i := range addrs {
-			models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i])
+			if err := models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i]); err != nil {
+				return nil, fmt.Errorf(
+					"GetUtxosByAddressWithOrdering: %w",
+					err,
+				)
+			}
 		}
 		if len(ors) == 0 {
 			base = base.Where("1 = 0")
@@ -437,7 +454,10 @@ func (d *MetadataStoreMysql) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery := addressWhereClause(db, addr)
+	addrQuery, err := addressWhereClause(db, addr)
+	if err != nil {
+		return nil, err
+	}
 	if addrQuery == nil {
 		return ret, nil
 	}

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -193,7 +193,7 @@ func addressWhereClause(
 	case hasPayment && hasStake:
 		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, fmt.Errorf("derive stake credential tag from address")
+			return nil, errors.New("derive stake credential tag from address")
 		}
 		return db.Where(
 			"payment_script = ? AND payment_key = ? AND credential_tag = ? AND staking_key = ?",
@@ -211,7 +211,7 @@ func addressWhereClause(
 	case hasStake:
 		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, fmt.Errorf("derive stake credential tag from address")
+			return nil, errors.New("derive stake credential tag from address")
 		}
 		return db.Where(
 			"credential_tag = ? AND staking_key = ?",

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -367,7 +367,10 @@ func (d *MetadataStorePostgres) SetAccount(
 		Active:     active,
 	}
 	onConflict := clause.OnConflict{
-		Columns: []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"added_slot", "pool", "drep", "active"},
 		),

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -102,14 +102,12 @@ func (d *MetadataStorePostgres) GetAccountsByCredential(
 		return nil, err
 	}
 
-	wanted := make(map[string]struct{}, len(refs))
-	stakeKeys := make([][]byte, 0, len(refs))
+	pairs := make([][]any, 0, len(refs))
 	for _, ref := range refs {
-		wanted[ref.MapKey()] = struct{}{}
-		stakeKeys = append(stakeKeys, ref.Key)
+		pairs = append(pairs, []any{ref.Tag, ref.Key})
 	}
-	for chunk := range slices.Chunk(stakeKeys, 400) {
-		query := db.Where("staking_key IN ?", chunk)
+	for chunk := range slices.Chunk(pairs, 400) {
+		query := db.Where("(credential_tag, staking_key) IN ?", chunk)
 		if !includeInactive {
 			query = query.Where("active = ?", true)
 		}
@@ -122,9 +120,7 @@ func (d *MetadataStorePostgres) GetAccountsByCredential(
 				Tag: row.CredentialTag,
 				Key: row.StakingKey,
 			}.MapKey()
-			if _, ok := wanted[key]; ok {
-				ret[key] = row
-			}
+			ret[key] = row
 		}
 	}
 	return ret, nil

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -102,14 +102,16 @@ func (d *MetadataStorePostgres) GetAccountsByCredential(
 	}
 	query := db.Where("1 = 0")
 	for _, ref := range refs {
+		conditions := "credential_tag = ? AND staking_key = ?"
+		args := []any{ref.Tag, ref.Key}
+		if !includeInactive {
+			conditions += " AND active = ?"
+			args = append(args, true)
+		}
 		query = query.Or(
-			"credential_tag = ? AND staking_key = ?",
-			ref.Tag,
-			ref.Key,
+			conditions,
+			args...,
 		)
-	}
-	if !includeInactive {
-		query = query.Where("active = ?", true)
 	}
 	var rows []*models.Account
 	if result := query.Find(&rows); result.Error != nil {

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -100,28 +101,31 @@ func (d *MetadataStorePostgres) GetAccountsByCredential(
 	if err != nil {
 		return nil, err
 	}
-	query := db.Where("1 = 0")
+
+	wanted := make(map[string]struct{}, len(refs))
+	stakeKeys := make([][]byte, 0, len(refs))
 	for _, ref := range refs {
-		conditions := "credential_tag = ? AND staking_key = ?"
-		args := []any{ref.Tag, ref.Key}
+		wanted[ref.MapKey()] = struct{}{}
+		stakeKeys = append(stakeKeys, ref.Key)
+	}
+	for chunk := range slices.Chunk(stakeKeys, 400) {
+		query := db.Where("staking_key IN ?", chunk)
 		if !includeInactive {
-			conditions += " AND active = ?"
-			args = append(args, true)
+			query = query.Where("active = ?", true)
 		}
-		query = query.Or(
-			conditions,
-			args...,
-		)
-	}
-	var rows []*models.Account
-	if result := query.Find(&rows); result.Error != nil {
-		return nil, result.Error
-	}
-	for _, row := range rows {
-		ret[models.StakeCredentialRef{
-			Tag: row.CredentialTag,
-			Key: row.StakingKey,
-		}.MapKey()] = row
+		var rows []*models.Account
+		if result := query.Find(&rows); result.Error != nil {
+			return nil, result.Error
+		}
+		for _, row := range rows {
+			key := models.StakeCredentialRef{
+				Tag: row.CredentialTag,
+				Key: row.StakingKey,
+			}.MapKey()
+			if _, ok := wanted[key]; ok {
+				ret[key] = row
+			}
+		}
 	}
 	return ret, nil
 }

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -24,8 +24,18 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetAccount gets an account
+// GetAccount gets an account by key credential hash.
 func (d *MetadataStorePostgres) GetAccount(
+	stakeKey []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Account, error) {
+	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
+}
+
+// GetAccountByCredential gets an account by credential tag and hash.
+func (d *MetadataStorePostgres) GetAccountByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	includeInactive bool,
 	txn types.Txn,
@@ -39,7 +49,12 @@ func (d *MetadataStorePostgres) GetAccount(
 	if !includeInactive {
 		query = query.Where("active = ?", true)
 	}
-	result := query.First(ret, "staking_key = ?", stakeKey)
+	result := query.First(
+		ret,
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakeKey,
+	)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -49,22 +64,50 @@ func (d *MetadataStorePostgres) GetAccount(
 	return ret, nil
 }
 
-// GetAccounts fetches multiple accounts in one IN-list query, keyed by
-// string(StakingKey). Stake keys with no matching row are omitted.
+// GetAccounts fetches multiple key-credential accounts.
 func (d *MetadataStorePostgres) GetAccounts(
 	stakeKeys [][]byte,
 	includeInactive bool,
 	txn types.Txn,
 ) (map[string]*models.Account, error) {
-	ret := make(map[string]*models.Account, len(stakeKeys))
-	if len(stakeKeys) == 0 {
+	refs := make([]models.StakeCredentialRef, 0, len(stakeKeys))
+	for _, stakeKey := range stakeKeys {
+		refs = append(refs, models.StakeCredentialRef{Key: stakeKey})
+	}
+	accounts, err := d.GetAccountsByCredential(refs, includeInactive, txn)
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]*models.Account, len(accounts))
+	for _, account := range accounts {
+		ret[string(account.StakingKey)] = account
+	}
+	return ret, nil
+}
+
+// GetAccountsByCredential fetches multiple accounts in one query, keyed by
+// StakeCredentialRef.MapKey(). Credentials with no matching row are omitted.
+func (d *MetadataStorePostgres) GetAccountsByCredential(
+	refs []models.StakeCredentialRef,
+	includeInactive bool,
+	txn types.Txn,
+) (map[string]*models.Account, error) {
+	ret := make(map[string]*models.Account, len(refs))
+	if len(refs) == 0 {
 		return ret, nil
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, err
 	}
-	query := db.Where("staking_key IN ?", stakeKeys)
+	query := db.Where("1 = 0")
+	for _, ref := range refs {
+		query = query.Or(
+			"credential_tag = ? AND staking_key = ?",
+			ref.Tag,
+			ref.Key,
+		)
+	}
 	if !includeInactive {
 		query = query.Where("active = ?", true)
 	}
@@ -73,13 +116,27 @@ func (d *MetadataStorePostgres) GetAccounts(
 		return nil, result.Error
 	}
 	for _, row := range rows {
-		ret[string(row.StakingKey)] = row
+		ret[models.StakeCredentialRef{
+			Tag: row.CredentialTag,
+			Key: row.StakingKey,
+		}.MapKey()] = row
 	}
 	return ret, nil
 }
 
-// AddAccountReward credits a registered reward account.
+// AddAccountReward credits a registered key-credential reward account.
 func (d *MetadataStorePostgres) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn types.Txn,
+) error {
+	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
+}
+
+// AddAccountRewardByCredential credits a registered reward account.
+func (d *MetadataStorePostgres) AddAccountRewardByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -102,7 +159,8 @@ func (d *MetadataStorePostgres) AddAccountReward(
 	credit := func(tx *gorm.DB) error {
 		var account models.Account
 		if err := tx.Where(
-			"staking_key = ? AND active = ?",
+			"credential_tag = ? AND staking_key = ? AND active = ?",
+			credentialTag,
 			stakeKey,
 			true,
 		).First(&account).Error; err != nil {
@@ -128,9 +186,10 @@ func (d *MetadataStorePostgres) AddAccountReward(
 			return models.ErrAccountNotFound
 		}
 		delta := &models.AccountRewardDelta{
-			StakingKey: stakeKey,
-			Amount:     types.Uint64(amount),
-			AddedSlot:  slot,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
+			Amount:        types.Uint64(amount),
+			AddedSlot:     slot,
 		}
 		return tx.Create(delta).Error
 	}
@@ -159,21 +218,6 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 		return err
 	}
 	withdraw := func(tx *gorm.DB) error {
-		if len(txHash) > 0 {
-			var existing models.AccountRewardDelta
-			result := tx.Where(
-				"withdrawal = ? AND tx_hash = ? AND staking_key = ?",
-				true,
-				txHash,
-				stakeKey,
-			).First(&existing)
-			if result.Error == nil {
-				return nil
-			}
-			if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-				return result.Error
-			}
-		}
 		var account models.Account
 		if err := tx.Where(
 			"staking_key = ? AND active = ?",
@@ -184,6 +228,22 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 				return models.ErrAccountNotFound
 			}
 			return err
+		}
+		if len(txHash) > 0 {
+			var existing models.AccountRewardDelta
+			result := tx.Where(
+				"withdrawal = ? AND tx_hash = ? AND credential_tag = ? AND staking_key = ?",
+				true,
+				txHash,
+				account.CredentialTag,
+				stakeKey,
+			).First(&existing)
+			if result.Error == nil {
+				return nil
+			}
+			if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+				return result.Error
+			}
 		}
 		current := uint64(account.Reward)
 		// Transaction validation proves the on-chain withdrawal amount is
@@ -197,6 +257,7 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 		}
 		delta := &models.AccountRewardDelta{
 			StakingKey:     stakeKey,
+			CredentialTag:  account.CredentialTag,
 			TxHash:         txHash,
 			Amount:         types.Uint64(amount),
 			PreviousReward: types.Uint64(current),
@@ -207,6 +268,7 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 			Columns: []clause.Column{
 				{Name: "withdrawal"},
 				{Name: "tx_hash"},
+				{Name: "credential_tag"},
 				{Name: "staking_key"},
 			},
 			DoNothing: true,
@@ -240,7 +302,8 @@ func (d *MetadataStorePostgres) DeleteAccountRewardsAfterSlot(
 		for _, delta := range deltas {
 			var account models.Account
 			if result := tx.Where(
-				"staking_key = ?",
+				"credential_tag = ? AND staking_key = ?",
+				delta.CredentialTag,
 				delta.StakingKey,
 			).First(&account); result.Error != nil {
 				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -376,6 +439,13 @@ func newAccountCertCache(capacity int) *accountCertCache {
 	}
 }
 
+func accountCertCacheKey(credentialTag uint8, stakingKey []byte) string {
+	return models.StakeCredentialRef{
+		Tag: credentialTag,
+		Key: stakingKey,
+	}.MapKey()
+}
+
 // updateReg updates the registration if this one is more recent.
 func (c *accountCertCache) updateReg(key string, rec certRecord) {
 	if !c.hasReg[key] || rec.isMoreRecent(c.latestReg[key]) {
@@ -466,18 +536,19 @@ func batchFetchStakeRegistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration t
@@ -485,14 +556,14 @@ func batchFetchStakeRegistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateReg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -506,18 +577,19 @@ func batchFetchStakeRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration_delegation t
@@ -525,13 +597,13 @@ func batchFetchStakeRegistrationDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			pool:       r.PoolKeyHash,
 			addedSlot:  r.AddedSlot,
@@ -551,20 +623,21 @@ func batchFetchStakeVoteRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		Drep        []byte
-		DrepType    uint64
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_registration_delegation t
@@ -572,13 +645,13 @@ func batchFetchStakeVoteRegistrationDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			pool:       r.PoolKeyHash,
 			drep:       r.Drep,
@@ -610,19 +683,20 @@ func batchFetchVoteRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		Drep       []byte
-		DrepType   uint64
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_registration_delegation t
@@ -630,13 +704,13 @@ func batchFetchVoteRegistrationDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			drep:       r.Drep,
 			drepType:   r.DrepType,
@@ -657,10 +731,11 @@ func batchFetchRegistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so synthetic genesis Registration rows (no certs row,
@@ -668,11 +743,11 @@ func batchFetchRegistration(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM registration t
@@ -680,14 +755,14 @@ func batchFetchRegistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateReg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -701,17 +776,18 @@ func batchFetchStakeDeregistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_deregistration t
@@ -719,14 +795,14 @@ func batchFetchStakeDeregistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDereg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -740,17 +816,18 @@ func batchFetchDeregistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM deregistration t
@@ -758,14 +835,14 @@ func batchFetchDeregistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDereg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -779,11 +856,12 @@ func batchFetchStakeDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so genesis stake_delegation rows (no certs row,
@@ -791,11 +869,11 @@ func batchFetchStakeDelegation(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_delegation t
@@ -803,14 +881,14 @@ func batchFetchStakeDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updatePoolDelegation(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{
 				pool:       r.PoolKeyHash,
 				addedSlot:  r.AddedSlot,
@@ -829,13 +907,14 @@ func batchFetchStakeVoteDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		Drep        []byte
-		DrepType    uint64
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so genesis stake_vote_delegation rows (no certs row,
@@ -843,11 +922,11 @@ func batchFetchStakeVoteDelegation(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_vote_delegation t
@@ -855,13 +934,13 @@ func batchFetchStakeVoteDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		cache.updatePoolDelegation(
 			key,
 			certRecord{
@@ -892,12 +971,13 @@ func batchFetchVoteDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		Drep       []byte
-		DrepType   uint64
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// LEFT JOIN so genesis vote_delegation rows (no certs row,
@@ -905,11 +985,11 @@ func batchFetchVoteDelegation(
 	// safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.drep, t.drep_type, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM vote_delegation t
@@ -917,14 +997,14 @@ func batchFetchVoteDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDrepDelegation(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{
 				drep:       r.Drep,
 				drepType:   r.DrepType,
@@ -979,7 +1059,7 @@ func (d *MetadataStorePostgres) RestoreAccountStateAtSlot(
 
 	// Process each account using the cached certificate data
 	for _, account := range accountsToRestore {
-		key := string(account.StakingKey)
+		key := accountCertCacheKey(account.CredentialTag, account.StakingKey)
 
 		// Check if this account had any registration before the rollback slot
 		latestReg, hasReg := cache.latestReg[key], cache.hasReg[key]

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -25,15 +25,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetAccount gets an account by key credential hash.
-func (d *MetadataStorePostgres) GetAccount(
-	stakeKey []byte,
-	includeInactive bool,
-	txn types.Txn,
-) (*models.Account, error) {
-	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
-}
-
 // GetAccountByCredential gets an account by credential tag and hash.
 func (d *MetadataStorePostgres) GetAccountByCredential(
 	credentialTag uint8,
@@ -61,27 +52,6 @@ func (d *MetadataStorePostgres) GetAccountByCredential(
 			return nil, nil
 		}
 		return nil, result.Error
-	}
-	return ret, nil
-}
-
-// GetAccounts fetches multiple key-credential accounts.
-func (d *MetadataStorePostgres) GetAccounts(
-	stakeKeys [][]byte,
-	includeInactive bool,
-	txn types.Txn,
-) (map[string]*models.Account, error) {
-	refs := make([]models.StakeCredentialRef, 0, len(stakeKeys))
-	for _, stakeKey := range stakeKeys {
-		refs = append(refs, models.StakeCredentialRef{Key: stakeKey})
-	}
-	accounts, err := d.GetAccountsByCredential(refs, includeInactive, txn)
-	if err != nil {
-		return nil, err
-	}
-	ret := make(map[string]*models.Account, len(accounts))
-	for _, account := range accounts {
-		ret[string(account.StakingKey)] = account
 	}
 	return ret, nil
 }
@@ -124,16 +94,6 @@ func (d *MetadataStorePostgres) GetAccountsByCredential(
 		}
 	}
 	return ret, nil
-}
-
-// AddAccountReward credits a registered key-credential reward account.
-func (d *MetadataStorePostgres) AddAccountReward(
-	stakeKey []byte,
-	amount uint64,
-	slot uint64,
-	txn types.Txn,
-) error {
-	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
 }
 
 // AddAccountRewardByCredential credits a registered reward account.

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -1110,7 +1110,10 @@ func (d *MetadataStorePostgres) ClearDanglingDRepDelegations(
 	// surprising semantics around NULL values in the subquery result.
 	liveDrepExists := db.Model(&models.Drep{}).
 		Select("1").
-		Where("drep.credential = account.drep AND drep.active = ?", true)
+		Where(
+			"drep.credential_tag = account.drep_type AND drep.credential = account.drep AND drep.active = ?",
+			true,
+		)
 	result := db.Model(&models.Account{}).
 		Where("drep IS NOT NULL").
 		Where(

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -447,14 +447,37 @@ func (c *accountCertCache) updateDrepDelegation(key string, rec certRecord) {
 	}
 }
 
-// batchFetchCerts fetches all relevant certificates for the given staking keys
+// batchFetchCerts fetches all relevant certificates for the given credential refs
 // at or before the given slot. Uses one query per certificate table.
+//
+// The SQL IN clause filters on staking_key hash only (not credential_tag) for
+// simplicity; the cache is post-filtered to entries whose composite (tag, hash)
+// key matches one of the input refs, so credentials sharing a 28-byte hash but
+// differing in tag are kept isolated.
 func batchFetchCerts(
 	db *gorm.DB,
-	stakingKeys [][]byte,
+	refs []models.StakeCredentialRef,
 	slot uint64,
 ) (*accountCertCache, error) {
-	cache := newAccountCertCache(len(stakingKeys))
+	cache := newAccountCertCache(len(refs))
+
+	// Build unique staking-key list for the SQL IN clause and a requested
+	// set (by composite cache key) for post-filtering.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var stakingKeys [][]byte
+	for _, ref := range refs {
+		requested[accountCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			stakingKeys = append(stakingKeys, ref.Key)
+		}
+	}
+
+	if len(stakingKeys) == 0 {
+		return cache, nil
+	}
 
 	// Registration certificates (5 types)
 	if err := batchFetchStakeRegistration(db, stakingKeys, slot, cache); err != nil {
@@ -493,6 +516,30 @@ func batchFetchCerts(
 	// DRep delegation certificates - VoteDelegation is DRep-only
 	if err := batchFetchVoteDelegation(db, stakingKeys, slot, cache); err != nil {
 		return nil, err
+	}
+
+	// Remove entries for credential variants not present in the input refs.
+	for key := range cache.latestReg {
+		if _, ok := requested[key]; !ok {
+			delete(cache.latestReg, key)
+			delete(cache.hasReg, key)
+		}
+	}
+	for key := range cache.latestDereg {
+		if _, ok := requested[key]; !ok {
+			delete(cache.latestDereg, key)
+			delete(cache.hasDereg, key)
+		}
+	}
+	for key := range cache.poolDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.poolDelegation, key)
+		}
+	}
+	for key := range cache.drepDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.drepDelegation, key)
+		}
 	}
 
 	return cache, nil
@@ -1014,14 +1061,14 @@ func (d *MetadataStorePostgres) RestoreAccountStateAtSlot(
 		return nil
 	}
 
-	// Extract staking keys for batch fetching
-	stakingKeys := make([][]byte, len(accountsToRestore))
+	// Extract credential refs for batch fetching
+	refs := make([]models.StakeCredentialRef, len(accountsToRestore))
 	for i, account := range accountsToRestore {
-		stakingKeys[i] = account.StakingKey
+		refs[i] = models.NewStakeCredentialRef(account.CredentialTag, account.StakingKey)
 	}
 
 	// Batch-fetch all certificates for all affected accounts
-	cache, err := batchFetchCerts(db, stakingKeys, slot)
+	cache, err := batchFetchCerts(db, refs, slot)
 	if err != nil {
 		return err
 	}

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -352,19 +352,21 @@ func (d *MetadataStorePostgres) DeleteAccountRewardsAfterSlot(
 	return db.Transaction(rollback)
 }
 
-// SetAccount saves an account
+// SetAccount saves an account by full stake credential identity.
 func (d *MetadataStorePostgres) SetAccount(
+	credentialTag uint8,
 	stakeKey, pkh, drep []byte,
 	slot uint64,
 	active bool,
 	txn types.Txn,
 ) error {
 	tmpItem := models.Account{
-		StakingKey: stakeKey,
-		AddedSlot:  slot,
-		Pool:       pkh,
-		Drep:       drep,
-		Active:     active,
+		StakingKey:    stakeKey,
+		CredentialTag: credentialTag,
+		AddedSlot:     slot,
+		Pool:          pkh,
+		Drep:          drep,
+		Active:        active,
 	}
 	onConflict := clause.OnConflict{
 		Columns: []clause.Column{

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -166,6 +166,7 @@ func (d *MetadataStorePostgres) AddAccountRewardByCredential(
 // rollback. The ledger rule clears the reward account when a withdrawal for
 // the credential appears in a valid transaction.
 func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -182,7 +183,8 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 	withdraw := func(tx *gorm.DB) error {
 		var account models.Account
 		if err := tx.Where(
-			"staking_key = ? AND active = ?",
+			"credential_tag = ? AND staking_key = ? AND active = ?",
+			credentialTag,
 			stakeKey,
 			true,
 		).First(&account).Error; err != nil {
@@ -197,7 +199,7 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 				"withdrawal = ? AND tx_hash = ? AND credential_tag = ? AND staking_key = ?",
 				true,
 				txHash,
-				account.CredentialTag,
+				credentialTag,
 				stakeKey,
 			).First(&existing)
 			if result.Error == nil {
@@ -219,7 +221,7 @@ func (d *MetadataStorePostgres) ApplyAccountRewardWithdrawal(
 		}
 		delta := &models.AccountRewardDelta{
 			StakingKey:     stakeKey,
-			CredentialTag:  account.CredentialTag,
+			CredentialTag:  credentialTag,
 			TxHash:         txHash,
 			Amount:         types.Uint64(amount),
 			PreviousReward: types.Uint64(current),

--- a/database/plugin/metadata/postgres/certs.go
+++ b/database/plugin/metadata/postgres/certs.go
@@ -21,8 +21,10 @@ import (
 	"gorm.io/gorm"
 )
 
-// GetStakeRegistrations returns stake registration certificates
-func (d *MetadataStorePostgres) GetStakeRegistrations(
+// GetStakeRegistrationsByCredential returns stake registration certificates
+// for a specific key/script credential tag and hash.
+func (d *MetadataStorePostgres) GetStakeRegistrationsByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) ([]lcommon.StakeRegistrationCertificate, error) {
@@ -32,7 +34,11 @@ func (d *MetadataStorePostgres) GetStakeRegistrations(
 	if err != nil {
 		return ret, err
 	}
-	result := db.Where("staking_key = ?", stakingKey).
+	result := db.Where(
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakingKey,
+	).
 		Order("id DESC").
 		Find(&certs)
 	if result.Error != nil {
@@ -43,14 +49,20 @@ func (d *MetadataStorePostgres) GetStakeRegistrations(
 		tmpCert = lcommon.StakeRegistrationCertificate{
 			CertType: uint(lcommon.CertificateTypeStakeRegistration),
 			StakeCredential: lcommon.Credential{
-				// TODO: determine correct type
-				// CredType: lcommon.CredentialTypeAddrKeyHash,
+				CredType:   stakeCredentialTypeFromTag(cert.CredentialTag),
 				Credential: lcommon.CredentialHash(cert.StakingKey),
 			},
 		}
 		ret = append(ret, tmpCert)
 	}
 	return ret, nil
+}
+
+func stakeCredentialTypeFromTag(tag uint8) uint {
+	if tag == 1 {
+		return lcommon.CredentialTypeScriptHash
+	}
+	return lcommon.CredentialTypeAddrKeyHash
 }
 
 // DeleteCertificatesAfterSlot removes all certificate records added after the given slot.

--- a/database/plugin/metadata/postgres/certs.go
+++ b/database/plugin/metadata/postgres/certs.go
@@ -39,7 +39,9 @@ func (d *MetadataStorePostgres) GetStakeRegistrationsByCredential(
 		credentialTag,
 		stakingKey,
 	).
-		Order("id DESC").
+		Joins("LEFT JOIN certs ON certs.id = stake_registration.certificate_id").
+		Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
+		Order(`stake_registration.added_slot DESC, COALESCE("transaction".block_index, 0) DESC, COALESCE(certs.cert_index, 0) DESC`).
 		Find(&certs)
 	if result.Error != nil {
 		return ret, result.Error

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -299,6 +299,13 @@ func (d *MetadataStorePostgres) Start() error {
 			"governance vote credential tag index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateAccountRewardDeltaCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"account reward delta credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -285,6 +285,20 @@ func (d *MetadataStorePostgres) Start() error {
 			"account credential tag index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateDrepCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"drep credential tag index migration failed: %w", err,
+		)
+	}
+	if err := models.MigrateGovernanceVoteCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"governance vote credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -278,6 +278,13 @@ func (d *MetadataStorePostgres) Start() error {
 			"block_nonce unique index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateAccountCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"account credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -240,20 +240,17 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.active = true AND ax.drep IN ?
-				    AND ax.drep_type = a.drep_type
-			  )
-			GROUP BY credential_tag, staking_key
+			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
+				   COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0) AS utxo_sum
+			FROM account ax
+			JOIN utxo ON utxo.credential_tag = ax.credential_tag
+			         AND utxo.staking_key = ax.staking_key
+			         AND utxo.deleted_slot = 0
+			WHERE ax.active = true AND ax.drep IN ?
+			GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
 		) u ON u.credential_tag = a.credential_tag
 			AND u.staking_key = a.staking_key
+			AND u.drep_type = a.drep_type
 		WHERE a.active = true AND a.drep IN ?
 		GROUP BY a.drep, a.drep_type
 	`, hashes, hashes).Scan(&rows).Error; err != nil {

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -24,7 +24,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetDrep gets a drep
+// GetDrep gets a drep by hash only (no tag filter).
 func (d *MetadataStorePostgres) GetDrep(
 	cred []byte,
 	includeInactive bool,
@@ -39,6 +39,34 @@ func (d *MetadataStorePostgres) GetDrep(
 		db = db.Where("active = ?", true)
 	}
 	if result := db.First(&drep, "credential = ?", cred); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &drep, nil
+}
+
+// GetDrepByCredential gets a drep by the full credential identity (tag + hash).
+func (d *MetadataStorePostgres) GetDrepByCredential(
+	credentialTag uint8,
+	cred []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Drep, error) {
+	var drep models.Drep
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if !includeInactive {
+		db = db.Where("active = ?", true)
+	}
+	if result := db.First(
+		&drep,
+		"credential_tag = ? AND credential = ?",
+		credentialTag, cred,
+	); result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -64,6 +92,7 @@ func (d *MetadataStorePostgres) GetActiveDreps(
 
 // SetDrep saves a drep
 func (d *MetadataStorePostgres) SetDrep(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -72,14 +101,18 @@ func (d *MetadataStorePostgres) SetDrep(
 	txn types.Txn,
 ) error {
 	tmpItem := models.Drep{
-		Credential: cred,
-		AddedSlot:  slot,
-		AnchorURL:  url,
-		AnchorHash: hash,
-		Active:     active,
+		CredentialTag: credentialTag,
+		Credential:    cred,
+		AddedSlot:     slot,
+		AnchorURL:     url,
+		AnchorHash:    hash,
+		Active:        active,
 	}
 	onConflict := clause.OnConflict{
-		Columns: []clause.Column{{Name: "credential"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "credential"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"added_slot",
 			"anchor_url",
@@ -101,6 +134,7 @@ func (d *MetadataStorePostgres) SetDrep(
 // the given credential. Existing rows are left untouched so the repair
 // path cannot clobber real registration metadata.
 func (d *MetadataStorePostgres) InsertDrepIfAbsent(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -109,11 +143,12 @@ func (d *MetadataStorePostgres) InsertDrepIfAbsent(
 	txn types.Txn,
 ) error {
 	tmpItem := models.Drep{
-		Credential: cred,
-		AddedSlot:  slot,
-		AnchorURL:  url,
-		AnchorHash: hash,
-		Active:     active,
+		CredentialTag: credentialTag,
+		Credential:    cred,
+		AddedSlot:     slot,
+		AnchorURL:     url,
+		AnchorHash:    hash,
+		Active:        active,
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -135,6 +170,7 @@ func (d *MetadataStorePostgres) InsertDrepIfAbsent(
 // parameter and use epoch-based stake snapshots for accurate
 // voting power at a specific point in time.
 func (d *MetadataStorePostgres) GetDRepVotingPower(
+	credentialTag uint8,
 	drepCredential []byte,
 	txn types.Txn,
 ) (uint64, error) {
@@ -156,12 +192,12 @@ func (d *MetadataStorePostgres) GetDRepVotingPower(
 			WHERE deleted_slot = 0
 			  AND staking_key IN (
 				  SELECT staking_key FROM account
-				  WHERE drep = $1 AND active = true
+				  WHERE drep = $1 AND drep_type = $2 AND active = true
 			  )
 			GROUP BY staking_key
 		) u ON u.staking_key = a.staking_key
-		WHERE a.drep = $1 AND a.active = true
-	`, drepCredential).Scan(&totalStake).Error; err != nil {
+		WHERE a.drep = $1 AND a.drep_type = $2 AND a.active = true
+	`, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 	return totalStake, nil
@@ -170,7 +206,7 @@ func (d *MetadataStorePostgres) GetDRepVotingPower(
 // GetDRepVotingPowerBatch returns voting power for each DRep credential
 // in a single query. See sqlite/drep.go for the documented contract.
 func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
-	drepCredentials [][]byte,
+	drepCredentials []models.StakeCredentialRef,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64, len(drepCredentials))
@@ -182,17 +218,17 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 		return nil, err
 	}
 	type row struct {
-		Drep  []byte
-		Stake uint64
+		Drep     []byte
+		DrepType uint64
+		Stake    uint64
+	}
+	hashes := make([][]byte, len(drepCredentials))
+	for i, ref := range drepCredentials {
+		hashes[i] = ref.Key
 	}
 	var rows []row
-	// Aggregate UTxO amounts per staking_key in a subquery before
-	// adding account.reward, otherwise the LEFT JOIN would multiply
-	// the per-account reward by the number of live UTxOs and inflate
-	// the totals. Each account contributes (utxo_sum + reward) once
-	// to its DRep bucket.
 	if err := db.Raw(`
-		SELECT a.drep AS drep,
+		SELECT a.drep AS drep, a.drep_type AS drep_type,
 			   COALESCE(SUM(
 				   COALESCE(u.utxo_sum, 0)
 				   + COALESCE(CAST(a.reward AS BIGINT), 0)
@@ -210,12 +246,13 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 			GROUP BY staking_key
 		) u ON u.staking_key = a.staking_key
 		WHERE a.active = true AND a.drep IN ?
-		GROUP BY a.drep
-	`, drepCredentials, drepCredentials).Scan(&rows).Error; err != nil {
+		GROUP BY a.drep, a.drep_type
+	`, hashes, hashes).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power batch: %w", err)
 	}
 	for _, r := range rows {
-		out[string(r.Drep)] = r.Stake
+		ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+		out[ref.MapKey()] = r.Stake
 	}
 	return out, nil
 }
@@ -280,6 +317,7 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerByType(
 // recalculates the expiry epoch.
 // Returns ErrDrepActivityNotUpdated if no matching DRep record was found.
 func (d *MetadataStorePostgres) UpdateDRepActivity(
+	credentialTag uint8,
 	drepCredential []byte,
 	activityEpoch uint64,
 	inactivityPeriod uint64,
@@ -291,7 +329,7 @@ func (d *MetadataStorePostgres) UpdateDRepActivity(
 	}
 	expiryEpoch := activityEpoch + inactivityPeriod
 	result := db.Model(&models.Drep{}).
-		Where("credential = ?", drepCredential).
+		Where("credential_tag = ? AND credential = ?", credentialTag, drepCredential).
 		Updates(map[string]any{
 			"last_activity_epoch": activityEpoch,
 			"expiry_epoch":        expiryEpoch,
@@ -395,6 +433,13 @@ type drepCertCache struct {
 	hasUpdate      map[string]bool
 }
 
+// drepCertCacheKey returns a composite cache key combining credential_tag and
+// credential so key-hash and script-hash DReps with the same hash are tracked
+// independently.
+func drepCertCacheKey(credentialTag uint8, credential []byte) string {
+	return string([]byte{credentialTag}) + string(credential)
+}
+
 // batchFetchDrepCerts fetches all relevant certificates for the given DRep credentials
 // at or before the given slot.
 func batchFetchDrepCerts(
@@ -415,6 +460,7 @@ func batchFetchDrepCerts(
 	{
 		type result struct {
 			DrepCredential []byte
+			CredentialTag  uint8
 			AnchorURL      string `gorm:"column:anchor_url"`
 			AnchorHash     []byte
 			AddedSlot      uint64
@@ -423,22 +469,22 @@ func batchFetchDrepCerts(
 		var records []result
 		query := `
 			WITH ranked AS (
-				SELECT t.drep_credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
+				SELECT t.credential_tag, t.drep_credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
 					ROW_NUMBER() OVER (
-						PARTITION BY t.drep_credential
+						PARTITION BY t.credential_tag, t.drep_credential
 						ORDER BY t.added_slot DESC, c.cert_index DESC
 					) as rn
 				FROM registration_drep t
 				INNER JOIN certs c ON c.id = t.certificate_id
 				WHERE t.drep_credential IN ? AND t.added_slot <= ?
 			)
-			SELECT drep_credential, anchor_url, anchor_hash, added_slot, cert_index
+			SELECT credential_tag, drep_credential, anchor_url, anchor_hash, added_slot, cert_index
 			FROM ranked WHERE rn = 1`
 		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
 			return nil, err
 		}
 		for _, r := range records {
-			key := string(r.DrepCredential)
+			key := drepCertCacheKey(r.CredentialTag, r.DrepCredential)
 			cache.registration[key] = drepCertRecord{
 				anchorURL:  r.AnchorURL,
 				anchorHash: r.AnchorHash,
@@ -453,28 +499,29 @@ func batchFetchDrepCerts(
 	{
 		type result struct {
 			DrepCredential []byte
+			CredentialTag  uint8
 			AddedSlot      uint64
 			CertIndex      uint32
 		}
 		var records []result
 		query := `
 			WITH ranked AS (
-				SELECT t.drep_credential, t.added_slot, c.cert_index,
+				SELECT t.credential_tag, t.drep_credential, t.added_slot, c.cert_index,
 					ROW_NUMBER() OVER (
-						PARTITION BY t.drep_credential
+						PARTITION BY t.credential_tag, t.drep_credential
 						ORDER BY t.added_slot DESC, c.cert_index DESC
 					) as rn
 				FROM deregistration_drep t
 				INNER JOIN certs c ON c.id = t.certificate_id
 				WHERE t.drep_credential IN ? AND t.added_slot <= ?
 			)
-			SELECT drep_credential, added_slot, cert_index
+			SELECT credential_tag, drep_credential, added_slot, cert_index
 			FROM ranked WHERE rn = 1`
 		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
 			return nil, err
 		}
 		for _, r := range records {
-			key := string(r.DrepCredential)
+			key := drepCertCacheKey(r.CredentialTag, r.DrepCredential)
 			cache.deregistration[key] = drepCertRecord{
 				addedSlot: r.AddedSlot,
 				certIndex: r.CertIndex,
@@ -486,31 +533,32 @@ func batchFetchDrepCerts(
 	// Fetch updates
 	{
 		type result struct {
-			Credential []byte
-			AnchorURL  string `gorm:"column:anchor_url"`
-			AnchorHash []byte
-			AddedSlot  uint64
-			CertIndex  uint32
+			Credential    []byte
+			CredentialTag uint8
+			AnchorURL     string `gorm:"column:anchor_url"`
+			AnchorHash    []byte
+			AddedSlot     uint64
+			CertIndex     uint32
 		}
 		var records []result
 		query := `
 			WITH ranked AS (
-				SELECT t.credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
+				SELECT t.credential_tag, t.credential, t.anchor_url, t.anchor_hash, t.added_slot, c.cert_index,
 					ROW_NUMBER() OVER (
-						PARTITION BY t.credential
+						PARTITION BY t.credential_tag, t.credential
 						ORDER BY t.added_slot DESC, c.cert_index DESC
 					) as rn
 				FROM update_drep t
 				INNER JOIN certs c ON c.id = t.certificate_id
 				WHERE t.credential IN ? AND t.added_slot <= ?
 			)
-			SELECT credential, anchor_url, anchor_hash, added_slot, cert_index
+			SELECT credential_tag, credential, anchor_url, anchor_hash, added_slot, cert_index
 			FROM ranked WHERE rn = 1`
 		if err := db.Raw(query, credentials, slot).Scan(&records).Error; err != nil {
 			return nil, err
 		}
 		for _, r := range records {
-			key := string(r.Credential)
+			key := drepCertCacheKey(r.CredentialTag, r.Credential)
 			cache.update[key] = drepCertRecord{
 				anchorURL:  r.AnchorURL,
 				anchorHash: r.AnchorHash,
@@ -552,7 +600,7 @@ func (d *MetadataStorePostgres) RestoreDrepStateAtSlot(
 			"NOT EXISTS (?)",
 			db.Model(&models.RegistrationDrep{}).
 				Select("1").
-				Where("registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
+				Where("registration_drep.credential_tag = drep.credential_tag AND registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
 		)
 
 	if result := db.Where(
@@ -587,7 +635,7 @@ func (d *MetadataStorePostgres) RestoreDrepStateAtSlot(
 
 	// Process each DRep using the cached certificate data
 	for _, drep := range drepsToRestore {
-		key := string(drep.Credential)
+		key := drepCertCacheKey(drep.CredentialTag, drep.Credential)
 
 		// Get registration from cache (must exist due to Phase 1 deletion)
 		lastReg, hasRegAtSlot := cache.registration[key], cache.hasReg[key]

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -249,6 +249,7 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 				  WHERE ax.credential_tag = utxo.credential_tag
 				    AND ax.staking_key = utxo.staking_key
 				    AND ax.active = true AND ax.drep IN ?
+				    AND ax.drep_type = a.drep_type
 			  )
 			GROUP BY credential_tag, staking_key
 		) u ON u.credential_tag = a.credential_tag

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -221,9 +221,9 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 		return nil, err
 	}
 	type row struct {
-		Drep     []byte
-		DrepType uint64
-		Stake    uint64
+		Drep          []byte
+		CredentialTag uint64
+		Stake         uint64
 	}
 	hashes := make([][]byte, len(drepCredentials))
 	requested := make(map[string]struct{}, len(drepCredentials))
@@ -233,7 +233,7 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 	}
 	var rows []row
 	if err := db.Raw(`
-		SELECT a.drep AS drep, a.drep_type AS drep_type,
+		SELECT a.drep AS drep, a.drep_type AS credential_tag,
 			   COALESCE(SUM(
 				   COALESCE(u.utxo_sum, 0)
 				   + COALESCE(CAST(a.reward AS BIGINT), 0)
@@ -259,7 +259,13 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 		return nil, fmt.Errorf("get drep voting power batch: %w", err)
 	}
 	for _, r := range rows {
-		ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+		// account.drep_type 0=key and 1=script align with credential_tag values
+		// by protocol spec; types ≥2 (ALWAYS_ABSTAIN, ALWAYS_NO_CONFIDENCE)
+		// carry no credential hash and are never in the requested map.
+		if r.CredentialTag > 1 {
+			continue
+		}
+		ref := models.StakeCredentialRef{Tag: uint8(r.CredentialTag), Key: r.Drep}
 		if _, ok := requested[ref.MapKey()]; !ok {
 			continue
 		}
@@ -454,20 +460,43 @@ func drepCertCacheKey(credentialTag uint8, credential []byte) string {
 	return string([]byte{credentialTag}) + string(credential)
 }
 
-// batchFetchDrepCerts fetches all relevant certificates for the given DRep credentials
+// batchFetchDrepCerts fetches all relevant certificates for the given DRep credential refs
 // at or before the given slot.
+//
+// The SQL IN clause filters on credential hash only (not credential_tag) for
+// simplicity; the cache is post-filtered to entries whose composite (tag, hash)
+// key matches one of the input refs, so credentials sharing a 28-byte hash but
+// differing in tag are kept isolated.
 func batchFetchDrepCerts(
 	db *gorm.DB,
-	credentials [][]byte,
+	refs []models.StakeCredentialRef,
 	slot uint64,
 ) (*drepCertCache, error) {
 	cache := &drepCertCache{
-		registration:   make(map[string]drepCertRecord, len(credentials)),
-		hasReg:         make(map[string]bool, len(credentials)),
-		deregistration: make(map[string]drepCertRecord, len(credentials)),
-		hasDereg:       make(map[string]bool, len(credentials)),
-		update:         make(map[string]drepCertRecord, len(credentials)),
-		hasUpdate:      make(map[string]bool, len(credentials)),
+		registration:   make(map[string]drepCertRecord, len(refs)),
+		hasReg:         make(map[string]bool, len(refs)),
+		deregistration: make(map[string]drepCertRecord, len(refs)),
+		hasDereg:       make(map[string]bool, len(refs)),
+		update:         make(map[string]drepCertRecord, len(refs)),
+		hasUpdate:      make(map[string]bool, len(refs)),
+	}
+
+	// Build unique credential list for the SQL IN clause and a requested
+	// set (by composite cache key) for post-filtering.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var credentials [][]byte
+	for _, ref := range refs {
+		requested[drepCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			credentials = append(credentials, ref.Key)
+		}
+	}
+
+	if len(credentials) == 0 {
+		return cache, nil
 	}
 
 	// Fetch registrations
@@ -583,6 +612,26 @@ func batchFetchDrepCerts(
 		}
 	}
 
+	// Remove entries for DRep credential variants not present in the input refs.
+	for key := range cache.registration {
+		if _, ok := requested[key]; !ok {
+			delete(cache.registration, key)
+			delete(cache.hasReg, key)
+		}
+	}
+	for key := range cache.deregistration {
+		if _, ok := requested[key]; !ok {
+			delete(cache.deregistration, key)
+			delete(cache.hasDereg, key)
+		}
+	}
+	for key := range cache.update {
+		if _, ok := requested[key]; !ok {
+			delete(cache.update, key)
+			delete(cache.hasUpdate, key)
+		}
+	}
+
 	return cache, nil
 }
 
@@ -635,14 +684,14 @@ func (d *MetadataStorePostgres) RestoreDrepStateAtSlot(
 		return nil
 	}
 
-	// Extract credentials for batch fetching
-	credentials := make([][]byte, len(drepsToRestore))
+	// Extract credential refs for batch fetching
+	drepRefs := make([]models.StakeCredentialRef, len(drepsToRestore))
 	for i, drep := range drepsToRestore {
-		credentials[i] = drep.Credential
+		drepRefs[i] = models.NewStakeCredentialRef(drep.CredentialTag, drep.Credential)
 	}
 
 	// Batch-fetch all certificates for all affected DReps
-	cache, err := batchFetchDrepCerts(db, credentials, slot)
+	cache, err := batchFetchDrepCerts(db, drepRefs, slot)
 	if err != nil {
 		return err
 	}

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -186,16 +186,19 @@ func (d *MetadataStorePostgres) GetDRepVotingPower(
 			   ), 0)
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE drep = $1 AND drep_type = $2 AND active = true
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.drep = $1 AND ax.drep_type = $2 AND ax.active = true
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.drep = $1 AND a.drep_type = $2 AND a.active = true
 	`, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
@@ -223,8 +226,10 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 		Stake    uint64
 	}
 	hashes := make([][]byte, len(drepCredentials))
+	requested := make(map[string]struct{}, len(drepCredentials))
 	for i, ref := range drepCredentials {
 		hashes[i] = ref.Key
+		requested[ref.MapKey()] = struct{}{}
 	}
 	var rows []row
 	if err := db.Raw(`
@@ -235,16 +240,19 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE active = true AND drep IN ?
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.active = true AND ax.drep IN ?
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.active = true AND a.drep IN ?
 		GROUP BY a.drep, a.drep_type
 	`, hashes, hashes).Scan(&rows).Error; err != nil {
@@ -252,6 +260,9 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 	}
 	for _, r := range rows {
 		ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+		if _, ok := requested[ref.MapKey()]; !ok {
+			continue
+		}
 		out[ref.MapKey()] = r.Stake
 	}
 	return out, nil
@@ -292,16 +303,19 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerByType(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE active = true AND drep_type IN ?
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.active = true AND ax.drep_type IN ?
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.active = true AND a.drep_type IN ?
 		GROUP BY a.drep_type
 	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {

--- a/database/plugin/metadata/postgres/drep_test.go
+++ b/database/plugin/metadata/postgres/drep_test.go
@@ -15,6 +15,7 @@
 package postgres
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -136,4 +137,114 @@ func TestPostgresGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *test
 	singlePower, err := pgStore.GetDRepVotingPower(0, drepCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1200), singlePower)
+}
+
+// TestPostgresGetDRepVotingPowerCrossTagIsolation verifies that key-hash and
+// script-hash DReps sharing the same 28-byte credential hash are treated as
+// independent identities. GetDRepVotingPower and GetDRepVotingPowerBatch must
+// only aggregate stake delegated to the exact (tag, hash) pair requested.
+func TestPostgresGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+	cleanupDRepVotingPowerTestData(t, pgStore)
+
+	sharedHash := bytes.Repeat([]byte{0x02}, 28)
+
+	require.NoError(t, pgStore.SetDrep(0, sharedHash, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.SetDrep(1, sharedHash, 1000, "", nil, true, nil))
+
+	keyStake := bytes.Repeat([]byte{0xA1}, 28)
+	require.NoError(t, pgStore.DB().Create(&models.Account{
+		StakingKey:    keyStake,
+		CredentialTag: 0,
+		Drep:          sharedHash,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		Reward:        types.Uint64(100),
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+
+	scriptStake := bytes.Repeat([]byte{0xA2}, 28)
+	require.NoError(t, pgStore.DB().Create(&models.Account{
+		StakingKey:    scriptStake,
+		CredentialTag: 1,
+		Drep:          sharedHash,
+		DrepType:      models.DrepTypeScriptHash,
+		Reward:        types.Uint64(200),
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+
+	keyPower, err := pgStore.GetDRepVotingPower(0, sharedHash, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), keyPower, "key-hash DRep power should be 100")
+
+	scriptPower, err := pgStore.GetDRepVotingPower(1, sharedHash, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(200), scriptPower, "script-hash DRep power should be 200")
+
+	powers, err := pgStore.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: sharedHash},
+			{Tag: 1, Key: sharedHash},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), powers[models.StakeCredentialRef{Tag: 0, Key: sharedHash}.MapKey()],
+		"batch: key-hash DRep power should be 100")
+	assert.Equal(t, uint64(200), powers[models.StakeCredentialRef{Tag: 1, Key: sharedHash}.MapKey()],
+		"batch: script-hash DRep power should be 200")
+}
+
+// TestPostgresRollbackRewardDeltaIsCredentialTagAware verifies that
+// DeleteAccountRewardsAfterSlot matches AccountRewardDelta rows to accounts
+// by the composite (credential_tag, staking_key) key. A credit delta for
+// tag=1 must adjust only the script-hash account, not the key-hash account
+// that shares the same 28-byte hash.
+func TestPostgresRollbackRewardDeltaIsCredentialTagAware(t *testing.T) {
+	pgStore := newTestPostgresStore(t)
+	defer pgStore.Close() //nolint:errcheck
+
+	stakeKey := bytes.Repeat([]byte{0xD1}, 28)
+	const baseReward = types.Uint64(1_000_000)
+	const creditAmount = uint64(500_000)
+	const slot = uint64(200)
+
+	keyAccount := &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+		AddedSlot:     10,
+		Reward:        baseReward,
+	}
+	scriptAccount := &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Active:        true,
+		AddedSlot:     10,
+		Reward:        baseReward,
+	}
+	require.NoError(t, pgStore.DB().Create(keyAccount).Error)
+	require.NoError(t, pgStore.DB().Create(scriptAccount).Error)
+
+	require.NoError(t, pgStore.AddAccountRewardByCredential(1, stakeKey, creditAmount, slot, nil))
+
+	keyBefore, err := pgStore.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward, keyBefore.Reward, "key-hash account must not be affected by script-hash credit")
+
+	scriptBefore, err := pgStore.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward+types.Uint64(creditAmount), scriptBefore.Reward, "script-hash account must have received credit")
+
+	require.NoError(t, pgStore.DeleteAccountRewardsAfterSlot(slot-1, nil))
+
+	keyAfter, err := pgStore.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward, keyAfter.Reward, "key-hash account reward must be unchanged after rollback")
+
+	scriptAfter, err := pgStore.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, baseReward, scriptAfter.Reward, "script-hash account reward must be restored to base after rollback")
 }

--- a/database/plugin/metadata/postgres/drep_test.go
+++ b/database/plugin/metadata/postgres/drep_test.go
@@ -40,7 +40,7 @@ func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	rewardOnlyCred := []byte("drep_reward_only_123456789012345678901234")
 	rewardOnlyStake := []byte("stake_reward_only_123456789012345678901")
 
-	require.NoError(t, pgStore.SetDrep(rewardOnlyCred, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.SetDrep(0, rewardOnlyCred, 1000, "", nil, true, nil))
 	require.NoError(t, pgStore.DB().Create(&models.Account{
 		StakingKey: rewardOnlyStake,
 		Drep:       rewardOnlyCred,
@@ -52,7 +52,7 @@ func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	multiUtxoCred := []byte("drep_multi_utxo_1234567890123456789012345")
 	multiUtxoStake := []byte("stake_multi_utxo_123456789012345678901234")
 
-	require.NoError(t, pgStore.SetDrep(multiUtxoCred, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.SetDrep(0, multiUtxoCred, 1000, "", nil, true, nil))
 	require.NoError(t, pgStore.DB().Create(&models.Account{
 		StakingKey: multiUtxoStake,
 		Drep:       multiUtxoCred,
@@ -76,18 +76,21 @@ func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	}).Error)
 
 	powers, err := pgStore.GetDRepVotingPowerBatch(
-		[][]byte{rewardOnlyCred, multiUtxoCred},
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: rewardOnlyCred},
+			{Tag: 0, Key: multiUtxoCred},
+		},
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(700), powers[string(rewardOnlyCred)])
-	assert.Equal(t, uint64(1000), powers[string(multiUtxoCred)])
+	assert.Equal(t, uint64(700), powers[models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey()])
+	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
 
-	singlePower, err := pgStore.GetDRepVotingPower(rewardOnlyCred, nil)
+	singlePower, err := pgStore.GetDRepVotingPower(0, rewardOnlyCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), singlePower)
 
-	singlePower, err = pgStore.GetDRepVotingPower(multiUtxoCred, nil)
+	singlePower, err = pgStore.GetDRepVotingPower(0, multiUtxoCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1000), singlePower)
 }
@@ -100,7 +103,7 @@ func TestPostgresGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *test
 	drepCred := []byte("drep_multi_reward_12345678901234567890123")
 	stakeKey := []byte("stake_multi_reward_1234567890123456789012")
 
-	require.NoError(t, pgStore.SetDrep(drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, pgStore.SetDrep(0, drepCred, 1000, "", nil, true, nil))
 	require.NoError(t, pgStore.DB().Create(&models.Account{
 		StakingKey: stakeKey,
 		Drep:       drepCred,
@@ -123,11 +126,14 @@ func TestPostgresGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *test
 		AddedSlot:  1000,
 	}).Error)
 
-	powers, err := pgStore.GetDRepVotingPowerBatch([][]byte{drepCred}, nil)
+	powers, err := pgStore.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		nil,
+	)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1200), powers[string(drepCred)])
+	assert.Equal(t, uint64(1200), powers[models.StakeCredentialRef{Tag: 0, Key: drepCred}.MapKey()])
 
-	singlePower, err := pgStore.GetDRepVotingPower(drepCred, nil)
+	singlePower, err := pgStore.GetDRepVotingPower(0, drepCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1200), singlePower)
 }

--- a/database/plugin/metadata/postgres/governance.go
+++ b/database/plugin/metadata/postgres/governance.go
@@ -302,6 +302,7 @@ func (d *MetadataStorePostgres) SetGovernanceVote(
 		Columns: []clause.Column{
 			{Name: "proposal_id"},
 			{Name: "voter_type"},
+			{Name: "voter_credential_tag"},
 			{Name: "voter_credential"},
 		},
 		// Note: added_slot is NOT updated on conflict to preserve rollback safety.

--- a/database/plugin/metadata/postgres/import.go
+++ b/database/plugin/metadata/postgres/import.go
@@ -167,7 +167,10 @@ func (d *MetadataStorePostgres) ImportAccount(
 		return fmt.Errorf("import account: %w", err)
 	}
 	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"pool", "drep", "drep_type", "active", "reward"},
 		),

--- a/database/plugin/metadata/postgres/import.go
+++ b/database/plugin/metadata/postgres/import.go
@@ -197,7 +197,7 @@ func (d *MetadataStorePostgres) ImportPool(
 		Columns: []clause.Column{{Name: "pool_key_hash"}},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"vrf_key_hash", "pledge", "cost",
-			"margin", "reward_account",
+			"margin", "reward_account", "reward_account_credential_tag",
 		}),
 	}).Create(pool)
 	if result.Error != nil {

--- a/database/plugin/metadata/postgres/import.go
+++ b/database/plugin/metadata/postgres/import.go
@@ -340,7 +340,10 @@ func (d *MetadataStorePostgres) ImportDrep(
 
 	// Upsert the DRep record
 	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "credential"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "credential"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"anchor_url", "anchor_hash", "active",
 		}),
@@ -353,7 +356,9 @@ func (d *MetadataStorePostgres) ImportDrep(
 	if drep.ID == 0 {
 		var existing models.Drep
 		if err := db.Where(
-			"credential = ?", drep.Credential,
+			"credential_tag = ? AND credential = ?",
+			drep.CredentialTag,
+			drep.Credential,
 		).First(&existing).Error; err != nil {
 			return fmt.Errorf(
 				"fetching drep ID after upsert: %w", err,
@@ -367,6 +372,7 @@ func (d *MetadataStorePostgres) ImportDrep(
 	// uniqueness key.
 	if result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{
+			{Name: "credential_tag"},
 			{Name: "drep_credential"},
 			{Name: "added_slot"},
 		},

--- a/database/plugin/metadata/postgres/mir.go
+++ b/database/plugin/metadata/postgres/mir.go
@@ -48,8 +48,9 @@ func (d *MetadataStorePostgres) GetMIRCertsInSlotRange(
 		effects[i].Rewards = make([]models.MIRReward, len(m.Rewards))
 		for j, r := range m.Rewards {
 			effects[i].Rewards[j] = models.MIRReward{
-				Credential: r.Credential,
-				Amount:     uint64(r.Amount),
+				Credential:    r.Credential,
+				CredentialTag: r.CredentialTag,
+				Amount:        uint64(r.Amount),
 			}
 		}
 	}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -498,14 +498,15 @@ func (d *MetadataStorePostgres) GetPoolByVrfKeyHash(
 // during pool state restoration.
 // Includes blockIndex, certIndex for deterministic same-slot disambiguation.
 type poolRegRecord struct {
-	pledge        types.Uint64
-	cost          types.Uint64
-	margin        *types.Rat
-	vrfKeyHash    []byte
-	rewardAccount []byte
-	addedSlot     uint64
-	blockIndex    uint32
-	certIndex     uint32
+	pledge                     types.Uint64
+	cost                       types.Uint64
+	margin                     *types.Rat
+	vrfKeyHash                 []byte
+	rewardAccount              []byte
+	rewardAccountCredentialTag uint8
+	addedSlot                  uint64
+	blockIndex                 uint32
+	certIndex                  uint32
 }
 
 // poolRegCache holds batch-fetched registration data for all pools being restored.
@@ -528,15 +529,16 @@ func batchFetchPoolRegs(
 	}
 
 	type result struct {
-		PoolID        uint
-		Pledge        types.Uint64
-		Cost          types.Uint64
-		Margin        *types.Rat
-		VrfKeyHash    []byte
-		RewardAccount []byte
-		AddedSlot     uint64
-		BlockIndex    uint32
-		CertIndex     uint32
+		PoolID                     uint
+		Pledge                     types.Uint64
+		Cost                       types.Uint64
+		Margin                     *types.Rat
+		VrfKeyHash                 []byte
+		RewardAccount              []byte
+		RewardAccountCredentialTag uint8
+		AddedSlot                  uint64
+		BlockIndex                 uint32
+		CertIndex                  uint32
 	}
 	var records []result
 
@@ -544,8 +546,9 @@ func batchFetchPoolRegs(
 	// Join transaction to get block_index for proper ordering (cert_index resets per tx)
 	query := `
 		WITH ranked AS (
-			SELECT pr.pool_id, pr.pledge, pr.cost, pr.margin,
-				pr.vrf_key_hash, pr.reward_account, pr.added_slot,
+				SELECT pr.pool_id, pr.pledge, pr.cost, pr.margin,
+					pr.vrf_key_hash, pr.reward_account,
+					pr.reward_account_credential_tag, pr.added_slot,
 				COALESCE(t.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
@@ -557,22 +560,23 @@ func batchFetchPoolRegs(
 			LEFT JOIN transaction t ON t.id = c.transaction_id
 			WHERE pr.pool_id IN ? AND pr.added_slot <= ?
 		)
-		SELECT pool_id, pledge, cost, margin, vrf_key_hash, reward_account, added_slot, block_index, cert_index
-		FROM ranked WHERE rn = 1`
+			SELECT pool_id, pledge, cost, margin, vrf_key_hash, reward_account, reward_account_credential_tag, added_slot, block_index, cert_index
+			FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, poolIDs, slot).Scan(&records).Error; err != nil {
 		return nil, err
 	}
 
 	for _, r := range records {
 		cache.registration[r.PoolID] = poolRegRecord{
-			pledge:        r.Pledge,
-			cost:          r.Cost,
-			margin:        r.Margin,
-			vrfKeyHash:    r.VrfKeyHash,
-			rewardAccount: r.RewardAccount,
-			addedSlot:     r.AddedSlot,
-			blockIndex:    r.BlockIndex,
-			certIndex:     r.CertIndex,
+			pledge:                     r.Pledge,
+			cost:                       r.Cost,
+			margin:                     r.Margin,
+			vrfKeyHash:                 r.VrfKeyHash,
+			rewardAccount:              r.RewardAccount,
+			rewardAccountCredentialTag: r.RewardAccountCredentialTag,
+			addedSlot:                  r.AddedSlot,
+			blockIndex:                 r.BlockIndex,
+			certIndex:                  r.CertIndex,
 		}
 		cache.hasReg[r.PoolID] = true
 	}
@@ -671,11 +675,12 @@ func (d *MetadataStorePostgres) RestorePoolStateAtSlot(
 
 		// Update the Pool's denormalized fields from the registration
 		if result := db.Model(&pool).Updates(map[string]any{
-			"pledge":         latestReg.pledge,
-			"cost":           latestReg.cost,
-			"margin":         latestReg.margin,
-			"vrf_key_hash":   latestReg.vrfKeyHash,
-			"reward_account": latestReg.rewardAccount,
+			"pledge":                        latestReg.pledge,
+			"cost":                          latestReg.cost,
+			"margin":                        latestReg.margin,
+			"vrf_key_hash":                  latestReg.vrfKeyHash,
+			"reward_account":                latestReg.rewardAccount,
+			"reward_account_credential_tag": latestReg.rewardAccountCredentialTag,
 		}); result.Error != nil {
 			return result.Error
 		}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -1116,7 +1116,7 @@ func (d *MetadataStorePostgres) GetStakeByPools(
 	var stakeResults []poolStakeResult
 	if err := db.Table("account").
 		Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
-		Joins("INNER JOIN utxo ON utxo.staking_key = account.staking_key").
+		Joins("INNER JOIN utxo ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 		Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", poolKeyHashes, true).
 		Group("account.pool").
 		Scan(&stakeResults).Error; err != nil {

--- a/database/plugin/metadata/postgres/poolreap.go
+++ b/database/plugin/metadata/postgres/poolreap.go
@@ -39,15 +39,16 @@ func (d *MetadataStorePostgres) GetPoolsRetiringAtEpoch(
 	}
 
 	type row struct {
-		PoolKeyHash   []byte
-		RewardAccount []byte
-		DepositAmount types.Uint64
+		PoolKeyHash                []byte
+		RewardAccount              []byte
+		RewardAccountCredentialTag uint8
+		DepositAmount              types.Uint64
 	}
 	var rows []row
 
 	query := `
 		WITH latest_reg AS (
-			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.reward_account_credential_tag, pr.deposit_amount,
 				COALESCE(t.block_index, 0) as blk_idx,
 				COALESCE(c.cert_index, 0) as cert_idx,
 				ROW_NUMBER() OVER (
@@ -72,7 +73,7 @@ func (d *MetadataStorePostgres) GetPoolsRetiringAtEpoch(
 			LEFT JOIN "transaction" t ON t.id = c.transaction_id
 			WHERE rt.added_slot < ?
 		)
-		SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+		SELECT p.pool_key_hash, lr.reward_account, lr.reward_account_credential_tag, lr.deposit_amount
 		FROM pool p
 		INNER JOIN latest_reg lr ON lr.pool_id = p.id AND lr.rn = 1
 		INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
@@ -94,9 +95,10 @@ func (d *MetadataStorePostgres) GetPoolsRetiringAtEpoch(
 	refunds := make([]models.PoolRetirementRefund, len(rows))
 	for i, r := range rows {
 		refunds[i] = models.PoolRetirementRefund{
-			PoolKeyHash:   r.PoolKeyHash,
-			RewardAccount: r.RewardAccount,
-			DepositAmount: r.DepositAmount,
+			PoolKeyHash:                r.PoolKeyHash,
+			RewardAccount:              r.RewardAccount,
+			RewardAccountCredentialTag: r.RewardAccountCredentialTag,
+			DepositAmount:              r.DepositAmount,
 		}
 	}
 	return refunds, nil

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -780,6 +780,7 @@ func TestPostgresSetAccountPreservesCertificateID(t *testing.T) {
 
 	// Now use SetAccount to update the account (this should NOT overwrite CertificateID)
 	err := pgStore.SetAccount(
+		0,
 		stakeKey,
 		[]byte("pool2"), // new pool
 		[]byte("drep2"), // new drep
@@ -793,7 +794,9 @@ func TestPostgresSetAccountPreservesCertificateID(t *testing.T) {
 
 	// Fetch the account and verify CertificateID was preserved
 	var updatedAccount models.Account
-	if result := pgStore.DB().Where("staking_key = ?", stakeKey).First(&updatedAccount); result.Error != nil {
+	if result := pgStore.DB().
+		Where("credential_tag = ? AND staking_key = ?", 0, stakeKey).
+		First(&updatedAccount); result.Error != nil {
 		t.Fatalf("failed to fetch updated account: %v", result.Error)
 	}
 

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1539,7 +1539,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(c)
+					rewardAcctTag, rewardAcctHash, err := certutil.PoolRewardAccount(c)
+					if err != nil {
+						return fmt.Errorf("pool reward account: %w", err)
+					}
 					tmpPool.RewardAccount = rewardAcctHash
 					tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
@@ -3045,7 +3048,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					rewardAcctTag2, rewardAcctHash2 := certutil.PoolRewardAccount(c)
+					rewardAcctTag2, rewardAcctHash2, err := certutil.PoolRewardAccount(c)
+					if err != nil {
+						return fmt.Errorf("pool reward account: %w", err)
+					}
 					tmpPool.RewardAccount = rewardAcctHash2
 					tmpPool.RewardAccountCredentialTag = rewardAcctTag2
 					tmpReg := models.PoolRegistration{
@@ -4034,7 +4040,10 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 		tmpPool.Pledge = types.Uint64(cert.Pledge)
 		tmpPool.Cost = types.Uint64(cert.Cost)
 		tmpPool.Margin = &types.Rat{Rat: cert.Margin.Rat}
-		rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(&cert)
+		rewardAcctTag, rewardAcctHash, err := certutil.PoolRewardAccount(&cert)
+		if err != nil {
+			return fmt.Errorf("pool reward account: %w", err)
+		}
 		tmpPool.RewardAccount = rewardAcctHash
 		tmpPool.RewardAccountCredentialTag = rewardAcctTag
 

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1629,7 +1629,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1691,7 +1694,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1733,7 +1739,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1776,7 +1785,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1805,7 +1817,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1835,7 +1850,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1877,7 +1895,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2027,7 +2048,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2069,7 +2093,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2109,7 +2136,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -3077,7 +3107,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3132,7 +3165,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3167,7 +3203,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3203,7 +3242,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3226,7 +3268,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3250,7 +3295,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3286,7 +3334,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3413,7 +3464,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3450,7 +3504,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3485,7 +3542,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -4064,7 +4124,10 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 			continue
 		}
 		stakeKey := cred.Credential[:]
-		credentialTag := uint8(cred.CredType)
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return err
+		}
 
 		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
 		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -207,7 +208,7 @@ func (d *MetadataStorePostgres) GetTransactionsByBlockHash(
 }
 
 // It builds AddressTransaction rows for a single transaction.
-// deduplication by (payment_key, staking_key) within the tx.
+// deduplication by (payment_key, credential_tag, staking_key) within the tx.
 func collectAddressTransactions(
 	transactionID uint,
 	slot uint64,
@@ -220,13 +221,19 @@ func collectAddressTransactions(
 		if len(utxo.PaymentKey) == 0 && len(utxo.StakingKey) == 0 {
 			continue
 		}
-		key := fmt.Sprintf("%x|%x", utxo.PaymentKey, utxo.StakingKey)
+		key := fmt.Sprintf(
+			"%x|%d|%x",
+			utxo.PaymentKey,
+			utxo.CredentialTag,
+			utxo.StakingKey,
+		)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
 		ret = append(ret, models.AddressTransaction{
 			PaymentKey:    append([]byte(nil), utxo.PaymentKey...),
+			CredentialTag: utxo.CredentialTag,
 			StakingKey:    append([]byte(nil), utxo.StakingKey...),
 			TransactionID: transactionID,
 			Slot:          slot,
@@ -240,6 +247,7 @@ func collectAddressTransactions(
 // the given payment/staking key with pagination support.
 func (d *MetadataStorePostgres) GetTransactionsByAddress(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -260,8 +268,9 @@ func (d *MetadataStorePostgres) GetTransactionsByAddress(
 	switch {
 	case len(paymentKey) > 0 && len(stakingKey) > 0:
 		addrQuery = addrQuery.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			paymentKey,
+			credentialTag,
 			stakingKey,
 		)
 	case len(paymentKey) > 0:
@@ -270,7 +279,11 @@ func (d *MetadataStorePostgres) GetTransactionsByAddress(
 			paymentKey,
 		)
 	default:
-		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+		addrQuery = addrQuery.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakingKey,
+		)
 	}
 
 	subQuery := addrQuery.Select("DISTINCT transaction_id")
@@ -308,6 +321,7 @@ func (d *MetadataStorePostgres) GetTransactionsByAddress(
 // payment/staking key.
 func (d *MetadataStorePostgres) CountTransactionsByAddress(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
@@ -324,8 +338,9 @@ func (d *MetadataStorePostgres) CountTransactionsByAddress(
 	switch {
 	case len(paymentKey) > 0 && len(stakingKey) > 0:
 		addrQuery = addrQuery.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			paymentKey,
+			credentialTag,
 			stakingKey,
 		)
 	case len(paymentKey) > 0:
@@ -334,7 +349,11 @@ func (d *MetadataStorePostgres) CountTransactionsByAddress(
 			paymentKey,
 		)
 	default:
-		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+		addrQuery = addrQuery.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakingKey,
+		)
 	}
 
 	var count int64
@@ -348,8 +367,9 @@ func (d *MetadataStorePostgres) CountTransactionsByAddress(
 	return int(count), nil
 }
 
-// GetAddressesByStakingKey returns distinct addresses mapped to a staking key.
-func (d *MetadataStorePostgres) GetAddressesByStakingKey(
+// GetAddressesByCredential returns distinct addresses mapped to a stake credential.
+func (d *MetadataStorePostgres) GetAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -365,9 +385,13 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 		return nil, err
 	}
 	query := db.Model(&models.AddressTransaction{}).
-		Select("MIN(id) AS id, payment_key, staking_key").
-		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
-		Group("payment_key, staking_key").
+		Select("MIN(id) AS id, payment_key, credential_tag, staking_key").
+		Where(
+			"credential_tag = ? AND staking_key = ? AND length(payment_key) > 0",
+			credentialTag,
+			stakingKey,
+		).
+		Group("payment_key, credential_tag, staking_key").
 		Order(addressOrderClause(order))
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -376,13 +400,14 @@ func (d *MetadataStorePostgres) GetAddressesByStakingKey(
 		query = query.Offset(offset)
 	}
 	if result := query.Find(&ret); result.Error != nil {
-		return nil, fmt.Errorf("get addresses by staking key: %w", result.Error)
+		return nil, fmt.Errorf("get addresses by stake credential: %w", result.Error)
 	}
 	return ret, nil
 }
 
-// CountAddressesByStakingKey returns the total number of distinct addresses mapped to a staking key.
-func (d *MetadataStorePostgres) CountAddressesByStakingKey(
+// CountAddressesByCredential returns the total number of distinct addresses mapped to a stake credential.
+func (d *MetadataStorePostgres) CountAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
@@ -392,16 +417,20 @@ func (d *MetadataStorePostgres) CountAddressesByStakingKey(
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"resolve DB for count addresses by staking key: %w",
+			"resolve DB for count addresses by stake credential: %w",
 			err,
 		)
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).
-		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
+		Where(
+			"credential_tag = ? AND staking_key = ? AND length(payment_key) > 0",
+			credentialTag,
+			stakingKey,
+		).
 		Distinct("payment_key").
 		Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("count addresses by staking key: %w", err)
+		return 0, fmt.Errorf("count addresses by stake credential: %w", err)
 	}
 	return int(count), nil
 }
@@ -1510,19 +1539,22 @@ func (d *MetadataStorePostgres) SetTransaction(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					tmpPool.RewardAccount = c.RewardAccount[:]
+					rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(c)
+					tmpPool.RewardAccount = rewardAcctHash
+					tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
 					// Create registration record
 					tmpReg := models.PoolRegistration{
-						PoolKeyHash:   c.Operator[:],
-						VrfKeyHash:    c.VrfKeyHash[:],
-						Pledge:        types.Uint64(c.Pledge),
-						Cost:          types.Uint64(c.Cost),
-						Margin:        &types.Rat{Rat: c.Margin.Rat},
-						RewardAccount: c.RewardAccount[:],
-						AddedSlot:     point.Slot,
-						DepositAmount: types.Uint64(deposit),
-						CertificateID: certIDMap[i],
+						PoolKeyHash:                c.Operator[:],
+						VrfKeyHash:                 c.VrfKeyHash[:],
+						Pledge:                     types.Uint64(c.Pledge),
+						Cost:                       types.Uint64(c.Cost),
+						Margin:                     &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount:              rewardAcctHash,
+						RewardAccountCredentialTag: rewardAcctTag,
+						AddedSlot:                  point.Slot,
+						DepositAmount:              types.Uint64(deposit),
+						CertificateID:              certIDMap[i],
 					}
 					if c.PoolMetadata != nil {
 						tmpReg.MetadataUrl = c.PoolMetadata.Url
@@ -1575,7 +1607,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 						},
 						DoUpdates: clause.AssignmentColumns([]string{
 							"vrf_key_hash", "pledge", "cost", "margin",
-							"reward_account", "certificate_id",
+							"reward_account", "reward_account_credential_tag", "certificate_id",
 							"metadata_url", "metadata_hash",
 						}),
 					}, clause.Returning{Columns: []clause.Column{{Name: "id"}}}).Omit("Owners", "Relays").Create(&tmpReg)
@@ -2248,10 +2280,15 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					// Save individual rewards
 					for credential, amount := range c.Reward.Rewards {
+						credentialTag, err := models.CredentialTagFromUint(credential.CredType)
+						if err != nil {
+							return fmt.Errorf("process certificate: %w", err)
+						}
 						tmpReward := models.MoveInstantaneousRewardsReward{
-							Credential: credential.Credential[:],
-							Amount:     types.Uint64(amount),
-							MIRID:      tmpMIR.ID,
+							Credential:    credential.Credential[:],
+							CredentialTag: credentialTag,
+							Amount:        types.Uint64(amount),
+							MIRID:         tmpMIR.ID,
 						}
 						result := db.Create(&tmpReward)
 						if result.Error != nil {
@@ -2992,17 +3029,20 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					tmpPool.RewardAccount = c.RewardAccount[:]
+					rewardAcctTag2, rewardAcctHash2 := certutil.PoolRewardAccount(c)
+					tmpPool.RewardAccount = rewardAcctHash2
+					tmpPool.RewardAccountCredentialTag = rewardAcctTag2
 					tmpReg := models.PoolRegistration{
-						PoolKeyHash:   c.Operator[:],
-						VrfKeyHash:    c.VrfKeyHash[:],
-						Pledge:        types.Uint64(c.Pledge),
-						Cost:          types.Uint64(c.Cost),
-						Margin:        &types.Rat{Rat: c.Margin.Rat},
-						RewardAccount: c.RewardAccount[:],
-						AddedSlot:     point.Slot,
-						DepositAmount: types.Uint64(deposit),
-						CertificateID: certIDMap[i],
+						PoolKeyHash:                c.Operator[:],
+						VrfKeyHash:                 c.VrfKeyHash[:],
+						Pledge:                     types.Uint64(c.Pledge),
+						Cost:                       types.Uint64(c.Cost),
+						Margin:                     &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount:              rewardAcctHash2,
+						RewardAccountCredentialTag: rewardAcctTag2,
+						AddedSlot:                  point.Slot,
+						DepositAmount:              types.Uint64(deposit),
+						CertificateID:              certIDMap[i],
 					}
 					if c.PoolMetadata != nil {
 						tmpReg.MetadataUrl = c.PoolMetadata.Url
@@ -3058,7 +3098,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						},
 						DoUpdates: clause.AssignmentColumns([]string{
 							"vrf_key_hash", "pledge", "cost", "margin",
-							"reward_account", "certificate_id",
+							"reward_account", "reward_account_credential_tag", "certificate_id",
 							"metadata_url", "metadata_hash", "deposit_amount",
 						}),
 					}).Omit("Owners", "Relays").Create(&tmpReg)
@@ -3640,10 +3680,15 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					}
 					certIDUpdates[certIDMap[i]] = tmpMIR.ID
 					for credential, amount := range c.Reward.Rewards {
+						credentialTag, err := models.CredentialTagFromUint(credential.CredType)
+						if err != nil {
+							return fmt.Errorf("process certificate: %w", err)
+						}
 						tmpReward := models.MoveInstantaneousRewardsReward{
-							Credential: credential.Credential[:],
-							Amount:     types.Uint64(amount),
-							MIRID:      tmpMIR.ID,
+							Credential:    credential.Credential[:],
+							CredentialTag: credentialTag,
+							Amount:        types.Uint64(amount),
+							MIRID:         tmpMIR.ID,
 						}
 						if r := db.Create(&tmpReward); r.Error != nil {
 							return fmt.Errorf("process certificate (batched): %w", r.Error)
@@ -3957,16 +4002,19 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 		tmpPool.Pledge = types.Uint64(cert.Pledge)
 		tmpPool.Cost = types.Uint64(cert.Cost)
 		tmpPool.Margin = &types.Rat{Rat: cert.Margin.Rat}
-		tmpPool.RewardAccount = cert.RewardAccount[:]
+		rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(&cert)
+		tmpPool.RewardAccount = rewardAcctHash
+		tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
 		tmpReg := models.PoolRegistration{
-			PoolKeyHash:   cert.Operator[:],
-			VrfKeyHash:    cert.VrfKeyHash[:],
-			Pledge:        types.Uint64(cert.Pledge),
-			Cost:          types.Uint64(cert.Cost),
-			Margin:        &types.Rat{Rat: cert.Margin.Rat},
-			RewardAccount: cert.RewardAccount[:],
-			AddedSlot:     0,
+			PoolKeyHash:                cert.Operator[:],
+			VrfKeyHash:                 cert.VrfKeyHash[:],
+			Pledge:                     types.Uint64(cert.Pledge),
+			Cost:                       types.Uint64(cert.Cost),
+			Margin:                     &types.Rat{Rat: cert.Margin.Rat},
+			RewardAccount:              rewardAcctHash,
+			RewardAccountCredentialTag: rewardAcctTag,
+			AddedSlot:                  0,
 		}
 		if cert.PoolMetadata != nil {
 			tmpReg.MetadataUrl = cert.PoolMetadata.Url

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1974,10 +1974,15 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.RegistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					// Registration (re)creates/activates the DRep regardless of prior state.
 
 					tmpReg := models.RegistrationDrep{
+						CredentialTag:  drepCredTag,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -1989,7 +1994,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					}
 
 					// Persist DRep anchor and active state
-					if err := d.SetDrep(drepCredential, point.Slot, tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -1998,6 +2003,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					// the registration fields instead of failing on the unique index.
 					result := db.Clauses(clause.OnConflict{
 						Columns: []clause.Column{
+							{Name: "credential_tag"},
 							{Name: "drep_credential"},
 							{Name: "added_slot"},
 						},
@@ -2014,8 +2020,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if tmpReg.ID == 0 {
 						var existing models.RegistrationDrep
 						if err := db.Where(
-							"drep_credential = ? AND added_slot = ?",
-							tmpReg.DrepCredential, tmpReg.AddedSlot,
+							"credential_tag = ? AND drep_credential = ? AND added_slot = ?",
+							drepCredTag, tmpReg.DrepCredential, tmpReg.AddedSlot,
 						).First(&existing).Error; err != nil {
 							return fmt.Errorf(
 								"fetching drep registration ID after upsert: %w",
@@ -2029,8 +2035,13 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.DeregistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					tmpDereg := models.DeregistrationDrep{
+						CredentialTag:  drepCredTag,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -2039,7 +2050,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					// Mark DRep inactive
 					// Ensure we don't create a new DRep during deregistration. Check existence first.
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag, drepCredential, true, txn)
 					if err != nil {
 						if !errors.Is(err, models.ErrDrepNotFound) {
 							return fmt.Errorf("process certificate: %w", err)
@@ -2048,7 +2059,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if existingDrep == nil {
 						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
 					}
-					if err := d.SetDrep(drepCredential, point.Slot, "", nil, false, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, "", nil, false, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -2060,8 +2071,13 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpDereg.ID
 				case *lcommon.UpdateDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					tmpUpdate := models.UpdateDrep{
+						CredentialTag: drepCredTag,
 						Credential:    drepCredential,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -2073,7 +2089,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					// Update DRep anchor and mark active
 					// Require that the DRep already exists for updates.
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag, drepCredential, true, txn)
 					if err != nil {
 						if !errors.Is(err, models.ErrDrepNotFound) {
 							return fmt.Errorf("process certificate: %w", err)
@@ -2082,7 +2098,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					if existingDrep == nil {
 						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
 					}
-					if err := d.SetDrep(drepCredential, point.Slot, tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -3425,7 +3441,12 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.RegistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpReg := models.RegistrationDrep{
+						CredentialTag:  drepCredTag2,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -3436,13 +3457,14 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						tmpReg.AnchorHash = c.Anchor.DataHash[:]
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot,
+						drepCredTag2, drepCredential, point.Slot,
 						tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					r2 := db.Clauses(clause.OnConflict{
 						Columns: []clause.Column{
+							{Name: "credential_tag"},
 							{Name: "drep_credential"},
 							{Name: "added_slot"},
 						},
@@ -3456,8 +3478,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					if tmpReg.ID == 0 {
 						var existing models.RegistrationDrep
 						if err := db.Where(
-							"drep_credential = ? AND added_slot = ?",
-							tmpReg.DrepCredential, tmpReg.AddedSlot,
+							"credential_tag = ? AND drep_credential = ? AND added_slot = ?",
+							drepCredTag2, tmpReg.DrepCredential, tmpReg.AddedSlot,
 						).First(&existing).Error; err != nil {
 							return fmt.Errorf(
 								"fetching drep registration ID after upsert (batched): %w",
@@ -3469,13 +3491,18 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.DeregistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpDereg := models.DeregistrationDrep{
+						CredentialTag:  drepCredTag2,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
 						CertificateID:  certIDMap[i],
 					}
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag2, drepCredential, true, txn)
 					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3486,7 +3513,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						)
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot, "", nil, false, txn,
+						drepCredTag2, drepCredential, point.Slot, "", nil, false, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3496,7 +3523,12 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpDereg.ID
 				case *lcommon.UpdateDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpUpdate := models.UpdateDrep{
+						CredentialTag: drepCredTag2,
 						Credential:    drepCredential,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -3505,7 +3537,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						tmpUpdate.AnchorURL = c.Anchor.Url
 						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
 					}
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag2, drepCredential, true, txn)
 					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3516,7 +3548,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 						)
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot,
+						drepCredTag2, drepCredential, point.Slot,
 						tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -4144,19 +4176,27 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 		if cred == nil {
 			continue
 		}
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return fmt.Errorf("genesis drep credential type: %w", err)
+		}
 		drepCred := cred.Credential[:]
 		drep := &models.Drep{
-			Credential:  drepCred,
-			AddedSlot:   0,
-			ExpiryEpoch: state.Expiry,
-			Active:      true,
+			CredentialTag: credentialTag,
+			Credential:    drepCred,
+			AddedSlot:     0,
+			ExpiryEpoch:   state.Expiry,
+			Active:        true,
 		}
 		if state.Anchor != nil {
 			drep.AnchorURL = state.Anchor.Url
 			drep.AnchorHash = state.Anchor.DataHash[:]
 		}
 		if result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "credential"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "credential"},
+			},
 			DoUpdates: clause.AssignmentColumns([]string{
 				"added_slot",
 				"anchor_url",
@@ -4172,6 +4212,7 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 		}
 
 		reg := &models.RegistrationDrep{
+			CredentialTag:  credentialTag,
 			DrepCredential: drepCred,
 			AddedSlot:      0,
 			DepositAmount:  types.Uint64(state.Deposit),
@@ -4182,6 +4223,7 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 		}
 		if result := db.Clauses(clause.OnConflict{
 			Columns: []clause.Column{
+				{Name: "credential_tag"},
 				{Name: "drep_credential"},
 				{Name: "added_slot"},
 			},

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -413,24 +413,6 @@ func addressOrderClause(order string) string {
 	return "payment_key ASC"
 }
 
-// GetAccountDelegationHistory returns delegation history rows for a staking key.
-func (d *MetadataStorePostgres) GetAccountDelegationHistory(
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn types.Txn,
-) ([]models.AccountDelegationHistoryRow, error) {
-	return d.GetAccountDelegationHistoryByCredential(
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
-}
-
 func (d *MetadataStorePostgres) GetAccountDelegationHistoryByCredential(
 	credentialTag uint8,
 	stakingKey []byte,
@@ -463,15 +445,6 @@ func (d *MetadataStorePostgres) GetAccountDelegationHistoryByCredential(
 	return rows, nil
 }
 
-// CountAccountDelegationHistory returns the total number of
-// delegation history rows for a staking key.
-func (d *MetadataStorePostgres) CountAccountDelegationHistory(
-	stakingKey []byte,
-	txn types.Txn,
-) (int, error) {
-	return d.CountAccountDelegationHistoryByCredential(0, stakingKey, txn)
-}
-
 func (d *MetadataStorePostgres) CountAccountDelegationHistoryByCredential(
 	credentialTag uint8,
 	stakingKey []byte,
@@ -496,24 +469,6 @@ func (d *MetadataStorePostgres) CountAccountDelegationHistoryByCredential(
 		)
 	}
 	return count, nil
-}
-
-// GetAccountRegistrationHistory returns registration history rows for a staking key.
-func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn types.Txn,
-) ([]models.AccountRegistrationHistoryRow, error) {
-	return d.GetAccountRegistrationHistoryByCredential(
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
 }
 
 func (d *MetadataStorePostgres) GetAccountRegistrationHistoryByCredential(
@@ -546,15 +501,6 @@ func (d *MetadataStorePostgres) GetAccountRegistrationHistoryByCredential(
 		)
 	}
 	return rows, nil
-}
-
-// CountAccountRegistrationHistory returns the total number of
-// registration history rows for a staking key.
-func (d *MetadataStorePostgres) CountAccountRegistrationHistory(
-	stakingKey []byte,
-	txn types.Txn,
-) (int, error) {
-	return d.CountAccountRegistrationHistoryByCredential(0, stakingKey, txn)
 }
 
 func (d *MetadataStorePostgres) CountAccountRegistrationHistoryByCredential(

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -421,6 +421,24 @@ func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 	order string,
 	txn types.Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
+	return d.GetAccountDelegationHistoryByCredential(
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func (d *MetadataStorePostgres) GetAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -428,8 +446,9 @@ func (d *MetadataStorePostgres) GetAccountDelegationHistory(
 			err,
 		)
 	}
-	rows, err := accounthistory.QueryDelegationHistory(
+	rows, err := accounthistory.QueryDelegationHistoryByCredential(
 		db,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -450,6 +469,14 @@ func (d *MetadataStorePostgres) CountAccountDelegationHistory(
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
+	return d.CountAccountDelegationHistoryByCredential(0, stakingKey, txn)
+}
+
+func (d *MetadataStorePostgres) CountAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
@@ -457,7 +484,11 @@ func (d *MetadataStorePostgres) CountAccountDelegationHistory(
 			err,
 		)
 	}
-	count, err := accounthistory.CountDelegationHistory(db, stakingKey)
+	count, err := accounthistory.CountDelegationHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"count account delegation history: %w",
@@ -475,6 +506,24 @@ func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
 	order string,
 	txn types.Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
+	return d.GetAccountRegistrationHistoryByCredential(
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func (d *MetadataStorePostgres) GetAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -482,8 +531,9 @@ func (d *MetadataStorePostgres) GetAccountRegistrationHistory(
 			err,
 		)
 	}
-	rows, err := accounthistory.QueryRegistrationHistory(
+	rows, err := accounthistory.QueryRegistrationHistoryByCredential(
 		db,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -504,6 +554,14 @@ func (d *MetadataStorePostgres) CountAccountRegistrationHistory(
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
+	return d.CountAccountRegistrationHistoryByCredential(0, stakingKey, txn)
+}
+
+func (d *MetadataStorePostgres) CountAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
@@ -511,7 +569,11 @@ func (d *MetadataStorePostgres) CountAccountRegistrationHistory(
 			err,
 		)
 	}
-	count, err := accounthistory.CountRegistrationHistory(db, stakingKey)
+	count, err := accounthistory.CountRegistrationHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"count account registration history: %w",

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -647,11 +647,12 @@ func certRequiresDeposit(cert lcommon.Certificate) bool {
 
 // getOrCreateAccount retrieves an existing account or creates a new one
 func (d *MetadataStorePostgres) getOrCreateAccount(
+	credentialTag uint8,
 	stakeKey []byte,
 	txn types.Txn,
 ) (*models.Account, error) {
 	// Include inactive accounts to allow reactivation on registration.
-	tmpAccount, err := d.GetAccount(stakeKey, true, txn)
+	tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, true, txn)
 	if err != nil {
 		if !errors.Is(err, models.ErrAccountNotFound) {
 			return nil, err
@@ -659,7 +660,8 @@ func (d *MetadataStorePostgres) getOrCreateAccount(
 	}
 	if tmpAccount == nil {
 		tmpAccount = &models.Account{
-			StakingKey: stakeKey,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
 		}
 	} else if !tmpAccount.Active {
 		tmpAccount.Active = true
@@ -668,12 +670,15 @@ func (d *MetadataStorePostgres) getOrCreateAccount(
 }
 
 // saveAccount persists the account to the database. It creates a new
-// record when `account.ID == 0` (with an upsert on `staking_key`) or saves
+// record when `account.ID == 0` (with an upsert on credential tag + staking key) or saves
 // the existing record otherwise.
 func saveAccount(account *models.Account, db *gorm.DB) error {
 	if account.ID == 0 {
 		result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "staking_key"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "staking_key"},
+			},
 			DoUpdates: clause.AssignmentColumns(
 				[]string{
 					"added_slot",
@@ -1624,13 +1629,15 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
 					tmpReg := models.StakeRegistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1684,14 +1691,16 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 					if tmpAccount == nil {
 						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
 						tmpAccount = &models.Account{
-							StakingKey: stakeKey,
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
@@ -1707,6 +1716,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1723,14 +1733,16 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 					if tmpAccount == nil {
 						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
 						tmpAccount = &models.Account{
-							StakingKey: stakeKey,
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
@@ -1746,6 +1758,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 						Amount:        types.Uint64(deposit),
@@ -1763,7 +1776,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1773,6 +1787,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -1790,7 +1805,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1800,6 +1816,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
@@ -1818,7 +1835,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1839,6 +1857,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -1858,13 +1877,15 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
 					tmpReg := models.Registration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -2006,7 +2027,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2026,6 +2048,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -2046,7 +2069,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2065,6 +2089,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -2084,7 +2109,8 @@ func (d *MetadataStorePostgres) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2103,6 +2129,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -3050,12 +3077,14 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					tmpReg := models.StakeRegistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -3103,12 +3132,16 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					if tmpAccount == nil {
-						tmpAccount = &models.Account{StakingKey: stakeKey}
+						tmpAccount = &models.Account{
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
+						}
 						r := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
 							UpdateAll: true,
@@ -3121,6 +3154,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -3133,12 +3167,16 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					if tmpAccount == nil {
-						tmpAccount = &models.Account{StakingKey: stakeKey}
+						tmpAccount = &models.Account{
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
+						}
 						r := db.Clauses(clause.OnConflict{
 							Columns:   []clause.Column{{Name: "staking_key"}},
 							UpdateAll: true,
@@ -3151,6 +3189,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 						Amount:        types.Uint64(deposit),
@@ -3164,7 +3203,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3172,6 +3212,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -3185,7 +3226,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3193,6 +3235,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
@@ -3207,7 +3250,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3226,6 +3270,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -3241,12 +3286,14 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					tmpReg := models.Registration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -3366,7 +3413,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3385,6 +3433,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -3401,7 +3450,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3419,6 +3469,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -3434,7 +3485,8 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3452,6 +3504,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -4011,6 +4064,7 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 			continue
 		}
 		stakeKey := cred.Credential[:]
+		credentialTag := uint8(cred.CredType)
 
 		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
 		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {
@@ -4023,7 +4077,7 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 			drepCredential = delegatee.DRep.Credential
 		}
 
-		account, err := d.getOrCreateAccount(stakeKey, txn)
+		account, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 		if err != nil {
 			return fmt.Errorf(
 				"get or create genesis delegatee account: %w",
@@ -4041,11 +4095,12 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 		// would delete a genesis-rooted account.
 		var existingReg models.Registration
 		regResult := db.Where(
-			"staking_key = ? AND added_slot = ?",
-			stakeKey, uint64(0),
+			"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+			credentialTag, stakeKey, uint64(0),
 		).Attrs(models.Registration{
-			StakingKey: stakeKey,
-			AddedSlot:  0,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
+			AddedSlot:     0,
 		}).FirstOrCreate(&existingReg)
 		if regResult.Error != nil {
 			return fmt.Errorf(
@@ -4072,9 +4127,10 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 				"staking_key = ? AND added_slot = ?",
 				stakeKey, uint64(0),
 			).Attrs(models.StakeDelegation{
-				StakingKey:  stakeKey,
-				PoolKeyHash: delegatee.PoolId[:],
-				AddedSlot:   0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				PoolKeyHash:   delegatee.PoolId[:],
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -4094,10 +4150,11 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 				"staking_key = ? AND added_slot = ?",
 				stakeKey, uint64(0),
 			).Attrs(models.VoteDelegation{
-				StakingKey: stakeKey,
-				Drep:       drepCredential,
-				DrepType:   drepType,
-				AddedSlot:  0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				Drep:          drepCredential,
+				DrepType:      drepType,
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -4118,11 +4175,12 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 				"staking_key = ? AND added_slot = ?",
 				stakeKey, uint64(0),
 			).Attrs(models.StakeVoteDelegation{
-				StakingKey:  stakeKey,
-				PoolKeyHash: delegatee.PoolId[:],
-				Drep:        drepCredential,
-				DrepType:    drepType,
-				AddedSlot:   0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				PoolKeyHash:   delegatee.PoolId[:],
+				Drep:          drepCredential,
+				DrepType:      drepType,
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -1709,7 +1709,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if result.Error != nil {
@@ -1754,7 +1757,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if result.Error != nil {
@@ -3179,7 +3185,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 							CredentialTag: credentialTag,
 						}
 						r := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if r.Error != nil {
@@ -3217,7 +3226,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 							CredentialTag: credentialTag,
 						}
 						r := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if r.Error != nil {
@@ -4025,10 +4037,11 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 		}
 
 		account := &models.Account{
-			StakingKey: stakerBytes,
-			Pool:       poolBytes,
-			Active:     true,
-			AddedSlot:  0,
+			StakingKey:    stakerBytes,
+			CredentialTag: 0,
+			Pool:          poolBytes,
+			Active:        true,
+			AddedSlot:     0,
 		}
 		// DoUpdates intentionally omits added_slot: RestoreAccountStateAtSlot
 		// selects rows by `added_slot > rollback_slot`, so resetting a
@@ -4036,7 +4049,10 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 		// Mithril after partial sync) would make that row invisible to
 		// every future rollback.
 		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "staking_key"},
+			},
 			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
@@ -4172,10 +4188,10 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 		}
 
 		// Delegation history tables have no unique constraint that covers
-		// (staking_key, added_slot), so we use FirstOrCreate to keep the
-		// slot-0 row idempotent across retries (e.g., resumed Mithril
-		// bootstrap). Each staking key contributes at most one genesis
-		// delegation row of a given type, so matching on staking_key +
+		// (credential_tag, staking_key, added_slot), so we use FirstOrCreate
+		// to keep the slot-0 row idempotent across retries (e.g., resumed
+		// Mithril bootstrap). Each stake credential contributes at most one
+		// genesis delegation row of a given type, so matching on tag + key +
 		// added_slot is sufficient.
 		switch delegatee.Type {
 		case conway.ConwayGenesisDelegateeTypeStake:
@@ -4187,8 +4203,8 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 			}
 			var existing models.StakeDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.StakeDelegation{
 				StakingKey:    stakeKey,
 				CredentialTag: credentialTag,
@@ -4210,8 +4226,8 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 			}
 			var existing models.VoteDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.VoteDelegation{
 				StakingKey:    stakeKey,
 				CredentialTag: credentialTag,
@@ -4235,8 +4251,8 @@ func (d *MetadataStorePostgres) SetGenesisGovernance(
 			}
 			var existing models.StakeVoteDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.StakeVoteDelegation{
 				StakingKey:    stakeKey,
 				CredentialTag: credentialTag,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2075,6 +2075,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 					tmpAccount.Pool = c.PoolKeyHash[:]
 					tmpAccount.Drep = drepCredential
 					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
@@ -2119,6 +2120,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpAccount.Drep = drepCredential
 					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
@@ -2162,6 +2164,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 
 					tmpAccount.Drep = drepCredential
 					tmpAccount.DrepType = drepType
+					tmpAccount.AddedSlot = point.Slot
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -4142,7 +4142,10 @@ func (d *MetadataStorePostgres) SetGenesisStaking(
 		}
 
 		account := &models.Account{
-			StakingKey:    stakerBytes,
+			StakingKey: stakerBytes,
+			// Shelley genesis staking section encodes stake credentials as
+			// raw 28-byte hashes with no type metadata. All Shelley-era
+			// genesis stake credentials are key-hash by protocol design.
 			CredentialTag: 0,
 			Pool:          poolBytes,
 			Active:        true,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2382,7 +2382,12 @@ func (d *MetadataStorePostgres) applyTransactionRewardWithdrawals(
 		if stakeKeyHash == zeroHash {
 			return errors.New("reward withdrawal missing stake credential")
 		}
+		credentialTag, ok := models.StakeCredentialTagFromAddress(*addr)
+		if !ok {
+			return errors.New("derive reward withdrawal credential tag")
+		}
 		if err := d.ApplyAccountRewardWithdrawal(
+			credentialTag,
 			stakeKeyHash.Bytes(),
 			amount.Uint64(),
 			slot,

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -76,9 +76,10 @@ func (d *MetadataStorePostgres) GetUtxoIncludingSpent(
 	return ret, nil
 }
 
-// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
-// controlled by the given staking key.
-func (d *MetadataStorePostgres) GetControlledAmountByStakingKey(
+// GetControlledAmountByCredential returns the sum of live UTxO amounts
+// controlled by the given stake credential.
+func (d *MetadataStorePostgres) GetControlledAmountByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (uint64, error) {
@@ -88,17 +89,21 @@ func (d *MetadataStorePostgres) GetControlledAmountByStakingKey(
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"resolve DB for controlled amount by staking key: %w",
+			"resolve DB for controlled amount by stake credential: %w",
 			err,
 		)
 	}
 	var total uint64
 	if err := db.Model(&models.Utxo{}).
-		Where("staking_key = ? AND deleted_slot = 0", stakingKey).
+		Where(
+			"credential_tag = ? AND staking_key = ? AND deleted_slot = 0",
+			credentialTag,
+			stakingKey,
+		).
 		Select("COALESCE(SUM(amount), 0)").
 		Scan(&total).Error; err != nil {
 		return 0, fmt.Errorf(
-			"get controlled amount by staking key: %w",
+			"get controlled amount by stake credential: %w",
 			err,
 		)
 	}
@@ -241,9 +246,11 @@ func addressWhereClause(
 
 	switch {
 	case hasPayment && hasStake:
+		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
 		return db.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			addr.PaymentKeyHash().Bytes(),
+			credentialTag,
 			addr.StakeKeyHash().Bytes(),
 		)
 	case hasPayment:
@@ -252,8 +259,10 @@ func addressWhereClause(
 			addr.PaymentKeyHash().Bytes(),
 		)
 	case hasStake:
+		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
 		return db.Where(
-			"staking_key = ?",
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
 			addr.StakeKeyHash().Bytes(),
 		)
 	default:

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -239,34 +239,43 @@ func (d *MetadataStorePostgres) GetUtxosDeletedBeforeSlot(
 func addressWhereClause(
 	db *gorm.DB,
 	addr lcommon.Address,
-) *gorm.DB {
+) (*gorm.DB, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	hasPayment := addr.PaymentKeyHash() != zeroHash
 	hasStake := addr.StakeKeyHash() != zeroHash
+	paymentScript := models.PaymentScriptFromAddress(addr)
 
 	switch {
 	case hasPayment && hasStake:
-		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
+		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, fmt.Errorf("derive stake credential tag from address")
+		}
 		return db.Where(
-			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
+			"payment_script = ? AND payment_key = ? AND credential_tag = ? AND staking_key = ?",
+			paymentScript,
 			addr.PaymentKeyHash().Bytes(),
 			credentialTag,
 			addr.StakeKeyHash().Bytes(),
-		)
+		), nil
 	case hasPayment:
 		return db.Where(
-			"payment_key = ?",
+			"payment_script = ? AND payment_key = ?",
+			paymentScript,
 			addr.PaymentKeyHash().Bytes(),
-		)
+		), nil
 	case hasStake:
-		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
+		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, fmt.Errorf("derive stake credential tag from address")
+		}
 		return db.Where(
 			"credential_tag = ? AND staking_key = ?",
 			credentialTag,
 			addr.StakeKeyHash().Bytes(),
-		)
+		), nil
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
@@ -280,7 +289,10 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery := addressWhereClause(db, addr)
+	addrQuery, err := addressWhereClause(db, addr)
+	if err != nil {
+		return nil, err
+	}
 	if addrQuery == nil {
 		return ret, nil
 	}
@@ -325,7 +337,12 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 		var ors []string
 		var args []any
 		for i := range addrs {
-			models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i])
+			if err := models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i]); err != nil {
+				return nil, fmt.Errorf(
+					"GetUtxosByAddressWithOrdering: %w",
+					err,
+				)
+			}
 		}
 		if len(ors) == 0 {
 			base = base.Where("1 = 0")
@@ -437,7 +454,10 @@ func (d *MetadataStorePostgres) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery := addressWhereClause(db, addr)
+	addrQuery, err := addressWhereClause(db, addr)
+	if err != nil {
+		return nil, err
+	}
 	if addrQuery == nil {
 		return ret, nil
 	}

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -249,7 +249,7 @@ func addressWhereClause(
 	case hasPayment && hasStake:
 		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, fmt.Errorf("derive stake credential tag from address")
+			return nil, errors.New("derive stake credential tag from address")
 		}
 		return db.Where(
 			"payment_script = ? AND payment_key = ? AND credential_tag = ? AND staking_key = ?",
@@ -267,7 +267,7 @@ func addressWhereClause(
 	case hasStake:
 		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, fmt.Errorf("derive stake credential tag from address")
+			return nil, errors.New("derive stake credential tag from address")
 		}
 		return db.Where(
 			"credential_tag = ? AND staking_key = ?",

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -83,6 +83,16 @@ func newAccountCertCache(capacity int) *accountCertCache {
 	}
 }
 
+func accountCertCacheKey(credentialTag uint8, stakingKey []byte) string {
+	if credentialTag == 0 {
+		return string(stakingKey)
+	}
+	return models.StakeCredentialRef{
+		Tag: credentialTag,
+		Key: stakingKey,
+	}.MapKey()
+}
+
 // updateReg updates the registration if this one is more recent.
 func (c *accountCertCache) updateReg(key string, rec certRecord) {
 	if !c.hasReg[key] || rec.isMoreRecent(c.latestReg[key]) {
@@ -180,18 +190,19 @@ func batchFetchStakeRegistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration t
@@ -199,14 +210,14 @@ func batchFetchStakeRegistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateReg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -220,19 +231,20 @@ func batchFetchStakeRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_registration_delegation t
@@ -240,13 +252,13 @@ func batchFetchStakeRegistrationDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			pool:       r.PoolKeyHash,
 			addedSlot:  r.AddedSlot,
@@ -266,21 +278,22 @@ func batchFetchStakeVoteRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		Drep        []byte
-		DrepType    uint64
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_vote_registration_delegation t
@@ -288,13 +301,13 @@ func batchFetchStakeVoteRegistrationDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			pool:       r.PoolKeyHash,
 			drep:       r.Drep,
@@ -326,20 +339,21 @@ func batchFetchVoteRegistrationDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		Drep       []byte
-		DrepType   uint64
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.drep, t.drep_type, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM vote_registration_delegation t
@@ -347,13 +361,13 @@ func batchFetchVoteRegistrationDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		rec := certRecord{
 			drep:       r.Drep,
 			drepType:   r.DrepType,
@@ -374,10 +388,11 @@ func batchFetchRegistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key.
@@ -386,11 +401,11 @@ func batchFetchRegistration(
 	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM registration t
@@ -398,14 +413,14 @@ func batchFetchRegistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateReg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -419,18 +434,19 @@ func batchFetchStakeDeregistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM stake_deregistration t
@@ -438,14 +454,14 @@ func batchFetchStakeDeregistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDereg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -459,18 +475,19 @@ func batchFetchDeregistration(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
+			SELECT t.credential_tag, t.staking_key, t.added_slot, c.cert_index, COALESCE(tx.block_index, 0) AS block_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, c.cert_index DESC
 				) as rn
 			FROM deregistration t
@@ -478,14 +495,14 @@ func batchFetchDeregistration(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDereg(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{addedSlot: r.AddedSlot, blockIndex: r.BlockIndex, certIndex: r.CertIndex},
 		)
 	}
@@ -499,11 +516,12 @@ func batchFetchStakeDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key.
@@ -512,11 +530,11 @@ func batchFetchStakeDelegation(
 	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_delegation t
@@ -524,14 +542,14 @@ func batchFetchStakeDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updatePoolDelegation(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{
 				pool:       r.PoolKeyHash,
 				addedSlot:  r.AddedSlot,
@@ -550,12 +568,13 @@ func batchFetchVoteDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey []byte
-		Drep       []byte
-		DrepType   uint64
-		AddedSlot  uint64
-		BlockIndex uint64
-		CertIndex  uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key.
@@ -564,11 +583,11 @@ func batchFetchVoteDelegation(
 	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.drep, t.drep_type, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.drep, t.drep_type, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM vote_delegation t
@@ -576,14 +595,14 @@ func batchFetchVoteDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
 		cache.updateDrepDelegation(
-			string(r.StakingKey),
+			accountCertCacheKey(r.CredentialTag, r.StakingKey),
 			certRecord{
 				drep:       r.Drep,
 				drepType:   r.DrepType,
@@ -603,13 +622,14 @@ func batchFetchStakeVoteDelegation(
 	cache *accountCertCache,
 ) error {
 	type result struct {
-		StakingKey  []byte
-		PoolKeyHash []byte
-		Drep        []byte
-		DrepType    uint64
-		AddedSlot   uint64
-		BlockIndex  uint64
-		CertIndex   uint32
+		CredentialTag uint8
+		StakingKey    []byte
+		PoolKeyHash   []byte
+		Drep          []byte
+		DrepType      uint64
+		AddedSlot     uint64
+		BlockIndex    uint64
+		CertIndex     uint32
 	}
 	var records []result
 	// Use ROW_NUMBER to fetch only the latest record per staking key.
@@ -618,11 +638,11 @@ func batchFetchStakeVoteDelegation(
 	// is safe because slot 0 precedes every real cert.
 	query := `
 		WITH ranked AS (
-			SELECT t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
+			SELECT t.credential_tag, t.staking_key, t.pool_key_hash, t.drep, t.drep_type, t.added_slot,
 				COALESCE(tx.block_index, 0) AS block_index,
 				COALESCE(c.cert_index, 0) AS cert_index,
 				ROW_NUMBER() OVER (
-					PARTITION BY t.staking_key
+					PARTITION BY t.credential_tag, t.staking_key
 					ORDER BY t.added_slot DESC, COALESCE(tx.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
 				) as rn
 			FROM stake_vote_delegation t
@@ -630,13 +650,13 @@ func batchFetchStakeVoteDelegation(
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE t.staking_key IN ? AND t.added_slot <= ?
 		)
-		SELECT staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
+		SELECT credential_tag, staking_key, pool_key_hash, drep, drep_type, added_slot, cert_index, block_index
 		FROM ranked WHERE rn = 1`
 	if err := db.Raw(query, stakingKeys, slot).Scan(&records).Error; err != nil {
 		return err
 	}
 	for _, r := range records {
-		key := string(r.StakingKey)
+		key := accountCertCacheKey(r.CredentialTag, r.StakingKey)
 		cache.updatePoolDelegation(
 			key,
 			certRecord{
@@ -660,8 +680,18 @@ func batchFetchStakeVoteDelegation(
 	return nil
 }
 
-// GetAccount gets an account
+// GetAccount gets an account by key credential hash.
 func (d *MetadataStoreSqlite) GetAccount(
+	stakeKey []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Account, error) {
+	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
+}
+
+// GetAccountByCredential gets an account by credential tag and hash.
+func (d *MetadataStoreSqlite) GetAccountByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	includeInactive bool,
 	txn types.Txn,
@@ -675,7 +705,12 @@ func (d *MetadataStoreSqlite) GetAccount(
 	if !includeInactive {
 		query = query.Where("active = ?", true)
 	}
-	result := query.First(ret, "staking_key = ?", stakeKey)
+	result := query.First(
+		ret,
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakeKey,
+	)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -685,22 +720,50 @@ func (d *MetadataStoreSqlite) GetAccount(
 	return ret, nil
 }
 
-// GetAccounts fetches multiple accounts in one IN-list query, keyed by
-// string(StakingKey). Stake keys with no matching row are omitted.
+// GetAccounts fetches multiple key-credential accounts.
 func (d *MetadataStoreSqlite) GetAccounts(
 	stakeKeys [][]byte,
 	includeInactive bool,
 	txn types.Txn,
 ) (map[string]*models.Account, error) {
-	ret := make(map[string]*models.Account, len(stakeKeys))
-	if len(stakeKeys) == 0 {
+	refs := make([]models.StakeCredentialRef, 0, len(stakeKeys))
+	for _, stakeKey := range stakeKeys {
+		refs = append(refs, models.StakeCredentialRef{Key: stakeKey})
+	}
+	accounts, err := d.GetAccountsByCredential(refs, includeInactive, txn)
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]*models.Account, len(accounts))
+	for _, account := range accounts {
+		ret[string(account.StakingKey)] = account
+	}
+	return ret, nil
+}
+
+// GetAccountsByCredential fetches multiple accounts in one query, keyed by
+// StakeCredentialRef.MapKey(). Credentials with no matching row are omitted.
+func (d *MetadataStoreSqlite) GetAccountsByCredential(
+	refs []models.StakeCredentialRef,
+	includeInactive bool,
+	txn types.Txn,
+) (map[string]*models.Account, error) {
+	ret := make(map[string]*models.Account, len(refs))
+	if len(refs) == 0 {
 		return ret, nil
 	}
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, err
 	}
-	query := db.Where("staking_key IN ?", stakeKeys)
+	query := db.Where("1 = 0")
+	for _, ref := range refs {
+		query = query.Or(
+			"credential_tag = ? AND staking_key = ?",
+			ref.Tag,
+			ref.Key,
+		)
+	}
 	if !includeInactive {
 		query = query.Where("active = ?", true)
 	}
@@ -709,13 +772,27 @@ func (d *MetadataStoreSqlite) GetAccounts(
 		return nil, result.Error
 	}
 	for _, row := range rows {
-		ret[string(row.StakingKey)] = row
+		ret[models.StakeCredentialRef{
+			Tag: row.CredentialTag,
+			Key: row.StakingKey,
+		}.MapKey()] = row
 	}
 	return ret, nil
 }
 
-// AddAccountReward credits a registered reward account.
+// AddAccountReward credits a registered key-credential reward account.
 func (d *MetadataStoreSqlite) AddAccountReward(
+	stakeKey []byte,
+	amount uint64,
+	slot uint64,
+	txn types.Txn,
+) error {
+	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
+}
+
+// AddAccountRewardByCredential credits a registered reward account.
+func (d *MetadataStoreSqlite) AddAccountRewardByCredential(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -738,7 +815,8 @@ func (d *MetadataStoreSqlite) AddAccountReward(
 	credit := func(tx *gorm.DB) error {
 		var account models.Account
 		if err := tx.Where(
-			"staking_key = ? AND active = ?",
+			"credential_tag = ? AND staking_key = ? AND active = ?",
+			credentialTag,
 			stakeKey,
 			true,
 		).First(&account).Error; err != nil {
@@ -764,9 +842,10 @@ func (d *MetadataStoreSqlite) AddAccountReward(
 			return models.ErrAccountNotFound
 		}
 		delta := &models.AccountRewardDelta{
-			StakingKey: stakeKey,
-			Amount:     types.Uint64(amount),
-			AddedSlot:  slot,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
+			Amount:        types.Uint64(amount),
+			AddedSlot:     slot,
 		}
 		return tx.Create(delta).Error
 	}
@@ -795,21 +874,6 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 		return err
 	}
 	withdraw := func(tx *gorm.DB) error {
-		if len(txHash) > 0 {
-			var existing models.AccountRewardDelta
-			result := tx.Where(
-				"withdrawal = ? AND tx_hash = ? AND staking_key = ?",
-				true,
-				txHash,
-				stakeKey,
-			).First(&existing)
-			if result.Error == nil {
-				return nil
-			}
-			if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-				return result.Error
-			}
-		}
 		var account models.Account
 		if err := tx.Where(
 			"staking_key = ? AND active = ?",
@@ -820,6 +884,22 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 				return models.ErrAccountNotFound
 			}
 			return err
+		}
+		if len(txHash) > 0 {
+			var existing models.AccountRewardDelta
+			result := tx.Where(
+				"withdrawal = ? AND tx_hash = ? AND credential_tag = ? AND staking_key = ?",
+				true,
+				txHash,
+				account.CredentialTag,
+				stakeKey,
+			).First(&existing)
+			if result.Error == nil {
+				return nil
+			}
+			if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+				return result.Error
+			}
 		}
 		current := uint64(account.Reward)
 		// Transaction validation proves the on-chain withdrawal amount is
@@ -833,6 +913,7 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 		}
 		delta := &models.AccountRewardDelta{
 			StakingKey:     stakeKey,
+			CredentialTag:  account.CredentialTag,
 			TxHash:         txHash,
 			Amount:         types.Uint64(amount),
 			PreviousReward: types.Uint64(current),
@@ -843,6 +924,7 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 			Columns: []clause.Column{
 				{Name: "withdrawal"},
 				{Name: "tx_hash"},
+				{Name: "credential_tag"},
 				{Name: "staking_key"},
 			},
 			DoNothing: true,
@@ -876,7 +958,8 @@ func (d *MetadataStoreSqlite) DeleteAccountRewardsAfterSlot(
 		for _, delta := range deltas {
 			var account models.Account
 			if result := tx.Where(
-				"staking_key = ?",
+				"credential_tag = ? AND staking_key = ?",
+				delta.CredentialTag,
 				delta.StakingKey,
 			).First(&account); result.Error != nil {
 				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -995,7 +1078,7 @@ func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
 
 	// Process each account using the cached certificate data
 	for _, account := range accountsToRestore {
-		key := string(account.StakingKey)
+		key := accountCertCacheKey(account.CredentialTag, account.StakingKey)
 
 		// Check if this account had any registration before the rollback slot
 		latestReg, hasReg := cache.latestReg[key], cache.hasReg[key]

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -681,15 +681,6 @@ func batchFetchStakeVoteDelegation(
 	return nil
 }
 
-// GetAccount gets an account by key credential hash.
-func (d *MetadataStoreSqlite) GetAccount(
-	stakeKey []byte,
-	includeInactive bool,
-	txn types.Txn,
-) (*models.Account, error) {
-	return d.GetAccountByCredential(0, stakeKey, includeInactive, txn)
-}
-
 // GetAccountByCredential gets an account by credential tag and hash.
 func (d *MetadataStoreSqlite) GetAccountByCredential(
 	credentialTag uint8,
@@ -717,27 +708,6 @@ func (d *MetadataStoreSqlite) GetAccountByCredential(
 			return nil, nil
 		}
 		return nil, result.Error
-	}
-	return ret, nil
-}
-
-// GetAccounts fetches multiple key-credential accounts.
-func (d *MetadataStoreSqlite) GetAccounts(
-	stakeKeys [][]byte,
-	includeInactive bool,
-	txn types.Txn,
-) (map[string]*models.Account, error) {
-	refs := make([]models.StakeCredentialRef, 0, len(stakeKeys))
-	for _, stakeKey := range stakeKeys {
-		refs = append(refs, models.StakeCredentialRef{Key: stakeKey})
-	}
-	accounts, err := d.GetAccountsByCredential(refs, includeInactive, txn)
-	if err != nil {
-		return nil, err
-	}
-	ret := make(map[string]*models.Account, len(accounts))
-	for _, account := range accounts {
-		ret[string(account.StakingKey)] = account
 	}
 	return ret, nil
 }
@@ -780,16 +750,6 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 		}
 	}
 	return ret, nil
-}
-
-// AddAccountReward credits a registered key-credential reward account.
-func (d *MetadataStoreSqlite) AddAccountReward(
-	stakeKey []byte,
-	amount uint64,
-	slot uint64,
-	txn types.Txn,
-) error {
-	return d.AddAccountRewardByCredential(0, stakeKey, amount, slot, txn)
 }
 
 // AddAccountRewardByCredential credits a registered reward account.

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -758,14 +758,16 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 	}
 	query := db.Where("1 = 0")
 	for _, ref := range refs {
+		conditions := "credential_tag = ? AND staking_key = ?"
+		args := []any{ref.Tag, ref.Key}
+		if !includeInactive {
+			conditions += " AND active = ?"
+			args = append(args, true)
+		}
 		query = query.Or(
-			"credential_tag = ? AND staking_key = ?",
-			ref.Tag,
-			ref.Key,
+			conditions,
+			args...,
 		)
-	}
-	if !includeInactive {
-		query = query.Where("active = ?", true)
 	}
 	var rows []*models.Account
 	if result := query.Find(&rows); result.Error != nil {

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -17,6 +17,7 @@ package sqlite
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -756,28 +757,31 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 	if err != nil {
 		return nil, err
 	}
-	query := db.Where("1 = 0")
+
+	wanted := make(map[string]struct{}, len(refs))
+	stakeKeys := make([][]byte, 0, len(refs))
 	for _, ref := range refs {
-		conditions := "credential_tag = ? AND staking_key = ?"
-		args := []any{ref.Tag, ref.Key}
+		wanted[ref.MapKey()] = struct{}{}
+		stakeKeys = append(stakeKeys, ref.Key)
+	}
+	for chunk := range slices.Chunk(stakeKeys, 400) {
+		query := db.Where("staking_key IN ?", chunk)
 		if !includeInactive {
-			conditions += " AND active = ?"
-			args = append(args, true)
+			query = query.Where("active = ?", true)
 		}
-		query = query.Or(
-			conditions,
-			args...,
-		)
-	}
-	var rows []*models.Account
-	if result := query.Find(&rows); result.Error != nil {
-		return nil, result.Error
-	}
-	for _, row := range rows {
-		ret[models.StakeCredentialRef{
-			Tag: row.CredentialTag,
-			Key: row.StakingKey,
-		}.MapKey()] = row
+		var rows []*models.Account
+		if result := query.Find(&rows); result.Error != nil {
+			return nil, result.Error
+		}
+		for _, row := range rows {
+			key := models.StakeCredentialRef{
+				Tag: row.CredentialTag,
+				Key: row.StakingKey,
+			}.MapKey()
+			if _, ok := wanted[key]; ok {
+				ret[key] = row
+			}
+		}
 	}
 	return ret, nil
 }

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -1008,19 +1008,21 @@ func (d *MetadataStoreSqlite) DeleteAccountRewardsAfterSlot(
 	return db.Transaction(rollback)
 }
 
-// SetAccount saves an account
+// SetAccount saves an account by full stake credential identity.
 func (d *MetadataStoreSqlite) SetAccount(
+	credentialTag uint8,
 	stakeKey, pkh, drep []byte,
 	slot uint64,
 	active bool,
 	txn types.Txn,
 ) error {
 	tmpItem := models.Account{
-		StakingKey: stakeKey,
-		AddedSlot:  slot,
-		Pool:       pkh,
-		Drep:       drep,
-		Active:     active,
+		StakingKey:    stakeKey,
+		CredentialTag: credentialTag,
+		AddedSlot:     slot,
+		Pool:          pkh,
+		Drep:          drep,
+		Active:        active,
 	}
 	onConflict := clause.OnConflict{
 		Columns: []clause.Column{

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -85,13 +85,7 @@ func newAccountCertCache(capacity int) *accountCertCache {
 }
 
 func accountCertCacheKey(credentialTag uint8, stakingKey []byte) string {
-	if credentialTag == 0 {
-		return string(stakingKey)
-	}
-	return models.StakeCredentialRef{
-		Tag: credentialTag,
-		Key: stakingKey,
-	}.MapKey()
+	return models.StakeCredentialRef{Tag: credentialTag, Key: stakingKey}.MapKey()
 }
 
 // updateReg updates the registration if this one is more recent.
@@ -126,21 +120,41 @@ func (c *accountCertCache) updateDrepDelegation(key string, rec certRecord) {
 	}
 }
 
-// batchFetchCerts fetches all relevant certificates for the given staking keys
+// batchFetchCerts fetches all relevant certificates for the given credential refs
 // at or before the given slot. Uses one query per certificate table. Chunks
 // queries to avoid exceeding SQLite bind variable limits.
+//
+// The SQL IN clause filters on staking_key hash only (not credential_tag) for
+// simplicity; the cache is post-filtered to entries whose composite (tag, hash)
+// key matches one of the input refs, so credentials sharing a 28-byte hash but
+// differing in tag are kept isolated.
 func batchFetchCerts(
 	db *gorm.DB,
-	stakingKeys [][]byte,
+	refs []models.StakeCredentialRef,
 	slot uint64,
 ) (*accountCertCache, error) {
-	cache := newAccountCertCache(len(stakingKeys))
+	cache := newAccountCertCache(len(refs))
+
+	// Build unique staking-key list for the SQL IN clause and a requested
+	// set (by composite cache key) for post-filtering.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var stakingKeys [][]byte
+	for _, ref := range refs {
+		requested[accountCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			stakingKeys = append(stakingKeys, ref.Key)
+		}
+	}
+
+	if len(stakingKeys) == 0 {
+		return cache, nil
+	}
 
 	// Process staking keys in chunks to avoid SQLite bind variable limits
-	for start := 0; start < len(stakingKeys); start += sqliteBindVarLimit {
-		end := min(start+sqliteBindVarLimit, len(stakingKeys))
-		keyChunk := stakingKeys[start:end]
-
+	for keyChunk := range slices.Chunk(stakingKeys, sqliteBindVarLimit) {
 		// Registration certificates (5 types)
 		if err := batchFetchStakeRegistration(db, keyChunk, slot, cache); err != nil {
 			return nil, err
@@ -178,6 +192,30 @@ func batchFetchCerts(
 		// DRep delegation certificates - VoteDelegation is DRep-only
 		if err := batchFetchVoteDelegation(db, keyChunk, slot, cache); err != nil {
 			return nil, err
+		}
+	}
+
+	// Remove entries for credential variants not present in the input refs.
+	for key := range cache.latestReg {
+		if _, ok := requested[key]; !ok {
+			delete(cache.latestReg, key)
+			delete(cache.hasReg, key)
+		}
+	}
+	for key := range cache.latestDereg {
+		if _, ok := requested[key]; !ok {
+			delete(cache.latestDereg, key)
+			delete(cache.hasDereg, key)
+		}
+	}
+	for key := range cache.poolDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.poolDelegation, key)
+		}
+	}
+	for key := range cache.drepDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.drepDelegation, key)
 		}
 	}
 
@@ -1033,14 +1071,14 @@ func (d *MetadataStoreSqlite) RestoreAccountStateAtSlot(
 		return nil
 	}
 
-	// Extract staking keys for batch fetching
-	stakingKeys := make([][]byte, len(accountsToRestore))
+	// Extract credential refs for batch fetching
+	refs := make([]models.StakeCredentialRef, len(accountsToRestore))
 	for i, account := range accountsToRestore {
-		stakingKeys[i] = account.StakingKey
+		refs[i] = models.NewStakeCredentialRef(account.CredentialTag, account.StakingKey)
 	}
 
 	// Batch-fetch all certificates for all affected accounts
-	cache, err := batchFetchCerts(db, stakingKeys, slot)
+	cache, err := batchFetchCerts(db, refs, slot)
 	if err != nil {
 		return err
 	}

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -758,14 +758,12 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 		return nil, err
 	}
 
-	wanted := make(map[string]struct{}, len(refs))
-	stakeKeys := make([][]byte, 0, len(refs))
+	pairs := make([][]any, 0, len(refs))
 	for _, ref := range refs {
-		wanted[ref.MapKey()] = struct{}{}
-		stakeKeys = append(stakeKeys, ref.Key)
+		pairs = append(pairs, []any{ref.Tag, ref.Key})
 	}
-	for chunk := range slices.Chunk(stakeKeys, 400) {
-		query := db.Where("staking_key IN ?", chunk)
+	for chunk := range slices.Chunk(pairs, 400) {
+		query := db.Where("(credential_tag, staking_key) IN ?", chunk)
 		if !includeInactive {
 			query = query.Where("active = ?", true)
 		}
@@ -778,9 +776,7 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 				Tag: row.CredentialTag,
 				Key: row.StakingKey,
 			}.MapKey()
-			if _, ok := wanted[key]; ok {
-				ret[key] = row
-			}
+			ret[key] = row
 		}
 	}
 	return ret, nil

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -1129,7 +1129,10 @@ func (d *MetadataStoreSqlite) ClearDanglingDRepDelegations(
 	// surprising semantics around NULL values in the subquery result.
 	liveDrepExists := db.Model(&models.Drep{}).
 		Select("1").
-		Where("drep.credential = account.drep AND drep.active = ?", true)
+		Where(
+			"drep.credential_tag = account.drep_type AND drep.credential = account.drep AND drep.active = ?",
+			true,
+		)
 	result := db.Model(&models.Account{}).
 		Where("drep IS NOT NULL").
 		Where(

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -1023,7 +1023,10 @@ func (d *MetadataStoreSqlite) SetAccount(
 		Active:     active,
 	}
 	onConflict := clause.OnConflict{
-		Columns: []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"added_slot", "pool", "drep", "active"},
 		),

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -822,6 +822,7 @@ func (d *MetadataStoreSqlite) AddAccountRewardByCredential(
 // rollback. The ledger rule clears the reward account when a withdrawal for
 // the credential appears in a valid transaction.
 func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
+	credentialTag uint8,
 	stakeKey []byte,
 	amount uint64,
 	slot uint64,
@@ -838,7 +839,8 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 	withdraw := func(tx *gorm.DB) error {
 		var account models.Account
 		if err := tx.Where(
-			"staking_key = ? AND active = ?",
+			"credential_tag = ? AND staking_key = ? AND active = ?",
+			credentialTag,
 			stakeKey,
 			true,
 		).First(&account).Error; err != nil {
@@ -853,7 +855,7 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 				"withdrawal = ? AND tx_hash = ? AND credential_tag = ? AND staking_key = ?",
 				true,
 				txHash,
-				account.CredentialTag,
+				credentialTag,
 				stakeKey,
 			).First(&existing)
 			if result.Error == nil {
@@ -875,7 +877,7 @@ func (d *MetadataStoreSqlite) ApplyAccountRewardWithdrawal(
 		}
 		delta := &models.AccountRewardDelta{
 			StakingKey:     stakeKey,
-			CredentialTag:  account.CredentialTag,
+			CredentialTag:  credentialTag,
 			TxHash:         txHash,
 			Amount:         types.Uint64(amount),
 			PreviousReward: types.Uint64(current),

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -205,6 +206,52 @@ func TestAccountHistoryQueriesAreCredentialTagAware(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, scriptRegistrationCount)
+}
+
+// TestGetStakeRegistrationsByCredentialIsTagAware verifies that certificate
+// reconstruction keeps key and script stake registrations with the same hash
+// separate and restores the correct on-chain credential type.
+func TestGetStakeRegistrationsByCredentialIsTagAware(t *testing.T) {
+	store := setupTestStore(t)
+	db := store.DB()
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xD1
+	}
+
+	require.NoError(t, db.Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		CertificateID: 2000,
+		AddedSlot:     10,
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		CertificateID: 2001,
+		AddedSlot:     20,
+	}).Error)
+
+	keyCerts, err := store.GetStakeRegistrationsByCredential(0, stakeKey, nil)
+	require.NoError(t, err)
+	require.Len(t, keyCerts, 1)
+	assert.Equal(
+		t,
+		uint(lcommon.CredentialTypeAddrKeyHash),
+		keyCerts[0].StakeCredential.CredType,
+	)
+	assert.Equal(t, stakeKey, keyCerts[0].StakeCredential.Credential.Bytes())
+
+	scriptCerts, err := store.GetStakeRegistrationsByCredential(1, stakeKey, nil)
+	require.NoError(t, err)
+	require.Len(t, scriptCerts, 1)
+	assert.Equal(
+		t,
+		uint(lcommon.CredentialTypeScriptHash),
+		scriptCerts[0].StakeCredential.CredType,
+	)
+	assert.Equal(t, stakeKey, scriptCerts[0].StakeCredential.Credential.Bytes())
 }
 
 // TestBatchFetchCerts_SameSlotTiebreakByBlockIndex pins the cert ordering

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -65,6 +65,148 @@ func TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse(t *testing.T) {
 	assert.False(t, got.Active, "returned account should have Active=false")
 }
 
+// TestAccountHistoryQueriesAreCredentialTagAware verifies that account
+// registration/delegation history queries do not merge key and script
+// credential rows that share the same 28-byte hash.
+func TestAccountHistoryQueriesAreCredentialTagAware(t *testing.T) {
+	store := setupTestStore(t)
+	db := store.DB()
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xA1
+	}
+	keyPool := make([]byte, 28)
+	for i := range keyPool {
+		keyPool[i] = 0xB1
+	}
+	scriptPool := make([]byte, 28)
+	for i := range scriptPool {
+		scriptPool[i] = 0xC1
+	}
+
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         100,
+		Hash:       []byte("tx_key_history_hash_123456789012"),
+		Slot:       10,
+		BlockIndex: 0,
+	}).Error)
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         101,
+		Hash:       []byte("tx_script_history_hash_123456789"),
+		Slot:       20,
+		BlockIndex: 0,
+	}).Error)
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            1000,
+		TransactionID: 100,
+		CertIndex:     0,
+		Slot:          10,
+		CertType:      11, // StakeRegistrationDelegation
+	}).Error)
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            1001,
+		TransactionID: 101,
+		CertIndex:     0,
+		Slot:          20,
+		CertType:      11, // StakeRegistrationDelegation
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeRegistrationDelegation{
+		ID:            1000,
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		PoolKeyHash:   keyPool,
+		CertificateID: 1000,
+		AddedSlot:     10,
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeRegistrationDelegation{
+		ID:            1001,
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		PoolKeyHash:   scriptPool,
+		CertificateID: 1001,
+		AddedSlot:     20,
+	}).Error)
+
+	keyDelegations, err := store.GetAccountDelegationHistoryByCredential(
+		0,
+		stakeKey,
+		10,
+		0,
+		"asc",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, keyDelegations, 1)
+	assert.Equal(t, keyPool, keyDelegations[0].PoolKeyHash)
+
+	scriptDelegations, err := store.GetAccountDelegationHistoryByCredential(
+		1,
+		stakeKey,
+		10,
+		0,
+		"asc",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, scriptDelegations, 1)
+	assert.Equal(t, scriptPool, scriptDelegations[0].PoolKeyHash)
+
+	keyDelegationCount, err := store.CountAccountDelegationHistoryByCredential(
+		0,
+		stakeKey,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, keyDelegationCount)
+	scriptDelegationCount, err := store.CountAccountDelegationHistoryByCredential(
+		1,
+		stakeKey,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, scriptDelegationCount)
+
+	keyRegistrations, err := store.GetAccountRegistrationHistoryByCredential(
+		0,
+		stakeKey,
+		10,
+		0,
+		"asc",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, keyRegistrations, 1)
+	assert.Equal(t, uint64(10), keyRegistrations[0].AddedSlot)
+
+	scriptRegistrations, err := store.GetAccountRegistrationHistoryByCredential(
+		1,
+		stakeKey,
+		10,
+		0,
+		"asc",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, scriptRegistrations, 1)
+	assert.Equal(t, uint64(20), scriptRegistrations[0].AddedSlot)
+
+	keyRegistrationCount, err := store.CountAccountRegistrationHistoryByCredential(
+		0,
+		stakeKey,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, keyRegistrationCount)
+	scriptRegistrationCount, err := store.CountAccountRegistrationHistoryByCredential(
+		1,
+		stakeKey,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, scriptRegistrationCount)
+}
+
 // TestBatchFetchCerts_SameSlotTiebreakByBlockIndex pins the cert ordering
 // invariant documented in CLAUDE.md: when two certs for the same staking
 // key live in the same slot but in different transactions of the same

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -144,7 +144,7 @@ func TestBatchFetchCerts_SameSlotTiebreakByBlockIndex(t *testing.T) {
 	cache, err := batchFetchCerts(db, [][]byte{stakeKey}, slot)
 	require.NoError(t, err)
 
-	rec, ok := cache.poolDelegation[string(stakeKey)]
+	rec, ok := cache.poolDelegation[accountCertCacheKey(0, stakeKey)]
 	require.True(t, ok, "expected pool delegation for staking key")
 	assert.Equal(
 		t,
@@ -239,7 +239,7 @@ func TestBatchFetchCerts_CrossTableTiebreakByBlockIndex(t *testing.T) {
 	cache, err := batchFetchCerts(db, [][]byte{stakeKey}, slot)
 	require.NoError(t, err)
 
-	rec, ok := cache.poolDelegation[string(stakeKey)]
+	rec, ok := cache.poolDelegation[accountCertCacheKey(0, stakeKey)]
 	require.True(t, ok, "expected pool delegation for staking key")
 	assert.Equal(
 		t,

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -330,7 +330,7 @@ func TestBatchFetchCerts_SameSlotTiebreakByBlockIndex(t *testing.T) {
 		AddedSlot:     slot,
 	}).Error)
 
-	cache, err := batchFetchCerts(db, [][]byte{stakeKey}, slot)
+	cache, err := batchFetchCerts(db, []models.StakeCredentialRef{{Tag: 0, Key: stakeKey}}, slot)
 	require.NoError(t, err)
 
 	rec, ok := cache.poolDelegation[accountCertCacheKey(0, stakeKey)]
@@ -425,7 +425,7 @@ func TestBatchFetchCerts_CrossTableTiebreakByBlockIndex(t *testing.T) {
 		AddedSlot:     slot,
 	}).Error)
 
-	cache, err := batchFetchCerts(db, [][]byte{stakeKey}, slot)
+	cache, err := batchFetchCerts(db, []models.StakeCredentialRef{{Tag: 0, Key: stakeKey}}, slot)
 	require.NoError(t, err)
 
 	rec, ok := cache.poolDelegation[accountCertCacheKey(0, stakeKey)]

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 // TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse pins the
-// includeInactive=false branch of GetAccount: a row with active=false must
-// not be returned. This is the semantic the
+// includeInactive=false branch of GetAccountByCredential: a row with
+// active=false must not be returned. This is the semantic the
 // queryShelleyFilteredDelegationAndRewardAccounts handler relies on when
 // it passes includeInactive=false; testing it here keeps the assertion
 // next to the SQL clause it actually tests, without forcing the ledger
@@ -55,11 +55,11 @@ func TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse(t *testing.T) {
 		Where("staking_key = ?", stakeKey).
 		Update("active", false).Error)
 
-	got, err := store.GetAccount(stakeKey, false /* includeInactive */, nil)
+	got, err := store.GetAccountByCredential(0, stakeKey, false /* includeInactive */, nil)
 	require.NoError(t, err)
 	assert.Nil(t, got, "inactive account must not be returned when includeInactive=false")
 
-	got, err = store.GetAccount(stakeKey, true /* includeInactive */, nil)
+	got, err = store.GetAccountByCredential(0, stakeKey, true /* includeInactive */, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got, "inactive account must be returned when includeInactive=true")
 	assert.False(t, got.Active, "returned account should have Active=false")

--- a/database/plugin/metadata/sqlite/bulk_sql.go
+++ b/database/plugin/metadata/sqlite/bulk_sql.go
@@ -47,13 +47,14 @@ var (
 		"ex_units_cpu", "index", "tag",
 	}
 	addressTxCols = []string{
-		"payment_key", "staking_key", "transaction_id", "slot", "tx_index",
+		"payment_key", "staking_key", "credential_tag",
+		"transaction_id", "slot", "tx_index",
 	}
 	utxoCols = []string{
 		"transaction_id", "collateral_return_for_tx_id", "tx_id",
-		"payment_key", "staking_key", "datum_hash", "spent_at_tx_id",
-		"referenced_by_tx_id", "collateral_by_tx_id", "added_slot",
-		"deleted_slot", "amount", "output_idx", "payment_script",
+		"payment_key", "staking_key", "credential_tag", "datum_hash",
+		"spent_at_tx_id", "referenced_by_tx_id", "collateral_by_tx_id",
+		"added_slot", "deleted_slot", "amount", "output_idx", "payment_script",
 	}
 	assetCols = []string{
 		"name", "name_hex", "policy_id", "fingerprint", "utxo_id", "amount",
@@ -75,8 +76,8 @@ const (
 func appendUtxoRow(dst []any, u *models.Utxo) []any {
 	return append(dst,
 		u.TransactionID, u.CollateralReturnForTxID, u.TxId,
-		u.PaymentKey, u.StakingKey, u.DatumHash, u.SpentAtTxId,
-		u.ReferencedByTxId, u.CollateralByTxId, u.AddedSlot,
+		u.PaymentKey, u.StakingKey, u.CredentialTag, u.DatumHash,
+		u.SpentAtTxId, u.ReferencedByTxId, u.CollateralByTxId, u.AddedSlot,
 		u.DeletedSlot, u.Amount, u.OutputIdx, u.PaymentScript,
 	)
 }
@@ -295,7 +296,8 @@ func insertAddressTxs(db *gorm.DB, items []models.AddressTransaction) error {
 		func(dst []any, i int) []any {
 			a := &items[i]
 			return append(dst,
-				a.PaymentKey, a.StakingKey, a.TransactionID, a.Slot, a.TxIndex,
+				a.PaymentKey, a.StakingKey, a.CredentialTag,
+				a.TransactionID, a.Slot, a.TxIndex,
 			)
 		},
 	)

--- a/database/plugin/metadata/sqlite/certs.go
+++ b/database/plugin/metadata/sqlite/certs.go
@@ -21,8 +21,10 @@ import (
 	"gorm.io/gorm"
 )
 
-// GetStakeRegistrations returns stake registration certificates
-func (d *MetadataStoreSqlite) GetStakeRegistrations(
+// GetStakeRegistrationsByCredential returns stake registration certificates
+// for a specific key/script credential tag and hash.
+func (d *MetadataStoreSqlite) GetStakeRegistrationsByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) ([]lcommon.StakeRegistrationCertificate, error) {
@@ -32,7 +34,11 @@ func (d *MetadataStoreSqlite) GetStakeRegistrations(
 	if err != nil {
 		return ret, err
 	}
-	result := db.Where("staking_key = ?", stakingKey).
+	result := db.Where(
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakingKey,
+	).
 		Order("id DESC").
 		Find(&certs)
 	if result.Error != nil {
@@ -43,14 +49,20 @@ func (d *MetadataStoreSqlite) GetStakeRegistrations(
 		tmpCert = lcommon.StakeRegistrationCertificate{
 			CertType: uint(lcommon.CertificateTypeStakeRegistration),
 			StakeCredential: lcommon.Credential{
-				// TODO: determine correct type
-				// CredType: lcommon.CredentialTypeAddrKeyHash,
+				CredType:   stakeCredentialTypeFromTag(cert.CredentialTag),
 				Credential: lcommon.CredentialHash(cert.StakingKey),
 			},
 		}
 		ret = append(ret, tmpCert)
 	}
 	return ret, nil
+}
+
+func stakeCredentialTypeFromTag(tag uint8) uint {
+	if tag == 1 {
+		return lcommon.CredentialTypeScriptHash
+	}
+	return lcommon.CredentialTypeAddrKeyHash
 }
 
 // DeleteCertificatesAfterSlot removes all certificate records added after the given slot.

--- a/database/plugin/metadata/sqlite/certs.go
+++ b/database/plugin/metadata/sqlite/certs.go
@@ -39,7 +39,9 @@ func (d *MetadataStoreSqlite) GetStakeRegistrationsByCredential(
 		credentialTag,
 		stakingKey,
 	).
-		Order("id DESC").
+		Joins("LEFT JOIN certs ON certs.id = stake_registration.certificate_id").
+		Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
+		Order(`stake_registration.added_slot DESC, COALESCE("transaction".block_index, 0) DESC, COALESCE(certs.cert_index, 0) DESC`).
 		Find(&certs)
 	if result.Error != nil {
 		return ret, result.Error

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -498,6 +498,13 @@ func (d *MetadataStoreSqlite) Start() error {
 			"governance vote credential tag index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateAccountRewardDeltaCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"account reward delta credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas (uses write connection)
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -477,6 +477,13 @@ func (d *MetadataStoreSqlite) Start() error {
 			"block_nonce unique index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateAccountCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"account credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas (uses write connection)
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -484,6 +484,20 @@ func (d *MetadataStoreSqlite) Start() error {
 			"account credential tag index migration failed: %w", err,
 		)
 	}
+	if err := models.MigrateDrepCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"drep credential tag index migration failed: %w", err,
+		)
+	}
+	if err := models.MigrateGovernanceVoteCredentialTagIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"governance vote credential tag index migration failed: %w", err,
+		)
+	}
 	// Create table schemas (uses write connection)
 	d.logger.Debug(
 		"creating table",

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -76,6 +76,13 @@ func newDrepCertCache(capacity int) *drepCertCache {
 	}
 }
 
+// drepCertCacheKey returns a composite cache key combining credential_tag and
+// credential so key-hash and script-hash DReps with the same hash are tracked
+// independently.
+func drepCertCacheKey(credentialTag uint8, credential []byte) string {
+	return string([]byte{credentialTag}) + string(credential)
+}
+
 // batchFetchDrepCerts fetches all relevant certificates for the given credentials
 // at or before the given slot. Uses one query per certificate table with JOIN
 // to get cert_index for same-slot disambiguation. Chunks queries to avoid
@@ -100,6 +107,7 @@ func batchFetchDrepCerts(
 		// orders certs within a tx.
 		type regResult struct {
 			DrepCredential []byte
+			CredentialTag  uint8
 			AddedSlot      uint64
 			BlockIndex     uint32
 			CertIndex      uint32
@@ -108,7 +116,7 @@ func batchFetchDrepCerts(
 		}
 		var regRecords []regResult
 		if err := db.Table("registration_drep").
-			Select(`registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, COALESCE("transaction".block_index, 0) AS block_index, COALESCE(certs.cert_index, 0) AS cert_index`).
+			Select(`registration_drep.credential_tag, registration_drep.drep_credential, registration_drep.added_slot, registration_drep.anchor_url, registration_drep.anchor_hash, COALESCE("transaction".block_index, 0) AS block_index, COALESCE(certs.cert_index, 0) AS cert_index`).
 			Joins("LEFT JOIN certs ON certs.id = registration_drep.certificate_id").
 			Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
 			Where("drep_credential IN ? AND registration_drep.added_slot <= ?", credChunk, slot).
@@ -116,7 +124,7 @@ func batchFetchDrepCerts(
 			return nil, err
 		}
 		for _, r := range regRecords {
-			key := string(r.DrepCredential)
+			key := drepCertCacheKey(r.CredentialTag, r.DrepCredential)
 			rec := drepCertRecord{
 				addedSlot:  r.AddedSlot,
 				blockIndex: r.BlockIndex,
@@ -133,13 +141,14 @@ func batchFetchDrepCerts(
 		// Fetch deregistration certificates with block_index + cert_index.
 		type deregResult struct {
 			DrepCredential []byte
+			CredentialTag  uint8
 			AddedSlot      uint64
 			BlockIndex     uint32
 			CertIndex      uint32
 		}
 		var deregRecords []deregResult
 		if err := db.Table("deregistration_drep").
-			Select(`deregistration_drep.drep_credential, deregistration_drep.added_slot, COALESCE("transaction".block_index, 0) AS block_index, certs.cert_index`).
+			Select(`deregistration_drep.credential_tag, deregistration_drep.drep_credential, deregistration_drep.added_slot, COALESCE("transaction".block_index, 0) AS block_index, certs.cert_index`).
 			Joins("INNER JOIN certs ON certs.id = deregistration_drep.certificate_id").
 			Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
 			Where("drep_credential IN ? AND deregistration_drep.added_slot <= ?", credChunk, slot).
@@ -147,7 +156,7 @@ func batchFetchDrepCerts(
 			return nil, err
 		}
 		for _, r := range deregRecords {
-			key := string(r.DrepCredential)
+			key := drepCertCacheKey(r.CredentialTag, r.DrepCredential)
 			rec := drepCertRecord{
 				addedSlot:  r.AddedSlot,
 				blockIndex: r.BlockIndex,
@@ -162,16 +171,17 @@ func batchFetchDrepCerts(
 
 		// Fetch update certificates with block_index + cert_index.
 		type updateResult struct {
-			Credential []byte
-			AddedSlot  uint64
-			BlockIndex uint32
-			CertIndex  uint32
-			AnchorURL  string `gorm:"column:anchor_url"`
-			AnchorHash []byte
+			Credential    []byte
+			CredentialTag uint8
+			AddedSlot     uint64
+			BlockIndex    uint32
+			CertIndex     uint32
+			AnchorURL     string `gorm:"column:anchor_url"`
+			AnchorHash    []byte
 		}
 		var updateRecords []updateResult
 		if err := db.Table("update_drep").
-			Select(`update_drep.credential, update_drep.added_slot, update_drep.anchor_url, update_drep.anchor_hash, COALESCE("transaction".block_index, 0) AS block_index, certs.cert_index`).
+			Select(`update_drep.credential_tag, update_drep.credential, update_drep.added_slot, update_drep.anchor_url, update_drep.anchor_hash, COALESCE("transaction".block_index, 0) AS block_index, certs.cert_index`).
 			Joins("INNER JOIN certs ON certs.id = update_drep.certificate_id").
 			Joins(`LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id`).
 			Where("credential IN ? AND update_drep.added_slot <= ?", credChunk, slot).
@@ -179,7 +189,7 @@ func batchFetchDrepCerts(
 			return nil, err
 		}
 		for _, r := range updateRecords {
-			key := string(r.Credential)
+			key := drepCertCacheKey(r.CredentialTag, r.Credential)
 			rec := drepCertRecord{
 				addedSlot:  r.AddedSlot,
 				blockIndex: r.BlockIndex,
@@ -197,7 +207,8 @@ func batchFetchDrepCerts(
 	return cache, nil
 }
 
-// GetDrep gets a drep
+// GetDrep gets a drep by hash only (no tag filter). Used for the protocol
+// validation path where only a Blake2b224 hash is available.
 func (d *MetadataStoreSqlite) GetDrep(
 	cred []byte,
 	includeInactive bool,
@@ -212,6 +223,34 @@ func (d *MetadataStoreSqlite) GetDrep(
 		db = db.Where("active = ?", true)
 	}
 	if result := db.First(&drep, "credential = ?", cred); result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return &drep, nil
+}
+
+// GetDrepByCredential gets a drep by the full credential identity (tag + hash).
+func (d *MetadataStoreSqlite) GetDrepByCredential(
+	credentialTag uint8,
+	cred []byte,
+	includeInactive bool,
+	txn types.Txn,
+) (*models.Drep, error) {
+	var drep models.Drep
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if !includeInactive {
+		db = db.Where("active = ?", true)
+	}
+	if result := db.First(
+		&drep,
+		"credential_tag = ? AND credential = ?",
+		credentialTag, cred,
+	); result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -261,7 +300,7 @@ func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
 			"NOT EXISTS (?)",
 			db.Model(&models.RegistrationDrep{}).
 				Select("1").
-				Where("registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
+				Where("registration_drep.credential_tag = drep.credential_tag AND registration_drep.drep_credential = drep.credential AND registration_drep.added_slot <= ?", slot),
 		)
 
 	if result := db.Where(
@@ -296,7 +335,7 @@ func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
 
 	// Process each DRep using the cached certificate data
 	for _, drep := range drepsToRestore {
-		key := string(drep.Credential)
+		key := drepCertCacheKey(drep.CredentialTag, drep.Credential)
 
 		// Get registration from cache (must exist due to Phase 1 deletion)
 		lastReg, hasRegAtSlot := cache.registration[key], cache.hasReg[key]
@@ -398,6 +437,7 @@ func (d *MetadataStoreSqlite) GetActiveDreps(
 
 // SetDrep saves a drep
 func (d *MetadataStoreSqlite) SetDrep(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -406,14 +446,18 @@ func (d *MetadataStoreSqlite) SetDrep(
 	txn types.Txn,
 ) error {
 	tmpItem := models.Drep{
-		Credential: cred,
-		AddedSlot:  slot,
-		AnchorURL:  url,
-		AnchorHash: hash,
-		Active:     active,
+		CredentialTag: credentialTag,
+		Credential:    cred,
+		AddedSlot:     slot,
+		AnchorURL:     url,
+		AnchorHash:    hash,
+		Active:        active,
 	}
 	onConflict := clause.OnConflict{
-		Columns: []clause.Column{{Name: "credential"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "credential"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"added_slot",
 			"anchor_url",
@@ -435,6 +479,7 @@ func (d *MetadataStoreSqlite) SetDrep(
 // the given credential. Existing rows are left untouched so the repair
 // path cannot clobber real registration metadata.
 func (d *MetadataStoreSqlite) InsertDrepIfAbsent(
+	credentialTag uint8,
 	cred []byte,
 	slot uint64,
 	url string,
@@ -443,11 +488,12 @@ func (d *MetadataStoreSqlite) InsertDrepIfAbsent(
 	txn types.Txn,
 ) error {
 	tmpItem := models.Drep{
-		Credential: cred,
-		AddedSlot:  slot,
-		AnchorURL:  url,
-		AnchorHash: hash,
-		Active:     active,
+		CredentialTag: credentialTag,
+		Credential:    cred,
+		AddedSlot:     slot,
+		AnchorURL:     url,
+		AnchorHash:    hash,
+		Active:        active,
 	}
 	db, err := d.resolveDB(txn)
 	if err != nil {
@@ -475,6 +521,7 @@ func (d *MetadataStoreSqlite) InsertDrepIfAbsent(
 //
 // Returns 0 if the DRep has no delegators.
 func (d *MetadataStoreSqlite) GetDRepVotingPower(
+	credentialTag uint8,
 	drepCredential []byte,
 	txn types.Txn,
 ) (uint64, error) {
@@ -497,12 +544,12 @@ func (d *MetadataStoreSqlite) GetDRepVotingPower(
 			WHERE deleted_slot = 0
 			  AND staking_key IN (
 				  SELECT staking_key FROM account
-				  WHERE drep = ? AND active = 1
+				  WHERE drep = ? AND drep_type = ? AND active = 1
 			  )
 			GROUP BY staking_key
 		) u ON u.staking_key = a.staking_key
-		WHERE a.drep = ? AND a.active = 1
-	`, drepCredential, drepCredential).Scan(&totalStake).Error; err != nil {
+		WHERE a.drep = ? AND a.drep_type = ? AND a.active = 1
+	`, drepCredential, credentialTag, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 
@@ -516,7 +563,7 @@ func (d *MetadataStoreSqlite) GetDRepVotingPower(
 // batch variant of GetDRepVotingPower and avoids N+1 queries when
 // tallying governance votes across many active DReps.
 func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
-	drepCredentials [][]byte,
+	drepCredentials []models.StakeCredentialRef,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64, len(drepCredentials))
@@ -528,23 +575,26 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 		return nil, err
 	}
 	type row struct {
-		Drep  []byte
-		Stake uint64
+		Drep     []byte
+		DrepType uint64
+		Stake    uint64
 	}
 	// Chunk credentials to stay under SQLite's default bind variable
 	// limit (SQLITE_MAX_VARIABLE_NUMBER = 999). A large active DRep
 	// set on mainnet can easily exceed this in a single IN clause.
-	for start := 0; start < len(drepCredentials); start += sqliteBindVarLimit {
-		end := min(start+sqliteBindVarLimit, len(drepCredentials))
-		chunk := drepCredentials[start:end]
+	// Build separate hash and type slices for the IN clauses.
+	hashes := make([][]byte, len(drepCredentials))
+	for i, ref := range drepCredentials {
+		hashes[i] = ref.Key
+	}
+	for start := 0; start < len(hashes); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(hashes))
+		chunk := hashes[start:end]
 		var rows []row
-		// Aggregate UTxO amounts per staking_key in a subquery before
-		// adding account.reward, otherwise the LEFT JOIN would multiply
-		// the per-account reward by the number of live UTxOs and inflate
-		// the totals. Each account contributes (utxo_sum + reward) once
-		// to its DRep bucket.
+		// Aggregate UTxO amounts per (staking_key, drep_type) before
+		// adding account.reward to avoid fan-out from the LEFT JOIN.
 		if err := db.Raw(`
-			SELECT a.drep AS drep,
+			SELECT a.drep AS drep, a.drep_type AS drep_type,
 				   COALESCE(SUM(
 					   COALESCE(u.utxo_sum, 0)
 					   + COALESCE(CAST(a.reward AS INTEGER), 0)
@@ -562,12 +612,13 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 				GROUP BY staking_key
 			) u ON u.staking_key = a.staking_key
 			WHERE a.active = 1 AND a.drep IN ?
-			GROUP BY a.drep
+			GROUP BY a.drep, a.drep_type
 		`, chunk, chunk).Scan(&rows).Error; err != nil {
 			return nil, fmt.Errorf("get drep voting power batch: %w", err)
 		}
 		for _, r := range rows {
-			out[string(r.Drep)] = r.Stake
+			ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+			out[ref.MapKey()] = r.Stake
 		}
 	}
 	return out, nil
@@ -634,6 +685,7 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerByType(
 // registration. The expiryEpoch is set to activityEpoch + inactivityPeriod.
 // Returns ErrDrepActivityNotUpdated if no matching DRep record was found.
 func (d *MetadataStoreSqlite) UpdateDRepActivity(
+	credentialTag uint8,
 	drepCredential []byte,
 	activityEpoch uint64,
 	inactivityPeriod uint64,
@@ -645,7 +697,7 @@ func (d *MetadataStoreSqlite) UpdateDRepActivity(
 	}
 	expiryEpoch := activityEpoch + inactivityPeriod
 	result := db.Model(&models.Drep{}).
-		Where("credential = ?", drepCredential).
+		Where("credential_tag = ? AND credential = ?", credentialTag, drepCredential).
 		Updates(map[string]any{
 			"last_activity_epoch": activityEpoch,
 			"expiry_epoch":        expiryEpoch,

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -538,16 +538,19 @@ func (d *MetadataStoreSqlite) GetDRepVotingPower(
 			   ), 0)
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE drep = ? AND drep_type = ? AND active = 1
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.drep = ? AND ax.drep_type = ? AND ax.active = 1
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.drep = ? AND a.drep_type = ? AND a.active = 1
 	`, drepCredential, credentialTag, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
@@ -584,8 +587,10 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 	// set on mainnet can easily exceed this in a single IN clause.
 	// Build separate hash and type slices for the IN clauses.
 	hashes := make([][]byte, len(drepCredentials))
+	requested := make(map[string]struct{}, len(drepCredentials))
 	for i, ref := range drepCredentials {
 		hashes[i] = ref.Key
+		requested[ref.MapKey()] = struct{}{}
 	}
 	for start := 0; start < len(hashes); start += sqliteBindVarLimit {
 		end := min(start+sqliteBindVarLimit, len(hashes))
@@ -601,16 +606,19 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 				   ), 0) AS stake
 			FROM account a
 			LEFT JOIN (
-				SELECT staking_key,
+				SELECT credential_tag, staking_key,
 					   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
 				FROM utxo
 				WHERE deleted_slot = 0
-				  AND staking_key IN (
-					  SELECT staking_key FROM account
-					  WHERE active = 1 AND drep IN ?
+				  AND EXISTS (
+					  SELECT 1 FROM account ax
+					  WHERE ax.credential_tag = utxo.credential_tag
+					    AND ax.staking_key = utxo.staking_key
+					    AND ax.active = 1 AND ax.drep IN ?
 				  )
-				GROUP BY staking_key
-			) u ON u.staking_key = a.staking_key
+				GROUP BY credential_tag, staking_key
+			) u ON u.credential_tag = a.credential_tag
+				AND u.staking_key = a.staking_key
 			WHERE a.active = 1 AND a.drep IN ?
 			GROUP BY a.drep, a.drep_type
 		`, chunk, chunk).Scan(&rows).Error; err != nil {
@@ -618,6 +626,9 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 		}
 		for _, r := range rows {
 			ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+			if _, ok := requested[ref.MapKey()]; !ok {
+				continue
+			}
 			out[ref.MapKey()] = r.Stake
 		}
 	}
@@ -659,16 +670,19 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerByType(
 			   ), 0) AS stake
 		FROM account a
 		LEFT JOIN (
-			SELECT staking_key,
+			SELECT credential_tag, staking_key,
 				   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
 			FROM utxo
 			WHERE deleted_slot = 0
-			  AND staking_key IN (
-				  SELECT staking_key FROM account
-				  WHERE active = 1 AND drep_type IN ?
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.active = 1 AND ax.drep_type IN ?
 			  )
-			GROUP BY staking_key
-		) u ON u.staking_key = a.staking_key
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
 		WHERE a.active = 1 AND a.drep_type IN ?
 		GROUP BY a.drep_type
 	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -649,20 +649,17 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 				   ), 0) AS stake
 			FROM account a
 			LEFT JOIN (
-				SELECT credential_tag, staking_key,
-					   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
-				FROM utxo
-				WHERE deleted_slot = 0
-				  AND EXISTS (
-					  SELECT 1 FROM account ax
-					  WHERE ax.credential_tag = utxo.credential_tag
-					    AND ax.staking_key = utxo.staking_key
-					    AND ax.active = 1 AND ax.drep IN ?
-					    AND ax.drep_type = a.drep_type
-				  )
-				GROUP BY credential_tag, staking_key
+				SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
+					   COALESCE(SUM(CAST(utxo.amount AS INTEGER)), 0) AS utxo_sum
+				FROM account ax
+				JOIN utxo ON utxo.credential_tag = ax.credential_tag
+				         AND utxo.staking_key = ax.staking_key
+				         AND utxo.deleted_slot = 0
+				WHERE ax.active = 1 AND ax.drep IN ?
+				GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
 			) u ON u.credential_tag = a.credential_tag
 				AND u.staking_key = a.staking_key
+				AND u.drep_type = a.drep_type
 			WHERE a.active = 1 AND a.drep IN ?
 			GROUP BY a.drep, a.drep_type
 		`, chunk, chunk).Scan(&rows).Error; err != nil {

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -658,6 +658,7 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 					  WHERE ax.credential_tag = utxo.credential_tag
 					    AND ax.staking_key = utxo.staking_key
 					    AND ax.active = 1 AND ax.drep IN ?
+					    AND ax.drep_type = a.drep_type
 				  )
 				GROUP BY credential_tag, staking_key
 			) u ON u.credential_tag = a.credential_tag

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -83,16 +83,39 @@ func drepCertCacheKey(credentialTag uint8, credential []byte) string {
 	return string([]byte{credentialTag}) + string(credential)
 }
 
-// batchFetchDrepCerts fetches all relevant certificates for the given credentials
+// batchFetchDrepCerts fetches all relevant certificates for the given credential refs
 // at or before the given slot. Uses one query per certificate table with JOIN
 // to get cert_index for same-slot disambiguation. Chunks queries to avoid
 // exceeding SQLite bind variable limits.
+//
+// The SQL IN clause filters on staking_key hash only (not credential_tag) for
+// simplicity; the cache is post-filtered to entries whose composite (tag, hash)
+// key matches one of the input refs, so credentials sharing a 28-byte hash but
+// differing in tag are kept isolated.
 func batchFetchDrepCerts(
 	db *gorm.DB,
-	credentials [][]byte,
+	refs []models.StakeCredentialRef,
 	slot uint64,
 ) (*drepCertCache, error) {
-	cache := newDrepCertCache(len(credentials))
+	cache := newDrepCertCache(len(refs))
+
+	// Build unique credential list for the SQL IN clause and a requested
+	// set (by composite cache key) for post-filtering.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var credentials [][]byte
+	for _, ref := range refs {
+		requested[drepCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			credentials = append(credentials, ref.Key)
+		}
+	}
+
+	if len(credentials) == 0 {
+		return cache, nil
+	}
 
 	// Process credentials in chunks to avoid SQLite bind variable limits
 	for start := 0; start < len(credentials); start += sqliteBindVarLimit {
@@ -201,6 +224,26 @@ func batchFetchDrepCerts(
 				cache.update[key] = rec
 				cache.hasUpdate[key] = true
 			}
+		}
+	}
+
+	// Remove entries for DRep credential variants not present in the input refs.
+	for key := range cache.registration {
+		if _, ok := requested[key]; !ok {
+			delete(cache.registration, key)
+			delete(cache.hasReg, key)
+		}
+	}
+	for key := range cache.deregistration {
+		if _, ok := requested[key]; !ok {
+			delete(cache.deregistration, key)
+			delete(cache.hasDereg, key)
+		}
+	}
+	for key := range cache.update {
+		if _, ok := requested[key]; !ok {
+			delete(cache.update, key)
+			delete(cache.hasUpdate, key)
 		}
 	}
 
@@ -321,14 +364,14 @@ func (d *MetadataStoreSqlite) RestoreDrepStateAtSlot(
 		return nil
 	}
 
-	// Extract credentials for batch fetching
-	credentials := make([][]byte, len(drepsToRestore))
+	// Extract credential refs for batch fetching
+	drepRefs := make([]models.StakeCredentialRef, len(drepsToRestore))
 	for i, drep := range drepsToRestore {
-		credentials[i] = drep.Credential
+		drepRefs[i] = models.NewStakeCredentialRef(drep.CredentialTag, drep.Credential)
 	}
 
 	// Batch-fetch all certificates for all affected DReps
-	cache, err := batchFetchDrepCerts(db, credentials, slot)
+	cache, err := batchFetchDrepCerts(db, drepRefs, slot)
 	if err != nil {
 		return err
 	}
@@ -578,9 +621,9 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 		return nil, err
 	}
 	type row struct {
-		Drep     []byte
-		DrepType uint64
-		Stake    uint64
+		Drep          []byte
+		CredentialTag uint64
+		Stake         uint64
 	}
 	// Chunk credentials to stay under SQLite's default bind variable
 	// limit (SQLITE_MAX_VARIABLE_NUMBER = 999). A large active DRep
@@ -599,7 +642,7 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 		// Aggregate UTxO amounts per (staking_key, drep_type) before
 		// adding account.reward to avoid fan-out from the LEFT JOIN.
 		if err := db.Raw(`
-			SELECT a.drep AS drep, a.drep_type AS drep_type,
+			SELECT a.drep AS drep, a.drep_type AS credential_tag,
 				   COALESCE(SUM(
 					   COALESCE(u.utxo_sum, 0)
 					   + COALESCE(CAST(a.reward AS INTEGER), 0)
@@ -625,7 +668,13 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 			return nil, fmt.Errorf("get drep voting power batch: %w", err)
 		}
 		for _, r := range rows {
-			ref := models.StakeCredentialRef{Tag: uint8(r.DrepType), Key: r.Drep} //nolint:gosec
+			// account.drep_type 0=key and 1=script align with credential_tag values
+			// by protocol spec; types ≥2 (ALWAYS_ABSTAIN, ALWAYS_NO_CONFIDENCE)
+			// carry no credential hash and are never in the requested map.
+			if r.CredentialTag > 1 {
+				continue
+			}
+			ref := models.StakeCredentialRef{Tag: uint8(r.CredentialTag), Key: r.Drep}
 			if _, ok := requested[ref.MapKey()]; !ok {
 				continue
 			}

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -155,6 +155,112 @@ func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testin
 	assert.Equal(t, uint64(1200), powers[models.StakeCredentialRef{Tag: 0, Key: drepCred}.MapKey()])
 }
 
+// Voting power must aggregate UTxOs by the full stake credential identity.
+// Same-hash key/script stake accounts must not share UTxO sums.
+func TestSqliteGetDRepVotingPowerUsesStakeCredentialTag(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	drepCred := []byte("drep_same_stake_hash_123456789012345")
+	stakeKey := []byte("same_stake_hash_123456789012345678")
+
+	require.NoError(t, store.SetDrep(0, drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Drep:          drepCred,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		Reward:        10,
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Drep:          drepCred,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		Reward:        20,
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:          []byte("tx_same_hash_key_12345678901234567890"),
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Amount:        100,
+		OutputIdx:     0,
+		AddedSlot:     1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:          []byte("tx_same_hash_script_12345678901234567"),
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Amount:        200,
+		OutputIdx:     1,
+		AddedSlot:     1000,
+	}).Error)
+
+	power, err := store.GetDRepVotingPower(0, drepCred, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(330), power)
+
+	powers, err := store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(330), powers[models.StakeCredentialRef{Tag: 0, Key: drepCred}.MapKey()])
+}
+
+// Predefined DRep voting power uses account drep_type instead of DRep hash.
+// It must still join UTxOs by (credential_tag, staking_key), not hash only.
+func TestSqliteGetDRepVotingPowerByTypeUsesStakeCredentialTag(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	stakeKey := []byte("same_predefined_hash_1234567890123")
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		DrepType:      models.DrepTypeAlwaysAbstain,
+		Reward:        10,
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		DrepType:      models.DrepTypeAlwaysAbstain,
+		Reward:        20,
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:          []byte("tx_predefined_key_123456789012345678"),
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Amount:        100,
+		OutputIdx:     0,
+		AddedSlot:     1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:          []byte("tx_predefined_script_123456789012345"),
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Amount:        200,
+		OutputIdx:     1,
+		AddedSlot:     1000,
+	}).Error)
+
+	powers, err := store.GetDRepVotingPowerByType(
+		[]uint64{models.DrepTypeAlwaysAbstain},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(330), powers[models.DrepTypeAlwaysAbstain])
+}
+
 func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {
 	t.Parallel()
 	store := setupTestStore(t)

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -30,7 +30,7 @@ func TestSqliteGetDRepVotingPowerIncludesReward(t *testing.T) {
 	rewardOnlyStake := []byte("stake_reward_only_123456789012345678901")
 	multiUtxoStake := []byte("stake_multi_utxo_123456789012345678901234")
 
-	require.NoError(t, store.SetDrep(drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(0, drepCred, 1000, "", nil, true, nil))
 	require.NoError(t, store.DB().Create(&models.Account{
 		StakingKey: rewardOnlyStake,
 		Drep:       drepCred,
@@ -60,7 +60,7 @@ func TestSqliteGetDRepVotingPowerIncludesReward(t *testing.T) {
 		AddedSlot:  1000,
 	}).Error)
 
-	power, err := store.GetDRepVotingPower(drepCred, nil)
+	power, err := store.GetDRepVotingPower(0, drepCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1700), power)
 }
@@ -74,8 +74,8 @@ func TestSqliteGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	multiUtxoCred := []byte("drep_multi_utxo_1234567890123456789012345")
 	multiUtxoStake := []byte("stake_multi_utxo_223456789012345678901234")
 
-	require.NoError(t, store.SetDrep(rewardOnlyCred, 1000, "", nil, true, nil))
-	require.NoError(t, store.SetDrep(multiUtxoCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(0, rewardOnlyCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(0, multiUtxoCred, 1000, "", nil, true, nil))
 	require.NoError(t, store.DB().Create(&models.Account{
 		StakingKey: rewardOnlyStake,
 		Drep:       rewardOnlyCred,
@@ -106,12 +106,15 @@ func TestSqliteGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	}).Error)
 
 	powers, err := store.GetDRepVotingPowerBatch(
-		[][]byte{rewardOnlyCred, multiUtxoCred},
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: rewardOnlyCred},
+			{Tag: 0, Key: multiUtxoCred},
+		},
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(700), powers[string(rewardOnlyCred)])
-	assert.Equal(t, uint64(1000), powers[string(multiUtxoCred)])
+	assert.Equal(t, uint64(700), powers[models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey()])
+	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
 }
 
 func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testing.T) {
@@ -121,7 +124,7 @@ func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testin
 	drepCred := []byte("drep_multi_reward_12345678901234567890123")
 	stakeKey := []byte("stake_multi_reward_1234567890123456789012")
 
-	require.NoError(t, store.SetDrep(drepCred, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(0, drepCred, 1000, "", nil, true, nil))
 	require.NoError(t, store.DB().Create(&models.Account{
 		StakingKey: stakeKey,
 		Drep:       drepCred,
@@ -144,9 +147,12 @@ func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testin
 		AddedSlot:  1000,
 	}).Error)
 
-	powers, err := store.GetDRepVotingPowerBatch([][]byte{drepCred}, nil)
+	powers, err := store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		nil,
+	)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1200), powers[string(drepCred)])
+	assert.Equal(t, uint64(1200), powers[models.StakeCredentialRef{Tag: 0, Key: drepCred}.MapKey()])
 }
 
 func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {
@@ -156,7 +162,7 @@ func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {
 	cred := []byte("drep_insert_absent_1234567890123456789012")
 	require.NoError(
 		t,
-		store.InsertDrepIfAbsent(cred, 1500, "", nil, true, nil),
+		store.InsertDrepIfAbsent(0, cred, 1500, "", nil, true, nil),
 	)
 
 	drep, err := store.GetDrep(cred, true, nil)
@@ -177,13 +183,13 @@ func TestSqliteInsertDrepIfAbsentLeavesExistingRowUntouched(t *testing.T) {
 	anchorHash := []byte("anchor_hash_1234567890123456789012345678")
 	require.NoError(
 		t,
-		store.SetDrep(cred, 1000, anchorURL, anchorHash, true, nil),
+		store.SetDrep(0, cred, 1000, anchorURL, anchorHash, true, nil),
 	)
 
 	// Attempt repair with placeholder values at a later slot — must be a no-op.
 	require.NoError(
 		t,
-		store.InsertDrepIfAbsent(cred, 9999, "", nil, true, nil),
+		store.InsertDrepIfAbsent(0, cred, 9999, "", nil, true, nil),
 	)
 
 	drep, err := store.GetDrep(cred, true, nil)
@@ -193,4 +199,60 @@ func TestSqliteInsertDrepIfAbsentLeavesExistingRowUntouched(t *testing.T) {
 	assert.Equal(t, anchorURL, drep.AnchorURL)
 	assert.Equal(t, anchorHash, drep.AnchorHash)
 	assert.True(t, drep.Active)
+}
+
+// Import must treat credential_tag as part of the DRep identity.
+// This keeps key-hash and script-hash DReps with the same hash as separate rows.
+func TestSqliteImportDrepUsesCredentialTagInConflictKeys(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	cred := []byte("same_hash_drep_12345678901234")
+
+	require.NoError(t, store.ImportDrep(
+		&models.Drep{
+			CredentialTag: 0,
+			Credential:    cred,
+			AddedSlot:     100,
+			AnchorURL:     "https://key.example/drep.json",
+			Active:        true,
+		},
+		&models.RegistrationDrep{
+			CredentialTag:  0,
+			DrepCredential: cred,
+			AddedSlot:      100,
+		},
+		nil,
+	))
+	require.NoError(t, store.ImportDrep(
+		&models.Drep{
+			CredentialTag: 1,
+			Credential:    cred,
+			AddedSlot:     100,
+			AnchorURL:     "https://script.example/drep.json",
+			Active:        true,
+		},
+		&models.RegistrationDrep{
+			CredentialTag:  1,
+			DrepCredential: cred,
+			AddedSlot:      100,
+		},
+		nil,
+	))
+
+	keyDrep, err := store.GetDrepByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, keyDrep)
+	assert.Equal(t, "https://key.example/drep.json", keyDrep.AnchorURL)
+
+	scriptDrep, err := store.GetDrepByCredential(1, cred, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, scriptDrep)
+	assert.Equal(t, "https://script.example/drep.json", scriptDrep.AnchorURL)
+
+	var regCount int64
+	require.NoError(t, store.DB().Model(&models.RegistrationDrep{}).
+		Where("drep_credential = ? AND added_slot = ?", cred, 100).
+		Count(&regCount).Error)
+	assert.Equal(t, int64(2), regCount)
 }

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -259,6 +260,70 @@ func TestSqliteGetDRepVotingPowerByTypeUsesStakeCredentialTag(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(330), powers[models.DrepTypeAlwaysAbstain])
+}
+
+// TestSqliteGetDRepVotingPowerCrossTagIsolation verifies that key-hash and
+// script-hash DReps sharing the same 28-byte credential hash are treated as
+// independent identities. GetDRepVotingPower and GetDRepVotingPowerBatch must
+// only aggregate stake delegated to the exact (tag, hash) pair requested.
+func TestSqliteGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	// One 28-byte hash, two DRep identities.
+	sharedHash := bytes.Repeat([]byte{0x01}, 28)
+
+	// Register both DReps.
+	require.NoError(t, store.SetDrep(0, sharedHash, 1000, "", nil, true, nil))
+	require.NoError(t, store.SetDrep(1, sharedHash, 1000, "", nil, true, nil))
+
+	// Account delegated to key-hash DRep (tag=0).
+	keyStake := []byte("key_stake_123456789012345678901234567")
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    keyStake,
+		CredentialTag: 0,
+		Drep:          sharedHash,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		Reward:        100,
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+
+	// Account delegated to script-hash DRep (tag=1).
+	scriptStake := []byte("script_stake_1234567890123456789012345")
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    scriptStake,
+		CredentialTag: 1,
+		Drep:          sharedHash,
+		DrepType:      models.DrepTypeScriptHash,
+		Reward:        200,
+		Active:        true,
+		AddedSlot:     1000,
+	}).Error)
+
+	// GetDRepVotingPower for key-hash DRep must only see the key account (100).
+	keyPower, err := store.GetDRepVotingPower(0, sharedHash, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), keyPower, "key-hash DRep power should be 100")
+
+	// GetDRepVotingPower for script-hash DRep must only see the script account (200).
+	scriptPower, err := store.GetDRepVotingPower(1, sharedHash, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(200), scriptPower, "script-hash DRep power should be 200")
+
+	// GetDRepVotingPowerBatch must return correct isolated values for both.
+	powers, err := store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: sharedHash},
+			{Tag: 1, Key: sharedHash},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), powers[models.StakeCredentialRef{Tag: 0, Key: sharedHash}.MapKey()],
+		"batch: key-hash DRep power should be 100")
+	assert.Equal(t, uint64(200), powers[models.StakeCredentialRef{Tag: 1, Key: sharedHash}.MapKey()],
+		"batch: script-hash DRep power should be 200")
 }
 
 func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -531,7 +531,7 @@ func TestSqliteRollbackPreservesGenesisVoteOnlyAccount(t *testing.T) {
 	// Rollback to slot 200: the genesis-rooted account must remain.
 	require.NoError(t, store.RestoreAccountStateAtSlot(200, nil))
 
-	restored, err := store.GetAccount(stakeCred.Credential[:], true, nil)
+	restored, err := store.GetAccountByCredential(0, stakeCred.Credential[:], true, nil)
 	require.NoError(t, err)
 	require.NotNil(t,
 		restored,
@@ -600,7 +600,7 @@ func TestSqliteRollbackPreservesGenesisStakeVoteAccount(t *testing.T) {
 	// with both pool and DRep restored to their genesis values.
 	require.NoError(t, store.RestoreAccountStateAtSlot(200, nil))
 
-	restored, err := store.GetAccount(stakeCred.Credential[:], true, nil)
+	restored, err := store.GetAccountByCredential(0, stakeCred.Credential[:], true, nil)
 	require.NoError(t, err)
 	require.NotNil(t,
 		restored,
@@ -751,7 +751,7 @@ func TestRollbackPicksLatestByBlockIndexAtSameSlot(t *testing.T) {
 	// block_index).
 	require.NoError(t, store.RestoreAccountStateAtSlot(200, nil))
 
-	restored, err := store.GetAccount(stakeKey, true, nil)
+	restored, err := store.GetAccountByCredential(0, stakeKey, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, restored)
 	assert.Equal(t, drepLate, restored.Drep,

--- a/database/plugin/metadata/sqlite/governance.go
+++ b/database/plugin/metadata/sqlite/governance.go
@@ -306,6 +306,7 @@ func (d *MetadataStoreSqlite) SetGovernanceVote(
 		Columns: []clause.Column{
 			{Name: "proposal_id"},
 			{Name: "voter_type"},
+			{Name: "voter_credential_tag"},
 			{Name: "voter_credential"},
 		},
 		// Note: added_slot is NOT updated on conflict to preserve rollback safety.

--- a/database/plugin/metadata/sqlite/governance_test.go
+++ b/database/plugin/metadata/sqlite/governance_test.go
@@ -35,6 +35,43 @@ func setupTestStore(t *testing.T) *MetadataStoreSqlite {
 	return store
 }
 
+func TestSetGovernanceVoteUsesCredentialTagInConflictKey(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	cred := []byte("same_hash_drep_vote_12345678")
+	slot := uint64(100)
+	require.NoError(t, store.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:         1,
+		VoterType:          models.VoterTypeDRep,
+		VoterCredentialTag: 0,
+		VoterCredential:    cred,
+		Vote:               models.VoteYes,
+		AddedSlot:          slot,
+		VoteUpdatedSlot:    &slot,
+	}, nil))
+	require.NoError(t, store.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:         1,
+		VoterType:          models.VoterTypeDRep,
+		VoterCredentialTag: 1,
+		VoterCredential:    cred,
+		Vote:               models.VoteNo,
+		AddedSlot:          slot,
+		VoteUpdatedSlot:    &slot,
+	}, nil))
+
+	votes, err := store.GetGovernanceVotes(1, nil)
+	require.NoError(t, err)
+	require.Len(t, votes, 2)
+
+	voteByTag := map[uint8]uint8{}
+	for _, vote := range votes {
+		voteByTag[vote.VoterCredentialTag] = vote.Vote
+	}
+	assert.Equal(t, uint8(models.VoteYes), voteByTag[0])
+	assert.Equal(t, uint8(models.VoteNo), voteByTag[1])
+}
+
 func TestGetConstitution(t *testing.T) {
 	t.Parallel()
 	store := setupTestStore(t)
@@ -269,6 +306,7 @@ func TestGetActiveDreps(t *testing.T) {
 
 	// Add an active DRep
 	err = store.SetDrep(
+		0,
 		[]byte("drep_credential_1234567890123456789012345a"),
 		1000,
 		"https://drep1.example.com",
@@ -280,6 +318,7 @@ func TestGetActiveDreps(t *testing.T) {
 
 	// Add another active DRep
 	err = store.SetDrep(
+		0,
 		[]byte("drep_credential_1234567890123456789012345b"),
 		2000,
 		"https://drep2.example.com",
@@ -330,6 +369,7 @@ func TestGetDrep(t *testing.T) {
 
 	// Add an active DRep
 	err = store.SetDrep(
+		0,
 		cred,
 		1000,
 		"https://drep.example.com",
@@ -763,7 +803,7 @@ func TestUpdateDRepActivity(t *testing.T) {
 	cred := []byte("drep_credential_1234567890123456789012345a")
 
 	// Create a DRep
-	err := store.SetDrep(cred, 1000, "https://drep.example.com",
+	err := store.SetDrep(0, cred, 1000, "https://drep.example.com",
 		[]byte("anchor_hash_1234567890123456789012"), true, nil)
 	require.NoError(t, err)
 
@@ -775,7 +815,7 @@ func TestUpdateDRepActivity(t *testing.T) {
 	assert.Equal(t, uint64(0), drep.ExpiryEpoch)
 
 	// Update activity at epoch 100 with inactivity period of 20
-	err = store.UpdateDRepActivity(cred, 100, 20, nil)
+	err = store.UpdateDRepActivity(0, cred, 100, 20, nil)
 	require.NoError(t, err)
 
 	// Verify activity was updated
@@ -786,7 +826,7 @@ func TestUpdateDRepActivity(t *testing.T) {
 	assert.Equal(t, uint64(120), drep.ExpiryEpoch)
 
 	// Update activity again at epoch 110
-	err = store.UpdateDRepActivity(cred, 110, 20, nil)
+	err = store.UpdateDRepActivity(0, cred, 110, 20, nil)
 	require.NoError(t, err)
 
 	drep, err = store.GetDrep(cred, false, nil)
@@ -797,6 +837,7 @@ func TestUpdateDRepActivity(t *testing.T) {
 
 	// Updating a non-existent DRep should return an error
 	err = store.UpdateDRepActivity(
+		0,
 		[]byte("nonexistent_credential_1234567890123456"),
 		200,
 		20,
@@ -814,19 +855,19 @@ func TestGetExpiredDReps(t *testing.T) {
 	credC := []byte("drep_credential_1234567890123456789012345c")
 
 	// Create three DReps
-	err := store.SetDrep(credA, 1000, "", nil, true, nil)
+	err := store.SetDrep(0, credA, 1000, "", nil, true, nil)
 	require.NoError(t, err)
-	err = store.SetDrep(credB, 1000, "", nil, true, nil)
+	err = store.SetDrep(0, credB, 1000, "", nil, true, nil)
 	require.NoError(t, err)
-	err = store.SetDrep(credC, 1000, "", nil, true, nil)
+	err = store.SetDrep(0, credC, 1000, "", nil, true, nil)
 	require.NoError(t, err)
 
 	// Set activity: A expires at epoch 120, B at 130, C at 150
-	err = store.UpdateDRepActivity(credA, 100, 20, nil)
+	err = store.UpdateDRepActivity(0, credA, 100, 20, nil)
 	require.NoError(t, err)
-	err = store.UpdateDRepActivity(credB, 110, 20, nil)
+	err = store.UpdateDRepActivity(0, credB, 110, 20, nil)
 	require.NoError(t, err)
-	err = store.UpdateDRepActivity(credC, 130, 20, nil)
+	err = store.UpdateDRepActivity(0, credC, 130, 20, nil)
 	require.NoError(t, err)
 
 	// At epoch 119: no DReps expired
@@ -858,11 +899,11 @@ func TestGetDRepVotingPower(t *testing.T) {
 	drepCred := []byte("drep_credential_1234567890123456789012345a")
 
 	// Create a DRep
-	err := store.SetDrep(drepCred, 1000, "", nil, true, nil)
+	err := store.SetDrep(0, drepCred, 1000, "", nil, true, nil)
 	require.NoError(t, err)
 
 	// No delegators = zero voting power
-	power, err := store.GetDRepVotingPower(drepCred, nil)
+	power, err := store.GetDRepVotingPower(0, drepCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), power)
 
@@ -926,7 +967,7 @@ func TestGetDRepVotingPower(t *testing.T) {
 	require.NoError(t, result.Error)
 
 	// Voting power should be 5M + 3M + 2M = 10M
-	power, err = store.GetDRepVotingPower(drepCred, nil)
+	power, err = store.GetDRepVotingPower(0, drepCred, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(10000000), power)
 }

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -354,7 +354,10 @@ func (d *MetadataStoreSqlite) ImportDrep(
 
 	// Upsert the DRep record
 	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "credential"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "credential"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"anchor_url", "anchor_hash", "active",
 		}),
@@ -366,7 +369,9 @@ func (d *MetadataStoreSqlite) ImportDrep(
 	if drep.ID == 0 {
 		var existing models.Drep
 		if err := db.Where(
-			"credential = ?", drep.Credential,
+			"credential_tag = ? AND credential = ?",
+			drep.CredentialTag,
+			drep.Credential,
 		).First(&existing).Error; err != nil {
 			return fmt.Errorf(
 				"fetching drep ID after upsert: %w", err,
@@ -380,6 +385,7 @@ func (d *MetadataStoreSqlite) ImportDrep(
 	// uniqueness key.
 	if result := db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{
+			{Name: "credential_tag"},
 			{Name: "drep_credential"},
 			{Name: "added_slot"},
 		},

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -209,7 +209,7 @@ func (d *MetadataStoreSqlite) ImportPool(
 		Columns: []clause.Column{{Name: "pool_key_hash"}},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"vrf_key_hash", "pledge", "cost",
-			"margin", "reward_account",
+			"margin", "reward_account", "reward_account_credential_tag",
 		}),
 	}).Create(pool)
 	if result.Error != nil {

--- a/database/plugin/metadata/sqlite/import.go
+++ b/database/plugin/metadata/sqlite/import.go
@@ -177,7 +177,10 @@ func (d *MetadataStoreSqlite) ImportAccount(
 		)
 	}
 	result := db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoUpdates: clause.AssignmentColumns(
 			[]string{"pool", "drep", "drep_type", "active", "reward"},
 		),

--- a/database/plugin/metadata/sqlite/mir.go
+++ b/database/plugin/metadata/sqlite/mir.go
@@ -48,8 +48,9 @@ func (d *MetadataStoreSqlite) GetMIRCertsInSlotRange(
 		effects[i].Rewards = make([]models.MIRReward, len(m.Rewards))
 		for j, r := range m.Rewards {
 			effects[i].Rewards[j] = models.MIRReward{
-				Credential: r.Credential,
-				Amount:     uint64(r.Amount),
+				Credential:    r.Credential,
+				CredentialTag: r.CredentialTag,
+				Amount:        uint64(r.Amount),
 			}
 		}
 	}

--- a/database/plugin/metadata/sqlite/plomin_test.go
+++ b/database/plugin/metadata/sqlite/plomin_test.go
@@ -155,6 +155,57 @@ func TestClearDanglingDRepDelegations_ScriptCredentialAlsoCleared(t *testing.T) 
 	assert.Nil(t, acct.Drep)
 }
 
+// A key-hash DRep and script-hash DRep can share the same credential bytes.
+// Dangling cleanup must match both the hash and credential tag before preserving a delegation.
+func TestClearDanglingDRepDelegations_DoesNotCrossMatchCredentialTag(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	sharedCred := bytes.Repeat([]byte{0x66}, 28)
+	keyStake := bytes.Repeat([]byte{0xC2}, 28)
+	scriptStake := bytes.Repeat([]byte{0xC3}, 28)
+
+	require.NoError(t, store.DB().Create(&models.Drep{
+		CredentialTag: 0,
+		Credential:    sharedCred,
+		Active:        true,
+		AddedSlot:     50,
+	}).Error)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: keyStake,
+		Drep:       sharedCred,
+		DrepType:   models.DrepTypeAddrKeyHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: scriptStake,
+		Drep:       sharedCred,
+		DrepType:   models.DrepTypeScriptHash,
+		Active:     true,
+		AddedSlot:  100,
+	}).Error)
+
+	n, err := store.ClearDanglingDRepDelegations(1_000, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	keyAcct, err := store.GetAccountByCredential(0, keyStake, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, keyAcct)
+	assert.Equal(t, sharedCred, keyAcct.Drep)
+	assert.Equal(t, models.DrepTypeAddrKeyHash, keyAcct.DrepType)
+	assert.Equal(t, uint64(100), keyAcct.AddedSlot)
+
+	scriptAcct, err := store.GetAccountByCredential(0, scriptStake, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, scriptAcct)
+	assert.Nil(t, scriptAcct.Drep)
+	assert.Equal(t, uint64(0), scriptAcct.DrepType)
+	assert.Equal(t, uint64(1_000), scriptAcct.AddedSlot)
+}
+
 // AlwaysAbstain / AlwaysNoConfidence delegations are pseudo-DReps with no
 // credential and must not be touched by the rule.
 func TestClearDanglingDRepDelegations_PseudoDRepDelegationsPreserved(t *testing.T) {

--- a/database/plugin/metadata/sqlite/plomin_test.go
+++ b/database/plugin/metadata/sqlite/plomin_test.go
@@ -70,7 +70,7 @@ func TestClearDanglingDRepDelegations_ClearsUnregisteredCredBackedDelegation(t *
 	assert.Equal(t, 1, n,
 		"exactly one account has a dangling delegation and should be cleared")
 
-	liveAcct, err := store.GetAccount(stakeKeyLive, true, nil)
+	liveAcct, err := store.GetAccountByCredential(0, stakeKeyLive, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, liveAcct)
 	assert.True(t, bytes.Equal(liveAcct.Drep, liveCred),
@@ -79,7 +79,7 @@ func TestClearDanglingDRepDelegations_ClearsUnregisteredCredBackedDelegation(t *
 	assert.Equal(t, uint64(100), liveAcct.AddedSlot,
 		"unchanged accounts keep their original AddedSlot")
 
-	deadAcct, err := store.GetAccount(stakeKeyDead, true, nil)
+	deadAcct, err := store.GetAccountByCredential(0, stakeKeyDead, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, deadAcct)
 	assert.Nil(t, deadAcct.Drep,
@@ -123,7 +123,7 @@ func TestClearDanglingDRepDelegations_InactiveDRepCountsAsDangling(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 
-	acct, err := store.GetAccount(stakeKey, true, nil)
+	acct, err := store.GetAccountByCredential(0, stakeKey, true, nil)
 	require.NoError(t, err)
 	assert.Nil(t, acct.Drep)
 	assert.Equal(t, uint64(2_000), acct.AddedSlot)
@@ -150,7 +150,7 @@ func TestClearDanglingDRepDelegations_ScriptCredentialAlsoCleared(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 
-	acct, err := store.GetAccount(stakeKey, true, nil)
+	acct, err := store.GetAccountByCredential(0, stakeKey, true, nil)
 	require.NoError(t, err)
 	assert.Nil(t, acct.Drep)
 }
@@ -185,12 +185,12 @@ func TestClearDanglingDRepDelegations_PseudoDRepDelegationsPreserved(t *testing.
 	assert.Equal(t, 0, n,
 		"pseudo-DRep delegations must never be counted as dangling")
 
-	a, err := store.GetAccount(stakeKeyA, true, nil)
+	a, err := store.GetAccountByCredential(0, stakeKeyA, true, nil)
 	require.NoError(t, err)
 	assert.Equal(t, models.DrepTypeAlwaysAbstain, a.DrepType)
 	assert.Equal(t, uint64(100), a.AddedSlot, "AddedSlot untouched")
 
-	b, err := store.GetAccount(stakeKeyB, true, nil)
+	b, err := store.GetAccountByCredential(0, stakeKeyB, true, nil)
 	require.NoError(t, err)
 	assert.Equal(t, models.DrepTypeAlwaysNoConfidence, b.DrepType)
 	assert.Equal(t, uint64(100), b.AddedSlot)
@@ -213,7 +213,7 @@ func TestClearDanglingDRepDelegations_NoDelegationUntouched(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 
-	acct, err := store.GetAccount(stakeKey, true, nil)
+	acct, err := store.GetAccountByCredential(0, stakeKey, true, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(100), acct.AddedSlot)
 }

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1169,7 +1169,7 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 		var chunkResults []poolStakeResult
 		if err := db.Table("account").
 			Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
-			Joins("INNER JOIN utxo ON utxo.staking_key = account.staking_key").
+			Joins("INNER JOIN utxo ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 			Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", chunk, true).
 			Group("account.pool").
 			Scan(&chunkResults).Error; err != nil {

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -28,15 +28,16 @@ import (
 // poolRegRecord holds registration data for batch processing during pool restoration.
 // Includes blockIndex, certIndex, and certID for deterministic same-slot disambiguation.
 type poolRegRecord struct {
-	pledge        types.Uint64
-	cost          types.Uint64
-	margin        *types.Rat
-	vrfKeyHash    []byte
-	rewardAccount []byte
-	addedSlot     uint64
-	blockIndex    uint32
-	certIndex     uint32
-	certID        uint
+	pledge                     types.Uint64
+	cost                       types.Uint64
+	margin                     *types.Rat
+	vrfKeyHash                 []byte
+	rewardAccount              []byte
+	rewardAccountCredentialTag uint8
+	addedSlot                  uint64
+	blockIndex                 uint32
+	certIndex                  uint32
+	certID                     uint
 }
 
 // isMoreRecent checks if this registration is more recent than the other.
@@ -89,20 +90,21 @@ func batchFetchPoolRegs(
 
 		// Fetch registration records with cert_index, block_index, and cert ID from joined tables
 		type regResult struct {
-			PoolID        uint
-			AddedSlot     uint64
-			BlockIndex    uint32
-			CertIndex     uint32
-			CertID        uint
-			Pledge        types.Uint64
-			Cost          types.Uint64
-			Margin        *types.Rat
-			VrfKeyHash    []byte
-			RewardAccount []byte
+			PoolID                     uint
+			AddedSlot                  uint64
+			BlockIndex                 uint32
+			CertIndex                  uint32
+			CertID                     uint
+			Pledge                     types.Uint64
+			Cost                       types.Uint64
+			Margin                     *types.Rat
+			VrfKeyHash                 []byte
+			RewardAccount              []byte
+			RewardAccountCredentialTag uint8
 		}
 		var regRecords []regResult
 		if err := db.Table("pool_registration").
-			Select("pool_registration.pool_id, pool_registration.added_slot, pool_registration.pledge, pool_registration.cost, pool_registration.margin, pool_registration.vrf_key_hash, pool_registration.reward_account, COALESCE(certs.cert_index, 0) AS cert_index, COALESCE(certs.id, 0) AS cert_id, COALESCE(\"transaction\".block_index, 0) AS block_index").
+			Select("pool_registration.pool_id, pool_registration.added_slot, pool_registration.pledge, pool_registration.cost, pool_registration.margin, pool_registration.vrf_key_hash, pool_registration.reward_account, pool_registration.reward_account_credential_tag, COALESCE(certs.cert_index, 0) AS cert_index, COALESCE(certs.id, 0) AS cert_id, COALESCE(\"transaction\".block_index, 0) AS block_index").
 			Joins("LEFT JOIN certs ON certs.id = pool_registration.certificate_id").
 			Joins("LEFT JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
 			Where("pool_registration.pool_id IN ? AND pool_registration.added_slot <= ?", idChunk, slot).
@@ -111,15 +113,16 @@ func batchFetchPoolRegs(
 		}
 		for _, r := range regRecords {
 			rec := poolRegRecord{
-				addedSlot:     r.AddedSlot,
-				blockIndex:    r.BlockIndex,
-				certIndex:     r.CertIndex,
-				certID:        r.CertID,
-				pledge:        r.Pledge,
-				cost:          r.Cost,
-				margin:        r.Margin,
-				vrfKeyHash:    r.VrfKeyHash,
-				rewardAccount: r.RewardAccount,
+				addedSlot:                  r.AddedSlot,
+				blockIndex:                 r.BlockIndex,
+				certIndex:                  r.CertIndex,
+				certID:                     r.CertID,
+				pledge:                     r.Pledge,
+				cost:                       r.Cost,
+				margin:                     r.Margin,
+				vrfKeyHash:                 r.VrfKeyHash,
+				rewardAccount:              r.RewardAccount,
+				rewardAccountCredentialTag: r.RewardAccountCredentialTag,
 			}
 			if !cache.hasReg[r.PoolID] ||
 				rec.isMoreRecent(cache.registration[r.PoolID]) {
@@ -602,11 +605,12 @@ func (d *MetadataStoreSqlite) RestorePoolStateAtSlot(
 
 		// Update the Pool's denormalized fields from the registration
 		if result := db.Model(&pool).Updates(map[string]any{
-			"pledge":         latestReg.pledge,
-			"cost":           latestReg.cost,
-			"margin":         latestReg.margin,
-			"vrf_key_hash":   latestReg.vrfKeyHash,
-			"reward_account": latestReg.rewardAccount,
+			"pledge":                        latestReg.pledge,
+			"cost":                          latestReg.cost,
+			"margin":                        latestReg.margin,
+			"vrf_key_hash":                  latestReg.vrfKeyHash,
+			"reward_account":                latestReg.rewardAccount,
+			"reward_account_credential_tag": latestReg.rewardAccountCredentialTag,
 		}); result.Error != nil {
 			return result.Error
 		}

--- a/database/plugin/metadata/sqlite/poolreap.go
+++ b/database/plugin/metadata/sqlite/poolreap.go
@@ -39,15 +39,16 @@ func (d *MetadataStoreSqlite) GetPoolsRetiringAtEpoch(
 	}
 
 	type row struct {
-		PoolKeyHash   []byte
-		RewardAccount []byte
-		DepositAmount types.Uint64
+		PoolKeyHash                []byte
+		RewardAccount              []byte
+		RewardAccountCredentialTag uint8
+		DepositAmount              types.Uint64
 	}
 	var rows []row
 
 	query := `
 		WITH latest_reg AS (
-			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.reward_account_credential_tag, pr.deposit_amount,
 				COALESCE(t.block_index, 0) as blk_idx,
 				COALESCE(c.cert_index, 0) as cert_idx,
 				ROW_NUMBER() OVER (
@@ -72,7 +73,7 @@ func (d *MetadataStoreSqlite) GetPoolsRetiringAtEpoch(
 			LEFT JOIN "transaction" t ON t.id = c.transaction_id
 			WHERE rt.added_slot < ?
 		)
-		SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+		SELECT p.pool_key_hash, lr.reward_account, lr.reward_account_credential_tag, lr.deposit_amount
 		FROM pool p
 		INNER JOIN latest_reg lr ON lr.pool_id = p.id AND lr.rn = 1
 		INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
@@ -94,9 +95,10 @@ func (d *MetadataStoreSqlite) GetPoolsRetiringAtEpoch(
 	refunds := make([]models.PoolRetirementRefund, len(rows))
 	for i, r := range rows {
 		refunds[i] = models.PoolRetirementRefund{
-			PoolKeyHash:   r.PoolKeyHash,
-			RewardAccount: r.RewardAccount,
-			DepositAmount: r.DepositAmount,
+			PoolKeyHash:                r.PoolKeyHash,
+			RewardAccount:              r.RewardAccount,
+			RewardAccountCredentialTag: r.RewardAccountCredentialTag,
+			DepositAmount:              r.DepositAmount,
 		}
 	}
 	return refunds, nil

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -1478,3 +1478,61 @@ func TestRollbackConcurrentUtxoSpend(t *testing.T) {
 		"UTxO should be spent by tx2",
 	)
 }
+
+// TestRollbackRewardDeltaIsCredentialTagAware verifies that
+// DeleteAccountRewardsAfterSlot matches AccountRewardDelta rows to accounts
+// by the composite (credential_tag, staking_key) key. A credit delta for
+// tag=1 must adjust only the script-hash account, not the key-hash account
+// that shares the same 28-byte hash.
+func TestRollbackRewardDeltaIsCredentialTagAware(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	stakeKey := bytes.Repeat([]byte{0xD1}, 28)
+	const baseReward = uint64(1_000_000)
+	const creditAmount = uint64(500_000)
+	const slot = uint64(200)
+
+	// Two accounts sharing the same hash, differing only in credential_tag.
+	keyAccount := &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+		AddedSlot:     10,
+		Reward:        types.Uint64(baseReward),
+	}
+	scriptAccount := &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Active:        true,
+		AddedSlot:     10,
+		Reward:        types.Uint64(baseReward),
+	}
+	require.NoError(t, store.DB().Create(keyAccount).Error)
+	require.NoError(t, store.DB().Create(scriptAccount).Error)
+
+	// Record a reward credit only for the script-hash account at slot 200.
+	require.NoError(t, store.AddAccountRewardByCredential(1, stakeKey, creditAmount, slot, nil))
+
+	// Verify only the script-hash account received the credit.
+	keyBefore, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, types.Uint64(baseReward), keyBefore.Reward, "key-hash account must not be affected by script-hash credit")
+
+	scriptBefore, err := store.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, types.Uint64(baseReward+creditAmount), scriptBefore.Reward, "script-hash account must have received credit")
+
+	// Roll back past the credit slot.
+	require.NoError(t, store.DeleteAccountRewardsAfterSlot(slot-1, nil))
+
+	// Key-hash account reward must be unchanged.
+	keyAfter, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, types.Uint64(baseReward), keyAfter.Reward, "key-hash account reward must be unchanged after rollback")
+
+	// Script-hash account reward must be restored to base.
+	scriptAfter, err := store.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, types.Uint64(baseReward), scriptAfter.Reward, "script-hash account reward must be restored to base after rollback")
+}

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -1178,6 +1178,105 @@ func TestRollbackAndReplay(t *testing.T) {
 	)
 }
 
+// TestRollbackRestoreAccountStateIsCredentialTagAware verifies that rollback
+// restore keeps key and script cert history separate when both credentials use
+// the same 28-byte staking hash.
+func TestRollbackRestoreAccountStateIsCredentialTagAware(t *testing.T) {
+	store := setupTestDB(t)
+
+	stakeKey := bytes.Repeat([]byte{0xE1}, 28)
+	keyPool := bytes.Repeat([]byte{0xA0}, 28)
+	scriptPool := bytes.Repeat([]byte{0xA1}, 28)
+	currentPool := bytes.Repeat([]byte{0xFF}, 28)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Pool:          currentPool,
+		AddedSlot:     200,
+		Active:        true,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Pool:          currentPool,
+		AddedSlot:     200,
+		Active:        true,
+	}).Error)
+
+	require.NoError(t, createTestTransaction(store.DB(), 51, 100))
+
+	keyRegCert := models.Certificate{
+		TransactionID: 51,
+		CertIndex:     0,
+		CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&keyRegCert).Error)
+	require.NoError(t, store.DB().Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		AddedSlot:     100,
+		CertificateID: keyRegCert.ID,
+	}).Error)
+
+	scriptRegCert := models.Certificate{
+		TransactionID: 51,
+		CertIndex:     1,
+		CertType:      uint(lcommon.CertificateTypeStakeRegistration),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&scriptRegCert).Error)
+	require.NoError(t, store.DB().Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		AddedSlot:     100,
+		CertificateID: scriptRegCert.ID,
+	}).Error)
+
+	keyDelegCert := models.Certificate{
+		TransactionID: 51,
+		CertIndex:     2,
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&keyDelegCert).Error)
+	require.NoError(t, store.DB().Create(&models.StakeDelegation{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		PoolKeyHash:   keyPool,
+		AddedSlot:     100,
+		CertificateID: keyDelegCert.ID,
+	}).Error)
+
+	scriptDelegCert := models.Certificate{
+		TransactionID: 51,
+		CertIndex:     3,
+		CertType:      uint(lcommon.CertificateTypeStakeDelegation),
+		Slot:          100,
+	}
+	require.NoError(t, store.DB().Create(&scriptDelegCert).Error)
+	require.NoError(t, store.DB().Create(&models.StakeDelegation{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		PoolKeyHash:   scriptPool,
+		AddedSlot:     100,
+		CertificateID: scriptDelegCert.ID,
+	}).Error)
+
+	require.NoError(t, store.RestoreAccountStateAtSlot(150, nil))
+
+	keyAccount, err := store.GetAccountByCredential(0, stakeKey, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, keyAccount)
+	require.Equal(t, keyPool, keyAccount.Pool)
+
+	scriptAccount, err := store.GetAccountByCredential(1, stakeKey, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, scriptAccount)
+	require.Equal(t, scriptPool, scriptAccount.Pool)
+}
+
 // TestRollbackPParamsDeletion tests that protocol parameters added
 // after the rollback slot are removed.
 func TestRollbackPParamsDeletion(t *testing.T) {

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -561,7 +561,7 @@ func TestRollbackAccountState(t *testing.T) {
 	require.NoError(t, err, "RestoreAccountStateAtSlot should succeed")
 
 	// Verify account was restored to pool1
-	restored, err := store.GetAccount(stakeKey, false, nil)
+	restored, err := store.GetAccountByCredential(0, stakeKey, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, restored, "account should still exist after rollback")
 	require.True(
@@ -593,7 +593,7 @@ func TestRollbackDeletesAccountRegisteredAfterSlot(t *testing.T) {
 	require.NoError(t, err)
 
 	// Account should be deleted since it was registered after rollback slot
-	restored, err := store.GetAccount(stakeKey, true, nil)
+	restored, err := store.GetAccountByCredential(0, stakeKey, true, nil)
 	require.NoError(t, err)
 	require.Nil(
 		t,
@@ -1112,7 +1112,7 @@ func TestRollbackAndReplay(t *testing.T) {
 	})
 
 	// Capture pre-rollback state at slot 200
-	preRollback, err := store.GetAccount(stakeKey, false, nil)
+	preRollback, err := store.GetAccountByCredential(0, stakeKey, false, nil)
 	require.NoError(t, err)
 	require.True(
 		t,
@@ -1130,7 +1130,7 @@ func TestRollbackAndReplay(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify rollback state
-	midRollback, err := store.GetAccount(stakeKey, false, nil)
+	midRollback, err := store.GetAccountByCredential(0, stakeKey, false, nil)
 	require.NoError(t, err)
 	require.NotNil(
 		t,
@@ -1168,7 +1168,7 @@ func TestRollbackAndReplay(t *testing.T) {
 	})
 
 	// Verify final state matches pre-rollback state
-	postReplay, err := store.GetAccount(stakeKey, false, nil)
+	postReplay, err := store.GetAccountByCredential(0, stakeKey, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, postReplay, "account should exist after replay")
 	require.True(

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -1162,6 +1162,18 @@ func TestStakeRegistrationCertificateProcessingIsCredentialTagAware(t *testing.T
 	if scriptAccount == nil {
 		t.Fatal("expected script credential account")
 	}
+	if keyAccount.CredentialTag != 0 {
+		t.Fatalf("expected key account tag 0, got %d", keyAccount.CredentialTag)
+	}
+	if scriptAccount.CredentialTag != 1 {
+		t.Fatalf(
+			"expected script account tag 1, got %d",
+			scriptAccount.CredentialTag,
+		)
+	}
+	if keyAccount.ID == scriptAccount.ID {
+		t.Fatal("expected distinct accounts for key and script credentials")
+	}
 
 	var registrations []models.StakeRegistration
 	if result := sqliteStore.DB().

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -746,15 +746,16 @@ func TestGetTransactionsByAddressIndex(t *testing.T) {
 	payment2 := bytes.Repeat([]byte{0x12}, 28)
 	stake1 := bytes.Repeat([]byte{0x22}, 28)
 	rows := []models.AddressTransaction{
-		{PaymentKey: payment1, StakingKey: stake1, TransactionID: 1, Slot: 100, TxIndex: 0},
-		{PaymentKey: payment1, StakingKey: stake1, TransactionID: 2, Slot: 200, TxIndex: 0},
-		{PaymentKey: payment2, StakingKey: stake1, TransactionID: 3, Slot: 300, TxIndex: 0},
+		{PaymentKey: payment1, CredentialTag: 0, StakingKey: stake1, TransactionID: 1, Slot: 100, TxIndex: 0},
+		{PaymentKey: payment1, CredentialTag: 0, StakingKey: stake1, TransactionID: 2, Slot: 200, TxIndex: 0},
+		{PaymentKey: payment2, CredentialTag: 0, StakingKey: stake1, TransactionID: 3, Slot: 300, TxIndex: 0},
+		{PaymentKey: payment1, CredentialTag: 1, StakingKey: stake1, TransactionID: 3, Slot: 300, TxIndex: 0},
 	}
 	if err := store.DB().Create(&rows).Error; err != nil {
 		t.Fatalf("failed to create address_tx rows: %v", err)
 	}
 
-	desc, err := store.GetTransactionsByAddress(payment1, stake1, 10, 0, "desc", nil)
+	desc, err := store.GetTransactionsByAddress(payment1, 0, stake1, 10, 0, "desc", nil)
 	if err != nil {
 		t.Fatalf("GetTransactionsByAddress desc failed: %v", err)
 	}
@@ -762,7 +763,7 @@ func TestGetTransactionsByAddressIndex(t *testing.T) {
 		t.Fatalf("unexpected desc order: %+v", desc)
 	}
 
-	asc, err := store.GetTransactionsByAddress(payment1, stake1, 10, 0, "asc", nil)
+	asc, err := store.GetTransactionsByAddress(payment1, 0, stake1, 10, 0, "asc", nil)
 	if err != nil {
 		t.Fatalf("GetTransactionsByAddress asc failed: %v", err)
 	}
@@ -770,7 +771,7 @@ func TestGetTransactionsByAddressIndex(t *testing.T) {
 		t.Fatalf("unexpected asc order: %+v", asc)
 	}
 
-	page, err := store.GetTransactionsByAddress(payment1, stake1, 1, 1, "desc", nil)
+	page, err := store.GetTransactionsByAddress(payment1, 0, stake1, 1, 1, "desc", nil)
 	if err != nil {
 		t.Fatalf("GetTransactionsByAddress pagination failed: %v", err)
 	}
@@ -786,29 +787,101 @@ func TestGetAddressesByStakingKey(t *testing.T) {
 	stake := bytes.Repeat([]byte{0x55}, 28)
 	paymentA := bytes.Repeat([]byte{0x66}, 28)
 	paymentB := bytes.Repeat([]byte{0x77}, 28)
+	paymentScript := bytes.Repeat([]byte{0x88}, 28)
 	rows := []models.AddressTransaction{
-		{PaymentKey: paymentA, StakingKey: stake, TransactionID: 1, Slot: 100, TxIndex: 0},
-		{PaymentKey: paymentA, StakingKey: stake, TransactionID: 2, Slot: 200, TxIndex: 0},
-		{PaymentKey: paymentB, StakingKey: stake, TransactionID: 3, Slot: 300, TxIndex: 0},
+		{PaymentKey: paymentA, CredentialTag: 0, StakingKey: stake, TransactionID: 1, Slot: 100, TxIndex: 0},
+		{PaymentKey: paymentA, CredentialTag: 0, StakingKey: stake, TransactionID: 2, Slot: 200, TxIndex: 0},
+		{PaymentKey: paymentB, CredentialTag: 0, StakingKey: stake, TransactionID: 3, Slot: 300, TxIndex: 0},
+		{PaymentKey: paymentScript, CredentialTag: 1, StakingKey: stake, TransactionID: 4, Slot: 400, TxIndex: 0},
 	}
 	if err := store.DB().Create(&rows).Error; err != nil {
 		t.Fatalf("failed to create address_tx rows: %v", err)
 	}
 
-	addrs, err := store.GetAddressesByStakingKey(stake, 10, 0, "asc", nil)
+	addrs, err := store.GetAddressesByCredential(0, stake, 10, 0, "asc", nil)
 	if err != nil {
-		t.Fatalf("GetAddressesByStakingKey failed: %v", err)
+		t.Fatalf("GetAddressesByCredential failed: %v", err)
 	}
 	if len(addrs) != 2 {
-		t.Fatalf("expected 2 distinct addresses, got %d", len(addrs))
+		t.Fatalf("expected 2 key credential addresses, got %d", len(addrs))
+	}
+	for _, addr := range addrs {
+		if addr.CredentialTag != 0 {
+			t.Fatalf("expected only key credential addresses, got tag %d", addr.CredentialTag)
+		}
 	}
 
-	page, err := store.GetAddressesByStakingKey(stake, 1, 1, "asc", nil)
+	scriptAddrs, err := store.GetAddressesByCredential(1, stake, 10, 0, "asc", nil)
 	if err != nil {
-		t.Fatalf("GetAddressesByStakingKey pagination failed: %v", err)
+		t.Fatalf("GetAddressesByCredential script lookup failed: %v", err)
+	}
+	if len(scriptAddrs) != 1 || scriptAddrs[0].CredentialTag != 1 {
+		t.Fatalf("expected 1 script credential address, got %+v", scriptAddrs)
+	}
+
+	count, err := store.CountAddressesByCredential(0, stake, nil)
+	if err != nil {
+		t.Fatalf("CountAddressesByCredential failed: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 key credential addresses, got %d", count)
+	}
+
+	page, err := store.GetAddressesByCredential(0, stake, 1, 1, "asc", nil)
+	if err != nil {
+		t.Fatalf("GetAddressesByCredential pagination failed: %v", err)
 	}
 	if len(page) != 1 {
 		t.Fatalf("expected 1 address in page, got %d", len(page))
+	}
+}
+
+func TestGetControlledAmountByCredential(t *testing.T) {
+	store := setupTestDB(t)
+
+	stake := bytes.Repeat([]byte{0x55}, 28)
+	rows := []models.Utxo{
+		{
+			TxId:          bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx:     0,
+			CredentialTag: 0,
+			StakingKey:    stake,
+			Amount:        types.Uint64(100),
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:     0,
+			CredentialTag: 1,
+			StakingKey:    stake,
+			Amount:        types.Uint64(250),
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:     0,
+			CredentialTag: 1,
+			StakingKey:    stake,
+			DeletedSlot:   10,
+			Amount:        types.Uint64(400),
+		},
+	}
+	if err := store.DB().Create(&rows).Error; err != nil {
+		t.Fatalf("failed to create utxo rows: %v", err)
+	}
+
+	keyAmount, err := store.GetControlledAmountByCredential(0, stake, nil)
+	if err != nil {
+		t.Fatalf("GetControlledAmountByCredential key lookup failed: %v", err)
+	}
+	if keyAmount != 100 {
+		t.Fatalf("expected key controlled amount 100, got %d", keyAmount)
+	}
+
+	scriptAmount, err := store.GetControlledAmountByCredential(1, stake, nil)
+	if err != nil {
+		t.Fatalf("GetControlledAmountByCredential script lookup failed: %v", err)
+	}
+	if scriptAmount != 250 {
+		t.Fatalf("expected script controlled amount 250, got %d", scriptAmount)
 	}
 }
 

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -1078,6 +1078,115 @@ func TestUnifiedCertificateCreation(t *testing.T) {
 	}
 }
 
+// TestStakeRegistrationCertificateProcessingIsCredentialTagAware verifies that
+// cert processing persists the on-chain credential tag instead of merging key
+// and script stake credentials that carry the same 28-byte hash.
+func TestStakeRegistrationCertificateProcessingIsCredentialTagAware(t *testing.T) {
+	sqliteStore := setupTestDB(t)
+	stakeKey := bytes.Repeat([]byte{0xA7}, 28)
+
+	mockTx := &mockTransaction{
+		hash:    lcommon.NewBlake2b256(bytes.Repeat([]byte{0xB8}, 32)),
+		isValid: true,
+		certificates: []lcommon.Certificate{
+			&lcommon.StakeRegistrationCertificate{
+				CertType: uint(lcommon.CertificateTypeStakeRegistration),
+				StakeCredential: lcommon.Credential{
+					CredType: lcommon.CredentialTypeAddrKeyHash,
+					Credential: lcommon.CredentialHash(
+						bytes.Clone(stakeKey),
+					),
+				},
+			},
+			&lcommon.StakeRegistrationCertificate{
+				CertType: uint(lcommon.CertificateTypeStakeRegistration),
+				StakeCredential: lcommon.Credential{
+					CredType: lcommon.CredentialTypeScriptHash,
+					Credential: lcommon.CredentialHash(
+						bytes.Clone(stakeKey),
+					),
+				},
+			},
+		},
+	}
+
+	point := ocommon.Point{
+		Hash: bytes.Repeat([]byte{0xC9}, 32),
+		Slot: 1000000,
+	}
+	certDeposits := map[int]uint64{
+		0: 2000000,
+		1: 2000000,
+	}
+	if err := sqliteStore.SetTransaction(
+		mockTx,
+		point,
+		0,
+		certDeposits,
+		nil,
+	); err != nil {
+		t.Fatalf("failed to set transaction: %v", err)
+	}
+
+	var accounts []models.Account
+	if result := sqliteStore.DB().
+		Where("staking_key = ?", stakeKey).
+		Order("credential_tag ASC").
+		Find(&accounts); result.Error != nil {
+		t.Fatalf("failed to query accounts: %v", result.Error)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("expected 2 accounts, got %d", len(accounts))
+	}
+	if accounts[0].CredentialTag != 0 {
+		t.Fatalf("expected key account tag 0, got %d", accounts[0].CredentialTag)
+	}
+	if accounts[1].CredentialTag != 1 {
+		t.Fatalf(
+			"expected script account tag 1, got %d",
+			accounts[1].CredentialTag,
+		)
+	}
+
+	keyAccount, err := sqliteStore.GetAccountByCredential(0, stakeKey, false, nil)
+	if err != nil {
+		t.Fatalf("failed to query key credential account: %v", err)
+	}
+	if keyAccount == nil {
+		t.Fatal("expected key credential account")
+	}
+	scriptAccount, err := sqliteStore.GetAccountByCredential(1, stakeKey, false, nil)
+	if err != nil {
+		t.Fatalf("failed to query script credential account: %v", err)
+	}
+	if scriptAccount == nil {
+		t.Fatal("expected script credential account")
+	}
+
+	var registrations []models.StakeRegistration
+	if result := sqliteStore.DB().
+		Where("staking_key = ?", stakeKey).
+		Order("credential_tag ASC").
+		Find(&registrations); result.Error != nil {
+		t.Fatalf("failed to query stake registrations: %v", result.Error)
+	}
+	if len(registrations) != 2 {
+		t.Fatalf("expected 2 stake registrations, got %d", len(registrations))
+	}
+	if registrations[0].CredentialTag != 0 {
+		t.Fatalf(
+			"expected key registration tag 0, got %d",
+			registrations[0].CredentialTag,
+		)
+	}
+	if registrations[1].CredentialTag != 1 {
+		t.Fatalf(
+			"expected script registration tag 1, got %d",
+			registrations[1].CredentialTag,
+		)
+	}
+}
+
 // TestDeleteCertificatesAfterSlot tests that certificates added after a given slot are deleted
 func TestDeleteCertificatesAfterSlot(t *testing.T) {
 	t.Parallel()

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -466,24 +466,6 @@ func addressOrderClause(order string) string {
 	return "payment_key ASC"
 }
 
-// GetAccountDelegationHistory returns delegation history rows for a staking key.
-func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn types.Txn,
-) ([]models.AccountDelegationHistoryRow, error) {
-	return d.GetAccountDelegationHistoryByCredential(
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
-}
-
 func (d *MetadataStoreSqlite) GetAccountDelegationHistoryByCredential(
 	credentialTag uint8,
 	stakingKey []byte,
@@ -516,15 +498,6 @@ func (d *MetadataStoreSqlite) GetAccountDelegationHistoryByCredential(
 	return rows, nil
 }
 
-// CountAccountDelegationHistory returns the total number of
-// delegation history rows for a staking key.
-func (d *MetadataStoreSqlite) CountAccountDelegationHistory(
-	stakingKey []byte,
-	txn types.Txn,
-) (int, error) {
-	return d.CountAccountDelegationHistoryByCredential(0, stakingKey, txn)
-}
-
 func (d *MetadataStoreSqlite) CountAccountDelegationHistoryByCredential(
 	credentialTag uint8,
 	stakingKey []byte,
@@ -549,24 +522,6 @@ func (d *MetadataStoreSqlite) CountAccountDelegationHistoryByCredential(
 		)
 	}
 	return count, nil
-}
-
-// GetAccountRegistrationHistory returns registration history rows for a staking key.
-func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-	txn types.Txn,
-) ([]models.AccountRegistrationHistoryRow, error) {
-	return d.GetAccountRegistrationHistoryByCredential(
-		0,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
-	)
 }
 
 func (d *MetadataStoreSqlite) GetAccountRegistrationHistoryByCredential(
@@ -599,15 +554,6 @@ func (d *MetadataStoreSqlite) GetAccountRegistrationHistoryByCredential(
 		)
 	}
 	return rows, nil
-}
-
-// CountAccountRegistrationHistory returns the total number of
-// registration history rows for a staking key.
-func (d *MetadataStoreSqlite) CountAccountRegistrationHistory(
-	stakingKey []byte,
-	txn types.Txn,
-) (int, error) {
-	return d.CountAccountRegistrationHistoryByCredential(0, stakingKey, txn)
 }
 
 func (d *MetadataStoreSqlite) CountAccountRegistrationHistoryByCredential(

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2158,10 +2158,15 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.RegistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					// Registration (re)creates/activates the DRep regardless of prior state.
 
 					tmpReg := models.RegistrationDrep{
+						CredentialTag:  drepCredTag,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -2173,7 +2178,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					}
 
 					// Persist DRep anchor and active state
-					if err := d.SetDrep(drepCredential, point.Slot, tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -2182,6 +2187,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					// the registration fields instead of failing on the unique index.
 					result := db.Clauses(clause.OnConflict{
 						Columns: []clause.Column{
+							{Name: "credential_tag"},
 							{Name: "drep_credential"},
 							{Name: "added_slot"},
 						},
@@ -2198,8 +2204,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if tmpReg.ID == 0 {
 						var existing models.RegistrationDrep
 						if err := db.Where(
-							"drep_credential = ? AND added_slot = ?",
-							tmpReg.DrepCredential, tmpReg.AddedSlot,
+							"credential_tag = ? AND drep_credential = ? AND added_slot = ?",
+							tmpReg.CredentialTag, tmpReg.DrepCredential, tmpReg.AddedSlot,
 						).First(&existing).Error; err != nil {
 							return fmt.Errorf(
 								"fetching drep registration ID after upsert: %w",
@@ -2213,8 +2219,13 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.DeregistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					tmpDereg := models.DeregistrationDrep{
+						CredentialTag:  drepCredTag,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -2223,7 +2234,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					// Mark DRep inactive
 					// Ensure we don't create a new DRep during deregistration. Check existence first.
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag, drepCredential, true, txn)
 					if err != nil {
 						if !errors.Is(err, models.ErrDrepNotFound) {
 							return fmt.Errorf("process certificate: %w", err)
@@ -2232,7 +2243,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if existingDrep == nil {
 						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
 					}
-					if err := d.SetDrep(drepCredential, point.Slot, "", nil, false, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, "", nil, false, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -2244,8 +2255,13 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpDereg.ID
 				case *lcommon.UpdateDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate: %w", err)
+					}
 
 					tmpUpdate := models.UpdateDrep{
+						CredentialTag: drepCredTag,
 						Credential:    drepCredential,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -2257,7 +2273,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					// Update DRep anchor and mark active
 					// Require that the DRep already exists for updates.
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag, drepCredential, true, txn)
 					if err != nil {
 						if !errors.Is(err, models.ErrDrepNotFound) {
 							return fmt.Errorf("process certificate: %w", err)
@@ -2266,7 +2282,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					if existingDrep == nil {
 						return fmt.Errorf("process certificate: %w", models.ErrDrepNotFound)
 					}
-					if err := d.SetDrep(drepCredential, point.Slot, tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn); err != nil {
+					if err := d.SetDrep(drepCredTag, drepCredential, point.Slot, tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn); err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
@@ -3700,7 +3716,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.RegistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpReg := models.RegistrationDrep{
+						CredentialTag:  drepCredTag2,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
@@ -3711,13 +3732,14 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						tmpReg.AnchorHash = c.Anchor.DataHash[:]
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot,
+						drepCredTag2, drepCredential, point.Slot,
 						tmpReg.AnchorURL, tmpReg.AnchorHash, true, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					r2 := db.Clauses(clause.OnConflict{
 						Columns: []clause.Column{
+							{Name: "credential_tag"},
 							{Name: "drep_credential"},
 							{Name: "added_slot"},
 						},
@@ -3731,8 +3753,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					if tmpReg.ID == 0 {
 						var existing models.RegistrationDrep
 						if err := db.Where(
-							"drep_credential = ? AND added_slot = ?",
-							tmpReg.DrepCredential, tmpReg.AddedSlot,
+							"credential_tag = ? AND drep_credential = ? AND added_slot = ?",
+							tmpReg.CredentialTag, tmpReg.DrepCredential, tmpReg.AddedSlot,
 						).First(&existing).Error; err != nil {
 							return fmt.Errorf(
 								"fetching drep registration ID after upsert (batched): %w",
@@ -3744,13 +3766,18 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.DeregistrationDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpDereg := models.DeregistrationDrep{
+						CredentialTag:  drepCredTag2,
 						DrepCredential: drepCredential,
 						AddedSlot:      point.Slot,
 						DepositAmount:  types.Uint64(deposit),
 						CertificateID:  certIDMap[i],
 					}
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag2, drepCredential, true, txn)
 					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3761,7 +3788,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						)
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot, "", nil, false, txn,
+						drepCredTag2, drepCredential, point.Slot, "", nil, false, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3771,7 +3798,12 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpDereg.ID
 				case *lcommon.UpdateDrepCertificate:
 					drepCredential := c.DrepCredential.Credential[:]
+					drepCredTag2, err := models.CredentialTagFromUint(c.DrepCredential.CredType)
+					if err != nil {
+						return fmt.Errorf("process certificate (batched): %w", err)
+					}
 					tmpUpdate := models.UpdateDrep{
+						CredentialTag: drepCredTag2,
 						Credential:    drepCredential,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -3780,7 +3812,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						tmpUpdate.AnchorURL = c.Anchor.Url
 						tmpUpdate.AnchorHash = c.Anchor.DataHash[:]
 					}
-					existingDrep, err := d.GetDrep(drepCredential, true, txn)
+					existingDrep, err := d.GetDrepByCredential(drepCredTag2, drepCredential, true, txn)
 					if err != nil && !errors.Is(err, models.ErrDrepNotFound) {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3791,7 +3823,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						)
 					}
 					if err := d.SetDrep(
-						drepCredential, point.Slot,
+						drepCredTag2, drepCredential, point.Slot,
 						tmpUpdate.AnchorURL, tmpUpdate.AnchorHash, true, txn,
 					); err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -4284,19 +4316,27 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 		if cred == nil {
 			continue
 		}
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return fmt.Errorf("genesis drep credential type: %w", err)
+		}
 		drepCred := cred.Credential[:]
 		drep := &models.Drep{
-			Credential:  drepCred,
-			AddedSlot:   0,
-			ExpiryEpoch: state.Expiry,
-			Active:      true,
+			CredentialTag: credentialTag,
+			Credential:    drepCred,
+			AddedSlot:     0,
+			ExpiryEpoch:   state.Expiry,
+			Active:        true,
 		}
 		if state.Anchor != nil {
 			drep.AnchorURL = state.Anchor.Url
 			drep.AnchorHash = state.Anchor.DataHash[:]
 		}
 		if result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "credential"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "credential"},
+			},
 			DoUpdates: clause.AssignmentColumns([]string{
 				"added_slot",
 				"anchor_url",
@@ -4312,6 +4352,7 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 		}
 
 		reg := &models.RegistrationDrep{
+			CredentialTag:  credentialTag,
 			DrepCredential: drepCred,
 			AddedSlot:      0,
 			DepositAmount:  types.Uint64(state.Deposit),
@@ -4322,6 +4363,7 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 		}
 		if result := db.Clauses(clause.OnConflict{
 			Columns: []clause.Column{
+				{Name: "credential_tag"},
 				{Name: "drep_credential"},
 				{Name: "added_slot"},
 			},

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -4284,9 +4284,13 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 
 		account := &models.Account{
 			StakingKey: stakerBytes,
-			Pool:       poolBytes,
-			Active:     true,
-			AddedSlot:  0,
+			// Shelley genesis staking section encodes stake credentials as
+			// raw 28-byte hashes with no type metadata. All Shelley-era
+			// genesis stake credentials are key-hash by protocol design.
+			CredentialTag: 0,
+			Pool:          poolBytes,
+			Active:        true,
+			AddedSlot:     0,
 		}
 		// DoUpdates intentionally omits added_slot: RestoreAccountStateAtSlot
 		// selects rows by `added_slot > rollback_slot`, so resetting a

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1718,7 +1718,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(c)
+					rewardAcctTag, rewardAcctHash, err := certutil.PoolRewardAccount(c)
+					if err != nil {
+						return fmt.Errorf("pool reward account: %w", err)
+					}
 					tmpPool.RewardAccount = rewardAcctHash
 					tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
@@ -3326,7 +3329,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					rewardAcctTag2, rewardAcctHash2 := certutil.PoolRewardAccount(c)
+					rewardAcctTag2, rewardAcctHash2, err := certutil.PoolRewardAccount(c)
+					if err != nil {
+						return fmt.Errorf("pool reward account: %w", err)
+					}
 					tmpPool.RewardAccount = rewardAcctHash2
 					tmpPool.RewardAccountCredentialTag = rewardAcctTag2
 					tmpReg := models.PoolRegistration{
@@ -4175,7 +4181,10 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 		tmpPool.Pledge = types.Uint64(cert.Pledge)
 		tmpPool.Cost = types.Uint64(cert.Cost)
 		tmpPool.Margin = &types.Rat{Rat: cert.Margin.Rat}
-		rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(&cert)
+		rewardAcctTag, rewardAcctHash, err := certutil.PoolRewardAccount(&cert)
+		if err != nil {
+			return fmt.Errorf("pool reward account: %w", err)
+		}
 		tmpPool.RewardAccount = rewardAcctHash
 		tmpPool.RewardAccountCredentialTag = rewardAcctTag
 

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -1818,7 +1818,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1877,7 +1880,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1922,7 +1928,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1968,7 +1977,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -1997,7 +2009,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2027,7 +2042,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2069,7 +2087,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2216,7 +2237,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2259,7 +2283,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -2300,7 +2327,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
@@ -3366,7 +3396,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3418,7 +3451,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3456,7 +3492,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3495,7 +3534,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3518,7 +3560,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3542,7 +3587,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3578,7 +3626,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3702,7 +3753,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3739,7 +3793,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -3774,7 +3831,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					credentialTag := uint8(c.StakeCredential.CredType)
+					credentialTag, err := models.CredentialTagFromUint(c.StakeCredential.CredType)
+					if err != nil {
+						return err
+					}
 					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
@@ -4222,7 +4282,10 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 			continue
 		}
 		stakeKey := cred.Credential[:]
-		credentialTag := uint8(cred.CredType)
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return err
+		}
 
 		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
 		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -232,7 +233,7 @@ func (d *MetadataStoreSqlite) GetTransactionsByBlockHash(
 }
 
 // It builds AddressTransaction rows for a single transaction.
-// deduplication by (payment_key, staking_key) within the tx.
+// deduplication by (payment_key, credential_tag, staking_key) within the tx.
 func collectAddressTransactions(
 	transactionID uint,
 	slot uint64,
@@ -263,7 +264,12 @@ func collectAddressTransactionsFromKeys(
 		if len(addressKey.PaymentKey) == 0 && len(addressKey.StakingKey) == 0 {
 			continue
 		}
-		key := fmt.Sprintf("%x|%x", addressKey.PaymentKey, addressKey.StakingKey)
+		key := fmt.Sprintf(
+			"%x|%d|%x",
+			addressKey.PaymentKey,
+			addressKey.CredentialTag,
+			addressKey.StakingKey,
+		)
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -271,6 +277,7 @@ func collectAddressTransactionsFromKeys(
 		ret = append(ret, models.AddressTransaction{
 			PaymentKey:    bytes.Clone(addressKey.PaymentKey),
 			StakingKey:    bytes.Clone(addressKey.StakingKey),
+			CredentialTag: addressKey.CredentialTag,
 			TransactionID: transactionID,
 			Slot:          slot,
 			TxIndex:       txIndex,
@@ -281,10 +288,11 @@ func collectAddressTransactionsFromKeys(
 
 func utxoAddressKeysFromUtxo(utxo models.Utxo) UtxoAddressKeys {
 	return UtxoAddressKeys{
-		TxId:       utxo.TxId,
-		OutputIdx:  utxo.OutputIdx,
-		PaymentKey: utxo.PaymentKey,
-		StakingKey: utxo.StakingKey,
+		TxId:          utxo.TxId,
+		OutputIdx:     utxo.OutputIdx,
+		PaymentKey:    utxo.PaymentKey,
+		StakingKey:    utxo.StakingKey,
+		CredentialTag: utxo.CredentialTag,
 	}
 }
 
@@ -292,6 +300,7 @@ func utxoAddressKeysFromUtxo(utxo models.Utxo) UtxoAddressKeys {
 // the given payment/staking key with pagination support.
 func (d *MetadataStoreSqlite) GetTransactionsByAddress(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -312,8 +321,9 @@ func (d *MetadataStoreSqlite) GetTransactionsByAddress(
 	switch {
 	case len(paymentKey) > 0 && len(stakingKey) > 0:
 		addrQuery = addrQuery.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			paymentKey,
+			credentialTag,
 			stakingKey,
 		)
 	case len(paymentKey) > 0:
@@ -322,7 +332,11 @@ func (d *MetadataStoreSqlite) GetTransactionsByAddress(
 			paymentKey,
 		)
 	default:
-		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+		addrQuery = addrQuery.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakingKey,
+		)
 	}
 
 	subQuery := addrQuery.Select("DISTINCT transaction_id")
@@ -360,6 +374,7 @@ func (d *MetadataStoreSqlite) GetTransactionsByAddress(
 // payment/staking key.
 func (d *MetadataStoreSqlite) CountTransactionsByAddress(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
@@ -376,8 +391,9 @@ func (d *MetadataStoreSqlite) CountTransactionsByAddress(
 	switch {
 	case len(paymentKey) > 0 && len(stakingKey) > 0:
 		addrQuery = addrQuery.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			paymentKey,
+			credentialTag,
 			stakingKey,
 		)
 	case len(paymentKey) > 0:
@@ -386,7 +402,11 @@ func (d *MetadataStoreSqlite) CountTransactionsByAddress(
 			paymentKey,
 		)
 	default:
-		addrQuery = addrQuery.Where("staking_key = ?", stakingKey)
+		addrQuery = addrQuery.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakingKey,
+		)
 	}
 
 	var count int64
@@ -400,8 +420,9 @@ func (d *MetadataStoreSqlite) CountTransactionsByAddress(
 	return int(count), nil
 }
 
-// GetAddressesByStakingKey returns distinct addresses mapped to a staking key.
-func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
+// GetAddressesByCredential returns distinct addresses mapped to a stake credential.
+func (d *MetadataStoreSqlite) GetAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -418,9 +439,13 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 	}
 
 	query := db.Model(&models.AddressTransaction{}).
-		Select("MIN(id) AS id, payment_key, staking_key").
-		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
-		Group("payment_key, staking_key").
+		Select("MIN(id) AS id, payment_key, credential_tag, staking_key").
+		Where(
+			"credential_tag = ? AND staking_key = ? AND length(payment_key) > 0",
+			credentialTag,
+			stakingKey,
+		).
+		Group("payment_key, credential_tag, staking_key").
 		Order(addressOrderClause(order))
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -429,13 +454,14 @@ func (d *MetadataStoreSqlite) GetAddressesByStakingKey(
 		query = query.Offset(offset)
 	}
 	if result := query.Find(&ret); result.Error != nil {
-		return nil, fmt.Errorf("get addresses by staking key: %w", result.Error)
+		return nil, fmt.Errorf("get addresses by stake credential: %w", result.Error)
 	}
 	return ret, nil
 }
 
-// CountAddressesByStakingKey returns the total number of distinct addresses mapped to a staking key.
-func (d *MetadataStoreSqlite) CountAddressesByStakingKey(
+// CountAddressesByCredential returns the total number of distinct addresses mapped to a stake credential.
+func (d *MetadataStoreSqlite) CountAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
@@ -445,16 +471,20 @@ func (d *MetadataStoreSqlite) CountAddressesByStakingKey(
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"resolve read DB for count addresses by staking key: %w",
+			"resolve read DB for count addresses by stake credential: %w",
 			err,
 		)
 	}
 	var count int64
 	if err := db.Model(&models.AddressTransaction{}).
-		Where("staking_key = ? AND length(payment_key) > 0", stakingKey).
+		Where(
+			"credential_tag = ? AND staking_key = ? AND length(payment_key) > 0",
+			credentialTag,
+			stakingKey,
+		).
 		Distinct("payment_key").
 		Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("count addresses by staking key: %w", err)
+		return 0, fmt.Errorf("count addresses by stake credential: %w", err)
 	}
 	return int(count), nil
 }
@@ -1688,19 +1718,22 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					tmpPool.RewardAccount = c.RewardAccount[:]
+					rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(c)
+					tmpPool.RewardAccount = rewardAcctHash
+					tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
 					// Create registration record
 					tmpReg := models.PoolRegistration{
-						PoolKeyHash:   c.Operator[:],
-						VrfKeyHash:    c.VrfKeyHash[:],
-						Pledge:        types.Uint64(c.Pledge),
-						Cost:          types.Uint64(c.Cost),
-						Margin:        &types.Rat{Rat: c.Margin.Rat},
-						RewardAccount: c.RewardAccount[:],
-						AddedSlot:     point.Slot,
-						DepositAmount: types.Uint64(deposit),
-						CertificateID: certIDMap[i],
+						PoolKeyHash:                c.Operator[:],
+						VrfKeyHash:                 c.VrfKeyHash[:],
+						Pledge:                     types.Uint64(c.Pledge),
+						Cost:                       types.Uint64(c.Cost),
+						Margin:                     &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount:              rewardAcctHash,
+						RewardAccountCredentialTag: rewardAcctTag,
+						AddedSlot:                  point.Slot,
+						DepositAmount:              types.Uint64(deposit),
+						CertificateID:              certIDMap[i],
 					}
 					if c.PoolMetadata != nil {
 						tmpReg.MetadataUrl = c.PoolMetadata.Url
@@ -1764,7 +1797,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 						},
 						DoUpdates: clause.AssignmentColumns([]string{
 							"vrf_key_hash", "pledge", "cost", "margin",
-							"reward_account", "certificate_id",
+							"reward_account", "reward_account_credential_tag", "certificate_id",
 							"metadata_url", "metadata_hash",
 							"deposit_amount",
 						}),
@@ -2431,10 +2464,15 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					// Save individual rewards
 					for credential, amount := range c.Reward.Rewards {
+						credentialTag, err := models.CredentialTagFromUint(credential.CredType)
+						if err != nil {
+							return fmt.Errorf("process certificate: %w", err)
+						}
 						tmpReward := models.MoveInstantaneousRewardsReward{
-							Credential: credential.Credential[:],
-							Amount:     types.Uint64(amount),
-							MIRID:      tmpMIR.ID,
+							Credential:    credential.Credential[:],
+							CredentialTag: credentialTag,
+							Amount:        types.Uint64(amount),
+							MIRID:         tmpMIR.ID,
 						}
 						result := db.Create(&tmpReward)
 						if result.Error != nil {
@@ -3272,17 +3310,20 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpPool.Pledge = types.Uint64(c.Pledge)
 					tmpPool.Cost = types.Uint64(c.Cost)
 					tmpPool.Margin = &types.Rat{Rat: c.Margin.Rat}
-					tmpPool.RewardAccount = c.RewardAccount[:]
+					rewardAcctTag2, rewardAcctHash2 := certutil.PoolRewardAccount(c)
+					tmpPool.RewardAccount = rewardAcctHash2
+					tmpPool.RewardAccountCredentialTag = rewardAcctTag2
 					tmpReg := models.PoolRegistration{
-						PoolKeyHash:   c.Operator[:],
-						VrfKeyHash:    c.VrfKeyHash[:],
-						Pledge:        types.Uint64(c.Pledge),
-						Cost:          types.Uint64(c.Cost),
-						Margin:        &types.Rat{Rat: c.Margin.Rat},
-						RewardAccount: c.RewardAccount[:],
-						AddedSlot:     point.Slot,
-						DepositAmount: types.Uint64(deposit),
-						CertificateID: certIDMap[i],
+						PoolKeyHash:                c.Operator[:],
+						VrfKeyHash:                 c.VrfKeyHash[:],
+						Pledge:                     types.Uint64(c.Pledge),
+						Cost:                       types.Uint64(c.Cost),
+						Margin:                     &types.Rat{Rat: c.Margin.Rat},
+						RewardAccount:              rewardAcctHash2,
+						RewardAccountCredentialTag: rewardAcctTag2,
+						AddedSlot:                  point.Slot,
+						DepositAmount:              types.Uint64(deposit),
+						CertificateID:              certIDMap[i],
 					}
 					if c.PoolMetadata != nil {
 						tmpReg.MetadataUrl = c.PoolMetadata.Url
@@ -3338,7 +3379,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 						},
 						DoUpdates: clause.AssignmentColumns([]string{
 							"vrf_key_hash", "pledge", "cost", "margin",
-							"reward_account", "certificate_id",
+							"reward_account", "reward_account_credential_tag", "certificate_id",
 							"metadata_url", "metadata_hash", "deposit_amount",
 						}),
 					}).Omit("Owners", "Relays").Create(&tmpReg)
@@ -3914,10 +3955,15 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					}
 					certIDUpdates[certIDMap[i]] = tmpMIR.ID
 					for credential, amount := range c.Reward.Rewards {
+						credentialTag, err := models.CredentialTagFromUint(credential.CredType)
+						if err != nil {
+							return fmt.Errorf("process certificate: %w", err)
+						}
 						tmpReward := models.MoveInstantaneousRewardsReward{
-							Credential: credential.Credential[:],
-							Amount:     types.Uint64(amount),
-							MIRID:      tmpMIR.ID,
+							Credential:    credential.Credential[:],
+							CredentialTag: credentialTag,
+							Amount:        types.Uint64(amount),
+							MIRID:         tmpMIR.ID,
 						}
 						if r := db.Create(&tmpReward); r.Error != nil {
 							return fmt.Errorf("process certificate (batched): %w", r.Error)
@@ -4097,16 +4143,19 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 		tmpPool.Pledge = types.Uint64(cert.Pledge)
 		tmpPool.Cost = types.Uint64(cert.Cost)
 		tmpPool.Margin = &types.Rat{Rat: cert.Margin.Rat}
-		tmpPool.RewardAccount = cert.RewardAccount[:]
+		rewardAcctTag, rewardAcctHash := certutil.PoolRewardAccount(&cert)
+		tmpPool.RewardAccount = rewardAcctHash
+		tmpPool.RewardAccountCredentialTag = rewardAcctTag
 
 		tmpReg := models.PoolRegistration{
-			PoolKeyHash:   cert.Operator[:],
-			VrfKeyHash:    cert.VrfKeyHash[:],
-			Pledge:        types.Uint64(cert.Pledge),
-			Cost:          types.Uint64(cert.Cost),
-			Margin:        &types.Rat{Rat: cert.Margin.Rat},
-			RewardAccount: cert.RewardAccount[:],
-			AddedSlot:     0,
+			PoolKeyHash:                cert.Operator[:],
+			VrfKeyHash:                 cert.VrfKeyHash[:],
+			Pledge:                     types.Uint64(cert.Pledge),
+			Cost:                       types.Uint64(cert.Cost),
+			Margin:                     &types.Rat{Rat: cert.Margin.Rat},
+			RewardAccount:              rewardAcctHash,
+			RewardAccountCredentialTag: rewardAcctTag,
+			AddedSlot:                  0,
 		}
 		if cert.PoolMetadata != nil {
 			tmpReg.MetadataUrl = cert.PoolMetadata.Url

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2563,7 +2563,12 @@ func (d *MetadataStoreSqlite) applyTransactionRewardWithdrawals(
 		if stakeKeyHash == zeroHash {
 			return errors.New("reward withdrawal missing stake credential")
 		}
+		credentialTag, ok := models.StakeCredentialTagFromAddress(*addr)
+		if !ok {
+			return errors.New("derive reward withdrawal credential tag")
+		}
 		if err := d.ApplyAccountRewardWithdrawal(
+			credentialTag,
 			stakeKeyHash.Bytes(),
 			amount.Uint64(),
 			slot,

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -474,6 +474,24 @@ func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 	order string,
 	txn types.Txn,
 ) ([]models.AccountDelegationHistoryRow, error) {
+	return d.GetAccountDelegationHistoryByCredential(
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func (d *MetadataStoreSqlite) GetAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountDelegationHistoryRow, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -481,8 +499,9 @@ func (d *MetadataStoreSqlite) GetAccountDelegationHistory(
 			err,
 		)
 	}
-	rows, err := accounthistory.QueryDelegationHistory(
+	rows, err := accounthistory.QueryDelegationHistoryByCredential(
 		db,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -503,6 +522,14 @@ func (d *MetadataStoreSqlite) CountAccountDelegationHistory(
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
+	return d.CountAccountDelegationHistoryByCredential(0, stakingKey, txn)
+}
+
+func (d *MetadataStoreSqlite) CountAccountDelegationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
@@ -510,7 +537,11 @@ func (d *MetadataStoreSqlite) CountAccountDelegationHistory(
 			err,
 		)
 	}
-	count, err := accounthistory.CountDelegationHistory(db, stakingKey)
+	count, err := accounthistory.CountDelegationHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"count account delegation history: %w",
@@ -528,6 +559,24 @@ func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
 	order string,
 	txn types.Txn,
 ) ([]models.AccountRegistrationHistoryRow, error) {
+	return d.GetAccountRegistrationHistoryByCredential(
+		0,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func (d *MetadataStoreSqlite) GetAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountRegistrationHistoryRow, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -535,8 +584,9 @@ func (d *MetadataStoreSqlite) GetAccountRegistrationHistory(
 			err,
 		)
 	}
-	rows, err := accounthistory.QueryRegistrationHistory(
+	rows, err := accounthistory.QueryRegistrationHistoryByCredential(
 		db,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -557,6 +607,14 @@ func (d *MetadataStoreSqlite) CountAccountRegistrationHistory(
 	stakingKey []byte,
 	txn types.Txn,
 ) (int, error) {
+	return d.CountAccountRegistrationHistoryByCredential(0, stakingKey, txn)
+}
+
+func (d *MetadataStoreSqlite) CountAccountRegistrationHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
@@ -564,7 +622,11 @@ func (d *MetadataStoreSqlite) CountAccountRegistrationHistory(
 			err,
 		)
 	}
-	count, err := accounthistory.CountRegistrationHistory(db, stakingKey)
+	count, err := accounthistory.CountRegistrationHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"count account registration history: %w",

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -708,6 +708,7 @@ func certRequiresDeposit(cert lcommon.Certificate) bool {
 // Uses a SELECT-then-INSERT pattern with OnConflict to handle race conditions
 // where two goroutines could both attempt to create the same account.
 func (d *MetadataStoreSqlite) getOrCreateAccount(
+	credentialTag uint8,
 	stakeKey []byte,
 	txn types.Txn,
 ) (*models.Account, error) {
@@ -718,7 +719,11 @@ func (d *MetadataStoreSqlite) getOrCreateAccount(
 
 	// First, try to find an existing account
 	var existing models.Account
-	result := db.Where("staking_key = ?", stakeKey).First(&existing)
+	result := db.Where(
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakeKey,
+	).First(&existing)
 	if result.Error == nil {
 		// Account exists - mark for reactivation if inactive
 		if !existing.Active {
@@ -731,11 +736,15 @@ func (d *MetadataStoreSqlite) getOrCreateAccount(
 	}
 
 	tmpAccount := &models.Account{
-		StakingKey: stakeKey,
-		Active:     true,
+		StakingKey:    stakeKey,
+		CredentialTag: credentialTag,
+		Active:        true,
 	}
 	result = db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "staking_key"}},
+		Columns: []clause.Column{
+			{Name: "credential_tag"},
+			{Name: "staking_key"},
+		},
 		DoNothing: true,
 	}).Create(tmpAccount)
 	if result.Error != nil {
@@ -744,7 +753,11 @@ func (d *MetadataStoreSqlite) getOrCreateAccount(
 
 	// If no row was inserted (conflict occurred), fetch the existing record
 	if result.RowsAffected == 0 {
-		result = db.Where("staking_key = ?", stakeKey).First(tmpAccount)
+		result = db.Where(
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
+			stakeKey,
+		).First(tmpAccount)
 		if result.Error != nil {
 			return nil, result.Error
 		}
@@ -758,12 +771,15 @@ func (d *MetadataStoreSqlite) getOrCreateAccount(
 }
 
 // saveAccount persists the account to the database. It creates a new
-// record when `account.ID == 0` (with an upsert on `staking_key`) or saves
-// the existing record otherwise.
+// record when `account.ID == 0` (with an upsert on credential tag + staking
+// key) or saves the existing record otherwise.
 func saveAccount(account *models.Account, db *gorm.DB) error {
 	if account.ID == 0 {
 		result := db.Clauses(clause.OnConflict{
-			Columns: []clause.Column{{Name: "staking_key"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "staking_key"},
+			},
 			DoUpdates: clause.AssignmentColumns(
 				[]string{
 					"added_slot",
@@ -1802,13 +1818,15 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
 					tmpReg := models.StakeRegistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -1859,17 +1877,22 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 					if tmpAccount == nil {
 						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
 						tmpAccount = &models.Account{
-							StakingKey: stakeKey,
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if result.Error != nil {
@@ -1882,6 +1905,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -1898,17 +1922,22 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 					if tmpAccount == nil {
 						d.logger.Warn("deregistering non-existent account", "hash", stakeKey)
 						tmpAccount = &models.Account{
-							StakingKey: stakeKey,
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
 						}
 						result := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if result.Error != nil {
@@ -1921,6 +1950,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 						Amount:        types.Uint64(deposit),
@@ -1938,7 +1968,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1948,6 +1979,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -1965,7 +1997,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -1975,6 +2008,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
@@ -1993,7 +2027,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2014,6 +2049,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -2033,13 +2069,15 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
 
 					tmpReg := models.Registration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -2178,7 +2216,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2199,6 +2238,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -2219,7 +2259,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2239,6 +2280,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -2258,7 +2300,8 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate: %w", err)
 					}
@@ -2278,6 +2321,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -3322,12 +3366,14 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeRegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					tmpReg := models.StakeRegistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -3372,14 +3418,21 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					if tmpAccount == nil {
-						tmpAccount = &models.Account{StakingKey: stakeKey}
+						tmpAccount = &models.Account{
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
+						}
 						r := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if r.Error != nil {
@@ -3390,6 +3443,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeDeregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -3402,14 +3456,21 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.DeregistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.GetAccount(stakeKey, false, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.GetAccountByCredential(credentialTag, stakeKey, false, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					if tmpAccount == nil {
-						tmpAccount = &models.Account{StakingKey: stakeKey}
+						tmpAccount = &models.Account{
+							StakingKey:    stakeKey,
+							CredentialTag: credentialTag,
+						}
 						r := db.Clauses(clause.OnConflict{
-							Columns:   []clause.Column{{Name: "staking_key"}},
+							Columns: []clause.Column{
+								{Name: "credential_tag"},
+								{Name: "staking_key"},
+							},
 							UpdateAll: true,
 						}).Create(tmpAccount)
 						if r.Error != nil {
@@ -3420,6 +3481,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.Deregistration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 						Amount:        types.Uint64(deposit),
@@ -3433,7 +3495,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3441,6 +3504,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
@@ -3454,7 +3518,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.StakeRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3462,6 +3527,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.StakeRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
@@ -3476,7 +3542,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.StakeVoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3495,6 +3562,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.StakeVoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -3510,12 +3578,14 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpItem.ID
 				case *lcommon.RegistrationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
 					tmpReg := models.Registration{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						AddedSlot:     point.Slot,
 						DepositAmount: types.Uint64(deposit),
 						CertificateID: certIDMap[i],
@@ -3632,7 +3702,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpUpdate.ID
 				case *lcommon.StakeVoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3651,6 +3722,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.StakeVoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						PoolKeyHash:   c.PoolKeyHash[:],
 						Drep:          drepCredential,
 						DrepType:      drepType,
@@ -3667,7 +3739,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteRegistrationDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3685,6 +3758,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpReg := models.VoteRegistrationDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -3700,7 +3774,8 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					certIDUpdates[certIDMap[i]] = tmpReg.ID
 				case *lcommon.VoteDelegationCertificate:
 					stakeKey := c.StakeCredential.Credential[:]
-					tmpAccount, err := d.getOrCreateAccount(stakeKey, txn)
+					credentialTag := uint8(c.StakeCredential.CredType)
+					tmpAccount, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 					if err != nil {
 						return fmt.Errorf("process certificate (batched): %w", err)
 					}
@@ -3718,6 +3793,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 					tmpAccount.AddedSlot = point.Slot
 					tmpItem := models.VoteDelegation{
 						StakingKey:    stakeKey,
+						CredentialTag: credentialTag,
 						Drep:          drepCredential,
 						DrepType:      drepType,
 						AddedSlot:     point.Slot,
@@ -4055,7 +4131,10 @@ func (d *MetadataStoreSqlite) SetGenesisStaking(
 		// Mithril after partial sync) would make that row invisible to
 		// every future rollback.
 		result := db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "staking_key"}},
+			Columns: []clause.Column{
+				{Name: "credential_tag"},
+				{Name: "staking_key"},
+			},
 			DoUpdates: clause.AssignmentColumns([]string{"pool", "active"}),
 		}).Create(account)
 		if result.Error != nil {
@@ -4143,6 +4222,7 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 			continue
 		}
 		stakeKey := cred.Credential[:]
+		credentialTag := uint8(cred.CredType)
 
 		drepType, err := models.DrepTypeFromInt(delegatee.DRep.Type)
 		if err != nil && delegatee.Type != conway.ConwayGenesisDelegateeTypeStake {
@@ -4155,7 +4235,7 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 			drepCredential = delegatee.DRep.Credential
 		}
 
-		account, err := d.getOrCreateAccount(stakeKey, txn)
+		account, err := d.getOrCreateAccount(credentialTag, stakeKey, txn)
 		if err != nil {
 			return fmt.Errorf(
 				"get or create genesis delegatee account: %w",
@@ -4173,11 +4253,12 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 		// would delete a genesis-rooted account.
 		var existingReg models.Registration
 		regResult := db.Where(
-			"staking_key = ? AND added_slot = ?",
-			stakeKey, uint64(0),
+			"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+			credentialTag, stakeKey, uint64(0),
 		).Attrs(models.Registration{
-			StakingKey: stakeKey,
-			AddedSlot:  0,
+			StakingKey:    stakeKey,
+			CredentialTag: credentialTag,
+			AddedSlot:     0,
 		}).FirstOrCreate(&existingReg)
 		if regResult.Error != nil {
 			return fmt.Errorf(
@@ -4201,12 +4282,13 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 			}
 			var existing models.StakeDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.StakeDelegation{
-				StakingKey:  stakeKey,
-				PoolKeyHash: delegatee.PoolId[:],
-				AddedSlot:   0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				PoolKeyHash:   delegatee.PoolId[:],
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -4223,13 +4305,14 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 			}
 			var existing models.VoteDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.VoteDelegation{
-				StakingKey: stakeKey,
-				Drep:       drepCredential,
-				DrepType:   drepType,
-				AddedSlot:  0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				Drep:          drepCredential,
+				DrepType:      drepType,
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -4247,14 +4330,15 @@ func (d *MetadataStoreSqlite) SetGenesisGovernance(
 			}
 			var existing models.StakeVoteDelegation
 			result := db.Where(
-				"staking_key = ? AND added_slot = ?",
-				stakeKey, uint64(0),
+				"credential_tag = ? AND staking_key = ? AND added_slot = ?",
+				credentialTag, stakeKey, uint64(0),
 			).Attrs(models.StakeVoteDelegation{
-				StakingKey:  stakeKey,
-				PoolKeyHash: delegatee.PoolId[:],
-				Drep:        drepCredential,
-				DrepType:    drepType,
-				AddedSlot:   0,
+				StakingKey:    stakeKey,
+				CredentialTag: credentialTag,
+				PoolKeyHash:   delegatee.PoolId[:],
+				Drep:          drepCredential,
+				DrepType:      drepType,
+				AddedSlot:     0,
 			}).FirstOrCreate(&existing)
 			if result.Error != nil {
 				return fmt.Errorf(

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -35,10 +35,11 @@ type UtxoRef struct {
 
 // UtxoAddressKeys is the skinny UTxO projection needed for address indexing.
 type UtxoAddressKeys struct {
-	TxId       []byte `gorm:"column:tx_id"`
-	PaymentKey []byte `gorm:"column:payment_key"`
-	StakingKey []byte `gorm:"column:staking_key"`
-	OutputIdx  uint32 `gorm:"column:output_idx"`
+	TxId          []byte `gorm:"column:tx_id"`
+	PaymentKey    []byte `gorm:"column:payment_key"`
+	StakingKey    []byte `gorm:"column:staking_key"`
+	CredentialTag uint8  `gorm:"column:credential_tag"`
+	OutputIdx     uint32 `gorm:"column:output_idx"`
 }
 
 // GetUtxo returns a Utxo by reference
@@ -180,7 +181,7 @@ func (d *MetadataStoreSqlite) GetUtxoAddressKeysBatch(
 
 		var rows []UtxoAddressKeys
 		query := db.Table(utxoRefIndexedTable()).
-			Select("tx_id", "output_idx", "payment_key", "staking_key").
+			Select("tx_id", "output_idx", "payment_key", "credential_tag", "staking_key").
 			Where("deleted_slot = 0").
 			Where("("+strings.Join(conditions, " OR ")+")", args...)
 		if queryResult := query.Find(&rows); queryResult.Error != nil {
@@ -310,9 +311,11 @@ func addressWhereClause(
 
 	switch {
 	case hasPayment && hasStake:
+		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
 		return db.Where(
-			"payment_key = ? AND staking_key = ?",
+			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
 			addr.PaymentKeyHash().Bytes(),
+			credentialTag,
 			addr.StakeKeyHash().Bytes(),
 		)
 	case hasPayment:
@@ -321,8 +324,10 @@ func addressWhereClause(
 			addr.PaymentKeyHash().Bytes(),
 		)
 	case hasStake:
+		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
 		return db.Where(
-			"staking_key = ?",
+			"credential_tag = ? AND staking_key = ?",
+			credentialTag,
 			addr.StakeKeyHash().Bytes(),
 		)
 	default:
@@ -355,9 +360,10 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 	return ret, nil
 }
 
-// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
-// controlled by the given staking key.
-func (d *MetadataStoreSqlite) GetControlledAmountByStakingKey(
+// GetControlledAmountByCredential returns the sum of live UTxO amounts
+// controlled by the given stake credential.
+func (d *MetadataStoreSqlite) GetControlledAmountByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn types.Txn,
 ) (uint64, error) {
@@ -367,17 +373,21 @@ func (d *MetadataStoreSqlite) GetControlledAmountByStakingKey(
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"resolve read DB for controlled amount by staking key: %w",
+			"resolve read DB for controlled amount by stake credential: %w",
 			err,
 		)
 	}
 	var total uint64
 	if err := db.Model(&models.Utxo{}).
-		Where("staking_key = ? AND deleted_slot = 0", stakingKey).
+		Where(
+			"credential_tag = ? AND staking_key = ? AND deleted_slot = 0",
+			credentialTag,
+			stakingKey,
+		).
 		Select("COALESCE(SUM(amount), 0)").
 		Scan(&total).Error; err != nil {
 		return 0, fmt.Errorf(
-			"get controlled amount by staking key: %w",
+			"get controlled amount by stake credential: %w",
 			err,
 		)
 	}

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -314,7 +314,7 @@ func addressWhereClause(
 	case hasPayment && hasStake:
 		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, fmt.Errorf("derive stake credential tag from address")
+			return nil, errors.New("derive stake credential tag from address")
 		}
 		return db.Where(
 			"payment_script = ? AND payment_key = ? AND credential_tag = ? AND staking_key = ?",
@@ -332,7 +332,7 @@ func addressWhereClause(
 	case hasStake:
 		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, fmt.Errorf("derive stake credential tag from address")
+			return nil, errors.New("derive stake credential tag from address")
 		}
 		return db.Where(
 			"credential_tag = ? AND staking_key = ?",

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -304,34 +304,43 @@ func (d *MetadataStoreSqlite) GetUtxosDeletedBeforeSlot(
 func addressWhereClause(
 	db *gorm.DB,
 	addr lcommon.Address,
-) *gorm.DB {
+) (*gorm.DB, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	hasPayment := addr.PaymentKeyHash() != zeroHash
 	hasStake := addr.StakeKeyHash() != zeroHash
+	paymentScript := models.PaymentScriptFromAddress(addr)
 
 	switch {
 	case hasPayment && hasStake:
-		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
+		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, fmt.Errorf("derive stake credential tag from address")
+		}
 		return db.Where(
-			"payment_key = ? AND credential_tag = ? AND staking_key = ?",
+			"payment_script = ? AND payment_key = ? AND credential_tag = ? AND staking_key = ?",
+			paymentScript,
 			addr.PaymentKeyHash().Bytes(),
 			credentialTag,
 			addr.StakeKeyHash().Bytes(),
-		)
+		), nil
 	case hasPayment:
 		return db.Where(
-			"payment_key = ?",
+			"payment_script = ? AND payment_key = ?",
+			paymentScript,
 			addr.PaymentKeyHash().Bytes(),
-		)
+		), nil
 	case hasStake:
-		credentialTag, _ := models.StakeCredentialTagFromAddress(addr)
+		credentialTag, ok := models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, fmt.Errorf("derive stake credential tag from address")
+		}
 		return db.Where(
 			"credential_tag = ? AND staking_key = ?",
 			credentialTag,
 			addr.StakeKeyHash().Bytes(),
-		)
+		), nil
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
@@ -345,7 +354,10 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery := addressWhereClause(db, addr)
+	addrQuery, err := addressWhereClause(db, addr)
+	if err != nil {
+		return nil, err
+	}
 	if addrQuery == nil {
 		return ret, nil
 	}
@@ -451,7 +463,12 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 		var ors []string
 		var args []any
 		for i := range addrs {
-			models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i])
+			if err := models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i]); err != nil {
+				return nil, fmt.Errorf(
+					"GetUtxosByAddressWithOrdering: %w",
+					err,
+				)
+			}
 		}
 		if len(ors) == 0 {
 			base = base.Where("1 = 0")
@@ -563,7 +580,10 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery := addressWhereClause(db, addr)
+	addrQuery, err := addressWhereClause(db, addr)
+	if err != nil {
+		return nil, err
+	}
 	if addrQuery == nil {
 		return ret, nil
 	}

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 func TestGetLiveUtxosBySlot(t *testing.T) {
@@ -452,4 +453,77 @@ func TestGetScriptLockedSupplyEmpty(t *testing.T) {
 	got, err := store.GetScriptLockedSupply(nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), got)
+}
+
+func TestGetUtxosByAddressUsesPaymentScript(t *testing.T) {
+	store := setupTestDB(t)
+
+	paymentHash := bytes.Repeat([]byte{0xAB}, lcommon.AddressHashSize)
+	stakeHash := bytes.Repeat([]byte{0xCD}, lcommon.AddressHashSize)
+	keyAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkMainnet,
+		paymentHash,
+		stakeHash,
+	)
+	require.NoError(t, err)
+	scriptAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptKey,
+		lcommon.AddressNetworkMainnet,
+		paymentHash,
+		stakeHash,
+	)
+	require.NoError(t, err)
+
+	txID := uint(1)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID:         txID,
+		Hash:       bytes.Repeat([]byte{0x01}, 32),
+		Slot:       10,
+		BlockIndex: 0,
+	}).Error)
+	keyUtxo := models.Utxo{
+		TransactionID: &txID,
+		TxId:          bytes.Repeat([]byte{0x10}, 32),
+		OutputIdx:     0,
+		PaymentKey:    paymentHash,
+		StakingKey:    stakeHash,
+		CredentialTag: 0,
+		AddedSlot:     10,
+		Amount:        types.Uint64(1_000_000),
+	}
+	scriptUtxo := models.Utxo{
+		TransactionID: &txID,
+		TxId:          bytes.Repeat([]byte{0x20}, 32),
+		OutputIdx:     0,
+		PaymentKey:    paymentHash,
+		StakingKey:    stakeHash,
+		CredentialTag: 0,
+		AddedSlot:     10,
+		Amount:        types.Uint64(2_000_000),
+		PaymentScript: true,
+	}
+	require.NoError(t, store.DB().Create(&keyUtxo).Error)
+	require.NoError(t, store.DB().Create(&scriptUtxo).Error)
+
+	keyRows, err := store.GetUtxosByAddress(keyAddr, nil)
+	require.NoError(t, err)
+	require.Len(t, keyRows, 1)
+	assert.False(t, keyRows[0].PaymentScript)
+	assert.Equal(t, keyUtxo.TxId, keyRows[0].TxId)
+
+	scriptRows, err := store.GetUtxosByAddress(scriptAddr, nil)
+	require.NoError(t, err)
+	require.Len(t, scriptRows, 1)
+	assert.True(t, scriptRows[0].PaymentScript)
+	assert.Equal(t, scriptUtxo.TxId, scriptRows[0].TxId)
+
+	orderedRows, err := store.GetUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{Addresses: []lcommon.Address{scriptAddr}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, orderedRows, 1)
+	assert.True(t, orderedRows[0].PaymentScript)
+	assert.Equal(t, scriptUtxo.TxId, orderedRows[0].TxId)
 }

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -295,14 +295,6 @@ type MetadataStore interface {
 	// GetTip retrieves the current chain tip.
 	GetTip(types.Txn) (ochainsync.Tip, error)
 
-	// GetAccount retrieves a key-credential account by staking key.
-	// This compatibility wrapper defaults credential_tag to 0.
-	GetAccount(
-		[]byte, // stakeKey
-		bool, // includeInactive
-		types.Txn,
-	) (*models.Account, error)
-
 	// GetAccountByCredential retrieves an account using the full stake credential identity.
 	// The credential tag separates key and script credentials that share the same hash.
 	GetAccountByCredential(
@@ -312,14 +304,6 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Account, error)
 
-	// GetAccounts retrieves key-credential accounts by staking key.
-	// This compatibility wrapper defaults credential_tag to 0.
-	GetAccounts(
-		[][]byte, // stakeKeys
-		bool, // includeInactive
-		types.Txn,
-	) (map[string]*models.Account, error)
-
 	// GetAccountsByCredential retrieves accounts in batch using tag-aware stake credentials.
 	// The returned map is keyed by StakeCredentialRef.MapKey() for tag plus hash lookups.
 	GetAccountsByCredential(
@@ -327,15 +311,6 @@ type MetadataStore interface {
 		bool, // includeInactive
 		types.Txn,
 	) (map[string]*models.Account, error)
-
-	// AddAccountReward credits a key-credential reward account by staking key.
-	// This compatibility wrapper defaults credential_tag to 0.
-	AddAccountReward(
-		[]byte, // stakeKey
-		uint64, // amount
-		uint64, // slot
-		types.Txn,
-	) error
 
 	// ApplyAccountRewardWithdrawal clears a registered reward account after a
 	// validated transaction withdrawal and records rollback state.
@@ -507,16 +482,6 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
-	// GetAccountDelegationHistory retrieves key-credential delegation history
-	// rows for a staking key. It is a tag-0 compatibility wrapper.
-	GetAccountDelegationHistory(
-		[]byte, // stakingKey
-		int, // limit
-		int, // offset
-		string, // order (asc|desc)
-		types.Txn,
-	) ([]models.AccountDelegationHistoryRow, error)
-
 	// GetAccountDelegationHistoryByCredential retrieves delegation history
 	// rows for a stake credential tag/hash pair.
 	GetAccountDelegationHistoryByCredential(
@@ -528,13 +493,6 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.AccountDelegationHistoryRow, error)
 
-	// CountAccountDelegationHistory retrieves the total count of key-credential
-	// delegation history rows for a staking key. It is a tag-0 compatibility wrapper.
-	CountAccountDelegationHistory(
-		[]byte, // stakingKey
-		types.Txn,
-	) (int, error)
-
 	// CountAccountDelegationHistoryByCredential retrieves the total count of
 	// delegation history rows for a stake credential tag/hash pair.
 	CountAccountDelegationHistoryByCredential(
@@ -542,16 +500,6 @@ type MetadataStore interface {
 		[]byte, // stakingKey
 		types.Txn,
 	) (int, error)
-
-	// GetAccountRegistrationHistory retrieves key-credential registration history
-	// rows for a staking key. It is a tag-0 compatibility wrapper.
-	GetAccountRegistrationHistory(
-		[]byte, // stakingKey
-		int, // limit
-		int, // offset
-		string, // order (asc|desc)
-		types.Txn,
-	) ([]models.AccountRegistrationHistoryRow, error)
 
 	// GetAccountRegistrationHistoryByCredential retrieves registration history
 	// rows for a stake credential tag/hash pair.
@@ -563,13 +511,6 @@ type MetadataStore interface {
 		string, // order (asc|desc)
 		types.Txn,
 	) ([]models.AccountRegistrationHistoryRow, error)
-
-	// CountAccountRegistrationHistory retrieves the total count of key-credential
-	// registration history rows for a staking key. It is a tag-0 compatibility wrapper.
-	CountAccountRegistrationHistory(
-		[]byte, // stakingKey
-		types.Txn,
-	) (int, error)
 
 	// CountAccountRegistrationHistoryByCredential retrieves the total count of
 	// registration history rows for a stake credential tag/hash pair.

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -295,7 +295,8 @@ type MetadataStore interface {
 	// GetTip retrieves the current chain tip.
 	GetTip(types.Txn) (ochainsync.Tip, error)
 
-	// GetAccount retrieves an account by stake credential, optionally including inactive accounts.
+	// GetAccount retrieves a key-credential account by staking key.
+	// This compatibility wrapper defaults credential_tag to 0.
 	GetAccount(
 		[]byte, // stakeKey
 		bool, // includeInactive
@@ -311,10 +312,8 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Account, error)
 
-	// GetAccounts retrieves multiple accounts by stake credential in a single query,
-	// optionally including inactive accounts. The returned map is keyed by the
-	// StakeCredentialRef MapKey; credentials with no matching row are omitted. An
-	// empty input returns an empty (non-nil) map and no error.
+	// GetAccounts retrieves key-credential accounts by staking key.
+	// This compatibility wrapper defaults credential_tag to 0.
 	GetAccounts(
 		[][]byte, // stakeKeys
 		bool, // includeInactive
@@ -329,7 +328,8 @@ type MetadataStore interface {
 		types.Txn,
 	) (map[string]*models.Account, error)
 
-	// AddAccountReward credits a reward account by stake credential.
+	// AddAccountReward credits a key-credential reward account by staking key.
+	// This compatibility wrapper defaults credential_tag to 0.
 	AddAccountReward(
 		[]byte, // stakeKey
 		uint64, // amount

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -317,6 +317,7 @@ type MetadataStore interface {
 	// ApplyAccountRewardWithdrawal clears a registered reward account after a
 	// validated transaction withdrawal and records rollback state.
 	ApplyAccountRewardWithdrawal(
+		uint8, // credentialTag
 		[]byte, // stakeKey
 		uint64, // amount
 		uint64, // slot

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -295,19 +295,36 @@ type MetadataStore interface {
 	// GetTip retrieves the current chain tip.
 	GetTip(types.Txn) (ochainsync.Tip, error)
 
-	// GetAccount retrieves an account by stake key, optionally including inactive accounts.
+	// GetAccount retrieves an account by stake credential, optionally including inactive accounts.
 	GetAccount(
 		[]byte, // stakeKey
 		bool, // includeInactive
 		types.Txn,
 	) (*models.Account, error)
 
-	// GetAccounts retrieves multiple accounts by stake key in a single query,
-	// optionally including inactive accounts. The returned map is keyed by
-	// string(StakingKey); stake keys with no matching row are omitted. An
+	// GetAccountByCredential retrieves an account using the full stake credential identity.
+	// The credential tag separates key and script credentials that share the same hash.
+	GetAccountByCredential(
+		uint8, // credentialTag
+		[]byte, // stakeKey
+		bool, // includeInactive
+		types.Txn,
+	) (*models.Account, error)
+
+	// GetAccounts retrieves multiple accounts by stake credential in a single query,
+	// optionally including inactive accounts. The returned map is keyed by the
+	// StakeCredentialRef MapKey; credentials with no matching row are omitted. An
 	// empty input returns an empty (non-nil) map and no error.
 	GetAccounts(
 		[][]byte, // stakeKeys
+		bool, // includeInactive
+		types.Txn,
+	) (map[string]*models.Account, error)
+
+	// GetAccountsByCredential retrieves accounts in batch using tag-aware stake credentials.
+	// The returned map is keyed by StakeCredentialRef.MapKey() for tag plus hash lookups.
+	GetAccountsByCredential(
+		[]models.StakeCredentialRef, // stakeCredentials
 		bool, // includeInactive
 		types.Txn,
 	) (map[string]*models.Account, error)
@@ -327,6 +344,16 @@ type MetadataStore interface {
 		uint64, // amount
 		uint64, // slot
 		[]byte, // txHash
+		types.Txn,
+	) error
+
+	// AddAccountRewardByCredential credits rewards using the full stake credential identity.
+	// The credential tag prevents key and script reward accounts with the same hash from merging.
+	AddAccountRewardByCredential(
+		uint8, // credentialTag
+		[]byte, // stakeKey
+		uint64, // amount
+		uint64, // slot
 		types.Txn,
 	) error
 

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -286,8 +286,10 @@ type MetadataStore interface {
 		types.Txn,
 	) (map[string]uint64, map[string]uint64, error)
 
-	// GetStakeRegistrations retrieves all stake registration certificates for an account.
-	GetStakeRegistrations(
+	// GetStakeRegistrationsByCredential retrieves stake registration certificates
+	// using the full credential identity: credential tag plus 28-byte hash.
+	GetStakeRegistrationsByCredential(
+		uint8, // credentialTag
 		[]byte, // stakeKey
 		types.Txn,
 	) ([]lcommon.StakeRegistrationCertificate, error)
@@ -448,9 +450,10 @@ type MetadataStore interface {
 	) ([]models.Transaction, error)
 
 	// GetTransactionsByAddress retrieves transactions involving
-	// the provided payment/staking key pair with pagination and ordering.
+	// the provided payment/staking credential pair with pagination and ordering.
 	GetTransactionsByAddress(
 		[]byte, // paymentKey
+		uint8, // credentialTag
 		[]byte, // stakingKey
 		int, // limit
 		int, // offset
@@ -459,16 +462,17 @@ type MetadataStore interface {
 	) ([]models.Transaction, error)
 
 	// CountTransactionsByAddress returns the total number of
-	// transactions involving the provided payment/staking
-	// key pair.
+	// transactions involving the provided payment/staking credential pair.
 	CountTransactionsByAddress(
 		[]byte, // paymentKey
+		uint8, // credentialTag
 		[]byte, // stakingKey
 		types.Txn,
 	) (int, error)
 
-	// GetAddressesByStakingKey retrieves distinct address mappings for a staking key.
-	GetAddressesByStakingKey(
+	// GetAddressesByCredential retrieves distinct address mappings for a stake credential.
+	GetAddressesByCredential(
+		uint8, // credentialTag
 		[]byte, // stakingKey
 		int, // limit
 		int, // offset
@@ -476,8 +480,9 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.AddressTransaction, error)
 
-	// CountAddressesByStakingKey retrieves the total count of distinct address mappings for a staking key.
-	CountAddressesByStakingKey(
+	// CountAddressesByCredential retrieves the total count of distinct address mappings for a stake credential.
+	CountAddressesByCredential(
+		uint8, // credentialTag
 		[]byte, // stakingKey
 		types.Txn,
 	) (int, error)
@@ -751,9 +756,9 @@ type MetadataStore interface {
 	// GetUtxosByAddress retrieves all UTxOs for a given address.
 	GetUtxosByAddress(ledger.Address, types.Txn) ([]models.Utxo, error)
 
-	// GetControlledAmountByStakingKey returns the sum of live UTxO
-	// amounts controlled by the given staking key.
-	GetControlledAmountByStakingKey([]byte, types.Txn) (uint64, error)
+	// GetControlledAmountByCredential returns the sum of live UTxO
+	// amounts controlled by the given stake credential.
+	GetControlledAmountByCredential(uint8, []byte, types.Txn) (uint64, error)
 
 	// GetScriptLockedSupply returns the sum of lovelace held in live
 	// UTxOs whose payment credential is a script. This is the network's

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -507,7 +507,8 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
-	// GetAccountDelegationHistory retrieves delegation history rows for a staking key.
+	// GetAccountDelegationHistory retrieves key-credential delegation history
+	// rows for a staking key. It is a tag-0 compatibility wrapper.
 	GetAccountDelegationHistory(
 		[]byte, // stakingKey
 		int, // limit
@@ -516,14 +517,34 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.AccountDelegationHistoryRow, error)
 
-	// CountAccountDelegationHistory retrieves the total count of
-	// delegation history rows for a staking key.
+	// GetAccountDelegationHistoryByCredential retrieves delegation history
+	// rows for a stake credential tag/hash pair.
+	GetAccountDelegationHistoryByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
+		types.Txn,
+	) ([]models.AccountDelegationHistoryRow, error)
+
+	// CountAccountDelegationHistory retrieves the total count of key-credential
+	// delegation history rows for a staking key. It is a tag-0 compatibility wrapper.
 	CountAccountDelegationHistory(
 		[]byte, // stakingKey
 		types.Txn,
 	) (int, error)
 
-	// GetAccountRegistrationHistory retrieves registration history rows for a staking key.
+	// CountAccountDelegationHistoryByCredential retrieves the total count of
+	// delegation history rows for a stake credential tag/hash pair.
+	CountAccountDelegationHistoryByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
+
+	// GetAccountRegistrationHistory retrieves key-credential registration history
+	// rows for a staking key. It is a tag-0 compatibility wrapper.
 	GetAccountRegistrationHistory(
 		[]byte, // stakingKey
 		int, // limit
@@ -532,9 +553,28 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]models.AccountRegistrationHistoryRow, error)
 
-	// CountAccountRegistrationHistory retrieves the total count of
-	// registration history rows for a staking key.
+	// GetAccountRegistrationHistoryByCredential retrieves registration history
+	// rows for a stake credential tag/hash pair.
+	GetAccountRegistrationHistoryByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
+		types.Txn,
+	) ([]models.AccountRegistrationHistoryRow, error)
+
+	// CountAccountRegistrationHistory retrieves the total count of key-credential
+	// registration history rows for a staking key. It is a tag-0 compatibility wrapper.
 	CountAccountRegistrationHistory(
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
+
+	// CountAccountRegistrationHistoryByCredential retrieves the total count of
+	// registration history rows for a stake credential tag/hash pair.
+	CountAccountRegistrationHistoryByCredential(
+		uint8, // credentialTag
 		[]byte, // stakingKey
 		types.Txn,
 	) (int, error)

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -365,8 +365,20 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Datum, error)
 
-	// GetDrep retrieves a DRep by its credential, optionally including inactive DReps.
+	// GetDrep retrieves a DRep by credential hash only (no tag filter).
+	// Used for the protocol validation path where only a Blake2b224 hash
+	// is available (e.g. LedgerView.DRepRegistration from gouroboros).
 	GetDrep(
+		[]byte, // credential
+		bool, // includeInactive
+		types.Txn,
+	) (*models.Drep, error)
+
+	// GetDrepByCredential retrieves a DRep using the full credential
+	// identity: tag (0=key, 1=script) plus 28-byte hash. Use this for
+	// all internal callers that know the credential type.
+	GetDrepByCredential(
+		uint8, // credentialTag
 		[]byte, // credential
 		bool, // includeInactive
 		types.Txn,
@@ -1127,12 +1139,13 @@ type MetadataStore interface {
 	// DRep voting power and activity methods
 
 	// InsertDrepIfAbsent inserts a minimal DRep row when no record
-	// exists for the given credential. If a row already exists, it is
-	// left untouched: added_slot, anchor_url, anchor_hash, and active
-	// are never overwritten. Used on the vote-replay recovery path to
-	// recreate rows lost during recovery/bootstrap without clobbering
-	// real registration metadata.
+	// exists for the given full credential identity (tag + hash). If a
+	// row already exists, it is left untouched: added_slot, anchor_url,
+	// anchor_hash, and active are never overwritten. Used on the
+	// vote-replay recovery path to recreate rows lost during
+	// recovery/bootstrap without clobbering real registration metadata.
 	InsertDrepIfAbsent(
+		credentialTag uint8,
 		cred []byte,
 		slot uint64,
 		url string,
@@ -1143,18 +1156,21 @@ type MetadataStore interface {
 
 	// GetDRepVotingPower calculates the voting power for a DRep by summing
 	// the current stake of all delegated accounts, approximated from live
-	// UTxO balance plus reward-account balance.
+	// UTxO balance plus reward-account balance. credentialTag distinguishes
+	// key (0) from script (1) DRep credentials that share the same hash.
 	GetDRepVotingPower(
+		uint8, // credentialTag
 		[]byte, // drepCredential
 		types.Txn,
 	) (uint64, error)
 
 	// GetDRepVotingPowerBatch is the batch form of GetDRepVotingPower.
-	// Returns a credential-to-power map; credentials with no delegated
-	// stake are omitted. Used by governance tallying to avoid N+1
-	// per-DRep lookups.
+	// Returns a StakeCredentialRef.MapKey()-to-power map; credentials with
+	// no delegated stake are omitted. Use StakeCredentialRef to carry both
+	// the tag and hash so that key-hash and script-hash DReps sharing a
+	// 28-byte hash are tallied independently.
 	GetDRepVotingPowerBatch(
-		drepCredentials [][]byte,
+		drepCredentials []models.StakeCredentialRef,
 		txn types.Txn,
 	) (map[string]uint64, error)
 
@@ -1168,8 +1184,10 @@ type MetadataStore interface {
 	) (map[uint64]uint64, error)
 
 	// UpdateDRepActivity updates the DRep's last activity epoch and
-	// recalculates the expiry epoch.
+	// recalculates the expiry epoch. credentialTag distinguishes key (0)
+	// from script (1) DRep credentials that share the same 28-byte hash.
 	UpdateDRepActivity(
+		uint8, // credentialTag
 		[]byte, // drepCredential
 		uint64, // activityEpoch
 		uint64, // inactivityPeriod

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -74,8 +74,9 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 		return fmt.Errorf("get pools: %w", err)
 	}
 
-	rewardAcctByPool := make(map[string][]byte, len(pools))
-	rewardAccounts := make([][]byte, 0, len(pools))
+	rewardAcctByPool := make(map[string]models.StakeCredentialRef, len(pools))
+	seenRefs := make(map[string]struct{}, len(pools))
+	rewardAccountRefs := make([]models.StakeCredentialRef, 0, len(pools))
 	for i := range pools {
 		ra := pools[i].RewardAccount
 		if len(ra) == 0 {
@@ -85,29 +86,23 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 		if _, dup := rewardAcctByPool[poolKey]; dup {
 			continue
 		}
-		rewardAcctByPool[poolKey] = ra
-		rewardAccounts = append(rewardAccounts, ra)
+		ref := models.StakeCredentialRef{
+			Tag: pools[i].RewardAccountCredentialTag,
+			Key: ra,
+		}
+		rewardAcctByPool[poolKey] = ref
+		mk := ref.MapKey()
+		if _, seen := seenRefs[mk]; !seen {
+			seenRefs[mk] = struct{}{}
+			rewardAccountRefs = append(rewardAccountRefs, ref)
+		}
 	}
-	if len(rewardAccounts) == 0 {
+	if len(rewardAccountRefs) == 0 {
 		return nil
 	}
 
 	// includeInactive=false so a deregistered reward account that
 	// still carries a stale predefined-DRep flag does not auto-vote.
-	rewardAccountRefs := make(
-		[]models.StakeCredentialRef,
-		0,
-		len(rewardAccounts),
-	)
-	for _, rewardAccount := range rewardAccounts {
-		rewardAccountRefs = append(
-			rewardAccountRefs,
-			models.StakeCredentialRef{
-				Tag: 0,
-				Key: rewardAccount,
-			},
-		)
-	}
 	accounts, err := d.GetAccountsByCredential(
 		rewardAccountRefs,
 		false,
@@ -117,11 +112,8 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 		return fmt.Errorf("get reward accounts: %w", err)
 	}
 
-	for poolKey, ra := range rewardAcctByPool {
-		acct, ok := accounts[models.StakeCredentialRef{
-			Tag: 0,
-			Key: ra,
-		}.MapKey()]
+	for poolKey, ref := range rewardAcctByPool {
+		acct, ok := accounts[ref.MapKey()]
 		if !ok {
 			continue
 		}

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -94,13 +94,34 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 
 	// includeInactive=false so a deregistered reward account that
 	// still carries a stale predefined-DRep flag does not auto-vote.
-	accounts, err := d.GetAccounts(rewardAccounts, false, txn)
+	rewardAccountRefs := make(
+		[]models.StakeCredentialRef,
+		0,
+		len(rewardAccounts),
+	)
+	for _, rewardAccount := range rewardAccounts {
+		rewardAccountRefs = append(
+			rewardAccountRefs,
+			models.StakeCredentialRef{
+				Tag: 0,
+				Key: rewardAccount,
+			},
+		)
+	}
+	accounts, err := d.GetAccountsByCredential(
+		rewardAccountRefs,
+		false,
+		txn,
+	)
 	if err != nil {
 		return fmt.Errorf("get reward accounts: %w", err)
 	}
 
 	for poolKey, ra := range rewardAcctByPool {
-		acct, ok := accounts[string(ra)]
+		acct, ok := accounts[models.StakeCredentialRef{
+			Tag: 0,
+			Key: ra,
+		}.MapKey()]
 		if !ok {
 			continue
 		}

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -886,7 +886,11 @@ func (d *Database) GetTransactionsByAddress(
 		paymentKey = pkh.Bytes()
 	}
 	if skh := addr.StakeKeyHash(); skh != zeroHash {
-		credentialTag, _ = models.StakeCredentialTagFromAddress(addr)
+		var ok bool
+		credentialTag, ok = models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, errors.New("derive stake credential tag from address")
+		}
 		stakingKey = skh.Bytes()
 	}
 	return d.GetTransactionsByAddressKeys(
@@ -917,7 +921,11 @@ func (d *Database) GetTransactionsByAddressWithOrder(
 		paymentKey = pkh.Bytes()
 	}
 	if skh := addr.StakeKeyHash(); skh != zeroHash {
-		credentialTag, _ = models.StakeCredentialTagFromAddress(addr)
+		var ok bool
+		credentialTag, ok = models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return nil, errors.New("derive stake credential tag from address")
+		}
 		stakingKey = skh.Bytes()
 	}
 	return d.GetTransactionsByAddressKeys(
@@ -983,7 +991,11 @@ func (d *Database) CountTransactionsByAddress(
 		paymentKey = pkh.Bytes()
 	}
 	if skh := addr.StakeKeyHash(); skh != zeroHash {
-		credentialTag, _ = models.StakeCredentialTagFromAddress(addr)
+		var ok bool
+		credentialTag, ok = models.StakeCredentialTagFromAddress(addr)
+		if !ok {
+			return 0, errors.New("derive stake credential tag from address")
+		}
 		stakingKey = skh.Bytes()
 	}
 	return d.CountTransactionsByAddressKeys(

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -880,15 +880,18 @@ func (d *Database) GetTransactionsByAddress(
 ) ([]models.Transaction, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	var paymentKey []byte
+	var credentialTag uint8
 	var stakingKey []byte
 	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
 		paymentKey = pkh.Bytes()
 	}
 	if skh := addr.StakeKeyHash(); skh != zeroHash {
+		credentialTag, _ = models.StakeCredentialTagFromAddress(addr)
 		stakingKey = skh.Bytes()
 	}
 	return d.GetTransactionsByAddressKeys(
 		paymentKey,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -908,15 +911,18 @@ func (d *Database) GetTransactionsByAddressWithOrder(
 ) ([]models.Transaction, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	var paymentKey []byte
+	var credentialTag uint8
 	var stakingKey []byte
 	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
 		paymentKey = pkh.Bytes()
 	}
 	if skh := addr.StakeKeyHash(); skh != zeroHash {
+		credentialTag, _ = models.StakeCredentialTagFromAddress(addr)
 		stakingKey = skh.Bytes()
 	}
 	return d.GetTransactionsByAddressKeys(
 		paymentKey,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -925,10 +931,11 @@ func (d *Database) GetTransactionsByAddressWithOrder(
 	)
 }
 
-// GetTransactionsByAddressKeys returns transactions for a payment/staking key
-// tuple with pagination and explicit order (asc|desc).
+// GetTransactionsByAddressKeys returns transactions for a payment/staking
+// credential tuple with pagination and explicit order (asc|desc).
 func (d *Database) GetTransactionsByAddressKeys(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -941,6 +948,7 @@ func (d *Database) GetTransactionsByAddressKeys(
 	}
 	txs, err := d.metadata.GetTransactionsByAddress(
 		paymentKey,
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -969,24 +977,28 @@ func (d *Database) CountTransactionsByAddress(
 ) (int, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	var paymentKey []byte
+	var credentialTag uint8
 	var stakingKey []byte
 	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
 		paymentKey = pkh.Bytes()
 	}
 	if skh := addr.StakeKeyHash(); skh != zeroHash {
+		credentialTag, _ = models.StakeCredentialTagFromAddress(addr)
 		stakingKey = skh.Bytes()
 	}
 	return d.CountTransactionsByAddressKeys(
 		paymentKey,
+		credentialTag,
 		stakingKey,
 		txn,
 	)
 }
 
 // CountTransactionsByAddressKeys returns the total number
-// of transactions for a payment/staking key tuple.
+// of transactions for a payment/staking credential tuple.
 func (d *Database) CountTransactionsByAddressKeys(
 	paymentKey []byte,
+	credentialTag uint8,
 	stakingKey []byte,
 	txn *Txn,
 ) (int, error) {
@@ -996,6 +1008,7 @@ func (d *Database) CountTransactionsByAddressKeys(
 	}
 	count, err := d.metadata.CountTransactionsByAddress(
 		paymentKey,
+		credentialTag,
 		stakingKey,
 		txn.Metadata(),
 	)
@@ -1010,8 +1023,9 @@ func (d *Database) CountTransactionsByAddressKeys(
 	return count, nil
 }
 
-// GetAddressesByStakingKey returns distinct address mappings for a staking key.
-func (d *Database) GetAddressesByStakingKey(
+// GetAddressesByCredential returns distinct address mappings for a stake credential.
+func (d *Database) GetAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	limit int,
 	offset int,
@@ -1022,7 +1036,8 @@ func (d *Database) GetAddressesByStakingKey(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	addresses, err := d.metadata.GetAddressesByStakingKey(
+	addresses, err := d.metadata.GetAddressesByCredential(
+		credentialTag,
 		stakingKey,
 		limit,
 		offset,
@@ -1031,7 +1046,8 @@ func (d *Database) GetAddressesByStakingKey(
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"get addresses by staking key=%x limit=%d offset=%d: %w",
+			"get addresses by credential tag=%d key=%x limit=%d offset=%d: %w",
+			credentialTag,
 			stakingKey,
 			limit,
 			offset,
@@ -1041,8 +1057,9 @@ func (d *Database) GetAddressesByStakingKey(
 	return addresses, nil
 }
 
-// CountAddressesByStakingKey returns the total number of distinct address mappings for a staking key.
-func (d *Database) CountAddressesByStakingKey(
+// CountAddressesByCredential returns the total number of distinct address mappings for a stake credential.
+func (d *Database) CountAddressesByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn *Txn,
 ) (int, error) {
@@ -1050,13 +1067,15 @@ func (d *Database) CountAddressesByStakingKey(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	count, err := d.metadata.CountAddressesByStakingKey(
+	count, err := d.metadata.CountAddressesByCredential(
+		credentialTag,
 		stakingKey,
 		txn.Metadata(),
 	)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"count addresses by staking key=%x: %w",
+			"count addresses by credential tag=%d key=%x: %w",
+			credentialTag,
 			stakingKey,
 			err,
 		)

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -518,9 +518,10 @@ func (d *Database) UtxosByAddress(
 	return utxos, nil
 }
 
-// GetControlledAmountByStakingKey returns the sum of live UTxO amounts
-// controlled by the given staking key.
-func (d *Database) GetControlledAmountByStakingKey(
+// GetControlledAmountByCredential returns the sum of live UTxO amounts
+// controlled by the given stake credential.
+func (d *Database) GetControlledAmountByCredential(
+	credentialTag uint8,
 	stakingKey []byte,
 	txn *Txn,
 ) (uint64, error) {
@@ -528,13 +529,15 @@ func (d *Database) GetControlledAmountByStakingKey(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	total, err := d.metadata.GetControlledAmountByStakingKey(
+	total, err := d.metadata.GetControlledAmountByCredential(
+		credentialTag,
 		stakingKey,
 		txn.Metadata(),
 	)
 	if err != nil {
 		return 0, fmt.Errorf(
-			"get controlled amount by staking key=%x: %w",
+			"get controlled amount by credential tag=%d key=%x: %w",
+			credentialTag,
 			stakingKey,
 			err,
 		)

--- a/examples/dingo-gov-lens/README.md
+++ b/examples/dingo-gov-lens/README.md
@@ -144,8 +144,8 @@ Open `http://127.0.0.1:8088`.
 - `GET /api/proposals?lifecycle=active&action_type=6`
 - `GET /api/proposals/{txHash}/{actionIndex}`
 - `GET /api/dreps?active=true`
-- `GET /api/dreps/{credentialHex}`
-- `GET /api/stake/{stakeCredentialHex}`
+- `GET /api/dreps/{credentialHex}?credential_tag=0`
+- `GET /api/stake/{stakeCredentialHex}?credential_tag=0`
 
 All query handlers use direct SQL against Dingo metadata tables. The browser
 never connects to Postgres directly.

--- a/examples/dingo-gov-lens/main.go
+++ b/examples/dingo-gov-lens/main.go
@@ -131,6 +131,7 @@ type voteRow struct {
 
 type drep struct {
 	Credential        string `json:"credential"`
+	CredentialTag     uint8  `json:"credentialTag"`
 	AnchorURL         string `json:"anchorUrl,omitempty"`
 	AnchorHash        string `json:"anchorHash,omitempty"`
 	AddedSlot         uint64 `json:"addedSlot"`
@@ -160,9 +161,10 @@ type drepVote struct {
 }
 
 type accountSummary struct {
-	StakingKey string `json:"stakingKey"`
-	Reward     string `json:"reward"`
-	Active     bool   `json:"active"`
+	StakingKey    string `json:"stakingKey"`
+	CredentialTag uint8  `json:"credentialTag"`
+	Reward        string `json:"reward"`
+	Active        bool   `json:"active"`
 }
 
 type drepHistoryItem struct {
@@ -175,12 +177,13 @@ type drepHistoryItem struct {
 }
 
 type stakeLookup struct {
-	StakingKey string `json:"stakingKey"`
-	Pool       string `json:"pool,omitempty"`
-	DRep       string `json:"drep,omitempty"`
-	DRepType   int64  `json:"drepType"`
-	Reward     string `json:"reward"`
-	Active     bool   `json:"active"`
+	StakingKey    string `json:"stakingKey"`
+	CredentialTag uint8  `json:"credentialTag"`
+	Pool          string `json:"pool,omitempty"`
+	DRep          string `json:"drep,omitempty"`
+	DRepType      int64  `json:"drepType"`
+	Reward        string `json:"reward"`
+	Active        bool   `json:"active"`
 }
 
 func main() {
@@ -600,6 +603,7 @@ func (a *app) handleDreps(w http.ResponseWriter, r *http.Request) {
 	rows, err := a.db.QueryContext(ctx, `
 		SELECT
 			encode(d.credential, 'hex'),
+			d.credential_tag,
 			COALESCE(d.anchor_url, ''),
 			COALESCE(encode(d.anchor_hash, 'hex'), ''),
 			d.added_slot,
@@ -610,7 +614,10 @@ func (a *app) handleDreps(w http.ResponseWriter, r *http.Request) {
 			COUNT(DISTINCT gv.id) FILTER (WHERE gv.deleted_slot IS NULL) AS vote_count
 		FROM drep d
 		LEFT JOIN account a ON a.drep = d.credential
-		LEFT JOIN governance_vote gv ON gv.voter_type = 1 AND gv.voter_credential = d.credential
+			AND a.drep_type = d.credential_tag
+		LEFT JOIN governance_vote gv ON gv.voter_type = 1
+			AND gv.voter_credential = d.credential
+			AND gv.voter_credential_tag = d.credential_tag
 		WHERE `+strings.Join(where, " AND ")+`
 		GROUP BY d.id
 		ORDER BY d.active DESC, d.last_activity_epoch DESC, d.added_slot DESC
@@ -627,6 +634,7 @@ func (a *app) handleDreps(w http.ResponseWriter, r *http.Request) {
 		var item drep
 		if err := rows.Scan(
 			&item.Credential,
+			&item.CredentialTag,
 			&item.AnchorURL,
 			&item.AnchorHash,
 			&item.AddedSlot,
@@ -655,10 +663,16 @@ func (a *app) handleDrepDetail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid drep credential", http.StatusBadRequest)
 		return
 	}
+	credentialTag, ok := parseCredentialTagParam(r)
+	if !ok {
+		http.Error(w, "invalid or missing credential_tag", http.StatusBadRequest)
+		return
+	}
 	var ret drepDetail
 	err := a.db.QueryRowContext(ctx, `
 		SELECT
 			encode(d.credential, 'hex'),
+			d.credential_tag,
 			COALESCE(d.anchor_url, ''),
 			COALESCE(encode(d.anchor_hash, 'hex'), ''),
 			d.added_slot,
@@ -669,11 +683,16 @@ func (a *app) handleDrepDetail(w http.ResponseWriter, r *http.Request) {
 			COUNT(DISTINCT gv.id) FILTER (WHERE gv.deleted_slot IS NULL) AS vote_count
 		FROM drep d
 		LEFT JOIN account a ON a.drep = d.credential
-		LEFT JOIN governance_vote gv ON gv.voter_type = 1 AND gv.voter_credential = d.credential
+			AND a.drep_type = d.credential_tag
+		LEFT JOIN governance_vote gv ON gv.voter_type = 1
+			AND gv.voter_credential = d.credential
+			AND gv.voter_credential_tag = d.credential_tag
 		WHERE d.credential = decode($1, 'hex')
+			AND d.credential_tag = $2
 		GROUP BY d.id
-	`, credential).Scan(
+	`, credential, credentialTag).Scan(
 		&ret.DRep.Credential,
+		&ret.DRep.CredentialTag,
 		&ret.DRep.AnchorURL,
 		&ret.DRep.AnchorHash,
 		&ret.DRep.AddedSlot,
@@ -691,17 +710,17 @@ func (a *app) handleDrepDetail(w http.ResponseWriter, r *http.Request) {
 		serverError(w, r, "query drep", err)
 		return
 	}
-	ret.RecentVotes, err = a.drepVotes(ctx, credential)
+	ret.RecentVotes, err = a.drepVotes(ctx, credential, credentialTag)
 	if err != nil {
 		serverError(w, r, "query drep votes", err)
 		return
 	}
-	ret.Delegations, err = a.drepDelegations(ctx, credential)
+	ret.Delegations, err = a.drepDelegations(ctx, credential, credentialTag)
 	if err != nil {
 		serverError(w, r, "query drep delegations", err)
 		return
 	}
-	ret.History, err = a.drepHistory(ctx, credential)
+	ret.History, err = a.drepHistory(ctx, credential, credentialTag)
 	if err != nil {
 		serverError(w, r, "query drep history", err)
 		return
@@ -716,10 +735,16 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid stake credential", http.StatusBadRequest)
 		return
 	}
+	credentialTag, ok := parseCredentialTagParam(r)
+	if !ok {
+		http.Error(w, "invalid or missing credential_tag", http.StatusBadRequest)
+		return
+	}
 	var ret stakeLookup
 	err := a.db.QueryRowContext(ctx, `
 		SELECT
 			encode(staking_key, 'hex'),
+			credential_tag,
 			COALESCE(encode(pool, 'hex'), ''),
 			COALESCE(encode(drep, 'hex'), ''),
 			drep_type,
@@ -727,7 +752,16 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 			active
 		FROM account
 		WHERE staking_key = decode($1, 'hex')
-	`, credential).Scan(&ret.StakingKey, &ret.Pool, &ret.DRep, &ret.DRepType, &ret.Reward, &ret.Active)
+			AND credential_tag = $2
+	`, credential, credentialTag).Scan(
+		&ret.StakingKey,
+		&ret.CredentialTag,
+		&ret.Pool,
+		&ret.DRep,
+		&ret.DRepType,
+		&ret.Reward,
+		&ret.Active,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.NotFound(w, r)
 		return
@@ -781,7 +815,11 @@ func (a *app) proposalVotes(ctx context.Context, proposalID int64) ([]voteRow, v
 	return ret, stats, rows.Err()
 }
 
-func (a *app) drepVotes(ctx context.Context, credential string) ([]drepVote, error) {
+func (a *app) drepVotes(
+	ctx context.Context,
+	credential string,
+	credentialTag uint8,
+) ([]drepVote, error) {
 	rows, err := a.db.QueryContext(ctx, `
 		SELECT
 			encode(gp.tx_hash, 'hex'),
@@ -794,11 +832,12 @@ func (a *app) drepVotes(ctx context.Context, credential string) ([]drepVote, err
 		JOIN governance_proposal gp ON gp.id = gv.proposal_id
 		WHERE gv.voter_type = 1
 			AND gv.voter_credential = decode($1, 'hex')
+			AND gv.voter_credential_tag = $2
 			AND gv.deleted_slot IS NULL
 			AND gp.deleted_slot IS NULL
 		ORDER BY gv.added_slot DESC
 		LIMIT 50
-	`, credential)
+	`, credential, credentialTag)
 	if err != nil {
 		return nil, err
 	}
@@ -825,15 +864,20 @@ func (a *app) drepVotes(ctx context.Context, credential string) ([]drepVote, err
 	return ret, rows.Err()
 }
 
-func (a *app) drepDelegations(ctx context.Context, credential string) ([]accountSummary, error) {
+func (a *app) drepDelegations(
+	ctx context.Context,
+	credential string,
+	credentialTag uint8,
+) ([]accountSummary, error) {
 	rows, err := a.db.QueryContext(ctx, `
-		SELECT encode(staking_key, 'hex'), reward::text, active
+		SELECT encode(staking_key, 'hex'), credential_tag, reward::text, active
 		FROM account
 		WHERE drep = decode($1, 'hex')
+			AND drep_type = $2
 			AND active = true
 		ORDER BY reward DESC, staking_key ASC
 		LIMIT 50
-	`, credential)
+	`, credential, credentialTag)
 	if err != nil {
 		return nil, err
 	}
@@ -841,7 +885,12 @@ func (a *app) drepDelegations(ctx context.Context, credential string) ([]account
 	ret := []accountSummary{}
 	for rows.Next() {
 		var item accountSummary
-		if err := rows.Scan(&item.StakingKey, &item.Reward, &item.Active); err != nil {
+		if err := rows.Scan(
+			&item.StakingKey,
+			&item.CredentialTag,
+			&item.Reward,
+			&item.Active,
+		); err != nil {
 			return nil, err
 		}
 		ret = append(ret, item)
@@ -849,7 +898,11 @@ func (a *app) drepDelegations(ctx context.Context, credential string) ([]account
 	return ret, rows.Err()
 }
 
-func (a *app) drepHistory(ctx context.Context, credential string) ([]drepHistoryItem, error) {
+func (a *app) drepHistory(
+	ctx context.Context,
+	credential string,
+	credentialTag uint8,
+) ([]drepHistoryItem, error) {
 	rows, err := a.db.QueryContext(ctx, `
 		SELECT kind, added_slot, tx_hash, anchor_url, anchor_hash, deposit
 		FROM (
@@ -864,6 +917,7 @@ func (a *app) drepHistory(ctx context.Context, credential string) ([]drepHistory
 			LEFT JOIN certs c ON c.id = rd.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE rd.drep_credential = decode($1, 'hex')
+				AND rd.credential_tag = $2
 
 			UNION ALL
 			SELECT
@@ -877,6 +931,7 @@ func (a *app) drepHistory(ctx context.Context, credential string) ([]drepHistory
 			LEFT JOIN certs c ON c.id = ud.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE ud.credential = decode($1, 'hex')
+				AND ud.credential_tag = $2
 
 			UNION ALL
 			SELECT
@@ -890,10 +945,11 @@ func (a *app) drepHistory(ctx context.Context, credential string) ([]drepHistory
 			LEFT JOIN certs c ON c.id = dd.certificate_id
 			LEFT JOIN "transaction" tx ON tx.id = c.transaction_id
 			WHERE dd.drep_credential = decode($1, 'hex')
+				AND dd.credential_tag = $2
 		) h
 		ORDER BY added_slot DESC
 		LIMIT 50
-	`, credential)
+	`, credential, credentialTag)
 	if err != nil {
 		return nil, err
 	}
@@ -1023,6 +1079,18 @@ func boundedLimit(raw string, def, max int) int {
 		return max
 	}
 	return n
+}
+
+func parseCredentialTagParam(r *http.Request) (uint8, bool) {
+	raw := strings.TrimSpace(r.URL.Query().Get("credential_tag"))
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(raw, 10, 8)
+	if err != nil || n > 1 {
+		return 0, false
+	}
+	return uint8(n), true
 }
 
 func isHex(s string, length int) bool {

--- a/examples/dingo-gov-lens/static/app.js
+++ b/examples/dingo-gov-lens/static/app.js
@@ -36,16 +36,20 @@ $("#wallet-connect").addEventListener("click", asyncHandler(connectWallet, showS
 $("#stake-form").addEventListener("submit", async (event) => {
   event.preventDefault();
   const credential = $("#stake-credential").value.trim().toLowerCase();
+  const credentialTag = $("#stake-credential-tag").value;
   const result = $("#stake-result");
   if (!credential) {
     result.innerHTML = `<div class="empty">Enter a stake credential hex value.</div>`;
     return;
   }
   try {
-    const data = await api(`/api/stake/${encodeURIComponent(credential)}`);
+    const data = await api(
+      `/api/stake/${encodeURIComponent(credential)}?credential_tag=${encodeURIComponent(credentialTag)}`,
+    );
     result.innerHTML = `
       <div class="detail-grid">
         ${metric("Stake", shortHex(data.stakingKey))}
+        ${metric("Type", credentialTypeName(data.credentialTag))}
         ${metric("Active", data.active ? "yes" : "no")}
         ${metric("Reward", lovelace(data.reward))}
         ${metric("DRep type", data.drepType)}
@@ -180,9 +184,10 @@ async function loadDreps() {
     .map((row) => `
       <tr>
         <td>
-          <button class="link-button" data-drep="${row.credential}" type="button">
+          <button class="link-button" data-drep="${row.credential}" data-credential-tag="${row.credentialTag}" type="button">
             <span class="mono">${shortHex(row.credential)}</span>
           </button>
+          <br /><span class="muted">${credentialTypeName(row.credentialTag)}</span>
           ${renderAnchorBreak(row.anchorUrl)}
         </td>
         <td><span class="pill ${row.active ? "active" : "inactive"}">${row.active ? "active" : "inactive"}</span></td>
@@ -193,17 +198,23 @@ async function loadDreps() {
     `)
     .join("");
   drepRows.querySelectorAll("[data-drep]").forEach((button) => {
-    button.addEventListener("click", asyncHandler(() => showDrep(button.dataset.drep)));
+    button.addEventListener(
+      "click",
+      asyncHandler(() => showDrep(button.dataset.drep, button.dataset.credentialTag)),
+    );
   });
 }
 
-async function showDrep(credential) {
-  const data = await api(`/api/dreps/${credential}`);
+async function showDrep(credential, credentialTag) {
+  const data = await api(
+    `/api/dreps/${credential}?credential_tag=${encodeURIComponent(credentialTag)}`,
+  );
   const d = data.drep;
   detailContent.innerHTML = `
     <h2>DRep</h2>
     <p class="mono">${d.credential}</p>
     <div class="detail-grid">
+      ${metric("Type", credentialTypeName(d.credentialTag))}
       ${metric("Status", d.active ? "active" : "inactive")}
       ${metric("Delegators", number(d.delegatorCount))}
       ${metric("Votes", number(d.voteCount))}
@@ -236,7 +247,7 @@ async function showDrep(credential) {
           <tbody>
             ${data.delegations.length ? data.delegations.map((account) => `
               <tr>
-                <td class="mono">${shortHex(account.stakingKey)}</td>
+                <td><span class="mono">${shortHex(account.stakingKey)}</span><br /><span class="muted">${credentialTypeName(account.credentialTag)}</span></td>
                 <td>${lovelace(account.reward)}</td>
                 <td>${account.active ? "yes" : "no"}</td>
               </tr>
@@ -323,6 +334,10 @@ function metric(label, value) {
       <div class="metric-value">${escapeHtml(String(value ?? "n/a"))}</div>
     </div>
   `;
+}
+
+function credentialTypeName(value) {
+  return Number(value) === 1 ? "Script" : "Key";
 }
 
 function voteGrid(votes) {
@@ -441,6 +456,7 @@ async function connectWallet() {
     return;
   }
   $("#stake-credential").value = rewardAddress.slice(2, 58);
+  $("#stake-credential-tag").value = rewardAddress.slice(0, 1) === "f" ? "1" : "0";
   $("#stake-form").requestSubmit();
 }
 

--- a/examples/dingo-gov-lens/static/index.html
+++ b/examples/dingo-gov-lens/static/index.html
@@ -111,6 +111,13 @@
             Stake credential hex
             <input id="stake-credential" placeholder="28-byte credential as hex" spellcheck="false" />
           </label>
+          <label>
+            Credential type
+            <select id="stake-credential-tag">
+              <option value="0">Key</option>
+              <option value="1">Script</option>
+            </select>
+          </label>
           <button type="submit">Lookup</button>
         </form>
         <div id="stake-result" class="lookup-result"></div>

--- a/examples/dingo-gov-lens/static/styles.css
+++ b/examples/dingo-gov-lens/static/styles.css
@@ -411,6 +411,11 @@ dialog::backdrop {
   padding: 24px;
 }
 
+.muted {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 a {
   color: var(--blink-amber-light);
 }

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -43,6 +43,16 @@ import (
 // given network is irrelevant here — so a single fixed value is fine.
 const conformanceSlotsPerEpoch uint64 = 432000
 
+func conformanceCredentialTag(credential common.Credential) uint8 {
+	credentialTag, err := models.CredentialTagFromUint(
+		credential.CredType,
+	)
+	if err != nil {
+		return 0
+	}
+	return credentialTag
+}
+
 // DingoStateManager implements conformance.StateManager using dingo's database
 // with an in-memory SQLite backend for testing.
 type DingoStateManager struct {
@@ -460,100 +470,127 @@ func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uin
 	switch certType {
 	case common.CertificateTypeStakeRegistration:
 		if regCert, ok := cert.(*common.StakeRegistrationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
+			stakeCredential := regCert.StakeCredential
+			credential := stakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Insert into database
 			account := models.Account{
-				StakingKey: credential[:],
-				AddedSlot:  slot,
-				Active:     true,
+				StakingKey:    credential[:],
+				CredentialTag: credentialTag,
+				AddedSlot:     slot,
+				Active:        true,
 			}
 			m.db.Create(&account)
 		}
 
 	case common.CertificateTypeRegistration:
 		if regCert, ok := cert.(*common.RegistrationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
+			stakeCredential := regCert.StakeCredential
+			credential := stakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Insert into database
 			account := models.Account{
-				StakingKey: credential[:],
-				AddedSlot:  slot,
-				Active:     true,
+				StakingKey:    credential[:],
+				CredentialTag: credentialTag,
+				AddedSlot:     slot,
+				Active:        true,
 			}
 			m.db.Create(&account)
 		}
 
 	case common.CertificateTypeStakeRegistrationDelegation:
 		if regCert, ok := cert.(*common.StakeRegistrationDelegationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
+			stakeCredential := regCert.StakeCredential
+			credential := stakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Insert into database
 			account := models.Account{
-				StakingKey: credential[:],
-				AddedSlot:  slot,
-				Active:     true,
+				StakingKey:    credential[:],
+				CredentialTag: credentialTag,
+				AddedSlot:     slot,
+				Active:        true,
 			}
 			m.db.Create(&account)
 		}
 
 	case common.CertificateTypeVoteRegistrationDelegation:
 		if regCert, ok := cert.(*common.VoteRegistrationDelegationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
+			stakeCredential := regCert.StakeCredential
+			credential := stakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Insert into database
 			account := models.Account{
-				StakingKey: credential[:],
-				AddedSlot:  slot,
-				Active:     true,
+				StakingKey:    credential[:],
+				CredentialTag: credentialTag,
+				AddedSlot:     slot,
+				Active:        true,
 			}
 			m.db.Create(&account)
 		}
 
 	case common.CertificateTypeStakeVoteRegistrationDelegation:
 		if regCert, ok := cert.(*common.StakeVoteRegistrationDelegationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
+			stakeCredential := regCert.StakeCredential
+			credential := stakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Insert into database
 			account := models.Account{
-				StakingKey: credential[:],
-				AddedSlot:  slot,
-				Active:     true,
+				StakingKey:    credential[:],
+				CredentialTag: credentialTag,
+				AddedSlot:     slot,
+				Active:        true,
 			}
 			m.db.Create(&account)
 		}
 
 	case common.CertificateTypeStakeDeregistration:
 		if deregCert, ok := cert.(*common.StakeDeregistrationCertificate); ok {
-			credential := deregCert.StakeCredential.Credential
+			stakeCredential := deregCert.StakeCredential
+			credential := stakeCredential.Credential
 			delete(m.stakeRegistrations, credential)
 			m.govState.DeregisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Update database
 			m.db.Model(&models.Account{}).
-				Where("staking_key = ?", credential[:]).
+				Where(
+					"credential_tag = ? AND staking_key = ?",
+					credentialTag,
+					credential[:],
+				).
 				Update("active", false)
 		}
 
 	case common.CertificateTypeDeregistration:
 		if deregCert, ok := cert.(*common.DeregistrationCertificate); ok {
-			credential := deregCert.StakeCredential.Credential
+			stakeCredential := deregCert.StakeCredential
+			credential := stakeCredential.Credential
 			delete(m.stakeRegistrations, credential)
 			m.govState.DeregisterStake(credential)
+			credentialTag := conformanceCredentialTag(stakeCredential)
 
 			// Update database
 			m.db.Model(&models.Account{}).
-				Where("staking_key = ?", credential[:]).
+				Where(
+					"credential_tag = ? AND staking_key = ?",
+					credentialTag,
+					credential[:],
+				).
 				Update("active", false)
 		}
 
@@ -596,8 +633,8 @@ func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uin
 			credential := drepCert.DrepCredential.Credential
 			m.drepRegistrations[credential] = true
 			m.govState.RegisterDRep(credential)
-			credentialTag, _ := models.CredentialTagFromUint(
-				drepCert.DrepCredential.CredType,
+			credentialTag := conformanceCredentialTag(
+				drepCert.DrepCredential,
 			)
 
 			// Insert into database
@@ -615,8 +652,8 @@ func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uin
 			credential := drepCert.DrepCredential.Credential
 			delete(m.drepRegistrations, credential)
 			m.govState.DeregisterDRep(credential)
-			credentialTag, _ := models.CredentialTagFromUint(
-				drepCert.DrepCredential.CredType,
+			credentialTag := conformanceCredentialTag(
+				drepCert.DrepCredential,
 			)
 
 			// Update database

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -596,12 +596,16 @@ func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uin
 			credential := drepCert.DrepCredential.Credential
 			m.drepRegistrations[credential] = true
 			m.govState.RegisterDRep(credential)
+			credentialTag, _ := models.CredentialTagFromUint(
+				drepCert.DrepCredential.CredType,
+			)
 
 			// Insert into database
 			drep := models.Drep{
-				Credential: credential[:],
-				AddedSlot:  slot,
-				Active:     true,
+				CredentialTag: credentialTag,
+				Credential:    credential[:],
+				AddedSlot:     slot,
+				Active:        true,
 			}
 			m.db.Create(&drep)
 		}
@@ -611,10 +615,17 @@ func (m *DingoStateManager) processCertificate(cert common.Certificate, slot uin
 			credential := drepCert.DrepCredential.Credential
 			delete(m.drepRegistrations, credential)
 			m.govState.DeregisterDRep(credential)
+			credentialTag, _ := models.CredentialTagFromUint(
+				drepCert.DrepCredential.CredType,
+			)
 
 			// Update database
 			m.db.Model(&models.Drep{}).
-				Where("credential = ?", credential[:]).
+				Where(
+					"credential_tag = ? AND credential = ?",
+					credentialTag,
+					credential[:],
+				).
 				Update("active", false)
 		}
 

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -532,7 +532,7 @@ func BenchmarkAccountLookupByStakeKeyNoData(b *testing.B) {
 
 	// Benchmark lookup (on empty database for now)
 	for b.Loop() {
-		_, err := db.Metadata().GetAccount(testStakeKey, false, nil)
+		_, err := db.Metadata().GetAccountByCredential(0, testStakeKey, false, nil)
 		if err != nil && !errors.Is(err, models.ErrAccountNotFound) {
 			b.Fatalf("unexpected error: %v", err)
 		}
@@ -609,7 +609,7 @@ func BenchmarkAccountLookupByStakeKeyRealData(b *testing.B) {
 	// Benchmark lookup against real seeded data
 	for i := 0; b.Loop(); i++ {
 		key := testStakeKeys[i%len(testStakeKeys)]
-		_, err := db.Metadata().GetAccount(key, false, nil)
+		_, err := db.Metadata().GetAccountByCredential(0, key, false, nil)
 		if err != nil && !errors.Is(err, models.ErrAccountNotFound) {
 			b.Fatalf("unexpected error: %v", err)
 		}

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -1185,7 +1185,7 @@ func BenchmarkStakeRegistrationLookupsNoData(b *testing.B) {
 	// Benchmark lookup (on empty database for now)
 	for i := 0; b.Loop(); i++ {
 		stakeKey := testStakeKeys[i%len(testStakeKeys)]
-		_, err := db.Metadata().GetStakeRegistrations(stakeKey, nil)
+		_, err := db.Metadata().GetStakeRegistrationsByCredential(0, stakeKey, nil)
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}
@@ -1262,7 +1262,7 @@ func BenchmarkStakeRegistrationLookupsRealData(b *testing.B) {
 	// Benchmark lookup against real seeded data
 	for i := 0; b.Loop(); i++ {
 		stakeKey := testStakeKeys[i%len(testStakeKeys)]
-		_, err := db.Metadata().GetStakeRegistrations(stakeKey, nil)
+		_, err := db.Metadata().GetStakeRegistrationsByCredential(0, stakeKey, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/ledger/governance/enact.go
+++ b/ledger/governance/enact.go
@@ -253,7 +253,7 @@ func applyTreasuryWithdrawal(
 		if err != nil {
 			return fmt.Errorf("encode treasury withdrawal reward address: %w", err)
 		}
-		stakeCredential, err := rewardAccountStakeCredential(
+		credentialTag, stakeCredential, err := rewardAccountStakeCredential(
 			rewardAddrBytes,
 		)
 		if err != nil {
@@ -262,6 +262,7 @@ func applyTreasuryWithdrawal(
 		credited, err := CreditRegisteredRewardAccount(
 			ctx.DB,
 			ctx.Txn,
+			credentialTag,
 			stakeCredential,
 			amount,
 			ctx.Slot,
@@ -293,11 +294,18 @@ func applyTreasuryWithdrawal(
 func CreditRegisteredRewardAccount(
 	db *database.Database,
 	txn *database.Txn,
+	credentialTag uint8,
 	stakeCredential []byte,
 	amount uint64,
 	slot uint64,
 ) (bool, error) {
-	err := db.AddAccountReward(stakeCredential, amount, slot, txn)
+	err := db.AddAccountRewardByCredential(
+		credentialTag,
+		stakeCredential,
+		amount,
+		slot,
+		txn,
+	)
 	if err == nil {
 		return true, nil
 	}

--- a/ledger/governance/enact_test.go
+++ b/ledger/governance/enact_test.go
@@ -315,7 +315,7 @@ func TestApplyTreasuryWithdrawal_CreditsRewardsAndDebitsTreasury(
 	}, a)
 	require.NoError(t, err)
 
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(12), uint64(account.Reward))
@@ -358,7 +358,7 @@ func TestApplyTreasuryWithdrawal_RejectsOverdrawnTreasury(
 		"treasury withdrawal of 7 exceeds tracked treasury withdrawal capacity 6",
 	)
 
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(5), uint64(account.Reward))
@@ -392,10 +392,10 @@ func TestApplyTreasuryWithdrawal_LeavesMissingRewardAccountInTreasury(
 	}, a)
 	require.NoError(t, err)
 
-	active, err := store.GetAccount(stakeCred, false, nil)
+	active, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	assert.Nil(t, active, "withdrawal must not create a reward account")
-	account, err := store.GetAccount(stakeCred, true, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, true, nil)
 	require.NoError(t, err)
 	assert.Nil(t, account)
 	state, err := store.GetNetworkState(nil)
@@ -437,10 +437,10 @@ func TestApplyTreasuryWithdrawal_LeavesInactiveRewardAccountInTreasury(
 	}, a)
 	require.NoError(t, err)
 
-	active, err := store.GetAccount(stakeCred, false, nil)
+	active, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	assert.Nil(t, active, "withdrawal must not reactivate the reward account")
-	account, err := store.GetAccount(stakeCred, true, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.False(t, account.Active)

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -531,7 +531,7 @@ func refundProposalDeposit(
 	if db == nil {
 		return errors.New("nil database")
 	}
-	stakeCredential, err := rewardAccountStakeCredential(
+	credentialTag, stakeCredential, err := rewardAccountStakeCredential(
 		proposal.ReturnAddress,
 	)
 	if err != nil {
@@ -540,6 +540,7 @@ func refundProposalDeposit(
 	credited, err := CreditRegisteredRewardAccount(
 		db,
 		txn,
+		credentialTag,
 		stakeCredential,
 		proposal.Deposit,
 		slot,
@@ -635,21 +636,25 @@ func removeOrphanedProposals(
 	return count, nil
 }
 
-func rewardAccountStakeCredential(returnAddress []byte) ([]byte, error) {
+func rewardAccountStakeCredential(returnAddress []byte) (uint8, []byte, error) {
 	addr, err := lcommon.NewAddressFromBytes(returnAddress)
 	if err != nil {
-		return nil, fmt.Errorf("decode return reward account: %w", err)
+		return 0, nil, fmt.Errorf("decode return reward account: %w", err)
 	}
+	var credentialTag uint8
 	switch addr.Type() {
-	case lcommon.AddressTypeNoneKey, lcommon.AddressTypeNoneScript:
+	case lcommon.AddressTypeNoneKey:
+		credentialTag = uint8(lcommon.CredentialTypeAddrKeyHash)
+	case lcommon.AddressTypeNoneScript:
+		credentialTag = uint8(lcommon.CredentialTypeScriptHash)
 	default:
-		return nil, fmt.Errorf(
+		return 0, nil, fmt.Errorf(
 			"return address is not a reward account: address type %d",
 			addr.Type(),
 		)
 	}
 	stakeHash := addr.StakeKeyHash()
-	return append([]byte(nil), stakeHash[:]...), nil
+	return credentialTag, append([]byte(nil), stakeHash[:]...), nil
 }
 
 // shortHash returns a hex-encoded prefix of a tx hash for logging.

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -524,7 +524,7 @@ func TestProcessEpochOrphanedChildRemovedAndRefunded(t *testing.T) {
 	assert.Equal(t, uint64(500), *child.ExpiredSlot)
 
 	// Enacted parent's deposit (30) + orphaned child's deposit (15) = 45.
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(45), uint64(account.Reward))
@@ -589,7 +589,7 @@ func TestProcessEpochOrphanedChildMissingReturnAccountGoesToTreasury(
 	require.NoError(t, err)
 	require.NotNil(t, child.ExpiredEpoch)
 
-	missing, err := store.GetAccount(missingStakeCred, false, nil)
+	missing, err := store.GetAccountByCredential(0, missingStakeCred, false, nil)
 	require.NoError(t, err)
 	assert.Nil(t, missing, "orphan refund must not create a reward account")
 
@@ -664,7 +664,7 @@ func TestProcessEpochTransitiveOrphanRemoval(t *testing.T) {
 	}
 
 	// Enacted parent's deposit (10) + orphaned child (20) + grandchild (30) = 60.
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(60), uint64(account.Reward))
@@ -784,7 +784,7 @@ func TestProcessEpochOrphanedChildRestoredOnRollback(t *testing.T) {
 	assert.Nil(t, child.ExpiredEpoch, "orphaned status must be reversed by rollback")
 	assert.Nil(t, child.ExpiredSlot)
 
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(0), uint64(account.Reward),
@@ -845,7 +845,7 @@ func TestProcessEpochOrphanAfterExpiry(t *testing.T) {
 	require.NotNil(t, child.ExpiredEpoch)
 	assert.Equal(t, uint64(5), *child.ExpiredEpoch)
 
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(30), uint64(account.Reward))

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -50,7 +50,7 @@ func TestRefundProposalDepositCreditsRewardAccount(t *testing.T) {
 	}, 123)
 	require.NoError(t, err)
 
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(12), uint64(account.Reward))
@@ -108,7 +108,7 @@ func TestProcessEpochExpiresProposalAndRefundsDeposit(t *testing.T) {
 	require.NoError(t, txn.Commit())
 
 	assert.Equal(t, 1, out.ExpiredCount)
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(12), uint64(account.Reward))
@@ -170,10 +170,10 @@ func TestProcessEpochReturnsMissingRewardAccountRefundToTreasury(
 	require.NoError(t, txn.Commit())
 	assert.Equal(t, 1, out.ExpiredCount)
 
-	active, err := store.GetAccount(stakeCred, false, nil)
+	active, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	assert.Nil(t, active, "refund must not create a reward account")
-	account, err := store.GetAccount(stakeCred, true, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, true, nil)
 	require.NoError(t, err)
 	assert.Nil(t, account)
 	state, err := store.GetNetworkState(nil)
@@ -329,10 +329,10 @@ func TestRefundProposalDepositReturnsInactiveRewardAccountToTreasury(
 	}, 123)
 	require.NoError(t, err)
 
-	active, err := store.GetAccount(stakeCred, false, nil)
+	active, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	assert.Nil(t, active, "refund must not reactivate the reward account")
-	account, err := store.GetAccount(stakeCred, true, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.False(t, account.Active)
@@ -369,7 +369,7 @@ func TestRewardCreditsRollbackBySlot(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, db.DeleteAccountRewardsAfterSlot(122, nil))
-	account, err := store.GetAccount(stakeCred, false, nil)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(5), uint64(account.Reward))

--- a/ledger/governance/processing.go
+++ b/ledger/governance/processing.go
@@ -206,9 +206,14 @@ func ProcessVotes(
 
 		// Update DRep activity when a DRep votes (once per DRep per tx)
 		if voterType == models.VoterTypeDRep {
-			credKey := string(voter.Hash[:])
+			var drepCredTag uint8
+			if voter.Type == lcommon.VoterTypeDRepScriptHash {
+				drepCredTag = 1
+			}
+			credKey := string([]byte{drepCredTag}) + string(voter.Hash[:])
 			if !drepActivityUpdated[credKey] {
 				err := db.UpdateDRepActivity(
+					drepCredTag,
 					voter.Hash[:],
 					currentEpoch,
 					drepInactivityPeriod,
@@ -223,6 +228,7 @@ func ProcessVotes(
 					// anchor_hash, active) is preserved and rollback semantics
 					// in RestoreDrepStateAtSlot remain intact.
 					if setErr := db.InsertDrepIfAbsent(
+						drepCredTag,
 						voter.Hash[:],
 						point.Slot,
 						"",
@@ -246,6 +252,7 @@ func ProcessVotes(
 						)
 					}
 					err = db.UpdateDRepActivity(
+						drepCredTag,
 						voter.Hash[:],
 						currentEpoch,
 						drepInactivityPeriod,
@@ -327,12 +334,13 @@ func ProcessVotes(
 			// code handles both cases correctly.
 			updatedSlot := point.Slot
 			vote := &models.GovernanceVote{
-				ProposalID:      proposal.ID,
-				VoterType:       voterType,
-				VoterCredential: voter.Hash[:],
-				Vote:            procedure.Vote,
-				AddedSlot:       point.Slot,
-				VoteUpdatedSlot: &updatedSlot,
+				ProposalID:         proposal.ID,
+				VoterType:          voterType,
+				VoterCredentialTag: voterCredentialTag(voter.Type),
+				VoterCredential:    voter.Hash[:],
+				Vote:               procedure.Vote,
+				AddedSlot:          point.Slot,
+				VoteUpdatedSlot:    &updatedSlot,
 			}
 
 			if procedure.Anchor != nil {
@@ -604,6 +612,16 @@ func extractGovActionInfo(
 		)
 	}
 	return actionType, parentTxHash, parentActionIdx, policyHash, nil
+}
+
+func voterCredentialTag(voterType uint8) uint8 {
+	switch voterType {
+	case lcommon.VoterTypeDRepScriptHash,
+		lcommon.VoterTypeConstitutionalCommitteeHotScriptHash:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // mapVoterType maps gouroboros voter type constants to the database model

--- a/ledger/governance/processing_test.go
+++ b/ledger/governance/processing_test.go
@@ -351,6 +351,7 @@ func TestProcessVotesRepairsMissingDRepRow(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, votes, 1)
 	assert.Equal(t, uint8(models.VoterTypeDRep), votes[0].VoterType)
+	assert.Equal(t, uint8(0), votes[0].VoterCredentialTag)
 	assert.Equal(t, drepCred, votes[0].VoterCredential)
 	assert.Equal(t, uint8(models.VoteYes), votes[0].Vote)
 	assert.Equal(t, point.Slot, votes[0].AddedSlot)

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -219,26 +219,31 @@ func tallyDRepVotes(
 	if len(dreps) > 0 {
 		// Batch-fetch voting power for all active DReps in one query to
 		// avoid the N+1 round-trip that the per-DRep lookup produced.
-		creds := make([][]byte, len(dreps))
+		creds := make([]models.StakeCredentialRef, len(dreps))
 		for i, drep := range dreps {
-			creds[i] = drep.Credential
+			creds[i] = models.StakeCredentialRef{Tag: drep.CredentialTag, Key: drep.Credential}
 		}
 		powers, err := ctx.DB.GetDRepVotingPowerBatch(creds, ctx.Txn)
 		if err != nil {
 			return fmt.Errorf("batch drep voting power: %w", err)
 		}
 
-		// Index votes by DRep credential for O(1) lookup.
+		// Index votes by full DRep credential identity for O(1) lookup.
 		voteByCred := make(map[string]uint8, len(votes))
 		for _, v := range votes {
-			voteByCred[string(v.VoterCredential)] = v.Vote
+			ref := models.StakeCredentialRef{
+				Tag: v.VoterCredentialTag,
+				Key: v.VoterCredential,
+			}
+			voteByCred[ref.MapKey()] = v.Vote
 		}
 
 		for _, drep := range dreps {
-			power := powers[string(drep.Credential)]
+			ref := models.StakeCredentialRef{Tag: drep.CredentialTag, Key: drep.Credential}
+			power := powers[ref.MapKey()]
 			tally.DRepTotalStake += power
 
-			vote, voted := voteByCred[string(drep.Credential)]
+			vote, voted := voteByCred[ref.MapKey()]
 			if !voted {
 				continue
 			}

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -119,6 +119,60 @@ func TestTallyDRepVotesIncludesAlwaysNoConfidence(t *testing.T) {
 	assert.False(t, updateCommitteeDecision.DRepApproved)
 }
 
+func TestTallyDRepVotesSeparatesSameHashByCredentialTag(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	drepCred := testBytes(28, 9)
+	keyStakeCred := testBytes(28, 10)
+	scriptStakeCred := testBytes(28, 11)
+
+	require.NoError(t, store.DB().Create(&models.Drep{
+		CredentialTag: 0,
+		Credential:    drepCred,
+		Active:        true,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Drep{
+		CredentialTag: 1,
+		Credential:    drepCred,
+		Active:        true,
+	}).Error)
+	seedDRepStake(
+		t, store, keyStakeCred, drepCred, models.DrepTypeAddrKeyHash, 60,
+		12,
+	)
+	seedDRepStake(
+		t, store, scriptStakeCred, drepCred, models.DrepTypeScriptHash, 40,
+		13,
+	)
+
+	tally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	err := tallyDRepVotes(
+		&TallyContext{DB: db},
+		[]*models.GovernanceVote{
+			{
+				VoterType:          models.VoterTypeDRep,
+				VoterCredentialTag: 0,
+				VoterCredential:    drepCred,
+				Vote:               models.VoteYes,
+			},
+			{
+				VoterType:          models.VoterTypeDRep,
+				VoterCredentialTag: 1,
+				VoterCredential:    drepCred,
+				Vote:               models.VoteNo,
+			},
+		},
+		tally,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(100), tally.DRepTotalStake)
+	assert.Equal(t, uint64(60), tally.DRepYesStake)
+	assert.Equal(t, uint64(40), tally.DRepNoStake)
+	assert.Equal(t, uint64(0), tally.DRepAbstainStake)
+}
+
 func TestTallyCCVotesRequiresSeatedAuthorizedCommitteeMembers(t *testing.T) {
 	db, store := newTallyTestDB(t)
 	coldA := testBytes(28, 10)

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -573,6 +573,51 @@ func TestTallySPOVotesAlwaysAbstainDelegation(t *testing.T) {
 	assert.Equal(t, 0, tally.SPOYesRatio().Sign())
 }
 
+func TestResolvePoolRewardAccountAutoVotesIsCredentialTagAware(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 62)
+	rewardAccount := testBytes(28, 63)
+
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash:                poolKeyHash,
+		RewardAccount:              rewardAccount,
+		RewardAccountCredentialTag: 1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        8,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(250),
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		CredentialTag: 0,
+		StakingKey:    rewardAccount,
+		DrepType:      models.DrepTypeAlwaysNoConfidence,
+		AddedSlot:     1,
+		Active:        true,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		CredentialTag: 1,
+		StakingKey:    rewardAccount,
+		DrepType:      models.DrepTypeAlwaysAbstain,
+		AddedSlot:     1,
+		Active:        true,
+	}).Error)
+
+	resolveSnapshotAutoVotes(t, db, 8)
+
+	var snapshot models.PoolStakeSnapshot
+	require.NoError(t, store.DB().
+		Where("epoch = ? AND snapshot_type = ? AND pool_key_hash = ?", 8, "mark", poolKeyHash).
+		First(&snapshot).Error)
+	assert.True(t, snapshot.RewardAccountAutoVoteResolved)
+	assert.Equal(
+		t,
+		models.PoolRewardAccountAutoVoteAbstain,
+		snapshot.RewardAccountAutoVote,
+	)
+}
+
 // TestTallySPOVotesAlwaysNoConfidenceFlipsByActionType asserts that
 // AlwaysNoConfidence reward-account delegation produces an auto-Yes on
 // NoConfidence actions and an auto-No on non-NoConfidence actions,
@@ -582,24 +627,24 @@ func TestTallySPOVotesAlwaysNoConfidenceFlipsByActionType(t *testing.T) {
 	noConfidenceRewardAcct := testBytes(28, 71)
 
 	cases := []struct {
-		name              string
-		actionType        lcommon.GovActionType
-		expectYesStake    uint64
-		expectNoStake     uint64
+		name               string
+		actionType         lcommon.GovActionType
+		expectYesStake     uint64
+		expectNoStake      uint64
 		expectAbstainStake uint64
 	}{
 		{
-			name:              "NoConfidence action → auto Yes",
-			actionType:        lcommon.GovActionTypeNoConfidence,
-			expectYesStake:    300,
-			expectNoStake:     0,
+			name:               "NoConfidence action → auto Yes",
+			actionType:         lcommon.GovActionTypeNoConfidence,
+			expectYesStake:     300,
+			expectNoStake:      0,
 			expectAbstainStake: 0,
 		},
 		{
-			name:              "TreasuryWithdrawal action → auto No",
-			actionType:        lcommon.GovActionTypeTreasuryWithdrawal,
-			expectYesStake:    0,
-			expectNoStake:     300,
+			name:               "TreasuryWithdrawal action → auto No",
+			actionType:         lcommon.GovActionTypeTreasuryWithdrawal,
+			expectYesStake:     0,
+			expectNoStake:      300,
 			expectAbstainStake: 0,
 		},
 	}

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -90,12 +90,12 @@ func TestApplyIntraEraHardForkRule_Pv10_ClearsDangling(t *testing.T) {
 		500,  // newEpoch (log-only)
 	))
 
-	live, err := db.GetAccount(keys.Live, true, nil)
+	live, err := db.GetAccountByCredential(0, keys.Live, true, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, live.Drep,
 		"delegation to registered DRep must survive the rule")
 
-	dead, err := db.GetAccount(keys.Dead, true, nil)
+	dead, err := db.GetAccountByCredential(0, keys.Dead, true, nil)
 	require.NoError(t, err)
 	assert.Nil(t, dead.Drep,
 		"dangling delegation must be cleared at pv10")
@@ -120,13 +120,13 @@ func TestApplyIntraEraHardForkRule_UnknownMajor_NoOp(t *testing.T) {
 		))
 	}
 
-	live, err := db.GetAccount(keys.Live, true, nil)
+	live, err := db.GetAccountByCredential(0, keys.Live, true, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, live.Drep)
 	assert.Equal(t, uint64(100), live.AddedSlot,
 		"unknown-major dispatch must not touch unrelated accounts")
 
-	dead, err := db.GetAccount(keys.Dead, true, nil)
+	dead, err := db.GetAccountByCredential(0, keys.Dead, true, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, dead.Drep,
 		"unknown-major dispatch must not touch even the dangling account")

--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -74,7 +74,12 @@ func (ls *LedgerState) applyMIRCerts(
 		var totalDebited uint64
 		for _, reward := range effect.Rewards {
 			credited, err := governance.CreditRegisteredRewardAccount(
-				ls.db, txn, reward.Credential, reward.Amount, boundarySlot,
+				ls.db,
+				txn,
+				reward.CredentialTag,
+				reward.Credential,
+				reward.Amount,
+				boundarySlot,
 			)
 			if err != nil {
 				return fmt.Errorf(

--- a/ledger/mir_test.go
+++ b/ledger/mir_test.go
@@ -116,7 +116,7 @@ func TestApplyMIRCerts_DistributionFromReserves_RegisteredAccount(t *testing.T) 
 
 	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
 
-	account, err := db.GetAccount(cred, false, nil)
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, mirAmount, uint64(account.Reward),
@@ -154,7 +154,7 @@ func TestApplyMIRCerts_DistributionFromTreasury_RegisteredAccount(t *testing.T) 
 
 	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
 
-	account, err := db.GetAccount(cred, false, nil)
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, mirAmount, uint64(account.Reward),
@@ -257,7 +257,7 @@ func TestApplyMIRCerts_OutsideEpochRange(t *testing.T) {
 	// epoch range: [100, 1000)
 	runApplyMIRCerts(t, ls, db, 100, 1_000)
 
-	account, err := db.GetAccount(cred, false, nil)
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(0), uint64(account.Reward),
@@ -293,7 +293,7 @@ func TestApplyMIRCerts_Rollback(t *testing.T) {
 
 	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
 
-	account, err := db.GetAccount(cred, false, nil)
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
 	require.NoError(t, err)
 	require.Equal(t, mirAmount, uint64(account.Reward), "MIR reward applied")
 	state, err := db.Metadata().GetNetworkState(nil)
@@ -305,7 +305,7 @@ func TestApplyMIRCerts_Rollback(t *testing.T) {
 	require.NoError(t, db.DeleteAccountRewardsAfterSlot(preBoundary, nil))
 	require.NoError(t, db.DeleteNetworkStateAfterSlot(preBoundary, nil))
 
-	account, err = db.GetAccount(cred, false, nil)
+	account, err = db.GetAccountByCredential(0, cred, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), uint64(account.Reward),
 		"reward credit reverted on rollback")
@@ -316,7 +316,7 @@ func TestApplyMIRCerts_Rollback(t *testing.T) {
 
 	// Re-apply must be deterministic.
 	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
-	account, err = db.GetAccount(cred, false, nil)
+	account, err = db.GetAccountByCredential(0, cred, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, mirAmount, uint64(account.Reward),
 		"re-applied MIR reward is deterministic")

--- a/ledger/network_donation_test.go
+++ b/ledger/network_donation_test.go
@@ -259,7 +259,7 @@ func TestEpochProcessWithdrawalThenDonation(t *testing.T) {
 	assert.Equal(t, initialReserves, reserves)
 
 	// The withdrawal credited the registered reward account.
-	account, err := db.GetAccount(stakeCred, false, nil)
+	account, err := db.GetAccountByCredential(0, stakeCred, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, withdrawal, uint64(account.Reward),

--- a/ledger/poolreap.go
+++ b/ledger/poolreap.go
@@ -72,6 +72,7 @@ func (ls *LedgerState) applyPoolRetirements(
 		credited, err := governance.CreditRegisteredRewardAccount(
 			ls.db,
 			txn,
+			refund.RewardAccountCredentialTag,
 			refund.RewardAccount,
 			deposit,
 			boundarySlot,

--- a/ledger/poolreap_test.go
+++ b/ledger/poolreap_test.go
@@ -122,7 +122,7 @@ func TestApplyPoolRetirements_CreditsRegisteredRewardAccount(t *testing.T) {
 
 	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
 
-	account, err := db.GetAccount(rewardAccount, false, nil)
+	account, err := db.GetAccountByCredential(0, rewardAccount, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, deposit, uint64(account.Reward),
@@ -178,7 +178,7 @@ func TestApplyPoolRetirements_UnregisteredAccountToTreasury(t *testing.T) {
 		"treasury update written at the boundary slot")
 
 	// The inactive account was not credited.
-	account, err := db.GetAccount(inactive, true, nil)
+	account, err := db.GetAccountByCredential(0, inactive, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(0), uint64(account.Reward),
@@ -202,7 +202,7 @@ func TestApplyPoolRetirements_WrongEpoch(t *testing.T) {
 
 	runApplyPoolRetirements(t, ls, db, 5, 1_000)
 
-	account, err := db.GetAccount(rewardAccount, false, nil)
+	account, err := db.GetAccountByCredential(0, rewardAccount, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, account)
 	assert.Equal(t, uint64(0), uint64(account.Reward),
@@ -236,7 +236,7 @@ func TestApplyPoolRetirements_Rollback(t *testing.T) {
 
 	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
 
-	account, err := db.GetAccount(registered, false, nil)
+	account, err := db.GetAccountByCredential(0, registered, false, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(500), uint64(account.Reward),
 		"registered pool deposit refunded")
@@ -249,7 +249,7 @@ func TestApplyPoolRetirements_Rollback(t *testing.T) {
 	require.NoError(t, db.DeleteAccountRewardsAfterSlot(preBoundary, nil))
 	require.NoError(t, db.DeleteNetworkStateAfterSlot(preBoundary, nil))
 
-	account, err = db.GetAccount(registered, false, nil)
+	account, err = db.GetAccountByCredential(0, registered, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), uint64(account.Reward),
 		"reward credit reverted on rollback")
@@ -261,7 +261,7 @@ func TestApplyPoolRetirements_Rollback(t *testing.T) {
 
 	// Re-applying the boundary reproduces the same effects (determinism).
 	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
-	account, err = db.GetAccount(registered, false, nil)
+	account, err = db.GetAccountByCredential(0, registered, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(500), uint64(account.Reward),
 		"re-applied refund is deterministic")

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -652,11 +652,6 @@ func (ls *LedgerState) queryShelleyUtxoByAddress(
 // filtered out. The delegations map only contains accounts whose `Pool`
 // is currently set; an account that is registered but undelegated will
 // appear in the rewards map only.
-//
-// Stake credential lookup is hash-only: dingo's Account.StakingKey is the
-// 28-byte Blake2b224 credential hash and does not carry the key/script
-// discriminator. Collisions across the two tag spaces are cryptographically
-// negligible. TODO(#394): refine if Account grows tag-aware storage.
 func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 	creds []olocalstatequery.StakeCredential,
 ) (any, error) {
@@ -665,22 +660,29 @@ func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 	if len(creds) == 0 {
 		return []any{[]any{delegations, rewards}}, nil
 	}
-	stakeKeys := make([][]byte, 0, len(creds))
+	stakeCreds := make([]models.StakeCredentialRef, 0, len(creds))
 	seen := make(map[string]struct{}, len(creds))
 	for _, cred := range creds {
-		key := string(cred.Bytes[:])
+		ref := models.StakeCredentialRef{
+			Tag: uint8(cred.Tag),
+			Key: cred.Bytes[:],
+		}
+		key := ref.MapKey()
 		if _, dup := seen[key]; dup {
 			continue
 		}
 		seen[key] = struct{}{}
-		stakeKeys = append(stakeKeys, cred.Bytes[:])
+		stakeCreds = append(stakeCreds, ref)
 	}
-	accounts, err := ls.db.GetAccounts(stakeKeys, false, nil)
+	accounts, err := ls.db.GetAccountsByCredential(stakeCreds, false, nil)
 	if err != nil {
 		return nil, err
 	}
 	for _, cred := range creds {
-		account, ok := accounts[string(cred.Bytes[:])]
+		account, ok := accounts[models.StakeCredentialRef{
+			Tag: uint8(cred.Tag),
+			Key: cred.Bytes[:],
+		}.MapKey()]
 		if !ok {
 			continue
 		}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -663,8 +663,12 @@ func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 	stakeCreds := make([]models.StakeCredentialRef, 0, len(creds))
 	seen := make(map[string]struct{}, len(creds))
 	for _, cred := range creds {
+		credentialTag, err := models.CredentialTagFromUint64(cred.Tag)
+		if err != nil {
+			return nil, err
+		}
 		ref := models.StakeCredentialRef{
-			Tag: uint8(cred.Tag),
+			Tag: credentialTag,
 			Key: cred.Bytes[:],
 		}
 		key := ref.MapKey()
@@ -679,8 +683,12 @@ func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 		return nil, err
 	}
 	for _, cred := range creds {
+		credentialTag, err := models.CredentialTagFromUint64(cred.Tag)
+		if err != nil {
+			return nil, err
+		}
 		account, ok := accounts[models.StakeCredentialRef{
-			Tag: uint8(cred.Tag),
+			Tag: credentialTag,
 			Key: cred.Bytes[:],
 		}.MapKey()]
 		if !ok {

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -515,7 +515,16 @@ func (ls *LedgerState) queryShelleyDRepState(
 		dreps = all
 	} else {
 		for _, cred := range creds {
-			drep, err := ls.db.GetDrep(cred.Credential[:], false, nil)
+			credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+			if err != nil {
+				return nil, err
+			}
+			drep, err := ls.db.GetDrepByCredential(
+				credentialTag,
+				cred.Credential[:],
+				false,
+				nil,
+			)
 			if err != nil {
 				if errors.Is(err, models.ErrDrepNotFound) {
 					continue
@@ -532,6 +541,7 @@ func (ls *LedgerState) queryShelleyDRepState(
 			continue
 		}
 		key := olocalstatequery.StakeCredential{
+			Tag:   uint64(drep.CredentialTag),
 			Bytes: ledger.NewBlake2b224(drep.Credential),
 		}
 		result[key] = olocalstatequery.DRepStateEntry{

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -422,6 +422,7 @@ func TestQueryShelleyFilteredDelegationAndRewardAccounts_AfterWithdrawal(t *test
 		Active:     true,
 	}))
 	require.NoError(t, db.Metadata().ApplyAccountRewardWithdrawal(
+		0,
 		stakeKey,
 		1_000_000,
 		42,

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -523,6 +523,52 @@ func TestQueryShelleyFilteredDelegationAndRewardAccounts_Mixed(t *testing.T) {
 	assert.Len(t, rwds, 2, "exactly two reward entries expected")
 }
 
+// TestQueryShelleyFilteredDelegationAndRewardAccounts_TagAware verifies that
+// filtered account lookup treats key and script credentials with the same hash
+// as distinct reward accounts.
+func TestQueryShelleyFilteredDelegationAndRewardAccounts_TagAware(t *testing.T) {
+	db := newTestDB(t)
+	stakeKey := stakeCred28(0x44)
+	keyPool := stakeCred28(0x45)
+	scriptPool := stakeCred28(0x46)
+
+	require.NoError(t, db.Metadata().CreateAccount(nil, &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Pool:          keyPool,
+		Reward:        types.Uint64(100),
+		Active:        true,
+	}))
+	require.NoError(t, db.Metadata().CreateAccount(nil, &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 1,
+		Pool:          scriptPool,
+		Reward:        types.Uint64(200),
+		Active:        true,
+	}))
+
+	ls := &LedgerState{db: db}
+	keyCred := olocalstatequery.StakeCredential{
+		Tag:   0,
+		Bytes: toBlake2b224(stakeKey),
+	}
+	scriptCred := olocalstatequery.StakeCredential{
+		Tag:   1,
+		Bytes: toBlake2b224(stakeKey),
+	}
+
+	result, err := ls.queryShelleyFilteredDelegationAndRewardAccounts(
+		[]olocalstatequery.StakeCredential{keyCred, scriptCred},
+	)
+	require.NoError(t, err)
+	dels, rwds := unwrapFilteredDelegationResult(t, result)
+
+	assert.Equal(t, toBlake2b224(keyPool), dels[keyCred])
+	assert.Equal(t, uint64(100), rwds[keyCred])
+	assert.Equal(t, toBlake2b224(scriptPool), dels[scriptCred])
+	assert.Equal(t, uint64(200), rwds[scriptCred])
+}
+
 func TestEpochPicoseconds(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -126,7 +126,23 @@ func (lv *LedgerView) StakeRegistration(
 	stakingKey []byte,
 ) ([]lcommon.StakeRegistrationCertificate, error) {
 	// stakingKey = lcommon.NewBlake2b224(stakingKey)
-	return lv.ls.db.GetStakeRegistrations(stakingKey, lv.txn)
+	return lv.ls.db.GetStakeRegistrationsByCredential(0, stakingKey, lv.txn)
+}
+
+// StakeRegistrationByCredential returns stake registration certificates for the
+// full stake credential identity, preserving key/script credential separation.
+func (lv *LedgerView) StakeRegistrationByCredential(
+	cred lcommon.Credential,
+) ([]lcommon.StakeRegistrationCertificate, error) {
+	credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+	if err != nil {
+		return nil, err
+	}
+	return lv.ls.db.GetStakeRegistrationsByCredential(
+		credentialTag,
+		cred.Credential[:],
+		lv.txn,
+	)
 }
 
 // IsStakeCredentialRegistered checks if a stake credential is currently registered

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -773,9 +773,10 @@ func (lv *LedgerView) GetTotalActiveStake(epoch uint64) (uint64, error) {
 // for accurate voting power. The current implementation approximates
 // voting power using current live balances.
 func (lv *LedgerView) GetDRepVotingPower(
+	credentialTag uint8,
 	drepCredential []byte,
 ) (uint64, error) {
-	power, err := lv.ls.db.GetDRepVotingPower(drepCredential, lv.txn)
+	power, err := lv.ls.db.GetDRepVotingPower(credentialTag, drepCredential, lv.txn)
 	if err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -133,7 +133,12 @@ func (lv *LedgerView) StakeRegistration(
 func (lv *LedgerView) IsStakeCredentialRegistered(
 	cred lcommon.Credential,
 ) bool {
-	account, err := lv.ls.db.GetAccount(cred.Credential[:], false, lv.txn)
+	account, err := lv.ls.db.GetAccountByCredential(
+		uint8(cred.CredType),
+		cred.Credential[:],
+		false,
+		lv.txn,
+	)
 	if err != nil {
 		if !errors.Is(err, models.ErrAccountNotFound) {
 			lv.ls.config.Logger.Error(
@@ -324,7 +329,12 @@ func (lv *LedgerView) UpdateAdaPots(adaPots lcommon.AdaPots) error {
 func (lv *LedgerView) IsRewardAccountRegistered(
 	cred lcommon.Credential,
 ) bool {
-	account, err := lv.ls.db.GetAccount(cred.Credential[:], false, lv.txn)
+	account, err := lv.ls.db.GetAccountByCredential(
+		uint8(cred.CredType),
+		cred.Credential[:],
+		false,
+		lv.txn,
+	)
 	if err != nil {
 		if !errors.Is(err, models.ErrAccountNotFound) {
 			lv.ls.config.Logger.Error(

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -133,8 +133,12 @@ func (lv *LedgerView) StakeRegistration(
 func (lv *LedgerView) IsStakeCredentialRegistered(
 	cred lcommon.Credential,
 ) bool {
+	credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+	if err != nil {
+		return false
+	}
 	account, err := lv.ls.db.GetAccountByCredential(
-		uint8(cred.CredType),
+		credentialTag,
 		cred.Credential[:],
 		false,
 		lv.txn,
@@ -329,8 +333,12 @@ func (lv *LedgerView) UpdateAdaPots(adaPots lcommon.AdaPots) error {
 func (lv *LedgerView) IsRewardAccountRegistered(
 	cred lcommon.Credential,
 ) bool {
+	credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+	if err != nil {
+		return false
+	}
 	account, err := lv.ls.db.GetAccountByCredential(
-		uint8(cred.CredType),
+		credentialTag,
 		cred.Credential[:],
 		false,
 		lv.txn,

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -837,7 +837,7 @@ func parsePoolParams(
 	// Reward account (index 5)
 	rewardAccount, rewardAccountTag, ok := parseRewardAccount(params[5])
 	if !ok {
-		return nil, errors.New("decoding reward account")
+		return nil, fmt.Errorf("decoding reward account for pool %x", poolKeyHash)
 	}
 	pool.RewardAccount = rewardAccount
 	pool.RewardAccountCredentialTag = rewardAccountTag

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/cbor"
 )
 
@@ -834,15 +835,12 @@ func parsePoolParams(
 	}
 
 	// Reward account (index 5)
-	if _, err := cbor.Decode(
-		params[5],
-		&pool.RewardAccount,
-	); err != nil {
-		return nil, fmt.Errorf(
-			"decoding reward account: %w",
-			err,
-		)
+	rewardAccount, rewardAccountTag, ok := parseRewardAccount(params[5])
+	if !ok {
+		return nil, errors.New("decoding reward account")
 	}
+	pool.RewardAccount = rewardAccount
+	pool.RewardAccountCredentialTag = rewardAccountTag
 
 	// Owners (index 6) - set of 28-byte key hashes
 	pool.Owners = parsePoolOwners(params[6])
@@ -900,8 +898,9 @@ func parsePoolParamsWithoutOperator(
 		pool.MarginDen = 1
 	}
 
-	if rewardAccount, ok := parseRewardAccount(params[4]); ok {
+	if rewardAccount, rewardAccountTag, ok := parseRewardAccount(params[4]); ok {
 		pool.RewardAccount = rewardAccount
+		pool.RewardAccountCredentialTag = rewardAccountTag
 	}
 
 	pool.Owners = parsePoolOwners(params[5])
@@ -923,29 +922,59 @@ func parsePoolParamsWithoutOperator(
 	return pool, true, nil
 }
 
-func parseRewardAccount(data []byte) ([]byte, bool) {
+func parseRewardAccount(data []byte) ([]byte, uint8, bool) {
 	var direct []byte
 	if _, err := cbor.Decode(data, &direct); err == nil {
-		return direct, true
+		return normalizeRewardAccountBytes(direct)
 	}
 
 	if cred, err := parseCredential(data); err == nil && len(cred.Hash) > 0 {
-		return cred.Hash, true
+		credentialTag, tagErr := models.CredentialTagFromUint(
+			uint(cred.Type),
+		)
+		if tagErr != nil {
+			return nil, 0, false
+		}
+		return cred.Hash, credentialTag, true
 	}
 
 	var parts []cbor.RawMessage
 	if _, err := cbor.Decode(data, &parts); err != nil || len(parts) < 2 {
-		return nil, false
+		return nil, 0, false
 	}
 	if cred, err := parseCredential(parts[1]); err == nil &&
 		len(cred.Hash) > 0 {
-		return cred.Hash, true
+		credentialTag, tagErr := models.CredentialTagFromUint(
+			uint(cred.Type),
+		)
+		if tagErr != nil {
+			return nil, 0, false
+		}
+		return cred.Hash, credentialTag, true
 	}
 	if _, err := cbor.Decode(parts[1], &direct); err == nil {
-		return direct, true
+		return normalizeRewardAccountBytes(direct)
 	}
 
-	return nil, false
+	return nil, 0, false
+}
+
+func normalizeRewardAccountBytes(data []byte) ([]byte, uint8, bool) {
+	switch len(data) {
+	case 28:
+		return slices.Clone(data), 0, true
+	case 29:
+		switch data[0] >> 4 {
+		case 14:
+			return slices.Clone(data[1:]), 0, true
+		case 15:
+			return slices.Clone(data[1:]), 1, true
+		default:
+			return nil, 0, false
+		}
+	default:
+		return nil, 0, false
+	}
 }
 
 func parsePoolOwners(data []byte) [][]byte {

--- a/ledgerstate/certstate_test.go
+++ b/ledgerstate/certstate_test.go
@@ -237,6 +237,12 @@ func TestParsePStateSelectsUTxOHDPoolMap(t *testing.T) {
 	if !bytes.Equal(pool.RewardAccount, rewardHash) {
 		t.Fatalf("reward account mismatch: %x", pool.RewardAccount)
 	}
+	if pool.RewardAccountCredentialTag != 0 {
+		t.Fatalf(
+			"expected reward account credential tag 0, got %d",
+			pool.RewardAccountCredentialTag,
+		)
+	}
 	if len(pool.Owners) != 1 || !bytes.Equal(pool.Owners[0], ownerHash) {
 		t.Fatalf("owners mismatch: %#v", pool.Owners)
 	}
@@ -253,6 +259,54 @@ func TestParsePStateSelectsUTxOHDPoolMap(t *testing.T) {
 	}
 	if pool.Deposit != 500_000_000 {
 		t.Fatalf("deposit mismatch: %d", pool.Deposit)
+	}
+}
+
+// TestParseRewardAccountNormalizesAddressBytes verifies full reward
+// addresses are stored as 28-byte hashes plus their credential tag.
+func TestParseRewardAccountNormalizesAddressBytes(t *testing.T) {
+	rewardHash := bytes.Repeat([]byte{0x62}, 28)
+
+	cases := []struct {
+		name    string
+		account []byte
+		wantTag uint8
+	}{
+		{
+			name:    "key reward address",
+			account: append([]byte{0xe0}, rewardHash...),
+			wantTag: 0,
+		},
+		{
+			name:    "script reward address",
+			account: append([]byte{0xf0}, rewardHash...),
+			wantTag: 1,
+		},
+		{
+			name:    "legacy hash only",
+			account: rewardHash,
+			wantTag: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := cbor.Encode(tc.account)
+			if err != nil {
+				t.Fatalf("encoding reward account: %v", err)
+			}
+
+			gotHash, gotTag, ok := parseRewardAccount(data)
+			if !ok {
+				t.Fatal("expected reward account to parse")
+			}
+			if !bytes.Equal(gotHash, rewardHash) {
+				t.Fatalf("reward hash mismatch: %x", gotHash)
+			}
+			if gotTag != tc.wantTag {
+				t.Fatalf("expected tag %d, got %d", tc.wantTag, gotTag)
+			}
+		})
 	}
 }
 

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -125,6 +125,7 @@ type ParsedUTxO struct {
 	Address       []byte // raw address bytes
 	PaymentKey    []byte // 28 bytes, extracted from address
 	StakingKey    []byte // 28 bytes, extracted from address
+	CredentialTag uint8  // stake credential tag: 0 key hash, 1 script hash
 	PaymentScript bool   // true when payment credential is a script hash
 	Amount        uint64 // lovelace
 	Assets        []ParsedAsset
@@ -178,18 +179,19 @@ type ParsedAccount struct {
 
 // ParsedPool represents a stake pool registration.
 type ParsedPool struct {
-	PoolKeyHash   []byte // 28 bytes
-	VrfKeyHash    []byte // 32 bytes
-	Pledge        uint64
-	Cost          uint64
-	MarginNum     uint64
-	MarginDen     uint64
-	RewardAccount []byte
-	Owners        [][]byte // list of 28-byte key hashes
-	Relays        []ParsedRelay
-	MetadataUrl   string
-	MetadataHash  []byte // 32 bytes
-	Deposit       uint64
+	PoolKeyHash                []byte // 28 bytes
+	VrfKeyHash                 []byte // 32 bytes
+	Pledge                     uint64
+	Cost                       uint64
+	MarginNum                  uint64
+	MarginDen                  uint64
+	RewardAccount              []byte
+	RewardAccountCredentialTag uint8
+	Owners                     [][]byte // list of 28-byte key hashes
+	Relays                     []ParsedRelay
+	MetadataUrl                string
+	MetadataHash               []byte // 32 bytes
+	Deposit                    uint64
 }
 
 // ParsedRelay represents a pool relay from the stake pool
@@ -802,14 +804,27 @@ func importAccounts(
 		default:
 		}
 
+		credentialTag, err := models.CredentialTagFromUint(
+			uint(acct.StakingKey.Type),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"importing account %x credential type %d: %w",
+				acct.StakingKey.Hash,
+				acct.StakingKey.Type,
+				err,
+			)
+		}
+
 		model := &models.Account{
-			StakingKey: acct.StakingKey.Hash,
-			Pool:       acct.PoolKeyHash,
-			Drep:       acct.DRepCred.Hash,
-			DrepType:   acct.DRepCred.Type,
-			AddedSlot:  slot,
-			Reward:     types.Uint64(acct.Reward),
-			Active:     acct.Active,
+			StakingKey:    acct.StakingKey.Hash,
+			CredentialTag: credentialTag,
+			Pool:          acct.PoolKeyHash,
+			Drep:          acct.DRepCred.Hash,
+			DrepType:      acct.DRepCred.Type,
+			AddedSlot:     slot,
+			Reward:        types.Uint64(acct.Reward),
+			Active:        acct.Active,
 		}
 
 		if err := store.ImportAccount(
@@ -892,12 +907,13 @@ func importPools(
 		}
 
 		model := &models.Pool{
-			PoolKeyHash:   pool.PoolKeyHash,
-			VrfKeyHash:    pool.VrfKeyHash,
-			Pledge:        types.Uint64(pool.Pledge),
-			Cost:          types.Uint64(pool.Cost),
-			Margin:        margin,
-			RewardAccount: pool.RewardAccount,
+			PoolKeyHash:                pool.PoolKeyHash,
+			VrfKeyHash:                 pool.VrfKeyHash,
+			Pledge:                     types.Uint64(pool.Pledge),
+			Cost:                       types.Uint64(pool.Cost),
+			Margin:                     margin,
+			RewardAccount:              pool.RewardAccount,
+			RewardAccountCredentialTag: pool.RewardAccountCredentialTag,
 		}
 
 		var owners []models.PoolRegistrationOwner
@@ -926,18 +942,19 @@ func importPools(
 		}
 
 		reg := &models.PoolRegistration{
-			PoolKeyHash:   pool.PoolKeyHash,
-			VrfKeyHash:    pool.VrfKeyHash,
-			Pledge:        types.Uint64(pool.Pledge),
-			Cost:          types.Uint64(pool.Cost),
-			Margin:        margin,
-			RewardAccount: pool.RewardAccount,
-			AddedSlot:     slot,
-			DepositAmount: types.Uint64(pool.Deposit),
-			Owners:        owners,
-			Relays:        relays,
-			MetadataUrl:   pool.MetadataUrl,
-			MetadataHash:  pool.MetadataHash,
+			PoolKeyHash:                pool.PoolKeyHash,
+			VrfKeyHash:                 pool.VrfKeyHash,
+			Pledge:                     types.Uint64(pool.Pledge),
+			Cost:                       types.Uint64(pool.Cost),
+			Margin:                     margin,
+			RewardAccount:              pool.RewardAccount,
+			RewardAccountCredentialTag: pool.RewardAccountCredentialTag,
+			AddedSlot:                  slot,
+			DepositAmount:              types.Uint64(pool.Deposit),
+			Owners:                     owners,
+			Relays:                     relays,
+			MetadataUrl:                pool.MetadataUrl,
+			MetadataHash:               pool.MetadataHash,
 		}
 
 		if err := store.ImportPool(

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1010,15 +1010,28 @@ func importDReps(
 		default:
 		}
 
+		credentialTag, err := models.CredentialTagFromUint(
+			uint(drep.Credential.Type),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"importing DRep %x credential type %d: %w",
+				drep.Credential.Hash,
+				drep.Credential.Type,
+				err,
+			)
+		}
 		model := &models.Drep{
-			Credential: drep.Credential.Hash,
-			AnchorURL:  drep.AnchorURL,
-			AnchorHash: drep.AnchorHash,
-			AddedSlot:  slot,
-			Active:     drep.Active,
+			CredentialTag: credentialTag,
+			Credential:    drep.Credential.Hash,
+			AnchorURL:     drep.AnchorURL,
+			AnchorHash:    drep.AnchorHash,
+			AddedSlot:     slot,
+			Active:        drep.Active,
 		}
 
 		reg := &models.RegistrationDrep{
+			CredentialTag:  credentialTag,
 			DrepCredential: drep.Credential.Hash,
 			AnchorURL:      drep.AnchorURL,
 			AnchorHash:     drep.AnchorHash,

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/stretchr/testify/require"
 )
@@ -357,10 +358,10 @@ func TestPersistImportedSnapshotResolvesAutoVoteOnlyForMark(t *testing.T) {
 	}
 
 	cases := []struct {
-		name           string
-		targetEpoch    uint64
-		wantResolved   bool
-		wantAutoVote   uint8
+		name         string
+		targetEpoch  uint64
+		wantResolved bool
+		wantAutoVote uint8
 	}{
 		{
 			name:         "mark",
@@ -450,6 +451,108 @@ func TestImportPParamsAnchorsAddedSlotToCurrentEpochStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pparams, 1)
 	require.Equal(t, uint64(17_700), pparams[0].AddedSlot)
+}
+
+func TestImportAccountsPreservesCredentialTag(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	stakeKey := bytes.Repeat([]byte{0xA4}, 28)
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+	}
+
+	require.NoError(t, importAccounts(
+		context.Background(),
+		cfg,
+		[]ParsedAccount{
+			{
+				StakingKey: Credential{
+					Type: CredentialTypeKey,
+					Hash: stakeKey,
+				},
+				Reward: 1,
+				Active: true,
+			},
+			{
+				StakingKey: Credential{
+					Type: CredentialTypeScript,
+					Hash: stakeKey,
+				},
+				Reward: 2,
+				Active: true,
+			},
+		},
+		123,
+	))
+
+	keyAcct, err := db.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint8(0), keyAcct.CredentialTag)
+	require.Equal(t, types.Uint64(1), keyAcct.Reward)
+
+	scriptAcct, err := db.GetAccountByCredential(1, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), scriptAcct.CredentialTag)
+	require.Equal(t, types.Uint64(2), scriptAcct.Reward)
+}
+
+// TestImportPoolsPreservesRewardAccountCredentialTag verifies snapshot
+// pool import stores reward account tags on Pool and PoolRegistration.
+func TestImportPoolsPreservesRewardAccountCredentialTag(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	poolKeyHash := bytes.Repeat([]byte{0x51}, 28)
+	vrfKeyHash := bytes.Repeat([]byte{0x52}, 32)
+	rewardAccount := bytes.Repeat([]byte{0x53}, 28)
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+	}
+
+	require.NoError(t, importPools(
+		context.Background(),
+		cfg,
+		[]ParsedPool{
+			{
+				PoolKeyHash:                poolKeyHash,
+				VrfKeyHash:                 vrfKeyHash,
+				RewardAccount:              rewardAccount,
+				RewardAccountCredentialTag: 1,
+				MarginDen:                  1,
+			},
+		},
+		456,
+	))
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test requires the sqlite metadata backend")
+
+	var pool models.Pool
+	require.NoError(t, store.DB().
+		Where("pool_key_hash = ?", poolKeyHash).
+		First(&pool).Error)
+	require.Equal(t, rewardAccount, []byte(pool.RewardAccount))
+	require.Equal(t, uint8(1), pool.RewardAccountCredentialTag)
+
+	var registration models.PoolRegistration
+	require.NoError(t, store.DB().
+		Where("pool_key_hash = ?", poolKeyHash).
+		First(&registration).Error)
+	require.Equal(t, rewardAccount, []byte(registration.RewardAccount))
+	require.Equal(t, uint8(1), registration.RewardAccountCredentialTag)
 }
 
 func TestImportGovStateAnchorsProposalAndConstitutionSlots(t *testing.T) {

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -440,6 +440,10 @@ func extractAddressKeys(addr []byte, result *ParsedUTxO) {
 		}
 		if addrType <= 1 { // staking is key for types 0,1
 			result.StakingKey = bytes.Clone(addr[29:57])
+			result.CredentialTag = 0
+		} else { // staking is script for types 2,3
+			result.StakingKey = bytes.Clone(addr[29:57])
+			result.CredentialTag = 1
 		}
 	case (addrType == 4 || addrType == 5) && len(addr) >= 29:
 		// Pointer address: 1 header + 28 payment + pointer
@@ -505,6 +509,9 @@ func parseCborTxOut(
 	skh := addr.StakeKeyHash()
 	if skh != zeroBlake2b224 {
 		result.StakingKey = skh.Bytes()
+		if credentialTag, ok := models.StakeCredentialTagFromAddress(addr); ok {
+			result.CredentialTag = credentialTag
+		}
 	}
 	if addr.Type()&lcommon.AddressTypeScriptBit == lcommon.AddressTypeScriptBit {
 		result.PaymentScript = true
@@ -711,6 +718,7 @@ func UTxOToModel(u *ParsedUTxO, slot uint64) models.Utxo {
 		OutputIdx:     u.OutputIndex,
 		PaymentKey:    u.PaymentKey,
 		StakingKey:    u.StakingKey,
+		CredentialTag: u.CredentialTag,
 		PaymentScript: u.PaymentScript,
 		Amount:        types.Uint64(u.Amount),
 		AddedSlot:     slot,

--- a/ledgerstate/utxo_test.go
+++ b/ledgerstate/utxo_test.go
@@ -40,11 +40,12 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 	stakeHash := bytes.Repeat([]byte{0x22}, 28)
 
 	tests := []struct {
-		name          string
-		addr          []byte
-		wantScript    bool
-		wantPayKey    bool
-		wantStakeKey  bool
+		name         string
+		addr         []byte
+		wantScript   bool
+		wantPayKey   bool
+		wantStakeKey bool
+		wantStakeTag uint8
 	}{
 		{
 			// Type 0: key payment + key staking — NOT script
@@ -53,6 +54,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			wantScript:   false,
 			wantPayKey:   true,
 			wantStakeKey: true,
+			wantStakeTag: 0,
 		},
 		{
 			// Type 1: script payment + key staking
@@ -61,13 +63,32 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			wantScript:   true,
 			wantPayKey:   false,
 			wantStakeKey: true,
+			wantStakeTag: 0,
+		},
+		{
+			// Type 2: key payment + script staking
+			name:         "type2_key_payment_script_staking",
+			addr:         buildShelleyAddr(2, 1, payHash, stakeHash),
+			wantScript:   false,
+			wantPayKey:   true,
+			wantStakeKey: true,
+			wantStakeTag: 1,
+		},
+		{
+			// Type 3: script payment + script staking
+			name:         "type3_script_payment_script_staking",
+			addr:         buildShelleyAddr(3, 1, payHash, stakeHash),
+			wantScript:   true,
+			wantPayKey:   false,
+			wantStakeKey: true,
+			wantStakeTag: 1,
 		},
 		{
 			// Type 5: script payment + pointer staking (enterprise-like min length)
-			name:        "type5_script_payment_pointer",
-			addr:        buildShelleyAddr(5, 1, payHash, nil),
-			wantScript:  true,
-			wantPayKey:  false,
+			name:       "type5_script_payment_pointer",
+			addr:       buildShelleyAddr(5, 1, payHash, nil),
+			wantScript: true,
+			wantPayKey: false,
 		},
 		{
 			// Type 6: enterprise key payment — NOT script
@@ -98,6 +119,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			}
 			if tc.wantStakeKey {
 				require.Equal(t, stakeHash, result.StakingKey, "StakingKey")
+				require.Equal(t, tc.wantStakeTag, result.CredentialTag, "CredentialTag")
 			} else {
 				require.Empty(t, result.StakingKey, "StakingKey should be empty for non-staking-key address types")
 			}
@@ -116,8 +138,10 @@ func TestUTxOToModel_PropagatesPaymentScript(t *testing.T) {
 			OutputIndex:   0,
 			Amount:        1_000_000,
 			PaymentScript: wantScript,
+			CredentialTag: 1,
 		}
 		m := UTxOToModel(u, 100)
 		require.Equal(t, wantScript, m.PaymentScript)
+		require.Equal(t, uint8(1), m.CredentialTag)
 	}
 }


### PR DESCRIPTION
1. Added `CredentialTag` to account and stake account certificate/history models.
2. Made changes for account identity from hash-only staking_key to (credential_tag + staking_key).
3. Added credential tag aware account APIs such as GetAccountByCredential, GetAccountsByCredential and AddAccountRewardByCredential.
4. I have kept old hash only APIs such as GetAccount as tag zero compatibility wrappers.
5. Updated sqlite/mysql/postgres account lookup, imports/upserts, reward crediting, and rollback restore logic.
6. Updated certificate processing to persist the real on-chain credential tag from stake credentials.
7. Updated ShelleyFilteredDelegationAndRewardAccountsQuery to query by tag along with hash.
8. Updated ledger stake/reward registration checks to use tag-aware lookup.
9. Made changes to rollback restore cert cache so key/script credentials with the same hash do not share restored cert state.
10. Added tests to check whether cert processing creates separate key/script stake accounts with the same hash and account delegation/reward query returns distinct accounts for tag 0 and tag 1.
11. Updated the database.md as well with account stake table with this new credential tag.
12. Added CredentialTag to drep, drep certificate, and governance vote models.
13. Made DRep identity tag-aware from hash-only credential to (credential_tag + credential) for storage, imports, conflicts, and refetch logic.
14. Updated sqlite/mysql/postgres drep import/upsert paths so same-hash key DReps and script DReps are stored as distinct rows.
15. Updated dangling drep delegation cleanup to match account.drep_type with drep.credential_tag, so key/script DRep delegations with the same hash do not cross-match.
16. Added GetDrepByCredential and kept hash-only GetDrep only for protocol validation paths where the caller only has the DRep hash.
17. Updated DRep registration, deregistration, update, genesis import, ledgerstate import, and conformance state handling to persist the real on-chain credential tag.
18. Updated governance vote storage and unique conflict key to include voter_credential_tag.
19. Updated drep tally/voting power logic to key DRep votes by (credential_tag + credential) instead of hash only.
20. Added tests for same-hash key/script DRep separation in import, dangling delegation cleanup, governance vote conflict handling, and tallying.
21. Updated DATABASE.md with the DRep credential-tag schema, unique keys, relationships, and query changes.
22. The following MetadataStore interface methods have been removed and replaced by ByCredential equivalents that take an explicit credentialTag uint8 parameter. Any downstream code that embeds or implements MetadataStore must be updated.

GetAccount([]byte, bool, Txn) → GetAccountByCredential(uint8, []byte, bool, Txn)
GetAccounts([][]byte, bool, Txn) → GetAccountsByCredential([]StakeCredentialRef, bool, Txn)
AddAccountReward([]byte, uint64, uint64, Txn) → AddAccountRewardByCredential(uint8, []byte, uint64, uint64, Txn)
GetStakeRegistrations([]byte, Txn) → GetStakeRegistrationsByCredential(uint8, []byte, Txn)
GetAddressesByStakingKey([]byte, ...) → GetAddressesByCredential(uint8, []byte, ...)
CountAddressesByStakingKey([]byte, Txn) → CountAddressesByCredential(uint8, []byte, Txn)
GetAccountDelegationHistory([]byte, ...) → GetAccountDelegationHistoryByCredential(uint8, []byte, ...)
CountAccountDelegationHistory([]byte, Txn) → CountAccountDelegationHistoryByCredential(uint8, []byte, Txn)
GetAccountRegistrationHistory([]byte, ...) → GetAccountRegistrationHistoryByCredential(uint8, []byte, ...)
CountAccountRegistrationHistory([]byte, Txn) → CountAccountRegistrationHistoryByCredential(uint8, []byte, Txn)
GetControlledAmountByStakingKey([]byte, Txn) → GetControlledAmountByCredential(uint8, []byte, Txn)

Closes #2096



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make stake and DRep identities tag-aware by using (credential_tag + hash) across the DB, APIs, ledger, and snapshot import. Queries, voting power/tallies, address indexing, pool reward-account handling, and reward credits/refunds now separate key vs script identities; CIP-129 DRep IDs are parsed to preserve type. Closes #2096.

- **Bug Fixes**
  - Accounts/APIs: added tag-aware APIs GetAccountByCredential, GetAccountsByCredential (batch via `models.StakeCredentialRef`), AddAccountRewardByCredential; delegation/registration/reward history uses ByCredential; rollback and cert caches split by tag; batch lookups and upserts key on (tag, key); dereg/genesis upserts and SetAccount include tag; filtered delegation/reward queries and snapshot auto-vote resolution use full identity.
  - DReps/governance: store `credential_tag` on DRep and GovernanceVote; added GetDrepByCredential; voting power (single/batch), tally, activity updates, repair paths, treasury withdrawals/refunds and pool retirement refunds pass tag+hash across SQLite/Postgres/MySQL; CIP-129 parsing preserves script/key and adapter falls back across tags when type is unknown; fixed handling of missing DReps in batch voting power; uniqueness for votes includes `voter_credential_tag`.
  - UTxO/transactions: persist `credential_tag` and `payment_script`; address indexing and `utxorpc` search dedupe on (payment script bit+hash, credential_tag, staking_key); GetTransactionsByAddress* derives/enforces the stake tag and errors on mismatches; controlled amounts via GetControlledAmountByCredential; `api/mesh` reconstructs addresses using `payment_script` and `credential_tag`.
  - Pools/snapshot/examples: decode and store pool `reward_account_credential_tag` from certs; joins on (credential_tag, staking_key); snapshot import preserves stake and pool reward-account tags; `examples/dingo-gov-lens` accepts `credential_tag` for `/api/dreps/{credentialHex}` and `/api/stake/{stakeCredentialHex}` and shows credential type; pool cert parsing errors include the pool key hash.
  - Blockfrost API: DRep handler parses CIP-129 IDs and keeps script/key type; adapter falls back across tags when type is unknown.
  - Tests: added cross-tag isolation and CIP-129 parsing tests across SQLite/Postgres/MySQL.

- **Migration**
  - Breaking APIs: use ByCredential variants (e.g., GetAccountByCredential, GetAccountsByCredential, AddAccountRewardByCredential, GetStakeRegistrationsByCredential, GetControlledAmountByCredential, GetDrepByCredential; account delegation/registration history via ByCredential). Hash-only wrappers have been removed.
  - Schema/indexes: add `credential_tag` to accounts, DReps, MIR rewards, account reward deltas, governance votes, `address_transaction`, `utxo`; add pool `reward_account_credential_tag`. New unique/covering indexes include accounts `(credential_tag, staking_key)`, DReps `(credential_tag, credential)`, votes `(proposal_id, voter_type, voter_credential_tag, voter_credential)`. Migrations added for SQLite/Postgres/MySQL.
  - Tag derivation: parse from stake/reward/DRep addresses (including CIP-129 for DRePs) or via `models.CredentialTagFromUint`; docs updated in DATABASE.md.

<sup>Written for commit 4bd46430d0bed3d9a35b5f7d4f1c96323bd4201e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Database Schema Updates**
  * Account, DRep, UTxO and address-transaction records now include a credential-tag paired with staking keys for precise identity and indexing.

* **Documentation**
  * Database docs, ER diagrams and SQL examples updated to reflect credential-tagged identities and composite keys.

* **Behavioral/API Changes**
  * Address, account, delegation, registration and reward queries are credential-aware; identical staking hashes under different credential types are treated distinctly, improving correctness for addresses, balances, and governance/voting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->