### PR TITLE
fix(leios): Fixes Leios EB vote-emission safety for mismatched slots.

### DIFF
--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -95,6 +95,16 @@ func (o *Ouroboros) storeLeiosEndorserBlock(
 	if o.leiosEndorserBlocks == nil {
 		o.leiosEndorserBlocks = make(map[string]*leiosEndorserBlockData)
 	}
+	o.pruneLeiosEndorserBlockCacheLocked(time.Now())
+	if existing := o.leiosEndorserBlocks[cacheKeys[0]]; existing != nil &&
+		existing.point.Slot != point.Slot {
+		o.leiosMu.Unlock()
+		return fmt.Errorf(
+			"leios endorser block cache: point slot mismatch for hash: cached %d, got %d",
+			existing.point.Slot,
+			point.Slot,
+		)
+	}
 	for _, key := range cacheKeys {
 		o.leiosEndorserBlocks[key] = data
 	}

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"encoding/binary"
 	"errors"
 	"testing"
 	"time"
@@ -99,10 +100,11 @@ func testLeiosEndorserBlockRawWithRefs(
 	t.Helper()
 	refs := make([]gleios.LeiosTransactionReference, refCount)
 	for refIdx := range refs {
+		var hashSeed [12]byte
+		binary.BigEndian.PutUint64(hashSeed[:8], uint64(idx))
+		binary.BigEndian.PutUint32(hashSeed[8:], uint32(refIdx))
 		refs[refIdx] = gleios.LeiosTransactionReference{
-			TransactionHash: lcommon.Blake2b256Hash(
-				[]byte{byte(idx), byte(refIdx)},
-			),
+			TransactionHash: lcommon.Blake2b256Hash(hashSeed[:]),
 			TransactionSize: uint16(refIdx + 1),
 		}
 	}

--- a/ouroboros/leiosvotes_test.go
+++ b/ouroboros/leiosvotes_test.go
@@ -206,6 +206,30 @@ func TestStoreLeiosEndorserBlockNotifiesVoteHandler(t *testing.T) {
 	assert.Equal(t, point.Hash, handler.ebs[0].ebHash.Bytes())
 }
 
+// A peer must not be able to make us vote for the same EB hash under a
+// different slot by replaying the same EB bytes with a different point.
+func TestStoreLeiosEndorserBlockRejectsSlotMismatchBeforeVote(
+	t *testing.T,
+) {
+	point, blockRaw := testLeiosEndorserBlockRaw(t, 10)
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	handler := &fakeLeiosVoteHandler{}
+	o.LeiosVotes = handler
+
+	require.NoError(t, o.storeLeiosEndorserBlock(point, blockRaw, nil))
+
+	mismatchedPoint := point
+	mismatchedPoint.Slot++
+	err := o.storeLeiosEndorserBlock(mismatchedPoint, blockRaw, nil)
+	require.ErrorContains(
+		t,
+		err,
+		"leios endorser block cache: point slot mismatch",
+	)
+	require.Len(t, handler.ebs, 1)
+	assert.Equal(t, uint64(10), handler.ebs[0].slot)
+}
+
 func TestStoreLeiosEndorserBlockWithoutHandler(t *testing.T) {
 	point, blockRaw := testLeiosEndorserBlockRaw(t, 11)
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})


### PR DESCRIPTION
1. Made changes to store the accepted slot for each cached EB hash.
2. Reject an EB if the same hash appears with a different slot.
3. Made chanegs to not emit a local Leios vote when that mismatch happens.
4. Added a test for replaying the same EB bytes with another slot.
5. Fix the EB test helper so test blocks have unique hashes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unsafe Leios vote emission when the same EB hash is replayed under a different slot. We now cache the accepted slot per EB hash and reject mismatches before voting.

- **Bug Fixes**
  - Store the accepted slot alongside each cached EB hash and prune the cache before insert.
  - Reject EBs when the same hash appears with a different slot and skip local vote emission.
  - Add a test for replaying the same EB bytes with another slot; update the test helper to generate unique transaction hashes.

<sup>Written for commit 22bc2b35af4d180fa8a2f770ef44bae6aae50c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of leios endorser blocks to reject replay attempts where the same block data is provided with a different slot, preventing potential consensus issues.
  * Enhanced error reporting to include both cached and provided slot values for better debugging and diagnostics.

* **Tests**
  * Added comprehensive test coverage for slot mismatch detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->