### PR TITLE
build(deps): gouroboros 0.182.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/aws/smithy-go v1.27.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.180.1
+	github.com/blinklabs-io/gouroboros v0.182.0
 	github.com/blinklabs-io/ouroboros-mock v0.12.0
-	github.com/blinklabs-io/plutigo v0.1.14
+	github.com/blinklabs-io/plutigo v0.1.15
 	github.com/blockfrost/blockfrost-go v0.4.0
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/consensys/gnark-crypto v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -133,12 +133,12 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.180.1 h1:rwZhXOTOzKNvkqTjK5AaT9pEEiJ3bsTbbX8m/yDnUiQ=
-github.com/blinklabs-io/gouroboros v0.180.1/go.mod h1:xjA3SxWqNzlZlmaZ1aJSRctIYryGa/o1W2pivaS4J3w=
+github.com/blinklabs-io/gouroboros v0.182.0 h1:qZN0DCFaSmbWdI7RF9r/J5lzq88VmtdWyysiMGEjPnA=
+github.com/blinklabs-io/gouroboros v0.182.0/go.mod h1:ZiABPLvB5+7qYPB8a2WgfYNr71RfUFQME3n/O3fFv5o=
 github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
 github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
-github.com/blinklabs-io/plutigo v0.1.14 h1:SUwrQQPVZkbAz1MumCC0O2qn7N7aLnz95/syW2tLl+4=
-github.com/blinklabs-io/plutigo v0.1.14/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
+github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
+github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=
 github.com/blockfrost/blockfrost-go v0.4.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -73,19 +74,19 @@ func (o *Ouroboros) storeLeiosEndorserBlock(
 	if err != nil {
 		return fmt.Errorf("decode leios endorser block: %w", err)
 	}
-	blockHash := block.Hash()
-	cacheKeys := []string{leiosBlockKey(blockHash.Bytes())}
-	if len(point.Hash) > 0 {
-		pointKey := leiosBlockKey(point.Hash)
-		if pointKey != cacheKeys[0] {
-			cacheKeys = append(cacheKeys, pointKey)
-		}
+	if len(point.Hash) == 0 {
+		return errors.New("leios endorser block cache: empty point hash")
 	}
+	blockHash := lcommon.Blake2b256Hash(blockRaw)
+	if !slices.Equal(blockHash.Bytes(), point.Hash) {
+		return errors.New("leios endorser block cache: point hash mismatch")
+	}
+	cacheKeys := []string{leiosBlockKey(point.Hash)}
 	data := &leiosEndorserBlockData{
 		point:      point,
 		blockRaw:   slices.Clone(blockRaw),
 		txsRaw:     cloneRawMessages(txsRaw),
-		txCount:    len(txsRaw),
+		txCount:    len(block.TransactionReferences),
 		cacheKeys:  cacheKeys,
 		insertedAt: time.Now(),
 	}

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
@@ -82,6 +83,38 @@ func testDijkstraBlockRaw(
 	return ocommon.NewPoint(uint64(idx), hash.Bytes()), cbor.RawMessage(raw)
 }
 
+func testLeiosEndorserBlockRaw(
+	t *testing.T,
+	idx int,
+) (ocommon.Point, cbor.RawMessage) {
+	t.Helper()
+	return testLeiosEndorserBlockRawWithRefs(t, idx, 1)
+}
+
+func testLeiosEndorserBlockRawWithRefs(
+	t *testing.T,
+	idx int,
+	refCount int,
+) (ocommon.Point, cbor.RawMessage) {
+	t.Helper()
+	refs := make([]gleios.LeiosTransactionReference, refCount)
+	for refIdx := range refs {
+		refs[refIdx] = gleios.LeiosTransactionReference{
+			TransactionHash: lcommon.Blake2b256Hash(
+				[]byte{byte(idx), byte(refIdx)},
+			),
+			TransactionSize: uint16(refIdx + 1),
+		}
+	}
+	block := gleios.LeiosEndorserBlock{
+		TransactionReferences: refs,
+	}
+	raw, err := cbor.Encode(&block)
+	require.NoError(t, err)
+	hash := lcommon.Blake2b256Hash(raw)
+	return ocommon.NewPoint(uint64(idx), hash.Bytes()), cbor.RawMessage(raw)
+}
+
 func TestMergedLeiosRankingBlockCborIsNoopForDijkstra(t *testing.T) {
 	_, blockRaw := testDijkstraBlockRaw(t, 1)
 
@@ -105,7 +138,7 @@ func TestLeiosTxsFromBitmapPreservesRequestedOrder(t *testing.T) {
 }
 
 func TestLeiosFetchServerBlockTxsRejectsIncompleteCache(t *testing.T) {
-	point, blockRaw := testDijkstraBlockRaw(t, 10)
+	point, blockRaw := testLeiosEndorserBlockRawWithRefs(t, 10, 2)
 
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
 	require.NoError(
@@ -116,9 +149,6 @@ func TestLeiosFetchServerBlockTxsRejectsIncompleteCache(t *testing.T) {
 			[]cbor.RawMessage{mustCbor(t, "tx0")},
 		),
 	)
-	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
-	require.True(t, ok)
-	data.txCount = 2
 
 	msg, err := o.leiosfetchServerBlockTxsRequest(
 		oleiosfetch.CallbackContext{},
@@ -131,7 +161,7 @@ func TestLeiosFetchServerBlockTxsRejectsIncompleteCache(t *testing.T) {
 }
 
 func TestLeiosFetchServerBlockTxsRejectsOutOfRangeBitmap(t *testing.T) {
-	point, blockRaw := testDijkstraBlockRaw(t, 10)
+	point, blockRaw := testLeiosEndorserBlockRawWithRefs(t, 10, 2)
 
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
 	require.NoError(
@@ -175,7 +205,7 @@ func TestLeiosNotifyBlockTxsOfferCacheMissIsNonFatal(t *testing.T) {
 func TestFetchCachedLeiosEndorserBlockTxsReturnsCompleteCacheWithoutFetch(
 	t *testing.T,
 ) {
-	point, blockRaw := testDijkstraBlockRaw(t, 10)
+	point, blockRaw := testLeiosEndorserBlockRaw(t, 10)
 	txRaw := mustCbor(t, "tx0")
 
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
@@ -198,9 +228,25 @@ func TestFetchCachedLeiosEndorserBlockTxsReturnsCompleteCacheWithoutFetch(
 	require.Equal(t, txRaw, cached.txsRaw[0])
 }
 
+func TestStoreLeiosEndorserBlockRejectsPointHashMismatch(t *testing.T) {
+	point, blockRaw := testLeiosEndorserBlockRaw(t, 10)
+	point.Hash[0] ^= 0xff
+
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	err := o.storeLeiosEndorserBlock(point, blockRaw, nil)
+	require.ErrorContains(
+		t,
+		err,
+		"leios endorser block cache: point hash mismatch",
+	)
+
+	_, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	require.False(t, ok)
+}
+
 func TestLeiosEndorserBlockLookupExpiresStaleEntries(t *testing.T) {
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
-	point, raw := testDijkstraBlockRaw(t, 1)
+	point, raw := testLeiosEndorserBlockRaw(t, 1)
 	require.NoError(t, o.storeLeiosEndorserBlock(point, raw, nil))
 	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
 	require.True(t, ok)
@@ -220,7 +266,7 @@ func TestLeiosEndorserBlockLookupExpiresStaleEntries(t *testing.T) {
 
 func TestLeiosEndorserBlockCachePrunesExpiredEntries(t *testing.T) {
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
-	oldPoint, oldRaw := testDijkstraBlockRaw(t, 1)
+	oldPoint, oldRaw := testLeiosEndorserBlockRaw(t, 1)
 	require.NoError(t, o.storeLeiosEndorserBlock(oldPoint, oldRaw, nil))
 	oldData, ok := o.lookupLeiosEndorserBlock(oldPoint.Hash)
 	require.True(t, ok)
@@ -229,7 +275,7 @@ func TestLeiosEndorserBlockCachePrunesExpiredEntries(t *testing.T) {
 	oldData.insertedAt = time.Now().Add(-leiosEndorserBlockCacheTTL - time.Second)
 	o.leiosMu.Unlock()
 
-	newPoint, newRaw := testDijkstraBlockRaw(t, 2)
+	newPoint, newRaw := testLeiosEndorserBlockRaw(t, 2)
 	require.NoError(t, o.storeLeiosEndorserBlock(newPoint, newRaw, nil))
 
 	_, ok = o.lookupLeiosEndorserBlock(oldPoint.Hash)
@@ -242,7 +288,7 @@ func TestLeiosEndorserBlockCachePrunesBySize(t *testing.T) {
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
 	var lastPoint ocommon.Point
 	for idx := 0; idx < leiosEndorserBlockCacheMaxEntries+1; idx++ {
-		point, raw := testDijkstraBlockRaw(t, idx)
+		point, raw := testLeiosEndorserBlockRaw(t, idx)
 		require.NoError(t, o.storeLeiosEndorserBlock(point, raw, nil))
 		lastPoint = point
 	}

--- a/utxorpc/utxorpc_test.go
+++ b/utxorpc/utxorpc_test.go
@@ -124,14 +124,18 @@ func TestRequestLimitEnforcement_Pattern(t *testing.T) {
 }
 
 func TestUtxorpc_StartStop(t *testing.T) {
-	// Start server on ephemeral port by setting Port to 0
 	u := NewUtxorpc(UtxorpcConfig{
 		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus: event.NewEventBus(nil, nil),
 		Host:     "127.0.0.1",
-		Port:     0,
 	})
-	err := u.Start(context.Background())
+	// NewUtxorpc defaults Port 0 to 9090 for runtime config. Force the
+	// test instance back to an ephemeral port to avoid local port conflicts.
+	u.config.Port = 0
+
+	startCtx, cancelStart := context.WithCancel(context.Background())
+	defer cancelStart()
+	err := u.Start(startCtx)
 	require.NoError(t, err, "failed to start utxorpc")
 
 	// Server is already listening after Start returns successfully


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `github.com/blinklabs-io/gouroboros` to v0.182.0 (and `github.com/blinklabs-io/plutigo` to v0.1.15) and tighten Leios endorser block caching to match the new format, including strict point-hash validation. Also make the UTxORPC Start/Stop test use an ephemeral port to avoid conflicts.

- **Dependencies**
  - Bump `github.com/blinklabs-io/gouroboros` to v0.182.0.
  - Bump `github.com/blinklabs-io/plutigo` to v0.1.15.

- **Bug Fixes**
  - Cache now keys by point hash, rejects empty hashes, and verifies the point hash matches the block’s Blake2b-256; `txCount` comes from `TransactionReferences`.
  - Tests build real Leios endorser blocks and add a point-hash mismatch case; UTxORPC test forces an ephemeral port and uses a cancellable context.

<sup>Written for commit 30ee219a117fb1489d95780c7d375b3bc5bf4664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Leios endorser block validation and cache handling to ensure proper block identification and transaction reference accuracy.

* **Chores**
  * Updated dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->