### PR TITLE
test(sqlite): isolate in-memory stores so metadata tests run in parallel

### DIFF
--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -32,6 +32,7 @@ import (
 // layer to import this package or to depend on the GORM default-tag
 // behavior of CreateAccount.
 func TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	stakeKey := make([]byte, 28)
@@ -75,6 +76,7 @@ func TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse(t *testing.T) {
 // "added_slot DESC, block_index DESC, cert_index DESC"; the account-side
 // queries must too.
 func TestBatchFetchCerts_SameSlotTiebreakByBlockIndex(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 	db := store.DB()
 	const slot = uint64(1000)
@@ -163,6 +165,7 @@ func TestBatchFetchCerts_SameSlotTiebreakByBlockIndex(t *testing.T) {
 // non-deterministic across refactors and makes the restore path silently
 // drift from the on-chain ordering.
 func TestBatchFetchCerts_CrossTableTiebreakByBlockIndex(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 	db := store.DB()
 	const slot = uint64(2000)

--- a/database/plugin/metadata/sqlite/analyze_test.go
+++ b/database/plugin/metadata/sqlite/analyze_test.go
@@ -54,6 +54,7 @@ func sqliteStatCount(t *testing.T, store *MetadataStoreSqlite, table string) int
 // TestUpdatePlannerStats_PopulatesStat1 verifies that after inserting rows and
 // calling UpdatePlannerStats, sqlite_stat1 is populated with at least one entry.
 func TestUpdatePlannerStats_PopulatesStat1(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	insertTestUtxos(t, store, 5)
 
@@ -68,6 +69,7 @@ func TestUpdatePlannerStats_PopulatesStat1(t *testing.T) {
 // TestUpdatePlannerStats_CollectsUtxoTableStats verifies that the utxo table
 // specifically gets stats. This is the table that caused bad query plans.
 func TestUpdatePlannerStats_CollectsUtxoTableStats(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	insertTestUtxos(t, store, 3)
 
@@ -84,6 +86,7 @@ func TestUpdatePlannerStats_CollectsUtxoTableStats(t *testing.T) {
 // TestUpdatePlannerStats_EmptyDB verifies UpdatePlannerStats does not error
 // on a freshly created database with no rows.
 func TestUpdatePlannerStats_EmptyDB(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	assert.NoError(t, store.UpdatePlannerStats())
 }
@@ -91,6 +94,7 @@ func TestUpdatePlannerStats_EmptyDB(t *testing.T) {
 // TestUpdatePlannerStats_Idempotent verifies that calling UpdatePlannerStats
 // more than once does not error. This matters for resume/restart paths.
 func TestUpdatePlannerStats_Idempotent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	insertTestUtxos(t, store, 3)
 
@@ -104,6 +108,7 @@ func TestUpdatePlannerStats_Idempotent(t *testing.T) {
 }
 
 func TestUpdatePlannerStats_ReturnsErrorWhenDatabaseClosed(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	require.NoError(t, store.Close())
 

--- a/database/plugin/metadata/sqlite/backfill_test.go
+++ b/database/plugin/metadata/sqlite/backfill_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestGetBackfillCheckpoint_NotFound(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	cp, err := store.GetBackfillCheckpoint("metadata", nil)
@@ -32,6 +33,7 @@ func TestGetBackfillCheckpoint_NotFound(t *testing.T) {
 }
 
 func TestSetBackfillCheckpoint_Create(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	now := time.Now().Truncate(time.Second)
@@ -57,6 +59,7 @@ func TestSetBackfillCheckpoint_Create(t *testing.T) {
 }
 
 func TestSetBackfillCheckpoint_Upsert(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	now := time.Now().Truncate(time.Second)
@@ -86,6 +89,7 @@ func TestSetBackfillCheckpoint_Upsert(t *testing.T) {
 }
 
 func TestSetBackfillCheckpoint_CompletedFlag(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	now := time.Now().Truncate(time.Second)
@@ -107,6 +111,7 @@ func TestSetBackfillCheckpoint_CompletedFlag(t *testing.T) {
 }
 
 func TestSetBackfillCheckpoint_WithTransaction(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	now := time.Now().Truncate(time.Second)

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestBatchAccumulator_AddAndReset(t *testing.T) {
+	t.Parallel()
 	ba := NewBatchAccumulator()
 	require.NotNil(t, ba)
 
@@ -150,6 +151,7 @@ func TestBatchAccumulator_AddAndReset(t *testing.T) {
 }
 
 func TestBatchAccumulator_InFlightProducerIndex(t *testing.T) {
+	t.Parallel()
 	ba := NewBatchAccumulator()
 
 	producerTx := bytes.Repeat([]byte{0xaa}, 32)
@@ -201,6 +203,7 @@ func TestBatchAccumulator_InFlightProducerIndex(t *testing.T) {
 }
 
 func TestBatchAccumulator_MergeFromIndex(t *testing.T) {
+	t.Parallel()
 	dst := NewBatchAccumulator()
 	src := NewBatchAccumulator()
 
@@ -225,6 +228,7 @@ func TestBatchAccumulator_MergeFromIndex(t *testing.T) {
 }
 
 func TestFlushBatch_Witnesses(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	batch := NewBatchAccumulator()
 
@@ -248,6 +252,7 @@ func TestFlushBatch_Witnesses(t *testing.T) {
 }
 
 func TestFlushBatch_UtxoOutputsAndSpends(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	batch := NewBatchAccumulator()
 
@@ -296,6 +301,7 @@ func TestFlushBatch_UtxoOutputsAndSpends(t *testing.T) {
 }
 
 func TestFlushBatch_MultipleSpends(t *testing.T) {
+	t.Parallel()
 	// This test specifically guards against the args-ordering bug in
 	// batchSpendUtxos: with N>1 spends the SQL has three separate CASE
 	// sections whose bindings must be grouped (all deletedSlot args, then
@@ -363,6 +369,7 @@ func TestFlushBatch_MultipleSpends(t *testing.T) {
 }
 
 func TestFlushBatch_Idempotent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	batch := NewBatchAccumulator()
 
@@ -431,6 +438,7 @@ func TestFlushBatch_Idempotent(t *testing.T) {
 // to the accumulator rather than the database.
 // A subsequent FlushBatch call must materialise those rows correctly.
 func TestSetTransactionBatched_AccumulatesCorrectly(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 
 	// ------------------------------------------------------------------ //

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -33,6 +33,7 @@ import (
 // column (or GORM names one differently than expected, e.g. ex_units_cpu),
 // this fails instead of silently writing the wrong columns.
 func TestBulkInsertColumnsMatchSchema(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	ns := store.DB().NamingStrategy
 
@@ -82,6 +83,7 @@ func TestBulkInsertColumnsMatchSchema(t *testing.T) {
 // a row count that is not a multiple of batchChunkRows must still write every
 // row (full chunks via the stable statement, the tail via a one-off statement).
 func TestExecBulkInsert_PartialChunkWritesAllRows(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	// 2 full chunks of batchChunkRows + a partial remainder.
 	n := 2*batchChunkRows + batchChunkRows/2
@@ -119,6 +121,7 @@ func TestExecBulkInsert_PartialChunkWritesAllRows(t *testing.T) {
 // semantics survive the GORM->fixed-shape conversion: re-inserting an existing
 // hash is a no-op that keeps the original row.
 func TestInsertScripts_ConflictDoNothing(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	hash := bytes.Repeat([]byte{0xAB}, 28)
 
@@ -142,6 +145,7 @@ func TestInsertScripts_ConflictDoNothing(t *testing.T) {
 // corrupts a value here. It also exercises asset linking, which depends on
 // BatchRefetchUtxoIDs recovering the utxo ID after a raw INSERT.
 func TestImportUtxos_FixedShapeRoundTrip(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	txid := bytes.Repeat([]byte{0x11}, 32)
 	in := models.Utxo{
@@ -184,6 +188,7 @@ func TestImportUtxos_FixedShapeRoundTrip(t *testing.T) {
 // ON CONFLICT(tx_id,output_idx) DO NOTHING semantics survive the conversion:
 // re-importing the same ref keeps the original row.
 func TestImportUtxos_ConflictDoNothingIdempotent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	txid := bytes.Repeat([]byte{0xAA}, 32)
 	require.NoError(t, store.ImportUtxos([]models.Utxo{{
@@ -206,6 +211,7 @@ func TestImportUtxos_ConflictDoNothingIdempotent(t *testing.T) {
 // row (e.g. on retry, or a different tx) is a no-op and leaves the first
 // spender's slot/hash intact.
 func TestBatchSpendUtxos_GuardSkipsAlreadySpent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 	txid := bytes.Repeat([]byte{0x55}, 32)
 	spender1 := bytes.Repeat([]byte{0x66}, 32)

--- a/database/plugin/metadata/sqlite/committee_member_test.go
+++ b/database/plugin/metadata/sqlite/committee_member_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestSetCommitteeMembers(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	members := []*models.CommitteeMember{
@@ -51,6 +52,7 @@ func TestSetCommitteeMembers(t *testing.T) {
 }
 
 func TestSetCommitteeQuorum(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	got, err := store.GetCommitteeQuorum(nil)
@@ -74,6 +76,7 @@ func TestSetCommitteeQuorum(t *testing.T) {
 }
 
 func TestSoftDeleteCommitteeMembers(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	credA := []byte("cred_hash_a_1234567890123456")
@@ -99,6 +102,7 @@ func TestSoftDeleteCommitteeMembers(t *testing.T) {
 }
 
 func TestSoftDeleteAllCommitteeMembers(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	err := store.SetCommitteeMembers([]*models.CommitteeMember{
@@ -116,6 +120,7 @@ func TestSoftDeleteAllCommitteeMembers(t *testing.T) {
 }
 
 func TestSoftDeleteCommitteeMembersEmpty(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	err := store.SetCommitteeMembers([]*models.CommitteeMember{
@@ -132,6 +137,7 @@ func TestSoftDeleteCommitteeMembersEmpty(t *testing.T) {
 }
 
 func TestSetCommitteeMembersEmpty(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Empty slice should be a no-op
@@ -146,6 +152,7 @@ func TestSetCommitteeMembersEmpty(t *testing.T) {
 }
 
 func TestSetCommitteeMembersUpsert(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred := []byte("cred_hash_1_2345678901234567")
@@ -180,6 +187,7 @@ func TestSetCommitteeMembersUpsert(t *testing.T) {
 }
 
 func TestGetCommitteeMembersExcludesDeleted(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred1 := []byte("cred_hash_1_2345678901234567")
@@ -214,6 +222,7 @@ func TestGetCommitteeMembersExcludesDeleted(t *testing.T) {
 }
 
 func TestDeleteCommitteeMembersAfterSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Add members at different slots
@@ -246,6 +255,7 @@ func TestDeleteCommitteeMembersAfterSlot(t *testing.T) {
 }
 
 func TestDeleteCommitteeMembersAfterSlotDeletesQuorum(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	require.NoError(t, store.SetCommitteeQuorum(
@@ -265,6 +275,7 @@ func TestDeleteCommitteeMembersAfterSlotDeletesQuorum(t *testing.T) {
 }
 
 func TestClearCommitteeQuorum(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Seed a quorum.
@@ -291,6 +302,7 @@ func TestClearCommitteeQuorum(t *testing.T) {
 }
 
 func TestClearCommitteeQuorumWhenNoPrior(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Clearing without any prior Set must still leave GetCommitteeQuorum
@@ -314,6 +326,7 @@ func TestClearCommitteeQuorumWhenNoPrior(t *testing.T) {
 }
 
 func TestClearCommitteeQuorumRollbackRestoresPrior(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	require.NoError(t, store.SetCommitteeQuorum(
@@ -331,6 +344,7 @@ func TestClearCommitteeQuorumRollbackRestoresPrior(t *testing.T) {
 }
 
 func TestDeleteCommitteeMembersAfterSlotClearsDeletedSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred := []byte("cred_hash_1_2345678901234567")

--- a/database/plugin/metadata/sqlite/concurrency_test.go
+++ b/database/plugin/metadata/sqlite/concurrency_test.go
@@ -48,6 +48,7 @@ func setupFileBasedStore(
 // do not produce SQLITE_BUSY errors while writes are in progress.
 // This is the core scenario the read/write pool separation fixes.
 func TestConcurrentReadsDuringWrites(t *testing.T) {
+	t.Parallel()
 	store := setupFileBasedStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -151,6 +152,7 @@ func TestConcurrentReadsDuringWrites(t *testing.T) {
 // errors. With a single-writer connection pool, writes serialize
 // naturally at the Go connection pool level.
 func TestConcurrentWriteTransactions(t *testing.T) {
+	t.Parallel()
 	store := setupFileBasedStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -223,6 +225,7 @@ func TestConcurrentWriteTransactions(t *testing.T) {
 // TestReadWritePoolSeparation verifies that the file-based store
 // has separate read and write database handles.
 func TestReadWritePoolSeparation(t *testing.T) {
+	t.Parallel()
 	store := setupFileBasedStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -246,6 +249,7 @@ func TestReadWritePoolSeparation(t *testing.T) {
 // TestInMemorySharedPool verifies that the in-memory store shares
 // a single pool for reads and writes.
 func TestInMemorySharedPool(t *testing.T) {
+	t.Parallel()
 	store, err := New("", nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, store.Start())
@@ -264,6 +268,7 @@ func TestInMemorySharedPool(t *testing.T) {
 // with many goroutines performing mixed read/write operations. This
 // is a stress test to verify the fix under load.
 func TestHighContentionReadWrite(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping stress test in short mode")
 	}
@@ -365,6 +370,7 @@ func TestHighContentionReadWrite(t *testing.T) {
 // TestWritePoolSingleConnection verifies that the write pool has
 // exactly 1 max open connection for file-based databases.
 func TestWritePoolSingleConnection(t *testing.T) {
+	t.Parallel()
 	store := setupFileBasedStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -383,6 +389,7 @@ func TestWritePoolSingleConnection(t *testing.T) {
 // TestReadPoolMultipleConnections verifies that the read pool
 // allows multiple connections for file-based databases.
 func TestReadPoolMultipleConnections(t *testing.T) {
+	t.Parallel()
 	store := setupFileBasedStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -401,6 +408,7 @@ func TestReadPoolMultipleConnections(t *testing.T) {
 // TestConcurrentReadsDontBlock verifies that many concurrent reads
 // complete quickly and don't block each other.
 func TestConcurrentReadsDontBlock(t *testing.T) {
+	t.Parallel()
 	store := setupFileBasedStore(t)
 	defer store.Close() //nolint:errcheck
 

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -43,6 +44,14 @@ const sqliteBindVarLimit = 400
 // is effectively unbounded, which performs poorly for API backfill because many
 // bulk INSERT/UPDATE statements have batch-dependent SQL text.
 const sqlitePrepareStmtMaxSize = 1024
+
+// inMemoryDBSeq hands each in-memory store a distinct shared-cache database
+// name. An anonymous "file::memory:?cache=shared" URI resolves to a single
+// process-global database, so every such store would otherwise share one set
+// of tables. A unique name per store keeps connections within a store sharing
+// the same in-memory database while isolating separate stores from each other,
+// which lets tests run in parallel.
+var inMemoryDBSeq atomic.Uint64
 
 // sqliteTxn wraps a gorm transaction and implements types.Txn
 type sqliteTxn struct {
@@ -252,16 +261,29 @@ func (d *MetadataStoreSqlite) Start() error {
 		// from multiple connections. This is needed for tests that
 		// verify concurrent transaction behavior.
 		//
+		// The database name is unique per store so that separate
+		// in-memory stores get separate databases. An anonymous
+		// "file::memory:?cache=shared" URI resolves to one shared
+		// process-global database, which would let independent stores
+		// (e.g. parallel tests) clobber each other's tables.
+		//
 		// Note: cache=shared can cause SQLITE_LOCKED with concurrent
 		// writes, but in-memory databases are only used for testing
 		// where write concurrency is controlled. The production
 		// file-based database uses WAL mode with separate read/write
 		// pools which handles concurrency properly.
+		memName := fmt.Sprintf(
+			"dingo_memdb_%d",
+			inMemoryDBSeq.Add(1),
+		)
 		metadataDb, err = gorm.Open(
 			sqlite.Open(
-				"file::memory:?cache=shared"+
-					"&_pragma=busy_timeout(30000)"+
-					"&_pragma=foreign_keys(1)",
+				fmt.Sprintf(
+					"file:%s?mode=memory&cache=shared"+
+						"&_pragma=busy_timeout(30000)"+
+						"&_pragma=foreign_keys(1)",
+					memName,
+				),
 			),
 			&gorm.Config{
 				Logger:                 d.gormLogger(),

--- a/database/plugin/metadata/sqlite/deferred_indexes_test.go
+++ b/database/plugin/metadata/sqlite/deferred_indexes_test.go
@@ -26,6 +26,7 @@ import (
 // accidentally being emptied — without entries we'd silently fall
 // back to no-op behavior and silently lose the bulk-load speed-up.
 func TestDeferredManifestNotEmpty(t *testing.T) {
+	t.Parallel()
 	if len(deferred.Manifest) == 0 {
 		t.Fatal("deferred.Manifest is empty; bulk-load optimization disabled")
 	}
@@ -38,6 +39,7 @@ func TestDeferredManifestNotEmpty(t *testing.T) {
 // renamed a field or dropped the `gorm:"index"` tag without
 // updating the manifest.
 func TestDeferredManifestResolvesToRealIndexes(t *testing.T) {
+	t.Parallel()
 	d := setupTestDB(t)
 	migrator := d.DB().Migrator()
 	for _, idx := range deferred.Manifest {
@@ -59,6 +61,7 @@ func TestDeferredManifestResolvesToRealIndexes(t *testing.T) {
 // state transitions are checked at each step so callers (mithril
 // sync, serve repair path) can rely on them.
 func TestDropAndBuildDeferredIndexesRoundTrip(t *testing.T) {
+	t.Parallel()
 	d := setupTestDB(t)
 
 	pending, err := d.HasDeferredIndexesPending()
@@ -117,6 +120,7 @@ func TestDropAndBuildDeferredIndexesRoundTrip(t *testing.T) {
 // split rebuild contract: critical indexes are restored first, lazy indexes
 // remain missing, and the pending marker is not cleared until the full rebuild.
 func TestBuildCriticalDeferredIndexesOnlyRebuildsCriticalSubset(t *testing.T) {
+	t.Parallel()
 	d := setupTestDB(t)
 	if err := d.DropDeferredIndexes(); err != nil {
 		t.Fatalf("DropDeferredIndexes: %v", err)
@@ -169,6 +173,7 @@ func TestBuildCriticalDeferredIndexesOnlyRebuildsCriticalSubset(t *testing.T) {
 // idx_asset_unique, because ledger-state UTxO import uses it as the
 // ON CONFLICT target for asset inserts.
 func TestDropDeferredIndexesPreservesAssetImportConflictTarget(t *testing.T) {
+	t.Parallel()
 	d := setupTestDB(t)
 	migrator := d.DB().Migrator()
 
@@ -235,6 +240,7 @@ func TestDropDeferredIndexesPreservesAssetImportConflictTarget(t *testing.T) {
 // already has every manifest entry). This is the path the serve
 // repair flow takes when no rebuild is actually outstanding.
 func TestBuildDeferredIndexesIsIdempotent(t *testing.T) {
+	t.Parallel()
 	d := setupTestDB(t)
 	if err := d.BuildDeferredIndexes(); err != nil {
 		t.Fatalf("first BuildDeferredIndexes: %v", err)
@@ -255,6 +261,7 @@ func TestBuildDeferredIndexesIsIdempotent(t *testing.T) {
 // path: a re-run of mithril sync after a partial drop should
 // complete without errors and leave the pending marker set.
 func TestDropDeferredIndexesIsIdempotent(t *testing.T) {
+	t.Parallel()
 	d := setupTestDB(t)
 	if err := d.DropDeferredIndexes(); err != nil {
 		t.Fatalf("first DropDeferredIndexes: %v", err)
@@ -278,6 +285,7 @@ func TestDropDeferredIndexesIsIdempotent(t *testing.T) {
 // recovery contract that `dingo serve` and `dingo mithril sync`
 // rely on: the pending marker must survive a process exit.
 func TestCrashRecoveryDetectedAcrossReopen(t *testing.T) {
+	t.Parallel()
 	dataDir := t.TempDir()
 
 	first, err := NewWithOptions(WithDataDir(dataDir))

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestSqliteGetDRepVotingPowerIncludesReward(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := []byte("drep_reward_only_123456789012345678901234")
@@ -65,6 +66,7 @@ func TestSqliteGetDRepVotingPowerIncludesReward(t *testing.T) {
 }
 
 func TestSqliteGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	rewardOnlyCred := []byte("drep_reward_only_22345678901234567890123")
@@ -113,6 +115,7 @@ func TestSqliteGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 }
 
 func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := []byte("drep_multi_reward_12345678901234567890123")
@@ -147,6 +150,7 @@ func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testin
 }
 
 func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred := []byte("drep_insert_absent_1234567890123456789012")
@@ -165,6 +169,7 @@ func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {
 }
 
 func TestSqliteInsertDrepIfAbsentLeavesExistingRowUntouched(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred := []byte("drep_insert_absent_2234567890123456789012")

--- a/database/plugin/metadata/sqlite/genesis_governance_test.go
+++ b/database/plugin/metadata/sqlite/genesis_governance_test.go
@@ -46,6 +46,7 @@ func makePoolId(b byte) lcommon.PoolId {
 }
 
 func TestSqliteSetGenesisGovernance(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := makeCred(0x11)
@@ -195,6 +196,7 @@ func TestSqliteSetGenesisGovernance(t *testing.T) {
 }
 
 func TestSqliteSetGenesisGovernanceIdempotent(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := makeCred(0x55)
@@ -246,6 +248,7 @@ func TestSqliteSetGenesisGovernanceIdempotent(t *testing.T) {
 }
 
 func TestSqliteSetGenesisGovernanceEmpty(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 	require.NoError(t, store.SetGenesisGovernance(
 		conway.ConwayGenesisInitialDReps{},
@@ -268,6 +271,7 @@ func TestSqliteSetGenesisGovernanceEmpty(t *testing.T) {
 // causing "DRep ... has no registration cert at or before slot ..." in
 // Phase 2 of RestoreDrepStateAtSlot.
 func TestSqliteRollbackPreservesGenesisDrep(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := makeCred(0x81)
@@ -338,6 +342,7 @@ func TestSqliteRollbackPreservesGenesisDrep(t *testing.T) {
 // genesis-rooted DReps (slot-0 registration) get their values
 // preserved.
 func TestSqliteRollbackResetsExpiryForOnChainDrep(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := bytes.Repeat([]byte{0xa1}, 28)
@@ -387,6 +392,7 @@ func TestSqliteRollbackResetsExpiryForOnChainDrep(t *testing.T) {
 // silently keeping the DRep active when it should have been
 // deregistered.
 func TestSqliteRollbackDrepCrossTypeBlockIndex(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := bytes.Repeat([]byte{0xb1}, 28)
@@ -472,6 +478,7 @@ func TestSqliteRollbackDrepCrossTypeBlockIndex(t *testing.T) {
 // hasReg was false, and the account was deleted by Phase 1 of
 // RestoreAccountStateAtSlot.
 func TestSqliteRollbackPreservesGenesisVoteOnlyAccount(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := makeCred(0x82)
@@ -539,6 +546,7 @@ func TestSqliteRollbackPreservesGenesisVoteOnlyAccount(t *testing.T) {
 // account created from a Conway-genesis stake+vote delegation is NOT
 // deleted when we roll back past a later on-chain StakeDelegation.
 func TestSqliteRollbackPreservesGenesisStakeVoteAccount(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := makeCred(0x84)
@@ -613,6 +621,7 @@ func TestSqliteRollbackPreservesGenesisStakeVoteAccount(t *testing.T) {
 // distinguishes them. (See CLAUDE.md: "Order certificates using
 // added_slot DESC, block_index DESC, cert_index DESC".)
 func TestCertRecordIsMoreRecentBlockIndex(t *testing.T) {
+	t.Parallel()
 	// Same slot, different block_index, same cert_index — the higher
 	// block_index must win.
 	earlier := certRecord{addedSlot: 100, blockIndex: 0, certIndex: 0}
@@ -653,6 +662,7 @@ func TestCertRecordIsMoreRecentBlockIndex(t *testing.T) {
 // ordering (slot, cert_index) both certs tied on cert_index=0 and the
 // outcome was non-deterministic.
 func TestRollbackPicksLatestByBlockIndexAtSameSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	stakeKey := bytes.Repeat([]byte{0x91}, 28)

--- a/database/plugin/metadata/sqlite/governance_test.go
+++ b/database/plugin/metadata/sqlite/governance_test.go
@@ -36,6 +36,7 @@ func setupTestStore(t *testing.T) *MetadataStoreSqlite {
 }
 
 func TestGetConstitution(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Initially no constitution
@@ -75,6 +76,7 @@ func TestGetConstitution(t *testing.T) {
 }
 
 func TestGetConstitutionDeletedSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Add a constitution
@@ -99,6 +101,7 @@ func TestGetConstitutionDeletedSlot(t *testing.T) {
 }
 
 func TestGetCommitteeMember(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	coldKey := []byte("cold_credential_12345678901234567890123456")
@@ -127,6 +130,7 @@ func TestGetCommitteeMember(t *testing.T) {
 }
 
 func TestGetActiveCommitteeMembers(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	coldKey1 := []byte("cold_credential_1234567890123456789012345a")
@@ -158,6 +162,7 @@ func TestGetActiveCommitteeMembers(t *testing.T) {
 }
 
 func TestIsCommitteeMemberResigned(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	coldKey := []byte("cold_credential_12345678901234567890123456")
@@ -197,6 +202,7 @@ func TestIsCommitteeMemberResigned(t *testing.T) {
 }
 
 func TestGetResignedCommitteeMembers(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	resignedCold := []byte("cold_credential_12345678901234567890123456")
@@ -253,6 +259,7 @@ func TestGetResignedCommitteeMembers(t *testing.T) {
 }
 
 func TestGetActiveDreps(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Initially empty
@@ -311,6 +318,7 @@ func TestGetActiveDreps(t *testing.T) {
 }
 
 func TestGetDrep(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred := []byte("drep_credential_1234567890123456789012345a")
@@ -359,6 +367,7 @@ func TestGetDrep(t *testing.T) {
 }
 
 func TestGetGovernanceProposal(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	txHash := []byte("tx_hash_1234567890123456789012345678901234")
@@ -403,6 +412,7 @@ func TestGetGovernanceProposal(t *testing.T) {
 }
 
 func TestGetActiveGovernanceProposals(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Add an active proposal (expires in epoch 200)
@@ -453,6 +463,7 @@ func TestGetActiveGovernanceProposals(t *testing.T) {
 // enforces at-most-one ratification per purpose per tick, so nodes
 // must see proposals in the same order.
 func TestGetActiveGovernanceProposals_DeterministicOrder(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Insert in reverse-sorted order; the query must return them in
@@ -512,6 +523,7 @@ func TestGetActiveGovernanceProposals_DeterministicOrder(t *testing.T) {
 }
 
 func TestGetRatifiedGovernanceProposals(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Active (not ratified)
@@ -582,6 +594,7 @@ func TestGetRatifiedGovernanceProposals(t *testing.T) {
 }
 
 func TestGetLastEnactedGovernanceProposal(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Enact two ParameterChange proposals at different slots.
@@ -670,6 +683,7 @@ func TestGetLastEnactedGovernanceProposal(t *testing.T) {
 // either via the purpose's action-type set must find the most
 // recently enacted of both.
 func TestGetLastEnactedGovernanceProposal_CommitteePurpose(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Enact a NoConfidence, then a later UpdateCommittee. Both belong
@@ -743,6 +757,7 @@ func TestGetLastEnactedGovernanceProposal_CommitteePurpose(t *testing.T) {
 }
 
 func TestUpdateDRepActivity(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	cred := []byte("drep_credential_1234567890123456789012345a")
@@ -791,6 +806,7 @@ func TestUpdateDRepActivity(t *testing.T) {
 }
 
 func TestGetExpiredDReps(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	credA := []byte("drep_credential_1234567890123456789012345a")
@@ -836,6 +852,7 @@ func TestGetExpiredDReps(t *testing.T) {
 }
 
 func TestGetDRepVotingPower(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	drepCred := []byte("drep_credential_1234567890123456789012345a")
@@ -915,6 +932,7 @@ func TestGetDRepVotingPower(t *testing.T) {
 }
 
 func TestGetDRepVotingPowerByTypeRejectsCredentialTypes(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	_, err := store.GetDRepVotingPowerByType(
@@ -937,6 +955,7 @@ func TestGetDRepVotingPowerByTypeRejectsCredentialTypes(t *testing.T) {
 }
 
 func TestGetCommitteeActiveCount(t *testing.T) {
+	t.Parallel()
 	store := setupTestStore(t)
 
 	// Initially zero

--- a/database/plugin/metadata/sqlite/import_test.go
+++ b/database/plugin/metadata/sqlite/import_test.go
@@ -87,6 +87,7 @@ func (r *importSQLRecorder) containsUpdate(table string) bool {
 }
 
 func TestImportUtxosAddsMissingAssetsForExistingUtxo(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	txID := bytes.Repeat([]byte{0x31}, 32)
@@ -153,6 +154,7 @@ func TestImportUtxosAddsMissingAssetsForExistingUtxo(t *testing.T) {
 }
 
 func TestImportUtxosSkipsHydrationForFreshInsert(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	txID := bytes.Repeat([]byte{0x41}, 32)
@@ -180,6 +182,7 @@ func TestImportUtxosSkipsHydrationForFreshInsert(t *testing.T) {
 }
 
 func TestImportUtxosHydratesSnapshotProvenance(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	txID := bytes.Repeat([]byte{0x51}, 32)
@@ -267,6 +270,7 @@ func TestImportUtxosHydratesSnapshotProvenance(t *testing.T) {
 }
 
 func TestImportUtxosHydratesSnapshotCollateralReturnProvenance(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	txID := bytes.Repeat([]byte{0x61}, 32)

--- a/database/plugin/metadata/sqlite/options_test.go
+++ b/database/plugin/metadata/sqlite/options_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestWithDataDir(t *testing.T) {
+	t.Parallel()
 	m := &MetadataStoreSqlite{}
 	option := WithDataDir("/tmp/test")
 
@@ -33,6 +34,7 @@ func TestWithDataDir(t *testing.T) {
 }
 
 func TestWithLogger(t *testing.T) {
+	t.Parallel()
 	logger := slog.New(slog.NewTextHandler(nil, nil))
 	m := &MetadataStoreSqlite{}
 	option := WithLogger(logger)
@@ -45,6 +47,7 @@ func TestWithLogger(t *testing.T) {
 }
 
 func TestWithPromRegistry(t *testing.T) {
+	t.Parallel()
 	reg := prometheus.NewRegistry()
 	m := &MetadataStoreSqlite{}
 	option := WithPromRegistry(reg)
@@ -57,6 +60,7 @@ func TestWithPromRegistry(t *testing.T) {
 }
 
 func TestWithMaxConnections(t *testing.T) {
+	t.Parallel()
 	m := &MetadataStoreSqlite{}
 	option := WithMaxConnections(10)
 
@@ -68,6 +72,7 @@ func TestWithMaxConnections(t *testing.T) {
 }
 
 func TestWithStorageMode(t *testing.T) {
+	t.Parallel()
 	m := &MetadataStoreSqlite{}
 	option := WithStorageMode("api")
 
@@ -79,6 +84,7 @@ func TestWithStorageMode(t *testing.T) {
 }
 
 func TestWithMaxConnections_DefaultUsed(t *testing.T) {
+	t.Parallel()
 	// Test that DefaultMaxConnections is used when maxConnections is 0
 	m := &MetadataStoreSqlite{}
 	// Don't set maxConnections, leave it at 0

--- a/database/plugin/metadata/sqlite/plomin_test.go
+++ b/database/plugin/metadata/sqlite/plomin_test.go
@@ -31,6 +31,7 @@ import (
 // account delegating to a credential that is not present in the drep
 // table is cleared.
 func TestClearDanglingDRepDelegations_ClearsUnregisteredCredBackedDelegation(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	liveCred := bytes.Repeat([]byte{0x11}, 28)
@@ -92,6 +93,7 @@ func TestClearDanglingDRepDelegations_ClearsUnregisteredCredBackedDelegation(t *
 // Inactive DReps (deregistered) are also not "live" and their delegators
 // must have their delegations cleared.
 func TestClearDanglingDRepDelegations_InactiveDRepCountsAsDangling(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	inactiveCred := bytes.Repeat([]byte{0x33}, 28)
@@ -130,6 +132,7 @@ func TestClearDanglingDRepDelegations_InactiveDRepCountsAsDangling(t *testing.T)
 // Script-credential delegations (DrepType 1) are treated the same way
 // as key credentials.
 func TestClearDanglingDRepDelegations_ScriptCredentialAlsoCleared(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	deadScriptCred := bytes.Repeat([]byte{0x44}, 28)
@@ -155,6 +158,7 @@ func TestClearDanglingDRepDelegations_ScriptCredentialAlsoCleared(t *testing.T) 
 // AlwaysAbstain / AlwaysNoConfidence delegations are pseudo-DReps with no
 // credential and must not be touched by the rule.
 func TestClearDanglingDRepDelegations_PseudoDRepDelegationsPreserved(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	stakeKeyA := bytes.Repeat([]byte{0xD1}, 28)
@@ -194,6 +198,7 @@ func TestClearDanglingDRepDelegations_PseudoDRepDelegationsPreserved(t *testing.
 
 // Accounts with no DRep delegation at all are not touched.
 func TestClearDanglingDRepDelegations_NoDelegationUntouched(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	stakeKey := bytes.Repeat([]byte{0xE1}, 28)
@@ -216,6 +221,7 @@ func TestClearDanglingDRepDelegations_NoDelegationUntouched(t *testing.T) {
 // Idempotent: once dangling delegations have been cleared, a second call
 // finds nothing to do.
 func TestClearDanglingDRepDelegations_Idempotent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	dead := bytes.Repeat([]byte{0x55}, 28)

--- a/database/plugin/metadata/sqlite/reward_state_test.go
+++ b/database/plugin/metadata/sqlite/reward_state_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestRewardAdaPotsCRUD(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	pots := &models.RewardAdaPots{
@@ -63,6 +64,7 @@ func TestRewardAdaPotsCRUD(t *testing.T) {
 }
 
 func TestRewardSnapshotCRUD(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	snapshot := &models.RewardSnapshot{
@@ -105,6 +107,7 @@ func TestRewardSnapshotCRUD(t *testing.T) {
 }
 
 func TestRewardPoolInputsCRUD(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	blocksProduced := uint64(12)
@@ -192,6 +195,7 @@ func TestRewardPoolInputsCRUD(t *testing.T) {
 }
 
 func TestDeleteRewardStateAfterSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	poolA := rewardStateTestHash(0xaa)
 	poolB := rewardStateTestHash(0xbb)
@@ -258,6 +262,7 @@ func TestDeleteRewardStateAfterSlot(t *testing.T) {
 }
 
 func TestDeleteRewardStateBeforeEpoch(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	require.NoError(t, store.SaveRewardAdaPots(&models.RewardAdaPots{
@@ -322,6 +327,7 @@ func TestDeleteRewardStateBeforeEpoch(t *testing.T) {
 }
 
 func TestGetPoolRegistrationsAtSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	poolA := rewardStateTestHash(0xaa)
 	poolB := rewardStateTestHash(0xbb)
@@ -387,6 +393,7 @@ func TestGetPoolRegistrationsAtSlot(t *testing.T) {
 }
 
 func TestGetPoolRegistrationsAtSlotTieBreaksSameAddedSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	poolKeyHash := rewardStateTestHash(0xcc)
 	poolHash := rewardStateTestPoolKeyHash(0xcc)

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -50,6 +50,7 @@ func (m *mockTransactionWithInputs) Inputs() []lcommon.TransactionInput {
 // --- Optimistic UTxO locking tests ---
 
 func TestSetUtxoDeletedAtSlotBackfillsSameSlotMissingSpender(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	utxoTxId := bytes.Repeat([]byte{0xAB}, 32)
@@ -97,6 +98,7 @@ func TestSetUtxoDeletedAtSlotBackfillsSameSlotMissingSpender(t *testing.T) {
 func TestSetUtxoDeletedAtSlotReturnsNotFoundWhenRowMissing(
 	t *testing.T,
 ) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	input := dbtestutil.NewMockInput(bytes.Repeat([]byte{0xEF}, 32), 0)
@@ -113,6 +115,7 @@ func TestSetUtxoDeletedAtSlotReturnsNotFoundWhenRowMissing(
 func TestSetUtxoDeletedAtSlotReturnsConflictWhenRowAlreadySpent(
 	t *testing.T,
 ) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	utxoTxId := bytes.Repeat([]byte{0xEF}, 32)
@@ -150,6 +153,7 @@ func TestSetUtxoDeletedAtSlotReturnsConflictWhenRowAlreadySpent(
 // locking mechanism in SetTransaction correctly detects when a UTxO
 // has already been spent by another transaction.
 func TestOptimisticLockingConflictDetection(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Create a UTxO that both transactions will try to spend
@@ -233,6 +237,7 @@ func TestOptimisticLockingConflictDetection(t *testing.T) {
 // transaction that already successfully consumed a UTxO is safe
 // (idempotent retry detection).
 func TestOptimisticLockingIdempotentRetry(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Create a UTxO
@@ -273,6 +278,7 @@ func TestOptimisticLockingIdempotentRetry(t *testing.T) {
 // TestOptimisticLockingMissingUtxo verifies that attempting to spend a
 // non-existent UTxO logs a warning but does not return an error.
 func TestOptimisticLockingMissingUtxo(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Transaction consumes a UTxO that doesn't exist
@@ -305,6 +311,7 @@ func TestOptimisticLockingMissingUtxo(t *testing.T) {
 // Validates AddressTransaction populates the data from transaction(input/output) participant
 // Validates whether it inserts a record per unique address (payment & staking key pair)
 func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, types.StorageModeAPI)
 
 	utxoTxId := bytes.Repeat([]byte{0xA1}, 32)
@@ -382,6 +389,7 @@ func TestSetTransactionIndexesAddressTransactions(t *testing.T) {
 // verifies that API-mode batched address indexing includes every input class
 // resolved through the skinny address-key lookup.
 func TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, types.StorageModeAPI)
 
 	inputTxId := bytes.Repeat([]byte{0xA1}, 32)
@@ -469,6 +477,7 @@ func TestSetTransactionBatchedIndexesInputCollateralAndReferenceAddressKeys(t *t
 // TestRollbackAccountState tests that RestoreAccountStateAtSlot correctly
 // restores account delegation state to a prior slot.
 func TestRollbackAccountState(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	stakeKey := bytes.Repeat([]byte{0x01}, 28)
@@ -566,6 +575,7 @@ func TestRollbackAccountState(t *testing.T) {
 // TestRollbackDeletesAccountRegisteredAfterSlot tests that accounts
 // registered only after the rollback slot are deleted.
 func TestRollbackDeletesAccountRegisteredAfterSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	stakeKey := bytes.Repeat([]byte{0x02}, 28)
@@ -595,6 +605,7 @@ func TestRollbackDeletesAccountRegisteredAfterSlot(t *testing.T) {
 // TestRollbackPoolState tests that RestorePoolStateAtSlot correctly
 // restores pool state to a prior slot.
 func TestRollbackPoolState(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	poolKeyHash := bytes.Repeat([]byte{0x10}, 28)
@@ -687,6 +698,7 @@ func TestRollbackPoolState(t *testing.T) {
 // TestRollbackDrepState tests that RestoreDrepStateAtSlot correctly
 // restores DRep state to a prior slot.
 func TestRollbackDrepState(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	drepCred := bytes.Repeat([]byte{0x30}, 28)
@@ -770,6 +782,7 @@ func TestRollbackDrepState(t *testing.T) {
 // TestRollbackDeletesCertificatesAfterSlot tests that
 // DeleteCertificatesAfterSlot removes certificates added after the slot.
 func TestRollbackDeletesCertificatesAfterSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Create transactions for FK constraints
@@ -835,6 +848,7 @@ func TestRollbackDeletesCertificatesAfterSlot(t *testing.T) {
 // TestRollbackUtxoRestoration tests that UTxOs are correctly unspent
 // and removed during rollback.
 func TestRollbackUtxoRestoration(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Create a transaction that will be referenced as the spender
@@ -935,6 +949,7 @@ func TestRollbackUtxoRestoration(t *testing.T) {
 // DeleteTransactionsAfterSlot removes transactions and restores
 // UTxO state correctly.
 func TestRollbackTransactionDeletion(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	spendingTxHash := bytes.Repeat([]byte{0x81}, 32)
@@ -1025,6 +1040,7 @@ func TestRollbackTransactionDeletion(t *testing.T) {
 // TestRollbackAndReplay processes state through slots, rolls back, then
 // replays the same operations and verifies the final state matches.
 func TestRollbackAndReplay(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	stakeKey := bytes.Repeat([]byte{0xD1}, 28)
@@ -1165,6 +1181,7 @@ func TestRollbackAndReplay(t *testing.T) {
 // TestRollbackPParamsDeletion tests that protocol parameters added
 // after the rollback slot are removed.
 func TestRollbackPParamsDeletion(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Create protocol parameters at different slots
@@ -1208,6 +1225,7 @@ func TestRollbackPParamsDeletion(t *testing.T) {
 // TestRollbackGovernanceProposalDeletion tests that governance proposals
 // added after the rollback slot are removed.
 func TestRollbackGovernanceProposalDeletion(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	prop1 := &models.GovernanceProposal{
@@ -1256,6 +1274,7 @@ func TestRollbackGovernanceProposalDeletion(t *testing.T) {
 // The optimistic locking should allow the second spend to succeed since
 // the rollback restored the UTxO to unspent state.
 func TestRollbackConcurrentUtxoSpend(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Create UTxO at slot 50

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -273,6 +273,7 @@ func (m *mockTransactionOutput) String() string {
 }
 
 func TestSetTransactionIdempotentlyStoresCollateralReturn(t *testing.T) {
+	t.Parallel()
 	sqliteStore := setupTestDB(t)
 
 	var txHash lcommon.Blake2b256
@@ -321,6 +322,7 @@ func TestSetTransactionIdempotentlyStoresCollateralReturn(t *testing.T) {
 }
 
 func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {
+	t.Parallel()
 	sqliteStore := setupTestDBWithMode(t, types.StorageModeAPI)
 	highBitLabel := uint64(16450635129309362000)
 
@@ -485,6 +487,7 @@ func TestTransactionMetadataLabelsIndexAndQuery(t *testing.T) {
 }
 
 func TestDeleteTransactionMetadataLabelsAfterSlot(t *testing.T) {
+	t.Parallel()
 	sqliteStore := setupTestDBWithMode(t, types.StorageModeAPI)
 
 	makeMetadata := func(label uint64, value string) lcommon.TransactionMetadatum {
@@ -575,6 +578,7 @@ func createTestTransaction(db *gorm.DB, id uint, slot uint64) error {
 }
 
 func TestGetTransactionsByAddressIndex(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	if err := createTestTransaction(store.DB(), 1, 100); err != nil {
@@ -625,6 +629,7 @@ func TestGetTransactionsByAddressIndex(t *testing.T) {
 }
 
 func TestGetAddressesByStakingKey(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	stake := bytes.Repeat([]byte{0x55}, 28)
@@ -657,6 +662,7 @@ func TestGetAddressesByStakingKey(t *testing.T) {
 }
 
 func TestDeleteAddressTransactionsAfterSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	rows := []models.AddressTransaction{
@@ -685,6 +691,7 @@ func TestDeleteAddressTransactionsAfterSlot(t *testing.T) {
 // concurrent transactions when using in-memory mode. This requires special URI flags, and
 // this is mostly making sure that we don't lose them
 func TestInMemorySqliteMultipleTransaction(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -730,6 +737,7 @@ func TestInMemorySqliteMultipleTransaction(t *testing.T) {
 // TestUnifiedCertificateCreation tests that unified certificate records are created
 // correctly and linked to specialized certificate records
 func TestUnifiedCertificateCreation(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -921,6 +929,7 @@ func TestUnifiedCertificateCreation(t *testing.T) {
 
 // TestDeleteCertificatesAfterSlot tests that certificates added after a given slot are deleted
 func TestDeleteCertificatesAfterSlot(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1035,6 +1044,7 @@ func TestDeleteCertificatesAfterSlot(t *testing.T) {
 
 // TestRestoreAccountStateAtSlot tests that account delegation state is correctly restored
 func TestRestoreAccountStateAtSlot(t *testing.T) {
+	t.Parallel()
 	t.Run("account delegation is restored to prior pool", func(t *testing.T) {
 		sqliteStore, err := New("", nil, nil)
 		if err != nil {
@@ -1473,6 +1483,7 @@ func TestRestoreAccountStateAtSlot(t *testing.T) {
 
 // TestDeletePParamsAfterSlot tests that protocol parameters after a slot are deleted
 func TestDeletePParamsAfterSlot(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1529,6 +1540,7 @@ func TestDeletePParamsAfterSlot(t *testing.T) {
 
 // TestDeletePParamUpdatesAfterSlot tests that protocol parameter updates after a slot are deleted
 func TestDeletePParamUpdatesAfterSlot(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1590,6 +1602,7 @@ func TestDeletePParamUpdatesAfterSlot(t *testing.T) {
 
 // TestDeleteTransactionsAfterSlot tests that transactions and their child records are deleted
 func TestDeleteTransactionsAfterSlot(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1755,6 +1768,7 @@ func TestDeleteTransactionsAfterSlot(t *testing.T) {
 
 // TestRestorePoolStateAtSlot tests that pool state is correctly restored during rollback
 func TestRestorePoolStateAtSlot(t *testing.T) {
+	t.Parallel()
 	t.Run("pool with no prior registrations is deleted", func(t *testing.T) {
 		sqliteStore, err := New("", nil, nil)
 		if err != nil {
@@ -1969,6 +1983,7 @@ func TestRestorePoolStateAtSlot(t *testing.T) {
 
 // TestGetActivePoolKeyHashesAtSlot tests that pools active at a specific slot are returned
 func TestGetActivePoolKeyHashesAtSlot(t *testing.T) {
+	t.Parallel()
 	t.Run("returns error when no epoch data", func(t *testing.T) {
 		sqliteStore := setupTestDB(t)
 
@@ -2811,6 +2826,7 @@ func TestGetActivePoolKeyHashesAtSlot(t *testing.T) {
 
 // TestRestoreDrepStateAtSlot tests that DRep state is correctly restored during rollback
 func TestRestoreDrepStateAtSlot(t *testing.T) {
+	t.Parallel()
 	t.Run("DRep with no prior registrations is deleted", func(t *testing.T) {
 		sqliteStore, err := New("", nil, nil)
 		if err != nil {
@@ -3515,6 +3531,7 @@ func TestRestoreDrepStateAtSlot(t *testing.T) {
 
 // TestPoolCascadeDelete tests that Pool deletion cascades correctly to child records
 func TestPoolCascadeDelete(t *testing.T) {
+	t.Parallel()
 	t.Run(
 		"pool deletion cascades to registrations, owners, relays",
 		func(t *testing.T) {
@@ -3740,6 +3757,7 @@ func TestPoolCascadeDelete(t *testing.T) {
 // TestPoolCrossPoolOwnerRelay tests that owners/relays with the same key hash
 // across different pools are stored as separate records and don't affect each other
 func TestPoolCrossPoolOwnerRelay(t *testing.T) {
+	t.Parallel()
 	t.Run(
 		"same owner key hash in different pools are independent records",
 		func(t *testing.T) {
@@ -3878,6 +3896,7 @@ func TestPoolCrossPoolOwnerRelay(t *testing.T) {
 
 // TestUtxoCascadeDelete tests that Utxo deletion cascades correctly to Asset records
 func TestUtxoCascadeDelete(t *testing.T) {
+	t.Parallel()
 	t.Run("utxo deletion cascades to assets", func(t *testing.T) {
 		sqliteStore, err := New("", nil, nil)
 		if err != nil {
@@ -4072,6 +4091,7 @@ func TestUtxoCascadeDelete(t *testing.T) {
 //   - Two UTXOs with the same non-NULL CollateralReturnForTxID are rejected (per Cardano protocol,
 //     a transaction has at most one collateral return output)
 func TestCollateralReturnUniqueConstraint(t *testing.T) {
+	t.Parallel()
 	t.Run("multiple NULL CollateralReturnForTxID allowed", func(t *testing.T) {
 		sqliteStore, err := New("", nil, nil)
 		if err != nil {
@@ -4206,6 +4226,7 @@ func TestCollateralReturnUniqueConstraint(t *testing.T) {
 
 // TestPoolStakeSnapshotCRUD tests basic CRUD operations for pool stake snapshots
 func TestPoolStakeSnapshotCRUD(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -4328,6 +4349,7 @@ func TestPoolStakeSnapshotCRUD(t *testing.T) {
 
 // TestEpochSummaryCRUD tests basic CRUD operations for epoch summaries
 func TestEpochSummaryCRUD(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -4414,6 +4436,7 @@ func TestEpochSummaryCRUD(t *testing.T) {
 
 // TestPoolStakeSnapshotEmptyBatch tests that empty batch save works
 func TestPoolStakeSnapshotEmptyBatch(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -4431,6 +4454,7 @@ func TestPoolStakeSnapshotEmptyBatch(t *testing.T) {
 
 // TestGetTotalActiveStakeEmpty tests GetTotalActiveStake when no snapshots exist
 func TestGetTotalActiveStakeEmpty(t *testing.T) {
+	t.Parallel()
 	sqliteStore, err := New("", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -39,6 +39,7 @@ func setupStakeSnapshotTestStore(t *testing.T) *MetadataStoreSqlite {
 
 // TestPoolStakeSnapshotSave tests saving a single pool stake snapshot
 func TestPoolStakeSnapshotSave(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -59,6 +60,7 @@ func TestPoolStakeSnapshotSave(t *testing.T) {
 
 // TestPoolStakeSnapshotGet tests retrieving a specific pool stake snapshot
 func TestPoolStakeSnapshotGet(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -83,6 +85,7 @@ func TestPoolStakeSnapshotGet(t *testing.T) {
 
 // TestPoolStakeSnapshotGetNotFound tests retrieval when snapshot does not exist
 func TestPoolStakeSnapshotGetNotFound(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -94,6 +97,7 @@ func TestPoolStakeSnapshotGetNotFound(t *testing.T) {
 
 // TestPoolStakeSnapshotsSaveBatch tests saving multiple snapshots in batch
 func TestPoolStakeSnapshotsSaveBatch(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -126,6 +130,7 @@ func TestPoolStakeSnapshotsSaveBatch(t *testing.T) {
 
 // TestPoolStakeSnapshotsSaveBatchEmpty tests that empty batch save works
 func TestPoolStakeSnapshotsSaveBatchEmpty(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -135,6 +140,7 @@ func TestPoolStakeSnapshotsSaveBatchEmpty(t *testing.T) {
 
 // TestPoolStakeSnapshotsGetByEpoch tests retrieving all snapshots for an epoch
 func TestPoolStakeSnapshotsGetByEpoch(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -179,6 +185,7 @@ func TestPoolStakeSnapshotsGetByEpoch(t *testing.T) {
 
 // TestGetTotalActiveStake tests summing all pool stakes for an epoch
 func TestGetTotalActiveStake(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -218,6 +225,7 @@ func TestGetTotalActiveStake(t *testing.T) {
 
 // TestGetTotalActiveStakeNoSnapshots tests GetTotalActiveStake when no snapshots exist
 func TestGetTotalActiveStakeNoSnapshots(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -228,6 +236,7 @@ func TestGetTotalActiveStakeNoSnapshots(t *testing.T) {
 
 // TestEpochSummarySave tests saving an epoch summary
 func TestEpochSummarySave(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -248,6 +257,7 @@ func TestEpochSummarySave(t *testing.T) {
 
 // TestEpochSummaryGet tests retrieving an epoch summary by epoch number
 func TestEpochSummaryGet(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -272,6 +282,7 @@ func TestEpochSummaryGet(t *testing.T) {
 
 // TestEpochSummaryGetNotFound tests retrieval when summary does not exist
 func TestEpochSummaryGetNotFound(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -282,6 +293,7 @@ func TestEpochSummaryGetNotFound(t *testing.T) {
 
 // TestEpochSummaryGetLatest tests retrieving the most recent epoch summary
 func TestEpochSummaryGetLatest(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -323,6 +335,7 @@ func TestEpochSummaryGetLatest(t *testing.T) {
 
 // TestEpochSummaryGetLatestEmpty tests GetLatestEpochSummary when no summaries exist
 func TestEpochSummaryGetLatestEmpty(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -332,6 +345,7 @@ func TestEpochSummaryGetLatestEmpty(t *testing.T) {
 }
 
 func TestSavePoolStakeSnapshotsUpsertsExistingRows(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -393,6 +407,7 @@ func TestSavePoolStakeSnapshotsUpsertsExistingRows(t *testing.T) {
 }
 
 func TestSaveEpochSummaryUpsertsExistingRow(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -431,6 +446,7 @@ func TestSaveEpochSummaryUpsertsExistingRow(t *testing.T) {
 
 // TestDeletePoolStakeSnapshotsForEpoch tests deleting snapshots for a specific epoch
 func TestDeletePoolStakeSnapshotsForEpoch(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -492,6 +508,7 @@ func TestDeletePoolStakeSnapshotsForEpoch(t *testing.T) {
 
 // TestDeletePoolStakeSnapshotsAfterEpoch tests deleting snapshots after a given epoch
 func TestDeletePoolStakeSnapshotsAfterEpoch(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -556,6 +573,7 @@ func TestDeletePoolStakeSnapshotsAfterEpoch(t *testing.T) {
 
 // TestDeleteEpochSummariesAfterEpoch tests deleting summaries after a given epoch
 func TestDeleteEpochSummariesAfterEpoch(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -629,6 +647,7 @@ func TestDeleteEpochSummariesAfterEpoch(t *testing.T) {
 // TestGetStakeByPoolsAggregatesUtxos tests that GetStakeByPools correctly
 // sums live UTxO amounts per pool by joining accounts with their UTxOs.
 func TestGetStakeByPoolsAggregatesUtxos(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -694,6 +713,7 @@ func TestGetStakeByPoolsAggregatesUtxos(t *testing.T) {
 // TestGetStakeByPoolsExcludesInactiveAccounts tests that inactive accounts
 // are excluded from stake aggregation.
 func TestGetStakeByPoolsExcludesInactiveAccounts(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -739,6 +759,7 @@ func TestGetStakeByPoolsExcludesInactiveAccounts(t *testing.T) {
 // TestGetStakeByPoolsNoDelegators tests that pools with no delegators
 // return zero stake.
 func TestGetStakeByPoolsNoDelegators(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 
@@ -755,6 +776,7 @@ func TestGetStakeByPoolsNoDelegators(t *testing.T) {
 
 // TestSnapshotTypesMarkSetGo tests all three snapshot types
 func TestSnapshotTypesMarkSetGo(t *testing.T) {
+	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
 	defer store.Close() //nolint:errcheck
 

--- a/database/plugin/metadata/sqlite/storage_mode_test.go
+++ b/database/plugin/metadata/sqlite/storage_mode_test.go
@@ -57,6 +57,7 @@ func newTestWitnessTransaction(
 }
 
 func TestStorageMode_CoreSkipsWitnesses(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "core")
 
 	tx := newTestWitnessTransaction(
@@ -89,6 +90,7 @@ func TestStorageMode_CoreSkipsWitnesses(t *testing.T) {
 }
 
 func TestStorageMode_APIStoresWitnesses(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "api")
 
 	tx := newTestWitnessTransaction(
@@ -121,6 +123,7 @@ func TestStorageMode_APIStoresWitnesses(t *testing.T) {
 }
 
 func TestStorageMode_CoreSkipsDatumIndex(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "core")
 
 	tx := newTestWitnessTransaction(
@@ -146,6 +149,7 @@ func TestStorageMode_CoreSkipsDatumIndex(t *testing.T) {
 }
 
 func TestStorageMode_DefaultIsCore(t *testing.T) {
+	t.Parallel()
 	// A store created without specifying storage mode should default to "core"
 	store, err := NewWithOptions()
 	require.NoError(t, err)
@@ -155,18 +159,21 @@ func TestStorageMode_DefaultIsCore(t *testing.T) {
 }
 
 func TestStorageMode_InvalidRejected(t *testing.T) {
+	t.Parallel()
 	_, err := NewWithOptions(WithStorageMode("invalid"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid storage mode")
 }
 
 func TestStorageMode_CaseNormalized(t *testing.T) {
+	t.Parallel()
 	store, err := NewWithOptions(WithStorageMode("API"))
 	require.NoError(t, err)
 	assert.Equal(t, "api", store.storageMode, "storage mode should be lowercased")
 }
 
 func TestNodeSettingsNilBeforeFirstSet(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "core")
 
 	settings, err := store.GetNodeSettings()
@@ -175,6 +182,7 @@ func TestNodeSettingsNilBeforeFirstSet(t *testing.T) {
 }
 
 func TestNodeSettingsRemainImmutable(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "core")
 
 	original := &types.NodeSettings{
@@ -194,6 +202,7 @@ func TestNodeSettingsRemainImmutable(t *testing.T) {
 }
 
 func TestNodeSettingsAllowDeferredNetworkInitialization(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "core")
 
 	require.NoError(t, store.SetNodeSettings(&types.NodeSettings{
@@ -215,6 +224,7 @@ func TestNodeSettingsAllowDeferredNetworkInitialization(t *testing.T) {
 }
 
 func TestNodeSettingsReadsOnlySingletonRow(t *testing.T) {
+	t.Parallel()
 	store := setupTestDBWithMode(t, "core")
 
 	require.NoError(t, store.DB().Create(&NodeSettings{

--- a/database/plugin/metadata/sqlite/utxo_iter_test.go
+++ b/database/plugin/metadata/sqlite/utxo_iter_test.go
@@ -48,6 +48,7 @@ func seedUtxos(t *testing.T, store *MetadataStoreSqlite, n int) [][]byte {
 // IterateLiveUtxos visits every live row exactly once and the
 // per-row pointer carries the column values we expect.
 func TestIterateLiveUtxos_VisitsEachLiveRow(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	ids := seedUtxos(t, store, 5)
 
@@ -66,6 +67,7 @@ func TestIterateLiveUtxos_VisitsEachLiveRow(t *testing.T) {
 
 // IterateLiveUtxos skips rows already marked deleted.
 func TestIterateLiveUtxos_SkipsDeleted(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	ids := seedUtxos(t, store, 3)
 
@@ -89,6 +91,7 @@ func TestIterateLiveUtxos_SkipsDeleted(t *testing.T) {
 // Returning a non-nil error from the callback aborts iteration and
 // propagates the error.
 func TestIterateLiveUtxos_AbortOnError(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	seedUtxos(t, store, 5)
 
@@ -108,6 +111,7 @@ func TestIterateLiveUtxos_AbortOnError(t *testing.T) {
 
 // Iteration paging: setting more rows than one page returns them all.
 func TestIterateLiveUtxos_Pagination(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	const total = liveUtxoIterPageSize + 17
 	for i := range total {
@@ -133,6 +137,7 @@ func TestIterateLiveUtxos_Pagination(t *testing.T) {
 // MarkUtxosDeletedAtSlot writes deleted_slot for the matching live
 // rows and is a no-op for refs that don't match anything.
 func TestMarkUtxosDeletedAtSlot_MarksOnlyMatching(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	ids := seedUtxos(t, store, 4)
 
@@ -156,6 +161,7 @@ func TestMarkUtxosDeletedAtSlot_MarksOnlyMatching(t *testing.T) {
 // Re-marking a row that's already deleted is a no-op (the WHERE
 // clause filters deleted_slot == 0).
 func TestMarkUtxosDeletedAtSlot_Idempotent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	ids := seedUtxos(t, store, 1)
 	ref := types.UtxoKey{TxId: ids[0], OutputIdx: 0}
@@ -171,6 +177,7 @@ func TestMarkUtxosDeletedAtSlot_Idempotent(t *testing.T) {
 
 // Empty refs slice is a no-op; no SQL is issued.
 func TestMarkUtxosDeletedAtSlot_EmptyNoop(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 	ids := seedUtxos(t, store, 2)
 

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetLiveUtxosBySlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	// Three UTxOs added at slot 100: two live, one already spent.
@@ -134,6 +135,7 @@ func TestGetLiveUtxosBySlot(t *testing.T) {
 // TestGetLiveUtxosBySlotExcludesSpentAtSameSlot verifies that a UTxO
 // spent in the same slot it was added is excluded.
 func TestGetLiveUtxosBySlotExcludesSpentAtSameSlot(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	live := models.Utxo{
@@ -160,6 +162,7 @@ func TestGetLiveUtxosBySlotExcludesSpentAtSameSlot(t *testing.T) {
 }
 
 func TestGetUtxosBatchUsesTxIdOutputIndex(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	refs := make([]UtxoRef, 0, 12)
@@ -220,6 +223,7 @@ func TestGetUtxosBatchUsesTxIdOutputIndex(t *testing.T) {
 // address-key lookup selects only the address-index fields and uses the UTxO ref
 // index instead of a broader deleted-slot scan.
 func TestGetUtxoAddressKeysBatchUsesSkinnyTxIdOutputIndexLookup(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	refs := make([]UtxoRef, 0, 12)
@@ -338,6 +342,7 @@ func BenchmarkGetUtxoAddressKeysBatch(b *testing.B) {
 // API storage mode relies on this so the pruner can materialize CBOR
 // bytes for retained spent UTxOs before tombstoning the source block.
 func TestGetUtxosBySlotIncludesSpent(t *testing.T) {
+	t.Parallel()
 	store := setupTestDB(t)
 
 	live := models.Utxo{


### PR DESCRIPTION
## Summary

The sqlite metadata in-memory store opened `file::memory:?cache=shared` — an *anonymous* shared-cache URI that SQLite resolves to a **single process-global database**. Every store built via `New("", ...)` therefore shared one set of tables, so the metadata tests (21 files, 201 tests) were safe only because they ran serially.

This gives each in-memory store a **unique** database name (`file:dingo_memdb_<N>?mode=memory&cache=shared`, `N` from an atomic counter) so connections *within* a store still share the cache, but separate stores are isolated. Tests in the package are then marked `t.Parallel()`.

The file-based production path is unchanged — the in-memory mode is test-only.

## Speedup (4-core machine, all runs green)

| Configuration | Serial | Parallel | Speedup |
|---|---|---|---|
| `go test` (default `-parallel=GOMAXPROCS=4`) | ~31–32 s | 10.8–16 s | ~2–3× |
| `go test -parallel=8` (sweet spot) | ~31 s | ~11 s | ~2.8× |
| `go test -race -parallel=8` (`make test`) | 512 s | 257 s | ~2.0× |

`-parallel=16` regresses (~14 s) — oversubscribing 4 cores adds scheduling/lock contention. The `-race` run completed **clean (no data races detected)**, validating the isolation.

## Verification

- `gofmt`, `go vet`, `golangci-lint run` — all clean on the package.
- Full package suite passes under parallelism, including `-race`.

## Docs

Checked `DATABASE.md` and `ARCHITECTURE.md` — not affected. The change is an internal, test-only naming detail of the in-memory store; no models, tables, query/API surface, encodings, plugins, or component/lifecycle behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated in-memory SQLite stores so each test gets its own database and can run in parallel; marked tests with `t.Parallel()` to cut suite time by ~2–3x. The file-based production path is unchanged.

- **Bug Fixes**
  - Replaced `file::memory:?cache=shared` with unique per-store DSNs: `file:dingo_memdb_<N>?mode=memory&cache=shared` (atomic counter) to prevent cross-test table sharing.
  - Kept shared cache within a store; isolated across stores. Enabled parallel tests via `t.Parallel()`.

- **Performance**
  - Suite runtime on 4 cores: `go test` ~31s → ~11–16s; `-parallel=8` ~31s → ~11s; `-race` 512s → 257s.
  - `-race` run is clean, confirming isolation.

<sup>Written for commit 48116210e4721df575e9fc39d32b9e6d541fd105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled parallel execution of test suite for improved performance across SQLite metadata tests.

* **Bug Fixes**
  * Fixed in-memory database isolation to prevent concurrent test instances from sharing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->