### PR TITLE
ci(publish): fail open on attestations for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,12 +188,14 @@ jobs:
             VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
             COMMIT_HASH=${{ github.sha }}
       - name: Attest Docker Hub image
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: docker.io/blinklabs/dingo
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
       - name: Attest GHCR image
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
@@ -232,6 +234,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
       - name: Attest antithesis Docker Hub image
         if: matrix.arch == 'amd64'
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: docker.io/blinklabs/dingo
@@ -239,6 +242,7 @@ jobs:
           push-to-registry: true
       - name: Attest antithesis GHCR image
         if: matrix.arch == 'amd64'
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
@@ -273,6 +277,7 @@ jobs:
           labels: ${{ steps.txpump-meta.outputs.labels }}
       - name: Attest txpump GHCR image
         if: matrix.arch == 'amd64'
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/dingo-txpump
@@ -307,6 +312,7 @@ jobs:
           labels: ${{ steps.configurator-meta.outputs.labels }}
       - name: Attest configurator GHCR image
         if: matrix.arch == 'amd64'
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/dingo-configurator
@@ -341,6 +347,7 @@ jobs:
           labels: ${{ steps.analysis-meta.outputs.labels }}
       - name: Attest analysis GHCR image
         if: matrix.arch == 'amd64'
+        continue-on-error: ${{ github.ref_type != 'tag' }}
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/dingo-analysis


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `continue-on-error: ${{ github.ref_type != 'tag' }}` on all `actions/attest` steps in the publish workflow to fail open on non-tag builds, avoiding blocked branch/PR publishes. Tagged releases still enforce attestations and will fail on errors.

<sup>Written for commit c6e61224b109b7b175df57448bb03eb0b10071ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

