### PR TITLE
fix(ledger): skip snapshot recalculation after mithril

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -597,7 +597,8 @@ When `Node.Run()` is called, components are initialized in this order:
  6. Bark remote archive adapter and History Expiry worker (if configured)
  7. Database recovery, if startup detects a recoverable timestamp conflict
  8. LedgerState start
- 9. Snapshot manager start (captures genesis snapshot)
+ 9. Snapshot manager start (captures genesis snapshot, or reuses an existing
+    post-Mithril Mark snapshot window)
 10. Mempool setup and injection into LedgerState/Ouroboros
 11. ChainsyncState (multi-client tracking, stall detection)
 12. ChainSelector (genesis/Praos comparison) start
@@ -1092,6 +1093,12 @@ The `mithril/` package itself has no internal Dingo imports. Database import,
 ledger-state import, ImmutableDB loading, and API-mode metadata backfill are
 orchestrated by `cmd/dingo` and `internal/node`. This is exposed via the
 `dingo mithril` CLI subcommand and the `dingo load` command.
+
+During API-mode startup after a Mithril bootstrap, `Node.Run()` asks the
+snapshot manager to ensure the initial stake snapshot state before starting the
+client APIs. If the imported database already contains a non-empty Mark snapshot
+window for the current epoch, N-1, and N-2, the snapshot manager reuses that
+window instead of recalculating stake distribution from live UTxO state.
 
 In API storage mode, the SQLite metadata plugin can defer selected query indexes
 during bulk load. Deferred indexes are classified as critical or lazy in

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -349,6 +349,28 @@ func (m *Manager) captureMarkSnapshot(
 // snapshot immediately.
 func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	start := time.Now()
+	if ok, epoch, pools, stake, err := m.hasExistingPostMithrilSnapshotWindow(); err != nil {
+		m.logger.Warn(
+			"failed to check existing post-Mithril snapshot window",
+			"component", "snapshot",
+			"error", err,
+		)
+	} else if ok {
+		if m.metrics != nil {
+			m.metrics.capturePoolsTotal.Set(float64(pools))
+			m.metrics.captureTotalStakeLovelace.Set(float64(stake))
+			m.metrics.lastSuccessfulEpoch.Set(float64(epoch))
+		}
+		m.logger.Info(
+			"post-Mithril snapshot window already present; skipping genesis snapshot capture",
+			"component", "snapshot",
+			"epoch", epoch,
+			"total_pools", pools,
+			"total_stake", stake,
+		)
+		return nil
+	}
+
 	calculator := NewCalculator(m.db)
 	successCount := uint64(0)
 	lastSuccessfulEpoch := uint64(0)
@@ -512,4 +534,58 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 		m.metrics.lastSuccessfulEpoch.Set(float64(lastSuccessfulEpoch))
 	}
 	return nil
+}
+
+func (m *Manager) hasExistingPostMithrilSnapshotWindow() (
+	bool,
+	uint64,
+	uint64,
+	uint64,
+	error,
+) {
+	epochs, err := m.db.GetEpochs(nil)
+	if err != nil {
+		return false, 0, 0, 0, fmt.Errorf("load epochs: %w", err)
+	}
+	if len(epochs) == 0 {
+		return false, 0, 0, 0, nil
+	}
+	currentEpoch := epochs[len(epochs)-1].EpochId
+	if currentEpoch == 0 {
+		return false, 0, 0, 0, nil
+	}
+
+	meta := m.db.Metadata()
+	var currentPools uint64
+	var currentStake uint64
+	for offset := uint64(0); offset <= 2 && offset <= currentEpoch; offset++ {
+		epoch := currentEpoch - offset
+		snapshots, err := meta.GetPoolStakeSnapshotsByEpoch(
+			epoch,
+			"mark",
+			nil,
+		)
+		if err != nil {
+			return false, 0, 0, 0, fmt.Errorf(
+				"load mark snapshots for epoch %d: %w",
+				epoch,
+				err,
+			)
+		}
+		if len(snapshots) == 0 {
+			return false, 0, 0, 0, nil
+		}
+		var totalStake uint64
+		for _, snapshot := range snapshots {
+			totalStake += uint64(snapshot.TotalStake)
+		}
+		if totalStake == 0 {
+			return false, 0, 0, 0, nil
+		}
+		if offset == 0 {
+			currentPools = uint64(len(snapshots))
+			currentStake = totalStake
+		}
+	}
+	return true, currentEpoch, currentPools, currentStake, nil
 }

--- a/ledger/snapshot/manager_test.go
+++ b/ledger/snapshot/manager_test.go
@@ -79,6 +79,59 @@ func TestCaptureGenesisSnapshot_PostMithril(t *testing.T) {
 	}
 }
 
+func TestCaptureGenesisSnapshot_PostMithrilSkipsExistingWindow(t *testing.T) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	for _, e := range []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+		{EpochId: 148, StartSlot: 63936000, LengthInSlots: 432000},
+		{EpochId: 149, StartSlot: 64368000, LengthInSlots: 432000},
+		{EpochId: 150, StartSlot: 64800000, LengthInSlots: 432000},
+	} {
+		require.NoError(t, gormDB.Create(&e).Error)
+	}
+
+	poolHash := []byte("poolM_12345678901234567890EF")
+	seedPoolAndDelegations(t, sqliteStore, poolHash, []struct {
+		stakingKey  []byte
+		utxoAmounts []types.Uint64
+	}{
+		{
+			stakingKey:  []byte("aliceEF_staking_key_1234567890"),
+			utxoAmounts: []types.Uint64{50000000},
+		},
+	}, 64800000)
+
+	for _, epoch := range []uint64{148, 149, 150} {
+		require.NoError(t, db.Metadata().SavePoolStakeSnapshot(
+			&models.PoolStakeSnapshot{
+				Epoch:          epoch,
+				SnapshotType:   "mark",
+				PoolKeyHash:    poolHash,
+				TotalStake:     types.Uint64(50000000),
+				DelegatorCount: 1,
+				CapturedSlot:   64800000,
+			},
+			nil,
+		))
+	}
+
+	eventBus := event.NewEventBus(nil, nil)
+	mgr := NewManager(db, eventBus, nil)
+
+	require.NoError(t, mgr.CaptureGenesisSnapshot(context.Background()))
+
+	snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+		0,
+		"mark",
+		poolHash,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, snapshot, "existing post-Mithril window should skip epoch-0 reseed")
+}
+
 // TestCaptureGenesisSnapshot_PostMithrilAutoVoteFlagOnlyOnCurrentEpoch
 // asserts the CIP-1694 reward-account auto-vote resolution gate on
 // the post-Mithril seeding loop: live Pool/Account state at bootstrap


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip stake snapshot recalculation on API-mode startup after a Mithril bootstrap by reusing an existing mark snapshot window (current, N-1, N-2). This speeds up startup and helps avoid tip stalls.

- **Bug Fixes**
  - In `CaptureGenesisSnapshot`, detect an existing post-Mithril mark snapshot window and return early; update metrics and logs.
  - Added `hasExistingPostMithrilSnapshotWindow()` to verify non-empty mark snapshots for current epoch, N-1, and N-2.
  - Tests: `TestCaptureGenesisSnapshot_PostMithrilSkipsExistingWindow` ensures epoch-0 reseed is skipped when a valid window exists.
  - Docs: Updated ARCHITECTURE.md to describe the reuse behavior after Mithril bootstrap.

<sup>Written for commit 8e4398c5c035f72943e80ce3882dfe3ad6a5c21d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify stake snapshot initialization behavior after Mithril bootstrap in API storage mode.

* **Refactor**
  * Optimized stake snapshot initialization to efficiently reuse existing post-Mithril snapshots instead of recalculating from genesis when available, reducing redundant computation during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->