### PR TITLE
test(mempool): fix metrics counting for expired tx

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -2307,13 +2307,15 @@ func TestMempool_TTL_ExpiredMetricUpdated(t *testing.T) {
 	m.consumersMutex.Unlock()
 	m.Unlock()
 
-	// Wait for cleanup to remove all expired transactions
+	// Wait for cleanup to remove all expired transactions and update metrics.
 	require.Eventually(t, func() bool {
 		m.RLock()
-		defer m.RUnlock()
-		return len(m.transactions) == 0
+		removed := len(m.transactions) == 0
+		m.RUnlock()
+		return removed &&
+			testutil.ToFloat64(m.metrics.txsExpired) == float64(5)
 	}, 2*time.Second, 10*time.Millisecond,
-		"all expired transactions should be removed",
+		"all expired transactions should be removed and counted",
 	)
 
 	// Verify the expired counter was incremented


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the TTL expiration metrics test to verify expired transactions are counted, not just removed. The test now waits for cleanup to finish and asserts `txsExpired` equals 5 once the `mempool` is empty.

<sup>Written for commit 9f1a03649363edf98e0103499ec8e8d390719643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

