### PR TITLE
fix: epoch clock stall

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -967,6 +967,7 @@ The `chainsync.State` tracks multiple concurrent chainsync clients:
 - Grace period before recycling stalled connections
 - Cooldown to prevent rapid reconnection flapping
 - Plateau detection: if the local tip stops advancing while peers are ahead, the active chainsync connection is recycled
+- Peer-governance connection-close lookup uses stable endpoint identity so reconnect and eligibility cleanup still run for equivalent connection IDs; when no active chainsync client remains, ledger clears its cached upstream tip so slot-clock epoch work does not run against a disconnected tip
 
 ## Peer Governance
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"slices"
 	"strings"
 	"time"
@@ -427,6 +428,12 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 	if sameConnectionId(ls.headerPipelineConnId, e.ConnectionId) {
 		ls.clearQueuedHeaders()
 	}
+	if ls.config.GetActiveConnectionFunc != nil {
+		activeConnId := ls.config.GetActiveConnectionFunc()
+		if activeConnId == nil || sameConnectionId(*activeConnId, e.ConnectionId) {
+			ls.syncUpstreamTipSlot.Store(0)
+		}
+	}
 }
 
 func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
@@ -777,20 +784,26 @@ func (ls *LedgerState) blockByHash(hash []byte) (models.Block, error) {
 	return database.BlockByHash(ls.db, hash)
 }
 
+func netAddrString(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
+}
+
+// connIdKey builds the key from nil-safe per-address strings because
+// ConnectionId.String() panics when either net.Addr field is nil.
 func connIdKey(connId ouroboros.ConnectionId) string {
 	if connId.LocalAddr == nil && connId.RemoteAddr == nil {
 		return ""
 	}
-	return connId.String()
+	return netAddrString(connId.LocalAddr) +
+		"<->" +
+		netAddrString(connId.RemoteAddr)
 }
 
 func sameConnectionId(a, b ouroboros.ConnectionId) bool {
-	keyA := connIdKey(a)
-	keyB := connIdKey(b)
-	if keyA == "" || keyB == "" {
-		return keyA == keyB
-	}
-	return keyA == keyB
+	return connIdKey(a) == connIdKey(b)
 }
 
 func desiredBlockfetchBatchHeaders(

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -34,6 +35,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testChainsyncConnId(localPort, remotePort int) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: localPort,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: remotePort,
+		},
+	}
+}
 
 type mockHeader struct {
 	hash        lcommon.Blake2b256
@@ -129,6 +143,57 @@ func TestDetectConnectionSwitchHandsOffQueuedHeadersToNewActiveConnection(
 	assert.Equal(t, 1, switchCalls)
 
 	ls.blockfetchRequestRangeCleanup()
+}
+
+func TestHandleConnectionClosedEventClearsUpstreamTipWhenActiveUnavailable(
+	t *testing.T,
+) {
+	closedConnId := testChainsyncConnId(6000, 3001)
+	equivalentClosedConnId := testChainsyncConnId(6000, 3001)
+	otherConnId := testChainsyncConnId(6000, 3002)
+
+	tests := []struct {
+		name       string
+		activeConn *ouroboros.ConnectionId
+		wantTip    uint64
+	}{
+		{
+			name:       "active connection closed",
+			activeConn: &equivalentClosedConnId,
+			wantTip:    0,
+		},
+		{
+			name:       "no active connection",
+			activeConn: nil,
+			wantTip:    0,
+		},
+		{
+			name:       "different active connection remains",
+			activeConn: &otherConnId,
+			wantTip:    114220800,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ls := &LedgerState{
+				config: LedgerStateConfig{
+					GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+						return tc.activeConn
+					},
+				},
+			}
+			ls.syncUpstreamTipSlot.Store(114220800)
+
+			ls.handleConnectionClosedEvent(event.NewEvent(
+				connmanager.ConnectionClosedEventType,
+				connmanager.ConnectionClosedEvent{
+					ConnectionId: closedConnId,
+				},
+			))
+
+			assert.Equal(t, tc.wantTip, ls.syncUpstreamTipSlot.Load())
+		})
+	}
 }
 
 func TestHandoffPipelineOnSwitchDropsStaleQueuedHeadersForNewBufferedPeer(

--- a/ledger/connid_test.go
+++ b/ledger/connid_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"net"
+	"testing"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+)
+
+func TestSameConnectionIdHandlesPartialNilAddrs(t *testing.T) {
+	remoteAddr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001}
+	remoteOnly := ouroboros.ConnectionId{RemoteAddr: remoteAddr}
+	remoteOnlySame := ouroboros.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+	remoteOnlyOther := ouroboros.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
+	}
+	localOnly := ouroboros.ConnectionId{LocalAddr: remoteAddr}
+	fullId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+
+	if !sameConnectionId(remoteOnly, remoteOnly) {
+		t.Fatal("sameConnectionId() = false, want true for identical remote-only ids")
+	}
+	if !sameConnectionId(remoteOnly, remoteOnlySame) {
+		t.Fatal("sameConnectionId() = false, want true for equal remote-only ids")
+	}
+	if sameConnectionId(remoteOnly, remoteOnlyOther) {
+		t.Fatal("sameConnectionId() = true, want false for differing remote-only ids")
+	}
+	if sameConnectionId(remoteOnly, localOnly) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs local-only")
+	}
+	if sameConnectionId(remoteOnly, ouroboros.ConnectionId{}) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs zero")
+	}
+	if sameConnectionId(remoteOnly, fullId) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs full id")
+	}
+}
+
+func TestConnIdKeyHandlesPartialNilAddrs(t *testing.T) {
+	remoteOnly := ouroboros.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+	localOnly := ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+
+	if connIdKey(ouroboros.ConnectionId{}) != "" {
+		t.Fatal("connIdKey() != \"\" for zero value")
+	}
+	if connIdKey(remoteOnly) == "" {
+		t.Fatal("connIdKey() = \"\" for remote-only id, want non-empty")
+	}
+	if connIdKey(remoteOnly) == connIdKey(localOnly) {
+		t.Fatal("connIdKey() equal for remote-only vs local-only, want distinct")
+	}
+}

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"sync"
 	"time"
 
@@ -130,14 +131,19 @@ func isOriginPoint(point ocommon.Point) bool {
 	return point.Slot == 0 && len(point.Hash) == 0
 }
 
-func sameConnectionId(a, b ouroboros.ConnectionId) bool {
-	if a.LocalAddr == nil && a.RemoteAddr == nil {
-		return b.LocalAddr == nil && b.RemoteAddr == nil
-	}
-	if b.LocalAddr == nil && b.RemoteAddr == nil {
-		return false
+// sameNetAddr compares addresses by string form, treating nil as equal
+// only to nil. ConnectionId.String() panics when either net.Addr field
+// is nil, so the addresses are compared individually instead.
+func sameNetAddr(a, b net.Addr) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
 	}
 	return a.String() == b.String()
+}
+
+func sameConnectionId(a, b ouroboros.ConnectionId) bool {
+	return sameNetAddr(a.LocalAddr, b.LocalAddr) &&
+		sameNetAddr(a.RemoteAddr, b.RemoteAddr)
 }
 
 func chainsyncResyncRequiresFreshConnection(reason string) bool {

--- a/ouroboros/connid_test.go
+++ b/ouroboros/connid_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"net"
+	"testing"
+
+	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
+)
+
+func TestSameConnectionIdHandlesPartialNilAddrs(t *testing.T) {
+	remoteAddr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001}
+	remoteOnly := ouroboros_conn.ConnectionId{RemoteAddr: remoteAddr}
+	remoteOnlySame := ouroboros_conn.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+	remoteOnlyOther := ouroboros_conn.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
+	}
+	localOnly := ouroboros_conn.ConnectionId{LocalAddr: remoteAddr}
+
+	if !sameConnectionId(remoteOnly, remoteOnly) {
+		t.Fatal("sameConnectionId() = false, want true for identical remote-only ids")
+	}
+	if !sameConnectionId(remoteOnly, remoteOnlySame) {
+		t.Fatal("sameConnectionId() = false, want true for equal remote-only ids")
+	}
+	if sameConnectionId(remoteOnly, remoteOnlyOther) {
+		t.Fatal("sameConnectionId() = true, want false for differing remote-only ids")
+	}
+	if sameConnectionId(remoteOnly, localOnly) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs local-only")
+	}
+	if sameConnectionId(remoteOnly, ouroboros_conn.ConnectionId{}) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs zero")
+	}
+	if sameConnectionId(remoteOnly, testConnId()) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs full id")
+	}
+}
+
+func TestSameConnectionIdZeroValues(t *testing.T) {
+	if !sameConnectionId(
+		ouroboros_conn.ConnectionId{},
+		ouroboros_conn.ConnectionId{},
+	) {
+		t.Fatal("sameConnectionId() = false, want true for zero values")
+	}
+	if sameConnectionId(ouroboros_conn.ConnectionId{}, testConnId()) {
+		t.Fatal("sameConnectionId() = true, want false for zero vs real")
+	}
+	if sameConnectionId(testConnId(), ouroboros_conn.ConnectionId{}) {
+		t.Fatal("sameConnectionId() = true, want false for real vs zero")
+	}
+}

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -395,11 +395,26 @@ func topologyGroupIDForPeer(peer *Peer, isTopology bool) string {
 func (p *PeerGovernor) peerIndexByConnId(connId ouroboros.ConnectionId) int {
 	for i, peer := range p.peers {
 		if peer != nil && peer.Connection != nil &&
-			peer.Connection.Id == connId {
+			sameConnectionId(peer.Connection.Id, connId) {
 			return i
 		}
 	}
 	return -1
+}
+
+// sameNetAddr compares addresses by string form, treating nil as equal
+// only to nil. ConnectionId.String() panics when either net.Addr field
+// is nil, so the addresses are compared individually instead.
+func sameNetAddr(a, b net.Addr) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.String() == b.String()
+}
+
+func sameConnectionId(a, b ouroboros.ConnectionId) bool {
+	return sameNetAddr(a.LocalAddr, b.LocalAddr) &&
+		sameNetAddr(a.RemoteAddr, b.RemoteAddr)
 }
 
 func (p *PeerGovernor) SetPeerHotByConnId(connId ouroboros.ConnectionId) {
@@ -520,7 +535,8 @@ func (p *PeerGovernor) appendChainSelectionEventsLocked(
 			peer.Connection,
 		)
 	}
-	if oldState.ok && newState.ok && oldState.connId == newState.connId {
+	if oldState.ok && newState.ok &&
+		sameConnectionId(oldState.connId, newState.connId) {
 		if oldState.eligible != newState.eligible {
 			events = append(events, pendingEvent{
 				PeerEligibilityChangedEventType,
@@ -562,7 +578,7 @@ func (p *PeerGovernor) appendChainSelectionEventsLocked(
 		}
 	}
 	if newState.ok {
-		if oldState.connId != newState.connId ||
+		if !sameConnectionId(oldState.connId, newState.connId) ||
 			oldState.eligible != newState.eligible {
 			events = append(events, pendingEvent{
 				PeerEligibilityChangedEventType,
@@ -573,7 +589,7 @@ func (p *PeerGovernor) appendChainSelectionEventsLocked(
 			})
 		}
 		if newState.priority != 0 &&
-			(oldState.connId != newState.connId ||
+			(!sameConnectionId(oldState.connId, newState.connId) ||
 				oldState.priority != newState.priority) {
 			events = append(events, pendingEvent{
 				PeerPriorityChangedEventType,

--- a/peergov/peers_test.go
+++ b/peergov/peers_test.go
@@ -14,7 +14,95 @@
 
 package peergov
 
-import "testing"
+import (
+	"net"
+	"testing"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+)
+
+func testPeerConnId(localPort, remotePort int) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: localPort,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: remotePort,
+		},
+	}
+}
+
+func TestPeerIndexByConnIdMatchesEquivalentEndpoint(t *testing.T) {
+	storedConnId := testPeerConnId(6000, 3001)
+	closedConnId := testPeerConnId(6000, 3001)
+	if storedConnId == closedConnId {
+		t.Fatal("test requires distinct address pointers")
+	}
+
+	pg := &PeerGovernor{
+		peers: []*Peer{
+			{
+				Source: PeerSourceTopologyLocalRoot,
+				Connection: &PeerConnection{
+					Id:       storedConnId,
+					IsClient: true,
+				},
+			},
+		},
+	}
+
+	if got := pg.peerIndexByConnId(closedConnId); got != 0 {
+		t.Fatalf("peerIndexByConnId() = %d, want 0", got)
+	}
+}
+
+func TestSameConnectionIdHandlesZeroValues(t *testing.T) {
+	zeroConnId := ouroboros.ConnectionId{}
+	realConnId := testPeerConnId(6000, 3001)
+
+	if !sameConnectionId(zeroConnId, zeroConnId) {
+		t.Fatal("sameConnectionId() = false, want true for zero values")
+	}
+	if sameConnectionId(zeroConnId, realConnId) {
+		t.Fatal("sameConnectionId() = true, want false for zero vs real")
+	}
+	if sameConnectionId(realConnId, zeroConnId) {
+		t.Fatal("sameConnectionId() = true, want false for real vs zero")
+	}
+}
+
+func TestSameConnectionIdHandlesPartialNilAddrs(t *testing.T) {
+	remoteAddr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001}
+	remoteOnly := ouroboros.ConnectionId{RemoteAddr: remoteAddr}
+	remoteOnlySame := ouroboros.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+	remoteOnlyOther := ouroboros.ConnectionId{
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
+	}
+	localOnly := ouroboros.ConnectionId{LocalAddr: remoteAddr}
+
+	if !sameConnectionId(remoteOnly, remoteOnly) {
+		t.Fatal("sameConnectionId() = false, want true for identical remote-only ids")
+	}
+	if !sameConnectionId(remoteOnly, remoteOnlySame) {
+		t.Fatal("sameConnectionId() = false, want true for equal remote-only ids")
+	}
+	if sameConnectionId(remoteOnly, remoteOnlyOther) {
+		t.Fatal("sameConnectionId() = true, want false for differing remote-only ids")
+	}
+	if sameConnectionId(remoteOnly, localOnly) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs local-only")
+	}
+	if sameConnectionId(remoteOnly, ouroboros.ConnectionId{}) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs zero")
+	}
+	if sameConnectionId(remoteOnly, testPeerConnId(6000, 3001)) {
+		t.Fatal("sameConnectionId() = true, want false for remote-only vs full id")
+	}
+}
 
 // TestChainSelectionEligible_FiltersRandomInboundSource ensures that inbound
 // connections from peers we don't know about (PeerSourceInboundConn) are not


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an epoch-clock stall by clearing the cached upstream tip when the active chainsync connection is closed or unavailable. Adds stable, nil-safe endpoint-based connection identity across reconnects to keep cleanup, priority, and eligibility updates correct.

- **Bug Fixes**
  - `ledger`: clear `syncUpstreamTipSlot` when the active chainsync connection closes or when no active connection exists; use per-address strings for connection-ID keys to handle nil/partial addresses.
  - `peergov`, `ouroboros`: use endpoint-based, nil-safe `sameConnectionId` matching across peer lookup, chain-selection, and chainsync logic (handles zero/partial IDs consistently).
  - Added tests for upstream-tip reset and connection-ID matching; updated ARCHITECTURE notes.

<sup>Written for commit 65ba855752af103a4971a05cfadb74dd786a0791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sync progress reporting to properly reset when active peer connections are lost
  * Improved peer connection identity matching for more reliable reconnection and recovery
  * Enhanced ledger state cleanup when all active connections become unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->